### PR TITLE
fix(wiz): the chart-type menu must list every FEASIBLE type, not only preferred ones

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -1998,11 +1998,32 @@ public class WizAutoBindingService {
 
    /**
     * Flattens the recommendation list into a feasibility-filtered, named chart-type menu (highest
-    * fit first). Chart candidates and their scores come from each {@link VSChartRecommendation}'s
-    * prefInfos; table/crosstab/gauge/text appear once each when feasible. Scores are normalized to
+    * fit first). table/crosstab/gauge/text appear once each when feasible. Scores are normalized to
     * [0,1] for ordering only. Every entry is a type the recommender found feasible for the fields.
+    *
+    * <p>MEMBERSHIP comes from {@code chartInfos}, ORDER from {@code prefInfos}. The two lists mean
+    * different things (see {@link ChartCombinationUtil.ChartInfosResult}): {@code chartInfos} is the
+    * full feasible set, always populated and already sorted by base data-score; {@code prefInfos} is
+    * the preference-adjusted ranking, and is **null whenever no pin was supplied**.
+    *
+    * <p>Reading only prefInfos — as this did — got both cases wrong, and in the same direction: it
+    * presented a NARROWER menu as though it were the feasible one.
+    * <ul>
+    *   <li><b>No pins</b> (the common case): prefInfos is null, so the menu contained NO chart types
+    *       at all — a plain month/Count line chart offered only "crosstab, table" while rendering
+    *       perfectly as a line.</li>
+    *   <li><b>With pins</b>: only pin-satisfying types survived, so pinning x/y on a one-date +
+    *       one-measure chart dropped bar, column and line out of the menu entirely and left
+    *       waterfall as the top suggestion — a cumulative-build-up chart for independent per-quarter
+    *       totals. Pinning an axis says where a field goes, NOT that the ordinary Cartesian types
+    *       stopped being possible.</li>
+    * </ul>
+    *
+    * <p>So every feasible type is listed, and a pin re-ranks rather than removes. Types known only
+    * from chartInfos carry no preference score and take 0, which sorts them after the preferred ones
+    * while a stable sort preserves the recommender's own base-score order among them.
     */
-   private List<ChartTypeCandidate> buildChartTypeCandidates(List<VSObjectRecommendation> recommendations) {
+   static List<ChartTypeCandidate> buildChartTypeCandidates(List<VSObjectRecommendation> recommendations) {
       if(recommendations == null || recommendations.isEmpty()) {
          return Collections.emptyList();
       }
@@ -2020,6 +2041,19 @@ public class WizAutoBindingService {
 
                   if(type != null) {
                      best.merge(type, si.getScore(), Math::max);
+                  }
+               }
+            }
+
+            // Then every remaining feasible type, in the recommender's own base-score order.
+            List<ChartInfo> chartInfos = vcr.getChartInfos();
+
+            if(chartInfos != null) {
+               for(ChartInfo ci : chartInfos) {
+                  String type = getChartTypeString(ci.getChartType());
+
+                  if(type != null) {
+                     best.putIfAbsent(type, 0);
                   }
                }
             }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceChartTypeCandidatesTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceChartTypeCandidatesTest.java
@@ -1,0 +1,148 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.uql.viewsheet.graph.ChartInfo;
+import inetsoft.uql.viewsheet.graph.GraphTypes;
+import inetsoft.web.vswizard.recommender.chart.ChartCombinationUtil;
+import inetsoft.web.vswizard.model.recommender.VSChartRecommendation;
+import inetsoft.web.vswizard.model.recommender.VSObjectRecommendation;
+import inetsoft.web.vswizard.model.recommender.VSTableRecommendation;
+import inetsoft.web.wiz.model.ChartTypeCandidate;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * The `candidates` chart-type menu returned to the AI layer.
+ *
+ * <p>MEMBERSHIP must come from {@code chartInfos} (the full feasible set, always populated) and ORDER
+ * from {@code prefInfos} (the preference ranking, null when no pin was supplied). Reading only
+ * prefInfos presented a narrower menu as though it were the feasible one — in both directions:
+ * without pins the menu held no chart types at all, and with pins the ordinary Cartesian types
+ * vanished, leaving a waterfall as the top suggestion for independent per-period totals.
+ */
+@Tag("core")
+class WizAutoBindingServiceChartTypeCandidatesTest {
+   private static ChartInfo info(int chartType) {
+      ChartInfo ci = mock(ChartInfo.class);
+      when(ci.getChartType()).thenReturn(chartType);
+      return ci;
+   }
+
+   private static ChartCombinationUtil.ScoredInfo scored(int chartType, int score) {
+      return new ChartCombinationUtil.ScoredInfo(info(chartType), score);
+   }
+
+   private static VSChartRecommendation chartRec(List<ChartInfo> chartInfos,
+                                                 List<ChartCombinationUtil.ScoredInfo> prefInfos)
+   {
+      VSChartRecommendation rec = mock(VSChartRecommendation.class);
+      when(rec.getChartInfos()).thenReturn(chartInfos);
+      when(rec.getPrefInfos()).thenReturn(prefInfos);
+      return rec;
+   }
+
+   private static List<String> typesOf(List<ChartTypeCandidate> candidates) {
+      return candidates.stream().map(ChartTypeCandidate::getType).toList();
+   }
+
+   /**
+    * The common case: no pin, so prefInfos is null. The menu used to come back with only
+    * "table"/"crosstab" while the chart itself rendered as a perfectly good line.
+    */
+   @Test
+   void listsEveryFeasibleTypeWhenNoPreferenceWasSupplied() {
+      List<ChartTypeCandidate> candidates = WizAutoBindingService.buildChartTypeCandidates(List.of(
+         chartRec(List.of(info(GraphTypes.CHART_BAR), info(GraphTypes.CHART_LINE),
+                          info(GraphTypes.CHART_POINT)),
+                  null),
+         mock(VSTableRecommendation.class)));
+
+      assertTrue(typesOf(candidates).containsAll(List.of("bar", "line", "point")),
+                 "feasible chart types must be listed even with no preference: " + typesOf(candidates));
+   }
+
+   /** Base-score order (the order chartInfos arrives in) survives the equal-score sort. */
+   @Test
+   void preservesTheRecommendersOwnOrderAmongUnpreferredTypes() {
+      List<ChartTypeCandidate> candidates = WizAutoBindingService.buildChartTypeCandidates(List.of(
+         chartRec(List.of(info(GraphTypes.CHART_LINE), info(GraphTypes.CHART_BAR),
+                          info(GraphTypes.CHART_POINT)),
+                  null)));
+
+      assertEquals(List.of("line", "bar", "point"), typesOf(candidates));
+   }
+
+   /**
+    * The B2 case: pinning x/y must not delete the Cartesian types from the menu. A pin says where a
+    * field goes, not that bar and line stopped being possible.
+    */
+   @Test
+   void aPinReRanksButNeverRemovesAFeasibleType() {
+      List<ChartTypeCandidate> candidates = WizAutoBindingService.buildChartTypeCandidates(List.of(
+         chartRec(List.of(info(GraphTypes.CHART_BAR), info(GraphTypes.CHART_LINE),
+                          info(GraphTypes.CHART_POINT), info(GraphTypes.CHART_WATERFALL)),
+                  List.of(scored(GraphTypes.CHART_POINT, 80),
+                          scored(GraphTypes.CHART_WATERFALL, 40)))));
+
+      List<String> types = typesOf(candidates);
+      assertTrue(types.containsAll(List.of("bar", "line")),
+                 "pinning an axis must not drop bar/line: " + types);
+
+      // The pinned preference still decides the ORDER — point first, then waterfall.
+      assertEquals("point", types.get(0));
+      assertEquals("waterfall", types.get(1));
+      assertTrue(candidates.get(0).getScore() > candidates.get(1).getScore());
+   }
+
+   /** A preferred type keeps its score; one known only from chartInfos takes 0 rather than an invented rank. */
+   @Test
+   void unpreferredTypesTakeZeroRatherThanAnInventedScore() {
+      List<ChartTypeCandidate> candidates = WizAutoBindingService.buildChartTypeCandidates(List.of(
+         chartRec(List.of(info(GraphTypes.CHART_POINT), info(GraphTypes.CHART_BAR)),
+                  List.of(scored(GraphTypes.CHART_POINT, 60)))));
+
+      assertEquals(1.0, candidates.get(0).getScore(), 0.0001);   // normalized against the max
+      assertEquals("bar", candidates.get(1).getType());
+      assertEquals(0.0, candidates.get(1).getScore(), 0.0001);
+   }
+
+   /** A type in both lists must appear once, at its preference score. */
+   @Test
+   void doesNotDuplicateATypePresentInBothLists() {
+      List<ChartTypeCandidate> candidates = WizAutoBindingService.buildChartTypeCandidates(List.of(
+         chartRec(List.of(info(GraphTypes.CHART_BAR), info(GraphTypes.CHART_LINE)),
+                  List.of(scored(GraphTypes.CHART_BAR, 50)))));
+
+      assertEquals(1, typesOf(candidates).stream().filter("bar"::equals).count());
+      assertEquals("bar", candidates.get(0).getType());
+      assertEquals(1.0, candidates.get(0).getScore(), 0.0001);
+   }
+
+   @Test
+   void returnsEmptyForNoRecommendations() {
+      assertTrue(WizAutoBindingService.buildChartTypeCandidates(null).isEmpty());
+      assertTrue(WizAutoBindingService.buildChartTypeCandidates(List.<VSObjectRecommendation>of()).isEmpty());
+   }
+}


### PR DESCRIPTION
## The defect

`candidates` is the chart-type menu the AI layer picks from. It was built only from a `VSChartRecommendation`'s **prefInfos**.

The two lists mean different things ([`ChartCombinationUtil.ChartInfosResult`](community/core/src/main/java/inetsoft/web/vswizard/recommender/chart/ChartCombinationUtil.java)):

- **`chartInfos`** — the full feasible set, **always populated**, already sorted by base data-score
- **`prefInfos`** — the preference-adjusted ranking, and **`null` whenever no pin was supplied**

Reading only prefInfos got both cases wrong, and in the same direction — it presented a **narrower** menu as though it were the feasible one.

### No pins (the common case)

`prefInfos` is null, so the menu contained **no chart types at all**. openproject B6 bound `Count(id)` by `Month(due_date)`, rendered a perfectly good line, and offered `candidates: [crosstab, table]`.

### With pins

Only pin-satisfying types survived. openproject B2 pinned `x=due_date, y=estimated_hours` on a one-date + one-measure chart — the canonical bar/line shape — and got back:

```
point, boxplot, waterfall, pareto, crosstab, table
```

**bar, column and line absent entirely**, with `waterfall` substituted as the top suggestion: a cumulative-build-up chart for independent per-quarter totals, which misrepresents the data.

Pinning an axis says *where a field goes*. It does not mean the ordinary Cartesian types stopped being possible.

## The fix

**Membership from `chartInfos`, order from `prefInfos`.** Every feasible type is listed; a pin re-ranks rather than removes. Types known only from chartInfos carry no preference score and take 0, which sorts them after the preferred ones while the stable sort preserves the recommender's own base-score order among them.

`buildChartTypeCandidates` becomes package-private static (it already used only static helpers), matching `replaceInPlace` / `resolveConditionSource` / `carryCondition` so it can be unit-tested directly.

## Verified live

Rebuilt as `local-1173` and re-ran B2's exact call:

| | before | after |
|---|---|---|
| pinned x/y | `point, boxplot, waterfall, pareto, crosstab, table` | **`point, boxplot, waterfall, pareto, bar, crosstab, table`** |
| no pins | `crosstab, table` | **`bar, point, boxplot, waterfall, pareto, crosstab, table`** |

## Known limitation, deliberately not addressed here

This fixes the **menu**. The **selection** still substitutes `waterfall` when `bar` is requested *with* pins, because the recommender genuinely has no pin-satisfying bar candidate — `setChartIndexForType` skips the unconstrained `chartInfos` scan when pins are present, which is an existing deliberate silent-bypass guard.

So a caller still cannot get a vertical bar with the date pinned to x. That is a real remaining gap, but changing the guard would let pins be silently ignored, which is worse. The paired stylebi-wiz PR makes the response say plainly which constraint blocked the type and that re-running without `explicitBindings` yields `bar` — verified to work.

## Tests

6 covering both regressions, ordering, no-duplicate, and score semantics. Verified 4 of the 6 fail with the chartInfos pass reverted. All 178 tests across the `WizAutoBindingService*` and `WizVsService*` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
