### PR TITLE
fix(wiz): a tall insights block overprinted the next chart in an exported PDF

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
@@ -121,14 +121,29 @@ public class WizPrintLayoutBuilder {
          vsLayouts.add(new VSAssemblyLayout(assembly.getName(), new Point(0, chartY),
             new Dimension(PAGE_CONTENT_WIDTH_PT, CHART_HEIGHT_PT)));
 
+         int contentBottom = chartY + CHART_HEIGHT_PT;
+
          if(c.insightsMarkdown() != null && !c.insightsMarkdown().isBlank()) {
-            int insightsY = chartY + CHART_HEIGHT_PT;
             // One markdown box; MarkdownPresenter renders headers/bullets/inline bold+italic and
             // the converter paints it via a presenter painter (see VsToReportConverter).
-            addMarkdownBlock(vsLayouts, "wizMarkdownInsights_" + i, c.insightsMarkdown(), insightsY);
+            contentBottom = addMarkdownBlock(vsLayouts, "wizMarkdownInsights_" + i,
+                                             c.insightsMarkdown(), contentBottom);
          }
 
-         page++;
+         // Advance past everything just placed, not by a fixed one page.
+         //
+         // THE DEFECT THIS FIXES. `page++` assumed a chart's block always fits inside one stride,
+         // but it does not: page 1 also carries the report header, and an insights block is as tall
+         // as its prose. On a letter page (stride ~713pt) a header of ~150 plus caption 30, chart
+         // 400 and a ~200pt insights block reaches ~780 — so the NEXT chart, pinned at
+         // 1 * stride = 713, was drawn straight over the tail of the previous one's insights.
+         // Observed in an exported PDF as the first chart's prose colliding with the second chart's
+         // caption and plot.
+         //
+         // addMarkdownBlock already measured and returned that bottom; the caller simply discarded
+         // it. Round up to the next page boundary at or after it, and never advance less than one
+         // page so every chart still starts on its own.
+         page = Math.max(page + 1, (int) Math.ceil((double) contentBottom / pageStride));
       }
 
       layout.setVSAssemblyLayouts(vsLayouts);

