### PR TITLE
Bug #75823, fix NPE regression in range slider fix for cube aggregate measures

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/TimeSliderVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/TimeSliderVSAQuery.java
@@ -1545,8 +1545,10 @@ public class TimeSliderVSAQuery extends AbstractSelectionVSAQuery {
 
             // a null value (e.g. a member with no aggregate/measure data) can't be a
             // meaningful min/max anchor for a single-value slider, so skip the row
-            // instead of showing a blank label
-            if(refs.length == 1 && obj == null) {
+            // instead of showing a blank label. only applies to SingleTimeInfo, which
+            // is the binding that used to exclude nulls in the query; a composite
+            // slider (which may also have a single ref) still shows null members.
+            if(tinfo instanceof SingleTimeInfo && obj == null) {
                continue rows;
             }
 

--- a/core/src/main/java/inetsoft/report/composition/execution/TimeSliderVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/TimeSliderVSAQuery.java
@@ -139,15 +139,6 @@ public class TimeSliderVSAQuery extends AbstractSelectionVSAQuery {
                sortinfo.addSort(sort);
                tassembly.setSortInfo(sortinfo);
             }
-
-            // ignore null otherwise a member with a null aggregate/measure value
-            // sorts to the front and shows as a blank min label
-            ConditionList conds = new ConditionList();
-            Condition cond = new Condition(column.getDataType());
-            cond.setNegated(true);
-            cond.setOperation(Condition.NULL);
-            conds.append(new ConditionItem(column, cond, 0));
-            tassembly.setPreRuntimeConditionList(conds);
          }
          else {
             if(column instanceof CalculateRef) {
@@ -1526,6 +1517,7 @@ public class TimeSliderVSAQuery extends AbstractSelectionVSAQuery {
       Object mobj = assembly.getSelectedMin();
       ColumnIndexMap columnIndexMap = new ColumnIndexMap(data, true);
 
+      rows:
       for(int i = 1; data.moreRows(i); i++) {
          StringBuilder label = new StringBuilder();
          StringBuilder vstr = new StringBuilder();
@@ -1550,6 +1542,13 @@ public class TimeSliderVSAQuery extends AbstractSelectionVSAQuery {
             Object obj = data instanceof MemberObjectTableLens ?
                ((MemberObjectTableLens) data).getMemberObject(i, j) :
                data.getObject(i, j);
+
+            // a null value (e.g. a member with no aggregate/measure data) can't be a
+            // meaningful min/max anchor for a single-value slider, so skip the row
+            // instead of showing a blank label
+            if(refs.length == 1 && obj == null) {
+               continue rows;
+            }
 
             if(data instanceof DataTableLens) {
                cellData = ((DataTableLens) data).getData(i, j);

--- a/core/src/test/java/inetsoft/report/composition/execution/TimeSliderVSAQueryTest.java
+++ b/core/src/test/java/inetsoft/report/composition/execution/TimeSliderVSAQueryTest.java
@@ -1,0 +1,171 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.report.composition.execution;
+
+import inetsoft.report.lens.DefaultTableLens;
+import inetsoft.test.*;
+import inetsoft.uql.XTable;
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.internal.TimeSliderVSAssemblyInfo;
+import inetsoft.util.CoreTool;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for null handling in the range slider selection list. Bug #75823 (a member with a
+ * null aggregate/measure value showed up as a blank min label) was originally fixed with a
+ * NULL-exclusion pre-runtime condition, which broke XMLA/cube-bound sliders; the null is
+ * now filtered on the query result instead, and only for a SingleTimeInfo binding.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(
+   classes = { BaseTestConfiguration.class, SwapperTestConfiguration.class },
+   initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+public class TimeSliderVSAQueryTest {
+   private Viewsheet viewsheet;
+   private TimeSliderVSAssembly assembly;
+   private TimeSliderVSAQuery query;
+
+   @BeforeEach
+   void setUp() {
+      viewsheet = new Viewsheet();
+      viewsheet.getVSAssemblyInfo().setName("vs1");
+
+      assembly = new TimeSliderVSAssembly();
+      ((TimeSliderVSAssemblyInfo) assembly.getVSAssemblyInfo()).setName(SLIDER);
+      viewsheet.addAssembly(assembly);
+
+      ViewsheetSandbox box = mock(ViewsheetSandbox.class);
+      when(box.getID()).thenReturn("vs1");
+      when(box.getViewsheet()).thenReturn(viewsheet);
+
+      query = new TimeSliderVSAQuery(box, SLIDER);
+   }
+
+   /**
+    * A single-bound slider can't anchor its min/max on a null, so the row is dropped
+    * rather than shown as a blank label.
+    */
+   @Test
+   void testSingleTimeInfoSkipsNullValue() throws Exception {
+      SingleTimeInfo tinfo = new SingleTimeInfo();
+      tinfo.setRangeTypeValue(TimeInfo.MEMBER);
+      tinfo.setDataRef(createRef(MEASURE));
+      assembly.setTimeInfo(tinfo);
+
+      query.refreshSelectionValue(createTable(new Object[][] {
+         { MEASURE },
+         { "a" },
+         { null },
+         { "b" }
+      }));
+
+      assertEquals(List.of("a", "b"), getSelectionValues());
+   }
+
+   /**
+    * A composite slider that happens to have a single ref is a different binding (e.g. a
+    * plain string dimension dragged onto a range slider), and still lists null members.
+    */
+   @Test
+   void testCompositeTimeInfoWithSingleRefKeepsNullValue() throws Exception {
+      CompositeTimeInfo tinfo = new CompositeTimeInfo();
+      tinfo.setDataRefs(new DataRef[]{ createRef(MEASURE) });
+      assembly.setTimeInfo(tinfo);
+
+      query.refreshSelectionValue(createTable(new Object[][] {
+         { MEASURE },
+         { "a" },
+         { null },
+         { "b" }
+      }));
+
+      assertEquals(List.of("a", CoreTool.FAKE_NULL, "b"), getSelectionValues());
+   }
+
+   /**
+    * A null in one column of a multi-ref composite slider never dropped the row.
+    */
+   @Test
+   void testCompositeTimeInfoWithMultipleRefsKeepsNullValue() throws Exception {
+      CompositeTimeInfo tinfo = new CompositeTimeInfo();
+      tinfo.setDataRefs(new DataRef[]{ createRef(MEASURE), createRef(OTHER) });
+      assembly.setTimeInfo(tinfo);
+
+      query.refreshSelectionValue(createTable(new Object[][] {
+         { MEASURE, OTHER },
+         { "a", "x" },
+         { null, "y" },
+         { "b", "z" }
+      }));
+
+      assertEquals(List.of("a::x", CoreTool.FAKE_NULL + "::y", "b::z"), getSelectionValues());
+   }
+
+   private static ColumnRef createRef(String name) {
+      ColumnRef ref = new ColumnRef(new AttributeRef(null, name));
+      ref.setDataType(XSchema.STRING);
+
+      return ref;
+   }
+
+   private static XTable createTable(Object[][] data) {
+      return new DefaultTableLens(data);
+   }
+
+   /**
+    * Get the values of the refreshed selection list, ignoring the artificial end value
+    * that is appended when the upper bound is exclusive.
+    */
+   private List<String> getSelectionValues() {
+      SelectionList slist = assembly.getSelectionList();
+      List<String> values = new ArrayList<>();
+
+      for(int i = 0; i < slist.getSelectionValueCount(); i++) {
+         SelectionValue value = slist.getSelectionValue(i);
+
+         if(!(value instanceof SelectionValue.UpperExclusiveEndValue)) {
+            values.add(value.getValue());
+         }
+      }
+
+      return values;
+   }
+
+   private static final String SLIDER = "RangeSlider1";
+   private static final String MEASURE = "Measure";
+   private static final String OTHER = "Other";
+}


### PR DESCRIPTION
## Summary

Follow-up to #4478 (Bug #75823), which fixed a RangeSlider not showing its minimum value when bound to a cube (XMLA) aggregate measure — the fix in that PR pushed a `NULL`-exclusion `PreRuntimeConditionList` on the measure column.

That approach breaks XMLA/cube-bound sliders: `XMLAQuery.getDimensions()` treats every condition column as a dimension filter and calls `XMLAUtil.getDimension()` on it. For a measure ref this returns `null`, and `XMLAHandler.cacheLevels()` then dereferences that `null`, throwing:

```
java.lang.NullPointerException: Cannot invoke "inetsoft.uql.xmla.Dimension.getLevelCount()" because "dim" is null
	at inetsoft.uql.xmla.XMLAQuery.getLevelCount(XMLAQuery.java:273)
	at inetsoft.uql.xmla.XMLAHandler.cacheLevels(XMLAHandler.java:457)
	...
```

This PR replaces the query-level condition with a Java-side fix: `TimeSliderVSAQuery.refreshDimensionsValue()` now skips a row entirely when the single bound ref's value is `null`, instead of building a `SelectionValue` with a blank label. This achieves the same result (a null-valued member can't become the slider's min/max anchor) without pushing anything down to the query/MDX layer, so it works for both SQL and cube-backed sliders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)