### PR TITLE
Bug #76041, fix selection parameters not sent to hyperlink-target viewsheet

### DIFF
--- a/core/src/main/java/inetsoft/uql/script/VariableScriptable.java
+++ b/core/src/main/java/inetsoft/uql/script/VariableScriptable.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.uql.script;
 
+import inetsoft.sree.security.SRPrincipal;
 import inetsoft.uql.VariableTable;
 import inetsoft.util.script.JavaScriptEngine;
 import inetsoft.util.script.graal.ScriptScope;
@@ -199,6 +200,13 @@ public class VariableScriptable implements ScriptScope {
 
          try {
             Object val = vars.get(name);
+
+            if(val instanceof Object[]) {
+               val = Arrays.asList((Object[]) val);
+            }
+            else if(val instanceof SRPrincipal) {
+               val = ((SRPrincipal) val).toString(false);
+            }
 
             if(sb.length() > 0) {
                sb.append(", ");

--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSLifecycleControllerService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSLifecycleControllerService.java
@@ -75,19 +75,12 @@ public class VSLifecycleControllerService {
                Object paramValue = hyperlinkRef.getParameter(pname);
                String[] values = new String[0];
 
+               // When adding parameters from selections, the parameter value can be an
+               // array with one entry per selected value.
                if(Tool.getDataType(paramValue).equals(Tool.ARRAY)) {
-                  if(((Object[]) paramValue).length > 0) {
-                     paramValue = ((Object[]) paramValue)[0].toString().split("\\^");
-                     Object[] params =
-                        (Object[]) Tool.getData(Tool.ARRAY, Tool.getDataString(paramValue));
-
-                     if(params != null && params.length > 0) {
-                        values = Arrays.stream(params)
-                           .map((param) -> Tool.getData(Tool.getDataType(param),
-                                                        Tool.getDataString(param)).toString())
-                           .toArray(String[]::new);
-                     }
-                  }
+                  values = Arrays.stream((Object[]) paramValue)
+                     .map(Tool::getDataString)
+                     .toArray(String[]::new);
                }
                else {
                   values = new String[]{ Tool.getDataString(paramValue) };

--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSLifecycleService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSLifecycleService.java
@@ -255,7 +255,8 @@ public class VSLifecycleService {
 
       // Add selection parameters if hyperlinkSourceID is set
       if(event.getHyperlinkSourceId() != null) {
-         serviceProxy.setRuntimeParameters(event.getHyperlinkSourceId(), parameters, principal);
+         parameters = serviceProxy.setRuntimeParameters(
+            event.getHyperlinkSourceId(), parameters, principal);
       }
 
       VariableTable variables = parameterService.readParameters(parameters);


### PR DESCRIPTION
## Summary
- `VSLifecycleService` discarded the updated parameter map returned by the cluster-proxied `setRuntimeParameters` call, so selection values from `SelectionList`/`SelectionTree` never reached a hyperlink-target viewsheet's variable table.
- `VSLifecycleControllerService` only read index `[0]` of each selection's value array and mangled it through a bogus `^`-split, dropping every other selected value.
- `VariableScriptable.toString()` printed array-valued and principal-valued parameters using Java's default `Object[]` toString(), so any script referencing the whole `parameter` scope (e.g. `Text1.value = parameter`) rendered `[Ljava.lang.Object;@hash` instead of readable values — now formatted the same way `VariableTable.toString()` already does.

## Test plan
- [x] Repro from the bug report: open `VS-Hyperlink/hyper9`, select AZ/CA in `SelectionList1` and Animal World/Barbie's Fashion in `SelectionTree2`, click `ClickMe_vsLink` — target viewsheet now receives the full selection value arrays (verified via debug logging before removal).
- [x] `core` module compiles cleanly (`./mvnw -pl core -am compile -DskipTests`).