### PR TITLE
Bug #75959, defer objectHeight write to avoid NG0100 on wrap text tables

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/table/base-table.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/table/base-table.ts
@@ -1642,7 +1642,21 @@ export abstract class BaseTable<T extends BaseTableModel> extends AbstractVSObje
             // add data row height
             this.model.scrollHeight;
 
-         return this.model.objectHeight = height;
+         // vsObject.objectHeight is read directly by the ancestor vs-object-container
+         // template, whose own bindings are checked before this component's template is
+         // refreshed. Mutating this.model.objectHeight synchronously here means the
+         // ancestor's checkNoChanges pass sees a different value than it just recorded,
+         // triggering ExpressionChangedAfterItHasBeenCheckedError (e.g. when wrap text
+         // changes the table's shrink-to-fit height). Defer the write so it lands in a
+         // later change detection cycle instead of the one currently in progress.
+         if(this.model.objectHeight !== height) {
+            Promise.resolve().then(() => {
+               this.model.objectHeight = height;
+               this.changeDetectorRef.markForCheck();
+            });
+         }
+
+         return height;
       }
       else {
          return this.model.objectFormat.height;

--- a/web/projects/portal/src/app/vsobjects/objects/table/base-table.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/table/base-table.ts
@@ -261,6 +261,8 @@ export abstract class BaseTable<T extends BaseTableModel> extends AbstractVSObje
    protected subscriptions = Subscription.EMPTY;
    protected scrollTopSubscription = Subscription.EMPTY;
    protected scrollLeftSubscription = Subscription.EMPTY;
+   private destroyed = false;
+   private pendingHeightUpdate = false;
    private _selected: boolean;
    preserveSelection: boolean = false;
    private resizingRowHeight: number;
@@ -390,6 +392,7 @@ export abstract class BaseTable<T extends BaseTableModel> extends AbstractVSObje
       this.subscriptions.unsubscribe();
       this.scrollTopSubscription.unsubscribe();
       this.scrollLeftSubscription.unsubscribe();
+      this.destroyed = true;
    }
 
    /**
@@ -1649,10 +1652,16 @@ export abstract class BaseTable<T extends BaseTableModel> extends AbstractVSObje
          // triggering ExpressionChangedAfterItHasBeenCheckedError (e.g. when wrap text
          // changes the table's shrink-to-fit height). Defer the write so it lands in a
          // later change detection cycle instead of the one currently in progress.
-         if(this.model.objectHeight !== height) {
+         if(this.model.objectHeight !== height && !this.pendingHeightUpdate) {
+            this.pendingHeightUpdate = true;
+
             Promise.resolve().then(() => {
-               this.model.objectHeight = height;
-               this.changeDetectorRef.markForCheck();
+               this.pendingHeightUpdate = false;
+
+               if(!this.destroyed) {
+                  this.model.objectHeight = height;
+                  this.changeDetectorRef.markForCheck();
+               }
             });
          }
 


### PR DESCRIPTION
## Summary
- Fixes an `ExpressionChangedAfterItHasBeenCheckedError` (NG0100) thrown in the browser when wrap text changes a table's shrink-to-fit height.
- `BaseTable.getObjectHeight()` mutated `model.objectHeight` as a side effect of a getter evaluated inside the table's own template. The ancestor `vs-object-container` reads that same field in its own template, which Angular checks before descending into the child table's template in the same change-detection pass — causing the dev-mode `checkNoChanges` pass to see a stale-vs-updated mismatch.
- The write is now deferred to a microtask (with `markForCheck()`) so it lands in the next change detection cycle instead of mutating shared state mid-cycle. The method's return value used for the table's own rendering is unaffected.

## Test plan
- [x] Reproduced the wraptext viewsheet scenario and confirmed the NG0100 console error no longer appears.
- [ ] `npm run test:portal` for `base-table`/`vs-table`/`vs-crosstab` specs.