### PR TITLE
Bug #76026, fix theme NPE when resetting format on table header

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/controller/FormatPainterService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/FormatPainterService.java
@@ -789,6 +789,10 @@ public class FormatPainterService {
          return warnStringFormat;
       }
 
+      if(format == null) {
+         return warnStringFormat;
+      }
+
       String formatType = format.getFormat();
       boolean badFormat = false;
       Pattern PLACEHOLDER = Pattern.compile("\\s*Cell \\[\\d+,\\d+\\]\\s*");


### PR DESCRIPTION
## Summary
- Fix a `NullPointerException` in `FormatPainterService.handleHeaderFormats()` when resetting a header format on a table column
- `event.getFormat()` is `null` when the user clicks Reset on the Format tab, but the method dereferenced it unconditionally via `format.getFormat()`

## Test plan
- [ ] Open a viewsheet with a table in composer
- [ ] Click a header cell, open the Format tab
- [ ] Click Reset, confirm the dialog — verify no NPE / console error and the format resets correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)