### PR TITLE
fix(wiz): board-export prose was measured at a width it is never painted at

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizPrintLayoutBuilder.java
@@ -98,11 +98,12 @@ public class WizPrintLayoutBuilder {
       // Stride each subsequent chart to the real printable page height (paper minus top/bottom
       // margins), not a fixed 11in — otherwise later pages drift down and leave awkward whitespace.
       int pageStride = pageContentHeightPt(pageSize);
+      int contentWidth = pageContentWidthPt(pageSize);
 
       // Page 1: report-style header — a prominent title, a "Generated <date>" line closed by a
       // thin rule, and the session recap as a markdown-stripped summary. Split into separate text
       // boxes because a single box can only carry one font. Returns the y where the body begins.
-      int headerBottom = addReportHeader(vsLayouts, title, recap);
+      int headerBottom = addReportHeader(vsLayouts, title, recap, contentWidth);
 
       for(int i = 0; i < ordered.size(); i++) {
          ChartCaption c = ordered.get(i);
@@ -116,10 +117,10 @@ public class WizPrintLayoutBuilder {
          String captionText = c.title() +
             (c.caption() != null && !c.caption().isBlank() ? " — " + c.caption() : "");
          vsLayouts.add(styledTextLayout("wizExportCaption_" + i, captionText,
-            new Point(0, captionY), new Dimension(PAGE_CONTENT_WIDTH_PT, CAPTION_HEIGHT_PT),
+            new Point(0, captionY), new Dimension(contentWidth, CAPTION_HEIGHT_PT),
             Font.BOLD, CAPTION_FONT_PT, CAPTION_COLOR, true));
          vsLayouts.add(new VSAssemblyLayout(assembly.getName(), new Point(0, chartY),
-            new Dimension(PAGE_CONTENT_WIDTH_PT, CHART_HEIGHT_PT)));
+            new Dimension(contentWidth, CHART_HEIGHT_PT)));
 
          int contentBottom = chartY + CHART_HEIGHT_PT;
 
@@ -127,7 +128,7 @@ public class WizPrintLayoutBuilder {
             // One markdown box; MarkdownPresenter renders headers/bullets/inline bold+italic and
             // the converter paints it via a presenter painter (see VsToReportConverter).
             contentBottom = addMarkdownBlock(vsLayouts, "wizMarkdownInsights_" + i,
-                                             c.insightsMarkdown(), contentBottom);
+                                             c.insightsMarkdown(), contentBottom, contentWidth);
          }
 
          // Advance past everything just placed, not by a fixed one page.
@@ -150,11 +151,43 @@ public class WizPrintLayoutBuilder {
       return layout;
    }
 
