### PR TITLE
Forward the wiz chat's already-resolved measure formula through changeType

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/model/ChangeTypeRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/ChangeTypeRequest.java
@@ -19,6 +19,8 @@ package inetsoft.web.wiz.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+import java.util.List;
+
 /**
  * Request body for {@code POST /api/wiz/viewsheet/changeType}.
  */
@@ -93,6 +95,25 @@ public class ChangeTypeRequest {
       this.assemblyName = assemblyName;
    }
 
+   /**
+    * Field-level overrides (currently only {@code aggregateFormula} is honored) carried over from
+    * the visualization being switched away from. changeType's own recommendation model — whether
+    * reused from a prior {@code autoBinding} call or freshly recomputed by the fallback below —
+    * has no idea what formula the LIVE chart actually ended up using for a measure (e.g. a
+    * complex-chart LLM node like the map binding path picks its own formula directly against
+    * {@code /viewsheet/create}, entirely bypassing the wizard recommender this model comes from),
+    * so its generic per-type default (e.g. Sum for any numeric column) can silently override an
+    * intentional choice like Count on the SAME field. Passing the caller's already-resolved
+    * formula here lets it win over that default instead of being clobbered on every type switch.
+    */
+   public List<SimpleFieldInfo> getFieldConfigs() {
+      return fieldConfigs;
+   }
+
+   public void setFieldConfigs(List<SimpleFieldInfo> fieldConfigs) {
+      this.fieldConfigs = fieldConfigs;
+   }
+
    private String worksheetId;
    private String visualizationType;
    /**
@@ -113,4 +134,5 @@ public class ChangeTypeRequest {
    private String viewsheetIdentifier;
    private boolean copy;
    private String assemblyName;
+   private List<SimpleFieldInfo> fieldConfigs;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/ChangeTypeRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/ChangeTypeRequest.java
@@ -95,17 +95,7 @@ public class ChangeTypeRequest {
       this.assemblyName = assemblyName;
    }
 
-   /**
-    * Field-level overrides (currently only {@code aggregateFormula} is honored) carried over from
-    * the visualization being switched away from. changeType's own recommendation model — whether
-    * reused from a prior {@code autoBinding} call or freshly recomputed by the fallback below —
-    * has no idea what formula the LIVE chart actually ended up using for a measure (e.g. a
-    * complex-chart LLM node like the map binding path picks its own formula directly against
-    * {@code /viewsheet/create}, entirely bypassing the wizard recommender this model comes from),
-    * so its generic per-type default (e.g. Sum for any numeric column) can silently override an
-    * intentional choice like Count on the SAME field. Passing the caller's already-resolved
-    * formula here lets it win over that default instead of being clobbered on every type switch.
-    */
+   /** See the {@link #fieldConfigs} field javadoc. */
    public List<SimpleFieldInfo> getFieldConfigs() {
       return fieldConfigs;
    }
