### PR TITLE
Bug #76056, guard against zero time conditions in redistributeTasks

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskService.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/ScheduleTaskService.java
@@ -950,6 +950,12 @@ public class ScheduleTaskService {
          .flatMap(ScheduleTask::getConditionStream)
          .filter(TimeCondition.class::isInstance)
          .count();
+
+      if(count == 0) {
+         throw new MessageException(Catalog.getCatalog(principal)
+            .getString("em.schedule.distribution.noTimeConditions"));
+      }
+
       long duration = Duration.between(startTime, endTime).get(ChronoUnit.SECONDS) / 60L;
       int concurrency;
       long interval = duration / count;

--- a/core/src/main/resources/inetsoft/util/srinter.properties
+++ b/core/src/main/resources/inetsoft/util/srinter.properties
@@ -4516,6 +4516,7 @@ em.schedule.deleteMultiple.task.confirm=Are you sure you want to delete these ta
 em.schedule.dependenciesFound=Dependencies Found
 em.schedule.distribution.dayError=Failed to get day distribution
 em.schedule.distribution.hourError=Failed to get hour distribution
+em.schedule.distribution.noTimeConditions=None of the selected tasks have a time condition to redistribute.
 em.schedule.distribution.weekError=Failed to get week distribution
 em.schedule.distributionDesc=The hard count is the number of tasks that will always occur in the given time slot. The soft count is the maximum number of additional tasks that may occur in the given time slot, such as those on a particular day of the month or those with an irregular interval.
 em.schedule.duplicateClasspath=Duplicate classpath

--- a/core/src/test/java/inetsoft/web/admin/schedule/ScheduleTaskServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/schedule/ScheduleTaskServiceTest.java
@@ -1,0 +1,100 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.schedule;
+
+import inetsoft.sree.AnalyticRepository;
+import inetsoft.sree.schedule.*;
+import inetsoft.util.MessageException;
+import inetsoft.web.admin.schedule.model.ScheduleTaskList;
+import org.junit.jupiter.api.*;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.security.Principal;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("core")
+class ScheduleTaskServiceTest {
+
+   @Mock
+   private AnalyticRepository analyticRepository;
+   @Mock
+   private ScheduleManager scheduleManager;
+   @Mock
+   private ScheduleService scheduleService;
+   @Mock
+   private Principal principal;
+
+   private ScheduleTaskService service;
+
+   @BeforeEach
+   void setUp() {
+      service = new ScheduleTaskService(
+         analyticRepository, scheduleManager, scheduleService, null, null, null, null);
+   }
+
+   // ── redistributeTasks ────────────────────────────────────────────────────
+
+   @Test
+   void redistributeTasks_noTimeConditions_throwsMessageException() throws Exception {
+      ScheduleTask task = new ScheduleTask("task1");
+      when(scheduleManager.getScheduleTask("task1")).thenReturn(task);
+
+      MessageException ex = assertThrows(MessageException.class, () ->
+         service.redistributeTasks(
+            LocalTime.of(0, 0), LocalTime.of(23, 0), 4, List.of("task1"), principal));
+
+      assertFalse(ex.getMessage().isEmpty(),
+         "the localized message must not be empty -- ensures the em.schedule." +
+         "distribution.noTimeConditions catalog key resolved rather than falling back");
+      verify(scheduleService, never()).saveTask(any(), any(), any());
+   }
+
+   @Test
+   void redistributeTasks_emptySelection_throwsMessageException() {
+      assertThrows(MessageException.class, () ->
+         service.redistributeTasks(
+            LocalTime.of(0, 0), LocalTime.of(23, 0), 4, List.of(), principal));
+   }
+
+   @Test
+   void redistributeTasks_hasTimeCondition_redistributesWithoutError() throws Exception {
+      ScheduleTask task = new ScheduleTask("task1");
+      TimeCondition tc = new TimeCondition();
+      tc.setType(TimeCondition.EVERY_DAY);
+      tc.setHour(1);
+      tc.setMinute(0);
+      task.addCondition(tc);
+
+      when(scheduleManager.getScheduleTask("task1")).thenReturn(task);
+      when(scheduleService.getScheduleTaskList("", "", principal))
+         .thenReturn(mock(ScheduleTaskList.class));
+
+      ScheduleTaskList result = service.redistributeTasks(
+         LocalTime.of(0, 0), LocalTime.of(23, 0), 4, List.of("task1"), principal);
+
+      assertNotNull(result);
+      verify(scheduleService).saveTask("task1", task, principal);
+   }
+}


### PR DESCRIPTION
`ScheduleTaskService.redistributeTasks` computed `duration / count`, where `count` is the number of `TimeCondition` instances across the selected tasks, with no guard against zero. Redistributing a        
  selection containing no time conditions threw `ArithmeticException: / by zero`.

  Issue #28611 reported this same exception from this same method in 2018 and was closed by disabling the Enterprise Manager button for the reported selection. That check keys off a fixed list of internal   
  task *names* (`ScheduleTaskListComponent.internalTask0`), which is unrelated to whether a task actually carries a `TimeCondition` — so the fault itself was never fixed, only one known client path to it.   
  Any other caller reaching `EMScheduleController.redistributeTasks` with a selection carrying no time condition still divided by zero.

  The codebase already encoded this precondition: `TaskBalancer.getInterval` performs the equivalent computation and rejects `conditions <= 0` explicitly, and `TaskBalancer.balanceTasks` short-circuits on an
  empty condition list before ever calling it. The two call sites disagreed about the same precondition.

  ## Fix

  - **`ScheduleTaskService.redistributeTasks`** — guard `count == 0` immediately after it is computed, before the division, throwing a localized `MessageException`. `MessageException` is the established     
  convention for user-facing validation errors in this package: `AdminExceptionHandler.handleException` special-cases it, returning the message intact to the client and logging at the exception's own level  
  without a stack dump, rather than falling through to a generic 500 + `ERROR`-level stack trace.
  - **`srinter.properties`** — add `em.schedule.distribution.noTimeConditions`, alongside the existing `em.schedule.distribution.*` keys.

  Enforced for every caller, rather than relying on a client disabling a control.

  ## Tests

  New `ScheduleTaskServiceTest`:
  - selection with no `TimeCondition` throws `MessageException` (not `ArithmeticException`) and never calls `saveTask`
  - empty selection likewise
  - selection **with** a `TimeCondition` still redistributes and saves — regression guard on the existing path

