### PR TITLE
Bug #75994, add rename_variable and delete_variable ops to the wiz worksheet agent

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
@@ -77,6 +77,8 @@ import java.util.Map;
  *   <li>{@code duplicate_assembly} — {@code table} (source), {@code name} (new name)</li>
  *   <li>{@code set_primary_assembly} — {@code table}</li>
  *   <li>{@code edit_variable} — {@code name}, {@code type}, {@code label}, {@code defaultValue}</li>
+ *   <li>{@code rename_variable} — {@code name}, {@code newName}</li>
+ *   <li>{@code delete_variable} — {@code name}</li>
  *   <li>{@code edit_named_group} — {@code name}, {@code groupMappings}, {@code groupOthers}</li>
  *   <li>{@code edit_sql_query} — {@code table}, {@code expression} (new SQL string)</li>
  *   <li>{@code update_mirror} — {@code table}</li>

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -893,6 +893,10 @@ public class WorksheetAgentController {
             editor.setPrimaryAssembly(req.table());
          case "edit_variable" ->
             editor.editVariable(req.name(), req.type(), req.label(), req.defaultValue());
+         case "rename_variable" ->
+            editor.renameVariable(req.name(), req.newName());
+         case "delete_variable" ->
+            editor.deleteVariable(req.name());
          case "edit_named_group" ->
             editor.editNamedGroup(req.name(), req.groupMappings(),
                                   req.groupOthers() != null && req.groupOthers());

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -1811,6 +1811,46 @@ public class WorksheetEditService {
          }
       }
 
+      /**
+       * Renames a variable assembly in the worksheet.  Dependent references
+       * (e.g. {@code $(name)} usages in conditions/expressions) are updated
+       * automatically by {@link Worksheet#renameAssembly}.
+       *
+       * @param oldName the current variable assembly name
+       * @param newName the desired new name
+       * @throws PairingException if no variable assembly with {@code oldName} exists or
+       *                          the rename fails
+       */
+      public void renameVariable(String oldName, String newName) throws PairingException {
+         Assembly a = ws.getAssembly(oldName);
+
+         if(!(a instanceof DefaultVariableAssembly)) {
+            throw new PairingException("Variable assembly not found: " + oldName);
+         }
+
+         if(!ws.renameAssembly(oldName, newName, true)) {
+            throw new PairingException(
+               "Failed to rename variable '" + oldName + "' to '" + newName +
+               "' — the name may already be in use.");
+         }
+      }
+
+      /**
+       * Removes a variable assembly from the worksheet.
+       *
+       * @param name the variable assembly name to delete
+       * @throws PairingException if no variable assembly with {@code name} exists
+       */
+      public void deleteVariable(String name) throws PairingException {
+         Assembly a = ws.getAssembly(name);
+
+         if(!(a instanceof DefaultVariableAssembly)) {
+            throw new PairingException("Variable assembly not found: " + name);
+         }
+
+         ws.removeAssembly(name);
+      }
+
       // -----------------------------------------------------------------------
       // Edit named group
       // -----------------------------------------------------------------------

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -420,6 +420,153 @@ class WorksheetAgentControllerTest {
    }
 
    // ---------------------------------------------------------------------------
