### PR TITLE
Bug #75922, apply round corner to TextInput/Text on Excel and PowerPoint export

### DIFF
--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
@@ -1011,15 +1011,6 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
 
    /**
     * Apply the format setting.
-    */
-   private void applyFormat(XSSFTextBox tb, RichTextString rts,
-                            VSCompositeFormat format, boolean shadowed)
-   {
-      applyFormat(tb, rts, format, shadowed, null);
-   }
-
-   /**
-    * Apply the format setting.
     * @param pixelBounds the pixel bounds of the shape, used to translate the round corner
     *                     radius (in pixels) into an OOXML preset geometry adjustment. May be
     *                     null, in which case round corners are not applied.

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
@@ -803,7 +803,7 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
       XSSFRichTextString rts = (XSSFRichTextString)
          PoiExcelVSUtil.createRichTextString(book, labelInfo.getLabelText());
       tb.setText(rts);
-      applyFormat(tb, rts, getLabelFormat(labelInfo), false);
+      applyFormat(tb, rts, getLabelFormat(labelInfo), false, padded);
    }
 
    /**
@@ -887,7 +887,7 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
          XSSFRichTextString rts = (XSSFRichTextString)
             PoiExcelVSUtil.createRichTextString(book, txt);
          tb.setText(rts);
-         applyFormat(tb, rts, getTextFormat(info), false);
+         applyFormat(tb, rts, getTextFormat(info), false, split[1]);
       }
       catch(SheetMaxRowsException e) {
          throw e;
@@ -994,7 +994,8 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
                tb.setBottomInset(padding.bottom);
             }
 
-            applyFormat(tb, rts, format, shadowed);
+            applyFormat(tb, rts, format, shadowed,
+                        new Rectangle2D.Double(0, 0, size.width, size.height));
          }
       }
       catch(SheetMaxRowsException e) {
@@ -1014,6 +1015,19 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
    private void applyFormat(XSSFTextBox tb, RichTextString rts,
                             VSCompositeFormat format, boolean shadowed)
    {
+      applyFormat(tb, rts, format, shadowed, null);
+   }
+
+   /**
+    * Apply the format setting.
+    * @param pixelBounds the pixel bounds of the shape, used to translate the round corner
+    *                     radius (in pixels) into an OOXML preset geometry adjustment. May be
+    *                     null, in which case round corners are not applied.
+    */
+   private void applyFormat(XSSFTextBox tb, RichTextString rts,
+                            VSCompositeFormat format, boolean shadowed,
+                            Rectangle2D pixelBounds)
+   {
       if(format == null) {
          return;
       }
@@ -1024,6 +1038,7 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
       BorderColors bcolors = format.getBorderColors();
       java.awt.Font font = format.getFont();
       int alpha = format.getAlpha();
+      int roundCorner = format.getRoundCorner();
 
       if(font != null) {
          rts.applyFont(PoiExcelVSUtil.getPOIFont(format, book, true));
@@ -1034,6 +1049,10 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
 
       if(bg != null) {
          tb.setFillColor(bg.getRed(), bg.getGreen(), bg.getBlue());
+      }
+
+      if(roundCorner > 0 && pixelBounds != null) {
+         applyRoundCorner(tb, roundCorner, pixelBounds);
       }
 
       if(borders != null) {

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
@@ -803,7 +803,9 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
       XSSFRichTextString rts = (XSSFRichTextString)
          PoiExcelVSUtil.createRichTextString(book, labelInfo.getLabelText());
       tb.setText(rts);
-      applyFormat(tb, rts, getLabelFormat(labelInfo), false, padded);
+      // Use the original (unpadded) bounds for the round-corner radius calculation so the
+      // font-metric slack added to padded's width doesn't skew the shorter-side comparison.
+      applyFormat(tb, rts, getLabelFormat(labelInfo), false, pixelBounds);
    }
 
    /**

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/ppt/PPTVSUtil.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/ppt/PPTVSUtil.java
@@ -88,6 +88,34 @@ public class PPTVSUtil {
       }
    }
 
+   /**
+    * Switch the shape's preset geometry to a rounded rectangle and set the corner
+    * adjustment ("adj" guide) so the rendered radius matches the given pixel radius.
+    * @param shape the shape to round.
+    * @param roundCorner the corner radius in pixels.
+    * @param bounds the shape's bounds, in the same point units as the shape's anchor.
+    */
+   public static void applyRoundCorner(XSLFAutoShape shape, int roundCorner, Rectangle2D bounds) {
+      double minSide = Math.min(bounds.getWidth(), bounds.getHeight());
+
+      if(minSide <= 0) {
+         return;
+      }
+
+      shape.setShapeType(ShapeType.ROUND_RECT);
+      double radius = roundCorner * PIXEL_TO_POINT;
+      // OOXML roundRect "adj" guide is a percentage (0-50000, i.e. 0%-50%) of the
+      // shorter side that the corner radius should occupy.
+      int adj = (int) Math.round(Math.min(1d, radius / (minSide / 2)) * 50000);
+      CTShape ctShape = (CTShape) shape.getXmlObject();
+      CTShapeProperties sppr = ctShape.getSpPr();
+      CTPresetGeometry2D prstGeom = sppr.getPrstGeom();
+      CTGeomGuideList avLst = prstGeom.isSetAvLst() ? prstGeom.getAvLst() : prstGeom.addNewAvLst();
+      CTGeomGuide gd = avLst.sizeOfGdArray() > 0 ? avLst.getGdArray(0) : avLst.addNewGd();
+      gd.setName("adj");
+      gd.setFmla("val " + adj);
+   }
+
    private static void setDoubleLineStyle(XSLFAutoShape line) {
       CTShape shape = (CTShape) line.getXmlObject();
       CTShapeProperties sppr = shape.getSpPr();

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/ppt/PPTValueHelper.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/ppt/PPTValueHelper.java
@@ -421,8 +421,14 @@ public class PPTValueHelper {
       // single rounded-rectangle outline instead when the round corner is set. Skip this
       // for table/crosstab/tree cells (cellType != 0): those rely on the per-side
       // CELL_TAIL/CELL_CONTENT skips below to avoid doubling up borders shared with
-      // adjacent cells, which a single all-sides shape can't replicate.
-      if(borders != null && format.getRoundCorner() > 0 && cellType == 0) {
+      // adjacent cells, which a single all-sides shape can't replicate. Also require all
+      // four sides to be set: a single-sided border (e.g. an "underline" with only
+      // borders.bottom set) can't be represented as one rounded outline without drawing an
+      // unwanted box around the other three sides, so fall through to the per-side lines
+      // below instead.
+      if(borders != null && format.getRoundCorner() > 0 && cellType == 0 &&
+         borders.top != 0 && borders.left != 0 && borders.right != 0 && borders.bottom != 0)
+      {
          int type;
          Color color;
 

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/ppt/PPTValueHelper.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/ppt/PPTValueHelper.java
@@ -417,20 +417,37 @@ public class PPTValueHelper {
          VSAssemblyInfo.DEFAULT_BORDER_COLOR,
          VSAssemblyInfo.DEFAULT_BORDER_COLOR);
 
-      // four independent straight-line shapes can't form a rounded corner, so draw a
-      // single rounded-rectangle outline instead when the round corner is set.
-      if(borders != null && format.getRoundCorner() > 0) {
-         int type = borders.top != 0 ? borders.top :
-            borders.left != 0 ? borders.left :
-            borders.right != 0 ? borders.right : borders.bottom;
+      // Four independent straight-line shapes can't form a rounded corner, so draw a
+      // single rounded-rectangle outline instead when the round corner is set. Skip this
+      // for table/crosstab/tree cells (cellType != 0): those rely on the per-side
+      // CELL_TAIL/CELL_CONTENT skips below to avoid doubling up borders shared with
+      // adjacent cells, which a single all-sides shape can't replicate.
+      if(borders != null && format.getRoundCorner() > 0 && cellType == 0) {
+         int type;
+         Color color;
+
+         if(borders.top != 0) {
+            type = borders.top;
+            color = colors == null || colors.topColor == null ?
+               defbcolors.topColor : colors.topColor;
+         }
+         else if(borders.left != 0) {
+            type = borders.left;
+            color = colors == null || colors.leftColor == null ?
+               defbcolors.leftColor : colors.leftColor;
+         }
+         else if(borders.right != 0) {
+            type = borders.right;
+            color = colors == null || colors.rightColor == null ?
+               defbcolors.rightColor : colors.rightColor;
+         }
+         else {
+            type = borders.bottom;
+            color = colors == null || colors.bottomColor == null ?
+               defbcolors.bottomColor : colors.bottomColor;
+         }
 
          if(PPTVSUtil.getBorderWidth(type) != 0) {
-            Color color = colors == null ? defbcolors.topColor :
-               colors.topColor != null ? colors.topColor :
-               colors.leftColor != null ? colors.leftColor :
-               colors.rightColor != null ? colors.rightColor :
-               colors.bottomColor != null ? colors.bottomColor : defbcolors.topColor;
-
             XSLFAutoShape roundBorder = slide.createAutoShape();
             roundBorder.setAnchor(new Rectangle(x, y, width, height));
             PPTVSUtil.applyRoundCorner(roundBorder, format.getRoundCorner(), bounds);

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/ppt/PPTValueHelper.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/ppt/PPTValueHelper.java
@@ -266,6 +266,10 @@ public class PPTValueHelper {
             format.getBackground()));
       }
 
+      if(format.getRoundCorner() > 0 && bounds != null) {
+         PPTVSUtil.applyRoundCorner(textbox, format.getRoundCorner(), bounds);
+      }
+
       if(format.getForeground() != null) {
          rtr.setFontColor(format.getForeground());
       }
@@ -412,6 +416,31 @@ public class PPTValueHelper {
          VSAssemblyInfo.DEFAULT_BORDER_COLOR,
          VSAssemblyInfo.DEFAULT_BORDER_COLOR,
          VSAssemblyInfo.DEFAULT_BORDER_COLOR);
+
+      // four independent straight-line shapes can't form a rounded corner, so draw a
+      // single rounded-rectangle outline instead when the round corner is set.
+      if(borders != null && format.getRoundCorner() > 0) {
+         int type = borders.top != 0 ? borders.top :
+            borders.left != 0 ? borders.left :
+            borders.right != 0 ? borders.right : borders.bottom;
+
+         if(PPTVSUtil.getBorderWidth(type) != 0) {
+            Color color = colors == null ? defbcolors.topColor :
+               colors.topColor != null ? colors.topColor :
+               colors.leftColor != null ? colors.leftColor :
+               colors.rightColor != null ? colors.rightColor :
+               colors.bottomColor != null ? colors.bottomColor : defbcolors.topColor;
+
+            XSLFAutoShape roundBorder = slide.createAutoShape();
+            roundBorder.setAnchor(new Rectangle(x, y, width, height));
+            PPTVSUtil.applyRoundCorner(roundBorder, format.getRoundCorner(), bounds);
+            roundBorder.setFillColor(null);
+            PPTVSUtil.applyLineStyle(roundBorder, type);
+            roundBorder.setLineColor(color);
+         }
+
+         return;
+      }
 
       if(borders != null) {
          if(PPTVSUtil.getBorderWidth(borders.left) != 0) {


### PR DESCRIPTION
## Summary
- TextInput (and Text) round-corner formatting was silently dropped when exporting to Excel or PowerPoint with "match layout" — the widget exported as a plain rectangle even though the viewer and PDF/SVG/PNG/HTML exports render it rounded.
- Root cause: the POI-based Excel and PPT exporters paint borders/shapes with their own from-scratch code that never reads `format.getRoundCorner()`, unlike the shared `ExportUtil.drawBorders()`/`drawRoundRect()` path used by PDF/SVG/PNG/HTML.
- Fix: when round corner is set, switch the shape's preset geometry to `roundRect` (Excel) / `ROUND_RECT` (PPT) and compute the OOXML `adj` guide from the pixel radius relative to the shape's shorter side.
  - Excel (`PoiExcelVSExporter.applyFormat`): rounds the `XSSFTextBox` used for labels, TextInput values, and text-as-image.
  - PowerPoint (`PPTValueHelper.writeContent`/`paintBorders`, `PPTVSUtil.applyRoundCorner`): rounds the fill/text shape, and replaces the four independent border-line shapes with a single rounded outline shape when round corner is set (four straight lines can't form a rounded corner).

## Test plan
- [ ] Create a viewsheet with a TextInput that has round corner + border set.
- [ ] Export to Excel with "match layout" and confirm the corners are rounded.
- [ ] Export to PowerPoint and confirm the corners are rounded.
- [ ] Confirm existing non-rounded TextInput/Text/table-cell borders in Excel/PPT export are unaffected.