### PR TITLE
Add Set Cell Size / Hide Column / drill-hierarchy to embed context menus (bug-75961)

### DIFF
--- a/web/projects/portal/src/app/embed/crosstab/embed-crosstab-actions.spec.ts
+++ b/web/projects/portal/src/app/embed/crosstab/embed-crosstab-actions.spec.ts
@@ -1,0 +1,163 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { TableDataPathTypes } from "../../common/data/table-data-path-types";
+import { TestUtils } from "../../common/test/test-utils";
+import { EmbedAssemblyContextProviderFactory } from "../../vsobjects/context-provider.service";
+import { VSCrosstabModel } from "../../vsobjects/model/vs-crosstab-model";
+import { EmbedCrosstabActions } from "./embed-crosstab-actions";
+
+describe("EmbedCrosstabActions", () => {
+   const createActions: (model: VSCrosstabModel) => EmbedCrosstabActions = (model) => {
+      return new EmbedCrosstabActions(model, EmbedAssemblyContextProviderFactory(),
+         false, null, null, null, null, () => false, () => {});
+   };
+
+   // Plain data/summary cell, no drill hierarchy defined on the field - e.g. a measure value,
+   // not a date field grouped by Year/Month/Day.
+   const selectNonDrillableDataCell: (model: VSCrosstabModel) => void = (model) => {
+      model.selectedHeaders = null;
+      model.selectedData = new Map<number, number[]>();
+      model.selectedData.set(0, [0]);
+      model.selectedRegions = [Object.assign(TestUtils.createMockselectedRegion(), {
+         path: ["Sum(Discount)"],
+         type: TableDataPathTypes.SUMMARY
+      })];
+      model.firstSelectedRow = 0;
+      model.firstSelectedColumn = 0;
+      model.cells = [[{
+         cellData: "16",
+         cellLabel: null,
+         row: 0,
+         col: 0,
+         vsFormatModel: TestUtils.createMockVSFormatModel(),
+         hyperlinks: [],
+         grouped: false,
+         dataPath: {
+            row: false, col: false, colIndex: -1, index: 0, level: -1,
+            dataType: "double", path: ["Sum(Discount)"], type: TableDataPathTypes.SUMMARY
+         },
+         presenter: null,
+         isImage: false
+      }]];
+   };
+
+   // Row header cell for a field with a drill hierarchy defined - e.g. Month(ORDER_DATE)
+   // grouped by Year/Quarter/Month, matching bugs/img_2.png.
+   const selectDrillableHeaderCell: (model: VSCrosstabModel) => void = (model) => {
+      model.selectedData = null;
+      model.selectedHeaders = new Map<number, number[]>();
+      model.selectedHeaders.set(0, [0]);
+      model.selectedRegions = [Object.assign(TestUtils.createMockselectedRegion(), {
+         path: ["Month(ORDER_DATE)"],
+         type: TableDataPathTypes.GROUP_HEADER
+      })];
+      model.firstSelectedRow = 0;
+      model.firstSelectedColumn = 0;
+      model.cells = [[{
+         cellData: "2025 10月",
+         cellLabel: "2025 10月",
+         row: 0,
+         col: 0,
+         vsFormatModel: TestUtils.createMockVSFormatModel(),
+         hyperlinks: [],
+         grouped: true,
+         drillOp: "+",
+         field: "Month(ORDER_DATE)",
+         dataPath: {
+            row: true, col: false, colIndex: -1, index: 0, level: 0,
+            dataType: "date", path: ["Month(ORDER_DATE)"], type: TableDataPathTypes.GROUP_HEADER
+         },
+         presenter: null,
+         isImage: false
+      }]];
+   };
+
+   it("should not show Show Details or Export in the context menu", () => {
+      const model = TestUtils.createMockVSCrosstabModel("Crosstab1");
+      const actions = createActions(model);
+      const menuActions = actions.menuActions;
+      selectNonDrillableDataCell(model);
+
+      const allIds = menuActions.flatMap(g => g.actions.map(a => a.id()));
+      expect(allIds).not.toContain("crosstab show-details");
+      expect(allIds).not.toContain("crosstab export");
+   });
+
+   it("should show Set Cell Size and Hide Column, but not the drill actions, for a plain data cell", () => {
+      const model = TestUtils.createMockVSCrosstabModel("Crosstab1");
+      const actions = createActions(model);
+      const menuActions = actions.menuActions;
+      selectNonDrillableDataCell(model);
+
+      const setCellSize = menuActions[0].actions[0];
+      const hideColumn = menuActions[1].actions[0];
+      const showColumns = menuActions[1].actions[1];
+      const expandAll = menuActions[2].actions[0];
+      const collapseAll = menuActions[2].actions[1];
+      const expandField = menuActions[2].actions[2];
+      const collapseField = menuActions[2].actions[3];
+
+      expect(setCellSize.id()).toBe("table cell size");
+      expect(setCellSize.visible()).toBeTruthy();
+      expect(hideColumn.id()).toBe("crosstab hide column");
+      expect(hideColumn.visible()).toBeTruthy();
+      expect(showColumns.id()).toBe("crosstab show columns");
+      expect(showColumns.visible()).toBeFalsy();
+      expect(expandAll.id()).toBe("expand all");
+      expect(expandAll.visible()).toBeFalsy();
+      expect(collapseAll.id()).toBe("collapse all");
+      expect(collapseAll.visible()).toBeFalsy();
+      expect(expandField.id()).toBe("expand field");
+      expect(expandField.visible()).toBeFalsy();
+      expect(collapseField.id()).toBe("collapse field");
+      expect(collapseField.visible()).toBeFalsy();
+   });
+
+   it("should show Set Cell Size, Hide Column and the drill actions for a header cell with a defined drill hierarchy", () => {
+      const model = TestUtils.createMockVSCrosstabModel("Crosstab1");
+      const actions = createActions(model);
+      const menuActions = actions.menuActions;
+      selectDrillableHeaderCell(model);
+
+      const setCellSize = menuActions[0].actions[0];
+      const hideColumn = menuActions[1].actions[0];
+      const expandAll = menuActions[2].actions[0];
+      const collapseAll = menuActions[2].actions[1];
+      const expandField = menuActions[2].actions[2];
+      const collapseField = menuActions[2].actions[3];
+
+      expect(setCellSize.visible()).toBeTruthy();
+      expect(hideColumn.visible()).toBeTruthy();
+      expect(expandAll.visible()).toBeTruthy();
+      expect(collapseAll.visible()).toBeTruthy();
+      expect(expandField.visible()).toBeTruthy();
+      expect(collapseField.visible()).toBeTruthy();
+   });
+
+   it("should show Show Columns when the model has a hidden column, regardless of cell selection", () => {
+      const model = TestUtils.createMockVSCrosstabModel("Crosstab1");
+      const actions = createActions(model);
+      const menuActions = actions.menuActions;
+      const showColumns = menuActions[1].actions[1];
+
+      expect(showColumns.visible()).toBeFalsy();
+
+      (model as any).hasHiddenColumn = true;
+      expect(showColumns.visible()).toBeTruthy();
+   });
+});

