### PR TITLE
Bug #75910, don't fail selection refresh when a slider's bound column is removed from its source

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
@@ -4705,11 +4705,16 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
             if(sassembly instanceof TimeSliderVSAssembly &&
                clist.getSelectionList().contains(sassembly.getAssemblyEntry()))
             {
+               TimeSliderVSAssembly tsassembly = (TimeSliderVSAssembly) sassembly;
+
                try {
                   TimeSliderVSAQuery query = (TimeSliderVSAQuery) VSAQuery.
                      createVSAQuery(this, sassembly, DataMap.NORMAL);
                   Object obj = getData(sassembly.getName());
                   query.refreshSelectionValue(obj);
+               }
+               catch(ConfirmException | CancelledException ex) {
+                  throw ex;
                }
                catch(Exception ex) {
                   // The column this slider is bound to (e.g. a chart measure, if this
@@ -4720,8 +4725,8 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
                   // or removed.
                   LOG.warn("Failed to refresh selection value for: {}",
                      sassembly.getAbsoluteName(), ex);
-                  ((TimeSliderVSAssembly) sassembly).setSelectionList(null);
-                  ((TimeSliderVSAssembly) sassembly).setStateSelectionList(null);
+                  tsassembly.setSelectionList(null);
+                  tsassembly.setStateSelectionList(null);
                }
             }
 

--- a/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
@@ -4705,10 +4705,24 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
             if(sassembly instanceof TimeSliderVSAssembly &&
                clist.getSelectionList().contains(sassembly.getAssemblyEntry()))
             {
-               TimeSliderVSAQuery query = (TimeSliderVSAQuery) VSAQuery.
-                  createVSAQuery(this, sassembly, DataMap.NORMAL);
-               Object obj = getData(sassembly.getName());
-               query.refreshSelectionValue(obj);
+               try {
+                  TimeSliderVSAQuery query = (TimeSliderVSAQuery) VSAQuery.
+                     createVSAQuery(this, sassembly, DataMap.NORMAL);
+                  Object obj = getData(sassembly.getName());
+                  query.refreshSelectionValue(obj);
+               }
+               catch(Exception ex) {
+                  // The column this slider is bound to (e.g. a chart measure, if this
+                  // slider is a filter on a chart) may have just been removed from its
+                  // source by the change that triggered this refresh. Don't let one
+                  // stale binding fail refreshing every other selection on the sheet;
+                  // just leave this slider showing no selection until it is rebound
+                  // or removed.
+                  LOG.warn("Failed to refresh selection value for: {}",
+                     sassembly.getAbsoluteName(), ex);
+                  ((TimeSliderVSAssembly) sassembly).setSelectionList(null);
+                  ((TimeSliderVSAssembly) sassembly).setStateSelectionList(null);
+               }
             }
 
             if(sassembly instanceof CalendarVSAssembly &&


### PR DESCRIPTION
## Summary
- Creating an ad hoc filter (a `TimeSlider`) on a chart measure, then removing that measure from the chart's binding via drag-and-drop, left the filter bound to a column that no longer exists.
- `ViewsheetSandbox.processSelection` refreshes every `TimeSliderVSAssembly` sharing the same table/chart binding as part of handling the change; that refresh threw an uncaught `RuntimeException` from `TimeSliderVSAQuery.createAssemblyTable` ("column ... not found in assembly ..."), which propagated all the way to the STOMP handler and surfaced to the user as "An unexpected error has occurred," aborting the rest of the selection refresh.
- Recover the same way a missing source table is already handled a few lines above in the same method: catch the failure, log a warning, and clear the slider's stale selection state instead of propagating.

## Root cause / repro
1. Bind a chart with a measure (e.g. `Count(Order:Num)`).
2. Create an ad hoc filter on that measure (drag-select on the bars) — creates a `TimeSlider`/`RangeSlider` bound to the chart and that measure.
3. Open the chart's binding editor and drag that same measure off the chart (unbind it).
4. The dependent ad hoc filter's selection-value refresh throws, and the drag-and-drop operation surfaces a generic error.

Traced via server stack trace: `VSChartDndController.removeColumns` → `VSChartDndService.removeColumns` → `applyChartInfo` → `VSChartDataHandler.changeChartData` → `ViewsheetSandbox.processChange` → `processSelections` → `processSelection`.

## Test plan
- [ ] Reproduce the steps above against this branch and confirm no error popup; the orphaned filter shows no selection instead.
- [ ] Confirm other dashboards with selection filters/time sliders bound to valid columns still refresh normally (no regression to the non-error path).