### PR TITLE
Bug #75908, fix org copy leaving Data Cycle task references unresolved in Run After

### DIFF
--- a/core/src/main/java/inetsoft/sree/schedule/ScheduleTask.java
+++ b/core/src/main/java/inetsoft/sree/schedule/ScheduleTask.java
@@ -1499,12 +1499,22 @@ public class ScheduleTask implements Serializable, Cloneable, XMLSerializable {
       String currOrgID = OrganizationManager.getInstance().getCurrentOrgID();
       String path = condition.getTaskName();
 
-      if(path == null || path.indexOf(":") < 0) {
+      if(path == null) {
          return;
       }
 
-      String pathUserID = path.substring(0, path.indexOf(":"));
-      String remaining = path.substring(path.indexOf(":"));
+      // cycle tasks use "<owner>__<name>" rather than "<owner>:<name>", and the task
+      // name itself (e.g. "DataCycle Task: Cycle1") contains a colon, so the cycle
+      // delimiter must be matched first or the owner key gets split in the wrong place
+      int cycleIdx = path.indexOf("__" + DataCycleManager.TASK_PREFIX);
+      int idx = cycleIdx >= 0 ? cycleIdx : path.indexOf(":");
+
+      if(idx < 0) {
+         return;
+      }
+
+      String pathUserID = path.substring(0, idx);
+      String remaining = path.substring(idx);
       IdentityID userID = IdentityID.getIdentityIDFromKey(pathUserID);
 
       if(!Tool.equals(userID.orgID, currOrgID)) {

--- a/core/src/main/java/inetsoft/util/MigrateUtil.java
+++ b/core/src/main/java/inetsoft/util/MigrateUtil.java
@@ -21,6 +21,7 @@ package inetsoft.util;
 import inetsoft.report.Hyperlink;
 import inetsoft.report.TableDataPath;
 import inetsoft.report.internal.table.TableHyperlinkAttr;
+import inetsoft.sree.internal.DataCycleManager;
 import inetsoft.sree.security.IdentityID;
 import inetsoft.sree.security.Organization;
 import inetsoft.uql.asset.Assembly;
@@ -129,7 +130,11 @@ public class MigrateUtil {
          return taskName;
       }
 
-      int index = taskName.indexOf(":");
+      // cycle tasks use "<owner>__<name>" rather than "<owner>:<name>", and the task name
+      // itself (e.g. "DataCycle Task: Cycle1") contains a colon, so the cycle delimiter must
+      // be matched first or the owner key gets split in the wrong place
+      int cycleIndex = taskName.indexOf("__" + DataCycleManager.TASK_PREFIX);
+      int index = cycleIndex >= 0 ? cycleIndex : taskName.indexOf(":");
 
       if(index > 0) {
          String name = taskName.substring(0, index);

--- a/core/src/test/java/inetsoft/sree/schedule/ScheduleTaskTest.java
+++ b/core/src/test/java/inetsoft/sree/schedule/ScheduleTaskTest.java
@@ -18,8 +18,11 @@
 
 package inetsoft.sree.schedule;
 
+import inetsoft.sree.internal.DataCycleManager;
 import inetsoft.sree.security.*;
 import inetsoft.test.*;
+import inetsoft.uql.XPrincipal;
+import inetsoft.util.Tool;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.Tag;
@@ -27,7 +30,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.w3c.dom.Element;
+import org.xml.sax.InputSource;
 
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.StringReader;
 import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -326,6 +333,76 @@ public class ScheduleTaskTest {
 
       task.removeCondition(0);
       assertFalse(task.getDependency().hasMoreElements());
+   }
+
+   // --- parseXML(elem, isSiteAdminImport) : org-copy rewrite of CompletionCondition ---
+
+   /*
+    * Bug: after copying an organization, a task's "Run After" completion condition pointing
+    * at a Data Cycle task showed up blank. Root cause: updateConditionTaskPath() located the
+    * owner/task-name split with path.indexOf(":"), but cycle-task ids use "<owner>__<name>"
+    * (ScheduleTask.getTaskId(), Type.CYCLE_TASK branch) and the name itself is
+    * "DataCycle Task: Cycle1", which contains its own colon. The first colon found was the one
+    * inside the task name, so the rewrite dropped "__DataCycle Task" entirely, producing a
+    * taskName that could never match a real task in the new org.
+    */
+   @Test
+   void parseXML_siteAdminImport_cycleTaskCompletionCondition_rewritesOwnerOrgPreservingTaskName()
+      throws Exception
+   {
+      String sourceOrg = "source-org";
+      String targetOrg = "target-org";
+      String cycleTaskId = new IdentityID(XPrincipal.SYSTEM, sourceOrg).convertToKey() +
+         "__" + DataCycleManager.TASK_PREFIX + "Cycle1";
+
+      String xml = "<Task name=\"task1\" owner=\"" +
+         Tool.escape(new IdentityID("admin", sourceOrg).convertToKey()) + "\" enabled=\"true\">" +
+         "<Condition type=\"Completion\" task=\"" + Tool.escape(cycleTaskId) + "\"/>" +
+         "</Task>";
+
+      Element elem = parseTaskXml(xml);
+      ScheduleTask task = new ScheduleTask();
+
+      OrganizationManager.runInOrgScope(targetOrg, () -> {
+         task.parseXML(elem, true);
+         return null;
+      });
+
+      CompletionCondition cc = (CompletionCondition) task.getCondition(0);
+      String expected = new IdentityID(XPrincipal.SYSTEM, targetOrg).convertToKey() +
+         "__" + DataCycleManager.TASK_PREFIX + "Cycle1";
+      assertEquals(expected, cc.getTaskName());
+   }
+
+   @Test
+   void parseXML_siteAdminImport_normalTaskCompletionCondition_rewritesOwnerOrg() throws Exception {
+      String sourceOrg = "source-org";
+      String targetOrg = "target-org";
+      String parentTaskId = new IdentityID("admin", sourceOrg).convertToKey() + ":parent task";
+
+      String xml = "<Task name=\"task1\" owner=\"" +
+         Tool.escape(new IdentityID("admin", sourceOrg).convertToKey()) + "\" enabled=\"true\">" +
+         "<Condition type=\"Completion\" task=\"" + Tool.escape(parentTaskId) + "\"/>" +
+         "</Task>";
+
+      Element elem = parseTaskXml(xml);
+      ScheduleTask task = new ScheduleTask();
+
+      OrganizationManager.runInOrgScope(targetOrg, () -> {
+         task.parseXML(elem, true);
+         return null;
+      });
+
+      CompletionCondition cc = (CompletionCondition) task.getCondition(0);
+      String expected = new IdentityID("admin", targetOrg).convertToKey() + ":parent task";
+      assertEquals(expected, cc.getTaskName());
+   }
+
+   private static Element parseTaskXml(String xml) throws Exception {
+      DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      return factory.newDocumentBuilder()
+         .parse(new InputSource(new StringReader(xml)))
+         .getDocumentElement();
    }
 
    private ScheduleTask createBasicScheduleTask(String taskName) {

--- a/core/src/test/java/inetsoft/util/MigrateUtilTest.java
+++ b/core/src/test/java/inetsoft/util/MigrateUtilTest.java
@@ -1,0 +1,88 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.util;
+
+import inetsoft.sree.internal.DataCycleManager;
+import inetsoft.sree.security.IdentityID;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/*
+ * Bug: copying an organization left a task's "Run After" completion condition pointing at a
+ * Data Cycle task blank in the new org. Root cause: MigrateScheduleTask.processAssemblies()
+ * rewrites a CompletionCondition's referenced task id via
+ * MigrateUtil.getNewOrgTaskName(completionTask, oldOrgId, newOrgId) during org copy, but that
+ * method located the owner/task-name split with taskName.indexOf(":"). Cycle-task ids are built
+ * as "<owner>__<name>" (ScheduleTask.getTaskId(), Type.CYCLE_TASK branch), and the name itself
+ * ("DataCycle Task: Cycle1") contains its own colon, so the first colon found was the one inside
+ * the task name -- not the real "__" delimiter. That corrupted the parsed owner org id so the
+ * "oorgID.equals(identityID.orgID)" guard never matched, the rewrite was skipped entirely, and
+ * the condition kept referencing the OLD org's task id, which does not exist in the new org.
+ */
+@Tag("core")
+class MigrateUtilTest {
+
+   @Test
+   void getNewOrgTaskName_cycleTaskCompletionReference_rewritesOwnerOrgPreservingTaskName() {
+      String oldOrgId = "host-org";
+      String newOrgId = "organization0";
+      String cycleTaskId = new IdentityID("INETSOFT_SYSTEM", oldOrgId).convertToKey() +
+         "__" + DataCycleManager.TASK_PREFIX + "Cycle1";
+
+      String result = MigrateUtil.getNewOrgTaskName(cycleTaskId, oldOrgId, newOrgId);
+
+      String expected = new IdentityID("INETSOFT_SYSTEM", newOrgId).convertToKey() +
+         "__" + DataCycleManager.TASK_PREFIX + "Cycle1";
+      assertEquals(expected, result);
+   }
+
+   @Test
+   void getNewOrgTaskName_normalTaskCompletionReference_rewritesOwnerOrg() {
+      String oldOrgId = "host-org";
+      String newOrgId = "organization0";
+      String parentTaskId = new IdentityID("admin", oldOrgId).convertToKey() + ":parent task";
+
+      String result = MigrateUtil.getNewOrgTaskName(parentTaskId, oldOrgId, newOrgId);
+
+      String expected = new IdentityID("admin", newOrgId).convertToKey() + ":parent task";
+      assertEquals(expected, result);
+   }
+
+   @Test
+   void getNewOrgTaskName_sameOrg_returnsUnchanged() {
+      String taskId = new IdentityID("admin", "host-org").convertToKey() + ":task1";
+
+      assertEquals(taskId, MigrateUtil.getNewOrgTaskName(taskId, "host-org", "host-org"));
+   }
+
+   @Test
+   void getNewOrgTaskName_noOwnerDelimiter_returnsUnchanged() {
+      // internal/plain task names have no IdentityID.KEY_DELIMITER prefix
+      assertEquals("__balance tasks__",
+         MigrateUtil.getNewOrgTaskName("__balance tasks__", "host-org", "organization0"));
+   }
+
+   @Test
+   void getNewOrgTaskName_ownerOrgDoesNotMatchOldOrg_returnsUnchanged() {
+      String taskId = new IdentityID("admin", "some-other-org").convertToKey() + ":task1";
+
+      assertEquals(taskId, MigrateUtil.getNewOrgTaskName(taskId, "host-org", "organization0"));
+   }
+}


### PR DESCRIPTION
## Summary
- Copying an organization left any task's "Run After" completion condition pointing at a Data Cycle task blank in the new org, because `MigrateUtil.getNewOrgTaskName()` split the referenced task id on the first `":"` to find the owner/task-name boundary — but Data Cycle task ids are `"<owner>__<name>"`, and the name itself (`"DataCycle Task: Cycle1"`) contains its own colon, so the split landed inside the task name and the owner-org rewrite was silently skipped, leaving the condition pointing at the old org.
- Also hardens `ScheduleTask.updateConditionTaskPath()` (used on the site-admin asset-import path), which had the same delimiter assumption.

## Test plan
- [x] Added `MigrateUtilTest` covering the cycle-task rewrite (the actual regression), a normal-task rewrite, same-org no-op, no-delimiter no-op, and org-mismatch no-op.
- [x] Added two tests to `ScheduleTaskTest` covering `parseXML(elem, isSiteAdminImport=true)` for both cycle-task and normal-task completion conditions.
- [x] `mvn test -pl core -Dtest=MigrateUtilTest,ScheduleTaskTest` — all pass.
- [x] Manually reproduced: create a Data Cycle + task with "Run After" set to the cycle task, copy the org, confirm "Run After" now resolves to the cycle task under the new org instead of showing blank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)