### PR TITLE
Bug #76028, restore Drill Down/Up Filter toolbar buttons in embedded crosstab

### DIFF
--- a/web/projects/portal/src/app/common/test/test-utils.ts
+++ b/web/projects/portal/src/app/common/test/test-utils.ts
@@ -404,6 +404,7 @@ export namespace TestUtils {
          timeSeriesNames: [],
          hasHiddenColumn: false,
          metadata: false,
+         filterFields: [],
          trendComparisonAggrNames: [],
          customPeriod: false,
          dateComparisonEnabled: false,

--- a/web/projects/portal/src/app/embed/crosstab/embed-crosstab-actions.spec.ts
+++ b/web/projects/portal/src/app/embed/crosstab/embed-crosstab-actions.spec.ts
@@ -18,6 +18,7 @@
 import { AssemblyActionGroup } from "../../common/action/assembly-action-group";
 import { TableDataPathTypes } from "../../common/data/table-data-path-types";
 import { TestUtils } from "../../common/test/test-utils";
+import { DrillLevel } from "../../composer/data/vs/drill-level";
 import { EmbedAssemblyContextProviderFactory } from "../../vsobjects/context-provider.service";
 import { VSCrosstabModel } from "../../vsobjects/model/vs-crosstab-model";
 import { EmbedCrosstabActions } from "./embed-crosstab-actions";
@@ -157,6 +158,49 @@ describe("EmbedCrosstabActions", () => {
          isImage: false
       }]];
    };
