### PR TITLE
Bug #75821, don't show a misleading permission error when EM help-links fails due to session expiry

### DIFF
--- a/web/projects/em/src/app/navbar/navbar.component.tl.spec.ts
+++ b/web/projects/em/src/app/navbar/navbar.component.tl.spec.ts
@@ -90,7 +90,10 @@ const ORG_ADMIN_ITEM_VISIBILITY: Array<[name: string, role: string, expectedVisi
    ["_#(Monitoring)", "link", true],
 ];
 
-async function renderComponent(permissions: ComponentPermissions) {
+async function renderComponent(
+   permissions: ComponentPermissions,
+   snackBar: { open: ReturnType<typeof vi.fn> } = { open: vi.fn() }
+) {
    server.use(
       http.get("*/api/em/navbar/get-navbar-model", () => HttpResponse.json(NAVBAR_MODEL))
    );
@@ -107,7 +110,7 @@ async function renderComponent(permissions: ComponentPermissions) {
          { provide: AppInfoService, useValue: { isEnterprise: () => of(true) } },
          { provide: LogoutService, useValue: { setFromEm: vi.fn(), setLogoutUrl: vi.fn(), inGracePeriod: of(false) } },
          { provide: MatDialog, useValue: { open: vi.fn() } },
-         { provide: MatSnackBar, useValue: { open: vi.fn() } },
+         { provide: MatSnackBar, useValue: snackBar },
       ],
       schemas: [NO_ERRORS_SCHEMA],
    });
@@ -137,5 +140,67 @@ describe("NavbarComponent — SECURITY: permission input visibility boundary", (
       expect(screen.queryByRole("link", { name: "_#(Settings)" })).toBeNull();
       expect(screen.queryByRole("link", { name: "_#(Monitoring)" })).toBeNull();
       expect(screen.queryByRole("button", { name: "_#(Send Notification)" })).toBeNull();
+   });
+});
+
+/**
+ * Bug #75821 — a 401/403 from GET em/help-links means the session expired or was invalidated
+ * (e.g. a cross-tab logout) while this request was in flight. InvalidSessionInterceptor already
+ * redirects to the login page for that case, so the component must not also pop a misleading
+ * "give this user permission to Enterprise Manager" toast on top of it. Any other failure (e.g. a
+ * 500) isn't handled by the interceptor's redirect, so the toast is still the right call there.
+ *
+ * console.error is unconditional in handleHelpLinkError and runs after the toast decision, so
+ * waiting for it gives a deterministic point at which to assert on the snackbar mock instead of
+ * racing the HTTP response.
+ */
+describe("NavbarComponent — help link error handling", () => {
+   // vitest-base.config.ts sets restoreMocks: true, so this spy is torn down automatically
+   // after each test.
+   let errorSpy: ReturnType<typeof vi.spyOn>;
+
+   beforeEach(() => {
+      errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+   });
+
+   it("suppresses the toast when help-links fails with 401 (session expired mid-load)", async () => {
+      server.use(
+         http.get("*/api/em/help-links", () => HttpResponse.json({ message: "Unauthorized" }, { status: 401 }))
+      );
+      const snackBar = { open: vi.fn() };
+
+      await renderComponent(ORG_ADMIN_PERMISSIONS, snackBar);
+      await screen.findByRole("link", { name: "_#(Settings)" });
+      await vi.waitFor(() => expect(errorSpy).toHaveBeenCalled());
+
+      expect(snackBar.open).not.toHaveBeenCalled();
+   });
+
+   it("suppresses the toast when help-links fails with 403", async () => {
+      server.use(
+         http.get("*/api/em/help-links", () => HttpResponse.json({ message: "Forbidden" }, { status: 403 }))
+      );
+      const snackBar = { open: vi.fn() };
+
+      await renderComponent(ORG_ADMIN_PERMISSIONS, snackBar);
+      await screen.findByRole("link", { name: "_#(Settings)" });
+      await vi.waitFor(() => expect(errorSpy).toHaveBeenCalled());
+
+      expect(snackBar.open).not.toHaveBeenCalled();
+   });
+
+   it("still shows the toast when help-links fails for a reason other than session expiry", async () => {
+      server.use(
+         http.get("*/api/em/help-links", () => HttpResponse.json({ message: "Internal error" }, { status: 500 }))
+      );
+      const snackBar = { open: vi.fn() };
+
+      await renderComponent(ORG_ADMIN_PERMISSIONS, snackBar);
+      await screen.findByRole("link", { name: "_#(Settings)" });
+      await vi.waitFor(() => expect(errorSpy).toHaveBeenCalled());
+
+      expect(snackBar.open).toHaveBeenCalledWith(
+         "_#(js:em.helpLinks.error)", null, expect.anything()
+      );
    });
 });

