### PR TITLE
Bug #76043, fix blank pop-up when a group container is used as a pop component

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.display.tl.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.display.tl.spec.ts
@@ -30,6 +30,7 @@
  *   Group 8   isChartAnnotationSelected — selectedAnnotations membership
  *   Group 9   needsZIndexBoost — data tip and pop component cases
  *   Group 10  toolbarForceHidden — delegates to miniToolbarService
+ *   Group 11  isActivePopComponent — active pop component, self and grouped-child cases
  */
 
 import {
@@ -281,5 +282,73 @@ describe("Group 9 — toolbarForceHidden: delegates to miniToolbarService.isMini
       const { comp } = makeComponent({ miniToolbarSvc: miniToolbarSvc as any });
       const obj = makeVSObject({ absoluteName: "Chart1" });
       expect(comp.toolbarForceHidden(obj)).toBe(true);
+   });
+});
+
+// ---------------------------------------------------------------------------
+// Group 11 — isActivePopComponent
+// ---------------------------------------------------------------------------
+
+describe("Group 11 — isActivePopComponent: active pop component, self and grouped-child cases", () => {
+   it("should return false when no pop component is active", () => {
+      const { comp } = makeComponent();
+      const obj = makeVSObject({ absoluteName: "GroupContainer1" });
+      expect(comp.isActivePopComponent(obj)).toBe(false);
+   });
+
+   it("should return true when the object itself is the active pop component", () => {
+      const popSvc = {
+         componentPop: { subscribe: vi.fn() } as any,
+         getPopComponent: vi.fn().mockReturnValue("GroupContainer1"),
+         isPopComponent: vi.fn((name: string) => name === "GroupContainer1"),
+         isPopSource: vi.fn().mockReturnValue(false),
+         hasPopUpComponentShowing: vi.fn().mockReturnValue(true),
+      };
+      const { comp } = makeComponent({ popSvc: popSvc as any });
+      const obj = makeVSObject({ absoluteName: "GroupContainer1" });
+      expect(comp.isActivePopComponent(obj)).toBe(true);
+   });
+
+   // Bug: "Group as popComponent, display blank" -- a group container's grouped
+   // children must also get the z-index boost when the container is the active
+   // pop component, otherwise they render underneath the container's own boosted,
+   // opaque background and the pop-up appears empty.
+   it("should return true for a grouped child when its container is the active pop component", () => {
+      const popSvc = {
+         componentPop: { subscribe: vi.fn() } as any,
+         getPopComponent: vi.fn().mockReturnValue("GroupContainer1"),
+         isPopComponent: vi.fn((name: string) => name === "GroupContainer1"),
+         isPopSource: vi.fn().mockReturnValue(false),
+         hasPopUpComponentShowing: vi.fn().mockReturnValue(true),
+      };
+      const { comp } = makeComponent({ popSvc: popSvc as any });
+      const child = makeVSObject({ absoluteName: "Text2", container: "GroupContainer1" });
+      expect(comp.isActivePopComponent(child)).toBe(true);
+   });
+
+   it("should return false for a grouped child when its container is not the active pop component", () => {
+      const popSvc = {
+         componentPop: { subscribe: vi.fn() } as any,
+         getPopComponent: vi.fn().mockReturnValue("OtherContainer"),
+         isPopComponent: vi.fn((name: string) => name === "OtherContainer"),
+         isPopSource: vi.fn().mockReturnValue(false),
+         hasPopUpComponentShowing: vi.fn().mockReturnValue(true),
+      };
+      const { comp } = makeComponent({ popSvc: popSvc as any });
+      const child = makeVSObject({ absoluteName: "Text2", container: "GroupContainer1" });
+      expect(comp.isActivePopComponent(child)).toBe(false);
+   });
+
+   it("should return false for an unrelated top-level object while a different pop component is active", () => {
+      const popSvc = {
+         componentPop: { subscribe: vi.fn() } as any,
+         getPopComponent: vi.fn().mockReturnValue("GroupContainer1"),
+         isPopComponent: vi.fn((name: string) => name === "GroupContainer1"),
+         isPopSource: vi.fn().mockReturnValue(false),
+         hasPopUpComponentShowing: vi.fn().mockReturnValue(true),
+      };
+      const { comp } = makeComponent({ popSvc: popSvc as any });
+      const obj = makeVSObject({ absoluteName: "Table1", container: null });
+      expect(comp.isActivePopComponent(obj)).toBe(false);
    });
 });

--- a/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.display.tl.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.display.tl.spec.ts
@@ -351,4 +351,38 @@ describe("Group 11 — isActivePopComponent: active pop component, self and grou
       const obj = makeVSObject({ absoluteName: "Table1", container: null });
       expect(comp.isActivePopComponent(obj)).toBe(false);
    });
