### PR TITLE
Bug #75991, reject add_variable when a duplicate name already exists

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -1480,7 +1480,19 @@ public class WorksheetAgentController {
     */
    private void createVariable(Worksheet ws, String name, String type,
                                String label, String defaultValue)
+      throws PairingException
    {
+      if(ws.getAssembly(name) != null) {
+         // Fail loud: Worksheet.addAssembly() silently replaces an existing assembly
+         // of the same name (or, for a same-name assembly of a different type, silently
+         // no-ops). Either way a second add_variable call would destroy or discard state
+         // without warning. edit_variable is the explicit path for changing an existing
+         // variable's type/label/default value.
+         throw new PairingException(
+            "An assembly named '" + name + "' already exists in this worksheet. " +
+            "Use edit_variable to change its type, label, or default value instead.");
+      }
+
       AssetVariable var = new AssetVariable(name);
 
       if(label != null) {

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -28,6 +28,7 @@ import inetsoft.uql.asset.*;
 import inetsoft.uql.asset.internal.SQLBoundTableAssemblyInfo;
 import inetsoft.uql.jdbc.JDBCDataSource;
 import inetsoft.uql.jdbc.JDBCQuery;
+import inetsoft.uql.schema.XSchema;
 import inetsoft.web.composer.ws.LayoutGraphService;
 import inetsoft.web.portal.controller.database.DataSourceService;
 import inetsoft.web.portal.controller.database.QueryManagerService;
@@ -417,6 +418,89 @@ class WorksheetAgentControllerTest {
       PairingException ex = assertThrows(PairingException.class,
          () -> ctrl.edit("TOK-EE", req, agent));
       assertTrue(ex.getMessage().contains("name"));
+   }
+
+   /** Builds an {@code add_variable} EditRequest that routes to addVariableFromEdit(). */
+   private static EditRequest addVariableRequest(String name, String type) {
+      return new EditRequest(
+         "add_variable", null, null, name, type, null, null, null, null, null, null, null, null, false,
+         null, null, null, null, null,
+         null, null, null, null, null, null, null, null, null, null, null, null, null,
+         null, null, null, null, null, null, null, null, null, null,
+         null, null, null, null,
+         null, null,
+         null, null,
+         null, null, null
+      );
+   }
+
+   @Test
+   void editAddVariableCreatesVariableWhenNameIsNew() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      Worksheet ws = new Worksheet();
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(sessions.resolve(eq("TOK-AV"), any())).thenReturn(session("TOK-AV"));
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+
+      WorksheetAgentController ctrl = controller(featureOn(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class));
+
+      ctrl.edit("TOK-AV", addVariableRequest("minTotal", "double"), agent);
+
+      Assembly a = ws.getAssembly("minTotal");
+      assertTrue(a instanceof VariableAssembly, "a variable assembly should have been created");
+   }
+
+   @Test
+   void editRejectsAddVariableWithDuplicateName() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      // Regression for Bug #75991: a second add_variable call with a name that
+      // already exists used to silently replace the existing variable assembly
+      // (including its type and default value) via Worksheet.addAssembly's
+      // generic same-name replace semantics. add_variable must fail loud instead
+      // and point the caller at edit_variable, which is the explicit modify path.
+      Worksheet ws = new Worksheet();
+      AssetVariable existingVar = new AssetVariable("minTotal");
+      existingVar.setTypeNode(XSchema.createPrimitiveType(XSchema.DOUBLE));
+      DefaultVariableAssembly existing = new DefaultVariableAssembly(ws, "minTotal");
+      existing.setVariable(existingVar);
+      ws.addAssembly(existing);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(sessions.resolve(eq("TOK-AVD"), any())).thenReturn(session("TOK-AVD"));
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+
+      WorksheetAgentController ctrl = controller(featureOn(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class));
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-AVD", addVariableRequest("minTotal", "date"), agent));
+      assertTrue(ex.getMessage().contains("already exists"));
+      assertTrue(ex.getMessage().contains("edit_variable"));
+
+      Assembly a = ws.getAssembly("minTotal");
+      assertSame(existing, a, "the original variable assembly must not be replaced");
+      assertEquals(XSchema.DOUBLE, ((VariableAssembly) a).getVariable().getTypeNode().getType(),
+                   "the original variable's type must be unchanged");
    }
 
    // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`add_variable` silently overwrote an existing worksheet variable when given a duplicate name, even if the existing variable had a different type — destroying its default value and any `$(name)` references with no warning.

## Root Cause

`WorksheetAgentController.createVariable()` always constructed a new `DefaultVariableAssembly` and called `ws.addAssembly(assembly)` without checking whether an assembly with that name already existed. `Worksheet.addAssembly()` silently replaces an existing assembly of the same name (by design — this generic replace-on-name-match behavior is relied on elsewhere and is out of scope here), so a second `add_variable` call for the same name silently discarded the original variable.

## Fix

`createVariable()` now throws a `PairingException` when an assembly with the given name already exists, directing the caller to use `edit_variable` instead — mirroring the existing duplicate-name guards already in this file for `add_column` and `duplicate_assembly`.

## Test Plan

- Added `editRejectsAddVariableWithDuplicateName` — asserts a second `add_variable` call for an existing name throws `PairingException` and leaves the original variable assembly (name, type, default value) untouched.
- Added `editAddVariableCreatesVariableWhenNameIsNew` — confirms the normal (non-duplicate) `add_variable` path is unaffected.
- `./mvnw test -pl core -Dtest='inetsoft.web.wiz.worksheet.**'` — 87 tests, 0 failures.
- `./mvnw clean install -pl core -am -DskipTests` — builds clean.
- Manually verified live via the worksheet-chat plugin: creating `minTotal` (double) then re-adding `minTotal` (date) now returns an error instead of silently overwriting.

Fixes Redmine #75991.