### PR TITLE
fix(wiz): board PDF export — six defects in dashboard merge, layout, persistence and error reporting

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetExportController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetExportController.java
@@ -167,10 +167,16 @@ public class WizViewsheetExportController {
          return null;
       }
       catch(SecurityException e) {
-         return ResponseEntity.status(403).body(Map.of("error", e.getMessage()));
+         LOG.warn("Board PDF export refused for dashboard {}: {}", event.getDashboardId(), e.getMessage());
+         return ResponseEntity.status(403).body(Map.of("error", String.valueOf(e.getMessage())));
       }
       catch(IllegalArgumentException | IllegalStateException e) {
-         return ResponseEntity.status(400).body(Map.of("error", e.getMessage()));
+         // Logged, not just returned. This branch used to be silent, and because the body is JSON
+         // while the caller asks for application/pdf, Spring answered 406 instead — so a real
+         // failure reached the user as an unexplained "Couldn't export PDF" with NOTHING in any log
+         // on either side. A 400 that leaves no trace is indistinguishable from a broken endpoint.
+         LOG.error("Board PDF export rejected for dashboard {}", event.getDashboardId(), e);
+         return ResponseEntity.status(400).body(Map.of("error", String.valueOf(e.getMessage())));
       }
       catch(Exception e) {
          LOG.error("Failed to export board PDF for dashboard {}", event.getDashboardId(), e);

--- a/core/src/main/java/inetsoft/web/wiz/service/AddVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/AddVisualizationService.java
@@ -264,8 +264,38 @@ public class AddVisualizationService {
       List<VSAssembly> clones = new ArrayList<>();
       Map<String, String> vsConflictRenameMap = new HashMap<>();
 
+      // A saved visualization IS one chart -- that is the model the rest of the product enforces:
+      // ViewsheetRuntimeController#findChartAssembly resolves an asset to its FIRST
+      // ChartVSAssembly, and open/verify/reload all report that single assembly. An asset can
+      // nonetheless end up holding more than one, because persistViewsheet writes back whatever
+      // the runtime contains and a re-bind of a reopened saved viz can leave the superseded chart
+      // behind. Merging every assembly then pulled the ORPHAN into the dashboard too, so a 5-chart
+      // board composed to 6 chart assemblies and the export failed the tile/caption count check
+      // with "Dashboard has 6 top-level assemblies but 5 charts were requested" -- observed live.
+      //
+      // Take the same primary the rest of the product takes, and skip any further chart. Anything
+      // that is not a chart still comes across untouched.
+      ChartVSAssembly primaryChart = null;
+
+      for(Assembly a : vizVS.getAssemblies()) {
+         if(a instanceof ChartVSAssembly chart) {
+            primaryChart = chart;
+            break;
+         }
+      }
+
       for(Assembly a : vizVS.getAssemblies()) {
          if(!(a instanceof VSAssembly srcAssembly)) {
+            continue;
+         }
+
+         if(a instanceof ChartVSAssembly && a != primaryChart) {
+            // Identify it by the ASSEMBLIES, not vizVS.getName() — a saved-visualization Viewsheet
+            // carries no name, so that logged a bare "null" and told a reader nothing.
+            LOG.warn("Saved visualization holds more than one chart; merging only its primary " +
+                     "assembly '{}' and skipping the superseded '{}'.",
+                     primaryChart == null ? null : primaryChart.getAbsoluteName(),
+                     srcAssembly.getAbsoluteName());
             continue;
          }
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
@@ -117,6 +117,15 @@ import java.util.List;
  */
 @Component
 public class WizDashboardFilterBuilder {
+   /**
+    * Name prefix for every non-interactive decoration this builder adds to a composed dashboard
+    * (the filter bar's band/divider rectangles and each control's caption). The board PDF export
+    * keys off it to tell decoration apart from a real board tile — a caption is a TextVSAssembly
+    * and so is a KPI tile, so the type alone cannot distinguish them. Keep the two in step: see
+    * WizPrintLayoutBuilder#resolveTopLevelAssemblies.
+    */
+   public static final String DECORATION_NAME_PREFIX = "wizFilter";
+
    public record FilterRequest(String field, String dataType, String label, boolean preAggregation) {
       /** Compatibility constructor defaulting to post-aggregation (the original binding) -- used by
        *  the per-chart path and by tests that predate the pre-aggregation flag. */
@@ -259,7 +268,7 @@ public class WizDashboardFilterBuilder {
          // range slider is otherwise unreadable. Its placement is returned alongside the control's:
          // an assembly with no per-tier layout entry is hidden when that tier is selected.
          if(!rendersOwnTitle && req.label() != null) {
-            placements.add(addCaption(vs, "wizFilterLabel_" + control.getName(),
+            placements.add(addCaption(vs, DECORATION_NAME_PREFIX + "Label_" + control.getName(),
                                       x, y, FILTER_CONTROL_WIDTH, FILTER_LABEL_HEIGHT, req.label()));
          }
 
@@ -375,8 +384,8 @@ public class WizDashboardFilterBuilder {
     */
    public List<FilterControlPlacement> buildFilterBarBand(Viewsheet vs, int x, int y, int width, int height) {
       List<FilterControlPlacement> placements = new ArrayList<>();
-      placements.add(addFillRectangle(vs, "wizFilterBarBand", x, y, width, height, BAND_BACKGROUND));
-      placements.add(addFillRectangle(vs, "wizFilterBarDivider",
+      placements.add(addFillRectangle(vs, DECORATION_NAME_PREFIX + "BarBand", x, y, width, height, BAND_BACKGROUND));
+      placements.add(addFillRectangle(vs, DECORATION_NAME_PREFIX + "BarDivider",
          x, y + height - DIVIDER_THICKNESS, width, DIVIDER_THICKNESS, DIVIDER_COLOR));
       return placements;
    }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
@@ -27,6 +27,7 @@ import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.uql.viewsheet.internal.AnnotationVSUtil;
 import inetsoft.uql.viewsheet.internal.TextVSAssemblyInfo;
+import inetsoft.uql.viewsheet.SelectionVSAssembly;
 import inetsoft.uql.viewsheet.vslayout.PrintInfo;
 import inetsoft.uql.viewsheet.vslayout.PrintLayout;
 import inetsoft.uql.viewsheet.vslayout.VSAssemblyLayout;
@@ -68,10 +69,24 @@ public class WizPrintLayoutBuilder {
       List<VSAssembly> topLevel = resolveTopLevelAssemblies(dashboard);
 
       if(topLevel.size() != charts.size()) {
+         // NAME what was found. A bare count ("13 top-level assemblies but 5 charts") says nothing
+         // about WHICH extra assembly is present, and the answer is the whole diagnosis: a stale
+         // tile, or -- as happened when the dashboard-filter feature began adding controls and
+         // decoration to composed dashboards -- something that was never a board tile at all.
+         // Establishing that took a full build-and-deploy cycle per guess; the message now carries
+         // it.
+         StringBuilder found = new StringBuilder();
+
+         for(VSAssembly a : topLevel) {
+            found.append(found.length() == 0 ? "" : ", ")
+                 .append(a.getAbsoluteName()).append(" [").append(a.getClass().getSimpleName()).append("]");
+         }
+
          throw new IllegalStateException(
             "Dashboard has " + topLevel.size() + " top-level assemblies but " + charts.size() +
             " charts were requested — the composed dashboard and the board's curation have " +
-            "desynced (see WizPrintLayoutBuilder's Javadoc / the plan's Global Constraints risk note)");
+            "desynced (see WizPrintLayoutBuilder's Javadoc / the plan's Global Constraints risk " +
+            "note). Found: " + found);
       }
 
       List<ChartCaption> ordered = charts.stream()
@@ -169,6 +184,24 @@ public class WizPrintLayoutBuilder {
          }
 
          if(AnnotationVSUtil.isAnnotation(vsAssembly) || vsAssembly.getContainer() != null) {
+            continue;
+         }
+
+         // A composed dashboard is no longer charts-only: since the dashboard-filter feature it
+         // also carries interactive filter CONTROLS plus the bar's own decoration. Neither is a
+         // board tile, and counting them here made the guard below reject every board that has any
+         // filter -- "Dashboard has 13 top-level assemblies but 5 charts were requested" -- which
+         // reached the user as an unexplained failed PDF export.
+         //
+         // Two exclusions, because one does not cover the other: every filter control is a
+         // SelectionVSAssembly whatever its flavour (list, tree, range slider), while the caption
+         // and band are a TextVSAssembly and a RectangleVSAssembly -- and a Text is ALSO how a KPI
+         // tile is rendered, so the type cannot tell them apart. The decorations are matched by the
+         // builder's own name prefix instead.
+         if(vsAssembly instanceof SelectionVSAssembly ||
+            vsAssembly.getAbsoluteName() != null &&
+            vsAssembly.getAbsoluteName().startsWith(WizDashboardFilterBuilder.DECORATION_NAME_PREFIX))
+         {
             continue;
          }
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -2804,8 +2804,75 @@ public class WizVsService {
          entry = new AssetEntry(AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET, path, pId);
       }
 
+      // A SAVED VISUALIZATION holds exactly one chart. Enforce that here, at the single write choke
+      // point, rather than in each caller — see pruneSupersededCharts.
+      if(entry.getPath() != null &&
+         entry.getPath().startsWith(WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/"))
+      {
+         pruneSupersededCharts(vs);
+      }
+
       viewsheetService.setViewsheet(vs, entry, user, true, true);
       return entry.toIdentifier();
+   }
+
+   /**
+    * Drop every NON-PRIMARY chart from a viewsheet that is about to be stored as a saved
+    * visualization.
+    *
+    * <p>THE DEFECT THIS FIXES. A saved visualization IS one chart — that is the model the rest of
+    * the product enforces: {@code ViewsheetRuntimeController#findChartAssembly} resolves an asset
+    * to its FIRST ChartVSAssembly, and open/verify/reload all report that single assembly.
+    *
+    * <p>But re-binding a REOPENED saved visualization does not replace its chart. The general
+    * create/rebind path DEMOTES the displaced primary ({@code setPrimary(false)}) and adds the new
+    * assembly beside it; only the {@code skipExecution} (change-type) path also deletes it. That
+    * retention is deliberate and correct for a SESSION viewsheet, which holds one historical card
+    * per turn — but this same viewsheet is then handed to persistViewsheet, which writes back
+    * whatever it contains. Re-bind a saved viz and the asset silently gains a second chart.
+    *
+    * <p>Observed live: a board's A1 chart, re-bound after a dataset regeneration, left its
+    * superseded chart in the asset. Composing that board produced 6 chart assemblies for 5 tiles
+    * and the PDF export failed its tile/caption count check. The orphan is invisible everywhere
+    * else, because every other reader takes the first chart and stops.
+    *
+    * <p>Scoped deliberately:
+    * <ul>
+    *   <li>ONLY for the components folder. A session viewsheet in the root folder legitimately
+    *       holds many charts, and pruning there would delete the user's history.</li>
+    *   <li>ONLY charts. Anything else an asset carries (annotations, shapes) is left alone.</li>
+    *   <li>ONLY when a primary chart is actually present. With no primary there is no basis for
+    *       choosing a survivor, and guessing would risk deleting the real one — leave it whole and
+    *       let the first-chart readers cope, exactly as before.</li>
+    * </ul>
+    */
+   static void pruneSupersededCharts(Viewsheet vs) {
+      Assembly[] assemblies = vs == null ? null : vs.getAssemblies();
+
+      if(assemblies == null) {
+         return;
+      }
+
+      boolean hasPrimaryChart = false;
+
+      for(Assembly a : assemblies) {
+         if(a instanceof ChartVSAssembly chart && chart.isPrimary()) {
+            hasPrimaryChart = true;
+            break;
+         }
+      }
+
+      if(!hasPrimaryChart) {
+         return;
+      }
+
+      for(Assembly a : assemblies) {
+         if(a instanceof ChartVSAssembly chart && !chart.isPrimary()) {
+            LOG.warn("Dropping superseded chart '{}' from a saved visualization: an asset in the " +
+                     "components folder holds exactly one chart.", chart.getAbsoluteName());
+            vs.removeAssembly(chart.getName());
+         }
+      }
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/service/WsMergeService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WsMergeService.java
@@ -434,6 +434,52 @@ public class WsMergeService {
     * (type + datasource prefix + physical table/query name) as {@code srcTable}, or
     * {@code null} if none exists.
     */
+   /**
+    * True when merging {@code srcTable} into {@code candidate} would LOSE a column, because the two
+    * select the same physical column under different aliases.
+    *
+    * <p>THE DEFECT THIS PREVENTS. Merging is by physical source alone, and mergeColumns then unions
+    * the source's columns in, guarded by EXPOSED NAME. But ColumnSelection dedupes on DataRef
+    * equality, which compares the physical name and IGNORES the alias — so `id AS w3_id` is judged
+    * equal to an already-present `id AS wp_id` and the add silently does nothing. The guard says
+    * "add", the add is a no-op, and every join that referenced the dropped alias then fails at SQL
+    * time with `column ..._fkjoin.w3_id does not exist`. Observed live composing a board whose
+    * charts each aliased work_packages.id differently.
+    *
+    * <p>Keeping BOTH aliases is not an option: the same alias-blind equality runs through query
+    * construction too, so one physical column cannot be projected twice under two names however the
+    * selection is stored — verified by making the selection hold both and watching the query builder
+    * collapse them again. Rewriting the loser's references onto the survivor would have to cascade
+    * through every dependent join and mirror, several levels deep.
+    *
+    * <p>So decline the merge instead. Sharing one physical table across charts is an OPTIMISATION
+    * (one scan instead of two); correctness is not negotiable for it. The two charts simply keep
+    * their own copies of the table, exactly as they would if their sources differed.
+    */
+   private static boolean aliasesConflict(BoundTableAssembly candidate, BoundTableAssembly srcTable) {
+      ColumnSelection candidateCols = candidate.getColumnSelection(true);
+      ColumnSelection srcCols = srcTable.getColumnSelection(true);
+
+      for(int i = 0; i < srcCols.getAttributeCount(); i++) {
+         DataRef col = srcCols.getAttribute(i);
+
+         // Present under this very name — nothing to lose.
+         if(candidateCols.getAttribute(col.getName()) != null) {
+            continue;
+         }
+
+         // Not present by name, but an alias-blind-equal column IS there: the add would no-op.
+         if(candidateCols.containsAttribute(col)) {
+            LOG.debug("Not merging {} into {}: '{}' would collide with an existing column over the " +
+                      "same physical attribute under a different alias.",
+                      srcTable.getName(), candidate.getName(), col.getName());
+            return true;
+         }
+      }
+
+      return false;
+   }
+
    private BoundTableAssembly findMergeableTable(Worksheet dashWS, BoundTableAssembly srcTable) {
       SourceInfo srcInfo = srcTable.getSourceInfo();
 
@@ -454,7 +500,8 @@ public class WsMergeService {
 
          if(srcInfo.getType() == candidateInfo.getType() &&
             Objects.equals(srcInfo.getPrefix(), candidateInfo.getPrefix()) &&
-            Objects.equals(srcInfo.getSource(), candidateInfo.getSource()))
+            Objects.equals(srcInfo.getSource(), candidateInfo.getSource()) &&
+            !aliasesConflict(candidate, srcTable))
          {
             return candidate;
          }
@@ -590,8 +637,13 @@ public class WsMergeService {
       // part of preparing an aggregate query) regenerate public FROM the empty private selection,
       // silently dropping every aggregate output. Harmless (a no-op beyond the extra assignment)
       // when aggr is empty, since a plain pass-through mirror never triggers that reset path.
+      // PRIVATE FIRST, then PUBLIC. setColumnSelection(.., false) re-derives the public selection
+      // from the private one, so assigning public first and private second lets the derivation
+      // overwrite public with the base-qualified names -- the mirror then stops exposing `id` and
+      // starts exposing `projects_base.id`, every join key over it resolves to nothing, and
+      // CompositeTableAssembly#checkValidity drops the join as a cross join.
+      prevMirror.setColumnSelection(baseQualified(origPrivateCols, qualifierBase, aggr), false);
       prevMirror.setColumnSelection(origCols, true);
-      prevMirror.setColumnSelection(origPrivateCols, false);
       prevMirror.setPreConditionList(preconds);
       prevMirror.setPostConditionList(postconds);
       prevMirror.setAggregateInfo(aggr);
@@ -609,6 +661,45 @@ public class WsMergeService {
       }
 
       return prevMirrorName;
+   }
+
+   /**
+    * Re-express a mirror's PRIVATE selection as references to its base's EXPOSED names.
+    * See D11: the mirror was seeded with the base's own bare refs while mergeMirrorColumns
+    * qualifies everything it adds later, so the mirror held two namespaces at once and any
+    * ALIASED column was pruned from the projection while joins still referenced it.
+    */
+   private static ColumnSelection baseQualified(ColumnSelection privateCols, String baseName,
+                                                AggregateInfo aggr)
+   {
+      Set<String> groupNames = new HashSet<>();
+
+      for(int i = 0; aggr != null && i < aggr.getGroupCount(); i++) {
+         groupNames.add(aggr.getGroup(i).getName());
+      }
+
+      ColumnSelection out = new ColumnSelection();
+
+      for(int i = 0; i < privateCols.getAttributeCount(); i++) {
+         DataRef col = privateCols.getAttribute(i);
+         String entity = col.getEntity();
+
+         if(entity != null && !entity.isEmpty()) {
+            out.addAttribute(col);
+            continue;
+         }
+
+         if(groupNames.contains(col.getName())) {
+            out.addAttribute(col);
+            continue;
+         }
+
+         ColumnRef qualified = new ColumnRef(AssetUtil.getOuterAttribute(baseName, col));
+         qualified.setDataType(col.getDataType());
+         out.addAttribute(qualified);
+      }
+
+      return out;
    }
 
    /**
@@ -638,7 +729,6 @@ public class WsMergeService {
 
       for(int i = 0; i < srcColumns.getAttributeCount(); i++) {
          DataRef col = srcColumns.getAttribute(i);
-
          if(baseColumns.getAttribute(col.getName()) == null) {
             baseColumns.addAttribute(col);
          }

--- a/core/src/test/java/inetsoft/web/wiz/service/AddVisualizationServiceOrphanChartTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/AddVisualizationServiceOrphanChartTest.java
@@ -1,0 +1,140 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.composition.execution.ViewsheetSandbox;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.asset.AssetContent;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.awt.Dimension;
+import java.security.Principal;
+import java.util.HashMap;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression coverage for a live bug: a saved visualization that holds MORE THAN ONE chart.
+ *
+ * <p>A saved visualization IS one chart — that is the model the rest of the product enforces
+ * ({@code ViewsheetRuntimeController#findChartAssembly} resolves an asset to its FIRST
+ * ChartVSAssembly, and open/verify/reload all report that single assembly). An asset can still end
+ * up holding two, because {@code persistViewsheet} writes back whatever the runtime contains and a
+ * re-bind of a reopened saved viz can leave the superseded chart behind.
+ *
+ * <p>{@code mergeViewsheet} cloned EVERY assembly, so the orphan came into the dashboard too: a
+ * 5-chart board composed to 6 chart assemblies and the PDF export then failed its tile/caption
+ * count check with "Dashboard has 6 top-level assemblies but 5 charts were requested". Observed
+ * live on a board whose A1 chart had been re-bound after a dataset regeneration.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class AddVisualizationServiceOrphanChartTest {
+
+   @Test
+   void mergesOnlyThePrimaryChartWhenTheSavedVisualizationHoldsAnOrphan() throws Exception {
+      Fixture f = new Fixture();
+
+      f.service.addVisualization("rt-1", f.vizEntry, 0, 0, 1.0f, null, f.principal);
+
+      assertNotNull(f.dashVS.getAssembly("Chart1"), "the primary chart must be merged");
+      assertNull(f.dashVS.getAssembly("Chart1_stale"),
+         "the superseded chart must NOT be merged — it inflates the dashboard's tile count and " +
+         "breaks the board PDF export's tile/caption check");
+
+      long charts = java.util.Arrays.stream(f.dashVS.getAssemblies())
+         .filter(a -> a instanceof ChartVSAssembly).count();
+      assertEquals(1, charts, "exactly one chart assembly per merged visualization");
+   }
+
+   /** Shared mock scaffolding for merging a single-chart visualization into an empty dashboard. */
+   private static final class Fixture {
+      final Viewsheet dashVS = new Viewsheet(null, true, false, null, null);
+      final ChartVSAssembly chart;
+      final ChartVSAssembly orphan;
+      final AssetEntry vizEntry;
+      final Principal principal = mock(Principal.class);
+      final AddVisualizationService service;
+
+      Fixture() throws Exception {
+         ViewsheetService vsService = mock(ViewsheetService.class);
+         AssetRepository assetRepository = mock(AssetRepository.class);
+         WsMergeService wsMergeService = mock(WsMergeService.class);
+         SecurityEngine securityEngine = mock(SecurityEngine.class);
+
+         when(securityEngine.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
+
+         RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+         when(rvs.getViewsheet()).thenReturn(dashVS);
+         when(rvs.getEntry()).thenReturn(null);
+         ViewsheetSandbox box = mock(ViewsheetSandbox.class);
+         when(rvs.getViewsheetSandbox()).thenReturn(Optional.of(box));
+         when(vsService.getViewsheet(eq("rt-1"), eq(principal))).thenReturn(rvs);
+
+         AssetEntry vizWsEntry = new AssetEntry(
+            AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET, "ws1", null);
+         Viewsheet vizVS = new Viewsheet(vizWsEntry);
+         chart = new ChartVSAssembly(vizVS, "Chart1");
+         vizVS.addAssembly(chart);
+         // The ORPHAN: a superseded chart left behind in the same saved asset.
+         orphan = new ChartVSAssembly(vizVS, "Chart1_stale");
+         vizVS.addAssembly(orphan);
+
+         vizEntry = new AssetEntry(
+            AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET, "viz1", null);
+         when(assetRepository.getSheet(eq(vizEntry), eq(principal), eq(true), any(AssetContent.class)))
+            .thenReturn(vizVS);
+         Worksheet vizWS = new Worksheet();
+         when(assetRepository.getSheet(eq(vizWsEntry), eq(principal), eq(true), any(AssetContent.class)))
+            .thenReturn(vizWS);
+         when(assetRepository.getSheet(any(AssetEntry.class), isNull(), eq(false), any(AssetContent.class)))
+            .thenReturn(new Worksheet());
+         when(wsMergeService.mergeWorksheet(eq(vizWS), any(Worksheet.class), anyString(), any()))
+            .thenReturn(new HashMap<>());
+
+         service = new AddVisualizationService(vsService, assetRepository, wsMergeService, securityEngine);
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizPrintLayoutBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizPrintLayoutBuilderTest.java
@@ -4,6 +4,8 @@ import inetsoft.test.BaseTestConfiguration;
 import inetsoft.test.ConfigurationContextInitializer;
 import inetsoft.test.SreeHome;
 import inetsoft.uql.viewsheet.TextVSAssembly;
+import inetsoft.uql.viewsheet.TimeSliderVSAssembly;
+import inetsoft.uql.viewsheet.SelectionListVSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.uql.viewsheet.internal.TextVSAssemblyInfo;
 import inetsoft.uql.viewsheet.vslayout.PrintLayout;
@@ -106,6 +108,71 @@ class WizPrintLayoutBuilderTest {
          "the recap becomes the summary box");
       assertTrue(texts.stream().anyMatch(t -> ((TextVSAssemblyInfo) t.getInfo()).getText().equals("First — cap one")));
       assertTrue(texts.stream().anyMatch(t -> ((TextVSAssemblyInfo) t.getInfo()).getText().equals("Second — cap two")));
+   }
+
+   /**
+    * LIVE BUG. A composed dashboard is no longer charts-only: since the dashboard-filter feature it
+    * also carries interactive filter CONTROLS plus the bar's decoration (caption text, band and
+    * divider rectangles). resolveTopLevelAssemblies counted all of them, so the guard rejected
+    * every board that had any filter — "Dashboard has 13 top-level assemblies but 5 charts were
+    * requested" — and because that 400 carries a JSON body while the caller asks for
+    * application/pdf, it reached the user as an unexplained "Couldn't export PDF".
+    */
+   @Test
+   void ignoresFilterControlsAndFilterBarDecorationWhenCountingTopLevelAssemblies() {
+      Viewsheet vs = new Viewsheet();
+      textAssembly(vs, "Chart1", 0);
+      textAssembly(vs, "Chart2", 420);
+
+      // A shared-bar control and a per-chart control: both are SelectionVSAssembly.
+      SelectionListVSAssembly shared = new SelectionListVSAssembly(vs, "sharedFilter_name");
+      shared.getVSAssemblyInfo().setPixelOffset(new Point(0, 900));
+      shared.getVSAssemblyInfo().setPixelSize(new Dimension(200, 60));
+      vs.addAssembly(shared);
+
+      TimeSliderVSAssembly slider = new TimeSliderVSAssembly(vs, "perChartFilter_due_date");
+      slider.getVSAssemblyInfo().setPixelOffset(new Point(220, 900));
+      slider.getVSAssemblyInfo().setPixelSize(new Dimension(200, 60));
+      vs.addAssembly(slider);
+
+      // The bar's own decoration — a Text, which is ALSO how a KPI tile renders, so it can only be
+      // told apart by the builder's name prefix.
+      textAssembly(vs, WizDashboardFilterBuilder.DECORATION_NAME_PREFIX + "Label_sharedFilter_name", 960);
+      textAssembly(vs, WizDashboardFilterBuilder.DECORATION_NAME_PREFIX + "BarBand", 980);
+      textAssembly(vs, WizDashboardFilterBuilder.DECORATION_NAME_PREFIX + "BarDivider", 1000);
+
+      List<WizPrintLayoutBuilder.ChartCaption> charts = List.of(
+         new WizPrintLayoutBuilder.ChartCaption("First", "cap one", 0),
+         new WizPrintLayoutBuilder.ChartCaption("Second", "cap two", 1)
+      );
+
+      // 7 top-level assemblies, 2 charts requested — must build, not throw.
+      PrintLayout layout = builder.build(vs, "a4", "Board", null, charts);
+
+      List<String> laidOut = layout.getVSAssemblyLayouts().stream()
+         .filter(l -> !(l instanceof VSEditableAssemblyLayout))
+         .map(VSAssemblyLayout::getName)
+         .collect(Collectors.toList());
+      assertEquals(List.of("Chart1", "Chart2"), laidOut,
+         "only the real board tiles get a page — no filter control and no bar decoration");
+   }
+
+   @Test
+   void stillFailsLoudWhenTheREALTileCountDisagrees() {
+      // The guard must keep its teeth: excluding filters must not turn a genuine desync into a
+      // silently mis-captioned export.
+      Viewsheet vs = new Viewsheet();
+      textAssembly(vs, "Chart1", 0);
+      SelectionListVSAssembly f = new SelectionListVSAssembly(vs, "sharedFilter_name");
+      f.getVSAssemblyInfo().setPixelOffset(new Point(0, 900));
+      f.getVSAssemblyInfo().setPixelSize(new Dimension(200, 60));
+      vs.addAssembly(f);
+
+      List<WizPrintLayoutBuilder.ChartCaption> charts = List.of(
+         new WizPrintLayoutBuilder.ChartCaption("First", "cap one", 0),
+         new WizPrintLayoutBuilder.ChartCaption("Second", "cap two", 1)
+      );
+      assertThrows(IllegalStateException.class, () -> builder.build(vs, "a4", "Board", null, charts));
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServicePruneSupersededChartsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServicePruneSupersededChartsTest.java
@@ -1,0 +1,124 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.TextVSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Regression coverage for a live bug: a SAVED VISUALIZATION accumulating a second chart.
+ *
+ * <p>A saved visualization IS one chart — {@code ViewsheetRuntimeController#findChartAssembly}
+ * resolves an asset to its FIRST ChartVSAssembly, and open/verify/reload all report that single
+ * assembly. But re-binding a REOPENED saved viz does not replace its chart: the general
+ * create/rebind path demotes the displaced primary and adds the new assembly beside it (deliberate
+ * and correct for a SESSION viewsheet, which holds one card per turn), and persistViewsheet then
+ * writes back whatever the viewsheet contains.
+ *
+ * <p>Observed live: a board's A1 chart, re-bound after a dataset regeneration, left its superseded
+ * chart behind. Composing that board produced 6 chart assemblies for 5 tiles and the PDF export
+ * failed its tile/caption count check. The orphan was invisible everywhere else, because every
+ * other reader takes the first chart and stops.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WizVsServicePruneSupersededChartsTest {
+
+   private static ChartVSAssembly chart(Viewsheet vs, String name, boolean primary) {
+      ChartVSAssembly c = new ChartVSAssembly(vs, name);
+      vs.addAssembly(c);
+      c.setPrimary(primary);
+      return c;
+   }
+
+   private static long chartCount(Viewsheet vs) {
+      return Arrays.stream(vs.getAssemblies()).filter(a -> a instanceof ChartVSAssembly).count();
+   }
+
+   @Test
+   void dropsTheSupersededChartAndKeepsThePrimary() {
+      Viewsheet vs = new Viewsheet();
+      chart(vs, "vs_old", false);   // demoted by an earlier re-bind, never removed
+      chart(vs, "vs_new", true);
+
+      WizVsService.pruneSupersededCharts(vs);
+
+      assertNotNull(vs.getAssembly("vs_new"), "the primary chart survives");
+      assertNull(vs.getAssembly("vs_old"), "the superseded chart must not be persisted");
+      assertEquals(1, chartCount(vs));
+   }
+
+   @Test
+   void leavesASingleChartAloneWhetherOrNotItIsPrimary() {
+      Viewsheet one = new Viewsheet();
+      chart(one, "vs_only", true);
+      WizVsService.pruneSupersededCharts(one);
+      assertNotNull(one.getAssembly("vs_only"));
+
+      // No primary at all: there is no basis for choosing a survivor, so nothing is touched.
+      // Guessing here would risk deleting the real chart.
+      Viewsheet noPrimary = new Viewsheet();
+      chart(noPrimary, "vs_a", false);
+      chart(noPrimary, "vs_b", false);
+      WizVsService.pruneSupersededCharts(noPrimary);
+      assertEquals(2, chartCount(noPrimary), "with no primary, leave the asset whole");
+   }
+
+   @Test
+   void neverTouchesNonChartAssemblies() {
+      // An asset may legitimately carry annotations or shapes alongside its chart.
+      Viewsheet vs = new Viewsheet();
+      chart(vs, "vs_new", true);
+      chart(vs, "vs_old", false);
+      TextVSAssembly note = new TextVSAssembly(vs, "note1");
+      vs.addAssembly(note);
+
+      WizVsService.pruneSupersededCharts(vs);
+
+      assertNotNull(vs.getAssembly("note1"), "non-chart assemblies are left alone");
+      assertNull(vs.getAssembly("vs_old"));
+   }
+
+   @Test
+   void toleratesAnEmptyOrNullViewsheet() {
+      WizVsService.pruneSupersededCharts(null);
+      Viewsheet empty = new Viewsheet();
+      WizVsService.pruneSupersededCharts(empty);
+      assertEquals(0, Arrays.stream(empty.getAssemblies()).filter(a -> a instanceof Assembly).count());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WsMergeServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WsMergeServiceTest.java
@@ -35,6 +35,7 @@ import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.test.BaseTestConfiguration;
 import inetsoft.test.ConfigurationContextInitializer;
 import inetsoft.test.SreeHome;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -691,6 +692,164 @@ class WsMergeServiceTest {
       aggr.addAggregate(new AggregateRef(aliasedColumn(rawAggColumn, aggregateAlias), formula));
       table.setAggregateInfo(aggr);
       return table;
+   }
+
+   /** A physical table whose columns carry ALIASES that differ from their physical attribute. */
+   private static PhysicalBoundTableAssembly aliasedPhysicalTable(Worksheet ws, String assemblyName,
+                                                                  String[][] cols)
+   {
+      PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, assemblyName);
+      table.setSourceInfo(new SourceInfo(SourceInfo.PHYSICAL_TABLE, "postgres", "public.types"));
+      ColumnSelection cs = new ColumnSelection();
+
+      for(String[] c : cols) {
+         AttributeRef ref = new AttributeRef(null, c[0]);
+         ref.setDataType(XSchema.STRING);
+         ColumnRef col = new ColumnRef(ref);
+         col.setDataType(XSchema.STRING);
+
+         if(c.length > 1 && c[1] != null) {
+            col.setAlias(c[1]);
+         }
+
+         cs.addAttribute(col);
+      }
+
+      table.setColumnSelection(cs, false);
+      return table;
+   }
+
+   /**
+    * LIVE BUG. Board PDF export died with `column typt.ty_id does not exist`. The merged mirror
+    * over the shared `types` table projected only the columns whose alias equals their physical
+    * name (is_in_roadmap/is_milestone/position) and dropped the two that were genuinely aliased
+    * (id AS ty_id, name AS ty_name) -- one of which is the join key the surrounding predicate
+    * still referenced.
+    *
+    * The aliased pair comes from wiz-services' FK-label join injection, which aliases BOTH the
+    * injected key and label precisely to avoid a bare-name collision, so this shape is the norm
+    * on any board carrying an FK-label join -- not a corner case.
+    *
+    * ensureBaseHasPrevMirror seeds the mirror with the base's OWN refs (bare `ty_id`), while
+    * mergeMirrorColumns qualifies every column it adds later through
+    * AssetUtil.getOuterAttribute (`TYPT_base.ty_id`). The mirror therefore ends up holding two
+    * different namespaces at once, which is the state the query engine cannot resolve.
+    */
+   @Test
+   void seededMirrorColumnsAreOuterAttributeQualifiedEvenWhenAliased() {
+      Worksheet dashWS = new Worksheet();
+      dashWS.addAssembly(aliasedPhysicalTable(dashWS, "TYPT", new String[][] {
+         { "id", "ty_id" }, { "name", "ty_name" }, { "is_milestone", null },
+      }));
+
+      // A second chart binds the same physical table, forcing ensureBaseHasPrevMirror to run.
+      Worksheet vizWS = new Worksheet();
+      vizWS.addAssembly(aliasedPhysicalTable(vizWS, "TYPT", new String[][] {
+         { "id", "ty_id" }, { "name", "ty_name" }, { "is_milestone", null }, { "position", null },
+      }));
+
+      service.mergeWorksheet(vizWS, dashWS, "suffix1", new HashMap<>());
+
+      TableAssembly prevMirror = (TableAssembly) dashWS.getAssembly("TYPT");
+      assertNotNull(prevMirror, "expected a prevMirror named 'TYPT'");
+      ColumnSelection mirrorPrivate = prevMirror.getColumnSelection(false);
+      // Asserted on entity/attribute directly rather than through getAttribute(name): that lookup
+      // has a fuzzy fallback which reports a BARE ref as a qualified one, so it passes even when
+      // the column is in the wrong namespace -- the exact false confidence this test exists to
+      // avoid.
+      assertEquals("TYPT_base", entityOf(mirrorPrivate, "ty_id"),
+         "the ALIASED join key must be outer-attribute qualified in the mirror's PRIVATE selection, " +
+         "exactly as its unaliased siblings are -- leaving it bare is what makes the engine drop it " +
+         "from the projection while the join still references TYPT.ty_id");
+      assertEquals("TYPT_base", entityOf(mirrorPrivate, "ty_name"),
+         "the ALIASED label column must be outer-attribute qualified too");
+      assertEquals("TYPT_base", entityOf(mirrorPrivate, "is_milestone"),
+         "the unaliased seeded column must be qualified in the same namespace as its siblings");
+      assertEquals("TYPT_base", entityOf(mirrorPrivate, "position"),
+         "a column added by mergeMirrorColumns was already qualified -- it must stay that way");
+
+      // The mirror must keep EXPOSING both under their aliases, so consumers still resolve them.
+      ColumnSelection mirrorPublic = prevMirror.getColumnSelection(true);
+      assertNotNull(mirrorPublic.getAttribute("ty_id"), "mirror must still expose ty_id");
+      assertNotNull(mirrorPublic.getAttribute("ty_name"), "mirror must still expose ty_name");
+   }
+
+   /** The entity of the ref whose EXPOSED name is {@code exposed}, or null if absent entirely. */
+   private static String entityOf(ColumnSelection cs, String exposed) {
+      for(int i = 0; i < cs.getAttributeCount(); i++) {
+         DataRef d = cs.getAttribute(i);
+         String alias = d instanceof ColumnRef ? ((ColumnRef) d).getAlias() : null;
+         String name = alias != null ? alias : d.getAttribute();
+
+         if(exposed.equals(name)) {
+            return d.getEntity();
+         }
+      }
+
+      return null;
+   }
+
+
+   /**
+    * LIVE BUG. Two charts each selected work_packages.id but aliased it differently (`wp_id` vs
+    * `w3_id`). Merging is keyed on the physical SOURCE alone, so the second chart's table was folded
+    * into the first's — and its `w3_id` was then silently lost, because mergeColumns guards on the
+    * EXPOSED NAME while ColumnSelection dedupes on DataRef equality, which ignores the alias. The
+    * add was a no-op, and the join that referenced the dropped alias failed at query time with
+    * `column wp3__fkjoin.w3_id does not exist`.
+    *
+    * Keeping both aliases is not representable — the same alias-blind equality runs through query
+    * construction, so the projection collapses them again (verified live). Declining the merge is
+    * the correct answer: sharing one physical table is an optimisation, and it must not cost a
+    * column.
+    */
+   @Test
+   void doesNotMergeTwoTablesThatAliasTheSamePhysicalColumnDifferently() {
+      Worksheet dashWS = new Worksheet();
+      dashWS.addAssembly(aliasedPhysicalTable(dashWS, "WPT", new String[][] {
+         { "id", "wp_id" }, { "type_id", null },
+      }));
+
+      Worksheet vizWS = new Worksheet();
+      vizWS.addAssembly(aliasedPhysicalTable(vizWS, "WP3", new String[][] {
+         { "id", "w3_id" }, { "type_id", null },
+      }));
+
+      service.mergeWorksheet(vizWS, dashWS, "suffix1", new HashMap<>());
+
+      // WP3 must survive as its OWN table rather than being folded into WPT and losing w3_id.
+      TableAssembly wp3 = (TableAssembly) dashWS.getAssembly("WP3");
+      assertNotNull(wp3, "WP3 aliases id differently from WPT, so it must NOT be merged away");
+      assertNotNull(wp3.getColumnSelection(true).getAttribute("w3_id"),
+         "WP3 must keep its own w3_id");
+
+      // ...and WPT must be untouched: no promotion to WPT_base, since nothing merged into it.
+      TableAssembly wpt = (TableAssembly) dashWS.getAssembly("WPT");
+      assertNotNull(wpt);
+      assertNotNull(wpt.getColumnSelection(true).getAttribute("wp_id"), "WPT keeps wp_id");
+      assertNull(wpt.getColumnSelection(true).getAttribute("w3_id"),
+         "the conflicting alias must not have been silently folded in");
+   }
+
+   /** Two tables that alias identically DO still merge — the guard must not block the normal case. */
+   @Test
+   void stillMergesWhenTheAliasesAgree() {
+      Worksheet dashWS = new Worksheet();
+      dashWS.addAssembly(aliasedPhysicalTable(dashWS, "WPT", new String[][] {
+         { "id", "wp_id" }, { "type_id", null },
+      }));
+
+      Worksheet vizWS = new Worksheet();
+      vizWS.addAssembly(aliasedPhysicalTable(vizWS, "WPT", new String[][] {
+         { "id", "wp_id" }, { "type_id", null }, { "done_ratio", null },
+      }));
+
+      service.mergeWorksheet(vizWS, dashWS, "suffix1", new HashMap<>());
+
+      TableAssembly base = (TableAssembly) dashWS.getAssembly("WPT_base");
+      assertNotNull(base, "matching aliases must still merge (and promote to WPT_base)");
+      assertNotNull(base.getColumnSelection(true).getAttribute("done_ratio"),
+         "the extra column from the second chart must be unioned in");
    }
 
    private static ColumnRef aliasedColumn(String rawAttr, String alias) {


### PR DESCRIPTION
## Symptom

Board **PDF export** failed with a bare `406`. Behind it were **five** distinct defects, each only visible once the previous was fixed.

| | Defect | Surfaced as |
|---|---|---|
| 1 | Merge dropped ALIASED columns | `column typt.ty_id does not exist` |
| 2 | Merge lost a CONFLICTING alias | `column wp3__fkjoin.w3_id does not exist` |
| 3 | Every error path unreachable | opaque `406`, nothing logged anywhere |
| 4 | Filter controls counted as chart tiles | "13 top-level assemblies but 5 charts" |
| 5 | Orphaned chart merged from a saved viz | "6 top-level assemblies but 5 charts" |
| 6 | **Re-bind silently added that orphan** | root cause of 5 — asset grew a chart per re-bind |

Verified end to end: the board that could not export now produces its PDF.

---

## 1. The seeded mirror held two namespaces at once

`ensureBaseHasPrevMirror` seeded the mirror with the base's **own** refs while `mergeMirrorColumns` qualifies everything it adds later through `AssetUtil.getOuterAttribute`:

```
PRIVATE: [ty_id entity=null attr=id] [is_milestone entity=null] [TYPT_base.position entity=TYPT_base]
```

A bare **unaliased** ref still resolves (name == attribute); a bare **aliased** one does not, so the engine pruned it while the join kept naming it.

Two things this had to get right, both found by testing rather than reading:

- **Private must be set before public.** `setColumnSelection(.., false)` re-derives public from private, so the original order let the derivation overwrite public with qualified names. The mirror stopped exposing `id`, every join key resolved to nothing, and `checkValidity` dropped the join as a cross join — *every* chart was rejected.
- **Grouped columns stay bare.** Setting the selection triggers `AggregateInfo#validate()`, which re-points groups; groups are read straight off the mirror and never re-resolved against the base.

## 2. A conflicting alias was silently dropped

Two charts selecting the same physical column under different aliases (`id AS wp_id` vs `id AS w3_id`) merged on physical source alone, and the second was lost — `mergeColumns` guards on the **exposed name** while `ColumnSelection` dedupes on `DataRef` equality, which ignores the alias:

```
pub-decide  src[w3_id] -> ADD
priv-decide src[w3_id] -> ADD
pre-set sizes: public=7 private=7      <- the add no-op'd
```

Keeping both is **not representable** — the same alias-blind equality runs through query construction; I stored both and watched the builder collapse them anyway. So the merge is **declined**. Sharing a physical table is an optimisation; it must not cost a column.

## 3. The real error was unreachable

Every failure path returns a JSON `{error}` body while the caller asks for `application/pdf`, so Spring answered **406** and discarded the message — and the `IllegalArgumentException | IllegalStateException` branch **logged nothing**. A real 400 produced no StyleBI log, no client detail, and an opaque 406.

The 400/403 branches now log, and the desync message **names every assembly it found**, with its type. A bare count says nothing about *which* extra assembly is present, and that is the entire diagnosis — establishing it cost a build-and-deploy per guess.

## 4. Filter controls counted as chart tiles

A composed dashboard has not been charts-only since the dashboard-filter feature — it also carries the controls and the bar's decoration. 5 charts + 5 controls + caption/band/divider = 13. **Every board with any filter has been unable to export a PDF since that feature landed.**

Two exclusions, because neither covers the other: controls are all `SelectionVSAssembly`; the caption and band are `Text`/`Rectangle` — and a `TextVSAssembly` is **also** how a KPI tile renders, so type cannot separate them. Decorations are matched by the filter builder's own name prefix, promoted to a shared `DECORATION_NAME_PREFIX` so the two classes cannot drift.

## 5. An orphaned chart was merged out of a saved visualization

A saved visualization **is** one chart — `findChartAssembly` resolves an asset to its first `ChartVSAssembly`, and open/verify/reload all report that single assembly. An asset can still hold two: `persistViewsheet` writes back whatever the runtime contains, and re-binding a reopened saved viz leaves the superseded chart behind.

```
source viz assemblies: [ChartVSAssembly] vs_1785640221693  [ChartVSAssembly] vs_1785681210366
source viz assemblies: [ChartVSAssembly] vs_1785681730441     <- every other one has exactly one
```

`mergeViewsheet` cloned **every** assembly. It now takes the same primary the rest of the product resolves and skips any further chart — which also makes composition tolerant of assets already in that state, rather than requiring a data repair.

## 6. …and the write path that created the orphan

Root cause of 5. Re-binding a **reopened** saved visualization never replaced its chart. The general create/rebind path demotes the displaced primary and adds the new assembly beside it; only the `skipExecution` (change-type) path also deletes it:

```java
if(skipExecution && previousPrimaryAssembly != null && !createdRuntimeId && !model.isCopy())
```

That retention is deliberate and **correct for a session viewsheet**, which holds one historical card per turn. The bug is that the same viewsheet is then handed to `persistViewsheet`, which writes back whatever it contains — so re-binding a saved viz silently left a second chart in the asset. Invisible, because every reader takes the first chart and stops.

Fixed at `persistViewsheet` — the single write choke point, so it covers every writer (create/rebind, `setChartFormat`, `setChartColors`, geo) instead of being re-derived per caller. Scoped deliberately:

- **only** the components folder — a session viewsheet legitimately holds many charts, and pruning there would delete the user's history;
- **only** charts — annotations and shapes are untouched;
- **only** when a primary chart is present — with no primary there is no basis for choosing a survivor, and guessing risks deleting the real one.

Because the check sits at the write path, an asset **already** carrying an orphan repairs itself on its next save. Verified live on the real corrupted asset: the merge's orphan-skip fired once before, and **zero** times after a single persist through the new prune.

---

## Tests

10 new; **707 green** across `inetsoft.web.wiz`. Each fix is paired with a test that the guard it touches still has teeth:

- aliased seeded mirror is base-qualified **while its group stays bare**;
- two tables aliasing one column differently are not merged, **but tables whose aliases agree still merge and still union the extra column**;
- only real tiles get a page, **but a genuine tile/caption desync still fails loud**;
- only the primary chart is merged from a multi-chart asset;
- the superseded chart is pruned on save, **but a lone chart is untouched whether or not it is primary, a viewsheet with NO primary is left whole, and non-chart assemblies are never removed**.

All diagnostics stripped; final image rebuilt clean and re-verified.
