### PR TITLE
fix(wiz): rebuild the wizard temp chart when a type change targets another chart

### DIFF
--- a/core/src/main/java/inetsoft/web/vswizard/model/recommender/VSTemporaryInfo.java
+++ b/core/src/main/java/inetsoft/web/vswizard/model/recommender/VSTemporaryInfo.java
@@ -187,6 +187,27 @@ public class VSTemporaryInfo implements Cloneable, Serializable, XMLSerializable
    }
 
    /**
+    * The output-viewsheet assembly this temp chart currently mirrors, or null when that is unknown.
+    *
+    * <p>Only the wiz (AI) path writes this. A wiz conversation reuses ONE recommendation runtime, and
+    * every autoBinding call re-initializes the temp chart from whichever chart it is building — so the
+    * temp chart, and the recommendation model generated from it, describe exactly one of the session's
+    * charts at a time. When a later call targets a DIFFERENT chart (the user edits an earlier history
+    * card), both are stale for that target and must be rebuilt from it; this name is how that is
+    * detected. See {@code WizAutoBindingService.changeType}.
+    *
+    * <p>Survives {@code initTemporary}, which reuses a non-destroyed VSTemporaryInfo — so every path
+    * that re-seeds the temp chart must overwrite it rather than rely on the re-init to clear it.
+    */
+   public String getWizSourceAssemblyName() {
+      return wizSourceAssemblyName;
+   }
+
+   public void setWizSourceAssemblyName(String wizSourceAssemblyName) {
+      this.wizSourceAssemblyName = wizSourceAssemblyName;
+   }
+
+   /**
     * Getter for wizard previewPaneSize.
     */
    public Dimension getPreviewPaneSize() {
@@ -204,6 +225,7 @@ public class VSTemporaryInfo implements Cloneable, Serializable, XMLSerializable
       destroyed = true;
       position = null;
       description = null;
+      wizSourceAssemblyName = null;
       tempChart = null;
       originalModel = null;
       recommendationModel = null;
@@ -288,6 +310,7 @@ public class VSTemporaryInfo implements Cloneable, Serializable, XMLSerializable
       }
 
       clone.description = description;
+      clone.wizSourceAssemblyName = wizSourceAssemblyName;
       clone.recommendationModel = (VSRecommendationModel) Tool.clone(recommendationModel);
       clone.originalModel = (VSWizardOriginalModel) Tool.clone(originalModel);
 
@@ -385,6 +408,10 @@ public class VSTemporaryInfo implements Cloneable, Serializable, XMLSerializable
 
       if(description != null) {
          writer.print(" description=\"" + description + "\"");
+      }
+
+      if(wizSourceAssemblyName != null) {
+         writer.print(" wizSourceAssemblyName=\"" + wizSourceAssemblyName + "\"");
       }
 
       if(selectedType != null) {
@@ -498,6 +525,7 @@ public class VSTemporaryInfo implements Cloneable, Serializable, XMLSerializable
       }
 
       description = Tool.getAttribute(elem, "description");
+      wizSourceAssemblyName = Tool.getAttribute(elem, "wizSourceAssemblyName");
       autoOrder = "true".equalsIgnoreCase(Tool.getAttribute(elem, "autoOrder"));
       showLegend = "true".equalsIgnoreCase(Tool.getAttribute(elem, "showLegend"));
       destroyed = "true".equalsIgnoreCase(Tool.getAttribute(elem, "destroyed"));
@@ -570,6 +598,7 @@ public class VSTemporaryInfo implements Cloneable, Serializable, XMLSerializable
    private Point position;
    private Dimension previewPaneSize;
    private String description;
+   private String wizSourceAssemblyName;
    private VSRecommendationModel recommendationModel;
    private VSWizardOriginalModel originalModel;
    private ChartVSAssembly tempChart;

