### PR TITLE
fix(ws): keep an outer join preserving the same table when the engine re-orients it

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/ws/joins/InnerJoinService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/joins/InnerJoinService.java
@@ -616,26 +616,10 @@ public class InnerJoinService extends WorksheetControllerService {
     * if nSameSideEqual, notify the op.
     */
    private void notifyOp(TableAssemblyOperator.Operator newOp) {
-      int op = newOp.getOperation();
-
-      switch(op) {
-      case TableAssemblyOperator.GREATER_JOIN:
-         op = TableAssemblyOperator.LESS_JOIN;
-         break;
-      case TableAssemblyOperator.LESS_JOIN:
-         op = TableAssemblyOperator.GREATER_JOIN;
-         break;
-      case TableAssemblyOperator.GREATER_EQUAL_JOIN:
-         op = TableAssemblyOperator.LESS_EQUAL_JOIN;
-         break;
-      case TableAssemblyOperator.LESS_EQUAL_JOIN:
-         op = TableAssemblyOperator.GREATER_EQUAL_JOIN;
-         break;
-      default:
-         break;
-      }
-
-      newOp.setOperation(op);
+      // The caller has already swapped this operator's operands to match an existing pair's
+      // orientation, so only the operation itself is left to mirror. It previously listed the
+      // inequalities but not LEFT/RIGHT, which lost the outer side the same way exchange() did.
+      newOp.setOperation(mirrorOperation(newOp.getOperation()));
    }
 
    private void exchange(TableAssemblyOperator.Operator op, TableAssembly[] narr) {
@@ -658,12 +642,13 @@ public class InnerJoinService extends WorksheetControllerService {
       }
 
       if(leftWeight != 0 && rightWeight != 0 && rightWeight > leftWeight) {
-         String tempTable = op.getLeftTable();
-         DataRef tempColumn = op.getLeftAttribute();
-         op.setLeftTable(op.getRightTable());
-         op.setRightTable(tempTable);
-         op.setLeftAttribute(op.getRightAttribute());
-         op.setRightAttribute(tempColumn);
+         // flipOp, not a hand-rolled swap: this used to move the tables and attributes while
+         // leaving the OPERATION alone, so a join whose right table happened to be declared
+         // earlier in the base array kept its `left` outer-ness attached to what was now the other
+         // side. `STATUSES LEFT JOIN WORK_PACKAGES` declared as [WORK_PACKAGES, STATUSES] came back
+         // as `WORK_PACKAGES LEFT JOIN STATUSES` -- no error, just 10 statuses instead of 14,
+         // because the four with no work packages stopped being preserved.
+         flipOp(op);
       }
    }
 
@@ -859,39 +844,31 @@ public class InnerJoinService extends WorksheetControllerService {
    }
 
    /**
+    * The operation that means the same thing once the two operands are swapped: an inequality
+    * reverses, and an outer join changes which side is preserved. Symmetric operations (inner,
+    * equal, not-equal, full, cross) are their own mirror.
+    *
+    * ONE definition, because three places need it and they used to disagree: flipOp had the full
+    * set, notifyOp omitted LEFT/RIGHT, and exchange() mirrored nothing at all while still swapping
+    * the operands -- silently turning `A LEFT JOIN B` into `B LEFT JOIN A`.
+    */
+   private static int mirrorOperation(int op) {
+      return switch(op) {
+         case TableAssemblyOperator.GREATER_JOIN       -> TableAssemblyOperator.LESS_JOIN;
+         case TableAssemblyOperator.LESS_JOIN          -> TableAssemblyOperator.GREATER_JOIN;
+         case TableAssemblyOperator.GREATER_EQUAL_JOIN -> TableAssemblyOperator.LESS_EQUAL_JOIN;
+         case TableAssemblyOperator.LESS_EQUAL_JOIN    -> TableAssemblyOperator.GREATER_EQUAL_JOIN;
+         case TableAssemblyOperator.LEFT_JOIN          -> TableAssemblyOperator.RIGHT_JOIN;
+         case TableAssemblyOperator.RIGHT_JOIN         -> TableAssemblyOperator.LEFT_JOIN;
+         default                                       -> op;
+      };
+   }
+
+   /**
     * Flip operator order.
     */
    public static void flipOp(TableAssemblyOperator.Operator operator) {
-      int op = operator.getOperation();
-
-      switch(op) {
-      case TableAssemblyOperator.GREATER_JOIN:
-         op = TableAssemblyOperator.LESS_JOIN;
-         break;
-
-      case TableAssemblyOperator.LESS_JOIN:
-         op = TableAssemblyOperator.GREATER_JOIN;
-         break;
-
-      case TableAssemblyOperator.GREATER_EQUAL_JOIN:
-         op = TableAssemblyOperator.LESS_EQUAL_JOIN;
-         break;
-
-      case TableAssemblyOperator.LESS_EQUAL_JOIN:
-         op = TableAssemblyOperator.GREATER_EQUAL_JOIN;
-         break;
-
-      case TableAssemblyOperator.LEFT_JOIN:
-         op = TableAssemblyOperator.RIGHT_JOIN;
-         break;
-
-      case TableAssemblyOperator.RIGHT_JOIN:
-         op = TableAssemblyOperator.LEFT_JOIN;
-         break;
-
-      default:
-         break;
-      }
+      int op = mirrorOperation(operator.getOperation());
 
       String leftTable = operator.getLeftTable();
       String rightTable = operator.getRightTable();

--- a/core/src/test/java/inetsoft/web/composer/ws/joins/InnerJoinServiceOperatorOrientationTest.java
+++ b/core/src/test/java/inetsoft/web/composer/ws/joins/InnerJoinServiceOperatorOrientationTest.java
@@ -79,7 +79,7 @@ class InnerJoinServiceOperatorOrientationTest {
 
       new InnerJoinService(null, null).editExistingJoinTable(ws, joinTable, noperator, true);
 
-      assertOperatorsConsistent(ws);
+      assertOperatorsConsistent(ws, 2);
    }
 
    /**
@@ -104,7 +104,63 @@ class InnerJoinServiceOperatorOrientationTest {
 
       new InnerJoinService(null, null).editExistingJoinTable(ws, joinTable, noperator, true);
 
-      assertOperatorsConsistent(ws);
+      assertOperatorsConsistent(ws, 2);
+   }
+
+   /**
+    * An outer join must keep preserving the same TABLE after the engine re-orients it. exchange()
+    * used to swap the operands while leaving the operation alone, so `STATUSES LEFT JOIN
+    * WORK_PACKAGES` declared as [WORK_PACKAGES, STATUSES] came back as `WORK_PACKAGES LEFT JOIN
+    * STATUSES` -- no error, just silently wrong rows (verified live on openproject: 10 statuses
+    * instead of 14, the four with no work packages dropped).
+    *
+    * Whichever way round it ends up stored, LEFT must still preserve STATUSES: either
+    * `STATUSES LEFT JOIN WORK_PACKAGES` or the equivalent `WORK_PACKAGES RIGHT JOIN STATUSES`.
+    */
+   @Test
+   void anOuterJoinKeepsPreservingTheSameTableAfterReorientation() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly workPackages = table(ws, "WORK_PACKAGES", "id", "status_id");
+      TableAssembly statuses = table(ws, "STATUSES", "id", "status_name");
+
+      // The referenced table is declared SECOND, which is what triggers the re-orientation.
+      RelationalJoinTableAssembly joinTable = new RelationalJoinTableAssembly(
+         ws, "JOINED", new TableAssembly[]{ workPackages, statuses },
+         new TableAssemblyOperator[0]);
+      ws.addAssembly(joinTable);
+
+      TableAssemblyOperator.Operator leftJoin =
+         innerJoin("STATUSES", "id", "WORK_PACKAGES", "status_id");
+      leftJoin.setOperation(TableAssemblyOperator.LEFT_JOIN);
+      TableAssemblyOperator noperator = new TableAssemblyOperator();
+      noperator.addOperator(leftJoin);
+
+      new InnerJoinService(null, null).editExistingJoinTable(ws, joinTable, noperator, true);
+
+      assertOperatorsConsistent(ws, 1);
+
+      TableAssemblyOperator.Operator stored = soleOperator(ws);
+      assertTrue(stored.getOperation() == TableAssemblyOperator.LEFT_JOIN
+                    || stored.getOperation() == TableAssemblyOperator.RIGHT_JOIN,
+                 "the join must still be an outer join, not degraded to inner");
+
+      String preserved = stored.getOperation() == TableAssemblyOperator.LEFT_JOIN
+         ? stored.getLeftTable()
+         : stored.getRightTable();
+      assertEquals("STATUSES", preserved,
+                   "LEFT/RIGHT must still preserve STATUSES, whichever side it ended up on");
+   }
+
+   /** The single stored operator, for a two-table join. */
+   private static TableAssemblyOperator.Operator soleOperator(Worksheet ws) {
+      RelationalJoinTableAssembly joinTable = joinTableOf(ws);
+      Enumeration<?> e = joinTable.getOperatorTables();
+      assertTrue(e.hasMoreElements(), "no operator pair stored");
+      String[] pair = (String[]) e.nextElement();
+      TableAssemblyOperator top = joinTable.getOperator(pair[0], pair[1]);
+      assertNotNull(top);
+      assertEquals(1, top.getOperatorCount());
+      return top.getOperator(0);
    }
 
    /**
@@ -113,16 +169,8 @@ class InnerJoinServiceOperatorOrientationTest {
     * right table. Reads the join assembly back out of the worksheet because concatenateTable can
     * replace it.
     */
-   private static void assertOperatorsConsistent(Worksheet ws) {
-      RelationalJoinTableAssembly joinTable = null;
-
-      for(Assembly assembly : ws.getAssemblies()) {
-         if(assembly instanceof RelationalJoinTableAssembly) {
-            joinTable = (RelationalJoinTableAssembly) assembly;
-         }
-      }
-
-      assertNotNull(joinTable, "no join table in the worksheet");
+   private static void assertOperatorsConsistent(Worksheet ws, int expectedConditions) {
+      RelationalJoinTableAssembly joinTable = joinTableOf(ws);
       int checked = 0;
 
       for(Enumeration<?> e = joinTable.getOperatorTables(); e.hasMoreElements(); ) {
@@ -144,7 +192,21 @@ class InnerJoinServiceOperatorOrientationTest {
          }
       }
 
-      assertEquals(2, checked, "expected both join conditions to be stored");
+      assertEquals(expectedConditions, checked, "expected every join condition to be stored");
+   }
+
+   /** The join assembly, read back out of the worksheet because concatenateTable can replace it. */
+   private static RelationalJoinTableAssembly joinTableOf(Worksheet ws) {
+      RelationalJoinTableAssembly joinTable = null;
+
+      for(Assembly assembly : ws.getAssemblies()) {
+         if(assembly instanceof RelationalJoinTableAssembly) {
+            joinTable = (RelationalJoinTableAssembly) assembly;
+         }
+      }
+
+      assertNotNull(joinTable, "no join table in the worksheet");
+      return joinTable;
    }
 
    /** The table an attribute belongs to, as encoded by AttributeRef's entity. */


### PR DESCRIPTION
## The bug

An outer join **silently returned the wrong rows — no error** — when its referenced table happened to be declared earlier in the base-table array.

`concatenateTable` → `setOperator` → `exchange()` re-orients an operator whenever its **right** table sits earlier in that array. It swapped the tables and attributes but left the **operation** untouched, so `left` stayed attached to what was now the other side:

```
STATUSES LEFT JOIN WORK_PACKAGES,  baseTables [WORK_PACKAGES, STATUSES]
  ->  WORK_PACKAGES LEFT JOIN STATUSES
```

## Verified live

openproject has 14 statuses, 4 of which no work package uses. Ran both orders with the client-side `baseTables` normalization **disabled**, so the engine is what is under test:

| `baseTables` | joinPath | rows |
|---|---|---|
| `[STATUSES, WORK_PACKAGES]` | `STATUSES LEFT JOIN WORK_PACKAGES` | **14** — the 4 unused statuses at Count 0 ✅ |
| `[WORK_PACKAGES, STATUSES]` | *same* | **10** — those 4 silently dropped ❌ |

Total was 984 in both, so nothing looked amiss on the surface. The chart had just quietly stopped being a LEFT join. That makes this **worse than the `column ... does not exist` failure fixed in #4498** — that one at least failed loudly; this one renders.

Post-fix on the same build: the reversed order returns the same 14 rows as the correct order, and #4498's inner-join case still renders its 13 projects.

## The fix

`exchange()` now calls `flipOp`, which already swaps the operands **and** mirrors the operation, instead of hand-rolling half of it.

The mirror rule is extracted to `mirrorOperation()` because three places needed it and they had drifted apart:

- `flipOp` — had the full set (inequalities + LEFT/RIGHT)
- `notifyOp` — listed the inequalities but **not** LEFT/RIGHT: the same omission, on the path where `setOperator` merges into an existing reversed pair
- `exchange` — none of it

One definition, so they cannot disagree again. Note `notifyOp`'s omission is fixed by consolidation rather than by a test of its own — I did not construct a case that reaches that specific branch, so it is corrected on the strength of it being the same rule, not on separate evidence.

## Tests

`InnerJoinServiceOperatorOrientationTest.anOuterJoinKeepsPreservingTheSameTableAfterReorientation` drives `editExistingJoinTable` over a real `Worksheet` and asserts the stored operator still preserves `STATUSES`, whichever side it ends up on (`STATUSES LEFT JOIN WORK_PACKAGES` or the equivalent `WORK_PACKAGES RIGHT JOIN STATUSES`) — and that it has not degraded to inner.

Against the pre-fix code (with #4498 still in place, so this is isolated to the new defect):

```
Tests run: 3, Failures: 1
LEFT/RIGHT must still preserve STATUSES, whichever side it ended up on
  ==> expected: <STATUSES> but was: <WORK_PACKAGES>
```

The other two tests pass both before and after — they are guards, including one pinning the declaration order that always worked.

`inetsoft.uql.asset.**` / `inetsoft.report.composition.**` / `inetsoft.web.composer.ws.**`: 237 tests, 0 failures.

## Related

Found while answering a review question on stylebi-wiz #1421 about whether outer joins were affected by base-table ordering. They are — and the client-side normalization there (left table first) leaves `exchange` nothing to swap, so it incidentally protects against this. This is the engine-side fix; sibling of #4498.

🤖 Generated with [Claude Code](https://claude.com/claude-code)