--- a/core/src/test/java/inetsoft/web/wiz/service/WizPrintLayoutBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizPrintLayoutBuilderTest.java
@@ -118,6 +118,73 @@ class WizPrintLayoutBuilderTest {
     * requested" — and because that 400 carries a JSON body while the caller asks for
     * application/pdf, it reached the user as an unexplained "Couldn't export PDF".
     */
+   /**
+    * LIVE BUG, seen in an exported PDF: the first chart's insights prose collided with the SECOND
+    * chart's caption and plot.
+    *
+    * <p>Each chart was pinned at {@code page * pageStride} with {@code page++} after it, which
+    * assumes a chart's block always fits inside one stride. It does not: page 1 also carries the
+    * report header, and an insights block is as tall as its prose. addMarkdownBlock already
+    * measured and RETURNED that bottom — the caller discarded it.
+    */
+   @Test
+   void aTallInsightsBlockPushesTheNextChartPastItInsteadOfUnderneathIt() {
+      Viewsheet vs = new Viewsheet();
+      textAssembly(vs, "Chart1", 0);
+      textAssembly(vs, "Chart2", 420);
+
+      String longInsights = ("**Finding.** " + "Lorem ipsum dolor sit amet consectetur. ".repeat(60));
+      List<WizPrintLayoutBuilder.ChartCaption> charts = List.of(
+         new WizPrintLayoutBuilder.ChartCaption("First", "cap one", 0, longInsights),
+         new WizPrintLayoutBuilder.ChartCaption("Second", "cap two", 1)
+      );
+
+      PrintLayout layout = builder.build(vs, "letter", "Board", "a recap line", charts);
+
+      int insightsBottom = bottomOf(layout, "wizMarkdownInsights_0");
+      int secondCaptionTop = topOf(layout, "wizExportCaption_1");
+      int secondChartTop = topOf(layout, "Chart2");
+
+      assertTrue(secondCaptionTop >= insightsBottom,
+         "the second chart's caption (y=" + secondCaptionTop + ") must start at or below the first " +
+         "chart's insights block (bottom=" + insightsBottom + ") — otherwise they overprint");
+      assertTrue(secondChartTop > insightsBottom,
+         "the second chart itself must clear the first chart's insights");
+   }
+
+   @Test
+   void everyChartStillGetsItsOwnPageWhenTheContentIsShort() {
+      // The overflow fix must not collapse two short charts onto one page.
+      Viewsheet vs = new Viewsheet();
+      textAssembly(vs, "Chart1", 0);
+      textAssembly(vs, "Chart2", 420);
+      List<WizPrintLayoutBuilder.ChartCaption> charts = List.of(
+         new WizPrintLayoutBuilder.ChartCaption("First", "c1", 0),
+         new WizPrintLayoutBuilder.ChartCaption("Second", "c2", 1)
+      );
+
+      PrintLayout layout = builder.build(vs, "letter", "Board", null, charts);
+
+      // letter stride = (11 - 0.55 - 0.55) * 72
+      int stride = (int) Math.round((11.0 - 0.55 - 0.55) * 72);
+      assertEquals(stride, topOf(layout, "wizExportCaption_1"),
+         "with short content the second chart still starts exactly one page down");
+   }
+
+   private static int topOf(PrintLayout layout, String name) {
+      return layout.getVSAssemblyLayouts().stream()
+         .filter(l -> name.equals(l.getName()))
+         .findFirst().orElseThrow(() -> new AssertionError("no layout named " + name))
+         .getPosition().y;
+   }
+
+   private static int bottomOf(PrintLayout layout, String name) {
+      VSAssemblyLayout l = layout.getVSAssemblyLayouts().stream()
+         .filter(x -> name.equals(x.getName()))
+         .findFirst().orElseThrow(() -> new AssertionError("no layout named " + name));
+      return l.getPosition().y + l.getSize().height;
+   }
+
    @Test
    void ignoresFilterControlsAndFilterBarDecorationWhenCountingTopLevelAssemblies() {
       Viewsheet vs = new Viewsheet();


### PR DESCRIPTION
## Symptom

In an exported board PDF, the first chart's insights prose collided with the **second** chart's caption and plot — several lines of bold and regular text drawn over one another, with the chart starting partway down the block.

## Cause

Each chart is pinned at `page * pageStride`, and the counter advanced with a bare `page++`:

```java
int pageTop   = page * pageStride;
int captionY  = i == 0 ? headerBottom : pageTop;
int chartY    = captionY + CAPTION_HEIGHT_PT;
int insightsY = chartY + CHART_HEIGHT_PT;
addMarkdownBlock(..., insightsY);      // height discarded
page++;
```

That assumes a chart's block always fits inside one stride. It doesn't:

- page 1 **also** carries the report header (title + generated-date + recap), and
- an insights block is exactly as tall as its prose.

On a letter page (stride ≈ 713pt): header ~150 + caption 30 + chart 400 + insights ~200 ≈ **780**. The next chart, pinned at `1 * stride = 713`, lands 67pt *above* where the previous chart's content ends.

Measured by the new test against the old code:

```
the second chart's caption (y=713) must start at or below the first chart's
insights block (bottom=912) — otherwise they overprint
```

A **199pt** overlap.

## Fix

`addMarkdownBlock` already measured that bottom and **returned** it — the caller discarded the value. The page counter now rounds up to the next page boundary at or after the real content bottom:

```java
page = Math.max(page + 1, (int) Math.ceil((double) contentBottom / pageStride));
```

The `max(page + 1, …)` keeps the existing guarantee that every chart starts on its own page.

## Tests

2 new; **709 green** across `inetsoft.web.wiz`:

- a tall insights block pushes the next chart clear of it;
- short content still puts the second chart **exactly** one page down — the overflow fix must not collapse two short charts onto one page.

Both were confirmed to **fail** against the old `page++` before the fix was restored, so they genuinely pin the behaviour rather than passing vacuously.