### PR TITLE
Bug #75957, resolve set_ranking field against AggregateInfo, not the pre-aggregate column

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -889,7 +889,13 @@ public final class WorksheetMutationSupport {
       int op = "BOTTOM_N".equalsIgnoreCase(spec.operation())
          ? XCondition.BOTTOM_N : XCondition.TOP_N;
 
-      DataRef ref = resolveField(t, spec.field());
+      // The RankingCondition itself always runs after aggregation (see
+      // AssetQuery.getRankingTableLens), so resolve against AggregateInfo first — this
+      // matches both an aggregate (e.g. "Sum(Total)") and a group-by dimension (e.g.
+      // "Employee") — before falling back to the plain column selection, like
+      // set_post_conditions does. Otherwise a rank on "Sum(Total)" binds to the raw
+      // "Total" column instead of the aggregate ref.
+      DataRef ref = resolveField(t, spec.field(), true);
       inetsoft.uql.asset.RankingCondition rc = new inetsoft.uql.asset.RankingCondition();
       rc.setOperation(op);
       rc.setN(spec.n());

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -890,12 +890,19 @@ public final class WorksheetMutationSupport {
          ? XCondition.BOTTOM_N : XCondition.TOP_N;
 
       // The RankingCondition itself always runs after aggregation (see
-      // AssetQuery.getRankingTableLens), so resolve against AggregateInfo first — this
-      // matches both an aggregate (e.g. "Sum(Total)") and a group-by dimension (e.g.
-      // "Employee") — before falling back to the plain column selection, like
-      // set_post_conditions does. Otherwise a rank on "Sum(Total)" binds to the raw
-      // "Total" column instead of the aggregate ref.
-      DataRef ref = resolveField(t, spec.field(), true);
+      // AssetQuery.getRankingTableLens), so prefer AggregateInfo — matching either an
+      // aggregate (e.g. "Sum(Total)") or a group-by dimension (e.g. "Employee") — over a
+      // plain column, otherwise a rank on "Sum(Total)" binds to the raw "Total" column
+      // instead of the aggregate ref. Unlike set_post_conditions, the fallback stays on
+      // the PRIVATE column selection (not the public one used by resolveField(t, f, true))
+      // so ranking on a non-aggregated table still finds columns hidden via
+      // set_column_visibility.
+      DataRef ref = resolveAggregateOrGroupField(t, spec.field());
+
+      if(ref == null) {
+         ref = resolveField(t, spec.field(), false);
+      }
+
       inetsoft.uql.asset.RankingCondition rc = new inetsoft.uql.asset.RankingCondition();
       rc.setOperation(op);
       rc.setN(spec.n());
@@ -936,32 +943,11 @@ public final class WorksheetMutationSupport {
       // is displayed as a pre-aggregate condition. The alias set by set_group_aggregate lives
       // on the column selection's ColumnRef too, so AggregateInfo must be searched FIRST or
       // the ColumnRef alias match below would win.
-      if(post && field != null) {
-         AggregateInfo ainfo = t.getAggregateInfo();
+      if(post) {
+         DataRef aggregateRef = resolveAggregateOrGroupField(t, field);
 
-         if(ainfo != null && !ainfo.isEmpty()) {
-            for(int i = 0; i < ainfo.getAggregateCount(); i++) {
-               AggregateRef ar = ainfo.getAggregate(i);
-
-               // Match the alias (e.g. "total_paid"), the view ("Sum(total_paid)"),
-               // or the base attribute name.
-               if(field.equals(ar.toView()) ||
-                  ar.getDataRef() instanceof ColumnRef cr &&
-                     (field.equals(cr.getAlias()) || field.equals(cr.getAttribute())))
-               {
-                  return ar;
-               }
-            }
-
-            for(int i = 0; i < ainfo.getGroupCount(); i++) {
-               GroupRef gr = ainfo.getGroup(i);
-
-               if(field.equals(gr.getAttribute()) ||
-                  gr.getDataRef() instanceof ColumnRef cr && field.equals(cr.getAlias()))
-               {
-                  return gr;
-               }
-            }
+         if(aggregateRef != null) {
+            return aggregateRef;
          }
       }
 
@@ -988,6 +974,49 @@ public final class WorksheetMutationSupport {
       }
 
       return new AttributeRef(null, field);
+   }
+
+   /**
+    * Matches {@code field} against the table's {@link AggregateInfo} — an aggregate ref (by
+    * alias, view, or base attribute) or a group-by dimension (by attribute or alias).
+    * Returns {@code null} if the table isn't aggregated or nothing matches, leaving the
+    * caller to fall back to a plain column lookup.
+    */
+   private static DataRef resolveAggregateOrGroupField(TableAssembly t, String field) {
+      if(field == null) {
+         return null;
+      }
+
+      AggregateInfo ainfo = t.getAggregateInfo();
+
+      if(ainfo == null || ainfo.isEmpty()) {
+         return null;
+      }
+
+      for(int i = 0; i < ainfo.getAggregateCount(); i++) {
+         AggregateRef ar = ainfo.getAggregate(i);
+
+         // Match the alias (e.g. "total_paid"), the view ("Sum(total_paid)"),
+         // or the base attribute name.
+         if(field.equals(ar.toView()) ||
+            ar.getDataRef() instanceof ColumnRef cr &&
+               (field.equals(cr.getAlias()) || field.equals(cr.getAttribute())))
+         {
+            return ar;
+         }
+      }
+
+      for(int i = 0; i < ainfo.getGroupCount(); i++) {
+         GroupRef gr = ainfo.getGroup(i);
+
+         if(field.equals(gr.getAttribute()) ||
+            gr.getDataRef() instanceof ColumnRef cr && field.equals(cr.getAlias()))
+         {
+            return gr;
+         }
+      }
+
+      return null;
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -23,6 +23,7 @@ import inetsoft.sree.security.ResourceType;
 import inetsoft.sree.security.SecurityEngine;
 import inetsoft.sree.security.SecurityException;
 import inetsoft.uql.ColumnSelection;
+import inetsoft.uql.ConditionList;
 import inetsoft.uql.XConstants;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.erm.AttributeRef;
@@ -358,6 +359,83 @@ class WorksheetEditServiceMutatorsTest {
          svc.apply("TOK", agent, ed ->
             ed.setGroupAggregate("T", List.of("no_such_group"), List.of())));
       assertTrue(ex2.getMessage().contains("no_such_group"));
+   }
+
+   // =========================================================================
+   // Ranking tests
+   // =========================================================================
+
+   @Test
+   void setRankingOnAggregatedTableResolvesAggregateRef() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "employee", "total");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> {
+         ed.setGroupAggregate("T", List.of("employee"),
+            List.of(new WorksheetMutationSupport.AggregateSpec("total", "SUM", null)));
+         ed.setRanking("T",
+            new WorksheetMutationSupport.RankingSpec("total", 3, "TOP_N", false));
+      });
+
+      ConditionList cl = t.getRankingConditionList().getConditionList();
+      assertNotNull(cl);
+      assertFalse(cl.isEmpty());
+
+      // Ranking is evaluated post-aggregate: it must bind to the Sum(total) aggregate
+      // ref, not a plain pre-aggregate reference to the raw "total" column — otherwise
+      // the filter displays as "total top3" instead of "Sum(total) top3".
+      DataRef ref = cl.getConditionItem(0).getAttribute();
+      assertTrue(ref instanceof AggregateRef,
+         "ranking on an aggregated table must resolve to the AggregateRef, got: " + ref);
+      assertEquals("total", ((AggregateRef) ref).getAttribute());
+   }
+
+   @Test
+   void setRankingOnAggregatedTableByDimensionResolvesGroupRef() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "employee", "total");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      // Ranking need not target the aggregate — it can also rank by one of the
+      // group-by (pre-aggregate) dimensions, e.g. top 3 employees alphabetically.
+      svc.apply("TOK", agent, ed -> {
+         ed.setGroupAggregate("T", List.of("employee"),
+            List.of(new WorksheetMutationSupport.AggregateSpec("total", "SUM", null)));
+         ed.setRanking("T",
+            new WorksheetMutationSupport.RankingSpec("employee", 3, "TOP_N", false));
+      });
+
+      ConditionList cl = t.getRankingConditionList().getConditionList();
+      DataRef ref = cl.getConditionItem(0).getAttribute();
+      assertTrue(ref instanceof GroupRef,
+         "ranking by a group dimension must resolve to the GroupRef, got: " + ref);
+      assertEquals("employee", ref.getAttribute());
+   }
+
+   @Test
+   void setRankingOnUngroupedTableResolvesRawColumn() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "employee", "total");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed ->
+         ed.setRanking("T",
+            new WorksheetMutationSupport.RankingSpec("total", 3, "TOP_N", false)));
+
+      ConditionList cl = t.getRankingConditionList().getConditionList();
+      DataRef ref = cl.getConditionItem(0).getAttribute();
+
+      // No AggregateInfo is set, so ranking must still fall back to the plain column —
+      // ranking on a non-aggregated table must keep working exactly as before.
+      assertFalse(ref instanceof AggregateRef);
+      assertEquals("total", ref.getAttribute());
    }
 
    // =========================================================================

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -438,6 +438,64 @@ class WorksheetEditServiceMutatorsTest {
       assertEquals("total", ref.getAttribute());
    }
 
