### PR TITLE
Bug #76034, fix custom shapes not deleted when resetting global presentation settings

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/presentation/PresentationSettingsController.java
+++ b/core/src/main/java/inetsoft/web/admin/presentation/PresentationSettingsController.java
@@ -304,7 +304,9 @@ public class PresentationSettingsController {
          timeSettingsService.resetSettings(globalSettings);
          dataSourceVisibilitySettingsService.resetSettings(globalSettings);
          webMapSettingsService.resetSettings(principal, globalSettings);
-         dataSpaceContentSettingsService.deleteDataSpaceNode(ImageShapes.getShapesDirectory(), false);
+         String shapesDirectory = globalSettings ?
+            ImageShapes.getGlobalShapesDirectory() : ImageShapes.getShapesDirectory();
+         dataSpaceContentSettingsService.deleteDataSpaceNode(shapesDirectory, false);
          welcomePageService.resetSettings(globalSettings);
          loginBannerSettingsService.resetSettings(globalSettings);
 


### PR DESCRIPTION
## Summary
- Resetting presentation settings at the host/global level deleted the org-scoped shapes directory instead of the global shapes directory the Custom Shapes upload actually writes to, so uploaded shapes survived a reset.
- `PresentationSettingsController.resetSettings()` now picks the same directory the upload path uses, based on the already-computed `globalSettings` flag.

## Test plan
- [ ] As host/global admin: EM → Presentation Settings → Look and Feel → Custom Shapes → upload a gif → close dialog → Reset to Default → OK → reopen Custom Shapes → confirm the gif is gone.
- [ ] As an org admin: repeat the same steps for an organization and confirm shapes still reset correctly (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)