### PR TITLE
Bug #75930, apply round corner to Table/Crosstab on Excel export

### DIFF
--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/ExcelCrosstabHelper.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/ExcelCrosstabHelper.java
@@ -270,6 +270,18 @@ public class ExcelCrosstabHelper extends VSCrosstabHelper {
    @Override
    protected void drawObjectFormat(TableDataVSAssemblyInfo info, VSTableLens lens,
                                    boolean borderOnly) {
+      // the border is drawn as an overlay shape on top of the cell data (rather than as
+      // native cell borders, which have no rounded-corner concept), so only draw once,
+      // after the cells are written, to match the "borderOnly" (second) pass used by
+      // PDF/SVG export.
+      if(!borderOnly || info == null) {
+         return;
+      }
+
+      Rectangle2D bounds = new Rectangle2D.Double(
+         info.getPixelOffset().x, info.getPixelOffset().y,
+         info.getPixelSize().width, info.getPixelSize().height);
+      ((PoiExcelVSExporter) getExporter()).drawTableRoundedBorder(bounds, info.getFormat());
    }
 
    /**

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/ExcelTableHelper.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/ExcelTableHelper.java
@@ -309,6 +309,18 @@ public class ExcelTableHelper extends VSTableHelper {
    @Override
    protected void drawObjectFormat(TableDataVSAssemblyInfo info, VSTableLens lens,
                                    boolean borderOnly) {
+      // the border is drawn as an overlay shape on top of the cell data (rather than as
+      // native cell borders, which have no rounded-corner concept), so only draw once,
+      // after the cells are written, to match the "borderOnly" (second) pass used by
+      // PDF/SVG export.
+      if(!borderOnly || info == null) {
+         return;
+      }
+
+      Rectangle2D bounds = new Rectangle2D.Double(
+         info.getPixelOffset().x, info.getPixelOffset().y,
+         info.getPixelSize().width, info.getPixelSize().height);
+      ((PoiExcelVSExporter) getExporter()).drawTableRoundedBorder(bounds, info.getFormat());
    }
 
    /**

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
@@ -49,6 +49,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.poi.hssf.util.HSSFColor;
 import org.apache.poi.openxml4j.opc.PackageRelationship;
 import org.apache.poi.openxml4j.opc.PackageRelationshipTypes;
+import org.apache.poi.sl.usermodel.ShapeType;
 import org.apache.poi.ss.usermodel.Font;
 import org.apache.poi.ss.usermodel.RichTextString;
 import org.apache.poi.ss.usermodel.*;
@@ -1070,6 +1071,147 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
             }
          }
       }
+   }
+
+   /**
+    * Switch the shape's preset geometry to a rounded rectangle and set the corner
+    * adjustment ("adj" guide) so the rendered radius matches the given pixel radius.
+    */
+   private void applyRoundCorner(XSSFSimpleShape tb, int roundCorner, Rectangle2D pixelBounds) {
+      double minSide = Math.min(pixelBounds.getWidth(), pixelBounds.getHeight());
+
+      if(minSide <= 0) {
+         return;
+      }
+
+      tb.setShapeType(ShapeType.ROUND_RECT.ooxmlId);
+      // OOXML roundRect "adj" guide is a percentage (0-50000, i.e. 0%-50%) of the
+      // shorter side that the corner radius should occupy.
+      int adj = (int) Math.round(Math.min(1d, roundCorner / (minSide / 2)) * 50000);
+      CTPresetGeometry2D prstGeom = tb.getCTShape().getSpPr().getPrstGeom();
+      CTGeomGuideList avLst = prstGeom.isSetAvLst() ? prstGeom.getAvLst() : prstGeom.addNewAvLst();
+      CTGeomGuide gd = avLst.sizeOfGdArray() > 0 ? avLst.getGdArray(0) : avLst.addNewGd();
+      gd.setName("adj");
+      gd.setFmla("val " + adj);
+   }
+
+   /**
+    * Largest corner radius (in pixels) used when rounding a table/crosstab's outer
+    * border. Table cell content fills the grid all the way to its edges (unlike
+    * TextInput/Text, which draw as a single shape) and Excel has no way to clip cell
+    * rendering to a rounded shape, so a large radius would visibly cut into cell text
+    * near the corners. Capping keeps the curve small enough to stay within the blank
+    * margin most cells have around their text, while still visibly rounding the corner.
+    */
+   private static final int MAX_TABLE_ROUND_RADIUS = 8;
+
+   /**
+    * Draw a rounded-rectangle outline around a table/crosstab's outer bounds when the
+    * object format has a round corner set. Tables write their cells directly to the sheet
+    * grid (not as a shape), so there is no shape for the border-drawing code in
+    * {@link #applyFormat} to round; this draws a standalone border-only overlay shape
+    * instead, matching the outer-frame rounding already done for Table/Crosstab in
+    * PDF/SVG (ExportUtil) and PowerPoint (PPTValueHelper) export.
+    */
+   public void drawTableRoundedBorder(Rectangle2D pixelBounds, VSCompositeFormat format) {
+      if(format == null || format.getRoundCorner() <= 0) {
+         return;
+      }
+
+      double minSide = Math.min(pixelBounds.getWidth(), pixelBounds.getHeight());
+
+      if(minSide <= 0) {
+         return;
+      }
+
+      int radius = (int) Math.min(
+         Math.min(format.getRoundCorner(), MAX_TABLE_ROUND_RADIUS), minSide / 2);
+
+      if(radius <= 0) {
+         return;
+      }
+
+      // Mask the square cell background/content that would otherwise stick out past the
+      // curve at each corner (e.g. a shaded title-row fill, or the corner-most cell's
+      // text) with a plain white square, the same way the viewer's overflow:hidden clips
+      // it. This must happen before the border outline below so the outline's curve is
+      // drawn on top of the mask, not under it.
+      maskTableCorners(pixelBounds, radius);
+
+      Insets borders = format.getBorders();
+
+      if(borders == null) {
+         return;
+      }
+
+      BorderColors bcolors = format.getBorderColors();
+      int type;
+      java.awt.Color color;
+
+      if(borders.top != 0) {
+         type = borders.top;
+         color = bcolors == null ? null : bcolors.topColor;
+      }
+      else if(borders.left != 0) {
+         type = borders.left;
+         color = bcolors == null ? null : bcolors.leftColor;
+      }
+      else if(borders.right != 0) {
+         type = borders.right;
+         color = bcolors == null ? null : bcolors.rightColor;
+      }
+      else if(borders.bottom != 0) {
+         type = borders.bottom;
+         color = bcolors == null ? null : bcolors.bottomColor;
+      }
+      else {
+         return;
+      }
+
+      int lineStyle = PoiExcelVSUtil.getLineStyle(type);
+
+      if(lineStyle == ExcelVSUtil.EXCEL_NO_BORDER) {
+         return;
+      }
+
+      XSSFSimpleShape shape = patriarch.createSimpleShape(
+         (XSSFClientAnchor) getAnchorFromPixelRect(pixelBounds));
+      shape.setNoFill(true);
+      applyRoundCorner(shape, radius, pixelBounds);
+
+      if(lineStyle != ExcelVSUtil.EXCEL_SOLID_BORDER) {
+         shape.setLineStyle(lineStyle);
+      }
+
+      if(color != null) {
+         shape.setLineStyleColor(color.getRed(), color.getGreen(), color.getBlue());
+      }
+      else {
+         shape.setLineStyleColor(0, 0, 0);
+      }
+   }
+
+   /**
+    * Paint over the four radius x radius corners of the given bounds with a plain white
+    * square, hiding whatever square cell content is underneath so it reads as clipped by
+    * the rounded corner instead of poking out past it.
+    */
+   private void maskTableCorners(Rectangle2D pixelBounds, int radius) {
+      double x = pixelBounds.getX();
+      double y = pixelBounds.getY();
+      double w = pixelBounds.getWidth();
+      double h = pixelBounds.getHeight();
+
+      maskCorner(x, y, radius);
+      maskCorner(x + w - radius, y, radius);
+      maskCorner(x, y + h - radius, radius);
+      maskCorner(x + w - radius, y + h - radius, radius);
+   }
+
+   private void maskCorner(double x, double y, double size) {
+      XSSFSimpleShape mask = patriarch.createSimpleShape((XSSFClientAnchor)
+         getAnchorFromPixelRect(new Rectangle2D.Double(x, y, size, size)));
+      mask.setFillColor(255, 255, 255);
    }
 
    private void fixAlignment(XSSFTextBox tb, int align) {

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
@@ -1135,40 +1135,24 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
       // curve at each corner (e.g. a shaded title-row fill, or the corner-most cell's
       // text) with a plain white square, the same way the viewer's overflow:hidden clips
       // it. This must happen before the border outline below so the outline's curve is
-      // drawn on top of the mask, not under it.
+      // drawn on top of the mask, not under it. Applies regardless of whether a border is
+      // configured, since it only affects background/content, not border lines.
       maskTableCorners(pixelBounds, radius);
 
       Insets borders = format.getBorders();
 
-      if(borders == null) {
+      // A single roundRect shape can only stroke a uniform outline around all four sides
+      // - unlike the per-side PDF/SVG/PPT border drawing (see ExportUtil.drawBorders), it
+      // can't selectively skip a side. Only draw the outline when every side actually has
+      // a border configured; otherwise skip it, so e.g. a top-only border doesn't
+      // incorrectly get a full box outline in Excel.
+      if(borders == null || borders.top == 0 || borders.left == 0 ||
+         borders.right == 0 || borders.bottom == 0)
+      {
          return;
       }
 
-      BorderColors bcolors = format.getBorderColors();
-      int type;
-      java.awt.Color color;
-
-      if(borders.top != 0) {
-         type = borders.top;
-         color = bcolors == null ? null : bcolors.topColor;
-      }
-      else if(borders.left != 0) {
-         type = borders.left;
-         color = bcolors == null ? null : bcolors.leftColor;
-      }
-      else if(borders.right != 0) {
-         type = borders.right;
-         color = bcolors == null ? null : bcolors.rightColor;
-      }
-      else if(borders.bottom != 0) {
-         type = borders.bottom;
-         color = bcolors == null ? null : bcolors.bottomColor;
-      }
-      else {
-         return;
-      }
-
-      int lineStyle = PoiExcelVSUtil.getLineStyle(type);
+      int lineStyle = PoiExcelVSUtil.getLineStyle(borders.top);
 
       if(lineStyle == ExcelVSUtil.EXCEL_NO_BORDER) {
          return;
@@ -1182,6 +1166,9 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
       if(lineStyle != ExcelVSUtil.EXCEL_SOLID_BORDER) {
          shape.setLineStyle(lineStyle);
       }
+
+      BorderColors bcolors = format.getBorderColors();
+      java.awt.Color color = bcolors == null ? null : bcolors.topColor;
 
       if(color != null) {
          shape.setLineStyleColor(color.getRed(), color.getGreen(), color.getBlue());


### PR DESCRIPTION
## Summary
- Table/Crosstab/CalcTable round-corner formatting was silently dropped in Excel export — the table rendered with plain square corners even though the viewer and PDF/SVG/PowerPoint export render it rounded.
- Root cause is different from Bug #75922 (TextInput/Text): tables write their cells directly to the sheet grid rather than as a floating shape, so `ExcelTableHelper.drawObjectFormat()` and `ExcelCrosstabHelper.drawObjectFormat()` were empty stubs — there was no shape at all for round-corner logic to apply to (unlike TextInput's `XSSFTextBox`).
- Fix: draw a rounded-rectangle outline overlay on top of the cell grid, matching the outer-frame rounding already done for Table/Crosstab in PDF/SVG (`ExportUtil`) and PowerPoint (`PPTValueHelper`/`PPTVSUtil`, fixed as part of #75922's review round).
  - `PoiExcelVSExporter.drawTableRoundedBorder()`: creates a borderless, rounded-rectangle outline shape anchored to the table's pixel bounds, picking border style/color from whichever side is set first (top → left → right → bottom).
  - Since Excel has no way to clip cell rendering to a rounded shape, the border curve intruding into the corner would otherwise cut across cell text/backgrounds that fill the grid all the way to the edge (e.g. a shaded title row, or the corner-most cell's value). To avoid this, the effective radius is capped (8px) and the four corners are masked with a plain white square before the outline is drawn, so the corner reads as cleanly clipped rather than bisected — mirroring the `overflow: hidden` clipping the viewer already applies at rounded corners.
  - `ExcelTableHelper.java` / `ExcelCrosstabHelper.java` (covers Table, Crosstab, and CalcTable/freehand table, which routes through `ExcelCrosstabHelper`): `drawObjectFormat()` now calls `drawTableRoundedBorder()` on the border-only pass, after cell data is written.

**Known limitation:** the corner mask assumes a white sheet background. If the canvas behind the table isn't white, the mask squares will show as a mismatched white patch instead of blending in.

## Test plan
- [ ] Create a viewsheet with a Table/Crosstab that has round corner + border set.
- [ ] Export to Excel with "match layout" and confirm the corners read as rounded, without the border cutting through cell text or a shaded title/header background poking past the curve.
- [ ] Confirm existing non-rounded Table/Crosstab exports are unaffected.
- [ ] Confirm PDF/SVG/PowerPoint table export is unaffected (already correct prior to this change).