### PR TITLE
Bug #75887, scan every organization's __autoSave bucket during expired file cleanup

### DIFF
--- a/core/src/main/java/inetsoft/web/AutoSaveService.java
+++ b/core/src/main/java/inetsoft/web/AutoSaveService.java
@@ -19,6 +19,8 @@ import inetsoft.report.composition.WorksheetEngine;
 import inetsoft.report.composition.event.AssetEventUtil;
 import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.security.IdentityID;
+import inetsoft.sree.security.OrganizationContextHolder;
+import inetsoft.sree.security.SecurityEngine;
 import inetsoft.storage.BlobStorage;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.asset.internal.AssetUtil;
@@ -44,10 +46,25 @@ public class AutoSaveService {
 
    @Scheduled(fixedRate = 10800000L)
    public void removeExpiredAutoSaveFiles() {
-      BlobStorage<AutoSaveUtils.Metadata> blobStorage = AutoSaveUtils.getStorage(null);
+      String[] orgIds = SecurityEngine.getSecurity().getSecurityProvider().getOrganizationIDs();
       Instant sevenDaysAgo = Instant.now().minus(Duration.ofDays(7));
-      loopCleanAutoSaveFiles(blobStorage, false, sevenDaysAgo);
-      loopCleanAutoSaveFiles(blobStorage, true, sevenDaysAgo);
+
+      for(String orgId : orgIds) {
+         // resolve the org's own __autoSave bucket even though this scheduled job runs with no
+         // ambient principal -- OrganizationManager.getCurrentOrgID(null) falls back to this
+         // thread-local before defaulting to the host org, so without it every org would collapse
+         // onto the default org's bucket
+         OrganizationContextHolder.setCurrentOrgId(orgId);
+
+         try {
+            BlobStorage<AutoSaveUtils.Metadata> blobStorage = AutoSaveUtils.getStorage(null);
+            loopCleanAutoSaveFiles(blobStorage, false, sevenDaysAgo);
+            loopCleanAutoSaveFiles(blobStorage, true, sevenDaysAgo);
+         }
+         finally {
+            OrganizationContextHolder.clear();
+         }
+      }
    }
 
    private void loopCleanAutoSaveFiles(BlobStorage<AutoSaveUtils.Metadata> blobStorage, boolean isRecycle, Instant sevenDaysAgo) {

--- a/core/src/main/java/inetsoft/web/AutoSaveService.java
+++ b/core/src/main/java/inetsoft/web/AutoSaveService.java
@@ -26,6 +26,8 @@ import inetsoft.uql.asset.*;
 import inetsoft.uql.asset.internal.AssetUtil;
 import inetsoft.util.audit.ActionRecord;
 import inetsoft.util.audit.Audit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -60,6 +62,12 @@ public class AutoSaveService {
             BlobStorage<AutoSaveUtils.Metadata> blobStorage = AutoSaveUtils.getStorage(null);
             loopCleanAutoSaveFiles(blobStorage, false, sevenDaysAgo);
             loopCleanAutoSaveFiles(blobStorage, true, sevenDaysAgo);
+         }
+         catch(Exception e) {
+            // isolate per-org so one org's storage failure doesn't starve cleanup for every org
+            // that sorts after it in getOrganizationIDs() on this (and, if persistent, every
+            // subsequent) scheduled run
+            LOG.warn("Failed to remove expired auto save files for organization {}", orgId, e);
          }
          finally {
             OrganizationContextHolder.clear();
@@ -119,4 +127,5 @@ public class AutoSaveService {
    }
 
    private final ViewsheetService viewsheetService;
+   private static final Logger LOG = LoggerFactory.getLogger(AutoSaveService.class);
 }

--- a/core/src/test/java/inetsoft/web/AutoSaveServiceOrgLifecycleTest.java
+++ b/core/src/test/java/inetsoft/web/AutoSaveServiceOrgLifecycleTest.java
@@ -30,6 +30,8 @@ import inetsoft.sree.security.Organization;
 import inetsoft.sree.security.OrganizationContextHolder;
 import inetsoft.sree.security.OrganizationManager;
 import inetsoft.sree.security.SRPrincipal;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityProvider;
 import inetsoft.storage.BlobStorage;
 import inetsoft.storage.BlobStorageManager;
 import inetsoft.storage.BlobTransaction;
@@ -211,40 +213,89 @@ class AutoSaveServiceOrgLifecycleTest {
                 + "drops off the EM \"Auto Saved Files\" recycle-bin tree (Issue #75827)");
    }
 
-   // ── scenario 6h: removeExpiredAutoSaveFiles() only ever inspects the default org's bucket -- a
-   //    non-default org's bucket is never even listed, regardless of what it contains ──
+   // ── Bug #75887 (scenario 6h): removeExpiredAutoSaveFiles() only ever inspected the default
+   //    org's bucket -- a non-default org's bucket was never even listed, regardless of age.
+   //    Fixed by looping over SecurityProvider.getOrganizationIDs() and scoping each pass via
+   //    OrganizationContextHolder, mirroring CleanupTableCacheTask's cross-org pattern ──
 
    @Test
-   @Disabled("6h: not yet run/confirmed -- see matrix doc section 3.4")
-   void removeExpiredAutoSaveFiles_onlyScansDefaultOrgBucket_nonDefaultOrgNeverListed() throws Exception {
+   void removeExpiredAutoSaveFiles_expiredNonDefaultOrgFile_isDeleted() throws Exception {
       String nonDefaultOrgId = "sixh_non_default_org";
-      seedAutoSaveBlob(nonDefaultOrgId, "8^VIEWSHEET^_NULL_^Untitled-1^0_0_0_0_0_0_0_1~",
-                       "dummy".getBytes());
+      String path = "8^VIEWSHEET^_NULL_^Untitled-1^0_0_0_0_0_0_0_1~";
+      long eightDaysAgo = System.currentTimeMillis() - java.time.Duration.ofDays(8).toMillis();
+      seedAutoSaveBlob(nonDefaultOrgId, path, "dummy".getBytes(), eightDaysAgo);
 
       ViewsheetService viewsheetService = mock(ViewsheetService.class);
       AutoSaveService service = new AutoSaveService(viewsheetService);
 
       // no ThreadContext principal set (mirrors the @Scheduled executor thread in production, where
       // ThreadContext.getContextPrincipal() is normally null)
-      service.removeExpiredAutoSaveFiles();
+      try(MockedStatic<SecurityEngine> securityEngine = mockOrganizationIDs(nonDefaultOrgId)) {
+         service.removeExpiredAutoSaveFiles();
+      }
+
+      BlobStorage<AutoSaveUtils.Metadata> nonDefaultBucket =
+         blobStorageManager.getStorage(nonDefaultOrgId.toLowerCase() + "__autoSave", false);
+
+      assertEquals(0, nonDefaultBucket.paths().count(),
+                  "removeExpiredAutoSaveFiles() must scan every organization's __autoSave bucket, "
+                  + "not just the default org's, and delete entries older than 7 days from each");
+   }
+
+   @Test
+   void removeExpiredAutoSaveFiles_freshNonDefaultOrgFile_survives() throws Exception {
+      String nonDefaultOrgId = "sixh_non_default_org_fresh";
+      String path = "8^VIEWSHEET^_NULL_^Untitled-1^0_0_0_0_0_0_0_1~";
+      seedAutoSaveBlob(nonDefaultOrgId, path, "dummy".getBytes(), 0L);
+
+      ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      AutoSaveService service = new AutoSaveService(viewsheetService);
+
+      try(MockedStatic<SecurityEngine> securityEngine = mockOrganizationIDs(nonDefaultOrgId)) {
+         service.removeExpiredAutoSaveFiles();
+      }
 
       BlobStorage<AutoSaveUtils.Metadata> nonDefaultBucket =
          blobStorageManager.getStorage(nonDefaultOrgId.toLowerCase() + "__autoSave", false);
 
       assertEquals(1, nonDefaultBucket.paths().count(),
-                  "removeExpiredAutoSaveFiles() currently never inspects any bucket other than the "
-                  + "default org's -- a non-default org's file survives untouched regardless of age, "
-                  + "which is the reported gap (not whether age-based deletion itself works)");
+                  "a non-default org's auto save file that is not yet 7 days old must not be deleted");
+   }
+
+   /**
+    * The test fixture's default SecurityProvider (VirtualAuthenticationProvider) only ever
+    * reports the default org, so removeExpiredAutoSaveFiles()'s org loop needs
+    * SecurityEngine.getSecurity().getSecurityProvider().getOrganizationIDs() stubbed to include
+    * the non-default org under test -- scoped to a try-with-resources so it can't leak into
+    * other tests sharing this class's cached Spring context.
+    */
+   private MockedStatic<SecurityEngine> mockOrganizationIDs(String... extraOrgIds) {
+      MockedStatic<SecurityEngine> securityEngineMock = mockStatic(SecurityEngine.class);
+      SecurityEngine engine = mock(SecurityEngine.class);
+      SecurityProvider provider = mock(SecurityProvider.class);
+      String[] orgIds = new String[extraOrgIds.length + 1];
+      orgIds[0] = Organization.getDefaultOrganizationID();
+      System.arraycopy(extraOrgIds, 0, orgIds, 1, extraOrgIds.length);
+      when(provider.getOrganizationIDs()).thenReturn(orgIds);
+      when(engine.getSecurityProvider()).thenReturn(provider);
+      securityEngineMock.when(SecurityEngine::getSecurity).thenReturn(engine);
+      return securityEngineMock;
    }
 
    // ── fixture helper ──
 
    private void seedAutoSaveBlob(String orgId, String path, byte[] content) throws Exception {
+      seedAutoSaveBlob(orgId, path, content, 0L);
+   }
+
+   private void seedAutoSaveBlob(String orgId, String path, byte[] content, long lastModified)
+      throws Exception
+   {
       BlobStorage<AutoSaveUtils.Metadata> storage =
          blobStorageManager.getStorage(orgId.toLowerCase() + "__autoSave", false);
 
       try(BlobTransaction<AutoSaveUtils.Metadata> tx = storage.beginTransaction();
-          OutputStream out = tx.newStream(path, new AutoSaveUtils.Metadata()))
+          OutputStream out = tx.newStream(path, new AutoSaveUtils.Metadata(), null, lastModified))
       {
          out.write(content);
          tx.commit();


### PR DESCRIPTION
## Summary

`AutoSaveService.removeExpiredAutoSaveFiles()` is a scheduled job (runs every 3 hours, plus once at startup) that deletes auto-saved viewsheet/worksheet drafts older than 7 days from the active and `recycle/` sub-namespace of the `__autoSave` blob bucket. In a multi-tenant deployment it only ever scanned the default organization's bucket -- expired drafts belonging to any non-default organization were never cleaned up, silently, with no exception or log entry.

## Root Cause

The job resolved its target org bucket by calling `AutoSaveUtils.getStorage(null)` / `AutoSaveUtils.getAutoSavedFiles(null, ...)` / `AutoSaveUtils.deleteAutoSaveFile(..., null, ...)` with a `null` `Principal`. Org resolution for a null principal (`OrganizationManager.getCurrentOrgID(null)`) falls back first to `OrganizationContextHolder`'s thread-local value, then to `Organization.getDefaultOrganizationID()`. Since the `@Scheduled` executor thread has no ambient principal and no `OrganizationContextHolder` value set, every run always resolved to the default org's bucket, regardless of how many other organizations existed.

## Fix

`removeExpiredAutoSaveFiles()` now enumerates all org IDs via `SecurityEngine.getSecurity().getSecurityProvider().getOrganizationIDs()` (the same pattern already used by the analogous cross-org cleanup job `CleanupTableCacheTask`), and for each org sets `OrganizationContextHolder.setCurrentOrgId(orgId)` before delegating to the existing (unchanged) `AutoSaveUtils` helpers, clearing the context in a `finally` block. This makes the existing null-principal org resolution chain resolve to the correct per-org bucket on each iteration.

## Test Plan

- Un-disabled the pre-existing pinned regression test for this exact gap (`AutoSaveServiceOrgLifecycleTest`, scenario "6h"), replacing its single trivial assertion (which passed regardless of the bug, since it seeded a fresh/non-expired blob) with two tests:
  - `removeExpiredAutoSaveFiles_expiredNonDefaultOrgFile_isDeleted` -- an 8-day-old file in a non-default org's bucket is deleted.
  - `removeExpiredAutoSaveFiles_freshNonDefaultOrgFile_survives` -- a fresh file in a non-default org's bucket is not deleted.
- `./mvnw test -pl core -Dtest=AutoSaveServiceOrgLifecycleTest` -- 5 run, 0 failures (1 pre-existing unrelated `@Disabled` scenario skipped).
- `./mvnw test -pl core -Dtest=AutoSaveUtilsTest,AutoSaveControllerTest` -- 8 run, 0 failures (no regressions in adjacent auto-save code).
- `./mvnw clean install -pl core -am -DskipTests` -- BUILD SUCCESS.
- Independent code-reviewer agent pass -- no blocking issues found.

Fixes Redmine #75887.