### PR TITLE
Bug #75964, fix web link field dropdown rendering all fields on one row

### DIFF
--- a/web/projects/portal/src/app/vsobjects/dialog/graph/hyperlink-dialog.component.html
+++ b/web/projects/portal/src/app/vsobjects/dialog/graph/hyperlink-dialog.component.html
@@ -74,16 +74,16 @@
                       <div class="col web-field">
                         <select [ngModel]="model.webLink" (ngModelChange)="selectWebLink($event)"
                           class="form-control" >
-                          <option [ngValue]="null" [selected]="model.webLink == null">
-                            @for (field of model.fields; track $index) {
-                              <option
-                                [ngValue]="'hyperlink:' + field.name" [selected]="field.name == model.webLink">
-                                hyperlink:{{field.view}}
-                              </option>
-                            }
-                          </select>
-                        </div>
-                      }
+                          <option [ngValue]="null" [selected]="model.webLink == null"></option>
+                          @for (field of model.fields; track $index) {
+                            <option
+                              [ngValue]="'hyperlink:' + field.name" [selected]="field.name == model.webLink">
+                              hyperlink:{{field.view}}
+                            </option>
+                          }
+                        </select>
+                      </div>
+                    }
                       @if (valueType == ValueType.EXPRESSION) {
                         <div class="col">
                           <expression-editor [vsId]="runtimeId"


### PR DESCRIPTION
## Summary
- In the viewsheet Hyperlink dialog, selecting Web Link → Field showed all available fields concatenated on a single row instead of each field on its own line.
- Root cause: the placeholder `<option>` in the field `<select>` was never closed before the `@for` loop generating per-field options, so those options became DOM children of the placeholder option instead of siblings inside `<select>`. A `<select>` only renders one row per direct child, so the browser collapsed all field names into one row.
- Fix: close the placeholder `<option>` immediately and make the `@for` block a sibling inside `<select>`.

## Test plan
- [ ] Open a viewsheet in Composer, right-click a table cell → Hyperlink
- [ ] Select Web Link, click "change value type" icon, select Field
- [ ] Expand the field dropdown and confirm each field renders on its own line