### PR TITLE
Add wiz datasource browsing and JDBC database endpoints

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/WizDatabaseController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizDatabaseController.java
@@ -1,0 +1,266 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.controller;
+
+import inetsoft.uql.XDataSource;
+import inetsoft.uql.XRepository;
+import inetsoft.uql.jdbc.JDBCDataSource;
+import inetsoft.web.portal.data.DataSourceBrowserService;
+import inetsoft.web.portal.data.DataSourceConnectionStatusRequest;
+import inetsoft.web.portal.data.DataSourceInfo;
+import inetsoft.web.portal.data.DataSourceStatus;
+import inetsoft.web.portal.data.ImmutableDataSourceConnectionStatusRequest;
+import inetsoft.web.portal.data.PortalDataType;
+import inetsoft.web.portal.service.datasource.DataSourceStatusService;
+import inetsoft.web.wiz.model.WizDatasourceBrowserModel;
+import inetsoft.web.wiz.model.WizDatasourceEntry;
+import inetsoft.web.wiz.model.WizDatasourceStatus;
+import inetsoft.web.wiz.request.WizDatasourceSearchRequest;
+import inetsoft.web.wiz.request.WizDatasourceStatusRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.util.*;
+
+/**
+ * Repository browsing for the wiz portal's data source management pages.
+ *
+ * <p>Lives under {@code /api/wiz} rather than proxying the native {@code /api/data/**} endpoints
+ * because the two filters that gate those prefixes disagree: {@code CSRFFilter} exempts only
+ * {@code /api/wiz/**}, while {@code AbstractSecurityFilter} authenticates a wiz caller by its
+ * cookie or its path. Calling a native endpoint with a wiz token therefore succeeds for GET and
+ * fails with 403 for every POST — an asymmetry that is very hard to diagnose from the client
+ * side.</p>
+ *
+ * <p>All work is delegated to the portal services, so permission filtering, folder resolution and
+ * connection probing behave exactly as they do in the native portal. Only the response shape
+ * differs: raw enum names and epoch millis instead of {@code Catalog}-translated labels and
+ * server-formatted dates, because the wiz portal does its own i18n.</p>
+ */
+@RestController
+@RequestMapping("/api/wiz")
+public class WizDatabaseController {
+   public WizDatabaseController(DataSourceBrowserService dataSourceBrowserService,
+                                DataSourceStatusService dataSourceStatusService,
+                                XRepository xrepository)
+   {
+      this.dataSourceBrowserService = dataSourceBrowserService;
+      this.dataSourceStatusService = dataSourceStatusService;
+      this.xrepository = xrepository;
+   }
+
+   /**
+    * Lists one folder of the data source repository.
+    *
+    * @param path      the folder to list. Omitted, empty or {@code "/"} lists the root.
+    * @param principal the current user; entries they cannot read are omitted by the service.
+    *
+    * @return the folder contents plus the breadcrumb trail leading to it.
+    */
+   @GetMapping(value = "/datasources/browser", produces = MediaType.APPLICATION_JSON_VALUE)
+   public WizDatasourceBrowserModel getDatasourceBrowser(
+      @RequestParam(value = "path", required = false) String path,
+      Principal principal)
+      throws Exception
+   {
+      String folder = normalizePath(path);
+
+      // root=false always: root=true is the move-dialog mode, which returns the single synthetic
+      // root folder entry instead of the folder contents.
+      List<DataSourceInfo> infos =
+         dataSourceBrowserService.getDataSources(folder, false, null, principal);
+
+      // home=true suppresses the synthetic "/" root crumb, whose label would come pre-translated
+      // from the server. The client renders its own root label.
+      List<DataSourceInfo> crumbs = dataSourceBrowserService.getBreadcrumbs(folder, true, principal);
+      List<String> breadcrumb = new ArrayList<>();
+
+      for(DataSourceInfo crumb : crumbs) {
+         if(crumb != null) {
+            breadcrumb.add(crumb.path());
+         }
+      }
+
+      return new WizDatasourceBrowserModel(toEntries(infos), breadcrumb, folder == null);
+   }
+
+   /**
+    * Searches data source and folder names recursively below a folder.
+    *
+    * @param request   the search scope and the substring to match.
+    * @param principal the current user.
+    *
+    * @return the matching entries, each carrying its full path, best match first. Empty when no
+    *         query was supplied — an empty query would otherwise match the entire repository.
+    */
+   @PostMapping(value = "/datasources/search", produces = MediaType.APPLICATION_JSON_VALUE)
+   public List<WizDatasourceEntry> searchDatasources(
+      @RequestBody WizDatasourceSearchRequest request,
+      Principal principal)
+      throws Exception
+   {
+      String query = request == null ? null : request.query();
+
+      if(query == null || query.isBlank()) {
+         return List.of();
+      }
+
+      String folder = normalizePath(request.path());
+
+      return toEntries(dataSourceBrowserService.getSearchDataSources(folder, query, principal));
+   }
+
+   /**
+    * Reports the recorded connection state of several data sources at once.
+    *
+    * <p>Never re-tests the connections: the underlying service would otherwise open a connection
+    * to every listed data source and write the outcome back to the repository. Browsing a folder
+    * must not have that side effect, so this reads the stored status only.</p>
+    *
+    * @param request   the data source paths to report on.
+    * @param principal the current user.
+    *
+    * @return one status per requested path, in the order requested.
+    */
+   @PostMapping(value = "/datasources/statuses", produces = MediaType.APPLICATION_JSON_VALUE)
+   public List<WizDatasourceStatus> getDatasourceStatuses(
+      @RequestBody WizDatasourceStatusRequest request,
+      Principal principal)
+      throws Exception
+   {
+      List<String> paths = request == null ? null : request.paths();
+
+      if(paths == null || paths.isEmpty()) {
+         return List.of();
+      }
+
+      DataSourceConnectionStatusRequest statusRequest =
+         ImmutableDataSourceConnectionStatusRequest.builder()
+            .paths(paths)
+            .updateStatus(false)
+            .timeZone(TimeZone.getDefault().getID())
+            .build();
+
+      List<DataSourceStatus> statuses =
+         dataSourceStatusService.getDataSourceConnectionStatuses(statusRequest, principal);
+      List<WizDatasourceStatus> result = new ArrayList<>();
+
+      // The service answers positionally and drops the path, so re-attach it by input order. A
+      // data source that has never been tested yields a null status rather than a missing element.
+      for(int i = 0; i < paths.size(); i++) {
+         DataSourceStatus status = i < statuses.size() ? statuses.get(i) : null;
+         result.add(new WizDatasourceStatus(paths.get(i), status != null && status.connected(),
+                                            status == null ? null : status.message()));
+      }
+
+      return result;
+   }
+
+   private List<WizDatasourceEntry> toEntries(List<DataSourceInfo> infos) {
+      List<WizDatasourceEntry> entries = new ArrayList<>();
+
+      if(infos == null) {
+         return entries;
+      }
+
+      for(DataSourceInfo info : infos) {
+         if(info != null) {
+            entries.add(toEntry(info));
+         }
+      }
+
+      return entries;
+   }
+
+   private WizDatasourceEntry toEntry(DataSourceInfo info) {
+      String nodeType = info.type() == null ? null : info.type().name();
+      boolean folder = isFolder(nodeType);
+      String sourceType = null;
+      String databaseType = null;
+
+      if(!folder) {
+         try {
+            XDataSource dataSource = xrepository.getDataSource(info.path());
+
+            if(dataSource != null) {
+               sourceType = dataSource.getType();
+
+               if(dataSource instanceof JDBCDataSource jdbcDataSource) {
+                  databaseType = jdbcDataSource.getDatabaseTypeString();
+               }
+            }
+         }
+         catch(Throwable ex) {
+            // One unreadable data source — a missing driver, a broken definition — must not take
+            // the whole listing down with it. The row still renders, just without a type.
+            LOG.debug("Failed to resolve the type of data source {}: {}", info.path(),
+                      ex.getMessage());
+         }
+      }
+
+      return new WizDatasourceEntry(info.name(), info.path(), nodeType, folder, sourceType,
+                                    databaseType, info.createdBy(), info.createdDate(),
+                                    info.editable(), info.deletable(), info.hasSubFolder());
+   }
+
+   private static boolean isFolder(String nodeType) {
+      if(nodeType == null) {
+         return false;
+      }
+
+      try {
+         return FOLDER_TYPES.contains(PortalDataType.valueOf(nodeType));
+      }
+      catch(IllegalArgumentException ex) {
+         // A node type this build does not know about is treated as a leaf, which is the safe
+         // default: the client will not try to descend into it.
+         return false;
+      }
+   }
+
+   /**
+    * Maps the browser's notion of "no folder" onto the services', which take null for the root but
+    * are given an empty string or a slash by clients that build the path by concatenation.
+    */
+   private static String normalizePath(String path) {
+      if(path == null || path.isBlank() || "/".equals(path)) {
+         return null;
+      }
+
+      return path;
+   }
+
+   private static final Set<PortalDataType> FOLDER_TYPES = EnumSet.of(
+      PortalDataType.FOLDER,
+      PortalDataType.DATA_SOURCE_FOLDER,
+      PortalDataType.DATA_SOURCE_ROOT_FOLDER,
+      PortalDataType.DATA_MODEL_FOLDER,
+      PortalDataType.VPM_FOLDER,
+      PortalDataType.PRIVATE_WORKSHEETS_FOLDER,
+      PortalDataType.SHARED_WORKSHEETS_FOLDER);
+
+   private static final Logger LOG = LoggerFactory.getLogger(WizDatabaseController.class);
+
+   private final DataSourceBrowserService dataSourceBrowserService;
+   private final DataSourceStatusService dataSourceStatusService;
+   private final XRepository xrepository;
+}

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizDatabaseController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizDatabaseController.java
@@ -19,6 +19,9 @@
 package inetsoft.web.wiz.controller;
 
 import inetsoft.report.internal.Util;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
 import inetsoft.uql.XDataSource;
 import inetsoft.uql.XRepository;
 import inetsoft.uql.jdbc.JDBCDataSource;
@@ -37,6 +40,9 @@ import inetsoft.web.portal.data.DataSourceStatus;
 import inetsoft.web.portal.data.ImmutableDataSourceConnectionStatusRequest;
 import inetsoft.web.portal.data.PortalDataType;
 import inetsoft.web.portal.service.datasource.DataSourceStatusService;
+import inetsoft.web.security.PermissionPath;
+import inetsoft.web.security.RequiredPermission;
+import inetsoft.web.security.Secured;
 import inetsoft.web.wiz.model.*;
 import inetsoft.web.wiz.request.*;
 import inetsoft.web.wiz.service.UnsupportedDatasourceException;
@@ -75,6 +81,16 @@ import java.util.*;
  * empty one), a null password is translated here into the mask constant that triggers that recovery,
  * and {@code permissions} is always left null so a save can never write permissions as a side
  * effect.</p>
