### PR TITLE
Fix intermittent core test failures from null Spring context poisoning Util's static initializer

### DIFF
--- a/core/src/main/java/inetsoft/report/StyleFont.java
+++ b/core/src/main/java/inetsoft/report/StyleFont.java
@@ -84,6 +84,10 @@ public class StyleFont extends Font implements StyleConstants, Cloneable {
     * The default font font family.
     */
    public static final String DEFAULT_FONT_FAMILY = "Default";
+   /**
+    * The font family used when the 'default.font.family' property cannot be read.
+    */
+   private static final String DEFAULT_FONT_FAMILY_FALLBACK = "Roboto";
    /* not implemented now
     public static final int OUTLINE = 0x200;
     public static final int EMBOSE = 0x400;
@@ -679,7 +683,18 @@ public class StyleFont extends Font implements StyleConstants, Cloneable {
    }
 
    public static String getDefaultFontFamily() {
-      return SreeEnv.getProperty("default.font.family", "Roboto");
+      // Resolving this property goes through PropertiesEngine, a Spring bean. Fonts are built
+      // from static initializers (Util.DEFAULT_FONT, Util.WATER_FONT), and an exception thrown
+      // out of a static initializer marks the class permanently unusable for the life of the
+      // JVM -- every later reference gets NoClassDefFoundError. Since Util underpins most of
+      // the report/chart code, letting a missing application context escape here takes down
+      // effectively everything. Fall back to the default instead of throwing when no context
+      // is available (server starting up or shutting down).
+      if(!SreeEnv.isInitialized()) {
+         return DEFAULT_FONT_FAMILY_FALLBACK;
+      }
+
+      return SreeEnv.getProperty("default.font.family", DEFAULT_FONT_FAMILY_FALLBACK);
    }
 
    /**

--- a/core/src/test/java/inetsoft/report/StyleFontDefaultFamilyTest.java
+++ b/core/src/test/java/inetsoft/report/StyleFontDefaultFamilyTest.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report;
+
+import inetsoft.util.ConfigurationContext;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/*
+ * StyleFont resolves 'default.font.family' through PropertiesEngine, a Spring bean, and fonts are
+ * built from static initializers (Util.DEFAULT_FONT, Util.WATER_FONT). An exception escaping a
+ * static initializer marks the class permanently unusable for the life of the JVM, so a missing
+ * application context used to poison Util -- and with it most of the report/chart code -- for the
+ * rest of the surefire fork. These tests pin the fallback that keeps that from happening.
+ */
+@Tag("core")
+class StyleFontDefaultFamilyTest {
+   @Test
+   void getDefaultFontFamilyFallsBackWhenNoApplicationContext() {
+      withoutApplicationContext(() -> {
+         assertEquals("Roboto", StyleFont.getDefaultFontFamily());
+      });
+   }
+
+   @Test
+   void constructingDefaultFontDoesNotThrowWhenNoApplicationContext() {
+      withoutApplicationContext(() -> {
+         StyleFont font =
+            assertDoesNotThrow(() -> new StyleFont(StyleFont.DEFAULT_FONT_FAMILY, 0, 10));
+         assertEquals("Roboto", font.getName());
+         assertTrue(StyleFont.isDefaultFont(font));
+      });
+   }
+
+   /**
+    * Runs the given assertions with the global application context cleared, restoring it
+    * afterwards so the rest of the fork is unaffected.
+    */
+   private void withoutApplicationContext(Runnable assertions) {
+      ConfigurationContext context = ConfigurationContext.getContext();
+      ApplicationContext saved = context.getApplicationContext();
+
+      try {
+         context.setApplicationContext(null);
+         assertions.run();
+      }
+      finally {
+         context.setApplicationContext(saved);
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/uql/ConditionTest.java
+++ b/core/src/test/java/inetsoft/uql/ConditionTest.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.uql;
 
+import inetsoft.test.*;
 import inetsoft.uql.asset.ExpressionValue;
 import inetsoft.uql.erm.AttributeRef;
 import inetsoft.uql.erm.DataRef;
@@ -25,10 +26,14 @@ import inetsoft.uql.schema.XSchema;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -73,6 +78,15 @@ import static org.junit.jupiter.api.Assertions.*;
  *        normalizeValue() already takes the first element. Only ROLE + STARTING_WITH/CONTAINS/LIKE
  *        could hit it; no known UI path — not tested.
  */
+// Condition's constructor calls Tool.isCaseSensitive(), which reads a property through
+// PropertiesEngine -- a Spring bean. Without an application context of its own this class only
+// passed when some earlier test class happened to leave one installed in ConfigurationContext,
+// so it failed intermittently in CI (and always when run in isolation).
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = BaseTestConfiguration.class,
+                      initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
 @Tag("core")
 class ConditionTest {
 


### PR DESCRIPTION
## Problem

`inetsoft-core` has been failing intermittently on `main` — builds 249, 251, 252, 253 and 260 of `StyleBI Multibranch/main`, while 250 and 254–259 passed. Build 260 reported **23 failures and 272 errors**; build 251 reported only 10 errors. Same underlying bug, different blast radius each run.

The 272 errors were not 272 broken tests. They were one class-initialization poisoning event:

```
GLine.<clinit>        (THIN_LINE)
 -> GTool.<clinit>    (Class.forName("inetsoft.report.internal.Common"))
   -> Util.<clinit>   (DEFAULT_FONT = new StyleFont(...))
     -> StyleFont.getDefaultFontFamily()
       -> SreeEnv.getProperty -> PropertiesEngine.getInstance()
         -> ConfigurationContext.getSpringBean() -> ShutdownException
```

Surefire runs all core tests in a single JVM (no `forkCount`/`reuseForks`/`runOrder` override), and `SreeHomeExtension.afterAll()` clears the global application context. So after every `@SreeHome` class there is a window with no context installed. An exception thrown out of a static initializer marks that class **permanently unusable for the life of the JVM**, so once `Util` was poisoned in such a window, every later test touching it failed with `NoClassDefFoundError: Could not initialize class inetsoft.report.internal.Util`. `Util` and `Common` underpin most of the report/chart code, hence the cascade.

Note this is *not* a product regression — build 260's only change was a submodule bump whose commits touch none of these classes.

## Changes

**1. `ConditionTest` declares its own Spring context.** `Condition`'s constructor calls `Tool.isCaseSensitive()`, which reads a property through `PropertiesEngine` (a Spring bean). The class declared no context, so it passed only when an earlier class happened to leave one installed. It now uses the same setup as its sibling `ConditionItemTest`; `BaseTestConfiguration` alone suffices since it provides the `PropertiesEngine` bean.

**2. `StyleFont.getDefaultFontFamily()` degrades instead of throwing.** Returns the `"Roboto"` fallback when `SreeEnv.isInitialized()` is false, so a missing context can no longer poison `Util.<clinit>`. This also covers `Util.WATER_FONT` and any other early font construction. `SreeEnv.isInitialized()` is the existing helper, already documented as a deliberately non-initializing presence check.

This is the same fix shape accepted for #75521 (`XUtil.<clinit>` hitting `ShutdownException`): degrade gracefully rather than let it escape a static initializer.

Clearing the context per test class is **kept deliberately** — each test should start from a clean context. The fix is to stop depending on leftover state, not to preserve it.

## Verification

- `ConditionTest` in isolation: **129 errors / 144 → 0 errors / 144**.
- New `StyleFontDefaultFamilyTest` verified to fail without the `StyleFont` change (both tests, exactly `ShutdownException`) and pass with it.
- Full `core` suite: **4282 tests, 0 failures, 0 errors**, `BUILD SUCCESS`, with **0** occurrences of `Could not initialize class`, `ExceptionInInitializerError`, or `NoClassDefFoundError`.

A single green run isn't proof for an order-dependent flake, so the argument is structural: change 1 removes `ConditionTest`'s ordering dependency outright, and change 2 removes the ability to poison a class on the `Util` path. Each is pinned by a test that fails deterministically without it.

## Not addressed here

- **~151 of 487 `@Tag("core")` classes still declare no Spring context.** Most are pure or Mockito-only tests that need none, but any that reach a bean have the same latent ordering dependency. Worth a separate sweep.
- **Benign teardown noise remains** (14 lines): `@PreDestroy` on `bookmarkLockManager` and `securityEngine` log `ShutdownException` because `afterAll()` clears the context reference before Spring closes the context. Pre-existing, present in passing builds, does not affect results.
- I never identified which graph test touched `GLine` in build 260. Change 2 makes that trigger harmless regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
