### PR TITLE
Bug #75911, register auto-created Save As folders so the Composer tree shows them

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/AbstractAssetEngine.java
+++ b/core/src/main/java/inetsoft/uql/asset/AbstractAssetEngine.java
@@ -2570,9 +2570,12 @@ public abstract class AbstractAssetEngine implements AssetRepository, AutoClosea
             }
 
             if(pfolder == null) {
-               IndexedStorage dstorage = getStorage(pentry);
-               pfolder = new AssetFolder();
-               dstorage.putXMLSerializable(pidentifier, pfolder);
+               // reuse addFolder so the missing folder (and any missing ancestors) are
+               // registered in their parent's entry list and an AssetChangeEvent is fired,
+               // instead of just leaving an orphaned storage entry the client tree can't see
+               checkAssetPermission(user, pentry, ResourceAction.WRITE);
+               addFolder(pentry, user);
+               pfolder = getParentFolder(entry, storage);
             }
 
             boolean contained = pfolder.containsEntry(entry);


### PR DESCRIPTION
## Summary

Saving a worksheet via "Save As" to a path whose folder didn't exist yet (e.g. `mynewfolder/ws1`) correctly created the worksheet asset and the folder on the backend, but the Composer's repository/asset tree never showed the new folder afterward. Enterprise Manager showed the asset fine (it lists by path-string matching), which is why the asset's existence wasn't in question — only the Composer tree's visibility of it.

## Root Cause

`AbstractAssetEngine.setSheet()` handled a missing parent folder by writing a bare `AssetFolder` storage object for it directly:

```java
if(pfolder == null) {
   IndexedStorage dstorage = getStorage(pentry);
   pfolder = new AssetFolder();
   dstorage.putXMLSerializable(pidentifier, pfolder);
}
```

This never registered the new folder in its own parent's `AssetFolder.addEntry()` list, and never fired an `AssetChangeEvent` for the folder itself. The Composer's repository tree (`asset-tree.component.ts`) lists children via parent-folder containment and refreshes via `AssetChangeEvent` over STOMP (`/user/asset-changed`) — since the new folder was never linked into any parent's child list, no refresh path could ever surface it, no matter how the tree was reloaded.

## Fix

Reuse the existing `addFolder()` method — the same one the explicit "New Folder" UI action uses — which already creates missing ancestor folders recursively, registers each in its parent's entry list, and fires the `AssetChangeEvent` the tree relies on:

```java
if(pfolder == null) {
   checkAssetPermission(user, pentry, ResourceAction.WRITE);
   addFolder(pentry, user);
   pfolder = getParentFolder(entry, storage);
}
```

The permission check now runs before folder creation (previously an unconditional folder write happened before any permission check later in the method), and the change only affects the previously-broken "auto-create missing folder(s) on save" path — it doesn't touch the existing-folder save path or the viewsheet auto-create-folder case (which throws earlier, unchanged).

## Test Plan

- Verified live: connect to a worksheet, "Save As" to a path with a brand-new folder (e.g. `mynewfolder/ws1`) — the folder now appears immediately in the Composer's repository tree.
- `community/core` compiles cleanly (`mvnw test-compile -pl core -am`, BUILD SUCCESS).
- Traced all 24 call sites of `setSheet()` in `community/` — none depend on the previous broken (orphaned-folder) behavior; they all expect the sheet to persist at the given path, which this fix now does correctly.
- No dedicated unit test previously existed for this method/`addFolder` interaction; confirmed via search.

Fixes Redmine #75911.