### PR TITLE
Bug #75999, fix reorder_columns silently no-oping on entity-qualified columns

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -1450,6 +1450,21 @@ public class WorksheetEditService {
          TableAssembly t = requireTable(table);
          ColumnSelection cs = t.getColumnSelection(false);
 
+         // Bare attribute names that occur more than once (e.g. "ID" from both a
+         // "Customers" and an "Orders" entity in a join) are ambiguous — keying the
+         // lookup map on the bare name for those would collide and silently drop one
+         // of the columns. Only use the bare name when it is unique; ambiguous ones
+         // fall back to the entity-qualified DataRef.getName().
+         java.util.Map<String, Integer> attributeNameCounts = new java.util.HashMap<>();
+
+         for(int i = 0; i < cs.getAttributeCount(); i++) {
+            DataRef ref = cs.getAttribute(i);
+
+            if(ref instanceof ColumnRef cr && (cr.getAlias() == null || cr.getAlias().isEmpty())) {
+               attributeNameCounts.merge(cr.getAttribute(), 1, Integer::sum);
+            }
+         }
+
          // Build a map of name → DataRef for fast lookup
          java.util.LinkedHashMap<String, DataRef> byName = new java.util.LinkedHashMap<>();
 
@@ -1461,8 +1476,15 @@ public class WorksheetEditService {
             // not DataRef.getName(), which is entity-qualified (e.g. "All Sales.Company")
             // for columns whose entity is non-blank, such as unpivot header columns.
             if(ref instanceof ColumnRef cr) {
-               name = cr.getAlias() != null && !cr.getAlias().isEmpty()
-                      ? cr.getAlias() : cr.getAttribute();
+               if(cr.getAlias() != null && !cr.getAlias().isEmpty()) {
+                  name = cr.getAlias();
+               }
+               else if(attributeNameCounts.get(cr.getAttribute()) > 1) {
+                  name = ref.getName();
+               }
+               else {
+                  name = cr.getAttribute();
+               }
             }
             else {
                name = ref.getName();

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -1455,9 +1455,19 @@ public class WorksheetEditService {
 
          for(int i = 0; i < cs.getAttributeCount(); i++) {
             DataRef ref = cs.getAttribute(i);
-            String name = ref instanceof ColumnRef cr && cr.getAlias() != null
-                          && !cr.getAlias().isEmpty()
-                          ? cr.getAlias() : ref.getName();
+            String name;
+
+            // Match on the bare attribute name (what the caller and the UI both use),
+            // not DataRef.getName(), which is entity-qualified (e.g. "All Sales.Company")
+            // for columns whose entity is non-blank, such as unpivot header columns.
+            if(ref instanceof ColumnRef cr) {
+               name = cr.getAlias() != null && !cr.getAlias().isEmpty()
+                      ? cr.getAlias() : cr.getAttribute();
+            }
+            else {
+               name = ref.getName();
+            }
+
             byName.put(name, ref);
          }
 

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -1457,4 +1457,33 @@ class WorksheetEditServiceMutatorsTest {
       assertEquals("a", reordered.getAttribute(1).getAttribute());
       assertEquals("b", reordered.getAttribute(2).getAttribute());
    }
+
+   @Test
+   void reorderColumnsDoesNotDropColumnsWithAmbiguousBareAttributeName() throws Exception {
+      // A join/concatenated table can expose two columns with the same bare attribute
+      // name but different entities (e.g. "Customers.ID" and "Orders.ID"). Keying the
+      // lookup solely on the bare name would let the second collide with and silently
+      // erase the first from the reordered selection.
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = new EmbeddedTableAssembly(ws, "T");
+      ColumnSelection cs = new ColumnSelection();
+      ColumnRef customerId = new ColumnRef(new AttributeRef("Customers", "ID"));
+      ColumnRef orderId = new ColumnRef(new AttributeRef("Orders", "ID"));
+      ColumnRef name = new ColumnRef(new AttributeRef(null, "Name"));
+      cs.addAttribute(customerId);
+      cs.addAttribute(orderId);
+      cs.addAttribute(name);
+      t.setColumnSelection(cs, false);
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.reorderColumns("T", List.of("Name", "ID")));
+
+      ColumnSelection reordered = t.getColumnSelection(false);
+      assertEquals(3, reordered.getAttributeCount(),
+         "an ambiguous bare-name collision must not silently drop a column");
+      assertTrue(reordered.containsAttribute(customerId), "Customers.ID must survive reordering");
+      assertTrue(reordered.containsAttribute(orderId), "Orders.ID must survive reordering");
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -1411,4 +1411,50 @@ class WorksheetEditServiceMutatorsTest {
                 "fix must recurse into the nested subquery's own selection and clear the mangled " +
                 "alias there, not just on the outer sql.getSelection()");
    }
+
+   // =========================================================================
+   // Column reorder tests
+   // =========================================================================
+
+   @Test
+   void reorderColumnsAppliesRequestedOrder() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "a", "b", "c");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.reorderColumns("T", List.of("c", "a", "b")));
+
+      ColumnSelection cs = t.getColumnSelection(false);
+      assertEquals("c", cs.getAttribute(0).getAttribute());
+      assertEquals("a", cs.getAttribute(1).getAttribute());
+      assertEquals("b", cs.getAttribute(2).getAttribute());
+   }
+
+   @Test
+   void reorderColumnsMatchesColumnsByBareNameNotEntityQualifiedName() throws Exception {
+      // Bug #75999: columns whose entity is non-blank (e.g. unpivot header columns,
+      // whose entity gets retroactively set to the base table's name the first time
+      // the table is queried) were never matched against the caller's bare column
+      // names, so reorderColumns silently fell back to the original order for them.
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = new EmbeddedTableAssembly(ws, "T");
+      ColumnSelection cs = new ColumnSelection();
+      cs.addAttribute(new ColumnRef(new AttributeRef("T", "a")));
+      cs.addAttribute(new ColumnRef(new AttributeRef("T", "b")));
+      cs.addAttribute(new ColumnRef(new AttributeRef("T", "c")));
+      t.setColumnSelection(cs, false);
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.reorderColumns("T", List.of("c", "a", "b")));
+
+      ColumnSelection reordered = t.getColumnSelection(false);
+      assertEquals("c", reordered.getAttribute(0).getAttribute(),
+         "entity-qualified columns must still be matched by their bare attribute name");
+      assertEquals("a", reordered.getAttribute(1).getAttribute());
+      assertEquals("b", reordered.getAttribute(2).getAttribute());
+   }
 }


