### PR TITLE
Bug #75894, fix blank gap above table header when title hidden in Excel export

### DIFF
--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/ExcelTableHelper.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/ExcelTableHelper.java
@@ -253,7 +253,13 @@ public class ExcelTableHelper extends VSTableHelper {
          (int) Math.round((double) info.getPixelSize().width / AssetUtil.defw));
 
       if(exporter.isMatchLayout()) {
-         rec.y = PoiExcelVSUtil.floorY(info.getPixelOffset().y) + titleH;
+         // Only round the anchor down to the grid line when the title is hidden
+         // (bug #75894) — the rounding slop is otherwise absorbed by the title
+         // bar, and rounding down here would shift a visible title's header row
+         // up into the title, same tradeoff documented for alignBottomTabsTables()
+         // in PoiExcelVSExporter.java.
+         rec.y = (info.isTitleVisible() ? PoiExcelVSUtil.ceilY(info.getPixelOffset().y) :
+            PoiExcelVSUtil.floorY(info.getPixelOffset().y)) + titleH;
       }
 
       return rec;

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/ExcelTableHelper.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/ExcelTableHelper.java
@@ -253,7 +253,7 @@ public class ExcelTableHelper extends VSTableHelper {
          (int) Math.round((double) info.getPixelSize().width / AssetUtil.defw));
 
       if(exporter.isMatchLayout()) {
-         rec.y = PoiExcelVSUtil.ceilY(info.getPixelOffset().y) + titleH;
+         rec.y = PoiExcelVSUtil.floorY(info.getPixelOffset().y) + titleH;
       }
 
       return rec;

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
@@ -491,10 +491,7 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
       int rowCount = Math.min(table.getRowCount(), getMaxRow(ypos));
 
       if(info instanceof TitledVSAssemblyInfo) {
-         titleRow = ((TitledVSAssemblyInfo) info).isTitleVisible() ? 0 :
-            (int)Math.round((double) ((TitledVSAssemblyInfo) info).getTitleHeight() /
-            AssetUtil.defh);
-         titleRow = Math.max(1, titleRow);
+         titleRow = ((TitledVSAssemblyInfo) info).isTitleVisible() ? 1 : 0;
       }
 
       int rows = titleRow;


### PR DESCRIPTION
## Summary
- When a table's title is hidden, exporting to Excel (match layout) still left a blank row above the header. `ExcelTableHelper.getTableRectangle()` rounded the table's Y position **up** to the next grid line (`ceilY`); with the title visible the rounding slop was hidden inside the title bar, but with the title hidden it was exposed as a bare gap. Switched to `floorY`, scoped to the hidden-title case only (`isTitleVisible() ? ceilY(...) : floorY(...)`) so a visible title's header row can't shift up into the title bar — same tradeoff already applied for bottom-tabs tables in bug #75778.
- Also fixed `PoiExcelVSExporter.getExpandTableHeight()`, which reserved a title row unconditionally regardless of `isTitleVisible()` due to an inverted ternary combined with a forced `Math.max(1, ...)` floor.

## Test plan
- [ ] Create a viewsheet with a Table, uncheck "Title Visible", export to Excel with match layout — confirm no blank row above the header.
- [ ] Re-check "Title Visible", export to Excel with match layout — confirm title still renders correctly with no regression, including when the table isn't grid-aligned (i.e. sits directly under another assembly with little gap) — header must not overlap/shift into the title bar.
- [ ] Export the same viewsheet (title hidden) to Excel **without** match layout checked — confirm no extra blank title row is reserved (covers `PoiExcelVSExporter.getExpandTableHeight()`).
- [ ] Export the same viewsheet to PDF/PNG/HTML — confirm no change in behavior (already correct).