### PR TITLE
fix(wiz): an explicitly-bound chart dimension echoed without its type or date grain

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizFieldInfoFactory.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizFieldInfoFactory.java
@@ -35,7 +35,13 @@ final class WizFieldInfoFactory {
 
    static DimensionFieldInfo createDimensionFieldInfo(VSDimensionRef dim) {
       DimensionFieldInfo info = baseDimensionFieldInfo(dim);
-      info.setFullName(dim.getFullName());
+      info.setType(dim.getDataType());
+      // Same derivation as the crosstab echo, and for the same reason: a ref built from an EXPLICIT
+      // binding carries no backing ColumnRef, so getFullName() never reaches its date-qualifying branch
+      // and returns the bare group column. A Year-grouped chart dimension then echoed as "due_date"
+      // while its data column was "Year(due_date)" — and a consumer that matches the two by name (the
+      // facts builder) found nothing, so a sunburst over TWO years reported "single value".
+      info.setFullName(dimFullName(dim));
       applyDateGroup(info, dim);
       applyRanking(info, dim);
       return info;
@@ -44,7 +50,7 @@ final class WizFieldInfoFactory {
    static DimensionFieldInfo createCrosstabDimensionFieldInfo(VSDimensionRef dim) {
       DimensionFieldInfo info = baseDimensionFieldInfo(dim);
       info.setType(dim.getDataType());
-      info.setFullName(crosstabDimFullName(dim));
+      info.setFullName(dimFullName(dim));
       applyDateGroup(info, dim);
       applyRanking(info, dim);
       info.setSummarize(dim.isSubTotalVisible());
@@ -52,7 +58,9 @@ final class WizFieldInfoFactory {
    }
 
    /**
-    * A crosstab design ref built from an explicit binding has no backing ColumnRef, so getVSName()
+    * Shared by the crosstab AND chart echoes — both build refs from explicit bindings and hit this.
+    *
+    * A design ref built from an explicit binding has no backing ColumnRef, so getVSName()
     * is empty and getFullName() short-circuits to "" before the date-qualifying branch. Derive the
     * name directly from the group column: a level-qualified name (e.g. "DayOfWeek(date_start)") for a
     * DATE-typed dimension that carries a real date level, else the plain column name.
@@ -62,7 +70,7 @@ final class WizFieldInfoFactory {
     * that pollutes the downstream facts pack. We only date-qualify genuine date dimensions, and always
     * fall back to the group column (never an empty string) for everything else.
     */
-   static String crosstabDimFullName(VSDimensionRef dim) {
+   static String dimFullName(VSDimensionRef dim) {
       String fullName = dim.getFullName();
       String groupColumn = dim.getGroupColumnValue();
 
@@ -81,7 +89,8 @@ final class WizFieldInfoFactory {
 
    static DimensionFieldInfo createChartDimensionFieldInfo(VSDimensionRef dim) {
       DimensionFieldInfo info = baseDimensionFieldInfo(dim);
-      info.setFullName(dim.getFullName());
+      info.setType(dim.getDataType());
+      info.setFullName(dimFullName(dim));
       applyDateGroup(info, dim);
       applyRanking(info, dim);
       return info;

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -2909,7 +2909,7 @@ public class WizVsService {
       // Chart dims are VSChartDimensionRef, whose groupColumnValue is non-empty, so
       // this branch is crosstab-only and leaves chart slot names unaffected.
       if((name == null || name.isEmpty()) && ref instanceof VSDimensionRef dim) {
-         return WizFieldInfoFactory.crosstabDimFullName(dim);
+         return WizFieldInfoFactory.dimFullName(dim);
       }
 
       return name;
@@ -4166,6 +4166,24 @@ public class WizVsService {
          ref.setManualOrderList(new java.util.ArrayList<>(dim.getManualOrder()));
       }
 
+      // The declared type, for EVERY explicit dimension — not only the numeric-bin one that used to be
+      // its sole setter (further down, where it was needed to make applyNumericBin work).
+      //
+      // Leaving it unset does not break the DATA: setDateLevelValue below drives the grouping, so a
+      // Year-grouped chart renders correctly. It breaks everything that later asks what this dimension
+      // IS. VSDimensionRef.isDateTime() reads getDataType(), so an unset type made a genuine date
+      // dimension look non-date, and the binding ECHO built from it lost both halves of its identity:
+      // `dateGroupLevel` came back null (applyDateGroup's date guard failed) and `fullName` came back
+      // "due_date" instead of "Year(due_date)" (getFullName() never reached its date-qualifying branch).
+      //
+      // Downstream that reads as a different chart: a sunburst over TWO years reported
+      // `single_value: "due_date has a single value ()"`, because the facts builder could not match the
+      // echoed "due_date" to the actual "Year(due_date)" column. The plugin now tolerates the bad echo
+      // (stylebi-wiz #1497), but the echo was the thing that was wrong.
+      if(base.getType() != null && !base.getType().isEmpty()) {
+         ref.setDataType(base.getType());
+      }
+
       if(dim != null && dim.getDateGroupLevel() != null) {
          ref.setDateLevelValue(String.valueOf(getDateGroupLevel(dim.getDateGroupLevel())));
          ref.setTimeSeries(dim.isTimeSeries());
@@ -4185,10 +4203,7 @@ public class WizVsService {
       }
 
       if(dim != null && dim.isNumericBin()) {
-         if(base.getType() != null && !base.getType().isEmpty()) {
-            ref.setDataType(base.getType());
-         }
-
+         // dataType is set unconditionally above; applyNumericBin still depends on it being present.
          WizardRecommenderUtil.applyNumericBin(ref);
       }
 


### PR DESCRIPTION
## Two halves of one identity, both lost

On the explicit-binding path (funnel/pareto/hierarchy/boxplot/gantt — every recommender-bypassed chart):

**1. No declared type.** `createVSChartDimensionRef` called `setDataType` **only inside its `isNumericBin` branch**. Every other explicit dimension had none. `VSDimensionRef.isDateTime()` reads `getDataType()`, so a genuine date dimension looked non-date and `applyDateGroup`'s date guard skipped it → `dateGroupLevel: null`.

**2. No date-qualified name.** A ref built from an explicit binding carries no backing `ColumnRef`, so `getFullName()` never reaches its date-qualifying branch and returns the bare group column → `fullName: "due_date"` for a column whose data header is `Year(due_date)`.

That second condition is exactly what `crosstabDimFullName` was written for — the chart echo just never used it. Renamed to `dimFullName` and shared, since both paths build refs from explicit bindings and hit the same thing.

## The data was never wrong

`setDateLevelValue` drives the grouping, so these charts rendered correctly throughout. What was wrong was everything that later asked *what the dimension is*.

Downstream that read as a different chart: a sunburst over **two** years reported `single_value: "due_date has a single value ()"`, because the facts builder could not match the echoed `due_date` to the actual `Year(due_date)` column. The plugin now tolerates a bad echo (stylebi-wiz #1497) — **this fixes the echo itself**, which was the thing that was wrong.

## Verified live across two build cycles

The halves fail independently, so each was confirmed separately rather than together:

| image | change | result |
|---|---|---|
| `local-1175` | dataType only | `dateGroupLevel` null → **"year"**; `fullName` still "due_date" |
| `local-1176` | + `dimFullName` | `fullName` → **"Year(due_date)"**; `type` null → **"date"** |

A **string** dimension in the same chart still echoes `type: "string"`, `dateGroupLevel: null`, `fullName: "projects_name"` — the date guard holds, no bogus `Year(projects_name)`. Data unchanged throughout (26 rows, 15,162); `caveats` now empty.

All `WizVsService*` / `WizAutoBindingService*` / `WizFieldInfo*` / `WizUtil*` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)