### PR TITLE
fix(wiz): a re-bind that replaces a chart in place must keep its filter

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
@@ -26,7 +26,9 @@ import inetsoft.sree.security.SecurityEngine;
 import inetsoft.sree.security.SecurityException;
 import inetsoft.uql.asset.Assembly;
 import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.ConditionList;
 import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.DataVSAssembly;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.util.Catalog;
@@ -117,6 +119,7 @@ public class ViewsheetRuntimeController {
       if(assembly != null) {
          result.setAssemblyName(assembly.getName());
          result.setBinding(wizVsService.collectFlatBinding(assembly));
+         result.setHasCondition(hasPreCondition(assembly));
       }
 
       // #75486: make a reopened saved viz re-bindable in place. Return its base worksheet
@@ -284,6 +287,28 @@ public class ViewsheetRuntimeController {
             log.warn("Failed to close runtime [{}] after verify", runtimeId);
          }
       }
+   }
+
+   /**
+    * Does the reopened chart carry a row-restricting pre-condition (a filter)?
+    *
+    * <p>Reported so a caller reopening a saved chart can tell a FILTERED chart from an unfiltered one.
+    * Without it the plugin's active-chart state defaulted to "no filter" for every reopened chart, and
+    * then advised merging into that empty model and calling apply_filter — which REPLACES the whole
+    * filter, so following the advice silently erased a filter the chart really had.
+    *
+    * <p>A boolean, not the condition itself: reporting the full model back would need a
+    * ConditionList -> VisualizationConditionModel reverse conversion that does not exist. Knowing a
+    * filter is THERE is enough to stop the caller from destroying it unknowingly.
+    */
+   private boolean hasPreCondition(VSAssembly assembly) {
+      if(!(assembly instanceof DataVSAssembly dataAsm)) {
+         return false;
+      }
+
+      ConditionList cond = dataAsm.getPreConditionList();
+
+      return cond != null && !cond.isEmpty();
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/model/OpenViewsheetResult.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/OpenViewsheetResult.java
@@ -51,6 +51,18 @@ public class OpenViewsheetResult {
       this.binding = binding;
    }
 
+   /**
+    * True when the reopened chart carries a row-restricting pre-condition (a filter); null when no
+    * chart assembly could be resolved, so "unknown" stays distinguishable from "none".
+    */
+   public Boolean getHasCondition() {
+      return hasCondition;
+   }
+
+   public void setHasCondition(Boolean hasCondition) {
+      this.hasCondition = hasCondition;
+   }
+
    public String getWorksheetIdentifier() {
       return worksheetIdentifier;
    }
@@ -62,6 +74,10 @@ public class OpenViewsheetResult {
    private String runtimeId;
    private String assemblyName;
    private CreateViewsheetResult.FlatBinding binding;
+   // Whether the reopened chart carries a row-restricting pre-condition. Boxed so NON_NULL omits it
+   // when no chart assembly was resolved (absent = unknown, false = known to have none) — a caller
+   // must not read "no chart found" as "this chart has no filter".
+   private Boolean hasCondition;
    // The reopened viewsheet's base worksheet identifier, so callers can re-bind in place
    // (update_binding re-runs autoBinding against this worksheet) without rebuilding. See #75486.
    private String worksheetIdentifier;

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -266,6 +266,30 @@ public class WizVsService {
       return replacedAssembly != null ? replacedAssembly : previousPrimaryAssembly;
    }
 
+   /**
+    * Should the condition source's pre-condition be carried onto the freshly-bound assembly?
+    *
+    * <p>{@code keepConditionRequested} is the explicit server-side ask — {@code changeType}'s rebuild
+    * branch, replacing a chart the user already filtered. It stays {@code @JsonIgnore} on
+    * {@link inetsoft.web.wiz.model.AutoBindingRequest} so a raw request body can never force a filter
+    * onto a rebind that asked for none.
+    *
+    * <p>{@code replaceInPlace} is the second, implicit case, and the one this method exists for: a
+    * re-bind that REPLACES the named chart produces the SAME chart — same assembly name, same saved
+    * identifier — just bound differently. A filter is a property of that chart, so dropping it silently
+    * widens the data (observed: a chart filtered to one project came back with the whole portfolio, ~100x
+    * the rows, with no error and no note, and the widening was then persisted to the saved viewsheet).
+    * Note {@code replaceInPlace} already implies {@code !syncMode && existingTarget != null}, so
+    * {@link #resolveConditionSource} returns exactly the chart being replaced — never an unrelated
+    * assembly whose filter the caller never asked for.
+    *
+    * <p>A COPY is deliberately excluded (it is not the same chart — it keeps the original as history), as
+    * is sync mode, where {@code syncConfigs} carries the condition instead.
+    */
+   static boolean carryCondition(boolean keepConditionRequested, boolean replaceInPlace) {
+      return keepConditionRequested || replaceInPlace;
+   }
+
    @FunctionalInterface
    public interface PostAssemblyHook {
       void apply(RuntimeViewsheet rvs, VSAssembly assembly) throws Exception;
@@ -1585,11 +1609,12 @@ public class WizVsService {
             }
 
             // Sync pre-condition from the chart being switched away from to the new one when the caller
-            // is performing a visualization type change (e.g. table → chart).
+            // is performing a visualization type change (e.g. table → chart), or whenever the re-bind
+            // REPLACES the named chart in place (see carryCondition).
             VSAssembly displacedForCondition = resolveConditionSource(
                syncMode, existingTarget, replacedAssembly, previousPrimaryAssembly);
 
-            if(model.isKeepCondition() &&
+            if(carryCondition(model.isKeepCondition(), replaceInPlace) &&
                displacedForCondition instanceof DataVSAssembly oldDataAsm &&
                assembly instanceof DataVSAssembly newDataAsm)
             {

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceReplaceInPlaceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceReplaceInPlaceTest.java
@@ -95,4 +95,34 @@ class WizVsServiceReplaceInPlaceTest {
       assertSame(previousPrimary,
                  WizVsService.resolveConditionSource(true, named, null, previousPrimary));
    }
+
+   /** The explicit server-side ask (changeType's rebuild branch) still carries the condition. */
+   @Test
+   void anExplicitKeepConditionCarriesTheFilter() {
+      assertTrue(WizVsService.carryCondition(true, false));
+   }
+
+   /**
+    * A replace-in-place re-bind produces the SAME chart — same assembly name, same saved identifier —
+    * so its filter must survive even though no caller asked for keepCondition (it is {@code @JsonIgnore},
+    * so update_binding CANNOT ask). Without this, re-binding a filtered chart silently returned the whole
+    * unfiltered dataset and persisted that widening to the saved viewsheet.
+    */
+   @Test
+   void aReplaceInPlaceRebindCarriesTheFilterWithoutBeingAsked() {
+      assertTrue(WizVsService.carryCondition(false, true));
+   }
+
+   /**
+    * A copy is NOT the same chart — it keeps the original as history — so it must not inherit a filter
+    * nobody asked it to have. Sync mode likewise falls through to syncConfigs.
+    */
+   @Test
+   void neitherACopyNorSyncModeInheritsAFilterUnasked() {
+      assertFalse(WizVsService.carryCondition(false, false));
+      assertFalse(WizVsService.carryCondition(
+         false, WizVsService.replaceInPlace(mock(VSAssembly.class), false, true)));
+      assertFalse(WizVsService.carryCondition(
+         false, WizVsService.replaceInPlace(mock(VSAssembly.class), true, false)));
+   }
 }


### PR DESCRIPTION
## The defect

Re-binding a **filtered** chart silently returned the **whole dataset**.

Found on the openproject sweep: a chart filtered to one project (9 work packages) re-bound to a coarser date grain came back with the entire portfolio — **984 rows**, ~100x — with no error and no note. `update_binding` then persisted that widening to the saved viewsheet, so the saved chart was permanently wrong.

## Root cause

`createViewsheetInternal` carried the displaced chart's pre-condition only when `model.isKeepCondition()`.

That flag is **`@JsonIgnore`** on `AutoBindingRequest` — deliberately server-side only, so a raw request body can't force a filter onto a rebind that asked for none. Its sole caller is `changeType`'s rebuild branch. **`update_binding` therefore cannot ask for it**, and nothing else on that path preserved the filter.

The other preservation route, `syncConfigs`, is not usable here: it flips `replaceInPlace` to false, and `update_binding`'s contract is to replace the chart in place and preserve its saved id.

`change_chart_type` was the natural control throughout — same runtime, same chart, it **kept** the filter, because it is the one caller that sets `keepCondition`.

## The fix

Gate the carry on `carryCondition(keepConditionRequested, replaceInPlace)`.

A replace-in-place re-bind produces the **same chart** — same assembly name, same saved identifier — just bound differently. A filter is a property of that chart, so it must survive.

This is safe by construction: `replaceInPlace` already implies `!syncMode && existingTarget != null`, so `resolveConditionSource` returns *exactly* the chart being replaced, never an unrelated assembly whose filter nobody asked for.

Deliberately excluded:
- **a copy** — not the same chart (it keeps the original as history), must not inherit a filter unasked
- **sync mode** — `syncConfigs` carries the condition there instead

## Also: report `hasCondition` on `/viewsheet/open`

So a client reopening a saved chart can tell a filtered chart from an unfiltered one. Before this the plugin defaulted every reopened chart to "no filter", then advised merging into that empty model and calling `apply_filter` — which REPLACES the whole filter, so following the advice **erased** a filter the chart really had.

A boolean, not the condition itself: there is no `ConditionList` -> `VisualizationConditionModel` reverse conversion, and knowing a filter is *there* is enough to stop a caller destroying it unknowingly. Boxed so "unknown" (no chart assembly resolved) stays distinct from "known to have none".

## Tests

`carryCondition` covered for the explicit ask, the replace-in-place case, and both must-not-inherit cases (copy, sync mode). Verified the replace-in-place test **fails** with the fix reverted (`expected: <true> but was: <false>`) and that it was the only failure.

All 15 `WizVsService*` suites pass (78 tests), including `WizVsServiceFilterCopyTest`, which guards the copy semantics this change preserves.

Pairs with stylebi-wiz #1491.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
