### PR TITLE
fix(wiz): a long slide caption overprinted the chart in the pptx export

### DIFF
--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/PoiPptxDeckMerger.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/PoiPptxDeckMerger.java
@@ -106,13 +106,80 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
    }
 
    private void addCaption(XSLFSlide slide, String title, String caption) {
-      XSLFTextBox captionBox = slide.createTextBox();
-      captionBox.setAnchor(new Rectangle2D.Double(MARGIN_PT, MARGIN_PT / 2.0,
-         SLIDE_WIDTH_PT - 2 * MARGIN_PT, 44));
       String text = (title == null ? "" : title) +
          (caption != null && !caption.isBlank() ? " — " + caption : "");
+      double boxWidthPt = SLIDE_WIDTH_PT - 2 * MARGIN_PT;
+
+      // FIT THE CAPTION TO ITS BAND. The caption is drawn ON TOP of the imported chart slide, so
+      // anything that does not fit the reserved band lands on the chart itself. At a fixed
+      // CAPTION_FONT_PT the band holds about two lines; a caption of real prose wraps to three or
+      // more and overprinted the plot -- observed in an exported deck, the heading covering the
+      // chart's own title and top bars.
+      //
+      // Shrink first (a smaller caption is still fully readable and loses nothing), and only
+      // truncate if it still does not fit at the floor. The untruncated caption remains on the
+      // board and in the PDF export, which reserve room for it.
+      double fontPt = CAPTION_FONT_PT;
+
+      while(fontPt > CAPTION_MIN_FONT_PT &&
+            textHeightPt(text, fontPt, boxWidthPt) > CAPTION_BOX_HEIGHT_PT)
+      {
+         fontPt -= 1.0;
+      }
+
+      if(textHeightPt(text, fontPt, boxWidthPt) > CAPTION_BOX_HEIGHT_PT) {
+         text = truncateToFit(text, fontPt, boxWidthPt, CAPTION_BOX_HEIGHT_PT);
+      }
+
+      XSLFTextBox captionBox = slide.createTextBox();
+      captionBox.setAnchor(new Rectangle2D.Double(MARGIN_PT, MARGIN_PT / 2.0,
+         boxWidthPt, CAPTION_BOX_HEIGHT_PT));
       captionBox.setText(text);
-      styleBox(captionBox, true, CAPTION_FONT_PT, ACCENT);
+      styleBox(captionBox, true, fontPt, ACCENT);
+   }
+
+   /** Wrapped height of {@code text} at {@code fontPt} within {@code widthPt}, greedily by word.
+    *  Uses the same headless java.awt FontMetrics approach as chunkInsightsText. */
+   static double textHeightPt(String text, double fontPt, double widthPt) {
+      if(text == null || text.isBlank()) {
+         return 0;
+      }
+
+      Font font = new Font(Font.SANS_SERIF, Font.BOLD, (int) Math.round(fontPt));
+      BufferedImage measuring = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
+      Graphics2D g = measuring.createGraphics();
+      FontMetrics fm = g.getFontMetrics(font);
+      g.dispose();
+
+      int lines = 1;
+      StringBuilder line = new StringBuilder();
+
+      for(String word : text.trim().split("\\s+")) {
+         String candidate = line.length() == 0 ? word : line + " " + word;
+
+         if(fm.stringWidth(candidate) > widthPt && line.length() > 0) {
+            lines++;
+            line.setLength(0);
+            line.append(word);
+         }
+         else {
+            line.setLength(0);
+            line.append(candidate);
+         }
+      }
+
+      return lines * (double) fm.getHeight();
+   }
+
+   /** Drop whole words from the end until the text fits, then mark the elision. */
+   private static String truncateToFit(String text, double fontPt, double widthPt, double heightPt) {
+      String candidate = text.trim();
+
+      while(candidate.contains(" ") && textHeightPt(candidate + "…", fontPt, widthPt) > heightPt) {
+         candidate = candidate.substring(0, candidate.lastIndexOf(' ')).trim();
+      }
+
+      return candidate + "…";
    }
 
    /** Apply a uniform bold/size/color to every run in every paragraph of a text box. */
@@ -333,4 +400,8 @@ public class PoiPptxDeckMerger implements PptxDeckMerger {
    private static final double BLOCK_SPACING_PT = 8.0;   // approx paragraph gap for height estimation
    private static final double INSIGHTS_TITLE_FONT_PT = 22.0;
    private static final int INSIGHTS_TITLE_HEIGHT_PT = 40;
+   /** The caption band reserved above the imported chart; anything beyond it overlays the plot. */
+   private static final int CAPTION_BOX_HEIGHT_PT = 44;
+   /** Floor for caption auto-shrink — below this it stops being a readable heading. */
+   private static final double CAPTION_MIN_FONT_PT = 12.0;
 }

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/report/io/viewsheet/PoiPptxDeckMergerTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/report/io/viewsheet/PoiPptxDeckMergerTest.java
@@ -71,6 +71,65 @@ class PoiPptxDeckMergerTest {
       return sb.toString();
    }
 
