### PR TITLE
Bug #75802, fix option dropdown font using sans-serif instead of Roboto

### DIFF
--- a/web/projects/portal/src/scss/internal/_html-override.scss
+++ b/web/projects/portal/src/scss/internal/_html-override.scss
@@ -21,7 +21,7 @@ body {
 
 // seems to be a chrome bug that font changes to serif after first selection
 option {
-  font-family: sans-serif;
+  font-family: var(--inet-font-family);
 }
 
 //override browser dropdown arrow


### PR DESCRIPTION
## Summary

In the worksheet composer, editing a query column's Auto Drill and opening the "Query Selection" dialog shows a native combobox (e.g. the "STATE" query parameter list) whose option text rendered in generic `sans-serif` instead of the app's Roboto font.

## Root Cause

`web/projects/portal/src/scss/internal/_html-override.scss` has a global, unscoped rule added as a workaround for a Chrome bug where `<option>` text reverts to serif after the first selection:

```scss
option {
  font-family: sans-serif;
}
```

This hardcodes the literal `sans-serif` keyword instead of the app's themed font stack, so every native `<option>` element in the portal — including the query parameter combobox reached via Auto Drill's "Query Selection" button (`SelectQueryFieldPaneComponent`) — renders in the browser default font instead of Roboto.

## Fix

Changed the rule to use the app's font variable instead of the literal keyword:

```scss
option {
  font-family: var(--inet-font-family);
}
```

This is the same variable used everywhere else in the app to apply the themed Roboto font stack (e.g. `body { font-family: var(--inet-font-family); }` in `_themeable.scss`), and it still sets an explicit `font-family` on `option`, preserving the original Chrome workaround.

## Test Plan

- [x] `ng build portal --configuration development` succeeds
- [ ] In Composer, open a query-bound worksheet table, click "Edit Query" on a column, click "Edit Auto Drill", click "Query Selection", expand a query parameter combobox (e.g. "STATE") — confirm the option list now renders in Roboto instead of sans-serif
- [ ] Spot-check other native `<select>`/`<option>` dropdowns in the app to confirm no unexpected visual regression

Fixes Redmine #75802.