--- a/web/projects/em/src/app/navbar/navbar.component.ts
+++ b/web/projects/em/src/app/navbar/navbar.component.ts
@@ -21,7 +21,7 @@ import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from "@angu
 import { MatDialog } from "@angular/material/dialog";
 import { MatSnackBar } from "@angular/material/snack-bar";
 import { NavigationEnd, Router, RouterLink, RouterLinkActive } from "@angular/router";
-import { Observable, Subject, Subscription, throwError } from "rxjs";
+import { EMPTY, Observable, Subject, Subscription } from "rxjs";
 import { catchError, concatMap, filter, map, takeUntil, tap } from "rxjs/operators";
 import { AiAssistantService } from "../../../../shared/ai-assistant/ai-assistant.service";
 import { AppInfoService } from "../../../../shared/util/app-info.service";
@@ -285,9 +285,19 @@ export class NavbarComponent implements OnInit, OnDestroy {
    }
 
    private handleHelpLinkError(error: HttpErrorResponse): Observable<HelpLinks> {
-      this.snackBar.open("_#(js:em.helpLinks.error)", null, { duration: Tool.SNACKBAR_DURATION });
+      // A 401/403 here means the session expired or was invalidated (e.g. by a cross-tab
+      // logout) while this request was in flight. InvalidSessionInterceptor already redirects
+      // to the login page for that case, so showing a permission error on top of it is
+      // redundant and misleading.
+      if(error.status !== 401 && error.status !== 403) {
+         this.snackBar.open("_#(js:em.helpLinks.error)", null, { duration: Tool.SNACKBAR_DURATION });
+      }
+
       console.error("Failed to load the context help links: ", error);
-      return throwError(error);
+      // Recover rather than rethrow: the subscriber below has no error callback, so
+      // propagating the error would surface as an unhandled exception on top of the
+      // handling already done above.
+      return EMPTY;
    }
 
    navigateToFavorite(route: string) {


### PR DESCRIPTION
## Summary

Logging into EM in one tab, logging into Portal with the same account in another tab (same shared session cookie), then logging out of Portal, can invalidate the shared session while the EM tab's initial page load is still in flight (reproducible by throttling the EM tab to a slow connection). The in-flight `GET em/help-links` request then legitimately gets a 401/403 because the session really is gone.

That failure is already handled correctly by `InvalidSessionInterceptor`, which redirects the user to the login page for any 401/403. `NavbarComponent`, however, also independently popped a "You may need to give this user permission to Enterprise Manager" toast for the exact same failure — which is misleading, since it isn't a permission problem, just a session that expired mid-load.

## Root Cause

- `NavbarComponent.handleHelpLinkError()` showed the same permission-themed error toast for every kind of `getHelpLinks()` failure, without distinguishing a session-expiry 401/403 (already handled elsewhere via redirect-to-login) from a genuine unexpected failure.
- The same method also unconditionally rethrew the error to a `.subscribe()` call with no error callback, which surfaces as an unhandled exception in the browser console on every help-links failure, independent of the toast issue.

## Fix

- Only show the help-links error toast when the failure is *not* a 401/403 — those are already handled by the app-wide session-expiry redirect.
- Recover (`EMPTY`) instead of rethrowing from `handleHelpLinkError`, since the error is already fully handled (logged + conditionally toasted) at that point and rethrowing to a subscriber with no error handler served no purpose beyond an unhandled-exception log.

## Test Plan

- [x] Added `navbar.component.tl.spec.ts` cases: 401 and 403 suppress the toast, a 500 still shows it — all assert against a real MSW-mocked HTTP response.
- [x] `npm run test:em` (356/356 passed) and `npm run test:em:tl` (818 passed, 19 pre-existing expected-fail) both green.
- [x] `npm run lint` clean (no new warnings).
- [x] `npm run build` succeeds for all Angular projects.
- [x] Manually reproduced the original bug (EM tab throttled to 3G, logout of Portal mid-load) and confirmed the toast no longer appears with this fix.

Fixes Redmine #75821.