--- a/core/src/main/java/inetsoft/web/vswizard/model/recommender/VSTemporaryInfo.java
+++ b/core/src/main/java/inetsoft/web/vswizard/model/recommender/VSTemporaryInfo.java
@@ -411,7 +411,10 @@ public class VSTemporaryInfo implements Cloneable, Serializable, XMLSerializable
       }
 
       if(wizSourceAssemblyName != null) {
-         writer.print(" wizSourceAssemblyName=\"" + wizSourceAssemblyName + "\"");
+         // Escaped, unlike the attributes around it: assembly names are generated identifiers today, but
+         // an unescaped attribute is only safe for as long as that stays true, and Tool.escape paired
+         // with Tool.getAttribute is what the rest of the XMLSerializable assembly infos do.
+         writer.print(" wizSourceAssemblyName=\"" + Tool.escape(wizSourceAssemblyName) + "\"");
       }
 
       if(selectedType != null) {

--- a/core/src/main/java/inetsoft/web/wiz/BindingFieldSettings.java
+++ b/core/src/main/java/inetsoft/web/wiz/BindingFieldSettings.java
@@ -108,6 +108,47 @@ public final class BindingFieldSettings {
    }
 
    /**
+    * The set of columns an assembly binds, keyed exactly as {@link #record}/{@link #restore} pair refs.
+    *
+    * <p>Used to decide whether a wizard temp chart still describes the assembly a call is about. Column
+    * identity is the right granularity for that question and the SETTINGS are not: a recommendation
+    * candidate carries per-type values the temp chart never had (the `order` and date level the
+    * recommender picked — the very reason {@code restore} copies only what the source carries), so
+    * comparing settings would report a difference after every ordinary autoBinding and force a rebuild
+    * every time. The candidate's refs, by contrast, are CLONES of the temp chart's, so equal column
+    * sets is a reliable "same binding" test.
+    *
+    * <p>Slot-agnostic on purpose — {@link #refsOf} flattens x/y and the aesthetics together, and a
+    * chart-type change is precisely a change of slot placement.
+    */
+   public static Set<String> columnKeys(VSAssembly assembly) {
+      return columnKeys(refsOf(assembly));
+   }
+
+   /**
+    * {@link #columnKeys(VSAssembly)} over refs already in hand — for a caller holding a
+    * {@link #snapshot}, whose keys must be read BEFORE a mutation (the pre-aggregation push rewrites
+    * the assembly's refs to the pushed columns) rather than off the live assembly.
+    */
+   public static Set<String> columnKeys(DataRef[] refs) {
+      if(refs == null) {
+         return Collections.emptySet();
+      }
+
+      Set<String> keys = new HashSet<>();
+
+      for(DataRef ref : refs) {
+         String key = fieldKey(ref);
+
+         if(key != null && !key.isEmpty()) {
+            keys.add(key);
+         }
+      }
+
+      return keys;
+   }
+
+   /**
     * RESTORE onto a freshly-rebuilt assembly: copies only the settings the source actually carries.
     *
     * <p>A default-valued source must not overwrite the ordering or date level the recommender chose for

--- a/core/src/main/java/inetsoft/web/wiz/model/AutoBindingRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/AutoBindingRequest.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.wiz.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.util.List;
@@ -187,15 +188,22 @@ public class AutoBindingRequest {
     * Carry the displaced assembly's pre-condition onto the freshly-bound one — forwarded straight to
     * {@link inetsoft.web.wiz.model.CreateVisualizationModel#isKeepCondition()}.
     *
-    * <p>Server-side only, never on the wire: the sole caller is {@code changeType}'s rebuild branch,
-    * which replaces a chart the user already filtered and so must keep that filter, exactly as the
-    * fast path does. A plain {@code /viewsheet/autoBinding} request is a (re)bind, not a type switch,
-    * and leaves this false — its own condition handling goes through {@code syncConfigs}.
+    * <p>Server-side only: the sole caller is {@code changeType}'s rebuild branch, which replaces a chart
+    * the user already filtered and so must keep that filter, exactly as the fast path does. A plain
+    * {@code /viewsheet/autoBinding} request is a (re)bind, not a type switch, and leaves this false — its
+    * own condition handling goes through {@code syncConfigs}.
+    *
+    * <p>{@code @JsonIgnore}, not merely {@code transient}: Jackson binds through the setter and ignores
+    * the field's transient marker unless {@code MapperFeature.PROPAGATE_TRANSIENT_MARKER} is on, which it
+    * is not here — so without the annotation a raw request body could set this and silently carry a
+    * filter onto a rebind that asked for none.
     */
+   @JsonIgnore
    public boolean isKeepCondition() {
       return keepCondition;
    }
 
+   @JsonIgnore
    public void setKeepCondition(boolean keepCondition) {
       this.keepCondition = keepCondition;
    }

--- a/core/src/main/java/inetsoft/web/wiz/model/AutoBindingRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/AutoBindingRequest.java
@@ -184,6 +184,23 @@ public class AutoBindingRequest {
    }
 
    /**
+    * Carry the displaced assembly's pre-condition onto the freshly-bound one — forwarded straight to
+    * {@link inetsoft.web.wiz.model.CreateVisualizationModel#isKeepCondition()}.
+    *
+    * <p>Server-side only, never on the wire: the sole caller is {@code changeType}'s rebuild branch,
+    * which replaces a chart the user already filtered and so must keep that filter, exactly as the
+    * fast path does. A plain {@code /viewsheet/autoBinding} request is a (re)bind, not a type switch,
+    * and leaves this false — its own condition handling goes through {@code syncConfigs}.
+    */
+   public boolean isKeepCondition() {
+      return keepCondition;
+   }
+
+   public void setKeepCondition(boolean keepCondition) {
+      this.keepCondition = keepCondition;
+   }
+
+   /**
     * Recommendation-computation RVS ID. Null on first call; returned by the server
     * and passed back on subsequent calls to reuse the same RVS.
     */
@@ -217,4 +234,5 @@ public class AutoBindingRequest {
    private boolean copy;
    private String assemblyName;
    private boolean syncConfigs;
+   private transient boolean keepCondition;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/CreateVisualizationModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/CreateVisualizationModel.java
@@ -18,6 +18,7 @@
 
 package inetsoft.web.wiz.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import inetsoft.uql.viewsheet.VSAssembly;
 
@@ -75,10 +76,21 @@ public class CreateVisualizationModel {
       this.primaryAssembly = primaryAssembly;
    }
 
+   /**
+    * Carry the displaced chart's pre-condition onto the new one, so a type change does not drop the
+    * user's filter. Set only by {@code WizAutoBindingService.changeType} (both branches).
+    *
+    * <p>{@code @JsonIgnore}, not merely {@code transient}: Jackson binds through the setter and ignores
+    * the field's transient marker unless {@code MapperFeature.PROPAGATE_TRANSIENT_MARKER} is on, which it
+    * is not here — so without the annotation a raw request body could set this and silently carry a
+    * filter onto a create that asked for none.
+    */
+   @JsonIgnore
    public boolean isKeepCondition() {
       return keepCondition;
    }
 
+   @JsonIgnore
    public void setKeepCondition(boolean keepCondition) {
       this.keepCondition = keepCondition;
    }
@@ -100,9 +112,9 @@ public class CreateVisualizationModel {
     *       replaced (the UI-click flow leaves this false to keep its existing delete-and-replace
     *       behavior).</li>
     * </ul>
-    * Default false (in-place / delete-and-replace, the existing behavior) in both paths. Not
-    * consulted by the standard path when {@link #getAssemblyName()} names an assembly to replace —
-    * see that field's javadoc.
+    * Default false (in-place / delete-and-replace, the existing behavior) in both paths. In the standard
+    * path this is also what decides whether a named {@link #getAssemblyName()} is REPLACED or merely
+    * named as the chart to build from — see that field's javadoc.
     */
    public boolean isCopy() {
       return copy;

--- a/core/src/main/java/inetsoft/web/wiz/model/CreateVisualizationModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/CreateVisualizationModel.java
@@ -163,12 +163,14 @@ public class CreateVisualizationModel {
     *       applied to, or duplicated from when {@link #isCopy()}). Without it, a filter built
     *       against an earlier chart's fields lands on a different chart, which at best filters the
     *       wrong chart and at worst references columns that chart does not bind.</li>
-    *   <li>Standard create/rebind path — the chart to REPLACE in place: the new assembly is added
-    *       under this same name with the old one's exact primary state carried over, and no other
-    *       assembly's primary flag is touched. Used for changeType on a non-current (historical)
-    *       card. {@link #isCopy()} is not consulted in this mode (see
-    *       {@code createViewsheetInternal}): replacing one specific historical card by name should
-    *       not also duplicate it.</li>
+    *   <li>Standard create/rebind path — the chart this call is ABOUT: the binding it rebuilds from,
+    *       and, when {@link #isCopy()} is false, the chart to REPLACE in place (the new assembly is
+    *       added under this same name with the old one's exact primary state carried over, and no
+    *       other assembly's primary flag is touched). With {@link #isCopy()} true the named chart is
+    *       kept as history and the result lands in a new assembly, exactly as it would with no name —
+    *       the name still matters, because it says which chart's binding and pre-condition to carry.
+    *       A click on a card's own chart-type menu is the former, a chat turn about that card the
+    *       latter.</li>
     * </ul>
     */
    public String getAssemblyName() {

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -339,6 +339,9 @@ public class WizAutoBindingService {
             vsModel.setCopy(request.isCopy());
             vsModel.setAssemblyName(request.getAssemblyName());
             vsModel.setSyncConfigs(request.isSyncConfigs());
+            // Only changeType's rebuild branch sets this — a chart it replaces may carry a filter the
+            // user must not lose to a type switch. See AutoBindingRequest.isKeepCondition().
+            vsModel.setKeepCondition(request.isKeepCondition());
 
             WizVsService.PostAssemblyHook hook = (wizRvs, asm) -> {
                if(asm instanceof ChartVSAssembly) {
@@ -368,6 +371,14 @@ public class WizAutoBindingService {
                                       explicitBindings, entries);
             }
          }
+
+         // The temp chart, and the recommendation model generated from it, now describe THIS assembly.
+         // Recording which one lets a later changeType aimed at a DIFFERENT chart (an earlier history
+         // card) see that both are stale for its target and rebuild them from it, instead of silently
+         // rendering this chart's binding under that card's name. Cleared when nothing was placed — a
+         // leftover name must never be mistaken for a match, and initTemporary reuses this object.
+         tempInfo.setWizSourceAssemblyName(
+            visualizationResult == null ? null : visualizationResult.getAssemblyName());
 
          // Phase 4: build response.
          RecommendedVisualization primary = recommendationToVisualization(selectedRec, entries, worksheetId);
@@ -599,6 +610,88 @@ public class WizAutoBindingService {
 
       BindingFieldSettings.restore(
          BindingFieldSettings.refsOf(tempChart), BindingFieldSettings.refsOf(assembly));
+   }
+
+   /**
+    * Whether the temp chart in {@code tempInfo} — and so the recommendation model generated from it —
+    * still describes {@code target}.
+    *
+    * <p>Two independent checks, both needed:
+    * <ul>
+    *   <li>the recorded source name, because two charts can bind the same columns and differ only in
+    *       their settings (one carries a top-3, the other does not);</li>
+    *   <li>the bound columns, because an explicit re-bind ({@code /viewsheet/create} with a config) can
+    *       add or drop a column without going through autoBinding at all — the temp chart is then stale
+    *       for a chart whose name it legitimately carries.</li>
+    * </ul>
+    *
+    * <p>Returns true when it cannot tell (no temp info, no temp chart, no target). "Cannot tell" must
+    * degrade to the pre-existing fast path rather than force a rebuild off state we were unable to read.
+    */
+   boolean tempChartDescribes(VSTemporaryInfo tempInfo, VSAssembly target) {
+      ChartVSAssembly tempChart = tempInfo == null ? null : tempInfo.getTempChart();
+
+      if(tempChart == null || tempChart.getVSChartInfo() == null || target == null) {
+         return true;
+      }
+
+      return Tool.equals(tempInfo.getWizSourceAssemblyName(), target.getName())
+         && BindingFieldSettings.columnKeys(tempChart)
+               .equals(BindingFieldSettings.columnKeys(target));
+   }
+
+   /**
+    * The target assembly's own binding as an {@code AutoBindingRequest.fieldConfigs} list, so a rebuild
+    * re-seeds the temp chart from THAT chart rather than from whatever autoBinding last built.
+    *
+    * <p>{@code WizVsService.collectFlatBinding} already reverse-maps a chart / crosstab / output
+    * assembly's refs into {@code DimensionFieldInfo} / {@code MeasureFieldInfo} — both
+    * {@code SimpleFieldInfo} subtypes, which is exactly the element type fieldConfigs takes — carrying
+    * ranking, sort order, date group level and aggregate formula along with the column names.
+    *
+    * <p>Empty (never null) when there is no target or it binds nothing readable.
+    */
+   List<SimpleFieldInfo> deriveFieldConfigs(VSAssembly target) {
+      if(target == null) {
+         return Collections.emptyList();
+      }
+
+      CreateViewsheetResult.FlatBinding binding = wizVsService.collectFlatBinding(target);
+
+      if(binding == null) {
+         return Collections.emptyList();
+      }
+
+      List<SimpleFieldInfo> configs = new ArrayList<>();
+
+      if(binding.getDimensions() != null) {
+         configs.addAll(binding.getDimensions());
+      }
+
+      if(binding.getMeasures() != null) {
+         configs.addAll(binding.getMeasures());
+      }
+
+      return configs;
+   }
+
+   /**
+    * The worksheet table {@code target} is bound to, so a rebuild reads its columns from that table.
+    *
+    * <p>Matters for a conversation whose worksheet holds several generations of tables: the chart being
+    * rebuilt may be bound to an older generation than the worksheet's current primary assembly, and
+    * resolving fieldConfigs against the wrong table fails them all as unknown columns.
+    *
+    * <p>Null when unavailable, which leaves autoBinding on the worksheet's primary assembly.
+    */
+   static String sourceTableName(VSAssembly target) {
+      if(!(target instanceof DataVSAssembly dataAsm)) {
+         return null;
+      }
+
+      SourceInfo source = dataAsm.getSourceInfo();
+
+      return source == null ? null : source.getSource();
    }
 
    /**
@@ -2186,11 +2279,14 @@ public class WizAutoBindingService {
     * Changes the visualization type of an existing wizard viewsheet without re-running queries.
     *
     * <p>The recommendation model previously computed by {@link #autoBinding} is read from the
-    * {@code autoBindingRuntimeId} RVS.  If it is absent the service falls back to a full
-    * {@link #autoBinding} call (which also handles placing the primary and returning the result).
-    * Otherwise the matching recommendation is selected and placed in the
-    * {@code wizRuntimeId} RVS without executing the sandbox, so the response is fast and does
-    * not carry row data.
+    * {@code autoBindingRuntimeId} RVS. When it is present AND still describes the chart this call
+    * targets, the matching recommendation is selected and placed in the {@code wizRuntimeId} RVS
+    * without executing the sandbox, so the response is fast and does not carry row data.
+    *
+    * <p>Otherwise — absent, or describing a different chart because the user aimed the type change at
+    * an earlier history card — it is rebuilt from the target's own binding through a full
+    * {@link #autoBinding} call, which also handles placing the primary and returning the result. See
+    * {@link #tempChartDescribes}.
     */
    public CreateViewsheetResult changeType(ChangeTypeRequest request, Principal user)
       throws Exception
@@ -2234,28 +2330,67 @@ public class WizAutoBindingService {
          }
       }
 
-      // 2. Model missing — fall back to full autoBinding (handles placement too).
-      if(model == null) {
+      // 1b. Which chart is this call about, and does the temp chart still describe it?
+      //
+      // A conversation reuses ONE recommendation runtime, and every autoBinding re-initializes its temp
+      // chart from whichever chart it is building — so the temp chart, and the recommendation model
+      // cloned from it, describe exactly one of the session's charts at a time. When the user aims a
+      // type change at an EARLIER history card, both are the latest chart's: the fast path below would
+      // rebuild that card with the latest chart's binding entirely (not merely lose its ranking), and
+      // applyTempChartFieldSettings would then push the latest chart's settings onto it.
+      //
+      // The check has to run in both directions — latest -> historical AND historical -> latest, and
+      // between two different historical cards — because whichever chart was rebuilt last is the one
+      // the temp chart describes from then on. Hence: rebuild whenever it does not describe the target,
+      // never "when the target is historical".
+      VSAssembly targetAssembly = wizVsService.findWizTargetAssembly(
+         wizRuntimeId, viewsheetIdentifier, request.getAssemblyName(), user);
+      // The target's binding as an authoritative field list. Empty when the target could not be
+      // resolved or binds nothing readable — in which case there is nothing to rebuild FROM, so a
+      // staleness verdict would be unactionable and the fast path (the pre-existing behavior) stands.
+      //
+      // Also empty without a worksheet: an authoritative field list is resolved against that
+      // worksheet's columns, so passing one with no worksheet to read turns what used to be an empty
+      // result into "Unknown field(s) in fieldConfigs … Available worksheet columns: []".
+      List<SimpleFieldInfo> targetFieldConfigs = Tool.isEmptyString(worksheetId)
+         ? Collections.emptyList() : deriveFieldConfigs(targetAssembly);
+      boolean staleForTarget = !targetFieldConfigs.isEmpty()
+         && !tempChartDescribes(autoBindingTempInfo, targetAssembly);
+
+      // 2. Temp chart missing, expired, or describing a different chart — rebuild it (and the
+      // recommendation model with it) from the target's own binding through a full autoBinding, which
+      // also handles placement.
+      if(model == null || staleForTarget) {
          AutoBindingRequest fallback = new AutoBindingRequest();
          fallback.setWorksheetId(worksheetId);
          fallback.setVisualizationType(visualizationType);
-         // Do not forward autoBindingRuntimeId: if it was non-empty but invalid (expired RVS),
-         // autoBindingInternal() would skip creating a new RVS and fail on the same dead id again.
+         // Reuse the SAME recommendation runtime when it is readable, so the rebuilt temp chart and
+         // model replace the stale ones this conversation will keep consulting. Only when the runtime
+         // itself could not be read is the id withheld: it may be a dead RVS, and forwarding it would
+         // make autoBindingInternal skip minting a fresh one and fail on the same dead id again.
+         fallback.setAutoBindingRuntimeId(
+            capturedAutoBindingRvs != null ? autoBindingRuntimeId : null);
          fallback.setWizRuntimeId(wizRuntimeId);
          fallback.setViewsheetIdentifier(viewsheetIdentifier);
          fallback.setCopy(request.isCopy());
          fallback.setAssemblyName(request.getAssemblyName());
-         // Deliberately NOT fallback.setFieldConfigs(fieldConfigs): AutoBindingRequest.fieldConfigs
-         // is the AUTHORITATIVE full field list (selectBindColumns filters the worksheet down to
-         // EXACTLY those columns) — forwarding our measures-only list here would silently drop every
-         // dimension (e.g. STATE) from the rebuild instead of just fixing a formula. Applied post-hoc
-         // onto the resulting assembly below instead, the same as the fast path.
-         // KNOWN GAP: unlike the fast path below, this branch cannot RESTORE field settings accumulated
-         // before this call. We are here precisely because the autoBinding RVS (and with it the temp
-         // chart holding them) could not be read, and the fresh one autoBindingInternal creates builds
-         // its temp chart from AssetEntries — which carry no ranking/sort. Reachable when the autoBinding
-         // runtime has expired (e.g. a long-idle conversation). The caller's own fieldConfigs are still
-         // both applied and RECORDED below, so this branch does not also drop what THIS call establishes.
+         // A type switch must not drop the chart's filter, exactly as the fast path's
+         // vsModel.setKeepCondition(true) below.
+         fallback.setKeepCondition(true);
+         // The target's own binding, as the AUTHORITATIVE full field list — this is what makes the
+         // rebuilt temp chart describe the target rather than whatever autoBinding last built, and it
+         // carries the target's ranking / sort / date level / formula along with the columns. Note this
+         // is NOT `fieldConfigs`: that one is the caller's measures-only formula overrides (see
+         // ChangeTypeRequest.fieldConfigs), and forwarding it here would filter the worksheet down to
+         // those measures alone, silently dropping every dimension from the rebuild. It is still
+         // applied post-hoc onto the resulting assembly below, so an explicit caller formula wins.
+         //
+         // Empty (target unresolvable, or no worksheet) leaves selectBindColumns binding every visible
+         // worksheet column, which is what this branch did before it could read the target at all —
+         // and with it the residue of the gap this replaced: nothing to seed FROM means a rebuild
+         // still cannot recover settings accumulated before an expired recommendation runtime.
+         fallback.setFieldConfigs(targetFieldConfigs);
+         fallback.setWsTableName(sourceTableName(targetAssembly));
          AutoBindingResponse resp = autoBindingInternal(fallback, user, true);
          CreateViewsheetResult result = resp.getVisualizationResult();
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -125,29 +125,37 @@ public class WizAutoBindingService {
          ? request.getFieldConfigs() : Collections.emptyList();
       String worksheetId = request.getWorksheetId();
 
-      // A caller that names a chart but sends no field list means "re-bind THAT chart", so take the
-      // chart's own binding as the list rather than falling through to "every visible column".
+      // Which fields to bind, most specific statement first:
       //
-      // The recommender-reslot path needs exactly this: switching to a non-Cartesian type re-binds
-      // through here to get the fields re-slotted, but it carries no fieldConfigs of its own, so the
+      //   1. the caller's fieldConfigs — the authoritative list;
+      //   2. else the binding of the chart named by assemblyName — "re-bind THAT chart";
+      //   3. else the binding of the output viewsheet's PRIMARY chart — "re-bind the active chart",
+      //      which is what a nameless call already means everywhere else in this API;
+      //   4. else every visible column of the worksheet table, and let the recommender choose.
+      //
+      // findWizTargetAssembly resolves 2 and 3 together (named, else primary) and returns null when
+      // there is no output viewsheet to look in at all — a first-time create, which lands on 4.
+      //
+      // The recommender-reslot path is what needs this: switching to a non-Cartesian type re-binds
+      // through here purely to get the fields re-slotted, and carries no fieldConfigs of its own, so the
       // rebind was against the whole worksheet table — every column of it, not merely the wrong chart's.
-      // The named chart is the only statement of which fields were meant.
-      //
-      // Also reached by a continuation turn whose hints produced no fields (autoBinding's syncConfigs
-      // caller names the chart being refined): deriving from that chart is what it meant too.
+      // The chart being re-bound is the only statement of which fields were meant.
       //
       // Same reverse map and the same limitation as changeType's rebuild — a binding whose aggregation
       // was pushed to the worksheet reads back in its pushed form (formula NONE, date level cleared).
-      VSAssembly namedAssembly = fieldConfigs.isEmpty() && !Tool.isEmptyString(request.getAssemblyName())
+      VSAssembly sourceAssembly = fieldConfigs.isEmpty()
          ? wizVsService.findWizTargetAssembly(request.getWizRuntimeId(),
                                               request.getViewsheetIdentifier(),
                                               request.getAssemblyName(), user)
          : null;
-      // The named chart's own worksheet table, unless the caller named one: a conversation's worksheet
+      // That chart's own worksheet table, unless the caller named one: a conversation's worksheet
       // accumulates a table per rebuild generation, and its columns must be read from the table that
       // chart is actually bound to.
-      String wsTableName = !Tool.isEmptyString(request.getWsTableName())
-         ? request.getWsTableName() : sourceTableName(namedAssembly);
+      String requestedTableName = request.getWsTableName();
+      String wsTableName = !Tool.isEmptyString(requestedTableName)
+         ? requestedTableName : sourceTableName(sourceAssembly);
+      boolean derivedTableName = Tool.isEmptyString(requestedTableName)
+         && !Tool.isEmptyString(wsTableName);
 
       // Phase 1: resolve or create the recommendation RVS.
       String autoBindingRuntimeId = request.getAutoBindingRuntimeId();
@@ -200,6 +208,18 @@ public class WizAutoBindingService {
                   }
                   else {
                      primary = (WSAssembly) ws.getAssembly(wsTableName);
+
+                     // A DERIVED name can point at a table a later rebuild generation replaced and the
+                     // orphan cleanup then removed. The caller never asked for that table, so fall back
+                     // to the primary rather than reading no columns at all — which would leave the
+                     // recommender with nothing and turn a re-bind that used to succeed (on the whole
+                     // table) into a hard failure. A name the CALLER supplied stays strict.
+                     if(primary == null && derivedTableName) {
+                        LOG.warn("Chart '{}' is bound to worksheet table '{}', which no longer exists; " +
+                                 "reading columns from the primary table instead.",
+                                 sourceAssembly.getName(), wsTableName);
+                        primary = ws.getPrimaryAssembly();
+                     }
                   }
 
                   if(primary instanceof TableAssembly ta) {
@@ -233,8 +253,8 @@ public class WizAutoBindingService {
             }
          }
 
-         if(namedAssembly != null) {
-            fieldConfigs = derivedFieldConfigsWithin(namedAssembly, worksheetColumns);
+         if(sourceAssembly != null) {
+            fieldConfigs = derivedFieldConfigsWithin(sourceAssembly, worksheetColumns);
          }
 
          Map<String, SimpleFieldInfo> configMap = fieldConfigs.stream()

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -125,6 +125,30 @@ public class WizAutoBindingService {
          ? request.getFieldConfigs() : Collections.emptyList();
       String worksheetId = request.getWorksheetId();
 
+      // A caller that names a chart but sends no field list means "re-bind THAT chart", so take the
+      // chart's own binding as the list rather than falling through to "every visible column".
+      //
+      // The recommender-reslot path needs exactly this: switching to a non-Cartesian type re-binds
+      // through here to get the fields re-slotted, but it carries no fieldConfigs of its own, so the
+      // rebind was against the whole worksheet table — every column of it, not merely the wrong chart's.
+      // The named chart is the only statement of which fields were meant.
+      //
+      // Also reached by a continuation turn whose hints produced no fields (autoBinding's syncConfigs
+      // caller names the chart being refined): deriving from that chart is what it meant too.
+      //
+      // Same reverse map and the same limitation as changeType's rebuild — a binding whose aggregation
+      // was pushed to the worksheet reads back in its pushed form (formula NONE, date level cleared).
+      VSAssembly namedAssembly = fieldConfigs.isEmpty() && !Tool.isEmptyString(request.getAssemblyName())
+         ? wizVsService.findWizTargetAssembly(request.getWizRuntimeId(),
+                                              request.getViewsheetIdentifier(),
+                                              request.getAssemblyName(), user)
+         : null;
+      // The named chart's own worksheet table, unless the caller named one: a conversation's worksheet
+      // accumulates a table per rebuild generation, and its columns must be read from the table that
+      // chart is actually bound to.
+      String wsTableName = !Tool.isEmptyString(request.getWsTableName())
+         ? request.getWsTableName() : sourceTableName(namedAssembly);
+
       // Phase 1: resolve or create the recommendation RVS.
       String autoBindingRuntimeId = request.getAutoBindingRuntimeId();
       boolean createdAutoBindingRvs = false;
@@ -169,7 +193,6 @@ public class WizAutoBindingService {
                AbstractSheet sheet = engine.getSheet(wsEntry, user, true, AssetContent.ALL);
 
                if(sheet instanceof Worksheet ws) {
-                  String wsTableName = request.getWsTableName();
                   WSAssembly primary = null;
 
                   if(Tool.isEmptyString(wsTableName)) {
@@ -208,6 +231,10 @@ public class WizAutoBindingService {
             catch(Exception e) {
                LOG.warn("Failed to load worksheet '{}': {}", worksheetId, e.getMessage());
             }
+         }
+
+         if(namedAssembly != null) {
+            fieldConfigs = derivedFieldConfigsWithin(namedAssembly, worksheetColumns);
          }
 
          Map<String, SimpleFieldInfo> configMap = fieldConfigs.stream()
@@ -673,6 +700,46 @@ public class WizAutoBindingService {
       }
 
       return configs;
+   }
+
+   /**
+    * {@link #deriveFieldConfigs} for the case where the list is INFERRED rather than supplied: empty
+    * unless every derived column is present in {@code worksheetColumns}.
+    *
+    * <p>All-or-nothing because an authoritative field list is enforced strictly — {@code
+    * selectBindColumns} throws on a column the worksheet does not have, which is right for a caller that
+    * NAMED its fields and wrong for a list we inferred on its behalf. A chart bound to a worksheet table
+    * that has since been replaced by a later rebuild generation would turn a type change into a 400.
+    *
+    * <p>And all-or-nothing rather than dropping the missing ones: half a binding is not the chart the
+    * caller meant either (a chart of one dimension and no measure, say), so falling back to the previous
+    * behavior — every visible column, re-slotted by the recommender — is the more predictable failure.
+    */
+   List<SimpleFieldInfo> derivedFieldConfigsWithin(VSAssembly target,
+                                                   List<ColumnRef> worksheetColumns)
+   {
+      List<SimpleFieldInfo> derived = deriveFieldConfigs(target);
+
+      if(derived.isEmpty()) {
+         return derived;
+      }
+
+      Set<String> available = worksheetColumns.stream()
+         .map(ColumnRef::getDisplayName)
+         .collect(Collectors.toSet());
+      List<String> missing = derived.stream()
+         .map(SimpleFieldInfo::getField)
+         .filter(f -> f != null && !available.contains(f))
+         .sorted()
+         .collect(Collectors.toList());
+
+      if(!missing.isEmpty()) {
+         LOG.warn("Not deriving a field list from '{}': column(s) {} are not in the worksheet table. " +
+                  "Binding every visible column instead.", target.getName(), missing);
+         return Collections.emptyList();
+      }
+
+      return derived;
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/service/WizFieldInfoFactory.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizFieldInfoFactory.java
@@ -147,7 +147,30 @@ final class WizFieldInfoFactory {
          info.setSortByCol(sortByCol);
       }
 
+      applySortOrder(info, dim);
       return info;
+   }
+
+   /**
+    * Reports the dimension's sort order, which is what gives a value-based sort (and a ranking) its
+    * direction — a sortByCol with no order is inert.
+    *
+    * <p>Only the four explicit orders. SORT_NONE / SORT_ORIGINAL carry no user intent, and echoing them
+    * would make a re-applied config override whatever order the recommender picked for the chart type.
+    * SORT_SPECIFIC is excluded because it is meaningless without the manual value list, which is NOT
+    * reported: {@code WizAutoBindingService.applyFieldConfig} REVERSES a supplied manual list for a
+    * funnel (the incoming list is in caller order, not ref order), so a list read off a funnel and
+    * re-applied to one would come back inverted. A manual order therefore still reaches a rebuilt chart
+    * only through {@code BindingFieldSettings}, which copies refs directly and does not transform.
+    */
+   private static void applySortOrder(DimensionFieldInfo info, VSDimensionRef dim) {
+      int order = dim.getOrder();
+
+      if(order == XConstants.SORT_ASC || order == XConstants.SORT_DESC ||
+         order == XConstants.SORT_VALUE_ASC || order == XConstants.SORT_VALUE_DESC)
+      {
+         info.setOrder(order);
+      }
    }
 
    private static void applyRanking(DimensionFieldInfo info, VSDimensionRef dim) {

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -103,13 +103,25 @@ public class WizVsService {
     * it is authoritative about what is no longer set as well as what is. A merge would leave a removed
     * ranking on the temp chart, and the next rebuild would push it back onto the chart.
     *
+    * <p>Only when the temp chart still binds the SAME columns as {@code fieldSettings}. Recording
+    * settings across two different bindings is what made the temp chart lie: a conversation reuses one
+    * recommendation runtime, so a call that edits an earlier history card would otherwise write that
+    * card's ranking onto a temp chart describing the latest chart — and, RECORD being authoritative,
+    * clear whatever the latest chart had. The next chart-type change then pushes the wrong settings
+    * back. When the columns differ the temp chart is stale for this assembly, so the marker is CLEARED
+    * instead, which makes {@code changeType} rebuild it from the target rather than trust it.
+    *
+    * <p>On a match the marker moves to {@code assemblyName}: the temp chart now describes this
+    * assembly. That is the ordinary case even for an in-place edit, because an explicit re-bind
+    * ({@code /viewsheet/create} with a config) lands in a NEWLY named assembly.
+    *
     * <p>Best-effort: no autoBindingRuntimeId (every caller that predates it, and the MCP path), an
     * expired runtime, or an RVS that never went through autoBinding all mean there is no temp chart to
     * record on — the assembly itself already has the settings either way, so this must never fail the
     * request that triggered it.
     */
-   private void recordFieldSettingsOnTempChart(String autoBindingRuntimeId, DataRef[] fieldSettings,
-                                               Principal user)
+   void recordFieldSettingsOnTempChart(String autoBindingRuntimeId, DataRef[] fieldSettings,
+                                       String assemblyName, Principal user)
    {
       if(Tool.isEmptyString(autoBindingRuntimeId) || fieldSettings == null || fieldSettings.length == 0) {
          return;
@@ -128,12 +140,66 @@ public class WizVsService {
             return;
          }
 
+         // Keys off the SNAPSHOT, not the live assembly: the pre-aggregation push rewrites the
+         // assembly's refs to the pushed columns, which would compare unequal against the temp chart
+         // for reasons that have nothing to do with which chart this is.
+         if(!BindingFieldSettings.columnKeys(fieldSettings).equals(
+               BindingFieldSettings.columnKeys(tempChart)))
+         {
+            tempInfo.setWizSourceAssemblyName(null);
+            return;
+         }
+
          BindingFieldSettings.record(fieldSettings, BindingFieldSettings.refsOf(tempChart));
+         tempInfo.setWizSourceAssemblyName(assemblyName);
       }
       catch(Exception e) {
          LOG.warn("Could not record field settings on the temp chart of {}: {}",
                   autoBindingRuntimeId, e.getMessage());
          LOG.debug("temp chart field-settings record stack trace", e);
+      }
+   }
+
+   /**
+    * The assembly a wiz call is about, in the output viewsheet named by {@code runtimeId}: the one
+    * {@code assemblyName} names, else whichever is currently primary (= the session's latest chart,
+    * which is what a caller carrying no name targets).
+    *
+    * <p>Deliberately best-effort — null on an expired runtime, a name that no longer resolves, or no
+    * primary at all. The caller ({@code changeType}) uses this only to decide whether the wizard temp
+    * chart is stale, and "cannot tell" must degrade to the pre-existing behavior rather than fail a
+    * type change.
+    *
+    * <p>Not {@link #resolveTargetAssembly}, which throws on ambiguity: a wiz session viewsheet
+    * legitimately holds many charts (every history card), so "multiple charts" is the normal state
+    * here, not an error.
+    */
+   VSAssembly findWizTargetAssembly(String runtimeId, String viewsheetIdentifier, String assemblyName,
+                                    Principal user)
+   {
+      if(Tool.isEmptyString(runtimeId)) {
+         return null;
+      }
+
+      try {
+         RuntimeViewsheet rvs = WizUtil.getViewsheetOrRestore(
+            viewsheetService, runtimeId, viewsheetIdentifier, user);
+         Viewsheet vs = rvs == null ? null : rvs.getViewsheet();
+
+         if(vs == null) {
+            return null;
+         }
+
+         if(!Tool.isEmptyString(assemblyName)) {
+            return vs.getAssembly(assemblyName) instanceof VSAssembly found ? found : null;
+         }
+
+         return findPrimaryAssembly(vs);
+      }
+      catch(Exception e) {
+         LOG.debug("Could not resolve wiz target assembly '{}' in {}: {}",
+                   assemblyName, runtimeId, e.getMessage());
+         return null;
       }
    }
 
@@ -1730,7 +1796,8 @@ public class WizVsService {
             // Recorded from the snapshot taken before the pre-aggregation push above, which rewrites
             // exactly these values (a pushed measure's formula becomes NONE and a bucketed dimension's
             // level is cleared): the temp chart must hold what the user asked for, not the pushed form.
-            recordFieldSettingsOnTempChart(model.getAutoBindingRuntimeId(), fieldSettings, user);
+            recordFieldSettingsOnTempChart(model.getAutoBindingRuntimeId(), fieldSettings,
+                                           assembly == null ? null : assembly.getName(), user);
 
             if(copyNote != null) {
                result.setNote(copyNote);

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -223,6 +223,49 @@ public class WizVsService {
       return replacedAssembly != null ? replacedAssembly : previousPrimaryAssembly;
    }
 
+   /**
+    * Whether the named assembly is REPLACED, or only named as the chart to build from.
+    *
+    * <p>{@code copy} decides, which is what lets one field name the target for both intents: a click on
+    * a card's own chart-type menu replaces that card ({@code copy} false), while a chat turn about it
+    * keeps it as history and adds a new card ({@code copy} true) — and either way the call needs to know
+    * WHICH chart it is about, so the binding it rebuilds from is that card's and not whichever chart
+    * happens to be primary.
+    *
+    * <p>Every pre-existing caller already maintained this as a caller-side invariant (a name is only
+    * ever sent with {@code copy} false — see validateBinding's mutually-exclusive assemblyName / copy),
+    * so honoring {@code copy} here changes no existing path; it only stops the {@code copy} true case
+    * from being silently reinterpreted as a replace.
+    *
+    * <p>Never in sync mode: there the named chart is the config SOURCE and the result is by definition a
+    * new assembly.
+    */
+   static boolean replaceInPlace(VSAssembly existingTarget, boolean syncMode, boolean copy) {
+      return existingTarget != null && !syncMode && !copy;
+   }
+
+   /**
+    * The assembly whose pre-condition a type change carries onto the new one (see
+    * {@code CreateVisualizationModel.isKeepCondition()}).
+    *
+    * <p>The NAMED chart wins when there is one: on a copy it is not the displaced assembly (the
+    * displaced one is whichever was primary, i.e. the latest chart), and carrying the latest chart's
+    * filter onto a type change made about an earlier card would apply a filter the user never asked for
+    * there. Identical to the displaced assembly whenever the two coincide — a replace.
+    *
+    * <p>Falls through in sync mode, where {@code syncConfigs} carries the condition instead.
+    */
+   static VSAssembly resolveConditionSource(boolean syncMode, VSAssembly existingTarget,
+                                            VSAssembly replacedAssembly,
+                                            VSAssembly previousPrimaryAssembly)
+   {
+      if(!syncMode && existingTarget != null) {
+         return existingTarget;
+      }
+
+      return replacedAssembly != null ? replacedAssembly : previousPrimaryAssembly;
+   }
+
    @FunctionalInterface
    public interface PostAssemblyHook {
       void apply(RuntimeViewsheet rvs, VSAssembly assembly) throws Exception;
@@ -1449,8 +1492,9 @@ public class WizVsService {
                targetVs.setBaseEntry(ctx.sourceWs());
             }
 
-            // In this (standard) path the named assembly is the one to REPLACE in place; the
-            // modificationOnly branch above reads the same field as the chart to modify.
+            // In this (standard) path the named assembly is the chart this call is ABOUT — the one it
+            // builds from and, unless copy says otherwise, replaces. The modificationOnly branch above
+            // reads the same field as the chart to modify.
             String targetAssemblyName = model.getAssemblyName();
             boolean syncMode = model.isSyncConfigs();
             VSAssembly existingTarget = null;
@@ -1470,7 +1514,10 @@ public class WizVsService {
                existingTarget = foundVs;
             }
 
-            String assemblyName = !(Tool.isEmptyString(targetAssemblyName) || syncMode)
+            boolean replaceInPlace = replaceInPlace(existingTarget, syncMode, model.isCopy());
+            // A copy MUST take a fresh name: reusing the target's would have addAssembly overwrite it by
+            // name below, destroying the very card copy exists to preserve.
+            String assemblyName = replaceInPlace
                ? targetAssemblyName : uniqueAssemblyName(targetVs, ctx.title());
 
             if(model.getPrimaryAssembly() != null) {
@@ -1490,13 +1537,9 @@ public class WizVsService {
                }
             }
 
-            if(existingTarget != null && !syncMode) {
+            if(replaceInPlace) {
                // Targeted replace: swap in the new assembly under the SAME name, carrying over the
                // old one's exact primary state — no other assembly is touched either way.
-               // model.isCopy() is NOT consulted here (only in the else branch below, via
-               // previousPrimaryAssembly): a caller that sets both assemblyName and copy=true gets
-               // copy silently bypassed — replacing one specific historical card by name should not
-               // also duplicate it. See CreateVisualizationModel.getAssemblyName()'s javadoc.
                replacedAssembly = existingTarget;
                replacedWasPrimary = existingTarget.isPrimary();
                targetVs.removeAssembly(targetAssemblyName);
@@ -1541,9 +1584,10 @@ public class WizVsService {
                rvs.getViewsheetSandbox().ifPresent(sandbox -> sandbox.clearGraph(assembly.getName()));
             }
 
-            // Sync pre-condition from the replaced assembly to the new one when the caller
+            // Sync pre-condition from the chart being switched away from to the new one when the caller
             // is performing a visualization type change (e.g. table → chart).
-            VSAssembly displacedForCondition = replacedAssembly != null ? replacedAssembly : previousPrimaryAssembly;
+            VSAssembly displacedForCondition = resolveConditionSource(
+               syncMode, existingTarget, replacedAssembly, previousPrimaryAssembly);
 
             if(model.isKeepCondition() &&
                displacedForCondition instanceof DataVSAssembly oldDataAsm &&

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceChangeTypeFieldFormulaTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceChangeTypeFieldFormulaTest.java
@@ -31,6 +31,7 @@ import inetsoft.uql.viewsheet.TableVSAssembly;
 import inetsoft.uql.viewsheet.VSAggregateRef;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.VSCrosstabInfo;
+import inetsoft.uql.asset.ColumnRef;
 import inetsoft.uql.asset.SourceInfo;
 import inetsoft.uql.viewsheet.graph.AestheticRef;
 import inetsoft.uql.viewsheet.graph.ChartRef;
@@ -53,6 +54,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -914,6 +916,55 @@ class WizAutoBindingServiceChangeTypeFieldFormulaTest {
          assertNull(WizAutoBindingService.sourceTableName(target));
          assertNull(WizAutoBindingService.sourceTableName(null));
          assertNull(WizAutoBindingService.sourceTableName(mock(TableVSAssembly.class)));
+      }
+
+      private static ColumnRef wsColumn(String name) {
+         ColumnRef col = mock(ColumnRef.class);
+         when(col.getDisplayName()).thenReturn(name);
+         return col;
+      }
+
+      private ChartVSAssembly targetBoundTo(String... fields) {
+         List<DimensionFieldInfo> dimensions = new ArrayList<>();
+
+         for(String field : fields) {
+            DimensionFieldInfo dim = new DimensionFieldInfo();
+            dim.setField(field);
+            dimensions.add(dim);
+         }
+
+         ChartVSAssembly target = mock(ChartVSAssembly.class);
+         when(target.getName()).thenReturn("Chart1");
+         when(wizVsService.collectFlatBinding(target)).thenReturn(
+            new CreateViewsheetResult.FlatBinding(dimensions, List.of(), Map.of()));
+         return target;
+      }
+
+      /**
+       * An INFERRED list is only used when the worksheet table actually has every column. `fieldConfigs`
+       * is enforced strictly — selectBindColumns throws on a column the table does not have, which is
+       * right for a caller that named its fields and wrong for a list inferred on its behalf.
+       */
+      @Test
+      void derivesOnlyWhenEveryColumnIsInTheTable() {
+         ChartVSAssembly target = targetBoundTo("MONTH", "REGION");
+
+         assertEquals(2, service.derivedFieldConfigsWithin(
+            target, List.of(wsColumn("MONTH"), wsColumn("REGION"), wsColumn("amount"))).size());
+      }
+
+      /**
+       * All-or-nothing rather than dropping the missing ones: half a binding is not the chart the caller
+       * meant either, so it falls back to the pre-existing behavior (every visible column, re-slotted).
+       * Reachable when the chart's table was replaced by a later rebuild generation.
+       */
+      @Test
+      void derivesNothingWhenAColumnIsMissing() {
+         ChartVSAssembly target = targetBoundTo("MONTH", "REGION");
+
+         assertEquals(List.of(),
+                      service.derivedFieldConfigsWithin(target, List.of(wsColumn("MONTH"))));
+         assertEquals(List.of(), service.derivedFieldConfigsWithin(target, List.of()));
       }
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceChangeTypeFieldFormulaTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceChangeTypeFieldFormulaTest.java
@@ -31,6 +31,8 @@ import inetsoft.uql.viewsheet.TableVSAssembly;
 import inetsoft.uql.viewsheet.VSAggregateRef;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.VSCrosstabInfo;
+import inetsoft.uql.asset.SourceInfo;
+import inetsoft.uql.viewsheet.graph.AestheticRef;
 import inetsoft.uql.viewsheet.graph.ChartRef;
 import inetsoft.uql.viewsheet.graph.VSChartAggregateRef;
 import inetsoft.uql.viewsheet.graph.VSChartDimensionRef;
@@ -38,6 +40,7 @@ import inetsoft.uql.viewsheet.graph.VSChartInfo;
 import inetsoft.web.vswizard.model.recommender.VSTemporaryInfo;
 import inetsoft.web.vswizard.service.VSWizardTemporaryInfoService;
 import inetsoft.web.wiz.BindingFieldSettings;
+import inetsoft.web.wiz.model.CreateViewsheetResult;
 import inetsoft.web.wiz.model.DimensionFieldInfo;
 import inetsoft.web.wiz.model.MeasureFieldInfo;
 import inetsoft.web.wiz.model.Ranking;
@@ -51,13 +54,17 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -685,6 +692,228 @@ class WizAutoBindingServiceChangeTypeFieldFormulaTest {
          assertNotSame(live, snapshot[0]);
          assertEquals(String.valueOf(XCondition.TOP_N),
                       ((VSChartDimensionRef) snapshot[0]).getRankingOptionValue());
+      }
+
+      /**
+       * columnKeys is the "is the temp chart still about this chart" test, so it must span every slot a
+       * column can sit in — a dimension moved onto colour for a pie is still the same bound column, and
+       * reporting a difference there would force a needless rebuild on every type switch.
+       */
+      @Test
+      void columnKeysSpansXYAndTheAesthetics() {
+         VSChartInfo info = mock(VSChartInfo.class);
+         when(info.getXFields()).thenReturn(new ChartRef[] { chartDim("MONTH") });
+         when(info.getYFields()).thenReturn(new ChartRef[] { chartAgg("amount", "Sum") });
+
+         AestheticRef color = mock(AestheticRef.class);
+         when(color.getDataRef()).thenReturn(chartDim("REGION"));
+         when(info.getColorField()).thenReturn(color);
+
+         ChartVSAssembly chart = mock(ChartVSAssembly.class);
+         when(chart.getVSChartInfo()).thenReturn(info);
+
+         assertEquals(Set.of("MONTH", "amount", "REGION"), BindingFieldSettings.columnKeys(chart));
+      }
+
+      /** A crosstab keys off the same value accessors, so the two sides compare on equal terms. */
+      @Test
+      void columnKeysReadsACrosstabsDesignHeaders() {
+         VSDimensionRef header = new VSDimensionRef();
+         header.setGroupColumnValue("MONTH");
+         VSAggregateRef aggregate = new VSAggregateRef();
+         aggregate.setColumnValue("amount");
+
+         VSCrosstabInfo info = mock(VSCrosstabInfo.class);
+         when(info.getDesignRowHeaders()).thenReturn(new DataRef[] { header });
+         when(info.getDesignColHeaders()).thenReturn(new DataRef[0]);
+         when(info.getDesignAggregates()).thenReturn(new DataRef[] { aggregate });
+
+         CrosstabVSAssembly crosstab = mock(CrosstabVSAssembly.class);
+         when(crosstab.getVSCrosstabInfo()).thenReturn(info);
+
+         assertEquals(Set.of("MONTH", "amount"), BindingFieldSettings.columnKeys(crosstab));
+      }
+
+      /**
+       * Unlike the record/restore index, a column bound twice is NOT dropped here. The question is which
+       * columns are bound, and dropping an ambiguous one would make a chart binding Sum(amount) and
+       * Average(amount) compare equal to one binding neither.
+       */
+      @Test
+      void columnKeysKeepsAColumnBoundTwice() {
+         VSChartInfo info = mock(VSChartInfo.class);
+         when(info.getXFields()).thenReturn(new ChartRef[0]);
+         when(info.getYFields()).thenReturn(
+            new ChartRef[] { chartAgg("amount", "Sum"), chartAgg("amount", "Average") });
+
+         ChartVSAssembly chart = mock(ChartVSAssembly.class);
+         when(chart.getVSChartInfo()).thenReturn(info);
+
+         assertEquals(Set.of("amount"), BindingFieldSettings.columnKeys(chart));
+      }
+   }
+
+   /**
+    * tempChartDescribes(VSTemporaryInfo, VSAssembly) — whether the temp chart, and the recommendation
+    * model generated from it, still describe the chart a changeType call targets.
+    *
+    * <p>A conversation reuses one recommendation runtime whose temp chart is re-seeded from whichever
+    * chart autoBinding last built. Aiming a type change at an earlier history card would otherwise
+    * rebuild that card from the LATEST chart's binding entirely, so this predicate is what routes such a
+    * call into a rebuild — in both directions, since after that rebuild the temp chart describes the
+    * historical card and a call on the latest chart is the stale one.
+    */
+   @Tag("core")
+   static class TempChartDescribesTest {
+      private WizAutoBindingService service;
+
+      @BeforeEach
+      void setUp() {
+         service = new WizAutoBindingService(null, null, null, null, null, null, null);
+      }
+
+      private static ChartVSAssembly chartBinding(String... columns) {
+         ChartRef[] x = new ChartRef[columns.length];
+
+         for(int i = 0; i < columns.length; i++) {
+            VSChartDimensionRef dim = mock(VSChartDimensionRef.class);
+            when(dim.getGroupColumnValue()).thenReturn(columns[i]);
+            x[i] = dim;
+         }
+
+         VSChartInfo info = mock(VSChartInfo.class);
+         when(info.getXFields()).thenReturn(x);
+         when(info.getYFields()).thenReturn(new ChartRef[0]);
+
+         ChartVSAssembly chart = mock(ChartVSAssembly.class);
+         when(chart.getVSChartInfo()).thenReturn(info);
+         return chart;
+      }
+
+      private static VSTemporaryInfo tempInfo(String sourceName, String... columns) {
+         // Built before the stubbing that consumes it: chartBinding() stubs mocks of its own, and
+         // nesting that inside when(...) leaves Mockito with an unfinished stubbing.
+         ChartVSAssembly tempChart = chartBinding(columns);
+         VSTemporaryInfo info = mock(VSTemporaryInfo.class);
+         when(info.getTempChart()).thenReturn(tempChart);
+         when(info.getWizSourceAssemblyName()).thenReturn(sourceName);
+         return info;
+      }
+
+      private static VSAssembly target(String name, String... columns) {
+         ChartVSAssembly chart = chartBinding(columns);
+         when(chart.getName()).thenReturn(name);
+         return chart;
+      }
+
+      @Test
+      void theChartItWasSeededFromMatches() {
+         assertTrue(service.tempChartDescribes(
+            tempInfo("Chart2", "MONTH", "amount"), target("Chart2", "MONTH", "amount")));
+      }
+
+      /** The historical-card case: same columns is not enough, the settings belong to another chart. */
+      @Test
+      void aDifferentChartWithTheSameColumnsDoesNotMatch() {
+         assertFalse(service.tempChartDescribes(
+            tempInfo("Chart2", "MONTH", "amount"), target("Chart1", "MONTH", "amount")));
+      }
+
+      /**
+       * The name alone is not enough either: an explicit re-bind lands in a newly named assembly and the
+       * record step carries the name across, but it cannot add a column to the temp chart — so a measure
+       * added that way leaves the temp chart stale for a chart whose name it legitimately holds.
+       */
+      @Test
+      void theRightChartWithAnAddedColumnDoesNotMatch() {
+         assertFalse(service.tempChartDescribes(
+            tempInfo("Chart2", "MONTH"), target("Chart2", "MONTH", "amount")));
+      }
+
+      /** Cleared marker — the record step's way of saying "stale, rebuild from the chart". */
+      @Test
+      void aClearedMarkerDoesNotMatch() {
+         assertFalse(service.tempChartDescribes(
+            tempInfo(null, "MONTH"), target("Chart2", "MONTH")));
+      }
+
+      /**
+       * Unreadable state must degrade to the pre-existing fast path. Forcing a rebuild off state we
+       * could not read would turn a missing temp chart into a full re-recommendation on every call.
+       */
+      @Test
+      void unreadableStateReportsAMatch() {
+         VSTemporaryInfo noTempChart = mock(VSTemporaryInfo.class);
+         when(noTempChart.getTempChart()).thenReturn(null);
+
+         assertTrue(service.tempChartDescribes(noTempChart, target("Chart2", "MONTH")));
+         assertTrue(service.tempChartDescribes(null, target("Chart2", "MONTH")));
+         assertTrue(service.tempChartDescribes(tempInfo("Chart2", "MONTH"), null));
+      }
+   }
+
+   /**
+    * deriveFieldConfigs / sourceTableName — how a rebuild learns what the target chart is bound to.
+    */
+   @Tag("core")
+   static class DeriveFieldConfigsTest {
+      private WizVsService wizVsService;
+      private WizAutoBindingService service;
+
+      @BeforeEach
+      void setUp() {
+         wizVsService = mock(WizVsService.class);
+         service = new WizAutoBindingService(null, null, null, null, null, wizVsService, null);
+      }
+
+      @Test
+      void flattensTheTargetsDimensionsAndMeasures() {
+         DimensionFieldInfo month = new DimensionFieldInfo();
+         month.setField("MONTH");
+         MeasureFieldInfo amount = measure("amount", "Sum");
+
+         ChartVSAssembly target = mock(ChartVSAssembly.class);
+         when(wizVsService.collectFlatBinding(target)).thenReturn(
+            new CreateViewsheetResult.FlatBinding(List.of(month), List.of(amount), Map.of()));
+
+         assertEquals(List.of(month, amount), service.deriveFieldConfigs(target));
+      }
+
+      /**
+       * Empty rather than null, and empty is what makes the caller stand down: with nothing to rebuild
+       * FROM, a staleness verdict is unactionable and the fast path must stay.
+       */
+      @Test
+      void anUnreadableTargetDerivesNothing() {
+         ChartVSAssembly target = mock(ChartVSAssembly.class);
+         when(wizVsService.collectFlatBinding(target)).thenReturn(null);
+
+         assertEquals(List.of(), service.deriveFieldConfigs(target));
+         assertEquals(List.of(), service.deriveFieldConfigs(null));
+      }
+
+      /**
+       * The target's own table, not the worksheet's primary: a conversation's worksheet accumulates a
+       * table per rebuild generation, and resolving the target's columns against the wrong one fails
+       * every one of them as unknown.
+       */
+      @Test
+      void readsTheTargetsOwnWorksheetTable() {
+         ChartVSAssembly target = mock(ChartVSAssembly.class);
+         when(target.getSourceInfo()).thenReturn(
+            new SourceInfo(SourceInfo.ASSET, null, "Query1_2"));
+
+         assertEquals("Query1_2", WizAutoBindingService.sourceTableName(target));
+      }
+
+      @Test
+      void noSourceInfoLeavesTheTableUnnamed() {
+         ChartVSAssembly target = mock(ChartVSAssembly.class);
+         when(target.getSourceInfo()).thenReturn(null);
+
+         assertNull(WizAutoBindingService.sourceTableName(target));
+         assertNull(WizAutoBindingService.sourceTableName(null));
+         assertNull(WizAutoBindingService.sourceTableName(mock(TableVSAssembly.class)));
       }
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizFieldInfoFactorySortOrderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizFieldInfoFactorySortOrderTest.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.uql.XConstants;
+import inetsoft.uql.viewsheet.VSDimensionRef;
+import inetsoft.web.wiz.model.DimensionFieldInfo;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * The sort order WizFieldInfoFactory reports for a dimension.
+ *
+ * <p>Load-bearing for changeType's rebuild branch, which re-seeds the wizard temp chart from the target
+ * chart's own binding via {@code collectFlatBinding}: order is what gives a value-based sort (and a
+ * ranking) its direction, so a sortByCol reported without it is inert and the rebuilt chart comes back
+ * unsorted.
+ */
+@Tag("core")
+class WizFieldInfoFactorySortOrderTest {
+   private static DimensionFieldInfo reported(int order) {
+      VSDimensionRef dim = mock(VSDimensionRef.class);
+      when(dim.getGroupColumnValue()).thenReturn("STATE");
+      when(dim.getOrder()).thenReturn(order);
+      return WizFieldInfoFactory.createChartDimensionFieldInfo(dim);
+   }
+
+   @Test
+   void reportsTheFourExplicitOrders() {
+      assertEquals(XConstants.SORT_ASC, reported(XConstants.SORT_ASC).getOrder());
+      assertEquals(XConstants.SORT_DESC, reported(XConstants.SORT_DESC).getOrder());
+      assertEquals(XConstants.SORT_VALUE_ASC, reported(XConstants.SORT_VALUE_ASC).getOrder());
+      assertEquals(XConstants.SORT_VALUE_DESC, reported(XConstants.SORT_VALUE_DESC).getOrder());
+   }
+
+   /**
+    * An order carrying no user intent must stay unreported: a re-applied config is authoritative, so
+    * echoing SORT_NONE would override whatever ordering the recommender picks for the target type.
+    */
+   @Test
+   void staysSilentOnAnOrderThatCarriesNoIntent() {
+      assertNull(reported(XConstants.SORT_NONE).getOrder());
+      assertNull(reported(XConstants.SORT_ORIGINAL).getOrder());
+   }
+
+   /**
+    * SORT_SPECIFIC is excluded because the manual value list it depends on is deliberately NOT reported
+    * (applyFieldConfig reverses a supplied list for a funnel, so a round trip through it inverts), and a
+    * manual order with no list would sort by nothing.
+    */
+   @Test
+   void staysSilentOnAManualOrder() {
+      assertNull(reported(XConstants.SORT_SPECIFIC).getOrder());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceRecordFieldSettingsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceRecordFieldSettingsTest.java
@@ -1,0 +1,172 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.XCondition;
+import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.graph.ChartRef;
+import inetsoft.uql.viewsheet.graph.VSChartDimensionRef;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
+import inetsoft.web.vswizard.model.recommender.VSTemporaryInfo;
+import inetsoft.web.vswizard.service.VSWizardTemporaryInfoService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * recordFieldSettingsOnTempChart — the write side of the wizard temp chart as durable binding state,
+ * and the column guard that keeps it honest.
+ *
+ * <p>A wiz conversation reuses ONE recommendation runtime, so its temp chart describes exactly one of
+ * the session's charts at a time. Recording a DIFFERENT chart's settings onto it (the user edits an
+ * earlier history card) would make it lie about the chart it names — and RECORD being authoritative,
+ * it would also clear what that chart had, so the next chart-type change pushes the wrong settings
+ * back. The guard is a column comparison: settings can move between two bindings of the same columns,
+ * nothing can move between different ones.
+ */
+@Tag("core")
+class WizVsServiceRecordFieldSettingsTest {
+   private static final String AUTO_BINDING_RUNTIME_ID = "wiz-rec-1";
+
+   private VSWizardTemporaryInfoService tempInfoService;
+   private VSTemporaryInfo tempInfo;
+   private WizVsService service;
+   private Principal user;
+
+   @BeforeEach
+   void setUp() throws Exception {
+      ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      tempInfoService = mock(VSWizardTemporaryInfoService.class);
+      user = mock(Principal.class);
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(viewsheetService.getViewsheet(AUTO_BINDING_RUNTIME_ID, user)).thenReturn(rvs);
+
+      tempInfo = mock(VSTemporaryInfo.class);
+      when(tempInfoService.getVSTemporaryInfo(rvs)).thenReturn(tempInfo);
+
+      service = new WizVsService(viewsheetService, null, null, null, tempInfoService);
+   }
+
+   /** Puts a temp chart bound to {@code columns} behind the recommendation runtime, and returns its refs. */
+   private VSChartDimensionRef[] tempChartBoundTo(String... columns) {
+      VSChartDimensionRef[] refs = new VSChartDimensionRef[columns.length];
+      ChartRef[] x = new ChartRef[columns.length];
+
+      for(int i = 0; i < columns.length; i++) {
+         refs[i] = mock(VSChartDimensionRef.class);
+         when(refs[i].getGroupColumnValue()).thenReturn(columns[i]);
+         x[i] = refs[i];
+      }
+
+      VSChartInfo info = mock(VSChartInfo.class);
+      when(info.getXFields()).thenReturn(x);
+      when(info.getYFields()).thenReturn(new ChartRef[0]);
+
+      ChartVSAssembly tempChart = mock(ChartVSAssembly.class);
+      when(tempChart.getVSChartInfo()).thenReturn(info);
+      when(tempInfo.getTempChart()).thenReturn(tempChart);
+
+      return refs;
+   }
+
+   private static DataRef rankedSnapshotDim(String column) {
+      VSChartDimensionRef dim = mock(VSChartDimensionRef.class);
+      when(dim.getGroupColumnValue()).thenReturn(column);
+      when(dim.getRankingOptionValue()).thenReturn(String.valueOf(XCondition.TOP_N));
+      when(dim.getRankingNValue()).thenReturn("3");
+      return dim;
+   }
+
+   @Test
+   void recordsOntoTheSameBindingAndMovesTheMarkerToThatAssembly() {
+      VSChartDimensionRef temp = tempChartBoundTo("MONTH")[0];
+
+      service.recordFieldSettingsOnTempChart(
+         AUTO_BINDING_RUNTIME_ID, new DataRef[] { rankedSnapshotDim("MONTH") }, "Chart3", user);
+
+      verify(temp).setRankingOptionValue(String.valueOf(XCondition.TOP_N));
+      verify(temp).setRankingNValue("3");
+      // The marker follows even for an in-place edit: an explicit re-bind lands in a NEWLY named
+      // assembly, so "same chart, same name" is the exception rather than the rule here.
+      verify(tempInfo).setWizSourceAssemblyName("Chart3");
+   }
+
+   /**
+    * The load-bearing case. Recording an earlier card's settings onto a temp chart bound to different
+    * columns would half-apply them (only the columns that happen to pair) and, being authoritative,
+    * clear the rest — so instead the marker is dropped and changeType rebuilds from the chart itself.
+    */
+   @Test
+   void skipsADifferentBindingAndClearsTheMarker() {
+      VSChartDimensionRef temp = tempChartBoundTo("REGION")[0];
+
+      service.recordFieldSettingsOnTempChart(
+         AUTO_BINDING_RUNTIME_ID, new DataRef[] { rankedSnapshotDim("MONTH") }, "Chart3", user);
+
+      verify(temp, never()).setRankingOptionValue(any());
+      verify(tempInfo).setWizSourceAssemblyName(null);
+   }
+
+   /** A column added by an explicit re-bind cannot reach the temp chart, so it is stale for that chart. */
+   @Test
+   void skipsAnAddedColumnAndClearsTheMarker() {
+      tempChartBoundTo("MONTH");
+
+      service.recordFieldSettingsOnTempChart(
+         AUTO_BINDING_RUNTIME_ID,
+         new DataRef[] { rankedSnapshotDim("MONTH"), rankedSnapshotDim("amount") }, "Chart3", user);
+
+      verify(tempInfo).setWizSourceAssemblyName(null);
+   }
+
+   /** No wizard runtime (the MCP path) or nothing to record: the marker must not be touched either. */
+   @Test
+   void nothingToRecordLeavesTheMarkerAlone() {
+      tempChartBoundTo("MONTH");
+
+      service.recordFieldSettingsOnTempChart(null, new DataRef[] { rankedSnapshotDim("MONTH") },
+                                             "Chart3", user);
+      service.recordFieldSettingsOnTempChart(AUTO_BINDING_RUNTIME_ID, new DataRef[0], "Chart3", user);
+      service.recordFieldSettingsOnTempChart(AUTO_BINDING_RUNTIME_ID, null, "Chart3", user);
+
+      verify(tempInfo, never()).setWizSourceAssemblyName(any());
+   }
+
+   /** An RVS that never went through autoBinding has no temp chart to record on or invalidate. */
+   @Test
+   void aMissingTempChartIsANoOp() {
+      when(tempInfo.getTempChart()).thenReturn(null);
+
+      service.recordFieldSettingsOnTempChart(
+         AUTO_BINDING_RUNTIME_ID, new DataRef[] { rankedSnapshotDim("MONTH") }, "Chart3", user);
+
+      verify(tempInfo, never()).setWizSourceAssemblyName(any());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceReplaceInPlaceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceReplaceInPlaceTest.java
@@ -1,0 +1,98 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.uql.viewsheet.VSAssembly;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * What {@code CreateVisualizationModel.assemblyName} means on the standard create/rebind path: the
+ * chart the call is ABOUT, with {@code copy} deciding whether that chart is replaced or kept.
+ *
+ * <p>One field for both intents, because both need the same thing — knowing WHICH chart the call is
+ * about, so the binding it rebuilds from is that chart's and not whichever happens to be primary (a
+ * session shares one viewsheet across every turn, so primary is always the latest chart). A click on a
+ * card's own chart-type menu replaces that card; a chat turn about it keeps it as history.
+ */
+@Tag("core")
+class WizVsServiceReplaceInPlaceTest {
+   @Test
+   void aNamedTargetIsReplacedWhenNotCopying() {
+      assertTrue(WizVsService.replaceInPlace(mock(VSAssembly.class), false, false));
+   }
+
+   /** copy=true keeps the named card and adds a new one — the chat-driven type change. */
+   @Test
+   void aNamedTargetIsKeptWhenCopying() {
+      assertFalse(WizVsService.replaceInPlace(mock(VSAssembly.class), false, true));
+   }
+
+   /** No name: nothing to replace, whatever copy says. */
+   @Test
+   void nothingIsReplacedWithoutANamedTarget() {
+      assertFalse(WizVsService.replaceInPlace(null, false, false));
+      assertFalse(WizVsService.replaceInPlace(null, false, true));
+   }
+
+   /** Sync mode names the config SOURCE; its result is by definition a new assembly. */
+   @Test
+   void syncModeNeverReplaces() {
+      assertFalse(WizVsService.replaceInPlace(mock(VSAssembly.class), true, false));
+      assertFalse(WizVsService.replaceInPlace(mock(VSAssembly.class), true, true));
+   }
+
+   /**
+    * keepCondition follows the NAMED chart, not the displaced one. On a copy the displaced assembly is
+    * whichever was primary — the latest chart — so carrying its filter onto a type change made about an
+    * earlier card would apply a filter the user never asked for there.
+    */
+   @Test
+   void theConditionComesFromTheNamedChart() {
+      VSAssembly named = mock(VSAssembly.class);
+      VSAssembly previousPrimary = mock(VSAssembly.class);
+
+      assertSame(named, WizVsService.resolveConditionSource(false, named, null, previousPrimary));
+   }
+
+   /** With no name it stays on the displaced assembly: replaced first, else the demoted primary. */
+   @Test
+   void withoutANameItFollowsTheDisplacedAssembly() {
+      VSAssembly replaced = mock(VSAssembly.class);
+      VSAssembly previousPrimary = mock(VSAssembly.class);
+
+      assertSame(replaced, WizVsService.resolveConditionSource(false, null, replaced, previousPrimary));
+      assertSame(previousPrimary,
+                 WizVsService.resolveConditionSource(false, null, null, previousPrimary));
+   }
+
+   /** Sync mode falls through — syncConfigs carries the condition there instead. */
+   @Test
+   void syncModeIgnoresTheNamedChart() {
+      VSAssembly named = mock(VSAssembly.class);
+      VSAssembly previousPrimary = mock(VSAssembly.class);
+
+      assertSame(previousPrimary,
+                 WizVsService.resolveConditionSource(true, named, null, previousPrimary));
+   }
+}


### PR DESCRIPTION
Follow-up to #4526, which made the wizard temp chart the durable store for a chart's binding-field settings (top-N ranking, sort, date group level, aggregate formula) so they survive a rebuild-from-recommendation.

## Problem

That mechanism assumes every call is about the session's newest chart. A wiz conversation reuses ONE recommendation runtime, and every autoBinding re-initializes its temp chart from whichever chart it is building (`WizAutoBindingService:158`, "Always re-initialize … regardless of reuse"). So the temp chart — and the recommendation model whose candidate refs are clones of it (`ChartTypeFilter.getAllRefs(true)`) — describe exactly one of the session's charts at a time.

Aim a type change at an earlier history card and both are the latest chart's:

| step | what happens |
|---|---|
| wiz sends the conversation-level `autoBindingRuntimeId` | it describes chart C3 |
| `changeType` reads the cached `recommendationModel` | C3's, candidates are clones of C3's refs |
| `refreshVisualizationBinding` | rebuilds the card with **C3's entire binding**, not merely without its ranking |
| `applyTempChartFieldSettings` | pairs by column; nothing pairs when the field sets differ, so it silently no-ops |

The write side had the mirror problem, and this one #4526 introduced: an edit to an earlier card recorded its settings onto a temp chart describing the latest chart and — RECORD being authoritative, i.e. clearing what the source does not carry — wiped what that chart had. The next type change then pushed the wrong settings back.

"Only rebuild when the target is historical" does not work: whichever chart was rebuilt last is the one the temp chart describes from then on, so latest → historical, historical → latest, and historical A → historical B all need it.

## Fix, part 1 — rebuild when the temp chart is about another chart (`977f69ca`)

`changeType` resolves the assembly it targets and rebuilds the temp chart and the recommendation model from that chart's own binding whenever they do not describe it. Same recommendation runtime, so nothing leaks and there is no second RVS to reconcile.

`VSTemporaryInfo` carries `wizSourceAssemblyName`, the assembly it was last seeded from. The record step keeps it in step: same columns records and moves the marker, different columns skips and clears it.

**Two checks, both needed.** The name, because two charts can bind the same columns and differ only in their settings. The columns, because an explicit re-bind (`/viewsheet/create` with a config) can add one without going through autoBinding at all — which also closes a gap #4526 did not cover, where a measure added that way was dropped by the next type change.

Not a settings fingerprint instead of the name: the recommender sets values on candidates the temp chart never had (`order`, `dateLevel` — the very reason `BindingFieldSettings.restore` copies only what the source carries), so after any ordinary turn temp ⊂ target and a fingerprint would force a rebuild every single call.

The rebuild reuses `autoBindingInternal`, structurally the branch that was already there, seeded from `WizVsService.collectFlatBinding` — already a reverse map of an assembly's refs into the `SimpleFieldInfo` subtypes `fieldConfigs` takes — with `wsTableName` from the target's own `SourceInfo`, since a conversation's worksheet accumulates a table per rebuild generation and resolving the columns against the wrong one fails them all as unknown. This subsumes the KNOWN GAP that branch documented, leaving only the narrow case where the target cannot be read at all.

`AutoBindingRequest` gains a `transient keepCondition` (off the wire, like `CreateVisualizationModel`'s) so a rebuild does not drop the filter the fast path preserves.

`WizFieldInfoFactory` now reports a dimension's sort order, without which a reported `sortByCol` is inert. Only the four explicit orders — `SORT_NONE`/`SORT_ORIGINAL` carry no intent and would override the recommender's per-type choice, and `SORT_SPECIFIC` is meaningless without the manual value list, which is deliberately not reported: `applyFieldConfig` reverses a supplied list for a funnel, so a round trip through it inverts. Manual order still reaches a rebuilt chart through `BindingFieldSettings`, which copies refs directly.

Reading unreadable state degrades to the pre-existing fast path throughout — "cannot tell" must not turn a missing temp chart into a full re-recommendation on every call.

## Fix, part 2 — `copy`, not the presence of a name, decides replace vs keep (`cb4616e5`)

Testing part 1 surfaced that the chat-driven path sends no `assemblyName` at all (only the GUI card type menu does), so it resolved to whichever assembly is primary — the latest chart — and part 1 did nothing for it.

It could not send one. `CreateVisualizationModel.assemblyName` meant "replace this in place", unconditionally, and documented that a caller setting both it and `copy=true` got copy silently bypassed. A chat turn is exactly that caller: it keeps the card it came from as history and adds a new one, so naming its source would have destroyed it.

The two intents are not in conflict; they needed separating by the flag that already exists. `copy` now decides. A click on a card's own type menu replaces that card (`copy` false), a chat turn about it keeps it (`copy` true), and either way the name says which chart's binding and pre-condition to carry.

**No existing path changes.** Every caller already maintained this as a caller-side invariant, sending a name only with `copy` false — see `validateBinding`'s mutually-exclusive `assemblyName` / `copy`, and `changeTypeNode`, which sends no `copy` at all. The skipExecution displaced-primary removal (`WizVsService:1786`) was already gated on `!isCopy()`.

Two details the split exposes:

- a copy MUST take a fresh name, or `addAssembly` would overwrite the target by name and destroy the card copy exists to keep;
- `keepCondition` now follows the NAMED chart rather than the displaced one — on a copy the displaced assembly is whichever was primary, i.e. the latest chart, so a type change made about an earlier card would otherwise inherit a filter the user never asked for there.

Both decisions are extracted as static helpers beside `resolveSyncSource`, which already had this shape and its own test file.

## Fix, part 3 — infer the field list from the named chart (`ea2149fd`)

Raised in review: parts 1 and 2 reach the plain-swap branch only. A chart-type change to a non-Cartesian target (pie, donut, treemap, sunburst, funnel, pareto, waterfall, marimekko) re-binds through `/viewsheet/autoBinding` instead, which does not consult part 1's staleness check — it re-seeds the temp chart from the request's `fieldConfigs`. That path carries none, and empty has always meant "every visible column of the worksheet table". So the symptom there was not "bound to the latest chart's fields" but **bound to the whole table**.

Naming a chart says "re-bind THAT chart", so the list now resolves as: the caller's `fieldConfigs`, else the named chart's binding, else every visible column. Same reverse map part 1's rebuild uses, and `wsTableName` defaults to that chart's own `SourceInfo`.

An inferred list is checked against the table and dropped **whole** if any column is missing. `fieldConfigs` is enforced strictly — `selectBindColumns` throws on a column the table does not have, which is right for a caller that named its fields and wrong for a list inferred on its behalf, and would turn a type change on a chart whose table a later generation replaced into a 400. Dropped whole rather than partially because half a binding is not the chart the caller meant either.

Also reached by a continuation turn whose hints produced no fields (autoBinding's `syncConfigs` caller already names the chart being refined) — deriving from that chart is what it meant too, and better than the whole table it got before. Carries part 1's limitation unchanged: a binding whose aggregation was pushed to the worksheet reads back in its pushed form.

The matching wiz-services change, which resolves the chart a chat turn is about and sends its name: inetsoft-technology/stylebi-wiz#1479

## Tests

29 cases added.

- `TempChartDescribesTest` — the staleness predicate: same chart matches; same columns under a different name does not; the right name with an added column does not; a cleared marker does not; unreadable state reports a match so the fast path stands.
- `DeriveFieldConfigsTest` — dimensions and measures flattened; empty (not null) when unreadable; `wsTableName` from the target's `SourceInfo`; null for a non-`DataVSAssembly`; an inferred list used only when the table has every column, and dropped whole when one is missing.
- `BindingFieldSettingsTest` +3 — `columnKeys` across x/y and the aesthetics, a crosstab's design headers, and a column bound twice NOT dropped (the opposite of the record/restore index, where dropping it is the point).
- `WizVsServiceRecordFieldSettingsTest` — same columns records and moves the marker; different columns and an added column skip and clear it; no runtime id / empty snapshot / missing temp chart leave it alone.
- `WizVsServiceReplaceInPlaceTest` — the `copy` split and the condition source, including sync mode on both.
- `WizFieldInfoFactorySortOrderTest` — the four explicit orders reported, the intent-free ones and manual order not.

`inetsoft.web.**` green at 1703 (0 failures, 4 pre-existing skips). Not yet exercised end to end against a live conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
