### PR TITLE
fix(ws): stop double-flipping a join operator that concatenateTable already re-oriented

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/internal/CompositeTableAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/asset/internal/CompositeTableAssemblyInfo.java
@@ -115,10 +115,50 @@ public class CompositeTableAssemblyInfo extends ComposedTableAssemblyInfo {
                   break;
                }
             }
+
+            // The operator was stored for (rtable, ltable) but the caller asked about
+            // (ltable, rtable). A <=> B is symmetric as a JOIN, but its OPERANDS are not
+            // interchangeable -- so hand back a reversed view rather than one whose
+            // left/right attributes belong to the opposite tables. Callers pair the
+            // attributes with the tables THEY named: JoinQuery walks base tables
+            // positionally (i < ri) and resolves getLeftAttribute() against tables[i], so a
+            // reverse-oriented operator made it qualify the key with the wrong table --
+            // emitting `column projects.project_id does not exist` when generating merged
+            // SQL, and silently dropping the condition into a cross join on the
+            // post-processing path. That made a perfectly well-formed worksheet fail (or
+            // quietly return wrong rows) purely because of the order its base tables were
+            // declared in.
+            if(operator != null) {
+               operator = reverse(operator);
+            }
          }
       }
 
       return operator;
+   }
+
+   /**
+    * Build a reversed view of an operator: left and right swapped on every child, so it reads
+    * correctly for the (ltable, rtable) order the caller asked about. Only ever applied to
+    * symmetric operations (the loop above rejects the asymmetric ones), for which swapping the
+    * operands preserves the meaning. Returns a copy -- the stored operator keeps its own
+    * orientation, and no caller mutates what getOperator hands back.
+    */
+   private static TableAssemblyOperator reverse(TableAssemblyOperator operator) {
+      TableAssemblyOperator reversed = new TableAssemblyOperator();
+
+      for(int i = 0; i < operator.getOperatorCount(); i++) {
+         TableAssemblyOperator.Operator op = operator.getOperator(i);
+         TableAssemblyOperator.Operator rop = (TableAssemblyOperator.Operator) op.clone();
+
+         rop.setLeftAttribute(op.getRightAttribute());
+         rop.setRightAttribute(op.getLeftAttribute());
+         rop.setLeftTable(op.getRightTable());
+         rop.setRightTable(op.getLeftTable());
+         reversed.addOperator(rop);
+      }
+
+      return reversed;
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/composer/ws/joins/InnerJoinService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/joins/InnerJoinService.java
@@ -737,9 +737,23 @@ public class InnerJoinService extends WorksheetControllerService {
          new HashMap<>();
 
       for(int i = 0; i < operators.size(); i++) {
-         addOperator(
-            leftTables[i], rightTables[i],
-            operators.get(i), joinTableAssembly, joins, joinedTables);
+         TableAssemblyOperator.Operator operator = operators.get(i);
+
+         // Read the table names off the operator ITSELF rather than the leftTables/rightTables
+         // arrays snapshotted before the concatenate loop above. concatenateTable() re-orients
+         // an operator in place to match the assembly it builds, so after it runs the snapshot
+         // can name the two tables in the opposite order to the operator's own attributes.
+         // addOperator() then compares those stale names against the subtable order, concludes
+         // it must flip, and flips an operator that was ALREADY correct -- storing it under the
+         // right key with its left/right attributes swapped. JoinQuery later resolves the left
+         // attribute against the positionally-left table, misses, and qualifies the key with
+         // the wrong table, emitting `column projects.project_id does not exist`; the
+         // post-processing path instead drops the condition and silently cross-joins. The
+         // arrays stay as the fallback for an operator that never carried table names.
+         String ltable = operator.getLeftTable() != null ? operator.getLeftTable() : leftTables[i];
+         String rtable = operator.getRightTable() != null ? operator.getRightTable() : rightTables[i];
+
+         addOperator(ltable, rtable, operator, joinTableAssembly, joins, joinedTables);
       }
 
       // Check for tables no longer joined. If any exist, join them using a

--- a/core/src/test/java/inetsoft/uql/asset/internal/CompositeTableAssemblyInfoTest.java
+++ b/core/src/test/java/inetsoft/uql/asset/internal/CompositeTableAssemblyInfoTest.java
@@ -1,0 +1,146 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.asset.internal;
+
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.asset.TableAssemblyOperator;
+import inetsoft.uql.erm.AttributeRef;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+class CompositeTableAssemblyInfoTest {
+   /**
+    * Regression test for a query-corruption bug. getOperator(l, r) falls back to the reversed
+    * key so a symmetric join can be looked up from either side -- but it used to return the
+    * stored operator AS-IS, with its left/right attributes still belonging to the opposite
+    * tables.
+    *
+    * Callers pair the attributes with the tables THEY named. JoinQuery walks the base tables
+    * positionally (i < ri) and resolves getLeftAttribute() against tables[i], so a
+    * reverse-oriented operator made it qualify the join key with the wrong table: merged SQL
+    * came out as `WHERE projects.project_id = work_packages.id` and the database rejected it
+    * with `column projects.project_id does not exist`, while the post-processing path found no
+    * such column, dropped the condition, and silently produced a cross join.
+    *
+    * The visible symptom was a worksheet that failed (or returned wrong rows) purely because of
+    * the ORDER its base tables happened to be declared in -- the joins themselves were correct.
+    */
+   @Test
+   void reversedLookupReturnsReorientedOperator() {
+      CompositeTableAssemblyInfo info = new CompositeTableAssemblyInfo();
+      info.setOperator("WORK_PACKAGES", "PROJECTS", innerJoin(
+         "WORK_PACKAGES", "project_id", "PROJECTS", "id"));
+
+      // Asked for in the stored orientation: unchanged, and the very same instance.
+      TableAssemblyOperator forward = info.getOperator("WORK_PACKAGES", "PROJECTS");
+      assertNotNull(forward);
+      assertEquals("project_id", attr(forward, true));
+      assertEquals("id", attr(forward, false));
+
+      // Asked for in the opposite orientation: the attributes must follow the tables the
+      // caller named, otherwise `project_id` gets qualified with PROJECTS.
+      TableAssemblyOperator reversed = info.getOperator("PROJECTS", "WORK_PACKAGES");
+      assertNotNull(reversed, "a symmetric join must still be findable from either side");
+      assertEquals("id", attr(reversed, true), "left attribute must belong to PROJECTS");
+      assertEquals("project_id", attr(reversed, false), "right attribute must belong to WORK_PACKAGES");
+      assertEquals("PROJECTS", reversed.getOperator(0).getLeftTable());
+      assertEquals("WORK_PACKAGES", reversed.getOperator(0).getRightTable());
+      assertEquals(TableAssemblyOperator.INNER_JOIN, reversed.getOperator(0).getOperation());
+   }
+
+   /** Reversing must not disturb what is stored -- the next lookup still sees the original. */
+   @Test
+   void reversedLookupLeavesTheStoredOperatorAlone() {
+      CompositeTableAssemblyInfo info = new CompositeTableAssemblyInfo();
+      info.setOperator("A", "B", innerJoin("A", "b_id", "B", "id"));
+
+      info.getOperator("B", "A");
+
+      TableAssemblyOperator stored = info.getOperator("A", "B");
+      assertEquals("b_id", attr(stored, true));
+      assertEquals("A", stored.getOperator(0).getLeftTable());
+   }
+
+   /** Every child of a multi-key join is reoriented, not just the first. */
+   @Test
+   void reversedLookupReorientsEveryOperator() {
+      CompositeTableAssemblyInfo info = new CompositeTableAssemblyInfo();
+      TableAssemblyOperator top = innerJoin("A", "k1", "B", "j1");
+      top.addOperator(operator("A", "k2", "B", "j2", TableAssemblyOperator.INNER_JOIN));
+      info.setOperator("A", "B", top);
+
+      TableAssemblyOperator reversed = info.getOperator("B", "A");
+      assertEquals(2, reversed.getOperatorCount());
+
+      for(int i = 0; i < reversed.getOperatorCount(); i++) {
+         assertEquals("B", reversed.getOperator(i).getLeftTable(), "child " + i);
+         assertEquals("A", reversed.getOperator(i).getRightTable(), "child " + i);
+      }
+
+      assertEquals("j1", attr(reversed, 0, true));
+      assertEquals("j2", attr(reversed, 1, true));
+   }
+
+   /**
+    * An asymmetric join genuinely differs when the tables are swapped, so it must stay
+    * unfindable from the reverse side -- reorienting must not turn that null into a result.
+    */
+   @Test
+   void asymmetricJoinIsStillNotReturnedForTheReversedPair() {
+      CompositeTableAssemblyInfo info = new CompositeTableAssemblyInfo();
+      info.setOperator("A", "B",
+                       wrap(operator("A", "b_id", "B", "id", TableAssemblyOperator.LEFT_JOIN)));
+
+      assertNotNull(info.getOperator("A", "B"));
+      assertNull(info.getOperator("B", "A"));
+   }
+
+   private static TableAssemblyOperator innerJoin(String lt, String lc, String rt, String rc) {
+      return wrap(operator(lt, lc, rt, rc, TableAssemblyOperator.INNER_JOIN));
+   }
+
+   private static TableAssemblyOperator wrap(TableAssemblyOperator.Operator op) {
+      TableAssemblyOperator top = new TableAssemblyOperator();
+      top.addOperator(op);
+      return top;
+   }
+
+   private static TableAssemblyOperator.Operator operator(String lt, String lc, String rt,
+                                                          String rc, int operation)
+   {
+      TableAssemblyOperator.Operator op = new TableAssemblyOperator.Operator();
+      op.setLeftTable(lt);
+      op.setRightTable(rt);
+      op.setLeftAttribute(new ColumnRef(new AttributeRef(lt, lc)));
+      op.setRightAttribute(new ColumnRef(new AttributeRef(rt, rc)));
+      op.setOperation(operation);
+      return op;
+   }
+
+   private static String attr(TableAssemblyOperator top, boolean left) {
+      return attr(top, 0, left);
+   }
+
+   private static String attr(TableAssemblyOperator top, int i, boolean left) {
+      TableAssemblyOperator.Operator op = top.getOperator(i);
+      return (left ? op.getLeftAttribute() : op.getRightAttribute()).getAttribute();
+   }
+}

--- a/core/src/test/java/inetsoft/web/composer/ws/joins/InnerJoinServiceOperatorOrientationTest.java
+++ b/core/src/test/java/inetsoft/web/composer/ws/joins/InnerJoinServiceOperatorOrientationTest.java
@@ -1,0 +1,180 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.composer.ws.joins;
+
+import inetsoft.test.*;
+import inetsoft.uql.ColumnSelection;
+import inetsoft.uql.asset.*;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.erm.DataRef;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * A join operator's left/right ATTRIBUTES must stay on the same side as the tables it is stored
+ * under. If they diverge, JoinQuery resolves the left attribute against the positionally-left
+ * table, misses, and qualifies the key with the wrong table -- emitting SQL like
+ * `column projects.project_id does not exist` when the query is merged, and silently dropping
+ * the condition into a cross join on the post-processing path.
+ *
+ * The divergence came from a DOUBLE FLIP: editExistingJoinTable snapshots the left/right table
+ * names off the incoming operators, then concatenateTable re-orients those operator objects IN
+ * PLACE (via exchange()) to match the assembly it builds. addOperator then compared the stale
+ * snapshot against the subtable order, concluded it had to flip, and flipped an operator that
+ * was already correct.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class, SwapperTestConfiguration.class },
+                      initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class InnerJoinServiceOperatorOrientationTest {
+   /**
+    * The regression. Base tables are declared [PROJECTS, WORK_PACKAGES, STATUSES] while both join
+    * paths drive from WORK_PACKAGES, so the PROJECTS<->WORK_PACKAGES operator is the one whose
+    * declared order runs opposite to the table array -- exactly the shape that failed live on
+    * openproject. Whichever way round each operator ends up being stored, its attributes must
+    * agree with its key.
+    */
+   @Test
+   void operatorAttributesStayOnTheSameSideAsTheirTables() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly projects = table(ws, "PROJECTS", "id", "name");
+      TableAssembly workPackages = table(ws, "WORK_PACKAGES", "id", "project_id", "status_id");
+      TableAssembly statuses = table(ws, "STATUSES", "id", "status_name");
+
+      // Declaration order puts PROJECTS first even though nothing joins FROM it.
+      RelationalJoinTableAssembly joinTable = new RelationalJoinTableAssembly(
+         ws, "JOINED", new TableAssembly[]{ projects, workPackages, statuses },
+         new TableAssemblyOperator[0]);
+      ws.addAssembly(joinTable);
+
+      TableAssemblyOperator noperator = new TableAssemblyOperator();
+      noperator.addOperator(innerJoin("WORK_PACKAGES", "status_id", "STATUSES", "id"));
+      noperator.addOperator(innerJoin("WORK_PACKAGES", "project_id", "PROJECTS", "id"));
+
+      new InnerJoinService(null, null).editExistingJoinTable(ws, joinTable, noperator, true);
+
+      assertOperatorsConsistent(ws);
+   }
+
+   /**
+    * The orientation that always worked must keep working -- guards against "fixing" the bug by
+    * flipping unconditionally, which would just move the breakage to the other declaration order.
+    */
+   @Test
+   void alreadyConsistentDeclarationOrderIsUnaffected() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly workPackages = table(ws, "WORK_PACKAGES", "id", "project_id", "status_id");
+      TableAssembly projects = table(ws, "PROJECTS", "id", "name");
+      TableAssembly statuses = table(ws, "STATUSES", "id", "status_name");
+
+      RelationalJoinTableAssembly joinTable = new RelationalJoinTableAssembly(
+         ws, "JOINED", new TableAssembly[]{ workPackages, projects, statuses },
+         new TableAssemblyOperator[0]);
+      ws.addAssembly(joinTable);
+
+      TableAssemblyOperator noperator = new TableAssemblyOperator();
+      noperator.addOperator(innerJoin("WORK_PACKAGES", "status_id", "STATUSES", "id"));
+      noperator.addOperator(innerJoin("WORK_PACKAGES", "project_id", "PROJECTS", "id"));
+
+      new InnerJoinService(null, null).editExistingJoinTable(ws, joinTable, noperator, true);
+
+      assertOperatorsConsistent(ws);
+   }
+
+   /**
+    * Walk every stored (ltable, rtable) pair and check the operator agrees with its own key: the
+    * left attribute must be a column of the left table and the right attribute a column of the
+    * right table. Reads the join assembly back out of the worksheet because concatenateTable can
+    * replace it.
+    */
+   private static void assertOperatorsConsistent(Worksheet ws) {
+      RelationalJoinTableAssembly joinTable = null;
+
+      for(Assembly assembly : ws.getAssemblies()) {
+         if(assembly instanceof RelationalJoinTableAssembly) {
+            joinTable = (RelationalJoinTableAssembly) assembly;
+         }
+      }
+
+      assertNotNull(joinTable, "no join table in the worksheet");
+      int checked = 0;
+
+      for(Enumeration<?> e = joinTable.getOperatorTables(); e.hasMoreElements(); ) {
+         String[] pair = (String[]) e.nextElement();
+         TableAssemblyOperator top = joinTable.getOperator(pair[0], pair[1]);
+         assertNotNull(top, "no operator for (" + pair[0] + "," + pair[1] + ")");
+
+         for(int i = 0; i < top.getOperatorCount(); i++) {
+            TableAssemblyOperator.Operator op = top.getOperator(i);
+            String where = "operator " + i + " stored under (" + pair[0] + "," + pair[1] + ")";
+
+            assertEquals(pair[0], op.getLeftTable(), where + ": leftTable");
+            assertEquals(pair[1], op.getRightTable(), where + ": rightTable");
+            // The attributes are what JoinQuery actually resolves; carrying the right table names
+            // with swapped columns is the exact shape of the bug.
+            assertEquals(pair[0], entityOf(op.getLeftAttribute()), where + ": left attribute owner");
+            assertEquals(pair[1], entityOf(op.getRightAttribute()), where + ": right attribute owner");
+            checked++;
+         }
+      }
+
+      assertEquals(2, checked, "expected both join conditions to be stored");
+   }
+
+   /** The table an attribute belongs to, as encoded by AttributeRef's entity. */
+   private static String entityOf(DataRef ref) {
+      return ref == null ? null : ref.getEntity();
+   }
+
+   private static TableAssembly table(Worksheet ws, String name, String... columns) {
+      EmbeddedTableAssembly assembly = new EmbeddedTableAssembly(ws, name);
+      ColumnSelection cols = new ColumnSelection();
+
+      for(String column : columns) {
+         cols.addAttribute(new ColumnRef(new AttributeRef(name, column)));
+      }
+
+      assembly.setColumnSelection(cols, false);
+      assembly.setColumnSelection(cols, true);
+      ws.addAssembly(assembly);
+      return assembly;
+   }
+
+   private static TableAssemblyOperator.Operator innerJoin(String lt, String lc,
+                                                           String rt, String rc)
+   {
+      TableAssemblyOperator.Operator op = new TableAssemblyOperator.Operator();
+      op.setLeftTable(lt);
+      op.setRightTable(rt);
+      op.setLeftAttribute(new ColumnRef(new AttributeRef(lt, lc)));
+      op.setRightAttribute(new ColumnRef(new AttributeRef(rt, rc)));
+      op.setOperation(TableAssemblyOperator.INNER_JOIN);
+      return op;
+   }
+}


