### PR TITLE
Bug #75982, allow schedule task permission changes for folder-scoped admins

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryObjectController.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryObjectController.java
@@ -19,6 +19,8 @@ package inetsoft.web.admin.content.repository;
 
 import inetsoft.report.internal.Util;
 import inetsoft.sree.RepositoryEntry;
+import inetsoft.sree.schedule.ScheduleManager;
+import inetsoft.sree.schedule.ScheduleTask;
 import inetsoft.sree.security.*;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.asset.internal.AssetUtil;
@@ -38,10 +40,12 @@ import java.security.Principal;
 public class RepositoryObjectController {
    @Autowired
    public RepositoryObjectController(RepositoryObjectService repositoryObjectService,
-                                     ResourcePermissionService permissionService)
+                                     ResourcePermissionService permissionService,
+                                     ScheduleManager scheduleManager)
    {
       this.repositoryObjectService = repositoryObjectService;
       this.permissionService = permissionService;
+      this.scheduleManager = scheduleManager;
    }
 
    @Secured(
@@ -80,9 +84,7 @@ public class RepositoryObjectController {
       Resource resource = permissionService.getRepositoryResourceType(resourceType, path);
       String fullPath = Util.getObjectFullPath(resourceType, path, principal);
 
-      if(!SecurityEngine.getSecurity().checkPermission(
-         principal, resource.getType(), resource.getPath(), ResourceAction.ADMIN))
-      {
+      if(!hasAdminPermission(resource, principal)) {
          throw new MessageException(Catalog.getCatalog().getString(
             "em.common.security.no.permission", path));
       }
@@ -150,6 +152,24 @@ public class RepositoryObjectController {
       repositoryObjectService.moveFiles(request, true, principal);
    }
 
+   /**
+    * Individual schedule tasks don't inherit permissions from their parent folder, so a user
+    * with only ADMIN on the folder can't be granted ADMIN via a permission record on the task
+    * itself. Fall back to the same owner/share based check used by the schedule task settings
+    * so a task's owner (or an admin over the owner) can still manage its permissions.
+    */
+   private boolean hasAdminPermission(Resource resource, Principal principal) throws Exception {
+      if(resource.getType() == ResourceType.SCHEDULE_TASK) {
+         ScheduleTask task = scheduleManager.getScheduleTask(resource.getPath());
+         return task != null &&
+            ScheduleManager.hasTaskPermission(task.getOwner(), principal, ResourceAction.ADMIN);
+      }
+
+      return SecurityEngine.getSecurity().checkPermission(
+         principal, resource.getType(), resource.getPath(), ResourceAction.ADMIN);
+   }
+
    private final RepositoryObjectService repositoryObjectService;
    private final ResourcePermissionService permissionService;
+   private final ScheduleManager scheduleManager;
 }

--- a/core/src/test/java/inetsoft/web/admin/content/repository/RepositoryObjectControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/content/repository/RepositoryObjectControllerTest.java
@@ -41,6 +41,7 @@ package inetsoft.web.admin.content.repository;
  * the injected service mocks.
  */
 
+import inetsoft.sree.schedule.ScheduleManager;
 import inetsoft.sree.security.Resource;
 import inetsoft.sree.security.ResourceType;
 import inetsoft.web.admin.content.repository.model.*;
@@ -62,6 +63,7 @@ class RepositoryObjectControllerTest {
 
    @Mock private RepositoryObjectService repositoryObjectService;
    @Mock private ResourcePermissionService permissionService;
+   @Mock private ScheduleManager scheduleManager;
    @Mock private Principal principal;
    @Mock private ResourcePermissionModel permissionModel;
    @Mock private ContentRepositoryTreeNode treeNode;
@@ -74,7 +76,8 @@ class RepositoryObjectControllerTest {
 
    @BeforeEach
    void setUp() {
-      controller = new RepositoryObjectController(repositoryObjectService, permissionService);
+      controller = new RepositoryObjectController(repositoryObjectService, permissionService,
+                                                   scheduleManager);
    }
 
    // -------------------------------------------------------------------------

--- a/web/projects/em/src/app/settings/content/repository/repository-permission-editor-page/repository-permission-editor-page.component.ts
+++ b/web/projects/em/src/app/settings/content/repository/repository-permission-editor-page/repository-permission-editor-page.component.ts
@@ -15,8 +15,11 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { HttpClient, HttpParams } from "@angular/common/http";
+import { HttpClient, HttpErrorResponse, HttpParams } from "@angular/common/http";
 import {Component, EventEmitter, Input, OnChanges, Output, SimpleChanges} from "@angular/core";
+import { MatSnackBar } from "@angular/material/snack-bar";
+import { Observable, throwError } from "rxjs";
+import { catchError } from "rxjs/operators";
 import {ResourcePermissionModel} from "../../../security/resource-permission/resource-permission-model";
 import {RepositoryEditorModel} from "../../../../../../../shared/util/model/repository-editor-model";
 import {Tool} from "../../../../../../../shared/util/tool";
@@ -48,7 +51,7 @@ export class RepositoryPermissionEditorPageComponent implements OnChanges {
    private _oldModel: RepositoryPermissionEditorModel;
    private permissionChanged: boolean = false;
 
-   constructor(private http: HttpClient) {
+   constructor(private http: HttpClient, private snackBar: MatSnackBar) {
    }
 
    ngOnChanges(changes: SimpleChanges): void {
@@ -62,10 +65,20 @@ export class RepositoryPermissionEditorPageComponent implements OnChanges {
 
       this.http.post("../api/em/content/repository/tree/node/permission",
          this.model.permissionModel, {params})
+          .pipe(catchError(error => this.handleApplyError(error)))
           .subscribe(() => {
              this.editorChanged.emit();
              this.permissionChanged = false;
           });
+   }
+
+   private handleApplyError(error: HttpErrorResponse): Observable<never> {
+      console.error("Failed to save permission settings: ", error);
+      const message = error.error && error.error.type === "MessageException" ?
+         error.error.message : "Failed to save permission settings.";
+      this.snackBar.open(message, "_#(js:Close)",
+         { duration: Tool.SNACKBAR_DURATION, panelClass: ["max-width"] });
+      return throwError(error);
    }
 
    reset() {


### PR DESCRIPTION
## Summary
- Repository permission "Apply" on an individual Schedule Task failed for a user whose only grant was ADMIN on the parent "Schedule Tasks" folder (not a literal permission record on the task itself), because `SCHEDULE_TASK` resources don't inherit permissions from their parent `SCHEDULE_TASK_FOLDER`.
- `RepositoryObjectController.setResourcePermission()` now falls back to the same owner/admin-over-owner check (`ScheduleManager.hasTaskPermission`) that `ResourcePermissionController` already uses for schedule tasks, so a task's owner (or an admin over the owner) can manage its permissions.
- The frontend `apply()` handler in `repository-permission-editor-page.component.ts` previously swallowed save failures silently, leaving the editor in a dirty state and popping the confusing "Repository Settings Changed" warning on navigation with no visible error. It now shows a snackbar error on failure.

## Test plan
- [x] `RepositoryObjectControllerTest` updated for the new `ScheduleManager` constructor dependency; passes.
- [x] `community/core` module compiles cleanly.
- [x] Manually verified in EM: user with only "Admin" on the Schedule Tasks folder node can now change permissions on a task they created under it, Apply succeeds, and no stale "unsaved changes" warning appears when switching nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)