### PR TITLE
Bug #75974, add Excel (.xls/.xlsx) import support to the worksheet agent

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -21,6 +21,8 @@ import inetsoft.report.composition.RuntimeWorksheet;
 import inetsoft.report.composition.WorksheetService;
 import inetsoft.report.composition.event.AssetEventUtil;
 import inetsoft.report.composition.execution.AssetQuerySandbox;
+import inetsoft.report.internal.Util;
+import inetsoft.sree.SreeEnv;
 import inetsoft.sree.security.IdentityID;
 import inetsoft.sree.security.ResourceAction;
 import inetsoft.sree.security.ResourceType;
@@ -49,10 +51,15 @@ import inetsoft.web.composer.ws.event.WSLayoutGraphEvent;
 import inetsoft.web.portal.controller.database.QueryManagerService;
 import inetsoft.web.wiz.pairing.*;
 import inetsoft.web.wiz.worksheet.model.WorksheetModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.awt.*;
@@ -612,38 +619,42 @@ public class WorksheetAgentController {
     * booleans round-trip correctly.</p>
     *
     * @param sessionToken the token obtained at join time
-    * @param body         name (optional), base64-encoded file bytes, file type, and sheet (optional)
+    * @param file         the uploaded workbook
+    * @param fileType     either {@code "XLS"} or {@code "XLSX"}
+    * @param sheet        sheet name to import (optional; defaults to the first sheet)
+    * @param name         table name (optional; defaults to a generated name)
     * @param user         the authenticated agent principal
     */
-   public record ImportExcelRequest(String name, String fileBase64, String fileType, String sheet) {}
-
-   @PostMapping("/api/wiz/v1/agent/worksheet/{sessionToken}/import-excel")
+   @PostMapping(value = "/api/wiz/v1/agent/worksheet/{sessionToken}/import-excel",
+                consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
    public ImportCsvResponse importExcel(@PathVariable String sessionToken,
-                                        @RequestBody ImportExcelRequest body,
+                                        @RequestPart(value = "file", required = false) MultipartFile file,
+                                        @RequestParam(required = false) String fileType,
+                                        @RequestParam(required = false) String sheet,
+                                        @RequestParam(required = false) String name,
                                         Principal user) throws Exception
    {
       requireEnabled();
 
-      if(body.fileBase64() == null || body.fileBase64().isBlank()) {
-         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "fileBase64 is required");
+      LOG.debug("importExcel: file={}, size={}, fileType={}, sheet={}, name={}",
+                file != null ? file.getOriginalFilename() : null,
+                file != null ? file.getSize() : null, fileType, sheet, name);
+
+      if(file == null || file.isEmpty()) {
+         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "file is required");
       }
 
-      boolean xls = "XLS".equalsIgnoreCase(body.fileType());
-      boolean xlsx = "XLSX".equalsIgnoreCase(body.fileType());
+      boolean xls = "XLS".equalsIgnoreCase(fileType);
+      boolean xlsx = "XLSX".equalsIgnoreCase(fileType);
 
       if(!xls && !xlsx) {
          throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
                                            "fileType must be either \"XLS\" or \"XLSX\"");
       }
 
-      byte[] bytes;
+      byte[] bytes = file.getBytes();
 
-      try {
-         bytes = Base64.getDecoder().decode(body.fileBase64());
-      }
-      catch(IllegalArgumentException e) {
-         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "fileBase64 is not valid base64");
-      }
+      checkExcelFileSize(bytes);
 
       ExcelFileReader reader = xls
          ? ExcelFileSupport.getInstance().createXLSReader()
