### PR TITLE
Bug #75891, propagate user rename to recycle bin entries

### DIFF
--- a/core/src/main/java/inetsoft/web/RecycleBin.java
+++ b/core/src/main/java/inetsoft/web/RecycleBin.java
@@ -137,6 +137,32 @@ public class RecycleBin implements XMLSerializable, AutoCloseable {
    }
 
    /**
+    * Updates the owner recorded on recycle bin entries (in the current org) after a user is
+    * renamed, so that entries deleted by the old username can still be located and restored.
+    */
+   public synchronized void renameUser(IdentityID oldUser, IdentityID newUser) {
+      Map<String, Entry> map = new HashMap<>();
+      KeyValueStorage<Entry> storage = getStorage();
+      storage.stream().forEach(p -> map.put(p.getKey(), p.getValue()));
+
+      for(Map.Entry<String, Entry> e : map.entrySet()) {
+         Entry entry = e.getValue();
+
+         if(Tool.equals(entry.getOriginalUser(), oldUser)) {
+            entry.setOriginalUser(newUser);
+
+            try {
+               storage.put(e.getKey(), entry).get(10L, TimeUnit.SECONDS);
+            }
+            catch(Exception ex) {
+               LOG.error("Failed to rename recycle bin entry owner from {} to {}",
+                         oldUser, newUser, ex);
+            }
+         }
+      }
+   }
+
+   /**
     * Get the original path of an item in recycle bin.
     */
    public synchronized String getOriginalPath(String path) {

--- a/core/src/main/java/inetsoft/web/RecycleBin.java
+++ b/core/src/main/java/inetsoft/web/RecycleBin.java
@@ -137,12 +137,14 @@ public class RecycleBin implements XMLSerializable, AutoCloseable {
    }
 
    /**
-    * Updates the owner recorded on recycle bin entries (in the current org) after a user is
+    * Updates the owner recorded on recycle bin entries (in the user's org) after a user is
     * renamed, so that entries deleted by the old username can still be located and restored.
+    * Resolves storage from {@code oldUser}'s org rather than the calling thread's ambient
+    * current org, so this is correct even when a site admin renames a user in a non-current org.
     */
    public synchronized void renameUser(IdentityID oldUser, IdentityID newUser) {
       Map<String, Entry> map = new HashMap<>();
-      KeyValueStorage<Entry> storage = getStorage();
+      KeyValueStorage<Entry> storage = getStorage(oldUser.getOrgID());
       storage.stream().forEach(p -> map.put(p.getKey(), p.getValue()));
 
       for(Map.Entry<String, Entry> e : map.entrySet()) {

--- a/core/src/main/java/inetsoft/web/RecycleUtils.java
+++ b/core/src/main/java/inetsoft/web/RecycleUtils.java
@@ -249,11 +249,21 @@ public final class RecycleUtils {
       IdentityID user = rEntry.getOriginalUser();
       AssetEntry oldEntry = getSheetEntry(path, isViewsheet, user);
 
+      if(oldEntry == null) {
+         throw new MessageException("Failed to restore sheet, the recycled asset at " +
+            path + " owned by " + user + " could not be found");
+      }
+
       if(SUtil.isMyDashboard(path)) {
          oldEntry = getAssetEntry(oldEntry.getType(), path, user);
       }
       else {
          oldEntry = getAssetEntry(oldEntry.getType(), path);
+      }
+
+      if(oldEntry == null) {
+         throw new MessageException("Failed to restore sheet, the recycled asset at " +
+            path + " owned by " + user + " could not be found");
       }
 
       String originalPath = rEntry.getOriginalPath();

--- a/core/src/main/java/inetsoft/web/RecycleUtils.java
+++ b/core/src/main/java/inetsoft/web/RecycleUtils.java
@@ -282,7 +282,7 @@ public final class RecycleUtils {
 
       newEntry.copyMetaData(oldEntry);
 
-      if(oldEntry != null && AssetUtil.isDuplicatedEntry(repository, newEntry)) {
+      if(AssetUtil.isDuplicatedEntry(repository, newEntry)) {
          if(overwrite) {
             repository.removeSheet(newEntry, principal, true);
          }

--- a/core/src/main/java/inetsoft/web/admin/security/user/UserTreeService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/user/UserTreeService.java
@@ -35,6 +35,7 @@ import inetsoft.uql.erm.vpm.VirtualPrivateModel;
 import inetsoft.uql.util.Identity;
 import inetsoft.util.*;
 import inetsoft.util.audit.*;
+import inetsoft.web.RecycleBin;
 import inetsoft.web.admin.favorites.FavoritesService;
 import inetsoft.web.admin.general.LocalizationSettingsService;
 import inetsoft.web.admin.general.model.LocalizationModel;
@@ -68,7 +69,8 @@ public class UserTreeService {
                           CustomThemesManager customThemesManager,
                           DashboardRegistryManager dashboardRegistryManager,
                           XRepository xRepository,
-                          DependencyStorageService dependencyStorageService)
+                          DependencyStorageService dependencyStorageService,
+                          RecycleBin recycleBin)
    {
       this.authenticationProviderService = authenticationProviderService;
       this.systemAdminService = systemAdminService;
@@ -87,6 +89,7 @@ public class UserTreeService {
       this.indexedStorage = indexedStorage;
       this.xRepository = xRepository;
       this.dependencyStorageService = dependencyStorageService;
+      this.recycleBin = recycleBin;
    }
 
    public List<String> getOrganizationTree(String providerName, Principal principal) {
@@ -1832,6 +1835,7 @@ public class UserTreeService {
       mvManager.updateMVUser(oldID, newID);
       cycleManager.updateCycleInfoNotify(oldID.getName(), newID.getName(), true);
       this.dependencyStorageService.migrateStorageData(oldID, newID);
+      recycleBin.renameUser(oldID, newID);
    }
 
    private SecurityProvider getSecurityProvider() {
@@ -1934,5 +1938,6 @@ public class UserTreeService {
    private final DashboardRegistryManager dashboardRegistryManager;
    private final XRepository xRepository;
    private final DependencyStorageService dependencyStorageService;
+   private final RecycleBin recycleBin;
    private final Set<String> propertyNames = Set.of("max.row.count", "max.col.count", "max.cell.size", "max.user.count");
 }

--- a/core/src/test/java/inetsoft/sree/security/OrgLifecycleScopedPropertiesIntegrationTest.java
+++ b/core/src/test/java/inetsoft/sree/security/OrgLifecycleScopedPropertiesIntegrationTest.java
@@ -68,6 +68,7 @@ import inetsoft.test.ConfigurationContextInitializer;
 import inetsoft.test.SreeHome;
 import inetsoft.uql.XRepository;
 import inetsoft.uql.asset.sync.DependencyStorageService;
+import inetsoft.web.RecycleBin;
 import inetsoft.web.admin.favorites.FavoritesService;
 import inetsoft.uql.util.Identity;
 import inetsoft.util.DataSpace;
@@ -348,7 +349,7 @@ class OrgLifecycleScopedPropertiesIntegrationTest {
          favoritesService, mock(DataCycleManager.class), mock(LicenseManager.class),
          mock(MVManager.class), mock(IndexedStorage.class), mock(CustomThemesManager.class),
          mock(DashboardRegistryManager.class), mock(XRepository.class),
-         mock(DependencyStorageService.class));
+         mock(DependencyStorageService.class), mock(RecycleBin.class));
 
       // The acting principal's own ambient "current org" is actingOrgId, deliberately different
       // from the org being edited -- this is the exact divergence the bug depended on. The

--- a/core/src/test/java/inetsoft/sree/security/PermissionMatrixOrgLifecycleTest.java
+++ b/core/src/test/java/inetsoft/sree/security/PermissionMatrixOrgLifecycleTest.java
@@ -299,7 +299,7 @@ public class PermissionMatrixOrgLifecycleTest {
       // (theme copy, sysAdmin-count safety checks), not for this duplicate-ID guard.
       UserTreeService userTreeService = new UserTreeService(
          null, null, null, null, SecurityEngine.getSecurity(), null, null, null, null, null, null,
-         null, null, null, null, null);
+         null, null, null, null, null, null);
 
       EditOrganizationPaneModel model = EditOrganizationPaneModel.builder()
          .name(orgAName)

--- a/core/src/test/java/inetsoft/web/RecycleBinOrgLifecycleTest.java
+++ b/core/src/test/java/inetsoft/web/RecycleBinOrgLifecycleTest.java
@@ -279,6 +279,63 @@ class RecycleBinOrgLifecycleTest {
                   "source org's entry must be completely untouched by the migrate");
    }
 
+   // ── renameUser(oldUser, newUser) -- Bug #75891 fix: re-owns entries after a user rename ──
+
+   @Test
+   void renameUser_updatesMatchingEntries_leavesOthersUntouched() {
+      recycleBin = new RecycleBin(keyValueStorageManager);
+      String orgId = "recyclebin_renameuser_same";
+
+      IdentityID oldUser = new IdentityID("guest", orgId);
+      IdentityID newUser = new IdentityID("guest2", orgId);
+      IdentityID otherUser = new IdentityID("alice", orgId);
+
+      actAs(orgId);
+      recycleBin.addEntry("Recycle Bin/pqr678", "My Dashboards/report6", "report6", null,
+                          RepositoryEntry.VIEWSHEET, AssetRepository.USER_SCOPE, oldUser);
+      recycleBin.addEntry("Recycle Bin/stu901", "My Dashboards/report7", "report7", null,
+                          RepositoryEntry.VIEWSHEET, AssetRepository.USER_SCOPE, otherUser);
+
+      recycleBin.renameUser(oldUser, newUser);
+
+      RecycleBin.Entry renamed = recycleBin.getEntry("Recycle Bin/pqr678");
+      assertEquals(newUser, renamed.getOriginalUser(),
+                  "entry owned by the renamed user must have originalUser updated to the new name, " +
+                  "so RecycleUtils.restoreSheet() can still locate it after the rename");
+
+      RecycleBin.Entry untouched = recycleBin.getEntry("Recycle Bin/stu901");
+      assertEquals(otherUser, untouched.getOriginalUser(),
+                  "entries owned by other users must not be touched by an unrelated rename");
+   }
+
+   // Regression guard for the org-scoping fix: renameUser() must resolve storage from oldUser's
+   // own org, not the calling thread's ambient "current org" -- otherwise a site admin renaming a
+   // user in a non-current org would silently mutate the wrong org's (or no) recycle bin bucket,
+   // the same bug shape as Bug #75769 (see file header + OrgLifecycleScopedPropertiesIntegrationTest).
+   @Test
+   void renameUser_resolvesStorageFromOldUsersOrg_notAmbientCurrentOrg() {
+      recycleBin = new RecycleBin(keyValueStorageManager);
+      String targetOrgId = "recyclebin_renameuser_target";
+      String actingOrgId = "recyclebin_renameuser_acting";
+
+      IdentityID oldUser = new IdentityID("guest", targetOrgId);
+      IdentityID newUser = new IdentityID("guest2", targetOrgId);
+
+      actAs(targetOrgId);
+      recycleBin.addEntry("Recycle Bin/vwx234", "My Dashboards/report8", "report8", null,
+                          RepositoryEntry.VIEWSHEET, AssetRepository.USER_SCOPE, oldUser);
+
+      // simulate a site admin whose ambient current org differs from the org being edited
+      actAs(actingOrgId);
+      recycleBin.renameUser(oldUser, newUser);
+
+      actAs(targetOrgId);
+      RecycleBin.Entry renamed = recycleBin.getEntry("Recycle Bin/vwx234");
+      assertEquals(newUser, renamed.getOriginalUser(),
+                  "renameUser() must update the entry in oldUser's own org even when the acting " +
+                  "thread's ambient current org is a different org entirely");
+   }
+
    // ── scenario 11c: removeStorage(orgID) -- whole bucket deleted ──
 
    @Test


### PR DESCRIPTION
## Summary
- Fixes an NPE in `RecycleUtils.restoreSheet` when restoring a recycled asset after the owning user has been renamed.
- Root cause: `UserTreeService.editUser()` -> `renameUserAsset()` migrates a renamed user's asset storage (IndexedStorage, MV, dependency storage, dashboard cycle info) to the new username, but never updated `RecycleBin.Entry.originalUser`. `RecycleUtils.restoreSheet` then looked up the recycled sheet under the stale old username, `getAssetEntry` returned `null`, and `oldEntry.getType()` NPE'd.
- Adds `RecycleBin.renameUser(oldUser, newUser)` (mirrors the existing `renameFolder` cascade) and calls it from `UserTreeService.renameUserAsset` alongside the other user-rename storage migrations.
- Adds defensive null-checks in `RecycleUtils.restoreSheet` so any already-stale recycle bin entries (created before this fix) fail with a clear `MessageException` instead of an NPE.

## Repro
1. Create user "guest", import a viewsheet owned by guest.
2. Delete guest's private viewsheet (moves to Recycle Bin).
3. Rename user "guest" to a new name.
4. Restore the asset from Recycle Bin -> NPE before this fix; restores successfully after.

## Test plan
- [x] `core` module compiles (`mvnw compile`)
- [x] `core` module test sources compile (`mvnw test-compile`) — updated two tests (`PermissionMatrixOrgLifecycleTest`, `OrgLifecycleScopedPropertiesIntegrationTest`) that construct `UserTreeService` positionally, for the new constructor parameter
- [ ] Manual repro steps above verified in a running instance