+
+   // A GroupContainer can contain a Tab (GroupContainer -> Tab -> children), so a
+   // grandchild's immediate .container points at the Tab, not the outer GroupContainer
+   // that is actually registered as the pop component. isActivePopComponent must walk
+   // the full ancestor chain (like zIndex() does) to still boost this grandchild.
+   it("should return true for a grandchild nested through an intermediate Tab when the outer group container is the active pop component", () => {
+      const popSvc = {
+         componentPop: { subscribe: vi.fn() } as any,
+         getPopComponent: vi.fn().mockReturnValue("GroupContainer1"),
+         isPopComponent: vi.fn((name: string) => name === "GroupContainer1"),
+         isPopSource: vi.fn().mockReturnValue(false),
+         hasPopUpComponentShowing: vi.fn().mockReturnValue(true),
+      };
+      const { comp } = makeComponent({ popSvc: popSvc as any });
+      const tab = makeVSObject({ absoluteName: "Tab1", container: "GroupContainer1" });
+      const grandchild = makeVSObject({ absoluteName: "Chart1", container: "Tab1" });
+      comp.vsInfo = makeVsInfo([tab, grandchild]);
+      expect(comp.isActivePopComponent(grandchild)).toBe(true);
+   });
+
+   it("should return false for a grandchild nested through an intermediate Tab when neither the tab nor its outer container is the active pop component", () => {
+      const popSvc = {
+         componentPop: { subscribe: vi.fn() } as any,
+         getPopComponent: vi.fn().mockReturnValue("OtherContainer"),
+         isPopComponent: vi.fn((name: string) => name === "OtherContainer"),
+         isPopSource: vi.fn().mockReturnValue(false),
+         hasPopUpComponentShowing: vi.fn().mockReturnValue(true),
+      };
+      const { comp } = makeComponent({ popSvc: popSvc as any });
+      const tab = makeVSObject({ absoluteName: "Tab1", container: "GroupContainer1" });
+      const grandchild = makeVSObject({ absoluteName: "Chart1", container: "Tab1" });
+      comp.vsInfo = makeVsInfo([tab, grandchild]);
+      expect(comp.isActivePopComponent(grandchild)).toBe(false);
+   });
 });

--- a/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.ts
@@ -518,15 +518,29 @@ export class VSObjectContainer implements AfterViewInit, OnChanges, OnDestroy {
          return false;
       }
 
+      if(this.popService.isPopComponent(vsObject.absoluteName) &&
+         popComponent === vsObject.absoluteName)
+      {
+         return true;
+      }
+
       // Also boost the z-index of the children of a group container when the group
       // container itself is the active pop component -- otherwise the children remain
       // stacked below the container's own boosted, opaque background image/border and
       // the pop-up appears blank. Mirrors DataTipService.isCurrentDataTip's
-      // container-match arm (see needsZIndexBoost's dataTip check just below).
-      return this.popService.isPopComponent(vsObject.absoluteName) &&
-            popComponent === vsObject.absoluteName ||
-         !!vsObject.container && this.popService.isPopComponent(vsObject.container) &&
-            popComponent === vsObject.container;
+      // container-match arm (see needsZIndexBoost's dataTip check just below). Walk the
+      // full container ancestor chain (mirrors zIndex()'s loop below) so a grandchild
+      // nested through an intermediate Tab/GroupContainer is still boosted.
+      for(let container = vsObject.container; container; ) {
+         if(this.popService.isPopComponent(container) && popComponent === container) {
+            return true;
+         }
+
+         const containerObj = this.vsInfo.vsObjects.find(v => v.absoluteName === container);
+         container = containerObj ? containerObj.container : null;
+      }
+
+      return false;
    }
 
    needsZIndexBoost(vsObject: VSObjectModel): boolean {

--- a/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/vs-object-container.component.ts
@@ -512,8 +512,21 @@ export class VSObjectContainer implements AfterViewInit, OnChanges, OnDestroy {
    }
 
    isActivePopComponent(vsObject: VSObjectModel): boolean {
+      const popComponent = this.popService.getPopComponent();
+
+      if(!popComponent) {
+         return false;
+      }
+
+      // Also boost the z-index of the children of a group container when the group
+      // container itself is the active pop component -- otherwise the children remain
+      // stacked below the container's own boosted, opaque background image/border and
+      // the pop-up appears blank. Mirrors DataTipService.isCurrentDataTip's
+      // container-match arm (see needsZIndexBoost's dataTip check just below).
       return this.popService.isPopComponent(vsObject.absoluteName) &&
-         this.popService.getPopComponent() === vsObject.absoluteName;
+            popComponent === vsObject.absoluteName ||
+         !!vsObject.container && this.popService.isPopComponent(vsObject.container) &&
+            popComponent === vsObject.container;
    }
 
    needsZIndexBoost(vsObject: VSObjectModel): boolean {


### PR DESCRIPTION
## Summary
Clicking a trigger whose **Pop Component** is set to a Group Container popped up a blank white box instead of showing the group's contents.

## Root cause
`isActivePopComponent()` in `vs-object-container.component.ts` only checked whether the object *itself* was the active pop component, never whether its `container` was. When a group container is popped out, its own div gets the `+99999` z-index boost needed to render above the dim overlay canvas (z-index 9996), but its grouped children (e.g. a `Text` and a `Gauge`) did not get that boost — leaving them stacked *underneath* the container's own opaque background image/border, which is what rendered as a blank white pop-up.

## Fix
`isActivePopComponent` now also matches when `vsObject.container` is the active, registered pop component — mirroring the existing `DataTipService.isCurrentDataTip(name, container)` two-way check already used for the equivalent data-tip case in `needsZIndexBoost` right below it.

## Testing
Added "Group 11 — isActivePopComponent" to `vs-object-container.component.display.tl.spec.ts` covering: no active pop, self-match, grouped-child match (the bug scenario), grouped-child non-match, and an unrelated top-level object while a different pop is active.

```
npx ng run portal:test-tl --include="**/vs-object-container.component.display.tl.spec.ts"
✓ 26 tests passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)