### PR TITLE
Stop offering non-JDBC sources as expandable in the wiz annotation tree

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -1264,7 +1264,8 @@ public class MetadataApiService {
       return response;
    }
 
-   private TreeNodeModel filterWizTree(TreeNodeModel node) {
+   // Package-private so a test can drive the real filter rather than only its helper.
+   TreeNodeModel filterWizTree(TreeNodeModel node) {
       return filterWizTree(node, new HashMap<>(), new HashMap<>());
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -1286,6 +1286,15 @@ public class MetadataApiService {
       TreeNodeModel.Builder builder = TreeNodeModel.builder().from(node);
       builder.children(new ArrayList<>());
 
+      // A non-relational source has no catalog/schema/table metadata to hand back, so expanding it
+      // returns an empty child list forever -- it looks identical to a database that is still
+      // loading. Marking it a leaf says plainly that there is nothing to open. It stays in the tree
+      // on purpose: the source IS usable, through a worksheet built on it, and hiding it would send
+      // the operator hunting for something they can see in StyleBI.
+      if(isNonJdbcDataSource(entry)) {
+         builder.leaf(true);
+      }
+
       for(TreeNodeModel child : node.children()) {
          TreeNodeModel filteredChild = filterWizTree(child, filterCache, partitionCache);
 
@@ -1295,6 +1304,35 @@ public class MetadataApiService {
       }
 
       return builder.build();
+   }
+
+   /**
+    * Whether this entry is a data source that is not relational.
+    *
+    * Tabular/NoSQL sources extend TabularDataSource rather than JDBCDataSource; the metadata calls
+    * behind a tree expansion have nothing to return for them.
+    *
+    * Answers false when the source cannot be resolved. A lookup failure is not evidence that a
+    * source is non-relational, and treating it as such would collapse a real database to a leaf and
+    * make its tables unreachable -- far worse than leaving one node expandable.
+    */
+   // Package-private so the tree-filtering decision can be tested directly.
+   boolean isNonJdbcDataSource(AssetEntry entry) {
+      if(entry == null || !entry.isDataSource()) {
+         return false;
+      }
+
+      try {
+         XDataSource dataSource = xrepository.getDataSource(entry.getPath());
+
+         return dataSource != null && !(dataSource instanceof JDBCDataSource);
+      }
+      catch(Exception e) {
+         log.debug("Could not resolve data source '{}' while filtering the wiz tree: {}",
+                   entry.getPath(), e.getMessage());
+
+         return false;
+      }
    }
 
    private boolean shouldHideWizTreeNode(

--- a/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceNonJdbcTreeTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceNonJdbcTreeTest.java
@@ -24,15 +24,21 @@ import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.asset.AssetRepository;
 import inetsoft.uql.jdbc.JDBCDataSource;
 import inetsoft.uql.tabular.TabularDataSource;
+import inetsoft.uql.xmla.XMLADataSource;
+import inetsoft.web.composer.model.TreeNodeModel;
 import inetsoft.web.composer.AssetTreeService;
 import inetsoft.web.portal.controller.database.DataSourceService;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A non-relational data source has no catalog/schema/table metadata behind it, so expanding it in
@@ -106,5 +112,39 @@ class MetadataApiServiceNonJdbcTreeTest {
    @Test
    void nullEntryIsNotFlagged() {
       assertFalse(service(mock(XRepository.class)).isNonJdbcDataSource(null));
+   }
+
+   private TreeNodeModel node(String name) {
+      return TreeNodeModel.builder().label(name).data(dataSourceEntry(name)).leaf(false).build();
+   }
+
+   /*
+    * Drives the real filter, which the per-predicate cases above cannot: they call the helper
+    * directly, so deleting the production change leaves every one of them green. This one fails if
+    * the filter stops marking a non-relational source as a leaf, or starts marking a JDBC one.
+    *
+    * XMLA is here because it is the other non-JDBC family in this tree and was previously untested.
+    */
+   @Test
+   void filterMarksOnlyNonRelationalSourcesAsLeaves() throws Exception {
+      XRepository repo = mock(XRepository.class);
+      when(repo.getDataSource("sakila")).thenReturn(mock(JDBCDataSource.class));
+      when(repo.getDataSource("cassandra")).thenReturn(mock(TabularDataSource.class));
+      when(repo.getDataSource("cube")).thenReturn(mock(XMLADataSource.class));
+
+      TreeNodeModel root = TreeNodeModel.builder()
+         .label("Data Source")
+         .addChildren(node("sakila"), node("cassandra"), node("cube"))
+         .build();
+
+      Map<String, Boolean> leafByLabel = new HashMap<>();
+
+      for(TreeNodeModel child : service(repo).filterWizTree(root).children()) {
+         leafByLabel.put(child.label(), child.leaf());
+      }
+
+      assertEquals(Boolean.FALSE, leafByLabel.get("sakila"), "a JDBC source stays expandable");
+      assertEquals(Boolean.TRUE, leafByLabel.get("cassandra"), "a tabular source becomes a leaf");
+      assertEquals(Boolean.TRUE, leafByLabel.get("cube"), "an XMLA source becomes a leaf");
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceNonJdbcTreeTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceNonJdbcTreeTest.java
@@ -1,0 +1,110 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.uql.XDataSource;
+import inetsoft.uql.XRepository;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.jdbc.JDBCDataSource;
+import inetsoft.uql.tabular.TabularDataSource;
+import inetsoft.web.composer.AssetTreeService;
+import inetsoft.web.portal.controller.database.DataSourceService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * A non-relational data source has no catalog/schema/table metadata behind it, so expanding it in
+ * the wiz tree returns an empty child list every time -- indistinguishable from a database that has
+ * not finished loading. It is marked a leaf instead.
+ *
+ * Reproduced against a running deployment before this was written: a registered Cassandra source
+ * appeared in the tree next to the JDBC ones with leaf=false, and expanding it returned HTTP 200
+ * with children: []. Note that it did NOT throw, which is what the design doc had assumed.
+ */
+@Tag("core")
+class MetadataApiServiceNonJdbcTreeTest {
+   private MetadataApiService service(XRepository repo) {
+      return new MetadataApiService(repo, mock(DataSourceService.class),
+                                    mock(AssetRepository.class), mock(AssetTreeService.class),
+                                    new ObjectMapper());
+   }
+
+   private AssetEntry dataSourceEntry(String name) {
+      return new AssetEntry(AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.DATA_SOURCE, name, null);
+   }
+
+   @Test
+   void tabularSourceIsNonJdbc() throws Exception {
+      XRepository repo = mock(XRepository.class);
+      when(repo.getDataSource("cassandra-one")).thenReturn(mock(TabularDataSource.class));
+
+      assertTrue(service(repo).isNonJdbcDataSource(dataSourceEntry("cassandra-one")));
+   }
+
+   @Test
+   void jdbcSourceIsNotFlagged() throws Exception {
+      XRepository repo = mock(XRepository.class);
+      when(repo.getDataSource("sakila")).thenReturn(mock(JDBCDataSource.class));
+
+      assertFalse(service(repo).isNonJdbcDataSource(dataSourceEntry("sakila")));
+   }
+
+   /*
+    * The three ways this must answer "no".
+    *
+    * A lookup that fails or comes back empty is not evidence that a source is non-relational.
+    * Answering yes there would collapse a real database to a leaf and put every table in it out of
+    * reach -- a far worse outcome than leaving one node pointlessly expandable.
+    */
+   @Test
+   void unresolvableSourceIsNotFlagged() throws Exception {
+      XRepository repo = mock(XRepository.class);
+      when(repo.getDataSource("gone")).thenReturn(null);
+
+      assertFalse(service(repo).isNonJdbcDataSource(dataSourceEntry("gone")));
+   }
+
+   @Test
+   void lookupFailureIsNotFlagged() throws Exception {
+      XRepository repo = mock(XRepository.class);
+      when(repo.getDataSource("broken")).thenThrow(new RuntimeException("repository down"));
+
+      assertFalse(service(repo).isNonJdbcDataSource(dataSourceEntry("broken")));
+   }
+
+   @Test
+   void nonDataSourceEntryIsNotFlagged() throws Exception {
+      XRepository repo = mock(XRepository.class);
+      AssetEntry folder =
+         new AssetEntry(AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.FOLDER, "somewhere", null);
+
+      assertFalse(service(repo).isNonJdbcDataSource(folder));
+   }
+
+   @Test
+   void nullEntryIsNotFlagged() {
+      assertFalse(service(mock(XRepository.class)).isNonJdbcDataSource(null));
+   }
+}


### PR DESCRIPTION
**Branch:** `feature-76074-server-fixes` · base `stylebi-wiz-main-rebase` · Redmine #76075

> **Scope reduced.** This PR originally carried a second commit that claimed to fix i18n token
> leakage in the elements bundle. Building the image proved that fix **inert**; it has been dropped.
> See the comment below for what the evidence actually showed. What remains is one fix, verified
> live.

## Non-JDBC sources are offered as expandable in the wiz annotation tree

A registered Cassandra source appeared in the wiz annotation tree beside the JDBC ones with
`leaf=false`. Expanding it returned **HTTP 200 with `children: []`** — every time, and
indistinguishable from a database that has not finished loading.

It does **not** throw `UnsupportedDatasourceException`, which is what the design assumed. Nothing
surfaces at all, which is the quieter and worse of the two failures.

Non-relational sources extend `TabularDataSource`, so the metadata calls behind an expansion have
nothing to return. They are now marked leaves.

They **stay in the tree** on purpose: the source *is* usable, through a worksheet built on it, and
hiding it would send the operator hunting for something they can plainly see in StyleBI.

A lookup that fails or comes back empty answers "not flagged". That is not evidence a source is
non-relational, and getting it wrong would collapse a real database to a leaf and put every table in
it out of reach — far worse than leaving one node pointlessly expandable.

This gets more reachable as registering non-JDBC sources from the wiz portal gets easier, which is
exactly what [stylebi-wiz#1556](https://github.com/inetsoft-technology/stylebi-wiz/pull/1556) does.

## Verification

**Verified live** on a locally built image (`local-1180`, full reactor). With a Cassandra source
registered, the wiz asset tree returns:

```
inventree           leaf=False      ← 8 JDBC sources, all still expandable
mysqltest           leaf=False
odoo                leaf=False
olist               leaf=False
openproject         leaf=False
orders              leaf=False
sakila              leaf=False
suitecrm            leaf=False
tab-verify-renamed  leaf=True       ← the Cassandra source
```

Reproduced before the fix on the same deployment: the same node came back `leaf=false` and expanded
to `children: []`.

**6 JUnit tests**, covering all four ways the check must answer "no" — JDBC source, unresolvable
source, a lookup that throws, and a non-data-source entry. `mvn -pl community/core test` BUILD
SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