+   /**
+    * LIVE BUG, seen in an exported deck: the slide caption ran over the chart, covering the plot's
+    * own title and top bars.
+    *
+    * <p>The caption is drawn ON TOP of the imported chart slide, in a fixed 44pt band at a fixed
+    * 22pt. That band holds about two lines; a caption made of real prose wraps to three or more and
+    * everything past the band lands on the chart. It now shrinks to fit, and truncates only if it
+    * still will not fit at the floor.
+    */
+   @Test
+   void aLongCaptionIsFittedToItsBandInsteadOfRunningOverTheChart() throws Exception {
+      String title = "bar";
+      String caption = "Portfolio shape: planned hours per project. Heavily right-tailed — one " +
+         "programme carries roughly a third of all planned effort, and the mean sits at more than " +
+         "double the median, so an average-project figure would describe none of them.";
+
+      byte[] deck = merger.mergeSlides("Board", null, List.of(
+         new PptxDeckMerger.ChartSlide(title, caption, oneSlideDeckWithText("chart"), false)));
+
+      try(XMLSlideShow show = new XMLSlideShow(new ByteArrayInputStream(deck))) {
+         XSLFTextBox captionBox = show.getSlides().get(1).getShapes().stream()
+            .filter(sh -> sh instanceof XSLFTextBox)
+            .map(sh -> (XSLFTextBox) sh)
+            .filter(b -> b.getText() != null && b.getText().startsWith("bar —"))
+            .findFirst().orElseThrow(() -> new AssertionError("no caption box on the chart slide"));
+
+         double fontPt = captionBox.getTextParagraphs().get(0).getTextRuns().get(0).getFontSize();
+         double bandPt = captionBox.getAnchor().getHeight();
+         double needed = PoiPptxDeckMerger.textHeightPt(captionBox.getText(), fontPt,
+                                                        captionBox.getAnchor().getWidth());
+
+         assertTrue(needed <= bandPt,
+            "the caption must fit its " + bandPt + "pt band (needs " + needed + "pt at " + fontPt +
+            "pt) — anything taller is painted over the chart");
+         assertTrue(fontPt <= 22.0 && fontPt >= 12.0,
+            "shrunk to fit but not below the readable floor (got " + fontPt + "pt)");
+      }
+   }
+
+   @Test
+   void aShortCaptionKeepsTheFullSizeAndIsNotTruncated() throws Exception {
+      // The fit logic must not shrink or clip a caption that already fits.
+      byte[] deck = merger.mergeSlides("Board", null, List.of(
+         new PptxDeckMerger.ChartSlide("Revenue", "by region", oneSlideDeckWithText("chart"), false)));
+
+      try(XMLSlideShow show = new XMLSlideShow(new ByteArrayInputStream(deck))) {
+         XSLFTextBox captionBox = show.getSlides().get(1).getShapes().stream()
+            .filter(sh -> sh instanceof XSLFTextBox)
+            .map(sh -> (XSLFTextBox) sh)
+            .filter(b -> b.getText() != null && b.getText().startsWith("Revenue"))
+            .findFirst().orElseThrow();
+
+         assertEquals("Revenue — by region", captionBox.getText(), "short caption kept verbatim");
+         assertEquals(22.0,
+            captionBox.getTextParagraphs().get(0).getTextRuns().get(0).getFontSize(), 0.01,
+            "no shrink when it already fits");
+      }
+   }
+
    @Test
    void mergesTitleSlidePlusOnePerChart() throws Exception {
       byte[] chart1 = oneSlideDeckWithText("CHART_ONE_MARKER");


### PR DESCRIPTION
## Symptom

In an exported deck the slide caption ran **over the chart**, covering the plot's own title and its top bars — three lines of heading on top of the image.

## Cause

The caption is drawn on top of the imported chart slide — it has to be, since `importContent` replaces the target slide's shape tree wholesale, so the caption can only be added afterwards. It went into a **fixed 44pt band at a fixed 22pt bold**:

```java
captionBox.setAnchor(new Rectangle2D.Double(MARGIN_PT, MARGIN_PT / 2.0,
   SLIDE_WIDTH_PT - 2 * MARGIN_PT, 44));
captionBox.setText(title + " — " + caption);
styleBox(captionBox, true, CAPTION_FONT_PT, ACCENT);
```

That band holds about two lines. A caption made of real prose wraps to three or more, and everything past the band lands on the chart. Measured by the new test against the old code:

```
the caption must fit its 44.0pt band (needs 124.0pt at 22.0pt)
```

A ~3× overflow.

## Fix

The caption now **fits its band**:

1. **Shrink** to fit, down to a 12pt floor — a smaller caption is still fully readable and loses nothing.
2. **Truncate** on a word boundary only if it still won't fit at the floor.
3. A caption that already fits is left exactly as it was — same text, same 22pt.

Truncation is a slide-design tradeoff, not data loss: the untruncated caption stays on the board and in the PDF export, both of which reserve room for it. A heading that covers the chart it labels is worse than an elided one.

Measurement reuses the headless `java.awt` `FontMetrics` approach already documented and relied on by `chunkInsightsText` in this same class, so the two agree about how text wraps.

## Tests

2 new; **23 green** in the module:

- a long caption is fitted to its band **and** stays within the readable floor;
- a short caption keeps its full size and exact text — the fit logic must not shrink or clip something that already fits.

Both were confirmed to **fail** against the old fixed-size behaviour before the fix was restored, so they pin the behaviour rather than passing vacuously.