### PR TITLE
Bug #75929, fix slider-bound form value not persisted on submit

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ViewsheetSandbox.java
@@ -4030,7 +4030,10 @@ public class ViewsheetSandbox implements Cloneable, ActionListener {
 
          if(ass instanceof EmbeddedTableAssembly) {
             EmbeddedTableAssembly eassembly = (EmbeddedTableAssembly) ass;
-            DataRef column = iassembly.getColumn();
+            // resolve the column from the current column selection instead of relying on
+            // iassembly.getColumn(), which is only refreshed on a full sandbox reset and
+            // may be stale if the binding was changed without reopening the viewsheet
+            DataRef column = eassembly.getColumnSelection(false).getAttribute(iassembly.getColumnValue());
             int row = iassembly.getRow();
 
             if(column != null && row > 0) {

--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSInputService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSInputService.java
@@ -296,12 +296,49 @@ public class VSInputService {
                .toArray();
             multiApplySelection(vsId, assemblyNames,
                                                        selectedObjects, principal, dispatcher, linkUri);
+
+            // Commit the submitted values into their bound embedded tables now, before the
+            // "refresh viewsheet after submit" button option (SubmitVSAssemblyInfo default)
+            // does a full viewsheet reset. That reset re-derives each input's selected value
+            // from its bound table cell, which would otherwise clobber the value just applied
+            // above with the stale, pre-submit value before it ever gets written back.
+            commitInputTableWrites(vsId, assemblyNames, principal, dispatcher, linkUri);
          }
       }
 
       onClick(vsId, name, x, y, linkUri, false, null, principal, dispatcher);
 
       return null;
+   }
+
+   /**
+    * Write the current (just-applied) selected values of the given input assemblies into
+    * their bound embedded table cells, if any.
+    */
+   private void commitInputTableWrites(String vsId, String[] assemblyNames, Principal principal,
+                                       CommandDispatcher dispatcher, String linkUri)
+      throws Exception
+   {
+      RuntimeViewsheet rvs = viewsheetService.getViewsheet(vsId, principal);
+      Optional<ViewsheetSandbox> box = rvs.getViewsheetSandbox();
+
+      if(box.isEmpty()) {
+         return;
+      }
+
+      ChangedAssemblyList clist =
+         coreLifecycleService.createList(true, dispatcher, rvs, linkUri);
+
+      box.get().lockWrite();
+
+      try {
+         for(String assemblyName : assemblyNames) {
+            box.get().processChange(assemblyName, VSAssembly.OUTPUT_DATA_CHANGED, clist);
+         }
+      }
+      finally {
+         box.get().unlockWrite();
+      }
    }
 
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
@@ -2575,8 +2612,15 @@ public class VSInputService {
          if(assembly instanceof SubmitVSAssembly &&
             ((SubmitVSAssemblyInfo) assembly.getInfo()).isRefresh())
          {
+            // resetRuntime=false: reset=true already re-executes every assembly against the
+            // sandbox's current (in-memory) worksheet data, which is all "refresh viewsheet
+            // after submit" needs. resetRuntime=true would additionally reload the base
+            // worksheet from the asset repository (RuntimeViewsheet.resetRuntime() ->
+            // Viewsheet.update()), discarding the embedded-table write that was just made
+            // above for any submitted, non-submit-on-change input (e.g. a slider bound to an
+            // embedded table cell) before it was ever persisted to storage.
             this.coreLifecycleService.refreshViewsheet(rvs, rvs.getID(), linkUri, dispatcher,
-                                                       false, true, true, clist, true);
+                                                       false, true, true, clist, false);
          }
          else {
             box.get().processChange(name, VSAssembly.INPUT_DATA_CHANGED, clist);


### PR DESCRIPTION
## Summary
- A vsform input (e.g. a Slider) bound to an embedded worksheet table cell via the Data tab, with submit-on-change off, did not write its value into the target cell when the Submit button was clicked, and the input's own runtime value snapped back to the stale value.
- Root cause: the Submit button's "refresh viewsheet after submit" option (checked by default) triggers `refreshViewsheet(..., resetRuntime=true)`, which reloads the entire base worksheet fresh from the asset repository (`RuntimeViewsheet.resetRuntime()` -> `Viewsheet.update()`). That discarded the in-memory embedded-table write before it was ever visible.
- Fix: commit the submitted values into their bound embedded tables immediately after they're applied (`VSInputService.commitInputTableWrites`), and stop forcing the destructive full worksheet reload for the "refresh after submit" case (`reset=true` already re-executes the viewsheet against current in-memory data). Also resolve the target column from the table's live `ColumnSelection` instead of a `DataRef` cached on the assembly info that's only refreshed on a full sandbox reset.

## Test plan
- [x] Manually reproduced: created a viewsheet with an embedded table, a Slider bound to a cell via Target/Column/Row, and a Submit button (submit-on-change off, default "refresh viewsheet after submit" on).
- [x] Confirmed before the fix: setting the slider and clicking Submit left the table cell unchanged and the slider reverted to its old value.
- [x] Confirmed after the fix: the table cell updates to the submitted value and the slider retains it.
- [x] `mvn clean install -pl core -am -DskipTests` builds successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)