### PR TITLE
Update ai assistant package version to most recent build

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -21,7 +21,7 @@
         "@angular/router": "^15.2.0",
         "@ckeditor/ckeditor5-angular": "^8.0.0",
         "@ctrl/tinycolor": "^3.4.1",
-        "@inetsoft-technology/ai-assistant": "^0.0.20260706011006",
+        "@inetsoft-technology/ai-assistant": "^0.0.20260811213502",
         "@ng-bootstrap/ng-bootstrap": "^14.2.0",
         "@thebespokepixel/es-tinycolor": "^2.1.1",
         "approx-string-match": "^2.0.0",
@@ -4260,9 +4260,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@inetsoft-technology/ai-assistant": {
-      "version": "0.0.20260706011006",
-      "resolved": "https://npm.pkg.github.com/download/@inetsoft-technology/ai-assistant/0.0.20260706011006/709b071c32ea4bf74f2924a7c39b145f13924870",
-      "integrity": "sha512-KuJMup6cw4HCWmuhM6CfKSjJ1POxYEuixZ3k+XBLvVKneaOJSzP6vgdRS0HNKz/vnWiFWtLQTgyptD9907xgZQ=="
+      "version": "0.0.20260811213502",
+      "resolved": "https://npm.pkg.github.com/download/@inetsoft-technology/ai-assistant/0.0.20260811213502/ffa5645e3745b782dc8b0a4315c9b8c5303c35db",
+      "integrity": "sha512-63pMni8p2rF5GC80Qc8LoPIOshK1cRAgt5qF/OY8J4k2i+D/iLmkLFEvHchmuQ8DwQ8Xu9R+FNgwSxe4lRoeCQ=="
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",

--- a/web/package.json
+++ b/web/package.json
@@ -32,7 +32,7 @@
     "@angular/router": "^15.2.0",
     "@ckeditor/ckeditor5-angular": "^8.0.0",
     "@ctrl/tinycolor": "^3.4.1",
-    "@inetsoft-technology/ai-assistant": "^0.0.20260706011006",
+    "@inetsoft-technology/ai-assistant": "^0.0.20260811213502",
     "@ng-bootstrap/ng-bootstrap": "^14.2.0",
     "@thebespokepixel/es-tinycolor": "^2.1.1",
     "approx-string-match": "^2.0.0",


### PR DESCRIPTION
## Summary
- Bump `@inetsoft-technology/ai-assistant` from `0.0.20260706011006` to `0.0.20260811213502` in `web/package.json` and `web/package-lock.json`, matching the newly published build.
- Targets the `v1.1.x` release maintenance branch (mirrors #4569 on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)