### PR TITLE
Fix outgoing joins pane not updating on graph node selection

### DIFF
--- a/core/src/main/resources/inetsoft/web/resources/js/login.js
+++ b/core/src/main/resources/inetsoft/web/resources/js/login.js
@@ -27,6 +27,7 @@ function initLoginView(requestedUrl, sessionExpired, defaultErrorMessage, gatewa
    var $loginAsNameField = $("#loginAsName");
 
    var $loginButton = $("#loginButton");
+   var $activeSession = $("#activeSession");
    var $confirmLogin = $("#confirmLogin");
    var $terminateSessionButton = $("#terminateSessionButton");
    var $sessionLimitTableBody = $("#sessionLimitTableBody");
@@ -94,7 +95,7 @@ function initLoginView(requestedUrl, sessionExpired, defaultErrorMessage, gatewa
       }
 
       if(!!currentUser && !!userName && currentUser != userName && !logoutCurrent) {
-         $("#activeSession").modal("show");
+         $activeSession.modal("show");
          return;
       }
 
@@ -188,6 +189,10 @@ function initLoginView(requestedUrl, sessionExpired, defaultErrorMessage, gatewa
       authenticate(false);
    });
 
+   $activeSession.on("shown.bs.modal", function() {
+      $confirmLogin.trigger("focus");
+   });
+
    $togglePassword.click(function() {
       var show = $passwordField.attr("type") === "password";
       $passwordField.attr("type", show ? "text" : "password");
@@ -208,7 +213,7 @@ function initLoginView(requestedUrl, sessionExpired, defaultErrorMessage, gatewa
    });
 
    $confirmLogin.click(function() {
-      $("#activeSession").modal("hide");
+      $activeSession.modal("hide");
       authenticate(true);
    });
 

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/database-physical-model.component.tl.spec.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/database-physical-model.component.tl.spec.ts
@@ -63,6 +63,7 @@ import { DataPhysicalModelService } from "../../../services/data-physical-model.
 import { PhysicalModelDefinition } from "../../../model/datasources/database/physical-model/physical-model-definition";
 import { PhysicalTableModel } from "../../../model/datasources/database/physical-model/physical-table-model";
 import { PhysicalTableType } from "../../../model/datasources/database/physical-model/physical-table-type.enum";
+import { GraphModel } from "../../../model/datasources/database/physical-model/graph/graph-model";
 import { FixedDropdownService } from "../../../../../widget/fixed-dropdown/fixed-dropdown.service";
 import { DatabasePhysicalModelComponent } from "./database-physical-model.component";
 
@@ -114,6 +115,37 @@ function createTable(overrides: Partial<PhysicalTableModel> = {}): PhysicalTable
       baseTable: false,
       ...overrides,
    };
