### PR TITLE
Bug #75976, stop wiping org Library on identity delete

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
+++ b/core/src/main/java/inetsoft/web/admin/security/IdentityService.java
@@ -545,13 +545,6 @@ public class IdentityService {
       int type = identity.getType();
       DashboardManager dmanager = dashboardManager;
       ScheduleManager smanager = scheduleManager;
-      LibManager manager = null;
-
-      if(identityId.orgID != null) {
-         // may be null for built-in roles (Site Admin and Org Admin), in which case the lib manager
-         // does not need to be cleared
-         manager = libManagerProvider.getManager(identityId.orgID);
-      }
 
       Identity nid = new DefaultIdentity(identityId, type);
       Identity oid = oID == null ? null : new DefaultIdentity(oID, type);
@@ -559,10 +552,6 @@ public class IdentityService {
       if(oID == null) {
          dmanager.setDashboards(nid, null);
          smanager.identityRemoved(identity, eprovider);
-
-         if(manager != null) {
-            manager.clearAssets();
-         }
       }
       else {
          if((type == Identity.USER || type == Identity.GROUP) && !identityId.equals(oID)) {


### PR DESCRIPTION
## Summary
- `IdentityService.syncIdentity()` called `LibManager.clearAssets()` whenever any user, group, or role in an org was deleted, which empties that org's shared Scripts/Table Styles collections in memory.
- `LibManager` is org-scoped with no per-user ownership of Library content, so deleting any identity wiped the entire org's Library — matching the report: cloning an org via "Copy from Host Org" works fine until the copied admin user is deleted, at which point Scripts/Table Styles disappear for everyone, including a newly created Organization Administrator.
- Root cause: a pre-multi-tenant refactor left behind a call that used to mean "invalidate this org's cache" (`LibManager.getManager().clear(orgID)` on the old global singleton) but was mechanically replaced with `clearAssets()` on the now per-org `LibManager`, which actually erases content instead of just invalidating a cache.
- Fix: remove the dead/destructive call (and its now-unused `LibManager` lookup) from the identity-delete path. Nothing else in that method used the `manager` variable.

## Test plan
- [ ] Create an org via "Copy from Host Org" in EM.
- [ ] Confirm Scripts/Table Styles are visible under Library after switching to the new org.
- [ ] Delete the copied admin user, create a new user, assign it the Organization Administrator role.
- [ ] Confirm Scripts/Table Styles are still visible for the new org admin.
- [ ] Confirm deleting a user/group/role in any org no longer clears that org's Library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)