### PR TITLE
Bug #75935, sync undo/redo state after agent-driven worksheet edits and saves

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/pairing/SheetAgentBroadcastService.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/SheetAgentBroadcastService.java
@@ -32,6 +32,7 @@ import inetsoft.web.composer.ws.command.RefreshWorksheetCommand;
 import inetsoft.web.composer.ws.command.SetWorksheetInfoCommand;
 import inetsoft.web.viewsheet.command.RefreshVSObjectCommand;
 import inetsoft.web.viewsheet.command.SaveSheetCommand;
+import inetsoft.web.viewsheet.command.UpdateUndoStateCommand;
 import inetsoft.web.viewsheet.model.VSObjectModel;
 import inetsoft.web.viewsheet.model.VSObjectModelFactoryService;
 import inetsoft.web.viewsheet.service.CommandDispatcher;
@@ -87,11 +88,13 @@ public class SheetAgentBroadcastService {
 
       if(sheetType == SheetType.VIEWSHEET) {
          broadcastViewsheetRefresh((RuntimeViewsheet) rs, runtimeId, sessionId, user);
+         sendUndoState(rs, runtimeId, sessionId, user);
          return;
       }
 
       Object command = buildCommand(sheetType, rs, owner);
       sendCommand(user, sessionId, runtimeId, command);
+      sendUndoState(rs, runtimeId, sessionId, user);
 
       LOG.info("Pairing broadcast refresh sent (sheetType={}, runtimeId={}, sessionId={})",
                sheetType, runtimeId, sessionId);
@@ -177,6 +180,25 @@ public class SheetAgentBroadcastService {
          .build();
 
       sendCommand(user, sessionId, runtimeId, saveCommand);
+
+      // 3. Sync current/savePoint/points so the Composer's modified indicator clears,
+      // even if this save is the first agent action in the session (no prior refresh).
+      sendUndoState(rs, runtimeId, sessionId, user);
+   }
+
+   /**
+    * Push the runtime's current undo/redo position to the browser so the Composer's
+    * "modified" indicator (current !== savePoint) stays in sync with agent-driven edits,
+    * mirroring what {@code VSLayoutService.makeUndoable()} does for the browser-native
+    * STOMP {@code @Undoable} path.
+    */
+   private void sendUndoState(RuntimeSheet rs, String runtimeId, String sessionId, String user) {
+      UpdateUndoStateCommand command = new UpdateUndoStateCommand();
+      command.setPoints(rs.size());
+      command.setCurrent(rs.getCurrent());
+      command.setSavePoint(rs.getSavePoint());
+      command.setId(rs.getID());
+      sendCommand(user, sessionId, runtimeId, command);
    }
 
    private void sendCommand(String user, String sessionId, String runtimeId, Object command) {

--- a/core/src/test/java/inetsoft/web/wiz/pairing/SheetAgentBroadcastServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/pairing/SheetAgentBroadcastServiceTest.java
@@ -23,6 +23,7 @@ import inetsoft.report.composition.RuntimeWorksheet;
 import inetsoft.uql.viewsheet.TextVSAssembly;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.viewsheet.command.UpdateUndoStateCommand;
 import inetsoft.web.viewsheet.model.VSObjectModel;
 import inetsoft.web.viewsheet.model.VSObjectModelFactoryService;
 import inetsoft.web.viewsheet.service.CommandDispatcher;
@@ -58,11 +59,12 @@ class SheetAgentBroadcastServiceTest {
 
       svc.broadcastRefresh(rs, SheetType.WORKSHEET, "Worksheet/foo-7", owner);
 
+      // One RefreshWorksheetCommand plus one UpdateUndoStateCommand (undo-state sync).
       ArgumentCaptor<MessageHeaders> headersCap = ArgumentCaptor.forClass(MessageHeaders.class);
-      verify(dispatcher).convertAndSendToUser(
+      verify(dispatcher, times(2)).convertAndSendToUser(
          eq("alice~;~host-org"), eq(CommandDispatcher.COMMANDS_TOPIC), any(), headersCap.capture());
 
-      MessageHeaders headers = headersCap.getValue();
+      MessageHeaders headers = headersCap.getAllValues().get(0);
       // session id must match
       assertEquals("stomp-1", SimpMessageHeaderAccessor.getSessionId(headers));
       // RUNTIME_ID_ATTR header set
@@ -114,7 +116,8 @@ class SheetAgentBroadcastServiceTest {
 
       // Only the visible assembly gets a command; the hidden one is skipped.
       verify(modelFactory, times(1)).createModel(any(), eq(rvs));
-      verify(dispatcher, times(1)).convertAndSendToUser(
+      // One RefreshVSObjectCommand plus one UpdateUndoStateCommand (undo-state sync).
+      verify(dispatcher, times(2)).convertAndSendToUser(
          eq("alice~;~host-org"), eq(CommandDispatcher.COMMANDS_TOPIC), any(), any());
    }
 
@@ -130,8 +133,83 @@ class SheetAgentBroadcastServiceTest {
 
       svc.broadcastRefresh(rs, SheetType.WORKSHEET, "Worksheet/foo-7", owner);
 
-      // falls back to owner.getName()
-      verify(dispatcher).convertAndSendToUser(
+      // falls back to owner.getName(); one RefreshWorksheetCommand plus one UpdateUndoStateCommand.
+      verify(dispatcher, times(2)).convertAndSendToUser(
          eq(owner.getName()), eq(CommandDispatcher.COMMANDS_TOPIC), any(), any());
+   }
+
+   @Test
+   void broadcastRefreshSendsUpdateUndoStateCommandWithRuntimeUndoPosition() {
+      CommandDispatcherService dispatcher = mock(CommandDispatcherService.class);
+      SheetAgentBroadcastService svc = new SheetAgentBroadcastService(dispatcher, noopModelFactory());
+
+      RuntimeWorksheet rs = mock(RuntimeWorksheet.class);
+      when(rs.getSocketSessionId()).thenReturn("stomp-1");
+      when(rs.getSocketUserName()).thenReturn("alice~;~host-org");
+      when(rs.size()).thenReturn(4);
+      when(rs.getCurrent()).thenReturn(3);
+      when(rs.getSavePoint()).thenReturn(1);
+      when(rs.getID()).thenReturn("Worksheet/foo-7");
+      Principal owner = TestPrincipals.user("alice", "host-org");
+
+      svc.broadcastRefresh(rs, SheetType.WORKSHEET, "Worksheet/foo-7", owner);
+
+      ArgumentCaptor<Object> commandCap = ArgumentCaptor.forClass(Object.class);
+      verify(dispatcher, times(2)).convertAndSendToUser(
+         eq("alice~;~host-org"), eq(CommandDispatcher.COMMANDS_TOPIC), commandCap.capture(), any());
+
+      Object undoCommand = commandCap.getAllValues().stream()
+         .filter(c -> c instanceof UpdateUndoStateCommand)
+         .findFirst()
+         .orElseThrow(() -> new AssertionError("No UpdateUndoStateCommand was sent"));
+
+      UpdateUndoStateCommand command = (UpdateUndoStateCommand) undoCommand;
+      assertEquals(4, command.getPoints());
+      assertEquals(3, command.getCurrent());
+      assertEquals(1, command.getSavePoint());
+      assertEquals("Worksheet/foo-7", command.getId());
+   }
+
+   @Test
+   void broadcastSaveSendsUpdateUndoStateCommandSoIndicatorClears() {
+      CommandDispatcherService dispatcher = mock(CommandDispatcherService.class);
+      SheetAgentBroadcastService svc = new SheetAgentBroadcastService(dispatcher, noopModelFactory());
+
+      RuntimeWorksheet rs = mock(RuntimeWorksheet.class);
+      when(rs.getSocketSessionId()).thenReturn("stomp-1");
+      when(rs.getSocketUserName()).thenReturn("alice~;~host-org");
+      // All-distinct values so the assertions below can catch a swapped/mis-mapped field —
+      // e.g. current/savePoint would be indistinguishable if stubbed equal.
+      when(rs.size()).thenReturn(6);
+      when(rs.getCurrent()).thenReturn(5);
+      when(rs.getSavePoint()).thenReturn(2);
+      when(rs.getID()).thenReturn("Worksheet/foo-7");
+      inetsoft.uql.asset.AssetEntry entry = mock(inetsoft.uql.asset.AssetEntry.class);
+      when(entry.toView()).thenReturn("foo-7");
+      when(entry.toIdentifier()).thenReturn("1^128^__NULL__^foo-7");
+      when(rs.getEntry()).thenReturn(entry);
+      Principal owner = TestPrincipals.user("alice", "host-org");
+
+      svc.broadcastSave(rs, "Worksheet/foo-7", owner);
+
+      // SetWorksheetInfoCommand + SaveSheetCommand + UpdateUndoStateCommand.
+      ArgumentCaptor<Object> commandCap = ArgumentCaptor.forClass(Object.class);
+      verify(dispatcher, times(3)).convertAndSendToUser(
+         eq("alice~;~host-org"), eq(CommandDispatcher.COMMANDS_TOPIC), commandCap.capture(), any());
+
+      Object undoCommand = commandCap.getAllValues().stream()
+         .filter(c -> c instanceof UpdateUndoStateCommand)
+         .findFirst()
+         .orElseThrow(() -> new AssertionError("No UpdateUndoStateCommand was sent"));
+
+      // Verify each field is forwarded from the runtime as-is (not swapped/dropped). In real
+      // usage the caller sets savePoint == current just before this broadcast, which is what
+      // makes the Composer's isModified() (current !== savePoint) false right after a save —
+      // this test only verifies broadcastSave's forwarding of whatever the runtime reports.
+      UpdateUndoStateCommand command = (UpdateUndoStateCommand) undoCommand;
+      assertEquals(6, command.getPoints());
+      assertEquals(5, command.getCurrent());
+      assertEquals(2, command.getSavePoint());
+      assertEquals("Worksheet/foo-7", command.getId());
    }
 }


### PR DESCRIPTION
## Summary

The `stylebi-worksheet-chat` MCP agent can headlessly edit and save a worksheet that's simultaneously open in a browser Composer tab, by directly manipulating the same live `RuntimeWorksheet`/`RuntimeViewsheet` and pushing STOMP refresh/save commands back to that tab. The Composer's "modified"/unsaved-changes tab indicator did not correctly reflect these agent-driven changes: it never turned on during agent edits, and could incorrectly remain "modified" right after a successful agent-triggered save.

## Root Cause

The Angular Composer's dirty indicator is `current !== savePoint` on the client-side `Sheet` model (`sheet.ts`). Those fields are updated client-side only by an `UpdateUndoStateCommand` STOMP message, which the normal browser-driven edit path sends automatically via an AspectJ advice around `@Undoable` STOMP handlers (`VSLayoutService.makeUndoable()`). The agent/pairing edit path (`WorksheetEditService` → `SheetAgentBroadcastService.broadcastRefresh()`, and `WorksheetAgentController.save()` → `broadcastSave()`) never sent this command, so the client's `current`/`savePoint` fields went stale relative to the server's actual runtime state — never advancing during edits (indicator stays off), and mismatched right after save (indicator turns on incorrectly).

## Fix

Add `SheetAgentBroadcastService.sendUndoState()`, which builds an `UpdateUndoStateCommand` from the runtime's `size()/getCurrent()/getSavePoint()/getID()` — mirroring `VSLayoutService.makeUndoable()`'s construction exactly — and call it after every `broadcastRefresh()` (worksheet and viewsheet branches) and after `broadcastSave()`, so the client's undo-state stays in sync regardless of whether the mutating request came from the browser's own STOMP session or the external agent session.

## Test Plan

- Added/updated unit tests in `SheetAgentBroadcastServiceTest` verifying `UpdateUndoStateCommand` is sent with the correct `points`/`current`/`savePoint`/`id` after both `broadcastRefresh()` and `broadcastSave()`.
- `./mvnw test -pl core -Dtest=SheetAgentBroadcastServiceTest` — 6/6 pass.
- `./mvnw test -pl core -Dtest="inetsoft.web.wiz.**.*Test"` — 782/782 pass (no regressions in the wiz package).
- `./mvnw clean install -pl core -am -DskipTests` — build succeeds.
- Manually verified end-to-end: connected to a live worksheet via `stylebi-worksheet-chat`, made an edit, confirmed the Composer tab's modified indicator turned on immediately; saved via the plugin and confirmed the indicator cleared and stayed cleared.

Fixes Redmine #75935.