### PR TITLE
Bug #76055, report scheduler health as unknown instead of a false UP

### DIFF
--- a/server/src/main/java/inetsoft/web/health/SchedulerHealthIndicator.java
+++ b/server/src/main/java/inetsoft/web/health/SchedulerHealthIndicator.java
@@ -39,34 +39,49 @@ public class SchedulerHealthIndicator implements HealthIndicator {
 
    @Override
    public Health health() {
-      if(client.isCloud() || client.isAutoStart()) {
-         try {
-            Optional<HealthStatus> status = client.getHealthStatus();
-
-            if(status.isPresent()) {
-               SchedulerStatus health = status.get().getSchedulerStatus();
-
-               if(!health.isHealthy()) {
-                  LoggerFactory.getLogger(getClass()).error(
-                     "SchedulerHealthIndicator DOWN: status={}", health);
-                  statusDumpService.dumpStatus();
-                  return Health.down()
-                     .withDetail("started", health.isStarted())
-                     .withDetail("shutdown", health.isShutdown())
-                     .withDetail("standby", health.isStandby())
-                     .withDetail("lastCheck", Instant.ofEpochMilli(health.getLastCheck()).toString())
-                     .withDetail("executingCount", health.getExecutingCount())
-                     .withDetail("threadCount", health.getThreadCount())
-                     .build();
-               }
-            }
-         }
-         catch(Exception e) {
-            LoggerFactory.getLogger(getClass()).error("Failed to get scheduler health", e);
-         }
+      if(!(client.isCloud() || client.isAutoStart())) {
+         // The scheduler runs as an independent process this node cannot reach
+         // (e.g. a clustered install, or a non-cloud install with auto-start
+         // disabled), so there is no way to determine its health from here.
+         return unknown("scheduler health cannot be determined from this node");
       }
 
-      return Health.up().build();
+      try {
+         Optional<HealthStatus> status = client.getHealthStatus();
+
+         if(status.isPresent()) {
+            SchedulerStatus health = status.get().getSchedulerStatus();
+
+            if(!health.isHealthy()) {
+               LoggerFactory.getLogger(getClass()).error(
+                  "SchedulerHealthIndicator DOWN: status={}", health);
+               statusDumpService.dumpStatus();
+               return Health.down()
+                  .withDetail("started", health.isStarted())
+                  .withDetail("shutdown", health.isShutdown())
+                  .withDetail("standby", health.isStandby())
+                  .withDetail("lastCheck", Instant.ofEpochMilli(health.getLastCheck()).toString())
+                  .withDetail("executingCount", health.getExecutingCount())
+                  .withDetail("threadCount", health.getThreadCount())
+                  .build();
+            }
+
+            return Health.up().build();
+         }
+
+         return unknown("scheduler health status unavailable");
+      }
+      catch(Exception e) {
+         // Don't include e.getMessage() in the response: the health endpoint may be
+         // reachable without authentication, and the exception could carry internal
+         // connection details. It's still fully captured in the server log below.
+         LoggerFactory.getLogger(getClass()).error("Failed to get scheduler health", e);
+         return unknown("failed to get scheduler health");
+      }
+   }
+
+   private static Health unknown(String reason) {
+      return Health.unknown().withDetail("reason", reason).build();
    }
 
    private final ScheduleClient client;

--- a/server/src/test/java/inetsoft/web/health/SchedulerHealthIndicatorTest.java
+++ b/server/src/test/java/inetsoft/web/health/SchedulerHealthIndicatorTest.java
@@ -1,0 +1,111 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.health;
+
+import inetsoft.sree.schedule.ScheduleClient;
+import inetsoft.util.StatusDumpService;
+import inetsoft.util.health.HealthStatus;
+import inetsoft.util.health.SchedulerStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+
+import java.util.Optional;
+import java.util.concurrent.Future;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SchedulerHealthIndicatorTest {
+   @Mock
+   private ScheduleClient client;
+   @Mock
+   private StatusDumpService statusDumpService;
+   @Mock
+   private HealthStatus healthStatus;
+
+   private SchedulerHealthIndicator indicator;
+
+   @BeforeEach
+   void setUp() {
+      indicator = new SchedulerHealthIndicator(client, statusDumpService);
+   }
+
+   @Test
+   void health_guardFalse_reportsUnknown() {
+      when(client.isCloud()).thenReturn(false);
+      when(client.isAutoStart()).thenReturn(false);
+
+      Health health = indicator.health();
+
+      assertEquals(Status.UNKNOWN, health.getStatus());
+      verifyNoInteractions(statusDumpService);
+   }
+
+   @Test
+   void health_statusAbsent_reportsUnknown() throws Exception {
+      when(client.isCloud()).thenReturn(true);
+      when(client.getHealthStatus()).thenReturn(Optional.empty());
+
+      Health health = indicator.health();
+
+      assertEquals(Status.UNKNOWN, health.getStatus());
+   }
+
+   @Test
+   void health_getHealthStatusThrows_reportsUnknown() throws Exception {
+      when(client.isCloud()).thenReturn(true);
+      when(client.getHealthStatus()).thenThrow(new RuntimeException("unreachable"));
+
+      Health health = indicator.health();
+
+      assertEquals(Status.UNKNOWN, health.getStatus());
+   }
+
+   @Test
+   void health_schedulerHealthy_reportsUp() throws Exception {
+      SchedulerStatus schedulerStatus = new SchedulerStatus(
+         true, false, false, 0L, 0L, Future.State.RUNNING, 0, 4);
+      when(client.isCloud()).thenReturn(true);
+      when(client.getHealthStatus()).thenReturn(Optional.of(healthStatus));
+      when(healthStatus.getSchedulerStatus()).thenReturn(schedulerStatus);
+
+      Health health = indicator.health();
+
+      assertEquals(Status.UP, health.getStatus());
+   }
+
+   @Test
+   void health_schedulerUnhealthy_reportsDown() throws Exception {
+      SchedulerStatus schedulerStatus = new SchedulerStatus(
+         false, true, false, 0L, 0L, Future.State.RUNNING, 0, 4);
+      when(client.isCloud()).thenReturn(true);
+      when(client.getHealthStatus()).thenReturn(Optional.of(healthStatus));
+      when(healthStatus.getSchedulerStatus()).thenReturn(schedulerStatus);
+
+      Health health = indicator.health();
+
+      assertEquals(Status.DOWN, health.getStatus());
+      verify(statusDumpService).dumpStatus();
+   }
+}


### PR DESCRIPTION
## Summary

`SchedulerHealthIndicator.health()` only queried the scheduler inside `if(client.isCloud() || client.isAutoStart())`. Every other path fell through to `return Health.up().build()`, so the endpoint asserted the scheduler was healthy without ever having looked:

- The guard itself is `false` on every non-cloud install with the default `schedule.auto.start=false` (the value `StorageInitializer` writes on first storage init), and on every clustered install regardless of that property (`ScheduleClient.isAutoStart()` ANDs in a not-clustered check). These are exactly the deployments where the scheduler runs as an independently failing process.
- Inside the guarded branch, an absent `HealthStatus` or a caught exception from `client.getHealthStatus()` also fell through to UP. The exception path is not hypothetical -- Bug #72788 and Bug #74509 are production reports of exactly that log line (`Failed to get scheduler health`) masking a real failure.

## Fix

Restructured `health()` so every "couldn't determine" path returns `Health.unknown()` instead of `Health.up()`. Only a check that actually completed and got a real `SchedulerStatus` now returns `Health.up()`/`Health.down()`, matching existing behavior for those two cases exactly (same detail fields, same logging, same `statusDumpService.dumpStatus()` call on DOWN).

The exception path logs the full exception server-side as before, but intentionally does not include the exception message in the health response detail, since `/health` is exposed with `show-details: always` and may not require authentication.

## Testing

Added `SchedulerHealthIndicatorTest` covering all five branches (guard false, absent status, exception, healthy, unhealthy):

```
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)