### PR TITLE
Bug #75988, fix INETSOFT_ADMIN_PASSWORD not reaching server/scheduler containers

### DIFF
--- a/Troubleshoot.md
+++ b/Troubleshoot.md
@@ -31,13 +31,12 @@ docker compose logs storage
 
 This error most commonly occurs when the `INETSOFT_ADMIN_PASSWORD` environment variable is missing or does not meet the password requirements. This variable sets the password for the "admin" user and is required — there is no default password. The password must be at least 8 characters and include an uppercase letter, a lowercase letter, a digit, and a special character.
 
-To resolve this, set `INETSOFT_ADMIN_PASSWORD` to a valid password before starting the containers, either in the `docker-compose.yaml` file:
+To resolve this, set `INETSOFT_ADMIN_PASSWORD` to a valid password before starting the containers, either in the `docker-compose.yaml` file's shared config (so it reaches the `storage`, `server`, and `scheduler` containers alike):
 
 ```yaml
-storage:
-  environment:
-    # the password for the "admin" user
-    INETSOFT_ADMIN_PASSWORD: "changeme"
+x-shared-config: &sharedenv
+  # the password for the "admin" user
+  INETSOFT_ADMIN_PASSWORD: "changeme"
 ```
 
 or as an environment variable in your shell before running `docker compose up`:

--- a/community-examples/docker-compose.yaml
+++ b/community-examples/docker-compose.yaml
@@ -3,6 +3,9 @@ x-shared-config: &sharedenv
   # the master password used for PBKDF2 encryption of sensitive data
   # (not part of inetsoft.yaml, but required by all containers)
   INETSOFT_MASTER_PASSWORD: "some_arbitrary_token"
+  # the password for the "admin" user - Required: set INETSOFT_ADMIN_PASSWORD in your shell environment before running docker compose.
+  # The password must be at least 8 characters and include uppercase, lowercase, digit, and special character.
+  INETSOFT_ADMIN_PASSWORD: "${INETSOFT_ADMIN_PASSWORD}"
   # the directory used for local plugin storage
   INETSOFTCONFIG_PLUGINDIRECTORY: "/var/lib/inetsoft/plugins"
   # use the MapDB key-value engine
@@ -48,9 +51,6 @@ services:
       - "inetsoft_files:/var/lib/inetsoft/files"
     environment:
       # initialize storage with these properties
-      # the password for the "admin" user - Required: set INETSOFT_ADMIN_PASSWORD in your shell environment before running docker compose.
-      # The password must be at least 8 characters and include uppercase, lowercase, digit, and special character.
-      INETSOFT_ADMIN_PASSWORD: "${INETSOFT_ADMIN_PASSWORD}"
       # set the cluster mode flag, required when using Docker (server.type property)
       INETSOFTENV_SERVER_TYPE: "server_cluster"
       # Additional application properties, like the mail server can be added here


### PR DESCRIPTION
## Summary
- `INETSOFT_ADMIN_PASSWORD` was only set in the `storage` init container's environment in `community-examples/docker-compose.yaml`, so the `server` and `scheduler` containers never received it, causing "Enable Security" to fail even with a compliant password.
- Moved `INETSOFT_ADMIN_PASSWORD` into the `x-shared-config` anchor so it's applied to all containers (storage, server, scheduler) from one place, and removed the now-redundant explicit entry from the `storage` service.

## Test plan
- [x] `docker compose config` validates the compose file with `INETSOFT_ADMIN_PASSWORD` set
- [ ] Manually verify `docker compose up` followed by enabling security in EM succeeds with the shared password