+   @Test
+   void setRankingFallsBackToPrivateSelectionWhenColumnMissingFromPublic() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "employee", "total");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      // Simulate what set_column_visibility ultimately produces: a column present in
+      // the PRIVATE selection but absent from the PUBLIC one (the public selection is
+      // what getColumnSelection(true) — the "post" lookup — falls back to). No
+      // AggregateInfo is set, so the AggregateInfo lookup is a no-op; ranking must still
+      // find "total" via the PRIVATE selection instead of returning a bogus
+      // AttributeRef, or a hidden column becomes unrankable.
+      ColumnSelection publicSelection = t.getColumnSelection(false).clone();
+      publicSelection.removeAttribute(publicSelection.getAttribute("total"));
+      t.setColumnSelection(publicSelection, true);
+
+      svc.apply("TOK", agent, ed ->
+         ed.setRanking("T", new WorksheetMutationSupport.RankingSpec("total", 3, "TOP_N", false)));
+
+      ConditionList cl = t.getRankingConditionList().getConditionList();
+      DataRef ref = cl.getConditionItem(0).getAttribute();
+      assertTrue(ref instanceof ColumnRef,
+         "ranking must fall back to the private selection when the column is missing " +
+         "from the public one, got: " + ref);
+      assertEquals("total", ref.getAttribute());
+   }
+
+   @Test
+   void setRankingOnAggregatedTableByUnrelatedColumnResolvesRawColumn() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t =
+         TestWorksheets.tableWithColumns(ws, "T", "employee", "total", "orderNumber");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      // Grouping/aggregating a table does not prune its column selection — a column
+      // that is neither a group nor an aggregate (here "orderNumber") remains a plain,
+      // resolvable column. Ranking by it must not be forced into an aggregate/group
+      // match; it must resolve to its own raw ColumnRef.
+      svc.apply("TOK", agent, ed -> {
+         ed.setGroupAggregate("T", List.of("employee"),
+            List.of(new WorksheetMutationSupport.AggregateSpec("total", "SUM", null)));
+         ed.setRanking("T",
+            new WorksheetMutationSupport.RankingSpec("orderNumber", 3, "TOP_N", false));
+      });
+
+      ConditionList cl = t.getRankingConditionList().getConditionList();
+      DataRef ref = cl.getConditionItem(0).getAttribute();
+      assertFalse(ref instanceof AggregateRef);
+      assertFalse(ref instanceof GroupRef);
+      assertTrue(ref instanceof ColumnRef,
+         "ranking by a column outside the group/aggregate must resolve to its raw ColumnRef, got: " + ref);
+      assertEquals("orderNumber", ref.getAttribute());
+   }
+
    // =========================================================================
    // Expression column test
    // =========================================================================


