### PR TITLE
Bug #75970, reject change_column_type on physical/bound table columns

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -1041,6 +1041,27 @@ public class WorksheetEditService {
             throw new PairingException("Column not found: " + col);
          }
 
+         // Mirrors the UI's WSHeaderCellComponent.supportChangeColumnType(): a type
+         // change only survives the post-edit refreshColumnSelection() pass for
+         // expression columns, or for embedded/tabular/SQL-bound/unpivot tables that
+         // persist the override into their own definition. Every other table type
+         // (plain bound/physical tables, joins, etc.) has its column selection rebuilt
+         // from the source schema, which silently discards the override — so reject
+         // the request here instead of reporting success for a change that won't stick.
+         boolean isRangeRef = cr.getDataRef() instanceof NumericRangeRef ||
+            cr.getDataRef() instanceof DateRangeRef;
+         boolean supportsTypeChange = !isRangeRef && (cr.isExpression() ||
+            t instanceof EmbeddedTableAssembly || t instanceof TabularTableAssembly ||
+            t instanceof SQLBoundTableAssembly || t instanceof UnpivotTableAssembly);
+
+         if(!supportsTypeChange) {
+            throw new PairingException(
+               "Column type cannot be changed for \"" + col + "\" on table \"" + table +
+               "\". Changing the data type is only supported for expression columns " +
+               "and embedded, tabular/REST, SQL-bound, or unpivot tables — physical " +
+               "(bound query) tables and joins do not support changing column types.");
+         }
+
          // Also update the matching ref from findAttribute (same approach as
          // ColumnTypeDialogService) to ensure the canonical ref is updated.
          ColumnRef cr2 = (ColumnRef) cs.findAttribute(cr);

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -1042,15 +1042,20 @@ public class WorksheetEditService {
          }
 
          // Mirrors the UI's WSHeaderCellComponent.supportChangeColumnType(): a type
-         // change only survives the post-edit refreshColumnSelection() pass for
+         // override only survives the post-edit refreshColumnSelection() pass for
          // expression columns, or for embedded/tabular/SQL-bound/unpivot tables that
-         // persist the override into their own definition. Every other table type
-         // (plain bound/physical tables, joins, etc.) has its column selection rebuilt
-         // from the source schema, which silently discards the override — so reject
-         // the request here instead of reporting success for a change that won't stick.
+         // persist it into their own definition — every other table type has its
+         // column selection rebuilt from the source schema, discarding the override.
          boolean isRangeRef = cr.getDataRef() instanceof NumericRangeRef ||
             cr.getDataRef() instanceof DateRangeRef;
