### PR TITLE
Bug #75952, support date-level grouping directly in set_group_aggregate

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
@@ -37,7 +37,8 @@ import java.util.Map;
  *   <li>{@code rename_column} — {@code table}, {@code column}, {@code newName}</li>
  *   <li>{@code add_filter} — {@code table}, {@code field}, {@code operation}, {@code values}</li>
  *   <li>{@code remove_filter} — {@code table}, {@code field}</li>
- *   <li>{@code set_group_aggregate} — {@code table}, {@code groups}, {@code aggregates}</li>
+ *   <li>{@code set_group_aggregate} — {@code table}, {@code groups} (each a column name or
+ *       {@code {field, dateLevel}}), {@code aggregates}</li>
  *   <li>{@code add_expression_column} — {@code table}, {@code name}, {@code expression}, {@code type}, {@code sql}</li>
  *   <li>{@code set_sort} — {@code table}, {@code field}, {@code direction} ("ASC" | "DESC")</li>
  *   <li>{@code add_join} — {@code name}, {@code leftTable}, {@code leftKey}, {@code rightTable}, {@code rightKey}, {@code joinType}; for multi-key joins use {@code leftKeys}/{@code rightKeys} instead of single key fields</li>
@@ -115,8 +116,13 @@ public record EditRequest(
    List<String> values,
    /** Sort direction — {@code "ASC"} or {@code "DESC"} — for set_sort. */
    String direction,
-   /** Group-by column names for set_group_aggregate. */
-   List<String> groups,
+   /**
+    * Group-by column specs for set_group_aggregate. Each entry is either a bare column
+    * name string, or an object {@code {"field": ..., "dateLevel": ...}} where
+    * {@code dateLevel} groups a date column directly at a coarser granularity (e.g.
+    * {@code "QUARTER"}) — same option strings as add_date_range_column's dateOption.
+    */
+   List<WorksheetMutationSupport.GroupSpec> groups,
    /** Aggregate measure specs for set_group_aggregate. */
    List<WorksheetMutationSupport.AggregateSpec> aggregates,
    /** Expression body for add_expression_column. */

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -775,7 +775,8 @@ public class WorksheetAgentController {
          case "remove_filter" ->
             editor.removeFilter(req.table(), req.field());
          case "set_group_aggregate" ->
-            editor.setGroupAggregate(req.table(), req.groups(),
+            editor.setGroupAggregate(req.table(),
+                                     req.groups() != null ? req.groups() : List.of(),
                                      req.aggregates() != null
                                         ? req.aggregates().stream()
                                             .map(a -> new WorksheetMutationSupport.AggregateSpec(

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -827,12 +827,13 @@ public class WorksheetEditService {
          t.setColumnSelection(cs, false);
       }
 
-      static int parseDateOption(String dateOption) {
+      static int parseDateOption(String dateOption) throws PairingException {
          if(dateOption == null) {
             return DateRangeRef.YEAR_INTERVAL;
          }
 
          return switch(dateOption.toUpperCase()) {
+            case "YEAR"    -> DateRangeRef.YEAR_INTERVAL;
             case "QUARTER" -> DateRangeRef.QUARTER_INTERVAL;
             case "MONTH"   -> DateRangeRef.MONTH_INTERVAL;
             case "WEEK"    -> DateRangeRef.WEEK_INTERVAL;
@@ -840,13 +841,19 @@ public class WorksheetEditService {
             case "HOUR"    -> DateRangeRef.HOUR_INTERVAL;
             case "MINUTE"  -> DateRangeRef.MINUTE_INTERVAL;
             case "SECOND"  -> DateRangeRef.SECOND_INTERVAL;
-            case "QUARTER_OF_YEAR" -> DateRangeRef.QUARTER_OF_YEAR_PART;
-            case "MONTH_OF_YEAR"   -> DateRangeRef.MONTH_OF_YEAR_PART;
-            case "WEEK_OF_YEAR"    -> DateRangeRef.WEEK_OF_YEAR_PART;
-            case "DAY_OF_MONTH"    -> DateRangeRef.DAY_OF_MONTH_PART;
-            case "DAY_OF_WEEK"     -> DateRangeRef.DAY_OF_WEEK_PART;
-            case "HOUR_OF_DAY"     -> DateRangeRef.HOUR_OF_DAY_PART;
-            default -> DateRangeRef.YEAR_INTERVAL;
+            case "QUARTER_OF_YEAR"   -> DateRangeRef.QUARTER_OF_YEAR_PART;
+            case "MONTH_OF_YEAR"     -> DateRangeRef.MONTH_OF_YEAR_PART;
+            case "WEEK_OF_YEAR"      -> DateRangeRef.WEEK_OF_YEAR_PART;
+            case "DAY_OF_MONTH"      -> DateRangeRef.DAY_OF_MONTH_PART;
+            case "DAY_OF_WEEK"       -> DateRangeRef.DAY_OF_WEEK_PART;
+            case "HOUR_OF_DAY"       -> DateRangeRef.HOUR_OF_DAY_PART;
+            case "MINUTE_OF_HOUR"    -> DateRangeRef.MINUTE_OF_HOUR_PART;
+            case "SECOND_OF_MINUTE"  -> DateRangeRef.SECOND_OF_MINUTE_PART;
+            default -> throw new PairingException(
+               "Unrecognized date level: '" + dateOption + "'. Valid values: YEAR, QUARTER, " +
+               "MONTH, WEEK, DAY, HOUR, MINUTE, SECOND, QUARTER_OF_YEAR, MONTH_OF_YEAR, " +
+               "WEEK_OF_YEAR, DAY_OF_MONTH, DAY_OF_WEEK, HOUR_OF_DAY, MINUTE_OF_HOUR, " +
+               "SECOND_OF_MINUTE.");
          };
       }
 
@@ -854,10 +861,15 @@ public class WorksheetEditService {
        * Reverse of {@link #parseDateOption}: converts a {@link GroupRef#getDateGroup()} /
        * {@link DateRangeRef} option constant back to the option string accepted by
        * {@code dateOption} / {@code dateLevel}. Returns {@code null} for
-       * {@code NONE_DATE_GROUP} or an unrecognized constant.
+       * {@code NONE_DATE_GROUP}. A recognized {@code XConstants} date-group constant that
+       * this vocabulary cannot name (reachable from the Composer's Group and Aggregate
+       * dialog but not from {@link #parseDateOption}) is reported as
+       * {@code "UNKNOWN_DATE_GROUP(<n>)"} rather than {@code null}, so callers can tell
+       * "no date group" apart from "grouped at a level this API can't yet name".
        */
       static String dateOptionName(int dateOption) {
          return switch(dateOption) {
+            case DateRangeRef.NONE_INTERVAL -> null;
             case DateRangeRef.YEAR_INTERVAL -> "YEAR";
             case DateRangeRef.QUARTER_INTERVAL -> "QUARTER";
             case DateRangeRef.MONTH_INTERVAL -> "MONTH";
@@ -872,7 +884,9 @@ public class WorksheetEditService {
             case DateRangeRef.DAY_OF_MONTH_PART -> "DAY_OF_MONTH";
             case DateRangeRef.DAY_OF_WEEK_PART -> "DAY_OF_WEEK";
             case DateRangeRef.HOUR_OF_DAY_PART -> "HOUR_OF_DAY";
-            default -> null;
+            case DateRangeRef.MINUTE_OF_HOUR_PART -> "MINUTE_OF_HOUR";
+            case DateRangeRef.SECOND_OF_MINUTE_PART -> "SECOND_OF_MINUTE";
+            default -> "UNKNOWN_DATE_GROUP(" + dateOption + ")";
          };
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -468,11 +468,11 @@ public class WorksheetEditService {
        * Builds and sets a new {@link AggregateInfo} on the named table.
        *
        * @param table      the assembly name
-       * @param groups     column names to group by
+       * @param groups     group-by column specs (name, plus optional date grouping level)
        * @param aggregates aggregate measures to apply
        * @throws PairingException if no {@link TableAssembly} with {@code table} exists
        */
-      public void setGroupAggregate(String table, List<String> groups,
+      public void setGroupAggregate(String table, List<WorksheetMutationSupport.GroupSpec> groups,
                                     List<WorksheetMutationSupport.AggregateSpec> aggregates)
          throws PairingException
       {
@@ -847,6 +847,32 @@ public class WorksheetEditService {
             case "DAY_OF_WEEK"     -> DateRangeRef.DAY_OF_WEEK_PART;
             case "HOUR_OF_DAY"     -> DateRangeRef.HOUR_OF_DAY_PART;
             default -> DateRangeRef.YEAR_INTERVAL;
+         };
+      }
+
+      /**
+       * Reverse of {@link #parseDateOption}: converts a {@link GroupRef#getDateGroup()} /
+       * {@link DateRangeRef} option constant back to the option string accepted by
+       * {@code dateOption} / {@code dateLevel}. Returns {@code null} for
+       * {@code NONE_DATE_GROUP} or an unrecognized constant.
+       */
+      static String dateOptionName(int dateOption) {
+         return switch(dateOption) {
+            case DateRangeRef.YEAR_INTERVAL -> "YEAR";
+            case DateRangeRef.QUARTER_INTERVAL -> "QUARTER";
+            case DateRangeRef.MONTH_INTERVAL -> "MONTH";
+            case DateRangeRef.WEEK_INTERVAL -> "WEEK";
+            case DateRangeRef.DAY_INTERVAL -> "DAY";
+            case DateRangeRef.HOUR_INTERVAL -> "HOUR";
+            case DateRangeRef.MINUTE_INTERVAL -> "MINUTE";
+            case DateRangeRef.SECOND_INTERVAL -> "SECOND";
+            case DateRangeRef.QUARTER_OF_YEAR_PART -> "QUARTER_OF_YEAR";
+            case DateRangeRef.MONTH_OF_YEAR_PART -> "MONTH_OF_YEAR";
+            case DateRangeRef.WEEK_OF_YEAR_PART -> "WEEK_OF_YEAR";
+            case DateRangeRef.DAY_OF_MONTH_PART -> "DAY_OF_MONTH";
+            case DateRangeRef.DAY_OF_WEEK_PART -> "DAY_OF_WEEK";
+            case DateRangeRef.HOUR_OF_DAY_PART -> "HOUR_OF_DAY";
+            default -> null;
          };
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -784,6 +784,12 @@ public class WorksheetEditService {
          String rangeName = DateRangeRef.getName(column, option);
          DateRangeRef dateRef = new DateRangeRef(rangeName, baseRef, option);
          dateRef.setOriginalType(origType);
+         // Not auto-created: this is a deliberate, standalone derived column (matching
+         // ValueRangeService's own setAutoCreate(false) for the Composer's equivalent
+         // UI action), so WorksheetMutationSupport#applyAggregateInfo's stale-range-
+         // column sweep never removes it just because a later set_group_aggregate call
+         // groups the same base column at some date level.
+         dateRef.setAutoCreate(false);
 
          ColumnRef colRef = new ColumnRef(dateRef);
          colRef.setDataType(XSchema.STRING);

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -26,6 +26,7 @@ import inetsoft.uql.*;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.erm.AttributeRef;
 import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.erm.DataRefWrapper;
 import inetsoft.uql.ColumnSelection;
 import inetsoft.uql.erm.ExpressionRef;
 import inetsoft.uql.jdbc.SelectTable;
@@ -312,6 +313,20 @@ public final class WorksheetMutationSupport {
       AggregateInfo ainfo = new AggregateInfo();
       ColumnSelection cs = t.getColumnSelection(false);
 
+      // The table's AggregateInfo as it stood before this call, captured before any
+      // mutation below — needed by the stale-range-column cleanup at the end, which
+      // (matching AggregateDialogService#processDateGrouping) treats a column as a
+      // candidate for removal only if it was one of THESE previous groups, not any
+      // DateRangeRef-wrapped column anywhere in the table's column selection.
+      AggregateInfo oaginfo = t.getAggregateInfo();
+      oaginfo = oaginfo == null ? new AggregateInfo() : oaginfo;
+
+      // The final DataRef for each of THIS call's groups, in order — mirrors
+      // AggregateDialogService's own `list`, used by the same cleanup to recognize a
+      // range column as still active even though it isn't reachable via `oaginfo`
+      // (e.g. it was just created a few lines above for this very call).
+      List<DataRef> activeGroupColumns = new ArrayList<>();
+
       // Aliases set by THIS call to label aggregate outputs; recorded on the table so
       // the next call's clearAggregateAliases() can tell them apart from aliases set
       // deliberately via rename_column on a column that also happens to be aggregated.
@@ -423,47 +438,55 @@ public final class WorksheetMutationSupport {
          }
 
          ainfo.addGroup(gr);
+         activeGroupColumns.add(gr.getDataRef());
       }
 
-      // Drop any auto-created DateRangeRef-wrapped column left behind by a PRIOR call
-      // that is not one of THIS call's active groups — covers both re-grouping the same
-      // field at a different level (the old "Quarter(orderDate)" is no longer any
-      // group's DataRef once "Month(orderDate)" is built above) and dropping a
-      // previously date-grouped field out of `groups` entirely (set_group_aggregate
-      // fully replaces the AggregateInfo each call, so a field simply absent from this
-      // call's `groups` is exactly as "no longer grouped" as one explicitly re-leveled).
-      // Gated on isAutoCreate() — default true for a column WE materialize here, but
-      // explicitly false for one add_date_range_column created (see addDateRangeColumn)
-      // — so a column the caller deliberately kept as a standalone derived column is
-      // never swept just because it happens to wrap the same base attribute as a group.
-      // Mirrors AggregateDialogService's "remove useless range column" pass, including
-      // its isAutoRangeColumn()-equivalent gate.
-      Set<DataRef> activeGroupColumns = new HashSet<>();
-
-      for(int i = 0; i < ainfo.getGroupCount(); i++) {
-         activeGroupColumns.add(ainfo.getGroup(i).getDataRef());
-      }
-
-      boolean removedStaleRangeColumn = false;
-
+      // Remove a range column left over from a PRIOR call's grouping that is no longer
+      // referenced — ported directly from AggregateDialogService#processDateGrouping's
+      // "remove useless range column" pass (same two conditions, same oaginfo/list
+      // scoping), so this only ever touches a column this mechanism itself put there,
+      // never one created by an unrelated operation (e.g. add_date_range_column, or a
+      // range column serving some other still-active purpose).
       for(int i = cs.getAttributeCount() - 1; i >= 0; i--) {
-         DataRef existing = cs.getAttribute(i);
+         DataRef ref0 = cs.getAttribute(i);
+         String name0 = ref0.getName();
+         boolean range = ref0 instanceof DataRefWrapper &&
+            ((DataRefWrapper) ref0).getDataRef() instanceof DateRangeRef;
 
-         if(existing instanceof ColumnRef cr && cr.getDataRef() instanceof DateRangeRef drr &&
-            drr.isAutoCreate() && !activeGroupColumns.contains(existing))
-         {
+         if(!range) {
+            for(int j = 0; j < oaginfo.getGroupCount(); j++) {
+               GroupRef gref = oaginfo.getGroup(j);
+               DateRangeRef dateRef = getDateRangeRef(gref);
+
+               if(dateRef != null && dateRef.isAutoCreate() && name0.equals(dateRef.getName())) {
+                  range = true;
+                  break;
+               }
+            }
+         }
+
+         if(range) {
+            if(activeGroupColumns.contains(ref0)) {
+               continue;
+            }
+
+            DateRangeRef dateRangeRef = getInnerDateRangeRef(ref0);
+
+            if(dateRangeRef != null && !isAutoRangeColumn(ref0) &&
+               cs.containsAttribute(dateRangeRef.getDataRef()))
+            {
+               continue;
+            }
+
             cs.removeAttribute(i);
-            removedStaleRangeColumn = true;
          }
       }
 
-      if(removedStaleRangeColumn) {
-         // A filter/ranking condition that referenced the removed column's synthetic
-         // name (e.g. add_filter on "Quarter(orderDate)", which read_worksheet_model
-         // does list) would otherwise be left pointing at a DataRef no longer in the
-         // selection. Matches AggregateDialogService's own post-cleanup call.
-         inetsoft.uql.asset.internal.AssetUtil.validateConditions(cs, t);
-      }
+      // Matches AggregateDialogService's own unconditional post-cleanup call: a filter/
+      // ranking condition that referenced a just-removed column's synthetic name (e.g.
+      // add_filter on "Quarter(orderDate)", which read_worksheet_model does list) would
+      // otherwise be left pointing at a DataRef no longer in the selection.
+      inetsoft.uql.asset.internal.AssetUtil.validateConditions(cs, t);
 
       for(AggregateSpec spec : aggregates) {
          AggregateFormula formula = AggregateFormula.getFormula(spec.formula());
@@ -570,6 +593,46 @@ public final class WorksheetMutationSupport {
                     appliedAliases.isEmpty() ? "" : String.join("\n", appliedAliases));
       t.setAggregateInfo(ainfo);
       t.setAggregate(!ainfo.isEmpty());
+   }
+
+   /**
+    * Ported from {@code AggregateDialogService#getDateRangeRef}: walks a
+    * {@link DataRefWrapper} chain looking for a {@link DateRangeRef}, stopping at the
+    * outermost one found.
+    */
+   private static DateRangeRef getDateRangeRef(DataRef ref0) {
+      while(ref0 instanceof DataRefWrapper) {
+         if(ref0 instanceof DateRangeRef) {
+            break;
+         }
+
+         ref0 = ((DataRefWrapper) ref0).getDataRef();
+      }
+
+      return ref0 instanceof DateRangeRef ? (DateRangeRef) ref0 : null;
+   }
+
+   /**
+    * Ported from {@code AggregateDialogService#getInnerDateRangeRef}: walks a
+    * {@link DataRefWrapper} chain looking for the innermost {@link DateRangeRef} that
+    * does not itself wrap another one (relevant for chained/nested date ranges).
+    */
+   private static DateRangeRef getInnerDateRangeRef(DataRef ref0) {
+      while(ref0 instanceof DataRefWrapper) {
+         if(ref0 instanceof DateRangeRef && !(((DateRangeRef) ref0).getDataRef() instanceof DateRangeRef)) {
+            break;
+         }
+
+         ref0 = ((DataRefWrapper) ref0).getDataRef();
+      }
+
+      return ref0 instanceof DateRangeRef ? (DateRangeRef) ref0 : null;
+   }
+
+   /** Ported from {@code AggregateDialogService#isAutoRangeColumn}. */
+   private static boolean isAutoRangeColumn(DataRef group) {
+      DateRangeRef dateRangeRef = getDateRangeRef(group);
+      return dateRangeRef != null && dateRangeRef.isAutoCreate();
    }
 
    // =========================================================================

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -102,8 +102,18 @@ public final class WorksheetMutationSupport {
                return new GroupSpec(node.asText());
             }
 
+            if(!node.isObject()) {
+               return ctxt.reportInputMismatch(GroupSpec.class,
+                  "Expected a group-by column name string or a {field, dateLevel} object, got: " +
+                  node);
+            }
+
             String field = node.hasNonNull("field") ? node.get("field").asText() : null;
-            String dateLevel = node.hasNonNull("dateLevel") ? node.get("dateLevel").asText() : null;
+            // "dateOption" is add_date_range_column's spelling of this same concept;
+            // accept it as an alias so that near-miss doesn't silently deserialize to an
+            // ungrouped date column.
+            String dateLevel = node.hasNonNull("dateLevel") ? node.get("dateLevel").asText() :
+               node.hasNonNull("dateOption") ? node.get("dateOption").asText() : null;
             return new GroupSpec(field, dateLevel);
          }
       }
@@ -259,17 +269,27 @@ public final class WorksheetMutationSupport {
     * Builds and sets a new {@link AggregateInfo} on the table from the supplied
     * group and aggregate specs.
     *
-    * <p>The column selection is not modified; columns referenced here must already
-    * exist in the private column selection.</p>
+    * <p>Columns referenced here must already exist in the private column selection,
+    * except that a group with a {@code dateLevel} replaces its base column with a
+    * {@link DateRangeRef}-wrapped one (see below).</p>
     *
     * @param t          the table assembly to mutate
-    * @param groups     group-by column specs (name, plus optional date grouping level)
-    * @param aggregates aggregate measures to apply
+    * @param groups     group-by column specs (name, plus optional date grouping level);
+    *                   {@code null} is treated as empty
+    * @param aggregates aggregate measures to apply; {@code null} is treated as empty
     */
    public static void applyAggregateInfo(TableAssembly t, List<GroupSpec> groups,
                                          List<AggregateSpec> aggregates)
       throws inetsoft.web.wiz.pairing.PairingException
    {
+      // Callers (e.g. WorksheetAgentController) may pass a null groups or aggregates
+      // list when the request omits that key entirely; normalize before either the
+      // emptiness check below or the per-spec loops run, so a null groups list paired
+      // with a non-empty aggregates list (or vice versa) can't NPE instead of being
+      // treated as "no groups".
+      groups = groups == null ? List.of() : groups;
+      aggregates = aggregates == null ? List.of() : aggregates;
+
       // Clear aliases left on the column selection by a PRIOR call's aggregate
       // outputs before resolving anything new. Those aliases exist purely to label
       // aggregate results; once the AggregateInfo is being replaced they become
@@ -282,9 +302,7 @@ public final class WorksheetMutationSupport {
       // result — a plausible-looking but numerically wrong answer.
       clearAggregateAliases(t);
 
-      if((groups == null || groups.isEmpty()) &&
-         (aggregates == null || aggregates.isEmpty()))
-      {
+      if(groups.isEmpty() && aggregates.isEmpty()) {
          t.setProperty(AGGREGATE_OUTPUT_ALIASES, "");
          t.setAggregateInfo(new AggregateInfo());
          t.setAggregate(false);
@@ -338,15 +356,26 @@ public final class WorksheetMutationSupport {
                availableColumns.keySet());
          }
 
-         GroupRef gr = new GroupRef(resolved);
+         GroupRef gr;
 
-         if(spec.dateLevel() != null) {
-            // Sets the date bucketing level directly on the GroupRef — this is what the
-            // worksheet query engine (AssetQuery/PreAssetQuery#getDateGroup) and the
-            // Composer's Group and Aggregate dialog (GroupRefModel#getDgroup) both read to
-            // decide the grouping granularity, so no derived date-range column is needed
-            // (see add_date_range_column for when an actual materialized bucketed column
-            // is wanted instead).
+         if(spec.dateLevel() == null) {
+            gr = new GroupRef(resolved);
+         }
+         else {
+            // A GroupRef whose DataRef is still the raw column, with only setDateGroup()
+            // called, has no effect once the aggregate is mergeable into SQL:
+            // PreAssetQuery.mergeGroupBy() builds the GROUP BY list purely from
+            // findColumn()/getColumn() on the GroupRef's DataRef and never consults
+            // getDateGroup(), and isMergeableDataType() only excludes date columns on
+            // SQLite — so on any regular JDBC-backed table this would silently group by
+            // the raw date value instead of the requested bucket. The Composer's Group
+            // and Aggregate dialog (AggregateDialogService#processDateGrouping) avoids
+            // this by INSERTING a DateRangeRef-wrapped column as the group's actual
+            // DataRef right alongside the raw base column — it does not remove the raw
+            // column, so it stays available (e.g. still shows in the Group and Aggregate
+            // dialog's column list, still filterable). setDateGroup() is then only a
+            // round-trip marker so the level survives a reload. Mirror that mechanism
+            // exactly here, including keeping the raw column.
             if(!XSchema.isDateType(resolved.getDataType())) {
                throw new inetsoft.web.wiz.pairing.PairingException(
                   "Column '" + spec.field() + "' is not a date type (type=" +
@@ -354,7 +383,43 @@ public final class WorksheetMutationSupport {
                   "timeInstant column.");
             }
 
-            gr.setDateGroup(WorksheetEditService.Editor.parseDateOption(spec.dateLevel()));
+            int dgroup = WorksheetEditService.Editor.parseDateOption(spec.dateLevel());
+            String colName = resolved.getName();
+            DateRangeRef dateRef = new DateRangeRef(
+               DateRangeRef.getName(colName, dgroup), resolved.getDataRef(), dgroup);
+            dateRef.setOriginalType(resolved.getDataType());
+
+            String dtype = dateRef.getDataType();
+
+            // Match AggregateDialogService's TIME special case: a plain time-of-day
+            // column keeps its TIME type for interval-style levels — DateRangeRef's
+            // default of TIME_INSTANT would be wrong since there is no date component.
+            if(XSchema.TIME.equals(dateRef.getOriginalType()) &&
+               dateRef.getDateOption() != DateRangeRef.HOUR_OF_DAY_DATE_GROUP)
+            {
+               dtype = dateRef.getOriginalType();
+            }
+
+            ColumnRef dateColumn = new ColumnRef(dateRef);
+            dateColumn.setDataType(dtype);
+
+            // Insert (not replace) at the raw column's position, exactly like
+            // AggregateDialogService#processDateGrouping — the raw column is left in
+            // the selection so it remains independently usable (e.g. add_filter on the
+            // raw date, or grouping it a second way later) and keeps showing up in the
+            // Composer's Group and Aggregate dialog the same way it would after a user
+            // applies a date level through the UI.
+            int bidx = cs.indexOfAttribute(resolved);
+
+            if(bidx >= 0) {
+               cs.addAttribute(bidx, dateColumn);
+            }
+            else {
+               cs.addAttribute(dateColumn);
+            }
+
+            gr = new GroupRef(dateColumn);
+            gr.setDateGroup(dgroup);
          }
 
          ainfo.addGroup(gr);

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -303,13 +303,13 @@ public final class WorksheetMutationSupport {
       // result — a plausible-looking but numerically wrong answer.
       clearAggregateAliases(t);
 
-      if(groups.isEmpty() && aggregates.isEmpty()) {
-         t.setProperty(AGGREGATE_OUTPUT_ALIASES, "");
-         t.setAggregateInfo(new AggregateInfo());
-         t.setAggregate(false);
-         return;
-      }
-
+      // Deliberately no early return for groups.isEmpty() && aggregates.isEmpty():
+      // AggregateDialogService#applyAggregateInfo runs its stale-range-column cleanup
+      // sweep and AssetUtil.validateConditions unconditionally, even when the new
+      // AggregateInfo is completely empty (a full clear), so a full clear here must
+      // too - otherwise a DateRangeRef-wrapped column materialized by an earlier
+      // dateLevel grouping (e.g. "Quarter(orderDate)") would be left behind forever,
+      // since the loops below produce the same empty-AggregateInfo end state either way.
       AggregateInfo ainfo = new AggregateInfo();
       ColumnSelection cs = t.getColumnSelection(false);
 

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -17,6 +17,11 @@
  */
 package inetsoft.web.wiz.worksheet;
 
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import inetsoft.uql.*;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.erm.AttributeRef;
@@ -65,6 +70,44 @@ public final class WorksheetMutationSupport {
     * @param alias   optional output alias; may be {@code null}
     */
    public record AggregateSpec(String field, String formula, String alias) {}
+
+   /**
+    * Describes a single group-by column for
+    * {@link #applyAggregateInfo(TableAssembly, List, List)}.
+    *
+    * <p>Accepted on the wire as either a bare column name string (equivalent to
+    * {@code dateLevel == null}) or an object {@code {"field": ..., "dateLevel": ...}} —
+    * see {@link Deserializer}.</p>
+    *
+    * @param field     the source column name
+    * @param dateLevel optional date grouping level applied directly to the group (no
+    *                  derived column needed) for date-type columns — one of the same
+    *                  option strings accepted by {@code add_date_range_column}'s
+    *                  {@code dateOption} (e.g. {@code "YEAR"}, {@code "QUARTER"},
+    *                  {@code "MONTH"}); {@code null} for a plain (non-date-bucketed) group
+    */
+   @JsonDeserialize(using = GroupSpec.Deserializer.class)
+   public record GroupSpec(String field, String dateLevel) {
+      public GroupSpec(String field) {
+         this(field, null);
+      }
+
+      /** Accepts either a plain JSON string (column name) or a {@code {field, dateLevel}} object. */
+      static final class Deserializer extends JsonDeserializer<GroupSpec> {
+         @Override
+         public GroupSpec deserialize(JsonParser p, DeserializationContext ctxt) throws java.io.IOException {
+            JsonNode node = p.getCodec().readTree(p);
+
+            if(node.isTextual()) {
+               return new GroupSpec(node.asText());
+            }
+
+            String field = node.hasNonNull("field") ? node.get("field").asText() : null;
+            String dateLevel = node.hasNonNull("dateLevel") ? node.get("dateLevel").asText() : null;
+            return new GroupSpec(field, dateLevel);
+         }
+      }
+   }
 
    /**
     * A named group mapping — group name to list of values that belong to that group.
@@ -220,10 +263,10 @@ public final class WorksheetMutationSupport {
     * exist in the private column selection.</p>
     *
     * @param t          the table assembly to mutate
-    * @param groups     column names to group by
+    * @param groups     group-by column specs (name, plus optional date grouping level)
     * @param aggregates aggregate measures to apply
     */
-   public static void applyAggregateInfo(TableAssembly t, List<String> groups,
+   public static void applyAggregateInfo(TableAssembly t, List<GroupSpec> groups,
                                          List<AggregateSpec> aggregates)
       throws inetsoft.web.wiz.pairing.PairingException
    {
@@ -282,8 +325,8 @@ public final class WorksheetMutationSupport {
          }
       }
 
-      for(String group : groups) {
-         ColumnRef resolved = availableColumns.get(group);
+      for(GroupSpec spec : groups) {
+         ColumnRef resolved = availableColumns.get(spec.field());
 
          if(resolved == null) {
             // Fail loud: a silently invalid GroupRef would be dropped by the next
@@ -291,11 +334,29 @@ public final class WorksheetMutationSupport {
             // practice because setting an aggregate alias RENAMES the base column, so
             // a later call referencing the old name misses.
             throw new inetsoft.web.wiz.pairing.PairingException(
-               "Column not found for group: '" + group + "'. Available columns: " +
+               "Column not found for group: '" + spec.field() + "'. Available columns: " +
                availableColumns.keySet());
          }
 
          GroupRef gr = new GroupRef(resolved);
+
+         if(spec.dateLevel() != null) {
+            // Sets the date bucketing level directly on the GroupRef — this is what the
+            // worksheet query engine (AssetQuery/PreAssetQuery#getDateGroup) and the
+            // Composer's Group and Aggregate dialog (GroupRefModel#getDgroup) both read to
+            // decide the grouping granularity, so no derived date-range column is needed
+            // (see add_date_range_column for when an actual materialized bucketed column
+            // is wanted instead).
+            if(!XSchema.isDateType(resolved.getDataType())) {
+               throw new inetsoft.web.wiz.pairing.PairingException(
+                  "Column '" + spec.field() + "' is not a date type (type=" +
+                  resolved.getDataType() + "). dateLevel requires a date, time, or " +
+                  "timeInstant column.");
+            }
+
+            gr.setDateGroup(WorksheetEditService.Editor.parseDateOption(spec.dateLevel()));
+         }
+
          ainfo.addGroup(gr);
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -356,6 +356,27 @@ public final class WorksheetMutationSupport {
                availableColumns.keySet());
          }
 
+         // Drop any DateRangeRef-wrapped sibling already materialized for this same base
+         // column by a PRIOR call — e.g. re-grouping "orderDate" from QUARTER to MONTH
+         // would otherwise leave "Quarter(orderDate)" behind forever, since each call
+         // resolves spec.field() back to the untouched raw column (see below) and never
+         // revisits earlier wrapped columns. Harmless to the generated SQL (mergeGroupBy
+         // skips a visible column with no group/aggregate), but it pollutes
+         // read_worksheet_model's column list with a phantom entry per level change.
+         // Mirrors the net effect of AggregateDialogService's "remove useless range
+         // column" cleanup pass (its dateRef.isAutoCreate()-gated removal), simplified
+         // since every date-wrapped column this API creates is auto-named — there is no
+         // user-custom-alias case here to preserve.
+         for(int i = cs.getAttributeCount() - 1; i >= 0; i--) {
+            DataRef existing = cs.getAttribute(i);
+
+            if(existing instanceof ColumnRef cr && cr.getDataRef() instanceof DateRangeRef drr &&
+               drr.getDataRef().equals(resolved.getDataRef()))
+            {
+               cs.removeAttribute(i);
+            }
+         }
+
          GroupRef gr;
 
          if(spec.dateLevel() == null) {

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -356,27 +356,6 @@ public final class WorksheetMutationSupport {
                availableColumns.keySet());
          }
 
-         // Drop any DateRangeRef-wrapped sibling already materialized for this same base
-         // column by a PRIOR call — e.g. re-grouping "orderDate" from QUARTER to MONTH
-         // would otherwise leave "Quarter(orderDate)" behind forever, since each call
-         // resolves spec.field() back to the untouched raw column (see below) and never
-         // revisits earlier wrapped columns. Harmless to the generated SQL (mergeGroupBy
-         // skips a visible column with no group/aggregate), but it pollutes
-         // read_worksheet_model's column list with a phantom entry per level change.
-         // Mirrors the net effect of AggregateDialogService's "remove useless range
-         // column" cleanup pass (its dateRef.isAutoCreate()-gated removal), simplified
-         // since every date-wrapped column this API creates is auto-named — there is no
-         // user-custom-alias case here to preserve.
-         for(int i = cs.getAttributeCount() - 1; i >= 0; i--) {
-            DataRef existing = cs.getAttribute(i);
-
-            if(existing instanceof ColumnRef cr && cr.getDataRef() instanceof DateRangeRef drr &&
-               drr.getDataRef().equals(resolved.getDataRef()))
-            {
-               cs.removeAttribute(i);
-            }
-         }
-
          GroupRef gr;
 
          if(spec.dateLevel() == null) {
@@ -444,6 +423,46 @@ public final class WorksheetMutationSupport {
          }
 
          ainfo.addGroup(gr);
+      }
+
+      // Drop any auto-created DateRangeRef-wrapped column left behind by a PRIOR call
+      // that is not one of THIS call's active groups — covers both re-grouping the same
+      // field at a different level (the old "Quarter(orderDate)" is no longer any
+      // group's DataRef once "Month(orderDate)" is built above) and dropping a
+      // previously date-grouped field out of `groups` entirely (set_group_aggregate
+      // fully replaces the AggregateInfo each call, so a field simply absent from this
+      // call's `groups` is exactly as "no longer grouped" as one explicitly re-leveled).
+      // Gated on isAutoCreate() — default true for a column WE materialize here, but
+      // explicitly false for one add_date_range_column created (see addDateRangeColumn)
+      // — so a column the caller deliberately kept as a standalone derived column is
+      // never swept just because it happens to wrap the same base attribute as a group.
+      // Mirrors AggregateDialogService's "remove useless range column" pass, including
+      // its isAutoRangeColumn()-equivalent gate.
+      Set<DataRef> activeGroupColumns = new HashSet<>();
+
+      for(int i = 0; i < ainfo.getGroupCount(); i++) {
+         activeGroupColumns.add(ainfo.getGroup(i).getDataRef());
+      }
+
+      boolean removedStaleRangeColumn = false;
+
+      for(int i = cs.getAttributeCount() - 1; i >= 0; i--) {
+         DataRef existing = cs.getAttribute(i);
+
+         if(existing instanceof ColumnRef cr && cr.getDataRef() instanceof DateRangeRef drr &&
+            drr.isAutoCreate() && !activeGroupColumns.contains(existing))
+         {
+            cs.removeAttribute(i);
+            removedStaleRangeColumn = true;
+         }
+      }
+
+      if(removedStaleRangeColumn) {
+         // A filter/ranking condition that referenced the removed column's synthetic
+         // name (e.g. add_filter on "Quarter(orderDate)", which read_worksheet_model
+         // does list) would otherwise be left pointing at a DataRef no longer in the
+         // selection. Matches AggregateDialogService's own post-cleanup call.
+         inetsoft.uql.asset.internal.AssetUtil.validateConditions(cs, t);
       }
 
       for(AggregateSpec spec : aggregates) {

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
@@ -385,7 +385,17 @@ public class WorksheetReadService {
 
       for(GroupRef gr : groupRefs) {
          String dateLevel = WorksheetEditService.Editor.dateOptionName(gr.getDateGroup());
-         groups.add(new WorksheetModel.AggregateModel.GroupModel(gr.getName(), dateLevel));
+
+         // set_group_aggregate materializes a date-level group as a DateRangeRef-wrapped
+         // column (see WorksheetMutationSupport#applyAggregateInfo) — gr.getName() on that
+         // would return the internal bucketing name (e.g. "Quarter(orderDate)"), not the
+         // field the caller originally asked to group by. Report the wrapped base column's
+         // name instead so the round trip is faithful to what set_group_aggregate accepted.
+         DataRef base = gr.getDataRef();
+         String field =
+            base instanceof ColumnRef cr && cr.getDataRef() instanceof DateRangeRef dr
+               ? dr.getDataRef().getName() : gr.getName();
+         groups.add(new WorksheetModel.AggregateModel.GroupModel(field, dateLevel));
       }
 
       // Aggregates (primary + secondary)

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
@@ -381,10 +381,11 @@ public class WorksheetReadService {
 
       // Groups
       GroupRef[] groupRefs = info.getGroups();
-      List<String> groups = new ArrayList<>(groupRefs.length);
+      List<WorksheetModel.AggregateModel.GroupModel> groups = new ArrayList<>(groupRefs.length);
 
       for(GroupRef gr : groupRefs) {
-         groups.add(gr.getName());
+         String dateLevel = WorksheetEditService.Editor.dateOptionName(gr.getDateGroup());
+         groups.add(new WorksheetModel.AggregateModel.GroupModel(gr.getName(), dateLevel));
       }
 
       // Aggregates (primary + secondary)

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/model/WorksheetModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/model/WorksheetModel.java
@@ -113,10 +113,21 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
    /**
     * Aggregation / group-by configuration for a table.
     *
-    * @param groups     group-by dimension names
+    * @param groups     group-by dimensions
     * @param aggregates measure aggregate definitions
     */
-   public record AggregateModel(List<String> groups, List<AggregateRefModel> aggregates) {
+   public record AggregateModel(List<GroupModel> groups, List<AggregateRefModel> aggregates) {
+
+      /**
+       * A single group-by dimension.
+       *
+       * @param field     source column name
+       * @param dateLevel the date grouping level applied directly to this group (e.g.
+       *                  {@code "QUARTER"}), same vocabulary as set_group_aggregate's
+       *                  {@code dateLevel} / add_date_range_column's {@code dateOption};
+       *                  {@code null} for a plain (non-date-bucketed) group
+       */
+      public record GroupModel(String field, String dateLevel) {}
 
       /**
        * A single aggregate measure.

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/GroupSpecDeserializationTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/GroupSpecDeserializationTest.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.worksheet;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.web.WebConfig;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies {@code EditRequest.groups} accepts both the original plain-string wire format
+ * and the new {@code {field, dateLevel}} object format (Bug #75952) — old callers of
+ * {@code set_group_aggregate} must keep working unchanged.
+ */
+@Tag("core")
+class GroupSpecDeserializationTest {
+
+   private final ObjectMapper mapper = new WebConfig().objectMapper();
+
+   @Test
+   void deserializesPlainStringGroup() throws Exception {
+      EditRequest req = mapper.readValue(
+         "{\"op\": \"set_group_aggregate\", \"table\": \"T\", \"groups\": [\"Department\"]}",
+         EditRequest.class);
+
+      assertEquals(1, req.groups().size());
+      assertEquals("Department", req.groups().get(0).field());
+      assertNull(req.groups().get(0).dateLevel());
+   }
+
+   @Test
+   void deserializesObjectGroupWithDateLevel() throws Exception {
+      EditRequest req = mapper.readValue(
+         "{\"op\": \"set_group_aggregate\", \"table\": \"T\", " +
+         "\"groups\": [{\"field\": \"Order Date\", \"dateLevel\": \"QUARTER\"}]}",
+         EditRequest.class);
+
+      assertEquals(1, req.groups().size());
+      assertEquals("Order Date", req.groups().get(0).field());
+      assertEquals("QUARTER", req.groups().get(0).dateLevel());
+   }
+
+   @Test
+   void deserializesMixedStringAndObjectGroups() throws Exception {
+      EditRequest req = mapper.readValue(
+         "{\"op\": \"set_group_aggregate\", \"table\": \"T\", " +
+         "\"groups\": [\"Employee\", {\"field\": \"Order Date\", \"dateLevel\": \"QUARTER\"}]}",
+         EditRequest.class);
+
+      assertEquals(2, req.groups().size());
+      assertEquals("Employee", req.groups().get(0).field());
+      assertNull(req.groups().get(0).dateLevel());
+      assertEquals("Order Date", req.groups().get(1).field());
+      assertEquals("QUARTER", req.groups().get(1).dateLevel());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/GroupSpecDeserializationTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/GroupSpecDeserializationTest.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.wiz.worksheet;
 
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import inetsoft.web.WebConfig;
 import org.junit.jupiter.api.Tag;
@@ -69,5 +70,31 @@ class GroupSpecDeserializationTest {
       assertNull(req.groups().get(0).dateLevel());
       assertEquals("Order Date", req.groups().get(1).field());
       assertEquals("QUARTER", req.groups().get(1).dateLevel());
+   }
+
+   @Test
+   void deserializesDateOptionAsDateLevelAlias() throws Exception {
+      // "dateOption" is add_date_range_column's spelling of this same concept — a highly
+      // plausible agent near-miss that must not silently deserialize to an ungrouped date
+      // (it would otherwise fall through to the unmapped "dateLevel" key and be dropped).
+      EditRequest req = mapper.readValue(
+         "{\"op\": \"set_group_aggregate\", \"table\": \"T\", " +
+         "\"groups\": [{\"field\": \"Order Date\", \"dateOption\": \"QUARTER\"}]}",
+         EditRequest.class);
+
+      assertEquals(1, req.groups().size());
+      assertEquals("Order Date", req.groups().get(0).field());
+      assertEquals("QUARTER", req.groups().get(0).dateLevel());
+   }
+
+   @Test
+   void rejectsNonStringNonObjectGroupEntry() {
+      // A group entry that is neither a string nor an object (e.g. a bare number or null
+      // in the array) must fail loud at the deserializer, not silently become
+      // GroupSpec(null, null) and surface later as a confusing "Column not found for
+      // group: 'null'".
+      assertThrows(JsonMappingException.class, () -> mapper.readValue(
+         "{\"op\": \"set_group_aggregate\", \"table\": \"T\", \"groups\": [5]}",
+         EditRequest.class));
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -535,6 +535,36 @@ class WorksheetEditServiceMutatorsTest {
    }
 
    @Test
+   void setGroupAggregateDropsStaleDateRangeColumnOnFullClear() throws Exception {
+      // A call with both groups and aggregates empty (e.g. "show me the raw rows again")
+      // must clean up a stale DateRangeRef column exactly like a re-level or a
+      // field-dropped-from-groups call does — AggregateDialogService#applyAggregateInfo
+      // (the UI path this mirrors) runs its cleanup sweep unconditionally, even when the
+      // new AggregateInfo ends up completely empty, so this must too.
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "orderDate", "total");
+      ws.addAssembly(t);
+      ColumnRef dateCol = (ColumnRef) t.getColumnSelection(false).getAttribute("orderDate");
+      dateCol.setDataType(XSchema.DATE);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed ->
+         ed.setGroupAggregate("T",
+            List.of(new WorksheetMutationSupport.GroupSpec("orderDate", "QUARTER")),
+            List.of(new WorksheetMutationSupport.AggregateSpec("total", "SUM", null))));
+
+      svc.apply("TOK", agent, ed -> ed.setGroupAggregate("T", List.of(), List.of()));
+
+      ColumnSelection cs = t.getColumnSelection(false);
+      assertNull(cs.getAttribute("Quarter(orderDate)"),
+                 "stale Quarter(orderDate) column must be dropped on a full clear");
+      assertNotNull(cs.getAttribute("orderDate"), "raw base column must still be present");
+      assertTrue(t.getAggregateInfo().isEmpty());
+      assertFalse(t.isAggregate());
+   }
+
+   @Test
    void setGroupAggregatePreservesAddDateRangeColumnCreatedColumn() throws Exception {
       // A column created via add_date_range_column is a deliberate, standalone derived
       // column (not tied to any group) — a later set_group_aggregate call that groups
@@ -1692,7 +1722,7 @@ class WorksheetEditServiceMutatorsTest {
       Principal agent = TestPrincipals.user("alice", "host-org");
       WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
 
-      svc.apply("TOK", agent, ed -> ed.setGroupAggregate("T", List.of("a"),
+      svc.apply("TOK", agent, ed -> ed.setGroupAggregate("T", groups("a"),
          List.of(new WorksheetMutationSupport.AggregateSpec("b", "SUM", null))));
 
       // "b" is a raw (non-expression) aggregate measure. The UI's isExpressionAggregate
@@ -1713,7 +1743,7 @@ class WorksheetEditServiceMutatorsTest {
       Principal agent = TestPrincipals.user("alice", "host-org");
       WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
 
-      svc.apply("TOK", agent, ed -> ed.setGroupAggregate("T", List.of("a"),
+      svc.apply("TOK", agent, ed -> ed.setGroupAggregate("T", groups("a"),
          List.of(new WorksheetMutationSupport.AggregateSpec("b", "SUM", null))));
 
       // The group-by column passes its value through unchanged (unlike an aggregate

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -501,6 +501,68 @@ class WorksheetEditServiceMutatorsTest {
    }
 
    @Test
+   void setGroupAggregateDropsStaleDateRangeColumnWhenFieldRemovedFromGroups() throws Exception {
+      // set_group_aggregate fully replaces the AggregateInfo each call, so a field
+      // simply absent from a later call's `groups` (the agent restructures to group by
+      // something else entirely, without mentioning the date field again) is exactly as
+      // "no longer grouped" as one explicitly re-leveled — the previously materialized
+      // "Quarter(orderDate)" must not be left behind just because this call's cleanup
+      // only used to look at fields present in THIS call's groups.
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t =
+         TestWorksheets.tableWithColumns(ws, "T", "orderDate", "cat", "total");
+      ws.addAssembly(t);
+      ColumnRef dateCol = (ColumnRef) t.getColumnSelection(false).getAttribute("orderDate");
+      dateCol.setDataType(XSchema.DATE);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed ->
+         ed.setGroupAggregate("T",
+            List.of(new WorksheetMutationSupport.GroupSpec("orderDate", "QUARTER")),
+            List.of(new WorksheetMutationSupport.AggregateSpec("total", "SUM", null))));
+
+      svc.apply("TOK", agent, ed ->
+         ed.setGroupAggregate("T",
+            groups("cat"),
+            List.of(new WorksheetMutationSupport.AggregateSpec("total", "SUM", null))));
+
+      ColumnSelection cs = t.getColumnSelection(false);
+      assertNull(cs.getAttribute("Quarter(orderDate)"),
+                 "stale Quarter(orderDate) column must be dropped when orderDate is no " +
+                 "longer grouped at all");
+      assertNotNull(cs.getAttribute("orderDate"), "raw base column must still be present");
+   }
+
+   @Test
+   void setGroupAggregatePreservesAddDateRangeColumnCreatedColumn() throws Exception {
+      // A column created via add_date_range_column is a deliberate, standalone derived
+      // column (not tied to any group) — a later set_group_aggregate call that groups
+      // the SAME base date column at some level must not sweep it away just because it
+      // wraps the same base attribute as the new group's DateRangeRef column.
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "orderDate", "total");
+      ws.addAssembly(t);
+      ColumnRef dateCol = (ColumnRef) t.getColumnSelection(false).getAttribute("orderDate");
+      dateCol.setDataType(XSchema.DATE);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.addDateRangeColumn("T", "orderDate", "YEAR"));
+
+      svc.apply("TOK", agent, ed ->
+         ed.setGroupAggregate("T",
+            List.of(new WorksheetMutationSupport.GroupSpec("orderDate", "QUARTER")),
+            List.of(new WorksheetMutationSupport.AggregateSpec("total", "SUM", null))));
+
+      ColumnSelection cs = t.getColumnSelection(false);
+      assertNotNull(cs.getAttribute("Year(orderDate)"),
+                    "add_date_range_column's standalone derived column must survive");
+      assertNotNull(cs.getAttribute("Quarter(orderDate)"));
+      assertNotNull(cs.getAttribute("orderDate"));
+   }
+
+   @Test
    void setGroupAggregateFailsLoudOnUnrecognizedDateLevel() throws Exception {
       Worksheet ws = new Worksheet();
       EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "orderDate", "total");

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -398,6 +398,27 @@ class WorksheetEditServiceMutatorsTest {
    }
 
    @Test
+   void setGroupAggregateTreatsNullGroupsAsEmpty() throws Exception {
+      // WorksheetAgentController defaults a missing "aggregates" key to List.of() but
+      // passes a missing "groups" key through as null unchanged; a null groups list
+      // paired with a non-empty aggregates list must not NPE in the group loop below the
+      // (groups empty && aggregates empty) early-return guard.
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "cat", "val");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed ->
+         ed.setGroupAggregate("T", null,
+            List.of(new WorksheetMutationSupport.AggregateSpec("val", "SUM", null))));
+
+      AggregateInfo ai = t.getAggregateInfo();
+      assertEquals(0, ai.getGroupCount());
+      assertEquals(1, ai.getAggregateCount());
+   }
+
+   @Test
    void setGroupAggregateAppliesDateLevelToDateColumn() throws Exception {
       Worksheet ws = new Worksheet();
       EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "orderDate", "total");
@@ -415,11 +436,49 @@ class WorksheetEditServiceMutatorsTest {
       AggregateInfo ai = t.getAggregateInfo();
       assertEquals(1, ai.getGroupCount());
 
-      // This is what both the worksheet query engine (AssetQuery#getDateGroup) and the
-      // Composer's Group and Aggregate dialog (GroupRefModel#getDgroup) read to decide the
-      // grouping granularity — leaving it unset (as before this fix) is exactly Bug #75952:
-      // the date group silently shows/behaves as "None" instead of "Quarter".
+      // setDateGroup() alone is read by the Composer's Group and Aggregate dialog
+      // (GroupRefModel#getDgroup), but PreAssetQuery.mergeGroupBy() builds the actual
+      // GROUP BY SQL purely from the GroupRef's DataRef and never consults
+      // getDateGroup() — so on any regular JDBC-mergeable table, a GroupRef still
+      // wrapping the raw column would silently group by the exact date value instead of
+      // by quarter. The DataRef itself must be a DateRangeRef-wrapped column for the
+      // bucketing to actually take effect; setDateGroup() is only a round-trip marker.
       assertEquals(XConstants.QUARTER_DATE_GROUP, ai.getGroup(0).getDateGroup());
+      DataRef groupDataRef = ai.getGroup(0).getDataRef();
+      assertInstanceOf(ColumnRef.class, groupDataRef);
+      DataRef inner = ((ColumnRef) groupDataRef).getDataRef();
+      assertInstanceOf(DateRangeRef.class, inner);
+      assertEquals(XConstants.QUARTER_DATE_GROUP, ((DateRangeRef) inner).getDateOption());
+      assertEquals("orderDate", ((DateRangeRef) inner).getDataRef().getName());
+
+      // The raw "orderDate" column is kept alongside the new wrapped column — matching
+      // AggregateDialogService#processDateGrouping, which inserts rather than replaces —
+      // so it stays independently usable (e.g. still shows up in the Composer's Group
+      // and Aggregate dialog, still filterable) exactly as it would after applying a
+      // date level through the UI.
+      assertNotNull(t.getColumnSelection(false).getAttribute("orderDate"));
+      ColumnRef rawAfter = (ColumnRef) t.getColumnSelection(false).getAttribute("orderDate");
+      assertFalse(rawAfter.getDataRef() instanceof DateRangeRef);
+   }
+
+   @Test
+   void setGroupAggregateFailsLoudOnUnrecognizedDateLevel() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "orderDate", "total");
+      ws.addAssembly(t);
+      ColumnRef dateCol = (ColumnRef) t.getColumnSelection(false).getAttribute("orderDate");
+      dateCol.setDataType(XSchema.DATE);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      // An unrecognized dateLevel must fail loud instead of silently defaulting to a
+      // yearly grouping, matching the fail-loud stance already taken for unknown columns.
+      PairingException ex = assertThrows(PairingException.class, () ->
+         svc.apply("TOK", agent, ed ->
+            ed.setGroupAggregate("T",
+               List.of(new WorksheetMutationSupport.GroupSpec("orderDate", "MONTHLY")),
+               List.of(new WorksheetMutationSupport.AggregateSpec("total", "SUM", null)))));
+      assertTrue(ex.getMessage().contains("MONTHLY"));
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -462,6 +462,45 @@ class WorksheetEditServiceMutatorsTest {
    }
 
    @Test
+   void setGroupAggregateDropsStaleDateRangeColumnOnLevelChange() throws Exception {
+      // Re-grouping the same field at a different level (e.g. the agent changes
+      // "group by Quarter" to "group by Month") must not leave the previous level's
+      // materialized DateRangeRef column ("Quarter(orderDate)") behind as an orphan —
+      // each call resolves the field back to the untouched raw column, so without
+      // explicit cleanup a stale wrapped column accumulates per level change and
+      // pollutes read_worksheet_model's column list with phantom entries forever.
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "orderDate", "total");
+      ws.addAssembly(t);
+      ColumnRef dateCol = (ColumnRef) t.getColumnSelection(false).getAttribute("orderDate");
+      dateCol.setDataType(XSchema.DATE);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed ->
+         ed.setGroupAggregate("T",
+            List.of(new WorksheetMutationSupport.GroupSpec("orderDate", "QUARTER")),
+            List.of(new WorksheetMutationSupport.AggregateSpec("total", "SUM", null))));
+
+      svc.apply("TOK", agent, ed ->
+         ed.setGroupAggregate("T",
+            List.of(new WorksheetMutationSupport.GroupSpec("orderDate", "MONTH")),
+            List.of(new WorksheetMutationSupport.AggregateSpec("total", "SUM", null))));
+
+      ColumnSelection cs = t.getColumnSelection(false);
+      assertNull(cs.getAttribute("Quarter(orderDate)"),
+                 "stale Quarter(orderDate) column must be dropped when re-grouped to MONTH");
+      assertNotNull(cs.getAttribute("Month(orderDate)"));
+      assertNotNull(cs.getAttribute("orderDate"), "raw base column must still be present");
+      assertEquals(3, cs.getAttributeCount(),
+                    "expected exactly orderDate, Month(orderDate), total — no leftovers");
+
+      AggregateInfo ai = t.getAggregateInfo();
+      assertEquals(1, ai.getGroupCount());
+      assertEquals("Month(orderDate)", ai.getGroup(0).getDataRef().getName());
+   }
+
+   @Test
    void setGroupAggregateFailsLoudOnUnrecognizedDateLevel() throws Exception {
       Worksheet ws = new Worksheet();
       EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "orderDate", "total");

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -91,6 +91,13 @@ class WorksheetEditServiceMutatorsTest {
       return rws;
    }
 
+   /** Plain (non-date-bucketed) group specs for the given column names. */
+   private static List<WorksheetMutationSupport.GroupSpec> groups(String... fields) {
+      return java.util.Arrays.stream(fields)
+         .map(WorksheetMutationSupport.GroupSpec::new)
+         .toList();
+   }
+
    // =========================================================================
    // Filter tests
    // =========================================================================
@@ -205,7 +212,7 @@ class WorksheetEditServiceMutatorsTest {
 
       svc.apply("TOK", agent, ed ->
          ed.setGroupAggregate("T",
-                              List.of("cat"),
+                              groups("cat"),
                               List.of(new WorksheetMutationSupport.AggregateSpec("val", "SUM", null)))
       );
 
@@ -226,7 +233,7 @@ class WorksheetEditServiceMutatorsTest {
 
       svc.apply("TOK", agent, ed ->
          ed.setGroupAggregate("T",
-            List.of("cat"),
+            groups("cat"),
             List.of(new WorksheetMutationSupport.AggregateSpec("price", "MIN", "min_price"),
                     new WorksheetMutationSupport.AggregateSpec("price", "MAX", "max_price"),
                     new WorksheetMutationSupport.AggregateSpec("price", "COUNT", "n"))));
@@ -281,7 +288,7 @@ class WorksheetEditServiceMutatorsTest {
       // First pass: per-customer average, aliased "customer_avg". This sets the alias
       // directly on the shared "amount" ColumnRef (the output-naming mechanism).
       svc.apply("TOK", agent, ed ->
-         ed.setGroupAggregate("T", List.of("cust", "store"),
+         ed.setGroupAggregate("T", groups("cust", "store"),
             List.of(new WorksheetMutationSupport.AggregateSpec("amount", "AVG", "customer_avg"))));
 
       // Second pass on the SAME table (no mirror), attempting to chain by referencing
@@ -294,7 +301,7 @@ class WorksheetEditServiceMutatorsTest {
       // prior aggregate's aliases are cleared.
       PairingException ex = assertThrows(PairingException.class, () ->
          svc.apply("TOK", agent, ed ->
-            ed.setGroupAggregate("T", List.of("store"),
+            ed.setGroupAggregate("T", groups("store"),
                List.of(new WorksheetMutationSupport.AggregateSpec(
                   "customer_avg", "AVG", "avg_of_avgs")))));
       assertTrue(ex.getMessage().contains("customer_avg"));
@@ -302,7 +309,7 @@ class WorksheetEditServiceMutatorsTest {
       // The raw "amount" column must be usable again under its own name — clearing the
       // stale alias must not leave the column unreachable.
       svc.apply("TOK", agent, ed ->
-         ed.setGroupAggregate("T", List.of("store"),
+         ed.setGroupAggregate("T", groups("store"),
             List.of(new WorksheetMutationSupport.AggregateSpec("amount", "SUM", "total"))));
       assertEquals(1, t.getAggregateInfo().getAggregateCount());
    }
@@ -324,10 +331,10 @@ class WorksheetEditServiceMutatorsTest {
       // indiscriminately, destroying the deliberate rename; it must now clear only the
       // aliases applyAggregateInfo itself recorded.
       svc.apply("TOK", agent, ed ->
-         ed.setGroupAggregate("T", List.of("cust"),
+         ed.setGroupAggregate("T", groups("cust"),
             List.of(new WorksheetMutationSupport.AggregateSpec("amount", "SUM", null))));
       svc.apply("TOK", agent, ed ->
-         ed.setGroupAggregate("T", List.of("store"),
+         ed.setGroupAggregate("T", groups("store"),
             List.of(new WorksheetMutationSupport.AggregateSpec("amount", "SUM", null))));
 
       ColumnRef base = (ColumnRef) t.getColumnSelection(false).getAttribute("revenue");
@@ -346,7 +353,7 @@ class WorksheetEditServiceMutatorsTest {
 
       svc.apply("TOK", agent, ed -> ed.renameColumn("T", "amount", "revenue"));
       svc.apply("TOK", agent, ed ->
-         ed.setGroupAggregate("T", List.of("cust"),
+         ed.setGroupAggregate("T", groups("cust"),
             List.of(new WorksheetMutationSupport.AggregateSpec("amount", "SUM", null))));
 
       // A FAILED intermediate call must not consume the alias bookkeeping of the
@@ -354,11 +361,11 @@ class WorksheetEditServiceMutatorsTest {
       // into the unknown-provenance clear-all fallback and wipe the rename.
       assertThrows(PairingException.class, () ->
          svc.apply("TOK", agent, ed ->
-            ed.setGroupAggregate("T", List.of("no_such_group"),
+            ed.setGroupAggregate("T", groups("no_such_group"),
                List.of(new WorksheetMutationSupport.AggregateSpec("amount", "SUM", null)))));
 
       svc.apply("TOK", agent, ed ->
-         ed.setGroupAggregate("T", List.of("store"),
+         ed.setGroupAggregate("T", groups("store"),
             List.of(new WorksheetMutationSupport.AggregateSpec("amount", "SUM", null))));
 
       ColumnRef base = (ColumnRef) t.getColumnSelection(false).getAttribute("revenue");
@@ -379,15 +386,60 @@ class WorksheetEditServiceMutatorsTest {
       // silently dropped — a plausible-but-wrong result. It must fail loud instead.
       PairingException ex = assertThrows(PairingException.class, () ->
          svc.apply("TOK", agent, ed ->
-            ed.setGroupAggregate("T", List.of("cat"),
+            ed.setGroupAggregate("T", groups("cat"),
                List.of(new WorksheetMutationSupport.AggregateSpec("no_such_col", "SUM", "x")))));
       assertTrue(ex.getMessage().contains("no_such_col"));
       assertTrue(ex.getMessage().contains("Available columns"));
 
       PairingException ex2 = assertThrows(PairingException.class, () ->
          svc.apply("TOK", agent, ed ->
-            ed.setGroupAggregate("T", List.of("no_such_group"), List.of())));
+            ed.setGroupAggregate("T", groups("no_such_group"), List.of())));
       assertTrue(ex2.getMessage().contains("no_such_group"));
+   }
+
+   @Test
+   void setGroupAggregateAppliesDateLevelToDateColumn() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "orderDate", "total");
+      ws.addAssembly(t);
+      ColumnRef dateCol = (ColumnRef) t.getColumnSelection(false).getAttribute("orderDate");
+      dateCol.setDataType(XSchema.DATE);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed ->
+         ed.setGroupAggregate("T",
+            List.of(new WorksheetMutationSupport.GroupSpec("orderDate", "QUARTER")),
+            List.of(new WorksheetMutationSupport.AggregateSpec("total", "SUM", null))));
+
+      AggregateInfo ai = t.getAggregateInfo();
+      assertEquals(1, ai.getGroupCount());
+
+      // This is what both the worksheet query engine (AssetQuery#getDateGroup) and the
+      // Composer's Group and Aggregate dialog (GroupRefModel#getDgroup) read to decide the
+      // grouping granularity — leaving it unset (as before this fix) is exactly Bug #75952:
+      // the date group silently shows/behaves as "None" instead of "Quarter".
+      assertEquals(XConstants.QUARTER_DATE_GROUP, ai.getGroup(0).getDateGroup());
+   }
+
+   @Test
+   void setGroupAggregateFailsLoudOnDateLevelForNonDateColumn() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "cat", "val");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      // "cat" is a plain string column (the default type from TestWorksheets); a dateLevel
+      // silently applied to it would produce a plausible-but-meaningless grouping instead
+      // of failing loud.
+      PairingException ex = assertThrows(PairingException.class, () ->
+         svc.apply("TOK", agent, ed ->
+            ed.setGroupAggregate("T",
+               List.of(new WorksheetMutationSupport.GroupSpec("cat", "QUARTER")),
+               List.of(new WorksheetMutationSupport.AggregateSpec("val", "SUM", null)))));
+      assertTrue(ex.getMessage().contains("cat"));
+      assertTrue(ex.getMessage().contains("date type"));
    }
 
    // =========================================================================
@@ -403,7 +455,7 @@ class WorksheetEditServiceMutatorsTest {
       WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
 
       svc.apply("TOK", agent, ed -> {
-         ed.setGroupAggregate("T", List.of("employee"),
+         ed.setGroupAggregate("T", groups("employee"),
             List.of(new WorksheetMutationSupport.AggregateSpec("total", "SUM", null)));
          ed.setRanking("T",
             new WorksheetMutationSupport.RankingSpec("total", 3, "TOP_N", false));
@@ -433,7 +485,7 @@ class WorksheetEditServiceMutatorsTest {
       // Ranking need not target the aggregate — it can also rank by one of the
       // group-by (pre-aggregate) dimensions, e.g. top 3 employees alphabetically.
       svc.apply("TOK", agent, ed -> {
-         ed.setGroupAggregate("T", List.of("employee"),
+         ed.setGroupAggregate("T", groups("employee"),
             List.of(new WorksheetMutationSupport.AggregateSpec("total", "SUM", null)));
          ed.setRanking("T",
             new WorksheetMutationSupport.RankingSpec("employee", 3, "TOP_N", false));
@@ -458,7 +510,7 @@ class WorksheetEditServiceMutatorsTest {
       // aggregate to rank it by. Both must resolve to their real AggregateInfo refs, not
       // a raw pre-aggregate ColumnRef, or the condition silently ranks by nothing.
       svc.apply("TOK", agent, ed -> {
-         ed.setGroupAggregate("T", List.of("employee"),
+         ed.setGroupAggregate("T", groups("employee"),
             List.of(new WorksheetMutationSupport.AggregateSpec("total", "SUM", null)));
          ed.setRanking("T",
             new WorksheetMutationSupport.RankingSpec("employee", 3, "TOP_N", false, "total"));
@@ -541,7 +593,7 @@ class WorksheetEditServiceMutatorsTest {
       // resolvable column. Ranking by it must not be forced into an aggregate/group
       // match; it must resolve to its own raw ColumnRef.
       svc.apply("TOK", agent, ed -> {
-         ed.setGroupAggregate("T", List.of("employee"),
+         ed.setGroupAggregate("T", groups("employee"),
             List.of(new WorksheetMutationSupport.AggregateSpec("total", "SUM", null)));
          ed.setRanking("T",
             new WorksheetMutationSupport.RankingSpec("orderNumber", 3, "TOP_N", false));

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
@@ -49,9 +49,35 @@ class WorksheetReadServiceTest {
       assertTrue(tm.columns().stream().anyMatch(c -> "a".equals(c.name())));
       assertNotNull(tm.aggregates());
       assertEquals(1, tm.aggregates().groups().size());
-      assertEquals("a", tm.aggregates().groups().get(0));
+      assertEquals("a", tm.aggregates().groups().get(0).field());
+      assertNull(tm.aggregates().groups().get(0).dateLevel());
       assertEquals(1, tm.aggregates().aggregates().size());
       assertFalse(tm.sorts().isEmpty());
+   }
+
+   @Test
+   void readsDateGroupLevelOnGroupedColumn() {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "orderDate", "total");
+      ws.addAssembly(t);
+
+      ColumnRef dateCol = (ColumnRef) t.getColumnSelection(false).getAttribute("orderDate");
+      ColumnRef sumCol = (ColumnRef) t.getColumnSelection(false).getAttribute("total");
+
+      GroupRef gref = new GroupRef(dateCol);
+      gref.setDateGroup(inetsoft.uql.XConstants.QUARTER_DATE_GROUP);
+      AggregateInfo ainfo = new AggregateInfo();
+      ainfo.addGroup(gref);
+      ainfo.addAggregate(new AggregateRef(sumCol, AggregateFormula.SUM));
+      t.setAggregateInfo(ainfo);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      WorksheetModel m = new WorksheetReadService().read(rws);
+      WorksheetModel.AggregateModel.GroupModel group = m.tables().get(0).aggregates().groups().get(0);
+      assertEquals("orderDate", group.field());
+      assertEquals("QUARTER", group.dateLevel());
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
@@ -25,6 +25,8 @@ import inetsoft.web.wiz.pairing.WizAgentTestSupport;
 import inetsoft.web.wiz.worksheet.model.WorksheetModel;
 import org.junit.jupiter.api.*;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -56,20 +58,21 @@ class WorksheetReadServiceTest {
    }
 
    @Test
-   void readsDateGroupLevelOnGroupedColumn() {
+   void readsDateGroupLevelOnGroupedColumn() throws Exception {
       Worksheet ws = new Worksheet();
       EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "orderDate", "total");
+      ((ColumnRef) t.getColumnSelection(false).getAttribute("orderDate"))
+         .setDataType(inetsoft.uql.schema.XSchema.DATE);
       ws.addAssembly(t);
 
-      ColumnRef dateCol = (ColumnRef) t.getColumnSelection(false).getAttribute("orderDate");
-      ColumnRef sumCol = (ColumnRef) t.getColumnSelection(false).getAttribute("total");
-
-      GroupRef gref = new GroupRef(dateCol);
-      gref.setDateGroup(inetsoft.uql.XConstants.QUARTER_DATE_GROUP);
-      AggregateInfo ainfo = new AggregateInfo();
-      ainfo.addGroup(gref);
-      ainfo.addAggregate(new AggregateRef(sumCol, AggregateFormula.SUM));
-      t.setAggregateInfo(ainfo);
+      // Round-trip through the actual production mutator (not a hand-built GroupRef)
+      // so this exercises the real shape applyAggregateInfo produces for a dateLevel
+      // group - a GroupRef wrapping ColumnRef(DateRangeRef(...)), not a plain ColumnRef
+      // with only setDateGroup() called - which is what WorksheetReadService's
+      // field-extraction branch actually has to unwrap.
+      WorksheetMutationSupport.applyAggregateInfo(t,
+         List.of(new WorksheetMutationSupport.GroupSpec("orderDate", "QUARTER")),
+         List.of(new WorksheetMutationSupport.AggregateSpec("total", "SUM", null)));
 
       RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
       when(rws.getWorksheet()).thenReturn(ws);


### PR DESCRIPTION
## Summary

The wiz worksheet-chat agent's `set_group_aggregate` had no way to group a date column at a coarser granularity (Year/Quarter/Month/etc.) directly. It only accepted plain column names for `groups`, so `GroupRef.getDateGroup()` was always left at `NONE_DATE_GROUP` — both the worksheet query engine and the Composer's Group and Aggregate dialog showed/behaved as "None" regardless of what the user asked for. The agent's only workaround was `add_date_range_column`, which materializes a separate derived column instead of grouping the existing date column in place — not what the user asked for.

## Root Cause

`WorksheetMutationSupport.applyAggregateInfo()` built a `GroupRef` for each entry in `groups` but never called `setDateGroup(...)` on it. That field is read directly by `AssetQuery`/`PreAssetQuery#getDateGroup` (query-time bucketing) and by `GroupRefModel#getDgroup` (the Composer's Group and Aggregate dialog) — leaving it unset means neither reflects the intended granularity, even if a differently-shaped derived column exists elsewhere.

## Fix

- Added `WorksheetMutationSupport.GroupSpec(String field, String dateLevel)`, mirroring the existing `AggregateSpec`. When `dateLevel` is set, the resolved column is validated as a date type (fails loud otherwise) and `GroupRef.setDateGroup(...)` is called via the existing `WorksheetEditService.Editor#parseDateOption` vocabulary (`YEAR`, `QUARTER`, `MONTH`, ...), already used by `add_date_range_column`.
- `EditRequest.groups` and `WorksheetEditService.Editor#setGroupAggregate` now take `List<GroupSpec>`. A custom Jackson deserializer keeps the wire format backward compatible — a bare string column name still works exactly as before.
- `read_worksheet_model`'s `AggregateModel.groups` now also surfaces `dateLevel` (via a new `dateOptionName` reverse mapping), so the agent can see the applied level when reading the model back.

## Test Plan

- `WorksheetEditServiceMutatorsTest` — added tests for date-level grouping applying `QUARTER_DATE_GROUP` on a date column, and failing loud when `dateLevel` is applied to a non-date column. All existing group-list call sites updated to the new `GroupSpec` type (converted via a `groups(String...)` test helper); all 55 tests pass.
- `WorksheetReadServiceTest` — added a round-trip test asserting `dateLevel` is read back correctly; existing test updated for the new `GroupModel` shape. All 4 tests pass.
- New `GroupSpecDeserializationTest` — verifies the custom deserializer accepts a plain string, a `{field, dateLevel}` object, and a mixed array of both. All 3 tests pass.
- `WorksheetAgentControllerTest` — unaffected (18 tests pass; no call site passes a non-null `groups` literal for `set_group_aggregate`).
- `./mvnw -pl community/core -am install -DskipTests` succeeds; full module test run: 80/80 passing across the four affected classes.

Companion plugin-side PR: inetsoft-technology/stylebi-wiz#1471 — updates the `set_group_aggregate` tool schema/description to expose `dateLevel` and steers the agent away from the `add_date_range_column` workaround for grouping purposes.

Fixes Redmine #75952.