### PR TITLE
Bug #75923, hide embed Show Details until a cell is selected

### DIFF
--- a/web/projects/portal/src/app/embed/crosstab/embed-crosstab-actions.ts
+++ b/web/projects/portal/src/app/embed/crosstab/embed-crosstab-actions.ts
@@ -43,7 +43,8 @@ export class EmbedCrosstabActions extends CrosstabActions {
             label: () => "_#(js:Show Details)",
             icon: () => "show-detail-icon",
             enabled: () => true,
-            visible: () => this.isActionVisibleInViewer("Show Details") && !this.annotationsSelected
+            visible: () => this.detailCellsSelected &&
+               this.isActionVisibleInViewer("Show Details") && !this.annotationsSelected
          },
          {
             id: () => "crosstab export",
@@ -97,7 +98,8 @@ export class EmbedCrosstabActions extends CrosstabActions {
             label: () => "_#(js:Show Details)",
             icon: () => "show-detail-icon",
             enabled: () => true,
-            visible: () => this.isActionVisibleInViewer("Show Details")
+            visible: () => this.detailCellsSelected &&
+               this.isActionVisibleInViewer("Show Details")
          },
          {
             id: () => "crosstab export",
@@ -130,5 +132,34 @@ export class EmbedCrosstabActions extends CrosstabActions {
          }]));
 
       return groups;
+   }
+
+   /**
+    * True when the selection holds at least one cell that can show details; nothing selected
+    * means nothing to drill into, so the action stays hidden. The per-cell test is the one
+    * CrosstabActions.showDetailsVisible applies in the viewer (mirrored here because that getter
+    * is private) and comes from ShowDetailEvent: a cell qualifies unless it sits in the corner
+    * header block, with the runtime row/col header counts deciding whether the first row/column
+    * is itself data. Unlike a plain table, a crosstab header selection does count - a row/column
+    * header shows the details behind that group - hence the fall back to selectedHeaders.
+    */
+   private get detailCellsSelected(): boolean {
+      const selectedCells = this.model.selectedData && this.model.selectedData.size ?
+         this.model.selectedData : this.model.selectedHeaders;
+      let detailsCell: boolean = false;
+
+      if(selectedCells) {
+         selectedCells.forEach((cols, row) => {
+            cols.forEach((col) => {
+               detailsCell = detailsCell ||
+                  (row > 0 || this.model.runtimeColHeaderCount > 0) &&
+                  (col > 0 || this.model.runtimeRowHeaderCount > 0 ||
+                     this.model.runtimeColHeaderCount === 0) &&
+                  !(row < this.model.headerRowCount && col < this.model.headerColCount);
+            });
+         });
+      }
+
+      return detailsCell;
    }
 }