-         boolean supportsTypeChange = !isRangeRef && (cr.isExpression() ||
+
+         // An aggregate measure's exposed type is computed from the formula + input
+         // type when the query runs, not read back off this ref's dataType, so an
+         // override here is discarded the same way regardless of table type.
+         boolean isAggregateMeasure = t.isAggregate() && t.getAggregateInfo() != null &&
+            t.getAggregateInfo().getAggregate(cr) != null;
+
+         boolean supportsTypeChange = !isRangeRef && !isAggregateMeasure && (cr.isExpression() ||
             t instanceof EmbeddedTableAssembly || t instanceof TabularTableAssembly ||
             t instanceof SQLBoundTableAssembly || t instanceof UnpivotTableAssembly);
 

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -1049,13 +1049,13 @@ public class WorksheetEditService {
          boolean isRangeRef = cr.getDataRef() instanceof NumericRangeRef ||
             cr.getDataRef() instanceof DateRangeRef;
 
-         // An aggregate measure's exposed type is computed from the formula + input
-         // type when the query runs, not read back off this ref's dataType, so an
-         // override here is discarded the same way regardless of table type.
-         boolean isAggregateMeasure = t.isAggregate() && t.getAggregateInfo() != null &&
-            t.getAggregateInfo().getAggregate(cr) != null;
+         // Mirrors the UI's isExpressionAggregate exclusion: an expression column
+         // that is also one of the table's aggregate measures is still rejected even
+         // though cr.isExpression() would otherwise allow it.
+         boolean isExpressionAggregate = cr.isExpression() && t.isAggregate() &&
+            t.getAggregateInfo() != null && t.getAggregateInfo().getAggregate(cr) != null;
 
-         boolean supportsTypeChange = !isRangeRef && !isAggregateMeasure && (cr.isExpression() ||
+         boolean supportsTypeChange = !isRangeRef && !isExpressionAggregate && (cr.isExpression() ||
             t instanceof EmbeddedTableAssembly || t instanceof TabularTableAssembly ||
             t instanceof SQLBoundTableAssembly || t instanceof UnpivotTableAssembly);
 

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -1449,7 +1449,31 @@ class WorksheetEditServiceMutatorsTest {
    }
 
    @Test
-   void changeColumnTypeRejectsAggregateMeasureOnEmbeddedTable() throws Exception {
+   void changeColumnTypeRejectsExpressionAggregateMeasureOnEmbeddedTable() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "a");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> {
+         ed.addExpressionColumn("T", "e", "field['a']", "double", false);
+         ed.setGroupAggregate("T", List.of(), List.of(
+            new WorksheetMutationSupport.AggregateSpec("e", "SUM", null)));
+      });
+
+      // Mirrors the UI's isExpressionAggregate exclusion: "e" would otherwise be
+      // allowed via cr.isExpression() (EmbeddedTableAssembly is also unconditionally
+      // allowed), but its exposed type is computed from the SUM formula when the
+      // query runs, not read back off this override, so it must be rejected.
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.changeColumnType("T", "e", "integer")));
+
+      assertTrue(ex.getMessage().toLowerCase().contains("cannot be changed"));
+   }
+
+   @Test
+   void changeColumnTypeAllowsNonExpressionAggregateMeasureOnEmbeddedTable() throws Exception {
       Worksheet ws = new Worksheet();
       EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "a", "b");
       ws.addAssembly(t);
@@ -1459,14 +1483,14 @@ class WorksheetEditServiceMutatorsTest {
       svc.apply("TOK", agent, ed -> ed.setGroupAggregate("T", List.of("a"),
          List.of(new WorksheetMutationSupport.AggregateSpec("b", "SUM", null))));
 
-      // Without this guard the request would otherwise succeed (EmbeddedTableAssembly
-      // is unconditionally allowed above), but "b"'s exposed type is computed from the
-      // SUM formula when the query runs, not read back off this override, so it must
-      // be rejected the same way a physical-table column is.
-      PairingException ex = assertThrows(PairingException.class,
-         () -> svc.apply("TOK", agent, ed -> ed.changeColumnType("T", "b", "integer")));
+      // "b" is a raw (non-expression) aggregate measure. The UI's isExpressionAggregate
+      // check only excludes EXPRESSION-typed aggregates, so this must stay allowed here
+      // too — the backend guard should not be more restrictive than the UI.
+      svc.apply("TOK", agent, ed -> ed.changeColumnType("T", "b", "integer"));
 
-      assertTrue(ex.getMessage().toLowerCase().contains("cannot be changed"));
+      DataRef ref = t.getColumnSelection(false).getAttribute("b");
+      assertInstanceOf(ColumnRef.class, ref);
+      assertEquals("integer", ((ColumnRef) ref).getDataType());
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -1411,4 +1411,40 @@ class WorksheetEditServiceMutatorsTest {
                 "fix must recurse into the nested subquery's own selection and clear the mangled " +
                 "alias there, not just on the outer sql.getSelection()");
    }
