### PR TITLE
Bug #75989, apply the sampled-preview cap per assembly, not worksheet-wide

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/WizUtil.java
+++ b/core/src/main/java/inetsoft/web/wiz/WizUtil.java
@@ -156,6 +156,88 @@ public class WizUtil {
       }
    }
 
+   /**
+    * Infix of the lookup table wiz injects purely to label a foreign key — {@code <source>__fk_<target>}
+    * in fkJoinBatchRewrite. Deliberately does NOT match the join itself ({@code <source>__fkjoin}, no
+    * trailing underscore), which carries the fact rows and must be capped like any other detail table.
+    */
+   private static final String FK_LABEL_LOOKUP_INFIX = "__fk_";
+
+   /**
+    * Applies the sampled-preview row cap to a worksheet's DETAIL tables, leaving any lookup table
+    * injected purely to label a foreign key uncapped. Pass {@code maxRows <= 0} for full data, which
+    * clears a cap left by an earlier sampled render on the same runtime.
+    *
+    * <p>Bug #75989. {@code WorksheetInfo.setDesignMaxRows} is worksheet-WIDE, so it capped every table
+    * assembly independently — including the few-row lookup wiz injects to turn an FK id into a name.
+    * Truncating the lookup side of an INNER join does not sample the facts, it destroys matches: every
+    * fact row whose key was truncated away disappears. Measured on a 984-row table, same binding, only
+    * the cap changed: 8 → <b>0 rows</b>, 12 → 12 rows, 20 → 20 rows; the lookup ({@code projects}) has
+    * 13 rows, which is exactly where the behaviour turns.
+    *
+    * <p>What makes that a defect rather than a rough edge: the injection is only sound BECAUSE the join
+    * is row-preserving — wiz probes for orphans and duplicate target keys before injecting, precisely so
+    * that no unfiltered aggregate changes. A worksheet-wide cap silently voids that precondition. And
+    * because the join is injected automatically, a caller who wrote a single-table worksheet and never
+    * asked for a join could hit it.
+    *
+    * <p>Applying the cap per assembly keeps the documented semantics — "aggregate at most maxRows detail
+    * rows" — while exempting the dimension tables that were never part of the sampled fact stream.
+    */
+   public static void applySampledPreviewCap(inetsoft.uql.asset.Worksheet ws, int maxRows) {
+      if(ws == null) {
+         return;
+      }
+
+      final int cap = Math.max(maxRows, 0);
+
+      // Never worksheet-wide (that is the bug). Cleared unconditionally so a cap set by an earlier
+      // render of this same runtime cannot linger once the caller asks for full data.
+      ws.getWorksheetInfo().setDesignMaxRows(0);
+
+      for(Assembly assembly : ws.getAssemblies()) {
+         if(assembly instanceof inetsoft.uql.asset.TableAssembly table) {
+            final String name = table.getName();
+            table.setMaxRows(name != null && name.contains(FK_LABEL_LOOKUP_INFIX) ? 0 : cap);
+         }
+      }
+   }
+
+   /**
+    * The sampled-preview cap currently in effect on {@code ws}, or 0 for full data.
+    *
+    * Companion to {@link #applySampledPreviewCap} and the reason it exists: the cap can no longer be
+    * read back off {@code designMaxRows}, because it is deliberately never set there any more (#75989).
+    * Two call sites depend on reading it back — the {@code sampled}/{@code sampleMaxRows} flags that tell
+    * the caller its Sum/Count is approximate, and the lazy re-fetch path that must keep a sampled render
+    * sampled. Left reading designMaxRows, the first silently claimed a sampled chart was full data and
+    * the second silently promoted it to full data.
+    *
+    * Reads the DETAIL tables only, mirroring how the cap is applied: an injected FK-label lookup is
+    * intentionally uncapped, so including it would always report 0.
+    */
+   public static int sampledPreviewCap(inetsoft.uql.asset.Worksheet ws) {
+      if(ws == null) {
+         return 0;
+      }
+
+      int cap = 0;
+
+      for(Assembly assembly : ws.getAssemblies()) {
+         if(assembly instanceof inetsoft.uql.asset.TableAssembly table) {
+            final String name = table.getName();
+
+            if(name != null && name.contains(FK_LABEL_LOOKUP_INFIX)) {
+               continue;
+            }
+
+            cap = Math.max(cap, table.getMaxRows());
+         }
+      }
+
+      return cap;
+   }
+
    public static final String ANNOTATION_RAW_DATA_MAX_ROW = "annotation.rawdata.maxrow";
 
    private static final Logger LOG = LoggerFactory.getLogger(WizUtil.class);

