### PR TITLE
Bug #75889, attach a chart highlight to the ref it names, not every ref

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -846,6 +846,13 @@ public class WizVsService {
     * callers legitimately send either: the full name ("DistinctCount(PRODUCT_ID)") or the plain one
     * ("PRODUCT_ID").
     *
+    * The plain form is ambiguous when a chart binds two aggregates over the same column (e.g. both
+    * {@code Sum(Sales)} and {@code Avg(Sales)}, each of whose {@code getName()} is "Sales"): a rule using
+    * {@code field = "Sales"} binds to whichever of them comes first in {@code allRefs} — the same
+    * ambiguity {@link #measureMatches} documents for the crosstab path. To target one specifically, pass
+    * the full name (e.g. {@code "Avg(Sales)"}); a full name only ever equals {@code getFullName()}, never
+    * another ref's plain name, so it resolves the same way whatever the ref order.
+    *
     * Falls back to ALL refs — the previous behaviour, so nothing that renders today regresses — when
     * the rule names no field, when the name matches no ref, or for the chart types whose highlightable
     * ref is not a plain X/Y binding: word cloud (text aesthetic), treemap (group fields), relation

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -867,8 +867,11 @@ public class WizVsService {
     * (source/target), gantt (start/end/milestone), scatter matrix. Those are enumerated by
     * GraphGenerator.getHighlightRefs(); narrowing them by an X/Y-shaped name would silently drop the
     * highlight rather than merely widen it.
+    *
+    * Package-private (not private) only so {@code WizVsServiceResolveRuleHighlightRefsTest} can drive it
+    * directly — the same reason executeAndExtract is.
     */
-   private List<HighlightRef> resolveRuleHighlightRefs(
+   List<HighlightRef> resolveRuleHighlightRefs(
       ApplyHighlightModel.Highlight rule, List<HighlightRef> allRefs, VSChartInfo chartInfo,
       boolean wordCloud)
    {

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -846,6 +846,14 @@ public class WizVsService {
     * callers legitimately send either: the full name ("DistinctCount(PRODUCT_ID)") or the plain one
     * ("PRODUCT_ID").
     *
+    * Both comparisons IGNORE CASE, unlike the crosstab-path {@link #measureMatches} and the detail-table
+    * header match, which are exact. That asymmetry is deliberate: those two fail loud on no match
+    * ({@link #applyTableHighlight} throws, naming the column), so a mis-cased name is reported back to the
+    * caller, whereas a miss here silently falls back to EVERY ref — reproducing the very bug this method
+    * exists to fix. Leniency is the safer default when the penalty for a miss is a wrong render rather
+    * than an error. A genuinely mis-cased request is still caught: the condition fields are resolved
+    * case-sensitively against the chart columns by rebindChartConditionFields, which throws first.
+    *
     * The plain form is ambiguous when a chart binds two aggregates over the same column (e.g. both
     * {@code Sum(Sales)} and {@code Avg(Sales)}, each of whose {@code getName()} is "Sales"): a rule using
     * {@code field = "Sales"} binds to whichever of them comes first in {@code allRefs} — the same

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -397,15 +397,6 @@ public class WizVsService {
          // so the condition ref's name/type match the header. Otherwise GraphConditionGroup.findColumn
          // can't resolve the field, the condition is dropped, and no mark is ever colored.
          ColumnSelection chartCols = buildChartHighlightColumns(chartInfo);
-         // A chart applies a highlight FONT only to a data label (text highlight) or to a font-capable
-         // mark — a dimension, or a DISCRETE measure — exactly the cases HighlightDialogService.setShowFont
-         // enables. A continuous-measure mark honors only the COLOR (foreground); its font is ignored. Since
-         // a wiz rule is attached to EVERY binding ref, the font still renders as long as ONE ref is
-         // font-capable; only when the whole chart has no dimension and no discrete measure does a font have
-         // nowhere to land. Precompute that so a font-only rule can fail loud (mirroring the background guard).
-         boolean chartHasFontCapableRef = highlightRefs.stream().anyMatch(
-            r -> r instanceof VSChartDimensionRef ||
-                 r instanceof VSChartAggregateRef agg && agg.isDiscrete());
          Map<HighlightRef, HighlightGroup> pointGroups = new LinkedHashMap<>();
          Map<HighlightRef, HighlightGroup> textGroups = new LinkedHashMap<>();
          Set<String> usedNames = new HashSet<>();
@@ -414,12 +405,18 @@ public class WizVsService {
             String name = uniqueName(rule.getName(), usedNames);
             Highlight hl = buildHighlight(rule, name, chartCols, true);
             boolean isText = !wordCloud && "dataLabel".equals(rule.getApplyArea());
+            // The refs THIS rule attaches to: only the one it names when that is unambiguous, otherwise
+            // every ref (the long-standing behaviour). See resolveRuleHighlightRefs.
+            List<HighlightRef> ruleRefs =
+               resolveRuleHighlightRefs(rule, highlightRefs, chartInfo, wordCloud);
 
             // A rule that sets ONLY a font (no foreground) has no visible effect when the font cannot render:
             // not a data-label highlight AND no font-capable ref to carry it (all marks are continuous
             // measures, which honor color only). Fail loud instead of silently no-opping — the font analogue
-            // of the background-only guard in buildHighlight.
-            if(hl.getForeground() == null && hl.getFont() != null && !isText && !chartHasFontCapableRef) {
+            // of the background-only guard in buildHighlight. Judged against the refs THIS rule lands on:
+            // now that a rule can be narrowed to a single ref, a font-capable ref elsewhere on the chart no
+            // longer means this rule's font has anywhere to render.
+            if(hl.getForeground() == null && hl.getFont() != null && !isText && !hasFontCapableRef(ruleRefs)) {
                throw new IllegalArgumentException(
                   "highlight '" + name + "' sets only a font, but this chart highlights a continuous measure " +
                   "mark, which honors color only — the font has nowhere to render. Set a foreground color, or " +
@@ -428,7 +425,7 @@ public class WizVsService {
 
             Map<HighlightRef, HighlightGroup> sink = isText ? textGroups : pointGroups;
 
-            for(HighlightRef hlRef : highlightRefs) {
+            for(HighlightRef hlRef : ruleRefs) {
                HighlightGroup group = sink.computeIfAbsent(hlRef, k -> new HighlightGroup());
                group.addHighlight(name, hl.clone());
             }
@@ -831,6 +828,74 @@ public class WizVsService {
       highlight.setFont(font);
       highlight.setConditionGroup(conditionGroup);
       return highlight;
+   }
+
+   /**
+    * The binding refs a single chart highlight rule should attach to.
+    *
+    * A chart renders a highlight group through TWO independent paths, both keyed off the SAME
+    * {@link HighlightRef#getHighlightGroup()}: GraphGenerator.applyHighlight() colors the PLOT marks,
+    * and GraphGenerator.addHighlightToAxis() colors the AXIS labels. The engine keeps them apart by ref
+    * KIND — findHighlightRef adopts a ref for the axis only when it is NOT a measure — so a group on a
+    * measure colors the plot, a group on a dimension colors the axis, and an ordinary chart gets one or
+    * the other, never both. Attaching every rule to EVERY binding ref therefore put a group on both
+    * kinds at once: a bar chart came back with its bars AND its category axis colored (Bug #75889).
+    *
+    * So a rule that names a field is attached to just that ref — the same use of the same `field` the
+    * table/crosstab branch already makes (where it is required). Either spelling is matched, since
+    * callers legitimately send either: the full name ("DistinctCount(PRODUCT_ID)") or the plain one
+    * ("PRODUCT_ID").
+    *
+    * Falls back to ALL refs — the previous behaviour, so nothing that renders today regresses — when
+    * the rule names no field, when the name matches no ref, or for the chart types whose highlightable
+    * ref is not a plain X/Y binding: word cloud (text aesthetic), treemap (group fields), relation
+    * (source/target), gantt (start/end/milestone), scatter matrix. Those are enumerated by
+    * GraphGenerator.getHighlightRefs(); narrowing them by an X/Y-shaped name would silently drop the
+    * highlight rather than merely widen it.
+    */
+   private List<HighlightRef> resolveRuleHighlightRefs(
+      ApplyHighlightModel.Highlight rule, List<HighlightRef> allRefs, VSChartInfo chartInfo,
+      boolean wordCloud)
+   {
+      String field = rule.getField();
+
+      if(field == null || field.trim().isEmpty() || allRefs.size() <= 1) {
+         return allRefs;
+      }
+
+      // Mirrors GraphGenerator.getHighlightRefs()'s own special-casing, including its use of the
+      // DESIGN chart type for gantt where the others read the runtime type.
+      if(wordCloud || GraphTypeUtil.isScatterMatrix(chartInfo) ||
+         GraphTypes.isTreemap(chartInfo.getRTChartType()) ||
+         GraphTypes.isRelation(chartInfo.getRTChartType()) ||
+         GraphTypes.isGantt(chartInfo.getChartType()))
+      {
+         return allRefs;
+      }
+
+      String target = field.trim();
+
+      for(HighlightRef hlRef : allRefs) {
+         if(hlRef instanceof VSDataRef dataRef &&
+            (target.equalsIgnoreCase(dataRef.getFullName()) ||
+             target.equalsIgnoreCase(dataRef.getName())))
+         {
+            return List.of(hlRef);
+         }
+      }
+
+      return allRefs;
+   }
+
+   /**
+    * Whether any of these refs can render a highlight FONT — a dimension or a DISCRETE measure, exactly
+    * the cases HighlightDialogService.setShowFont enables. A continuous-measure mark honors the
+    * foreground color only, so a font attached there has nowhere to land.
+    */
+   private static boolean hasFontCapableRef(List<HighlightRef> refs) {
+      return refs.stream().anyMatch(
+         r -> r instanceof VSChartDimensionRef ||
+              r instanceof VSChartAggregateRef agg && agg.isDiscrete());
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceResolveRuleHighlightRefsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceResolveRuleHighlightRefsTest.java
@@ -1,0 +1,197 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.viewsheet.graph.GraphTypes;
+import inetsoft.uql.viewsheet.graph.HighlightRef;
+import inetsoft.uql.viewsheet.graph.VSChartAggregateRef;
+import inetsoft.uql.viewsheet.graph.VSChartDimensionRef;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
+import inetsoft.web.wiz.model.ApplyHighlightModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Bug #75889: a chart highlight rule must attach to the ONE binding ref it names, not to every ref.
+ * Attaching a rule to every ref put the same HighlightGroup on a measure AND a dimension at once, and
+ * because GraphGenerator splits plot-vs-axis coloring by ref KIND (findHighlightRef adopts a ref for the
+ * axis only when it is not a measure), a bar chart came back with its bars AND its category axis colored.
+ *
+ * <p>These cover {@link WizVsService#resolveRuleHighlightRefs} directly: it is the whole of the fix, and
+ * {@link WizVsServiceApplyHighlightCopyTest} — the only other highlight test — exercises the TEXT-output
+ * branch, which never touches chart binding refs.
+ *
+ * <p>The narrowing cases assert the SINGLE named ref comes back; the fallback cases assert the SAME list
+ * instance comes back, since "fall back to all refs" is deliberately the untouched pre-fix behaviour.
+ *
+ * <p>WizVsService's constructor has no side effects (see {@link WizVsServiceFilterCopyTest}), and this
+ * method reads nothing but the rule, the ref list and the chart info, so the three collaborators are
+ * plain mocks this path never touches.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WizVsServiceResolveRuleHighlightRefsTest {
+   private WizVsService service;
+   private VSChartDimensionRef dim;
+   private VSChartAggregateRef agg;
+   private VSChartInfo chartInfo;
+   private List<HighlightRef> allRefs;
+
+   @BeforeEach
+   void setUp() {
+      service = new WizVsService(
+         mock(ViewsheetService.class), mock(AssetRepository.class), mock(SecurityEngine.class), null);
+
+      // The exact shape bug #75889 reproduced on: one dimension on X, one measure on Y — a plain bar
+      // chart, where the dimension carries the axis highlight and the measure the plot highlight.
+      dim = new VSChartDimensionRef();
+      dim.setGroupColumnValue("State");
+
+      agg = new VSChartAggregateRef();
+      agg.setColumnValue("Sales");
+      agg.setFormulaValue("Sum");
+
+      chartInfo = new VSChartInfo();
+      chartInfo.addXField(dim);
+      chartInfo.addYField(agg);
+
+      allRefs = List.of(dim, agg);
+   }
+
+   private static ApplyHighlightModel.Highlight ruleOn(String field) {
+      ApplyHighlightModel.Highlight rule = new ApplyHighlightModel.Highlight();
+      rule.setName("r1");
+      rule.setField(field);
+      return rule;
+   }
+
+   @Test
+   void aRuleNamingAMeasureByItsFullNameNarrowsToThatRefAlone() {
+      // The spelling the chart DataSet exposes as a header, e.g. "Sum(Sales)". Guard first that it really
+      // is distinct from the plain name, so this case isn't silently identical to the one below.
+      String fullName = agg.getFullName();
+      assertNotEquals(agg.getName(), fullName);
+
+      List<HighlightRef> refs = service.resolveRuleHighlightRefs(
+         ruleOn(fullName), allRefs, chartInfo, false);
+
+      assertEquals(1, refs.size());
+      assertSame(agg, refs.get(0));
+   }
+
+   @Test
+   void aRuleNamingAMeasureByItsPlainNameNarrowsToThatRefAlone() {
+      List<HighlightRef> refs = service.resolveRuleHighlightRefs(
+         ruleOn(agg.getName()), allRefs, chartInfo, false);
+
+      assertEquals(1, refs.size());
+      assertSame(agg, refs.get(0));
+   }
+
+   @Test
+   void aRuleNamingTheDimensionNarrowsToTheDimensionNotTheMeasure() {
+      // The other half of the bug: naming the dimension must colour the axis only, leaving the measure —
+      // and so the plot marks — untouched.
+      List<HighlightRef> refs = service.resolveRuleHighlightRefs(
+         ruleOn(dim.getFullName()), allRefs, chartInfo, false);
+
+      assertEquals(1, refs.size());
+      assertSame(dim, refs.get(0));
+   }
+
+   @Test
+   void matchingIgnoresCase() {
+      // Deliberately lenient, unlike the case-sensitive crosstab path: a miss here silently widens to every
+      // ref (i.e. reproduces this very bug) rather than failing loud the way applyTableHighlight does.
+      List<HighlightRef> refs = service.resolveRuleHighlightRefs(
+         ruleOn(agg.getName().toUpperCase()), allRefs, chartInfo, false);
+
+      assertEquals(1, refs.size());
+      assertSame(agg, refs.get(0));
+   }
+
+   @Test
+   void aRuleNamingNoFieldFallsBackToEveryRef() {
+      assertSame(allRefs, service.resolveRuleHighlightRefs(ruleOn(null), allRefs, chartInfo, false));
+      assertSame(allRefs, service.resolveRuleHighlightRefs(ruleOn("   "), allRefs, chartInfo, false));
+   }
+
+   @Test
+   void aRuleNamingAnUnboundFieldFallsBackToEveryRef() {
+      assertSame(allRefs, service.resolveRuleHighlightRefs(
+         ruleOn("NoSuchColumn"), allRefs, chartInfo, false));
+   }
+
+   @Test
+   void aWordCloudFallsBackToEveryRefEvenWhenTheFieldMatches() {
+      // Its highlightable ref is the TEXT aesthetic, not the X/Y binding this narrowing understands, so
+      // narrowing by an X/Y-shaped name would drop the highlight rather than merely widen it.
+      assertSame(allRefs, service.resolveRuleHighlightRefs(
+         ruleOn(agg.getFullName()), allRefs, chartInfo, true));
+   }
+
+   @Test
+   void aTreemapFallsBackToEveryRefEvenWhenTheFieldMatches() {
+      chartInfo.setChartType(GraphTypes.CHART_TREEMAP);
+
+      assertSame(allRefs, service.resolveRuleHighlightRefs(
+         ruleOn(agg.getFullName()), allRefs, chartInfo, false));
+   }
+
+   @Test
+   void aGanttIsRecognisedByItsDESIGNChartTypeNotItsRuntimeOne() {
+      // GraphGenerator.getHighlightRefs() special-cases gantt off the design-time type where it reads the
+      // runtime type for the others; resolveRuleHighlightRefs mirrors that. A runtime type that is NOT
+      // gantt must therefore not defeat the fallback.
+      chartInfo.setChartType(GraphTypes.CHART_GANTT);
+      chartInfo.setRTChartType(GraphTypes.CHART_BAR);
+
+      assertSame(allRefs, service.resolveRuleHighlightRefs(
+         ruleOn(agg.getFullName()), allRefs, chartInfo, false));
+   }
+
+   @Test
+   void aSingleRefChartShortCircuitsToThatRef() {
+      // Nothing to narrow: one ref cannot be attached to "every ref" wrongly, so the name is never consulted.
+      List<HighlightRef> single = List.of(agg);
+
+      assertSame(single, service.resolveRuleHighlightRefs(
+         ruleOn("NoSuchColumn"), single, chartInfo, false));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceResolveRuleHighlightRefsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceResolveRuleHighlightRefsTest.java
@@ -83,15 +83,20 @@ class WizVsServiceResolveRuleHighlightRefsTest {
       dim = new VSChartDimensionRef();
       dim.setGroupColumnValue("State");
 
-      agg = new VSChartAggregateRef();
-      agg.setColumnValue("Sales");
-      agg.setFormulaValue("Sum");
+      agg = measure("Sales");
 
       chartInfo = new VSChartInfo();
       chartInfo.addXField(dim);
       chartInfo.addYField(agg);
 
       allRefs = List.of(dim, agg);
+   }
+
+   private static VSChartAggregateRef measure(String column) {
+      VSChartAggregateRef ref = new VSChartAggregateRef();
+      ref.setColumnValue(column);
+      ref.setFormulaValue("Sum");
+      return ref;
    }
 
    private static ApplyHighlightModel.Highlight ruleOn(String field) {
@@ -184,6 +189,33 @@ class WizVsServiceResolveRuleHighlightRefsTest {
 
       assertSame(allRefs, service.resolveRuleHighlightRefs(
          ruleOn(agg.getFullName()), allRefs, chartInfo, false));
+   }
+
+   @Test
+   void aRelationChartFallsBackToEveryRefEvenWhenTheFieldMatches() {
+      // Its highlightable refs are the source/target fields, not the X/Y binding.
+      chartInfo.setChartType(GraphTypes.CHART_NETWORK);
+
+      assertSame(allRefs, service.resolveRuleHighlightRefs(
+         ruleOn(agg.getFullName()), allRefs, chartInfo, false));
+   }
+
+   @Test
+   void aScatterMatrixFallsBackToEveryRefEvenWhenTheFieldMatches() {
+      // GraphTypeUtil.isScatterMatrix recognises the shape rather than a chart type: the SAME measures on
+      // both axes and no dimension on either, which is why this case needs its own chart info.
+      VSChartAggregateRef sales = measure("Sales");
+      VSChartAggregateRef profit = measure("Profit");
+      VSChartInfo matrix = new VSChartInfo();
+      matrix.addXField(measure("Sales"));
+      matrix.addXField(measure("Profit"));
+      matrix.addYField(sales);
+      matrix.addYField(profit);
+
+      List<HighlightRef> matrixRefs = List.of(sales, profit);
+
+      assertSame(matrixRefs, service.resolveRuleHighlightRefs(
+         ruleOn(sales.getFullName()), matrixRefs, matrix, false));
    }
 
    @Test


### PR DESCRIPTION
- A chart renders a highlight group through two independent paths, both keyed off the same HighlightRef.getHighlightGroup(): GraphGenerator.applyHighlight() colors the PLOT marks, and addHighlightToAxis() colors the AXIS labels. The engine keeps them apart by ref KIND -- findHighlightRef adopts a ref for the axis only when it is not a measure -- so an ordinary chart gets one or the other.
- Attaching every rule to EVERY binding ref put a group on both kinds at once, so a bar chart came back with its bars AND its category axis colored. A rule that names a `field` is now attached to just that ref, matching either its full name ("DistinctCount(PRODUCT_ID)") or its plain one ("PRODUCT_ID") -- the same use of the same field the table/crosstab branch already makes, where it is required.
- Falls back to all refs, i.e. the previous behaviour, when the rule names no field, when the name matches no ref, and for the chart types whose highlightable ref is not a plain X/Y binding (word cloud, treemap, relation, gantt, scatter matrix -- the special cases GraphGenerator.getHighlightRefs() itself enumerates). Narrowing those by an X/Y-shaped name would drop the highlight rather than widen it.
- The font-capable guard now judges the refs the rule actually lands on. It previously relied on the rule reaching every ref, so one font-capable ref anywhere on the chart was enough; once a rule can be narrowed to a single continuous measure, that no longer holds and a font-only rule there must still fail loud.