-   /** Printable content height in points: paper height minus top/bottom margins. */
+   /**
+    * Printable content height in points: paper height minus top/bottom margins.
+    *
+    * Truncated, not rounded, to match {@link inetsoft.uql.viewsheet.internal.VsToReportConverter}'s
+    * getPageContentSize() exactly — it is that value the converter paginates against
+    * (getPageNumber(y, pageHeight)), so a builder that strides by even one point more puts an
+    * element the builder believes sits at the top of page N onto page N+1.
+    */
    private int pageContentHeightPt(String pageSize) {
+      Size size = paperSize(pageSize);
+      return (int) ((size.height - MARGIN_TOP_IN - MARGIN_BOTTOM_IN) * 72.0);
+   }
+
+   /**
+    * Printable content WIDTH in points: paper width minus left/right margins.
+    *
+    * THE DEFECT THIS FIXES. This used to be a hardcoded 8in (576pt) for both paper sizes, but the
+    * printable width is 544pt on Letter and 527pt on A4 at these margins, and the converter paints
+    * every box at the printable width (PainterElementDef.print: painterW = min(size, areaW) where
+    * areaW comes from getPageContentSize()). A markdown block's reserved height is measured by
+    * MarkdownPresenter at the width passed here, so measuring at 576 and painting at 544 wraps into
+    * MORE lines than were reserved — and the overflow is not flowed onto the next page, it is
+    * DROPPED: getPainterPreferredSize() returns an element's explicit size when one is set, so
+    * isEnd() halts the painter at the reserved height. In an exported board that surfaced as prose
+    * cut off mid-sentence at the bottom of a page, with the next page starting on the next chart.
+    *
+    * Same arithmetic as the converter's getPageContentSize() so the measured width is exactly the
+    * painted width.
+    */
+   private int pageContentWidthPt(String pageSize) {
+      Size size = paperSize(pageSize);
+      return (int) ((size.width - MARGIN_LEFT_IN - MARGIN_RIGHT_IN) * 72.0);
+   }
+
+   private Size paperSize(String pageSize) {
       String canonicalName = PAGE_SIZE_NAMES.get(pageSize == null ? "" : pageSize.toLowerCase());
-      Size size = PaperSize.getSize(canonicalName);
-      return (int) Math.round((size.height - MARGIN_TOP_IN - MARGIN_BOTTOM_IN) * 72);
+      return PaperSize.getSize(canonicalName);
    }
 
    private PrintInfo buildPrintInfo(String pageSize) {
@@ -232,23 +265,25 @@ public class WizPrintLayoutBuilder {
     * Emits the page-1 report header (title, generated-date line + rule, recap summary) and
     * returns the y-coordinate (in points) where the body content should start.
     */
-   private int addReportHeader(List<VSAssemblyLayout> vsLayouts, String title, String recap) {
+   private int addReportHeader(List<VSAssemblyLayout> vsLayouts, String title, String recap,
+                               int contentWidth)
+   {
       String heading = title == null || title.isBlank() ? "Analysis Report" : title.trim();
       int y = 0;
 
       vsLayouts.add(styledTextLayout("wizExportTitle", heading, new Point(0, y),
-         new Dimension(PAGE_CONTENT_WIDTH_PT, TITLE_HEIGHT_PT),
+         new Dimension(contentWidth, TITLE_HEIGHT_PT),
          Font.BOLD, TITLE_FONT_PT, TITLE_COLOR, false));
       y += TITLE_HEIGHT_PT;
 
       vsLayouts.add(styledTextLayout("wizExportDate", generatedDateLine(), new Point(0, y),
-         new Dimension(PAGE_CONTENT_WIDTH_PT, DATE_HEIGHT_PT),
+         new Dimension(contentWidth, DATE_HEIGHT_PT),
          Font.PLAIN, DATE_FONT_PT, DATE_COLOR, true));
       y += DATE_HEIGHT_PT;
 
       if(recap != null && !recap.isBlank()) {
          y += SUMMARY_GAP_PT;
-         y = addMarkdownBlock(vsLayouts, "wizMarkdownSummary", recap, y);
+         y = addMarkdownBlock(vsLayouts, "wizMarkdownSummary", recap, y, contentWidth);
       }
 
       return y + HEADER_BOTTOM_GAP_PT;
@@ -261,18 +296,20 @@ public class WizPrintLayoutBuilder {
     * Returns the y just past the box.
     */
    private int addMarkdownBlock(List<VSAssemblyLayout> vsLayouts, String name, String markdown,
-                                int startY)
+                                int startY, int contentWidth)
    {
       MarkdownPresenter presenter = new MarkdownPresenter();
       // Match the font the converter will hand the presenter (the box's body font) so the
       // height we reserve equals what gets painted.
       presenter.setFont(inetsoft.uql.viewsheet.internal.VSAssemblyInfo.getDefaultFont(Font.PLAIN, BODY_FONT_PT));
-      int h = presenter.getPreferredSize(markdown, PAGE_CONTENT_WIDTH_PT).height + BLOCK_GAP_PT;
+      // Measure at contentWidth — the SAME width the converter paints at. Anything the box does not
+      // reserve room for is clipped, never flowed (see pageContentWidthPt).
+      int h = presenter.getPreferredSize(markdown, contentWidth).height + BLOCK_GAP_PT;
 
       // The box carries the raw markdown as its text and a plain body font; the converter reads
       // that font for the presenter and paints the markdown (the box's own text is not drawn).
       vsLayouts.add(styledTextLayout(name, markdown, new Point(0, startY),
-         new Dimension(PAGE_CONTENT_WIDTH_PT, h), Font.PLAIN, BODY_FONT_PT, SUMMARY_COLOR, false));
+         new Dimension(contentWidth, h), Font.PLAIN, BODY_FONT_PT, SUMMARY_COLOR, false));
       return startY + h;
    }
 
@@ -308,9 +345,9 @@ public class WizPrintLayoutBuilder {
    /** Points-per-inch used by VsToReportConverter's print-layout-to-report conversion
     *  (see VsToReportConverter.java:3226, INCH_POINT = 72) — VSAssemblyLayout position/size
     *  values feed that same pipeline, so page/content geometry below is expressed in points.
-    *  CONFIRM in Task 3's integration test that content doesn't clip/overlap across the page
-    *  boundary; adjust these constants if it does. */
-   private static final int PAGE_CONTENT_WIDTH_PT = 8 * 72;
+    *  Content width/height are NOT constants: they are derived per page size by
+    *  {@link #pageContentWidthPt}/{@link #pageContentHeightPt} so they equal what the converter
+    *  paints into. */
    private static final int CAPTION_HEIGHT_PT = 30;
    private static final int CAPTION_FONT_PT = 13;
    private static final String CAPTION_COLOR = "0x3B6EA5";   // slate-blue accent

--- a/core/src/test/java/inetsoft/web/wiz/service/WizPrintLayoutBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizPrintLayoutBuilderTest.java
@@ -165,8 +165,12 @@ class WizPrintLayoutBuilderTest {
 
       PrintLayout layout = builder.build(vs, "letter", "Board", null, charts);
 
-      // letter stride = (11 - 0.55 - 0.55) * 72
-      int stride = (int) Math.round((11.0 - 0.55 - 0.55) * 72);
+      // Letter stride = (11 - 0.55 - 0.55) * 72, TRUNCATED — the same arithmetic as
+      // VsToReportConverter.getPageContentSize(), which is what the converter paginates against.
+      // Rounding up to 713 instead put each page's content one point past the converter's own page
+      // boundary, so getPageNumber() read it as belonging to the next page.
+      int stride = (int) ((11.0 - 0.55 - 0.55) * 72.0);
+      assertEquals(712, stride, "guards the truncation, not just the expression");
       assertEquals(stride, topOf(layout, "wizExportCaption_1"),
          "with short content the second chart still starts exactly one page down");
    }
@@ -272,9 +276,10 @@ class WizPrintLayoutBuilderTest {
          .filter(l -> !(l instanceof VSEditableAssemblyLayout))
          .filter(l -> l.getName().equals("Chart1"))
          .findFirst().orElseThrow();
-      // 576x400 = PAGE_CONTENT_WIDTH_PT x CHART_HEIGHT_PT (private constants; hardcoded here since
+      // width = A4's printable content width (paper minus left/right margins, the width the
+      // converter paints into); height = CHART_HEIGHT_PT (a private constant, hardcoded here since
       // this test lives in the same package but not the same class, so private members aren't visible).
-      assertEquals(new Dimension(576, 400), chartLayout.getSize(),
+      assertEquals(new Dimension(printableContentWidthPt(layout), 400), chartLayout.getSize(),
          "chart box is not resized when insights are present");
 
       List<VSEditableAssemblyLayout> texts = all.stream()
@@ -382,5 +387,82 @@ class WizPrintLayoutBuilderTest {
          .filter(l -> l instanceof VSEditableAssemblyLayout).count();
       // null recap -> report header is title + date only (no summary box), + caption = 3
       assertEquals(3, editableTextBlocks, "the 3-arg compatibility constructor omits insights");
+   }
+
+   /**
+    * LIVE BUG. An exported board's insights prose was cut off mid-sentence at the bottom of a page —
+    * the tail of the paragraph simply never appeared, and the next page began with the next chart.
+    *
+    * The block is a markdown box whose height the builder reserves from
+    * MarkdownPresenter.getPreferredSize(md, width). It passed a hardcoded 8in (576pt) as that width,
+    * but the box is PAINTED at the page's real printable width — VsToReportConverter's
+    * getPageContentSize() is (paper - left - right) * 72, i.e. 544pt on Letter and 527pt on A4 at
+    * this layout's margins. Narrower paint width means MORE wrapped lines than were measured, and
+    * PainterElementDef.getPainterPreferredSize() returns the element's EXPLICIT size when one is
+    * set, so isEnd() stops the painter dead at the reserved height: every line past it is dropped,
+    * silently. ~6% under-measurement is one or two lines on a full-page block — exactly the observed
+    * "cut off at the bottom of page three".
+    *
+    * The measure width must equal the paint width, for both page sizes.
+    */
+   @Test
+   void insightsBoxReservesTheHeightItsTextNeedsAtThePageWidthItIsPaintedAt() {
+      String insights = """
+         **The warning on the counted view did not survive contact with the data — weighting by \
+         effort barely changes anything.**
+
+         The expectation going in was that a count would mislead, because it treats a 160-hour Epic \
+         and a 2-hour Bug alike. It doesn't here. Re-weighting by hours leaves the ranking identical \
+         and each tier's share of the whole within about a point of where it was, and the spread even \
+         narrows slightly. Whatever you concluded from the counted chart still stands.
+
+         **The reason is the more useful finding: priority and size are close to independent.** \
+         Urgent items are only slightly larger on average than low-priority ones — a gradient exists, \
+         but a weak one. That matters because effort on this dataset scales *strongly* with \
+         work-package type, Epics running an order of magnitude above Bugs.
+
+         **So what:** priority is safe to analyse by row count, which is the cheaper and more robust \
+         cut — you are not hiding an effort story behind it. The corollary is the caution: do not use \
+         priority to forecast capacity.
+
+         **Better cuts:** priority against type, to confirm directly that the two are independent \
+         rather than inferring it from the flatness here; or priority against status, which asks the \
+         question this chart cannot — whether urgent work is actually being cleared or just piling up.
+         """;
+
+      for(String pageSize : List.of("letter", "a4")) {
+         Viewsheet vs = new Viewsheet();
+         textAssembly(vs, "Chart1", 0);
+         PrintLayout layout = builder.build(vs, pageSize, "Project maturity", null,
+            List.of(new WizPrintLayoutBuilder.ChartCaption("Priority vs effort", null, 0, insights)));
+
+         VSEditableAssemblyLayout box = layout.getVSAssemblyLayouts().stream()
+            .filter(l -> l instanceof VSEditableAssemblyLayout)
+            .map(l -> (VSEditableAssemblyLayout) l)
+            .filter(t -> t.getName().startsWith("wizMarkdownInsights"))
+            .findFirst().orElseThrow();
+
+         int paintWidth = printableContentWidthPt(layout);
+
+         assertEquals(paintWidth, box.getSize().width, pageSize +
+            ": the markdown box must be as wide as the page's printable area, since that is the " +
+            "width VsToReportConverter paints it at");
+
+         MarkdownPresenter presenter = new MarkdownPresenter();
+         presenter.setFont(inetsoft.uql.viewsheet.internal.VSAssemblyInfo.getDefaultFont(Font.PLAIN, 11));
+         int needed = presenter.getPreferredSize(insights, paintWidth).height;
+
+         assertTrue(box.getSize().height >= needed, pageSize +
+            ": reserved " + box.getSize().height + "pt for a block that needs " + needed +
+            "pt when wrapped at the " + paintWidth + "pt paint width — the overflow is clipped, " +
+            "not flowed, so the tail of the prose is lost");
+      }
+   }
+
+   /** VsToReportConverter.getPageContentSize().width, recomputed from the layout's own print info. */
+   private static int printableContentWidthPt(PrintLayout layout) {
+      inetsoft.uql.viewsheet.vslayout.PrintInfo info = layout.getPrintInfo();
+      inetsoft.report.Margin margin = info.getMargin();
+      return (int) ((info.getSize().getWidth() - margin.left - margin.right) * 72.0);
    }
 }


### PR DESCRIPTION
## The defect

An exported board's insights text was **cut off mid-sentence at the bottom of a page** — the tail of the paragraph never appeared, and the next page simply began with the next chart. Reported from a real export ("Project maturity — share of work still in New", page 3 ending at "…whether urgent work is").

## Root cause

`WizPrintLayoutBuilder` reserves a markdown block's height from `MarkdownPresenter.getPreferredSize(md, width)` — and passed a hardcoded 8in (**576pt**) as that width, for both paper sizes.

But the box is *painted* at the page's real printable width. `VsToReportConverter.getPageContentSize()` is `(paper − left − right) × 72`, which at this layout's 0.47in side margins is **544pt on Letter, 527pt on A4** (`PainterElementDef.print`: `painterW = min(size, areaW)`). Wrapping at 544 instead of 576 produces ~6% more lines than were measured.

That overflow is **not flowed onto the next page — it is dropped**. `PainterElementDef.getPainterPreferredSize()` returns the element's *explicit* size whenever one is set, so `isEnd()` halts the painter dead at the reserved height and every line past it is discarded, with no warning. On a full-page block that is the last line or two.

## The fix

- Replace the `PAGE_CONTENT_WIDTH_PT = 8 * 72` constant with `pageContentWidthPt(pageSize)`, derived from the paper size and margins using the converter's own arithmetic, and thread it through the report header, captions, chart boxes and markdown blocks — so the measured width is exactly the painted width.
- Switch `pageContentHeightPt` from `Math.round` to the converter's truncation. It was striding 713pt against the converter's 712pt page, so content the builder placed at the top of page N sat one point past the converter's boundary and `getPageNumber()` read it as belonging to page N+1.

## Tests

New regression test `insightsBoxReservesTheHeightItsTextNeedsAtThePageWidthItIsPaintedAt` covers both page sizes: it asserts the box is as wide as the printable area, and that the reserved height is at least what `MarkdownPresenter` needs when wrapped at that width. It fails on the old code with `expected: <544> but was: <576>`.

- `WizPrintLayoutBuilderTest` 17/17, `MarkdownPresenterTest` 5/5, `WizViewsheetExportControllerTest` 12/12
- Full `inetsoft.web.wiz` package: **858 tests, 0 failures**

## Verification

Built as `local-1177` and deployed locally; re-exporting the board that showed the defect renders the previously-truncated paragraph in full. Confirmed by the reporter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)