### PR TITLE
Bug #76008, read SMTP OAuth flags from the property they are written to

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/general/EmailSettingsService.java
+++ b/core/src/main/java/inetsoft/web/admin/general/EmailSettingsService.java
@@ -48,11 +48,22 @@ public class EmailSettingsService {
          .smtpAuthUri(SreeEnv.getProperty("mail.smtp.authUri"))
          .smtpTokenUri(SreeEnv.getPassword("mail.smtp.tokenUri"))
          .smtpOAuthScopes(SreeEnv.getProperty("mail.smtp.oauthScopes"))
-         .smtpOAuthFlags(SreeEnv.getPassword("mail.smtp.outhFlags"))
+         .smtpOAuthFlags(getOAuthFlags())
          .smtpAccessToken(SreeEnv.getPassword("mail.smtp.accessToken"))
          .smtpRefreshToken(SreeEnv.getPassword("mail.smtp.refreshToken"))
          .tokenExpiration(SreeEnv.getProperty("mail.smtp.tokenExpiration"))
          .build();
+   }
+
+   /**
+    * Gets the SMTP OAuth flags. The flags are stored as a plain text property, so they must be
+    * read with getProperty() and not getPassword(). Earlier versions read the flags from the
+    * misspelled "mail.smtp.outhFlags" property, so that name is still honored if the correctly
+    * spelled property is not set.
+    */
+   private String getOAuthFlags() {
+      String flags = SreeEnv.getProperty("mail.smtp.oauthFlags");
+      return Tool.isEmptyString(flags) ? SreeEnv.getProperty("mail.smtp.outhFlags") : flags;
    }
 
    @Audited(

--- a/core/src/test/java/inetsoft/web/admin/general/EmailSettingsServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/general/EmailSettingsServiceTest.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.admin.general;
+
+import inetsoft.sree.SreeEnv;
+import inetsoft.util.Tool;
+import org.junit.jupiter.api.*;
+import org.mockito.MockedStatic;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class EmailSettingsServiceTest {
+   private EmailSettingsService service;
+   private MockedStatic<SreeEnv> sreeEnvStatic;
+   private MockedStatic<Tool> toolStatic;
+
+   @BeforeEach
+   void setUp() {
+      service = new EmailSettingsService();
+      sreeEnvStatic = mockStatic(SreeEnv.class, withSettings().lenient());
+      toolStatic =
+         mockStatic(Tool.class, withSettings().lenient().defaultAnswer(CALLS_REAL_METHODS));
+      toolStatic.when(Tool::isCloudSecrets).thenReturn(false);
+
+      // properties that are required to build the model
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("mail.smtp.auth")).thenReturn("saslXOauth2");
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("mail.from.address"))
+         .thenReturn("noreply@example.com");
+   }
+
+   @AfterEach
+   void tearDown() {
+      toolStatic.close();
+      sreeEnvStatic.close();
+   }
+
+   // the OAuth flags are written to mail.smtp.oauthFlags, so they must be read from the same
+   // property and as a plain text property
+   @Test
+   void getModelReadsOAuthFlagsFromWrittenProperty() {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("mail.smtp.oauthFlags"))
+         .thenReturn("flag1 flag2");
+
+      assertEquals("flag1 flag2", service.getModel().smtpOAuthFlags());
+      sreeEnvStatic.verify(() -> SreeEnv.getPassword("mail.smtp.oauthFlags"), never());
+   }
+
+   // deployments that set the misspelled property directly must keep working
+   @Test
+   void getModelFallsBackToLegacyOAuthFlagsProperty() {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("mail.smtp.outhFlags")).thenReturn("legacyFlag");
+
+      assertEquals("legacyFlag", service.getModel().smtpOAuthFlags());
+   }
+
+   @Test
+   void getModelPrefersOAuthFlagsOverLegacyProperty() {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("mail.smtp.oauthFlags")).thenReturn("newFlag");
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("mail.smtp.outhFlags")).thenReturn("legacyFlag");
+
+      assertEquals("newFlag", service.getModel().smtpOAuthFlags());
+   }
+
+   @Test
+   void getModelReturnsNullOAuthFlagsWhenNotConfigured() {
+      assertNull(service.getModel().smtpOAuthFlags());
+   }
+}


### PR DESCRIPTION
## Summary

The SMTP OAuth flags configured on **Settings > General > Email** in the Enterprise Manager never round-tripped: the value was saved, but the field came back blank on the next page load and the flags were never carried into the OAuth authorization request. No error was reported at any point.

## Root Cause

`EmailSettingsService` wrote the flags to one property and read them back from a different one, with a second mismatch in the accessor used:

```java
// getModel(), line 51 - READ
.smtpOAuthFlags(SreeEnv.getPassword("mail.smtp.outhFlags"))

// setModel(), line 86 - WRITE
SreeEnv.setProperty("mail.smtp.oauthFlags", model.smtpOAuthFlags());
```

1. **Property name** — `outhFlags` on read versus `oauthFlags` on write. `PropertiesEngine.computePropertyNameCase` only lowercases the name; it does not reconcile the two spellings, so these are two distinct properties. Nothing in the codebase ever writes the misspelled one, so the read always returned empty.
2. **Accessor** — the read used `SreeEnv.getPassword()` while the write used `SreeEnv.setProperty()` (plain text). With local encryption `getPassword()` happens to pass clear text through unchanged, but when cloud secrets are enabled it treats the value as a vault secret ID and calls `Tool.loadCredentials()`, which throws for a non-JSON value. Correcting only the property name would therefore have turned this into a 500 on the general settings page for cloud-secrets deployments.

Both lines date back to the SASL XOAUTH2 support added in commit 58ba1d4c6 (Bug #71033).

## Fix

`getModel()` now reads the flags through a small helper that uses `SreeEnv.getProperty("mail.smtp.oauthFlags")` — the property `setModel()` actually writes — and falls back to the legacy misspelled `mail.smtp.outhFlags` when the correct one is not set, so a deployment that populated the old name directly in `sree.properties` keeps working. The first save from the Enterprise Manager promotes such a value to the correctly spelled property.

The write path, the property name written, the model contract and the REST payload are all unchanged.

Added `EmailSettingsServiceTest` covering the correct property, the legacy fallback, precedence between the two, and the unconfigured case. Three of the four tests fail against the unfixed code.

## Test Plan

- `./mvnw test -pl core -Dtest='EmailSettingsServiceTest,GeneralSettingsPageControllerTest,PropertiesControllerTest'` — all green.
- Manual: EM > Settings > General > Email, set SMTP Authentication to *SASL XOAUTH2*, enter a value in **OAuth Flags**, save, reload the page — the field is repopulated, and *Authorize* now includes the flags in the authorization request.
- Regression: with no flags configured the field is blank as before; other email settings (host, user, password, tokens, subject formats) are untouched.

Fixes Redmine #76008.