### PR TITLE
Bug #75997, fix spurious delete-permission warning when creating a private worksheet folder

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryFolderService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/repository/RepositoryFolderService.java
@@ -58,7 +58,13 @@ public class RepositoryFolderService {
    {
       owner = owner != null && owner.name.length() > 0 ? owner : null;
       ResourceType resourceType = isWorksheetFolder ? ResourceType.ASSET : ResourceType.REPORT;
-      registryManager.checkPermission(path, resourceType, ResourceAction.ADMIN, principal);
+
+      // private/owned assets (e.g. a user's own "My Dashboards"/"Data Worksheets" folders)
+      // are not governed by the shared security policy grid, so skip the ADMIN check for
+      // them just like the security tab is hidden for them below.
+      if(owner == null && !Tool.MY_DASHBOARD.equals(path)) {
+         registryManager.checkPermission(path, resourceType, ResourceAction.ADMIN, principal);
+      }
       RepletRegistry registry = repletRegistryManager.getRegistry(owner);
       String folderName = "/".equals(path) ? "/" : registryManager.getName(path);
       int idx = path.lastIndexOf(folderName);


### PR DESCRIPTION
## Summary
- Creating a folder under a non-admin user's own private "Data Worksheets" tree (User Private Assets) triggered an unexpected "Permission denied to delete: <name>" toast right after the folder was successfully created.
- Root cause: `RepositoryFolderService.getSettings()` ran an unconditional `ADMIN` permission check on the new folder. Private/owned assets (owner != null, or the `MY_DASHBOARD` root) are not governed by the shared security policy grid — this is already recognized a few lines later where the security tab is hidden for these paths — but the earlier ADMIN check had no such exemption, so it failed for the non-admin owner and got mislabeled as a delete-authority error.
- Fix: skip the ADMIN check for owned/private folders, mirroring the existing `securityTabEnabled` exemption in the same method.

## Test plan
- [ ] Create a non-admin user with EM access, log in as that user, and create a folder under User Private Assets/<user>/Data Worksheets — verify no permission-denied toast appears and the folder is created normally.
- [ ] Verify folder settings/security tab behavior for shared (non-private) worksheet and report folders is unchanged for both admin and non-admin users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)