+
+   // =========================================================================
+   // Column type tests
+   // =========================================================================
+
+   @Test
+   void changeColumnTypeRejectsPhysicalBoundTable() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly t = TestWorksheets.nonEmbeddedTableWithColumns(ws, "T", "a");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.changeColumnType("T", "a", "integer")));
+
+      assertTrue(ex.getMessage().toLowerCase().contains("cannot be changed"));
+      DataRef ref = t.getColumnSelection(false).getAttribute("a");
+      assertInstanceOf(ColumnRef.class, ref);
+      assertNotEquals("integer", ((ColumnRef) ref).getDataType());
+   }
+
+   @Test
+   void changeColumnTypeAllowsEmbeddedTable() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "a");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.changeColumnType("T", "a", "integer"));
+
+      DataRef ref = t.getColumnSelection(false).getAttribute("a");
+      assertInstanceOf(ColumnRef.class, ref);
+      assertEquals("integer", ((ColumnRef) ref).getDataType());
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -1447,4 +1447,45 @@ class WorksheetEditServiceMutatorsTest {
       assertInstanceOf(ColumnRef.class, ref);
       assertEquals("integer", ((ColumnRef) ref).getDataType());
    }
+
+   @Test
+   void changeColumnTypeRejectsAggregateMeasureOnEmbeddedTable() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "a", "b");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.setGroupAggregate("T", List.of("a"),
+         List.of(new WorksheetMutationSupport.AggregateSpec("b", "SUM", null))));
+
+      // Without this guard the request would otherwise succeed (EmbeddedTableAssembly
+      // is unconditionally allowed above), but "b"'s exposed type is computed from the
+      // SUM formula when the query runs, not read back off this override, so it must
+      // be rejected the same way a physical-table column is.
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.changeColumnType("T", "b", "integer")));
+
+      assertTrue(ex.getMessage().toLowerCase().contains("cannot be changed"));
+   }
+
+   @Test
+   void changeColumnTypeAllowsGroupColumnOnAggregatedEmbeddedTable() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "a", "b");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.setGroupAggregate("T", List.of("a"),
+         List.of(new WorksheetMutationSupport.AggregateSpec("b", "SUM", null))));
+
+      // The group-by column passes its value through unchanged (unlike an aggregate
+      // output), so its type change should still be allowed even on an aggregated table.
+      svc.apply("TOK", agent, ed -> ed.changeColumnType("T", "a", "integer"));
+
+      DataRef ref = t.getColumnSelection(false).getAttribute("a");
+      assertInstanceOf(ColumnRef.class, ref);
+      assertEquals("integer", ((ColumnRef) ref).getDataType());
+   }
 }

--- a/web/projects/portal/src/app/embed/table/embed-table.component.spec.ts
+++ b/web/projects/portal/src/app/embed/table/embed-table.component.spec.ts
@@ -18,6 +18,7 @@
 import { AssemblyActionGroup } from "../../common/action/assembly-action-group";
 import { TestUtils } from "../../common/test/test-utils";
 import { EmbedAssemblyContextProviderFactory } from "../../vsobjects/context-provider.service";
+import { VSTableModel } from "../../vsobjects/model/vs-table-model";
 import { EmbedTableActions } from "./embed-table-actions";
 import { EmbedTableComponent } from "./embed-table.component";
 
