### PR TITLE
Bug #76012, fix org-scope exclusion for CheckPermissionStrategy property

### DIFF
--- a/core/src/main/java/inetsoft/sree/PropertiesEngine.java
+++ b/core/src/main/java/inetsoft/sree/PropertiesEngine.java
@@ -1048,6 +1048,6 @@ public class PropertiesEngine {
    private final Map<String, String> propertyNameCaseCache = new ConcurrentHashMap<>();
    private static final Set<String> EXCLUDED_ORG_PROPERTIES = Set.of(
       "security.enabled", "sree.security.listeners", "security.cache", "security.cache.interval",
-      "inetsoft.sree.security.CheckPermissionStrategy");
+      "inetsoft.sree.security.checkpermissionstrategy");
    private static final Logger LOG = LoggerFactory.getLogger(PropertiesEngine.class);
 }


### PR DESCRIPTION
## Summary
- `EXCLUDED_ORG_PROPERTIES` in `PropertiesEngine` listed `inetsoft.sree.security.CheckPermissionStrategy` in mixed case, but property lookups always compare against the case-normalized (lowercased) name before checking the exclusion set.
- As a result this entry never matched, so the property was incorrectly org-scopable — an organization could override the global permission-check strategy for itself via `inetsoft.org.<orgID>.inetsoft.sree.security.checkpermissionstrategy`, which the exclusion list exists to prevent.
- Fixed by lowercasing the entry to match the normalized lookup key. The other four entries were already lowercase and unaffected.

## Test plan
- [x] Traced `CompositeSecurityProvider.createCheckPermissionStrategy()` → `SreeEnv.getProperty(CheckPermissionStrategy.class.getName())` → `PropertiesEngine.getProperty` (org-scoped by default) → `fixPropertyName` → `computePropertyNameCase` (lowercases the name) → `useAvailableOrgProperty` now correctly matches the exclusion set and short-circuits before consulting any per-org override.