### PR TITLE
Bug #75946, enforce destination-folder WRITE permission when moving schedule tasks

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskFolderService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskFolderService.java
@@ -294,7 +294,10 @@ public class ScheduleTaskFolderService {
    public void moveScheduleItems(ScheduleTaskModel[] taskModels, String[] folders, AssetEntry targetEntry, Principal principal)
       throws Exception
    {
-      if(folders != null && folders.length > 0) {
+      boolean hasTasks = taskModels != null && taskModels.length > 0;
+      boolean hasFolders = folders != null && folders.length > 0;
+
+      if(hasFolders || hasTasks) {
          if(!checkFolderPermission(targetEntry.getPath(), principal, ResourceAction.WRITE)) {
             throw new MessageException(Catalog.getCatalog().getString(
                "common.writeAuthority", targetEntry.getPath()));


### PR DESCRIPTION
## Summary
- `ScheduleTaskFolderService.moveScheduleItems()` only checked destination-folder `WRITE` permission when the request's `folders` array was non-empty (i.e. moving subfolders). Moving a plain schedule task sends an empty `folders` array, so the WRITE check was skipped entirely and `moveTask()` performed the move with no authorization check.
- This let a user with only READ access on a destination schedule folder move tasks into it, bypassing folder permissions.
- Fix: the destination WRITE check now runs whenever either `folders` or `taskModels` is non-empty, reusing the existing check/exception.

## Test plan
- [ ] As an admin, create user0 with an advanced role
- [ ] Create folder1 under Schedule and grant user0 only READ permission on it
- [ ] Log in as user0 and attempt to move a schedule task into folder1
- [ ] Verify a "you do not have write authority" error is returned and the task is not moved
- [ ] Verify moving tasks into a folder the user has WRITE on still succeeds
- [ ] Verify moving subfolders still works as before (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)