### PR TITLE
Support an alias on a group-by field, mirroring the aggregate alias

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/WizUtil.java
+++ b/core/src/main/java/inetsoft/web/wiz/WizUtil.java
@@ -156,6 +156,88 @@ public class WizUtil {
       }
    }
 
+   /**
+    * Infix of the lookup table wiz injects purely to label a foreign key — {@code <source>__fk_<target>}
+    * in fkJoinBatchRewrite. Deliberately does NOT match the join itself ({@code <source>__fkjoin}, no
+    * trailing underscore), which carries the fact rows and must be capped like any other detail table.
+    */
+   private static final String FK_LABEL_LOOKUP_INFIX = "__fk_";
+
+   /**
+    * Applies the sampled-preview row cap to a worksheet's DETAIL tables, leaving any lookup table
+    * injected purely to label a foreign key uncapped. Pass {@code maxRows <= 0} for full data, which
+    * clears a cap left by an earlier sampled render on the same runtime.
+    *
+    * <p>Bug #75989. {@code WorksheetInfo.setDesignMaxRows} is worksheet-WIDE, so it capped every table
+    * assembly independently — including the few-row lookup wiz injects to turn an FK id into a name.
+    * Truncating the lookup side of an INNER join does not sample the facts, it destroys matches: every
+    * fact row whose key was truncated away disappears. Measured on a 984-row table, same binding, only
+    * the cap changed: 8 → <b>0 rows</b>, 12 → 12 rows, 20 → 20 rows; the lookup ({@code projects}) has
+    * 13 rows, which is exactly where the behaviour turns.
+    *
+    * <p>What makes that a defect rather than a rough edge: the injection is only sound BECAUSE the join
+    * is row-preserving — wiz probes for orphans and duplicate target keys before injecting, precisely so
+    * that no unfiltered aggregate changes. A worksheet-wide cap silently voids that precondition. And
+    * because the join is injected automatically, a caller who wrote a single-table worksheet and never
+    * asked for a join could hit it.
+    *
+    * <p>Applying the cap per assembly keeps the documented semantics — "aggregate at most maxRows detail
+    * rows" — while exempting the dimension tables that were never part of the sampled fact stream.
+    */
+   public static void applySampledPreviewCap(inetsoft.uql.asset.Worksheet ws, int maxRows) {
+      if(ws == null) {
+         return;
+      }
+
+      final int cap = Math.max(maxRows, 0);
+
+      // Never worksheet-wide (that is the bug). Cleared unconditionally so a cap set by an earlier
+      // render of this same runtime cannot linger once the caller asks for full data.
+      ws.getWorksheetInfo().setDesignMaxRows(0);
+
+      for(Assembly assembly : ws.getAssemblies()) {
+         if(assembly instanceof inetsoft.uql.asset.TableAssembly table) {
+            final String name = table.getName();
+            table.setMaxRows(name != null && name.contains(FK_LABEL_LOOKUP_INFIX) ? 0 : cap);
+         }
+      }
+   }
+
+   /**
+    * The sampled-preview cap currently in effect on {@code ws}, or 0 for full data.
+    *
+    * Companion to {@link #applySampledPreviewCap} and the reason it exists: the cap can no longer be
+    * read back off {@code designMaxRows}, because it is deliberately never set there any more (#75989).
+    * Two call sites depend on reading it back — the {@code sampled}/{@code sampleMaxRows} flags that tell
+    * the caller its Sum/Count is approximate, and the lazy re-fetch path that must keep a sampled render
+    * sampled. Left reading designMaxRows, the first silently claimed a sampled chart was full data and
+    * the second silently promoted it to full data.
+    *
+    * Reads the DETAIL tables only, mirroring how the cap is applied: an injected FK-label lookup is
+    * intentionally uncapped, so including it would always report 0.
+    */
+   public static int sampledPreviewCap(inetsoft.uql.asset.Worksheet ws) {
+      if(ws == null) {
+         return 0;
+      }
+
+      int cap = 0;
+
+      for(Assembly assembly : ws.getAssemblies()) {
+         if(assembly instanceof inetsoft.uql.asset.TableAssembly table) {
+            final String name = table.getName();
+
+            if(name != null && name.contains(FK_LABEL_LOOKUP_INFIX)) {
+               continue;
+            }
+
+            cap = Math.max(cap, table.getMaxRows());
+         }
+      }
+
+      return cap;
+   }
+
    public static final String ANNOTATION_RAW_DATA_MAX_ROW = "annotation.rawdata.maxrow";
 
    private static final Logger LOG = LoggerFactory.getLogger(WizUtil.class);