--- a/web/projects/portal/src/app/embed/crosstab/embed-crosstab-actions.ts
+++ b/web/projects/portal/src/app/embed/crosstab/embed-crosstab-actions.ts
@@ -37,25 +37,72 @@ export class EmbedCrosstabActions extends CrosstabActions {
    }
 
    protected createMenuActions(groups: AssemblyActionGroup[]): AssemblyActionGroup[] {
+      // Show Details / Export are deliberately not offered here anymore (right-click context
+      // menu) per explicit request - they're still available from the mini-toolbar, see
+      // createToolbarActions below.
       groups.push(new AssemblyActionGroup([
          {
-            // detailCellsSelected is CrosstabActions' own cell test (protected for this reuse):
-            // nothing selected means nothing to drill into. Its showDetailsVisible is this plus
-            // the same isActionVisibleInViewer check, so the embed matches the viewer exactly.
-            id: () => "crosstab show-details",
-            label: () => "_#(js:Show Details)",
-            icon: () => "show-detail-icon",
+            // Same visibility rule as CrosstabActions' own "table cell size" - oneCellSelected
+            // is protected on BaseTableActions already, nothing to widen.
+            id: () => "table cell size",
+            label: () => "_#(js:Set Cell Size)",
+            icon: () => "place-holder-icon icon-edit",
             enabled: () => true,
-            visible: () => this.detailCellsSelected &&
-               this.isActionVisibleInViewer("Show Details") && !this.annotationsSelected
+            visible: () => this.oneCellSelected && this.isActionVisibleInViewer("Set Cell Size")
+         },
+      ]));
+      groups.push(new AssemblyActionGroup([
+         {
+            id: () => "crosstab hide column",
+            label: () => "_#(js:Hide Column)",
+            icon: () => "place-holder-icon icon-hyperlink",
+            enabled: () => true,
+            visible: () => !this.annotationsSelected &&
+               !this.model.titleSelected && !this.model.metadata && this.cellSelected &&
+               this.isActionVisibleInViewer("Hide Column")
          },
          {
-            id: () => "crosstab export",
-            label: () => "_#(js:Export)",
-            icon: () => "export-icon",
+            id: () => "crosstab show columns",
+            label: () => "_#(js:Show Columns)",
+            icon: () => "place-holder-icon icon-highlight",
             enabled: () => true,
-            visible: () => this.isActionVisible("Export") && !this.annotationsSelected
+            visible: () => !this.annotationsSelected && this.model.hasHiddenColumn &&
+               !this.model.metadata
+         }
+      ]));
+      groups.push(new AssemblyActionGroup([
+         {
+            // getDrillLabel()/getDrillContextMenuVisible() are CrosstabActions' own drill-hierarchy
+            // logic (protected for this reuse, same precedent as detailCellsSelected) - the
+            // criterion is whether the selected field has a drill level defined (drillOp), not
+            // whether it looks like a date field.
+            id: () => "expand all",
+            label: () => this.getDrillLabel(),
+            icon: () => "place-holder-icon",
+            enabled: () => true,
+            visible: () => this.getDrillContextMenuVisible()
          },
+         {
+            id: () => "collapse all",
+            label: () => this.getDrillLabel(false),
+            icon: () => "place-holder-icon",
+            enabled: () => true,
+            visible: () => this.getDrillContextMenuVisible(false, true)
+         },
+         {
+            id: () => "expand field",
+            label: () => this.getDrillLabel(true, true),
+            icon: () => "place-holder-icon",
+            enabled: () => true,
+            visible: () => this.getDrillContextMenuVisible(true)
+         },
+         {
+            id: () => "collapse field",
+            label: () => this.getDrillLabel(false, true),
+            icon: () => "place-holder-icon",
+            enabled: () => true,
+            visible: () => this.getDrillContextMenuVisible(true)
+         }
       ]));
       groups.push(new AssemblyActionGroup([
          {

--- a/web/projects/portal/src/app/embed/table/embed-table-actions.spec.ts
+++ b/web/projects/portal/src/app/embed/table/embed-table-actions.spec.ts
@@ -1,0 +1,70 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { TableDataPathTypes } from "../../common/data/table-data-path-types";
+import { TestUtils } from "../../common/test/test-utils";
+import { EmbedAssemblyContextProviderFactory } from "../../vsobjects/context-provider.service";
+import { VSTableModel } from "../../vsobjects/model/vs-table-model";
+import { EmbedTableActions } from "./embed-table-actions";
+
+describe("EmbedTableActions", () => {
+   const createActions: (model: VSTableModel) => EmbedTableActions = (model) => {
+      return new EmbedTableActions(model, EmbedAssemblyContextProviderFactory(),
+         false, null, null, null, null, () => false, () => {});
+   };
+
+   // A plain detail/data cell - table-actions.ts has no row/column grouping concept, so unlike
+   // crosstab there is no Hide Column/Show Columns/drill hierarchy to reuse here, only Set Cell
+   // Size exists on both.
+   const selectDetailCell: (model: VSTableModel) => void = (model) => {
+      let region = TestUtils.createMockselectedRegion();
+      region.path = ["City"];
+      region.type = TableDataPathTypes.DETAIL;
+
+      model.titleSelected = false;
+      model.firstSelectedRow = 1;
+      model.firstSelectedColumn = 3;
+      model.selectedHeaders = null;
+      model.selectedData = new Map<number, number[]>();
+      model.selectedData.set(1, [3]);
+      model.selectedRegions = [region];
+   };
+
+   it("should not show Show Details or Export in the context menu", () => {
+      const model = TestUtils.createMockVSTableModel("Table1");
+      const actions = createActions(model);
+      const menuActions = actions.menuActions;
+      selectDetailCell(model);
+
+      const allIds = menuActions.flatMap(g => g.actions.map(a => a.id()));
+      expect(allIds).not.toContain("table show-details");
+      expect(allIds).not.toContain("table export");
+   });
+
+   it("should show Set Cell Size when a single cell is selected", () => {
+      const model = TestUtils.createMockVSTableModel("Table1");
+      const actions = createActions(model);
+      const menuActions = actions.menuActions;
+
+      const setCellSize = menuActions[0].actions[0];
+      expect(setCellSize.id()).toBe("table cell size");
+      expect(setCellSize.visible()).toBeFalsy();
+
+      selectDetailCell(model);
+      expect(setCellSize.visible()).toBeTruthy();
+   });
+});

--- a/web/projects/portal/src/app/embed/table/embed-table-actions.ts
+++ b/web/projects/portal/src/app/embed/table/embed-table-actions.ts
@@ -37,27 +37,21 @@ export class EmbedTableActions extends TableActions {
    }
 
    protected createMenuActions(groups: AssemblyActionGroup[]): AssemblyActionGroup[] {
+      // Show Details / Export are deliberately not offered here anymore (right-click context
+      // menu) per explicit request - they're still available from the mini-toolbar, see
+      // createToolbarActions below. Same treatment as EmbedCrosstabActions; unlike crosstab,
+      // TableActions has no Hide Column/Show Columns or drill-hierarchy concept (no row/column
+      // grouping on a plain table), so Set Cell Size is the only item to add here - it's the
+      // only one that exists on both.
       groups.push(new AssemblyActionGroup([
          {
-            // detailCellsSelected is TableActions' own selection rule (protected for this
-            // reuse). Its showDetailsVisible pairs that with model.summary, which the embed
-            // deliberately drops: summary is assembly.isSummaryTable() on the server, false for
-            // the plain detail tables the wiz generates, so requiring it would hide the action
-            // permanently. Everything else - Show Details needs cells to drill into, and
-            // BaseTableShowDetailsService reads the selection off the event - applies here.
-            id: () => "table show-details",
-            label: () => "_#(js:Show Details)",
-            icon: () => "show-detail-icon",
+            // Same visibility rule as TableActions' own "table cell size" - oneCellSelected is
+            // protected on BaseTableActions already, nothing to widen.
+            id: () => "table cell size",
+            label: () => "_#(js:Set Cell Size)",
+            icon: () => "place-holder-icon icon-edit",
             enabled: () => true,
-            visible: () => this.detailCellsSelected &&
-               this.isActionVisibleInViewer("Show Details") && !this.annotationsSelected
-         },
-         {
-            id: () => "table export",
-            label: () => "_#(js:Export)",
-            icon: () => "export-icon",
-            enabled: () => true,
-            visible: () => this.isActionVisible("Export") && !this.annotationsSelected
+            visible: () => this.oneCellSelected && this.isActionVisibleInViewer("Set Cell Size")
          },
       ]));
       groups.push(new AssemblyActionGroup([

--- a/web/projects/portal/src/app/vsobjects/action/crosstab-actions.ts
+++ b/web/projects/portal/src/app/vsobjects/action/crosstab-actions.ts
@@ -609,7 +609,12 @@ export class CrosstabActions extends BaseTableActions<VSCrosstabModel> {
       });
    }
 
-   private getDrillLabel(isExpand: boolean = true, drillField: boolean = false): string {
+   /**
+    * Protected (rather than private) so EmbedCrosstabActions can reuse this verbatim for its
+    * own "expand/collapse hierarchy/field" menu items - same precedent as detailCellsSelected
+    * above.
+    */
+   protected getDrillLabel(isExpand: boolean = true, drillField: boolean = false): string {
       const row: number = +this.model.firstSelectedRow - this.startRowIndex;
       const col: number = +this.model.firstSelectedColumn;
       let prefix = "";
@@ -641,7 +646,11 @@ export class CrosstabActions extends BaseTableActions<VSCrosstabModel> {
       return `${prefix} ${suffix}`;
    }
 
-   private getDrillContextMenuVisible(drillField: boolean = false, isCollapse = false): boolean {
+   /**
+    * Protected (rather than private) so EmbedCrosstabActions can reuse this verbatim - see
+    * getDrillLabel above.
+    */
+   protected getDrillContextMenuVisible(drillField: boolean = false, isCollapse = false): boolean {
       if(!this.model.cells || this.model.cells.length <= 0 || this.annotationsSelected ||
          this.model.dateComparisonDefined)
       {


### PR DESCRIPTION
## Summary

`EmbedCrosstabActions`/`EmbedTableActions` fully replace `createMenuActions()`
rather than extending it, which had reduced the embed right-click context
menu down to just Show Details / Export - dropping everything else
`CrosstabActions`/`TableActions` expose in the full Viewer/Composer.

- Removed Show Details / Export from the context menu on both crosstab and
  table (they remain available from the mini-toolbar, untouched).
- **Crosstab**: added Set Cell Size, Hide Column, Show Columns, and the
  Expand/Collapse Hierarchy/Field drill actions. These reuse
  `CrosstabActions`' own visibility logic verbatim (no reimplementation) -
  `getDrillLabel()`/`getDrillContextMenuVisible()` were widened from
  `private` to `protected`, same precedent already set for
  `detailCellsSelected`.
- **Table**: added Set Cell Size only. `TableActions` has no row/column
  grouping concept at all, so unlike crosstab there is no Hide
  Column/Show Columns/drill-hierarchy equivalent to reuse.

## Testing

Added `embed-crosstab-actions.spec.ts` (3 tests) and
`embed-table-actions.spec.ts` (2 tests), covering the new items'
visibility across plain vs. drillable/groupable cell selections. Full
`crosstab-actions.spec.ts` (23 tests) and `table-actions.spec.ts` (26
tests) still pass, confirming the `private` -> `protected` visibility
change didn't alter existing behavior.

```
✓ embed-crosstab-actions.spec.ts (3 tests)
✓ embed-table-actions.spec.ts (2 tests)
✓ crosstab-actions.spec.ts (23 tests)
✓ table-actions.spec.ts (26 tests)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)