### PR TITLE
Bug #75972, guard updateColumnRange against uninitialized columnRightPositions

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/table/preview-table.component.interaction.tl.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/table/preview-table.component.interaction.tl.spec.ts
@@ -162,6 +162,18 @@ describe("Group 4 — horizontalScroll / resizeListener", () => {
       // horizontalDist = clientWidth + scrollLeft
       expect((comp as any).horizontalDist).toBe(480);
    });
+
+   it("resizeListener should not throw when a window:resize fires before tableData has ever been set", () => {
+      // 🔁 Regression: the "Show detail" dialog registers @HostListener("window:resize") as soon
+      // as the component is constructed, but columnRightPositions stays undefined until the first
+      // LoadTableDataCommand response runs through the tableData setter. A resize event racing
+      // ahead of that response (e.g. the dialog's open animation) used to throw inside
+      // BinarySearch.numbers(undefined).ceiling() — "Cannot read properties of undefined (reading
+      // 'length')" — even though the table went on to render correctly once data arrived.
+      const { comp } = createPreviewComponent({ skipInitialTableData: true });
+      expect((comp as any).columnRightPositions).toBeUndefined();
+      expect(() => comp.resizeListener()).not.toThrow();
+   });
 });
 
 // ── Group 5 — resizeEnd: HTTP PUT ─────────────────────────────────────────────

--- a/web/projects/portal/src/app/vsobjects/objects/table/preview-table.component.interaction.tl.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/table/preview-table.component.interaction.tl.spec.ts
@@ -174,6 +174,16 @@ describe("Group 4 — horizontalScroll / resizeListener", () => {
       expect((comp as any).columnRightPositions).toBeUndefined();
       expect(() => comp.resizeListener()).not.toThrow();
    });
+
+   it("startResize should not throw and should not register window listeners when columnRightPositions is not yet initialized", () => {
+      // 🔁 Regression: startResize() indexes columnRightPositions[index] the same way
+      // updateColumnRange() indexed it before the fix above — guard it the same way.
+      const { comp, renderer } = createPreviewComponent({ skipInitialTableData: true });
+      expect(() =>
+         comp.startResize({ preventDefault: vi.fn() } as any, 0)
+      ).not.toThrow();
+      expect(renderer.listen).not.toHaveBeenCalled();
+   });
 });
 
 // ── Group 5 — resizeEnd: HTTP PUT ─────────────────────────────────────────────

--- a/web/projects/portal/src/app/vsobjects/objects/table/preview-table.component.test-helpers.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/table/preview-table.component.test-helpers.ts
@@ -95,6 +95,10 @@ export interface PreviewTableTestOverrides {
    hostElement?: any;
    /** Initial tableData — defaults to makeTableData(2,3) */
    tableData?: BaseTableCellModel[][];
+   /** Skip the initial `comp.tableData = data` assignment, leaving columnRightPositions/
+    *  _columnWidths uninitialized — reproduces the window still open before the first
+    *  LoadTableDataCommand response has been applied. */
+   skipInitialTableData?: boolean;
 }
 
 // ── Component factory ─────────────────────────────────────────────────────────
@@ -201,8 +205,10 @@ export function createPreviewComponent(overrides: PreviewTableTestOverrides = {}
    (comp as any).dropdowns = { forEach: vi.fn() };
 
    // Trigger tableData setter — requires previewContainer to already be set
-   const data = overrides.tableData ?? makeTableData(2, 3);
-   comp.tableData = data;
+   if(!overrides.skipInitialTableData) {
+      const data = overrides.tableData ?? makeTableData(2, 3);
+      comp.tableData = data;
+   }
 
    return { comp, renderer, hyperlinkService, contextProvider, dropdownService, modelService, changeRef, hostElement, previewContainerEl };
 }

--- a/web/projects/portal/src/app/vsobjects/objects/table/preview-table.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/table/preview-table.component.ts
@@ -120,7 +120,8 @@ export class PreviewTableComponent implements OnDestroy, AfterViewChecked, After
    tableHeight: number;
    scrollY: number = 0;
    horizontalDist = 0;
-   columnRightPositions: number[];
+   // undefined until the first tableData response runs through initColumnWidths()/updateWidths()
+   columnRightPositions: number[] | undefined;
    columnIndexRange: Range;
    leftOfColRangeWidth: number;
    rightOfColRangeWidth: number;
@@ -375,6 +376,13 @@ export class PreviewTableComponent implements OnDestroy, AfterViewChecked, After
    }
 
    startResize(event: MouseEvent, index: number) {
+      if(this.columnRightPositions == null) {
+         // Columns haven't been initialized yet (no tableData response applied) — there is
+         // no resize handle to render at this point, but guard anyway since this shares the
+         // same "not yet initialized" hazard as updateColumnRange().
+         return;
+      }
+
       event.preventDefault();
       this.windowListeners = [
          this.renderer.listen("window", "mousemove", (e) => this.resizeMove(e)),

--- a/web/projects/portal/src/app/vsobjects/objects/table/preview-table.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/table/preview-table.component.ts
@@ -484,6 +484,13 @@ export class PreviewTableComponent implements OnDestroy, AfterViewChecked, After
    }
 
    private updateColumnRange(): void {
+      if(this.columnRightPositions == null) {
+         // Not yet initialized — e.g. a window:resize fired before the first tableData
+         // response ran through initColumnWidths()/updateWidths(). Nothing to range yet;
+         // updateWidths() will call this again once column widths are computed.
+         return;
+      }
+
       const leftViewBound = this.previewContainer.nativeElement.scrollLeft;
       const rightViewBound = leftViewBound + this.previewContainer.nativeElement.clientWidth;
       const search = BinarySearch.numbers(this.columnRightPositions);


### PR DESCRIPTION
## Summary
- Repro: build a crosstab, click a cell, click **Show Details** — the browser console throws `TypeError: Cannot read properties of undefined (reading 'length')` at `ceiling` → `updateColumnRange` → `horizontalScroll`, even though the detail table still renders correctly.
- Root cause: `PreviewTableComponent` (the Show Details table) registers `@HostListener("window:resize")` in the constructor, but `columnRightPositions` is only populated later, inside `initColumnWidths()`/`updateWidths()`, once the first `tableData` response arrives. If a `resize` event fires in that window (e.g. from the dialog's open animation), `horizontalScroll() -> updateColumnRange()` calls `BinarySearch.numbers(this.columnRightPositions).ceiling(...)` with `columnRightPositions` still `undefined`, and `ceiling()` throws reading `.length` on it.
- Fix: `updateColumnRange()` now returns early when `columnRightPositions` hasn't been computed yet. `updateWidths()` already re-invokes `updateColumnRange()` (via `setTimeout`) once column widths are known, so behavior once data loads is unchanged.

## Test plan
- [x] Added a regression test in `preview-table.component.interaction.tl.spec.ts` (Group 4) that constructs the component without ever setting `tableData` (new `skipInitialTableData` test-helper option) and calls `resizeListener()` — reproduces the exact `TypeError` before the fix, passes after.
- [x] `ng run portal:test-tl --include=".../preview-table.component.{interaction,risk,display}.tl.spec.ts"` — 89/89 passing.