### PR TITLE
feat(wiz): expose the chart color aesthetic and reject colors that cannot apply

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
@@ -29,6 +29,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.security.Principal;
 import java.util.LinkedHashMap;
@@ -165,6 +166,16 @@ public class WizViewsheetController {
       }
       catch(IllegalArgumentException e) {
          return ResponseEntity.badRequest().body(Map.of("error", nullToEmpty(e.getMessage())));
+      }
+      // Honour the status the thrower chose. ResponseStatusException is a plain RuntimeException, so
+      // without this it fell through to the generic handler below and every deliberate 4xx was returned
+      // as a content-free 500 — the caller was told "unexpected error, please try again" about a request
+      // that could never succeed as sent, and an automated one replays it instead of correcting it.
+      // Pre-dates the colour validation that now leans on this: the malformed-hex and unknown-palette
+      // rejections in WizAutoBindingService have always thrown this type.
+      catch(ResponseStatusException e) {
+         return ResponseEntity.status(e.getStatusCode().value())
+            .body(Map.of("error", nullToEmpty(e.getReason())));
       }
       catch(Exception e) {
          LOG.error("Failed to {}", action, e);

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
@@ -93,6 +93,19 @@ public class WizViewsheetController {
       return run("set chart colors", () -> wizAutoBindingService.setChartColors(request, user));
    }
 
+   /**
+    * Read-only companion to /viewsheet/colors: which colour parameters the chart can accept. Callers must
+    * read this first — the accepted parameters are fixed by the chart's colour binding, and the only
+    * valid categoryColors / measureColors keys come from here.
+    */
+   @PostMapping(value = "/chart/aestheticModel", produces = MediaType.APPLICATION_JSON_VALUE)
+   public ResponseEntity<?> getChartAestheticModel(@RequestBody ChartAestheticModelRequest request,
+                                                  Principal user)
+   {
+      return run("read chart aesthetic model",
+         () -> wizAutoBindingService.getChartAestheticModel(request, user));
+   }
+
    @PostMapping(value = "/viewsheet/geo/detect", produces = MediaType.APPLICATION_JSON_VALUE)
    public ResponseEntity<?> geoDetect(@Valid @RequestBody GeoDetectRequest request, Principal user) {
       return run("geo detect", () -> wizGeoService.detect(request, user));

--- a/core/src/main/java/inetsoft/web/wiz/model/ChartAestheticModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/ChartAestheticModel.java
@@ -1,0 +1,129 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Response for {@code POST /api/wiz/chart/aestheticModel} — what the chart's COLOR aesthetic can
+ * currently accept. Read-only.
+ *
+ * A caller of {@code /viewsheet/colors} cannot choose between staticColor / measureColors /
+ * paletteName / colorList / categoryColors without this: which of them applies is fixed by whether a
+ * field sits on the color aesthetic and whether that field is a dimension or a measure, and a parameter
+ * that does not fit the binding is rejected.
+ */
+public class ChartAestheticModel {
+   /**
+    * The live runtime id. Reading the model restores a reaped runtime when it has to, which changes the
+    * id, so this is echoed unconditionally and the caller must adopt it before applying anything —
+    * otherwise the apply targets the dead instance. Same contract as {@link WizBrowseDataResponse}.
+    */
+   public String getRuntimeId() { return runtimeId; }
+   public void setRuntimeId(String runtimeId) { this.runtimeId = runtimeId; }
+
+   /** null when nothing is on the color aesthetic (the staticColor / measureColors case). */
+   public ColorField getColorField() { return colorField; }
+   public void setColorField(ColorField colorField) { this.colorField = colorField; }
+
+   /** null unless {@link #getColorField()} is a dimension. */
+   public ColorValues getColorValues() { return colorValues; }
+   public void setColorValues(ColorValues colorValues) { this.colorValues = colorValues; }
+
+   /** The measures that can carry a color aesthetic; the only valid {@code measureColors} keys. */
+   public List<AestheticAggregate> getAestheticAggregates() { return aestheticAggregates; }
+   public void setAestheticAggregates(List<AestheticAggregate> aestheticAggregates) {
+      this.aestheticAggregates = aestheticAggregates;
+   }
+
+   /** The field on the color aesthetic, as {@code VSChartInfo.getColorField()} resolves it. */
+   public static class ColorField {
+      public ColorField() {
+      }
+
+      public ColorField(String fullName, String role) {
+         this.fullName = fullName;
+         this.role = role;
+      }
+
+      public String getFullName() { return fullName; }
+      public void setFullName(String fullName) { this.fullName = fullName; }
+
+      /** "dimension" (categorical) or "measure" (continuous scale — gradient only). */
+      public String getRole() { return role; }
+      public void setRole(String role) { this.role = role; }
+
+      private String fullName;
+      private String role;
+   }
+
+   /**
+    * The color dimension's values, as the strings {@code categoryColors} must be keyed by.
+    *
+    * These are produced with {@code GTool.toString}, which is the SAME function
+    * {@code CategoricalColorFrame.setColor}/{@code getColor} key the color map with. A key copied from
+    * this list therefore matches by construction, and no type or format conversion happens on the way
+    * back in — which is what keeps a date-grouped color dimension ("Month(order_date)") working without
+    * either side having to agree on a display pattern.
+    */
+   public static class ColorValues {
+      public ColorValues() {
+      }
+
+      public ColorValues(List<String> values, boolean truncated) {
+         this.values = values;
+         this.truncated = truncated;
+      }
+
+      public List<String> getValues() { return values; }
+      public void setValues(List<String> values) { this.values = values; }
+
+      /** true when the value set was cut off by the cap, so the list is not exhaustive. */
+      public boolean isTruncated() { return truncated; }
+      public void setTruncated(boolean truncated) { this.truncated = truncated; }
+
+      private List<String> values = new ArrayList<>();
+      private boolean truncated;
+   }
+
+   /** A measure that can carry a color / marker aesthetic. */
+   public static class AestheticAggregate {
+      public AestheticAggregate() {
+      }
+
+      public AestheticAggregate(String fullName) {
+         this.fullName = fullName;
+      }
+
+      /**
+       * The aggregate's full name ("Sum(sales)") — {@code VSAggregateRef.getFullName()}, the same
+       * convention the wiz API already uses for {@code binding.measures[]}, {@code slots}, and
+       * {@code rankingCol}, so one spelling serves every side.
+       */
+      public String getFullName() { return fullName; }
+      public void setFullName(String fullName) { this.fullName = fullName; }
+
+      private String fullName;
+   }
+
+   private String runtimeId;
+   private ColorField colorField;
+   private ColorValues colorValues;
+   private List<AestheticAggregate> aestheticAggregates = new ArrayList<>();
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/ChartAestheticModelRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/ChartAestheticModelRequest.java
@@ -1,0 +1,40 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+/**
+ * Request body for {@code POST /api/wiz/chart/aestheticModel}. A pure read — no {@code copy} flag,
+ * since nothing is mutated and there is no original to protect.
+ */
+public class ChartAestheticModelRequest {
+   public String getWizRuntimeId() { return wizRuntimeId; }
+   public void setWizRuntimeId(String wizRuntimeId) { this.wizRuntimeId = wizRuntimeId; }
+
+   public String getAssemblyName() { return assemblyName; }
+   public void setAssemblyName(String assemblyName) { this.assemblyName = assemblyName; }
+
+   /** Durable asset id, used to restore a reaped runtime; optional. */
+   public String getViewsheetIdentifier() { return viewsheetIdentifier; }
+   public void setViewsheetIdentifier(String viewsheetIdentifier) {
+      this.viewsheetIdentifier = viewsheetIdentifier;
+   }
+
+   private String wizRuntimeId;
+   private String assemblyName;
+   private String viewsheetIdentifier;
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/ChartColorsRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/ChartColorsRequest.java
@@ -58,6 +58,16 @@ public class ChartColorsRequest {
    public Map<String, String> getCategoryColors() { return categoryColors; }
    public void setCategoryColors(Map<String, String> categoryColors) { this.categoryColors = categoryColors; }
 
+   /**
+    * Per-series colors when NO field is on the color aesthetic: measure full name -> hex. Keys must be
+    * {@code aestheticAggregates[].fullName} from {@code /chart/aestheticModel}.
+    *
+    * {@link #getStaticColor()} colors EVERY bound measure, so it cannot express "make profit red and
+    * leave revenue alone" on a chart with several measures — that is what this is for.
+    */
+   public Map<String, String> getMeasureColors() { return measureColors; }
+   public void setMeasureColors(Map<String, String> measureColors) { this.measureColors = measureColors; }
+
    private String wizRuntimeId;
    private String assemblyName;
    private String viewsheetIdentifier;
@@ -66,4 +76,5 @@ public class ChartColorsRequest {
    private String paletteName;
    private List<String> colorList;
    private Map<String, String> categoryColors;
+   private Map<String, String> measureColors;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -3119,7 +3119,7 @@ public class WizAutoBindingService {
          CategoricalColorFrame frame = asCategoricalFrame(colorField);
 
          for(Map.Entry<String, String> e : request.getCategoryColors().entrySet()) {
-            frame.setColor(e.getKey(), parseColor(e.getValue()));
+            frame.setColor(Tool.getData(colorField.getDataType(), e.getKey()), parseColor(e.getValue()));
          }
 
          colorField.setVisualFrame(frame);

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -2643,7 +2643,15 @@ public class WizAutoBindingService {
          throw new IllegalArgumentException("Chart assembly not found: " + request.getAssemblyName());
       }
 
-      String note = null;
+      // Validate against the ORIGINAL chart, before the copy below. A duplicate carries the same colour
+      // binding, so checking it here is equivalent — and rejecting BEFORE any assembly is added means a
+      // bad request needs no rollback at all.
+      VSChartInfo originalChartInfo = chart.getChartInfo().getVSChartInfo();
+      validateColorRequest(
+         originalChartInfo,
+         originalChartInfo == null ? null : originalChartInfo.getColorField(),
+         request);
+
       String copyNote = null;
       String targetAssemblyName = request.getAssemblyName();
       VSAssembly demotedOriginal = null;
@@ -2684,26 +2692,24 @@ public class WizAutoBindingService {
       try {
          if(colorField == null || colorField.getDataRef() == null) {
             if(request.getStaticColor() != null) {
-               if(vsChartInfo == null) {
-                  note = "Chart has no binding info; static color could not be applied.";
-               }
-               else {
-                  applyStaticColor(vsChartInfo, parseColor(request.getStaticColor()));
-               }
+               applyStaticColor(vsChartInfo, parseColor(request.getStaticColor()));
             }
 
-            if(request.getPaletteName() != null || request.getColorList() != null ||
-               request.getCategoryColors() != null)
-            {
-               note = "This chart has no color dimension, so a palette/per-category colors can't apply. " +
-                  "Recreate with a dimension on the color aesthetic (fieldConfigs/explicitBindings), or use staticColor.";
+            if(request.getMeasureColors() != null && !request.getMeasureColors().isEmpty()) {
+               Map<String, Color> colors = new LinkedHashMap<>();
+
+               for(Map.Entry<String, String> e : request.getMeasureColors().entrySet()) {
+                  colors.put(e.getKey(), parseColor(e.getValue()));
+               }
+
+               applyMeasureColors(vsChartInfo, colors);
             }
          }
          else if(colorField.getDataRef() instanceof VSChartAggregateRef) {
-            note = applyGradient(colorField, request);
+            applyGradient(colorField, request);
          }
          else {
-            note = applyCategoricalColors(colorField, request);
+            applyCategoricalColors(colorField, request);
          }
 
          info.setRTChartDescriptor(null);
@@ -2759,13 +2765,110 @@ public class WizAutoBindingService {
          result.setViewsheetIdentifier(request.getViewsheetIdentifier());
       }
 
-      String combinedNote = combineNotes(copyNote, note);
-
-      if(combinedNote != null) {
-         result.setNote(combinedNote);
+      // Only the copy-decline notice can reach `note` now: a colour that does not fit the binding is
+      // rejected up front with a 400 instead of being reported here. That is what makes `note` on this
+      // endpoint mean exactly one thing, so a caller can act on it without parsing prose.
+      if(copyNote != null) {
+         result.setNote(copyNote);
       }
 
       return result;
+   }
+
+   /**
+    * Reads what this chart's COLOR aesthetic can accept. Pure read: no mutation, no persist, no copy.
+    *
+    * Everything here is StyleBI's own determination, deliberately: which field colors the chart
+    * (getColorField() — the group slot plays no part), whether it is categorical or continuous
+    * (VSChartAggregateRef), and which measures can carry an aesthetic (getAestheticAggregateRefs, whose
+    * derivation differs per chart type). A caller that re-derived any of these from a binding echo would
+    * have to track those per-type rules itself and would drift the first time one changed.
+    */
+   public ChartAestheticModel getChartAestheticModel(ChartAestheticModelRequest request, Principal user)
+      throws Exception
+   {
+      if(!securityEngine.checkPermission(user, ResourceType.VIEWSHEET, "*", ResourceAction.ACCESS)) {
+         throw new SecurityException(Catalog.getCatalog().getString(
+            "composer.authorization.permissionDenied"));
+      }
+
+      RuntimeViewsheet rvs = WizUtil.getViewsheetOrRestore(
+         viewsheetService, request.getWizRuntimeId(), request.getViewsheetIdentifier(), user);
+
+      if(rvs == null || rvs.getViewsheet() == null) {
+         throw new IllegalArgumentException("Chart runtime not found: " + request.getWizRuntimeId());
+      }
+
+      VSAssembly assembly = rvs.getViewsheet().getAssembly(request.getAssemblyName());
+
+      if(!(assembly instanceof ChartVSAssembly chart)) {
+         throw new IllegalArgumentException("Chart assembly not found: " + request.getAssemblyName());
+      }
+
+      VSChartInfo vsChartInfo = chart.getChartInfo().getVSChartInfo();
+      AestheticRef colorField = vsChartInfo == null ? null : vsChartInfo.getColorField();
+
+      ChartAestheticModel model = new ChartAestheticModel();
+      // Unconditional: the restore above may have revived the runtime under a new id, and an apply sent
+      // to the old one lands on a dead instance.
+      model.setRuntimeId(rvs.getID());
+      model.setAestheticAggregates(collectAestheticAggregates(vsChartInfo));
+
+      if(colorField != null && colorField.getDataRef() != null) {
+         DataRef ref = colorField.getDataRef();
+         boolean measure = ref instanceof VSChartAggregateRef;
+         String fullName = WizVsService.slotName(ref);
+         model.setColorField(new ChartAestheticModel.ColorField(
+            fullName, measure ? "measure" : "dimension"));
+
+         // Values only for a dimension: a measure on color is a continuous scale, where per-value colors
+         // have no meaning and the list would be a large, useless read.
+         if(!measure) {
+            model.setColorValues(
+               wizVsService.collectColorValues(rvs, request.getAssemblyName(), fullName));
+         }
+      }
+
+      return model;
+   }
+
+   /**
+    * The measures that can carry a color / marker aesthetic, runtime refs preferred.
+    *
+    * Runtime first because that is what the renderer reads and the two can diverge (a chart-type change
+    * or a date comparison rewrites the runtime aggregates); design refs are the pre-execution fallback.
+    * Names are getFullName(), the same spelling measureColors keys and the binding echo use.
+    */
+   private List<ChartAestheticModel.AestheticAggregate> collectAestheticAggregates(VSChartInfo vsChartInfo) {
+      List<ChartAestheticModel.AestheticAggregate> aggregates = new ArrayList<>();
+
+      if(vsChartInfo == null) {
+         return aggregates;
+      }
+
+      List<ChartAggregateRef> refs = vsChartInfo.getAestheticAggregateRefs(true);
+
+      if(refs == null || refs.isEmpty()) {
+         refs = vsChartInfo.getAestheticAggregateRefs(false);
+      }
+
+      if(refs == null) {
+         return aggregates;
+      }
+
+      Set<String> seen = new HashSet<>();
+
+      for(ChartAggregateRef ref : refs) {
+         if(ref instanceof VSAggregateRef agg) {
+            String fullName = agg.getFullName();
+
+            if(fullName != null && !fullName.isEmpty() && seen.add(fullName)) {
+               aggregates.add(new ChartAestheticModel.AestheticAggregate(fullName));
+            }
+         }
+      }
+
+      return aggregates;
    }
 
    /**
@@ -2775,40 +2878,176 @@ public class WizAutoBindingService {
     * painting only the design refs would leave the next render on the old color).
     */
    private void applyStaticColor(VSChartInfo vsChartInfo, Color color) {
-      if(vsChartInfo == null) {
-         return;
+      for(VSChartAggregateRef agg : collectAggregateRefs(vsChartInfo)) {
+         agg.setColorFrame(new StaticColorFrame(color));
       }
+   }
 
-      List<ChartRef> refs = new ArrayList<>();
+   /**
+    * Applies a color to individual measures, keyed by full name — the per-series counterpart of
+    * applyStaticColor, which cannot express "only this measure" because it paints all of them.
+    *
+    * Keys were validated against the aesthetic aggregates before anything was mutated, so an unmatched
+    * name cannot reach here; matching against every bound aggregate ref (rather than the aesthetic list)
+    * is what makes the design and runtime clones both get painted.
+    */
+   private void applyMeasureColors(VSChartInfo vsChartInfo, Map<String, Color> colors) {
+      for(VSChartAggregateRef agg : collectAggregateRefs(vsChartInfo)) {
+         Color color = colors.get(agg.getFullName());
 
-      if(vsChartInfo.getYFields() != null) {
-         refs.addAll(Arrays.asList(vsChartInfo.getYFields()));
-      }
-
-      if(vsChartInfo.getXFields() != null) {
-         refs.addAll(Arrays.asList(vsChartInfo.getXFields()));
-      }
-
-      if(vsChartInfo.getRTYFields() != null) {
-         refs.addAll(Arrays.asList(vsChartInfo.getRTYFields()));
-      }
-
-      if(vsChartInfo.getRTXFields() != null) {
-         refs.addAll(Arrays.asList(vsChartInfo.getRTXFields()));
-      }
-
-      for(ChartRef ref : refs) {
-         if(ref instanceof VSChartAggregateRef agg) {
+         if(color != null) {
             agg.setColorFrame(new StaticColorFrame(color));
          }
       }
    }
 
    /**
-    * Applies categorical colors to a dimension that is bound to the color aesthetic. Returns a note
-    * if none of the categorical fields were provided.
+    * Every bound measure ref, DESIGN and RUNTIME both.
+    *
+    * Design refs so the change survives runtime regeneration and a save; runtime refs because the
+    * renderer reads getRTYFields()/getRTXFields(), which are clones made at execution time — painting
+    * only the design refs leaves the next render on the old color.
     */
-   private String applyCategoricalColors(AestheticRef colorField, ChartColorsRequest request) {
+   private List<VSChartAggregateRef> collectAggregateRefs(VSChartInfo vsChartInfo) {
+      List<VSChartAggregateRef> aggregates = new ArrayList<>();
+
+      if(vsChartInfo == null) {
+         return aggregates;
+      }
+
+      List<ChartRef> refs = new ArrayList<>();
+
+      for(ChartRef[] slot : new ChartRef[][]{
+         vsChartInfo.getYFields(), vsChartInfo.getXFields(),
+         vsChartInfo.getRTYFields(), vsChartInfo.getRTXFields()
+      }) {
+         if(slot != null) {
+            refs.addAll(Arrays.asList(slot));
+         }
+      }
+
+      for(ChartRef ref : refs) {
+         if(ref instanceof VSChartAggregateRef agg) {
+            aggregates.add(agg);
+         }
+      }
+
+      return aggregates;
+   }
+
+   /**
+    * Rejects a color request that does not fit this chart's color binding, BEFORE anything is mutated.
+    *
+    * Validate-then-apply, and all-or-nothing. The alternative this replaces — applying whatever fit and
+    * returning a prose `note` about the rest — was unusable by an automated caller in two ways. The note
+    * shares one field with the copy-then-apply decline notice, so "your colors did not fit" and "the
+    * duplicate could not be made" arrived indistinguishable; and a partial apply makes "did this land?"
+    * unanswerable, so a retry re-applies the half that already succeeded.
+    *
+    * A 400 with the reason is what the caller can act on: it names the offending parameter, states what
+    * the binding actually is, and names the parameter that WOULD work, which is enough for a retry to
+    * correct itself. It also needs no rollback, since it is thrown before the copy is made.
+    */
+   private void validateColorRequest(VSChartInfo vsChartInfo, AestheticRef colorField,
+                                     ChartColorsRequest request)
+   {
+      boolean hasStatic = request.getStaticColor() != null;
+      boolean hasPalette = request.getPaletteName() != null;
+      boolean hasList = request.getColorList() != null && !request.getColorList().isEmpty();
+      boolean hasCategories = request.getCategoryColors() != null && !request.getCategoryColors().isEmpty();
+      boolean hasMeasures = request.getMeasureColors() != null && !request.getMeasureColors().isEmpty();
+
+      if(!hasStatic && !hasPalette && !hasList && !hasCategories && !hasMeasures) {
+         throw badColorRequest("No color provided. Pass one of staticColor, measureColors, paletteName, " +
+            "colorList, or categoryColors.");
+      }
+
+      // paletteName and colorList both replace the SAME CategoricalColorFrame, so accepting both would
+      // silently discard one of them (colorList's setDefaultColors overwrites the palette just installed).
+      if(hasPalette && hasList) {
+         throw badColorRequest("paletteName and colorList are mutually exclusive (both replace the " +
+            "categorical color frame). Pass exactly one; categoryColors may be combined with either.");
+      }
+
+      boolean hasColorField = colorField != null && colorField.getDataRef() != null;
+      boolean measureOnColor = hasColorField && colorField.getDataRef() instanceof VSChartAggregateRef;
+
+      if(!hasColorField) {
+         if(hasPalette || hasList || hasCategories) {
+            throw badColorRequest("This chart has no color dimension, so a palette / color list / " +
+               "per-category colors cannot apply. Use staticColor for one color across the measures, " +
+               "measureColors to color individual measures, or recreate the chart with a dimension on " +
+               "the color aesthetic.");
+         }
+
+         if(hasMeasures) {
+            validateMeasureKeys(vsChartInfo, request.getMeasureColors().keySet());
+         }
+
+         return;
+      }
+
+      if(measureOnColor) {
+         if(hasList || hasCategories) {
+            throw badColorRequest("This chart has a measure on color (a continuous scale), so colorList " +
+               "/ categoryColors do not apply. Use paletteName with a gradient name (" +
+               VALID_GRADIENTS + ").");
+         }
+
+         if(hasStatic || hasMeasures) {
+            throw badColorRequest("This chart uses a measure-driven color scale, so staticColor / " +
+               "measureColors do not apply. Use paletteName with a gradient name (" +
+               VALID_GRADIENTS + ").");
+         }
+
+         if(gradientFrameForName(request.getPaletteName()) == null) {
+            throw badColorRequest("Unknown gradient '" + request.getPaletteName() +
+               "'. Valid gradients: " + VALID_GRADIENTS + ".");
+         }
+
+         return;
+      }
+
+      if(hasStatic || hasMeasures) {
+         throw badColorRequest("This chart has a dimension on color, so staticColor / measureColors do " +
+            "not apply. Use paletteName, colorList, or categoryColors to color the categories.");
+      }
+
+      if(hasPalette && ColorPalettes.getPalette(request.getPaletteName()) == null) {
+         throw badColorRequest("Unknown palette '" + request.getPaletteName() + "'. Valid palettes: " +
+            String.join(", ", ColorPalettes.getPaletteNames()));
+      }
+   }
+
+   /**
+    * Rejects measureColors keys that name no colorable measure.
+    *
+    * Naming a measure the chart does not have is otherwise silent: applyMeasureColors matches by full
+    * name, finds nothing, and the chart renders unchanged while the call reports success. Listing the
+    * real names in the message is what lets a retry fix the spelling instead of guessing again.
+    */
+   private void validateMeasureKeys(VSChartInfo vsChartInfo, Set<String> keys) {
+      List<String> valid = collectAestheticAggregates(vsChartInfo).stream()
+         .map(ChartAestheticModel.AestheticAggregate::getFullName)
+         .collect(Collectors.toList());
+      List<String> unknown = keys.stream().filter(k -> !valid.contains(k)).collect(Collectors.toList());
+
+      if(!unknown.isEmpty()) {
+         throw badColorRequest("measureColors names no colorable measure: " +
+            String.join(", ", unknown) + ". Valid measures: " +
+            (valid.isEmpty() ? "(none)" : String.join(", ", valid)) + ".");
+      }
+   }
+
+   private static ResponseStatusException badColorRequest(String message) {
+      return new ResponseStatusException(HttpStatus.BAD_REQUEST, message);
+   }
+
+   /**
+    * Applies categorical colors to a dimension that is bound to the color aesthetic. Every fit check ran
+    * in validateColorRequest before any mutation, so this only has to apply.
+    */
+   private void applyCategoricalColors(AestheticRef colorField, ChartColorsRequest request) {
       if(request.getPaletteName() != null) {
          CategoricalColorFrame palette = ColorPalettes.getPalette(request.getPaletteName());
 
@@ -2840,19 +3079,6 @@ public class WizAutoBindingService {
 
          colorField.setVisualFrame(frame);
       }
-
-      if(request.getStaticColor() != null) {
-         return "staticColor was ignored: this chart has a color dimension. Use paletteName, " +
-            "colorList, or categoryColors to color the categories.";
-      }
-
-      if(request.getPaletteName() == null && request.getColorList() == null &&
-         request.getCategoryColors() == null)
-      {
-         return "No categorical color provided. Pass paletteName, colorList, or categoryColors.";
-      }
-
-      return null;
    }
 
    /** Returns the color field's current CategoricalColorFrame, or a fresh one if it isn't categorical. */
@@ -2863,31 +3089,11 @@ public class WizAutoBindingService {
 
    /**
     * Applies a named gradient when a measure is on the color aesthetic. Only paletteName is meaningful
-    * for a continuous color scale; colorList/categoryColors return a note.
+    * for a continuous color scale; validateColorRequest already rejected everything else, and rejected
+    * an unknown gradient name, so this only has to apply.
     */
-   private String applyGradient(AestheticRef colorField, ChartColorsRequest request) {
-      if(request.getColorList() != null || request.getCategoryColors() != null) {
-         return "This chart has a measure on color (a continuous scale), so colorList/categoryColors " +
-            "don't apply. Use paletteName with a gradient name (e.g. " + VALID_GRADIENTS + ").";
-      }
-
-      if(request.getStaticColor() != null) {
-         return "staticColor was ignored: this chart uses a measure-driven color scale. Use paletteName " +
-            "with a gradient name.";
-      }
-
-      if(request.getPaletteName() == null) {
-         return "No gradient provided. Pass paletteName with a gradient name (" + VALID_GRADIENTS + ").";
-      }
-
-      ColorFrame gradient = gradientFrameForName(request.getPaletteName());
-
-      if(gradient == null) {
-         return "Unknown gradient '" + request.getPaletteName() + "'. Valid gradients: " + VALID_GRADIENTS + ".";
-      }
-
-      colorField.setVisualFrame(gradient);
-      return null;
+   private void applyGradient(AestheticRef colorField, ChartColorsRequest request) {
+      colorField.setVisualFrame(gradientFrameForName(request.getPaletteName()));
    }
 
    /** The named gradients accepted by {@link #gradientFrameForName} (kept in sync with that switch). */

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -2651,6 +2651,7 @@ public class WizAutoBindingService {
          originalChartInfo,
          originalChartInfo == null ? null : originalChartInfo.getColorField(),
          request);
+      validateColorFormats(request);
 
       String copyNote = null;
       String targetAssemblyName = request.getAssemblyName();
@@ -2902,11 +2903,19 @@ public class WizAutoBindingService {
    }
 
    /**
-    * Every bound measure ref, DESIGN and RUNTIME both.
+    * Every measure ref a colour can be painted on, DESIGN and RUNTIME both.
     *
     * Design refs so the change survives runtime regeneration and a save; runtime refs because the
     * renderer reads getRTYFields()/getRTXFields(), which are clones made at execution time — painting
     * only the design refs leaves the next render on the old color.
+    *
+    * The X/Y arrays alone are NOT enough, and the union with getAestheticAggregateRefs is what keeps this
+    * set a superset of the one validateMeasureKeys validates against. Those two are not the same list:
+    * GanttVSChartInfo adds its start/end/milestone fields to getAestheticAggregateRefs, and none of them
+    * live in X or Y. Validating against one list and painting from the other let a measureColors key pass
+    * every check and then paint nothing — silently, which is the exact failure this endpoint exists to
+    * remove. Deriving the paint set from both sources makes them agree for every chart type rather than
+    * for the ones someone remembered to special-case.
     */
    private List<VSChartAggregateRef> collectAggregateRefs(VSChartInfo vsChartInfo) {
       List<VSChartAggregateRef> aggregates = new ArrayList<>();
@@ -2915,7 +2924,7 @@ public class WizAutoBindingService {
          return aggregates;
       }
 
-      List<ChartRef> refs = new ArrayList<>();
+      List<DataRef> refs = new ArrayList<>();
 
       for(ChartRef[] slot : new ChartRef[][]{
          vsChartInfo.getYFields(), vsChartInfo.getXFields(),
@@ -2926,8 +2935,20 @@ public class WizAutoBindingService {
          }
       }
 
-      for(ChartRef ref : refs) {
-         if(ref instanceof VSChartAggregateRef agg) {
+      for(boolean runtime : new boolean[]{ false, true }) {
+         List<ChartAggregateRef> aesthetic = vsChartInfo.getAestheticAggregateRefs(runtime);
+
+         if(aesthetic != null) {
+            refs.addAll(aesthetic);
+         }
+      }
+
+      // Identity, not equals: the same measure appears as distinct design and runtime clones that must
+      // BOTH be painted, and equals/hashCode on a ref would collapse them into one.
+      Set<DataRef> seen = Collections.newSetFromMap(new IdentityHashMap<>());
+
+      for(DataRef ref : refs) {
+         if(ref instanceof VSChartAggregateRef agg && seen.add(ref)) {
             aggregates.add(agg);
          }
       }
@@ -3016,6 +3037,30 @@ public class WizAutoBindingService {
       if(hasPalette && ColorPalettes.getPalette(request.getPaletteName()) == null) {
          throw badColorRequest("Unknown palette '" + request.getPaletteName() + "'. Valid palettes: " +
             String.join(", ", ColorPalettes.getPaletteNames()));
+      }
+   }
+
+   /**
+    * Parses every hex in the request so a malformed one is rejected before anything is mutated.
+    *
+    * parseColor already throws on a bad value, but it used to do so from INSIDE the apply, part-way
+    * through a map — the earlier entries were already painted, and an in-place apply (no copy to roll
+    * back) kept them. That is the partial apply this endpoint's all-or-nothing contract rules out, so the
+    * parse happens here instead and the apply's own parseColor calls re-parse known-good strings.
+    */
+   private void validateColorFormats(ChartColorsRequest request) {
+      if(request.getStaticColor() != null) {
+         parseColor(request.getStaticColor());
+      }
+
+      if(request.getColorList() != null) {
+         request.getColorList().forEach(WizAutoBindingService::parseColor);
+      }
+
+      for(Map<String, String> colors : Arrays.asList(request.getCategoryColors(), request.getMeasureColors())) {
+         if(colors != null) {
+            colors.values().forEach(WizAutoBindingService::parseColor);
+         }
       }
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -2706,12 +2706,23 @@ public class WizVsService {
                continue;
             }
 
+            String value = GTool.toString(val);
+
+            // Membership BEFORE the cap check: a chart with exactly MAX distinct values over thousands of
+            // rows is complete, and flagging it truncated because rows remain would tell the caller its
+            // list might be missing something when it is not. `truncated` is only true once a value that
+            // genuinely is not in the list has been found and could not be added, because the caller uses
+            // it to decide whether an unlisted key is unverifiable or provably fake.
+            if(values.contains(value)) {
+               continue;
+            }
+
             if(values.size() >= MAX_COLOR_VALUES) {
                truncated = true;
                break;
             }
 
-            values.add(GTool.toString(val));
+            values.add(value);
          }
 
          return new ChartAestheticModel.ColorValues(new ArrayList<>(values), truncated);

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -22,6 +22,7 @@ import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.analytic.composition.event.VSEventUtil;
 import inetsoft.graph.aesthetic.LinearSizeFrame;
 import inetsoft.graph.data.*;
+import inetsoft.graph.internal.GTool;
 import inetsoft.report.composition.graph.GraphTypeUtil;
 import inetsoft.report.composition.graph.GraphUtil;
 import inetsoft.report.composition.VSTableLens;
@@ -2601,7 +2602,9 @@ public class WizVsService {
       return names;
    }
 
-   private static String slotName(DataRef ref) {
+   // Package-private, not private: WizAutoBindingService's aesthetic-model read must name the color
+   // field with the SAME convention the slots echo uses, and a second copy of this would drift from it.
+   static String slotName(DataRef ref) {
       if(ref instanceof VSAggregateRef agg) {
          return agg.getFullName();
       }
@@ -2623,6 +2626,103 @@ public class WizVsService {
 
    private static String aestheticSlotName(AestheticRef aref) {
       return aref == null || aref.getDataRef() == null ? null : slotName(aref.getDataRef());
+   }
+
+   /** Cap on the color values reported by the aesthetic model; see collectColorValues. */
+   private static final int MAX_COLOR_VALUES = 200;
+
+   /**
+    * The distinct values of {@code columnHeader} in the chart's OWN rendered dataset, as the strings a
+    * {@code categoryColors} key must equal. Returns null when there is no dataset yet or the header is
+    * not in it.
+    *
+    * The chart's dataset — not a worksheet browse — for two reasons. It already holds the values the
+    * chart actually renders (date-grouped, filtered, ranked), so a key taken from here names a real
+    * category rather than a raw column value the chart never shows. And stringifying with
+    * {@code GTool.toString} matches {@code CategoricalColorFrame}'s own key function exactly, so the
+    * value round-trips with no format agreement between the two sides.
+    *
+    * Insertion-ordered (LinkedHashSet) purely so the list is stable across calls; assignment order is
+    * StyleBI's business and no caller may read meaning into the sequence.
+    */
+   ChartAestheticModel.ColorValues collectColorValues(RuntimeViewsheet rvs, String assemblyName,
+                                                     String columnHeader)
+   {
+      if(columnHeader == null) {
+         return null;
+      }
+
+      Optional<ViewsheetSandbox> boxOpt = rvs.getViewsheetSandbox();
+
+      if(boxOpt.isEmpty()) {
+         return null;
+      }
+
+      try {
+         VGraphPair pair = boxOpt.get().getVGraphPair(assemblyName, true);
+         DataSet dset = pair == null ? null : pair.getData();
+
+         if(dset == null) {
+            return null;
+         }
+
+         // Same unwrapping as fetchAssemblyData: the outer wrappers do not carry the aggregated columns.
+         while(true) {
+            if(dset instanceof VSDataSet) {
+               break;
+            }
+            else if(dset instanceof PairsDataSet) {
+               dset = ((PairsDataSet) dset).getDataSet();
+            }
+            else if(dset instanceof DataSetFilter) {
+               dset = ((DataSetFilter) dset).getDataSet();
+            }
+            else {
+               break;
+            }
+         }
+
+         int col = -1;
+
+         for(int c = 0; c < dset.getColCount(); c++) {
+            if(columnHeader.equals(dset.getHeader(c))) {
+               col = c;
+               break;
+            }
+         }
+
+         if(col < 0) {
+            return null;
+         }
+
+         Set<String> values = new LinkedHashSet<>();
+         int rowCount = dset.getRowCount();
+         boolean truncated = false;
+
+         for(int r = 0; r < rowCount; r++) {
+            Object val = dset.getData(col, r);
+
+            if(val == null) {
+               continue;
+            }
+
+            if(values.size() >= MAX_COLOR_VALUES) {
+               truncated = true;
+               break;
+            }
+
+            values.add(GTool.toString(val));
+         }
+
+         return new ChartAestheticModel.ColorValues(new ArrayList<>(values), truncated);
+      }
+      catch(Exception ex) {
+         // A read that cannot be made is not an error the caller can act on: the aesthetic model still
+         // reports the color FIELD, and its consumer withholds the value-keyed parameters when the list
+         // is absent. Failing the whole read here would take the mode information down with it.
+         LOG.warn("Could not collect color values for {} on {}", columnHeader, assemblyName, ex);
+         return null;
+      }
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceAestheticModelTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceAestheticModelTest.java
@@ -1,0 +1,211 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.graph.AestheticRef;
+import inetsoft.uql.viewsheet.graph.VSChartAggregateRef;
+import inetsoft.uql.viewsheet.graph.VSChartDimensionRef;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
+import inetsoft.uql.viewsheet.internal.ChartVSAssemblyInfo;
+import inetsoft.web.wiz.model.ChartAestheticModel;
+import inetsoft.web.wiz.model.ChartAestheticModelRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * /chart/aestheticModel is what makes a colour request a decision rather than a guess: the caller cannot
+ * tell staticColor from measureColors from a palette without knowing which field colours the chart. These
+ * tests pin the three answers it has to distinguish, since a wrong one silently sends the caller down the
+ * branch whose parameters cannot apply.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WizAutoBindingServiceAestheticModelTest {
+   private WizAutoBindingService service;
+   private WizVsService wizVsService;
+   private RuntimeViewsheet rvs;
+   private VSChartInfo vsChartInfo;
+
+   @BeforeEach
+   void setUp() throws Exception {
+      ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      wizVsService = mock(WizVsService.class);
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
+      service = new WizAutoBindingService(
+         viewsheetService, null, null, null, null, wizVsService, securityEngine);
+
+      vsChartInfo = mock(VSChartInfo.class);
+      ChartVSAssemblyInfo info = mock(ChartVSAssemblyInfo.class);
+      when(info.getVSChartInfo()).thenReturn(vsChartInfo);
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      when(chart.getChartInfo()).thenReturn(info);
+
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssembly("vs_1")).thenReturn(chart);
+      rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(rvs.getID()).thenReturn("rt-1");
+      when(viewsheetService.getViewsheet(anyString(), any())).thenReturn(rvs);
+   }
+
+   private static ChartAestheticModelRequest request() {
+      ChartAestheticModelRequest request = new ChartAestheticModelRequest();
+      request.setWizRuntimeId("rt-1");
+      request.setAssemblyName("vs_1");
+      return request;
+   }
+
+   private void bindColorField(Object dataRef) {
+      AestheticRef colorField = mock(AestheticRef.class);
+      when(colorField.getDataRef()).thenReturn((inetsoft.uql.erm.DataRef) dataRef);
+      when(vsChartInfo.getColorField()).thenReturn(colorField);
+   }
+
+   @Test
+   void reportsAnEmptyColorAestheticAsNullSoTheCallerReachesForStaticOrMeasureColors() throws Exception {
+      when(vsChartInfo.getColorField()).thenReturn(null);
+
+      ChartAestheticModel model = service.getChartAestheticModel(request(), null);
+
+      assertNull(model.getColorField());
+      assertNull(model.getColorValues(), "no color field means there is nothing to enumerate");
+      // No point paying for a dataset read when no dimension can consume the values.
+      verify(wizVsService, never()).collectColorValues(any(), anyString(), anyString());
+   }
+
+   @Test
+   void reportsAMeasureOnColorAsAContinuousScaleAndSkipsTheValueRead() throws Exception {
+      VSChartAggregateRef measure = mock(VSChartAggregateRef.class);
+      when(measure.getFullName()).thenReturn("Sum(sales)");
+      bindColorField(measure);
+
+      ChartAestheticModel model = service.getChartAestheticModel(request(), null);
+
+      assertNotNull(model.getColorField());
+      assertEquals("measure", model.getColorField().getRole());
+      assertEquals("Sum(sales)", model.getColorField().getFullName());
+      // Per-value colours are meaningless on a gradient, so the values are not read at all.
+      assertNull(model.getColorValues());
+      verify(wizVsService, never()).collectColorValues(any(), anyString(), anyString());
+   }
+
+   @Test
+   void reportsADimensionOnColorWithItsValues() throws Exception {
+      VSChartDimensionRef dimension = mock(VSChartDimensionRef.class);
+      when(dimension.getFullName()).thenReturn("STATE");
+      bindColorField(dimension);
+      when(wizVsService.collectColorValues(rvs, "vs_1", "STATE"))
+         .thenReturn(new ChartAestheticModel.ColorValues(List.of("CA", "NY"), false));
+
+      ChartAestheticModel model = service.getChartAestheticModel(request(), null);
+
+      assertEquals("dimension", model.getColorField().getRole());
+      assertEquals(List.of("CA", "NY"), model.getColorValues().getValues());
+      assertEquals(false, model.getColorValues().isTruncated());
+   }
+
+   @Test
+   void echoesTheLiveRuntimeIdSoARestoredRuntimeIsNotLost() throws Exception {
+      when(rvs.getID()).thenReturn("rt-restored");
+
+      assertEquals("rt-restored", service.getChartAestheticModel(request(), null).getRuntimeId());
+   }
+
+   @Test
+   void prefersRuntimeAestheticAggregatesAndFallsBackToTheDesignRefs() throws Exception {
+      VSChartAggregateRef design = mock(VSChartAggregateRef.class);
+      when(design.getFullName()).thenReturn("Sum(design)");
+      VSChartAggregateRef runtime = mock(VSChartAggregateRef.class);
+      when(runtime.getFullName()).thenReturn("Sum(runtime)");
+      when(vsChartInfo.getAestheticAggregateRefs(true)).thenReturn(new ArrayList<>(List.of(runtime)));
+      when(vsChartInfo.getAestheticAggregateRefs(false)).thenReturn(new ArrayList<>(List.of(design)));
+
+      // Runtime is what the renderer reads, and the two diverge after a chart-type change.
+      assertEquals("Sum(runtime)",
+         service.getChartAestheticModel(request(), null).getAestheticAggregates().get(0).getFullName());
+
+      when(vsChartInfo.getAestheticAggregateRefs(true)).thenReturn(new ArrayList<>());
+
+      assertEquals("Sum(design)",
+         service.getChartAestheticModel(request(), null).getAestheticAggregates().get(0).getFullName());
+   }
+
+   @Test
+   void deduplicatesAggregatesByFullNameAndDropsUnnamedOnes() throws Exception {
+      VSChartAggregateRef first = mock(VSChartAggregateRef.class);
+      when(first.getFullName()).thenReturn("Sum(sales)");
+      VSChartAggregateRef duplicate = mock(VSChartAggregateRef.class);
+      when(duplicate.getFullName()).thenReturn("Sum(sales)");
+      VSChartAggregateRef unnamed = mock(VSChartAggregateRef.class);
+      when(unnamed.getFullName()).thenReturn("");
+      when(vsChartInfo.getAestheticAggregateRefs(anyBoolean()))
+         .thenReturn(new ArrayList<>(List.of(first, duplicate, unnamed)));
+
+      List<ChartAestheticModel.AestheticAggregate> aggregates =
+         service.getChartAestheticModel(request(), null).getAestheticAggregates();
+
+      // The caller keys measureColors by these strings, so a duplicate reads as two different targets and
+      // an empty one as a nameless target it can never match.
+      assertEquals(1, aggregates.size());
+      assertEquals("Sum(sales)", aggregates.get(0).getFullName());
+   }
+
+   @Test
+   void returnsAnEmptyAggregateListRatherThanNullWhenTheChartHasNoBindingInfo() throws Exception {
+      when(vsChartInfo.getAestheticAggregateRefs(anyBoolean())).thenReturn(null);
+
+      ChartAestheticModel model = service.getChartAestheticModel(request(), null);
+
+      // The caller treats an empty list as authoritative ("nothing here can carry a colour"), so it must
+      // never have to distinguish null from empty on this field.
+      assertNotNull(model.getAestheticAggregates());
+      assertTrue(model.getAestheticAggregates().isEmpty());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartColorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartColorsTest.java
@@ -35,8 +35,11 @@ import inetsoft.test.BaseTestConfiguration;
 import inetsoft.test.ConfigurationContextInitializer;
 import inetsoft.test.SreeHome;
 import inetsoft.uql.viewsheet.internal.ChartVSAssemblyInfo;
+import inetsoft.web.wiz.model.ChartAestheticModel;
+import inetsoft.web.wiz.model.ChartAestheticModelRequest;
 import inetsoft.web.wiz.model.ChartColorsRequest;
 import inetsoft.web.wiz.model.CreateViewsheetResult;
+import org.springframework.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -49,12 +52,20 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.awt.Color;
 import java.security.Principal;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -242,51 +253,60 @@ class WizAutoBindingServiceSetChartColorsTest {
    }
 
    @Test
-   void copyFailureNoteSurvivesAlongsideAnUnrelatedBindingNote() throws Exception {
-      // Regression: the copy-fallback note used to be stored in the SAME `note` local later
-      // reassigned unconditionally by the color-binding logic, silently discarding the
-      // copy-failure warning whenever the color application itself also produced (or cleared) a
-      // note. Both must now survive, concatenated.
+   void copyFailureNoteIsTheOnlyThingNoteEverCarries() throws Exception {
+      // Supersedes copyFailureNoteSurvivesAlongsideAnUnrelatedBindingNote. That test pinned the two
+      // notes being concatenated, because the copy-fallback warning used to share the `note` local with
+      // the color-binding logic and got silently discarded when both fired. It cannot be written any
+      // more: a color that does not fit the binding is now rejected with a 400 before anything is
+      // applied, so `note` has exactly one possible source. The clobber it guarded against is gone by
+      // construction rather than by assertion, and what matters now is that the copy warning still
+      // reaches the caller on a request that DOES fit.
       when(wizVsService.duplicatePrimaryAssembly(rvs, chart)).thenReturn(null);
 
+      ChartColorsRequest request = staticRed();
+      request.setCopy(true);
+
+      CreateViewsheetResult result = service.setChartColors(request, null);
+
+      assertEquals("Copy requested but could not be created; colors applied in place.", result.getNote());
+   }
+
+   @Test
+   void aColorThatCannotApplyIsRejectedInsteadOfReportedInTheNote() throws Exception {
+      // The other half of the change above: a palette on a chart with no color dimension used to apply
+      // nothing and describe that in `note`, which a caller could not tell apart from the copy warning.
       ChartColorsRequest request = new ChartColorsRequest();
       request.setWizRuntimeId("rt-1");
       request.setAssemblyName("vs_1");
       request.setPaletteName("Blues");
-      request.setCopy(true);
-      // colorField stays null (static/no-color-binding chart from setUp), so requesting a
-      // palette produces the "no color dimension" note in addition to the copy failure.
 
-      CreateViewsheetResult result = service.setChartColors(request, null);
+      ResponseStatusException thrown =
+         assertThrows(ResponseStatusException.class, () -> service.setChartColors(request, null));
 
-      assertEquals(
-         "Copy requested but could not be created; colors applied in place. " +
-         "This chart has no color dimension, so a palette/per-category colors can't apply. " +
-         "Recreate with a dimension on the color aesthetic (fieldConfigs/explicitBindings), or use staticColor.",
-         result.getNote());
+      assertEquals(HttpStatus.BAD_REQUEST, thrown.getStatusCode());
+      assertTrue(thrown.getReason().contains("no color dimension"),
+         "the reason must name the actual binding so a caller can correct its request: " + thrown.getReason());
+      // Nothing was touched: not the refs, not the graph cache, not the persisted asset.
+      verify(yAgg, never()).setColorFrame(any());
+      verify(box, never()).clearGraph(anyString());
+      verify(wizVsService, never()).persistViewsheet(any(), any(), any());
    }
 
    @Test
-   void copySucceedsThenApplyThrowsRollsBackTheDuplicateAndRestoresTheOriginalAsPrimary() throws Exception {
-      // A categorical color field bound to an unknown palette makes ColorPalettes.getPalette(...)
-      // throw AFTER duplicatePrimaryAssembly has already mutated the live runtime (added the copy,
-      // demoted the original, promoted the copy) but BEFORE persistViewsheet ever runs. That
-      // live-runtime mutation must be undone, not left dangling.
+   void anUnknownPaletteIsRejectedBeforeTheCopyIsEverMade() throws Exception {
+      // Replaces copySucceedsThenApplyThrowsRollsBackTheDuplicateAndRestoresTheOriginalAsPrimary, which
+      // used an unknown palette to make the apply throw AFTER duplicatePrimaryAssembly had mutated the
+      // live runtime, then asserted the rollback. Validation now runs against the ORIGINAL chart before
+      // the copy, so this request never reaches the duplication at all — a stronger guarantee than
+      // rolling it back, and the reason a bad request no longer needs a rollback path.
+      //
+      // The rollback itself is still covered, by copySucceedsButFetchAssemblyDataThrowsRollsBackTheDuplicate:
+      // fetchAssemblyData is the step that can genuinely fail after the copy, since nothing about the
+      // payload can any more.
       AestheticRef colorField = mock(AestheticRef.class);
       DataRef dimensionRef = mock(DataRef.class);
       when(colorField.getDataRef()).thenReturn(dimensionRef);
-
-      VSChartAggregateRef copyYAgg = mock(VSChartAggregateRef.class);
-      VSChartInfo copyChartInfo = mock(VSChartInfo.class);
-      when(copyChartInfo.getColorField()).thenReturn(colorField);
-      when(copyChartInfo.getYFields()).thenReturn(new ChartRef[] { copyYAgg });
-      ChartVSAssemblyInfo copyInfo = mock(ChartVSAssemblyInfo.class);
-      when(copyInfo.getVSChartInfo()).thenReturn(copyChartInfo);
-      ChartVSAssembly copyChart = mock(ChartVSAssembly.class);
-      when(copyChart.getChartInfo()).thenReturn(copyInfo);
-      when(copyChart.getName()).thenReturn("vs_1_copy1");
-
-      when(wizVsService.duplicatePrimaryAssembly(rvs, chart)).thenReturn(copyChart);
+      when(chart.getChartInfo().getVSChartInfo().getColorField()).thenReturn(colorField);
 
       ChartColorsRequest request = new ChartColorsRequest();
       request.setWizRuntimeId("rt-1");
@@ -294,15 +314,124 @@ class WizAutoBindingServiceSetChartColorsTest {
       request.setPaletteName("NotARealPalette");
       request.setCopy(true);
 
-      assertThrows(ResponseStatusException.class, () -> service.setChartColors(request, null));
+      ResponseStatusException thrown =
+         assertThrows(ResponseStatusException.class, () -> service.setChartColors(request, null));
 
-      // Rollback: the duplicated assembly is removed from the live viewsheet and the original is
-      // re-promoted to primary.
-      verify(vs).removeAssembly("vs_1_copy1");
-      verify(chart).setPrimary(true);
-      // Nothing was persisted or fetched — the exception must propagate before either.
+      assertEquals(HttpStatus.BAD_REQUEST, thrown.getStatusCode());
+      assertTrue(thrown.getReason().contains("Unknown palette"), thrown.getReason());
+      // No copy was made, so there is nothing to roll back and nothing to undo.
+      verify(wizVsService, never()).duplicatePrimaryAssembly(any(), any());
+      verify(vs, never()).removeAssembly(anyString());
       verify(wizVsService, never()).persistViewsheet(any(), any(), any());
       verify(wizVsService, never()).fetchAssemblyData(anyString(), anyString(), any());
+   }
+
+   @Test
+   void aMalformedHexIsRejectedBeforeAnyColorIsPainted() throws Exception {
+      // parseColor used to throw from inside the apply, part-way through the map — the entries before the
+      // bad one were already painted, and an in-place apply has no copy to roll back, so they stayed.
+      // Formats are now parsed up front, which is what makes "apply nothing on rejection" true rather
+      // than true-for-most-inputs.
+      AestheticRef colorField = mock(AestheticRef.class);
+      when(colorField.getDataRef()).thenReturn(mock(DataRef.class));
+      when(chart.getChartInfo().getVSChartInfo().getColorField()).thenReturn(colorField);
+
+      // Insertion-ordered so the VALID entry is processed first: that is the one the old flow painted
+      // and kept before throwing on the second.
+      Map<String, String> categories = new LinkedHashMap<>();
+      categories.put("CA", "#ff0000");
+      categories.put("NY", "not-a-hex");
+
+      ChartColorsRequest request = new ChartColorsRequest();
+      request.setWizRuntimeId("rt-1");
+      request.setAssemblyName("vs_1");
+      request.setCategoryColors(categories);
+
+      assertThrows(ResponseStatusException.class, () -> service.setChartColors(request, null));
+
+      verify(colorField, never()).setVisualFrame(any());
+      verify(box, never()).clearGraph(anyString());
+   }
+
+   @Test
+   void measureColorsPaintsAnAestheticAggregateThatIsNotInXOrY() throws Exception {
+      // The Gantt shape: GanttVSChartInfo adds its start/end/milestone fields to
+      // getAestheticAggregateRefs, and none of them appear in the X or Y arrays. Validation reads the
+      // former and the apply used to scan only the latter, so a key could pass every check and then paint
+      // nothing — silently, which is the failure this endpoint exists to remove. The paint set is now the
+      // union of both, so anything validateMeasureKeys accepts is something the apply can reach.
+      VSChartAggregateRef aestheticOnly = mock(VSChartAggregateRef.class);
+      when(aestheticOnly.getFullName()).thenReturn("Max(end_date)");
+      VSChartInfo vsChartInfo = chart.getChartInfo().getVSChartInfo();
+      when(vsChartInfo.getAestheticAggregateRefs(anyBoolean()))
+         .thenReturn(new ArrayList<>(List.of(aestheticOnly)));
+
+      ChartColorsRequest request = new ChartColorsRequest();
+      request.setWizRuntimeId("rt-1");
+      request.setAssemblyName("vs_1");
+      request.setMeasureColors(Map.of("Max(end_date)", "#d62728"));
+
+      service.setChartColors(request, null);
+
+      ArgumentCaptor<ColorFrame> captor = ArgumentCaptor.forClass(ColorFrame.class);
+      verify(aestheticOnly).setColorFrame(captor.capture());
+      assertEquals(new Color(0xd6, 0x27, 0x28),
+         assertInstanceOf(StaticColorFrame.class, captor.getValue()).getColor());
+   }
+
+   @Test
+   void measureColorsNamingNoColorableMeasureIsRejectedWithTheValidNamesListed() throws Exception {
+      VSChartAggregateRef colorable = mock(VSChartAggregateRef.class);
+      when(colorable.getFullName()).thenReturn("Sum(sales)");
+      when(chart.getChartInfo().getVSChartInfo().getAestheticAggregateRefs(anyBoolean()))
+         .thenReturn(new ArrayList<>(List.of(colorable)));
+
+      ChartColorsRequest request = new ChartColorsRequest();
+      request.setWizRuntimeId("rt-1");
+      request.setAssemblyName("vs_1");
+      request.setMeasureColors(Map.of("Sum(revenue)", "#d62728"));
+
+      ResponseStatusException thrown =
+         assertThrows(ResponseStatusException.class, () -> service.setChartColors(request, null));
+
+      assertEquals(HttpStatus.BAD_REQUEST, thrown.getStatusCode());
+      // Both halves matter: an automated caller needs to know which key was wrong AND what it could
+      // have said instead, or the retry is another guess.
+      assertTrue(thrown.getReason().contains("Sum(revenue)"), thrown.getReason());
+      assertTrue(thrown.getReason().contains("Sum(sales)"), thrown.getReason());
+      verify(colorable, never()).setColorFrame(any());
+   }
+
+   @Test
+   void paletteAndColorListTogetherAreRejectedRatherThanSilentlyDiscardingOne() throws Exception {
+      AestheticRef colorField = mock(AestheticRef.class);
+      when(colorField.getDataRef()).thenReturn(mock(DataRef.class));
+      when(chart.getChartInfo().getVSChartInfo().getColorField()).thenReturn(colorField);
+
+      ChartColorsRequest request = new ChartColorsRequest();
+      request.setWizRuntimeId("rt-1");
+      request.setAssemblyName("vs_1");
+      request.setPaletteName("Blues");
+      request.setColorList(List.of("#ff0000"));
+
+      ResponseStatusException thrown =
+         assertThrows(ResponseStatusException.class, () -> service.setChartColors(request, null));
+
+      assertEquals(HttpStatus.BAD_REQUEST, thrown.getStatusCode());
+      assertTrue(thrown.getReason().contains("mutually exclusive"), thrown.getReason());
+      verify(colorField, never()).setVisualFrame(any());
+   }
+
+   @Test
+   void anEmptyColorRequestIsRejected() {
+      ChartColorsRequest request = new ChartColorsRequest();
+      request.setWizRuntimeId("rt-1");
+      request.setAssemblyName("vs_1");
+
+      ResponseStatusException thrown =
+         assertThrows(ResponseStatusException.class, () -> service.setChartColors(request, null));
+
+      assertEquals(HttpStatus.BAD_REQUEST, thrown.getStatusCode());
    }
 
    /** A successful copy whose color application also succeeds cleanly (static color, no color field). */


### PR DESCRIPTION
## Why

A caller of `/viewsheet/colors` cannot choose between `staticColor`, `paletteName`, `colorList` and `categoryColors` without knowing the chart's color binding — and had no way to read it. It also had no source for `categoryColors` keys, so an invented value was applied literally, matched no mark, and rendered **with no effect and no error**.

Worse, a parameter that did not fit the binding was reported in `note`, which is the same field the copy-then-apply decline notice uses (`combineNotes` merged the two). A caller could not tell "your colors did not fit" from "the duplicate could not be made", so a mismatch read as success.

## What

**New `POST /api/wiz/chart/aestheticModel`** — a pure read reporting what the color aesthetic can accept:

- the effective color field via `getColorField()` (the `group` slot plays no part in coloring) and whether it is a dimension or a measure;
- that dimension's values;
- the measures that can carry an aesthetic, via `getAestheticAggregateRefs(true)` — its derivation differs per chart type, so it belongs here rather than in a caller that would have to track those rules itself.

**Color values come from the chart's own dataset**, not a worksheet browse. The dataset already holds the categories the chart renders (date-grouped, filtered, ranked), so a key taken from it names a real category. And stringifying with `GTool.toString` matches the function `CategoricalColorFrame` keys its color map with (`setColor` stores under it, `getColor` looks up by it), so a value round-trips as a `categoryColors` key **by construction** — no data type or display format has to be agreed between the two sides, and a date-grouped color dimension works without either side parsing a date. Capped at 200 with `truncated` set when the cap bites.

**New `measureColors`** (measure full name → hex) for the several-measures case: a bare `staticColor` paints every bound measure, so it cannot express "make profit red and leave revenue alone".

**Reject a request that does not fit the binding with a 400**, instead of applying what fits and describing the rest in prose:

- validation runs against the original chart *before* the copy, so a rejected request needs no rollback;
- a partial apply makes "did this land?" unanswerable, so a retry re-applies the half that already succeeded;
- `applyCategoricalColors` / `applyGradient` lose their now-unreachable note returns and narrow to `void`;
- `note` on this endpoint now means exactly one thing — the copy decline.

Messages name the offending parameter, the actual binding, and the parameter that *would* work, because an automated caller feeds them straight into a retry.

`WizVsService.slotName` was widened to package-private so the color field is named by the same convention as the `slots` echo, rather than a second copy that would drift.

## Verification

`./mvnw -o -pl core compile` clean. Not yet exercised against a live runtime — the date-grouped color dimension and the 400-into-retry path are argued from the code, not observed.

## Consumer

Paired with inetsoft-technology/stylebi-wiz#1433, which reads this endpoint in the modification flow's COLORS node and exposes it as an MCP tool. Full design: `wiz-services/docs/CHART_AESTHETIC_MODEL_DESIGN.md` in that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)