### PR TITLE
Bug #75930, fix round corner export follow-up for Table/Crosstab (Excel/PDF/SVG/PNG/PPT/HTML)

### DIFF
--- a/core/src/main/java/inetsoft/report/io/viewsheet/VSTableDataHelper.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/VSTableDataHelper.java
@@ -345,16 +345,45 @@ public abstract class VSTableDataHelper extends ExporterHelper {
       int infoWidth = CoordinateHelper.getAssemblySize(
          assembly, CoordinateHelper.getLensSize(lens, true)).width;
       calculateColumnsPosition(info, lens);
-      drawObjectFormat(info, lens, false);
-      writeTitle(info, infoWidth);
+      // clip the background fill too, not just the title/data drawn after it - the
+      // background is a plain unclipped fillRect (see ExportUtil.drawTextBox) that
+      // otherwise sticks out square past the rounded border at each corner.
+      beginRoundCornerClip(info, lens);
 
-      if(lens != null) {
-         writeData(info, lens);
+      try {
+         drawObjectFormat(info, lens, false);
+         writeTitle(info, infoWidth);
+
+         if(lens != null) {
+            writeData(info, lens);
+         }
+      }
+      finally {
+         // always restore the clip, even on failure, so a bad cell/title write doesn't
+         // leave the shared Graphics device (PDF/SVG) clipped for whatever is drawn next.
+         endRoundCornerClip();
       }
 
       // @by stephenwebster, draw after the data so the object borders are on top
       // of the data borders.
       drawObjectFormat(info, lens, true);
+   }
+
+   /**
+    * Clip subsequent drawing (the object's own background fill, title, and cell data) to
+    * the object's rounded-corner bounds, so none of it sticks out past the rounded border
+    * drawn afterward by {@link #drawObjectFormat}. No-op by default: cell content is
+    * written directly to a native grid (Excel) or shape-based slide (PowerPoint) in some
+    * export formats, neither of which support clipping; only Graphics2D-based exports
+    * (PDF/SVG) override this.
+    */
+   protected void beginRoundCornerClip(TableDataVSAssemblyInfo info, VSTableLens lens) {
+   }
+
+   /**
+    * Restore the clip pushed by {@link #beginRoundCornerClip}, if any.
+    */
+   protected void endRoundCornerClip() {
    }
 
    /**

--- a/core/src/main/java/inetsoft/report/io/viewsheet/html/HTMLCoordinateHelper.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/html/HTMLCoordinateHelper.java
@@ -355,10 +355,13 @@ public class HTMLCoordinateHelper extends CoordinateHelper {
          buffer.append("box-sizing:border-box;");
       }
 
-      if(format.getRoundCornerValue() != 0) {
+      if(format.getRoundCorner() != 0) {
          buffer.append(";border-radius:");
-         buffer.append(format.getRoundCornerValue());
+         buffer.append(format.getRoundCorner());
          buffer.append("px;");
+         // clip the square cell content to the rounded corner, matching the viewer
+         // (vs-table.component.html pairs border-radius with overflow:hidden the same way).
+         buffer.append("overflow:hidden;");
       }
 
       return buffer.toString();

--- a/core/src/main/java/inetsoft/report/io/viewsheet/pdf/PDFCoordinateHelper.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/pdf/PDFCoordinateHelper.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import java.awt.*;
 import java.awt.geom.Rectangle2D;
+import java.awt.geom.RoundRectangle2D;
 import java.awt.image.BufferedImage;
 import java.io.OutputStream;
 import java.util.HashMap;
@@ -216,6 +217,32 @@ public class PDFCoordinateHelper extends CoordinateHelper {
    }
 
    /**
+    * Clip subsequent drawing to a rounded-corner rectangle, so square cell
+    * backgrounds/text don't stick out past the rounded border drawn on top afterward.
+    * @param roundCorner the round corner radius; a value &lt;= 0 leaves the clip unchanged.
+    */
+   public void beginRoundCornerClip(Rectangle2D bounds, int roundCorner) {
+      if(roundCorner <= 0) {
+         return;
+      }
+
+      savedClip = printer.getClip();
+      double r = roundCorner * 2d;
+      printer.setClip(new RoundRectangle2D.Double(bounds.getX(), bounds.getY(),
+                                                   bounds.getWidth(), bounds.getHeight(), r, r));
+   }
+
+   /**
+    * Restore the clip pushed by {@link #beginRoundCornerClip}, if any.
+    */
+   public void endRoundCornerClip() {
+      if(savedClip != null) {
+         printer.setClip(savedClip);
+         savedClip = null;
+      }
+   }
+
+   /**
     * Get the page count.
     */
    int getPage() {
@@ -383,6 +410,7 @@ public class PDFCoordinateHelper extends CoordinateHelper {
 
    private HashMap<Integer, LinkedHashMap<Object, Hyperlink.Ref>> linksMap = new HashMap<>();
    private PDFPrinter printer;
+   private Shape savedClip;
    private int page = -1;
    private static final Logger LOG =
       LoggerFactory.getLogger(PDFCoordinateHelper.class);

--- a/core/src/main/java/inetsoft/report/io/viewsheet/pdf/PDFCoordinateHelper.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/pdf/PDFCoordinateHelper.java
@@ -226,7 +226,11 @@ public class PDFCoordinateHelper extends CoordinateHelper {
          return;
       }
 
+      // getClip() legitimately returns null when no clip is currently set - don't use
+      // savedClip's null-ness to decide whether to restore, or a null prior clip (the
+      // common case) will look like "nothing to restore" and leave this clip stuck.
       savedClip = printer.getClip();
+      roundCornerClipped = true;
       double r = roundCorner * 2d;
       printer.setClip(new RoundRectangle2D.Double(bounds.getX(), bounds.getY(),
                                                    bounds.getWidth(), bounds.getHeight(), r, r));
@@ -236,9 +240,10 @@ public class PDFCoordinateHelper extends CoordinateHelper {
     * Restore the clip pushed by {@link #beginRoundCornerClip}, if any.
     */
    public void endRoundCornerClip() {
-      if(savedClip != null) {
+      if(roundCornerClipped) {
          printer.setClip(savedClip);
          savedClip = null;
+         roundCornerClipped = false;
       }
    }
 
@@ -411,6 +416,7 @@ public class PDFCoordinateHelper extends CoordinateHelper {
    private HashMap<Integer, LinkedHashMap<Object, Hyperlink.Ref>> linksMap = new HashMap<>();
    private PDFPrinter printer;
    private Shape savedClip;
+   private boolean roundCornerClipped;
    private int page = -1;
    private static final Logger LOG =
       LoggerFactory.getLogger(PDFCoordinateHelper.class);

--- a/core/src/main/java/inetsoft/report/io/viewsheet/pdf/PDFCrosstabHelper.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/pdf/PDFCrosstabHelper.java
@@ -39,6 +39,28 @@ import java.awt.geom.Rectangle2D;
  */
 public class PDFCrosstabHelper extends VSCrosstabHelper {
    /**
+    * Clip the title/data drawing that follows to the object's rounded-corner bounds, so
+    * the square cell backgrounds/text don't stick out past the rounded border drawn on
+    * top afterward by {@link #drawObjectFormat}.
+    */
+   @Override
+   protected void beginRoundCornerClip(TableDataVSAssemblyInfo info, VSTableLens lens) {
+      VSCompositeFormat format = info.getFormat();
+
+      if(format == null) {
+         return;
+      }
+
+      vHelper.beginRoundCornerClip(getObjectPixelBounds(info, lens, vHelper),
+                                   format.getRoundCorner());
+   }
+
+   @Override
+   protected void endRoundCornerClip() {
+      vHelper.endRoundCornerClip();
+   }
+
+   /**
     * Constructor.
     * @param helper the PDFCoordinateHelper provides bounds info and drawing.
     * @param vs the viewsheet the assembly is on.
@@ -132,6 +154,7 @@ public class PDFCrosstabHelper extends VSCrosstabHelper {
          format2.getUserDefinedFormat().setBorders(format.getBorders());
          format2.getUserDefinedFormat().setBorderColors(format.getBorderColors());
          format2.getUserDefinedFormat().setBackground(null);
+         format2.getUserDefinedFormat().setRoundCorner(format.getRoundCorner());
 
          format = format2;
       }

--- a/core/src/main/java/inetsoft/report/io/viewsheet/pdf/PDFTableHelper.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/pdf/PDFTableHelper.java
@@ -39,6 +39,28 @@ import java.awt.geom.Rectangle2D;
  */
 public class PDFTableHelper extends VSTableHelper {
    /**
+    * Clip the title/data drawing that follows to the object's rounded-corner bounds, so
+    * the square cell backgrounds/text don't stick out past the rounded border drawn on
+    * top afterward by {@link #drawObjectFormat}.
+    */
+   @Override
+   protected void beginRoundCornerClip(TableDataVSAssemblyInfo info, VSTableLens lens) {
+      VSCompositeFormat format = info.getFormat();
+
+      if(format == null) {
+         return;
+      }
+
+      vHelper.beginRoundCornerClip(getObjectPixelBounds(info, lens, vHelper),
+                                   format.getRoundCorner());
+   }
+
+   @Override
+   protected void endRoundCornerClip() {
+      vHelper.endRoundCornerClip();
+   }
+
+   /**
     * Constructor.
     * @param helper the PDFCoordinateHelper provides bounds info and drawing.
     * @param vs the viewsheet the assembly is on.
@@ -131,6 +153,7 @@ public class PDFTableHelper extends VSTableHelper {
          format2.getUserDefinedFormat().setBorders(format.getBorders());
          format2.getUserDefinedFormat().setBorderColors(format.getBorderColors());
          format2.getUserDefinedFormat().setBackground(null);
+         format2.getUserDefinedFormat().setRoundCorner(format.getRoundCorner());
 
          format = format2;
       }

--- a/core/src/main/java/inetsoft/report/io/viewsheet/svg/SVGCoordinateHelper.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/svg/SVGCoordinateHelper.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import java.awt.*;
 import java.awt.geom.Rectangle2D;
+import java.awt.geom.RoundRectangle2D;
 import java.awt.image.BufferedImage;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
@@ -64,6 +65,33 @@ public class SVGCoordinateHelper extends CoordinateHelper {
     */
    Graphics2D getGraphics() {
       return svgGraphics;
+   }
+
+   /**
+    * Clip subsequent drawing to a rounded-corner rectangle, so square cell
+    * backgrounds/text don't stick out past the rounded border drawn on top afterward.
+    * @param roundCorner the round corner radius; a value &lt;= 0 leaves the clip unchanged.
+    */
+   void beginRoundCornerClip(Rectangle2D bounds, int roundCorner) {
+      if(roundCorner <= 0) {
+         return;
+      }
+
+      savedClip = svgGraphics.getClip();
+      double r = roundCorner * 2d;
+      svgGraphics.setClip(new RoundRectangle2D.Double(bounds.getX(), bounds.getY(),
+                                                       bounds.getWidth(), bounds.getHeight(),
+                                                       r, r));
+   }
+
+   /**
+    * Restore the clip pushed by {@link #beginRoundCornerClip}, if any.
+    */
+   void endRoundCornerClip() {
+      if(savedClip != null) {
+         svgGraphics.setClip(savedClip);
+         savedClip = null;
+      }
    }
 
    /**
@@ -365,6 +393,7 @@ public class SVGCoordinateHelper extends CoordinateHelper {
    }
 
    private Graphics2D svgGraphics;
+   private Shape savedClip;
    private final Rectangle svgBounds;
    private static final Logger LOG = LoggerFactory.getLogger(SVGCoordinateHelper.class);
 }

--- a/core/src/main/java/inetsoft/report/io/viewsheet/svg/SVGCoordinateHelper.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/svg/SVGCoordinateHelper.java
@@ -77,7 +77,11 @@ public class SVGCoordinateHelper extends CoordinateHelper {
          return;
       }
 
+      // getClip() legitimately returns null when no clip is currently set - don't use
+      // savedClip's null-ness to decide whether to restore, or a null prior clip (the
+      // common case) will look like "nothing to restore" and leave this clip stuck.
       savedClip = svgGraphics.getClip();
+      roundCornerClipped = true;
       double r = roundCorner * 2d;
       svgGraphics.setClip(new RoundRectangle2D.Double(bounds.getX(), bounds.getY(),
                                                        bounds.getWidth(), bounds.getHeight(),
@@ -88,9 +92,10 @@ public class SVGCoordinateHelper extends CoordinateHelper {
     * Restore the clip pushed by {@link #beginRoundCornerClip}, if any.
     */
    void endRoundCornerClip() {
-      if(savedClip != null) {
+      if(roundCornerClipped) {
          svgGraphics.setClip(savedClip);
          savedClip = null;
+         roundCornerClipped = false;
       }
    }
 
@@ -394,6 +399,7 @@ public class SVGCoordinateHelper extends CoordinateHelper {
 
    private Graphics2D svgGraphics;
    private Shape savedClip;
+   private boolean roundCornerClipped;
    private final Rectangle svgBounds;
    private static final Logger LOG = LoggerFactory.getLogger(SVGCoordinateHelper.class);
 }

--- a/core/src/main/java/inetsoft/report/io/viewsheet/svg/SVGCrosstabHelper.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/svg/SVGCrosstabHelper.java
@@ -35,6 +35,28 @@ import java.awt.geom.Rectangle2D;
  */
 public class SVGCrosstabHelper extends VSCrosstabHelper {
    /**
+    * Clip the title/data drawing that follows to the object's rounded-corner bounds, so
+    * the square cell backgrounds/text don't stick out past the rounded border drawn on
+    * top afterward by {@link #drawObjectFormat}.
+    */
+   @Override
+   protected void beginRoundCornerClip(TableDataVSAssemblyInfo info, VSTableLens lens) {
+      VSCompositeFormat format = info.getFormat();
+
+      if(format == null) {
+         return;
+      }
+
+      vHelper.beginRoundCornerClip(getObjectPixelBounds(info, lens, vHelper),
+                                   format.getRoundCorner());
+   }
+
+   @Override
+   protected void endRoundCornerClip() {
+      vHelper.endRoundCornerClip();
+   }
+
+   /**
     * Creates a new instance of <tt>SVGCrosstabHelper</tt>.
     *
     * @param helper the coordinate helper.
@@ -106,6 +128,7 @@ public class SVGCrosstabHelper extends VSCrosstabHelper {
          format2.getUserDefinedFormat().setBorders(format.getBorders());
          format2.getUserDefinedFormat().setBorderColors(format.getBorderColors());
          format2.getUserDefinedFormat().setBackground(null);
+         format2.getUserDefinedFormat().setRoundCorner(format.getRoundCorner());
 
          format = format2;
       }

--- a/core/src/main/java/inetsoft/report/io/viewsheet/svg/SVGTableHelper.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/svg/SVGTableHelper.java
@@ -33,6 +33,28 @@ import java.awt.geom.Rectangle2D;
  */
 public class SVGTableHelper extends VSTableHelper {
    /**
+    * Clip the title/data drawing that follows to the object's rounded-corner bounds, so
+    * the square cell backgrounds/text don't stick out past the rounded border drawn on
+    * top afterward by {@link #drawObjectFormat}.
+    */
+   @Override
+   protected void beginRoundCornerClip(TableDataVSAssemblyInfo info, VSTableLens lens) {
+      VSCompositeFormat format = info.getFormat();
+
+      if(format == null) {
+         return;
+      }
+
+      vHelper.beginRoundCornerClip(getObjectPixelBounds(info, lens, vHelper),
+                                   format.getRoundCorner());
+   }
+
+   @Override
+   protected void endRoundCornerClip() {
+      vHelper.endRoundCornerClip();
+   }
+
+   /**
     * Creates a new instance of <tt>SVGTableHelper</tt>.
     *
     * @param helper the coordinate helper.
@@ -104,6 +126,7 @@ public class SVGTableHelper extends VSTableHelper {
          format2.getUserDefinedFormat().setBorders(format.getBorders());
          format2.getUserDefinedFormat().setBorderColors(format.getBorderColors());
          format2.getUserDefinedFormat().setBackground(null);
+         format2.getUserDefinedFormat().setRoundCorner(format.getRoundCorner());
 
          format = format2;
       }

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
@@ -1140,32 +1140,52 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
          return;
       }
 
-      // Mask the square cell background/content that would otherwise stick out past the
-      // curve at each corner (e.g. a shaded title-row fill, or the corner-most cell's
-      // text) with a plain white square, the same way the viewer's overflow:hidden clips
-      // it. This must happen before the border outline below so the outline's curve is
-      // drawn on top of the mask, not under it. Applies regardless of whether a border is
-      // configured, since it only affects background/content, not border lines.
-      maskTableCorners(pixelBounds, radius);
-
-      Insets borders = format.getBorders();
-
       // A single roundRect shape can only stroke a uniform outline around all four sides
       // - unlike the per-side PDF/SVG/PPT border drawing (see ExportUtil.drawBorders), it
-      // can't selectively skip a side. Only draw the outline when every side actually has
-      // a border configured; otherwise skip it, so e.g. a top-only border doesn't
-      // incorrectly get a full box outline in Excel.
-      if(borders == null || borders.top == 0 || borders.left == 0 ||
-         borders.right == 0 || borders.bottom == 0)
-      {
+      // can't selectively skip a side. Approximate by using whichever side has a border
+      // configured first (top, then left/right/bottom) for the whole outline's style and
+      // color; a table with only a partial border will get a full box outline as a result,
+      // an accepted tradeoff for a uniformly-rounded look in the common case.
+      Insets borders = format.getBorders();
+      int type;
+      java.awt.Color color;
+      BorderColors bcolors = format.getBorderColors();
+
+      if(borders != null && borders.top != 0) {
+         type = borders.top;
+         color = bcolors == null ? null : bcolors.topColor;
+      }
+      else if(borders != null && borders.left != 0) {
+         type = borders.left;
+         color = bcolors == null ? null : bcolors.leftColor;
+      }
+      else if(borders != null && borders.right != 0) {
+         type = borders.right;
+         color = bcolors == null ? null : bcolors.rightColor;
+      }
+      else if(borders != null && borders.bottom != 0) {
+         type = borders.bottom;
+         color = bcolors == null ? null : bcolors.bottomColor;
+      }
+      else {
+         // No border configured at all: there's no outline to compensate the mask with a
+         // curve, so skip masking too rather than leaving an unrounded white square with
+         // no border and no explanation.
          return;
       }
 
-      int lineStyle = PoiExcelVSUtil.getLineStyle(borders.top);
+      int lineStyle = PoiExcelVSUtil.getLineStyle(type);
 
       if(lineStyle == ExcelVSUtil.EXCEL_NO_BORDER) {
          return;
       }
+
+      // Mask the square cell background/content that would otherwise stick out past the
+      // curve at each corner (e.g. a shaded title-row fill, or the corner-most cell's
+      // text) with a plain white square, the same way the viewer's overflow:hidden clips
+      // it. This must happen before the border outline below so the outline's curve is
+      // drawn on top of the mask, not under it.
+      maskTableCorners(pixelBounds, radius);
 
       XSSFSimpleShape shape = patriarch.createSimpleShape(
          (XSSFClientAnchor) getAnchorFromPixelRect(pixelBounds));
@@ -1175,9 +1195,6 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
       if(lineStyle != ExcelVSUtil.EXCEL_SOLID_BORDER) {
          shape.setLineStyle(lineStyle);
       }
-
-      BorderColors bcolors = format.getBorderColors();
-      java.awt.Color color = bcolors == null ? null : bcolors.topColor;
 
       if(color != null) {
          shape.setLineStyleColor(color.getRed(), color.getGreen(), color.getBlue());

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/ppt/PPTCrosstabHelper.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/ppt/PPTCrosstabHelper.java
@@ -133,6 +133,7 @@ public class PPTCrosstabHelper extends VSCrosstabHelper {
          format2.getUserDefinedFormat().setBorders(format.getBorders());
          format2.getUserDefinedFormat().setBorderColors(format.getBorderColors());
          format2.getUserDefinedFormat().setBackground(null);
+         format2.getUserDefinedFormat().setRoundCorner(format.getRoundCorner());
 
          format = format2;
       }
@@ -141,6 +142,10 @@ public class PPTCrosstabHelper extends VSCrosstabHelper {
          format.getUserDefinedFormat().setBorders(new Insets(0, 0, 0, 0));
       }
 
+      // vHelper is reused across individual cell writes, which set a non-zero cellType
+      // (CELL_TAIL/CELL_CONTENT) for per-side border dedup; reset it here so this
+      // whole-object border draw isn't mistaken for a per-cell one.
+      vHelper.setCellType(0);
       vHelper.setValue(null);
       vHelper.setFormat(format);
       vHelper.writeTextBox();

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/ppt/PPTTableHelper.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/ppt/PPTTableHelper.java
@@ -135,6 +135,7 @@ public class PPTTableHelper extends VSTableHelper {
          format2.getUserDefinedFormat().setBorders(format.getBorders());
          format2.getUserDefinedFormat().setBorderColors(format.getBorderColors());
          format2.getUserDefinedFormat().setBackground(null);
+         format2.getUserDefinedFormat().setRoundCorner(format.getRoundCorner());
 
          format = format2;
       }
@@ -143,6 +144,10 @@ public class PPTTableHelper extends VSTableHelper {
          format.getUserDefinedFormat().setBorders(new Insets(0, 0, 0, 0));
       }
 
+      // vHelper is reused across individual cell writes, which set a non-zero cellType
+      // (CELL_TAIL/CELL_CONTENT) for per-side border dedup; reset it here so this
+      // whole-object border draw isn't mistaken for a per-cell one.
+      vHelper.setCellType(0);
       vHelper.setValue(null);
       vHelper.setBounds(bounds);
       vHelper.setFormat(format);

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/ppt/PPTValueHelper.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/ppt/PPTValueHelper.java
@@ -418,19 +418,16 @@ public class PPTValueHelper {
          VSAssemblyInfo.DEFAULT_BORDER_COLOR);
 
       // Four independent straight-line shapes can't form a rounded corner, so draw a
-      // single rounded-rectangle outline instead when the round corner is set. Skip this
-      // for table/crosstab/tree cells (cellType != 0): those rely on the per-side
-      // CELL_TAIL/CELL_CONTENT skips below to avoid doubling up borders shared with
-      // adjacent cells, which a single all-sides shape can't replicate. Also require all
-      // four sides to be set: a single-sided border (e.g. an "underline" with only
-      // borders.bottom set) can't be represented as one rounded outline without drawing an
-      // unwanted box around the other three sides, so fall through to the per-side lines
-      // below instead.
-      if(borders != null && format.getRoundCorner() > 0 && cellType == 0 &&
-         borders.top != 0 && borders.left != 0 && borders.right != 0 && borders.bottom != 0)
-      {
-         int type;
-         Color color;
+      // single rounded-rectangle outline instead when the round corner is set, using
+      // whichever side has a border configured first (top, then left/right/bottom) for
+      // the whole outline's style/color - a partial border gets a full box outline as a
+      // tradeoff for a uniformly-rounded look. Skip this for table/crosstab/tree cells
+      // (cellType != 0): those rely on the per-side CELL_TAIL/CELL_CONTENT skips below to
+      // avoid doubling up borders shared with adjacent cells, which a single all-sides
+      // shape can't replicate.
+      if(borders != null && format.getRoundCorner() > 0 && cellType == 0) {
+         int type = 0;
+         Color color = null;
 
          if(borders.top != 0) {
             type = borders.top;
@@ -447,13 +444,21 @@ public class PPTValueHelper {
             color = colors == null || colors.rightColor == null ?
                defbcolors.rightColor : colors.rightColor;
          }
-         else {
+         else if(borders.bottom != 0) {
             type = borders.bottom;
             color = colors == null || colors.bottomColor == null ?
                defbcolors.bottomColor : colors.bottomColor;
          }
 
-         if(PPTVSUtil.getBorderWidth(type) != 0) {
+         if(type != 0 && PPTVSUtil.getBorderWidth(type) != 0) {
+            // Table/crosstab cells are written as individual shapes with their own
+            // (non-rounded) borders, so the single rounded outline drawn on top doesn't
+            // automatically hide the square cell content that sticks out past the curve
+            // near each corner (PPT has no Graphics2D-style clip to lean on, unlike
+            // PDF/SVG). Mask it with a plain white square first, mirroring
+            // PoiExcelVSExporter's corner mask for the same underlying limitation.
+            maskTableCorners(x, y, width, height, format.getRoundCorner());
+
             XSLFAutoShape roundBorder = slide.createAutoShape();
             roundBorder.setAnchor(new Rectangle(x, y, width, height));
             PPTVSUtil.applyRoundCorner(roundBorder, format.getRoundCorner(), bounds);
@@ -526,6 +531,31 @@ public class PPTValueHelper {
             }
          }
       }
+   }
+
+   /**
+    * Paint over the four radius x radius corners with a plain white square, hiding
+    * whatever square cell content is underneath so it reads as clipped by the rounded
+    * corner instead of poking out past it.
+    */
+   private void maskTableCorners(int x, int y, int width, int height, int roundCorner) {
+      int r = (int) Math.min(roundCorner * PPTVSUtil.PIXEL_TO_POINT,
+                             Math.min(width, height) / 2d);
+
+      if(r <= 0) {
+         return;
+      }
+
+      maskCorner(x, y, r);
+      maskCorner(x + width - r, y, r);
+      maskCorner(x, y + height - r, r);
+      maskCorner(x + width - r, y + height - r, r);
+   }
+
+   private void maskCorner(int x, int y, int size) {
+      XSLFAutoShape mask = slide.createAutoShape();
+      mask.setAnchor(new Rectangle(x, y, size, size));
+      mask.setFillColor(Color.WHITE);
    }
 
    private Rectangle2D bounds = null;


### PR DESCRIPTION
## Summary
Follow-up to #4516 after testing real exports of a round-corner table surfaced several remaining issues across every export format:

- **Excel**: the corner mask always ran, but the compensating rounded border outline required all four sides to have a border configured - and no border at all is the default/common case (`VSCompositeFormat.getBorders()` returns null when never set), so most tables got naked white squares with no curve. Now uses whichever side has a border configured first for the outline's style/color, and skips masking entirely when no side has one to compensate with.
- **PDF/SVG/PNG/PPT** (`PDFTableHelper`, `PDFCrosstabHelper`, `SVGTableHelper`, `SVGCrosstabHelper`, `PPTTableHelper`, `PPTCrosstabHelper`): the pass that draws the actual visible border stroke builds a fresh `VSCompositeFormat` and copies borders/colors, but never round corner - so the border always rendered square regardless of the setting, in all five of these formats. Fixed by copying it across in each.
- **PPT**: `PPTValueHelper` is a shared instance reused across per-cell writes, which leaves a stale non-zero `cellType` from the last cell written by the time the whole-object border draw runs, incorrectly gating off the round-corner branch. Reset it before that draw. Also relaxed the same "require all four sides" restriction as Excel, and added the same corner-masking (PPT has no Graphics2D-style clip to rely on).
- **PDF/SVG/PNG**: added a real `Graphics2D` clip (`RoundRectangle2D`) around the background fill, title, and per-cell data writing (new `beginRoundCornerClip`/`endRoundCornerClip` hooks in `VSTableDataHelper`, wrapped in try/finally so a write failure can't leave the shared graphics device permanently clipped), so square cell content is cleanly clipped to the rounded shape instead of leaving stray square border/background artifacts poking out past the curve at each corner - PDF/SVG can do this properly, unlike Excel/PPT.
- **HTML**: unrelated pre-existing bug - `getBorderString()`'s `border-radius` CSS was gated on `format.getRoundCornerValue()` (resolves only dynamic-value-configured round corners) instead of `format.getRoundCorner()` (the correctly resolved accessor used everywhere else), so it never emitted for the common case of a plain static round-corner number. Fixed the accessor and paired `border-radius` with `overflow:hidden` to match how the viewer clips rounded corners.

## Test plan
- [ ] Export a Table/Crosstab with round corner + a full border to Excel, PDF, SVG/PNG, PPT, and HTML; confirm all five show a clean rounded corner with no stray square artifacts.
- [ ] Repeat with round corner set but no border at all; confirm no naked white squares/mask artifacts in Excel/PPT.
- [ ] Repeat with only a partial border (e.g. top only); confirm the accepted uniform-outline tradeoff looks reasonable rather than broken.
- [ ] Confirm non-rounded tables are unaffected in all formats.