### PR TITLE
fix(embed): include Roboto webfonts in the embed npm package (bug-75971)

### DIFF
--- a/web/scripts/build-embed-package.mjs
+++ b/web/scripts/build-embed-package.mjs
@@ -24,6 +24,12 @@ export const GENERATED_RESOURCES_DIR = path.join(PROJECT_ROOT, "target", "genera
 const GULP_APP_DIR = path.join(GENERATED_RESOURCES_DIR, "gulp", "inetsoft", "web", "resources", "app");
 const NG_ELEMENTS_ASSETS_DIR = path.join(GENERATED_RESOURCES_DIR, "ng", "inetsoft", "web", "resources", "elements", "assets");
 const FALLBACK_ASSETS_DIR = path.join(PROJECT_ROOT, "projects", "portal", "src", "assets");
+// elements.css/viewer-element.css (copied from GULP_APP_DIR below) declare @font-face rules
+// pointing at "assets/roboto/*". The "fonts:stage" gulp task is what actually populates that
+// folder (from node_modules/roboto-fontface) -- it lands in the Gulp app output, not in the
+// Angular "elements" project assets or projects/portal/src/assets, so resolveAssetsDir() never
+// picks it up on its own and the shipped package silently ships without any Roboto webfonts.
+const GULP_ROBOTO_ASSETS_DIR = path.join(GULP_APP_DIR, "assets", "roboto");
 
 // Configuration
 const verbose = process.env.VERBOSE === "true" || process.env.VERBOSE === "1";
@@ -72,6 +78,10 @@ export function buildEmbedPackage() {
    const assetsDir = resolveAssetsDir();
    log(`Copying assets from: ${path.relative(PROJECT_ROOT, assetsDir)}`);
    copyDir(assetsDir, path.join(OUTPUT_DIR, "assets"));
+
+   ensureRobotoFontsExist();
+   log(`Copying Roboto webfonts from: ${path.relative(PROJECT_ROOT, GULP_ROBOTO_ASSETS_DIR)}`);
+   copyDir(GULP_ROBOTO_ASSETS_DIR, path.join(OUTPUT_DIR, "assets", "roboto"));
 
    log("Copying template files...");
    copyTemplateFiles();
@@ -196,6 +206,19 @@ function ensureFilesExist(files) {
       throw new Error(
          `Missing embed build artifacts:\n  - ${relativeFiles}\n\n` +
          `Run "npm run build:embed:prod" first.`
+      );
+   }
+}
+
+/**
+ * Validates that the Gulp-staged Roboto webfonts exist before they're copied into the package.
+ * @throws {Error} If the "fonts:stage" gulp task has not been run
+ */
+function ensureRobotoFontsExist() {
+   if(!fs.existsSync(GULP_ROBOTO_ASSETS_DIR) || fs.readdirSync(GULP_ROBOTO_ASSETS_DIR).length === 0) {
+      throw new Error(
+         `Missing Roboto webfonts: ${path.relative(PROJECT_ROOT, GULP_ROBOTO_ASSETS_DIR)}\n\n` +
+         `elements.css/viewer-element.css reference assets/roboto/* -- run "gulp fonts:stage" first.`
       );
    }
 }


### PR DESCRIPTION
## Summary
- `elements.css`/`viewer-element.css` declare `@font-face` rules pointing at `assets/roboto/*.woff2|woff`, but `build-embed-package.mjs`'s `resolveAssetsDir()` only ever sources the `assets/` folder from the Angular "elements" project output (or `projects/portal/src/assets`) — neither of which has ever contained a `roboto` directory. The Roboto webfonts are only staged by the separate `fonts:stage` gulp task into the Gulp app output, alongside the CSS/JS this script already copies from there.
- Result: the published `@inetsoft-technology/stylebi-embed-elements` package has been silently shipping without any Roboto fonts. Every consumer's browser requests `assets/roboto/*.woff2` and gets back whatever the dev server falls back to for an unknown path (e.g. `index.html` for a Vite dev server), producing "Failed to decode downloaded font" / `OTS parsing error: invalid sfntVersion` console errors.
- Fix: copy the Gulp-staged `assets/roboto` directory into the package output alongside the existing assets, and fail the build loudly (`ensureRobotoFontsExist()`) if that directory is missing or empty instead of silently shipping an incomplete package.

## Test plan
- [x] Ran `npm run package:embed:only` against existing build artifacts; confirmed `target/npm/stylebi-embed-elements/assets/roboto/` now contains all 23 Roboto woff/woff2 files, including `Roboto-Regular.woff2`, `Roboto-Regular.woff`, `Roboto-Bold.woff2`, `Roboto-Bold.woff` (the exact files seen failing in a consumer's browser console).
- [x] Confirmed existing non-font assets (chart type icons, etc.) are still copied and unaffected.
- [x] Simulated a missing/un-staged fonts directory and confirmed the build now fails loudly with a clear message instead of silently producing an incomplete package.
- [ ] Full `npm run package:embed:prod` / `publish:embed` run and downstream consumer (wiz) verification after a version bump — not run here since it requires a full rebuild + publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)