### PR TITLE
fix(wiz): stop serializing a locale timezone table into every chart-data cell

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/WizUtil.java
+++ b/core/src/main/java/inetsoft/web/wiz/WizUtil.java
@@ -19,6 +19,8 @@
 package inetsoft.web.wiz;
 
 import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.graph.internal.LabelValue;
+import inetsoft.report.filter.DCMergeCell;
 import inetsoft.report.composition.ExpiredSheetException;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.asset.Assembly;
@@ -236,6 +238,53 @@ public class WizUtil {
       }
 
       return cap;
+   }
+
+   /**
+    * Reduce one chart-data cell to something worth putting on the wire.
+    *
+    * <p>A DataSet cell is not always a scalar. A date comparison over CUSTOM ranges yields
+    * {@link inetsoft.report.filter.DCMergeDatesCell} — a domain object carrying the merged dates, the
+    * original value, and its {@link java.text.Format}. Handed to Jackson it is walked getter by getter,
+    * and {@code getFormat()} drags in a {@code SimpleDateFormat} -> {@code DateFormatSymbols} ->
+    * {@code zoneStrings}: the whole Java locale timezone table, <b>597 zones, ~67KB, per cell</b>.
+    *
+    * <p>Measured on a 14-row year-over-year comparison (openproject B6): each cell serialized to
+    * ~69KB, of which 97% was zoneStrings; the 14 cells appeared twice (the rows array and the facts
+    * table computed from it) for <b>~1.9M characters, 99.8% of the response</b>, to convey fourteen
+    * short labels. It exceeded the caller's token limit outright, so the tool result could not be read.
+    *
+    * <p>{@link LabelValue#getText()} is what the chart actually draws for such a cell, and — because a
+    * comparison plots every series against one shared axis — it is period-independent, which is what
+    * lets a consumer pair the same grain point across periods. So it is the string emitted here, and it
+    * matches what the plugin's own defensive scalarizer picks (stylebi-wiz #1495), leaving the figures
+    * derived downstream unchanged. Note this is deliberately NOT {@code toString()}: on the outer cell
+    * that joins EVERY merged date with "&" ("2025 Jun&2026 Jun") rather than naming the point.
+    *
+    * <p>Scalars pass through untouched, so the ordinary path is unaffected.
+    */
+   public static Object toResponseCell(Object value) {
+      if(value == null || value instanceof Number || value instanceof String ||
+         value instanceof Boolean || value instanceof java.util.Date)
+      {
+         return value;
+      }
+
+      if(value instanceof LabelValue label) {
+         String text = label.getText();
+
+         if(text != null && !text.isEmpty()) {
+            return text;
+         }
+      }
+
+      // Any other non-scalar (a merge cell without a usable label, a custom value object) still must
+      // not reach Jackson as an object graph.
+      if(value instanceof DCMergeCell || !(value instanceof Comparable)) {
+         return value.toString();
+      }
+
+      return value;
    }
 
    public static final String ANNOTATION_RAW_DATA_MAX_ROW = "annotation.rawdata.maxrow";

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -2456,7 +2456,9 @@ public class WizVsService {
             Map<String, Object> row = new LinkedHashMap<>(colCount);
 
             for(int c = 0; c < colCount; c++) {
-               row.put(headers.get(c), dset.getData(c, r));
+               // Not the raw cell: a date-comparison DataSet yields DCMergeDatesCell, whose getFormat()
+               // drags the entire locale timezone table into the response (see WizUtil.toResponseCell).
+               row.put(headers.get(c), WizUtil.toResponseCell(dset.getData(c, r)));
             }
 
             rows.add(row);

--- a/core/src/test/java/inetsoft/web/wiz/WizUtilResponseCellTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/WizUtilResponseCellTest.java
@@ -1,0 +1,123 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.graph.internal.LabelValue;
+import inetsoft.report.filter.DCMergeDatesCell;
+import inetsoft.uql.asset.DateRangeRef;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * A DataSet cell is not always a scalar, and handing a non-scalar to Jackson is expensive in a way that
+ * is invisible until it breaks something: a {@link DCMergeDatesCell}'s {@code getFormat()} drags in
+ * SimpleDateFormat -> DateFormatSymbols -> zoneStrings, the whole locale timezone table, per cell.
+ *
+ * <p>Measured on a 14-row year-over-year comparison (openproject B6): ~69KB per cell, 97% of it
+ * zoneStrings, and since the cells appear twice (rows + the facts table computed from them) the
+ * response reached ~1.9M characters — over the caller's token limit, so its own result was unreadable.
+ */
+@Tag("core")
+class WizUtilResponseCellTest {
+   private static Date date(int year, int month, int day) {
+      Calendar cal = Calendar.getInstance();
+      cal.clear();
+      cal.set(year, month - 1, day);
+      return cal.getTime();
+   }
+
+   private static DCMergeDatesCell mergedCell(int month) {
+      DCMergeDatesCell cell = new DCMergeDatesCell(
+         true, DateRangeRef.MONTH_INTERVAL, Map.of(), false);
+      cell.setDates(List.of(date(2025, month, 1), date(2026, month, 1)));
+      cell.setFormat(new SimpleDateFormat("yyyy MMM"));
+      return cell;
+   }
+
+   private static DCMergeDatesCell mergedCell() {
+      return mergedCell(6);
+   }
+
+   @Test
+   void passesScalarsThrough() {
+      assertNull(WizUtil.toResponseCell(null));
+      assertEquals(23, WizUtil.toResponseCell(23));
+      assertEquals(4.5, WizUtil.toResponseCell(4.5));
+      assertEquals("2026 Jun", WizUtil.toResponseCell("2026 Jun"));
+      assertEquals(Boolean.TRUE, WizUtil.toResponseCell(true));
+
+      Date d = date(2025, 6, 1);
+      assertSame(d, WizUtil.toResponseCell(d));
+   }
+
+   /**
+    * The label the chart actually draws. Deliberately NOT the outer toString(), which joins every merged
+    * date with "&" ("2025 Jun&2026 Jun") instead of naming the point.
+    */
+   @Test
+   void reducesAMergedDateCellToTheLabelTheChartDraws() {
+      Object out = WizUtil.toResponseCell(mergedCell().getMergeLabelCell());
+
+      assertInstanceOf(String.class, out);
+      assertFalse(((String) out).contains("&"), "should be the point's label, not every merged date: " + out);
+   }
+
+   /** The point of the whole exercise: what goes on the wire has to be small. */
+   @Test
+   void collapsesTheSerializedSizeByOrdersOfMagnitude() throws Exception {
+      ObjectMapper mapper = new ObjectMapper();
+      LabelValue raw = (LabelValue) mergedCell().getMergeLabelCell();
+
+      int before = mapper.writeValueAsString(raw).length();
+      int after = mapper.writeValueAsString(WizUtil.toResponseCell(raw)).length();
+
+      assertTrue(before > 10_000, "the raw cell should be the huge thing this test is about: " + before);
+      assertTrue(after < 100, "the converted cell should be a short label, was " + after + " chars");
+      assertTrue(after * 100 < before, before + " -> " + after + " is not the collapse expected");
+   }
+
+   /** zoneStrings is 97% of the payload — it must not survive the conversion. */
+   @Test
+   void dropsTheLocaleTimezoneTable() throws Exception {
+      ObjectMapper mapper = new ObjectMapper();
+      String out = mapper.writeValueAsString(WizUtil.toResponseCell(mergedCell().getMergeLabelCell()));
+
+      assertFalse(out.contains("zoneStrings"), out);
+      assertFalse(out.contains("dateFormatSymbols"), out);
+      assertFalse(out.contains("Pacific Standard Time"), out);
+   }
+
+   /** Distinct points must stay distinct, or a consumer keying on them collapses them together. */
+   @Test
+   void keepsDistinctPointsDistinct() {
+      DCMergeDatesCell jun = mergedCell(6);
+      DCMergeDatesCell jul = mergedCell(7);
+
+      assertNotEquals(WizUtil.toResponseCell(jun.getMergeLabelCell()),
+                      WizUtil.toResponseCell(jul.getMergeLabelCell()));
+   }
+}


### PR DESCRIPTION
## A locale timezone table, per cell

A DataSet cell is not always a scalar, and the row builder put whatever `getData()` returned straight into the response. A date comparison over **custom** ranges yields `DCMergeDatesCell` — a domain object carrying its dates, the original value, and its `java.text.Format`. Handed to Jackson it is walked getter by getter, and `getFormat()` drags in `SimpleDateFormat` → `DateFormatSymbols` → `zoneStrings`: the entire Java locale timezone table, **597 zones, ~67 KB, per cell**.

Measured on a 14-row year-over-year comparison (openproject B6):

| | chars |
|---|---|
| one cell | **69,368** |
| └ its `format` | 69,145 |
| &nbsp;&nbsp;└ `dateFormatSymbols` | 68,006 |
| &nbsp;&nbsp;&nbsp;&nbsp;└ **`zoneStrings`** | **67,483** — 97% of the cell |

And because the same cells are re-serialized into the facts table computed from them, they appear **28 times**: the response reached **~1.9M characters, 99.8% of it that one table**, to convey fourteen short labels like `"2026 Jun"`.

It exceeded the caller's token limit outright — so the agent that invoked `apply_date_comparison` **could not read its own result**. The tool was unusable on that path.

## The fix

Every cell now goes through `WizUtil.toResponseCell`. Scalars pass through untouched, so the ordinary path is unaffected.

A `LabelValue` yields `getText()` — the label the chart actually draws, and the same string the plugin's own defensive scalarizer already picks (stylebi-wiz #1495). That equivalence is deliberate: it means downstream figures are **unchanged**, not fixed twice in two places that might disagree.

Deliberately **not** `toString()`: on the outer cell that joins *every* merged date with `&` (`"2025 Jun&2026 Jun"`) instead of naming the point, which would break the prior-period pairing that keys on it. Any other non-scalar is stringified rather than reaching Jackson as an object graph.

## Verified live on `local-1174`

Re-ran the exact call that produced the 1.8 MB response:

```json
{"Month(due_date)":"2026 Jun","DataGroup(due_date)":"2025","Count(id)":23, ...}
```

Plain strings, response readable inline. **Every figure is identical** to the run before this change — `-5.8%`, `Change: -21 — from 363`, `2026 total: 342 — 7 months`, both `partial_period_end` caveats, and the annotated biggest mover — confirming the two fixes agree rather than merely both being present.

## Tests

5: scalars pass through, the merged cell reduces to the drawn label, serialized size collapses by >100×, `zoneStrings`/`dateFormatSymbols` do not survive, and distinct points stay distinct.

Verified 3 of the 5 fail with the conversion reverted — and the failure output shows the raw cell at **66,018 chars**, independently reproducing the diagnosis inside a plain JVM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
