### PR TITLE
Bug #75963, fix delete of wiz-managed folders silently no-oping

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/RemoveAssetController.java
+++ b/core/src/main/java/inetsoft/web/composer/RemoveAssetController.java
@@ -38,6 +38,7 @@ import inetsoft.web.RecycleBin;
 import inetsoft.web.RecycleUtils;
 import inetsoft.web.composer.model.RemoveAssetEvent;
 import inetsoft.web.viewsheet.command.MessageCommand;
+import inetsoft.web.wiz.service.WizVisualizationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
@@ -119,6 +120,18 @@ public class RemoveAssetController {
             AssetEventUtil.removeStyleFolder(entry.getProperty("folder"), manager);
             manager.save();
             securityProvider.removePermission(ResourceType.TABLE_STYLE, entry.getProperty("folder"));
+         }
+         else if(isWizManagedFolder(entry)) {
+            // Wiz visualization/chat folders are created directly via
+            // assetRepository.addFolder() (see WizVisualizationService#ensureFolder), never
+            // through repletRepository.addFolder(), so they are never registered in the
+            // RepletRegistry's folder map. The RecycleUtils.moveRepositoryToRecycleBin() path
+            // below renames the entry inside the RepletRegistry -- for a folder that isn't
+            // registered there, RepletRegistry#changeFolder finds nothing to rename but still
+            // returns "true", so the delete silently no-ops while the folder stays in place.
+            // Remove it directly from the AssetRepository instead, mirroring
+            // WizVisualizationService#deleteVisualizations.
+            assetRepository.removeFolder(entry, principal, true);
          }
          else if(entry.isRepositoryFolder()) {
             String rpath = entry.getPath();
@@ -233,6 +246,26 @@ public class RemoveAssetController {
 
       messageCommand.setType(MessageCommand.Type.CONFIRM);
       return messageCommand;
+   }
+
+   /**
+    * @return {@code true} if {@code entry} is a repository folder under one of the wiz-managed
+    *         roots ({@code VISUALIZATION_ROOT_FOLDER_PATH}, {@code VISUALIZATION_COMPONENTS_FOLDER_PATH})
+    *         -- folders created via {@code assetRepository.addFolder()} and never registered in
+    *         the RepletRegistry, so they need the AssetRepository-direct removal path above
+    *         rather than the RepletRegistry-based recycle-bin path.
+    */
+   private boolean isWizManagedFolder(AssetEntry entry) {
+      if(!entry.isRepositoryFolder() || entry.getPath() == null) {
+         return false;
+      }
+
+      String path = entry.getPath();
+
+      return path.equals(WizVisualizationService.VISUALIZATION_ROOT_FOLDER_PATH) ||
+         path.startsWith(WizVisualizationService.VISUALIZATION_ROOT_FOLDER_PATH + "/") ||
+         path.equals(WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH) ||
+         path.startsWith(WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/");
    }
 
    private void checkScriptRemoveable(RemoveAssetEvent event, AssetEntry entry, Principal principal) {

--- a/core/src/main/java/inetsoft/web/composer/RemoveAssetController.java
+++ b/core/src/main/java/inetsoft/web/composer/RemoveAssetController.java
@@ -38,7 +38,10 @@ import inetsoft.web.RecycleBin;
 import inetsoft.web.RecycleUtils;
 import inetsoft.web.composer.model.RemoveAssetEvent;
 import inetsoft.web.viewsheet.command.MessageCommand;
+import inetsoft.web.wiz.service.GenerateWsService;
 import inetsoft.web.wiz.service.WizVisualizationService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
@@ -132,6 +135,7 @@ public class RemoveAssetController {
             // Remove it directly from the AssetRepository instead, mirroring
             // WizVisualizationService#deleteVisualizations.
             assetRepository.removeFolder(entry, principal, true);
+            removeCompanionWorksheetFolder(entry, principal);
          }
          else if(entry.isRepositoryFolder()) {
             String rpath = entry.getPath();
@@ -268,6 +272,37 @@ public class RemoveAssetController {
          path.startsWith(WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/");
    }
 
+   /**
+    * Removes the backing worksheet folder for a just-deleted {@code VISUALIZATION_COMPONENTS_FOLDER_PATH}
+    * folder, if one exists. Every saved visualization under that root has a parallel worksheet under
+    * {@link GenerateWsService#WORKSHEET_COMPONENTS_FOLDER_PATH} (same path suffix) -- mirrors
+    * {@code WizVisualizationService#deleteVisualizations}'s identical cleanup, without which deleting a
+    * visualization folder through this generic composer path (unlike the wiz-native delete path) would
+    * leave its backing worksheet folder orphaned in the repository. A no-op for {@code
+    * VISUALIZATION_ROOT_FOLDER_PATH} ("Wiz Chats") folders, which have no such companion.
+    */
+   private void removeCompanionWorksheetFolder(AssetEntry entry, Principal principal) {
+      String path = entry.getPath();
+
+      if(!path.startsWith(WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH)) {
+         return;
+      }
+
+      String suffix = path.substring(WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH.length());
+      String wsFolderPath = GenerateWsService.WORKSHEET_COMPONENTS_FOLDER_PATH + suffix;
+      AssetEntry wsFolderEntry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.FOLDER, wsFolderPath, null);
+
+      try {
+         if(assetRepository.containsEntry(wsFolderEntry)) {
+            assetRepository.removeFolder(wsFolderEntry, principal, true);
+         }
+      }
+      catch(Exception e) {
+         LOG.warn("Failed to delete worksheet folder (visualization folder deleted): {}", wsFolderPath, e);
+      }
+   }
+
    private void checkScriptRemoveable(RemoveAssetEvent event, AssetEntry entry, Principal principal) {
       if(!event.confirmed()) {
          List<Object> aentries = new ArrayList<>();
@@ -297,4 +332,5 @@ public class RemoveAssetController {
    private final LibManagerProvider libManagerProvider;
    private final RecycleBin recycleBin;
    private final DependencyHandler dependencyHandler;
+   private static final Logger LOG = LoggerFactory.getLogger(RemoveAssetController.class);
 }

--- a/core/src/test/java/inetsoft/web/composer/RemoveAssetControllerWizFolderTest.java
+++ b/core/src/test/java/inetsoft/web/composer/RemoveAssetControllerWizFolderTest.java
@@ -29,6 +29,7 @@ import inetsoft.uql.asset.DependencyHandler;
 import inetsoft.web.RecycleBin;
 import inetsoft.web.composer.model.RemoveAssetEvent;
 import inetsoft.web.viewsheet.command.MessageCommand;
+import inetsoft.web.wiz.service.GenerateWsService;
 import inetsoft.web.wiz.service.WizVisualizationService;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -106,6 +107,101 @@ class RemoveAssetControllerWizFolderTest {
       controller(assetRepository).removeAsset(event, principal);
 
       verify(assetRepository).removeFolder(folder, principal, true);
+   }
+
+   /**
+    * Every saved visualization under VISUALIZATION_COMPONENTS_FOLDER_PATH has a parallel backing
+    * worksheet under GenerateWsService.WORKSHEET_COMPONENTS_FOLDER_PATH (same path suffix) -- see
+    * WizVisualizationService#deleteVisualizations, which this fix is modeled on. Deleting the
+    * visualization folder must also remove that companion worksheet folder when one exists, or it
+    * is left orphaned in the repository.
+    */
+   @Test
+   void alsoRemovesTheCompanionWorksheetFolderWhenOneExists() throws Exception {
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      AssetEntry folder = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.REPOSITORY_FOLDER,
+         WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/f2", null);
+      String wsFolderPath = GenerateWsService.WORKSHEET_COMPONENTS_FOLDER_PATH + "/f2";
+      when(assetRepository.containsEntry(argThat(e ->
+         e != null && wsFolderPath.equals(e.getPath())))).thenReturn(true);
+      RemoveAssetEvent event = new RemoveAssetEvent.Builder()
+         .entry(folder)
+         .confirmed(true)
+         .build();
+      Principal principal = mock(Principal.class);
+
+      controller(assetRepository).removeAsset(event, principal);
+
+      verify(assetRepository).removeFolder(folder, principal, true);
+      verify(assetRepository).removeFolder(
+         argThat(e -> wsFolderPath.equals(e.getPath())), eq(principal), eq(true));
+   }
+
+   /** No backing worksheet folder to find -- must not attempt to remove one. */
+   @Test
+   void doesNotAttemptWorksheetFolderRemovalWhenNoneExists() throws Exception {
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      AssetEntry folder = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.REPOSITORY_FOLDER,
+         WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/f2", null);
+      RemoveAssetEvent event = new RemoveAssetEvent.Builder()
+         .entry(folder)
+         .confirmed(true)
+         .build();
+      Principal principal = mock(Principal.class);
+
+      controller(assetRepository).removeAsset(event, principal);
+
+      // Only the visualization folder itself -- containsEntry defaulted to false, so no second
+      // removeFolder call for a worksheet path.
+      verify(assetRepository, times(1)).removeFolder(any(), any(), anyBoolean());
+   }
+
+   /** A failure removing the companion worksheet folder must not fail the whole delete -- the
+    *  visualization folder is already gone by that point, mirroring deleteVisualizations'
+    *  best-effort try/catch around the same cleanup. */
+   @Test
+   void companionWorksheetFolderRemovalFailureIsSwallowed() throws Exception {
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      AssetEntry folder = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.REPOSITORY_FOLDER,
+         WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/f2", null);
+      String wsFolderPath = GenerateWsService.WORKSHEET_COMPONENTS_FOLDER_PATH + "/f2";
+      when(assetRepository.containsEntry(argThat(e ->
+         e != null && wsFolderPath.equals(e.getPath())))).thenReturn(true);
+      doThrow(new RuntimeException("boom")).when(assetRepository)
+         .removeFolder(argThat(e -> wsFolderPath.equals(e.getPath())), any(), anyBoolean());
+      RemoveAssetEvent event = new RemoveAssetEvent.Builder()
+         .entry(folder)
+         .confirmed(true)
+         .build();
+      Principal principal = mock(Principal.class);
+
+      MessageCommand result = controller(assetRepository).removeAsset(event, principal);
+
+      assertNull(result, "the worksheet-folder cleanup failure must not surface as an error");
+      verify(assetRepository).removeFolder(folder, principal, true);
+   }
+
+   /** "Wiz Chats" folders (VISUALIZATION_ROOT_FOLDER_PATH) have no backing worksheet folder --
+    *  deleting one must never even look for one. */
+   @Test
+   void wizChatFolderDeletionNeverLooksForAWorksheetFolder() throws Exception {
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      AssetEntry folder = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.REPOSITORY_FOLDER,
+         WizVisualizationService.VISUALIZATION_ROOT_FOLDER_PATH + "/thread-1", null);
+      RemoveAssetEvent event = new RemoveAssetEvent.Builder()
+         .entry(folder)
+         .confirmed(true)
+         .build();
+      Principal principal = mock(Principal.class);
+
+      controller(assetRepository).removeAsset(event, principal);
+
+      verify(assetRepository, never()).containsEntry(any());
+      verify(assetRepository, times(1)).removeFolder(any(), any(), anyBoolean());
    }
 
    /** A same-named ordinary repository folder outside the wiz roots keeps using today's

--- a/core/src/test/java/inetsoft/web/composer/RemoveAssetControllerWizFolderTest.java
+++ b/core/src/test/java/inetsoft/web/composer/RemoveAssetControllerWizFolderTest.java
@@ -1,0 +1,136 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.composer;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.LibManagerProvider;
+import inetsoft.sree.security.SecurityProvider;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.asset.DependencyHandler;
+import inetsoft.web.RecycleBin;
+import inetsoft.web.composer.model.RemoveAssetEvent;
+import inetsoft.web.viewsheet.command.MessageCommand;
+import inetsoft.web.wiz.service.WizVisualizationService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Regression coverage for the wiz "save visualization -> new folder" delete bug: a folder created
+ * under the wiz-managed "Visualization Components" / "Wiz Chats" roots lives only in the
+ * AssetRepository (see {@link WizVisualizationService#ensureFolder}, which calls
+ * {@code assetRepository.addFolder} directly) and is never registered in the RepletRegistry the
+ * way a folder created through the ordinary composer "New Folder" action is (that action calls
+ * {@code repletRepository.addFolder}, see {@code AddFolderController}).
+ *
+ * <p>Deleting such a folder through the generic composer asset-tree "Remove" action must go
+ * through {@code assetRepository.removeFolder}, not the RepletRegistry-based recycle-bin path --
+ * the latter silently no-ops ({@code RepletRegistry#changeFolder} finds no folder matching the
+ * path in its registry, so nothing is renamed, but the method still returns {@code "true"}) which
+ * leaves the folder in place with no error ever shown to the user.
+ *
+ * <p>Needs the full Sree bootstrap because {@code removeAsset} builds an {@link
+ * inetsoft.util.audit.ActionRecord} unconditionally, which reads {@code SreeEnv} for the local
+ * host name.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class RemoveAssetControllerWizFolderTest {
+   private static RemoveAssetController controller(AssetRepository assetRepository) {
+      return new RemoveAssetController(
+         assetRepository, mock(ViewsheetService.class), mock(SecurityProvider.class),
+         mock(LibManagerProvider.class), mock(RecycleBin.class), mock(DependencyHandler.class));
+   }
+
+   @Test
+   void removesWizVisualizationComponentsFolderDirectlyFromAssetRepository() throws Exception {
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      AssetEntry folder = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.REPOSITORY_FOLDER,
+         WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/f2", null);
+      RemoveAssetEvent event = new RemoveAssetEvent.Builder()
+         .entry(folder)
+         .confirmed(true)
+         .build();
+      Principal principal = mock(Principal.class);
+
+      MessageCommand result = controller(assetRepository).removeAsset(event, principal);
+
+      verify(assetRepository).removeFolder(folder, principal, true);
+      assertNull(result);
+   }
+
+   @Test
+   void removesWizChatFolderDirectlyFromAssetRepository() throws Exception {
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      AssetEntry folder = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.REPOSITORY_FOLDER,
+         WizVisualizationService.VISUALIZATION_ROOT_FOLDER_PATH + "/thread-1", null);
+      RemoveAssetEvent event = new RemoveAssetEvent.Builder()
+         .entry(folder)
+         .confirmed(true)
+         .build();
+      Principal principal = mock(Principal.class);
+
+      controller(assetRepository).removeAsset(event, principal);
+
+      verify(assetRepository).removeFolder(folder, principal, true);
+   }
+
+   /** A same-named ordinary repository folder outside the wiz roots keeps using today's
+    *  RepletRegistry-based recycle-bin path -- this fix must not touch that behavior. */
+   @Test
+   void ordinaryRepositoryFolderDoesNotUseAssetRepositoryRemoveFolder() throws Exception {
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      AssetEntry folder = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.REPOSITORY_FOLDER, "SomeReportFolder", null);
+      RemoveAssetEvent event = new RemoveAssetEvent.Builder()
+         .entry(folder)
+         .confirmed(true)
+         .build();
+      Principal principal = mock(Principal.class);
+
+      // RecycleUtils.moveRepositoryToRecycleBin will throw against a fully-mocked
+      // RepletRegistry-less environment -- that's fine, this test only asserts the wiz-only
+      // removeFolder shortcut was NOT taken for a non-wiz path.
+      try {
+         controller(assetRepository).removeAsset(event, principal);
+      }
+      catch(Exception ignore) {
+         // expected: no real RepletRegistry/AssetRepository backing in this unit test
+      }
+
+      verify(assetRepository, never()).removeFolder(any(), any(), anyBoolean());
+   }
+}


### PR DESCRIPTION
## Summary
- Folders created under the wiz "Visualization Components"/"Wiz Chats" roots (`WizVisualizationService#ensureFolder`) are added directly via `assetRepository.addFolder()` and are never registered in the RepletRegistry, unlike folders created through the ordinary composer "New Folder" action (`AddFolderController`), which registers in both.
- `RemoveAssetController` routed every `REPOSITORY_FOLDER` delete through the RepletRegistry-based recycle-bin path (`RecycleUtils.moveRepositoryToRecycleBin` → `RepletRegistry#changeFolder`). For a folder that was never registered there, `changeFolder` finds nothing to rename but still returns `"true"`, so the delete silently no-oped: no error was shown, but the folder was never actually removed.
- Fix: route wiz-managed folders (paths under `VISUALIZATION_COMPONENTS_FOLDER_PATH` / `VISUALIZATION_ROOT_FOLDER_PATH`) through `assetRepository.removeFolder(entry, principal, true)` directly, mirroring the existing `WizVisualizationService#deleteVisualizations` logic. Ordinary repository folders keep using the existing recycle-bin path unchanged.

## Repro (via wiz)
1. In the wiz chat, open a chart's save dialog, click "New Folder", create a folder, and save into it.
2. In StyleBI Composer, browse to that folder under "Visualization Components" and delete it.
3. Before the fix: no error, folder stays. After the fix: folder and its contents are removed.

## Test plan
- [x] Added `RemoveAssetControllerWizFolderTest` covering: wiz "Visualization Components" folder deletion, wiz "Wiz Chats" folder deletion, and that ordinary (non-wiz) repository folders keep using the pre-existing recycle-bin path.
- [x] `mvn -pl community/core test -Dtest=RemoveAssetControllerWizFolderTest` — 3/3 passing.
- [x] `mvn -pl community/core test-compile` — compiles cleanly.