--- a/web/projects/portal/src/app/embed/crosstab/embed-crosstab-actions.ts
+++ b/web/projects/portal/src/app/embed/crosstab/embed-crosstab-actions.ts
@@ -39,6 +39,9 @@ export class EmbedCrosstabActions extends CrosstabActions {
    protected createMenuActions(groups: AssemblyActionGroup[]): AssemblyActionGroup[] {
       groups.push(new AssemblyActionGroup([
          {
+            // detailCellsSelected is CrosstabActions' own cell test (protected for this reuse):
+            // nothing selected means nothing to drill into. Its showDetailsVisible is this plus
+            // the same isActionVisibleInViewer check, so the embed matches the viewer exactly.
             id: () => "crosstab show-details",
             label: () => "_#(js:Show Details)",
             icon: () => "show-detail-icon",
@@ -132,34 +135,5 @@ export class EmbedCrosstabActions extends CrosstabActions {
          }]));
 
       return groups;
-   }
-
-   /**
-    * True when the selection holds at least one cell that can show details; nothing selected
-    * means nothing to drill into, so the action stays hidden. The per-cell test is the one
-    * CrosstabActions.showDetailsVisible applies in the viewer (mirrored here because that getter
-    * is private) and comes from ShowDetailEvent: a cell qualifies unless it sits in the corner
-    * header block, with the runtime row/col header counts deciding whether the first row/column
-    * is itself data. Unlike a plain table, a crosstab header selection does count - a row/column
-    * header shows the details behind that group - hence the fall back to selectedHeaders.
-    */
-   private get detailCellsSelected(): boolean {
-      const selectedCells = this.model.selectedData && this.model.selectedData.size ?
-         this.model.selectedData : this.model.selectedHeaders;
-      let detailsCell: boolean = false;
-
-      if(selectedCells) {
-         selectedCells.forEach((cols, row) => {
-            cols.forEach((col) => {
-               detailsCell = detailsCell ||
-                  (row > 0 || this.model.runtimeColHeaderCount > 0) &&
-                  (col > 0 || this.model.runtimeRowHeaderCount > 0 ||
-                     this.model.runtimeColHeaderCount === 0) &&
-                  !(row < this.model.headerRowCount && col < this.model.headerColCount);
-            });
-         });
-      }
-
-      return detailsCell;
    }
 }

--- a/web/projects/portal/src/app/embed/table/embed-table-actions.ts
+++ b/web/projects/portal/src/app/embed/table/embed-table-actions.ts
@@ -43,7 +43,8 @@ export class EmbedTableActions extends TableActions {
             label: () => "_#(js:Show Details)",
             icon: () => "show-detail-icon",
             enabled: () => true,
-            visible: () => this.isActionVisibleInViewer("Show Details") && !this.annotationsSelected
+            visible: () => this.detailCellsSelected &&
+               this.isActionVisibleInViewer("Show Details") && !this.annotationsSelected
          },
          {
             id: () => "table export",
@@ -96,7 +97,8 @@ export class EmbedTableActions extends TableActions {
             label: () => "_#(js:Show Details)",
             icon: () => "show-detail-icon",
             enabled: () => true,
-            visible: () => this.isActionVisibleInViewer("Show Details")
+            visible: () => this.detailCellsSelected &&
+               this.isActionVisibleInViewer("Show Details")
          },
          {
             id: () => "table export",
@@ -129,5 +131,18 @@ export class EmbedTableActions extends TableActions {
          }]));
 
       return groups;
+   }
+
+   /**
+    * Show Details drills into the selected data cells - BaseTableShowDetailsService reads the
+    * selection off the event - so with nothing selected there is nothing to show and the action
+    * stays hidden. Same rule TableActions.showDetailsVisible applies in the viewer (mirrored
+    * here because that getter is private), minus its this.model.summary check: summary is
+    * assembly.isSummaryTable() on the server, false for the plain detail tables the wiz
+    * generates, and requiring it would hide the action permanently. Header-only selections do
+    * not count - selecting a header clears selectedData (see vs-table.component.ts).
+    */
+   private get detailCellsSelected(): boolean {
+      return !this.model.form && !!this.model.selectedData && this.model.selectedData.size > 0;
    }
 }

