### PR TITLE
Fix Clear All recycle bin button stuck in loading state

### DIFF
--- a/web/projects/em/src/app/settings/content/repository/repository-editor-page/repository-editor-page.component.spec.ts
+++ b/web/projects/em/src/app/settings/content/repository/repository-editor-page/repository-editor-page.component.spec.ts
@@ -24,6 +24,7 @@ import { MatCheckboxModule } from "@angular/material/checkbox";
 import { MatOptionModule } from "@angular/material/core";
 import { MatInputModule } from "@angular/material/input";
 import { MatSelectModule } from "@angular/material/select";
+import { MatSnackBarModule } from "@angular/material/snack-bar";
 import { RouterModule } from "@angular/router";
 import { of as observableOf } from "rxjs";
 import { ContentRepositoryService } from "../content-repository-page/content-repository.service";
@@ -47,7 +48,7 @@ describe("RepositoryEditorPageComponent", () => {
       TestBed.configureTestingModule({
          imports: [
             RouterModule.forRoot([]), FormsModule, ReactiveFormsModule, MatCheckboxModule,
-            MatSelectModule, MatOptionModule, MatInputModule, HttpClientTestingModule,
+            MatSelectModule, MatOptionModule, MatInputModule, MatSnackBarModule, HttpClientTestingModule,
             RepositoryEditorPageComponent, RepositoryViewsheetSettingsPageComponent, RepositoryWorksheetSettingsPageComponent, RepositoryDataSourceSettingsPageComponent, RepositoryFolderTrashcanSettingsPageComponent, RepositoryFolderSettingsPageComponent, RepositoryPermissionEditorPageComponent],
          providers: [{provide: ContentRepositoryService, useValue: service}],
          schemas: [

--- a/web/projects/em/src/app/settings/content/repository/repository-editor-page/repository-editor-page.component.ts
+++ b/web/projects/em/src/app/settings/content/repository/repository-editor-page/repository-editor-page.component.ts
@@ -15,8 +15,11 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { HttpClient } from "@angular/common/http";
+import { HttpClient, HttpErrorResponse } from "@angular/common/http";
 import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges } from "@angular/core";
+import { MatSnackBar } from "@angular/material/snack-bar";
+import { finalize } from "rxjs/operators";
+import { Tool } from "../../../../../../../shared/util/tool";
 import { RepositoryEntryType } from "../../../../../../../shared/data/repository-entry-type.enum";
 import { RepositoryEditorModel } from "../../../../../../../shared/util/model/repository-editor-model";
 import { ContentRepositoryService } from "../content-repository-page/content-repository.service";
@@ -163,7 +166,9 @@ export class RepositoryEditorPageComponent implements OnChanges, OnInit {
       return this.repositoryService.selectedNode?.type;
    }
 
-   constructor(public repositoryService: ContentRepositoryService, private httpClient: HttpClient) {
+   constructor(public repositoryService: ContentRepositoryService, private httpClient: HttpClient,
+               private snackBar: MatSnackBar)
+   {
    }
 
    ngOnInit(): void {
@@ -211,15 +216,17 @@ export class RepositoryEditorPageComponent implements OnChanges, OnInit {
 
    public mangleAssets() {
       let timeout = setTimeout(() => this.loading = true, 1000);
-      const done = () => {
-         clearTimeout(timeout);
-         this.loading = false;
-      };
 
       this.httpClient.delete("../api/em/repository/recycle-bin/entries")
+         .pipe(finalize(() => {
+            clearTimeout(timeout);
+            this.loading = false;
+         }))
          .subscribe({
-            next: done,
-            error: done
+            error: (error: HttpErrorResponse) => {
+               this.snackBar.open(error.error?.message || error.message,
+                  "_#(js:Close)", {duration: Tool.SNACKBAR_DURATION});
+            }
          });
    }
 }

--- a/web/projects/em/src/app/settings/content/repository/repository-editor-page/repository-editor-page.component.ts
+++ b/web/projects/em/src/app/settings/content/repository/repository-editor-page/repository-editor-page.component.ts
@@ -211,11 +211,15 @@ export class RepositoryEditorPageComponent implements OnChanges, OnInit {
 
    public mangleAssets() {
       let timeout = setTimeout(() => this.loading = true, 1000);
+      const done = () => {
+         clearTimeout(timeout);
+         this.loading = false;
+      };
 
       this.httpClient.delete("../api/em/repository/recycle-bin/entries")
-         .subscribe(() => {
-            clearTimeout(timeout);
-            this.loading = false;
+         .subscribe({
+            next: done,
+            error: done
          });
    }
 }


### PR DESCRIPTION
## Summary
- In the EM Content Repository page, clicking "Clear All" on the Recycle Bin issues a `DELETE .../recycle-bin/entries` request and only resets the loading flag in the `subscribe()` success callback.
- If that request fails (e.g. when clearing the recycle bin for a switched/cloned organization rather than the host org), the success callback never fires, so `loading` stays `true` and the button spins forever.
- Added an `error` handler alongside `next` so the loading state is always cleared, whether the request succeeds or fails.

## Test plan
- [ ] Clone an org from the host org
- [ ] Switch to the cloned org in EM > Content > Repository
- [ ] Delete a viewsheet so it lands in Recycle Bin
- [ ] Click Recycle Bin, then click "Clear All"
- [ ] Verify the button no longer gets stuck in a permanent loading state