### PR TITLE
Fix chart point annotation cannot be removed without selecting chart first

### DIFF
--- a/web/projects/portal/src/app/vsobjects/event/annotation/remove-annotation-event.ts
+++ b/web/projects/portal/src/app/vsobjects/event/annotation/remove-annotation-event.ts
@@ -36,26 +36,36 @@ export class RemoveAnnotationEvent implements ViewsheetEvent {
    public static create(vsObjects: VSObjectModel[],
                         selectedAssemblies: number[]): RemoveAnnotationEvent
    {
-      if(selectedAssemblies) {
-         const names = selectedAssemblies
-            .map(index => vsObjects[index])
-            .reduce((selected, current) => {
-               if(current.objectType === "VSAnnotation") {
-                  return selected.concat(current.absoluteName);
-               }
-               else if(current.selectedAnnotations) {
-                  return selected.concat(current.selectedAnnotations);
-               }
-               else {
-                  return selected;
-               }
-            }, []);
+      const names: string[] = [];
 
-         if(names.length > 0) {
-            return new RemoveAnnotationEvent(names);
+      if(selectedAssemblies) {
+         for(let index of selectedAssemblies) {
+            const current = vsObjects[index];
+
+            if(current && current.objectType === "VSAnnotation" &&
+               names.indexOf(current.absoluteName) === -1)
+            {
+               names.push(current.absoluteName);
+            }
          }
       }
 
-      return null;
+      // chart data point annotations are selected via a separate overlay
+      // (see chart-annotation-overlay in vs-object-container.component.html) that doesn't add
+      // the chart itself to selectedAssemblies, so selectedAnnotations must be checked on every
+      // vsObject rather than only ones already in selectedAssemblies
+      if(vsObjects) {
+         for(let vsObject of vsObjects) {
+            if(vsObject && vsObject.selectedAnnotations) {
+               for(let name of vsObject.selectedAnnotations) {
+                  if(names.indexOf(name) === -1) {
+                     names.push(name);
+                  }
+               }
+            }
+         }
+      }
+
+      return names.length > 0 ? new RemoveAnnotationEvent(names) : null;
    }
 }

--- a/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
@@ -2991,10 +2991,11 @@ export class ViewerAppComponent extends CommandProcessor implements OnInit, Afte
       const event = RemoveAnnotationEvent.create(this.vsObjects, this.selectedAssemblies);
 
       if(event) {
-         if(this.vsObjects && this.selectedAssemblies) {
-            for(let index of this.selectedAssemblies) {
-               let model = this.vsObjects[index];
-               model.selectedAnnotations = [];
+         if(this.vsObjects) {
+            for(let model of this.vsObjects) {
+               if(model && model.selectedAnnotations) {
+                  model.selectedAnnotations = [];
+               }
             }
          }
 


### PR DESCRIPTION
## Summary
- Chart point/data annotations are selected via a separate overlay (`chart-annotation-overlay` in `vs-object-container.component.html`) that never adds the chart's own index to `selectedAssemblies`.
- `RemoveAnnotationEvent.create()` only inspected `vsObjects` already present in `selectedAssemblies`, so removing a chart annotation without first clicking the chart itself silently returned `null` and `removeAnnotations()` no-op'd — no request sent, no error shown.
- Crosstab/table cell annotations were unaffected because they're selected through the table's own normal selection flow, which always keeps the table in `selectedAssemblies`.
- `create()` now also scans every `vsObject` for a non-empty `selectedAnnotations`, regardless of `selectedAssemblies`. `viewer-app.component.ts#removeAnnotations()` clears `selectedAnnotations` on every object that had any, matching the broadened lookup.

## Test plan
- [x] `ng run portal:test-tl --include='**/vs-object-container.component.interaction.tl.spec.ts'` — 17/17 passing
- [x] Manually reproduced: added chart point annotation, right-clicked it without first selecting the chart, clicked Remove — previously silently failed (no network request), now removes correctly
- [x] Verified crosstab annotation removal still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)