+ *
+ * <p>Authorization is this controller's own responsibility, not the services'. {@code
+ * DataSourceBrowserService} filters what it lists by READ, but {@code DatabaseDatasourcesService}
+ * and {@code DataSourceStatusService} do not gate their reads at all — the native controllers gate
+ * them with {@code @Secured} before delegating, and the equivalent gates are repeated here. Where
+ * the rule is conditional and an annotation cannot express it — the connection test, which only
+ * needs a permission when it names an existing database — {@code SecurityEngine} is consulted
+ * directly. Every denial leaves as a {@code SecurityException}, which
+ * {@code WizControllerErrorHandler} turns into a 403; this class must therefore never declare a
+ * local {@code @ExceptionHandler}, which would take precedence over that advice.</p>
  */
 @RestController
 @RequestMapping("/api/wiz")
@@ -83,6 +99,7 @@ public class WizDatabaseController {
                                 DataSourceStatusService dataSourceStatusService,
                                 DatabaseDatasourcesService databaseDatasourcesService,
                                 DatabaseTypeService databaseTypeService,
+                                SecurityEngine securityEngine,
                                 Config uqlConfig,
                                 XRepository xrepository)
    {
@@ -90,6 +107,7 @@ public class WizDatabaseController {
       this.dataSourceStatusService = dataSourceStatusService;
       this.databaseDatasourcesService = databaseDatasourcesService;
       this.databaseTypeService = databaseTypeService;
+      this.securityEngine = securityEngine;
       this.uqlConfig = uqlConfig;
       this.xrepository = xrepository;
    }
@@ -162,10 +180,16 @@ public class WizDatabaseController {
     * to every listed data source and write the outcome back to the repository. Browsing a folder
     * must not have that side effect, so this reads the stored status only.</p>
     *
+    * <p>{@code DataSourceStatusService} performs no permission check of its own, so the requested
+    * paths are filtered to those the caller can read before it is handed anything. A path the
+    * caller cannot read is dropped rather than rejected: the client pairs results with requests by
+    * path, so a short answer degrades to "no status known" instead of failing the whole listing,
+    * and a probe learns nothing it did not already supply.</p>
+    *
     * @param request   the data source paths to report on.
     * @param principal the current user.
     *
-    * @return one status per requested path, in the order requested.
+    * @return one status per readable requested path, in the order requested.
     */
    @PostMapping(value = "/datasources/statuses", produces = MediaType.APPLICATION_JSON_VALUE)
    public List<WizDatasourceStatus> getDatasourceStatuses(
@@ -173,9 +197,23 @@ public class WizDatabaseController {
       Principal principal)
       throws Exception
    {
-      List<String> paths = request == null ? null : request.paths();
+      List<String> requested = request == null ? null : request.paths();
 
-      if(paths == null || paths.isEmpty()) {
+      if(requested == null || requested.isEmpty()) {
+         return List.of();
+      }
+
+      List<String> paths = new ArrayList<>();
+
+      for(String path : requested) {
+         if(path != null && securityEngine.checkPermission(
+            principal, ResourceType.DATA_SOURCE, path, ResourceAction.READ))
+         {
+            paths.add(path);
+         }
+      }
+
+      if(paths.isEmpty()) {
          return List.of();
       }
 
@@ -211,21 +249,10 @@ public class WizDatabaseController {
    public WizDatabaseMeta getDatabaseMeta() {
       DriverAvailability availability = databaseDatasourcesService.getDriverAvailability();
       List<WizDatabaseTypeInfo> types = new ArrayList<>();
-      Set<String> seen = new HashSet<>();
 
-      if(availability.getDrivers() != null) {
-         for(DriverAvailability.DriverInfo driver : availability.getDrivers()) {
-            String type = driver == null ? null : driver.getType();
-
-            // Several driver beans can share one type identifier (DB2 and Sybase each ship more
-            // than one driver class), and the editor offers the type, not the driver.
-            if(type == null || EXCLUDED_DATABASE_TYPES.contains(type) || !seen.add(type)) {
-               continue;
-            }
-
-            types.add(
-               new WizDatabaseTypeInfo(type, driver.isInstalled(), driver.getDefaultPort()));
-         }
+      for(DriverAvailability.DriverInfo driver : offeredDrivers(availability)) {
+         types.add(new WizDatabaseTypeInfo(driver.getType(), driver.isInstalled(),
+                                           driver.getDefaultPort()));
       }
 
       String[] driverClasses = availability.getDriverClasses();
@@ -252,6 +279,13 @@ public class WizDatabaseController {
    /**
     * Reads an existing database's connection settings.
     *
+    * <p>Gated on WRITE rather than READ, matching the native
+    * {@code DatabaseDatasourcesController.getDataSourceModel}: the response is the connection's
+    * configuration — host, port, user name, driver class, JDBC or custom URL, pool properties —
+    * which is what an editor needs and what a reader of the data has no business seeing.
+    * {@code DatabaseDatasourcesService} does not check this itself; it uses the principal only to
+    * decide the {@code deletable} flag.</p>
+    *
     * @param path      the database's full repository path.
     * @param principal the current user.
     *
@@ -262,8 +296,13 @@ public class WizDatabaseController {
     *                                        and is edited elsewhere.
     */
    @GetMapping(value = "/databases/definition", produces = MediaType.APPLICATION_JSON_VALUE)
-   public WizDatabaseDefinition getDatabaseDefinition(@RequestParam("path") String path,
-                                                      Principal principal)
+   @Secured({
+      @RequiredPermission(
+         resourceType = ResourceType.DATA_SOURCE, actions = ResourceAction.WRITE
+      )
+   })
+   public WizDatabaseDefinition getDatabaseDefinition(
+      @PermissionPath @RequestParam("path") String path, Principal principal)
       throws Exception
    {
       String database = requirePath(path);
@@ -273,6 +312,11 @@ public class WizDatabaseController {
 
    /**
     * Suggests the connection test query for a database type.
+    *
+    * <p>The type is checked against the list {@code getDatabaseMeta} offers before it is used.
+    * {@code SQLHelper} answers an unrecognized type with its generic base helper, so an unchecked
+    * value would come back as a plausible {@code SELECT 1} attributed to a database the editor
+    * cannot even configure; a rejection is the honest answer.</p>
     *
     * @param type   the database type identifier.
     * @param driver the JDBC driver class. Only consulted for {@code CUSTOM}, whose real product is
@@ -285,6 +329,10 @@ public class WizDatabaseController {
       @RequestParam("type") String type,
       @RequestParam(value = "driver", required = false) String driver)
    {
+      if(!offeredDatabaseTypes().contains(type)) {
+         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unknown database type: " + type);
+      }
+
       String dbType = type;
 
       if(CustomDatabaseType.TYPE.equals(dbType)) {
@@ -299,6 +347,19 @@ public class WizDatabaseController {
    /**
     * Opens a connection with the supplied settings without saving them.
     *
+    * <p>Requires WRITE on {@code path} whenever one is given, and nothing at all when it is
+    * omitted. The asymmetry is the whole point: naming an existing database turns this into a
+    * credential read. The password of an unchanged connection is recovered server-side (see
+    * {@code oldName} below) and then used to connect to whatever host the request's own definition
+    * names, so without the check a caller who cannot read the database at all could recover its
+    * password by pointing the test at a host they control. A request with no path is creating a
+    * connection that does not exist yet: there is no stored credential to recover and the whole
+    * definition, password included, is already the caller's own.</p>
+    *
+    * <p>The condition is why this is an explicit {@code SecurityEngine} call and not a
+    * {@code @Secured} annotation, which would have to demand the permission unconditionally and
+    * would then reject the legitimate "test before creating" case outright.</p>
+    *
     * @param request   the settings to test, and the path of the database they came from when it
     *                  already exists.
     * @param principal the current user.
@@ -308,6 +369,7 @@ public class WizDatabaseController {
    @PostMapping(value = "/databases/test", produces = MediaType.APPLICATION_JSON_VALUE)
    public WizConnectionTestResult testDatabaseConnection(
       @RequestBody WizDatabaseTestRequest request, Principal principal)
+      throws Exception
    {
       WizDatabaseDefinition definition = request == null ? null : request.definition();
 
@@ -316,6 +378,10 @@ public class WizDatabaseController {
       }
 
       String path = normalizePath(request.path());
+
+      if(path != null) {
+         requireDataSourcePermission(path, ResourceAction.WRITE, principal);
+      }
 
       // Same reason as on update: without oldName the stored password cannot be recovered, so a
       // test of an otherwise-unchanged connection would connect with an empty password and fail.
@@ -335,6 +401,10 @@ public class WizDatabaseController {
     * parent folder as its path, which cannot ever succeed — that lookup necessarily finds no data
     * source and reports "Datasource Lost" — so it is not reproduced here.</p>
     *
+    * <p>The permission check up front is defence in depth rather than the only gate:
+    * {@code saveDatabase} refuses an unauthorized create on its own, but only after it has resolved
+    * the folder and read the repository.</p>
+    *
     * @param request   the parent folder and the new database.
     * @param principal the current user.
     *
@@ -349,6 +419,8 @@ public class WizDatabaseController {
       String name = requireName(definition);
       String parentPath = normalizePath(request.parentPath());
 
+      requireCreatePermission(parentPath, principal);
+
       // oldName stays null: a database that does not exist yet has no stored password to recover,
       // and a non-null value would send the recovery lookup after an unrelated data source.
       DatabaseDefinition database = toDatabaseDefinition(definition, null);
@@ -362,6 +434,11 @@ public class WizDatabaseController {
    /**
     * Updates an existing database's connection settings.
     *
+    * <p>Gated the same way as the read, and for a reason the internal check does not cover:
+    * {@code saveDatabase} does verify WRITE, but this method has by then already read the stored
+    * definition in order to carry {@code unasgn} and the credential reference forward. The gate
+    * belongs at the entry point, before anything is read.</p>
+    *
     * @param path       the database's current full repository path. Also the sole source of
     *                   {@code oldName} — see the class javadoc.
     * @param definition the new settings.
@@ -374,7 +451,12 @@ public class WizDatabaseController {
     *                                        database.
     */
    @PostMapping(value = "/databases/update", produces = MediaType.APPLICATION_JSON_VALUE)
-   public WizDatabaseSaveResult updateDatabase(@RequestParam("path") String path,
+   @Secured({
+      @RequiredPermission(
+         resourceType = ResourceType.DATA_SOURCE, actions = ResourceAction.WRITE
+      )
+   })
+   public WizDatabaseSaveResult updateDatabase(@PermissionPath @RequestParam("path") String path,
                                                @RequestBody WizDatabaseDefinition definition,
                                                Principal principal)
       throws Exception
@@ -399,6 +481,84 @@ public class WizDatabaseController {
       int index = database.lastIndexOf('/');
 
       return toSaveResult(status, index < 0 ? name : database.substring(0, index + 1) + name);
+   }
+
+   /**
+    * Fails unless the caller holds the action on a data source.
+    *
+    * <p>Throws {@code java.lang.SecurityException}, which is what {@code SecuredAspect} throws for
+    * the annotated endpoints, so a denial from here and a denial from an annotation reach
+    * {@code WizControllerErrorHandler} — and the client — as the same 403.</p>
+    */
+   private void requireDataSourcePermission(String path, ResourceAction action, Principal principal)
+      throws Exception
+   {
+      if(!securityEngine.checkPermission(principal, ResourceType.DATA_SOURCE, path, action)) {
+         throw new SecurityException(
+            "Unauthorized access to data source \"" + path + "\" by user " + principal);
+      }
+   }
+
+   /**
+    * Fails unless the caller may create a database in a folder.
+    *
+    * <p>The rule is the one {@code DataSourceController} applies to its {@code newDatasourceEnabled}
+    * flag: WRITE on the parent folder, or, at the root only, the standalone
+    * {@code CREATE_DATA_SOURCE} grant that lets a user own data sources without holding the root
+    * folder. The native controller's fuller rule set is not reproduced — this is a guard in front of
+    * {@code saveDatabase}, which enforces the real thing.</p>
+    */
+   private void requireCreatePermission(String parentPath, Principal principal) throws Exception {
+      boolean root = parentPath == null;
+      boolean allowed = securityEngine.checkPermission(
+         principal, ResourceType.DATA_SOURCE_FOLDER, root ? "/" : parentPath, ResourceAction.WRITE);
+
+      if(!allowed && root) {
+         allowed = securityEngine.checkPermission(
+            principal, ResourceType.CREATE_DATA_SOURCE, "*", ResourceAction.ACCESS);
+      }
+
+      if(!allowed) {
+         throw new SecurityException("Unauthorized access to data source folder \"" +
+                                        (root ? "/" : parentPath) + "\" by user " + principal);
+      }
+   }
+
+   /** The database type identifiers the editor offers, i.e. what {@code getDatabaseMeta} returns. */
+   private Set<String> offeredDatabaseTypes() {
+      Set<String> types = new LinkedHashSet<>();
+
+      for(DriverAvailability.DriverInfo driver :
+         offeredDrivers(databaseDatasourcesService.getDriverAvailability()))
+      {
+         types.add(driver.getType());
+      }
+
+      return types;
+   }
+
+   private static List<DriverAvailability.DriverInfo> offeredDrivers(DriverAvailability availability)
+   {
+      List<DriverAvailability.DriverInfo> drivers = new ArrayList<>();
+      Set<String> seen = new HashSet<>();
+
+      if(availability == null || availability.getDrivers() == null) {
+         return drivers;
+      }
+
+      for(DriverAvailability.DriverInfo driver : availability.getDrivers()) {
+         String type = driver == null ? null : driver.getType();
+
+         // Several driver beans can share one type identifier (DB2 and Sybase each ship more than
+         // one driver class), and the editor offers the type, not the driver.
+         if(type == null || EXCLUDED_DATABASE_TYPES.contains(type) || !seen.add(type)) {
+            continue;
+         }
+
+         drivers.add(driver);
+      }
+
+      return drivers;
    }
 
    private List<WizDatasourceEntry> toEntries(List<DataSourceInfo> infos) {
@@ -798,9 +958,13 @@ public class WizDatabaseController {
    /**
     * Database types the wiz editor cannot configure. Access needs a file upload for the .mdb, and
     * ODBC needs the server to enumerate its DSNs; neither has a form here, so neither is offered.
+    *
+    * <p>Only the Access entry currently does anything: no ODBC {@code DatabaseType} bean is
+    * registered, so no driver ever reports that identifier. It is kept so that registering one
+    * would not silently put an unconfigurable type in the dropdown.</p>
     */
    private static final Set<String> EXCLUDED_DATABASE_TYPES =
-      Set.of(AccessDatabaseType.TYPE, "ODBC");
+      Set.of(AccessDatabaseType.TYPE, JDBCDataSource.ODBC);
 
    /** The save path's status strings, mapped to codes the client can branch on. */
    private static final Map<String, String> SAVE_FAILURE_REASONS = Map.of(
@@ -815,6 +979,7 @@ public class WizDatabaseController {
    private final DataSourceStatusService dataSourceStatusService;
    private final DatabaseDatasourcesService databaseDatasourcesService;
    private final DatabaseTypeService databaseTypeService;
+   private final SecurityEngine securityEngine;
    private final Config uqlConfig;
    private final XRepository xrepository;
 }

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizDatabaseController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizDatabaseController.java
@@ -18,9 +18,18 @@
 
 package inetsoft.web.wiz.controller;
 
+import inetsoft.report.internal.Util;
 import inetsoft.uql.XDataSource;
 import inetsoft.uql.XRepository;
 import inetsoft.uql.jdbc.JDBCDataSource;
+import inetsoft.uql.jdbc.SQLHelper;
+import inetsoft.uql.util.Config;
+import inetsoft.util.audit.ActionRecord;
+import inetsoft.web.admin.content.database.*;
+import inetsoft.web.admin.content.database.types.*;
+import inetsoft.web.admin.content.repository.DataSourceSettingsModel;
+import inetsoft.web.admin.content.repository.DatabaseDatasourcesService;
+import inetsoft.web.admin.security.ConnectionStatus;
 import inetsoft.web.portal.data.DataSourceBrowserService;
 import inetsoft.web.portal.data.DataSourceConnectionStatusRequest;
 import inetsoft.web.portal.data.DataSourceInfo;
@@ -28,21 +37,21 @@ import inetsoft.web.portal.data.DataSourceStatus;
 import inetsoft.web.portal.data.ImmutableDataSourceConnectionStatusRequest;
 import inetsoft.web.portal.data.PortalDataType;
 import inetsoft.web.portal.service.datasource.DataSourceStatusService;
-import inetsoft.web.wiz.model.WizDatasourceBrowserModel;
-import inetsoft.web.wiz.model.WizDatasourceEntry;
-import inetsoft.web.wiz.model.WizDatasourceStatus;
-import inetsoft.web.wiz.request.WizDatasourceSearchRequest;
-import inetsoft.web.wiz.request.WizDatasourceStatusRequest;
+import inetsoft.web.wiz.model.*;
+import inetsoft.web.wiz.request.*;
+import inetsoft.web.wiz.service.UnsupportedDatasourceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.security.Principal;
 import java.util.*;
 
 /**
- * Repository browsing for the wiz portal's data source management pages.
+ * Repository browsing and JDBC database editing for the wiz portal's data source management pages.
  *
  * <p>Lives under {@code /api/wiz} rather than proxying the native {@code /api/data/**} endpoints
  * because the two filters that gate those prefixes disagree: {@code CSRFFilter} exempts only
@@ -55,16 +64,33 @@ import java.util.*;
  * connection probing behave exactly as they do in the native portal. Only the response shape
  * differs: raw enum names and epoch millis instead of {@code Catalog}-translated labels and
  * server-formatted dates, because the wiz portal does its own i18n.</p>
+ *
+ * <p>The database editing endpoints likewise delegate to {@code DatabaseDatasourcesService}, the
+ * same service the native editor and the EM use, but they absorb three contracts that service
+ * inherits from its Angular caller and that no typed client can be expected to honour. The native
+ * editor treats the settings model as an opaque envelope it receives and returns untouched; a client
+ * that rebuilds the payload from an interface definition would drop exactly the fields that are not
+ * in the interface. So: {@code oldName} is filled in here from the request path rather than trusted
+ * from the client (without it a save cannot recover the stored password and overwrites it with an
+ * empty one), a null password is translated here into the mask constant that triggers that recovery,
+ * and {@code permissions} is always left null so a save can never write permissions as a side
+ * effect.</p>
  */
 @RestController
 @RequestMapping("/api/wiz")
 public class WizDatabaseController {
    public WizDatabaseController(DataSourceBrowserService dataSourceBrowserService,
                                 DataSourceStatusService dataSourceStatusService,
+                                DatabaseDatasourcesService databaseDatasourcesService,
+                                DatabaseTypeService databaseTypeService,
+                                Config uqlConfig,
                                 XRepository xrepository)
    {
       this.dataSourceBrowserService = dataSourceBrowserService;
       this.dataSourceStatusService = dataSourceStatusService;
+      this.databaseDatasourcesService = databaseDatasourcesService;
+      this.databaseTypeService = databaseTypeService;
+      this.uqlConfig = uqlConfig;
       this.xrepository = xrepository;
    }
 
@@ -175,6 +201,206 @@ public class WizDatabaseController {
       return result;
    }
 
+   /**
+    * Lists the database types the wiz editor can configure, plus the installed driver classes.
+    *
+    * @return the type dropdown's contents. Types whose driver is not installed are still listed —
+    *         the client explains the problem rather than hiding the option.
+    */
+   @GetMapping(value = "/databases/meta", produces = MediaType.APPLICATION_JSON_VALUE)
+   public WizDatabaseMeta getDatabaseMeta() {
+      DriverAvailability availability = databaseDatasourcesService.getDriverAvailability();
+      List<WizDatabaseTypeInfo> types = new ArrayList<>();
+      Set<String> seen = new HashSet<>();
+
+      if(availability.getDrivers() != null) {
+         for(DriverAvailability.DriverInfo driver : availability.getDrivers()) {
+            String type = driver == null ? null : driver.getType();
+
+            // Several driver beans can share one type identifier (DB2 and Sybase each ship more
+            // than one driver class), and the editor offers the type, not the driver.
+            if(type == null || EXCLUDED_DATABASE_TYPES.contains(type) || !seen.add(type)) {
+               continue;
+            }
+
+            types.add(
+               new WizDatabaseTypeInfo(type, driver.isInstalled(), driver.getDefaultPort()));
+         }
+      }
+
+      String[] driverClasses = availability.getDriverClasses();
+
+      return new WizDatabaseMeta(
+         types, driverClasses == null ? List.of() : Arrays.asList(driverClasses));
+   }
+
+   /**
+    * Returns the blank definition a new database starts from.
+    *
+    * @param principal the current user.
+    *
+    * @return a {@code CUSTOM} definition with an empty name, no network location and no
+    *         credentials.
+    */
+   @GetMapping(value = "/databases/template", produces = MediaType.APPLICATION_JSON_VALUE)
+   public WizDatabaseDefinition getDatabaseTemplate(Principal principal) {
+      DataSourceSettingsModel model = databaseDatasourcesService.getDefaultDatabase(principal);
+
+      return toWizDefinition(model.dataSource());
+   }
+
+   /**
+    * Reads an existing database's connection settings.
+    *
+    * @param path      the database's full repository path.
+    * @param principal the current user.
+    *
+    * @return the settings, with the password suppressed.
+    *
+    * @throws UnsupportedDatasourceException if the path names a data source that is not a JDBC
+    *                                        database — a tabular source has no equivalent settings
+    *                                        and is edited elsewhere.
+    */
+   @GetMapping(value = "/databases/definition", produces = MediaType.APPLICATION_JSON_VALUE)
+   public WizDatabaseDefinition getDatabaseDefinition(@RequestParam("path") String path,
+                                                      Principal principal)
+      throws Exception
+   {
+      String database = requirePath(path);
+
+      return toWizDefinition(requireJdbcDefinition(database, principal));
+   }
+
+   /**
+    * Suggests the connection test query for a database type.
+    *
+    * @param type   the database type identifier.
+    * @param driver the JDBC driver class. Only consulted for {@code CUSTOM}, whose real product is
+    *               only knowable from its driver.
+    *
+    * @return the query, or a null query when the type has no known default.
+    */
+   @GetMapping(value = "/databases/default-test-query", produces = MediaType.APPLICATION_JSON_VALUE)
+   public WizDefaultTestQuery getDefaultTestQuery(
+      @RequestParam("type") String type,
+      @RequestParam(value = "driver", required = false) String driver)
+   {
+      String dbType = type;
+
+      if(CustomDatabaseType.TYPE.equals(dbType)) {
+         dbType = uqlConfig.getJDBCType(driver);
+      }
+
+      SQLHelper helper = SQLHelper.getSQLHelper(Objects.toString(dbType, "").toLowerCase());
+
+      return new WizDefaultTestQuery(helper.getConnectionTestQuery());
+   }
+
+   /**
+    * Opens a connection with the supplied settings without saving them.
+    *
+    * @param request   the settings to test, and the path of the database they came from when it
+    *                  already exists.
+    * @param principal the current user.
+    *
+    * @return whether the connection succeeded, and the server's account of why not.
+    */
+   @PostMapping(value = "/databases/test", produces = MediaType.APPLICATION_JSON_VALUE)
+   public WizConnectionTestResult testDatabaseConnection(
+      @RequestBody WizDatabaseTestRequest request, Principal principal)
+   {
+      WizDatabaseDefinition definition = request == null ? null : request.definition();
+
+      if(definition == null) {
+         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "definition is required");
+      }
+
+      String path = normalizePath(request.path());
+
+      // Same reason as on update: without oldName the stored password cannot be recovered, so a
+      // test of an otherwise-unchanged connection would connect with an empty password and fail.
+      DatabaseDefinition database = toDatabaseDefinition(definition, lastSegment(path));
+      ConnectionStatus status = databaseDatasourcesService.testDataSourceConnection(
+         path == null ? "" : path, database, principal, false);
+
+      return new WizConnectionTestResult(status != null && status.isConnected(),
+                                         status == null ? null : status.getStatus());
+   }
+
+   /**
+    * Creates a database in a folder.
+    *
+    * <p>Always saves with the {@code create} action, i.e. the equivalent of the native editor's
+    * {@code create=true}. The native "blank new database" route passes {@code create=false} with the
+    * parent folder as its path, which cannot ever succeed — that lookup necessarily finds no data
+    * source and reports "Datasource Lost" — so it is not reproduced here.</p>
+    *
+    * @param request   the parent folder and the new database.
+    * @param principal the current user.
+    *
+    * @return the saved path, or the reason the save was rejected.
+    */
+   @PostMapping(value = "/databases/create", produces = MediaType.APPLICATION_JSON_VALUE)
+   public WizDatabaseSaveResult createDatabase(@RequestBody WizDatabaseCreateRequest request,
+                                               Principal principal)
+      throws Exception
+   {
+      WizDatabaseDefinition definition = request == null ? null : request.definition();
+      String name = requireName(definition);
+      String parentPath = normalizePath(request.parentPath());
+
+      // oldName stays null: a database that does not exist yet has no stored password to recover,
+      // and a non-null value would send the recovery lookup after an unrelated data source.
+      DatabaseDefinition database = toDatabaseDefinition(definition, null);
+      ConnectionStatus status = databaseDatasourcesService.saveDatabase(
+         parentPath == null ? "" : parentPath, toSettingsModel(database),
+         ActionRecord.ACTION_NAME_CREATE, principal);
+
+      return toSaveResult(status, parentPath == null ? name : parentPath + "/" + name);
+   }
+
+   /**
+    * Updates an existing database's connection settings.
+    *
+    * @param path       the database's current full repository path. Also the sole source of
+    *                   {@code oldName} — see the class javadoc.
+    * @param definition the new settings.
+    * @param principal  the current user.
+    *
+    * @return the saved path, which differs from {@code path} when the connection was renamed, or
+    *         the reason the save was rejected.
+    *
+    * @throws UnsupportedDatasourceException if the path names a data source that is not a JDBC
+    *                                        database.
+    */
+   @PostMapping(value = "/databases/update", produces = MediaType.APPLICATION_JSON_VALUE)
+   public WizDatabaseSaveResult updateDatabase(@RequestParam("path") String path,
+                                               @RequestBody WizDatabaseDefinition definition,
+                                               Principal principal)
+      throws Exception
+   {
+      String database = requirePath(path);
+      String name = requireName(definition);
+      String actionName = databaseDatasourcesService.getActionName(database, name);
+
+      // The save path treats a path with no data source behind it as a parent folder and would
+      // silently create a second database instead of updating one. This is the check the native
+      // controller performs with create=false.
+      if(!ActionRecord.ACTION_NAME_EDIT.equals(actionName)) {
+         return new WizDatabaseSaveResult(false, "DATASOURCE_LOST", null);
+      }
+
+      DatabaseDefinition current = requireJdbcDefinition(database, principal);
+      DatabaseDefinition updated = toDatabaseDefinition(definition, lastSegment(database));
+      carryOverUneditedSettings(current, updated);
+
+      ConnectionStatus status = databaseDatasourcesService.saveDatabase(
+         database, toSettingsModel(updated), actionName, principal);
+      int index = database.lastIndexOf('/');
+
+      return toSaveResult(status, index < 0 ? name : database.substring(0, index + 1) + name);
+   }
+
    private List<WizDatasourceEntry> toEntries(List<DataSourceInfo> infos) {
       List<WizDatasourceEntry> entries = new ArrayList<>();
 
@@ -222,6 +448,317 @@ public class WizDatabaseController {
                                     info.editable(), info.deletable(), info.hasSubFolder());
    }
 
+   /**
+    * Loads a database definition, rejecting anything that is not a JDBC database.
+    *
+    * <p>{@code getDatabaseDefinition} answers null rather than throwing for a tabular data source.
+    * Letting that null through would be worse than an error: on the read path the client would get
+    * an empty body, and on the save path {@code saveDatabase} would return the same null it returns
+    * for success, so a save that did nothing at all would be reported as having worked.</p>
+    */
+   private DatabaseDefinition requireJdbcDefinition(String path, Principal principal)
+      throws Exception
+   {
+      DatabaseDefinition definition =
+         databaseDatasourcesService.getDatabaseDefinition(path, principal);
+
+      if(definition == null) {
+         String sourceType = null;
+
+         try {
+            XDataSource dataSource = xrepository.getDataSource(path);
+            sourceType = dataSource == null ? null : dataSource.getType();
+         }
+         catch(Throwable ex) {
+            LOG.debug("Failed to resolve the type of data source {}: {}", path, ex.getMessage());
+         }
+
+         throw new UnsupportedDatasourceException(path, sourceType);
+      }
+
+      return definition;
+   }
+
+   /**
+    * Copies forward the settings the wiz editor does not expose.
+    *
+    * <p>Every field of the stored definition that the wire contract omits would otherwise be reset
+    * to its default by an update, since the definition handed to the save path is built from
+    * scratch. Two are worth preserving: {@code unasgn} governs whether users with no explicit grant
+    * are denied data, and the cloud-secret credential reference replaces the user name and password
+    * entirely — clearing either through a connection edit would be a silent security change.</p>
+    */
+   private static void carryOverUneditedSettings(DatabaseDefinition current,
+                                                 DatabaseDefinition updated)
+   {
+      updated.setUnasgn(current.isUnasgn());
+
+      AuthenticationDetails currentAuth = current.getAuthentication();
+      AuthenticationDetails updatedAuth = updated.getAuthentication();
+
+      if(currentAuth != null && updatedAuth != null) {
+         updatedAuth.setUseCredentialId(currentAuth.isUseCredentialId());
+         updatedAuth.setCredentialId(currentAuth.getCredentialId());
+      }
+   }
+
+   /**
+    * Wraps a definition for the save path.
+    *
+    * <p>{@code permissions} is left null deliberately: the save path writes whatever permissions it
+    * is handed as long as their {@code changed} flag survives, and the wiz portal has no permission
+    * editor whose intent that could reflect. {@code additionalDataSources} is left null for the same
+    * reason — a non-null value there is read as the complete list and would delete every additional
+    * connection the database has.</p>
+    */
+   private static DataSourceSettingsModel toSettingsModel(DatabaseDefinition definition) {
+      return DataSourceSettingsModel.builder()
+         .dataSource(definition)
+         .uploadEnabled(false)
+         .build();
+   }
+
+   /**
+    * Turns the save path's status string into a result the client can branch on.
+    *
+    * <p>A business failure arrives as an English string inside a successful call, and a null status
+    * means the save went through.</p>
+    */
+   private static WizDatabaseSaveResult toSaveResult(ConnectionStatus status, String path) {
+      String reason = status == null ? null : status.getStatus();
+
+      if(reason == null) {
+         return new WizDatabaseSaveResult(true, null, path);
+      }
+
+      String code = SAVE_FAILURE_REASONS.get(reason);
+
+      if(code == null) {
+         // Not swallowed: the client only ever sees UNKNOWN, so the original wording has to be
+         // recoverable from the server log for anyone diagnosing it.
+         LOG.warn("Unrecognized database save status for {}: {}", path, reason);
+         code = "UNKNOWN";
+      }
+
+      return new WizDatabaseSaveResult(false, code, null);
+   }
+
+   private WizDatabaseDefinition toWizDefinition(DatabaseDefinition definition) {
+      if(definition == null) {
+         return null;
+      }
+
+      NetworkLocation network = definition.getNetwork();
+      WizNetworkLocation wizNetwork = network == null
+         ? null : new WizNetworkLocation(network.getHostName(), network.getPortNumber());
+      AuthenticationDetails authentication = definition.getAuthentication();
+
+      // The password is dropped, never masked. StyleBI's own model sends a placeholder constant
+      // here, but a client that returned that constant unchanged would be indistinguishable from a
+      // user who had typed it, and the wiz contract expresses "unchanged" as null instead.
+      WizAuthentication wizAuthentication = authentication == null
+         ? new WizAuthentication(false, null, null)
+         : new WizAuthentication(authentication.isRequired(), authentication.getUserName(), null);
+
+      return new WizDatabaseDefinition(
+         definition.getName(), definition.getDescription(), definition.getType(), wizNetwork,
+         wizAuthentication, toWizInfo(definition.getInfo()), definition.isAnsiJoin(),
+         definition.getTransactionIsolation(), definition.getTableNameOption(),
+         definition.getDefaultDatabase(), definition.isChangeDefaultDB(),
+         definition.isDeletable());
+   }
+
+   private WizDatabaseInfo toWizInfo(DatabaseInfo info) {
+      if(info == null) {
+         return null;
+      }
+
+      String databaseName = null;
+      String sid = null;
+      String instanceName = null;
+      String serverName = null;
+      String databaseLocale = null;
+      String driverClass = null;
+      String jdbcUrl = null;
+      String testQuery = null;
+
+      // Dispatched on the subclass rather than on the type identifier: the two agree, but only the
+      // subclass can be trusted to actually have the accessor being called.
+      if(info instanceof DatabaseNameInfo nameInfo) {
+         databaseName = nameInfo.getDatabaseName();
+      }
+
+      if(info instanceof OracleDatabaseType.OracleDatabaseInfo oracleInfo) {
+         sid = oracleInfo.getSid();
+      }
+
+      if(info instanceof SQLServerDatabaseType.SQLServerDatabaseInfo sqlServerInfo) {
+         instanceName = sqlServerInfo.getInstanceName();
+      }
+
+      if(info instanceof InformixDatabaseType.InformixDatabaseInfo informixInfo) {
+         serverName = informixInfo.getServerName();
+         databaseLocale = informixInfo.getDatabaseLocale();
+      }
+
+      if(info instanceof CustomDatabaseType.CustomDatabaseInfo customInfo) {
+         driverClass = customInfo.getDriverClass();
+         jdbcUrl = customInfo.getJdbcUrl();
+         testQuery = customInfo.getTestQuery();
+      }
+
+      Map<String, String> poolProperties = info.getPoolProperties() == null
+         ? null : new LinkedHashMap<>(info.getPoolProperties());
+
+      return new WizDatabaseInfo(databaseName, sid, instanceName, serverName, databaseLocale,
+                                 driverClass, jdbcUrl, testQuery, info.isCustomEditMode(),
+                                 info.getCustomUrl(), poolProperties);
+   }
+
+   /**
+    * Builds the definition the save and test paths take.
+    *
+    * @param definition the client's settings.
+    * @param oldName    the name the database is stored under, or null when it does not exist yet.
+    *                   Never taken from the client: it is the key to the stored password, and a save
+    *                   without it leaves the password at the placeholder, skips {@code setPassword}
+    *                   and then has the whole credential — placeholder and all — copied over the
+    *                   real one. The password is gone with no error anywhere.
+    */
+   private DatabaseDefinition toDatabaseDefinition(WizDatabaseDefinition definition,
+                                                   String oldName)
+   {
+      DatabaseDefinition result = new DatabaseDefinition();
+      result.setName(definition.name());
+      result.setOldName(oldName);
+      result.setType(definition.type());
+      result.setDescription(definition.description());
+      result.setInfo(toDatabaseInfo(definition.type(), definition.info()));
+
+      // Always non-null: the URL formatters read the host and port unconditionally for every type
+      // that has them, so a client that omitted the network would get a NullPointerException.
+      NetworkLocation network = new NetworkLocation();
+
+      if(definition.network() != null) {
+         network.setHostName(definition.network().hostName());
+         network.setPortNumber(definition.network().portNumber());
+      }
+
+      result.setNetwork(network);
+
+      AuthenticationDetails authentication = new AuthenticationDetails();
+      WizAuthentication wizAuthentication = definition.authentication();
+      authentication.setRequired(wizAuthentication != null && wizAuthentication.required());
+
+      if(wizAuthentication != null) {
+         authentication.setUserName(wizAuthentication.userName());
+      }
+
+      // null means "leave the stored password alone", which the save path expresses as the
+      // placeholder constant; paired with oldName above it recovers the real password. An empty
+      // string is a deliberate clear and is passed through as itself.
+      String password = wizAuthentication == null ? null : wizAuthentication.password();
+      authentication.setPassword(password == null ? Util.PLACEHOLDER_PASSWORD : password);
+      result.setAuthentication(authentication);
+
+      result.setAnsiJoin(definition.ansiJoin());
+      result.setTransactionIsolation(definition.transactionIsolation());
+      result.setTableNameOption(definition.tableNameOption());
+      result.setDefaultDatabase(definition.defaultDatabase());
+      result.setChangeDefaultDB(definition.changeDefaultDB());
+      result.setDeletable(definition.deletable());
+
+      return result;
+   }
+
+   private DatabaseInfo toDatabaseInfo(String type, WizDatabaseInfo wizInfo) {
+      DatabaseType<?> databaseType = databaseTypeService.getDatabaseType(type);
+
+      if(databaseType == null) {
+         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unknown database type: " + type);
+      }
+
+      DatabaseInfo info = databaseType.createDatabaseInfo();
+
+      // Never left null: the save path reads the pool properties unconditionally.
+      info.setPoolProperties(wizInfo == null || wizInfo.poolProperties() == null
+                                ? new TreeMap<>() : new TreeMap<>(wizInfo.poolProperties()));
+
+      if(wizInfo != null) {
+         info.setCustomEditMode(wizInfo.customEditMode());
+         info.setCustomUrl(wizInfo.customUrl());
+
+         if(info instanceof DatabaseNameInfo nameInfo) {
+            nameInfo.setDatabaseName(wizInfo.databaseName());
+         }
+
+         if(info instanceof OracleDatabaseType.OracleDatabaseInfo oracleInfo) {
+            oracleInfo.setSid(wizInfo.sid());
+         }
+
+         if(info instanceof SQLServerDatabaseType.SQLServerDatabaseInfo sqlServerInfo) {
+            sqlServerInfo.setInstanceName(wizInfo.instanceName());
+         }
+
+         if(info instanceof InformixDatabaseType.InformixDatabaseInfo informixInfo) {
+            informixInfo.setServerName(wizInfo.serverName());
+            informixInfo.setDatabaseLocale(wizInfo.databaseLocale());
+         }
+
+         if(info instanceof CustomDatabaseType.CustomDatabaseInfo customInfo) {
+            customInfo.setDriverClass(wizInfo.driverClass());
+            customInfo.setJdbcUrl(wizInfo.jdbcUrl());
+            customInfo.setTestQuery(wizInfo.testQuery());
+
+            // A CUSTOM connection is always read back with customEditMode set, and in that mode the
+            // stored URL is taken from customUrl, not from jdbcUrl. Pinning the flag and falling
+            // back to jdbcUrl keeps a client that filled in only one of the two from saving a
+            // database with no URL at all.
+            customInfo.setCustomEditMode(true);
+
+            if(customInfo.getCustomUrl() == null) {
+               customInfo.setCustomUrl(wizInfo.jdbcUrl());
+            }
+         }
+      }
+
+      return info;
+   }
+
+   private static String requirePath(String path) {
+      String normalized = normalizePath(path);
+
+      if(normalized == null) {
+         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "path is required");
+      }
+
+      return normalized;
+   }
+
+   private static String requireName(WizDatabaseDefinition definition) {
+      if(definition == null) {
+         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "definition is required");
+      }
+
+      String name = definition.name() == null ? null : definition.name().trim();
+
+      if(name == null || name.isEmpty()) {
+         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "name is required");
+      }
+
+      return name;
+   }
+
+   private static String lastSegment(String path) {
+      if(path == null) {
+         return null;
+      }
+
+      int index = path.lastIndexOf('/');
+
+      return index < 0 ? path : path.substring(index + 1);
+   }
+
    private static boolean isFolder(String nodeType) {
       if(nodeType == null) {
          return false;
@@ -258,9 +795,26 @@ public class WizDatabaseController {
       PortalDataType.PRIVATE_WORKSHEETS_FOLDER,
       PortalDataType.SHARED_WORKSHEETS_FOLDER);
 
+   /**
+    * Database types the wiz editor cannot configure. Access needs a file upload for the .mdb, and
+    * ODBC needs the server to enumerate its DSNs; neither has a form here, so neither is offered.
+    */
+   private static final Set<String> EXCLUDED_DATABASE_TYPES =
+      Set.of(AccessDatabaseType.TYPE, "ODBC");
+
+   /** The save path's status strings, mapped to codes the client can branch on. */
+   private static final Map<String, String> SAVE_FAILURE_REASONS = Map.of(
+      "Duplicate", "DUPLICATE_NAME",
+      "Duplicate Folder", "DUPLICATE_FOLDER",
+      "Datasource Lost", "DATASOURCE_LOST",
+      "Invalid Folder", "INVALID_FOLDER");
+
    private static final Logger LOG = LoggerFactory.getLogger(WizDatabaseController.class);
 
    private final DataSourceBrowserService dataSourceBrowserService;
    private final DataSourceStatusService dataSourceStatusService;
+   private final DatabaseDatasourcesService databaseDatasourcesService;
+   private final DatabaseTypeService databaseTypeService;
+   private final Config uqlConfig;
    private final XRepository xrepository;
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/WizAuthentication.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizAuthentication.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.model;
+
+/**
+ * The credentials used to connect to the database.
+ *
+ * <p><b>Password semantics.</b> On the way out, {@code password} is <em>always</em> null: the stored
+ * password never leaves the server, not even as the mask constant StyleBI's own admin API sends. If
+ * the mask were echoed to the client, a client that faithfully returned what it received would be
+ * indistinguishable from a user who had literally typed the mask, and one of those two must lose.</p>
+ *
+ * <p>On the way in, {@code password} is a three-way switch:</p>
+ * <ul>
+ *    <li>{@code null} — leave the stored password alone. The controller translates this into the
+ *        mask constant that triggers StyleBI's existing recovery path, which is also why the
+ *        controller must fill in {@code oldName} itself on every update.</li>
+ *    <li>{@code ""} — clear the password.</li>
+ *    <li>anything else — set the password to that value.</li>
+ * </ul>
+ *
+ * @param required whether the database requires a login at all. When false the other two fields are
+ *                 ignored by the server.
+ * @param userName the user name, may be null.
+ * @param password see above. Always null on read.
+ */
+public record WizAuthentication(boolean required, String userName, String password) {
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/WizConnectionTestResult.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizConnectionTestResult.java
@@ -1,0 +1,31 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.model;
+
+/**
+ * The outcome of a connection test.
+ *
+ * @param connected whether the driver opened a connection.
+ * @param message   the server's account of what happened. Translated by {@code Catalog} into the
+ *                  StyleBI server language and carrying the raw driver error text on failure, with
+ *                  no structured form available — display it as an opaque string, do not parse it
+ *                  and do not translate it again.
+ */
+public record WizConnectionTestResult(boolean connected, String message) {
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/WizDatabaseDefinition.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizDatabaseDefinition.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.model;
+
+/**
+ * A JDBC database connection as the wiz portal edits it.
+ *
+ * <p>Deliberately not StyleBI's own {@code DatabaseDefinition}, which carries three fields the
+ * native Angular editor only gets away with because it round-trips the server's JSON untouched
+ * rather than rebuilding it from a typed interface:</p>
+ * <ul>
+ *    <li>{@code oldName} — absent here on purpose. It is what lets the server recover the stored
+ *        password when the client did not send one; a client that omitted it (as any client
+ *        building the payload field by field naturally would) would silently blank the password on
+ *        every save. The controller fills it in from the request's {@code path} instead, so the
+ *        wire contract cannot get it wrong.</li>
+ *    <li>{@code permissions} — absent here. The wiz portal does not edit permissions, and the
+ *        native model writes them whenever a {@code changed} flag survives the round trip.</li>
+ *    <li>the password mask constant — see {@link WizAuthentication}.</li>
+ * </ul>
+ *
+ * @param name                 the connection name, i.e. the last segment of its repository path.
+ *                             Never null; the blank template supplies {@code ""}.
+ * @param description          free-text description, may be null.
+ * @param type                 the database type identifier, e.g. {@code "MYSQL"} or {@code "CUSTOM"}.
+ * @param network              host and port; null for {@code CUSTOM}.
+ * @param authentication       the credentials; never null on read.
+ * @param info                 the type-specific settings; never null on read.
+ * @param ansiJoin             whether to generate ANSI join syntax.
+ * @param transactionIsolation JDBC isolation level: -1 default, or 1 / 2 / 4 / 8.
+ * @param tableNameOption      how table names are qualified: 0 Catalog.Schema.Table,
+ *                             1 Schema.Table, 2 Table, 3 default.
+ * @param defaultDatabase      the database to switch to on connect; only applied when
+ *                             {@code changeDefaultDB} is set.
+ * @param changeDefaultDB      whether {@code defaultDatabase} is applied at all.
+ * @param deletable            whether the caller may delete this connection. Read-only; ignored on
+ *                             write.
+ */
+public record WizDatabaseDefinition(
+   String name,
+   String description,
+   String type,
+   WizNetworkLocation network,
+   WizAuthentication authentication,
+   WizDatabaseInfo info,
+   boolean ansiJoin,
+   int transactionIsolation,
+   int tableNameOption,
+   String defaultDatabase,
+   boolean changeDefaultDB,
+   boolean deletable)
+{
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/WizDatabaseInfo.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizDatabaseInfo.java
@@ -1,0 +1,64 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.model;
+
+import java.util.Map;
+
+/**
+ * The type-specific half of a database definition, flattened.
+ *
+ * <p>StyleBI models this as an abstract {@code DatabaseInfo} with one subclass per database type,
+ * serialized with an external type discriminator. Reproducing that polymorphism across the wire
+ * would force the wiz portal to know the discriminator rules; instead every type's fields live side
+ * by side here and only the ones that apply to the current {@code type} are populated. The
+ * controller maps this onto the right subclass in both directions.</p>
+ *
+ * <p>Fields not relevant to the current type are null on read and ignored on write.</p>
+ *
+ * @param databaseName   the database/catalog name. {@code MYSQL}, {@code DB2}, {@code POSTGRESQL},
+ *                       {@code SQLSERVER}, {@code INFORMIX} (and {@code SYBASE}).
+ * @param sid            the Oracle SID. {@code ORACLE} only.
+ * @param instanceName   the named instance. {@code SQLSERVER} only.
+ * @param serverName     the INFORMIXSERVER value. {@code INFORMIX} only.
+ * @param databaseLocale the db_locale value. {@code INFORMIX} only.
+ * @param driverClass    the JDBC driver class name. {@code CUSTOM} only.
+ * @param jdbcUrl        the JDBC URL as parsed from the stored connection. {@code CUSTOM} only, and
+ *                       read-only in practice — see {@code customUrl}.
+ * @param testQuery      the connection test query. {@code CUSTOM} only.
+ * @param customEditMode whether the URL is written by hand rather than assembled from host and port.
+ *                       Always true for {@code CUSTOM}.
+ * @param customUrl      the hand-written URL. This, not {@code jdbcUrl}, is what the server stores
+ *                       when {@code customEditMode} is set, so it is the field a {@code CUSTOM}
+ *                       editor must write to.
+ * @param poolProperties the connection pool properties, may be null.
+ */
+public record WizDatabaseInfo(
+   String databaseName,
+   String sid,
+   String instanceName,
+   String serverName,
+   String databaseLocale,
+   String driverClass,
+   String jdbcUrl,
+   String testQuery,
+   boolean customEditMode,
+   String customUrl,
+   Map<String, String> poolProperties)
+{
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/WizDatabaseMeta.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizDatabaseMeta.java
@@ -1,0 +1,33 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.model;
+
+import java.util.List;
+
+/**
+ * Everything the wiz database editor needs to render its type dropdown, fetched once per page.
+ *
+ * @param types         the database types the wiz editor supports, in server registration order.
+ *                      Never null; never contains {@code ACCESS} or {@code ODBC}, which need a file
+ *                      upload and a server-side DSN enumeration respectively and are out of scope.
+ * @param driverClasses the JDBC driver classes installed on the server, for the {@code CUSTOM}
+ *                      type's driver-class autocomplete. Never null, possibly empty.
+ */
+public record WizDatabaseMeta(List<WizDatabaseTypeInfo> types, List<String> driverClasses) {
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/WizDatabaseSaveResult.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizDatabaseSaveResult.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.model;
+
+/**
+ * The outcome of creating or updating a database.
+ *
+ * <p>StyleBI reports a business failure here as a bare English status string inside an HTTP 200, so
+ * the controller maps that string onto the stable {@code reason} codes below. The client branches on
+ * the code and writes its own message; it must never compare the underlying string.</p>
+ *
+ * @param ok     whether the database was saved.
+ * @param reason null when {@code ok}. Otherwise one of {@code DUPLICATE_NAME} (a data source of that
+ *               name already exists), {@code DUPLICATE_FOLDER} (a <em>folder</em> of that name
+ *               already exists), {@code DATASOURCE_LOST} (the database being updated is no longer
+ *               there), {@code INVALID_FOLDER} (the parent folder does not exist), or
+ *               {@code UNKNOWN} — the last meaning StyleBI reported a status this mapping does not
+ *               recognize, which is logged verbatim server-side rather than swallowed.
+ * @param path   the saved database's full repository path, which differs from the requested path
+ *               when the connection was renamed. Null on failure.
+ */
+public record WizDatabaseSaveResult(boolean ok, String reason, String path) {
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/WizDatabaseTypeInfo.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizDatabaseTypeInfo.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.model;
+
+/**
+ * One selectable database type in the wiz database editor.
+ *
+ * <p>{@code installed} is not a filter: a type whose JDBC driver is missing is still offered, so the
+ * client can explain why the connection will fail instead of failing silently at save time. Only
+ * types the wiz editor has no form for at all are omitted server-side.</p>
+ *
+ * @param type        the raw type identifier, e.g. {@code "MYSQL"}. Untranslated — the wiz portal
+ *                    maps it to a label itself.
+ * @param installed   whether the JDBC driver for this type is on the server classpath.
+ * @param defaultPort the port to pre-fill when the user picks this type; 0 for types that have no
+ *                    network location ({@code CUSTOM}).
+ */
+public record WizDatabaseTypeInfo(String type, boolean installed, int defaultPort) {
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/WizDatasourceBrowserModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizDatasourceBrowserModel.java
@@ -1,0 +1,40 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.model;
+
+import java.util.List;
+
+/**
+ * One page of the wiz data source browser: the contents of a folder plus the trail that leads to
+ * it.
+ *
+ * @param entries    the folders and data sources directly under the requested path, already
+ *                   filtered to what the caller may read.
+ * @param breadcrumb the folder trail as full paths, outermost first, <em>including the requested
+ *                   folder itself</em> as the last element. Empty at the root. The synthetic "/"
+ *                   root folder is not included — the client supplies its own root label, since
+ *                   the server's would be pre-translated.
+ * @param root       whether this page is the repository root (no path was requested).
+ */
+public record WizDatasourceBrowserModel(
+   List<WizDatasourceEntry> entries,
+   List<String> breadcrumb,
+   boolean root)
+{
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/WizDatasourceEntry.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizDatasourceEntry.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.model;
+
+/**
+ * One row of the wiz data source browser: either a data source folder or a data source.
+ *
+ * <p>Deliberately not the portal's own {@code DataSourceInfo}. That model carries a
+ * {@code NameLabelTuple} whose label has already been translated by {@code Catalog} into the
+ * StyleBI server language, and it carries a pre-formatted {@code createdDateLabel} in the server
+ * time zone. The wiz portal runs its own i18n, so every field here is raw: enum names verbatim and
+ * epoch millis, formatted client-side.</p>
+ *
+ * <p>{@code DataSourceInfo.type()} names the <em>kind of node</em> ({@code DATABASE},
+ * {@code DATA_SOURCE}, {@code DATA_SOURCE_FOLDER}, …), never the database product. The product is
+ * a separate lookup against the repository, which is why {@code sourceType} and
+ * {@code databaseType} exist alongside {@code nodeType}.</p>
+ *
+ * @param name         the display name (the last path segment).
+ * @param path         the full path, e.g. {@code "Examples/Orders"}.
+ * @param nodeType     the raw {@link inetsoft.web.portal.data.PortalDataType} name, untranslated.
+ * @param folder       derived from {@code nodeType}; the client's branch between "enter" and
+ *                     "select".
+ * @param sourceType   {@code XDataSource.getType()}, e.g. {@code "jdbc"} / {@code "Rest"}. Null for
+ *                     folders, and null when the data source could not be loaded.
+ * @param databaseType {@code JDBCDataSource.getDatabaseTypeString()}, e.g. {@code "MYSQL"}. Null for
+ *                     anything that is not a JDBC database.
+ * @param createdBy    the alias of the creating user, may be null.
+ * @param createdDate  creation time in epoch millis, 0 when unknown. Not formatted.
+ * @param editable     whether the caller holds WRITE on this entry.
+ * @param deletable    whether the caller holds DELETE on this entry.
+ * @param hasSubFolder whether a folder entry contains further folders.
+ */
+public record WizDatasourceEntry(
+   String name,
+   String path,
+   String nodeType,
+   boolean folder,
+   String sourceType,
+   String databaseType,
+   String createdBy,
+   long createdDate,
+   boolean editable,
+   boolean deletable,
+   boolean hasSubFolder)
+{
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/WizDatasourceStatus.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizDatasourceStatus.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.model;
+
+/**
+ * The last known connection state of one data source.
+ *
+ * <p>The portal's own {@code DataSourceStatus} carries only {@code connected} and {@code message},
+ * with no way back to the data source it describes — the native client relies on positional
+ * correspondence with the request. This model re-attaches the path so the wiz client can fill in
+ * rows out of order.</p>
+ *
+ * @param path      the requested data source path, echoed back.
+ * @param connected whether the last recorded connection attempt succeeded.
+ * @param message   the human-readable status text. Already translated by {@code Catalog} into the
+ *                  StyleBI server language and stamped with a server-formatted timestamp; it is
+ *                  passed through because there is no structured form of it to hand out. Null when
+ *                  the data source has never been tested.
+ */
+public record WizDatasourceStatus(
+   String path,
+   boolean connected,
+   String message)
+{
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/WizDefaultTestQuery.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizDefaultTestQuery.java
@@ -1,0 +1,31 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.model;
+
+/**
+ * The suggested connection test query for a database type.
+ *
+ * <p>A wrapper around a single string rather than the bare string the native endpoint returns:
+ * Spring serves a {@code String} return value through {@code StringHttpMessageConverter} as
+ * {@code text/plain}, which a client sending {@code Accept: application/json} rejects with 406.</p>
+ *
+ * @param query the test query, e.g. {@code "SELECT 1"}. Null when the type has no known default.
+ */
+public record WizDefaultTestQuery(String query) {
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/WizNetworkLocation.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizNetworkLocation.java
@@ -1,0 +1,31 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.model;
+
+/**
+ * Where the database server listens.
+ *
+ * <p>Null for {@code CUSTOM}, whose URL is written by hand and never assembled from host and port.
+ * For every other type the server assembles the JDBC URL from these two values, so both matter.</p>
+ *
+ * @param hostName   the host name or IP address.
+ * @param portNumber the listening port.
+ */
+public record WizNetworkLocation(String hostName, int portNumber) {
+}

--- a/core/src/main/java/inetsoft/web/wiz/request/WizDatabaseCreateRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/request/WizDatabaseCreateRequest.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.request;
+
+import inetsoft.web.wiz.model.WizDatabaseDefinition;
+
+/**
+ * Creates a database inside a folder.
+ *
+ * <p>The parent folder travels in the body, unlike the update endpoint's {@code path} query
+ * parameter, because it does not identify the resource being written — the new database's own path
+ * is not known until its name is combined with this folder.</p>
+ *
+ * @param parentPath the folder to create the database in. Null, empty or {@code "/"} means the root.
+ * @param definition the new database.
+ */
+public record WizDatabaseCreateRequest(String parentPath, WizDatabaseDefinition definition) {
+}

--- a/core/src/main/java/inetsoft/web/wiz/request/WizDatabaseTestRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/request/WizDatabaseTestRequest.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.request;
+
+import inetsoft.web.wiz.model.WizDatabaseDefinition;
+
+/**
+ * Tests a database connection without saving it.
+ *
+ * <p>{@code path} is what makes testing an existing database with an untouched password work: it is
+ * how the server locates the stored password to test with. Omit it and a test of an unchanged
+ * connection will connect with no password and fail, even though saving it would have succeeded.</p>
+ *
+ * @param path       the existing database's full path. Null or empty when testing a database that
+ *                   has not been created yet.
+ * @param definition the settings to test, as currently shown in the editor.
+ */
+public record WizDatabaseTestRequest(String path, WizDatabaseDefinition definition) {
+}

--- a/core/src/main/java/inetsoft/web/wiz/request/WizDatasourceSearchRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/request/WizDatasourceSearchRequest.java
@@ -1,0 +1,29 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.request;
+
+/**
+ * Scoped data source search.
+ *
+ * @param path  the folder to search within, recursively. Null, empty or {@code "/"} searches the
+ *              whole repository.
+ * @param query the substring to match against entry names, case-insensitive.
+ */
+public record WizDatasourceSearchRequest(String path, String query) {
+}

--- a/core/src/main/java/inetsoft/web/wiz/request/WizDatasourceStatusRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/request/WizDatasourceStatusRequest.java
@@ -1,0 +1,30 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.request;
+
+import java.util.List;
+
+/**
+ * Batch lookup of the recorded connection state of several data sources.
+ *
+ * @param paths the full data source paths to report on. Folder paths are meaningless here and will
+ *              report as disconnected.
+ */
+public record WizDatasourceStatusRequest(List<String> paths) {
+}

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizDatabaseControllerSecurityTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizDatabaseControllerSecurityTest.java
@@ -1,0 +1,354 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.controller;
+
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.uql.XRepository;
+import inetsoft.uql.util.Config;
+import inetsoft.web.admin.content.database.DatabaseDefinition;
+import inetsoft.web.admin.content.database.DatabaseTypeService;
+import inetsoft.web.admin.content.database.types.MySQLDatabaseType;
+import inetsoft.web.admin.content.repository.DatabaseDatasourcesService;
+import inetsoft.web.admin.security.ConnectionStatus;
+import inetsoft.web.portal.data.DataSourceBrowserService;
+import inetsoft.web.portal.data.DataSourceConnectionStatusRequest;
+import inetsoft.web.portal.data.DataSourceStatus;
+import inetsoft.web.portal.service.datasource.DataSourceStatusService;
+import inetsoft.web.security.PermissionPath;
+import inetsoft.web.security.RequiredPermission;
+import inetsoft.web.security.Secured;
+import inetsoft.web.wiz.model.*;
+import inetsoft.web.wiz.request.WizDatabaseTestRequest;
+import inetsoft.web.wiz.request.WizDatasourceStatusRequest;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.security.Principal;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Pins the request-mapping prefix and the authorization gates of {@code WizDatabaseController}.
+ *
+ * <p><b>The prefix.</b> {@code /api/wiz/**} is load-bearing rather than cosmetic, for the same
+ * reason spelled out in {@code AdminAiControllerMappingTest}: {@code CSRFFilter} exempts only that
+ * prefix, and {@code WizServiceAuthenticationFilter} validates a wiz caller's bearer token only
+ * there. Moved off it, this controller breaks asymmetrically — every POST fails with a CSRF 403
+ * while every GET keeps working, which is the harder half to diagnose from the client.</p>
+ *
+ * <p><b>The gates.</b> Neither {@code DatabaseDatasourcesService} nor {@code DataSourceStatusService}
+ * checks permissions on its reads, so the checks the native controllers perform before delegating
+ * are this controller's own responsibility. Two of them are {@code @Secured} annotations, and an
+ * annotation without a {@code @PermissionPath} parameter has no path to check — so both halves are
+ * asserted. The third, on the connection test, is conditional and therefore cannot be an annotation
+ * at all; being ordinary code inside the method body, it is also the one most easily lost in a
+ * refactor, which is why it gets three cases here.</p>
+ */
+@Tag("core")
+class WizDatabaseControllerSecurityTest {
+   @Test
+   void everyEndpointLivesUnderTheWizPrefix() {
+      List<String> paths = mappedPaths();
+      assertFalse(paths.isEmpty(), "expected request mappings on WizDatabaseController");
+
+      for(String path : paths) {
+         assertTrue(path.startsWith(WIZ_PREFIX), "endpoint '" + path + "' must live under '" +
+            WIZ_PREFIX + "' or every POST from the wiz portal fails the CSRF filter while every " +
+            "GET keeps working");
+      }
+   }
+
+   @Test
+   void mappingsMatchTheFrozenContract() {
+      assertEquals(
+         Set.of("/api/wiz/datasources/browser",
+                "/api/wiz/datasources/search",
+                "/api/wiz/datasources/statuses",
+                "/api/wiz/databases/meta",
+                "/api/wiz/databases/template",
+                "/api/wiz/databases/definition",
+                "/api/wiz/databases/default-test-query",
+                "/api/wiz/databases/test",
+                "/api/wiz/databases/create",
+                "/api/wiz/databases/update"),
+         new HashSet<>(mappedPaths()));
+   }
+
+   @Test
+   void databaseDefinitionIsGatedOnWriteWithAWiredPermissionPath() throws Exception {
+      assertWriteGateOnPathParameter(
+         WizDatabaseController.class.getDeclaredMethod(
+            "getDatabaseDefinition", String.class, Principal.class));
+   }
+
+   @Test
+   void databaseUpdateIsGatedOnWriteWithAWiredPermissionPath() throws Exception {
+      assertWriteGateOnPathParameter(
+         WizDatabaseController.class.getDeclaredMethod(
+            "updateDatabase", String.class, WizDatabaseDefinition.class, Principal.class));
+   }
+
+   /**
+    * A test that names an existing database is a credential read: the controller fills in
+    * {@code oldName} from the path so an unmodified connection can be tested, which is exactly what
+    * triggers StyleBI's stored-password recovery. Without this gate a caller could pass a victim's
+    * path together with a definition pointing at a host they control, and have the server dial out
+    * to that host using the victim's real password.
+    */
+   @Test
+   void testDatabaseConnection_deniesAndNeverConnectsWhenPathGivenWithoutWrite() throws Exception {
+      Fixture fixture = new Fixture();
+      when(fixture.securityEngine.checkPermission(
+         eq(fixture.principal), eq(ResourceType.DATA_SOURCE), eq(EXISTING_PATH),
+         eq(ResourceAction.WRITE)))
+         .thenReturn(false);
+
+      WizDatabaseTestRequest request =
+         new WizDatabaseTestRequest(EXISTING_PATH, mysqlDefinition());
+
+      // java.lang.SecurityException, the same type SecuredAspect throws for the annotated
+      // endpoints, so both denials reach WizControllerErrorHandler as one 403.
+      assertThrows(SecurityException.class,
+                   () -> fixture.controller.testDatabaseConnection(request, fixture.principal));
+
+      verify(fixture.databaseDatasourcesService, never())
+         .testDataSourceConnection(any(), any(), any(), anyBoolean());
+   }
+
+   @Test
+   void testDatabaseConnection_proceedsWhenPathGivenAndCallerHoldsWrite() throws Exception {
+      Fixture fixture = new Fixture();
+      when(fixture.securityEngine.checkPermission(
+         eq(fixture.principal), eq(ResourceType.DATA_SOURCE), eq(EXISTING_PATH),
+         eq(ResourceAction.WRITE)))
+         .thenReturn(true);
+      when(fixture.databaseDatasourcesService.testDataSourceConnection(
+         any(), any(), any(), anyBoolean()))
+         .thenReturn(new ConnectionStatus(null, true));
+
+      WizDatabaseTestRequest request =
+         new WizDatabaseTestRequest(EXISTING_PATH, mysqlDefinition());
+      WizConnectionTestResult result =
+         fixture.controller.testDatabaseConnection(request, fixture.principal);
+
+      assertTrue(result.connected(), "an authorized test should report the connection outcome");
+
+      ArgumentCaptor<DatabaseDefinition> definition =
+         ArgumentCaptor.forClass(DatabaseDefinition.class);
+      verify(fixture.databaseDatasourcesService).testDataSourceConnection(
+         eq(EXISTING_PATH), definition.capture(), eq(fixture.principal), eq(false));
+
+      // oldName is what makes the stored password recoverable, i.e. what makes the gate above
+      // necessary in the first place.
+      assertEquals("orders", definition.getValue().getOldName(),
+                   "oldName must come from the request path, not from the client");
+   }
+
+   @Test
+   void testDatabaseConnection_skipsThePermissionCheckWhenNoPathIsGiven() throws Exception {
+      Fixture fixture = new Fixture();
+      when(fixture.databaseDatasourcesService.testDataSourceConnection(
+         any(), any(), any(), anyBoolean()))
+         .thenReturn(new ConnectionStatus(null, true));
+
+      WizDatabaseTestRequest request = new WizDatabaseTestRequest(null, mysqlDefinition());
+      WizConnectionTestResult result =
+         fixture.controller.testDatabaseConnection(request, fixture.principal);
+
+      assertTrue(result.connected(),
+                 "testing a connection that does not exist yet must not require a permission");
+
+      // Nothing is stored under a path that was never given, so there is no credential to recover
+      // and nothing to check a permission against.
+      verifyNoInteractions(fixture.securityEngine);
+
+      ArgumentCaptor<DatabaseDefinition> definition =
+         ArgumentCaptor.forClass(DatabaseDefinition.class);
+      verify(fixture.databaseDatasourcesService).testDataSourceConnection(
+         eq(""), definition.capture(), eq(fixture.principal), eq(false));
+      assertNull(definition.getValue().getOldName(),
+                 "a database that does not exist yet has no stored password to recover");
+   }
+
+   /**
+    * {@code DataSourceStatusService} checks nothing, so the paths it is handed must already be the
+    * readable ones. An unreadable path is dropped rather than rejected: the client pairs answers
+    * with requests by path, so a short answer degrades to "no status known" instead of failing the
+    * whole folder listing.
+    */
+   @Test
+   void datasourceStatuses_dropsPathsTheCallerCannotRead() throws Exception {
+      Fixture fixture = new Fixture();
+      when(fixture.securityEngine.checkPermission(
+         eq(fixture.principal), eq(ResourceType.DATA_SOURCE), eq("/readable"),
+         eq(ResourceAction.READ)))
+         .thenReturn(true);
+      when(fixture.securityEngine.checkPermission(
+         eq(fixture.principal), eq(ResourceType.DATA_SOURCE), eq("/secret"),
+         eq(ResourceAction.READ)))
+         .thenReturn(false);
+      when(fixture.dataSourceStatusService.getDataSourceConnectionStatuses(any(), any()))
+         .thenReturn(List.of(
+            DataSourceStatus.builder().connected(true).message("connected").build()));
+
+      List<WizDatasourceStatus> result = fixture.controller.getDatasourceStatuses(
+         new WizDatasourceStatusRequest(List.of("/readable", "/secret")), fixture.principal);
+
+      ArgumentCaptor<DataSourceConnectionStatusRequest> statusRequest =
+         ArgumentCaptor.forClass(DataSourceConnectionStatusRequest.class);
+      verify(fixture.dataSourceStatusService)
+         .getDataSourceConnectionStatuses(statusRequest.capture(), eq(fixture.principal));
+
+      assertEquals(List.of("/readable"), statusRequest.getValue().paths(),
+                   "the status service must never be handed a path the caller cannot read");
+      assertEquals(List.of("/readable"), result.stream().map(WizDatasourceStatus::path).toList());
+   }
+
+   @Test
+   void datasourceStatuses_neverCallsTheServiceWhenNoPathIsReadable() throws Exception {
+      Fixture fixture = new Fixture();
+      when(fixture.securityEngine.checkPermission(
+         any(), eq(ResourceType.DATA_SOURCE), any(String.class), eq(ResourceAction.READ)))
+         .thenReturn(false);
+
+      List<WizDatasourceStatus> result = fixture.controller.getDatasourceStatuses(
+         new WizDatasourceStatusRequest(List.of("/secret")), fixture.principal);
+
+      assertTrue(result.isEmpty(), "an unreadable path yields no status rather than an error");
+      verifyNoInteractions(fixture.dataSourceStatusService);
+   }
+
+   /**
+    * Asserts that a handler carries the DATA_SOURCE/WRITE gate <em>and</em> that the gate is wired
+    * to the path parameter. An annotation whose {@code @PermissionPath} has gone missing still
+    * looks correct in a diff, but {@code SecuredAspect} then has no resource to check.
+    */
+   private static void assertWriteGateOnPathParameter(Method method) {
+      Secured secured = method.getAnnotation(Secured.class);
+      assertNotNull(secured, method.getName() + " must carry @Secured");
+      assertEquals(1, secured.value().length,
+                   method.getName() + " should declare exactly one required permission");
+
+      RequiredPermission permission = secured.value()[0];
+      assertEquals(ResourceType.DATA_SOURCE, permission.resourceType(),
+                   method.getName() + " must be gated on the data source, not another resource");
+      assertArrayEquals(new ResourceAction[]{ ResourceAction.WRITE }, permission.actions(),
+                        method.getName() + " must require WRITE: the connection settings are the " +
+                           "editor's business, not a data reader's");
+      assertEquals("", permission.resource(),
+                   method.getName() + " must resolve its resource from the request path, not a " +
+                      "fixed resource name");
+
+      List<Parameter> annotated = new ArrayList<>();
+
+      for(Parameter parameter : method.getParameters()) {
+         if(parameter.getAnnotation(PermissionPath.class) != null) {
+            annotated.add(parameter);
+         }
+      }
+
+      assertEquals(1, annotated.size(), method.getName() +
+         " must have exactly one @PermissionPath parameter, or SecuredAspect has no path to check");
+
+      RequestParam requestParam = annotated.get(0).getAnnotation(RequestParam.class);
+      assertNotNull(requestParam,
+                    "the @PermissionPath parameter of " + method.getName() +
+                       " must be the request's own path parameter");
+      assertEquals("path", requestParam.value(),
+                   "the gate must check the same path the handler acts on");
+   }
+
+   /** Every mapped path of the controller, class-level prefix included. */
+   private static List<String> mappedPaths() {
+      RequestMapping classMapping = WizDatabaseController.class.getAnnotation(RequestMapping.class);
+      String prefix = classMapping == null || classMapping.value().length == 0
+         ? "" : classMapping.value()[0];
+      List<String> paths = new ArrayList<>();
+
+      for(Method method : WizDatabaseController.class.getDeclaredMethods()) {
+         List<String> methodPaths = new ArrayList<>();
+         GetMapping get = method.getAnnotation(GetMapping.class);
+         PostMapping post = method.getAnnotation(PostMapping.class);
+         RequestMapping generic = method.getAnnotation(RequestMapping.class);
+
+         if(get != null) {
+            methodPaths.addAll(Arrays.asList(get.value()));
+         }
+
+         if(post != null) {
+            methodPaths.addAll(Arrays.asList(post.value()));
+         }
+
+         if(generic != null) {
+            methodPaths.addAll(Arrays.asList(generic.value()));
+         }
+
+         for(String path : methodPaths) {
+            paths.add(prefix + path);
+         }
+      }
+
+      return paths;
+   }
+
+   /** A definition of a type the editor actually offers, so the mapping to the stored model works. */
+   private static WizDatabaseDefinition mysqlDefinition() {
+      return new WizDatabaseDefinition(
+         "orders", null, MySQLDatabaseType.TYPE, new WizNetworkLocation("attacker.example", 3306),
+         new WizAuthentication(true, "victim", null), null, false, -1, 3, null, false, false);
+   }
+
+   /** The controller with every collaborator mocked. */
+   private static final class Fixture {
+      Fixture() {
+         doReturn(new MySQLDatabaseType())
+            .when(databaseTypeService).getDatabaseType(MySQLDatabaseType.TYPE);
+         controller = new WizDatabaseController(
+            dataSourceBrowserService, dataSourceStatusService, databaseDatasourcesService,
+            databaseTypeService, securityEngine, uqlConfig, xrepository);
+      }
+
+      final DataSourceBrowserService dataSourceBrowserService = mock(DataSourceBrowserService.class);
+      final DataSourceStatusService dataSourceStatusService = mock(DataSourceStatusService.class);
+      final DatabaseDatasourcesService databaseDatasourcesService =
+         mock(DatabaseDatasourcesService.class);
+      final DatabaseTypeService databaseTypeService = mock(DatabaseTypeService.class);
+      final SecurityEngine securityEngine = mock(SecurityEngine.class);
+      final Config uqlConfig = mock(Config.class);
+      final XRepository xrepository = mock(XRepository.class);
+      final Principal principal = mock(Principal.class);
+      final WizDatabaseController controller;
+   }
+
+   private static final String WIZ_PREFIX = "/api/wiz/";
+   private static final String EXISTING_PATH = "/orders";
+}


### PR DESCRIPTION
Adds `WizDatabaseController` under `/api/wiz` so the wiz portal can browse the datasource repository and create/edit JDBC database connections. Paired with inetsoft-technology/stylebi-wiz#1542, which contains the wiz-services and portal sides.

## Why the `/api/wiz` prefix is load-bearing

wiz-services calls these server-to-server with the operator's SSO bearer token and no browser session. `CSRFFilter` exempts only `/api/wiz/**`, and `AbstractSecurityFilter.isWizRequest()` uses a *different* judgement (the `wiz_auth` cookie, or the path).

Proxying StyleBI's native portal endpoints instead would therefore fail asymmetrically: every GET succeeds, every POST returns a CSRF 403. That is the hardest kind of failure to diagnose, and `AdminAiControllerMappingTest` already documents it. Moving these mappings off the prefix breaks the portal the same way.

## Why these do not reuse the native models

`DataSourceInfo.type` names the *kind of node* (`PortalDataType`), never the database product, and its label has already been translated by `Catalog` into the server language. `createdDateLabel` is pre-formatted in the server time zone. The wiz portal runs its own i18n and locale, so the response records here are deliberately raw: enum names verbatim, epoch millis, no formatting. The database product is a separate lookup (`XDataSource.getType()` plus `JDBCDataSource.getDatabaseTypeString()`).

## The three hidden contracts in `DataSourceSettingsModel`

StyleBI's Angular editor round-trips that model verbatim as an opaque envelope, which conceals three contracts any hand-built client would break on. These endpoints absorb all three so the portal never sees them:

- **`oldName` is not on the wire.** On update and on test it is derived server-side from the `path` parameter. Without it StyleBI cannot recover the stored password, and the `setCredential` that follows overwrites the password with an empty one — data loss, not a failed save.
- **`password` is never handed out.** Reads always emit `null`; a `null` on write becomes `PLACEHOLDER_PASSWORD` so the existing recovery path fires. The placeholder must not cross this layer: a client echoing it back would be indistinguishable from a user who genuinely typed it.
- **`permissions` and `additionalDataSources` are always left null.** A non-null `permissions` with `changed=true` writes permissions as a side effect of saving a connection; a non-null `additionalDataSources` deletes every additional connection the database has.

## Notes

- Non-JDBC datasources are rejected with 422 rather than relying on null. `getDatabaseDefinition` returns null for a tabular source and `saveDatabase` also returns null on success, so without the guard a save that did nothing reports `ok`.
- `ConnectionStatus` expresses failure as a status string over HTTP 200; that is mapped to a structured `reason` so the portal never compares strings.
- No local `@ExceptionHandler` is added — it would take precedence over `WizControllerErrorHandler` and downgrade a permission 403 to a 400.
- The type list filters ACCESS (needs a file upload). ODBC has no registered `DatabaseType` at all. SYBASE therefore remains, and behaves as a `databaseName`-only type.

## Testing

Compiled with javac 21 (`-Xlint:all`) against the prebuilt `core/target/classes` and the full compile classpath. Exercised end-to-end against a running server together with the paired wiz-services and portal changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
