### PR TITLE
Bug #75885, add created-by/created-date metadata to data model folders

### DIFF
--- a/core/src/main/java/inetsoft/uql/erm/XDataModel.java
+++ b/core/src/main/java/inetsoft/uql/erm/XDataModel.java
@@ -892,6 +892,10 @@ public class XDataModel implements Cloneable, Serializable, XDomain,
     * Rename a folder in the data model, preserving its creation metadata.
     */
    public void renameFolder(String oldName, String newName) {
+      if(Tool.equals(oldName, newName)) {
+         return;
+      }
+
       FolderInfo info = getFolderInfo(oldName);
 
       if(info != null) {

--- a/core/src/main/java/inetsoft/uql/erm/XDataModel.java
+++ b/core/src/main/java/inetsoft/uql/erm/XDataModel.java
@@ -796,8 +796,18 @@ public class XDataModel implements Cloneable, Serializable, XDomain,
    public void writeXML(PrintWriter writer) {
       writeStart(writer);
 
-      for(String folder : folders) {
-         writer.println("<folder name=\"" + Tool.escape(folder) + "\"/>");
+      for(FolderInfo folder : folders) {
+         writer.print("<folder name=\"" + Tool.escape(folder.getName()) + "\"");
+
+         if(folder.getCreatedBy() != null) {
+            writer.print(" createdBy=\"" + Tool.escape(folder.getCreatedBy()) + "\"");
+         }
+
+         if(folder.getCreatedDate() > 0) {
+            writer.print(" createdDate=\"" + folder.getCreatedDate() + "\"");
+         }
+
+         writer.println("/>");
       }
 
       writeEnd(writer);
@@ -820,7 +830,10 @@ public class XDataModel implements Cloneable, Serializable, XDomain,
 
       for(int i = 0; nlist != null && i < nlist.getLength(); i++) {
          Element node = (Element) nlist.item(i);
-         addFolder(Tool.getAttribute(node, "name"));
+         String createdDateStr = Tool.getAttribute(node, "createdDate");
+         long createdDate = createdDateStr == null ? 0 : Long.parseLong(createdDateStr);
+         addFolder(Tool.getAttribute(node, "name"), Tool.getAttribute(node, "createdBy"),
+            createdDate);
       }
    }
 
@@ -851,8 +864,20 @@ public class XDataModel implements Cloneable, Serializable, XDomain,
     * Add a folder to the data model.
     */
    public void addFolder(String folder) {
-      if(!folders.contains(folder)) {
-         folders.add(folder);
+      addFolder(folder, null, 0);
+   }
+
+   /**
+    * Add a folder to the data model.
+    *
+    * @param folder the name of the folder.
+    * @param createdBy the name of the user that created the folder, or
+    *                  {@code null} if unknown.
+    * @param createdDate the date the folder was created, or 0 if unknown.
+    */
+   public void addFolder(String folder, String createdBy, long createdDate) {
+      if(getFolderInfo(folder) == null) {
+         folders.add(new FolderInfo(folder, createdBy, createdDate));
       }
    }
 
@@ -860,14 +885,66 @@ public class XDataModel implements Cloneable, Serializable, XDomain,
     * Remove a folder from the data model.
     */
    public void removeFolder(String folder) {
-      folders.remove(folder);
+      folders.removeIf(info -> Tool.equals(info.getName(), folder));
+   }
+
+   /**
+    * Rename a folder in the data model, preserving its creation metadata.
+    */
+   public void renameFolder(String oldName, String newName) {
+      FolderInfo info = getFolderInfo(oldName);
+
+      if(info != null) {
+         if(getFolderInfo(newName) == null) {
+            info.setName(newName);
+         }
+         else {
+            // newName already exists, drop the old entry rather than create a duplicate
+            folders.remove(info);
+         }
+      }
+      else {
+         addFolder(newName);
+      }
    }
 
    /**
     * Get all folders of a data model.
     */
    public String[] getFolders() {
-      return folders.toArray(new String[folders.size()]);
+      String[] result = new String[folders.size()];
+
+      for(int i = 0; i < folders.size(); i++) {
+         result[i] = folders.get(i).getName();
+      }
+
+      return result;
+   }
+
+   /**
+    * Get the name of the user that created the given folder.
+    */
+   public String getFolderCreatedBy(String folder) {
+      FolderInfo info = getFolderInfo(folder);
+      return info == null ? null : info.getCreatedBy();
+   }
+
+   /**
+    * Get the creation date of the given folder.
+    */
+   public long getFolderCreatedDate(String folder) {
+      FolderInfo info = getFolderInfo(folder);
+      return info == null ? 0 : info.getCreatedDate();
+   }
+
+   private FolderInfo getFolderInfo(String folder) {
+      for(FolderInfo info : folders) {
+         if(Tool.equals(info.getName(), folder)) {
+            return info;
+         }
+      }
+
+      return null;
    }
 
    /**
@@ -875,6 +952,37 @@ public class XDataModel implements Cloneable, Serializable, XDomain,
     */
    public void removeFolders() {
       folders.clear();
+   }
+
+   /**
+    * Metadata for a data model folder.
+    */
+   private static class FolderInfo implements Serializable {
+      FolderInfo(String name, String createdBy, long createdDate) {
+         this.name = name;
+         this.createdBy = createdBy;
+         this.createdDate = createdDate;
+      }
+
+      String getName() {
+         return name;
+      }
+
+      void setName(String name) {
+         this.name = name;
+      }
+
+      String getCreatedBy() {
+         return createdBy;
+      }
+
+      long getCreatedDate() {
+         return createdDate;
+      }
+
+      private String name;
+      private final String createdBy;
+      private final long createdDate;
    }
 
    /**
@@ -942,7 +1050,7 @@ public class XDataModel implements Cloneable, Serializable, XDomain,
    }
 
    private String datasource;
-   private ArrayList<String> folders = new ArrayList<>();
+   private ArrayList<FolderInfo> folders = new ArrayList<>();
 
    private static final Logger LOG =
       LoggerFactory.getLogger(XDataModel.class);

--- a/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
+++ b/core/src/main/java/inetsoft/uql/service/DataSourceRegistry.java
@@ -666,7 +666,10 @@ public class DataSourceRegistry implements MessageListener {
 
          for(int j = 0; j < folderList.getLength(); j++) {
             Element node = (Element) folderList.item(j);
-            dmodel.addFolder(Tool.getAttribute(node, "name"));
+            String createdDateStr = Tool.getAttribute(node, "createdDate");
+            long createdDate = createdDateStr == null ? 0 : Long.parseLong(createdDateStr);
+            dmodel.addFolder(Tool.getAttribute(node, "name"), Tool.getAttribute(node, "createdBy"),
+               createdDate);
          }
       }
 

--- a/core/src/main/java/inetsoft/web/admin/content/database/model/DataModelFolderManagerService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/database/model/DataModelFolderManagerService.java
@@ -85,7 +85,8 @@ public class DataModelFolderManagerService {
          throw new FileExistsException(databasePath);
       }
 
-      dataModel.addFolder(folderName);
+      IdentityID createdBy = IdentityID.getIdentityIDFromKey(principal.getName());
+      dataModel.addFolder(folderName, createdBy.name, System.currentTimeMillis());
       repository.updateDataModel(dataModel);
    }
 

--- a/core/src/main/java/inetsoft/web/admin/content/database/model/DataModelFolderManagerService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/database/model/DataModelFolderManagerService.java
@@ -86,7 +86,7 @@ public class DataModelFolderManagerService {
       }
 
       IdentityID createdBy = IdentityID.getIdentityIDFromKey(principal.getName());
-      dataModel.addFolder(folderName, createdBy.name, System.currentTimeMillis());
+      dataModel.addFolder(folderName, createdBy.convertToKey(), System.currentTimeMillis());
       repository.updateDataModel(dataModel);
    }
 

--- a/core/src/main/java/inetsoft/web/portal/controller/database/DatabaseModelBrowserService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/DatabaseModelBrowserService.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.portal.controller.database;
 
+import inetsoft.sree.SreeEnv;
 import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.security.SecurityException;
 import inetsoft.sree.security.*;
@@ -45,6 +46,9 @@ import org.springframework.stereotype.Service;
 import java.io.FileNotFoundException;
 import java.security.Principal;
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Stream;
 
@@ -291,11 +295,46 @@ public class DatabaseModelBrowserService {
             folderModel.setEditable(editable);
             folderModel.setDeletable(deletable);
             folderModel.setDatabaseName(database);
+            setFolderCreatedInfo(folderModel, dataModel, folder);
             result.add(folderModel);
          }
       }
 
       return result;
+   }
+
+   /**
+    * Populate the created-by/created-date fields on a data model folder bean.
+    */
+   private void setFolderCreatedInfo(DataModelFolder folderModel, XDataModel dataModel,
+                                     String folder)
+   {
+      String createdUsername = dataModel.getFolderCreatedBy(folder);
+
+      if(createdUsername != null) {
+         SecurityProvider provider = securityEngine.getSecurityProvider();
+         IdentityID createdUserID = new IdentityID(createdUsername,
+            OrganizationManager.getInstance().getCurrentOrgID());
+         User user = provider.getUser(createdUserID);
+
+         if(user != null) {
+            folderModel.setCreatedBy(user.getAlias() == null ? user.getName() : user.getAlias());
+         }
+         else {
+            folderModel.setCreatedBy(SUtil.getUserAlias(createdUserID));
+         }
+      }
+
+      long createdDate = dataModel.getFolderCreatedDate(folder);
+
+      if(createdDate > 0) {
+         LocalDateTime cdate = new Date(createdDate).toInstant()
+            .atZone(ZoneId.systemDefault()).toLocalDateTime();
+         String fmt = SreeEnv.getProperty("format.date.time");
+         DateTimeFormatter df = DateTimeFormatter.ofPattern(fmt);
+         folderModel.setCreatedDate(createdDate);
+         folderModel.setCreatedDateLabel(df.format(cdate));
+      }
    }
 
    public void moveDataModels(String database, List<AssetItem> items, String folder,
@@ -755,8 +794,7 @@ public class DatabaseModelBrowserService {
 
          Permission permission = securityEngine.getPermission(
             ResourceType.DATA_MODEL_FOLDER, databasePath + "/" + oldName);
-         dataModel.removeFolder(oldName);
-         dataModel.addFolder(folderName);
+         dataModel.renameFolder(oldName, folderName);
          repository.updateDataModel(dataModel);
          renameTransformHandler.addTransformTask(dinfo);
 

--- a/core/src/main/java/inetsoft/web/portal/controller/database/DatabaseModelBrowserService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/DatabaseModelBrowserService.java
@@ -309,12 +309,11 @@ public class DatabaseModelBrowserService {
    private void setFolderCreatedInfo(DataModelFolder folderModel, XDataModel dataModel,
                                      String folder)
    {
-      String createdUsername = dataModel.getFolderCreatedBy(folder);
+      String createdByKey = dataModel.getFolderCreatedBy(folder);
 
-      if(createdUsername != null) {
+      if(createdByKey != null) {
          SecurityProvider provider = securityEngine.getSecurityProvider();
-         IdentityID createdUserID = new IdentityID(createdUsername,
-            OrganizationManager.getInstance().getCurrentOrgID());
+         IdentityID createdUserID = IdentityID.getIdentityIDFromKey(createdByKey);
          User user = provider.getUser(createdUserID);
 
          if(user != null) {
@@ -326,15 +325,18 @@ public class DatabaseModelBrowserService {
       }
 
       long createdDate = dataModel.getFolderCreatedDate(folder);
+      String dateLabel = "";
 
       if(createdDate > 0) {
          LocalDateTime cdate = new Date(createdDate).toInstant()
             .atZone(ZoneId.systemDefault()).toLocalDateTime();
          String fmt = SreeEnv.getProperty("format.date.time");
          DateTimeFormatter df = DateTimeFormatter.ofPattern(fmt);
-         folderModel.setCreatedDate(createdDate);
-         folderModel.setCreatedDateLabel(df.format(cdate));
+         dateLabel = df.format(cdate);
       }
+
+      folderModel.setCreatedDate(createdDate > 0 ? createdDate : -1);
+      folderModel.setCreatedDateLabel(dateLabel);
    }
 
    public void moveDataModels(String database, List<AssetItem> items, String folder,


### PR DESCRIPTION
## Summary
- Data Model folders (folders inside a JDBC data source's logical/physical model tree) were stored as bare `String`s on `XDataModel`, so they never carried creation metadata — the "Created By"/"Creation Date" columns in the portal Data Model folder browser were always blank, for every user (not just non-admin R/W users, as originally reported).
- `XDataModel` now tracks a `createdBy`/`createdDate` per folder, persisted in the data model XML (backward-compatible with existing XML lacking the new attributes).
- Folder creation (`DataModelFolderManagerService.setDataModelFolder`) stamps the creating principal and timestamp.
- `DatabaseModelBrowserService.getDataModelFolders` resolves and displays the creator's alias and formatted creation date, mirroring the existing pattern used for LogicalModel/PhysicalModel/Vpm.
- Renaming a folder now preserves its creation metadata (previously done via remove+re-add, which silently dropped it); the new `renameFolder()` also guards against creating a duplicate entry if renamed onto an existing folder name.

## Test plan
- [x] `./mvnw clean install -pl core -am -DskipTests` compiles cleanly
- [ ] Manually verify: create a Data Model folder as a non-admin user with R/W permission on Data Model Folder → "Created By"/"Creation Date" now populate in the folder browser grid
- [ ] Manually verify: rename a Data Model folder → creator/date persist after rename