### PR TITLE
Bug #76024, fix Top-N group-others merge for none-formula measures in CrossTabFilter

### DIFF
--- a/core/src/main/java/inetsoft/report/filter/CrossTabFilter.java
+++ b/core/src/main/java/inetsoft/report/filter/CrossTabFilter.java
@@ -4472,11 +4472,25 @@ public class CrossTabFilter extends AbstractTableLens
 
       Formula formula = null;
 
-      try {
-         formula = (Formula) sum[k].clone();
+      // NoneFormula is a pass-through (last-value-wins) formula, only valid when exactly
+      // one raw row maps to a cell. Top-N + "group others" (or any other grouping that
+      // folds multiple already-aggregated rows into one merged cell, e.g. a pre-aggregated
+      // worksheet column bound with formula "none") forces multiple raw rows into this
+      // merged cell; replaying a cloned NoneFormula over them just overwrites the value on
+      // every addValue() call, so the merged cell silently ends up holding whichever row
+      // happened to be processed last instead of the total across the merged rows. Sum is
+      // the correct way to recombine values that are already per-row aggregates.
+      if(!(sum[k] instanceof NoneFormula)) {
+         try {
+            formula = (Formula) sum[k].clone();
+         }
+         catch(Exception e) {
+            LOG.warn("Failed to reset merged grand total formula", e);
+         }
       }
-      catch(Exception e) {
-         LOG.warn("Failed to reset merged grand total formula", e);
+
+      if(formula == null) {
+         formula = new SumFormula();
       }
 
       for(PairN cellPair : list) {

--- a/core/src/test/java/inetsoft/report/filter/CrossTabFilterTest.java
+++ b/core/src/test/java/inetsoft/report/filter/CrossTabFilterTest.java
@@ -19,6 +19,7 @@
 package inetsoft.report.filter;
 
 import inetsoft.report.composition.execution.AssetQuerySandbox;
+import inetsoft.report.lens.DefaultTableLens;
 import inetsoft.test.*;
 import inetsoft.uql.XTable;
 import inetsoft.uql.asset.Worksheet;
@@ -64,5 +65,52 @@ public class CrossTabFilterTest {
                                                         dcol, formulas);
       XTable deserializedTable = TestSerializeUtils.serializeAndDeserialize(originalTable);
       Assertions.assertEquals(CrossTabFilter.class, deserializedTable.getClass());
+   }
+
+   /**
+    * A measure bound with formula "none" is valid only when the worksheet already
+    * pre-aggregates to exactly one row per dimension value (e.g. a mirror table that
+    * grouped by STATE and computed a DistinctCount alias). Applying a chart/crosstab-level
+    * "top N + group others" ranking on that dimension folds the non-top-N rows into a
+    * single merged "Others" cell, so the crosstab must re-total those already-aggregated
+    * rows. Before the fix, the merged cell was recomputed by replaying a cloned NoneFormula
+    * over every merged row — NoneFormula.addValue() overwrites rather than accumulates, so
+    * the "Others" cell ended up holding whatever row was processed last (here, WA's 1)
+    * instead of the sum of all merged rows (NY+TX+WA = 6).
+    */
+   @Test
+   public void testTopNGroupOthersWithNoneFormulaSumsMergedRows() {
+      Object[][] data = new Object[][]{
+         { "STATE", "CUSTOMER_COUNT" },
+         { "NJ", 6 },
+         { "CA", 4 },
+         { "MA", 4 },
+         { "NY", 3 },
+         { "TX", 2 },
+         { "WA", 1 },
+      };
+
+      int[] rowh = new int[]{ 0 };
+      int[] colh = new int[0];
+      int[] dcol = new int[]{ 1 };
+      Formula[] formulas = new Formula[]{ new NoneFormula() };
+
+      CrossTabFilter table = new CrossTabFilter(new DefaultTableLens(data), rowh, colh, dcol,
+                                                formulas);
+      // top 3 states by CUSTOMER_COUNT, remaining states grouped into "Others".
+      table.setRowTopN(0, 0, 3, false, true);
+
+      Object othersTotal = null;
+
+      for(int r = 0; r < table.getRowCount(); r++) {
+         if("Others".equals(table.getObject(r, 0))) {
+            othersTotal = table.getObject(r, 1);
+         }
+      }
+
+      Assertions.assertNotNull(othersTotal, "Others row not found in crosstab output");
+      Assertions.assertEquals(6.0, ((Number) othersTotal).doubleValue(), 0.0001,
+                              "Others should sum the merged NY+TX+WA rows (3+2+1=6), " +
+                              "not just the last-processed row's raw value");
    }
 }


### PR DESCRIPTION
## Summary
- `CrossTabFilter.getMergedFormula(int, Tuple, Tuple)` recomputes a merged "Others" cell (Top-N + group-others) by cloning the bound `Formula` and replaying it over every raw row folded into that cell. That's correct for real accumulators (Sum/Max/Count/...), but `NoneFormula.addValue()` overwrites its value instead of accumulating — so a measure bound with `aggregateFormula: "none"` (e.g. a worksheet that already pre-aggregated to one row per dimension value, such as a `DistinctCount` mirror table) ended up with the "Others" cell holding whichever underlying row was processed last, not the sum across the merged rows.
- Fix: substitute a fresh `SumFormula` whenever the bound formula is `NoneFormula`, since summing already-per-row-aggregated values is the correct way to recombine them.
- Added a regression test (`CrossTabFilterTest.testTopNGroupOthersWithNoneFormulaSumsMergedRows`) that reproduces the exact scenario: 6 states, Top-3 + group-others, `NoneFormula` measure. Verified the test fails without the fix (`expected: 6.0 but was: 1.0`) and passes with it.

## Test plan
- [x] `mvn test -pl community/core -am -Dtest=CrossTabFilterTest` — 3/3 pass
- [x] Confirmed regression: reverted only the `CrossTabFilter.java` change (kept the test) and reran — test fails with `expected: <6.0> but was: <1.0>`, matching the reported bug's wrong "Others" value
- [x] Restored the fix and reran — 3/3 pass again

🤖 Generated with [Claude Code](https://claude.com/claude-code)