### PR TITLE
Bug #75992, fix PPT export wrapping non-wrap-text table cells

### DIFF
--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/ppt/PPTValueHelper.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/ppt/PPTValueHelper.java
@@ -201,6 +201,14 @@ public class PPTValueHelper {
 
       if(!format.isWrapping()) {
          inBounds.width -= 2; // must consider margin for ppt!
+
+         // bug #75992, ppt may still auto-wrap text that just barely
+         // fits, even with word-wrap disabled on the textbox, because ppt's
+         // own font metrics differ slightly from the server's. Use the same
+         // safety margin as the wrapping table cell case below.
+         if(isTableCell) {
+            inBounds.width -= WRAP_GAP;
+         }
       }
       else {
          // bug1166609586046, although the text can showed whole on textbox
@@ -232,7 +240,7 @@ public class PPTValueHelper {
          // if wrap is set to false, the lines will not be
          // chop off at the right bound, so we need to it explicitly
          if(!format.isWrapping()) {
-            int idx = Util.breakLine(txt, bounds.getWidth() - 1, txtFont, false);
+            int idx = Util.breakLine(txt, inBounds.width, txtFont, false);
             txt = (idx < 0) ? txt : txt.substring(0, idx);
          }
 


### PR DESCRIPTION
## Summary
- When a table column has wrap-text disabled, exporting to PowerPoint with "match layout" could still visually wrap the cell's text in the exported PPTX, even though `setWordWrap(false)` was applied — differing from the portal preview.
- Root cause: `PPTValueHelper.writeContent()` decided where to truncate non-wrapping cell text using the full cell width (`bounds.getWidth() - 1`) with no safety margin. Because PowerPoint's font-rendering metrics differ slightly from the server's AWT metrics, text judged to "just fit" server-side rendered marginally too wide in PowerPoint, which then auto-wrapped it despite word-wrap being off. This is the same underlying PPT quirk already called out for the wrapping case (see existing `bug1166609586046` comment), but the safety margin (`WRAP_GAP`) added for that case was never applied to the non-wrapping path.
- Fix: apply the same `WRAP_GAP` margin to the non-wrapping table-cell case, and use the margin-adjusted width instead of the near-full cell width when deciding where to truncate.

## Test plan
- [ ] Open a viewsheet with a table where one column has wrap-text disabled and text close to the column width (e.g. "Company" in the reported case)
- [ ] Export to PowerPoint with "match layout"
- [ ] Confirm the column no longer wraps in the exported PPTX and matches the portal preview
- [ ] Confirm columns with wrap-text enabled still wrap correctly (no regression)