@@ -134,5 +124,16 @@ public class ChangeTypeRequest {
    private String viewsheetIdentifier;
    private boolean copy;
    private String assemblyName;
+   /**
+    * Field-level overrides (currently only {@code aggregateFormula} is honored) carried over from
+    * the visualization being switched away from. changeType's own recommendation model — whether
+    * reused from a prior {@code autoBinding} call or freshly recomputed by the fallback below —
+    * has no idea what formula the LIVE chart actually ended up using for a measure (e.g. a
+    * complex-chart LLM node like the map binding path picks its own formula directly against
+    * {@code /viewsheet/create}, entirely bypassing the wizard recommender this model comes from),
+    * so its generic per-type default (e.g. Sum for any numeric column) can silently override an
+    * intentional choice like Count on the SAME field. Passing the caller's already-resolved
+    * formula here lets it win over that default instead of being clobbered on every type switch.
+    */
    private List<SimpleFieldInfo> fieldConfigs;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -496,6 +496,74 @@ public class WizAutoBindingService {
    }
 
    /**
+    * Re-applies the caller's already-resolved per-measure formulas (see ChangeTypeRequest.fieldConfigs
+    * javadoc) onto whichever assembly type changeType() ends up with — dispatches to the chart or
+    * crosstab-specific applicator; a no-op for any other assembly type (e.g. table, which has no
+    * per-cell aggregate formula to override in the same sense).
+    */
+   private void applyResolvedFormulaOverrides(VSAssembly assembly, Map<String, SimpleFieldInfo> configMap) {
+      if(assembly instanceof ChartVSAssembly chartAsm && chartAsm.getVSChartInfo() != null) {
+         applyFieldConfigs(chartAsm.getVSChartInfo(), configMap);
+      }
+      else if(assembly instanceof CrosstabVSAssembly crosstabAsm && crosstabAsm.getVSCrosstabInfo() != null) {
+         applyCrosstabAggregateFormulas(crosstabAsm.getVSCrosstabInfo(), configMap);
+      }
+   }
+
+   /**
+    * {@link #applyResolvedFormulaOverrides(VSAssembly, Map)} for the changeType() fallback path,
+    * which only has the resulting runtimeId/assemblyName (autoBindingInternal() already executed
+    * and returned a DTO, not the live assembly) — looks it up and applies the same override.
+    * Best-effort: swallows lookup failures so a formula-override miss never fails the whole
+    * changeType call when the rest of it already succeeded.
+    */
+   private void applyResolvedFormulaOverrides(String runtimeId, String assemblyName,
+                                               Map<String, SimpleFieldInfo> configMap, Principal user)
+   {
+      try {
+         RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, user);
+         VSAssembly assembly = rvs == null ? null :
+            (VSAssembly) rvs.getViewsheet().getAssembly(assemblyName);
+         applyResolvedFormulaOverrides(assembly, configMap);
+      }
+      catch(Exception e) {
+         LOG.warn("changeType: failed to apply resolved formula overrides for '{}': {}",
+                  assemblyName, e.getMessage());
+      }
+   }
+
+   /**
+    * changeType()'s crosstab counterpart to {@link #applyFieldConfigs(VSChartInfo, Map)} — that one
+    * only walks a {@link VSChartInfo}, so a crosstab recommendation's aggregate formulas were never
+    * overridden by the caller's resolved fieldConfigs. Only {@code aggregateFormula} applies here;
+    * a crosstab aggregate has no ranking/date-group/calculator of its own to carry over.
+    *
+    * <p>Package-private and static so it can be unit-tested directly with mocked refs, mirroring
+    * {@link #repartitionHeaders}.
+    */
+   static void applyCrosstabAggregateFormulas(VSCrosstabInfo crosstabInfo,
+                                               Map<String, SimpleFieldInfo> configMap)
+   {
+      DataRef[] aggregates = crosstabInfo.getDesignAggregates();
+
+      if(aggregates == null) {
+         return;
+      }
+
+      for(DataRef ref : aggregates) {
+         if(!(ref instanceof VSAggregateRef agg)) {
+            continue;
+         }
+
+         SimpleFieldInfo fc = configMap.get(agg.getColumnValue());
+
+         if(fc instanceof MeasureFieldInfo meaFc && meaFc.getAggregateFormula() != null) {
+            agg.setFormulaValue(meaFc.getAggregateFormula());
+         }
+      }
+   }
+
+   /**
     * Title the X/Y AXES from the {@code title} on whichever fieldConfig is bound to each axis.
     *
     * <p>THE DEFECT THIS FIXES. A caller-supplied {@code title} was accepted, forwarded, and applied
@@ -2008,6 +2076,15 @@ public class WizAutoBindingService {
       String wizRuntimeId = request.getWizRuntimeId();
       String worksheetId = request.getWorksheetId();
       String viewsheetIdentifier = request.getViewsheetIdentifier();
+      // See ChangeTypeRequest.fieldConfigs javadoc: lets the caller's already-resolved formula for
+      // a measure (e.g. Count, chosen by a complex-chart LLM node that never touched this model)
+      // win over whatever generic per-type default the recommendation model below would otherwise
+      // assign that same field.
+      List<SimpleFieldInfo> fieldConfigs = request.getFieldConfigs();
+      Map<String, SimpleFieldInfo> configMap = fieldConfigs == null ? Collections.emptyMap() :
+         fieldConfigs.stream()
+            .filter(f -> f != null && f.getField() != null)
+            .collect(Collectors.toMap(SimpleFieldInfo::getField, f -> f, (a, b) -> a));
 
       // 1. Try to get the recommendation model stored by a prior autoBinding call.
       VSRecommendationModel model = null;
@@ -2044,6 +2121,11 @@ public class WizAutoBindingService {
          fallback.setViewsheetIdentifier(viewsheetIdentifier);
          fallback.setCopy(request.isCopy());
          fallback.setAssemblyName(request.getAssemblyName());
+         // Deliberately NOT fallback.setFieldConfigs(fieldConfigs): AutoBindingRequest.fieldConfigs
+         // is the AUTHORITATIVE full field list (selectBindColumns filters the worksheet down to
+         // EXACTLY those columns) — forwarding our measures-only list here would silently drop every
+         // dimension (e.g. STATE) from the rebuild instead of just fixing a formula. Applied post-hoc
+         // onto the resulting assembly below instead, the same as the fast path.
          AutoBindingResponse resp = autoBindingInternal(fallback, user, true);
          CreateViewsheetResult result = resp.getVisualizationResult();
 
@@ -2060,6 +2142,14 @@ public class WizAutoBindingService {
             try {
                String fallbackRuntimeId = !Tool.isEmptyString(result.getRuntimeId())
                   ? result.getRuntimeId() : wizRuntimeId;
+
+               // Override the freshly-recommended assembly's formulas with the caller's already-
+               // resolved ones BEFORE fetching data, so the fetched headers/rows already reflect it
+               // instead of the generic per-type default autoBindingInternal() picked blind.
+               if(!configMap.isEmpty()) {
+                  applyResolvedFormulaOverrides(fallbackRuntimeId, result.getAssemblyName(), configMap, user);
+               }
+
                CreateViewsheetResult dataResult = wizVsService.fetchAssemblyData(
                   fallbackRuntimeId, result.getAssemblyName(), user);
                result.setHeaders(dataResult.getHeaders());
@@ -2103,6 +2193,13 @@ public class WizAutoBindingService {
 
       if(capturedAutoBindingRvs != null) {
          primaryAssembly = refreshVisualizationBinding(selectedRec, capturedAutoBindingRvs, user);
+
+         // Re-apply the caller's resolved formulas to the freshly-selected recommendation — this
+         // model's own candidate for `visualizationType` was built independent of them (see
+         // ChangeTypeRequest.fieldConfigs javadoc).
+         if(!configMap.isEmpty()) {
+            applyResolvedFormulaOverrides(primaryAssembly, configMap);
+         }
       }
 
       // 4. Place the new primary in wizRuntimeId without executing the sandbox.

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -299,6 +299,13 @@ public class WizAutoBindingService {
                        crosstabAsm.getVSCrosstabInfo() != null)
                {
                   applyCrosstabHeaderPins(crosstabAsm.getVSCrosstabInfo(), explicitBindings);
+                  // Mirror the chart branch's applyFieldConfigs() call above: the crosstab
+                  // recommender builds its own aggregate formula for each measure (its generic
+                  // per-type default, e.g. Sum for any numeric column) independent of what the
+                  // caller's fieldConfigs actually resolved — same root cause changeType() had to
+                  // guard against (see ChangeTypeRequest.fieldConfigs), just reachable here too on
+                  // a FRESH autoBinding call that resolves straight to a crosstab.
+                  applyCrosstabAggregateFormulas(crosstabAsm.getVSCrosstabInfo(), configMap);
                }
             }
          }
@@ -500,8 +507,12 @@ public class WizAutoBindingService {
     * javadoc) onto whichever assembly type changeType() ends up with — dispatches to the chart or
     * crosstab-specific applicator; a no-op for any other assembly type (e.g. table, which has no
     * per-cell aggregate formula to override in the same sense).
+    *
+    * <p>Package-private (not {@code static} — {@link #applyFieldConfigs} it delegates to is an
+    * instance method) so the dispatch itself can be unit-tested directly against a service instance
+    * with mocked assemblies, rather than only indirectly through the full {@link #changeType}.
     */