+}
+
+function createGraph(
+   overrides: Partial<Omit<GraphModel, "node">> & { node?: Partial<GraphModel["node"]> } = {}
+): GraphModel {
+   const id = overrides.node?.id ?? overrides.node?.name ?? "Orders";
+
+   return {
+      edge: { input: [], output: [] },
+      cols: [],
+      bounds: null,
+      showColumns: false,
+      alias: false,
+      autoAlias: false,
+      sql: false,
+      baseTable: false,
+      autoAliasByOutgoing: false,
+      designModeAlias: false,
+      ...overrides,
+      node: {
+         id,
+         name: id,
+         tableName: id,
+         label: id,
+         tooltip: id,
+         treeLink: `SalesDB/${id}`,
+         aliasSource: null,
+         outgoingAliasSource: null,
+         ...overrides.node,
+      },
+   } as GraphModel;
 }
 
 function createPhysicalModel(overrides: Partial<PhysicalModelDefinition> = {}): PhysicalModelDefinition {
@@ -371,31 +403,38 @@ describe("DatabasePhysicalModelComponent - graphNodesSelected - outgoing joins p
 
    // Regression-sensitive: graph selection should drive the joins pane even when the
    // lazy table tree cannot resolve and re-emit the selected node synchronously.
-   it("should set editingTable from a single selected graph node path", async () => {
+   it("should set editingTable from a single selected source graph node identity", async () => {
+      const ordersAlias = createTable({
+         qualifiedName: "Orders_Alias",
+         path: "SalesDB/Orders",
+         alias: "Orders_Alias",
+         aliasSource: "Orders",
+      });
       const orders = createTable({
          qualifiedName: "Orders",
          path: "SalesDB/Orders",
          joins: [{ foreignTable: "Customers" } as any],
       });
       const { fixture } = await renderPhysical(createPhysicalModel({
-         tables: [orders],
+         tables: [ordersAlias, orders],
       }));
       const comp = fixture.componentInstance;
+      const graph = createGraph({
+         node: {
+            id: "Orders",
+            name: "Orders",
+            treeLink: "SalesDB/Orders",
+         },
+      });
       (comp as any).graphViewModel = {
-         graphs: [{
-            node: {
-               treeLink: "SalesDB/Orders",
-               name: "Orders",
-            },
-            autoAlias: false,
-            autoAliasByOutgoing: false,
-         }],
+         graphs: [graph],
       };
       comp.databaseRoot.children = [];
 
-      comp.graphNodesSelected(["SalesDB/Orders"]);
+      comp.graphNodesSelected([graph]);
 
       expect(comp.editingTable).toBe(orders);
+      expect(comp.selectedGraphModels).toEqual([graph]);
    });
 
    it("should resolve an auto-alias graph node to its source table", async () => {
@@ -403,25 +442,167 @@ describe("DatabasePhysicalModelComponent - graphNodesSelected - outgoing joins p
          qualifiedName: "Orders",
          path: "SalesDB/Orders",
       });
+      const ordersAlias = createTable({
+         qualifiedName: "Orders_Alias",
+         path: "SalesDB/Orders",
+         alias: "Orders_Alias",
+         aliasSource: "Orders",
+         joins: [{ foreignTable: "Customers" } as any],
+      });
       const { fixture } = await renderPhysical(createPhysicalModel({
-         tables: [orders],
+         tables: [ordersAlias, orders],
       }));
       const comp = fixture.componentInstance;
+      const aliasGraph = createGraph({
+         autoAlias: true,
+         node: {
+            id: "Orders_Alias",
+            name: "Orders_Alias",
+            treeLink: "SalesDB/NoMatchingTablePath",
+            aliasSource: "Orders",
+         },
+      });
       (comp as any).graphViewModel = {
-         graphs: [{
-            node: {
-               treeLink: "SalesDB/Orders",
-               name: "Orders_Alias",
-               aliasSource: "Orders",
-            },
-            autoAlias: true,
-            autoAliasByOutgoing: false,
-         }],
+         graphs: [aliasGraph],
       };
       comp.databaseRoot.children = [];
 
-      comp.graphNodesSelected(["SalesDB/Orders"]);
+      comp.graphNodesSelected([aliasGraph]);
 
       expect(comp.editingTable).toBe(orders);
+   });
+
+   it("should not re-resolve a graph selection through a loaded tree node", async () => {
+      const orders = createTable({
+         qualifiedName: "Orders",
+         path: "SalesDB/Orders",
+      });
+      const ordersAlias = createTable({
+         qualifiedName: "Orders_Alias",
+         path: "SalesDB/Orders",
+         alias: "Orders_Alias",
+         aliasSource: "Orders",
+      });
+      const { fixture } = await renderPhysical(createPhysicalModel({
+         tables: [ordersAlias, orders],
+      }));
+      const comp = fixture.componentInstance;
+      const aliasGraph = createGraph({
+         autoAlias: true,
+         node: {
+            id: "Orders_Alias",
+            name: "Orders_Alias",
+            treeLink: "SalesDB/Orders",
+            aliasSource: "Orders",
+         },
+      });
+      comp.databaseRoot.children = [{
+         label: "Orders",
+         leaf: true,
+         data: {
+            path: "SalesDB/Orders",
+            qualifiedName: "Orders",
+         },
+      }];
+
+      comp.graphNodesSelected([aliasGraph]);
+
+      expect(comp.editingTable).toBe(orders);
+      expect(comp.tableTree.selectNode).not.toHaveBeenCalled();
+      expect(comp.tableTree.selectedNodes).toEqual([comp.databaseRoot.children[0]]);
+   });
+
+   it("should resolve multiple auto-alias graph nodes with a shared path to the same source table", async () => {
+      const orders = createTable({
+         qualifiedName: "Orders",
+         path: "SalesDB/Orders",
+      });
+      const ordersAlias = createTable({
+         qualifiedName: "Orders_Alias",
+         path: "SalesDB/Orders",
+         alias: "Orders_Alias",
+         aliasSource: "Orders",
+      });
+      const ordersAlias2 = createTable({
+         qualifiedName: "Orders_Alias_2",
+         path: "SalesDB/Orders",
+         alias: "Orders_Alias_2",
+         aliasSource: "Orders",
+      });
+      const { fixture } = await renderPhysical(createPhysicalModel({
+         tables: [ordersAlias, ordersAlias2, orders],
+      }));
+      const comp = fixture.componentInstance;
+      const aliasGraph = createGraph({
+         autoAlias: true,
+         node: {
+            id: "Orders_Alias",
+            name: "Orders_Alias",
+            treeLink: "SalesDB/Orders",
+            aliasSource: "Orders",
+         },
+      });
+      const aliasGraph2 = createGraph({
+         autoAlias: true,
+         node: {
+            id: "Orders_Alias_2",
+            name: "Orders_Alias_2",
+            treeLink: "SalesDB/Orders",
+            aliasSource: "Orders",
+         },
+      });
+      (comp as any).graphViewModel = {
+         graphs: [aliasGraph, aliasGraph2],
+      };
+      comp.databaseRoot.children = [];
+
+      comp.graphNodesSelected([aliasGraph2]);
+
+      expect(comp.editingTable).toBe(orders);
+   });
+
+   it("should keep editingTable cleared for multi-select when only one selected path is loaded in the tree", async () => {
+      const orders = createTable({
+         qualifiedName: "Orders",
+         path: "SalesDB/Orders",
+      });
+      const customers = createTable({
+         qualifiedName: "Customers",
+         path: "SalesDB/Customers",
+      });
+      const { fixture } = await renderPhysical(createPhysicalModel({
+         tables: [orders, customers],
+      }));
+      const comp = fixture.componentInstance;
+      const ordersGraph = createGraph({
+         node: {
+            id: "Orders",
+            name: "Orders",
+            treeLink: "SalesDB/Orders",
+         },
+      });
+      const customersGraph = createGraph({
+         node: {
+            id: "Customers",
+            name: "Customers",
+            treeLink: "SalesDB/Customers",
+         },
+      });
+      comp.editingTable = orders;
+      comp.databaseRoot.children = [{
+         label: "Orders",
+         leaf: true,
+         data: {
+            path: "SalesDB/Orders",
+            qualifiedName: "Orders",
+         },
+      }];
+
+      comp.graphNodesSelected([ordersGraph, customersGraph]);
+
+      expect(comp.editingTable).toBeNull();
+      expect(comp.selectedGraphModels).toEqual([ordersGraph, customersGraph]);
+      expect(comp.tableTree.selectNode).not.toHaveBeenCalled();
+      expect(comp.tableTree.selectedNodes).toEqual([comp.databaseRoot.children[0]]);
    });
 });

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/database-physical-model.component.tl.spec.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/database-physical-model.component.tl.spec.ts
@@ -24,6 +24,7 @@
  *   Group 2 [Risk 3] - isDuplicateTableName: optional backend fields must not crash duplicate checks
  *   Group 3 [Risk 3] - refreshWarnings0: warning confirmation must persist warning state and callback ownership
  *   Group 4 [Risk 2] - showTreeContextMenu: context menu must keep the original DOM source event
+ *   Group 5 [Risk 2] - graphNodesSelected: graph clicks must update the outgoing-joins pane
  *
  * Confirmed bugs (it.failing - remove wrapper once fixed Issue #75158):
  *
@@ -359,5 +360,68 @@ describe("DatabasePhysicalModelComponent - showTreeContextMenu - source event ow
       expect(dropdownService.open).toHaveBeenCalledTimes(1);
       expect(contextmenu["sourceEvent"]).toBe(domEvent);
       expect(contextmenu["actions"].length).toBeGreaterThan(0);
+   });
+});
+
+// ---------------------------------------------------------------------------
+// Group 5 - graphNodesSelected: outgoing joins pane table ownership [Risk 2]
+// ---------------------------------------------------------------------------
+
+describe("DatabasePhysicalModelComponent - graphNodesSelected - outgoing joins pane [Group 5, Risk 2]", () => {
+
+   // Regression-sensitive: graph selection should drive the joins pane even when the
+   // lazy table tree cannot resolve and re-emit the selected node synchronously.
+   it("should set editingTable from a single selected graph node path", async () => {
+      const orders = createTable({
+         qualifiedName: "Orders",
+         path: "SalesDB/Orders",
+         joins: [{ foreignTable: "Customers" } as any],
+      });
+      const { fixture } = await renderPhysical(createPhysicalModel({
+         tables: [orders],
+      }));
+      const comp = fixture.componentInstance;
+      (comp as any).graphViewModel = {
+         graphs: [{
+            node: {
+               treeLink: "SalesDB/Orders",
+               name: "Orders",
+            },
+            autoAlias: false,
+            autoAliasByOutgoing: false,
+         }],
+      };
+      comp.databaseRoot.children = [];
+
+      comp.graphNodesSelected(["SalesDB/Orders"]);
+
+      expect(comp.editingTable).toBe(orders);
+   });
+
+   it("should resolve an auto-alias graph node to its source table", async () => {
+      const orders = createTable({
+         qualifiedName: "Orders",
+         path: "SalesDB/Orders",
+      });
+      const { fixture } = await renderPhysical(createPhysicalModel({
+         tables: [orders],
+      }));
+      const comp = fixture.componentInstance;
+      (comp as any).graphViewModel = {
+         graphs: [{
+            node: {
+               treeLink: "SalesDB/Orders",
+               name: "Orders_Alias",
+               aliasSource: "Orders",
+            },
+            autoAlias: true,
+            autoAliasByOutgoing: false,
+         }],
+      };
+      comp.databaseRoot.children = [];
+
+      comp.graphNodesSelected(["SalesDB/Orders"]);
+
+      expect(comp.editingTable).toBe(orders);
    });
 });

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/database-physical-model.component.tl.spec.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/database-physical-model.component.tl.spec.ts
@@ -472,6 +472,41 @@ describe("DatabasePhysicalModelComponent - graphNodesSelected - outgoing joins p
       expect(comp.editingTable).toBe(orders);
    });
 