### PR DESCRIPTION
## Summary

The `set_ranking` worksheet-agent op resolved its field against the pre-aggregate column selection only, never checking `AggregateInfo`. Ranking a grouped/aggregated table by the aggregate (e.g. top 3 employees by `Sum(Total)`) bound the ranking condition to the raw pre-aggregate `Total` column instead of the `Sum(Total)` aggregate, so the resulting filter displayed as `Total top3` instead of `Sum(Total) top3`.

## Root Cause

`WorksheetMutationSupport.setRanking()` called the 2-arg `resolveField(t, spec.field())` overload, which always passes `post=false` and therefore only searches the private/pre-aggregate `ColumnSelection`. The sibling post-aggregate (HAVING) condition path, `setConditions(..., post=true)`, already resolves via the 3-arg overload, which checks `AggregateInfo` (aggregate or group-by dimension) first before falling back to the column selection.

`RankingCondition` always runs after aggregation in the query pipeline (`AssetQuery.getRankingTableLens`, step 9, after `getSummaryTableLens`), so it should resolve the same way post-aggregate conditions do.

## Fix

Changed `setRanking()` to call `resolveField(t, spec.field(), true)`. This resolves the field against `AggregateInfo` first — matching either an aggregate ref (by alias, view, or base attribute) or a group-by dimension — before falling back to the plain column selection, exactly like `set_post_conditions`. Ranking on a non-aggregated table is unaffected, since an empty `AggregateInfo` falls straight through to the existing column-selection lookup.

## Test Plan

- Added `setRankingOnAggregatedTableResolvesAggregateRef`: ranking by the aggregate on a grouped table resolves to the `AggregateRef`.
- Added `setRankingOnAggregatedTableByDimensionResolvesGroupRef`: ranking by the group-by dimension (not the aggregate) on the same table resolves to the `GroupRef`.
- Added `setRankingOnUngroupedTableResolvesRawColumn`: ranking on a plain, non-aggregated table still resolves to the raw column (no regression).
- `./mvnw test -pl core -Dtest=WorksheetEditServiceMutatorsTest` — all 45 tests pass.
- Manually verified in the live worksheet-chat plugin: grouping by Employee, aggregating Total via Sum, then asking for the top 3 employees by Sum(Total) now shows the filter as `Sum(Total) top3`.

Fixes Redmine #75957.