### PR TITLE
Bug #76054, fix org-scoped property name case handling in PropertiesEngine

### DIFF
--- a/core/src/main/java/inetsoft/sree/PropertiesEngine.java
+++ b/core/src/main/java/inetsoft/sree/PropertiesEngine.java
@@ -349,20 +349,27 @@ public class PropertiesEngine {
    }
 
    private String computePropertyNameCase(String name) {
+      // organization-scoped property names carry the org ID as a case-insensitive segment;
+      // strip and lowercase it, then apply the case rules below to the remaining property name
+      // so it matches what useAvailableOrgProperty() looks up.
+      if(name.startsWith("inetsoft.org.")) {
+         int dot = name.indexOf('.', "inetsoft.org.".length());
+
+         if(dot >= 0) {
+            String orgPrefix = name.substring(0, dot + 1);
+            String suffix = name.substring(dot + 1);
+            return orgPrefix.toLowerCase() + computePropertyNameCase(suffix);
+         }
+
+         return name.toLowerCase();
+      }
+
       if(!name.startsWith("log.level.") &&
          !name.startsWith("plugin.extra.classpath.") &&
          !name.matches("^log\\.[A-Z_]+\\.level\\..+$") &&
          !name.matches("^inetsoft\\.uql\\.jdbc\\.pool\\..+\\.connectionTestQuery$"))
       {
          return name.toLowerCase();
-      }
-
-      if(name.startsWith("inetsoft.org.")) {
-         int index = name.substring(13).indexOf('.');
-
-         if(index >= 0) {
-            return name.substring(0, 14 + index) + name.substring(14 + index).toLowerCase();
-         }
       }
 
       return name;

--- a/core/src/main/java/inetsoft/sree/PropertiesEngine.java
+++ b/core/src/main/java/inetsoft/sree/PropertiesEngine.java
@@ -358,6 +358,11 @@ public class PropertiesEngine {
          if(dot >= 0) {
             String orgPrefix = name.substring(0, dot + 1);
             String suffix = name.substring(dot + 1);
+            // recurse directly rather than through fixPropertyNameCase(): that would re-enter
+            // propertyNameCaseCache.computeIfAbsent() for a second key while the outer call for
+            // this name is still computing, which ConcurrentHashMap can reject with a recursive
+            // update IllegalStateException. Bypassing the cache here is deliberate; recursion is
+            // one level deep (org prefix, then the real name), so the cost is negligible.
             return orgPrefix.toLowerCase() + computePropertyNameCase(suffix);
          }
 

--- a/core/src/test/java/inetsoft/sree/security/OrgLifecycleScopedPropertiesIntegrationTest.java
+++ b/core/src/test/java/inetsoft/sree/security/OrgLifecycleScopedPropertiesIntegrationTest.java
@@ -161,6 +161,29 @@ class OrgLifecycleScopedPropertiesIntegrationTest {
                   "old org id must fall back to the global default, not keep the migrated-away value");
    }
 
+   // ── Bug #76054: computePropertyNameCase() had an unreachable inetsoft.org. branch, so the
+   //    org-scoped write path (setProperty(name, val, true)) ran the whole already-prefixed
+   //    "inetsoft.org.<orgid>.<name>" string back through the plain lowercase rule, while the
+   //    read path (useAvailableOrgProperty) looked it up with the property name's case intact.
+   //    A mixed-case org-scoped name matching one of the case-preserving guards (log.level. here)
+   //    would be stored lowercased and never found on read. This locks in the fix: org id segment
+   //    is lowercased, the log.level. suffix's case survives storage and lookup. ──
+   @Test
+   void orgScoped_setProperty_mixedCaseLogLevelName_roundTripsWithCasePreserved() {
+      String orgId = "scopedprops_case_org";
+
+      actAs(orgId);
+      SreeEnv.setProperty("log.level.com.MyCompany.Service", "DEBUG", true);
+
+      assertEquals("DEBUG",
+                  SreeEnv.getProperty("log.level.com.MyCompany.Service", false, true),
+                  "org-scoped mixed-case log level property must be readable back under its own "
+                  + "org context");
+      assertEquals("DEBUG",
+                  SreeEnv.getProperty("inetsoft.org." + orgId + ".log.level.com.MyCompany.Service"),
+                  "the log.level. suffix's case must survive storage under the org-scoped key");
+   }
+
    private static void actAs(String orgId) {
       ThreadContext.setContextPrincipal(new SRPrincipal(new IdentityID("tester", orgId),
          new IdentityID[0], new String[0], orgId, 1L));


### PR DESCRIPTION
## Summary
`PropertiesEngine.computePropertyNameCase` had an `inetsoft.org.` branch that no property name could ever reach, and the write/read case asymmetry it was presumably meant to prevent was real (latent) on the org-scoped property write path.

## The dead branch
All four case-preserving guards (`log.level.`, `plugin.extra.classpath.`, `^log\.[A-Z_]+\.level\..+$`, `^inetsoft\.uql\.jdbc\.pool\..+\.connectionTestQuery$`) are anchored at the start of the name and can never co-occur with an `inetsoft.org.` prefix. Any name that reached the `inetsoft.org.` check had already been lowercased and returned by the branch above it.

## The asymmetry it left in place
- **Write**: `setProperty(name, val, true)` builds the org-prefixed name and passes it back through the 2-arg `setProperty`, which re-runs the whole prefixed string through `computePropertyNameCase` — lowercasing it entirely, including a mixed-case suffix like a logger name.
- **Read**: `useAvailableOrgProperty` prefixes an already case-fixed name and looks it up with the suffix's case intact.

A mixed-case org-scoped property (e.g. a logger name) would therefore be stored as `...log.level.foo` and looked up as `...log.level.Foo` — never found, with no error anywhere.

This was latent, not active: no current caller writes a log level org-scoped (`setLogLevel` only uses the global 2-arg `setProperty`; org-scoped log levels are handled separately via `LogSettingService.fixLogName`), so nothing is broken today. But the trap was set for the first future caller of the org-scoped overload with a mixed-case name.

## Fix
Check the `inetsoft.org.` prefix first, lowercase only that prefix (matching `useAvailableOrgProperty`'s own `orgID.toLowerCase()`), and recurse the existing case-preserving rules onto the remaining property name. Non-org-prefixed names are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)