@@ -35,6 +36,7 @@ describe("EmbedTableComponent.onOpenContextMenu", () => {
    let dropdownService: any;
    let miniToolbarService: any;
    let component: TestUtils.ContextMenuHost;
+   let table: VSTableModel;
 
    beforeEach(() => {
       dropdownRef = {
@@ -44,8 +46,9 @@ describe("EmbedTableComponent.onOpenContextMenu", () => {
       dropdownService = { open: vi.fn(() => dropdownRef) };
       miniToolbarService = { hiddenFreeze: vi.fn(), hiddenUnfreeze: vi.fn() };
 
+      table = TestUtils.createMockVSTableModel("Table1");
       component = Object.create(EmbedTableComponent.prototype);
-      component.vsObject = TestUtils.createMockVSTableModel("Table1");
+      component.vsObject = table;
       component.dropdownService = dropdownService;
       component.miniToolbarService = miniToolbarService;
    });
@@ -54,7 +57,7 @@ describe("EmbedTableComponent.onOpenContextMenu", () => {
    // ones there are), so on an untouched table nothing is visible - and without the guard every
    // right click opened an empty dropdown and left the mini toolbar frozen behind it.
    it("opens nothing when the assembly has no visible menu action", () => {
-      component.vsObjectActions = new EmbedTableActions(component.vsObject,
+      component.vsObjectActions = new EmbedTableActions(table,
          EmbedAssemblyContextProviderFactory(), false, null, null, null, null,
          () => false, () => {});
       const event: any = {


### PR DESCRIPTION
## Summary

The Wiz worksheet-chat `change_column_type` MCP tool would mutate a column's `ColumnRef` data type in memory and report success, even for columns where the override is not actually persistable — either because the column lives on a plain physical/bound query table or join, or because it's a computed expression-aggregate measure.

## Root Cause

Every mutation applied via the Wiz session ends with `WorksheetEditService.refreshAssemblies()`, which calls `WorksheetEventUtil.refreshColumnSelection()` for every table. For a plain bound/physical table this re-derives the column selection straight from the live DB schema, silently discarding any manually-set type override moments after it was applied. Only embedded, tabular/REST, SQL-bound, and unpivot tables (and expression columns) have a persistence hook that survives this refresh — which is exactly why the browser Composer UI's `WSHeaderCellComponent.supportChangeColumnType()` only enables the "Column Type" action for those cases.

A second commit closes a narrower instance of the same failure mode, mirroring the UI's own `isExpressionAggregate` exclusion: an expression column that is also one of the table's aggregate measures (e.g. `SUM(some_expression)`) has its exposed type computed from the formula when the query runs, not read back off the column ref's `dataType`, so an override there is discarded too — even on an otherwise-allowed embedded/tabular/SQL-bound/unpivot table.

`WorksheetEditService.Editor.changeColumnType()` never enforced either restriction, so it reported `ok: true` for changes that were discarded immediately afterward.

## Fix

- Added a guard in `changeColumnType()` mirroring the UI's `supportChangeColumnType()` logic: rejected unless the column is an expression, or the table is `EmbeddedTableAssembly` (covers snapshot too), `TabularTableAssembly`, `SQLBoundTableAssembly`, or `UnpivotTableAssembly`.
- Added a second guard mirroring the UI's `isExpressionAggregate` exclusion: rejects an expression column that is also one of the table's configured aggregate measures (`AggregateInfo.getAggregate(DataRef)`). Scoped to match the UI exactly (expression-typed aggregates only) — a raw, non-expression aggregate measure stays allowed, confirmed against a live server that the UI itself allows this.

Both reject with a clear `PairingException` instead of reporting success for a change that won't stick.

Two additional restrictions raised in review were investigated and intentionally not added, since live testing against a running server contradicted the premise for both: a live+aggregate table-wide restriction for `TabularTableAssembly`/`SQLBoundTableAssembly`/`UnpivotTableAssembly` (a non-aggregate group-by column's type change on a live aggregated SQL-bound table persisted correctly after a forced refresh), and a concern that `SQLBoundTableAssembly` type overrides don't survive `refreshColumnSelection()` at all (also persisted correctly in the same live test).

## Test Plan

- Regression tests in `WorksheetEditServiceMutatorsTest`: `changeColumnTypeRejectsPhysicalBoundTable`, `changeColumnTypeAllowsEmbeddedTable`, `changeColumnTypeRejectsExpressionAggregateMeasureOnEmbeddedTable`, `changeColumnTypeAllowsNonExpressionAggregateMeasureOnEmbeddedTable`, `changeColumnTypeAllowsGroupColumnOnAggregatedEmbeddedTable`.
- `mvnw test -pl core -Dtest=WorksheetEditServiceMutatorsTest,WorksheetEditServiceTest,WorksheetAgentControllerTest` — 79 tests, 0 failures.
- `mvnw clean install -pl core -am -DskipTests` — build succeeds.
- User verified live against a running server via the worksheet-chat MCP tool on the reported repro (ORDERS1.DISCOUNT), plus additional live verification of the aggregate/live-mode edge cases discussed in review.

Fixes Redmine #75970.