### PR TITLE
Bug #76001, add type parameter to add_named_group for standalone groupings

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
@@ -68,7 +68,9 @@ import java.util.Map;
  *   <li>{@code reorder_columns} — {@code table}, {@code columnOrder}</li>
  *   <li>{@code add_concat_subtable} — {@code table} (concat assembly), {@code name} (subtable to add)</li>
  *   <li>{@code remove_concat_subtable} — {@code table} (concat assembly), {@code name} (subtable to remove)</li>
- *   <li>{@code add_named_group} — {@code name}, {@code table}, {@code column}, {@code groupMappings}, {@code groupOthers}</li>
+ *   <li>{@code add_named_group} — {@code name}, {@code groupMappings}, {@code groupOthers}; either
+ *       {@code table} + {@code column} (attach to a column) or {@code type} (standalone grouping,
+ *       matched by data type; defaults to {@code "string"})</li>
  *   <li>{@code set_column_description} — {@code table}, {@code column}, {@code description}</li>
  *   <li>{@code set_variable_values} — {@code variableValues} (map of variable name → value)</li>
  *   <li>{@code set_mirror_auto_update} — {@code table}, {@code visible} (true=auto-update on, false=off)</li>

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -875,7 +875,7 @@ public class WorksheetAgentController {
          case "remove_concat_subtable" ->
             editor.removeConcatSubtable(req.table(), req.name());
          case "add_named_group" ->
-            editor.addNamedGroup(req.name(), req.table(), req.column(),
+            editor.addNamedGroup(req.name(), req.table(), req.column(), req.type(),
                req.groupMappings(),
                req.groupOthers() != null && req.groupOthers());
          case "set_column_description" ->

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -1617,26 +1617,47 @@ public class WorksheetEditService {
       // -----------------------------------------------------------------------
 
       /**
-       * Creates a {@link DefaultNamedGroupAssembly} with simple value-list mappings.
+       * Creates a {@link DefaultNamedGroupAssembly} with simple value-list mappings. When
+       * {@code table} and {@code column} are both provided, the grouping is attached to that
+       * column. When both are omitted, a standalone grouping is created instead, matched at
+       * runtime by data type rather than by column — mirroring the "Type" option in the
+       * Composer's Grouping Properties dialog.
        *
        * @param name       the assembly name
-       * @param table      the table containing the column to group
-       * @param column     the column to attach the grouping to
+       * @param table      the table containing the column to group, or {@code null} for a
+       *                   standalone grouping
+       * @param column     the column to attach the grouping to, or {@code null} for a
+       *                   standalone grouping
+       * @param type       output data type for a standalone grouping (defaults to
+       *                   {@link XSchema#STRING} if not specified); ignored when
+       *                   {@code table}/{@code column} are provided
        * @param mappings   group name → value list mappings
        * @param groupOthers whether to group unmapped values as "Others"
-       * @throws PairingException if the table or column is not found
+       * @throws PairingException if the table or column is not found, or if only one of
+       *                          {@code table}/{@code column} is provided
        */
-      public void addNamedGroup(String name, String table, String column,
+      public void addNamedGroup(String name, String table, String column, String type,
                                 List<WorksheetMutationSupport.GroupMapping> mappings,
                                 boolean groupOthers) throws PairingException
       {
-         TableAssembly t = requireTable(table);
-         ColumnSelection cs = t.getColumnSelection(false);
-         DataRef ref = cs.getAttribute(column);
-
-         if(ref == null) {
-            throw new PairingException("Column not found: " + column);
+         if((table == null) != (column == null)) {
+            throw new PairingException(
+               "table and column must both be specified, or both omitted for a standalone grouping");
          }
+
+         DataRef ref = null;
+
+         if(table != null) {
+            TableAssembly t = requireTable(table);
+            ColumnSelection cs = t.getColumnSelection(false);
+            ref = cs.getAttribute(column);
+
+            if(ref == null) {
+               throw new PairingException("Column not found: " + column);
+            }
+         }
+
+         String conditionType = ref != null ? ref.getDataType() : type != null ? type : XSchema.STRING;
 
          NamedGroupInfo ngi = new NamedGroupInfo();
          ngi.setOthers(groupOthers
@@ -1655,7 +1676,7 @@ public class WorksheetEditService {
                      conds.append(junc);
                   }
 
-                  Condition c = new Condition(ref.getDataType());
+                  Condition c = new Condition(conditionType);
                   c.setOperation(XCondition.EQUAL_TO);
                   c.addValue(m.values().get(i));
                   conds.append(new ConditionItem(ref, c, 0));
@@ -1667,9 +1688,16 @@ public class WorksheetEditService {
 
          DefaultNamedGroupAssembly assembly = new DefaultNamedGroupAssembly(ws, name);
          assembly.setNamedGroupInfo(ngi);
-         assembly.setAttachedType(AttachedAssembly.COLUMN_ATTACHED);
-         assembly.setAttachedSource(new SourceInfo(SourceInfo.ASSET, null, table));
-         assembly.setAttachedAttribute(ref);
+
+         if(ref != null) {
+            assembly.setAttachedType(AttachedAssembly.COLUMN_ATTACHED);
+            assembly.setAttachedSource(new SourceInfo(SourceInfo.ASSET, null, table));
+            assembly.setAttachedAttribute(ref);
+         }
+         else {
+            assembly.setAttachedType(AttachedAssembly.DATA_TYPE_ATTACHED);
+            assembly.setAttachedDataType(conditionType);
+         }
 
          placeAssembly(assembly);
       }

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -19,6 +19,7 @@ package inetsoft.web.wiz.worksheet;
 
 import inetsoft.report.composition.RuntimeWorksheet;
 import inetsoft.report.composition.event.AssetEventUtil;
+import inetsoft.report.internal.binding.BaseField;
 import inetsoft.sree.security.IdentityID;
 import inetsoft.sree.security.ResourceAction;
 import inetsoft.sree.security.ResourceType;
@@ -1658,6 +1659,7 @@ public class WorksheetEditService {
          }
 
          String conditionType = ref != null ? ref.getDataType() : type != null ? type : XSchema.STRING;
+         DataRef conditionRef = namedGroupConditionRef(ref, conditionType);
 
          NamedGroupInfo ngi = new NamedGroupInfo();
          ngi.setOthers(groupOthers
@@ -1679,7 +1681,7 @@ public class WorksheetEditService {
                   Condition c = new Condition(conditionType);
                   c.setOperation(XCondition.EQUAL_TO);
                   c.addValue(m.values().get(i));
-                  conds.append(new ConditionItem(ref, c, 0));
+                  conds.append(new ConditionItem(conditionRef, c, 0));
                }
 
                ngi.setGroupCondition(m.name(), conds);
@@ -1966,6 +1968,8 @@ public class WorksheetEditService {
 
          if(mappings != null) {
             DataRef ref = nga.getAttachedAttribute();
+            String conditionType = ref != null ? ref.getDataType() : XSchema.STRING;
+            DataRef conditionRef = namedGroupConditionRef(ref, conditionType);
 
             for(WorksheetMutationSupport.GroupMapping m : mappings) {
                ConditionList conds = new ConditionList();
@@ -1976,10 +1980,10 @@ public class WorksheetEditService {
                      conds.append(junc);
                   }
 
-                  Condition c = new Condition(ref != null ? ref.getDataType() : XSchema.STRING);
+                  Condition c = new Condition(conditionType);
                   c.setOperation(XCondition.EQUAL_TO);
                   c.addValue(m.values().get(i));
-                  conds.append(new ConditionItem(ref, c, 0));
+                  conds.append(new ConditionItem(conditionRef, c, 0));
                }
 
                ngi.setGroupCondition(m.name(), conds);
@@ -2129,6 +2133,24 @@ public class WorksheetEditService {
          if(cs.getAttribute(column) == null) {
             throw new PairingException("Column not found: " + column);
          }
+      }
+
+      /**
+       * Returns the {@link DataRef} to use inside a named group's {@link ConditionItem}s.
+       * {@code ConditionItem} requires a non-null attribute — a null one NPEs in
+       * {@code ConditionItem.toString()}, which runs whenever the worksheet is cloned (e.g. on
+       * touch/save). When the group isn't attached to a real column, the Composer's own Grouping
+       * Properties dialog ({@code grouping-condition-dialog.component.ts}) substitutes a "this"
+       * placeholder {@link BaseField} instead of leaving the ref null; this mirrors that.
+       */
+      private DataRef namedGroupConditionRef(DataRef ref, String dataType) {
+         if(ref != null) {
+            return ref;
+         }
+
+         BaseField thisField = new BaseField("this");
+         thisField.setDataType(dataType);
+         return thisField;
       }
 
       /**

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -1634,8 +1634,9 @@ public class WorksheetEditService {
        *                   {@code table}/{@code column} are provided
        * @param mappings   group name → value list mappings
        * @param groupOthers whether to group unmapped values as "Others"
-       * @throws PairingException if the table or column is not found, or if only one of
-       *                          {@code table}/{@code column} is provided
+       * @throws PairingException if the table or column is not found, if only one of
+       *                          {@code table}/{@code column} is provided, or if
+       *                          {@code type} is not a recognized primitive type
        */
       public void addNamedGroup(String name, String table, String column, String type,
                                 List<WorksheetMutationSupport.GroupMapping> mappings,
@@ -1644,6 +1645,13 @@ public class WorksheetEditService {
          if((table == null) != (column == null)) {
             throw new PairingException(
                "table and column must both be specified, or both omitted for a standalone grouping");
+         }
+
+         if(type != null && !XSchema.isPrimitiveType(type)) {
+            throw new PairingException(
+               "Invalid type: \"" + type + "\". Valid types: " +
+               "string, boolean, float, double, integer, long, short, byte, " +
+               "char, date, time, timeInstant.");
          }
 
          DataRef ref = null;

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceTest.java
@@ -217,4 +217,78 @@ class WorksheetEditServiceTest {
          () -> svc.apply("TOK", agent,
                          ed -> ed.addNamedGroup("G", "T", null, null, List.of(), false)));
    }
+
+   @Test
+   void addNamedGroupStandaloneConditionUsesThisPlaceholderAndSurvivesClone() throws Exception {
+      Worksheet ws = new Worksheet();
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      JoinSession s = new JoinSession("TOK", "Worksheet/foo-7", "alice~;~host-org",
+                                     SheetType.WORKSHEET, 0L, Long.MAX_VALUE,
+                                     JoinSession.ConnectionMode.PAIRED, null, null);
+      when(sessions.resolve(eq("TOK"), any())).thenReturn(s);
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+
+      List<WorksheetMutationSupport.GroupMapping> mappings = List.of(
+         new WorksheetMutationSupport.GroupMapping("Northeast", List.of("NY", "NJ", "CT")),
+         new WorksheetMutationSupport.GroupMapping("West", List.of("CA")));
+
+      svc.apply("TOK", agent,
+                ed -> ed.addNamedGroup("StateRegion", null, null, "string", mappings, false));
+
+      DefaultNamedGroupAssembly nga = (DefaultNamedGroupAssembly) ws.getAssembly("StateRegion");
+      DataRef conditionRef = nga.getNamedGroupInfo().getGroupCondition("Northeast")
+         .getConditionItem(0).getAttribute();
+      assertNotNull(conditionRef);
+      assertEquals("this", conditionRef.getAttribute());
+
+      // Regression for NPE in ConditionItem.toString() (invoked via NamedGroupInfo.clone() during
+      // worksheet clone, e.g. TouchAssetService) when the condition's DataRef was left null.
+      assertDoesNotThrow(() -> ws.clone());
+   }
+
+   @Test
+   void editNamedGroupOnStandaloneGroupSurvivesClone() throws Exception {
+      Worksheet ws = new Worksheet();
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      JoinSession s = new JoinSession("TOK", "Worksheet/foo-7", "alice~;~host-org",
+                                     SheetType.WORKSHEET, 0L, Long.MAX_VALUE,
+                                     JoinSession.ConnectionMode.PAIRED, null, null);
+      when(sessions.resolve(eq("TOK"), any())).thenReturn(s);
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+
+      svc.apply("TOK", agent,
+                ed -> ed.addNamedGroup("StateRegion", null, null, "string", List.of(), false));
+      svc.apply("TOK", agent,
+                ed -> ed.editNamedGroup("StateRegion",
+                                        List.of(new WorksheetMutationSupport.GroupMapping(
+                                           "West", List.of("CA"))),
+                                        false));
+
+      DefaultNamedGroupAssembly nga = (DefaultNamedGroupAssembly) ws.getAssembly("StateRegion");
+      DataRef conditionRef = nga.getNamedGroupInfo().getGroupCondition("West")
+         .getConditionItem(0).getAttribute();
+      assertNotNull(conditionRef);
+      assertEquals("this", conditionRef.getAttribute());
+
+      // NamedGroupInfo.clone() catches and swallows its own NPE (logging "Failed to clone
+      // object" and returning null) rather than propagating it, so this alone would not have
+      // caught the regression — the assertions above on the condition ref are what matter here.
+      assertDoesNotThrow(() -> ws.clone());
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceTest.java
@@ -219,6 +219,29 @@ class WorksheetEditServiceTest {
    }
 
    @Test
+   void addNamedGroupRejectsInvalidStandaloneType() throws Exception {
+      Worksheet ws = new Worksheet();
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      JoinSession s = new JoinSession("TOK", "Worksheet/foo-7", "alice~;~host-org",
+                                     SheetType.WORKSHEET, 0L, Long.MAX_VALUE,
+                                     JoinSession.ConnectionMode.PAIRED, null, null);
+      when(sessions.resolve(eq("TOK"), any())).thenReturn(s);
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+
+      assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent,
+                         ed -> ed.addNamedGroup("G", null, null, "strnig", List.of(), false)));
+   }
+
+   @Test
    void addNamedGroupStandaloneConditionUsesThisPlaceholderAndSurvivesClone() throws Exception {
       Worksheet ws = new Worksheet();
       RuntimeWorksheet rws = mock(RuntimeWorksheet.class);

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceTest.java
@@ -22,6 +22,7 @@ import inetsoft.sree.security.SecurityEngine;
 import inetsoft.uql.ColumnSelection;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.schema.XSchema;
 import inetsoft.web.wiz.pairing.*;
 import inetsoft.web.wiz.pairing.TestPrincipals;
 import inetsoft.web.wiz.pairing.TestWorksheets;
@@ -29,6 +30,7 @@ import inetsoft.web.wiz.pairing.WizAgentTestSupport;
 import org.junit.jupiter.api.*;
 
 import java.security.Principal;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -131,5 +133,88 @@ class WorksheetEditServiceTest {
       if(ref instanceof ColumnRef cr) {
          assertEquals("alpha", cr.getAlias());
       }
+   }
+
+   @Test
+   void addNamedGroupCreatesStandaloneGroupingWhenTableAndColumnOmitted() throws Exception {
+      Worksheet ws = new Worksheet();
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      JoinSession s = new JoinSession("TOK", "Worksheet/foo-7", "alice~;~host-org",
+                                     SheetType.WORKSHEET, 0L, Long.MAX_VALUE,
+                                     JoinSession.ConnectionMode.PAIRED, null, null);
+      when(sessions.resolve(eq("TOK"), any())).thenReturn(s);
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+
+      List<WorksheetMutationSupport.GroupMapping> mappings = List.of(
+         new WorksheetMutationSupport.GroupMapping("Northeast", List.of("NY", "NJ", "CT")),
+         new WorksheetMutationSupport.GroupMapping("West", List.of("CA")));
+
+      svc.apply("TOK", agent,
+                ed -> ed.addNamedGroup("StateRegion", null, null, "string", mappings, false));
+
+      Assembly a = ws.getAssembly("StateRegion");
+      assertInstanceOf(DefaultNamedGroupAssembly.class, a);
+      NamedGroupAssembly nga = (NamedGroupAssembly) a;
+      assertEquals(AttachedAssembly.DATA_TYPE_ATTACHED, nga.getAttachedType());
+      assertEquals(XSchema.STRING, nga.getAttachedDataType());
+      assertNull(nga.getAttachedAttribute());
+   }
+
+   @Test
+   void addNamedGroupDefaultsStandaloneTypeToString() throws Exception {
+      Worksheet ws = new Worksheet();
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      JoinSession s = new JoinSession("TOK", "Worksheet/foo-7", "alice~;~host-org",
+                                     SheetType.WORKSHEET, 0L, Long.MAX_VALUE,
+                                     JoinSession.ConnectionMode.PAIRED, null, null);
+      when(sessions.resolve(eq("TOK"), any())).thenReturn(s);
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+
+      svc.apply("TOK", agent,
+                ed -> ed.addNamedGroup("StateRegion", null, null, null, List.of(), false));
+
+      NamedGroupAssembly nga = (NamedGroupAssembly) ws.getAssembly("StateRegion");
+      assertEquals(XSchema.STRING, nga.getAttachedDataType());
+   }
+
+   @Test
+   void addNamedGroupRejectsMismatchedTableAndColumn() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "a");
+      ws.addAssembly(t);
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      JoinSession s = new JoinSession("TOK", "Worksheet/foo-7", "alice~;~host-org",
+                                     SheetType.WORKSHEET, 0L, Long.MAX_VALUE,
+                                     JoinSession.ConnectionMode.PAIRED, null, null);
+      when(sessions.resolve(eq("TOK"), any())).thenReturn(s);
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+
+      assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent,
+                         ed -> ed.addNamedGroup("G", "T", null, null, List.of(), false)));
    }
 }


### PR DESCRIPTION
## Summary

`add_named_group` (the wiz worksheet-chat MCP tool's backend) always required an existing `table`/`column` to attach the grouping to, and had no way to set the grouping's output data type. When a user asked for a standalone grouping (e.g. "add a grouping with type string: NY/NJ/CT → Northeast, CA → West"), the agent had no way to satisfy it and instead had to fabricate a table just to get a column of the right type to attach to.

## Root Cause

StyleBI's own Composer "Grouping Properties" dialog (`GroupingAssemblyDialogService`) already supports a second mode: a standalone grouping not attached to any column, driven by a `type` field, which sets `DATA_TYPE_ATTACHED` instead of `COLUMN_ATTACHED` on the `DefaultNamedGroupAssembly` (matched later by data-type compatibility in `GroupRef.update()`). The wiz agent's `addNamedGroup` never exposed this second mode — `table`/`column` were mandatory and `type` was never wired through or applied via `setAttachedDataType`.

## Fix

- `EditRequest` doc comment updated (the `type` field already existed on the record, reused from other ops).
- `WorksheetAgentController` passes `req.type()` into `editor.addNamedGroup(...)`.
- `WorksheetEditService.addNamedGroup` gains a `type` parameter:
  - `table`+`column` both provided → unchanged existing `COLUMN_ATTACHED` behavior.
  - Only one of `table`/`column` provided → throws `PairingException`.
  - Neither provided → skips table/column resolution, defaults `type` to `XSchema.STRING` if omitted, and creates a `DATA_TYPE_ATTACHED` standalone grouping instead (mirroring the existing `editNamedGroup` fallback and the Composer dialog's own logic).
- Added unit tests covering the standalone path, the string-type default, and the mismatched table/column guard.

Companion plugin-side change: https://github.com/inetsoft-technology/stylebi-wiz/pull/new/bug-76001 (adds the `type` param + optional `table`/`column` to the MCP tool schema).

## Test Plan

- `WorksheetEditServiceTest` / `WorksheetAgentControllerTest` pass (7 relevant + full suite unaffected).
- `core` module compiles and test-compiles cleanly.
- Manually verified end-to-end via a live worksheet-chat session: asking to add a standalone string-typed named grouping (no existing table) now succeeds directly instead of requiring a table to be created first.

Fixes Redmine #76001.