### PR TITLE
feat(wiz): report options that were accepted but did not take effect

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/model/ApplyWarning.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/ApplyWarning.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * One option the request asked for that did not take effect, while the rest of the request applied
+ * normally. Distinct from an error: the call succeeded and the chart changed — this names the part
+ * of it that did not.
+ *
+ * <p>The alternative, rejecting the whole request with a 400, is worse rather than stricter: a single
+ * misspelled legend position would discard the title and the axis range that were computed correctly
+ * in the same call, turning a partial success into a total failure. The fallback behaviour is
+ * therefore unchanged — a skipped option stays skipped, a defaulted one stays defaulted — and this
+ * only reports it.
+ *
+ * <p>Not to be confused with {@code CreateViewsheetResult.note}, which is the copy-then-apply fallback
+ * channel and nothing else: only that one means the caller's original chart was mutated rather than
+ * duplicated. Mixing the two made the caller read a legend typo as a failed copy.
+ *
+ * <p>Only BUSINESS-level skips belong here — ones caused by what the request asked for (a chart with
+ * no Y axis to scale, a value outside the legal set, a formula name that is not recognized). A
+ * defensive null check that only trips on an internally inconsistent chart is a bug to be found in the
+ * logs, and reporting it would bury the warnings that a user can act on.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApplyWarning {
+   public ApplyWarning() {
+   }
+
+   public ApplyWarning(String option, String reason) {
+      this.option = option;
+      this.reason = reason;
+   }
+
+   /** The request field that did not take effect, e.g. "yAxisScale", "legendPosition", "filter:STATE". */
+   public String getOption() {
+      return option;
+   }
+
+   public void setOption(String option) {
+      this.option = option;
+   }
+
+   /**
+    * A single sentence written for the END USER — it is relayed into the chat reply as it stands.
+    * Never an exception message, a stack trace or an internal identifier.
+    */
+   public String getReason() {
+      return reason;
+   }
+
+   public void setReason(String reason) {
+      this.reason = reason;
+   }
+
+   private String option;
+   private String reason;
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/CreateViewsheetResult.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/CreateViewsheetResult.java
@@ -20,6 +20,7 @@ package inetsoft.web.wiz.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -141,6 +142,36 @@ public class CreateViewsheetResult {
       this.note = note;
    }
 
+   public List<ApplyWarning> getWarnings() {
+      return warnings;
+   }
+
+   public void setWarnings(List<ApplyWarning> warnings) {
+      this.warnings = warnings;
+   }
+
+   /**
+    * Append one warning, creating the list on first use. Callers collect these as they walk a request's
+    * options, so the alternative is the same null check repeated at every skip site — which is exactly
+    * where it would eventually be forgotten and the skip go back to being silent.
+    */
+   public void addWarning(ApplyWarning warning) {
+      if(warning == null) {
+         return;
+      }
+
+      if(warnings == null) {
+         warnings = new ArrayList<>();
+      }
+
+      warnings.add(warning);
+   }
+
+   /** Convenience for the common call shape; see {@link ApplyWarning} for what belongs here. */
+   public void addWarning(String option, String reason) {
+      addWarning(new ApplyWarning(option, reason));
+   }
+
    public String getTitle() {
       return title;
    }
@@ -164,8 +195,19 @@ public class CreateViewsheetResult {
    private Boolean hasData;
    /** Echoed back so the client can reuse the recommendation RVS on the next changeType call. */
    private String autoBindingRuntimeId;
+   /**
+    * The copy-then-apply fallback channel, and nothing else: set only when a {@code copy=true} request
+    * could not duplicate the chart and the change was applied to the original in place. It is the one
+    * thing that tells the caller its original chart is no longer untouched, so anything else written
+    * here is read as that — see {@code warnings} for options that simply did not take effect.
+    */
    private String note;
    private String title;
+   /**
+    * Options this request asked for that did not take effect while the rest of it applied. Absent
+    * (rather than empty) when everything applied, so a caller can test the field itself.
+    */
+   private List<ApplyWarning> warnings;
 
    // -------------------------------------------------------------------------
    // Nested model

--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -1868,6 +1868,62 @@ public class WizAutoBindingService {
       return false;
    }
 
+   /**
+    * The type name of the candidate {@code rec} currently has selected, or null when it cannot be
+    * named.
+    *
+    * <p>Exists so a substituted chart type can be REPORTED by the name the user will see rather than
+    * by the name they asked for. Reads {@code selectedIndex} through the same two-range scheme
+    * {@link #setChartIndexForType} writes it with — indexes below {@code chartInfos.size()} address
+    * chartInfos, the rest address prefInfos offset by that size — because reading it any other way
+    * would name a different chart than the one that actually renders.
+    *
+    * <p>Null rather than a placeholder when the type cannot be determined: a warning that names the
+    * wrong type is worse than one that only says the requested type was unavailable.
+    *
+    * <p>Package-private (not private) only so {@code WizAutoBindingServiceChartTypeCandidatesTest} can
+    * drive it directly, the same reason {@link #buildChartTypeCandidates} is — the index arithmetic
+    * below is exactly the part that would name the wrong chart without anyone noticing.
+    */
+   static String selectedRecommendationType(VSObjectRecommendation rec) {
+      if(rec instanceof VSCrosstabRecommendation) {
+         return "crosstab";
+      }
+
+      if(rec instanceof VSTableRecommendation) {
+         return "table";
+      }
+
+      if(rec instanceof VSGaugeRecommendation) {
+         return "gauge";
+      }
+
+      if(rec instanceof VSTextRecommendation) {
+         return "text";
+      }
+
+      if(!(rec instanceof VSChartRecommendation vcr)) {
+         return null;
+      }
+
+      List<ChartInfo> chartInfos = vcr.getChartInfos();
+      int chartInfosSize = chartInfos != null ? chartInfos.size() : 0;
+      int index = vcr.getSelectedIndex();
+
+      if(index >= 0 && index < chartInfosSize) {
+         return getChartTypeString(chartInfos.get(index).getChartType());
+      }
+
+      List<ChartCombinationUtil.ScoredInfo> prefInfos = vcr.getPrefInfos();
+      int prefIndex = index - chartInfosSize;
+
+      if(prefInfos != null && prefIndex >= 0 && prefIndex < prefInfos.size()) {
+         return getChartTypeString(prefInfos.get(prefIndex).getInfo().getChartType());
+      }
+
+      return null;
+   }
+
    /** Sets {@code selectedIndex} on {@code vcr} by identity-matching {@code info} in chartInfos then prefInfos. */
    private static void setChartSelectedIndex(VSChartRecommendation vcr, ChartInfo info) {
       List<ChartInfo> chartInfos = vcr.getChartInfos();
@@ -2679,6 +2735,11 @@ public class WizAutoBindingService {
       // 3. Select the recommendation for the requested type. changeType is an explicit user type
       // switch (no explicit-binding pins in play), so the unconstrained chartInfos fallback is fine.
       VSObjectRecommendation selectedRec = findRecByType(visualizationType, model, false);
+      // The requested type has no candidate for this data, so the first recommendation is used instead.
+      // The chart still changes and the call still returns 200 with ordinary coordinates, so the caller
+      // has no way to notice — and it narrates the type IT asked for, which is how "changed to a pie"
+      // ends up printed above a bar chart. Recorded here, where both names are still in hand.
+      String substitutedType = null;
 
       if(selectedRec == null) {
          selectedRec = model.getRecommendationList().stream()
@@ -2689,12 +2750,28 @@ public class WizAutoBindingService {
          if(selectedRec instanceof VSChartRecommendation vcr) {
             vcr.setSelectedIndex(0);
          }
+
+         if(selectedRec != null) {
+            substitutedType = selectedRecommendationType(selectedRec);
+         }
       }
 
       if(selectedRec == null || Tool.isEmptyString(worksheetId) || Tool.isEmptyString(wizRuntimeId)) {
          LOG.warn("changeType skipped: selectedRec={}, worksheetId='{}', wizRuntimeId='{}'",
                   selectedRec, worksheetId, wizRuntimeId);
-         return new CreateViewsheetResult();
+
+         CreateViewsheetResult skipped = new CreateViewsheetResult();
+
+         // Only the recommendation-list case is reported: an empty list means this data supports no
+         // chart at all, which is about what the user asked for. Empty worksheetId/wizRuntimeId are
+         // defensive — the caller failed to send its own coordinates, which is a bug in the caller and
+         // belongs in the log, not in front of the user.
+         if(selectedRec == null) {
+            skipped.addWarning("chartType",
+               "No chart type could be applied to this data, so the chart was left unchanged.");
+         }
+
+         return skipped;
       }
 
       // Mirror the wizard path: update autoBindingRvs so its state stays consistent
@@ -2752,6 +2829,12 @@ public class WizAutoBindingService {
 
       // Echo the autoBindingRuntimeId back so the client can reuse it on the next call.
       result.setAutoBindingRuntimeId(autoBindingRuntimeId);
+
+      if(substitutedType != null) {
+         result.addWarning("chartType",
+            "A " + visualizationType + " chart is not available for this data, so a " +
+            substitutedType + " chart was used instead.");
+      }
 
       // Populate headers/rows so the caller can generate data insight.
       // createViewsheetSkipExecution omits row data for speed; fetch it here separately.
@@ -2815,8 +2898,11 @@ public class WizAutoBindingService {
          throw new IllegalArgumentException("Chart assembly not found: " + request.getAssemblyName());
       }
 
-      String note = null;
       String copyNote = null;
+      // Options this request asked for that end up not taking effect. Collected as the options are
+      // walked rather than derived afterwards: by the time the method returns, the reason a particular
+      // setting was skipped is no longer recoverable from the chart.
+      List<ApplyWarning> warnings = new ArrayList<>();
       String targetAssemblyName = request.getAssemblyName();
       VSAssembly demotedOriginal = null;
       VSAssembly rollbackCopy = null;
@@ -2881,6 +2967,13 @@ public class WizAutoBindingService {
          boolean scaleChange = request.getYAxisMin() != null || request.getYAxisMax() != null ||
             request.getYAxisIncrement() != null || request.getYAxisLogarithmic() != null;
 
+         // Counted rather than inferred from an else branch, because the two ways this silently does
+         // nothing are both INSIDE the success path: getYFields() can return an empty array (the outer
+         // condition holds and the loop runs zero times), or every ref can lack an AxisDescriptor and
+         // continue past. A pie chart asked to set a Y-axis maximum takes the first of those and
+         // returns a perfectly ordinary 200 with a chart that did not change.
+         int appliedAxes = 0;
+
          if(scaleChange && vsChartInfo != null && vsChartInfo.getYFields() != null) {
             for(ChartRef yref : vsChartInfo.getYFields()) {
                if(yref == null || yref.getAxisDescriptor() == null) {
@@ -2904,7 +2997,14 @@ public class WizAutoBindingService {
                if(request.getYAxisLogarithmic() != null) {
                   ax.setLogarithmicScale(request.getYAxisLogarithmic());
                }
+
+               appliedAxes++;
             }
+         }
+
+         if(scaleChange && appliedAxes == 0) {
+            warnings.add(new ApplyWarning("yAxisScale",
+               "This chart has no Y axis, so the axis scale settings were not applied."));
          }
 
          // Legend placement
@@ -2912,8 +3012,12 @@ public class WizAutoBindingService {
             int layout = legendLayout(request.getLegendPosition());
 
             if(layout < 0) {
-               note = "Unknown legendPosition '" + request.getLegendPosition() +
-                  "'; valid: none, top, right, bottom, left, in_place. Legend left unchanged.";
+               // Wording unchanged — it was already right. Moved off `note` because that field means
+               // "your original chart was modified in place", which this is not: the rest of the format
+               // request applied normally and only the legend was left alone.
+               warnings.add(new ApplyWarning("legendPosition",
+                  "Unknown legendPosition '" + request.getLegendPosition() +
+                  "'; valid: none, top, right, bottom, left, in_place. Legend left unchanged."));
             }
             else {
                desc.getLegendsDescriptor().setLayout(layout);
@@ -2933,6 +3037,17 @@ public class WizAutoBindingService {
 
                if(request.getMarkerShape() != null) {
                   plot.setMarkerShape(request.getMarkerShape());
+
+                  // The value is passed through unchanged — the renderer's own fallback is what decides
+                  // what appears, and changing that here would alter charts that render today. But that
+                  // fallback is silent: GraphGenerator.mapMarkerShape switches on the name and its
+                  // default arm returns FILLED_CIRCLE, so "hexagon" draws circles and reports success.
+                  // Validate only to SAY so.
+                  if(!MARKER_SHAPES.contains(request.getMarkerShape().toLowerCase())) {
+                     warnings.add(new ApplyWarning("markerShape",
+                        "'" + request.getMarkerShape() + "' is not a marker shape I recognize (" +
+                        String.join(", ", MARKER_SHAPES) + "), so the points are drawn as circles."));
+                  }
                }
 
                if(request.getMarkerSize() != null) {
@@ -3023,10 +3138,16 @@ public class WizAutoBindingService {
          result.setViewsheetIdentifier(request.getViewsheetIdentifier());
       }
 
-      String combinedNote = combineNotes(copyNote, note);
+      // note carries the copy fallback alone; every other "asked for but not applied" goes to warnings.
+      // They used to be concatenated into this one field, which left the caller unable to tell the two
+      // apart: a legend typo made a SUCCESSFUL copy read as a declined one, so the next edit in the same
+      // turn duplicated the chart a second time.
+      if(copyNote != null) {
+         result.setNote(copyNote);
+      }
 
-      if(combinedNote != null) {
-         result.setNote(combinedNote);
+      if(!warnings.isEmpty()) {
+         result.setWarnings(warnings);
       }
 
       return result;
@@ -3204,21 +3325,15 @@ public class WizAutoBindingService {
    }
 
    /**
-    * Combines two independent, optional warning notes (e.g. a copy-fallback warning and a separate
-    * binding/legend validation warning) without either silently overwriting the other. Either or both
-    * may be null; returns null only when both are.
+    * The marker shapes the renderer actually distinguishes, lower-cased.
+    *
+    * <p>Must stay in step with {@code GraphGenerator.mapMarkerShape}, which is the only place a shape
+    * name is interpreted. Kept here rather than read from there because that method has no value set to
+    * expose — it is a switch whose default arm swallows everything else, which is exactly why this list
+    * is needed to notice a name it will swallow.
     */
-   private static String combineNotes(String first, String second) {
-      if(first == null) {
-         return second;
-      }
-
-      if(second == null) {
-         return first;
-      }
-
-      return first + " " + second;
-   }
+   private static final Set<String> MARKER_SHAPES =
+      Set.of("circle", "square", "diamond", "triangle", "cross", "x", "star");
 
    /** Maps a legend-position string to a {@link LegendsDescriptor} layout constant; -1 if unknown. */
    private static int legendLayout(String position) {

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -519,6 +519,10 @@ public class WizVsService {
          ? VSUtil.getBaseColumns(dataAssembly, true) : null;
 
       CreateViewsheetResult result;
+      // Rules whose named target resolved to nothing, so they were widened to every ref. The highlight
+      // itself still applies, which is why this is collected rather than thrown — see
+      // resolveRuleHighlightRefs.
+      List<ApplyWarning> highlightWarnings = new ArrayList<>();
 
       // The copy (when one was made) has already been added to rvs.getViewsheet() and marked primary —
       // demotedOriginal/rollbackCopy stay non-null only in that case. Nothing through persistViewsheet
@@ -590,7 +594,7 @@ public class WizVsService {
             // The refs THIS rule attaches to: only the one it names when that is unambiguous, otherwise
             // every ref (the long-standing behaviour). See resolveRuleHighlightRefs.
             List<HighlightRef> ruleRefs =
-               resolveRuleHighlightRefs(rule, highlightRefs, chartInfo, wordCloud);
+               resolveRuleHighlightRefs(rule, highlightRefs, chartInfo, wordCloud, highlightWarnings);
 
             // A rule that sets ONLY a font (no foreground) has no visible effect when the font cannot render:
             // not a data-label highlight AND no font-capable ref to carry it (all marks are continuous
@@ -714,6 +718,10 @@ public class WizVsService {
 
       if(copyNote != null) {
          result.setNote(copyNote);
+      }
+
+      if(!highlightWarnings.isEmpty()) {
+         result.setWarnings(highlightWarnings);
       }
 
       return result;
@@ -967,7 +975,10 @@ public class WizVsService {
 
       VisualizationConditionModel cm = new VisualizationConditionModel();
       cm.setBaseConditions(rule.getConditions());
-      ConditionList conditionGroup = buildConditionList(cm, columns);
+      // No collector: this path reports every condition problem by THROWING (naming the rule and the
+      // valid columns — see the checks right below), so warnings gathered here would either duplicate
+      // an exception the caller already gets or describe a call that never returns.
+      ConditionList conditionGroup = buildConditionList(cm, columns, null);
 
       if(chartRebind) {
          Set<String> unresolved = rebindChartConditionFields(conditionGroup, columns);
@@ -1052,10 +1063,19 @@ public class WizVsService {
     *
     * Package-private (not private) only so {@code WizVsServiceResolveRuleHighlightRefsTest} can drive it
     * directly — the same reason executeAndExtract is.
+    *
+    * <p>{@code warnings} collects only the NO-MATCH fallback: the rule named a field, the chart has
+    * several highlightable refs, and none of them is that field. The name the caller supplied did
+    * nothing, and instead of the one series they asked about the chart highlights all of them — a
+    * visibly different result behind a clean 200, and the one case they can act on by correcting the
+    * name. The other two paths to the same {@code allRefs} return are deliberately silent: a rule that
+    * names no field never asked to be narrowed, and the special chart types below cannot be narrowed at
+    * all, so reporting them would fire on every rule those charts ever carry and bury the case above.
+    * May be null for a caller that reports by throwing instead.
     */
    List<HighlightRef> resolveRuleHighlightRefs(
       ApplyHighlightModel.Highlight rule, List<HighlightRef> allRefs, VSChartInfo chartInfo,
-      boolean wordCloud)
+      boolean wordCloud, List<ApplyWarning> warnings)
    {
       String field = rule.getField();
 
@@ -1083,6 +1103,10 @@ public class WizVsService {
             return List.of(hlRef);
          }
       }
+
+      addWarning(warnings, "highlight:" + target,
+         "'" + target + "' does not match anything this chart highlights, so the highlight was " +
+         "applied to every series instead of just that one.");
 
       return allRefs;
    }
@@ -1668,6 +1692,12 @@ public class WizVsService {
          Worksheet originWs = null;
          boolean wsModified = false;
          boolean removedPreviousPrimary = false;
+         // Options this request asked for that end up not taking effect (a filter condition that would
+         // not build, a field that is not in the data, an unrecognized aggregation). Declared out here
+         // because the three places that fill it — the pre-aggregation push, the worksheet condition
+         // write and the VS-assembly condition write — are mutually exclusive branches below, and only
+         // one shared collector keeps the response's shape independent of which branch ran.
+         List<ApplyWarning> applyWarnings = new ArrayList<>();
 
          try {
             // All mutations happen inside this try so the catch can roll back everything
@@ -1683,7 +1713,7 @@ public class WizVsService {
 
                   // Push aggregation and conditions to worksheet
                   PreAggregationMapping preAggMapping = pushAggregationToWorksheet(
-                     binding, conditionModel, tableAsm);
+                     binding, conditionModel, tableAsm, applyWarnings);
 
                   if(wsEntry != null) {
                      engine.setSheet(wsEntry, ws, user, true);
@@ -1700,12 +1730,12 @@ public class WizVsService {
                   // Fallback to original path if worksheet table not found
                   LOG.warn("Aggregate conditions specified but worksheet table '{}' not found; " +
                               "aggregate conditions will be ignored", wsTableName);
-                  applyConditionModel(assembly, conditionModel);
+                  applyConditionModel(assembly, conditionModel, applyWarnings);
                }
             }
             else {
                // Original path: apply base conditions to VS assembly
-               applyConditionModel(assembly, conditionModel);
+               applyConditionModel(assembly, conditionModel, applyWarnings);
             }
 
             // In incremental mode, GenerateWsService may have added new WS assemblies. Reload
@@ -1871,6 +1901,13 @@ public class WizVsService {
 
             if(copyNote != null) {
                result.setNote(copyNote);
+            }
+
+            // Attached only on the success return: a request that rolls back applied nothing, so its
+            // partial-application warnings would describe a chart that does not exist. Kept off `note`,
+            // which means "your original chart was modified in place" and nothing else.
+            if(!applyWarnings.isEmpty()) {
+               result.setWarnings(applyWarnings);
             }
 
             return result;
@@ -4544,8 +4581,15 @@ public class WizVsService {
    /**
     * Applies base conditions from the condition model to the VS assembly.
     * Only base conditions are applied here; aggregate conditions require pushing to worksheet.
+    *
+    * @param warnings collects the conditions the request asked for that did not make it into the
+    *                 applied filter. A dropped condition WIDENS the result rather than emptying it, so
+    *                 the chart looks perfectly normal while answering a question nobody asked — the
+    *                 caller has no way to detect it and no way to reconstruct it afterwards.
     */
-   private void applyConditionModel(VSAssembly assembly, VisualizationConditionModel conditionModel) {
+   private void applyConditionModel(VSAssembly assembly, VisualizationConditionModel conditionModel,
+                                    List<ApplyWarning> warnings)
+   {
       // The model itself is the boundary: absent means the request said nothing about conditions and
       // whatever the assembly carries must be left alone, present means it IS the complete new
       // condition state. Within a present model an empty list and a null list say the same thing —
@@ -4564,9 +4608,9 @@ public class WizVsService {
       // Resolve the assembly's candidate condition fields so condition values can be coerced
       // to each field's data type (see buildConditionItem).
       ColumnSelection columns = VSUtil.getBaseColumns(dataAssembly, true);
-      ConditionList conditions = buildConditionList(conditionModel, columns);
+      ConditionList conditions = buildConditionList(conditionModel, columns, warnings);
 
-      if(!canApplyConditions(conditions, conditionModel.getBaseConditions(), "base")) {
+      if(!canApplyConditions(conditions, conditionModel.getBaseConditions(), "base", warnings)) {
          return;
       }
 
@@ -4579,13 +4623,14 @@ public class WizVsService {
     * Builds a ConditionList from the base conditions in the model.
     */
    private ConditionList buildConditionList(VisualizationConditionModel wizModel,
-                                            ColumnSelection columns)
+                                            ColumnSelection columns,
+                                            List<ApplyWarning> warnings)
    {
       ConditionList conditionList = new ConditionList();
 
       if(wizModel != null && wizModel.getBaseConditions() != null) {
          appendConditionNodes(wizModel.getBaseConditions(), 0, conditionList, new boolean[]{ true },
-                              null, columns);
+                              null, columns, warnings);
       }
 
       return conditionList;
@@ -4603,13 +4648,16 @@ public class WizVsService {
     *                         used for validating dateGroupLevel to DateRangeRef column names
     * @param columns          optional candidate condition fields used to resolve each field's data
     *                         type so condition values are coerced correctly; may be null
+    * @param warnings         collects each node this drops or silently alters, so a partially applied
+    *                         filter can be reported instead of passing for a complete one
     */
    private void appendConditionNodes(List<VisualizationConditionModel.ConditionNode> nodes,
                                      int depth,
                                      ConditionList result,
                                      boolean[] isFirst,
                                      Set<String> dimColumnMapping,
-                                     ColumnSelection columns)
+                                     ColumnSelection columns,
+                                     List<ApplyWarning> warnings)
    {
       for(VisualizationConditionModel.ConditionNode node : nodes) {
          if(node == null) {
@@ -4626,6 +4674,9 @@ public class WizVsService {
                // is unrecoverable.
                LOG.warn("Dropping a condition node with no field; the applied filter will be wider " +
                            "than requested");
+               addWarning(warnings, "filter",
+                  "One of the requested filters named no column, so it was left out and the chart " +
+                  "shows more data than asked for.");
                continue;
             }
 
@@ -4633,7 +4684,7 @@ public class WizVsService {
                result.append(new JunctionOperator(parseJunction(leaf.getJunction()), depth));
             }
 
-            result.append(buildConditionItem(spec, depth, dimColumnMapping, columns));
+            result.append(buildConditionItem(spec, depth, dimColumnMapping, columns, warnings));
             isFirst[0] = false;
          }
          else if(node instanceof VisualizationConditionModel.ConditionGroup group) {
@@ -4647,7 +4698,7 @@ public class WizVsService {
             // whether it produced any valid items before committing a junction.
             ConditionList groupContents = new ConditionList();
             appendConditionNodes(items, depth + 1, groupContents, new boolean[]{ true },
-                                 dimColumnMapping, columns);
+                                 dimColumnMapping, columns, warnings);
 
             if(groupContents.isEmpty()) {
                continue;
@@ -4683,11 +4734,13 @@ public class WizVsService {
     *                         used for mapping dateGroupLevel to DateRangeRef column names
     * @param columns          optional candidate condition fields used to resolve the field's data
     *                         type; may be null
+    * @param warnings         collects a silently substituted aggregate formula (see below)
     */
    private ConditionItem buildConditionItem(VisualizationConditionModel.ConditionSpec spec,
                                             int level,
                                             Set<String> dimColumnMapping,
-                                            ColumnSelection columns)
+                                            ColumnSelection columns,
+                                            List<ApplyWarning> warnings)
    {
       Condition condition = new Condition();
       condition.setOperation(mapConditionOperation(spec.getOperation()));
@@ -4730,6 +4783,13 @@ public class WizVsService {
          if(formula == null) {
             LOG.warn("Aggregate formula '{}' for measure '{}' is null or unrecognized; " +
                         "defaulting to SUM", spec.getAggregateFormula(), spec.getField());
+            // The condition still applies, but against a different number than the one requested:
+            // "regions where the AVERAGE sale is over 100" silently becomes "where the TOTAL is over
+            // 100", which keeps a different set of rows. The chart looks filtered and is, just not by
+            // what was asked — so the fallback stays and the substitution is reported.
+            addWarning(warnings, "filter:" + spec.getField(),
+               "'" + spec.getAggregateFormula() + "' is not an aggregation I recognize, so the filter " +
+               "on " + spec.getField() + " compared the total instead.");
             formula = AggregateFormula.SUM;
          }
 
@@ -4933,7 +4993,8 @@ public class WizVsService {
    private PreAggregationMapping pushAggregationToWorksheet(
       CreateViewsheetResult.FlatBinding binding,
       VisualizationConditionModel conditionModel,
-      AbstractTableAssembly table)
+      AbstractTableAssembly table,
+      List<ApplyWarning> warnings)
    {
       ColumnSelection cols = table.getColumnSelection(false);
       AggregateInfo aggInfo = new AggregateInfo();
@@ -4949,6 +5010,12 @@ public class WizVsService {
             if(colRef == null) {
                LOG.warn("Dimension field '{}' not found in worksheet column selection; " +
                            "skipping from aggregation", dim.getField());
+               // Dropping a grouping level does not empty the chart, it COARSENS it — the same
+               // measures come back aggregated over fewer groups, which looks like a perfectly
+               // reasonable chart of a question the user did not ask.
+               addWarning(warnings, "dimension:" + dim.getField(),
+                  "'" + dim.getField() + "' is not a column in this chart's data, so it was left out " +
+                  "of the grouping.");
                continue;
             }
 
@@ -5007,6 +5074,9 @@ public class WizVsService {
             if(colRef == null) {
                LOG.warn("Measure field '{}' not found in worksheet column selection; " +
                            "skipping from aggregation", measure.getField());
+               addWarning(warnings, "measure:" + measure.getField(),
+                  "'" + measure.getField() + "' is not a column in this chart's data, so it was " +
+                  "left out.");
                continue;
             }
 
@@ -5015,6 +5085,14 @@ public class WizVsService {
             if(formula == null) {
                LOG.warn("Aggregate formula '{}' for measure '{}' is null or unrecognized; " +
                            "defaulting to SUM", measure.getAggregateFormula(), measure.getField());
+               // The one fallback here that changes what the NUMBERS MEAN rather than which of them
+               // appear: every value plotted is a total where an average was asked for, and nothing
+               // about the rendered chart gives that away. The default stays — an unrecognized formula
+               // name should not cost the user the whole chart — so the substitution must be named,
+               // including which default was taken.
+               addWarning(warnings, "aggregateFormula:" + measure.getField(),
+                  "'" + measure.getAggregateFormula() + "' is not an aggregation I recognize, so " +
+                  measure.getField() + " was summed instead.");
                formula = AggregateFormula.SUM;
             }
 
@@ -5045,7 +5123,7 @@ public class WizVsService {
       table.setAggregate(!aggInfo.isEmpty());
 
       // Apply base conditions as pre-conditions and aggregate conditions as post-conditions
-      applyConditionsToWorksheet(table, conditionModel, dimColumnMapping);
+      applyConditionsToWorksheet(table, conditionModel, dimColumnMapping, warnings);
 
       return new PreAggregationMapping(dimColumnMapping, pushedMeasureFullNames);
    }
@@ -5060,7 +5138,8 @@ public class WizVsService {
    private void applyConditionsToWorksheet(
       AbstractTableAssembly table,
       VisualizationConditionModel conditionModel,
-      Set<String> dimColumnMapping)
+      Set<String> dimColumnMapping,
+      List<ApplyWarning> warnings)
    {
       if(conditionModel == null) {
          return;
@@ -5077,10 +5156,10 @@ public class WizVsService {
 
       // Apply base conditions as pre-conditions (WHERE equivalent)
       if(base != null) {
-         appendConditionNodes(base, 0, preCondList, new boolean[]{ true }, null, columns);
+         appendConditionNodes(base, 0, preCondList, new boolean[]{ true }, null, columns, warnings);
       }
 
-      if(canApplyConditions(preCondList, base, "base")) {
+      if(canApplyConditions(preCondList, base, "base", warnings)) {
          table.setPreConditionList(preCondList);
       }
 
@@ -5093,10 +5172,10 @@ public class WizVsService {
 
       if(aggregate != null) {
          appendConditionNodes(aggregate, 0, postCondList, new boolean[]{ true }, dimColumnMapping,
-                              columns);
+                              columns, warnings);
       }
 
-      if(canApplyConditions(postCondList, aggregate, "aggregate")) {
+      if(canApplyConditions(postCondList, aggregate, "aggregate", warnings)) {
          table.setPostConditionList(postCondList);
       }
    }
@@ -5113,10 +5192,15 @@ public class WizVsService {
     * @param compiled  the condition list built from {@code requested}
     * @param requested the condition nodes the request carried; null when it carried none
     * @param label     which half of the model this is, for the log line
+    * @param warnings  collects the summary of a total failure. The per-node reasons are already
+    *                  recorded by {@link #appendConditionNodes}; this adds the consequence, which no
+    *                  individual node can state — the filter as a whole did not take effect, so the
+    *                  chart still shows everything.
     */
    private boolean canApplyConditions(ConditionList compiled,
                                       List<VisualizationConditionModel.ConditionNode> requested,
-                                      String label)
+                                      String label,
+                                      List<ApplyWarning> warnings)
    {
       if(!compiled.isEmpty() || requested == null || requested.isEmpty()) {
          return true;
@@ -5124,7 +5208,23 @@ public class WizVsService {
 
       LOG.warn("None of the {} {} condition(s) could be built; leaving the existing conditions " +
                   "untouched", requested.size(), label);
+      addWarning(warnings, "filter",
+         "None of the requested filters could be applied, so the chart still shows all the data.");
       return false;
+   }
+
+   /**
+    * Appends a warning to a collector that may be null.
+    *
+    * <p>Null-tolerant on purpose: several of the paths that build conditions are shared with callers
+    * that report failures by THROWING (the highlight builder), and forcing each of them to invent a
+    * list they discard is how a real collector eventually gets replaced by a throwaway one by
+    * accident.
+    */
+   private static void addWarning(List<ApplyWarning> warnings, String option, String reason) {
+      if(warnings != null) {
+         warnings.add(new ApplyWarning(option, reason));
+      }
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceChartTypeCandidatesTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceChartTypeCandidatesTest.java
@@ -145,4 +145,53 @@ class WizAutoBindingServiceChartTypeCandidatesTest {
       assertTrue(WizAutoBindingService.buildChartTypeCandidates(null).isEmpty());
       assertTrue(WizAutoBindingService.buildChartTypeCandidates(List.<VSObjectRecommendation>of()).isEmpty());
    }
+
+   /**
+    * Naming the type a substituted recommendation actually renders as.
+    *
+    * <p>changeType falls back to the first recommendation when the requested type has no candidate,
+    * and returns 200 with ordinary coordinates — so the caller narrates the type it ASKED for and
+    * prints "changed to a pie" over a bar chart. The warning that fixes that is only as good as this
+    * lookup: name the wrong type and it is worse than saying nothing.
+    *
+    * <p>The index is the part worth pinning. {@code selectedIndex} addresses two lists through one
+    * number — below {@code chartInfos.size()} it means chartInfos, at or above it means prefInfos
+    * offset by that size (see setChartIndexForType, which writes it) — so reading it as a plain index
+    * into either list alone silently names a different chart.
+    */
+   @Test
+   void namesTheChartTypeAtASelectedIndexInChartInfos() {
+      VSChartRecommendation rec = chartRec(
+         List.of(info(GraphTypes.CHART_BAR), info(GraphTypes.CHART_LINE)), null);
+      // The fallback changeType applies when nothing matched the requested type.
+      when(rec.getSelectedIndex()).thenReturn(0);
+
+      assertEquals("bar", WizAutoBindingService.selectedRecommendationType(rec));
+   }
+
+   @Test
+   void namesTheChartTypeAtASelectedIndexThatAddressesPrefInfos() {
+      VSChartRecommendation rec = chartRec(
+         List.of(info(GraphTypes.CHART_BAR), info(GraphTypes.CHART_LINE)),
+         List.of(scored(GraphTypes.CHART_PIE, 90)));
+      // chartInfos.size() == 2, so index 2 is prefInfos[0] — not an out-of-range chartInfos read.
+      when(rec.getSelectedIndex()).thenReturn(2);
+
+      assertEquals("pie", WizAutoBindingService.selectedRecommendationType(rec));
+   }
+
+   @Test
+   void namesTheNonChartRecommendationTypes() {
+      assertEquals("table",
+                   WizAutoBindingService.selectedRecommendationType(mock(VSTableRecommendation.class)));
+   }
+
+   @Test
+   void returnsNullRatherThanGuessingWhenTheIndexAddressesNothing() {
+      // Better to say only that the requested type was unavailable than to name a chart at random.
+      VSChartRecommendation rec = chartRec(List.of(info(GraphTypes.CHART_BAR)), null);
+      when(rec.getSelectedIndex()).thenReturn(7);
+
+      assertNull(WizAutoBindingService.selectedRecommendationType(rec));
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartFormatTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceSetChartFormatTest.java
@@ -27,8 +27,12 @@ import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.viewsheet.ChartVSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.uql.viewsheet.internal.ChartVSAssemblyInfo;
+import inetsoft.uql.viewsheet.graph.AxisDescriptor;
 import inetsoft.uql.viewsheet.graph.ChartDescriptor;
+import inetsoft.uql.viewsheet.graph.ChartRef;
 import inetsoft.uql.viewsheet.graph.LegendsDescriptor;
+import inetsoft.uql.viewsheet.graph.PlotDescriptor;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
 import inetsoft.web.wiz.model.ChartFormatRequest;
 import inetsoft.web.wiz.model.CreateViewsheetResult;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,8 +43,10 @@ import java.security.Principal;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -232,11 +238,12 @@ class WizAutoBindingServiceSetChartFormatTest {
    }
 
    @Test
-   void copyFailureNoteSurvivesAlongsideAnUnrelatedLegendNote() throws Exception {
-      // Regression: the copy-fallback note used to be stored in the SAME `note` local later
-      // reassigned unconditionally by the legend-validation logic, silently discarding the
-      // copy-failure warning whenever the legend position was ALSO invalid. Both must now
-      // survive, concatenated.
+   void copyFailureAndAnInvalidLegendAreReportedOnSEPARATEChannels() throws Exception {
+      // Both survive — that part is long-standing (the copy note used to be clobbered by the legend
+      // message) — but they no longer share the `note` field. They are different KINDS of fact and a
+      // caller has to act on them differently: `note` means the caller's original chart was modified
+      // in place, which nothing else does, so a legend typo landing there made a SUCCESSFUL copy read
+      // as a declined one.
       LegendsDescriptor legends = mock(LegendsDescriptor.class);
       ChartDescriptor desc = mock(ChartDescriptor.class);
       when(desc.getLegendsDescriptor()).thenReturn(legends);
@@ -251,10 +258,102 @@ class WizAutoBindingServiceSetChartFormatTest {
 
       CreateViewsheetResult result = service.setChartFormat(request, null);
 
+      assertEquals("Copy requested but could not be created; format applied in place.", result.getNote());
+      assertEquals(1, result.getWarnings().size());
+      assertEquals("legendPosition", result.getWarnings().get(0).getOption());
       assertEquals(
-         "Copy requested but could not be created; format applied in place. " +
          "Unknown legendPosition 'sideways'; valid: none, top, right, bottom, left, in_place. Legend left unchanged.",
-         result.getNote());
+         result.getWarnings().get(0).getReason());
+      // The legend was NOT set — behaviour is unchanged, only the reporting channel moved.
+      verify(legends, never()).setLayout(anyInt());
+   }
+
+   // ── Options accepted but not applied ─────────────────────────────────────────────────────────
+   //
+   // Each of these returns 200 with a chart that changed, so the response is the only thing that can
+   // say which part of the request did not take. The fallback behaviour itself is deliberately left
+   // exactly as it was: rejecting the whole call would discard the settings that DID apply.
+
+   @Test
+   void aScaleRequestOnAChartWithNoYAxisIsReportedWhileTheRestStillApplies() throws Exception {
+      // The pie case. getYFields() returns an EMPTY array, so the guarded loop runs zero times — there
+      // is no else branch to hang this on, which is why the applied axes are counted instead.
+      VSChartInfo chartInfo = mock(VSChartInfo.class);
+      when(chartInfo.getYFields()).thenReturn(new ChartRef[0]);
+      when(info.getVSChartInfo()).thenReturn(chartInfo);
+
+      ChartFormatRequest request = titleRequest("visualizations-xyz");
+      request.setYAxisMax(1000.0);
+
+      CreateViewsheetResult result = service.setChartFormat(request, null);
+
+      // The title in the SAME request still lands: this is a partial success, not a failure.
+      verify(info).setTitleValue("Contacts per Account");
+      assertEquals(1, result.getWarnings().size());
+      assertEquals("yAxisScale", result.getWarnings().get(0).getOption());
+      assertNull(result.getNote(), "nothing to do with copying");
+   }
+
+   @Test
+   void aScaleRequestThatReachesAnAxisIsNotReported() throws Exception {
+      AxisDescriptor axis = mock(AxisDescriptor.class);
+      ChartRef yref = mock(ChartRef.class);
+      when(yref.getAxisDescriptor()).thenReturn(axis);
+      VSChartInfo chartInfo = mock(VSChartInfo.class);
+      when(chartInfo.getYFields()).thenReturn(new ChartRef[]{ yref });
+      when(info.getVSChartInfo()).thenReturn(chartInfo);
+
+      ChartFormatRequest request = titleRequest("visualizations-xyz");
+      request.setYAxisMax(1000.0);
+
+      CreateViewsheetResult result = service.setChartFormat(request, null);
+
+      verify(axis).setMaximum(1000.0);
+      assertNull(result.getWarnings());
+   }
+
+   @Test
+   void anUnrecognizedMarkerShapeIsReportedButStillPassedThrough() throws Exception {
+      // The renderer's own fallback decides what appears (GraphGenerator.mapMarkerShape defaults to a
+      // filled circle), and that is left alone — the value is still written. The check exists purely
+      // so the silent substitution can be named.
+      PlotDescriptor plot = mock(PlotDescriptor.class);
+      ChartDescriptor desc = mock(ChartDescriptor.class);
+      when(desc.getPlotDescriptor()).thenReturn(plot);
+      when(info.getChartDescriptor()).thenReturn(desc);
+
+      ChartFormatRequest request = new ChartFormatRequest();
+      request.setWizRuntimeId("rt-1");
+      request.setAssemblyName("vs_1");
+      request.setMarkerShape("hexagon");
+
+      CreateViewsheetResult result = service.setChartFormat(request, null);
+
+      verify(plot).setMarkerShape("hexagon");
+      assertEquals(1, result.getWarnings().size());
+      assertEquals("markerShape", result.getWarnings().get(0).getOption());
+   }
+
+   @Test
+   void aRecognizedMarkerShapeIsNotReported() throws Exception {
+      PlotDescriptor plot = mock(PlotDescriptor.class);
+      ChartDescriptor desc = mock(ChartDescriptor.class);
+      when(desc.getPlotDescriptor()).thenReturn(plot);
+      when(info.getChartDescriptor()).thenReturn(desc);
+
+      ChartFormatRequest request = new ChartFormatRequest();
+      request.setWizRuntimeId("rt-1");
+      request.setAssemblyName("vs_1");
+      // Matched case-insensitively, like the renderer's own switch.
+      request.setMarkerShape("Square");
+
+      assertNull(service.setChartFormat(request, null).getWarnings());
+   }
+
+   @Test
+   void aFullyAppliedFormatRequestCarriesNoWarnings() throws Exception {
+      // Regression guard: the field stays ABSENT rather than becoming an empty list.
+      assertNull(service.setChartFormat(titleRequest("visualizations-xyz"), null).getWarnings());
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceFilterCopyTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceFilterCopyTest.java
@@ -197,6 +197,91 @@ class WizVsServiceFilterCopyTest {
       verify(assembly).setPreConditionList(any());
    }
 
+   // ── Conditions the request asked for that did not make it into the applied filter ─────────────
+   //
+   // A dropped condition WIDENS the result instead of emptying it, so the chart renders normally and
+   // answers a question nobody asked. The response is the only place that can say so: nothing about
+   // the applied ConditionList records which nodes were meant to be in it.
+
+   /** A leaf carrying no field name at all — the shape appendConditionNodes drops. */
+   private static VisualizationConditionModel.ConditionLeaf fieldlessLeaf(String junction) {
+      return new VisualizationConditionModel.ConditionLeaf(junction,
+         new VisualizationConditionModel.ConditionSpec(
+            null, null, null, null, null, false, "EQUAL_TO", null,
+            List.of(new VisualizationConditionModel.ValueSpec("VALUE", "A", null))));
+   }
+
+   private static VisualizationConditionModel.ConditionLeaf validLeaf(String junction, String field) {
+      return new VisualizationConditionModel.ConditionLeaf(junction,
+         new VisualizationConditionModel.ConditionSpec(
+            field, null, null, null, null, false, "EQUAL_TO", null,
+            List.of(new VisualizationConditionModel.ValueSpec("VALUE", "A", null))));
+   }
+
+   private static CreateVisualizationModel conditionRequest(
+      List<VisualizationConditionModel.ConditionNode> nodes)
+   {
+      VisualizationConditionModel cm = new VisualizationConditionModel();
+      cm.setBaseConditions(nodes);
+
+      CreateVisualizationModel model = new CreateVisualizationModel();
+      model.setRuntimeId("rt-1");
+      model.setConditionModel(cm);
+      return model;
+   }
+
+   @Test
+   void aPartiallyDroppedFilterStillAppliesAndReportsWhatWasDropped() throws Exception {
+      // The most dangerous of the two: canApplyConditions passes (the list is non-empty), so the
+      // partial filter is written as though it were the complete one and the call is an ordinary
+      // success. Only the warning distinguishes it.
+      CreateViewsheetResult result = service.createViewsheet(
+         conditionRequest(List.of(validLeaf(null, "Category"), fieldlessLeaf("AND"))), user);
+
+      verify(assembly).setPreConditionList(any());
+      assertEquals(1, result.getWarnings().size());
+      assertEquals("filter", result.getWarnings().get(0).getOption());
+      assertTrue(result.getWarnings().get(0).getReason().contains("more data than asked for"),
+                 "the reason must say the chart is WIDER than requested, which is the whole risk");
+   }
+
+   @Test
+   void aFilterThatCouldNotBeBuiltAtAllIsReportedPerNodeAndAsAWhole() throws Exception {
+      CreateViewsheetResult result = service.createViewsheet(
+         conditionRequest(List.of(fieldlessLeaf(null), fieldlessLeaf("AND"))), user);
+
+      // Behaviour is unchanged: an all-unusable list leaves the existing conditions alone rather than
+      // clearing them. Reporting it is the only thing that is new.
+      verify(assembly, never()).setPreConditionList(any());
+      // Two per-node reasons plus the consequence no single node can state.
+      assertEquals(3, result.getWarnings().size());
+      assertTrue(result.getWarnings().get(2).getReason().contains("still shows all the data"));
+   }
+
+   @Test
+   void anUnrecognizedAggregationInAFilterReportsWhatItComparedInstead() throws Exception {
+      // The formula falls back to SUM rather than failing, which keeps the chart — but "regions where
+      // the AVERAGE sale is over 100" then means "where the TOTAL is over 100", a different set of
+      // rows with nothing on screen to give it away.
+      CreateViewsheetResult result = service.createViewsheet(conditionRequest(List.of(
+         new VisualizationConditionModel.ConditionLeaf(null,
+            new VisualizationConditionModel.ConditionSpec(
+               "amount", "avg_value", null, null, null, false, "GREATER_THAN", null,
+               List.of(new VisualizationConditionModel.ValueSpec("VALUE", "100", null)))))), user);
+
+      verify(assembly).setPreConditionList(any());
+      assertEquals(1, result.getWarnings().size());
+      assertEquals("filter:amount", result.getWarnings().get(0).getOption());
+      assertTrue(result.getWarnings().get(0).getReason().contains("compared the total instead"));
+   }
+
+   @Test
+   void aFilterThatFullyAppliesReportsNoWarnings() throws Exception {
+      // Regression guard: the field must stay ABSENT on the ordinary path, so a caller can test it
+      // rather than having to check an always-present empty list.
+      assertNull(service.createViewsheet(request(false), user).getWarnings());
+   }
+
    @Test
    void copyTrueDuplicatesBeforeApplyingAndTargetsTheCopy() throws Exception {
       ChartVSAssembly copy = mock(ChartVSAssembly.class);

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceResolveRuleHighlightRefsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceResolveRuleHighlightRefsTest.java
@@ -29,6 +29,7 @@ import inetsoft.uql.viewsheet.graph.VSChartAggregateRef;
 import inetsoft.uql.viewsheet.graph.VSChartDimensionRef;
 import inetsoft.uql.viewsheet.graph.VSChartInfo;
 import inetsoft.web.wiz.model.ApplyHighlightModel;
+import inetsoft.web.wiz.model.ApplyWarning;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -37,11 +38,13 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -114,7 +117,7 @@ class WizVsServiceResolveRuleHighlightRefsTest {
       assertNotEquals(agg.getName(), fullName);
 
       List<HighlightRef> refs = service.resolveRuleHighlightRefs(
-         ruleOn(fullName), allRefs, chartInfo, false);
+         ruleOn(fullName), allRefs, chartInfo, false, null);
 
       assertEquals(1, refs.size());
       assertSame(agg, refs.get(0));
@@ -123,7 +126,7 @@ class WizVsServiceResolveRuleHighlightRefsTest {
    @Test
    void aRuleNamingAMeasureByItsPlainNameNarrowsToThatRefAlone() {
       List<HighlightRef> refs = service.resolveRuleHighlightRefs(
-         ruleOn(agg.getName()), allRefs, chartInfo, false);
+         ruleOn(agg.getName()), allRefs, chartInfo, false, null);
 
       assertEquals(1, refs.size());
       assertSame(agg, refs.get(0));
@@ -134,7 +137,7 @@ class WizVsServiceResolveRuleHighlightRefsTest {
       // The other half of the bug: naming the dimension must colour the axis only, leaving the measure —
       // and so the plot marks — untouched.
       List<HighlightRef> refs = service.resolveRuleHighlightRefs(
-         ruleOn(dim.getFullName()), allRefs, chartInfo, false);
+         ruleOn(dim.getFullName()), allRefs, chartInfo, false, null);
 
       assertEquals(1, refs.size());
       assertSame(dim, refs.get(0));
@@ -145,7 +148,7 @@ class WizVsServiceResolveRuleHighlightRefsTest {
       // Deliberately lenient, unlike the case-sensitive crosstab path: a miss here silently widens to every
       // ref (i.e. reproduces this very bug) rather than failing loud the way applyTableHighlight does.
       List<HighlightRef> refs = service.resolveRuleHighlightRefs(
-         ruleOn(agg.getName().toUpperCase()), allRefs, chartInfo, false);
+         ruleOn(agg.getName().toUpperCase()), allRefs, chartInfo, false, null);
 
       assertEquals(1, refs.size());
       assertSame(agg, refs.get(0));
@@ -153,14 +156,14 @@ class WizVsServiceResolveRuleHighlightRefsTest {
 
    @Test
    void aRuleNamingNoFieldFallsBackToEveryRef() {
-      assertSame(allRefs, service.resolveRuleHighlightRefs(ruleOn(null), allRefs, chartInfo, false));
-      assertSame(allRefs, service.resolveRuleHighlightRefs(ruleOn("   "), allRefs, chartInfo, false));
+      assertSame(allRefs, service.resolveRuleHighlightRefs(ruleOn(null), allRefs, chartInfo, false, null));
+      assertSame(allRefs, service.resolveRuleHighlightRefs(ruleOn("   "), allRefs, chartInfo, false, null));
    }
 
    @Test
    void aRuleNamingAnUnboundFieldFallsBackToEveryRef() {
       assertSame(allRefs, service.resolveRuleHighlightRefs(
-         ruleOn("NoSuchColumn"), allRefs, chartInfo, false));
+         ruleOn("NoSuchColumn"), allRefs, chartInfo, false, null));
    }
 
    @Test
@@ -168,7 +171,7 @@ class WizVsServiceResolveRuleHighlightRefsTest {
       // Its highlightable ref is the TEXT aesthetic, not the X/Y binding this narrowing understands, so
       // narrowing by an X/Y-shaped name would drop the highlight rather than merely widen it.
       assertSame(allRefs, service.resolveRuleHighlightRefs(
-         ruleOn(agg.getFullName()), allRefs, chartInfo, true));
+         ruleOn(agg.getFullName()), allRefs, chartInfo, true, null));
    }
 
    @Test
@@ -176,7 +179,7 @@ class WizVsServiceResolveRuleHighlightRefsTest {
       chartInfo.setChartType(GraphTypes.CHART_TREEMAP);
 
       assertSame(allRefs, service.resolveRuleHighlightRefs(
-         ruleOn(agg.getFullName()), allRefs, chartInfo, false));
+         ruleOn(agg.getFullName()), allRefs, chartInfo, false, null));
    }
 
    @Test
@@ -188,7 +191,7 @@ class WizVsServiceResolveRuleHighlightRefsTest {
       chartInfo.setRTChartType(GraphTypes.CHART_BAR);
 
       assertSame(allRefs, service.resolveRuleHighlightRefs(
-         ruleOn(agg.getFullName()), allRefs, chartInfo, false));
+         ruleOn(agg.getFullName()), allRefs, chartInfo, false, null));
    }
 
    @Test
@@ -197,7 +200,7 @@ class WizVsServiceResolveRuleHighlightRefsTest {
       chartInfo.setChartType(GraphTypes.CHART_NETWORK);
 
       assertSame(allRefs, service.resolveRuleHighlightRefs(
-         ruleOn(agg.getFullName()), allRefs, chartInfo, false));
+         ruleOn(agg.getFullName()), allRefs, chartInfo, false, null));
    }
 
    @Test
@@ -215,7 +218,49 @@ class WizVsServiceResolveRuleHighlightRefsTest {
       List<HighlightRef> matrixRefs = List.of(sales, profit);
 
       assertSame(matrixRefs, service.resolveRuleHighlightRefs(
-         ruleOn(sales.getFullName()), matrixRefs, matrix, false));
+         ruleOn(sales.getFullName()), matrixRefs, matrix, false, null));
+   }
+
+   /**
+    * Reporting the one fallback the caller cannot otherwise detect.
+    *
+    * <p>Falling back to every ref is deliberate and stays — narrowing wrongly would drop the highlight
+    * entirely, which is worse than widening it. But when the rule NAMED a field and nothing matched, the
+    * name the caller supplied did nothing and every series is highlighted instead of the one they asked
+    * about. Nothing in the 200 response said so, and the caller went on to report a clean success.
+    */
+   @Test
+   void aRuleNamingAnUnboundFieldReportsThatItWasWidened() {
+      List<ApplyWarning> warnings = new ArrayList<>();
+
+      assertSame(allRefs, service.resolveRuleHighlightRefs(
+         ruleOn("NoSuchColumn"), allRefs, chartInfo, false, warnings));
+
+      assertEquals(1, warnings.size());
+      assertEquals("highlight:NoSuchColumn", warnings.get(0).getOption());
+      assertTrue(warnings.get(0).getReason().contains("every series"),
+                 "the reason must say what happened INSTEAD, not just that the name was unknown");
+   }
+
+   @Test
+   void aRuleThatNarrowsSuccessfullyReportsNothing() {
+      List<ApplyWarning> warnings = new ArrayList<>();
+
+      service.resolveRuleHighlightRefs(ruleOn(agg.getFullName()), allRefs, chartInfo, false, warnings);
+
+      assertTrue(warnings.isEmpty());
+   }
+
+   @Test
+   void theFallbacksThatWereNeverAskedToNarrowReportNothing() {
+      // A rule naming no field never asked for one ref, and the special chart types cannot be narrowed
+      // at all — reporting those would fire on every rule those charts carry and bury the case above.
+      List<ApplyWarning> warnings = new ArrayList<>();
+
+      service.resolveRuleHighlightRefs(ruleOn(null), allRefs, chartInfo, false, warnings);
+      service.resolveRuleHighlightRefs(ruleOn("NoSuchColumn"), allRefs, chartInfo, true, warnings);
+
+      assertTrue(warnings.isEmpty());
    }
 
    @Test
@@ -224,6 +269,6 @@ class WizVsServiceResolveRuleHighlightRefsTest {
       List<HighlightRef> single = List.of(agg);
 
       assertSame(single, service.resolveRuleHighlightRefs(
-         ruleOn("NoSuchColumn"), single, chartInfo, false));
+         ruleOn("NoSuchColumn"), single, chartInfo, false, null));
    }
 }


### PR DESCRIPTION
Several apply paths take a request, skip the part of it that cannot apply to this chart, and return 200 for the rest. That is the right behaviour — rejecting the whole request over one unusable option would discard the settings that were fine — but the caller had no way to learn which part was dropped, so an edit that did nothing was reported to the user as done.

This carries those as warnings on the response. **Execution is unchanged throughout**: what was skipped is still skipped, what fell back to a default still falls back, and no status code changes.

## What now reports

| Option | Behaviour |
|---|---|
| y-axis scale on a chart with no y-axis | Neither the empty `getYFields()` nor the missing `AxisDescriptor` sits in an else branch, so the check counts the axes actually written |
| unrecognized `legendPosition` | Previously the one case that did report, via `note` |
| unrecognized `markerShape` | `GraphGenerator` maps it to `FILLED_CIRCLE` through a switch default, so the value is still passed through and the warning names the shape actually drawn |
| filter leaf naming no column | `canApplyConditions` refuses only a list where every node was unusable, so a partial drop widened the result and read as a correct answer |
| dimension / measure absent from the worksheet columns | Dropped from the aggregation |
| unrecognized aggregate formula | Both the binding and the having-clause path. This one changes what the numbers mean, so the reason states that the measure was summed instead |
| chart type with no matching recommendation | Substituted by the first available one. The reason names the type actually rendered, since the caller narrates the type it asked for |
| highlight rule naming a field that matches no ref | Silently colours every series instead of the one the rule meant |

Warnings are user-facing sentences, not internal labels — they reach the chat window through the wiz side.

## note is a single-purpose channel again

`combineNotes` merged the copy-fallback warning with unrelated parameter warnings into one string the caller could not tell apart, and the caller consequently read a legend rejection as a declined copy. It is gone; `note` carries the copy fallback alone.

## Testing

`mvn test` on the four affected classes — 55 passed, 0 failures.

- `WizVsServiceFilterCopyTest` 13 (+4)
- `WizAutoBindingServiceSetChartFormatTest` 17 (+5, 1 rewritten)
- `WizAutoBindingServiceChartTypeCandidatesTest` 10 (+4)
- `WizVsServiceResolveRuleHighlightRefsTest` 15 (+3)

The rewritten case asserted the note-concatenation behaviour this change removes; it now asserts the two channels stay separate. Paths without existing test coverage were changed without adding new test files, per the repository convention.

The consuming side is inetsoft-technology/stylebi-wiz#1554.

🤖 Generated with [Claude Code](https://claude.com/claude-code)