### PR TITLE
Bug #75858, give AssetQueryScope a parent-chain fallback for qualified viewsheet-assembly reads

### DIFF
--- a/core/src/main/java/inetsoft/report/script/formula/AssetQueryScope.java
+++ b/core/src/main/java/inetsoft/report/script/formula/AssetQueryScope.java
@@ -112,9 +112,15 @@ public class AssetQueryScope implements DynamicScope, Cloneable {
          LOG.error("Failed to get property from asset query: " + id, ex);
       }
 
+      if(members.containsKey(id)) {
+         return members.get(id);
+      }
+
       // the dynamic scope fallback (executing scope) is now provided
       // centrally by BindingRootProxy
-      return members.get(id);
+      ScriptScope owner = findInChain(id);
+
+      return owner == null ? null : owner.getMember(id);
    }
 
    @Override
@@ -128,7 +134,42 @@ public class AssetQueryScope implements DynamicScope, Cloneable {
          // ignore
       }
 
-      return members.containsKey(id);
+      if(members.containsKey(id)) {
+         return true;
+      }
+
+      return findInChain(id) != null;
+   }
+
+   /**
+    * Find the scope in this scope's lookup chain that defines a name this scope
+    * does not define itself. The chain is populated by
+    * {@link AssetQuerySandbox#createAssetQueryScope()} -- in practice with a
+    * {@code ViewsheetScope}, which resolves viewsheet assembly names (added by
+    * Bug #75526 so viewsheet assemblies are visible in worksheet scripts).
+    *
+    * <p>A qualified read such as {@code worksheet['<viewsheet assembly>']} is
+    * dispatched straight at this scope by {@code ScopeProxy}, so it never goes
+    * through {@code BindingRootProxy}'s chain walk (that only covers unqualified
+    * names). Both the read and the presence test need this, since GraalJS only
+    * calls {@code getMember} after {@code hasMember} reported the name present.
+    * Mirrors {@code ViewsheetScope.findInChain()} (#75807), the same defect on
+    * the other side of the viewsheet/worksheet scope link.
+    *
+    * @param name the member name to look for.
+    *
+    * @return the owning scope, or <tt>null</tt> if the name is not in the chain.
+    */
+   private ScriptScope findInChain(String name) {
+      for(ScriptScope scope = getParentScope();
+          scope != null && scope != this; scope = scope.getParentScope())
+      {
+         if(scope.hasMember(name)) {
+            return scope;
+         }
+      }
+
+      return null;
    }
 
    /**

--- a/core/src/test/java/inetsoft/report/script/formula/AssetQueryScopeTest.java
+++ b/core/src/test/java/inetsoft/report/script/formula/AssetQueryScopeTest.java
@@ -1,0 +1,105 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.report.script.formula;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.composition.execution.AssetQuerySandbox;
+import inetsoft.report.composition.execution.ViewsheetSandbox;
+import inetsoft.report.script.viewsheet.ViewsheetScope;
+import inetsoft.test.*;
+import inetsoft.uql.asset.Assembly;
+import inetsoft.util.script.JavaScriptEngine;
+import inetsoft.web.viewsheet.event.OpenViewsheetEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.Tag;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class, IntegrationTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome(importResources = "/inetsoft/report/script/viewsheet/ViewsheetScopeTest.vso")
+@Tag("core")
+@Tag("integration")
+public class AssetQueryScopeTest {
+   @RegisterExtension
+   RuntimeViewsheetExtension viewsheetResource =
+      new RuntimeViewsheetExtension(createOpenViewsheetEvent());
+
+   private ViewsheetSandbox sandbox;
+   private AssetQuerySandbox wbox;
+
+   @BeforeEach
+   void setUp() {
+      RuntimeViewsheet rvs = viewsheetResource.getRuntimeViewsheet();
+      sandbox = rvs.getViewsheetSandbox().orElseThrow();
+      wbox = sandbox.getAssetQuerySandbox();
+   }
+
+   /**
+    * A qualified read of a viewsheet assembly name -- e.g.
+    * worksheet['TableView1'] -- is dispatched straight at the worksheet's
+    * AssetQueryScope, so it has to resolve through the chain that
+    * AssetQuerySandbox#createAssetQueryScope() links to the viewsheet's
+    * ViewsheetScope (added by Bug #75526 so viewsheet assemblies are visible in
+    * worksheet scripts). Mirrors
+    * ViewsheetScopeTest#testWorksheetTableResolvedThroughChain (#75807), the
+    * same defect on the other side of the viewsheet/worksheet scope link.
+    */
+   @Test
+   void testViewsheetAssemblyResolvedThroughChain() {
+      AssetQueryScope scope = new AssetQueryScope(wbox);
+      String aname = Arrays.stream(sandbox.getViewsheet().getAssemblies())
+         .map(Assembly::getName)
+         .filter(name -> !scope.hasMember(name))
+         .findFirst()
+         .orElseThrow();
+
+      // not resolvable until the viewsheet scope is chained onto this scope
+      assertFalse(scope.hasMember(aname));
+      assertNull(scope.getMember(aname));
+
+      ViewsheetScope vscope = new ViewsheetScope(sandbox, false);
+      JavaScriptEngine.addToPrototype(scope, vscope);
+
+      assertTrue(scope.hasMember(aname));
+      assertNotNull(scope.getMember(aname));
+
+      // a name owned by neither scope stays absent
+      assertFalse(scope.hasMember("NoSuchAssembly"));
+      assertNull(scope.getMember("NoSuchAssembly"));
+   }
+
+   private static OpenViewsheetEvent createOpenViewsheetEvent() {
+      OpenViewsheetEvent event = new OpenViewsheetEvent();
+      event.setEntryId(ASSET_ID);
+      event.setViewer(true);
+      return event;
+   }
+
+   public static final String ASSET_ID = "1^128^__NULL__^ViewsheetScopeTest";
+}