+
+   // ---------------------------------------------------------------- toolbar drill actions
+   //
+   // Drill Down/Up Filter were toolbar buttons on CrosstabActions that createToolbarActions's
+   // full override had dropped - same shape as the menu-only gap above, just on the toolbar
+   // instead of "More".
+
+   it("hides drill down/up filter until a header cell with a drill level is selected", () => {
+      const model = TestUtils.createMockVSCrosstabModel("Crosstab1");
+      const actions = createActions(model);
+
+      expect(find(actions.toolbarActions, "crosstab drilldown").visible()).toBeFalsy();
+      expect(find(actions.toolbarActions, "crosstab drillup").visible()).toBeFalsy();
+   });
+
+   it("hides drill down/up filter for a plain data cell with no drill level", () => {
+      const model = TestUtils.createMockVSCrosstabModel("Crosstab1");
+      const actions = createActions(model);
+      selectNonDrillableDataCell(model);
+
+      expect(find(actions.toolbarActions, "crosstab drilldown").visible()).toBeFalsy();
+      expect(find(actions.toolbarActions, "crosstab drillup").visible()).toBeFalsy();
+   });
+
+   it("shows drill down filter (not drill up) for a root-level drillable header cell", () => {
+      const model = TestUtils.createMockVSCrosstabModel("Crosstab1");
+      const actions = createActions(model);
+      selectDrillableHeaderCell(model);
+      model.cells[0][0].drillLevel = DrillLevel.Root;
+
+      expect(find(actions.toolbarActions, "crosstab drilldown").visible()).toBeTruthy();
+      expect(find(actions.toolbarActions, "crosstab drillup").visible()).toBeFalsy();
+   });
+
+   it("shows both drill down and drill up filter for a middle-level drillable header cell", () => {
+      const model = TestUtils.createMockVSCrosstabModel("Crosstab1");
+      const actions = createActions(model);
+      selectDrillableHeaderCell(model);
+      model.cells[0][0].drillLevel = DrillLevel.Middle;
+
+      expect(find(actions.toolbarActions, "crosstab drilldown").visible()).toBeTruthy();
+      expect(find(actions.toolbarActions, "crosstab drillup").visible()).toBeTruthy();
+   });
 
    it("should not show Show Details or Export in the context menu", () => {
       const model = TestUtils.createMockVSCrosstabModel("Crosstab1");

--- a/web/projects/portal/src/app/embed/crosstab/embed-crosstab-actions.ts
+++ b/web/projects/portal/src/app/embed/crosstab/embed-crosstab-actions.ts
@@ -124,6 +124,28 @@ export class EmbedCrosstabActions extends CrosstabActions {
    protected createToolbarActions(groups: AssemblyActionGroup[]): AssemblyActionGroup[] {
       groups.push(new AssemblyActionGroup([
          {
+            // Copied verbatim from CrosstabActions.createToolbarActions - id/label/icon/enabled/
+            // visible unchanged. Click handling (drillAction()) already lives in the shared
+            // vs-crosstab.component.ts switch on the action id, and the resulting DrillEvent
+            // travels the same viewsheetClient/STOMP path the regular Viewer uses, so restoring
+            // these two entries is enough to make drill-down/up work in the embed too - nothing
+            // else needs to change.
+            id: () => "crosstab drilldown",
+            label: () => "_#(js:Drill Down Filter)",
+            icon: () => "drill-down-filter-icon",
+            enabled: () => true,
+            visible: () => this.drillActionVisible() && this.isActionVisibleInViewer("Drill Down Filter")
+               && !this.isDataTip() && !this.isPopComponent()
+         },
+         {
+            id: () => "crosstab drillup",
+            label: () => "_#(js:Drill Up Filter)",
+            icon: () => "drill-up-filter-icon",
+            enabled: () => true,
+            visible: () => this.drillActionVisible(true) && this.isActionVisibleInViewer("Drill Up Filter")
+               && !this.isDataTip() && !this.isPopComponent()
+         },
+         {
             // Deliberately independent of this.model.maxMode / openMaxMode()/closeMaxMode(): in
             // the embed context CoreLifecycleService.applyEmbedChartSize() always sets the
             // assembly's maxSize to whatever pixel size the embed container was given, so

--- a/web/projects/portal/src/app/vsobjects/action/crosstab-actions.ts
+++ b/web/projects/portal/src/app/vsobjects/action/crosstab-actions.ts
@@ -577,7 +577,11 @@ export class CrosstabActions extends BaseTableActions<VSCrosstabModel> {
       return cell != null && cell.grouped && !dateRange;
    }
 
-   private drillActionVisible(drillUp: boolean = false): boolean {
+   /**
+    * Protected (rather than private) so EmbedCrosstabActions can reuse this verbatim - see
+    * getDrillContextMenuVisible above.
+    */
+   protected drillActionVisible(drillUp: boolean = false): boolean {
       if(this.vsWizardPreview || this.binding || this.model.dateComparisonDefined ||
          this.model.sourceType == SourceInfoType.VS_ASSEMBLY)
       {


### PR DESCRIPTION
## Summary
- `EmbedCrosstabActions.createToolbarActions()` fully overrides `CrosstabActions.createToolbarActions()` without calling `super()`, which had silently dropped the "crosstab drilldown"/"crosstab drillup" toolbar buttons (same shape as the menu-only gap fixed in bug-75961). Restored verbatim from the parent class - id/label/icon/enabled/visible unchanged.
- Widened `drillActionVisible()` from `private` to `protected` on `CrosstabActions` so the embed subclass can reuse it, following the existing `getDrillLabel()`/`getDrillContextMenuVisible()` precedent.
- Click handling (`drillAction()` in `vs-crosstab.component.ts`) and the backend drill/filter STOMP pipeline are already shared with the regular Viewer, so nothing else needed to change.
- Fixed `createMockVSCrosstabModel` missing a `filterFields` default (the field exists on `VSCrosstabModel` and `createMockVSChartModel` already set it; crosstab's mock never needed it until the new drill-up tests exercised that branch).

wiz side (stylebi-wiz repo) needs no source change - `embedLabelDictionary.ts` already has the "Drill Down Filter"/"Drill Up Filter" Chinese translations from an earlier pass; they were simply unused dead entries because the buttons never rendered in the embed.

## Test plan
- [x] `embed-crosstab-actions.spec.ts` - added 4 tests (hidden until selection, hidden for plain data cell, Root-level shows drill-down only, Middle-level shows both drill-down and drill-up); 13/13 pass
- [x] `crosstab-actions.spec.ts` regression - 23/23 pass (private→protected didn't change behavior)
- [ ] Manual browser verification in wiz: rebuild `stylebi-embed-elements` (`npm run package:embed`), copy into wiz's `node_modules`, select a header cell on a date-grouped crosstab (e.g. Year/Quarter/Month), confirm the Drill Down Filter button appears and works

🤖 Generated with [Claude Code](https://claude.com/claude-code)