### PR TITLE
Bug #75956, enforce Monitoring permission on debug dump endpoints

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/server/DebugMonitoringController.java
+++ b/core/src/main/java/inetsoft/web/admin/server/DebugMonitoringController.java
@@ -22,11 +22,15 @@ import inetsoft.report.LibManagerProvider;
 import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.internal.cluster.Cluster;
 import inetsoft.sree.security.Organization;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
 import inetsoft.sree.security.SecurityEngine;
 import inetsoft.storage.KeyValueEngine;
 import inetsoft.storage.KeyValuePair;
 import inetsoft.uql.asset.EmbeddedTableStorage;
 import inetsoft.util.*;
+import inetsoft.web.security.RequiredPermission;
+import inetsoft.web.security.Secured;
 import jakarta.servlet.http.HttpServletResponse;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -46,6 +50,13 @@ public class DebugMonitoringController {
       this.libManagerProvider = libManagerProvider;
    }
 
+   @Secured(
+      @RequiredPermission(
+         resourceType = ResourceType.EM_COMPONENT,
+         resource = "monitoring/summary",
+         actions = ResourceAction.ACCESS
+      )
+   )
    @GetMapping("/em/monitoring/server/debug/key-value-storage-dump")
    public void getKVDump(HttpServletResponse response) throws Exception
    {
@@ -85,6 +96,13 @@ public class DebugMonitoringController {
       }
    }
 
+   @Secured(
+      @RequiredPermission(
+         resourceType = ResourceType.EM_COMPONENT,
+         resource = "monitoring/summary",
+         actions = ResourceAction.ACCESS
+      )
+   )
    @GetMapping("/em/monitoring/server/debug/blob-path-dump")
    public void getBlobPathsDump(HttpServletResponse response) throws Exception
    {


### PR DESCRIPTION
## Summary
- `DebugMonitoringController` exposed `/em/monitoring/server/debug/key-value-storage-dump` and `/em/monitoring/server/debug/blob-path-dump` with no authorization annotation.
- Any authenticated EM user (even without the Monitoring permission) could download the full key-value store dump and cross-organization blob paths.
- Added `@Secured(@RequiredPermission(resourceType = ResourceType.EM_COMPONENT, resource = "monitoring/summary", actions = ResourceAction.ACCESS))` to both endpoints, matching the pattern already used by every other monitoring endpoint in `ServerMonitoringController` (thread dump, heap dump, usage history, cluster cache usage, etc.).

## Test plan
- [x] `core` module compiles cleanly with the change
- [ ] Manually verify a low-privilege EM user (no Monitoring permission) now receives a permission-denied error on both debug endpoints
- [ ] Verify a user with Monitoring permission can still download both dumps successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)