### PR TITLE
Bug #75893, fix physical view table layout not preserved on reload

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/controller/database/PhysicalGraphModelService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/PhysicalGraphModelService.java
@@ -131,8 +131,8 @@ public class PhysicalGraphModelService {
 
       partition.setAliasTable(alias, sourceTable);
       runtimePartition.setPartition(partition);
-      partitionService.saveRuntimePartition(runtimePartition);
       modelService.fixTableBounds(runtimeId, partition, alias);
+      partitionService.saveRuntimePartition(runtimePartition);
    }
 
    public void editAlias(String alias, String oldAlias, String runtimeId) {

--- a/core/src/main/java/inetsoft/web/portal/controller/database/PhysicalModelService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/PhysicalModelService.java
@@ -883,7 +883,10 @@ public class PhysicalModelService {
                }
             }
 
-            rPartition.setBounds(
+            // set directly on the live partition (not rPartition, which is a
+            // separate cached copy fetched by ID) so the width/height actually
+            // persist instead of being silently discarded
+            partition.setBounds(
                tableName,
                new Rectangle(DEFAULT_GRAPH_LEFT_GAP, DEFAULT_GRAPH_TOP_GAP, width, height));
          }

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/database-physical-model.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/database-physical-model.component.ts
@@ -131,11 +131,13 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
    readonly INIT_TREE_PANE_SIZE = 35;
    treePaneSize: number = this.INIT_TREE_PANE_SIZE;
    private subscription: Subscription;
-   // Serializes table/add requests: the server does a read-modify-write on the
-   // cached runtime partition, so firing requests concurrently (e.g. quickly
-   // checking several tables in the schema tree) risks one add overwriting another.
-   private addTableQueue: Subject<EditTableEvent> = new Subject<EditTableEvent>();
-   private addTableQueueSubscription: Subscription;
+   // Serializes table/add and table/remove requests: the server does a read-modify-write
+   // on the cached runtime partition, so firing requests concurrently (e.g. quickly
+   // checking/unchecking several tables in the schema tree) risks one edit overwriting
+   // another.
+   private tableEditQueue: Subject<{action: "add" | "remove", event: EditTableEvent, node?: TreeNodeModel}>
+      = new Subject();
+   private tableEditQueueSubscription: Subscription;
    loadingTree: boolean = false;
    private graphViewModel: GraphViewModel;
    selectedGraphModels: GraphModel[] = [];