### PR DESCRIPTION
## Summary

`reorder_columns` (the worksheet-chat MCP tool, backed by `WorksheetEditService.reorderColumns`) silently failed to reorder columns on `UnpivotTableAssembly` tables — the requested order was ignored and columns reverted to something close to their original order.

## Root Cause

`reorderColumns` matched the caller-supplied column names against `DataRef.getName()`, which returns the entity-qualified name (`"entity.attribute"`, e.g. `"All Sales.Company"`) whenever a column's entity is non-blank. Callers always pass the bare attribute name (e.g. `"Company"`), matching what the UI/model displays.

For a plain bound table, column entity happens to be blank, so `getName()` equals the bare name and the lookup worked. But `UnpivotTableAssembly`'s header columns get their entity retroactively set to the base table's name by `UnpivotQuery.fixColumnSelection0` the first time the table is queried/previewed. After that, `getName()` for those columns becomes entity-qualified and never matches the bare names in `columnOrder` — those columns silently fall through to the "append remaining in original order" branch instead of being placed per the request.

Confirmed live against a running server: reordering an unpivot table reproduced the exact scrambled order reported in the issue (`Dimension, Measure, Employee, Order Number, Company, Order Date`).

## Fix

Match on the bare attribute name (`ColumnRef.getAttribute()`) instead of the entity-qualified `DataRef.getName()`, consistent with every other name-based column lookup in this file (e.g. `ColumnSelection.getAttribute(String)`, used by `addDateRangeColumn` and others).

## Test Plan

- Added `reorderColumnsAppliesRequestedOrder` (baseline coverage) and `reorderColumnsMatchesColumnsByBareNameNotEntityQualifiedName` (reproduces the entity-qualification bug directly) to `WorksheetEditServiceMutatorsTest`.
- `./mvnw test -pl core -Dtest=inetsoft.web.wiz.worksheet.**` — all pass (55/55 in `WorksheetEditServiceMutatorsTest`).
- Verified live: reproduced the bug on a running server against the `Sample Queries/All Sales` worksheet, applied the fix, rebuilt, restarted the server, and confirmed `reorder_columns` now applies the requested order on the unpivot table.

Fixes Redmine #75999.