+   it("should resolve an outgoing auto-alias graph node to its outgoing source table", async () => {
+      const orders = createTable({
+         qualifiedName: "Orders",
+         path: "SalesDB/Orders",
+      });
+      const ordersAlias = createTable({
+         qualifiedName: "Orders_Alias",
+         path: "SalesDB/Orders",
+         alias: "Orders_Alias",
+         aliasSource: "Orders",
+         joins: [{ foreignTable: "Customers" } as any],
+      });
+      const { fixture } = await renderPhysical(createPhysicalModel({
+         tables: [ordersAlias, orders],
+      }));
+      const comp = fixture.componentInstance;
+      const aliasGraph = createGraph({
+         autoAliasByOutgoing: true,
+         node: {
+            id: "Orders_Alias",
+            name: "Orders_Alias",
+            treeLink: "SalesDB/NoMatchingTablePath",
+            outgoingAliasSource: "Orders",
+         },
+      });
+      (comp as any).graphViewModel = {
+         graphs: [aliasGraph],
+      };
+      comp.databaseRoot.children = [];
+
+      comp.graphNodesSelected([aliasGraph]);
+
+      expect(comp.editingTable).toBe(orders);
+   });
+
    it("should not re-resolve a graph selection through a loaded tree node", async () => {
       const orders = createTable({
          qualifiedName: "Orders",

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/database-physical-model.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/database-physical-model.component.ts
@@ -1444,9 +1444,54 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
          this.selectNode(null);
       }
       else {
+         if(nodes.length == 1) {
+            this.changeEditingTableByGraphPath(nodes[0]);
+         }
+         else {
+            this.changeEditingTableByName(null);
+         }
+
          this.resetSearchMode();
          this.selectAndExpandToPath(nodes);
       }
+   }
+
+   private changeEditingTableByGraphPath(path: string): void {
+      if(!path) {
+         this.changeEditingTableByName(null);
+         return;
+      }
+
+      const graph = this.graphViewModel?.graphs
+         ?.find(g => g?.node?.treeLink === path);
+      const tableName = this.getGraphTableName(graph);
+      const aliasName = this.getGraphAliasName(graph);
+
+      this.editingTable = this.physicalModel?.tables
+         ?.find(table => this.getTablePath(table) === path || table.path === path ||
+            table.qualifiedName === tableName ||
+            (!!graph?.node?.id && table.qualifiedName === graph.node.id) ||
+            (!!aliasName && table.qualifiedName === aliasName)) ?? null;
+   }
+
+   private getGraphTableName(graph: GraphModel | null | undefined): string | null {
+      if(!graph) {
+         return null;
+      }
+
+      if(graph.autoAlias) {
+         return graph.node.aliasSource;
+      }
+
+      if(graph.autoAliasByOutgoing) {
+         return graph.node.outgoingAliasSource;
+      }
+
+      return graph.node.name;
+   }
+
+   private getGraphAliasName(graph: GraphModel | null | undefined): string | null {
+      return graph?.autoAlias || graph?.autoAliasByOutgoing ? graph.node.name : null;
    }
 
    tableRemoved(tables: GraphModel[]): void {

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/database-physical-model.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/database-physical-model.component.ts
@@ -257,7 +257,7 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
             this.parent = Tool.byteDecode(params.get("parent"));
             this.refreshSupportFullOuterJoin();
             //edit table should be hidden when open another(create/editing) physical model.
-            this.editingTable = null;
+            this.setEditingTable(null);
 
             if(this.editing) {
                this.dataPhysicalModelService.resetModel();
@@ -991,7 +991,7 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
             .subscribe(() => this.dataPhysicalModelService.emitModelChange());
 
          if(this.tableTree.selectedNodes?.length == 1 &&  this.tableTree.selectedNodes[0] == node) {
-            this.editingTable = newTable;
+            this.setEditingTable(newTable);
          }
       }
       else {
@@ -1059,12 +1059,16 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
 
    private changeEditingTableByName(qualifiedName: string) {
       if(!!qualifiedName) {
-         this.editingTable = this.physicalModel.tables
-            .find(table => qualifiedName === table.qualifiedName);
+         this.setEditingTable(this.physicalModel.tables
+            .find(table => qualifiedName === table.qualifiedName));
       }
       else {
-         this.editingTable = null;
+         this.setEditingTable(null);
       }
+   }
+
+   private setEditingTable(table: PhysicalTableModel | null | undefined): void {
+      this.editingTable = table ?? null;
    }
 
    get databaseParr(): string {
@@ -1226,7 +1230,7 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
 
       if(!!this.editingTable && this.editingTable.qualifiedName == nodeData.qualifiedName) {
          // if the removed table was selected, set selected table to null
-         this.editingTable = null;
+         this.setEditingTable(null);
       }
    }
 
@@ -1436,8 +1440,9 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
       this.isModified = this.isModified || isModified;
    }
 
-   graphNodesSelected(nodes: string[]) {
+   graphNodesSelected(nodes: GraphModel[]) {
       this.tableTree.selectedNodes = [];
+      this.selectedGraphModels = nodes ? [...nodes] : [];
 
       if(!nodes || nodes.length == 0) {
          this.tableTree.selectedNodes = [];
@@ -1445,53 +1450,53 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
       }
       else {
          if(nodes.length == 1) {
-            this.changeEditingTableByGraphPath(nodes[0]);
+            this.changeEditingTableByGraph(nodes[0]);
          }
          else {
             this.changeEditingTableByName(null);
          }
 
          this.resetSearchMode();
-         this.selectAndExpandToPath(nodes);
+         const emitTreeSelection = false;
+         this.selectAndExpandToPath(nodes
+            .map(graph => graph?.node?.treeLink)
+            .filter((path): path is string => !!path), this.databaseRoot, emitTreeSelection);
       }
    }
 
-   private changeEditingTableByGraphPath(path: string): void {
-      if(!path) {
+   private changeEditingTableByGraph(graph: GraphModel): void {
+      if(!graph?.node) {
          this.changeEditingTableByName(null);
          return;
       }
 
-      const graph = this.graphViewModel?.graphs
-         ?.find(g => g?.node?.treeLink === path);
-      const tableName = this.getGraphTableName(graph);
-      const aliasName = this.getGraphAliasName(graph);
-
-      this.editingTable = this.physicalModel?.tables
-         ?.find(table => this.getTablePath(table) === path || table.path === path ||
-            table.qualifiedName === tableName ||
-            (!!graph?.node?.id && table.qualifiedName === graph.node.id) ||
-            (!!aliasName && table.qualifiedName === aliasName)) ?? null;
+      const tables = this.physicalModel?.tables ?? [];
+      this.setEditingTable(tables.find(table => this.matchesGraphNode(table, graph)));
    }
 
-   private getGraphTableName(graph: GraphModel | null | undefined): string | null {
-      if(!graph) {
-         return null;
+   private matchesGraphNode(table: PhysicalTableModel, graph: GraphModel): boolean {
+      if(!table || !graph?.node) {
+         return false;
       }
 
       if(graph.autoAlias) {
-         return graph.node.aliasSource;
+         return table.qualifiedName === graph.node.aliasSource;
       }
 
       if(graph.autoAliasByOutgoing) {
-         return graph.node.outgoingAliasSource;
+         return table.qualifiedName === graph.node.outgoingAliasSource;
       }
 
-      return graph.node.name;
-   }
+      if(graph.alias || graph.node.aliasSource || graph.node.outgoingAliasSource) {
+         return table.qualifiedName === (graph.node.id || graph.node.name);
+      }
 
-   private getGraphAliasName(graph: GraphModel | null | undefined): string | null {
-      return graph?.autoAlias || graph?.autoAliasByOutgoing ? graph.node.name : null;
+      if(table.qualifiedName === (graph.node.id || graph.node.name)) {
+         return true;
+      }
+
+      return !table.alias &&
+         (this.getTablePath(table) === graph.node.treeLink || table.path === graph.node.treeLink);
    }
 
    tableRemoved(tables: GraphModel[]): void {
@@ -1516,7 +1521,7 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
                   this.editingTable.qualifiedName == tableData.qualifiedName)
                {
                   // if the removed table was selected, set selected table to null
-                  this.editingTable = null;
+                  this.setEditingTable(null);
                }
             }
          }
@@ -1528,12 +1533,18 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
     * @param paths    the path to find
     * @param parent  the current parent node to search
     */
-   private selectAndExpandToPath(paths: string[], parent: TreeNodeModel = this.databaseRoot): void {
+   private selectAndExpandToPath(paths: string[], parent: TreeNodeModel = this.databaseRoot,
+                                 emitSelection: boolean = true): void {
       for(let child of parent.children) {
          const childPath: string = (<DatabaseTreeNodeModel> child.data).path;
 
          if(paths.includes(childPath)) {
-            this.tableTree.selectNode(child);
+            if(emitSelection) {
+               this.tableTree.selectNode(child);
+            }
+            else {
+               this.tableTree.selectedNodes.push(child);
+            }
          }
          else if(paths.some(p => !!p && p.indexOf(childPath + "/") === 0)) {
             child.expanded = true;
@@ -1543,11 +1554,11 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
                   .subscribe(
                      data => {
                         this.setExpandedNodeChildren(child, data);
-                        this.selectAndExpandToPath(paths, child);
+                        this.selectAndExpandToPath(paths, child, emitSelection);
                      });
             }
             else {
-               this.selectAndExpandToPath(paths, child);
+               this.selectAndExpandToPath(paths, child, emitSelection);
             }
          }
       }
@@ -1607,10 +1618,10 @@ export class DatabasePhysicalModelComponent implements OnInit, DoCheck, OnDestro
          });
 
          if(newTable) {
-            this.editingTable = newTable;
+            this.setEditingTable(newTable);
          }
          else {
-            this.editingTable = null;
+            this.setEditingTable(null);
          }
       }
    }

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-graph-pane/physical-graph-pane.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-graph-pane/physical-graph-pane.component.ts
@@ -64,7 +64,7 @@ export class PhysicalGraphPane implements OnInit, AfterViewChecked, OnDestroy {
    @Output() onJoinEditing: EventEmitter<boolean> = new EventEmitter<boolean>();
    @Output() onPhysicalGraph: EventEmitter<GraphViewModel> = new EventEmitter<GraphViewModel>();
    @Output() onModified: EventEmitter<boolean> = new EventEmitter<boolean>();
-   @Output() onNodeSelected: EventEmitter<string[]> = new EventEmitter<string[]>();
+   @Output() onNodeSelected: EventEmitter<GraphModel[]> = new EventEmitter<GraphModel[]>();
    @Output() onRemoveTable: EventEmitter<GraphModel[]> = new EventEmitter<GraphModel[]>();
    @Output() onZoom: EventEmitter<number> = new EventEmitter<number>();
 

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-edit-table/physical-table-joins/physical-table-joins.component.html
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-edit-table/physical-table-joins/physical-table-joins.component.html
@@ -47,19 +47,22 @@
     </div>
   </div>
   <div class="outgoing-tree-pane flex-fixed-content content-overflow-all d-inline-flex p-1">
-    <div class="physical-table-joins-pane__empty" *ngIf="!foreignTableRoot.children?.length">
-      _#(No joins yet. Add a join to connect this table to another table in the physical view.)
-    </div>
-    <tree *ngIf="foreignTableRoot.children?.length"
-          #joinsTree class="outgoing-tree"
-          [root]="foreignTableRoot"
-          [showRoot]="false"
-          [showIcon]="false"
-          [multiSelect]="true"
-          [disabled]="disabled"
-          [selectedNodes]="selectedNodes"
-          (nodesSelected)="selectNode($event)">
-    </tree>
+    @if (!foreignTableRoot.children?.length) {
+      <div class="physical-table-joins-pane__empty">
+        _#(No joins yet. Add a join to connect this table to another table in the physical view.)
+      </div>
+    }
+    @if (foreignTableRoot.children?.length) {
+      <tree #joinsTree class="outgoing-tree"
+            [root]="foreignTableRoot"
+            [showRoot]="false"
+            [showIcon]="false"
+            [multiSelect]="true"
+            [disabled]="disabled"
+            [selectedNodes]="selectedNodes"
+            (nodesSelected)="selectNode($event)">
+      </tree>
+    }
   </div>
 </div>
 <ng-template #addJoinDialog let-close="close" let-dismiss="dismiss">

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-edit-table/physical-table-joins/physical-table-joins.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-edit-table/physical-table-joins/physical-table-joins.component.ts
@@ -25,7 +25,6 @@ import {
    IterableDiffer,
    OnInit, Output, EventEmitter, OnDestroy
 } from "@angular/core";
-import { NgIf } from "@angular/common";
 
 import { HttpClient, HttpParams } from "@angular/common/http";
 import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
@@ -67,7 +66,7 @@ class JoinTreeType {
     selector: "physical-table-joins",
     templateUrl: "physical-table-joins.component.html",
     styleUrls: ["physical-table-joins.component.scss"],
-    imports: [NgIf, TreeComponent, AddJoinDialog, EditJoinDialog]
+    imports: [TreeComponent, AddJoinDialog, EditJoinDialog]
 })
 export class PhysicalTableJoinsComponent implements DoCheck, OnDestroy {
    @Input() physicalModel: PhysicalModelDefinition;

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-edit-table/physical-table-joins/physical-table-joins.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-edit-table/physical-table-joins/physical-table-joins.component.ts
@@ -25,6 +25,7 @@ import {
    IterableDiffer,
    OnInit, Output, EventEmitter, OnDestroy
 } from "@angular/core";
+import { NgIf } from "@angular/common";
 
 import { HttpClient, HttpParams } from "@angular/common/http";
 import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
@@ -66,7 +67,7 @@ class JoinTreeType {
     selector: "physical-table-joins",
     templateUrl: "physical-table-joins.component.html",
     styleUrls: ["physical-table-joins.component.scss"],
-    imports: [TreeComponent, AddJoinDialog, EditJoinDialog]
+    imports: [NgIf, TreeComponent, AddJoinDialog, EditJoinDialog]
 })
 export class PhysicalTableJoinsComponent implements DoCheck, OnDestroy {
    @Input() physicalModel: PhysicalModelDefinition;

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-network-graph/physical-model-network-graph.component.interaction.tl.spec.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-network-graph/physical-model-network-graph.component.interaction.tl.spec.ts
@@ -21,7 +21,7 @@
  *
  * Risk-first coverage:
  *   Group 1 [Risk 3] — selectNode(): already-selected guard; ctrl/shift append; plain replace;
- *                        emits correct treeLinks via onNodeSelected
+ *                        emits selected graph models via onNodeSelected
  *   Group 2 [Risk 2] — selectAll(), onSelectionBox(), clearSelection()
  *   Group 3 [Risk 2] — removeSelectTables(): no-confirm path; confirm path (ok / cancel);
  *                        baseTable exclusion
@@ -113,7 +113,7 @@ describe("PhysicalModelNetworkGraphComponent — selectNode()", () => {
       expect((comp as any).dragNodes).toEqual([g1, g2]);
    });
 
-   it("should emit onNodeSelected with treeLinks of all dragNodes after selection", async () => {
+   it("should emit onNodeSelected with all selected graph models after selection", async () => {
       const g1 = makeGraph("t1");
       const g2 = makeGraph("t2");
       const { comp, onNodeSelectedSpy } = await renderComp({ graphViewModel: makeViewModel([g1, g2]) });
@@ -122,9 +122,7 @@ describe("PhysicalModelNetworkGraphComponent — selectNode()", () => {
 
       comp.selectNode({ ctrlKey: true, shiftKey: false } as MouseEvent, g2);
 
-      expect(onNodeSelectedSpy).toHaveBeenCalledWith(
-         [g1.node.treeLink, g2.node.treeLink]
-      );
+      expect(onNodeSelectedSpy).toHaveBeenCalledWith([g1, g2]);
    });
 
    // 🔁 Regression-sensitive: this is the bug this file's changes fix -- plain-clicking one
@@ -161,16 +159,14 @@ describe("PhysicalModelNetworkGraphComponent — selectAll()", () => {
       expect((comp as any).dragNodes).toBe(graphs);
    });
 
-   it("should emit onNodeSelected with all treeLinks after selectAll()", async () => {
+   it("should emit onNodeSelected with all graph models after selectAll()", async () => {
       const graphs = [makeGraph("t1"), makeGraph("t2")];
       const { comp, onNodeSelectedSpy } = await renderComp({ graphViewModel: makeViewModel(graphs) });
       vi.spyOn(comp as any, "refreshDragSelection").mockImplementation(() => {});
 
       comp.selectAll();
 
-      expect(onNodeSelectedSpy).toHaveBeenCalledWith(
-         graphs.map(g => g.node.treeLink)
-      );
+      expect(onNodeSelectedSpy).toHaveBeenCalledWith(graphs);
    });
 });
 
@@ -188,7 +184,7 @@ describe("PhysicalModelNetworkGraphComponent — onSelectionBox()", () => {
       comp.onSelectionBox({ box: new Rectangle(0, 0, 50, 50) } as any);
 
       expect((comp as any).dragNodes).toEqual([g1]);
-      expect(onNodeSelectedSpy).toHaveBeenCalledWith([g1.node.treeLink]);
+      expect(onNodeSelectedSpy).toHaveBeenCalledWith([g1]);
    });
 
    it("should clear dragNodes when no graphs intersect the selection box", async () => {

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-network-graph/physical-model-network-graph.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-model-network-graph/physical-model-network-graph.component.ts
@@ -91,7 +91,7 @@ export class PhysicalModelNetworkGraphComponent implements OnInit, OnChanges, Af
    @Output() onEditInlineView = new EventEmitter<string>();
    @Output() onRefreshPhysicalGraph = new EventEmitter<TableJoinInfo>();
    @Output() onModified: EventEmitter<boolean> = new EventEmitter<boolean>();
-   @Output() onNodeSelected: EventEmitter<string[]> = new EventEmitter<string[]>();
+   @Output() onNodeSelected: EventEmitter<GraphModel[]> = new EventEmitter<GraphModel[]>();
    @Output() onRemoveTable: EventEmitter<GraphModel[]> = new EventEmitter<GraphModel[]>();
 
    @ViewChild("jspContainerMain") jspContainerMain: ElementRef<HTMLDivElement>;
@@ -695,15 +695,7 @@ export class PhysicalModelNetworkGraphComponent implements OnInit, OnChanges, Af
    }
 
    private fireSelectedNodesChanged(): void {
-      let selectedPath: string[] = [];
-
-      this.dragNodes.forEach(node => {
-         if(node && node.node) {
-            selectedPath.push(node.node.treeLink);
-         }
-      });
-
-      this.onNodeSelected.emit(selectedPath);
+      this.onNodeSelected.emit(this.dragNodes.filter(node => !!node?.node));
    }
 
    @HostListener("contextmenu", ["$event"])


### PR DESCRIPTION
## Summary
- Clicking a single node in the physical model graph (including auto-alias
  and auto-alias-by-outgoing nodes) didn't update `editingTable`, so the
  outgoing joins pane stayed stale or empty instead of reflecting the
  clicked table.
- `graphNodesSelected()` now resolves the selected node's tree path back to
  its source table (new `changeEditingTableByGraphPath()` /
  `getGraphTableName()` / `getGraphAliasName()` helpers), clearing
  `editingTable` when zero or multiple nodes are selected.
- Fixed a missing `NgIf` import in `PhysicalTableJoinsComponent`'s
  standalone `imports` array.

## Test plan
- [ ] `npm run test:portal:tl` — new Group 5 tests in
      `database-physical-model.component.tl.spec.ts` (single-node select,
      auto-alias resolution)
- [ ] Manual: open a physical model, click a single table node in the graph,
      confirm the outgoing joins pane updates to that table
- [ ] Manual: click an auto-alias node, confirm it resolves to the alias's
      source table
- [ ] Manual: click multiple nodes / deselect, confirm the joins pane clears