@@ -237,12 +239,38 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
    }
 
    ngOnInit(): void {
-      this.addTableQueueSubscription = this.addTableQueue
-         .pipe(concatMap(event =>
-            this.httpClient.post<PhysicalModelDefinition>(PHYSICAL_MODEL_TABLE_URI + "add", event)
-               // an error here must not terminate the queue subscription, or every
-               // subsequent table addition for the rest of the session would silently no-op
-               .pipe(catchError(() => EMPTY))))
+      this.tableEditQueueSubscription = this.tableEditQueue
+         .pipe(concatMap(({action, event, node}) =>
+            this.httpClient.post<PhysicalModelDefinition>(PHYSICAL_MODEL_TABLE_URI + action, event)
+               .pipe(
+                  tap(() => {
+                     if(action === "remove" && !!node) {
+                        const index = this.tableTree.selectedNodes.indexOf(node);
+
+                        if(index >= 0) {
+                           this.tableTree.selectedNodes.splice(index, 1);
+                        }
+                     }
+                  }),
+                  // an error here must not terminate the queue subscription, or every
+                  // subsequent table edit for the rest of the session would silently no-op.
+                  // revert the checkbox state and notify the user so the discrepancy
+                  // between the tree and the model doesn't go unnoticed.
+                  catchError(error => {
+                     if(action === "add" && !!event.node) {
+                        event.node.selected = false;
+                     }
+                     else if(action === "remove" && !!node?.data) {
+                        (<PhysicalModelTreeNodeModel> node.data).selected = true;
+                     }
+
+                     ComponentTool.showHttpError(
+                        action === "add" ? "Failed to add table" : "Failed to remove table",
+                        error, this.modalService);
+
+                     return EMPTY;
+                  })
+               )))
          .subscribe(() => this.dataPhysicalModelService.emitModelChange());
 
       // subscribe to route parameters and update current database model
@@ -985,8 +1013,8 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
          const newTable: PhysicalTableModel = this.createPhysicalTableModel(nodeData);
          let event: EditTableEvent = new EditTableEvent(this.physicalModel.id, newTable,
             null, nodeData);
-         // queued (not posted directly) so rapid successive additions don't race
-         this.addTableQueue.next(event);
+         // queued (not posted directly) so rapid successive add/remove requests don't race
+         this.tableEditQueue.next({action: "add", event});
 
          if(this.tableTree.selectedNodes?.length == 1 &&  this.tableTree.selectedNodes[0] == node) {
             this.editingTable = newTable;
@@ -1174,16 +1202,8 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
       if(!!removeTable) {
          let event: EditTableEvent = new EditTableEvent(this.physicalModel.id,
             removeTable);
-         this.httpClient.post<PhysicalModelDefinition>(PHYSICAL_MODEL_TABLE_URI + "remove", event)
-            .subscribe(() => {
-               let index = this.tableTree.selectedNodes.indexOf(node);
-
-               if(index >= 0) {
-                  this.tableTree.selectedNodes.splice(index, 1);
-               }
-
-               this.dataPhysicalModelService.emitModelChange();
-            });
+         // queued (not posted directly) so rapid successive add/remove requests don't race
+         this.tableEditQueue.next({action: "remove", event, node});
       }
 
       // if node is sql or inline view, remove from tree
@@ -1346,9 +1366,9 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
          this.subscription = null;
       }
 
-      if(!!this.addTableQueueSubscription) {
-         this.addTableQueueSubscription.unsubscribe();
-         this.addTableQueueSubscription = null;
+      if(!!this.tableEditQueueSubscription) {
+         this.tableEditQueueSubscription.unsubscribe();
+         this.tableEditQueueSubscription = null;
       }
 
       clearInterval(this.heartbeatIntervalId);

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/database-physical-model.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/database-physical-model.component.ts
@@ -19,7 +19,7 @@ import {
    Component, OnInit, OnDestroy, DoCheck, ViewChild, TemplateRef, HostListener
 } from "@angular/core";
 import { CanComponentDeactivate } from "../../../../../../../../shared/util/guard/can-component-deactivate";
-import { Observable, of, Subscription } from "rxjs";
+import { EMPTY, Observable, of, Subject, Subscription } from "rxjs";
 import { NotificationData } from "../../../../../widget/repository-tree/repository-tree.service";
 import { SplitPane } from "../../../../../widget/split-pane/split-pane.component";
 import { PhysicalTableAliasesDialog } from "../../../../dialog/physical-table-aliases-dialog/physical-table-aliases-dialog.component";
@@ -37,7 +37,7 @@ import { NameChangeModel } from "../../../model/name-change-model";
 import { NotificationsComponent } from "../../../../../widget/notifications/notifications.component";
 import { DatabaseTreeNodeModel } from "../../../model/datasources/database/physical-model/database-tree-node-model";
 import { PhysicalModelTreeNodeModel } from "../../../model/datasources/database/physical-model/physical-model-tree-node-model";
-import { tap } from "rxjs/operators";
+import { catchError, concatMap, tap } from "rxjs/operators";
 import { PhysicalTableType } from "../../../model/datasources/database/physical-model/physical-table-type.enum";
 import { FolderChangeModel } from "../../../model/folder-change-model";
 import { AddPhysicalModelEvent } from "../../../model/datasources/database/events/add-physical-model-event";
@@ -131,6 +131,11 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
    readonly INIT_TREE_PANE_SIZE = 35;
    treePaneSize: number = this.INIT_TREE_PANE_SIZE;
    private subscription: Subscription;
+   // Serializes table/add requests: the server does a read-modify-write on the
+   // cached runtime partition, so firing requests concurrently (e.g. quickly
+   // checking several tables in the schema tree) risks one add overwriting another.
+   private addTableQueue: Subject<EditTableEvent> = new Subject<EditTableEvent>();
+   private addTableQueueSubscription: Subscription;
    loadingTree: boolean = false;
    private graphViewModel: GraphViewModel;
    selectedGraphModels: GraphModel[] = [];
@@ -232,6 +237,14 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
    }
 
    ngOnInit(): void {
+      this.addTableQueueSubscription = this.addTableQueue
+         .pipe(concatMap(event =>
+            this.httpClient.post<PhysicalModelDefinition>(PHYSICAL_MODEL_TABLE_URI + "add", event)
+               // an error here must not terminate the queue subscription, or every
+               // subsequent table addition for the rest of the session would silently no-op
+               .pipe(catchError(() => EMPTY))))
+         .subscribe(() => this.dataPhysicalModelService.emitModelChange());
+
       // subscribe to route parameters and update current database model
       this.routeParamSubscription = this.route.paramMap
          .subscribe((params: ParamMap) => {
@@ -972,8 +985,8 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
          const newTable: PhysicalTableModel = this.createPhysicalTableModel(nodeData);
          let event: EditTableEvent = new EditTableEvent(this.physicalModel.id, newTable,
             null, nodeData);
-         this.httpClient.post<PhysicalModelDefinition>(PHYSICAL_MODEL_TABLE_URI + "add", event)
-            .subscribe(() => this.dataPhysicalModelService.emitModelChange());
+         // queued (not posted directly) so rapid successive additions don't race
+         this.addTableQueue.next(event);
 
          if(this.tableTree.selectedNodes?.length == 1 &&  this.tableTree.selectedNodes[0] == node) {
             this.editingTable = newTable;
@@ -1331,6 +1344,11 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
       if(!!this.subscription) {
          this.subscription.unsubscribe();
          this.subscription = null;
+      }
+
+      if(!!this.addTableQueueSubscription) {
+         this.addTableQueueSubscription.unsubscribe();
+         this.addTableQueueSubscription = null;
       }
 
       clearInterval(this.heartbeatIntervalId);


### PR DESCRIPTION
## Summary
- `fixTableBounds()` computed a newly added table's real x/y/width/height on a `RuntimeXPartition` fetched fresh from the Ignite runtime-partition cache, instead of on the caller's own instance. Cache `get()` returns a deserialized copy, so that mutation was silently discarded — only a separate statement that touched just the table's `y` coordinate actually landed on the persisted partition. Every newly added, never-dragged table therefore kept `x=-1/width=-1/height=-1` (the initial placeholder sentinel), so new tables collapsed to the same degenerate position once the model was reloaded. Manually dragging a table masked the bug because dragging sets bounds through a different, correct code path.
- Fix: set bounds directly on the live `partition` passed into `fixTableBounds`, not the stale cache copy.
- Also serialized the frontend's `table/add` HTTP requests through an RxJS queue (with error isolation via `catchError`) so quickly checking multiple tables in the schema tree can't race against the server's read-modify-write on the same cached runtime partition and silently drop an addition.

## Test plan
- [ ] Create a new physical view, expand a schema, select two tables (e.g. ORDERS and REGIONS) via the tree checkboxes without dragging either, save, and reopen — tables should retain distinct, non-overlapping positions.
- [ ] Repeat quickly checking several tables in rapid succession to confirm no table is silently dropped.
- [ ] Confirm manually dragging a table (existing working path) still persists correctly.
- [ ] `tsc --noEmit` passes on the frontend component; `core` module compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)