### PR TITLE
Bug #76013, fix org admin Look and Feel save writing repository tree sort globally

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/presentation/LookAndFeelService.java
+++ b/core/src/main/java/inetsoft/web/admin/presentation/LookAndFeelService.java
@@ -158,7 +158,7 @@ public class LookAndFeelService {
       String sort = model.ascending() ? "Ascending" : "Descending";
       int repoTree = model.repositoryTree() ? 0 : 1;
 
-      SreeEnv.setProperty("repository.tree.sort", sort);
+      SreeEnv.setProperty("repository.tree.sort", sort, !globalSettings);
       manager.setReportListType(repoTree);
       manager.setAutoExpand(model.expand());
 
@@ -245,7 +245,7 @@ public class LookAndFeelService {
       if(globalSettings) {
          int repoTree = 0;
 
-         SreeEnv.setProperty("repository.tree.sort", defaultProp.getProperty("repository.tree.sort"));
+         SreeEnv.setProperty("repository.tree.sort", defaultProp.getProperty("repository.tree.sort"), !globalSettings);
          manager.setReportListType(repoTree);
          manager.setAutoExpand(false);
          manager.setLogoStyle(false);


### PR DESCRIPTION
## Summary
- `LookAndFeelService.setModel` wrote `repository.tree.sort` with the unscoped 2-arg `SreeEnv.setProperty` overload, outside the `if(globalSettings)` branch that every other property write in this method (and its sibling services like `ShareSettingsService`) uses to route writes per organization.
- As a result, an org admin saving Settings > Presentation > Look and Feel changed the repository tree sort order (Ascending/Descending) for every organization on the server, with no error or indication the change was server-wide.
- Threaded the `globalSettings` flag into the write: `SreeEnv.setProperty("repository.tree.sort", sort, !globalSettings)`.
- Also updated the equivalent write in `resetSettings` (already inside its own `if(globalSettings)` block, so not independently reachable by an org admin) for consistency.

## Test plan
- [ ] As an org admin, change Repository Tree Sort under Settings > Presentation > Look and Feel and save; verify only that organization's setting changes.
- [ ] As a site admin, change the same setting and verify it still applies globally as before.
- [ ] Verify Reset to defaults still behaves as before for both site admin and org admin.