### PR TITLE
Update ai assistant package version to most recent build

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -22,7 +22,7 @@
         "@angular/router": "^21.2.15",
         "@ckeditor/ckeditor5-angular": "^9.1.0",
         "@ctrl/tinycolor": "^3.4.1",
-        "@inetsoft-technology/ai-assistant": "^0.0.20260729181003",
+        "@inetsoft-technology/ai-assistant": "^0.0.20260811213502",
         "@ng-bootstrap/ng-bootstrap": "^20.0.0",
         "@popperjs/core": "^2.11.8",
         "@thebespokepixel/es-tinycolor": "^2.1.1",
@@ -5030,9 +5030,9 @@
       }
     },
     "node_modules/@inetsoft-technology/ai-assistant": {
-      "version": "0.0.20260729181003",
-      "resolved": "https://npm.pkg.github.com/download/@inetsoft-technology/ai-assistant/0.0.20260729181003/f75eca8f06225b3b6c2f2c830a9b8c2246b58b70",
-      "integrity": "sha512-wLvKi1Mt01HJstSl5c30KKaOBH+1n8XufgZKDVVJ+q/4yUXibca2m4dEqlBK2Lql/+EXNWkN/sntMNHOnwudJg=="
+      "version": "0.0.20260811213502",
+      "resolved": "https://npm.pkg.github.com/download/@inetsoft-technology/ai-assistant/0.0.20260811213502/ffa5645e3745b782dc8b0a4315c9b8c5303c35db",
+      "integrity": "sha512-63pMni8p2rF5GC80Qc8LoPIOshK1cRAgt5qF/OY8J4k2i+D/iLmkLFEvHchmuQ8DwQ8Xu9R+FNgwSxe4lRoeCQ=="
     },
     "node_modules/@inquirer/ansi": {
       "version": "2.0.5",

--- a/web/package.json
+++ b/web/package.json
@@ -35,7 +35,7 @@
     "@angular/router": "^21.2.15",
     "@ckeditor/ckeditor5-angular": "^9.1.0",
     "@ctrl/tinycolor": "^3.4.1",
-    "@inetsoft-technology/ai-assistant": "^0.0.20260729181003",
+    "@inetsoft-technology/ai-assistant": "^0.0.20260811213502",
     "@ng-bootstrap/ng-bootstrap": "^20.0.0",
     "@popperjs/core": "^2.11.8",
     "@thebespokepixel/es-tinycolor": "^2.1.1",


### PR DESCRIPTION
## Summary
- Bump `@inetsoft-technology/ai-assistant` from `0.0.20260729181003` to `0.0.20260811213502` in `web/package.json` and `web/package-lock.json`, matching the newly published build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)