### PR TITLE
feat(wiz-docs): POST /api/wiz/v1/docs/search proxying to the assistant server (#75966)

### DIFF
--- a/core/src/main/java/inetsoft/web/assistant/AIAssistantController.java
+++ b/core/src/main/java/inetsoft/web/assistant/AIAssistantController.java
@@ -187,7 +187,7 @@ public class AIAssistantController {
     */
    @GetMapping("/api/assistant/health")
    public CompletableFuture<ResponseEntity<Boolean>> checkAssistantHealth() {
-      String upstreamBase = resolveUpstreamBase();
+      String upstreamBase = resolveAssistantBaseUrl();
 
       if(upstreamBase == null) {
          return CompletableFuture.completedFuture(ResponseEntity.noContent().build());
@@ -211,7 +211,15 @@ public class AIAssistantController {
          });
    }
 
-   private String resolveUpstreamBase() {
+   /**
+    * Resolves the assistant server's base URL: the server-to-server URL when proxy mode is
+    * configured, otherwise the browser-facing one, otherwise null.
+    *
+    * <p>Public and static because {@code WizDocSearchController} must resolve the assistant the
+    * same way this controller's health check does. Two independent resolutions would let the
+    * health check report "online" while doc search reported "not configured".</p>
+    */
+   public static String resolveAssistantBaseUrl() {
       String internalUrl = SreeEnv.getProperty(CHAT_APP_INTERNAL_URL);
 
       if(internalUrl != null && !internalUrl.trim().isEmpty()) {

--- a/core/src/main/java/inetsoft/web/assistant/AIAssistantController.java
+++ b/core/src/main/java/inetsoft/web/assistant/AIAssistantController.java
@@ -50,30 +50,7 @@ public class AIAssistantController {
    public void createHealthClient() {
       HttpClient.Builder builder = HttpClient.newBuilder()
          .connectTimeout(Duration.ofSeconds(3));
-
-      if(!isSslVerifyEnabled()) {
-         LOG.warn("SSL certificate verification is disabled for AI assistant health check " +
-                     "connections (chat.app.server.ssl.verify=false). Set to true in production when " +
-                     "the assistant server uses a CA-signed certificate.");
-
-         try {
-            SSLContext sslContext = SSLContext.getInstance("TLS");
-            sslContext.init(null, new TrustManager[] {
-               new X509TrustManager() {
-                  public void checkClientTrusted(X509Certificate[] chain, String authType) {}
-                  public void checkServerTrusted(X509Certificate[] chain, String authType) {}
-                  public X509Certificate[] getAcceptedIssuers() { return new X509Certificate[0]; }
-               }
-            }, null);
-            SSLParameters sslParameters = new SSLParameters();
-            sslParameters.setEndpointIdentificationAlgorithm("");
-            builder.sslContext(sslContext).sslParameters(sslParameters);
-         }
-         catch(NoSuchAlgorithmException | KeyManagementException e) {
-            LOG.warn("Could not configure trust-all SSL context for AI assistant health check", e);
-         }
-      }
-
+      applyAssistantTls(builder, "health check");
       healthClient = builder.build();
    }
 
@@ -172,6 +149,45 @@ public class AIAssistantController {
     */
    public static boolean isSslVerifyEnabled() {
       return "true".equalsIgnoreCase(SreeEnv.getProperty("chat.app.server.ssl.verify", "false"));
+   }
+
+   /**
+    * Configures an {@code HttpClient.Builder} to skip TLS certificate <em>and</em> hostname
+    * verification when {@code chat.app.server.ssl.verify} is disabled, so that private-network
+    * deployments with self-signed certificates work out of the box.
+    *
+    * <p>Public and static so every outbound connection to the assistant server — the health
+    * check here and {@code HttpAssistantDocSearchGateway}'s doc-search POST — trusts the same
+    * certificates the same way. A trust-all {@code X509TrustManager} alone only skips chain
+    * validation; without clearing {@code SSLParameters}' endpoint identification algorithm too,
+    * {@code HttpClient} still enforces hostname verification, so a self-signed certificate
+    * whose CN/SAN doesn't match the connect host would still fail here even though the operator
+    * disabled verification for exactly that case.</p>
+    *
+    * @param builder the client builder to configure, mutated in place.
+    * @param connectionLabel a short label identifying the caller, used only in the warning log
+    *                         message (e.g. {@code "health check"}, {@code "doc search"}).
+    */
+   public static void applyAssistantTls(HttpClient.Builder builder, String connectionLabel) {
+      if(isSslVerifyEnabled()) {
+         return;
+      }
+
+      LOG.warn("SSL certificate verification is disabled for AI assistant {} connections " +
+                  "(chat.app.server.ssl.verify=false). Set to true in production when the " +
+                  "assistant server uses a CA-signed certificate.", connectionLabel);
+
+      try {
+         SSLContext sslContext = SSLContext.getInstance("TLS");
+         sslContext.init(null, new TrustManager[] { TRUST_ALL }, null);
+         SSLParameters sslParameters = new SSLParameters();
+         sslParameters.setEndpointIdentificationAlgorithm("");
+         builder.sslContext(sslContext).sslParameters(sslParameters);
+      }
+      catch(NoSuchAlgorithmException | KeyManagementException e) {
+         LOG.warn("Could not configure trust-all SSL context for AI assistant " +
+                     connectionLabel, e);
+      }
    }
 
    /**
@@ -343,5 +359,21 @@ public class AIAssistantController {
    public static final String CHAT_APP_LOGO_URL = "chat.app.logo.url";
    public static final String PROXY_PATH_PREFIX = "/api/assistant/proxy";
    public static final String AI_ASSISTANT_VISIBLE = "ai.assistant.visible";
+
+   private static final X509TrustManager TRUST_ALL = new X509TrustManager() {
+      @Override
+      public void checkClientTrusted(X509Certificate[] chain, String authType) {
+      }
+
+      @Override
+      public void checkServerTrusted(X509Certificate[] chain, String authType) {
+      }
+
+      @Override
+      public X509Certificate[] getAcceptedIssuers() {
+         return new X509Certificate[0];
+      }
+   };
+
    private static final Logger LOG = LoggerFactory.getLogger(AIAssistantController.class);
 }

--- a/core/src/main/java/inetsoft/web/wiz/docs/AssistantDocSearchGateway.java
+++ b/core/src/main/java/inetsoft/web/wiz/docs/AssistantDocSearchGateway.java
@@ -1,0 +1,40 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.docs;
+
+import java.io.IOException;
+
+/**
+ * One outbound JSON POST to the AI assistant server.
+ *
+ * <p>Exists as an interface so {@link WizDocSearchController} — which owns every decision about
+ * status mapping and configuration — can be unit-tested without opening a socket. The HTTP
+ * implementation is verified by the live smoke test.</p>
+ */
+public interface AssistantDocSearchGateway {
+   /** The assistant's raw reply. A null body is normalised to "" by implementations. */
+   record Response(int status, String body) {}
+
+   /**
+    * @param authorization the caller's Authorization header, forwarded verbatim; may be null.
+    * @throws IOException when the assistant produced no response at all (refused connection,
+    *                     DNS failure, timeout) — as opposed to responding with an error status.
+    */
+   Response post(String baseUrl, String path, String body, String authorization)
+      throws IOException, InterruptedException;
+}

--- a/core/src/main/java/inetsoft/web/wiz/docs/HttpAssistantDocSearchGateway.java
+++ b/core/src/main/java/inetsoft/web/wiz/docs/HttpAssistantDocSearchGateway.java
@@ -18,21 +18,15 @@
 package inetsoft.web.wiz.docs;
 
 import inetsoft.web.assistant.AIAssistantController;
+import jakarta.annotation.PreDestroy;
 import org.springframework.stereotype.Component;
 
-import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
-import java.security.cert.X509Certificate;
 import java.time.Duration;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
 
 /**
  * {@link AssistantDocSearchGateway} over {@code java.net.http.HttpClient}, matching the client
@@ -73,38 +67,19 @@ public class HttpAssistantDocSearchGateway implements AssistantDocSearchGateway 
       if(cachedClient == null) {
          HttpClient.Builder builder = HttpClient.newBuilder()
             .connectTimeout(CONNECT_TIMEOUT);
-
-         if(!AIAssistantController.isSslVerifyEnabled()) {
-            try {
-               SSLContext sslContext = SSLContext.getInstance("TLS");
-               sslContext.init(null, new TrustManager[]{ TRUST_ALL }, new SecureRandom());
-               builder.sslContext(sslContext);
-            }
-            catch(NoSuchAlgorithmException | KeyManagementException e) {
-               throw new RuntimeException("Failed to build assistant doc-search HTTP client", e);
-            }
-         }
-
+         AIAssistantController.applyAssistantTls(builder, "doc search");
          cachedClient = builder.build();
       }
 
       return cachedClient;
    }
 
-   private static final X509TrustManager TRUST_ALL = new X509TrustManager() {
-      @Override
-      public void checkClientTrusted(X509Certificate[] chain, String authType) {
+   @PreDestroy
+   public void closeClient() {
+      if(cachedClient != null) {
+         cachedClient.close();
       }
-
-      @Override
-      public void checkServerTrusted(X509Certificate[] chain, String authType) {
-      }
-
-      @Override
-      public X509Certificate[] getAcceptedIssuers() {
-         return new X509Certificate[0];
-      }
-   };
+   }
 
    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
    private static final Duration RESPONSE_TIMEOUT = Duration.ofSeconds(20);

--- a/core/src/main/java/inetsoft/web/wiz/docs/HttpAssistantDocSearchGateway.java
+++ b/core/src/main/java/inetsoft/web/wiz/docs/HttpAssistantDocSearchGateway.java
@@ -1,0 +1,113 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.docs;
+
+import inetsoft.web.assistant.AIAssistantController;
+import org.springframework.stereotype.Component;
+
+import javax.net.ssl.SSLContext;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+/**
+ * {@link AssistantDocSearchGateway} over {@code java.net.http.HttpClient}, matching the client
+ * style {@code AIAssistantController} already uses for its assistant health check.
+ *
+ * <p>Honours {@code chat.app.server.ssl.verify} for parity with the rest of the assistant
+ * integration: private-network deployments commonly run the assistant with a self-signed
+ * certificate.</p>
+ */
+@Component
+public class HttpAssistantDocSearchGateway implements AssistantDocSearchGateway {
+   @Override
+   public Response post(String baseUrl, String path, String body, String authorization)
+      throws IOException, InterruptedException
+   {
+      String url = baseUrl.endsWith("/")
+         ? baseUrl.substring(0, baseUrl.length() - 1) + path
+         : baseUrl + path;
+
+      HttpRequest.Builder builder = HttpRequest.newBuilder()
+         .uri(URI.create(url))
+         .timeout(RESPONSE_TIMEOUT)
+         .header("Content-Type", "application/json")
+         .POST(HttpRequest.BodyPublishers.ofString(body));
+
+      if(authorization != null && !authorization.isEmpty()) {
+         builder.header("Authorization", authorization);
+      }
+
+      HttpResponse<String> response =
+         client().send(builder.build(), HttpResponse.BodyHandlers.ofString());
+
+      return new Response(response.statusCode(),
+         response.body() == null ? "" : response.body());
+   }
+
+   private synchronized HttpClient client() {
+      if(cachedClient == null) {
+         HttpClient.Builder builder = HttpClient.newBuilder()
+            .connectTimeout(CONNECT_TIMEOUT);
+
+         if(!AIAssistantController.isSslVerifyEnabled()) {
+            try {
+               SSLContext sslContext = SSLContext.getInstance("TLS");
+               sslContext.init(null, new TrustManager[]{ TRUST_ALL }, new SecureRandom());
+               builder.sslContext(sslContext);
+            }
+            catch(NoSuchAlgorithmException | KeyManagementException e) {
+               throw new RuntimeException("Failed to build assistant doc-search HTTP client", e);
+            }
+         }
+
+         cachedClient = builder.build();
+      }
+
+      return cachedClient;
+   }
+
+   private static final X509TrustManager TRUST_ALL = new X509TrustManager() {
+      @Override
+      public void checkClientTrusted(X509Certificate[] chain, String authType) {
+      }
+
+      @Override
+      public void checkServerTrusted(X509Certificate[] chain, String authType) {
+      }
+
+      @Override
+      public X509Certificate[] getAcceptedIssuers() {
+         return new X509Certificate[0];
+      }
+   };
+
+   private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
+   private static final Duration RESPONSE_TIMEOUT = Duration.ofSeconds(20);
+
+   private HttpClient cachedClient;
+}

--- a/core/src/main/java/inetsoft/web/wiz/docs/HttpAssistantDocSearchGateway.java
+++ b/core/src/main/java/inetsoft/web/wiz/docs/HttpAssistantDocSearchGateway.java
@@ -84,5 +84,5 @@ public class HttpAssistantDocSearchGateway implements AssistantDocSearchGateway 
    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
    private static final Duration RESPONSE_TIMEOUT = Duration.ofSeconds(20);
 
-   private HttpClient cachedClient;
+   private volatile HttpClient cachedClient;
 }

--- a/core/src/main/java/inetsoft/web/wiz/docs/WizDocSearchController.java
+++ b/core/src/main/java/inetsoft/web/wiz/docs/WizDocSearchController.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of StyleBI.
- * Copyright (C) 2024  InetSoft Technology
+ * Copyright (C) 2025  InetSoft Technology
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.wiz.docs;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import inetsoft.web.admin.ai.AdminAiCallerGuard;
 import inetsoft.web.assistant.AIAssistantController;
 import jakarta.servlet.http.HttpServletRequest;
@@ -30,6 +31,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 
 /**
  * Proxies the plugins' documentation search to the configured AI assistant server.
@@ -99,36 +101,44 @@ public class WizDocSearchController {
          return;
       }
 
+      // Only the network call to the assistant is guarded here. Writing the response is done
+      // after the try returns, so a client disconnect mid-write (an IOException from the servlet
+      // output stream) propagates as-is instead of being caught below, logged as an assistant
+      // failure it was not, and followed by a second, doomed write to an already-committed
+      // response.
+      AssistantDocSearchGateway.Response gatewayResponse;
+
       try {
-         AssistantDocSearchGateway.Response gatewayResponse =
-            gateway.post(baseUrl, ASSISTANT_PATH, body, request.getHeader("Authorization"));
-
-         // A bare 404 reads as "no such StyleBI route" and sends the operator to debug the wrong
-         // layer. It actually means the assistant predates this endpoint.
-         if(gatewayResponse.status() == HttpStatus.NOT_FOUND.value()) {
-            LOG.warn("AI assistant at {} has no {} endpoint", baseUrl, ASSISTANT_PATH);
-
-            writeJson(response, HttpStatus.BAD_GATEWAY.value(), errorBody(
-               "The AI assistant server does not support document search — upgrade required."));
-            return;
-         }
-
-         // Everything else passes through untouched so the assistant's field-named validation
-         // errors reach the agent intact. Written straight to the servlet response (not returned
-         // as a ResponseEntity<String>) because WebConfig's only application/json-capable
-         // converter is Jackson, which would re-serialize this already-serialized JSON string as
-         // a JSON string literal — the mirror image of the request-binding defect this endpoint
-         // was previously fixed for.
-         writeJson(response, gatewayResponse.status(), gatewayResponse.body());
+         gatewayResponse = gateway.post(baseUrl, ASSISTANT_PATH, body, request.getHeader("Authorization"));
       }
       catch(InterruptedException e) {
          Thread.currentThread().interrupt();
 
          unreachable(response, baseUrl, e);
+         return;
       }
       catch(Exception e) {
          unreachable(response, baseUrl, e);
+         return;
       }
+
+      // A bare 404 reads as "no such StyleBI route" and sends the operator to debug the wrong
+      // layer. It actually means the assistant predates this endpoint.
+      if(gatewayResponse.status() == HttpStatus.NOT_FOUND.value()) {
+         LOG.warn("AI assistant at {} has no {} endpoint", baseUrl, ASSISTANT_PATH);
+
+         writeJson(response, HttpStatus.BAD_GATEWAY.value(), errorBody(
+            "The AI assistant server does not support document search — upgrade required."));
+         return;
+      }
+
+      // Everything else passes through untouched so the assistant's field-named validation
+      // errors reach the agent intact. Written straight to the servlet response (not returned
+      // as a ResponseEntity<String>) because WebConfig's only application/json-capable
+      // converter is Jackson, which would re-serialize this already-serialized JSON string as
+      // a JSON string literal — the mirror image of the request-binding defect this endpoint
+      // was previously fixed for.
+      writeJson(response, gatewayResponse.status(), gatewayResponse.body());
    }
 
    private void unreachable(HttpServletResponse response, String baseUrl, Exception e)
@@ -140,8 +150,13 @@ public class WizDocSearchController {
          errorBody("The AI assistant server did not respond."));
    }
 
-   private String errorBody(String message) {
-      return "{\"error\":\"" + message.replace("\"", "\\\"") + "\"}";
+   /**
+    * Serializes {@code message} through Jackson rather than hand-building the JSON literal, so
+    * this stays correct for any message text without relying on callers passing only string
+    * literals (the previous implementation escaped only {@code "} and had no such guarantee).
+    */
+   private String errorBody(String message) throws IOException {
+      return MAPPER.writeValueAsString(Collections.singletonMap("error", message));
    }
 
    /**
@@ -173,6 +188,7 @@ public class WizDocSearchController {
     */
    private static final int MAX_REQUEST_BODY_CHARS = 64 * 1024;
    private static final Logger LOG = LoggerFactory.getLogger(WizDocSearchController.class);
+   private static final ObjectMapper MAPPER = new ObjectMapper();
 
    private final AssistantDocSearchGateway gateway;
 }

--- a/core/src/main/java/inetsoft/web/wiz/docs/WizDocSearchController.java
+++ b/core/src/main/java/inetsoft/web/wiz/docs/WizDocSearchController.java
@@ -20,12 +20,12 @@ package inetsoft.web.wiz.docs;
 import inetsoft.web.admin.ai.AdminAiCallerGuard;
 import inetsoft.web.assistant.AIAssistantController;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
@@ -54,7 +54,7 @@ public class WizDocSearchController {
       value = "/api/wiz/v1/docs/search",
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
-   public ResponseEntity<String> search(HttpServletRequest request) throws IOException {
+   public void search(HttpServletRequest request, HttpServletResponse response) throws IOException {
       // Defence in depth rather than load-bearing here: the endpoint is read-only over public
       // product documentation. Kept for consistency with the other plugin-facing AI endpoints,
       // which rely on it as a CSRF backstop under the /api/wiz/** exemption.
@@ -70,7 +70,9 @@ public class WizDocSearchController {
       // Reject a body that is already oversized by its declared Content-Length without ever
       // opening the input stream.
       if(request.getContentLengthLong() > MAX_REQUEST_BODY_CHARS) {
-         return error(HttpStatus.PAYLOAD_TOO_LARGE, "Request body too large.");
+         writeJson(response, HttpStatus.PAYLOAD_TOO_LARGE.value(),
+            errorBody("Request body too large."));
+         return;
       }
 
       // A doc-search body is a short question. Anything larger is a caller bug or an attack;
@@ -81,7 +83,9 @@ public class WizDocSearchController {
       byte[] bytes = request.getInputStream().readNBytes(MAX_REQUEST_BODY_CHARS + 1);
 
       if(bytes.length > MAX_REQUEST_BODY_CHARS) {
-         return error(HttpStatus.PAYLOAD_TOO_LARGE, "Request body too large.");
+         writeJson(response, HttpStatus.PAYLOAD_TOO_LARGE.value(),
+            errorBody("Request body too large."));
+         return;
       }
 
       String body = new String(bytes, StandardCharsets.UTF_8);
@@ -89,50 +93,76 @@ public class WizDocSearchController {
       String baseUrl = AIAssistantController.resolveAssistantBaseUrl();
 
       if(baseUrl == null) {
-         return error(HttpStatus.SERVICE_UNAVAILABLE,
+         writeJson(response, HttpStatus.SERVICE_UNAVAILABLE.value(), errorBody(
             "AI assistant server is not configured on this StyleBI server " +
-            "(chat.app.internal.url or chat.app.server.url).");
+            "(chat.app.internal.url or chat.app.server.url)."));
+         return;
       }
 
       try {
-         AssistantDocSearchGateway.Response response =
+         AssistantDocSearchGateway.Response gatewayResponse =
             gateway.post(baseUrl, ASSISTANT_PATH, body, request.getHeader("Authorization"));
 
          // A bare 404 reads as "no such StyleBI route" and sends the operator to debug the wrong
          // layer. It actually means the assistant predates this endpoint.
-         if(response.status() == HttpStatus.NOT_FOUND.value()) {
+         if(gatewayResponse.status() == HttpStatus.NOT_FOUND.value()) {
             LOG.warn("AI assistant at {} has no {} endpoint", baseUrl, ASSISTANT_PATH);
 
-            return error(HttpStatus.BAD_GATEWAY,
-               "The AI assistant server does not support document search — upgrade required.");
+            writeJson(response, HttpStatus.BAD_GATEWAY.value(), errorBody(
+               "The AI assistant server does not support document search — upgrade required."));
+            return;
          }
 
          // Everything else passes through untouched so the assistant's field-named validation
-         // errors reach the agent intact.
-         return ResponseEntity.status(response.status())
-            .contentType(MediaType.APPLICATION_JSON)
-            .body(response.body());
+         // errors reach the agent intact. Written straight to the servlet response (not returned
+         // as a ResponseEntity<String>) because WebConfig's only application/json-capable
+         // converter is Jackson, which would re-serialize this already-serialized JSON string as
+         // a JSON string literal — the mirror image of the request-binding defect this endpoint
+         // was previously fixed for.
+         writeJson(response, gatewayResponse.status(), gatewayResponse.body());
       }
       catch(InterruptedException e) {
          Thread.currentThread().interrupt();
 
-         return unreachable(baseUrl, e);
+         unreachable(response, baseUrl, e);
       }
       catch(Exception e) {
-         return unreachable(baseUrl, e);
+         unreachable(response, baseUrl, e);
       }
    }
 
-   private ResponseEntity<String> unreachable(String baseUrl, Exception e) {
+   private void unreachable(HttpServletResponse response, String baseUrl, Exception e)
+      throws IOException
+   {
       LOG.warn("AI assistant doc search failed for {}: {}", baseUrl, e.getMessage());
 
-      return error(HttpStatus.BAD_GATEWAY, "The AI assistant server did not respond.");
+      writeJson(response, HttpStatus.BAD_GATEWAY.value(),
+         errorBody("The AI assistant server did not respond."));
    }
 
-   private ResponseEntity<String> error(HttpStatus status, String message) {
-      return ResponseEntity.status(status)
-         .contentType(MediaType.APPLICATION_JSON)
-         .body("{\"error\":\"" + message.replace("\"", "\\\"") + "\"}");
+   private String errorBody(String message) {
+      return "{\"error\":\"" + message.replace("\"", "\\\"") + "\"}";
+   }
+
+   /**
+    * Writes {@code json} to {@code response} directly, bypassing {@code HttpMessageConverter}
+    * selection entirely — the same pattern {@link inetsoft.web.assistant.AssistantProxyController}
+    * uses for its own proxied responses. {@code json} is always already a complete, valid JSON
+    * document (either relayed verbatim from the assistant or built by {@link #errorBody}), so no
+    * converter is needed or wanted: routing it through one, as {@code ResponseEntity<String>}
+    * did, hands it to {@code MappingJackson2HttpMessageConverter} (the only registered converter
+    * that supports {@code application/json}), which re-serializes the {@code String} as a JSON
+    * string literal instead of writing it as-is.
+    */
+   private void writeJson(HttpServletResponse response, int status, String json)
+      throws IOException
+   {
+      byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
+      response.setStatus(status);
+      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+      response.setContentLength(bytes.length);
+      response.getOutputStream().write(bytes);
    }
 
    private static final String ASSISTANT_PATH = "/api/doc-search";

--- a/core/src/main/java/inetsoft/web/wiz/docs/WizDocSearchController.java
+++ b/core/src/main/java/inetsoft/web/wiz/docs/WizDocSearchController.java
@@ -28,6 +28,9 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
 /**
  * Proxies the plugins' documentation search to the configured AI assistant server.
  *
@@ -51,17 +54,37 @@ public class WizDocSearchController {
       value = "/api/wiz/v1/docs/search",
       consumes = MediaType.APPLICATION_JSON_VALUE,
       produces = MediaType.APPLICATION_JSON_VALUE)
-   public ResponseEntity<String> search(@RequestBody String body, HttpServletRequest request) {
+   public ResponseEntity<String> search(HttpServletRequest request) throws IOException {
       // Defence in depth rather than load-bearing here: the endpoint is read-only over public
       // product documentation. Kept for consistency with the other plugin-facing AI endpoints,
       // which rely on it as a CSRF backstop under the /api/wiz/** exemption.
       AdminAiCallerGuard.requireBearerAuthenticatedRequest();
 
-      // A doc-search body is a short question. Anything larger is a caller bug or an attack;
-      // relaying it upstream to find that out only spends the assistant's resources too.
-      if(body != null && body.length() > MAX_REQUEST_BODY_CHARS) {
+      // Read the raw body from the request stream instead of via @RequestBody. WebConfig
+      // replaces Spring's default converters, and none of the registered ones can bind a JSON
+      // request body onto a String target: MappingJackson2HttpMessageConverter tries to map
+      // the JSON object onto String and fails, and StringHttpMessageConverter is restricted to
+      // text/plain. A typed DTO isn't the fix either — this controller is a deliberate thin
+      // passthrough (see class javadoc) and must not duplicate the assistant's validation.
+
+      // Reject a body that is already oversized by its declared Content-Length without ever
+      // opening the input stream.
+      if(request.getContentLengthLong() > MAX_REQUEST_BODY_CHARS) {
          return error(HttpStatus.PAYLOAD_TOO_LARGE, "Request body too large.");
       }
+
+      // A doc-search body is a short question. Anything larger is a caller bug or an attack;
+      // relaying it upstream to find that out only spends the assistant's resources too.
+      // readNBytes(cap + 1) never buffers more than cap + 1 bytes, so a chunked body (no
+      // Content-Length) or a dishonest header is still bounded, without a duplicate of
+      // AssistantProxyController's LimitedInputStream.
+      byte[] bytes = request.getInputStream().readNBytes(MAX_REQUEST_BODY_CHARS + 1);
+
+      if(bytes.length > MAX_REQUEST_BODY_CHARS) {
+         return error(HttpStatus.PAYLOAD_TOO_LARGE, "Request body too large.");
+      }
+
+      String body = new String(bytes, StandardCharsets.UTF_8);
 
       String baseUrl = AIAssistantController.resolveAssistantBaseUrl();
 
@@ -113,7 +136,11 @@ public class WizDocSearchController {
    }
 
    private static final String ASSISTANT_PATH = "/api/doc-search";
-   /** Generous next to the assistant's own 2000-character query limit, but bounded. */
+   /**
+    * Generous next to the assistant's own 2000-character query limit, but bounded. Enforced
+    * against the raw UTF-8 byte count read from the request, which is never smaller than the
+    * decoded character count, so this is at least as strict as a character-based cap.
+    */
    private static final int MAX_REQUEST_BODY_CHARS = 64 * 1024;
    private static final Logger LOG = LoggerFactory.getLogger(WizDocSearchController.class);
 

--- a/core/src/main/java/inetsoft/web/wiz/docs/WizDocSearchController.java
+++ b/core/src/main/java/inetsoft/web/wiz/docs/WizDocSearchController.java
@@ -1,0 +1,121 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.docs;
+
+import inetsoft.web.admin.ai.AdminAiCallerGuard;
+import inetsoft.web.assistant.AIAssistantController;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Proxies the plugins' documentation search to the configured AI assistant server.
+ *
+ * <p>StyleBI sits in this path so the plugin never needs the assistant's URL and so the request
+ * is authenticated: {@code /api/wiz/**} is the only prefix where
+ * {@code WizServiceAuthenticationFilter} validates a bearer JWT and {@code CSRFFilter} grants an
+ * exemption. The Pinecone and Voyage credentials stay in the assistant server; StyleBI knows
+ * only where the assistant is.</p>
+ *
+ * <p>Deliberately a thin passthrough. Request validation lives in the assistant, which owns the
+ * module vocabulary; duplicating it here would produce two validators that drift apart.</p>
+ */
+@RestController
+public class WizDocSearchController {
+   @Autowired
+   public WizDocSearchController(AssistantDocSearchGateway gateway) {
+      this.gateway = gateway;
+   }
+
+   @PostMapping(
+      value = "/api/wiz/v1/docs/search",
+      consumes = MediaType.APPLICATION_JSON_VALUE,
+      produces = MediaType.APPLICATION_JSON_VALUE)
+   public ResponseEntity<String> search(@RequestBody String body, HttpServletRequest request) {
+      // Defence in depth rather than load-bearing here: the endpoint is read-only over public
+      // product documentation. Kept for consistency with the other plugin-facing AI endpoints,
+      // which rely on it as a CSRF backstop under the /api/wiz/** exemption.
+      AdminAiCallerGuard.requireBearerAuthenticatedRequest();
+
+      // A doc-search body is a short question. Anything larger is a caller bug or an attack;
+      // relaying it upstream to find that out only spends the assistant's resources too.
+      if(body != null && body.length() > MAX_REQUEST_BODY_CHARS) {
+         return error(HttpStatus.PAYLOAD_TOO_LARGE, "Request body too large.");
+      }
+
+      String baseUrl = AIAssistantController.resolveAssistantBaseUrl();
+
+      if(baseUrl == null) {
+         return error(HttpStatus.SERVICE_UNAVAILABLE,
+            "AI assistant server is not configured on this StyleBI server " +
+            "(chat.app.internal.url or chat.app.server.url).");
+      }
+
+      try {
+         AssistantDocSearchGateway.Response response =
+            gateway.post(baseUrl, ASSISTANT_PATH, body, request.getHeader("Authorization"));
+
+         // A bare 404 reads as "no such StyleBI route" and sends the operator to debug the wrong
+         // layer. It actually means the assistant predates this endpoint.
+         if(response.status() == HttpStatus.NOT_FOUND.value()) {
+            LOG.warn("AI assistant at {} has no {} endpoint", baseUrl, ASSISTANT_PATH);
+
+            return error(HttpStatus.BAD_GATEWAY,
+               "The AI assistant server does not support document search — upgrade required.");
+         }
+
+         // Everything else passes through untouched so the assistant's field-named validation
+         // errors reach the agent intact.
+         return ResponseEntity.status(response.status())
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(response.body());
+      }
+      catch(InterruptedException e) {
+         Thread.currentThread().interrupt();
+
+         return unreachable(baseUrl, e);
+      }
+      catch(Exception e) {
+         return unreachable(baseUrl, e);
+      }
+   }
+
+   private ResponseEntity<String> unreachable(String baseUrl, Exception e) {
+      LOG.warn("AI assistant doc search failed for {}: {}", baseUrl, e.getMessage());
+
+      return error(HttpStatus.BAD_GATEWAY, "The AI assistant server did not respond.");
+   }
+
+   private ResponseEntity<String> error(HttpStatus status, String message) {
+      return ResponseEntity.status(status)
+         .contentType(MediaType.APPLICATION_JSON)
+         .body("{\"error\":\"" + message.replace("\"", "\\\"") + "\"}");
+   }
+
+   private static final String ASSISTANT_PATH = "/api/doc-search";
+   /** Generous next to the assistant's own 2000-character query limit, but bounded. */
+   private static final int MAX_REQUEST_BODY_CHARS = 64 * 1024;
+   private static final Logger LOG = LoggerFactory.getLogger(WizDocSearchController.class);
+
+   private final AssistantDocSearchGateway gateway;
+}

--- a/core/src/test/java/inetsoft/web/assistant/AIAssistantControllerTest.java
+++ b/core/src/test/java/inetsoft/web/assistant/AIAssistantControllerTest.java
@@ -1,0 +1,118 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.assistant;
+
+import inetsoft.sree.SreeEnv;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.net.ssl.SSLContext;
+import java.net.http.HttpClient;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Covers the two static helpers shared by {@link AIAssistantController} and
+ * {@code HttpAssistantDocSearchGateway}: base-URL resolution and the trust-all TLS bypass.
+ *
+ * <p>Neither helper had test coverage before this class. In particular {@code applyAssistantTls}
+ * fixed a real defect (a trust-all {@code X509TrustManager} alone skips certificate chain
+ * validation but not hostname verification, unless {@code SSLParameters}' endpoint identification
+ * algorithm is also cleared) with no regression test — this class is that regression test.</p>
+ */
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class AIAssistantControllerTest {
+   private MockedStatic<SreeEnv> sreeEnv;
+
+   @BeforeEach
+   void setUp() {
+      sreeEnv = mockStatic(SreeEnv.class, withSettings().lenient());
+   }
+
+   @AfterEach
+   void tearDown() {
+      sreeEnv.close();
+   }
+
+   @Test
+   void resolvesTheInternalUrlTrimmedWhenConfigured() {
+      sreeEnv.when(() -> SreeEnv.getProperty("chat.app.internal.url"))
+         .thenReturn("  https://internal.example.com  ");
+      sreeEnv.when(() -> SreeEnv.getProperty("chat.app.server.url"))
+         .thenReturn("https://direct.example.com");
+
+      assertEquals("https://internal.example.com", AIAssistantController.resolveAssistantBaseUrl());
+   }
+
+   @Test
+   void fallsBackToTheServerUrlWhenTheInternalUrlIsBlank() {
+      sreeEnv.when(() -> SreeEnv.getProperty("chat.app.internal.url")).thenReturn("   ");
+      sreeEnv.when(() -> SreeEnv.getProperty("chat.app.server.url"))
+         .thenReturn("https://direct.example.com");
+
+      assertEquals("https://direct.example.com", AIAssistantController.resolveAssistantBaseUrl());
+   }
+
+   @Test
+   void returnsNullWhenNeitherUrlIsConfigured() {
+      sreeEnv.when(() -> SreeEnv.getProperty("chat.app.internal.url")).thenReturn(null);
+      sreeEnv.when(() -> SreeEnv.getProperty("chat.app.server.url")).thenReturn(null);
+
+      assertNull(AIAssistantController.resolveAssistantBaseUrl());
+   }
+
+   // This is exactly the defect the underlying fix closed: a trust-all TrustManager skips chain
+   // validation but NOT hostname verification unless endpoint identification is cleared too.
+   @Test
+   void disablesHostnameVerificationAndInstallsATrustAllContextWhenVerificationIsDisabled()
+      throws Exception
+   {
+      sreeEnv.when(() -> SreeEnv.getProperty("chat.app.server.ssl.verify", "false"))
+         .thenReturn("false");
+
+      HttpClient.Builder builder = HttpClient.newBuilder();
+      AIAssistantController.applyAssistantTls(builder, "doc search");
+      HttpClient client = builder.build();
+
+      assertEquals("", client.sslParameters().getEndpointIdentificationAlgorithm());
+      // An untouched HttpClient.Builder's SSLContext is the JVM default (verified empirically:
+      // HttpClient.newBuilder().build().sslContext() == SSLContext.getDefault()). A distinct
+      // instance here confirms the trust-all context was actually installed, not just requested.
+      assertNotSame(SSLContext.getDefault(), client.sslContext());
+   }
+
+   @Test
+   void leavesTlsUntouchedWhenVerificationIsEnabled() throws Exception {
+      sreeEnv.when(() -> SreeEnv.getProperty("chat.app.server.ssl.verify", "false"))
+         .thenReturn("true");
+
+      HttpClient.Builder builder = HttpClient.newBuilder();
+      AIAssistantController.applyAssistantTls(builder, "doc search");
+      HttpClient client = builder.build();
+
+      // Observed empirically on an untouched builder (Temurin 21): the endpoint identification
+      // algorithm defaults to null, not "HTTPS" or "". Asserting against that observed baseline
+      // rather than an assumed one.
+      assertNull(client.sslParameters().getEndpointIdentificationAlgorithm());
+      assertSame(SSLContext.getDefault(), client.sslContext());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/docs/WizDocSearchControllerMappingTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/docs/WizDocSearchControllerMappingTest.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of StyleBI.
- * Copyright (C) 2024  InetSoft Technology
+ * Copyright (C) 2025  InetSoft Technology
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/core/src/test/java/inetsoft/web/wiz/docs/WizDocSearchControllerMappingTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/docs/WizDocSearchControllerMappingTest.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.docs;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import java.lang.reflect.Method;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Guards the request-mapping prefix of the doc-search endpoint.
+ *
+ * <p>The prefix is load-bearing, not convention: {@code WizServiceAuthenticationFilter} validates
+ * the plugin's bearer token only under {@code /api/wiz/**}, and {@code CSRFFilter} exempts only
+ * that prefix. Moved elsewhere, the endpoint would not authenticate the plugin at all.</p>
+ */
+@Tag("core")
+class WizDocSearchControllerMappingTest {
+   @Test
+   void everyEndpointLivesUnderTheWizPrefix() {
+      List<String> paths = getMappingPaths(WizDocSearchController.class);
+      assertFalse(paths.isEmpty(), "expected @PostMapping annotations on WizDocSearchController");
+
+      for(String path : paths) {
+         assertTrue(path.startsWith(WIZ_PREFIX), "endpoint '" + path + "' must live under '" +
+            WIZ_PREFIX + "' or the plugin cannot authenticate to it");
+      }
+   }
+
+   @Test
+   void mappingsMatchThePluginContract() {
+      assertEquals(Set.of("/api/wiz/v1/docs/search"),
+                   new HashSet<>(getMappingPaths(WizDocSearchController.class)));
+   }
+
+   private static List<String> getMappingPaths(Class<?> controller) {
+      List<String> paths = new ArrayList<>();
+
+      for(Method method : controller.getDeclaredMethods()) {
+         PostMapping mapping = method.getAnnotation(PostMapping.class);
+
+         if(mapping != null) {
+            paths.addAll(Arrays.asList(mapping.value()));
+         }
+      }
+
+      return paths;
+   }
+
+   private static final String WIZ_PREFIX = "/api/wiz/";
+}

--- a/core/src/test/java/inetsoft/web/wiz/docs/WizDocSearchControllerRequestBindingTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/docs/WizDocSearchControllerRequestBindingTest.java
@@ -1,0 +1,120 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.docs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.sree.SreeEnv;
+import inetsoft.web.admin.ai.AdminAiCallerGuard;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.ByteArrayHttpMessageConverter;
+import org.springframework.http.converter.ResourceHttpMessageConverter;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Exercises {@link WizDocSearchController#search} through real Spring MVC request binding,
+ * the way {@code WizDocSearchControllerTest} cannot: those tests call {@code controller.search(...)}
+ * directly and so never go through an {@code HttpMessageConverter} at all. That is exactly why
+ * they did not catch Redmine #75966 — {@code @RequestBody String} with a
+ * {@code Content-Type: application/json} body fails at binding under this application's real
+ * converter set (see {@link inetsoft.web.WebConfig#configureMessageConverters}) before the
+ * controller body ever runs.
+ *
+ * <p>The message converters registered on the {@link MockMvc} builder below deliberately mirror
+ * {@code WebConfig}'s list and order (Jackson, Resource, a {@code text/plain}-only String
+ * converter, then ByteArray) rather than {@code standaloneSetup}'s permissive defaults. A
+ * {@code standaloneSetup} with default converters accepts {@code @RequestBody String} for a JSON
+ * body just fine — its default {@code StringHttpMessageConverter} supports every media type — so
+ * a test built that way would pass against both the broken and the fixed signature and would not
+ * be a real regression guard. Registering the application's actual converters reproduces the
+ * failure this defect report describes.</p>
+ */
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class WizDocSearchControllerRequestBindingTest {
+   @Mock private AssistantDocSearchGateway gateway;
+   private MockedStatic<AdminAiCallerGuard> guard;
+   private MockedStatic<SreeEnv> sreeEnv;
+   private MockMvc mvc;
+
+   @BeforeEach
+   void setUp() {
+      guard = mockStatic(AdminAiCallerGuard.class, withSettings().lenient());
+      sreeEnv = mockStatic(SreeEnv.class, withSettings().lenient());
+      sreeEnv.when(() -> SreeEnv.getProperty("chat.app.internal.url"))
+         .thenReturn("https://assistant.example.com");
+      sreeEnv.when(() -> SreeEnv.getProperty("chat.app.server.url")).thenReturn(null);
+
+      MappingJackson2HttpMessageConverter jackson =
+         new MappingJackson2HttpMessageConverter(new ObjectMapper());
+
+      ResourceHttpMessageConverter resource = new ResourceHttpMessageConverter();
+      resource.setSupportedMediaTypes(List.of(
+         MediaType.IMAGE_GIF, MediaType.IMAGE_JPEG, MediaType.IMAGE_PNG, MediaType.APPLICATION_PDF,
+         MediaType.parseMediaType("image/svg+xml")));
+
+      StringHttpMessageConverter text = new StringHttpMessageConverter();
+      text.setSupportedMediaTypes(List.of(
+         MediaType.TEXT_PLAIN, MediaType.parseMediaType("application/openmetrics-text")));
+
+      ByteArrayHttpMessageConverter byteArray = new ByteArrayHttpMessageConverter();
+      byteArray.setSupportedMediaTypes(List.of(
+         MediaType.APPLICATION_OCTET_STREAM, MediaType.TEXT_PLAIN,
+         MediaType.parseMediaType("application/openmetrics-text")));
+
+      mvc = MockMvcBuilders.standaloneSetup(new WizDocSearchController(gateway))
+         .setMessageConverters(jackson, resource, text, byteArray)
+         .build();
+   }
+
+   @AfterEach
+   void tearDown() {
+      guard.close();
+      sreeEnv.close();
+   }
+
+   @Test
+   void bindsAJsonPostBodyAndRelaysTheGatewaysStatus() throws Exception {
+      when(gateway.post(any(), any(), any(), any()))
+         .thenReturn(new AssistantDocSearchGateway.Response(200, "{\"matches\":[]}"));
+
+      mvc.perform(post("/api/wiz/v1/docs/search")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"query\":\"q\"}"))
+         .andExpect(status().isOk());
+
+      // The request must reach the gateway with the body intact — proof that binding, not just
+      // routing, succeeded.
+      verify(gateway).post(any(), any(), eq("{\"query\":\"q\"}"), any());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/docs/WizDocSearchControllerRequestBindingTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/docs/WizDocSearchControllerRequestBindingTest.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of StyleBI.
- * Copyright (C) 2024  InetSoft Technology
+ * Copyright (C) 2025  InetSoft Technology
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/core/src/test/java/inetsoft/web/wiz/docs/WizDocSearchControllerRequestBindingTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/docs/WizDocSearchControllerRequestBindingTest.java
@@ -31,8 +31,10 @@ import org.springframework.http.converter.ResourceHttpMessageConverter;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -116,5 +118,35 @@ class WizDocSearchControllerRequestBindingTest {
       // The request must reach the gateway with the body intact — proof that binding, not just
       // routing, succeeded.
       verify(gateway).post(any(), any(), eq("{\"query\":\"q\"}"), any());
+   }
+
+   /**
+    * Guards the mirror-image defect from the request-binding one above: the gateway's response
+    * body is already-serialized JSON text, and under the application's real converter set
+    * (Jackson registered ahead of a {@code text/plain}-only {@code StringHttpMessageConverter})
+    * {@code ResponseEntity<String>.contentType(APPLICATION_JSON)} gets written by Jackson, which
+    * re-serializes the {@code String} as a JSON string literal — {@code "{\"matches\":[]}"}
+    * instead of {@code {"matches":[]}}. A test built on {@code standaloneSetup}'s permissive
+    * default converters would not catch this, for the same reason described in the class
+    * javadoc.
+    */
+   @Test
+   void relaysTheResponseBodyAsRealJsonRatherThanADoubleEncodedString() throws Exception {
+      when(gateway.post(any(), any(), any(), any()))
+         .thenReturn(new AssistantDocSearchGateway.Response(200, "{\"matches\":[]}"));
+
+      MvcResult result = mvc.perform(post("/api/wiz/v1/docs/search")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"query\":\"q\"}"))
+         .andExpect(status().isOk())
+         .andReturn();
+
+      String body = result.getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+      assertFalse(body.startsWith("\""),
+         "response body must be a JSON object, not a JSON string literal: " + body);
+      assertFalse(body.contains("\\\""),
+         "response body must not contain escaped quotes (double-encoded JSON): " + body);
+      assertEquals("{\"matches\":[]}", body);
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/docs/WizDocSearchControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/docs/WizDocSearchControllerTest.java
@@ -24,9 +24,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -43,6 +42,7 @@ class WizDocSearchControllerTest {
    private MockedStatic<AdminAiCallerGuard> guard;
    private WizDocSearchController controller;
    private MockHttpServletRequest request;
+   private MockHttpServletResponse response;
 
    @BeforeEach
    void setUp() {
@@ -51,6 +51,7 @@ class WizDocSearchControllerTest {
       guard = mockStatic(AdminAiCallerGuard.class, withSettings().lenient());
       request = new MockHttpServletRequest();
       request.addHeader("Authorization", "Bearer operator-token");
+      response = new MockHttpServletResponse();
       configureAssistant("https://assistant.example.com");
    }
 
@@ -80,10 +81,11 @@ class WizDocSearchControllerTest {
       when(gateway.post(any(), any(), any(), any()))
          .thenReturn(new AssistantDocSearchGateway.Response(200, "{\"matches\":[]}"));
 
-      ResponseEntity<String> result = controller.search(request);
+      controller.search(request, response);
 
-      assertEquals(HttpStatus.OK.value(), result.getStatusCode().value());
-      assertEquals("{\"matches\":[]}", result.getBody());
+      assertEquals(200, response.getStatus());
+      assertEquals("{\"matches\":[]}", response.getContentAsString());
+      assertEquals("application/json;charset=UTF-8", response.getContentType());
    }
 
    @Test
@@ -92,7 +94,7 @@ class WizDocSearchControllerTest {
       when(gateway.post(any(), any(), any(), any()))
          .thenReturn(new AssistantDocSearchGateway.Response(200, "{}"));
 
-      controller.search(request);
+      controller.search(request, response);
 
       verify(gateway).post("https://assistant.example.com", "/api/doc-search",
                            "{\"query\":\"q\"}", "Bearer operator-token");
@@ -104,7 +106,7 @@ class WizDocSearchControllerTest {
       when(gateway.post(any(), any(), any(), any()))
          .thenReturn(new AssistantDocSearchGateway.Response(200, "{}"));
 
-      controller.search(request);
+      controller.search(request, response);
 
       guard.verify(AdminAiCallerGuard::requireBearerAuthenticatedRequest);
    }
@@ -115,10 +117,10 @@ class WizDocSearchControllerTest {
       when(gateway.post(any(), any(), any(), any())).thenReturn(
          new AssistantDocSearchGateway.Response(400, "{\"error\":\"modules[0]: unknown module\"}"));
 
-      ResponseEntity<String> result = controller.search(request);
+      controller.search(request, response);
 
-      assertEquals(400, result.getStatusCode().value());
-      assertTrue(result.getBody().contains("modules[0]"));
+      assertEquals(400, response.getStatus());
+      assertTrue(response.getContentAsString().contains("modules[0]"));
    }
 
    @Test
@@ -127,10 +129,10 @@ class WizDocSearchControllerTest {
       when(gateway.post(any(), any(), any(), any()))
          .thenReturn(new AssistantDocSearchGateway.Response(500, "{\"error\":\"Document search failed\"}"));
 
-      ResponseEntity<String> result = controller.search(request);
+      controller.search(request, response);
 
-      assertEquals(500, result.getStatusCode().value());
-      assertTrue(result.getBody().contains("Document search failed"));
+      assertEquals(500, response.getStatus());
+      assertTrue(response.getContentAsString().contains("Document search failed"));
    }
 
    // A doc-search body is a short question; anything larger is a caller bug or an attack, and
@@ -140,9 +142,9 @@ class WizDocSearchControllerTest {
       String huge = "{\"query\":\"" + "x".repeat(70_000) + "\"}";
       setBody(request, huge);
 
-      ResponseEntity<String> result = controller.search(request);
+      controller.search(request, response);
 
-      assertEquals(413, result.getStatusCode().value());
+      assertEquals(413, response.getStatus());
       verifyNoInteractions(gateway);
    }
 
@@ -151,11 +153,11 @@ class WizDocSearchControllerTest {
       setBody(request, "{\"query\":\"q\"}");
       configureAssistant(null);
 
-      ResponseEntity<String> result = controller.search(request);
+      controller.search(request, response);
 
-      assertEquals(503, result.getStatusCode().value());
-      assertTrue(result.getBody().contains("chat.app.internal.url"));
-      assertTrue(result.getBody().contains("chat.app.server.url"));
+      assertEquals(503, response.getStatus());
+      assertTrue(response.getContentAsString().contains("chat.app.internal.url"));
+      assertTrue(response.getContentAsString().contains("chat.app.server.url"));
       verifyNoInteractions(gateway);
    }
 
@@ -168,7 +170,7 @@ class WizDocSearchControllerTest {
       when(gateway.post(any(), any(), any(), any()))
          .thenReturn(new AssistantDocSearchGateway.Response(200, "{}"));
 
-      controller.search(request);
+      controller.search(request, response);
 
       verify(gateway).post(eq("https://direct.example.com"), any(), any(), any());
    }
@@ -180,11 +182,11 @@ class WizDocSearchControllerTest {
       when(gateway.post(any(), any(), any(), any()))
          .thenReturn(new AssistantDocSearchGateway.Response(404, "Cannot POST /api/doc-search"));
 
-      ResponseEntity<String> result = controller.search(request);
+      controller.search(request, response);
 
-      assertEquals(502, result.getStatusCode().value());
-      assertTrue(result.getBody().toLowerCase().contains("upgrade"));
-      assertFalse(result.getBody().contains("Cannot POST"));
+      assertEquals(502, response.getStatus());
+      assertTrue(response.getContentAsString().toLowerCase().contains("upgrade"));
+      assertFalse(response.getContentAsString().contains("Cannot POST"));
    }
 
    @Test
@@ -193,10 +195,10 @@ class WizDocSearchControllerTest {
       when(gateway.post(any(), any(), any(), any()))
          .thenThrow(new IOException("Connection refused"));
 
-      ResponseEntity<String> result = controller.search(request);
+      controller.search(request, response);
 
-      assertEquals(502, result.getStatusCode().value());
-      assertTrue(result.getBody().contains("did not respond"));
+      assertEquals(502, response.getStatus());
+      assertTrue(response.getContentAsString().contains("did not respond"));
    }
 
    @Test
@@ -206,7 +208,7 @@ class WizDocSearchControllerTest {
       when(gateway.post(any(), any(), any(), any()))
          .thenReturn(new AssistantDocSearchGateway.Response(200, "{}"));
 
-      controller.search(anonymous);
+      controller.search(anonymous, response);
 
       verify(gateway).post(any(), any(), any(), isNull());
    }

--- a/core/src/test/java/inetsoft/web/wiz/docs/WizDocSearchControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/docs/WizDocSearchControllerTest.java
@@ -29,6 +29,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -64,12 +65,22 @@ class WizDocSearchControllerTest {
       sreeEnv.when(() -> SreeEnv.getProperty("chat.app.server.url")).thenReturn(null);
    }
 
+   /**
+    * The production controller now reads the body from the request stream instead of via
+    * {@code @RequestBody}, so tests supply it the same way {@code MockHttpServletRequest}
+    * would receive it off the wire.
+    */
+   private static void setBody(MockHttpServletRequest request, String body) {
+      request.setContent(body.getBytes(StandardCharsets.UTF_8));
+   }
+
    @Test
    void relaysASuccessfulResponseVerbatim() throws Exception {
+      setBody(request, "{\"query\":\"q\"}");
       when(gateway.post(any(), any(), any(), any()))
          .thenReturn(new AssistantDocSearchGateway.Response(200, "{\"matches\":[]}"));
 
-      ResponseEntity<String> result = controller.search("{\"query\":\"q\"}", request);
+      ResponseEntity<String> result = controller.search(request);
 
       assertEquals(HttpStatus.OK.value(), result.getStatusCode().value());
       assertEquals("{\"matches\":[]}", result.getBody());
@@ -77,10 +88,11 @@ class WizDocSearchControllerTest {
 
    @Test
    void forwardsTheCallersBearerTokenAndBody() throws Exception {
+      setBody(request, "{\"query\":\"q\"}");
       when(gateway.post(any(), any(), any(), any()))
          .thenReturn(new AssistantDocSearchGateway.Response(200, "{}"));
 
-      controller.search("{\"query\":\"q\"}", request);
+      controller.search(request);
 
       verify(gateway).post("https://assistant.example.com", "/api/doc-search",
                            "{\"query\":\"q\"}", "Bearer operator-token");
@@ -88,20 +100,22 @@ class WizDocSearchControllerTest {
 
    @Test
    void requiresABearerAuthenticatedRequest() throws Exception {
+      setBody(request, "{\"query\":\"q\"}");
       when(gateway.post(any(), any(), any(), any()))
          .thenReturn(new AssistantDocSearchGateway.Response(200, "{}"));
 
-      controller.search("{\"query\":\"q\"}", request);
+      controller.search(request);
 
       guard.verify(AdminAiCallerGuard::requireBearerAuthenticatedRequest);
    }
 
    @Test
    void relaysAValidationErrorVerbatimSoTheAgentSeesTheNamedField() throws Exception {
+      setBody(request, "{}");
       when(gateway.post(any(), any(), any(), any())).thenReturn(
          new AssistantDocSearchGateway.Response(400, "{\"error\":\"modules[0]: unknown module\"}"));
 
-      ResponseEntity<String> result = controller.search("{}", request);
+      ResponseEntity<String> result = controller.search(request);
 
       assertEquals(400, result.getStatusCode().value());
       assertTrue(result.getBody().contains("modules[0]"));
@@ -109,10 +123,11 @@ class WizDocSearchControllerTest {
 
    @Test
    void relaysAnAssistantServerErrorVerbatim() throws Exception {
+      setBody(request, "{}");
       when(gateway.post(any(), any(), any(), any()))
          .thenReturn(new AssistantDocSearchGateway.Response(500, "{\"error\":\"Document search failed\"}"));
 
-      ResponseEntity<String> result = controller.search("{}", request);
+      ResponseEntity<String> result = controller.search(request);
 
       assertEquals(500, result.getStatusCode().value());
       assertTrue(result.getBody().contains("Document search failed"));
@@ -123,8 +138,9 @@ class WizDocSearchControllerTest {
    @Test
    void rejectsAnOversizedBodyBeforeCallingTheAssistant() throws Exception {
       String huge = "{\"query\":\"" + "x".repeat(70_000) + "\"}";
+      setBody(request, huge);
 
-      ResponseEntity<String> result = controller.search(huge, request);
+      ResponseEntity<String> result = controller.search(request);
 
       assertEquals(413, result.getStatusCode().value());
       verifyNoInteractions(gateway);
@@ -132,9 +148,10 @@ class WizDocSearchControllerTest {
 
    @Test
    void returns503NamingBothPropertiesWhenNoAssistantIsConfigured() throws Exception {
+      setBody(request, "{\"query\":\"q\"}");
       configureAssistant(null);
 
-      ResponseEntity<String> result = controller.search("{\"query\":\"q\"}", request);
+      ResponseEntity<String> result = controller.search(request);
 
       assertEquals(503, result.getStatusCode().value());
       assertTrue(result.getBody().contains("chat.app.internal.url"));
@@ -144,13 +161,14 @@ class WizDocSearchControllerTest {
 
    @Test
    void fallsBackToTheBrowserFacingUrlInDirectMode() throws Exception {
+      setBody(request, "{\"query\":\"q\"}");
       sreeEnv.when(() -> SreeEnv.getProperty("chat.app.internal.url")).thenReturn("");
       sreeEnv.when(() -> SreeEnv.getProperty("chat.app.server.url"))
          .thenReturn("https://direct.example.com");
       when(gateway.post(any(), any(), any(), any()))
          .thenReturn(new AssistantDocSearchGateway.Response(200, "{}"));
 
-      controller.search("{\"query\":\"q\"}", request);
+      controller.search(request);
 
       verify(gateway).post(eq("https://direct.example.com"), any(), any(), any());
    }
@@ -158,10 +176,11 @@ class WizDocSearchControllerTest {
    // A bare 404 would read as "no such StyleBI route" and send the operator to the wrong layer.
    @Test
    void mapsAssistant404ToAnUpgradeMessage() throws Exception {
+      setBody(request, "{\"query\":\"q\"}");
       when(gateway.post(any(), any(), any(), any()))
          .thenReturn(new AssistantDocSearchGateway.Response(404, "Cannot POST /api/doc-search"));
 
-      ResponseEntity<String> result = controller.search("{\"query\":\"q\"}", request);
+      ResponseEntity<String> result = controller.search(request);
 
       assertEquals(502, result.getStatusCode().value());
       assertTrue(result.getBody().toLowerCase().contains("upgrade"));
@@ -170,10 +189,11 @@ class WizDocSearchControllerTest {
 
    @Test
    void returns502WhenTheAssistantDoesNotRespond() throws Exception {
+      setBody(request, "{\"query\":\"q\"}");
       when(gateway.post(any(), any(), any(), any()))
          .thenThrow(new IOException("Connection refused"));
 
-      ResponseEntity<String> result = controller.search("{\"query\":\"q\"}", request);
+      ResponseEntity<String> result = controller.search(request);
 
       assertEquals(502, result.getStatusCode().value());
       assertTrue(result.getBody().contains("did not respond"));
@@ -182,10 +202,11 @@ class WizDocSearchControllerTest {
    @Test
    void toleratesAMissingAuthorizationHeader() throws Exception {
       MockHttpServletRequest anonymous = new MockHttpServletRequest();
+      setBody(anonymous, "{\"query\":\"q\"}");
       when(gateway.post(any(), any(), any(), any()))
          .thenReturn(new AssistantDocSearchGateway.Response(200, "{}"));
 
-      controller.search("{\"query\":\"q\"}", anonymous);
+      controller.search(anonymous);
 
       verify(gateway).post(any(), any(), any(), isNull());
    }

--- a/core/src/test/java/inetsoft/web/wiz/docs/WizDocSearchControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/docs/WizDocSearchControllerTest.java
@@ -1,0 +1,192 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.docs;
+
+import inetsoft.sree.SreeEnv;
+import inetsoft.web.admin.ai.AdminAiCallerGuard;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class WizDocSearchControllerTest {
+   @Mock private AssistantDocSearchGateway gateway;
+   private MockedStatic<SreeEnv> sreeEnv;
+   private MockedStatic<AdminAiCallerGuard> guard;
+   private WizDocSearchController controller;
+   private MockHttpServletRequest request;
+
+   @BeforeEach
+   void setUp() {
+      controller = new WizDocSearchController(gateway);
+      sreeEnv = mockStatic(SreeEnv.class, withSettings().lenient());
+      guard = mockStatic(AdminAiCallerGuard.class, withSettings().lenient());
+      request = new MockHttpServletRequest();
+      request.addHeader("Authorization", "Bearer operator-token");
+      configureAssistant("https://assistant.example.com");
+   }
+
+   @AfterEach
+   void tearDown() {
+      sreeEnv.close();
+      guard.close();
+   }
+
+   private void configureAssistant(String internalUrl) {
+      sreeEnv.when(() -> SreeEnv.getProperty("chat.app.internal.url")).thenReturn(internalUrl);
+      sreeEnv.when(() -> SreeEnv.getProperty("chat.app.server.url")).thenReturn(null);
+   }
+
+   @Test
+   void relaysASuccessfulResponseVerbatim() throws Exception {
+      when(gateway.post(any(), any(), any(), any()))
+         .thenReturn(new AssistantDocSearchGateway.Response(200, "{\"matches\":[]}"));
+
+      ResponseEntity<String> result = controller.search("{\"query\":\"q\"}", request);
+
+      assertEquals(HttpStatus.OK.value(), result.getStatusCode().value());
+      assertEquals("{\"matches\":[]}", result.getBody());
+   }
+
+   @Test
+   void forwardsTheCallersBearerTokenAndBody() throws Exception {
+      when(gateway.post(any(), any(), any(), any()))
+         .thenReturn(new AssistantDocSearchGateway.Response(200, "{}"));
+
+      controller.search("{\"query\":\"q\"}", request);
+
+      verify(gateway).post("https://assistant.example.com", "/api/doc-search",
+                           "{\"query\":\"q\"}", "Bearer operator-token");
+   }
+
+   @Test
+   void requiresABearerAuthenticatedRequest() throws Exception {
+      when(gateway.post(any(), any(), any(), any()))
+         .thenReturn(new AssistantDocSearchGateway.Response(200, "{}"));
+
+      controller.search("{\"query\":\"q\"}", request);
+
+      guard.verify(AdminAiCallerGuard::requireBearerAuthenticatedRequest);
+   }
+
+   @Test
+   void relaysAValidationErrorVerbatimSoTheAgentSeesTheNamedField() throws Exception {
+      when(gateway.post(any(), any(), any(), any())).thenReturn(
+         new AssistantDocSearchGateway.Response(400, "{\"error\":\"modules[0]: unknown module\"}"));
+
+      ResponseEntity<String> result = controller.search("{}", request);
+
+      assertEquals(400, result.getStatusCode().value());
+      assertTrue(result.getBody().contains("modules[0]"));
+   }
+
+   @Test
+   void relaysAnAssistantServerErrorVerbatim() throws Exception {
+      when(gateway.post(any(), any(), any(), any()))
+         .thenReturn(new AssistantDocSearchGateway.Response(500, "{\"error\":\"Document search failed\"}"));
+
+      ResponseEntity<String> result = controller.search("{}", request);
+
+      assertEquals(500, result.getStatusCode().value());
+      assertTrue(result.getBody().contains("Document search failed"));
+   }
+
+   // A doc-search body is a short question; anything larger is a caller bug or an attack, and
+   // there is no reason to relay it upstream to find that out.
+   @Test
+   void rejectsAnOversizedBodyBeforeCallingTheAssistant() throws Exception {
+      String huge = "{\"query\":\"" + "x".repeat(70_000) + "\"}";
+
+      ResponseEntity<String> result = controller.search(huge, request);
+
+      assertEquals(413, result.getStatusCode().value());
+      verifyNoInteractions(gateway);
+   }
+
+   @Test
+   void returns503NamingBothPropertiesWhenNoAssistantIsConfigured() throws Exception {
+      configureAssistant(null);
+
+      ResponseEntity<String> result = controller.search("{\"query\":\"q\"}", request);
+
+      assertEquals(503, result.getStatusCode().value());
+      assertTrue(result.getBody().contains("chat.app.internal.url"));
+      assertTrue(result.getBody().contains("chat.app.server.url"));
+      verifyNoInteractions(gateway);
+   }
+
+   @Test
+   void fallsBackToTheBrowserFacingUrlInDirectMode() throws Exception {
+      sreeEnv.when(() -> SreeEnv.getProperty("chat.app.internal.url")).thenReturn("");
+      sreeEnv.when(() -> SreeEnv.getProperty("chat.app.server.url"))
+         .thenReturn("https://direct.example.com");
+      when(gateway.post(any(), any(), any(), any()))
+         .thenReturn(new AssistantDocSearchGateway.Response(200, "{}"));
+
+      controller.search("{\"query\":\"q\"}", request);
+
+      verify(gateway).post(eq("https://direct.example.com"), any(), any(), any());
+   }
+
+   // A bare 404 would read as "no such StyleBI route" and send the operator to the wrong layer.
+   @Test
+   void mapsAssistant404ToAnUpgradeMessage() throws Exception {
+      when(gateway.post(any(), any(), any(), any()))
+         .thenReturn(new AssistantDocSearchGateway.Response(404, "Cannot POST /api/doc-search"));
+
+      ResponseEntity<String> result = controller.search("{\"query\":\"q\"}", request);
+
+      assertEquals(502, result.getStatusCode().value());
+      assertTrue(result.getBody().toLowerCase().contains("upgrade"));
+      assertFalse(result.getBody().contains("Cannot POST"));
+   }
+
+   @Test
+   void returns502WhenTheAssistantDoesNotRespond() throws Exception {
+      when(gateway.post(any(), any(), any(), any()))
+         .thenThrow(new IOException("Connection refused"));
+
+      ResponseEntity<String> result = controller.search("{\"query\":\"q\"}", request);
+
+      assertEquals(502, result.getStatusCode().value());
+      assertTrue(result.getBody().contains("did not respond"));
+   }
+
+   @Test
+   void toleratesAMissingAuthorizationHeader() throws Exception {
+      MockHttpServletRequest anonymous = new MockHttpServletRequest();
+      when(gateway.post(any(), any(), any(), any()))
+         .thenReturn(new AssistantDocSearchGateway.Response(200, "{}"));
+
+      controller.search("{\"query\":\"q\"}", anonymous);
+
+      verify(gateway).post(any(), any(), any(), isNull());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/docs/WizDocSearchControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/docs/WizDocSearchControllerTest.java
@@ -1,6 +1,6 @@
 /*
  * This file is part of StyleBI.
- * Copyright (C) 2024  InetSoft Technology
+ * Copyright (C) 2025  InetSoft Technology
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -24,8 +24,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -109,6 +111,19 @@ class WizDocSearchControllerTest {
       controller.search(request, response);
 
       guard.verify(AdminAiCallerGuard::requireBearerAuthenticatedRequest);
+   }
+
+   // The test above only proves the guard was called; it would still pass if the controller
+   // ignored a thrown failure and pressed on. This proves the guard actually stops the request.
+   @Test
+   void aGuardFailureStopsTheRequestBeforeTheGatewayIsCalled() {
+      setBody(request, "{\"query\":\"q\"}");
+      guard.when(AdminAiCallerGuard::requireBearerAuthenticatedRequest)
+         .thenThrow(new ResponseStatusException(HttpStatus.FORBIDDEN));
+
+      assertThrows(ResponseStatusException.class, () -> controller.search(request, response));
+
+      verifyNoInteractions(gateway);
    }
 
    @Test


### PR DESCRIPTION
Adds the StyleBI hop that lets the Claude Code plugins search product documentation without holding any credential: StyleBI resolves the configured assistant base URL, forwards the operator's bearer token, and relays the reply.

**Part of a three-repo change (Redmine #75966):** `inetsoft-technology/assistant` PR #892 serves `/api/doc-search`; `inetsoft-technology/stylebi-wiz` carries the MCP tool. Community-only — no enterprise counterpart.

## Base branch

Targets `stylebi-wiz-main-rebase`, **not `main`**, deliberately. This work builds on the unmerged admin-chat feature (`inetsoft/web/admin/ai/`) which exists only on that branch. Against `main` the diff is 568 files / 103k lines and unreviewable; against this base it is 8 files / 958 lines. It follows admin-chat to `main`.

## Why StyleBI is in the path

`/api/wiz/**` is the only prefix where `WizServiceAuthenticationFilter` validates a bearer JWT and `CSRFFilter` grants an exemption. A plugin calling the assistant directly would bypass the plugin security model and need the assistant's URL on every operator's machine. The prefix is load-bearing, not convention — a mapping test pins it so a silent path change breaks the build.

## Design notes

**A thin passthrough in both directions.** Request validation lives in the assistant, which owns the module vocabulary; duplicating it here would create two validators that drift. The body is read from `request.getInputStream()` and the response written straight to `HttpServletResponse` — `WebConfig` replaces Spring's default converters and scopes `StringHttpMessageConverter` to `text/plain`, so `@RequestBody String` cannot bind JSON and `ResponseEntity<String>` would be double-encoded by Jackson. Both were real defects found by live testing after unit tests passed; both now carry regression tests proven to fail against the broken code.

**One exception to verbatim relay:** a 404 from the assistant becomes a 502 with an upgrade message. A bare 404 reads as "no such StyleBI route" and sends an operator to debug the wrong layer. Every other status, including 400 and 500, passes through untouched so the assistant's field-named validation errors reach the agent intact.

**`AIAssistantController.applyAssistantTls()`** extracts the trust-all TLS setup previously duplicated in `createHealthClient()`. The copies had already diverged: only one cleared `SSLParameters.setEndpointIdentificationAlgorithm("")`, so with `chat.app.server.ssl.verify=false` and a self-signed cert the health check would report online while doc search failed the hostname check. `AIAssistantControllerTest` is new — that class previously had no coverage at all.

## Verification

21/21 across four suites; BUILD SUCCESS. Live smoke test 2026-08-05 driven only through the plugin's MCP tools, exercising the direct-mode base-URL fallback and the trust-all TLS path against a self-signed assistant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)