### PR DESCRIPTION
## Summary

- A qualified read of a viewsheet assembly from a worksheet/asset-query script -- e.g. `worksheet['Crosstab2']` -- resolves to `undefined` under GraalJS, even though the scope chain that owns the name is correctly linked.
- `ScopeProxy` dispatches a qualified read straight at the wrapped scope and never reaches `BindingRootProxy`'s central parent-chain walk (that walk only covers unqualified names). `AssetQueryScope.getMember`/`hasMember` only consulted `getTableValue()` (worksheet tables) and the local `members` map, so the `ViewsheetScope` chained on by `AssetQuerySandbox.createAssetQueryScope()` (added by Bug #75526 so viewsheet assemblies are visible in worksheet scripts) was never checked. Because `hasMember()` gates `getMember()` under GraalJS, the read silently produced `undefined` with no error or log line.
- This is the mirror-image gap, on the other side of the viewsheet<->worksheet scope link, from Bug #75807 (`ViewsheetScope`'s qualified read of a worksheet table, PR #4455). `AssetQueryScope.getMember`/`hasMember` now fall back to a `findInChain()` helper that walks `getParentScope()`, following the same pattern (including the `scope != this` cycle guard). `getMemberKeys()` is left alone, since Rhino's `getIds()` likewise did not enumerate prototype ids.
- Not observed in a customer asset -- found by code inspection and a direct scope-level check while fixing #75807.

## Test plan

- [x] Added `AssetQueryScopeTest#testViewsheetAssemblyResolvedThroughChain`, mirroring `ViewsheetScopeTest#testWorksheetTableResolvedThroughChain`: confirms a viewsheet assembly name is unresolvable through a bare `AssetQueryScope`, then resolvable once a `ViewsheetScope` is chained on via `JavaScriptEngine.addToPrototype()` (the same wiring `AssetQuerySandbox.createAssetQueryScope()` performs in production), and confirms an unrelated name stays absent.
- [x] Verified the new test fails without the fix and passes with it.
- [x] `./mvnw -pl core test -Dtest=AssetQueryScopeTest` passes.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>