### PR DESCRIPTION
## The bug

A relational join over 3+ tables could emit SQL that qualified a join key with the wrong table:

```
ERROR: column projects.project_id does not exist
```

`project_id` is the FK on `work_packages`, not a column of `projects`. The join was declared correctly — the operator's attributes had been swapped out from under it. Whether it fired depended on the order the base tables happened to be declared in, which is why it looked nondeterministic.

## Root cause (commit 1 — the actual fix)

`editExistingJoinTable` snapshots `leftTables[]`/`rightTables[]` from the incoming operators, then (when `containsNewTable`) runs `concatenateTable` per operator. **`concatenateTable` re-orients an operator in place** to match the assembly it builds, so afterwards the snapshot can name the two tables in the opposite order to the operator's own attributes. `addOperator` compares those stale names against the subtable order, concludes it must flip, and flips an operator that was **already correct** — storing it under the right key with left/right attributes swapped.

Downstream, `JoinQuery` walks base tables positionally and resolves `getLeftAttribute()` against `tables[i]`. With attributes reversed it looks `project_id` up in `projects`, misses, and — because `AssetUtil.findColumn` returns the ref **unchanged** rather than `null` on a miss, so the `if(lcolumn == null) continue` guard never fires — qualifies it as `projects.project_id`.

The post-processing join path shares the cause with a quieter symptom: it checks its index properly, logs `Join column not found in left-hand table`, drops the condition and **silently cross-joins**.

