### PR TITLE
Bug #75912, force-resync the schedule task Save button after a failed save

### DIFF
--- a/web/projects/em/src/app/settings/schedule/schedule-task-editor-page/schedule-task-editor-page.component.html
+++ b/web/projects/em/src/app/settings/schedule/schedule-task-editor-page/schedule-task-editor-page.component.html
@@ -15,7 +15,7 @@
 ~ You should have received a copy of the GNU Affero General Public License
 ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -->
-<em-editor-panel
+<em-editor-panel #editorPanel
   contentClass="tabbed-editor-panel-content"
   applyLabel="_#(Save)"
   [applyDisabled]="!(valid && taskChanged)"

--- a/web/projects/em/src/app/settings/schedule/schedule-task-editor-page/schedule-task-editor-page.component.ts
+++ b/web/projects/em/src/app/settings/schedule/schedule-task-editor-page/schedule-task-editor-page.component.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import { HttpErrorResponse } from "@angular/common/http";
-import { Component, HostBinding, OnInit, ViewEncapsulation } from "@angular/core";
+import { Component, HostBinding, OnInit, ViewChild, ViewEncapsulation } from "@angular/core";
 import { UntypedFormBuilder, UntypedFormGroup, Validators, FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { MatDialog } from "@angular/material/dialog";
 import { MatSnackBar } from "@angular/material/snack-bar";
@@ -77,6 +77,7 @@ export class TaskItem {
 })
 export class ScheduleTaskEditorPageComponent implements OnInit {
    @HostBinding("class") hostClass = "schedule-task-editor";
+   @ViewChild("editorPanel") editorPanel: EditorPanelComponent;
    originalModel: ScheduleTaskDialogModel;
    model: ScheduleTaskDialogModel;
 
@@ -501,6 +502,14 @@ export class ScheduleTaskEditorPageComponent implements OnInit {
       });
 
       console.error("Failed to save task: ", error);
+
+      // EditorPanelComponent.handleClick() optimistically disables the Save button on click
+      // and relies on the [applyDisabled] input binding to re-enable it. Angular only re-pushes
+      // that input when the bound expression's value actually changes; on a failed save, "valid"
+      // is unchanged from before the click, so the binding update is skipped and the button is
+      // left stuck disabled. Force a resync here.
+      this.editorPanel?.changeApplyDisabledState(!this.valid);
+
       return throwError(error);
    }
 }


### PR DESCRIPTION
## Summary

In the EM Schedule Task editor, after a save fails (e.g. a server-side "duplicate task name" error triggered by changing a task's owner to a value that collides with an existing task name), the Save button gets stuck permanently disabled — even after the user renames the task to resolve the conflict.

## Root Cause

`em-editor-panel`'s Save button is bound via `[applyDisabled]="!(valid && taskChanged)"`. `EditorPanelComponent.handleClick()` also optimistically sets its own `applyDisabled = true` on click, to guard its 200ms debounce, relying on the parent re-pushing the `@Input` on the next change-detection pass.

Angular only re-pushes an `@Input` when the parent's bound *expression* value differs from the previous check — not merely because the child mutated the property internally. When a save fails and `valid && taskChanged` is `true` both immediately before and after the click (nothing about client-side validity changed — this was confirmed with a real DOM-level Angular TestBed reproduction: `comp.valid`, `comp.taskChanged`, and `comp.optionsValid` were all `true` after the failure, yet the actual rendered button stayed `disabled`), the expression's value never differs across the round trip, so Angular never re-pushes `applyDisabled` back to `false` — the `true` set by `handleClick()` sticks forever, even after the user renames the task.

## Fix

`ScheduleTaskEditorPageComponent` now holds a `@ViewChild("editorPanel")` reference to the editor panel and calls its existing public `changeApplyDisabledState()` escape hatch from `handleSaveError()` to force a resync after a failed save. This mirrors an already-established pattern in the codebase (`DataSpaceFileSettingsViewComponent`, `DataSpaceFolderSettingsViewComponent`), so no change to the shared `EditorPanelComponent` was needed.

## Test Plan

- Verified via a real DOM-level Angular TestBed reproduction (owner change → real button click → mocked server duplicate-name error → rename): before the fix, `button.disabled` stayed `true` even though `comp.valid`/`comp.taskChanged`/`comp.optionsValid` were all `true`; after the fix, `button.disabled` correctly becomes `false` right after the failure and stays clickable through the rename.
- Full existing suite for this component passes unchanged: `schedule-task-editor-page.component.spec.ts` (18/18) and `schedule-task-editor-page.component.tl.spec.ts` (20/23, 3 pre-existing documented `it.fails` unrelated to this change).
- `ng build em` succeeds; `eslint` clean on the changed file.

Fixes Redmine #75912.