### PR TITLE
fix(wiz): seed a TITLEPATH format for every shared-bar filter control

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizDashboardFilterBuilder.java
@@ -244,14 +244,21 @@ public class WizDashboardFilterBuilder {
          if(control instanceof SelectionListVSAssembly list) {
             list.setShowTypeValue(SelectionVSAssemblyInfo.DROPDOWN_SHOW_TYPE);
             list.getSelectionListInfo().setTitleHeightValue(controlHeight);
-            centerTitleVertically(list);
             applyDropdownPopupStyle(list);
          }
 
-         // KNOWN UNFIXED: a shared-bar range slider renders with NO visible title -- a numeric slider
-         // shows a bare "6..216" with nothing telling the user it filters partner_id. The label IS
-         // applied above (setTitleValue). These explanations have each been RULED OUT by test, so do
-         // NOT retry them:
+         // EVERY control, not just the dropdown. This seeds the TITLEPATH format, and nothing else in
+         // this builder's path does -- AddFilterService.createFilterAssembly just `new`s the assembly
+         // and neither the constructor nor Viewsheet.addAssembly calls initDefaultFormat(). A
+         // TimeSlider was left without one entirely, so FormatInfo.getFormat(TITLEPATH, false)
+         // returned null and VSRangeSliderModel built its titleFormat straight from that. See the
+         // range-slider note below for why this is the surviving explanation of the missing title.
+         centerTitleVertically(control);
+
+         // RANGE-SLIDER TITLE: a shared-bar range slider rendered with NO visible title -- a numeric
+         // slider showed a bare "6..216" with nothing telling the user it filters partner_id. The
+         // label IS applied above (setTitleValue). These explanations were each RULED OUT by test, so
+         // do NOT retry them:
          //   - the DESIGN title-visible value (getTitleVisibleValue) is already true by default;
          //   - the RUNTIME flag (isTitleVisible) is already true by default;
          //   - the title height is already AssetUtil.defh (20), not zero.
@@ -260,9 +267,27 @@ public class WizDashboardFilterBuilder {
          // them -- so any such "fix" here is vacuous. TitleInfo's no-arg constructor does leave
          // titleVisible as a valueless DynamicValue2 (vs TitleInfo(String) seeding "true"), which
          // looked like the cause but is not: both getters still report true.
-         // Remaining hypothesis: the client-side TimeSlider component renders no title area at all,
-         // which has to be investigated in the Angular viewer, not here. NOTE this is ALSO why the
-         // caption cannot simply be deleted for every control: it is the slider's only label.
+         //
+         // Note what those all have in common: they are FLAGS. The gap none of them covers is the
+         // FORMAT, and that one is real and now closed -- centerTitleVertically is called for every
+         // control above, where it used to run only for the dropdown, so the slider no longer goes
+         // without a TITLEPATH format (regression test:
+         // sharedBarRangeSliderGetsItsOwnTitlePathFormatLikeTheDropdownDoes, which fails without it).
+         //
+         // THREE PRIOR HYPOTHESES, ALL DISPROVED -- recorded so they are not re-tried:
+         //   - "the client-side TimeSlider renders no title area at all, investigate the Angular
+         //     viewer": WRONG. vs-range-slider.component.html DOES render a title div, gated only on
+         //     !editingTitle. This one was the previously recorded remaining hypothesis and it sent
+         //     the investigation at the wrong layer.
+         //   - "titleRatio collapses the title to zero width": WRONG. VSRangeSliderModel declares
+         //     `titleRatio = 1`; it is only reassigned inside the CurrentSelection-container branch.
+         //   - "titleFormat has no size on the standalone path": WRONG. titleFormat.setPositions is
+         //     called with a real Dimension before that branch.
+         //
+         // STILL UNCONFIRMED VISUALLY: that seeding the format makes the title actually appear. The
+         // absent-format gap is proven by test; the rendered outcome needs eyes on a live dashboard.
+         // NOTE the caption below cannot simply be deleted for every control until that is confirmed:
+         // it is currently the slider's only label.
 
          // Caption above the control, so a user can tell what the control filters -- a bare "6..216"
          // range slider is otherwise unreadable. Its placement is returned alongside the control's:

--- a/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizDashboardFilterBuilderTest.java
@@ -313,6 +313,48 @@ class WizDashboardFilterBuilderTest {
                    "the shared bar must use the per-chart path's established natural row height");
    }
 
+   /**
+    * DIAGNOSTIC for the KNOWN UNFIXED note in WizDashboardFilterBuilder: a shared-bar range slider
+    * renders with NO visible title, even though the label IS applied (setTitleValue), titleVisible is
+    * true on both the design and runtime flags, and the title height is 20 rather than 0.
+    *
+    * Those ruled-out explanations are all FLAGS. This asserts the thing none of them covers: whether
+    * the slider ends up with a TITLEPATH FORMAT at all. centerTitleVertically() -- the only thing in
+    * this builder that seeds one -- is called solely for SelectionListVSAssembly, so a TimeSlider
+    * goes without. FormatInfo.getFormat(path, shrink=false) then returns null unless an OBJECTPATH
+    * entry exists to synthesise from, and VSRangeSliderModel builds its titleFormat straight from
+    * that composite.
+    *
+    * The comment's recorded hypothesis -- "the client-side TimeSlider component renders no title area
+    * at all" -- is demonstrably wrong: vs-range-slider.component.html does render a title div, gated
+    * only on !editingTitle. Two follow-on theories were also checked and disproved: titleRatio
+    * defaults to 1 (not 0), and titleFormat gets its size on the standalone path too, so the div is
+    * not zero-width.
+    */
+   @Test
+   void sharedBarRangeSliderGetsItsOwnTitlePathFormatLikeTheDropdownDoes() {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(physicalTable(ws, "SO", "date_order"));
+
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly chart = new ChartVSAssembly(vs, "C");
+      boundToTable(chart, "SO");
+      vs.addAssembly(chart);
+
+      builder.build(vs, ws, List.of(
+         new WizDashboardFilterBuilder.FilterRequest("date_order", "date", "Order Date")), 0);
+
+      VSAssembly slider = (VSAssembly) java.util.Arrays.stream(vs.getAssemblies())
+         .filter(a -> a instanceof TimeSliderVSAssembly).findFirst().orElseThrow();
+
+      VSCompositeFormat titleFormat = slider.getVSAssemblyInfo().getFormatInfo()
+         .getFormat(VSAssemblyInfo.TITLEPATH);
+      assertNotNull(titleFormat,
+                    "the slider needs its own TITLEPATH format for its title to render at all");
+      assertTrue((titleFormat.getAlignmentValue() & StyleConstants.V_CENTER) != 0,
+                 "the slider's title must be vertically centred, as the dropdown's is");
+   }
+
    private static SelectionListVSAssembly dropdown(Viewsheet vs) {
       return java.util.Arrays.stream(vs.getAssemblies())
          .filter(a -> a instanceof SelectionListVSAssembly)


### PR DESCRIPTION
## The defect

A shared-bar **range slider renders with no visible title** — a numeric slider shows a bare `6..216` with nothing telling the user it filters `partner_id`. This was recorded in-file as `KNOWN UNFIXED`, with a "do NOT retry" list and a remaining hypothesis pointing at the Angular viewer.

Found while working K4 of the OpenProject board sweep, where `due_date` on the shared bar is exactly this control.

## The recorded hypothesis was wrong — and so were two follow-ons

All three are now written into the comment so nobody re-runs them:

| hypothesis | verdict |
|---|---|
| "the client-side TimeSlider renders no title area at all — investigate the Angular viewer" | **WRONG.** `vs-range-slider.component.html:87-112` does render a title div, gated only on `!editingTitle`. This was the recorded remaining hypothesis, and it pointed at the wrong layer. |
| "`titleRatio` collapses the title to zero width" | **WRONG.** `VSRangeSliderModel` declares `private double titleRatio = 1`, reassigned only inside the `CurrentSelection`-container branch. |
| "`titleFormat` has no size on the standalone path" | **WRONG.** `titleFormat.setPositions(...)` is called with a real `Dimension` before that branch. |

## The actual gap

Every previously ruled-out explanation is a **flag** — the design title-visible value, the runtime flag, the title height. The one thing none of them covers is the **format**.

`centerTitleVertically()` — the only thing in this builder that seeds a TITLEPATH format — ran solely for `SelectionListVSAssembly`. A `TimeSliderVSAssembly` went without one entirely. `FormatInfo.getFormat(TITLEPATH, false)` then returns `null` unless an OBJECTPATH entry exists to synthesise from, and `VSRangeSliderModel` builds its `titleFormat` straight from that composite.

Same root-cause family the builder already documents for the dropdown's top-pinned title: *nothing in this path ever calls `initDefaultFormat()`*.

## The fix

Call `centerTitleVertically(control)` for **every** control instead of only the dropdown. It already took a plain `VSAssembly`, so nothing else changed.

## Proven, not argued

New `sharedBarRangeSliderGetsItsOwnTitlePathFormatLikeTheDropdownDoes` fails on the parent commit with `the slider needs its own TITLEPATH format for its title to render at all ==> expected: not <null>`.

- `WizDashboardFilterBuilderTest` 31/31, `WizDashboardServiceTest` 4/4, `WizDashboardServiceGridTest` 17/17
- Full `inetsoft.web.wiz` package: **859 tests, 0 failures**

## Deliberately NOT claimed

That this makes the title **visibly appear**. The absent-format gap is proven by test; the rendered outcome needs eyes on a live dashboard. The comment says so explicitly, and the caption above the slider is left in place — it is currently the slider's only label, and removing it before visual confirmation would risk trading one invisible label for none at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)