-   private void applyResolvedFormulaOverrides(VSAssembly assembly, Map<String, SimpleFieldInfo> configMap) {
+   void applyResolvedFormulaOverrides(VSAssembly assembly, Map<String, SimpleFieldInfo> configMap) {
       if(assembly instanceof ChartVSAssembly chartAsm && chartAsm.getVSChartInfo() != null) {
          applyFieldConfigs(chartAsm.getVSChartInfo(), configMap);
       }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -555,8 +555,22 @@ public class WizAutoBindingService {
    static void applyCrosstabAggregateFormulas(VSCrosstabInfo crosstabInfo,
                                                Map<String, SimpleFieldInfo> configMap)
    {
-      DataRef[] aggregates = crosstabInfo.getDesignAggregates();
+      applyAggregateFormulasTo(crosstabInfo.getDesignAggregates(), configMap);
 
+      // Runtime aggregates are normally re-derived from design at execution (VSCrosstabInfo.update()
+      // rebuilds aggrs2 from aggrs), but — same reasoning as applyCrosstabHeaderPins just below —
+      // update them in lockstep when already populated, so the override survives regardless of
+      // whether something reads getRuntimeAggregates() before the next execution re-derives it.
+      DataRef[] runtimeAggregates = crosstabInfo.getRuntimeAggregates();
+
+      if(runtimeAggregates != null && runtimeAggregates.length > 0) {
+         applyAggregateFormulasTo(runtimeAggregates, configMap);
+      }
+   }
+
+   /** Shared per-ref mutation for {@link #applyCrosstabAggregateFormulas} — applied to whichever
+    *  {@code DataRef[]} (design or runtime) the caller passes in. */
+   private static void applyAggregateFormulasTo(DataRef[] aggregates, Map<String, SimpleFieldInfo> configMap) {
       if(aggregates == null) {
          return;
       }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceChangeTypeFieldFormulaTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceChangeTypeFieldFormulaTest.java
@@ -28,7 +28,6 @@ import inetsoft.uql.viewsheet.graph.VSChartAggregateRef;
 import inetsoft.uql.viewsheet.graph.VSChartInfo;
 import inetsoft.web.wiz.model.MeasureFieldInfo;
 import inetsoft.web.wiz.model.SimpleFieldInfo;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceChangeTypeFieldFormulaTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceChangeTypeFieldFormulaTest.java
@@ -118,6 +118,52 @@ class WizAutoBindingServiceChangeTypeFieldFormulaTest {
          info, configMap(measure("CUSTOMER_COUNT", "Count"))));
    }
 
+   // Regression for PR #4509 review: query execution reads getRuntimeAggregates(), not
+   // getDesignAggregates() — the design-only override could be silently lost if runtime aggregates
+   // were already populated (e.g. by an earlier refreshVisualizationBinding execution) and nothing
+   // forces a fresh VSCrosstabInfo.update() before the response's data-fetch step reads them.
+
+   @Test
+   void alsoOverridesAlreadyPopulatedRuntimeAggregates() {
+      VSAggregateRef designRef = agg("CUSTOMER_COUNT");
+      VSAggregateRef runtimeRef = agg("CUSTOMER_COUNT");
+      VSCrosstabInfo info = mock(VSCrosstabInfo.class);
+      when(info.getDesignAggregates()).thenReturn(new DataRef[] { designRef });
+      when(info.getRuntimeAggregates()).thenReturn(new DataRef[] { runtimeRef });
+
+      WizAutoBindingService.applyCrosstabAggregateFormulas(
+         info, configMap(measure("CUSTOMER_COUNT", "Count")));
+
+      verify(designRef).setFormulaValue("Count");
+      verify(runtimeRef).setFormulaValue("Count");
+   }
+
+   @Test
+   void emptyRuntimeAggregatesArrayIsLeftAlone() {
+      VSAggregateRef designRef = agg("CUSTOMER_COUNT");
+      VSCrosstabInfo info = mock(VSCrosstabInfo.class);
+      when(info.getDesignAggregates()).thenReturn(new DataRef[] { designRef });
+      when(info.getRuntimeAggregates()).thenReturn(new DataRef[0]);
+
+      assertDoesNotThrow(() -> WizAutoBindingService.applyCrosstabAggregateFormulas(
+         info, configMap(measure("CUSTOMER_COUNT", "Count"))));
+
+      verify(designRef).setFormulaValue("Count");
+   }
+
+   @Test
+   void nullRuntimeAggregatesIsSafe() {
+      VSAggregateRef designRef = agg("CUSTOMER_COUNT");
+      VSCrosstabInfo info = mock(VSCrosstabInfo.class);
+      when(info.getDesignAggregates()).thenReturn(new DataRef[] { designRef });
+      when(info.getRuntimeAggregates()).thenReturn(null);
+
+      assertDoesNotThrow(() -> WizAutoBindingService.applyCrosstabAggregateFormulas(
+         info, configMap(measure("CUSTOMER_COUNT", "Count"))));
+
+      verify(designRef).setFormulaValue("Count");
+   }
+
    /**
     * applyResolvedFormulaOverrides(VSAssembly, Map) dispatch — the piece that decides WHICH
     * applicator (chart vs. crosstab vs. neither) a changeType() result actually reaches. Only the

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceChangeTypeFieldFormulaTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceChangeTypeFieldFormulaTest.java
@@ -1,0 +1,114 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.viewsheet.VSAggregateRef;
+import inetsoft.uql.viewsheet.VSCrosstabInfo;
+import inetsoft.web.wiz.model.MeasureFieldInfo;
+import inetsoft.web.wiz.model.SimpleFieldInfo;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link WizAutoBindingService#applyCrosstabAggregateFormulas} — the crosstab
+ * counterpart of {@code applyFieldConfigs} added so {@code changeType()} can re-apply a caller's
+ * already-resolved measure formula (e.g. Count) onto a freshly-selected crosstab recommendation.
+ *
+ * <p>Regression for map→crosstab silently turning Count(CUSTOMER_COUNT) into Sum(CUSTOMER_COUNT):
+ * a complex-chart LLM node (e.g. the map binding path) picks its own formula directly against
+ * {@code /viewsheet/create}, entirely bypassing the wizard recommender — so the recommendation
+ * model changeType() consults for the destination type has no idea a measure was already resolved
+ * to something other than its own generic per-type default (Sum for any numeric column).
+ */
+@Tag("core")
+class WizAutoBindingServiceChangeTypeFieldFormulaTest {
+   private static VSAggregateRef agg(String column) {
+      VSAggregateRef ref = mock(VSAggregateRef.class);
+      when(ref.getColumnValue()).thenReturn(column);
+      return ref;
+   }
+
+   private static MeasureFieldInfo measure(String field, String formula) {
+      MeasureFieldInfo fc = new MeasureFieldInfo();
+      fc.setField(field);
+      fc.setAggregateFormula(formula);
+      return fc;
+   }
+
+   private static Map<String, SimpleFieldInfo> configMap(SimpleFieldInfo... configs) {
+      Map<String, SimpleFieldInfo> map = new HashMap<>();
+
+      for(SimpleFieldInfo fc : configs) {
+         map.put(fc.getField(), fc);
+      }
+
+      return map;
+   }
+
+   @Test
+   void overridesFormulaForMatchingField() {
+      VSAggregateRef ref = agg("CUSTOMER_COUNT");
+      VSCrosstabInfo info = mock(VSCrosstabInfo.class);
+      when(info.getDesignAggregates()).thenReturn(new DataRef[] { ref });
+
+      WizAutoBindingService.applyCrosstabAggregateFormulas(
+         info, configMap(measure("CUSTOMER_COUNT", "Count")));
+
+      verify(ref).setFormulaValue("Count");
+   }
+
+   @Test
+   void leavesUnmatchedFieldsUntouched() {
+      VSAggregateRef ref = agg("ORDER_TOTAL");
+      VSCrosstabInfo info = mock(VSCrosstabInfo.class);
+      when(info.getDesignAggregates()).thenReturn(new DataRef[] { ref });
+
+      WizAutoBindingService.applyCrosstabAggregateFormulas(
+         info, configMap(measure("CUSTOMER_COUNT", "Count")));
+
+      verify(ref, never()).setFormulaValue(anyString());
+   }
+
+   @Test
+   void emptyConfigMapIsSafe() {
+      VSAggregateRef ref = agg("CUSTOMER_COUNT");
+      VSCrosstabInfo info = mock(VSCrosstabInfo.class);
+      when(info.getDesignAggregates()).thenReturn(new DataRef[] { ref });
+
+      WizAutoBindingService.applyCrosstabAggregateFormulas(info, new HashMap<>());
+
+      verify(ref, never()).setFormulaValue(anyString());
+   }
+
+   @Test
+   void nullAggregatesIsSafe() {
+      VSCrosstabInfo info = mock(VSCrosstabInfo.class);
+      when(info.getDesignAggregates()).thenReturn(null);
+
+      assertDoesNotThrow(() -> WizAutoBindingService.applyCrosstabAggregateFormulas(
+         info, configMap(measure("CUSTOMER_COUNT", "Count"))));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceChangeTypeFieldFormulaTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceChangeTypeFieldFormulaTest.java
@@ -18,10 +18,17 @@
 package inetsoft.web.wiz.service;
 
 import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.CrosstabVSAssembly;
+import inetsoft.uql.viewsheet.TableVSAssembly;
 import inetsoft.uql.viewsheet.VSAggregateRef;
+import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.VSCrosstabInfo;
+import inetsoft.uql.viewsheet.graph.VSChartAggregateRef;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
 import inetsoft.web.wiz.model.MeasureFieldInfo;
 import inetsoft.web.wiz.model.SimpleFieldInfo;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -110,5 +117,65 @@ class WizAutoBindingServiceChangeTypeFieldFormulaTest {
 
       assertDoesNotThrow(() -> WizAutoBindingService.applyCrosstabAggregateFormulas(
          info, configMap(measure("CUSTOMER_COUNT", "Count"))));
+   }
+
+   /**
+    * applyResolvedFormulaOverrides(VSAssembly, Map) dispatch — the piece that decides WHICH
+    * applicator (chart vs. crosstab vs. neither) a changeType() result actually reaches. Only the
+    * dispatch is exercised here (via a service instance with every unused collaborator left null,
+    * mirroring WizAutoBindingServiceSetChartFormatTest's pattern) — not the full changeType() call.
+    */
+   @Tag("core")
+   static class ApplyResolvedFormulaOverridesDispatchTest {
+      private final WizAutoBindingService service =
+         new WizAutoBindingService(null, null, null, null, null, null, null);
+
+      @Test
+      void dispatchesChartAssemblyToApplyFieldConfigs() {
+         VSChartAggregateRef yRef = mock(VSChartAggregateRef.class);
+         when(yRef.getColumnValue()).thenReturn("CUSTOMER_COUNT");
+
+         VSChartInfo chartInfo = mock(VSChartInfo.class);
+         when(chartInfo.getXFields()).thenReturn(new inetsoft.uql.viewsheet.graph.ChartRef[0]);
+         when(chartInfo.getYFields()).thenReturn(
+            new inetsoft.uql.viewsheet.graph.ChartRef[] { yRef });
+
+         ChartVSAssembly chartAsm = mock(ChartVSAssembly.class);
+         when(chartAsm.getVSChartInfo()).thenReturn(chartInfo);
+
+         service.applyResolvedFormulaOverrides(
+            (VSAssembly) chartAsm, configMap(measure("CUSTOMER_COUNT", "Count")));
+
+         verify(yRef).setFormulaValue("Count");
+      }
+
+      @Test
+      void dispatchesCrosstabAssemblyToApplyCrosstabAggregateFormulas() {
+         VSAggregateRef ref = agg("CUSTOMER_COUNT");
+         VSCrosstabInfo crosstabInfo = mock(VSCrosstabInfo.class);
+         when(crosstabInfo.getDesignAggregates()).thenReturn(new DataRef[] { ref });
+
+         CrosstabVSAssembly crosstabAsm = mock(CrosstabVSAssembly.class);
+         when(crosstabAsm.getVSCrosstabInfo()).thenReturn(crosstabInfo);
+
+         service.applyResolvedFormulaOverrides(
+            (VSAssembly) crosstabAsm, configMap(measure("CUSTOMER_COUNT", "Count")));
+
+         verify(ref).setFormulaValue("Count");
+      }
+
+      @Test
+      void neitherChartNorCrosstabIsANoOp() {
+         TableVSAssembly tableAsm = mock(TableVSAssembly.class);
+
+         assertDoesNotThrow(() -> service.applyResolvedFormulaOverrides(
+            (VSAssembly) tableAsm, configMap(measure("CUSTOMER_COUNT", "Count"))));
+      }
+
+      @Test
+      void nullAssemblyIsANoOp() {
+         assertDoesNotThrow(() -> service.applyResolvedFormulaOverrides(
+            null, configMap(measure("CUSTOMER_COUNT", "Count"))));
+      }
    }
 }


### PR DESCRIPTION
## Summary

- `changeType()` re-renders the target `visualizationType` using a recommendation model built **independently** of the chart being switched away from.
- A complex-chart LLM node on the wiz-services side (e.g. the map binding path) can pick its own `aggregateFormula` for a measure directly against `/viewsheet/create`, bypassing this model entirely — so that choice was never visible to `changeType`, and its own per-type default (e.g. `Sum` for any numeric column) could silently overwrite it on every type switch.
- `ChangeTypeRequest` gains an optional `fieldConfigs` list carrying the caller's already-resolved formula per measure. `WizAutoBindingService.changeType()` applies it in **both** branches:
  - **fast path** (recommendation model reused): re-applies `fieldConfigs` onto the freshly-selected recommendation via the new `applyResolvedFormulaOverrides`, mirroring the existing `applyFieldConfigs(VSChartInfo, ...)` for chart assemblies, with a new `applyCrosstabAggregateFormulas` for crosstab (which had no equivalent before this change).
  - **fallback path** (model missing, full `autoBindingInternal()` re-run): looks up the resulting assembly by `runtimeId`/`assemblyName` and applies the same override before fetching data for the response — deliberately **NOT** forwarded through `AutoBindingRequest.fieldConfigs`, since that field is the AUTHORITATIVE full column list (`selectBindColumns` filters the worksheet down to exactly those columns) — forwarding a measures-only list there would silently drop every dimension from the rebuild.

Companion fix on the wiz-services side ([inetsoft-technology/stylebi-wiz#1445](https://github.com/inetsoft-technology/stylebi-wiz/pull/1445)) addresses the root cause — a map/complex-chart LLM node picking the wrong formula in the first place for an already-aggregated worksheet column. This PR makes `changeType` robust to that class of mismatch regardless of source.

## Tests

- New: `WizAutoBindingServiceChangeTypeFieldFormulaTest` (4 cases) for `applyCrosstabAggregateFormulas`.
- Existing `WizAutoBindingServiceCrosstabPinsTest` / `SelectBindColumnsTest` / `AxisTitleTest` / `DateGroupTest` all still pass.
- `mvnw -pl core -am compile` and `mvnw -pl server -am compile` (from this repo's root) both clean.

## Not yet done

- End-to-end verification against a running instance (local dev environment was unstable during this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)