### PR TITLE
Bug #75916, fix mini-toolbar z-index clamp so it isn't covered by sibling assemblies

### DIFF
--- a/web/projects/portal/src/app/common/util/gui-tool.ts
+++ b/web/projects/portal/src/app/common/util/gui-tool.ts
@@ -57,6 +57,11 @@ export class GuiTool {
 
    static readonly MINI_TOOLBAR_HEIGHT = 28;
 
+   // Must stay in sync with the base .mini-toolbar z-index in mini-toolbar.component.scss.
+   // Used as a floor so the toolbar always outranks ordinary sibling assemblies, even when
+   // its own assembly's server-assigned z-index is low.
+   static readonly MINI_TOOLBAR_MIN_ZINDEX = 9920;
+
    static readonly MINIMUM_TITLE_HEIGHT = 18;
 
    private static scrollbarWidth: number;

--- a/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.html
@@ -350,7 +350,7 @@
           [top]="getToolbarTop(vsObject, i)"
           [left]="getToolbarLeft(vsObject, i)"
           [width]="getToolbarWidth(vsObject)"
-          [zIndex]="getContainerZIndex(vsObject) + 1"
+          [zIndex]="getMiniToolbarZIndex(vsObject)"
           [maxMode]="vsObject.maxMode"
           [style.display]="isAssemblyVisible(vsObject) ? 'block' : 'none'"
           [visible]="isAssemblyVisible(vsObject)"

--- a/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.ts
@@ -567,6 +567,16 @@ export class VSObjectContainer implements AfterViewInit, OnChanges, OnDestroy {
          : this.zIndex(vsObject);
    }
 
+   // The mini-toolbar's z-index (see [zIndex] binding on <mini-toolbar> in the template) is
+   // getContainerZIndex(vsObject) + 1 -- it only needs to outrank its own assembly's stacking
+   // context, not unrelated sibling assemblies elsewhere on the canvas. Clamp it to the same
+   // floor as the toolbar's base CSS z-index so it still beats ordinary siblings with a higher
+   // server-assigned z-index (e.g. #75948), while preserving the larger boosted value for
+   // max-mode/embedded/datatip cases where the server z-index can exceed that floor.
+   getMiniToolbarZIndex(vsObject: VSObjectModel): number {
+      return Math.max(this.getContainerZIndex(vsObject) + 1, GuiTool.MINI_TOOLBAR_MIN_ZINDEX);
+   }
+
    zIndex(vsObject: VSObjectModel): number {
       const adhocFilter = (<any> vsObject).adhocFilter;
 


### PR DESCRIPTION
## Summary
- The floating assembly mini-toolbar (shown on hover, e.g. over a chart) could be rendered underneath/covered by sibling assemblies with a higher server-assigned z-index, because its z-index was derived solely from its own assembly's z-index (`getContainerZIndex(vsObject) + 1`) — a change made in #75794 to fix max-mode/embedded-viewsheet stacking.
- Adds `GuiTool.MINI_TOOLBAR_MIN_ZINDEX` (9920, matching the toolbar's original fixed CSS z-index) and a new `getMiniToolbarZIndex()` that clamps the dynamic z-index to that floor via `Math.max`.
- This restores "toolbar beats ordinary siblings" for normal hover cases while preserving the larger boosted value for max-mode/embedded-viewsheet/datatip cases (which can already exceed 9920), so the #75794 fix is not reverted.

## Test plan
- [ ] Open viewsheet `Examples/Census` in portal, hover over the chart, confirm the toolbar renders above/clear of the text box (previously covered)
- [ ] Verify max-mode toolbar visibility still works correctly (no regression to #75794 fix)
- [ ] `npx tsc --noEmit` passes on the portal project

🤖 Generated with [Claude Code](https://claude.com/claude-code)