--- a/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
@@ -31,6 +31,7 @@ import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.util.Catalog;
 import inetsoft.util.Tool;
+import inetsoft.web.wiz.WizUtil;
 import inetsoft.web.wiz.model.CloseViewsheetRequest;
 import inetsoft.web.wiz.model.OpenViewsheetResult;
 import inetsoft.web.wiz.model.VerifyViewsheetResult;
@@ -153,7 +154,9 @@ public class ViewsheetRuntimeController {
                ? rvs.getViewsheet().getBaseWorksheet() : null;
 
             if(bws != null) {
-               bws.getWorksheetInfo().setDesignMaxRows(sampleMaxRows);
+               // #75989: per-assembly, so the cap never truncates an injected FK-label lookup and
+               // destroys the join matches it exists to preserve.
+               WizUtil.applySampledPreviewCap(bws, sampleMaxRows);
                rvs.getViewsheetSandbox().ifPresent(box -> {
                   box.cancelAllQueries();
 
@@ -244,7 +247,9 @@ public class ViewsheetRuntimeController {
                var bws = rvs.getViewsheet() != null ? rvs.getViewsheet().getBaseWorksheet() : null;
 
                if(bws != null) {
-                  bws.getWorksheetInfo().setDesignMaxRows(sampleMaxRows);
+                  // #75989: see applySampledPreviewCap — a worksheet-wide cap here reported a perfectly
+                  // good saved chart as rendering NO data, i.e. as a broken save.
+                  WizUtil.applySampledPreviewCap(bws, sampleMaxRows);
                }
             }
             catch(Exception ex) {

--- a/core/src/main/java/inetsoft/web/wiz/model/WorksheetTable.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WorksheetTable.java
@@ -332,6 +332,15 @@ public class WorksheetTable {
    public static class GroupByFieldInfo {
       private String fieldName;
       private String dateGroupLevel;
+      /**
+       * Output-column name for this group, mirroring AggregateFieldInfo.alias.
+       *
+       * Matters most for a dateGroupLevel group: without an alias its output name is the RENDERED
+       * expression DateRangeRef produces ("Month(T.due_date)"), which is not a SQL alias and therefore
+       * cannot be referenced from a downstream sql:true expression column at all — the canonical
+       * COALESCE(left_key, right_key) over a FULL join had no way to name its own join keys.
+       */
+      private String alias;
       /** Business meaning of the group-by output column (english); persisted onto the output column. */
       private String description;
 
@@ -339,6 +348,8 @@ public class WorksheetTable {
       public void setFieldName(String fieldName) { this.fieldName = fieldName; }
       public String getDateGroupLevel() { return dateGroupLevel; }
       public void setDateGroupLevel(String dateGroupLevel) { this.dateGroupLevel = dateGroupLevel; }
+      public String getAlias() { return alias; }
+      public void setAlias(String alias) { this.alias = alias; }
       public String getDescription() { return description; }
       public void setDescription(String description) { this.description = description; }
    }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -1850,7 +1850,11 @@ public class WizVsService {
       var bws = rvs.getViewsheet() != null ? rvs.getViewsheet().getBaseWorksheet() : null;
 
       if(bws != null) {
-         bws.getWorksheetInfo().setDesignMaxRows(Math.max(sampleMaxRows, 0));
+         // #75989: per-assembly rather than worksheet-wide. A worksheet-wide cap also truncated the
+         // few-row lookup wiz injects to label an FK, destroying the INNER join's matches — a cap of 8
+         // returned 0 rows from a 984-row table. applySampledPreviewCap also clears a previous render's
+         // cap when sampleMaxRows <= 0, which is what the full-data path relies on.
+         WizUtil.applySampledPreviewCap(bws, sampleMaxRows);
 
          try {
             box.resetDataMap(assembly.getName());
@@ -1900,7 +1904,9 @@ public class WizVsService {
       // #75456: preserve the current data-mode on this lazy re-fetch path — pass the design-max
       // already set on the source worksheet (no-op for full; keeps sampled mode sampled).
       var fetchWs = vs.getBaseWorksheet();
-      int curMax = fetchWs != null ? fetchWs.getWorksheetInfo().getDesignMaxRows() : 0;
+      // #75989: read the cap back from the assemblies, not designMaxRows — the cap is applied per
+      // assembly now, so reading designMaxRows here would silently promote a sampled render to full data.
+      int curMax = WizUtil.sampledPreviewCap(fetchWs);
       CreateViewsheetResult result = executeAndExtract(rvs, assembly, curMax);
 
       if(result != null) {
@@ -2188,7 +2194,9 @@ public class WizVsService {
          // worksheet design-max to 0 (unlimited) -> no flag. Best-effort; absence just means no warning.
          try {
             var bws = rvs.getViewsheet() != null ? rvs.getViewsheet().getBaseWorksheet() : null;
-            int dmax = bws != null ? bws.getWorksheetInfo().getDesignMaxRows() : 0;
+            // #75989: same reason — designMaxRows is no longer where the cap lives, and reading it
+            // here reported a sampled 8-of-984-row chart as full data with no approximate-totals warning.
+            int dmax = WizUtil.sampledPreviewCap(bws);
 
             if(dmax > 0) {
                result.setSampled(true);

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -1469,6 +1469,25 @@ public class WorksheetTableService {
             // built date-grouped column (DateRangeRef carries none), or a group key with no upstream
             // annotation. Aggregate MEASURES are handled separately below and DO take the model's
             // description, since aggregation genuinely changes the column's meaning.
+            // Output-column alias, mirroring the aggregate branch below (which sets it on the PRIVATE
+            // ColumnRef, because the public selection is regenerated as clones of privateCs). Resolved
+            // to the same private target the description uses just below: the DateRangeRef column for a
+            // date-grouped field, otherwise the private column of the same name.
+            //
+            // Without this a dateGroupLevel group's output name is DateRangeRef's RENDERED expression
+            // ("Month(T.due_date)"), which is not a SQL alias — so it could not be referenced from a
+            // downstream sql:true expression under any form, and the canonical
+            // COALESCE(left_key, right_key) over a FULL join was unexpressible in pushed-down SQL.
+            if(!Tool.isEmptyString(grp.getAlias())) {
+               ColumnRef aliasTarget = grp.getDateGroupLevel() != null
+                  ? column
+                  : (privateCs.getAttribute(grp.getFieldName()) instanceof ColumnRef pc ? pc : null);
+
+               if(aliasTarget != null) {
+                  aliasTarget.setAlias(grp.getAlias());
+               }
+            }
+
             if(!Tool.isEmptyString(grp.getDescription())) {
                // Best-effort: unlike the aggregate branch below (which falls back to the public
                // `column` when privateCs lookup misses), a plain group whose fieldName does not

--- a/core/src/test/java/inetsoft/web/wiz/WizUtilSampledPreviewCapTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/WizUtilSampledPreviewCapTest.java
@@ -1,0 +1,157 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz;
+
+import inetsoft.uql.asset.PhysicalBoundTableAssembly;
+import inetsoft.uql.asset.TableAssembly;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Bug #75989. The sampled-preview cap used to be set worksheet-WIDE
+ * ({@code WorksheetInfo.setDesignMaxRows}), which capped every table assembly independently —
+ * including the few-row lookup wiz injects to label a foreign key. Truncating the lookup side of that
+ * INNER join destroys matches rather than sampling facts: measured on a 984-row table, a cap of 8
+ * returned ZERO rows while the same binding at cap 20 returned 20.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WizUtilSampledPreviewCapTest {
+   @Test
+   void capsTheFactTableAndTheJoinButNotTheInjectedLookup() {
+      Worksheet ws = worksheetWithFkLabelJoin();
+
+      WizUtil.applySampledPreviewCap(ws, 8);
+
+      // The fact table and the join carry the sampled rows, so both are capped...
+      assertEquals(8, table(ws, "work_packages").getMaxRows());
+      assertEquals(8, table(ws, "work_packages__fkjoin").getMaxRows());
+      // ...but the injected lookup is a dimension table, never part of the sampled fact stream.
+      assertEquals(0, table(ws, "work_packages__fk_projects").getMaxRows(),
+                   "an injected FK-label lookup must stay uncapped, or the join loses matches");
+      // And never worksheet-wide — that is the defect itself.
+      assertEquals(0, ws.getWorksheetInfo().getDesignMaxRows());
+   }
+
+   @Test
+   void clearsAPreviousCapWhenTheCallerAsksForFullData() {
+      // Same runtime is re-rendered repeatedly (WizVsService), so a lingering cap would silently make
+      // "full data" partial.
+      Worksheet ws = worksheetWithFkLabelJoin();
+      WizUtil.applySampledPreviewCap(ws, 8);
+
+      WizUtil.applySampledPreviewCap(ws, 0);
+
+      assertEquals(0, table(ws, "work_packages").getMaxRows());
+      assertEquals(0, table(ws, "work_packages__fkjoin").getMaxRows());
+      assertEquals(0, table(ws, "work_packages__fk_projects").getMaxRows());
+      assertEquals(0, ws.getWorksheetInfo().getDesignMaxRows());
+   }
+
+   @Test
+   void treatsANegativeCapAsFullDataRatherThanAnInvalidRowLimit() {
+      Worksheet ws = worksheetWithFkLabelJoin();
+
+      WizUtil.applySampledPreviewCap(ws, -5);
+
+      assertEquals(0, table(ws, "work_packages").getMaxRows());
+   }
+
+   @Test
+   void doesNotConfuseTheJoinItselfWithTheLookup() {
+      // "__fkjoin" has no trailing underscore, so it must NOT match the "__fk_" lookup infix — the join
+      // is where the fact rows are and has to be capped like any other detail table.
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(new PhysicalBoundTableAssembly(ws, "orders__fkjoin"));
+
+      WizUtil.applySampledPreviewCap(ws, 25);
+
+      assertEquals(25, table(ws, "orders__fkjoin").getMaxRows());
+   }
+
+   // The cap has to be READABLE again afterwards, and that is not cosmetic: the sampled/sampleMaxRows
+   // flags (which tell the caller its Sum/Count is approximate) and the lazy re-fetch path both read it
+   // back. Left reading designMaxRows, a live 8-of-984-row sample reported itself as full data with no
+   // warning at all — caught only by running it, since the caps themselves were set correctly.
+   @Test
+   void reportsTheCapBackSoSampledStaysSampled() {
+      Worksheet ws = worksheetWithFkLabelJoin();
+
+      WizUtil.applySampledPreviewCap(ws, 8);
+
+      assertEquals(8, WizUtil.sampledPreviewCap(ws));
+   }
+
+   @Test
+   void reportsZeroOnFullDataAndAfterAPreviousCapIsCleared() {
+      Worksheet ws = worksheetWithFkLabelJoin();
+      assertEquals(0, WizUtil.sampledPreviewCap(ws));
+
+      WizUtil.applySampledPreviewCap(ws, 8);
+      WizUtil.applySampledPreviewCap(ws, 0);
+
+      assertEquals(0, WizUtil.sampledPreviewCap(ws));
+   }
+
+   @Test
+   void readsTheCapFromDetailTablesRatherThanTheUncappedLookup() {
+      // The lookup is deliberately left at 0, so a reader that included it would always report 0 —
+      // i.e. "not sampled" — no matter what cap was requested.
+      Worksheet ws = worksheetWithFkLabelJoin();
+
+      WizUtil.applySampledPreviewCap(ws, 12);
+
+      assertEquals(0, table(ws, "work_packages__fk_projects").getMaxRows());
+      assertEquals(12, WizUtil.sampledPreviewCap(ws));
+   }
+
+   @Test
+   void toleratesANullWorksheet() {
+      assertDoesNotThrow(() -> WizUtil.applySampledPreviewCap(null, 8));
+      assertEquals(0, WizUtil.sampledPreviewCap(null));
+   }
+
+   /** A single-table worksheet after FK-label injection: fact table, injected lookup, and the join. */
+   private static Worksheet worksheetWithFkLabelJoin() {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(new PhysicalBoundTableAssembly(ws, "work_packages"));
+      ws.addAssembly(new PhysicalBoundTableAssembly(ws, "work_packages__fk_projects"));
+      ws.addAssembly(new PhysicalBoundTableAssembly(ws, "work_packages__fkjoin"));
+      return ws;
+   }
+
+   private static TableAssembly table(Worksheet ws, String name) {
+      TableAssembly table = (TableAssembly) ws.getAssembly(name);
+      assertNotNull(table, "test fixture is missing assembly " + name);
+      return table;
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceGroupAliasTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceGroupAliasTest.java
@@ -1,0 +1,185 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.ColumnSelection;
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.asset.PhysicalBoundTableAssembly;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.web.wiz.model.WorksheetTable;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Contract test for a group-by {@code alias} in {@link WorksheetTableService#applyAggregateInfo},
+ * mirroring the aggregate alias that has always been supported.
+ *
+ * <p>Why it matters beyond tidier names: an unaliased dateGroupLevel group is named after the
+ * expression {@code DateRangeRef} renders — {@code Month(T.due_date)} — which is NOT a SQL alias. It
+ * therefore cannot be referenced from a downstream {@code sql:true} expression column under any form
+ * (a bare reference reports "column does not exist"; a table-qualified one reports "missing FROM-clause
+ * entry"), which made the canonical {@code COALESCE(left_key, right_key)} shared axis over a FULL join
+ * unexpressible in pushed-down SQL. Aliasing the group gives it an addressable name.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WorksheetTableServiceGroupAliasTest {
+   private static final ObjectMapper MAPPER = new ObjectMapper();
+
+   private static WorksheetTableService service() {
+      // applyAggregateInfo uses only its parameters + table state + static helpers, never instance
+      // dependencies (mirrors WorksheetTableServiceAggregateDescriptionTest).
+      return new WorksheetTableService(null, null, null, null, null, null, null, null, null);
+   }
+
+   private static WorksheetTable.AggregateInfo aggInfo(String json) throws Exception {
+      return MAPPER.readValue(json, WorksheetTable.AggregateInfo.class);
+   }
+
+   /** Find a public output column by attribute name OR alias, matching how /ws/structure reads them. */
+   private static ColumnRef output(PhysicalBoundTableAssembly table, String nameOrAlias) {
+      ColumnSelection pub = table.getColumnSelection(true);
+
+      for(int i = 0; i < pub.getAttributeCount(); i++) {
+         DataRef ref = pub.getAttribute(i);
+
+         if(ref instanceof ColumnRef col
+            && (nameOrAlias.equals(col.getAttribute()) || nameOrAlias.equals(col.getAlias())))
+         {
+            return col;
+         }
+      }
+
+      return null;
+   }
+
+   private static PhysicalBoundTableAssembly ordersTable() {
+      Worksheet ws = new Worksheet();
+      PhysicalBoundTableAssembly table = new PhysicalBoundTableAssembly(ws, "orders");
+      ColumnSelection cs = new ColumnSelection();
+      AttributeRef dueRef = new AttributeRef(null, "DUE_DATE");
+      dueRef.setDataType(XSchema.DATE);
+      cs.addAttribute(new ColumnRef(dueRef));
+      AttributeRef idRef = new AttributeRef(null, "ORDER_ID");
+      idRef.setDataType(XSchema.STRING);
+      cs.addAttribute(new ColumnRef(idRef));
+      table.setColumnSelection(cs, false);
+      return table;
+   }
+
+   @Test
+   void aliasesADateGroupedColumnSoItIsAddressableInsteadOfARenderedExpression() throws Exception {
+      WorksheetTable.AggregateInfo info = aggInfo("""
+         {
+           "groups": [
+             { "fieldName": "DUE_DATE", "dateGroupLevel": "month", "alias": "due_month" }
+           ],
+           "aggregates": [
+             { "fieldName": "ORDER_ID", "formula": "Count", "alias": "order_count" }
+           ]
+         }
+         """);
+      PhysicalBoundTableAssembly table = ordersTable();
+
+      service().applyAggregateInfo(table, info);
+
+      assertNotNull(output(table, "due_month"),
+                    "the date-grouped column must be reachable by its alias, not only by Month(DUE_DATE)");
+      assertNotNull(output(table, "order_count"), "the aggregate alias must still work as before");
+   }
+
+   @Test
+   void aliasesAPlainGroupColumnToo() throws Exception {
+      WorksheetTable.AggregateInfo info = aggInfo("""
+         {
+           "groups": [ { "fieldName": "ORDER_ID", "alias": "order_key" } ],
+           "aggregates": []
+         }
+         """);
+      PhysicalBoundTableAssembly table = ordersTable();
+
+      service().applyAggregateInfo(table, info);
+
+      assertNotNull(output(table, "order_key"));
+   }
+
+   @Test
+   void leavesTheRenderedNameAloneWhenNoAliasIsGiven() throws Exception {
+      // The pre-existing behaviour, pinned: omitting the alias must keep the DateRangeRef name rather
+      // than inventing one, so this change cannot move an existing caller's column names.
+      WorksheetTable.AggregateInfo info = aggInfo("""
+         {
+           "groups": [ { "fieldName": "DUE_DATE", "dateGroupLevel": "month" } ],
+           "aggregates": [ { "fieldName": "ORDER_ID", "formula": "Count", "alias": "order_count" } ]
+         }
+         """);
+      PhysicalBoundTableAssembly table = ordersTable();
+
+      service().applyAggregateInfo(table, info);
+
+      ColumnSelection pub = table.getColumnSelection(true);
+      boolean hasRenderedName = false;
+
+      for(int i = 0; i < pub.getAttributeCount(); i++) {
+         if(pub.getAttribute(i) instanceof ColumnRef col) {
+            String attr = col.getAttribute();
+
+            if(attr != null && attr.contains("DUE_DATE") && attr.contains("(")) {
+               hasRenderedName = true;
+               assertNull(col.getAlias(), "an unaliased group must not acquire an alias");
+            }
+         }
+      }
+
+      assertTrue(hasRenderedName, "the date-grouped column should still carry its rendered name");
+   }
+
+   @Test
+   void anEmptyAliasIsIgnoredRatherThanBlankingTheColumnName() throws Exception {
+      WorksheetTable.AggregateInfo info = aggInfo("""
+         {
+           "groups": [ { "fieldName": "ORDER_ID", "alias": "  " } ],
+           "aggregates": []
+         }
+         """);
+      PhysicalBoundTableAssembly table = ordersTable();
+
+      service().applyAggregateInfo(table, info);
+
+      ColumnRef out = output(table, "ORDER_ID");
+      assertNotNull(out, "a blank alias must leave the column reachable by its own name");
+      assertTrue(out.getAlias() == null || out.getAlias().isBlank());
+   }
+}


### PR DESCRIPTION
An aggregate has always been able to name its output column; a group could not. That asymmetry made one
thing **impossible**, not merely untidy.

## The problem

An unaliased `dateGroupLevel` group is named after the expression `DateRangeRef` renders —
`Month(T.due_date)`. That is not a SQL alias, so it cannot be referenced from a downstream `sql: true`
expression column under **any** form:

| reference | result |
|---|---|
| `Month(T.due_date)` bare | ❌ `column "Month(T.due_date)" does not exist` |
| `"Mirror"."Month(...)"` | ❌ `missing FROM-clause entry for table` |
| `field['…']` in `sql:true` | ❌ JS-evaluated → `ReferenceError: COALESCE is not defined` |

So the canonical shared axis over a FULL join — `COALESCE(left_key, right_key)` — had no way to name its
own join keys, and was unexpressible in pushed-down SQL. Aggregates were fine (`COALESCE(starting, due)`
works) *precisely because* they can be aliased.

The workaround is a `sql: false` JS expression, and it isn't free: **one `sql: false` expression makes the
table not `sqlMergeable`**, so the entire pipeline stops being pushed to the database. Fine on a thousand
rows; not on a large table.

## The change

`applyAggregateInfo` now honours `GroupByFieldInfo.alias`, resolved to the **same private `ColumnRef` the
group description already uses** — the `DateRangeRef` column for a date-grouped field, otherwise the
private column of the same name — because the public selection is regenerated as clones of `privateCs`.
That is exactly how the aggregate branch a few lines below already applies its own alias.

## Verification

Live, against a locally built image (`local-1169`) on a real datasource: two aggregate mirrors grouped by
month with aliases `start_month` / `due_month`, FULL-joined on those aliases, then
`COALESCE(start_month, due_month)` as a `sql: true` expression.

Renders 20 months with both series totalling 984 — **row-for-row identical** to the `sql: false` JS
equivalent it replaces, with no pre-truncation mirror and the coalesce pushed down to the database.

4 unit tests (`WorksheetTableServiceGroupAliasTest`):
- a date-grouped alias becomes addressable
- a plain group alias works
- **an omitted alias leaves the rendered name untouched**, so no existing caller's column names move
- a blank alias is ignored rather than blanking the column name

## Compatibility

Additive and opt-in — an omitted alias behaves exactly as before (pinned by a test). Note the request
model is `@JsonIgnoreProperties(ignoreUnknown = true)`, so an older StyleBI silently ignores the field;
the wiz side detects that and reports `groupAliasesNotApplied` rather than letting a caller discover it
as a downstream "column does not exist". Paired wiz PR: inetsoft-technology/stylebi-wiz#1488.

🤖 Generated with [Claude Code](https://claude.com/claude-code)