--- a/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
@@ -31,6 +31,7 @@ import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.util.Catalog;
 import inetsoft.util.Tool;
+import inetsoft.web.wiz.WizUtil;
 import inetsoft.web.wiz.model.CloseViewsheetRequest;
 import inetsoft.web.wiz.model.OpenViewsheetResult;
 import inetsoft.web.wiz.model.VerifyViewsheetResult;
@@ -153,7 +154,9 @@ public class ViewsheetRuntimeController {
                ? rvs.getViewsheet().getBaseWorksheet() : null;
 
             if(bws != null) {
-               bws.getWorksheetInfo().setDesignMaxRows(sampleMaxRows);
+               // #75989: per-assembly, so the cap never truncates an injected FK-label lookup and
+               // destroys the join matches it exists to preserve.
+               WizUtil.applySampledPreviewCap(bws, sampleMaxRows);
                rvs.getViewsheetSandbox().ifPresent(box -> {
                   box.cancelAllQueries();
 
@@ -244,7 +247,9 @@ public class ViewsheetRuntimeController {
                var bws = rvs.getViewsheet() != null ? rvs.getViewsheet().getBaseWorksheet() : null;
 
                if(bws != null) {
-                  bws.getWorksheetInfo().setDesignMaxRows(sampleMaxRows);
+                  // #75989: see applySampledPreviewCap — a worksheet-wide cap here reported a perfectly
+                  // good saved chart as rendering NO data, i.e. as a broken save.
+                  WizUtil.applySampledPreviewCap(bws, sampleMaxRows);
                }
             }
             catch(Exception ex) {

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -1850,7 +1850,11 @@ public class WizVsService {
       var bws = rvs.getViewsheet() != null ? rvs.getViewsheet().getBaseWorksheet() : null;
 
       if(bws != null) {
-         bws.getWorksheetInfo().setDesignMaxRows(Math.max(sampleMaxRows, 0));
+         // #75989: per-assembly rather than worksheet-wide. A worksheet-wide cap also truncated the
+         // few-row lookup wiz injects to label an FK, destroying the INNER join's matches — a cap of 8
+         // returned 0 rows from a 984-row table. applySampledPreviewCap also clears a previous render's
+         // cap when sampleMaxRows <= 0, which is what the full-data path relies on.
+         WizUtil.applySampledPreviewCap(bws, sampleMaxRows);
 
          try {
             box.resetDataMap(assembly.getName());
@@ -1900,7 +1904,9 @@ public class WizVsService {
       // #75456: preserve the current data-mode on this lazy re-fetch path — pass the design-max
       // already set on the source worksheet (no-op for full; keeps sampled mode sampled).
       var fetchWs = vs.getBaseWorksheet();
-      int curMax = fetchWs != null ? fetchWs.getWorksheetInfo().getDesignMaxRows() : 0;
+      // #75989: read the cap back from the assemblies, not designMaxRows — the cap is applied per
+      // assembly now, so reading designMaxRows here would silently promote a sampled render to full data.
+      int curMax = WizUtil.sampledPreviewCap(fetchWs);
       CreateViewsheetResult result = executeAndExtract(rvs, assembly, curMax);
 
       if(result != null) {
@@ -2188,7 +2194,9 @@ public class WizVsService {
          // worksheet design-max to 0 (unlimited) -> no flag. Best-effort; absence just means no warning.
          try {
             var bws = rvs.getViewsheet() != null ? rvs.getViewsheet().getBaseWorksheet() : null;
-            int dmax = bws != null ? bws.getWorksheetInfo().getDesignMaxRows() : 0;
+            // #75989: same reason — designMaxRows is no longer where the cap lives, and reading it
+            // here reported a sampled 8-of-984-row chart as full data with no approximate-totals warning.
+            int dmax = WizUtil.sampledPreviewCap(bws);
 
             if(dmax > 0) {
                result.setSampled(true);

--- a/core/src/test/java/inetsoft/web/wiz/WizUtilSampledPreviewCapTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/WizUtilSampledPreviewCapTest.java
@@ -1,0 +1,157 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz;
+
+import inetsoft.uql.asset.PhysicalBoundTableAssembly;
+import inetsoft.uql.asset.TableAssembly;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Bug #75989. The sampled-preview cap used to be set worksheet-WIDE
+ * ({@code WorksheetInfo.setDesignMaxRows}), which capped every table assembly independently —
+ * including the few-row lookup wiz injects to label a foreign key. Truncating the lookup side of that
+ * INNER join destroys matches rather than sampling facts: measured on a 984-row table, a cap of 8
+ * returned ZERO rows while the same binding at cap 20 returned 20.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WizUtilSampledPreviewCapTest {
+   @Test
+   void capsTheFactTableAndTheJoinButNotTheInjectedLookup() {
+      Worksheet ws = worksheetWithFkLabelJoin();
+
+      WizUtil.applySampledPreviewCap(ws, 8);
+
+      // The fact table and the join carry the sampled rows, so both are capped...
+      assertEquals(8, table(ws, "work_packages").getMaxRows());
+      assertEquals(8, table(ws, "work_packages__fkjoin").getMaxRows());
+      // ...but the injected lookup is a dimension table, never part of the sampled fact stream.
+      assertEquals(0, table(ws, "work_packages__fk_projects").getMaxRows(),
+                   "an injected FK-label lookup must stay uncapped, or the join loses matches");
+      // And never worksheet-wide — that is the defect itself.
+      assertEquals(0, ws.getWorksheetInfo().getDesignMaxRows());
+   }
+
+   @Test
+   void clearsAPreviousCapWhenTheCallerAsksForFullData() {
+      // Same runtime is re-rendered repeatedly (WizVsService), so a lingering cap would silently make
+      // "full data" partial.
+      Worksheet ws = worksheetWithFkLabelJoin();
+      WizUtil.applySampledPreviewCap(ws, 8);
+
+      WizUtil.applySampledPreviewCap(ws, 0);
+
+      assertEquals(0, table(ws, "work_packages").getMaxRows());
+      assertEquals(0, table(ws, "work_packages__fkjoin").getMaxRows());
+      assertEquals(0, table(ws, "work_packages__fk_projects").getMaxRows());
+      assertEquals(0, ws.getWorksheetInfo().getDesignMaxRows());
+   }
+
+   @Test
+   void treatsANegativeCapAsFullDataRatherThanAnInvalidRowLimit() {
+      Worksheet ws = worksheetWithFkLabelJoin();
+
+      WizUtil.applySampledPreviewCap(ws, -5);
+
+      assertEquals(0, table(ws, "work_packages").getMaxRows());
+   }
+
+   @Test
+   void doesNotConfuseTheJoinItselfWithTheLookup() {
+      // "__fkjoin" has no trailing underscore, so it must NOT match the "__fk_" lookup infix — the join
+      // is where the fact rows are and has to be capped like any other detail table.
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(new PhysicalBoundTableAssembly(ws, "orders__fkjoin"));
+
+      WizUtil.applySampledPreviewCap(ws, 25);
+
+      assertEquals(25, table(ws, "orders__fkjoin").getMaxRows());
+   }
+
+   // The cap has to be READABLE again afterwards, and that is not cosmetic: the sampled/sampleMaxRows
+   // flags (which tell the caller its Sum/Count is approximate) and the lazy re-fetch path both read it
+   // back. Left reading designMaxRows, a live 8-of-984-row sample reported itself as full data with no
+   // warning at all — caught only by running it, since the caps themselves were set correctly.
+   @Test
+   void reportsTheCapBackSoSampledStaysSampled() {
+      Worksheet ws = worksheetWithFkLabelJoin();
+
+      WizUtil.applySampledPreviewCap(ws, 8);
+
+      assertEquals(8, WizUtil.sampledPreviewCap(ws));
+   }
+
+   @Test
+   void reportsZeroOnFullDataAndAfterAPreviousCapIsCleared() {
+      Worksheet ws = worksheetWithFkLabelJoin();
+      assertEquals(0, WizUtil.sampledPreviewCap(ws));
+
+      WizUtil.applySampledPreviewCap(ws, 8);
+      WizUtil.applySampledPreviewCap(ws, 0);
+
+      assertEquals(0, WizUtil.sampledPreviewCap(ws));
+   }
+
+   @Test
+   void readsTheCapFromDetailTablesRatherThanTheUncappedLookup() {
+      // The lookup is deliberately left at 0, so a reader that included it would always report 0 —
+      // i.e. "not sampled" — no matter what cap was requested.
+      Worksheet ws = worksheetWithFkLabelJoin();
+
+      WizUtil.applySampledPreviewCap(ws, 12);
+
+      assertEquals(0, table(ws, "work_packages__fk_projects").getMaxRows());
+      assertEquals(12, WizUtil.sampledPreviewCap(ws));
+   }
+
+   @Test
+   void toleratesANullWorksheet() {
+      assertDoesNotThrow(() -> WizUtil.applySampledPreviewCap(null, 8));
+      assertEquals(0, WizUtil.sampledPreviewCap(null));
+   }
+
+   /** A single-table worksheet after FK-label injection: fact table, injected lookup, and the join. */
+   private static Worksheet worksheetWithFkLabelJoin() {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(new PhysicalBoundTableAssembly(ws, "work_packages"));
+      ws.addAssembly(new PhysicalBoundTableAssembly(ws, "work_packages__fk_projects"));
+      ws.addAssembly(new PhysicalBoundTableAssembly(ws, "work_packages__fkjoin"));
+      return ws;
+   }
+
+   private static TableAssembly table(Worksheet ws, String name) {
+      TableAssembly table = (TableAssembly) ws.getAssembly(name);
+      assertNotNull(table, "test fixture is missing assembly " + name);
+      return table;
+   }
+}


### PR DESCRIPTION
Fixes Redmine **#75989**.

## The symptom

`create_viewsheet` with `sampleMaxRows: 8` returned **0 rows** (`hasData: false`) from a 984-row table,
on a binding that was completely valid — and the caller was told *"No data for this binding"*, i.e. the
failure was attributed to the binding rather than to sampling.

## Why

`WorksheetInfo.setDesignMaxRows` is worksheet-**wide**, so it capped every table assembly
independently — including the few-row lookup wiz injects to turn an FK id into a name. Truncating the
lookup side of that **INNER** join doesn't sample the facts, it **destroys matches**: every fact row
whose key was truncated away disappears.

Same worksheet, same binding, only the cap changed:

| cap | result |
|---|---|
| 8 | **0 rows** |
| 12 | 12 rows |
| 20 | 20 rows |

`projects` has **13 rows** — exactly where the behaviour turns. Two controls isolate it: a
**single-table** worksheet at cap 8 returns 8 rows, and a **different binding** on the same joined
worksheet fails identically at cap 8. So it is neither the cap value nor the bound columns.

**What makes it a defect rather than a rough edge:** the injection is only sound *because* the join is
row-preserving — `fkJoinBatchRewrite` probes for orphans and duplicate target keys before injecting,
precisely so no unfiltered aggregate changes. A worksheet-wide cap silently voids that precondition.
And the join is injected **automatically**, so a caller who wrote a single-table worksheet and never
asked for a join can hit it.

## The change

`WizUtil.applySampledPreviewCap(ws, maxRows)` applies the cap **per assembly**, leaving an injected
FK-label lookup uncapped — it's a dimension table, never part of the sampled fact stream. The
documented semantics ("aggregate at most `maxRows` detail rows") are preserved for the fact table and
the join. Used at all **three** sites that set the cap: viewsheet open, verify, and render.

Two details that carry the correctness:

- **It clears the cap when `maxRows <= 0`.** `WizVsService` re-renders the same runtime repeatedly, so a
  lingering per-assembly cap would silently make a later "full data" render partial.
- **`WizUtil.sampledPreviewCap(ws)` reads the cap back**, because two call sites read it off
  `designMaxRows` and would otherwise both break *silently*: the `sampled`/`sampleMaxRows` flags that
  tell the caller its Sum/Count is approximate, and the lazy re-fetch path that must keep a sampled
  render sampled. My first build shipped without this and a live 8-of-984-row sample reported itself as
  **full data with no approximate-totals warning at any layer** — invisible to the unit tests, because
  the caps themselves were set correctly. Caught only by running it.

`__fk_` deliberately does not match `__fkjoin` (no trailing underscore): the join carries the fact rows
and must be capped like any other detail table. Pinned by a test, since it's the easy thing to break.

## Verification

8 unit tests (`WizUtilSampledPreviewCapTest`), and live on a locally built image (`local-1168`) against
openproject:

| case | result |
|---|---|
| cap 8, FK-joined ws | 7 buckets totalling **8 rows**, `sampled: true`, `sampleMaxRows: 8`, `approximate_totals` present — **was 0 rows** |
| full data, same ws | 19 buckets, total **984**, no sampled flag — **unchanged** |
| cap 8, single table | 8 rows — **unchanged** |

## Scope

This fixes the lookups **wiz injects**. A user-authored join has the same underlying hazard — capping
any input side of a join corrupts matches — and the general fix (cap the join *output* rather than its
inputs) is a larger semantic change I have not attempted here. Noted on #75989 so it isn't lost.

The plugin-side counterpart (stylebi-wiz #1473) fixed only the *misattribution*: the messages now name
the cap and the lookup-join mechanism instead of blaming the binding. This is the actual repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)