--- a/web/projects/portal/src/app/embed/table/embed-table-actions.ts
+++ b/web/projects/portal/src/app/embed/table/embed-table-actions.ts
@@ -39,6 +39,12 @@ export class EmbedTableActions extends TableActions {
    protected createMenuActions(groups: AssemblyActionGroup[]): AssemblyActionGroup[] {
       groups.push(new AssemblyActionGroup([
          {
+            // detailCellsSelected is TableActions' own selection rule (protected for this
+            // reuse). Its showDetailsVisible pairs that with model.summary, which the embed
+            // deliberately drops: summary is assembly.isSummaryTable() on the server, false for
+            // the plain detail tables the wiz generates, so requiring it would hide the action
+            // permanently. Everything else - Show Details needs cells to drill into, and
+            // BaseTableShowDetailsService reads the selection off the event - applies here.
             id: () => "table show-details",
             label: () => "_#(js:Show Details)",
             icon: () => "show-detail-icon",
@@ -131,18 +137,5 @@ export class EmbedTableActions extends TableActions {
          }]));
 
       return groups;
-   }
-
-   /**
-    * Show Details drills into the selected data cells - BaseTableShowDetailsService reads the
-    * selection off the event - so with nothing selected there is nothing to show and the action
-    * stays hidden. Same rule TableActions.showDetailsVisible applies in the viewer (mirrored
-    * here because that getter is private), minus its this.model.summary check: summary is
-    * assembly.isSummaryTable() on the server, false for the plain detail tables the wiz
-    * generates, and requiring it would hide the action permanently. Header-only selections do
-    * not count - selecting a header clears selectedData (see vs-table.component.ts).
-    */
-   private get detailCellsSelected(): boolean {
-      return !this.model.form && !!this.model.selectedData && this.model.selectedData.size > 0;
    }
 }

--- a/web/projects/portal/src/app/vsobjects/action/crosstab-actions.ts
+++ b/web/projects/portal/src/app/vsobjects/action/crosstab-actions.ts
@@ -697,6 +697,17 @@ export class CrosstabActions extends BaseTableActions<VSCrosstabModel> {
          return false;
       }
 
+      return this.detailCellsSelected;
+   }
+
+   /**
+    * Whether the selection holds at least one cell Show Details can act on. Unlike a plain
+    * table, a crosstab header selection counts - a row/column header shows the details behind
+    * that group - hence the fall back to selectedHeaders. Split out of showDetailsVisible and
+    * protected so subclasses can reuse the rule rather than copy the cell iteration;
+    * EmbedCrosstabActions does exactly that.
+    */
+   protected get detailCellsSelected(): boolean {
       const selectedCells = this.model.selectedData && this.model.selectedData.size ?
          this.model.selectedData : this.model.selectedHeaders;
       let detailsCell: boolean = false;

--- a/web/projects/portal/src/app/vsobjects/action/table-actions.ts
+++ b/web/projects/portal/src/app/vsobjects/action/table-actions.ts
@@ -326,8 +326,19 @@ export class TableActions extends BaseTableActions<VSTableModel> {
    }
 
    private get showDetailsVisible(): boolean {
-      return this.model.summary && this.model.selectedData && !this.model.form
-         && this.model.selectedData.size > 0 && this.isActionVisibleInViewer("Show Details");
+      return this.model.summary && this.detailCellsSelected &&
+         this.isActionVisibleInViewer("Show Details");
+   }
+
+   /**
+    * Whether the selection is something Show Details can act on: at least one data cell, on a
+    * table that is not a form. Selecting a header does not qualify - vs-table clears
+    * selectedData when a header is picked. Split out of showDetailsVisible and protected so
+    * subclasses can reuse the selection rule without copying it; EmbedTableActions does exactly
+    * that, and deliberately leaves out the model.summary half.
+    */
+   protected get detailCellsSelected(): boolean {
+      return !this.model.form && !!this.model.selectedData && this.model.selectedData.size > 0;
    }
 
    private get selectionApplyVisible(): boolean {


### PR DESCRIPTION
- EmbedTableActions/EmbedCrosstabActions override createToolbarActions and createMenuActions, and their show-details entries checked only isActionVisibleInViewer("Show Details") -- dropping the selection test the base classes apply. The button therefore showed with nothing selected, where it has no cells to drill into.
- Each subclass now gates the toolbar and menu action on a detailCellsSelected getter. A new name is required: the base getters are named showDetailsVisible and are private, so redeclaring that name would not compile.
- Table: !form && selectedData.size > 0. TableActions.showDetailsVisible also requires model.summary, which is assembly.isSummaryTable() on the server and false for the plain detail tables the wiz generates -- copying it would have hidden the action permanently. Selecting a header does not qualify, since vs-table clears selectedData when a header is picked.
- Crosstab: the per-cell test from CrosstabActions.showDetailsVisible verbatim (originally from ShowDetailEvent) -- a cell qualifies unless it sits in the corner header block, with the runtime row/col header counts deciding whether the first row/column is itself data. Unlike a table, a crosstab header selection does count, so selectedHeaders is still the fallback.