Fix: take the table names off the operator itself, which `concatenateTable` keeps in sync with the attributes; fall back to the snapshot only for an operator that never carried names.

## Commit 2 — hardening (not the fix)

`getOperator(l, r)` falls back to the `(r, l)` key so a symmetric join is findable from either side, but returned the operator as-is, with attributes still belonging to the opposite tables. It now returns a reversed copy. Only symmetric operations reach that path (the existing loop already refuses LEFT/RIGHT/GREATER/LESS/MINUS). Stated plainly: this did **not** fix the failure above — the operator was stored under the *forward* key already mis-oriented, so the reversed path never fired. It closes the same class of defect one layer down.

## Verification

- **Diagnosed by instrumentation**, not inference — a temporary trace in `addOperator` showed the operator arriving already oriented `PROJECTS`-left and leaving `fkjoin`-left after the spurious flip. Two earlier hypotheses (a missing mirror column; per-pair operator binding) were checked and discarded first.
- **End-to-end**: a 3-table openproject join declared `[PROJECTS, WORK_PACKAGES, STATUSES]` failed before this change and returns the correct 13 rows after, with the client-side workaround disabled so the fix is what's being tested.
- 4 new unit tests on `CompositeTableAssemblyInfo` (2 fail against unpatched code with `expected: <id> but was: <project_id>`; 2 are guards that pass both ways).
- `inetsoft.uql.asset.**` + `inetsoft.report.composition.**` + `inetsoft.web.composer.ws.**`: 234 tests, 0 failures.

The `InnerJoinService` change is covered by the end-to-end run rather than a unit test — exercising it needs a live `Worksheet` through `concatenateTable`, and a mock-heavy test there would assert the scaffolding rather than the behaviour. Happy to add one if you'd prefer it.

## Related

`stylebi-wiz` PR #1421 normalizes `baseTables` order client-side so callers stop hitting this. That workaround stays useful for older engines, but this is the real fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)