@@ -651,7 +662,7 @@ public class WorksheetAgentController {
 
       TextOutput output = new TextOutput();
       ExcelFileInfo headerInfo = new ExcelFileInfo();
-      headerInfo.setSheet(body.sheet());
+      headerInfo.setSheet(sheet);
       headerInfo.setStartRow(0);
       headerInfo.setEndRow(0);
       headerInfo.setStartColumn(0);
@@ -659,7 +670,7 @@ public class WorksheetAgentController {
       output.setHeaderInfo(headerInfo);
 
       ExcelFileInfo bodyInfo = new ExcelFileInfo();
-      bodyInfo.setSheet(body.sheet());
+      bodyInfo.setSheet(sheet);
       bodyInfo.setStartRow(1);
       bodyInfo.setEndRow(-1);
       bodyInfo.setStartColumn(0);
@@ -668,8 +679,10 @@ public class WorksheetAgentController {
 
       XTypeNode meta;
 
+      int colLimit = Util.getOrganizationMaxColumn() > 0 ? Util.getOrganizationMaxColumn() : -1;
+
       try {
-         meta = reader.importHeader(new ByteArrayInputStream(bytes), "UTF-8", output, 0, -1);
+         meta = reader.importHeader(new ByteArrayInputStream(bytes), "UTF-8", output, 0, colLimit);
       }
       catch(Exception e) {
          throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
@@ -683,6 +696,7 @@ public class WorksheetAgentController {
                                            "Excel sheet must have a header row and at least one data row");
       }
 
+      headerInfo.setEndColumn(ncols - 1);
       bodyInfo.setEndColumn(ncols - 1);
 
       String[] headers = new String[ncols];
@@ -694,20 +708,30 @@ public class WorksheetAgentController {
          types[c] = col.getType();
       }
 
-      XTableNode excelData = reader.read(new ByteArrayInputStream(bytes), "UTF-8", null, output,
-                                         0, ncols, true, null, false);
-
       List<Object[]> dataRows = new ArrayList<>();
       dataRows.add(headers);
 
-      while(excelData.next()) {
-         Object[] row = new Object[ncols];
+      // +1 to account for the header row, which reader.read() also counts against the row limit
+      // since firstRowHeader is true below.
+      int rowLimit = Util.getOrganizationMaxRow() > 0 ? Util.getOrganizationMaxRow() + 1 : -1;
 
-         for(int c = 0; c < ncols; c++) {
-            row[c] = excelData.getObject(c);
+      try {
+         XTableNode excelData = reader.read(new ByteArrayInputStream(bytes), "UTF-8", null, output,
+                                            rowLimit, ncols, true, null, false);
+
+         while(excelData.next()) {
+            Object[] row = new Object[ncols];
+
+            for(int c = 0; c < ncols; c++) {
+               row[c] = excelData.getObject(c);
+            }
+
+            dataRows.add(row);
          }
-
-         dataRows.add(row);
+      }
+      catch(Exception e) {
+         throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                                           "Failed to read Excel file: " + e.getMessage());
       }
 
       if(dataRows.size() < 2) {
@@ -718,7 +742,20 @@ public class WorksheetAgentController {
       int nrows = dataRows.size();
       Object[][] data = dataRows.toArray(new Object[0][]);
 
-      return createEmbeddedTable(sessionToken, user, body.name(), types, data, nrows, ncols);
+      return createEmbeddedTable(sessionToken, user, name, types, data, nrows, ncols);
+   }
+
+   private void checkExcelFileSize(byte[] bytes) {
+      String excelImportMax = SreeEnv.getProperty("excel.import.max");
+      String max = excelImportMax != null ? excelImportMax : SreeEnv.getProperty("csv.import.max");
+
+      if(max != null && bytes.length > Long.parseLong(max)) {
+         long sizeK = Long.parseLong(max) / 1024;
+         long sizeM = sizeK / 1024;
+         String sizeStr = sizeM > 0 ? sizeM + "M" : sizeK + "K";
+         throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                                           "Excel file exceeds the maximum allowed size (" + sizeStr + ")");
+      }
    }
 
    /**
@@ -1949,6 +1986,15 @@ public class WorksheetAgentController {
    // Exception handling
    // ---------------------------------------------------------------------------
 
+   @ExceptionHandler(ResponseStatusException.class)
+   public ResponseEntity<Map<String, String>> handleResponseStatusException(ResponseStatusException e) {
+      String reason = e.getReason() != null ? e.getReason() : e.getMessage();
+      LOG.warn("Rejecting request: {} ({})", reason, e.getStatusCode());
+      Map<String, String> body = new LinkedHashMap<>();
+      body.put("error", reason);
+      return ResponseEntity.status(e.getStatusCode()).body(body);
+   }
+
    @ExceptionHandler(PairingException.class)
    public ResponseEntity<Map<String, String>> handlePairingException(PairingException e) {
       HttpStatus status = switch(e.getKind()) {
@@ -1963,6 +2009,15 @@ public class WorksheetAgentController {
       body.put("error", e.getMessage());
       body.put("errorCode", e.getKind().name());
       return ResponseEntity.status(status).body(body);
+   }
+
+   @ExceptionHandler(MaxUploadSizeExceededException.class)
+   public ResponseEntity<Map<String, String>> handleMaxUploadSizeException(
+      MaxUploadSizeExceededException e)
+   {
+      Map<String, String> body = new LinkedHashMap<>();
+      body.put("error", "Request body too large");
+      return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE).body(body);
    }
 
    // ---------------------------------------------------------------------------
@@ -1984,4 +2039,5 @@ public class WorksheetAgentController {
    private final LayoutGraphService layoutGraphService;
    private final DataSourceService dataSourceService;
    private final SecurityEngine securityEngine;
+   private static final Logger LOG = LoggerFactory.getLogger(WorksheetAgentController.class);
 }

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -35,8 +35,13 @@ import inetsoft.uql.asset.internal.*;
 import inetsoft.uql.jdbc.*;
 import inetsoft.uql.jdbc.util.JDBCUtil;
 import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.schema.XTypeNode;
+import inetsoft.uql.text.TextOutput;
 import inetsoft.uql.util.DefaultMetaDataProvider;
 import inetsoft.uql.util.XEmbeddedTable;
+import inetsoft.uql.util.filereader.ExcelFileInfo;
+import inetsoft.uql.util.filereader.ExcelFileReader;
+import inetsoft.uql.util.filereader.ExcelFileSupport;
 import inetsoft.util.Catalog;
 import inetsoft.web.composer.ws.LayoutGraphService;
 import inetsoft.web.composer.ws.assembly.WorksheetEventUtil;
@@ -595,10 +600,140 @@ public class WorksheetAgentController {
          }
       }
 
+      return createEmbeddedTable(sessionToken, user, body.name(), types, data, nrows, ncols);
+   }
+
+   /**
+    * Import an Excel file (.xls/.xlsx) as a new embedded table assembly in the worksheet.
+    *
+    * <p>Unlike {@link #importCsv}, column types are taken directly from the workbook's own
+    * cell types (via {@link ExcelFileReader}, the same POI-backed reader the Composer's
+    * "Import Data" dialog uses) rather than inferred from text, so numbers, dates, and
+    * booleans round-trip correctly.</p>
+    *
+    * @param sessionToken the token obtained at join time
+    * @param body         name (optional), base64-encoded file bytes, file type, and sheet (optional)
+    * @param user         the authenticated agent principal
+    */
+   public record ImportExcelRequest(String name, String fileBase64, String fileType, String sheet) {}
+
+   @PostMapping("/api/wiz/v1/agent/worksheet/{sessionToken}/import-excel")
+   public ImportCsvResponse importExcel(@PathVariable String sessionToken,
+                                        @RequestBody ImportExcelRequest body,
+                                        Principal user) throws Exception
+   {
+      requireEnabled();
+
+      if(body.fileBase64() == null || body.fileBase64().isBlank()) {
+         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "fileBase64 is required");
+      }
+
+      boolean xls = "XLS".equalsIgnoreCase(body.fileType());
+      boolean xlsx = "XLSX".equalsIgnoreCase(body.fileType());
+
+      if(!xls && !xlsx) {
+         throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                                           "fileType must be either \"XLS\" or \"XLSX\"");
+      }
+
+      byte[] bytes;
+
+      try {
+         bytes = Base64.getDecoder().decode(body.fileBase64());
+      }
+      catch(IllegalArgumentException e) {
+         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "fileBase64 is not valid base64");
+      }
+
+      ExcelFileReader reader = xls
+         ? ExcelFileSupport.getInstance().createXLSReader()
+         : ExcelFileSupport.getInstance().createXLSXReader();
+
+      TextOutput output = new TextOutput();
+      ExcelFileInfo headerInfo = new ExcelFileInfo();
+      headerInfo.setSheet(body.sheet());
+      headerInfo.setStartRow(0);
+      headerInfo.setEndRow(0);
+      headerInfo.setStartColumn(0);
+      headerInfo.setEndColumn(-1);
+      output.setHeaderInfo(headerInfo);
+
+      ExcelFileInfo bodyInfo = new ExcelFileInfo();
+      bodyInfo.setSheet(body.sheet());
+      bodyInfo.setStartRow(1);
+      bodyInfo.setEndRow(-1);
+      bodyInfo.setStartColumn(0);
+      bodyInfo.setEndColumn(-1);
+      output.setBodyInfo(bodyInfo);
+
+      XTypeNode meta;
+
+      try {
+         meta = reader.importHeader(new ByteArrayInputStream(bytes), "UTF-8", output, 0, -1);
+      }
+      catch(Exception e) {
+         throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                                           "Failed to read Excel file: " + e.getMessage());
+      }
+
+      int ncols = meta.getChildCount();
+
+      if(ncols == 0) {
+         throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                                           "Excel sheet must have a header row and at least one data row");
+      }
+
+      bodyInfo.setEndColumn(ncols - 1);
+
+      String[] headers = new String[ncols];
+      String[] types = new String[ncols];
+
+      for(int c = 0; c < ncols; c++) {
+         XTypeNode col = (XTypeNode) meta.getChild(c);
+         headers[c] = col.getName();
+         types[c] = col.getType();
+      }
+
+      XTableNode excelData = reader.read(new ByteArrayInputStream(bytes), "UTF-8", null, output,
+                                         0, ncols, true, null, false);
+
+      List<Object[]> dataRows = new ArrayList<>();
+      dataRows.add(headers);
+
+      while(excelData.next()) {
+         Object[] row = new Object[ncols];
+
+         for(int c = 0; c < ncols; c++) {
+            row[c] = excelData.getObject(c);
+         }
+
+         dataRows.add(row);
+      }
+
+      if(dataRows.size() < 2) {
+         throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                                           "Excel sheet must have a header row and at least one data row");
+      }
+
+      int nrows = dataRows.size();
+      Object[][] data = dataRows.toArray(new Object[0][]);
+
+      return createEmbeddedTable(sessionToken, user, body.name(), types, data, nrows, ncols);
+   }
+
+   /**
+    * Shared tail of {@link #importCsv} and {@link #importExcel}: builds a new
+    * {@link EmbeddedTableAssembly} from already-typed header+data rows and adds it to the
+    * worksheet.
+    */
+   private ImportCsvResponse createEmbeddedTable(String sessionToken, Principal user, String name,
+                                                 String[] types, Object[][] data, int nrows, int ncols)
+      throws Exception
+   {
       return editService.applyOnRuntime(sessionToken, user, rws -> {
          Worksheet ws = rws.getWorksheet();
-         String tableName = (body.name() != null && !body.name().isBlank())
-            ? body.name()
+         String tableName = (name != null && !name.isBlank())
+            ? name
             : AssetUtil.getNextName(ws, AbstractSheet.TABLE_ASSET);
 
          EmbeddedTableAssembly assembly = new EmbeddedTableAssembly(ws, tableName);

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -637,8 +637,9 @@ public class WorksheetAgentController {
       requireEnabled();
 
       LOG.debug("importExcel: file={}, size={}, fileType={}, sheet={}, name={}",
-                file != null ? file.getOriginalFilename() : null,
-                file != null ? file.getSize() : null, fileType, sheet, name);
+                file != null ? sanitizeForLog(file.getOriginalFilename()) : null,
+                file != null ? file.getSize() : null, sanitizeForLog(fileType),
+                sanitizeForLog(sheet), sanitizeForLog(name));
 
       if(file == null || file.isEmpty()) {
          throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "file is required");
@@ -756,13 +757,31 @@ public class WorksheetAgentController {
       String excelImportMax = SreeEnv.getProperty("excel.import.max");
       String max = excelImportMax != null ? excelImportMax : SreeEnv.getProperty("csv.import.max");
 
-      if(max != null && size > Long.parseLong(max)) {
-         long sizeK = Long.parseLong(max) / 1024;
+      if(max == null) {
+         return;
+      }
+
+      long maxBytes;
+
+      try {
+         maxBytes = Long.parseLong(max);
+      }
+      catch(NumberFormatException e) {
+         LOG.warn("Ignoring non-numeric excel.import.max/csv.import.max value: {}", max);
+         return;
+      }
+
+      if(size > maxBytes) {
+         long sizeK = maxBytes / 1024;
          long sizeM = sizeK / 1024;
          String sizeStr = sizeM > 0 ? sizeM + "M" : sizeK + "K";
          throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
                                            "Excel file exceeds the maximum allowed size (" + sizeStr + ")");
       }
+   }
+
+   private static String sanitizeForLog(String value) {
+      return value == null ? null : value.replaceAll("[\r\n]", "_");
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -652,9 +652,9 @@ public class WorksheetAgentController {
                                            "fileType must be either \"XLS\" or \"XLSX\"");
       }
 
-      byte[] bytes = file.getBytes();
+      checkExcelFileSize(file.getSize());
 
-      checkExcelFileSize(bytes);
+      byte[] bytes = file.getBytes();
 
       ExcelFileReader reader = xls
          ? ExcelFileSupport.getInstance().createXLSReader()
@@ -715,9 +715,11 @@ public class WorksheetAgentController {
       // since firstRowHeader is true below.
       int rowLimit = Util.getOrganizationMaxRow() > 0 ? Util.getOrganizationMaxRow() + 1 : -1;
 
+      XTableNode excelData = null;
+
       try {
-         XTableNode excelData = reader.read(new ByteArrayInputStream(bytes), "UTF-8", null, output,
-                                            rowLimit, ncols, true, null, false);
+         excelData = reader.read(new ByteArrayInputStream(bytes), "UTF-8", null, output,
+                                 rowLimit, ncols, true, null, false);
 
          while(excelData.next()) {
             Object[] row = new Object[ncols];
@@ -733,6 +735,11 @@ public class WorksheetAgentController {
          throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
                                            "Failed to read Excel file: " + e.getMessage());
       }
+      finally {
+         if(excelData != null) {
+            excelData.close();
+         }
+      }
 
       if(dataRows.size() < 2) {
          throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
@@ -745,11 +752,11 @@ public class WorksheetAgentController {
       return createEmbeddedTable(sessionToken, user, name, types, data, nrows, ncols);
    }
 
-   private void checkExcelFileSize(byte[] bytes) {
+   private void checkExcelFileSize(long size) {
       String excelImportMax = SreeEnv.getProperty("excel.import.max");
       String max = excelImportMax != null ? excelImportMax : SreeEnv.getProperty("csv.import.max");
 
-      if(max != null && bytes.length > Long.parseLong(max)) {
+      if(max != null && size > Long.parseLong(max)) {
          long sizeK = Long.parseLong(max) / 1024;
          long sizeM = sizeK / 1024;
          String sizeStr = sizeM > 0 ? sizeM + "M" : sizeK + "K";

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -420,6 +420,91 @@ class WorksheetAgentControllerTest {
    }
 
    // ---------------------------------------------------------------------------
+   // importCsv / importExcel
+   // ---------------------------------------------------------------------------
+
+   private static WorksheetAgentController importController(String token, RuntimeWorksheet rws) throws Exception {
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(sessions.resolve(eq(token), any())).thenReturn(session(token));
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+
+      return controller(featureOn(), mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class));
+   }
+
+   @Test
+   void importCsvCreatesEmbeddedTable() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      Worksheet ws = new Worksheet();
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      WorksheetAgentController ctrl = importController("TOK-CSV", rws);
+
+      WorksheetAgentController.ImportCsvResponse resp = ctrl.importCsv(
+         "TOK-CSV", new WorksheetAgentController.ImportCsvRequest("Imported", "a,b\n1,x\n2,y"), agent);
+
+      assertEquals("Imported", resp.tableName());
+      assertEquals(2, resp.rows());
+      assertEquals(2, resp.columns());
+      assertNotNull(ws.getAssembly("Imported"));
+   }
+
+   @Test
+   void importCsvRejectsBlankCsv() {
+      WorksheetAgentController ctrl = controller(featureOn(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), mock(WorksheetEditService.class),
+         mock(WorksheetService.class));
+
+      ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+         () -> ctrl.importCsv("TOK", new WorksheetAgentController.ImportCsvRequest(null, " "),
+                              TestPrincipals.user("alice", "host-org")));
+      assertEquals(400, ex.getStatusCode().value());
+   }
+
+   // NOTE: there is no test here exercising a real .xlsx round-trip through importExcel().
+   // ExcelFileSupport.getInstance() reflectively loads PoiExcelFileSupport from the
+   // inetsoft-xml-formats module, which itself depends on inetsoft-core — core cannot
+   // depend on it back (even at test scope) without creating a cyclic Maven reactor
+   // reference. This mirrors the pre-existing gap in ImportCSVDialogService's own Excel
+   // path, which has no core-module test coverage for the same structural reason; both
+   // are exercised only where core and inetsoft-xml-formats are both on the classpath,
+   // i.e. the packaged server.
+
+   @Test
+   void importExcelRejectsUnknownFileType() {
+      WorksheetAgentController ctrl = controller(featureOn(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), mock(WorksheetEditService.class),
+         mock(WorksheetService.class));
+
+      ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+         () -> ctrl.importExcel("TOK", new WorksheetAgentController.ImportExcelRequest(
+                                    null, "AAAA", "PDF", null),
+                                TestPrincipals.user("alice", "host-org")));
+      assertEquals(400, ex.getStatusCode().value());
+   }
+
+   @Test
+   void importExcelRejectsInvalidBase64() {
+      WorksheetAgentController ctrl = controller(featureOn(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), mock(WorksheetEditService.class),
+         mock(WorksheetService.class));
+
+      ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+         () -> ctrl.importExcel("TOK", new WorksheetAgentController.ImportExcelRequest(
+                                    null, "not base64 !!!", "XLSX", null),
+                                TestPrincipals.user("alice", "host-org")));
+      assertEquals(400, ex.getStatusCode().value());
+   }
+
+   // ---------------------------------------------------------------------------
    // detach
    // ---------------------------------------------------------------------------
 

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -20,6 +20,7 @@ package inetsoft.web.wiz.worksheet;
 import inetsoft.report.composition.RuntimeWorksheet;
 import inetsoft.report.composition.WorksheetService;
 import inetsoft.report.composition.execution.AssetQuerySandbox;
+import inetsoft.sree.SreeEnv;
 import inetsoft.sree.security.ResourceAction;
 import inetsoft.sree.security.ResourceType;
 import inetsoft.sree.security.SecurityEngine;
@@ -37,10 +38,15 @@ import inetsoft.web.wiz.service.MetadataApiService;
 import inetsoft.web.wiz.worksheet.model.WorksheetModel;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.security.Principal;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -478,6 +484,31 @@ class WorksheetAgentControllerTest {
    // are exercised only where core and inetsoft-xml-formats are both on the classpath,
    // i.e. the packaged server.
 
+   // NOTE: the framework-level blanket cap (spring.servlet.multipart.max-file-size /
+   // max-request-size, application.yaml) is enforced by Spring/Tomcat's multipart parsing
+   // before this controller method is ever invoked, converting an oversized upload to a
+   // MaxUploadSizeExceededException (handled by handleMaxUploadSizeException() below). That
+   // parsing isn't exercised by calling the controller method directly, so it has no unit
+   // test here — it's covered by the same structural gap noted above.
+
+   private static MockMultipartFile excelFile(byte[] content) {
+      return new MockMultipartFile("file", "workbook.xlsx",
+         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", content);
+   }
+
+   @Test
+   void importExcelRejectsMissingFile() {
+      WorksheetAgentController ctrl = controller(featureOn(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), mock(WorksheetEditService.class),
+         mock(WorksheetService.class));
+
+      ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+         () -> ctrl.importExcel("TOK", null, "XLSX", null, null,
+                                TestPrincipals.user("alice", "host-org")));
+      assertEquals(400, ex.getStatusCode().value());
+   }
+
    @Test
    void importExcelRejectsUnknownFileType() {
       WorksheetAgentController ctrl = controller(featureOn(),
@@ -485,25 +516,51 @@ class WorksheetAgentControllerTest {
          mock(WorksheetReadService.class), mock(WorksheetEditService.class),
          mock(WorksheetService.class));
 
+      MockMultipartFile file = excelFile(new byte[]{1, 2, 3, 4});
+
       ResponseStatusException ex = assertThrows(ResponseStatusException.class,
-         () -> ctrl.importExcel("TOK", new WorksheetAgentController.ImportExcelRequest(
-                                    null, "AAAA", "PDF", null),
+         () -> ctrl.importExcel("TOK", file, "PDF", null, null,
                                 TestPrincipals.user("alice", "host-org")));
       assertEquals(400, ex.getStatusCode().value());
    }
 
    @Test
-   void importExcelRejectsInvalidBase64() {
+   void importExcelRejectsFileTooLarge() {
       WorksheetAgentController ctrl = controller(featureOn(),
          mock(SheetJoinService.class), mock(SheetSessionService.class),
          mock(WorksheetReadService.class), mock(WorksheetEditService.class),
          mock(WorksheetService.class));
 
-      ResponseStatusException ex = assertThrows(ResponseStatusException.class,
-         () -> ctrl.importExcel("TOK", new WorksheetAgentController.ImportExcelRequest(
-                                    null, "not base64 !!!", "XLSX", null),
-                                TestPrincipals.user("alice", "host-org")));
-      assertEquals(400, ex.getStatusCode().value());
+      MockMultipartFile file = excelFile(new byte[10]);
+
+      try(MockedStatic<SreeEnv> sreeEnv = mockStatic(SreeEnv.class)) {
+         sreeEnv.when(() -> SreeEnv.getProperty("excel.import.max")).thenReturn("5");
+
+         ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+            () -> ctrl.importExcel("TOK", file, "XLSX", null, null,
+                                   TestPrincipals.user("alice", "host-org")));
+         assertEquals(400, ex.getStatusCode().value());
+      }
+   }
+
+   // ---------------------------------------------------------------------------
+   // Exception handling
+   // ---------------------------------------------------------------------------
+
+   @Test
+   void handleResponseStatusExceptionIncludesReasonInBody() {
+      WorksheetAgentController ctrl = controller(featureOn(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), mock(WorksheetEditService.class),
+         mock(WorksheetService.class));
+
+      ResponseStatusException ex = new ResponseStatusException(
+         HttpStatus.BAD_REQUEST, "fileType must be either \"XLS\" or \"XLSX\"");
+
+      ResponseEntity<Map<String, String>> response = ctrl.handleResponseStatusException(ex);
+
+      assertEquals(400, response.getStatusCode().value());
+      assertEquals("fileType must be either \"XLS\" or \"XLSX\"", response.getBody().get("error"));
    }
 
    // ---------------------------------------------------------------------------

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -19,6 +19,7 @@ package inetsoft.web.wiz.worksheet;
 
 import inetsoft.report.composition.RuntimeWorksheet;
 import inetsoft.report.composition.WorksheetService;
+import inetsoft.report.composition.execution.AssetQuerySandbox;
 import inetsoft.sree.security.ResourceAction;
 import inetsoft.sree.security.ResourceType;
 import inetsoft.sree.security.SecurityEngine;
@@ -442,6 +443,7 @@ class WorksheetAgentControllerTest {
       Worksheet ws = new Worksheet();
       RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
       when(rws.getWorksheet()).thenReturn(ws);
+      when(rws.getAssetQuerySandbox()).thenReturn(mock(AssetQuerySandbox.class));
 
       WorksheetAgentController ctrl = importController("TOK-CSV", rws);
 


### PR DESCRIPTION
## Summary

The `stylebi-worksheet-chat` Claude Code plugin's worksheet agent could only import CSV/delimited text files. Asking it to import an Excel (`.xlsx`) file failed silently (the file was read as raw UTF-8 text and comma-parsed as garbage), and the LLM incorrectly told the user Excel import wasn't possible and that there's no such thing as a "snapshot table."

## Root Cause

`WorksheetAgentController.importCsv` was the only file-import endpoint exposed to the agent. It reads the request body's `csv` string and runs it through a hand-rolled comma-delimited parser (`parseCsv`/`parseCsvLine`) — there was no code path for binary spreadsheet formats. The Composer UI's own Excel-import feature (`ImportCSVDialogService`) exists but is tied to a stateful, session-bound composer/WebSocket flow (server-side upload cache, `CommandDispatcher`) that the stateless agent REST endpoint can't reach directly.

## Fix

- Added a new `POST /api/wiz/v1/agent/worksheet/{sessionToken}/import-excel` endpoint accepting `{name?, fileBase64, fileType: "XLS"|"XLSX", sheet?}`. It decodes the base64 payload and parses it with StyleBI's existing POI-backed Excel reader (`ExcelFileSupport`/`ExcelFileReader`, the same reader classes the Composer's Import Data dialog uses) via `importHeader`/`read`, so column names/types/values come directly from the workbook (real number/date/boolean typing, not text-inferred).
- Extracted the shared embedded-table-assembly-creation tail of `importCsv` into a new private `createEmbeddedTable(...)` helper, now called by both `importCsv` and `importExcel`. `importCsv`'s own behavior is unchanged.
- Added unit tests: a CSV-path regression test (`importCsvCreatesEmbeddedTable`) and Excel-path validation tests (`importExcelRejectsUnknownFileType`, `importExcelRejectsInvalidBase64`, plus the existing `importCsvRejectsBlankCsv`).

**Known test-coverage gap (documented in the test file):** a real `.xlsx`-round-trip test could not be added — `inetsoft-xml-formats` (which provides the real POI-backed reader via `ExcelFileSupport.getInstance()`'s reflective class-load) itself depends on `inetsoft-core`, so `core` cannot depend back on it, even at test scope, without creating a cyclic Maven reactor reference. This mirrors a pre-existing gap: the Composer UI's own Excel-import path (`ImportCSVDialogService`) has zero test coverage in `core` for the same structural reason. The actual Excel-parsing logic was verified by tracing the reader implementation (`XLSXFileReader`/`ExcelLoader`/`XTableTableNode`) against the reference usage pattern in `ImportCSVDialogService`, and by manual end-to-end testing (see companion `stylebi-wiz` PR), but is not covered by an automated test in `core`.

## Test Plan

- [x] `WorksheetAgentControllerTest` passes (18 tests, including the new ones)
- [x] `core` module builds and installs cleanly (`mvnw clean install -pl core -am -DskipTests`)
- [ ] Manual verification: connect the worksheet-chat agent to a live worksheet and ask it to import a `.xlsx` file (tracked in the companion `stylebi-wiz` PR)

Fixes Redmine #75974.

## Follow-up: request-body protection, error surfacing (post-review)

Code review on the initial version surfaced several issues, addressed in follow-up commits:

- Switched `import-excel` from a JSON `@RequestBody` with a base64-encoded file to `multipart/form-data`, so uploads are bounded by Spring's `spring.servlet.multipart.max-file-size`/`max-request-size` before the controller runs, on top of the existing `excel.import.max`/`csv.import.max`/org row-column limits (mirroring `ImportCSVDialogService`).
- Wrapped the row-parsing read in the same try/catch as the header parse, for consistent 400s instead of unhandled 500s on a corrupt/adversarial file.
- Added a controller-local `@ExceptionHandler(ResponseStatusException.class)` so the rejection reason actually reaches the caller. **Note:** since this handler is declared directly on `WorksheetAgentController` (not a `@ControllerAdvice`), it applies to every endpoint in this controller, not just `import-excel` — every pre-existing `ResponseStatusException` this controller throws now returns `{"error": "<reason>"}` instead of an empty body (this repo doesn't set `spring.mvc.problemdetails.enabled`, so there was no body before). Confirmed this doesn't break the `stylebi-wiz` MCP client, which already handles a missing/empty error body gracefully.
- `checkExcelFileSize` now checks `MultipartFile.getSize()` before `getBytes()`, and guards `Long.parseLong(excel.import.max/csv.import.max)` against a non-numeric value (fails open with a warning log instead of an unhandled 500).
- `excelData` (the `XTableNode` from `reader.read(...)`) is now closed in a `finally` block, matching `ImportCSVDialogService.loadData`.

Companion `stylebi-wiz` PR for the client-side multipart switch: https://github.com/inetsoft-technology/stylebi-wiz/pull/1535