+   // edit — rename_variable / delete_variable dispatch (Bug #75994)
+   // ---------------------------------------------------------------------------
+
+   /** Builds a {@code rename_variable} EditRequest that routes to renameVariable(). */
+   private static EditRequest renameVariableRequest(String name, String newName) {
+      return new EditRequest(
+         "rename_variable", null, null, name, null, newName, null, null, null, null,
+         null, null, null, false, null, null, null, null, null, null, null, null, null, null,
+         null, null, null, null, null, null, null, null, null, null, null, null, null,
+         null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+         null, null
+      );
+   }
+
+   /** Builds a {@code delete_variable} EditRequest that routes to deleteVariable(). */
+   private static EditRequest deleteVariableRequest(String name) {
+      return new EditRequest(
+         "delete_variable", null, null, name, null, null, null, null, null, null,
+         null, null, null, false, null, null, null, null, null, null, null, null, null, null,
+         null, null, null, null, null, null, null, null, null, null, null, null, null,
+         null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+         null, null
+      );
+   }
+
+   private static DefaultVariableAssembly addVariable(Worksheet ws, String name) {
+      AssetVariable var = new AssetVariable(name);
+      DefaultVariableAssembly assembly = new DefaultVariableAssembly(ws, name);
+      assembly.setVariable(var);
+      ws.addAssembly(assembly);
+      return assembly;
+   }
+
+   @Test
+   void editDispatchesRenameVariable() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      Worksheet ws = new Worksheet();
+      addVariable(ws, "minTotal");
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(sessions.resolve(eq("TOK-RV"), any())).thenReturn(session("TOK-RV"));
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+
+      WorksheetAgentController ctrl = controller(featureOn(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class));
+
+      ctrl.edit("TOK-RV", renameVariableRequest("minTotal", "employee"), agent);
+
+      assertNull(ws.getAssembly("minTotal"), "old variable name should no longer exist");
+      assertTrue(ws.getAssembly("employee") instanceof DefaultVariableAssembly,
+                 "renamed variable should exist under the new name");
+   }
+
+   @Test
+   void editRenameVariableThrowsWhenAssemblyNotFound() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      Worksheet ws = new Worksheet();
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(sessions.resolve(eq("TOK-RV2"), any())).thenReturn(session("TOK-RV2"));
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+
+      WorksheetAgentController ctrl = controller(featureOn(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class));
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-RV2", renameVariableRequest("noSuchVar", "employee"), agent));
+      assertTrue(ex.getMessage().contains("noSuchVar"));
+   }
+
+   @Test
+   void editDispatchesDeleteVariable() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      Worksheet ws = new Worksheet();
+      addVariable(ws, "minTotal");
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(sessions.resolve(eq("TOK-DV"), any())).thenReturn(session("TOK-DV"));
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+
+      WorksheetAgentController ctrl = controller(featureOn(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class));
+
+      ctrl.edit("TOK-DV", deleteVariableRequest("minTotal"), agent);
+
+      assertNull(ws.getAssembly("minTotal"), "variable should have been removed");
+   }
+
+   @Test
+   void editDeleteVariableThrowsWhenAssemblyNotFound() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "x", "y");
+      ws.addAssembly(t);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(sessions.resolve(eq("TOK-DV2"), any())).thenReturn(session("TOK-DV2"));
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+
+      WorksheetAgentController ctrl = controller(featureOn(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class));
+
+      // "T" exists but is a table, not a variable — delete_variable must reject it
+      // rather than silently deleting a same-named table assembly.
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-DV2", deleteVariableRequest("T"), agent));
+      assertTrue(ex.getMessage().contains("T"));
+      assertNotNull(ws.getAssembly("T"), "table should not have been deleted");
+   }
+
+   // ---------------------------------------------------------------------------
    // detach
    // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

The wiz-plugin-worksheet MCP tool surface (used by Claude Code to live-edit an open StyleBI worksheet) had `add_variable`/`edit_variable`/`set_variable_values` for worksheet variables, but no way to rename or delete one — both operations failed with "can't rename"/"can't delete".

## Root Cause

`WorksheetAgentController.dispatch()` had `rename_table`/`delete_table` ops but no variable equivalent, so any such request fell through to `default -> throw new PairingException("Unknown op: ...")`. `WorksheetEditService.Editor` had `editVariable` but no `renameVariable`/`deleteVariable`. This was purely a missing-capability gap — `Worksheet.renameAssembly`/`removeAssembly` already fully support variable assemblies generically (`renameAssembly` special-cases `VariableAssembly` and fixes up `$(name)` references via `renameDepended`).

## Fix

- `WorksheetEditService.Editor`: added `renameVariable(oldName, newName)` and `deleteVariable(name)`, mirroring the existing `renameTable`/`deleteTable` pattern but validating `instanceof DefaultVariableAssembly` for accurate error messages.
- `WorksheetAgentController.dispatch()`: added `rename_variable`/`delete_variable` cases routing to the new `Editor` methods. No new `EditRequest` fields needed — `name`/`newName` already exist and are reused from `rename_table`/`rename_column`.
- `EditRequest.java`: documented the two new `op` values in the javadoc.
- Added `WorksheetAgentControllerTest` coverage: successful rename, successful delete, and not-found rejection for both (including a case confirming `delete_variable` won't delete a same-named table assembly).

The companion plugin-side change (adding the `rename_variable`/`delete_variable` MCP tools) is in `inetsoft-technology/stylebi-wiz#bug-75994`.

## Test Plan

- [x] `./mvnw clean install -pl core -am -DskipTests` — clean build
- [x] `./mvnw test -pl core -Dtest=WorksheetAgentControllerTest` — 22/22 pass (4 new)
- [x] Manually verified end-to-end via the worksheet-chat plugin: add a variable, rename it, delete it — all succeed against a running server with this change

Fixes Redmine #75994.