### PR TITLE
Bug #75969, fix adhoc filter popup hidden behind enlarged assembly in Group Container/Tab

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.ts
@@ -588,7 +588,11 @@ export class VSObjectContainer implements AfterViewInit, OnChanges, OnDestroy {
 
       let zIndex = vsObject.objectFormat.zIndex;
 
-      for(let container = vsObject.container; container; ) {
+      // A max-mode (enlarged) assembly is rendered pulled out of its Group Container/Tab, so
+      // that container's own z-index is no longer meaningful to its stacking and must not be
+      // added on top -- otherwise the container's z-index can push the enlarged assembly above
+      // its own adhoc filter popup, which has no container and so never gets this addition (#75990).
+      for(let container = !(<any> vsObject).maxMode ? vsObject.container : null; container; ) {
          let containerObj = this.vsInfo.vsObjects.find(v => v.absoluteName == container);
 
          if(containerObj) {


### PR DESCRIPTION
## Summary
- When a crosstab/chart nested inside a Group Container or Tab is enlarged ("Show Enlarged"), clicking a cell's right-click "Filter" action created the adhoc filter popup, but it rendered *behind* the enlarged view and appeared not to show up at all.
- Root cause: `VSObjectContainer.zIndex()` walks up an assembly's `container` chain and adds each ancestor's own z-index on top of the assembly's own. This is meaningful for normal (non-enlarged) stacking, but an enlarged assembly is rendered pulled out of its container — that container's z-index is no longer relevant to its stacking, yet it was still being added. This pushed the enlarged assembly's effective z-index *above* its own adhoc filter popup (which has no `container` and so never received this addition), causing the filter to render underneath it.
- Fix: skip the container z-index walk when the assembly itself is the currently-maximized one.

## Test plan
- [x] Import a viewsheet with a crosstab inside a Group Container; click "Show Enlarged" on the crosstab, right-click a cell, choose "Filter" — popup now appears above the enlarged crosstab.
- [x] Same test with a chart inside a Tab, using the chart VO right-click "Filter" — popup appears correctly.
- [x] Verified normal (non-enlarged) adhoc filter behavior is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)