### PR TITLE
Bug #75904, fix adhoc filter popup not visible in enlarged crosstab

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.html
@@ -18,7 +18,8 @@
 @for (vsObject of vsInfo.vsObjects; track trackByName(i, vsObject); let i = $index) {
   @if (isObjectRendered(vsObject)) {
     <div [style.display]="isMaxModeHidden(vsObject) ? 'none' : 'block'"
-         [class.max-mode-view-filter]="isFilterInMaxModeView(vsObject)">
+         [class.max-mode-view-filter]="isFilterInMaxModeView(vsObject)"
+         [style.z-index]="isFilterInMaxModeView(vsObject) ? getContainerZIndex(vsObject) : null">
       <div class="focus-assembly {{getAssemblyAsClass(vsObject)}}"
         [id]="getAssemblyDivId(vsObject)"
         VSDataTip [dataTipName]="vsObject.absoluteName"

--- a/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.scss
+++ b/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.scss
@@ -67,5 +67,4 @@
 
 .max-mode-view-filter {
   position: fixed;
-  z-index: 9910 !important;
 }


### PR DESCRIPTION
## Summary

When a crosstab is enlarged ("Show Enlarged" / max mode) and the user right-clicks a cell to add an ad-hoc filter (e.g. a range slider on a numeric/date column), the filter popup renders in the DOM at the correct position but is visually hidden underneath the enlarged crosstab.

## Root Cause

The `.max-mode-view-filter` CSS class (added by a prior fix, Bug #75280) is applied to an ad-hoc filter's outer wrapper while any assembly is in max mode. It sets `position: fixed` (to escape the max-mode `overflow:hidden` clipping) with a hardcoded `z-index: 9910 !important`.

Separately, `needsZIndexBoost()` boosts a max-mode source assembly's own z-index by `+99999` (`DateTipHelper.getPopUpContentBoostZIndex()`) specifically so it escapes ancestor stacking contexts when enlarged. Since `9910` is always less than `anything + 99999`, the enlarged crosstab's stacking context always wins over the ad-hoc filter's hardcoded `9910`, hiding the filter behind it.

Confirmed live with the reporter: manually raising the wrapper's z-index in DevTools made the filter visible.

## Fix

- Bind the outer wrapper's z-index to `getContainerZIndex(vsObject)` — the same method already used for the filter's inner content, which correctly resolves to `filterZIndex + 99999` and is guaranteed to exceed the max-mode source assembly's own boosted z-index.
- Remove the now-redundant hardcoded `z-index: 9910 !important` from `.max-mode-view-filter` in the SCSS (keeping `position: fixed`).

## Test Plan

- [x] Reproduced: imported the attached `.vso`, enlarged the crosstab, right-clicked a cell → Filter on a numeric column — filter popup was hidden.
- [x] Applied fix, rebuilt, reproduced again — filter popup now renders above the enlarged crosstab.
- [x] Confirmed with the bug reporter that the fix resolves the issue.
- [x] `vsobjects` unit test suite (67 tests) passes.
- [x] Frontend build succeeds (portal, em, elements, viewer-element).
- [x] Code review found no blocking issues; also confirmed a similar-looking `.max-mode-view-filter` rule in the composer (`viewsheet-pane.component.scss`) is a distinct code path unaffected by this bug.

Fixes Redmine #75904.