### PR TITLE
Bug #76009, fix accessibility.enabled property key typo in CoreLifecycleService

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/CoreLifecycleService.java
@@ -296,7 +296,7 @@ public class CoreLifecycleService {
          infoMap.put("metadata", vsInfo.isMetadata());
 
          boolean accessible =
-            Boolean.parseBoolean((SreeEnv.getProperty(" accessibility.enabled", "false")));
+            Boolean.parseBoolean((SreeEnv.getProperty("accessibility.enabled", "false")));
 
          infoMap.put("accessible", accessible);
          infoMap.put("messageLevels", vsInfo.getMessageLevels());


### PR DESCRIPTION
## Summary

`CoreLifecycleService` read the accessibility property with a leading space in the key (`" accessibility.enabled"`), so the lookup could never match a property that any deployment can actually set. Accessibility was honoured in the portal and in PDF generation but silently ignored on the viewsheet lifecycle path.

## Root Cause

`PropertiesEngine.computePropertyNameCase` (`core/src/main/java/inetsoft/sree/PropertiesEngine.java:351`) lowercases a property name but does not trim it, so `" accessibility.enabled"` and `"accessibility.enabled"` are two distinct keys. Nothing writes the spaced form — `java.util.Properties` strips leading key whitespace on load, and the environment-variable path produces the unspaced form — so the read path at `CoreLifecycleService:299` always missed and fell back to its `"false"` default, permanently reporting `accessible = false`.

The two other call sites read the key correctly:

- `core/src/main/java/inetsoft/web/portal/controller/PortalController.java:80`
- `core/src/main/java/inetsoft/report/pdf/PDF3Generator.java:89`

The `accessible` value is sent to the browser in the `SetViewsheetInfoCommand` info map and consumed in `web/projects/portal/src/app/vsobjects/viewer-app.component.ts:2745`, where it enables Tab-key focus navigation in the viewsheet viewer and adds the `accessible` body class for standalone/embedded viewers. With the typo, an administrator who enabled accessibility got it in the portal chrome and in PDF export, but never in the viewsheet viewer.

The typo predates the initial open-source commit (carried over from `PlaceholderService`), so this is long-standing rather than a regression.

## Fix

Removed the leading space from the property key. Minimal scope — no other code in the surrounding block was touched.

## Test Plan

- Set `accessibility.enabled=true` (via `sree.properties` or the corresponding environment variable) and restart.
- Open a viewsheet in the viewer and confirm Tab-key focus navigation moves between assemblies. Outside the portal (standalone/embedded viewer), confirm the `accessible` class is applied to `<body>`. Before this change neither happened regardless of the setting.
- Regression: with the property unset or set to `false`, behavior is unchanged — the lookup returns the `"false"` default exactly as before.
- `./mvnw clean install -pl core -am -DskipTests` — BUILD SUCCESS.
- `./mvnw test -pl core` — 4282 tests run, 0 failures, 0 errors, 67 skipped.

Fixes Redmine #76009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)