### PR TITLE
Bug #75958, fix TypeError when opening highlight conditions dialog

### DIFF
--- a/web/projects/portal/src/app/vsobjects/dialog/vs-condition-dialog.component.ts
+++ b/web/projects/portal/src/app/vsobjects/dialog/vs-condition-dialog.component.ts
@@ -105,7 +105,13 @@ export class VSConditionDialog extends BaseResizeableDialogComponent implements 
 
          // the field in condition may not contain complete information (named group).
          // get the field from the field list which is more accurate. (60408)
+         // conditionList alternates conditions (even index) and junction operators
+         // (odd index), so items without a field (junctions) must be skipped.
          this.model.conditionList.forEach(cond => {
+            if(!cond || !cond.field) {
+               return;
+            }
+
             const field = this.model.fields.find(a => a.view == cond.field.view);
             if(field) {
                cond.field = field;


### PR DESCRIPTION
## Summary
- `VSConditionDialog.ngOnInit()` looked up the accurate field definition for every entry in `conditionList`, but that array alternates between `Condition` objects (even indices) and junction-operator objects (odd indices). Junction entries have no `field` property, so `cond.field.view` threw `TypeError: Cannot read properties of undefined (reading 'view')`.
- The thrown error aborted `ngOnInit` partway through, which is why the highlight Conditions dialog appeared to hang before eventually opening in a broken state.
- Skip entries without a `field` (junction operators) before doing the field lookup.

## Test plan
- [x] Open a viewsheet with a highlight that has an AND/OR condition list, right-click the highlighted cell → Highlight → select a highlight → Edit, and confirm the Conditions dialog opens immediately with no console error.