### PR TITLE
fix(wiz): a chart highlight was dropped by changeType and again on re-execution

### DIFF
--- a/core/src/main/java/inetsoft/web/vswizard/handler/SyncChartHandler.java
+++ b/core/src/main/java/inetsoft/web/vswizard/handler/SyncChartHandler.java
@@ -506,14 +506,28 @@ public class SyncChartHandler extends SyncAssemblyHandler {
       }
    }
 
-   private void syncHighlight(ChartVSAssembly fromChart, ChartVSAssembly targetChart) {
+   /**
+    * Copies highlight rules from fromChart onto targetChart by matching bound refs (same rule
+    * {@link #syncChart} applies internally). Exposed separately so a caller that wants ONLY the
+    * highlight carried over — {@code changeType}'s fast path, which must not also pull in
+    * {@link #syncChart}'s format/legend/condition/hyperlink copying — can invoke it directly.
+    *
+    * <p>Matches on the DESIGN refs ({@code getBindingRefs(false)}), not runtime ones. Runtime X/Y
+    * fields are transient clones regenerated from the design refs on every execution/re-render (see
+    * {@code WizVsService#applyHighlight}, which attaches highlight the same way for the same reason,
+    * quoting: "clearRuntime()/executeView regenerate the runtime refs as clones that carry the
+    * group, so it survives the re-render"). A highlight copied onto a RUNTIME ref only lives until the
+    * next execution discards that ref and clones a fresh (highlight-less) one from the design ref — the
+    * copy would silently disappear the next time the chart re-executes (e.g. a second changeType call).
+    */
+   public void syncHighlight(ChartVSAssembly fromChart, ChartVSAssembly targetChart) {
       VSChartInfo fromChartInfo = fromChart.getVSChartInfo();
       VSChartInfo targetChartInfo = targetChart.getVSChartInfo();
 
       HighlightGroup highlightGroup;
       boolean mergedProcessed = false; // just only process once
-      VSDataRef[] fromXYFields = fromChartInfo.getRTFields(true, false, false, false);
-      VSDataRef[] targetXYFields = targetChartInfo.getRTFields(true, false, false, false);
+      VSDataRef[] fromXYFields = fromChartInfo.getBindingRefs(false);
+      VSDataRef[] targetXYFields = targetChartInfo.getBindingRefs(false);
 
       for (VSDataRef ref: fromXYFields) {
          List<Integer> targetBindingRefs = VSWizardBindingHandler.findIndex(targetXYFields, ref, true);

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -38,6 +38,7 @@ import inetsoft.sree.security.SecurityException;
 import inetsoft.util.Catalog;
 import inetsoft.util.Tool;
 import inetsoft.web.adhoc.model.FormatInfoModel;
+import inetsoft.web.vswizard.handler.SyncChartHandler;
 import inetsoft.web.vswizard.handler.VSWizardBindingHandler;
 import inetsoft.web.vswizard.model.VSWizardData;
 import inetsoft.web.vswizard.model.recommender.*;
@@ -75,7 +76,8 @@ public class WizAutoBindingService {
                                 VSWizardBindingHandler bindingHandler,
                                 VSDefaultRecommendationFactory defaultRecommendationFactory,
                                 WizVsService wizVsService,
-                                SecurityEngine securityEngine)
+                                SecurityEngine securityEngine,
+                                SyncChartHandler syncChartHandler)
    {
       this.viewsheetService = viewsheetService;
       this.engine = engine;
@@ -84,6 +86,7 @@ public class WizAutoBindingService {
       this.defaultRecommendationFactory = defaultRecommendationFactory;
       this.wizVsService = wizVsService;
       this.securityEngine = securityEngine;
+      this.syncChartHandler = syncChartHandler;
    }
 
    public AutoBindingResponse autoBinding(AutoBindingRequest request, Principal user)
@@ -797,6 +800,64 @@ public class WizAutoBindingService {
       }
       else if(assembly instanceof CrosstabVSAssembly crosstabAsm && crosstabAsm.getVSCrosstabInfo() != null) {
          applyCrosstabAggregateFormulas(crosstabAsm.getVSCrosstabInfo(), configMap);
+      }
+   }
+
+   /**
+    * Carries highlight rules from the chart being switched away from (source) onto the freshly-bound
+    * chart for the new type (target) — a chart-only operation, a no-op for any other assembly type
+    * (e.g. table/crosstab, which key their highlight differently — see
+    * {@code WizVsService#applyTableHighlight} — and are not reached by changeType's fast path).
+    *
+    * <p>Needed because changeType()'s createViewsheetSkipExecution() call never runs
+    * {@code SyncInfoHandler#syncConfigs} — that only fires on the /viewsheet/autoBinding
+    * (skipExecution=false) path — so without this, a highlight applied via /viewsheet/highlight was
+    * silently dropped on every chart-type switch (the GUI's "change chart style" action).
+    *
+    * <p>Package-private so the dispatch itself can be unit-tested directly against a service instance
+    * with mocked assemblies, mirroring {@link #applyResolvedFormulaOverrides(VSAssembly, Map)}.
+    */
+   void syncHighlightOnTypeChange(VSAssembly source, VSAssembly target) {
+      if(source instanceof ChartVSAssembly fromChart && target instanceof ChartVSAssembly toChart) {
+         syncChartHandler.syncHighlight(fromChart, toChart);
+      }
+   }
+
+   /**
+    * {@link #syncHighlightOnTypeChange(VSAssembly, VSAssembly)} for a call site that only has the
+    * resulting runtimeId/assemblyName (createViewsheetSkipExecution / autoBindingInternal already ran
+    * and returned a DTO, not the live assembly) — looks up the live target assembly and applies the
+    * same sync, then invalidates the sandbox's cached graph for it.
+    *
+    * <p>The graph-clear matters regardless of when this runs relative to execution: by the time this
+    * is called (after fetchAssemblyData, so headers/rows are ready for the response), that same call
+    * already executed and cached a graph built from the PRE-highlight design refs. Mutating the design
+    * refs afterward (see {@code SyncChartHandler#syncHighlight}'s javadoc on why it targets design, not
+    * runtime, refs) doesn't retroactively change that cached graph — {@code applyHighlight} avoids this
+    * by mutating before its own execution; this call site can't, because the target chart doesn't exist
+    * yet before createViewsheetSkipExecution places it. Without clearing it, the sandbox keeps serving
+    * the pre-highlight graph to every later request (the browser's post-refreshViewsheet re-render
+    * included) until something else happens to invalidate it.
+    *
+    * <p>Best-effort: swallows lookup failures so a highlight-carry miss never fails the whole changeType
+    * call when the rest of it already succeeded, mirroring
+    * {@link #applyResolvedFormulaOverrides(String, String, Map, Principal)}.
+    */
+   private void syncHighlightOnTypeChange(VSAssembly source, String runtimeId, String assemblyName,
+                                           Principal user)
+   {
+      try {
+         RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, user);
+         VSAssembly target = rvs == null ? null :
+            (VSAssembly) rvs.getViewsheet().getAssembly(assemblyName);
+         syncHighlightOnTypeChange(source, target);
+
+         if(rvs != null) {
+            rvs.getViewsheetSandbox().ifPresent(box -> box.clearGraph(assemblyName));
+         }
+      }
+      catch(Exception e) {
+         LOG.warn("changeType: failed to sync highlight for '{}': {}", assemblyName, e.getMessage());
       }
    }
 
@@ -2547,6 +2608,11 @@ public class WizAutoBindingService {
                result.setRows(dataResult.getRows());
                result.setHasData(dataResult.getHasData());
                result.setTruncated(dataResult.getTruncated());
+
+               // Carry the highlight from the chart being switched away from onto the rebuilt chart,
+               // then invalidate the graph fetchAssemblyData (above) already cached from before the
+               // highlight was attached — see syncHighlightOnTypeChange's javadoc.
+               syncHighlightOnTypeChange(targetAssembly, fallbackRuntimeId, result.getAssemblyName(), user);
             }
             catch(Exception e) {
                LOG.warn("changeType fallback: failed to fetch assembly data for insight (non-critical): {}", e.getMessage());
@@ -2644,6 +2710,11 @@ public class WizAutoBindingService {
             result.setRows(dataResult.getRows());
             result.setHasData(dataResult.getHasData());
             result.setTruncated(dataResult.getTruncated());
+
+            // Carry the highlight from the chart being switched away from onto the rebuilt chart,
+            // then invalidate the graph fetchAssemblyData (above) already cached from before the
+            // highlight was attached — see syncHighlightOnTypeChange's javadoc.
+            syncHighlightOnTypeChange(targetAssembly, result.getRuntimeId(), result.getAssemblyName(), user);
          }
          catch(Exception e) {
             LOG.warn("changeType: failed to fetch assembly data for insight (non-critical): {}", e.getMessage());
@@ -3694,4 +3765,5 @@ public class WizAutoBindingService {
    private final VSDefaultRecommendationFactory defaultRecommendationFactory;
    private final WizVsService wizVsService;
    private final SecurityEngine securityEngine;
+   private final SyncChartHandler syncChartHandler;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -805,9 +805,12 @@ public class WizAutoBindingService {
 
    /**
     * Carries highlight rules from the chart being switched away from (source) onto the freshly-bound
-    * chart for the new type (target) — a chart-only operation, a no-op for any other assembly type
-    * (e.g. table/crosstab, which key their highlight differently — see
-    * {@code WizVsService#applyTableHighlight} — and are not reached by changeType's fast path).
+    * chart for the new type (target) — a chart-only operation, a no-op for any other assembly type.
+    * Table/crosstab/gauge/text recommendations DO reach changeType's fast path too (see
+    * {@link #findRecByType}) — they key their highlight differently (see
+    * {@code WizVsService#applyTableHighlight}) and are simply not handled here yet, so a highlight is
+    * still silently dropped switching a chart to/from one of those. Only the chart-to-chart case
+    * reported in bug #76025 is fixed by this method.
     *
     * <p>Needed because changeType()'s createViewsheetSkipExecution() call never runs
     * {@code SyncInfoHandler#syncConfigs} — that only fires on the /viewsheet/autoBinding
@@ -839,15 +842,23 @@ public class WizAutoBindingService {
     * the pre-highlight graph to every later request (the browser's post-refreshViewsheet re-render
     * included) until something else happens to invalidate it.
     *
+    * <p>{@code source} is whatever {@code findWizTargetAssembly} resolved at the top of {@code
+    * changeType}. That method is documented as deliberately best-effort — built for a staleness
+    * check that tolerates "cannot tell" — not as a guaranteed-fresh handle; this call site leans on it
+    * for the highlight's source of truth anyway, so a future change to its resolution/null-handling
+    * that stays within its own contract could make highlight-carry silently no-op more often without
+    * that being an obviously-related regression.
+    *
     * <p>Best-effort: swallows lookup failures so a highlight-carry miss never fails the whole changeType
     * call when the rest of it already succeeded, mirroring
     * {@link #applyResolvedFormulaOverrides(String, String, Map, Principal)}.
     */
-   private void syncHighlightOnTypeChange(VSAssembly source, String runtimeId, String assemblyName,
-                                           Principal user)
+   private void syncHighlightOnTypeChange(VSAssembly source, String runtimeId, String viewsheetIdentifier,
+                                           String assemblyName, Principal user)
    {
       try {
-         RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, user);
+         RuntimeViewsheet rvs = WizUtil.getViewsheetOrRestore(
+            viewsheetService, runtimeId, viewsheetIdentifier, user);
          VSAssembly target = rvs == null ? null :
             (VSAssembly) rvs.getViewsheet().getAssembly(assemblyName);
          syncHighlightOnTypeChange(source, target);
@@ -2612,7 +2623,8 @@ public class WizAutoBindingService {
                // Carry the highlight from the chart being switched away from onto the rebuilt chart,
                // then invalidate the graph fetchAssemblyData (above) already cached from before the
                // highlight was attached — see syncHighlightOnTypeChange's javadoc.
-               syncHighlightOnTypeChange(targetAssembly, fallbackRuntimeId, result.getAssemblyName(), user);
+               syncHighlightOnTypeChange(
+                  targetAssembly, fallbackRuntimeId, viewsheetIdentifier, result.getAssemblyName(), user);
             }
             catch(Exception e) {
                LOG.warn("changeType fallback: failed to fetch assembly data for insight (non-critical): {}", e.getMessage());
@@ -2714,7 +2726,8 @@ public class WizAutoBindingService {
             // Carry the highlight from the chart being switched away from onto the rebuilt chart,
             // then invalidate the graph fetchAssemblyData (above) already cached from before the
             // highlight was attached — see syncHighlightOnTypeChange's javadoc.
-            syncHighlightOnTypeChange(targetAssembly, result.getRuntimeId(), result.getAssemblyName(), user);
+            syncHighlightOnTypeChange(
+               targetAssembly, result.getRuntimeId(), viewsheetIdentifier, result.getAssemblyName(), user);
          }
          catch(Exception e) {
             LOG.warn("changeType: failed to fetch assembly data for insight (non-critical): {}", e.getMessage());

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -885,8 +885,13 @@ public class WizAutoBindingService {
     * the common no-highlight changeType call doesn't pay for either. Mirrors exactly what {@link
     * SyncChartHandler#syncHighlight} would look for: a per-ref highlight/text-highlight group on any
     * design ref, or (for a merged chart) the chart-level group.
+    *
+    * <p>Package-private (not {@code private}) so this short-circuit can be unit-tested directly,
+    * mirroring {@link #syncHighlightOnTypeChange(VSAssembly, VSAssembly)} — a filter that silently
+    * starts under-detecting after some future change to {@code syncHighlight}'s matching rules would
+    * reintroduce the exact "highlight silently dropped" bug this class of fix exists for.
     */
-   private static boolean hasHighlightToCarry(VSAssembly source) {
+   static boolean hasHighlightToCarry(VSAssembly source) {
       if(!(source instanceof ChartVSAssembly chartAsm) || chartAsm.getVSChartInfo() == null) {
          return false;
       }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -856,6 +856,13 @@ public class WizAutoBindingService {
    private void syncHighlightOnTypeChange(VSAssembly source, String runtimeId, String viewsheetIdentifier,
                                            String assemblyName, Principal user)
    {
+      // The common case: most type switches aren't touching a highlighted chart at all. Skip the RVS
+      // lookup and the graph-clear below (which forces the NEXT render to fully rebuild) when there is
+      // nothing on source to carry, rather than paying that cost on every single changeType call.
+      if(!hasHighlightToCarry(source)) {
+         return;
+      }
+
       try {
          RuntimeViewsheet rvs = WizUtil.getViewsheetOrRestore(
             viewsheetService, runtimeId, viewsheetIdentifier, user);
@@ -870,6 +877,35 @@ public class WizAutoBindingService {
       catch(Exception e) {
          LOG.warn("changeType: failed to sync highlight for '{}': {}", assemblyName, e.getMessage());
       }
+   }
+
+   /**
+    * Whether {@code source} carries any highlight worth the lookup + graph-clear in {@link
+    * #syncHighlightOnTypeChange(VSAssembly, String, String, String, Principal)} — checked upfront so
+    * the common no-highlight changeType call doesn't pay for either. Mirrors exactly what {@link
+    * SyncChartHandler#syncHighlight} would look for: a per-ref highlight/text-highlight group on any
+    * design ref, or (for a merged chart) the chart-level group.
+    */
+   private static boolean hasHighlightToCarry(VSAssembly source) {
+      if(!(source instanceof ChartVSAssembly chartAsm) || chartAsm.getVSChartInfo() == null) {
+         return false;
+      }
+
+      VSChartInfo info = chartAsm.getVSChartInfo();
+
+      if(info.getHighlightGroup() != null) {
+         return true;
+      }
+
+      for(ChartRef ref : info.getBindingRefs(false)) {
+         if(ref instanceof HighlightRef hlRef &&
+            (hlRef.getHighlightGroup() != null || hlRef.getTextHighlightGroup() != null))
+         {
+            return true;
+         }
+      }
+
+      return false;
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/vswizard/handler/SyncChartHandlerHighlightDesignRefsTest.java
+++ b/core/src/test/java/inetsoft/web/vswizard/handler/SyncChartHandlerHighlightDesignRefsTest.java
@@ -1,0 +1,139 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.vswizard.handler;
+
+import inetsoft.report.filter.HighlightGroup;
+import inetsoft.report.filter.TextHighlight;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.VSCube;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.graph.ChartDescriptor;
+import inetsoft.uql.viewsheet.graph.ChartRef;
+import inetsoft.uql.viewsheet.graph.VSChartAggregateRef;
+import inetsoft.uql.viewsheet.graph.VSChartDimensionRef;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
+import inetsoft.web.graph.handler.ChartRegionHandler;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Regression for the reported bug: a highlight applied to a chart via /viewsheet/highlight
+ * disappeared after switching chart type through the GUI (changeType), and — even after fixing
+ * that — disappeared AGAIN the next time the chart re-executed (e.g. a second changeType call).
+ *
+ * <p>Root cause: {@link SyncChartHandler#syncHighlight} matched on {@code VSChartInfo#getRTFields}
+ * (runtime refs). Runtime X/Y refs are transient — every execution discards them and clones fresh
+ * ones from the DESIGN refs (see {@code WizVsService#applyHighlight}'s own comment on why it attaches
+ * to design refs for exactly this reason). A highlight copied onto a runtime ref only survives until
+ * the chart's next execution, at which point the ref carrying it is discarded and replaced with a
+ * highlight-less clone of the (never-touched) design ref.
+ *
+ * <p>Drives the real handler (not mocks) — same reasoning as {@link SyncChartHandlerNullTempInfoTest}:
+ * VSChartInfo/ChartVSAssembly need SreeEnv/Spring statics that can't be stubbed away.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class SyncChartHandlerHighlightDesignRefsTest {
+   private static ChartVSAssembly newChart(Viewsheet vs, String name, String measureColumn) {
+      ChartVSAssembly chart = new ChartVSAssembly(vs, name);
+      VSChartInfo info = new VSChartInfo();
+
+      VSChartDimensionRef dim = new VSChartDimensionRef();
+      dim.setGroupColumnValue("STATE");
+      info.addXField(dim);
+
+      VSChartAggregateRef agg = new VSChartAggregateRef();
+      agg.setColumnValue(measureColumn);
+      agg.setFormulaValue("Sum");
+      info.addYField(agg);
+
+      chart.setVSChartInfo(info);
+      chart.setXCube(new VSCube());
+      chart.setChartDescriptor(new ChartDescriptor());
+      return chart;
+   }
+
+   private static HighlightGroup redAboveThreshold() {
+      HighlightGroup group = new HighlightGroup();
+      TextHighlight highlight = new TextHighlight();
+      highlight.setName("highlight1");
+      group.addHighlight("highlight1", highlight);
+      return group;
+   }
+
+   private static VSChartAggregateRef designAggregate(ChartVSAssembly chart) {
+      for(ChartRef ref : chart.getVSChartInfo().getBindingRefs(false)) {
+         if(ref instanceof VSChartAggregateRef aggRef) {
+            return aggRef;
+         }
+      }
+
+      throw new IllegalStateException("no aggregate ref bound");
+   }
+
+   /**
+    * The fix: syncHighlight must land the copy on the TARGET's design ref, so it is still there the
+    * next time the chart executes (runtime refs get regenerated fresh from design on every execution;
+    * a copy that only ever touched the runtime ref would vanish on that next execution).
+    */
+   @Test
+   void copiesHighlightOntoTheTargetsDesignRef() {
+      SyncChartHandler handler = new SyncChartHandler(mock(ChartRegionHandler.class));
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly from = newChart(vs, "Source", "SALES_AMOUNT");
+      ChartVSAssembly target = newChart(vs, "Target", "SALES_AMOUNT");
+
+      designAggregate(from).setHighlightGroup(redAboveThreshold());
+      assertNull(designAggregate(target).getHighlightGroup(), "target starts with no highlight");
+
+      handler.syncHighlight(from, target);
+
+      assertNotNull(designAggregate(target).getHighlightGroup(),
+         "syncHighlight must copy onto the target's DESIGN ref — a copy that only reached a " +
+         "transient runtime ref would be silently discarded the next time the chart executes");
+   }
+
+   /** No matching column on the target — nothing to copy onto, must not throw. */
+   @Test
+   void noMatchingColumnIsANoOp() {
+      SyncChartHandler handler = new SyncChartHandler(mock(ChartRegionHandler.class));
+      Viewsheet vs = new Viewsheet();
+      ChartVSAssembly from = newChart(vs, "Source", "SALES_AMOUNT");
+      ChartVSAssembly target = newChart(vs, "Target", "ORDER_COUNT");
+
+      designAggregate(from).setHighlightGroup(redAboveThreshold());
+
+      handler.syncHighlight(from, target);
+
+      assertNull(designAggregate(target).getHighlightGroup());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceAestheticModelTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceAestheticModelTest.java
@@ -79,7 +79,7 @@ class WizAutoBindingServiceAestheticModelTest {
       SecurityEngine securityEngine = mock(SecurityEngine.class);
       when(securityEngine.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
       service = new WizAutoBindingService(
-         viewsheetService, null, null, null, null, wizVsService, securityEngine);
+         viewsheetService, null, null, null, null, wizVsService, securityEngine, null);
 
       vsChartInfo = mock(VSChartInfo.class);
       ChartVSAssemblyInfo info = mock(ChartVSAssemblyInfo.class);

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceAutoBindingSecurityTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceAutoBindingSecurityTest.java
@@ -58,7 +58,7 @@ class WizAutoBindingServiceAutoBindingSecurityTest {
       // environment (no Spring context) — mirroring the WizAutoBindingServiceSetChartColorsTest /
       // WizAutoBindingServiceSetChartFormatTest pattern in this package, pass null instead.
       return new WizAutoBindingService(
-         viewsheetService, null, null, null, null, mock(WizVsService.class), securityEngine);
+         viewsheetService, null, null, null, null, mock(WizVsService.class), securityEngine, null);
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceChangeTypeFieldFormulaTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceChangeTypeFieldFormulaTest.java
@@ -19,6 +19,7 @@ package inetsoft.web.wiz.service;
 
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.graph.calc.PercentCalc;
+import inetsoft.report.filter.HighlightGroup;
 import inetsoft.test.BaseTestConfiguration;
 import inetsoft.test.ConfigurationContextInitializer;
 import inetsoft.test.SreeHome;
@@ -313,6 +314,95 @@ class WizAutoBindingServiceChangeTypeFieldFormulaTest {
       void nullAssembliesAreANoOp() {
          assertDoesNotThrow(() -> service.syncHighlightOnTypeChange(null, null));
          verify(syncChartHandler, never()).syncHighlight(any(), any());
+      }
+   }
+
+   /**
+    * hasHighlightToCarry(VSAssembly) — the upfront filter that lets changeType() skip the RVS lookup
+    * and sandbox graph-clear for the common case of switching a chart that was never highlighted.
+    * Must mirror SyncChartHandler#syncHighlight's own copy logic closely enough to never
+    * under-detect: a false negative here means a real highlight silently stops carrying across a
+    * type switch again, exactly the class of bug this fix exists for. Over-detecting (running the
+    * lookup when nothing actually matches on the target) is harmless by comparison.
+    */
+   @Tag("core")
+   static class HasHighlightToCarryTest {
+      @Test
+      void nonChartSourceIsFalse() {
+         TableVSAssembly table = mock(TableVSAssembly.class);
+
+         assertFalse(WizAutoBindingService.hasHighlightToCarry(table));
+      }
+
+      @Test
+      void nullSourceIsFalse() {
+         assertFalse(WizAutoBindingService.hasHighlightToCarry(null));
+      }
+
+      @Test
+      void chartWithNoChartInfoIsFalse() {
+         ChartVSAssembly chart = mock(ChartVSAssembly.class);
+         when(chart.getVSChartInfo()).thenReturn(null);
+
+         assertFalse(WizAutoBindingService.hasHighlightToCarry(chart));
+      }
+
+      @Test
+      void chartWithNoHighlightAnywhereIsFalse() {
+         VSChartAggregateRef agg = mock(VSChartAggregateRef.class);
+         when(agg.getHighlightGroup()).thenReturn(null);
+         when(agg.getTextHighlightGroup()).thenReturn(null);
+
+         VSChartInfo info = mock(VSChartInfo.class);
+         when(info.getHighlightGroup()).thenReturn(null);
+         when(info.getBindingRefs(false)).thenReturn(new ChartRef[] { agg });
+
+         ChartVSAssembly chart = mock(ChartVSAssembly.class);
+         when(chart.getVSChartInfo()).thenReturn(info);
+
+         assertFalse(WizAutoBindingService.hasHighlightToCarry(chart));
+      }
+
+      @Test
+      void aPerRefHighlightGroupIsTrue() {
+         VSChartAggregateRef agg = mock(VSChartAggregateRef.class);
+         when(agg.getHighlightGroup()).thenReturn(mock(HighlightGroup.class));
+
+         VSChartInfo info = mock(VSChartInfo.class);
+         when(info.getBindingRefs(false)).thenReturn(new ChartRef[] { agg });
+
+         ChartVSAssembly chart = mock(ChartVSAssembly.class);
+         when(chart.getVSChartInfo()).thenReturn(info);
+
+         assertTrue(WizAutoBindingService.hasHighlightToCarry(chart));
+      }
+
+      @Test
+      void aPerRefTextHighlightGroupIsTrue() {
+         VSChartDimensionRef dim = mock(VSChartDimensionRef.class);
+         when(dim.getHighlightGroup()).thenReturn(null);
+         when(dim.getTextHighlightGroup()).thenReturn(mock(HighlightGroup.class));
+
+         VSChartInfo info = mock(VSChartInfo.class);
+         when(info.getBindingRefs(false)).thenReturn(new ChartRef[] { dim });
+
+         ChartVSAssembly chart = mock(ChartVSAssembly.class);
+         when(chart.getVSChartInfo()).thenReturn(info);
+
+         assertTrue(WizAutoBindingService.hasHighlightToCarry(chart));
+      }
+
+      /** The merged-chart case: chart-level group, not any single ref's. */
+      @Test
+      void aChartLevelHighlightGroupIsTrue() {
+         VSChartInfo info = mock(VSChartInfo.class);
+         when(info.getHighlightGroup()).thenReturn(mock(HighlightGroup.class));
+         when(info.getBindingRefs(false)).thenReturn(new ChartRef[0]);
+
+         ChartVSAssembly chart = mock(ChartVSAssembly.class);
+         when(chart.getVSChartInfo()).thenReturn(info);
+
+         assertTrue(WizAutoBindingService.hasHighlightToCarry(chart));
       }
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceChangeTypeFieldFormulaTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceChangeTypeFieldFormulaTest.java
@@ -38,6 +38,7 @@ import inetsoft.uql.viewsheet.graph.ChartRef;
 import inetsoft.uql.viewsheet.graph.VSChartAggregateRef;
 import inetsoft.uql.viewsheet.graph.VSChartDimensionRef;
 import inetsoft.uql.viewsheet.graph.VSChartInfo;
+import inetsoft.web.vswizard.handler.SyncChartHandler;
 import inetsoft.web.vswizard.model.recommender.VSTemporaryInfo;
 import inetsoft.web.vswizard.service.VSWizardTemporaryInfoService;
 import inetsoft.web.wiz.BindingFieldSettings;
@@ -207,7 +208,7 @@ class WizAutoBindingServiceChangeTypeFieldFormulaTest {
    @Tag("core")
    static class ApplyResolvedFormulaOverridesDispatchTest {
       private final WizAutoBindingService service =
-         new WizAutoBindingService(null, null, null, null, null, null, null);
+         new WizAutoBindingService(null, null, null, null, null, null, null, null);
 
       @Test
       void dispatchesChartAssemblyToApplyFieldConfigs() {
@@ -259,6 +260,63 @@ class WizAutoBindingServiceChangeTypeFieldFormulaTest {
    }
 
    /**
+    * syncHighlightOnTypeChange(VSAssembly, VSAssembly) — the fix for the reported bug: a highlight
+    * applied via /viewsheet/highlight disappeared after switching chart type through the GUI's
+    * "change chart style" action (candidate-type buttons), because changeType()'s fast path never
+    * ran SyncInfoHandler#syncConfigs (that only fires on the /viewsheet/autoBinding path — see
+    * WizVsService's syncSource block). Only the chart/chart dispatch is exercised here — the actual
+    * ref-matching and HighlightGroup copy is SyncChartHandler#syncHighlight's own concern, covered by
+    * its own tests.
+    */
+   @Tag("core")
+   static class SyncHighlightOnTypeChangeTest {
+      private SyncChartHandler syncChartHandler;
+      private WizAutoBindingService service;
+
+      @BeforeEach
+      void setUp() {
+         syncChartHandler = mock(SyncChartHandler.class);
+         service = new WizAutoBindingService(null, null, null, null, null, null, null, syncChartHandler);
+      }
+
+      @Test
+      void copiesHighlightWhenBothSidesAreCharts() {
+         ChartVSAssembly fromChart = mock(ChartVSAssembly.class);
+         ChartVSAssembly toChart = mock(ChartVSAssembly.class);
+
+         service.syncHighlightOnTypeChange(fromChart, toChart);
+
+         verify(syncChartHandler).syncHighlight(fromChart, toChart);
+      }
+
+      @Test
+      void sourceNotAChartIsANoOp() {
+         TableVSAssembly fromTable = mock(TableVSAssembly.class);
+         ChartVSAssembly toChart = mock(ChartVSAssembly.class);
+
+         service.syncHighlightOnTypeChange(fromTable, toChart);
+
+         verify(syncChartHandler, never()).syncHighlight(any(), any());
+      }
+
+      @Test
+      void targetNotAChartIsANoOp() {
+         ChartVSAssembly fromChart = mock(ChartVSAssembly.class);
+         TableVSAssembly toTable = mock(TableVSAssembly.class);
+
+         service.syncHighlightOnTypeChange(fromChart, toTable);
+
+         verify(syncChartHandler, never()).syncHighlight(any(), any());
+      }
+
+      @Test
+      void nullAssembliesAreANoOp() {
+         assertDoesNotThrow(() -> service.syncHighlightOnTypeChange(null, null));
+         verify(syncChartHandler, never()).syncHighlight(any(), any());
+      }
+   }
+
+   /**
     * applyFieldConfigsToTempChart(RuntimeViewsheet, Map) — records the caller's field settings on the
     * autoBinding RVS's TEMP CHART x/y refs, not just on the rendered assembly.
     *
@@ -276,7 +334,7 @@ class WizAutoBindingServiceChangeTypeFieldFormulaTest {
       @BeforeEach
       void setUp() {
          tempInfoService = mock(VSWizardTemporaryInfoService.class);
-         service = new WizAutoBindingService(null, null, tempInfoService, null, null, null, null);
+         service = new WizAutoBindingService(null, null, tempInfoService, null, null, null, null, null);
       }
 
       private static DimensionFieldInfo topN(String field, int n, String rankingCol) {
@@ -394,7 +452,7 @@ class WizAutoBindingServiceChangeTypeFieldFormulaTest {
       @BeforeEach
       void setUp() {
          tempInfoService = mock(VSWizardTemporaryInfoService.class);
-         service = new WizAutoBindingService(null, null, tempInfoService, null, null, null, null);
+         service = new WizAutoBindingService(null, null, tempInfoService, null, null, null, null, null);
       }
 
       private static VSChartDimensionRef rankedTempDim(String field) {
@@ -771,7 +829,7 @@ class WizAutoBindingServiceChangeTypeFieldFormulaTest {
 
       @BeforeEach
       void setUp() {
-         service = new WizAutoBindingService(null, null, null, null, null, null, null);
+         service = new WizAutoBindingService(null, null, null, null, null, null, null, null);
       }
 
       private static ChartVSAssembly chartBinding(String... columns) {
@@ -865,7 +923,7 @@ class WizAutoBindingServiceChangeTypeFieldFormulaTest {
       @BeforeEach
       void setUp() {
          wizVsService = mock(WizVsService.class);
-         service = new WizAutoBindingService(null, null, null, null, null, wizVsService, null);
+         service = new WizAutoBindingService(null, null, null, null, null, wizVsService, null, null);
       }
 
       @Test

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartColorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartColorsTest.java
@@ -105,7 +105,7 @@ class WizAutoBindingServiceSetChartColorsTest {
       securityEngine = mock(SecurityEngine.class);
       when(securityEngine.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
       service = new WizAutoBindingService(
-         viewsheetService, null, null, null, null, wizVsService, securityEngine);
+         viewsheetService, null, null, null, null, wizVsService, securityEngine, null);
 
       // Real Viewsheet/assembly/info objects need SreeEnv (Spring context), so mock the
       // whole chain and hand the service a mock measure ref to capture the applied frame.

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartFormatTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartFormatTest.java
@@ -79,7 +79,7 @@ class WizAutoBindingServiceSetChartFormatTest {
       securityEngine = mock(SecurityEngine.class);
       when(securityEngine.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
       service = new WizAutoBindingService(
-         viewsheetService, null, null, null, null, wizVsService, securityEngine);
+         viewsheetService, null, null, null, null, wizVsService, securityEngine, null);
 
       // getChartInfo() and getVSAssemblyInfo() both return the ChartVSAssemblyInfo for a chart;
       // one mock backs both. A title-only request leaves the descriptor null, so every axis/


### PR DESCRIPTION
## Summary
- Bug #76025: a chart highlight applied via `/viewsheet/highlight` disappeared after switching chart type through the GUI's "change chart style" candidate buttons (`changeType()`), and disappeared again on a second switch even after a first fix.
- `WizAutoBindingService.changeType()`'s fast path now carries the highlight from the chart being switched away from onto the freshly-bound chart (via a new `syncHighlightOnTypeChange()`, called after `fetchAssemblyData`) and invalidates the sandbox's stale cached graph, since `createViewsheetSkipExecution` never runs `SyncInfoHandler#syncConfigs`.
- Root cause of the "disappears again on the next switch": `SyncChartHandler#syncHighlight` matched/copied highlight onto **runtime** chart refs, which are transient and regenerated fresh from **design** refs on every execution. Switched it to match on design refs (`getBindingRefs(false)`), mirroring `WizVsService#applyHighlight`'s own approach.
- `WizAutoBindingService` gained a `SyncChartHandler` constructor dependency; updated 5 existing tests' constructor calls accordingly.

## Test plan
- [x] `mvn -o compile` / `test-compile` on `community/core` — clean
- [x] `WizAutoBindingServiceChangeTypeFieldFormulaTest` (incl. new `SyncHighlightOnTypeChangeTest`) — pass
- [x] New `SyncChartHandlerHighlightDesignRefsTest` (real-object regression for the design-vs-runtime-ref root cause) — pass
- [x] Existing `SyncChartHandlerNullTempInfoTest` — pass (unaffected)
- [ ] Manual UI verification: create chart → apply highlight → switch type → switch type again, confirm highlight survives both switches

🤖 Generated with [Claude Code](https://claude.com/claude-code)