### PR TITLE
Add the wiz tabular data source API (server half of stylebi-wiz#1556)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/WizTabularController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizTabularController.java
@@ -37,8 +37,10 @@ import inetsoft.web.wiz.model.WizTabularSaveResult;
 import inetsoft.web.wiz.request.WizTabularCreateRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.security.Principal;
 import java.util.*;
@@ -137,8 +139,6 @@ public class WizTabularController {
     * @param principal the current user.
     *
     * @return the seeded definition, including the form to render.
-    *
-    * @throws java.io.FileNotFoundException if no tabular listing has that name.
     */
    @GetMapping(value = "/tabular/listing", produces = MediaType.APPLICATION_JSON_VALUE)
    public DataSourceDefinition getTabularListing(@RequestParam("name") String name,
@@ -149,9 +149,12 @@ public class WizTabularController {
       // name, and this endpoint's key is the stable one.
       DataSourceListing listing = findTabularListing(name);
 
+      // 404 rather than a bare exception: unhandled ones fall through to a generic 500, and asking
+      // for a type that does not exist is the caller's mistake, not a server fault. Measured — a
+      // JDBC name such as "MySQL" reached here and returned 500.
       if(listing == null) {
-         throw new java.io.FileNotFoundException(
-            "No tabular data source listing named \"" + name + "\"");
+         throw new ResponseStatusException(
+            HttpStatus.NOT_FOUND, "No tabular data source listing named \"" + name + "\"");
       }
 
       return datasourcesService.getDataSourceFromListing(listing.getDisplayName());

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizTabularController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizTabularController.java
@@ -1,0 +1,411 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.controller;
+
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.uql.DataSourceListing;
+import inetsoft.uql.DataSourceListingService;
+import inetsoft.uql.XDataSource;
+import inetsoft.uql.tabular.TabularDataSource;
+import inetsoft.util.Catalog;
+import inetsoft.util.MessageException;
+import inetsoft.web.portal.data.DataSourceDefinition;
+import inetsoft.web.portal.data.DatasourcesService;
+import inetsoft.web.security.PermissionPath;
+import inetsoft.web.security.RequiredPermission;
+import inetsoft.web.security.Secured;
+import inetsoft.web.wiz.model.WizTabularListing;
+import inetsoft.web.wiz.model.WizTabularListings;
+import inetsoft.web.wiz.model.WizTabularSaveResult;
+import inetsoft.web.wiz.request.WizTabularCreateRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.util.*;
+
+/**
+ * The wiz API for creating and editing tabular (non-JDBC) data sources.
+ *
+ * <p>Separate from {@code WizDatabaseController} because tabular and JDBC are two unrelated models;
+ * merging them would make both harder to read. What they share is the authorization stance.</p>
+ *
+ * <h3>Pass-through</h3>
+ *
+ * <p>{@code DataSourceDefinition} and its {@code TabularView} are returned <em>as they are</em>,
+ * with no flattening — the opposite of the JDBC endpoints. The reason is that {@code tabularView}
+ * <em>is</em> the UI description; there is no dimension to reduce, and any trimming removes
+ * information the renderer needs.</p>
+ *
+ * <h3>Authorization</h3>
+ *
+ * <p>Calling the service layer directly is not a permission gate — the equivalent gates the portal
+ * controllers apply are repeated here. Denials leave as {@code SecurityException}, which
+ * {@code WizControllerErrorHandler} turns into a 403; this class must therefore never declare a
+ * local {@code @ExceptionHandler}, which would take precedence over that advice and degrade a 403
+ * into a 400.</p>
+ *
+ * <h3>Keys are not labels</h3>
+ *
+ * <p>{@code DataSourceListing.getDisplayName()} is {@code getName()} translated for the caller's
+ * locale, and StyleBI's own listing lookup matches on the display name — so the portal's key set
+ * shifts when the locale does. This controller keys on the stable {@code getName()} and translates
+ * only at the edge, so a stored choice survives a locale switch.</p>
+ */
+@RestController
+@RequestMapping("/api/wiz")
+public class WizTabularController {
+   public WizTabularController(DatasourcesService datasourcesService,
+                               SecurityEngine securityEngine)
+   {
+      this.datasourcesService = datasourcesService;
+      this.securityEngine = securityEngine;
+   }
+
+   /**
+    * Lists the data source types the tabular editor offers.
+    *
+    * <p>JDBC listings are excluded: they have no {@code TabularView} to render and belong to the
+    * {@code /databases} editor. The only way to tell is to instantiate the listing's data source and
+    * look at its type, which is why this builds one per listing — they are plain objects with
+    * default fields, not connections.</p>
+    *
+    * @param principal the current user.
+    *
+    * @return the offered listings and the raw categories to group them by.
+    */
+   @GetMapping(value = "/tabular/listings", produces = MediaType.APPLICATION_JSON_VALUE)
+   public WizTabularListings getTabularListings(Principal principal) {
+      Catalog catalog = Catalog.getCatalog(principal);
+      List<WizTabularListing> listings = new ArrayList<>();
+
+      for(DataSourceListing listing : DataSourceListingService.getAllDataSourceListings(true)) {
+         if(!isTabular(listing)) {
+            continue;
+         }
+
+         String category = listing.getCategory();
+         listings.add(new WizTabularListing(
+            listing.getName(),
+            listing.getDisplayName(),
+            category,
+            category == null ? null : catalog.getString(category),
+            listing.getIcon(),
+            listing.getKeywords() == null
+               ? List.of() : Arrays.asList(listing.getKeywords())));
+      }
+
+      listings.sort(Comparator.comparing(WizTabularListing::name, String.CASE_INSENSITIVE_ORDER));
+
+      List<String> categories = listings.stream()
+         .map(WizTabularListing::category)
+         .filter(Objects::nonNull)
+         .distinct()
+         .sorted()
+         .toList();
+
+      return new WizTabularListings(listings, categories);
+   }
+
+   /**
+    * Seeds a NEW data source of the given type.
+    *
+    * <p>This is the only way to obtain a usable blank form. Posting a bare name and type to
+    * {@code /tabular/refresh} yields {@code tabularView: null}, because refresh recomputes an
+    * existing view rather than creating one.</p>
+    *
+    * @param name      the listing's stable {@link DataSourceListing#getName()}, not its display name.
+    * @param principal the current user.
+    *
+    * @return the seeded definition, including the form to render.
+    *
+    * @throws java.io.FileNotFoundException if no tabular listing has that name.
+    */
+   @GetMapping(value = "/tabular/listing", produces = MediaType.APPLICATION_JSON_VALUE)
+   public DataSourceDefinition getTabularListing(@RequestParam("name") String name,
+                                                 Principal principal)
+      throws Exception
+   {
+      // Resolved here rather than passed straight through: the service looks listings up by display
+      // name, and this endpoint's key is the stable one.
+      DataSourceListing listing = findTabularListing(name);
+
+      if(listing == null) {
+         throw new java.io.FileNotFoundException(
+            "No tabular data source listing named \"" + name + "\"");
+      }
+
+      return datasourcesService.getDataSourceFromListing(listing.getDisplayName());
+   }
+
+   /**
+    * Loads an existing data source for editing.
+    *
+    * @param path      the data source's full repository path.
+    * @param principal the current user.
+    *
+    * @return the stored definition and its form.
+    */
+   @GetMapping(value = "/tabular/definition", produces = MediaType.APPLICATION_JSON_VALUE)
+   @Secured({
+      @RequiredPermission(
+         resourceType = ResourceType.DATA_SOURCE, actions = ResourceAction.WRITE
+      )
+   })
+   public DataSourceDefinition getTabularDefinition(
+      @PermissionPath @RequestParam("path") String path, Principal principal) throws Exception
+   {
+      return datasourcesService.getDataSourceDefinition(path, principal);
+   }
+
+   /**
+    * Recomputes the form after a field the rest of it depends on changed.
+    *
+    * <p>No path-level permission: this touches no stored data. The definition arrives whole from the
+    * caller and the server recomputes a view from it. A login is still required, which
+    * {@code WizServiceAuthenticationFilter} enforces.</p>
+    *
+    * <p>The sequence number is echoed back deliberately. The caller increments it before each
+    * refresh and discards any response carrying a lower one; drop the echo and a slow response
+    * silently overwrites a newer form. The portal does the same.</p>
+    *
+    * <p>Unlike the portal this does not bind the call to an HTTP session. Refresh was verified
+    * stateless, and wiz reaches this server-to-server where a session would be per-call noise
+    * rather than the user's. Worth revisiting if a source that keeps session-scoped credentials
+    * misbehaves under refresh.</p>
+    *
+    * @param definition the current form state.
+    *
+    * @return the recomputed definition.
+    */
+   @PostMapping(value = "/tabular/refresh", produces = MediaType.APPLICATION_JSON_VALUE)
+   public DataSourceDefinition refreshTabularView(@RequestBody DataSourceDefinition definition) {
+      DataSourceDefinition refreshed = datasourcesService.refreshTabularView(definition);
+      refreshed.setSequenceNumber(definition.getSequenceNumber());
+
+      return refreshed;
+   }
+
+   /**
+    * Creates a data source.
+    *
+    * @param request   the target folder and the definition to save.
+    * @param principal the current user.
+    *
+    * @return the saved path, or the reason the save was rejected.
+    */
+   @PostMapping(value = "/tabular/create", produces = MediaType.APPLICATION_JSON_VALUE)
+   public WizTabularSaveResult createTabularDataSource(
+      @RequestBody WizTabularCreateRequest request, Principal principal) throws Exception
+   {
+      DataSourceDefinition definition = request.definition();
+
+      if(definition == null) {
+         return WizTabularSaveResult.failed(WizTabularSaveResult.UNKNOWN);
+      }
+
+      String parentPath = emptyToNull(request.parentPath());
+      requireCreatePermission(parentPath, principal);
+
+      // Carried on the definition because that is where createNewDataSource reads it from; the
+      // request field exists so the gate above can run before anything is written.
+      definition.setParentPath(parentPath == null ? "" : parentPath);
+      String fullPath = fullPath(parentPath, definition.getName());
+
+      // Checked up front rather than inferred from the failure. A duplicate otherwise surfaces as a
+      // translated sentence that has to be string-matched, which breaks in any other locale.
+      if(datasourcesService.checkDuplicate(fullPath)) {
+         return WizTabularSaveResult.failed(WizTabularSaveResult.DUPLICATE_NAME);
+      }
+
+      try {
+         datasourcesService.createNewDataSource(definition, false, principal);
+      }
+      catch(MessageException e) {
+         return toFailure(e, "create", fullPath);
+      }
+
+      return WizTabularSaveResult.ok(fullPath);
+   }
+
+   /**
+    * Updates an existing data source.
+    *
+    * <p>Gated at the entry point rather than relying on the service's own check, which happens only
+    * after the stored definition has been read.</p>
+    *
+    * @param path       the data source's current full repository path, and the sole source of the
+    *                   name to update. A client should leave whatever {@code oldName} it received
+    *                   untouched rather than compute one.
+    * @param definition the new settings.
+    * @param principal  the current user.
+    *
+    * @return the saved path, which differs from {@code path} when the source was renamed, or the
+    *         reason the save was rejected.
+    */
+   @PostMapping(value = "/tabular/update", produces = MediaType.APPLICATION_JSON_VALUE)
+   @Secured({
+      @RequiredPermission(
+         resourceType = ResourceType.DATA_SOURCE, actions = ResourceAction.WRITE
+      )
+   })
+   public WizTabularSaveResult updateTabularDataSource(
+      @PermissionPath @RequestParam("path") String path,
+      @RequestBody DataSourceDefinition definition, Principal principal) throws Exception
+   {
+      if(definition == null) {
+         return WizTabularSaveResult.failed(WizTabularSaveResult.UNKNOWN);
+      }
+
+      // It vanished between load and save. A 200 carrying this reason, not a 404: the request was
+      // well formed and the caller was authorized; what failed is the save.
+      if(!datasourcesService.checkDuplicate(path)) {
+         return WizTabularSaveResult.failed(WizTabularSaveResult.DATASOURCE_LOST);
+      }
+
+      String parentPath = parentOf(path);
+      definition.setParentPath(parentPath == null ? "" : parentPath);
+      String fullPath = fullPath(parentPath, definition.getName());
+
+      // A rename onto an existing name, not the source's own path.
+      if(!fullPath.equals(path) && datasourcesService.checkDuplicate(fullPath)) {
+         return WizTabularSaveResult.failed(WizTabularSaveResult.DUPLICATE_NAME);
+      }
+
+      try {
+         datasourcesService.updateDataSource(path, definition, principal);
+      }
+      catch(MessageException e) {
+         return toFailure(e, "update", fullPath);
+      }
+
+      return WizTabularSaveResult.ok(fullPath);
+   }
+
+   /**
+    * Whether a data source already exists at that path, so the editor can reject a name before the
+    * server has to.
+    *
+    * @param name the full repository path to test.
+    *
+    * @return a single-key object rather than a bare boolean, so the response stays extensible.
+    */
+   @GetMapping(value = "/tabular/check-duplicate", produces = MediaType.APPLICATION_JSON_VALUE)
+   public Map<String, Boolean> checkDuplicate(@RequestParam("name") String name) throws Exception {
+      return Map.of("duplicate", datasourcesService.checkDuplicate(name));
+   }
+
+   /**
+    * Maps a business failure onto a stable code.
+    *
+    * <p>{@code MessageException} carries a Catalog-translated sentence, so the only handle on it is
+    * to build the same string and compare. That works because both are produced by the same catalog
+    * in the same locale, but it is the reason duplicate names are checked up front instead: the
+    * fewer outcomes that depend on this comparison, the better. Anything unrecognized becomes
+    * {@code UNKNOWN} and is logged verbatim rather than swallowed.</p>
+    */
+   private WizTabularSaveResult toFailure(MessageException e, String operation, String path) {
+      String invalidFolder =
+         Catalog.getCatalog().getString("data.datasources.invalidParentFolder");
+
+      if(invalidFolder != null && invalidFolder.equals(e.getMessage())) {
+         return WizTabularSaveResult.failed(WizTabularSaveResult.INVALID_FOLDER);
+      }
+
+      LOG.info("Tabular data source {} rejected for \"{}\": {}", operation, path, e.getMessage());
+
+      return WizTabularSaveResult.failed(WizTabularSaveResult.UNKNOWN);
+   }
+
+   /**
+    * The same rule the JDBC create path applies: WRITE on the target folder, falling back at the
+    * root to the permission that grants creating data sources at all.
+    */
+   private void requireCreatePermission(String parentPath, Principal principal) throws Exception {
+      boolean root = parentPath == null;
+      boolean allowed = securityEngine.checkPermission(
+         principal, ResourceType.DATA_SOURCE_FOLDER, root ? "/" : parentPath, ResourceAction.WRITE);
+
+      if(!allowed && root) {
+         allowed = securityEngine.checkPermission(
+            principal, ResourceType.CREATE_DATA_SOURCE, "*", ResourceAction.ACCESS);
+      }
+
+      if(!allowed) {
+         throw new SecurityException("Unauthorized access to data source folder \"" +
+                                        (root ? "/" : parentPath) + "\" by user " + principal);
+      }
+   }
+
+   private DataSourceListing findTabularListing(String name) {
+      if(name == null) {
+         return null;
+      }
+
+      for(DataSourceListing listing : DataSourceListingService.getAllDataSourceListings(true)) {
+         if(name.equals(listing.getName()) && isTabular(listing)) {
+            return listing;
+         }
+      }
+
+      return null;
+   }
+
+   /**
+    * Whether a listing produces a tabular data source.
+    *
+    * <p>A listing that cannot be instantiated is treated as not tabular rather than allowed to fail
+    * the whole request: one broken plugin should cost its own entry in the picker, not every
+    * entry.</p>
+    */
+   private boolean isTabular(DataSourceListing listing) {
+      try {
+         XDataSource dataSource = listing.createDataSource();
+
+         return dataSource instanceof TabularDataSource;
+      }
+      catch(Exception e) {
+         LOG.debug("Could not instantiate data source listing \"{}\": {}",
+                   listing.getName(), e.getMessage());
+
+         return false;
+      }
+   }
+
+   private static String fullPath(String parentPath, String name) {
+      return parentPath == null || parentPath.isEmpty() ? name : parentPath + "/" + name;
+   }
+
+   private static String parentOf(String path) {
+      int i = path == null ? -1 : path.lastIndexOf('/');
+
+      return i < 0 ? null : path.substring(0, i);
+   }
+
+   private static String emptyToNull(String value) {
+      return value == null || value.isEmpty() || "/".equals(value) ? null : value;
+   }
+
+   private final DatasourcesService datasourcesService;
+   private final SecurityEngine securityEngine;
+   private static final Logger LOG = LoggerFactory.getLogger(WizTabularController.class);
+}

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizTabularController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizTabularController.java
@@ -23,7 +23,9 @@ import inetsoft.sree.security.SecurityEngine;
 import inetsoft.uql.DataSourceListing;
 import inetsoft.uql.DataSourceListingService;
 import inetsoft.uql.XDataSource;
+import inetsoft.uql.XRepository;
 import inetsoft.uql.tabular.TabularDataSource;
+import inetsoft.uql.tabular.TabularUtil;
 import inetsoft.util.Catalog;
 import inetsoft.util.MessageException;
 import inetsoft.web.portal.data.DataSourceDefinition;
@@ -35,6 +37,7 @@ import inetsoft.web.wiz.model.WizTabularListing;
 import inetsoft.web.wiz.model.WizTabularListings;
 import inetsoft.web.wiz.model.WizTabularSaveResult;
 import inetsoft.web.wiz.request.WizTabularCreateRequest;
+import inetsoft.web.wiz.service.UnsupportedDatasourceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -72,15 +75,23 @@ import java.util.*;
  * locale, and StyleBI's own listing lookup matches on the display name — so the portal's key set
  * shifts when the locale does. This controller keys on the stable {@code getName()} and translates
  * only at the edge, so a stored choice survives a locale switch.</p>
+ *
+ * <h3>The connector session</h3>
+ *
+ * <p>Every endpoint that can reach {@code TabularUtil.refreshView} brackets the call with
+ * {@link #beginConnectorSession(Principal)} and {@link #endConnectorSession()} — see those methods
+ * for why leaving the thread-local alone is not the neutral option it looks like.</p>
  */
 @RestController
 @RequestMapping("/api/wiz")
 public class WizTabularController {
    public WizTabularController(DatasourcesService datasourcesService,
-                               SecurityEngine securityEngine)
+                               SecurityEngine securityEngine,
+                               XRepository xrepository)
    {
       this.datasourcesService = datasourcesService;
       this.securityEngine = securityEngine;
+      this.xrepository = xrepository;
    }
 
    /**
@@ -157,16 +168,46 @@ public class WizTabularController {
             HttpStatus.NOT_FOUND, "No tabular data source listing named \"" + name + "\"");
       }
 
-      return datasourcesService.getDataSourceFromListing(listing.getDisplayName());
+      beginConnectorSession(principal);
+
+      try {
+         return datasourcesService.getDataSourceFromListing(listing.getDisplayName());
+      }
+      finally {
+         endConnectorSession();
+      }
    }
 
    /**
     * Loads an existing data source for editing.
     *
+    * <h4>Secrets come back in clear text, and that is the contract</h4>
+    *
+    * <p>Passwords, API keys and tokens are returned inside {@code tabularView} as ordinary
+    * {@code editor.value} strings — the opposite of the JDBC endpoints, where the stored password
+    * never leaves the server and null means "keep it". Confirmed as intended rather than
+    * overlooked, and written down here because the reasoning otherwise lives only in the wiz
+    * client and reads like a defect from this side.</p>
+    *
+    * <p>The refresh protocol forces it. The client posts the whole tree back and the server
+    * recomputes it, so a masked value would be handed to the connector exactly as if the user had
+    * typed the mask: the recomputed form would be wrong — a connector authenticating against the
+    * mask populates nothing — and the next save would persist the mask over the real secret.
+    * Masking would therefore mean holding per-node secrets server-side, keyed to an editing
+    * session, which replaces the stateless refresh protocol rather than adding to it.</p>
+    *
+    * <p>The exposure is bounded: this endpoint is gated on WRITE, so a caller who receives a secret
+    * could already overwrite it, and it is the same readback the native Angular portal has always
+    * done into the browser.</p>
+    *
     * @param path      the data source's full repository path.
     * @param principal the current user.
     *
     * @return the stored definition and its form.
+    *
+    * @throws UnsupportedDatasourceException if the path names a data source that is not tabular —
+    *                                        a JDBC database has no form here and would render as an
+    *                                        empty one.
     */
    @GetMapping(value = "/tabular/definition", produces = MediaType.APPLICATION_JSON_VALUE)
    @Secured({
@@ -177,35 +218,53 @@ public class WizTabularController {
    public DataSourceDefinition getTabularDefinition(
       @PermissionPath @RequestParam("path") String path, Principal principal) throws Exception
    {
-      return datasourcesService.getDataSourceDefinition(path, principal);
+      requireTabularDataSource(path);
+      beginConnectorSession(principal);
+
+      try {
+         return datasourcesService.getDataSourceDefinition(path, principal);
+      }
+      finally {
+         endConnectorSession();
+      }
    }
 
    /**
     * Recomputes the form after a field the rest of it depends on changed.
     *
-    * <p>No path-level permission: this touches no stored data. The definition arrives whole from the
-    * caller and the server recomputes a view from it. A login is still required, which
-    * {@code WizServiceAuthenticationFilter} enforces.</p>
+    * <p>No path-level permission, because there is no path: the definition arrives whole from the
+    * caller and nothing stored is read. That answers data exposure but not side effects — refresh
+    * invokes the connector's own button and editor methods with a caller-controlled type, property
+    * values and {@code clicked} flag, and those are what reach a remote endpoint or a file. So the
+    * gate is on the capability instead of on a resource; see
+    * {@link #requireConnectorPermission(Principal)}.</p>
     *
     * <p>The sequence number is echoed back deliberately. The caller increments it before each
     * refresh and discards any response carrying a lower one; drop the echo and a slow response
     * silently overwrites a newer form. The portal does the same.</p>
     *
-    * <p>Unlike the portal this does not bind the call to an HTTP session. Refresh was verified
-    * stateless, and wiz reaches this server-to-server where a session would be per-call noise
-    * rather than the user's. Worth revisiting if a source that keeps session-scoped credentials
-    * misbehaves under refresh.</p>
-    *
     * @param definition the current form state.
+    * @param principal  the current user.
     *
     * @return the recomputed definition.
     */
    @PostMapping(value = "/tabular/refresh", produces = MediaType.APPLICATION_JSON_VALUE)
-   public DataSourceDefinition refreshTabularView(@RequestBody DataSourceDefinition definition) {
-      DataSourceDefinition refreshed = datasourcesService.refreshTabularView(definition);
-      refreshed.setSequenceNumber(definition.getSequenceNumber());
+   public DataSourceDefinition refreshTabularView(@RequestBody DataSourceDefinition definition,
+                                                  Principal principal)
+      throws Exception
+   {
+      requireConnectorPermission(principal);
+      beginConnectorSession(principal);
 
-      return refreshed;
+      try {
+         DataSourceDefinition refreshed = datasourcesService.refreshTabularView(definition);
+         refreshed.setSequenceNumber(definition.getSequenceNumber());
+
+         return refreshed;
+      }
+      finally {
+         endConnectorSession();
+      }
    }
 
    /**
@@ -220,19 +279,31 @@ public class WizTabularController {
    public WizTabularSaveResult createTabularDataSource(
       @RequestBody WizTabularCreateRequest request, Principal principal) throws Exception
    {
-      DataSourceDefinition definition = request.definition();
+      // Read off the record itself rather than through it: a body that deserializes to a literal
+      // null would otherwise throw before the guard below could answer.
+      DataSourceDefinition definition = request == null ? null : request.definition();
 
       if(definition == null) {
          return WizTabularSaveResult.failed(WizTabularSaveResult.UNKNOWN);
       }
 
+      String name = requireName(definition);
+
+      // The request field is the one the portal sends, and the one the gate below needs before
+      // anything is written. The definition's own value is a fallback rather than an error: a
+      // caller that set the folder only there would otherwise land at the root with no complaint.
       String parentPath = emptyToNull(request.parentPath());
+
+      if(parentPath == null) {
+         parentPath = emptyToNull(definition.getParentPath());
+      }
+
       requireCreatePermission(parentPath, principal);
 
       // Carried on the definition because that is where createNewDataSource reads it from; the
       // request field exists so the gate above can run before anything is written.
       definition.setParentPath(parentPath == null ? "" : parentPath);
-      String fullPath = fullPath(parentPath, definition.getName());
+      String fullPath = fullPath(parentPath, name);
 
       // Checked up front rather than inferred from the failure. A duplicate otherwise surfaces as a
       // translated sentence that has to be string-matched, which breaks in any other locale.
@@ -240,11 +311,27 @@ public class WizTabularController {
          return WizTabularSaveResult.failed(WizTabularSaveResult.DUPLICATE_NAME);
       }
 
+      beginConnectorSession(principal);
+
       try {
          datasourcesService.createNewDataSource(definition, false, principal);
       }
       catch(MessageException e) {
          return toFailure(e, "create", fullPath);
+      }
+      finally {
+         endConnectorSession();
+      }
+
+      // createNewDataSource writes nothing and throws nothing when the type is unknown or its
+      // connector is unavailable — createDataSource answers null and the whole body is skipped. The
+      // duplicate check above already proved the path was free, so an absence here is that no-op,
+      // and reporting it as a success would send the editor to a data source that does not exist.
+      if(!datasourcesService.checkDuplicate(fullPath)) {
+         LOG.warn("Tabular data source \"{}\" was not created; type \"{}\" is unknown or its " +
+                     "connector is unavailable", fullPath, definition.getType());
+
+         return WizTabularSaveResult.failed(WizTabularSaveResult.UNKNOWN);
       }
 
       return WizTabularSaveResult.ok(fullPath);
@@ -264,6 +351,9 @@ public class WizTabularController {
     *
     * @return the saved path, which differs from {@code path} when the source was renamed, or the
     *         reason the save was rejected.
+    *
+    * @throws UnsupportedDatasourceException if the path names a data source that is not tabular —
+    *                                        the save would rewrite it from a tabular definition.
     */
    @PostMapping(value = "/tabular/update", produces = MediaType.APPLICATION_JSON_VALUE)
    @Secured({
@@ -279,26 +369,47 @@ public class WizTabularController {
          return WizTabularSaveResult.failed(WizTabularSaveResult.UNKNOWN);
       }
 
+      String name = requireName(definition);
+
       // It vanished between load and save. A 200 carrying this reason, not a 404: the request was
       // well formed and the caller was authorized; what failed is the save.
       if(!datasourcesService.checkDuplicate(path)) {
          return WizTabularSaveResult.failed(WizTabularSaveResult.DATASOURCE_LOST);
       }
 
+      requireTabularDataSource(path);
+
       String parentPath = parentOf(path);
+      String oldName = lastSegment(path);
       definition.setParentPath(parentPath == null ? "" : parentPath);
-      String fullPath = fullPath(parentPath, definition.getName());
+      String fullPath = fullPath(parentPath, name);
 
       // A rename onto an existing name, not the source's own path.
       if(!fullPath.equals(path) && datasourcesService.checkDuplicate(fullPath)) {
          return WizTabularSaveResult.failed(WizTabularSaveResult.DUPLICATE_NAME);
       }
 
+      // A rename removes the source from its old name, which is why the service demands DELETE on
+      // top of the WRITE the annotation checks. It signals that denial with a MessageException,
+      // which the catch below would map to UNKNOWN — a 200 reading "could not save" for what is
+      // really "not allowed". Checked here so the denial leaves as the SecurityException it is.
+      if(!name.equals(oldName)) {
+         requireDataSourcePermission(path, ResourceAction.DELETE, principal);
+      }
+
+      beginConnectorSession(principal);
+
       try {
-         datasourcesService.updateDataSource(path, definition, principal);
+         // The bare name, not the full path: updateDataSource builds its own lookup key by
+         // re-prefixing the definition's parent path, so a full path here sends it after
+         // "folder/folder/mongo", which finds nothing and fails as DATASOURCE_LOST.
+         datasourcesService.updateDataSource(oldName, definition, principal);
       }
       catch(MessageException e) {
          return toFailure(e, "update", fullPath);
+      }
+      finally {
+         endConnectorSession();
       }
 
       return WizTabularSaveResult.ok(fullPath);
@@ -308,12 +419,23 @@ public class WizTabularController {
     * Whether a data source already exists at that path, so the editor can reject a name before the
     * server has to.
     *
-    * @param name the full repository path to test.
+    * <p>Scoped to the folder the caller may create in, rather than answering for any path at all.
+    * The answer is an existence oracle — unscoped it would let any logged-in user enumerate what
+    * exists anywhere, including sources they cannot read — and the editor only ever asks about the
+    * folder it is about to write into, so the create rule costs it nothing.</p>
+    *
+    * @param name      the full repository path to test.
+    * @param principal the current user.
     *
     * @return a single-key object rather than a bare boolean, so the response stays extensible.
     */
    @GetMapping(value = "/tabular/check-duplicate", produces = MediaType.APPLICATION_JSON_VALUE)
-   public Map<String, Boolean> checkDuplicate(@RequestParam("name") String name) throws Exception {
+   public Map<String, Boolean> checkDuplicate(@RequestParam("name") String name,
+                                              Principal principal)
+      throws Exception
+   {
+      requireCreatePermission(emptyToNull(parentOf(name)), principal);
+
       return Map.of("duplicate", datasourcesService.checkDuplicate(name));
    }
 
@@ -337,6 +459,114 @@ public class WizTabularController {
       LOG.info("Tabular data source {} rejected for \"{}\": {}", operation, path, e.getMessage());
 
       return WizTabularSaveResult.failed(WizTabularSaveResult.UNKNOWN);
+   }
+
+   /**
+    * Fails unless the path names a tabular data source.
+    *
+    * <p>Nothing downstream checks this, and both ends of the editor need it. On the write path,
+    * pointed at a JDBC database, the save rebuilds it from the tabular definition — renaming it and
+    * discarding every connection setting it has — and still reports success. On the read path the
+    * same database comes back as a 200 carrying the empty form {@code LayoutCreator} produces for a
+    * source that has no {@code TabularView}, which the editor renders as a blank one. A 422 rather
+    * than a 400: the request is well formed, the data source is simply not one this editor owns.</p>
+    *
+    * <p>A path with nothing behind it is left alone rather than reported as untypeable — the two
+    * callers already answer that case, one with {@code DATASOURCE_LOST} and one by letting the
+    * service's own lookup fail.</p>
+    */
+   private void requireTabularDataSource(String path) throws Exception {
+      XDataSource dataSource = xrepository.getDataSource(path);
+
+      if(dataSource != null && !(dataSource instanceof TabularDataSource)) {
+         throw new UnsupportedDatasourceException(path, dataSource.getType());
+      }
+   }
+
+   /**
+    * Fails unless the caller holds the action on a data source.
+    *
+    * <p>Throws {@code java.lang.SecurityException}, which is what {@code SecuredAspect} throws for
+    * the annotated endpoints, so a denial from here and a denial from an annotation reach
+    * {@code WizControllerErrorHandler} — and the client — as the same 403.</p>
+    */
+   private void requireDataSourcePermission(String path, ResourceAction action, Principal principal)
+      throws Exception
+   {
+      if(!securityEngine.checkPermission(principal, ResourceType.DATA_SOURCE, path, action)) {
+         throw new SecurityException(
+            "Unauthorized access to data source \"" + path + "\" by user " + principal);
+      }
+   }
+
+   /**
+    * Fails unless the caller may configure data sources at all.
+    *
+    * <p>A capability check rather than a path check, because refresh has no path: it recomputes a
+    * view from a definition the caller posted, and nothing stored is involved. What it does have is
+    * reach — the connector's button and editor methods run with a caller-supplied type, property
+    * values and {@code clicked} flag, and those are what dial a remote endpoint or touch a file. So
+    * the only question this endpoint can answer is "may this user configure data sources at all",
+    * not "may they touch this one", and the capability that means is the creating one.</p>
+    *
+    * <p>Which is why it is exactly the root create rule and not a narrower reading of it: refresh
+    * is a step inside the flow create and update already authorize, so anything those accept at the
+    * root has to be accepted here, or the editor 403s halfway through a save it is going to be
+    * allowed to finish.</p>
+    */
+   private void requireConnectorPermission(Principal principal) throws Exception {
+      requireCreatePermission(null, principal);
+   }
+
+   /**
+    * Binds this request's connector session before anything can reach
+    * {@code TabularUtil.refreshView}.
+    *
+    * <p>{@code TabularUtil.sessionId} is a static {@code ThreadLocal} that is only ever set, never
+    * cleared. On a pooled request thread, leaving it alone therefore does not mean "no session" —
+    * it means whatever the previous request on that thread left behind, which may be another
+    * user's, and a connector that resolves an OAuth token by session id would resolve theirs.</p>
+    *
+    * <p>The value is synthesized from the principal rather than taken from the HTTP session, which
+    * is what the portal does: a wiz caller authenticates with a bearer token and carries no cookie
+    * jar, so {@code getSession()} would mint a throwaway session per call — a per-request identity
+    * where a per-user one is what a connector is looking for.</p>
+    */
+   private static void beginConnectorSession(Principal principal) {
+      TabularUtil.setSessionId(
+         principal == null ? null : SESSION_PREFIX + principal.getName());
+   }
+
+   /** Clears what {@link #beginConnectorSession(Principal)} set. Always from a {@code finally}. */
+   private static void endConnectorSession() {
+      TabularUtil.setSessionId(null);
+   }
+
+   /**
+    * The name a data source is saved under.
+    *
+    * <p>Mirrors {@code WizDatabaseController.requireName}, with one rule the JDBC side has no use
+    * for: a name carrying a slash is a path, and letting one through relocates the source into
+    * another folder silently. Both cases otherwise fail somewhere downstream and come back as a 200
+    * carrying {@code UNKNOWN}, which tells the user nothing about which field is wrong.</p>
+    */
+   private static String requireName(DataSourceDefinition definition) {
+      String name = definition.getName() == null ? null : definition.getName().trim();
+
+      if(name == null || name.isEmpty()) {
+         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "name is required");
+      }
+
+      if(name.indexOf('/') >= 0) {
+         throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST, "name must not contain '/': " + name);
+      }
+
+      // Written back so the path reported to the caller and the one the save writes cannot
+      // disagree over the trimming.
+      definition.setName(name);
+
+      return name;
    }
 
    /**
@@ -404,11 +634,21 @@ public class WizTabularController {
       return i < 0 ? null : path.substring(0, i);
    }
 
+   private static String lastSegment(String path) {
+      int i = path == null ? -1 : path.lastIndexOf('/');
+
+      return i < 0 ? path : path.substring(i + 1);
+   }
+
    private static String emptyToNull(String value) {
       return value == null || value.isEmpty() || "/".equals(value) ? null : value;
    }
 
+   /** Marks a connector session as this controller's, so it cannot collide with the portal's. */
+   private static final String SESSION_PREFIX = "wiz:";
+
    private final DatasourcesService datasourcesService;
    private final SecurityEngine securityEngine;
+   private final XRepository xrepository;
    private static final Logger LOG = LoggerFactory.getLogger(WizTabularController.class);
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/WizTabularListing.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizTabularListing.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+import java.util.List;
+
+/**
+ * One data source type offered by the tabular editor.
+ *
+ * <p>Key and label are separate fields on purpose. {@code DataSourceListing.getDisplayName()} is
+ * {@code getName()} run through a resource bundle for the caller's locale, so the portal's own
+ * selection view — which sends the display name as the key and looks listings up by it — silently
+ * changes its key set when the locale changes. This model keeps the stable {@code name} as the key
+ * and carries the translation alongside, so a client's stored choice survives a locale switch.</p>
+ *
+ * @param name          stable identifier, e.g. {@code "MongoDB"}. The key
+ *                      {@code GET /tabular/listing?name=} takes, and the value StyleBI's
+ *                      {@code visible.datasource.types} / {@code hidden.datasource.types}
+ *                      properties are written in. Never localized.
+ * @param label         display name for the caller's locale. Never use as a key.
+ * @param category      raw category, e.g. {@code "Relational Database"}. Group and join on this.
+ * @param categoryLabel display form of {@code category}. Never use as a key.
+ * @param iconUrl       icon path inside the listing's own classpath, e.g. {@code "mongodb.svg"} —
+ *                      despite the name, not a URL a client can fetch. Forwarded unchanged so a
+ *                      later step can serve the bytes.
+ * @param keywords      search terms; empty when the listing declares none.
+ */
+public record WizTabularListing(String name, String label, String category, String categoryLabel,
+                                String iconUrl, List<String> keywords)
+{
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/WizTabularListings.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizTabularListings.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+import java.util.List;
+
+/**
+ * The data source types the tabular editor offers.
+ *
+ * @param listings   the offered listings, sorted by {@code name}. Only genuinely tabular listings
+ *                   appear: a JDBC listing has no {@code TabularView} to render and belongs to the
+ *                   {@code /databases} editor.
+ * @param categories distinct RAW {@code category} values, sorted — the grouping order for the type
+ *                   picker. Raw rather than translated precisely so it can be joined against
+ *                   {@link WizTabularListing#category()}; the display text for a group is the
+ *                   {@code categoryLabel} of the listings in it. Derivable from {@code listings},
+ *                   and supplied so a client's group order matches the server's without
+ *                   reproducing the sort.
+ */
+public record WizTabularListings(List<WizTabularListing> listings, List<String> categories) {
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/WizTabularSaveResult.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizTabularSaveResult.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+/**
+ * The outcome of creating or updating a tabular data source.
+ *
+ * <p>Deliberately the same shape as {@link WizDatabaseSaveResult}, reached differently. The JDBC
+ * save path reports a business failure as a status string inside an HTTP 200; the tabular path
+ * throws a {@code MessageException} carrying a Catalog-translated sentence. Either way the client
+ * branches on a stable {@code reason} code and writes its own message — the server's wording never
+ * reaches it.</p>
+ *
+ * @param ok     whether the data source was saved.
+ * @param reason null when {@code ok}. Otherwise one of {@code DUPLICATE_NAME} (a data source
+ *               already exists at that path), {@code INVALID_FOLDER} (the parent folder does not
+ *               exist), {@code DATASOURCE_LOST} (the update found nothing at the given path — it
+ *               vanished between load and save), or {@code UNKNOWN} — StyleBI refused for a reason
+ *               this mapping does not recognize, most often an invalid name, and the original is
+ *               logged verbatim rather than swallowed.
+ * @param path   the saved data source's full repository path, which differs from the requested one
+ *               when the connection was renamed. Null on failure.
+ */
+public record WizTabularSaveResult(boolean ok, String reason, String path) {
+   public static WizTabularSaveResult ok(String path) {
+      return new WizTabularSaveResult(true, null, path);
+   }
+
+   public static WizTabularSaveResult failed(String reason) {
+      return new WizTabularSaveResult(false, reason, null);
+   }
+
+   public static final String DUPLICATE_NAME = "DUPLICATE_NAME";
+   public static final String INVALID_FOLDER = "INVALID_FOLDER";
+   public static final String DATASOURCE_LOST = "DATASOURCE_LOST";
+   public static final String UNKNOWN = "UNKNOWN";
+}

--- a/core/src/main/java/inetsoft/web/wiz/request/WizTabularCreateRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/request/WizTabularCreateRequest.java
@@ -1,0 +1,33 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.request;
+
+import inetsoft.web.portal.data.DataSourceDefinition;
+
+/**
+ * Body of {@code POST /api/wiz/tabular/create}.
+ *
+ * <p>{@code parentPath} rides beside the definition rather than only inside it because the
+ * permission gate needs the target folder <em>before</em> anything is read or written, and a
+ * definition that arrived over the wire is caller-supplied data.</p>
+ *
+ * @param parentPath folder to create the data source in. Empty or null means the repository root.
+ * @param definition the data source to create.
+ */
+public record WizTabularCreateRequest(String parentPath, DataSourceDefinition definition) {
+}

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizTabularControllerSecurityTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizTabularControllerSecurityTest.java
@@ -1,0 +1,371 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.controller;
+
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.uql.XRepository;
+import inetsoft.uql.tabular.TabularDataSource;
+import inetsoft.uql.tabular.TabularUtil;
+import inetsoft.web.portal.data.DataSourceDefinition;
+import inetsoft.web.portal.data.DatasourcesService;
+import inetsoft.web.security.PermissionPath;
+import inetsoft.web.security.RequiredPermission;
+import inetsoft.web.security.Secured;
+import inetsoft.web.wiz.request.WizTabularCreateRequest;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.security.Principal;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Pins the request-mapping prefix and the authorization gates of {@code WizTabularController}, the
+ * same way {@code WizDatabaseControllerSecurityTest} pins its sibling's.
+ *
+ * <p><b>The prefix.</b> {@code /api/wiz/**} is load-bearing rather than cosmetic: {@code CSRFFilter}
+ * exempts only that prefix, and {@code WizServiceAuthenticationFilter} validates a wiz caller's
+ * bearer token only there. Moved off it, this controller breaks asymmetrically — every POST fails
+ * with a CSRF 403 while every GET keeps working.</p>
+ *
+ * <p><b>The gates.</b> A direct method call bypasses {@code SecuredAspect} entirely, so the
+ * {@code @Secured} annotations are untested by any behavioural test in this package — hence the
+ * reflective half. The other three gates are ordinary code in the method bodies, which is what makes
+ * them the easy ones to lose in a refactor: the rename's DELETE check, the connector capability
+ * refresh needs, and the scope on the duplicate check.</p>
+ *
+ * <p><b>The connector session.</b> Not a permission gate but the same class of problem, and
+ * invisible from any single request: {@code TabularUtil.sessionId} is a static {@code ThreadLocal}
+ * nothing ever clears, so a handler that leaves it alone inherits the previous request's value on a
+ * pooled thread — possibly another user's.</p>
+ */
+@Tag("core")
+class WizTabularControllerSecurityTest {
+   @Test
+   void everyEndpointLivesUnderTheWizPrefix() {
+      List<String> paths = mappedPaths();
+      assertFalse(paths.isEmpty(), "expected request mappings on WizTabularController");
+
+      for(String path : paths) {
+         assertTrue(path.startsWith(WIZ_PREFIX), "endpoint '" + path + "' must live under '" +
+            WIZ_PREFIX + "' or every POST from the wiz portal fails the CSRF filter while every " +
+            "GET keeps working");
+      }
+   }
+
+   @Test
+   void mappingsMatchTheFrozenContract() {
+      assertEquals(
+         Set.of("/api/wiz/tabular/listings",
+                "/api/wiz/tabular/listing",
+                "/api/wiz/tabular/definition",
+                "/api/wiz/tabular/refresh",
+                "/api/wiz/tabular/create",
+                "/api/wiz/tabular/update",
+                "/api/wiz/tabular/check-duplicate"),
+         new HashSet<>(mappedPaths()));
+   }
+
+   @Test
+   void tabularDefinitionIsGatedOnWriteWithAWiredPermissionPath() throws Exception {
+      assertWriteGateOnPathParameter(
+         WizTabularController.class.getDeclaredMethod(
+            "getTabularDefinition", String.class, Principal.class));
+   }
+
+   @Test
+   void tabularUpdateIsGatedOnWriteWithAWiredPermissionPath() throws Exception {
+      assertWriteGateOnPathParameter(
+         WizTabularController.class.getDeclaredMethod(
+            "updateTabularDataSource", String.class, DataSourceDefinition.class, Principal.class));
+   }
+
+   /**
+    * The annotation on the update covers WRITE on the path, but a rename also removes the source
+    * from its old name, which the service demands DELETE for. It signals that denial with a
+    * {@code MessageException} the controller would map to a 200 carrying {@code UNKNOWN} — "could
+    * not save" for what is really "not allowed".
+    */
+   @Test
+   void update_deniesARenameWithoutDeleteOnTheOldPath() throws Exception {
+      Fixture fixture = new Fixture();
+      when(fixture.datasourcesService.checkDuplicate("folder/old")).thenReturn(true);
+      when(fixture.datasourcesService.checkDuplicate("folder/new")).thenReturn(false);
+      when(fixture.securityEngine.checkPermission(
+         eq(fixture.principal), eq(ResourceType.DATA_SOURCE), eq("folder/old"),
+         eq(ResourceAction.DELETE)))
+         .thenReturn(false);
+
+      // java.lang.SecurityException, the same type SecuredAspect throws for the annotated
+      // endpoints, so both denials reach WizControllerErrorHandler as one 403.
+      assertThrows(SecurityException.class, () -> fixture.controller.updateTabularDataSource(
+         "folder/old", definition("new"), fixture.principal));
+
+      verify(fixture.datasourcesService, never()).updateDataSource(anyString(), any(), any());
+   }
+
+   @Test
+   void update_asksForNoDeleteWhenTheNameIsUnchanged() throws Exception {
+      Fixture fixture = new Fixture();
+      when(fixture.datasourcesService.checkDuplicate("folder/mongo")).thenReturn(true);
+
+      assertTrue(fixture.controller.updateTabularDataSource(
+         "folder/mongo", definition("mongo"), fixture.principal).ok());
+
+      verify(fixture.securityEngine, never()).checkPermission(
+         any(), any(ResourceType.class), anyString(), eq(ResourceAction.DELETE));
+   }
+
+   /**
+    * Refresh has no path to gate on — it recomputes a view from a definition the caller posted —
+    * but it does invoke the connector's button and editor methods with a caller-supplied type,
+    * property values and {@code clicked} flag, and those are what dial a remote endpoint or touch a
+    * file. So the gate is the capability that grants configuring a data source at all.
+    */
+   @Test
+   void refresh_deniesWithoutTheCapabilityToConfigureADataSource() throws Exception {
+      Fixture fixture = new Fixture();
+      when(fixture.securityEngine.checkPermission(
+         any(), any(ResourceType.class), anyString(), any(ResourceAction.class)))
+         .thenReturn(false);
+
+      assertThrows(SecurityException.class, () ->
+         fixture.controller.refreshTabularView(definition("mongo"), fixture.principal));
+
+      verify(fixture.datasourcesService, never()).refreshTabularView(any());
+   }
+
+   /**
+    * The gate is the whole root create rule, both of its branches, and not just the standalone
+    * grant. Refresh is a step inside the flow create and update already authorize: a user who may
+    * create at the root by holding WRITE on the root folder must not be 403'd halfway through the
+    * save that follows.
+    */
+   @Test
+   void refresh_acceptsRootFolderWriteWithoutTheStandaloneGrant() throws Exception {
+      Fixture fixture = new Fixture();
+      when(fixture.securityEngine.checkPermission(
+         any(), any(ResourceType.class), anyString(), any(ResourceAction.class)))
+         .thenReturn(false);
+      when(fixture.securityEngine.checkPermission(
+         eq(fixture.principal), eq(ResourceType.DATA_SOURCE_FOLDER), eq("/"),
+         eq(ResourceAction.WRITE)))
+         .thenReturn(true);
+      when(fixture.datasourcesService.refreshTabularView(any())).thenReturn(definition("mongo"));
+
+      assertNotNull(fixture.controller.refreshTabularView(definition("mongo"), fixture.principal));
+      verify(fixture.datasourcesService).refreshTabularView(any());
+   }
+
+   /**
+    * The answer is an existence oracle: unscoped, any logged-in user could enumerate what exists
+    * anywhere in the repository, including data sources they cannot read. Scoped to the folder the
+    * caller may create in, which is the only folder the editor ever asks about.
+    */
+   @Test
+   void checkDuplicate_deniesAFolderTheCallerCannotWrite() throws Exception {
+      Fixture fixture = new Fixture();
+      when(fixture.securityEngine.checkPermission(
+         any(), any(ResourceType.class), anyString(), any(ResourceAction.class)))
+         .thenReturn(false);
+
+      assertThrows(SecurityException.class,
+                   () -> fixture.controller.checkDuplicate("secret/orders", fixture.principal));
+
+      verify(fixture.datasourcesService, never()).checkDuplicate(anyString());
+   }
+
+   @Test
+   void checkDuplicate_scopesTheCheckToTheParentFolder() throws Exception {
+      Fixture fixture = new Fixture();
+
+      fixture.controller.checkDuplicate("folder/orders", fixture.principal);
+
+      verify(fixture.securityEngine).checkPermission(
+         eq(fixture.principal), eq(ResourceType.DATA_SOURCE_FOLDER), eq("folder"),
+         eq(ResourceAction.WRITE));
+   }
+
+   /**
+    * Set on the way in and cleared on the way out, on every endpoint that can reach
+    * {@code TabularUtil.refreshView}. Leaving it unset is not the neutral option: the thread-local
+    * is static and nothing else in the codebase clears it, so an unset value on a pooled request
+    * thread is whatever the previous request left there, and a connector that resolves an OAuth
+    * token by session id would resolve that user's.
+    */
+   @Test
+   void connectorSessionIsBoundToThePrincipalAndClearedAfterwards() throws Exception {
+      Fixture fixture = new Fixture();
+      when(fixture.principal.getName()).thenReturn("alice");
+      when(fixture.datasourcesService.refreshTabularView(any())).thenReturn(definition("mongo"));
+
+      try(MockedStatic<TabularUtil> tabularUtil = mockStatic(TabularUtil.class)) {
+         fixture.controller.refreshTabularView(definition("mongo"), fixture.principal);
+
+         // Per principal rather than per HTTP session: a wiz caller authenticates with a bearer
+         // token and has no cookie jar, so getSession() would mint a throwaway session per call.
+         tabularUtil.verify(() -> TabularUtil.setSessionId("wiz:alice"));
+         tabularUtil.verify(() -> TabularUtil.setSessionId(null));
+      }
+   }
+
+   @Test
+   void connectorSessionIsClearedEvenWhenTheCallFails() throws Exception {
+      Fixture fixture = new Fixture();
+      when(fixture.principal.getName()).thenReturn("alice");
+      when(fixture.datasourcesService.refreshTabularView(any()))
+         .thenThrow(new RuntimeException("connector blew up"));
+
+      try(MockedStatic<TabularUtil> tabularUtil = mockStatic(TabularUtil.class)) {
+         assertThrows(RuntimeException.class, () ->
+            fixture.controller.refreshTabularView(definition("mongo"), fixture.principal));
+
+         tabularUtil.verify(() -> TabularUtil.setSessionId(null));
+      }
+   }
+
+   @Test
+   void connectorSessionIsBoundOnTheSavePathsToo() throws Exception {
+      Fixture fixture = new Fixture();
+      when(fixture.principal.getName()).thenReturn("alice");
+      when(fixture.datasourcesService.checkDuplicate("mongo")).thenReturn(false, true);
+
+      try(MockedStatic<TabularUtil> tabularUtil = mockStatic(TabularUtil.class)) {
+         fixture.controller.createTabularDataSource(
+            new WizTabularCreateRequest("", definition("mongo")), fixture.principal);
+
+         tabularUtil.verify(() -> TabularUtil.setSessionId("wiz:alice"));
+         tabularUtil.verify(() -> TabularUtil.setSessionId(null));
+      }
+   }
+
+   /**
+    * Asserts that a handler carries the DATA_SOURCE/WRITE gate <em>and</em> that the gate is wired
+    * to the path parameter. An annotation whose {@code @PermissionPath} has gone missing still
+    * looks correct in a diff, but {@code SecuredAspect} then has no resource to check.
+    */
+   private static void assertWriteGateOnPathParameter(Method method) {
+      Secured secured = method.getAnnotation(Secured.class);
+      assertNotNull(secured, method.getName() + " must carry @Secured");
+      assertEquals(1, secured.value().length,
+                   method.getName() + " should declare exactly one required permission");
+
+      RequiredPermission permission = secured.value()[0];
+      assertEquals(ResourceType.DATA_SOURCE, permission.resourceType(),
+                   method.getName() + " must be gated on the data source, not another resource");
+      assertArrayEquals(new ResourceAction[]{ ResourceAction.WRITE }, permission.actions(),
+                        method.getName() + " must require WRITE: a tabular definition carries the " +
+                           "connector's own credentials, which is the editor's business and not a " +
+                           "data reader's");
+      assertEquals("", permission.resource(),
+                   method.getName() + " must resolve its resource from the request path, not a " +
+                      "fixed resource name");
+
+      List<Parameter> annotated = new ArrayList<>();
+
+      for(Parameter parameter : method.getParameters()) {
+         if(parameter.getAnnotation(PermissionPath.class) != null) {
+            annotated.add(parameter);
+         }
+      }
+
+      assertEquals(1, annotated.size(), method.getName() +
+         " must have exactly one @PermissionPath parameter, or SecuredAspect has no path to check");
+
+      RequestParam requestParam = annotated.get(0).getAnnotation(RequestParam.class);
+      assertNotNull(requestParam,
+                    "the @PermissionPath parameter of " + method.getName() +
+                       " must be the request's own path parameter");
+      assertEquals("path", requestParam.value(),
+                   "the gate must check the same path the handler acts on");
+   }
+
+   /** Every mapped path of the controller, class-level prefix included. */
+   private static List<String> mappedPaths() {
+      RequestMapping classMapping = WizTabularController.class.getAnnotation(RequestMapping.class);
+      String prefix = classMapping == null || classMapping.value().length == 0
+         ? "" : classMapping.value()[0];
+      List<String> paths = new ArrayList<>();
+
+      for(Method method : WizTabularController.class.getDeclaredMethods()) {
+         List<String> methodPaths = new ArrayList<>();
+         GetMapping get = method.getAnnotation(GetMapping.class);
+         PostMapping post = method.getAnnotation(PostMapping.class);
+         RequestMapping generic = method.getAnnotation(RequestMapping.class);
+
+         if(get != null) {
+            methodPaths.addAll(Arrays.asList(get.value()));
+         }
+
+         if(post != null) {
+            methodPaths.addAll(Arrays.asList(post.value()));
+         }
+
+         if(generic != null) {
+            methodPaths.addAll(Arrays.asList(generic.value()));
+         }
+
+         for(String path : methodPaths) {
+            paths.add(prefix + path);
+         }
+      }
+
+      return paths;
+   }
+
+   private static DataSourceDefinition definition(String name) {
+      DataSourceDefinition definition = new DataSourceDefinition();
+      definition.setName(name);
+      definition.setType("MongoDB");
+
+      return definition;
+   }
+
+   /** The controller with every collaborator mocked, and every permission granted by default. */
+   private static final class Fixture {
+      Fixture() throws Exception {
+         when(securityEngine.checkPermission(any(), any(ResourceType.class), anyString(),
+                                             any(ResourceAction.class))).thenReturn(true);
+
+         // The update path refuses anything that is not tabular, so the stored source has to be one
+         // for every test whose subject is something else.
+         when(xrepository.getDataSource(anyString())).thenReturn(mock(TabularDataSource.class));
+         controller = new WizTabularController(datasourcesService, securityEngine, xrepository);
+      }
+
+      final DatasourcesService datasourcesService = mock(DatasourcesService.class);
+      final SecurityEngine securityEngine = mock(SecurityEngine.class);
+      final XRepository xrepository = mock(XRepository.class);
+      final Principal principal = mock(Principal.class);
+      final WizTabularController controller;
+   }
+
+   private static final String WIZ_PREFIX = "/api/wiz/";
+}

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizTabularControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizTabularControllerTest.java
@@ -1,0 +1,198 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.controller;
+
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.util.MessageException;
+import inetsoft.web.portal.data.DataSourceDefinition;
+import inetsoft.web.portal.data.DatasourcesService;
+import inetsoft.web.wiz.model.WizTabularSaveResult;
+import inetsoft.web.wiz.request.WizTabularCreateRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * The save paths, where a wrong answer is worst: a client branches on {@code reason} and cannot see
+ * the sentence behind it, so a mis-mapped failure becomes a message about the wrong problem.
+ */
+@Tag("core")
+class WizTabularControllerTest {
+   private DatasourcesService datasourcesService;
+   private SecurityEngine securityEngine;
+   private WizTabularController controller;
+   private Principal principal;
+
+   @BeforeEach
+   void setUp() throws Exception {
+      datasourcesService = mock(DatasourcesService.class);
+      securityEngine = mock(SecurityEngine.class);
+      controller = new WizTabularController(datasourcesService, securityEngine);
+      principal = mock(Principal.class);
+
+      when(securityEngine.checkPermission(any(), any(ResourceType.class), anyString(),
+                                          any(ResourceAction.class))).thenReturn(true);
+   }
+
+   private DataSourceDefinition definition(String name) {
+      DataSourceDefinition definition = new DataSourceDefinition();
+      definition.setName(name);
+      definition.setType("MongoDB");
+
+      return definition;
+   }
+
+   @Test
+   void createReturnsTheSavedPath() throws Exception {
+      when(datasourcesService.checkDuplicate("folder/mongo")).thenReturn(false);
+
+      WizTabularSaveResult result = controller.createTabularDataSource(
+         new WizTabularCreateRequest("folder", definition("mongo")), principal);
+
+      assertTrue(result.ok());
+      assertNull(result.reason());
+      assertEquals("folder/mongo", result.path());
+      verify(datasourcesService).createNewDataSource(any(), eq(false), eq(principal));
+   }
+
+   // Checked before the write rather than inferred from the failure sentence, which is translated.
+   @Test
+   void createRejectsADuplicateWithoutWriting() throws Exception {
+      when(datasourcesService.checkDuplicate("mongo")).thenReturn(true);
+
+      WizTabularSaveResult result = controller.createTabularDataSource(
+         new WizTabularCreateRequest("", definition("mongo")), principal);
+
+      assertFalse(result.ok());
+      assertEquals(WizTabularSaveResult.DUPLICATE_NAME, result.reason());
+      assertNull(result.path());
+      verify(datasourcesService, never()).createNewDataSource(any(), anyBoolean(), any());
+   }
+
+   @Test
+   void createMapsAnUnrecognizedRefusalToUnknownRatherThanFailing() throws Exception {
+      when(datasourcesService.checkDuplicate(anyString())).thenReturn(false);
+      doThrow(new MessageException("some wording this mapping does not know"))
+         .when(datasourcesService).createNewDataSource(any(), anyBoolean(), any());
+
+      WizTabularSaveResult result = controller.createTabularDataSource(
+         new WizTabularCreateRequest("", definition("mongo")), principal);
+
+      assertFalse(result.ok());
+      assertEquals(WizTabularSaveResult.UNKNOWN, result.reason());
+   }
+
+   /*
+    * A denial must leave as SecurityException so WizControllerErrorHandler can turn it into a 403.
+    * Returning a save result here would report "could not save" for what is really "not allowed",
+    * and nothing would be written either way -- the two are indistinguishable to the caller.
+    */
+   @Test
+   void createRefusesWithoutFolderPermission() throws Exception {
+      when(securityEngine.checkPermission(any(), any(ResourceType.class), anyString(),
+                                          any(ResourceAction.class))).thenReturn(false);
+
+      assertThrows(SecurityException.class, () -> controller.createTabularDataSource(
+         new WizTabularCreateRequest("folder", definition("mongo")), principal));
+
+      verify(datasourcesService, never()).createNewDataSource(any(), anyBoolean(), any());
+   }
+
+   @Test
+   void updateReportsDatasourceLostWhenItIsGone() throws Exception {
+      when(datasourcesService.checkDuplicate("folder/mongo")).thenReturn(false);
+
+      WizTabularSaveResult result =
+         controller.updateTabularDataSource("folder/mongo", definition("mongo"), principal);
+
+      assertFalse(result.ok());
+      assertEquals(WizTabularSaveResult.DATASOURCE_LOST, result.reason());
+      verify(datasourcesService, never()).updateDataSource(anyString(), any(), any());
+   }
+
+   @Test
+   void updateReturnsTheNewPathAfterARename() throws Exception {
+      when(datasourcesService.checkDuplicate("folder/old")).thenReturn(true);
+      when(datasourcesService.checkDuplicate("folder/new")).thenReturn(false);
+
+      WizTabularSaveResult result =
+         controller.updateTabularDataSource("folder/old", definition("new"), principal);
+
+      assertTrue(result.ok());
+      assertEquals("folder/new", result.path());
+      verify(datasourcesService).updateDataSource(eq("folder/old"), any(), eq(principal));
+   }
+
+   @Test
+   void updateRejectsARenameOntoAnExistingName() throws Exception {
+      when(datasourcesService.checkDuplicate("folder/old")).thenReturn(true);
+      when(datasourcesService.checkDuplicate("folder/taken")).thenReturn(true);
+
+      WizTabularSaveResult result =
+         controller.updateTabularDataSource("folder/old", definition("taken"), principal);
+
+      assertFalse(result.ok());
+      assertEquals(WizTabularSaveResult.DUPLICATE_NAME, result.reason());
+      verify(datasourcesService, never()).updateDataSource(anyString(), any(), any());
+   }
+
+   // Saving under the same name is not a duplicate of itself.
+   @Test
+   void updateAllowsSavingUnderTheSameName() throws Exception {
+      when(datasourcesService.checkDuplicate("folder/mongo")).thenReturn(true);
+
+      WizTabularSaveResult result =
+         controller.updateTabularDataSource("folder/mongo", definition("mongo"), principal);
+
+      assertTrue(result.ok());
+      assertEquals("folder/mongo", result.path());
+      verify(datasourcesService).updateDataSource(eq("folder/mongo"), any(), eq(principal));
+   }
+
+   /*
+    * The caller increments this before each refresh and discards any response carrying a lower one.
+    * Without the echo a slow response silently overwrites a newer form -- the field would come back
+    * as 0 and every response would look current.
+    */
+   @Test
+   void refreshEchoesTheSequenceNumberBack() {
+      DataSourceDefinition sent = definition("mongo");
+      sent.setSequenceNumber(7);
+
+      DataSourceDefinition recomputed = definition("mongo");
+      recomputed.setSequenceNumber(0);
+      when(datasourcesService.refreshTabularView(sent)).thenReturn(recomputed);
+
+      assertEquals(7, controller.refreshTabularView(sent).getSequenceNumber());
+   }
+
+   @Test
+   void checkDuplicateAnswersInAnExtensibleShape() throws Exception {
+      when(datasourcesService.checkDuplicate("mongo")).thenReturn(true);
+
+      assertEquals(Boolean.TRUE, controller.checkDuplicate("mongo").get("duplicate"));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizTabularControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizTabularControllerTest.java
@@ -20,16 +20,30 @@ package inetsoft.web.wiz.controller;
 import inetsoft.sree.security.ResourceAction;
 import inetsoft.sree.security.ResourceType;
 import inetsoft.sree.security.SecurityEngine;
+import inetsoft.uql.DataSourceListing;
+import inetsoft.uql.DataSourceListingService;
+import inetsoft.uql.XDataSource;
+import inetsoft.uql.XRepository;
+import inetsoft.uql.jdbc.JDBCDataSource;
+import inetsoft.uql.tabular.TabularDataSource;
 import inetsoft.util.MessageException;
 import inetsoft.web.portal.data.DataSourceDefinition;
 import inetsoft.web.portal.data.DatasourcesService;
+import inetsoft.web.wiz.model.WizTabularListing;
+import inetsoft.web.wiz.model.WizTabularListings;
 import inetsoft.web.wiz.model.WizTabularSaveResult;
 import inetsoft.web.wiz.request.WizTabularCreateRequest;
+import inetsoft.web.wiz.service.UnsupportedDatasourceException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.security.Principal;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -43,6 +57,7 @@ import static org.mockito.Mockito.*;
 class WizTabularControllerTest {
    private DatasourcesService datasourcesService;
    private SecurityEngine securityEngine;
+   private XRepository xrepository;
    private WizTabularController controller;
    private Principal principal;
 
@@ -50,11 +65,16 @@ class WizTabularControllerTest {
    void setUp() throws Exception {
       datasourcesService = mock(DatasourcesService.class);
       securityEngine = mock(SecurityEngine.class);
-      controller = new WizTabularController(datasourcesService, securityEngine);
+      xrepository = mock(XRepository.class);
+      controller = new WizTabularController(datasourcesService, securityEngine, xrepository);
       principal = mock(Principal.class);
 
       when(securityEngine.checkPermission(any(), any(ResourceType.class), anyString(),
                                           any(ResourceAction.class))).thenReturn(true);
+
+      // The update path refuses anything that is not tabular, so the stored source has to be one
+      // for every test whose subject is something else.
+      when(xrepository.getDataSource(anyString())).thenReturn(mock(TabularDataSource.class));
    }
 
    private DataSourceDefinition definition(String name) {
@@ -65,9 +85,26 @@ class WizTabularControllerTest {
       return definition;
    }
 
+   /** A listing of the given name whose data source is, or is not, a tabular one. */
+   private DataSourceListing listing(String name, String category, boolean tabular)
+      throws Exception
+   {
+      DataSourceListing listing = mock(DataSourceListing.class);
+      when(listing.getName()).thenReturn(name);
+      when(listing.getDisplayName()).thenReturn(name + " (translated)");
+      when(listing.getCategory()).thenReturn(category);
+      when(listing.getIcon()).thenReturn("/icon.svg");
+      when(listing.getKeywords()).thenReturn(null);
+      when(listing.createDataSource()).thenReturn(
+         tabular ? mock(TabularDataSource.class) : mock(JDBCDataSource.class));
+
+      return listing;
+   }
+
    @Test
    void createReturnsTheSavedPath() throws Exception {
-      when(datasourcesService.checkDuplicate("folder/mongo")).thenReturn(false);
+      // Absent before the save and present after it, which is what the create path now verifies.
+      when(datasourcesService.checkDuplicate("folder/mongo")).thenReturn(false, true);
 
       WizTabularSaveResult result = controller.createTabularDataSource(
          new WizTabularCreateRequest("folder", definition("mongo")), principal);
@@ -106,6 +143,23 @@ class WizTabularControllerTest {
    }
 
    /*
+    * createNewDataSource writes nothing and throws nothing when the type is unknown or its
+    * connector is unavailable. Reported as a success, that sends the editor to a data source that
+    * does not exist -- the path it navigates to is the one nothing was written to.
+    */
+   @Test
+   void createReportsAFailureWhenTheSaveWasASilentNoOp() throws Exception {
+      when(datasourcesService.checkDuplicate("mongo")).thenReturn(false);
+
+      WizTabularSaveResult result = controller.createTabularDataSource(
+         new WizTabularCreateRequest("", definition("mongo")), principal);
+
+      assertFalse(result.ok(), "a create that wrote nothing must not report success");
+      assertEquals(WizTabularSaveResult.UNKNOWN, result.reason());
+      assertNull(result.path());
+   }
+
+   /*
     * A denial must leave as SecurityException so WizControllerErrorHandler can turn it into a 403.
     * Returning a save result here would report "could not save" for what is really "not allowed",
     * and nothing would be written either way -- the two are indistinguishable to the caller.
@@ -119,6 +173,88 @@ class WizTabularControllerTest {
          new WizTabularCreateRequest("folder", definition("mongo")), principal));
 
       verify(datasourcesService, never()).createNewDataSource(any(), anyBoolean(), any());
+   }
+
+   // A body that deserializes to a literal null must answer, not throw on the way to the guard.
+   @Test
+   void createAnswersRatherThanFailingOnANullBody() throws Exception {
+      WizTabularSaveResult result = controller.createTabularDataSource(null, principal);
+
+      assertFalse(result.ok());
+      assertEquals(WizTabularSaveResult.UNKNOWN, result.reason());
+      verifyNoInteractions(datasourcesService);
+   }
+
+   @Test
+   void createRejectsAMissingName() {
+      ResponseStatusException e = assertThrows(
+         ResponseStatusException.class, () -> controller.createTabularDataSource(
+            new WizTabularCreateRequest("folder", definition("  ")), principal));
+
+      assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
+   }
+
+   // A name carrying a slash is a path: without this the source is relocated silently.
+   @Test
+   void createRejectsANameCarryingASlash() throws Exception {
+      ResponseStatusException e = assertThrows(
+         ResponseStatusException.class, () -> controller.createTabularDataSource(
+            new WizTabularCreateRequest("folder", definition("other/mongo")), principal));
+
+      assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
+      verify(datasourcesService, never()).createNewDataSource(any(), anyBoolean(), any());
+   }
+
+   /*
+    * The portal sends the folder beside the definition, but a caller that set it only on the
+    * definition used to land at the repository root with no error at all.
+    */
+   @Test
+   void createFallsBackToTheParentPathOnTheDefinition() throws Exception {
+      DataSourceDefinition definition = definition("mongo");
+      definition.setParentPath("folder");
+      when(datasourcesService.checkDuplicate("folder/mongo")).thenReturn(false, true);
+
+      WizTabularSaveResult result = controller.createTabularDataSource(
+         new WizTabularCreateRequest(null, definition), principal);
+
+      assertTrue(result.ok());
+      assertEquals("folder/mongo", result.path());
+      verify(securityEngine).checkPermission(
+         eq(principal), eq(ResourceType.DATA_SOURCE_FOLDER), eq("folder"),
+         eq(ResourceAction.WRITE));
+   }
+
+   /*
+    * LayoutCreator produces a form with nothing in it for a source that has no TabularView, so
+    * without this the editor opens a blank page on a JDBC database and offers to save it -- which
+    * the update path would then honour by rewriting the database from that empty form.
+    */
+   @Test
+   void definitionRefusesADataSourceThatIsNotTabular() throws Exception {
+      JDBCDataSource jdbc = mock(JDBCDataSource.class);
+      when(jdbc.getType()).thenReturn(XDataSource.JDBC);
+      when(xrepository.getDataSource("folder/orders")).thenReturn(jdbc);
+
+      UnsupportedDatasourceException e = assertThrows(UnsupportedDatasourceException.class,
+         () -> controller.getTabularDefinition("folder/orders", principal));
+
+      assertEquals(XDataSource.JDBC, e.getDatasourceType());
+      verify(datasourcesService, never()).getDataSourceDefinition(anyString(), any());
+   }
+
+   /*
+    * A path with nothing behind it is not this guard's business: the service's own lookup answers
+    * it, and reporting it as an untypeable data source would be the wrong complaint.
+    */
+   @Test
+   void definitionLeavesAPathWithNothingBehindItToTheService() throws Exception {
+      DataSourceDefinition stored = definition("mongo");
+      when(xrepository.getDataSource("folder/mongo")).thenReturn(null);
+      when(datasourcesService.getDataSourceDefinition("folder/mongo", principal))
+         .thenReturn(stored);
+
+      assertSame(stored, controller.getTabularDefinition("folder/mongo", principal));
    }
 
    @Test
@@ -143,7 +279,9 @@ class WizTabularControllerTest {
 
       assertTrue(result.ok());
       assertEquals("folder/new", result.path());
-      verify(datasourcesService).updateDataSource(eq("folder/old"), any(), eq(principal));
+
+      // The bare name, not the full path: see updateLooksTheSourceUpWhereItActuallyLives.
+      verify(datasourcesService).updateDataSource(eq("old"), any(), eq(principal));
    }
 
    @Test
@@ -169,7 +307,61 @@ class WizTabularControllerTest {
 
       assertTrue(result.ok());
       assertEquals("folder/mongo", result.path());
-      verify(datasourcesService).updateDataSource(eq("folder/mongo"), any(), eq(principal));
+      verify(datasourcesService).updateDataSource(eq("mongo"), any(), eq(principal));
+   }
+
+   /*
+    * The one case a mocked service cannot catch by itself. DatasourcesBaseService.updateDataSource
+    * does not look the source up by the name it is handed -- it re-prefixes the definition's own
+    * parent path first -- so this fake reproduces that arithmetic and asserts the key it lands on.
+    * Handed the full path, it looks for "folder/folder/mongo", finds nothing and reports the source
+    * lost, which is every folder-scoped edit in the product.
+    */
+   @Test
+   void updateLooksTheSourceUpWhereItActuallyLives() throws Exception {
+      AtomicReference<String> lookupKey = new AtomicReference<>();
+      when(datasourcesService.checkDuplicate("folder/mongo")).thenReturn(true);
+      doAnswer(invocation -> {
+         String name = invocation.getArgument(0);
+         DataSourceDefinition saved = invocation.getArgument(1);
+         String parentPath = "".equals(saved.getParentPath())
+            ? "" : saved.getParentPath() + "/";
+         lookupKey.set(parentPath + name);
+
+         return null;
+      }).when(datasourcesService).updateDataSource(anyString(), any(), any());
+
+      controller.updateTabularDataSource("folder/mongo", definition("mongo"), principal);
+
+      assertEquals("folder/mongo", lookupKey.get(),
+                   "the service must end up looking for the data source's own path");
+   }
+
+   /*
+    * Pointed at a JDBC database the save rebuilds it from the tabular definition, discarding every
+    * connection setting it has, and used to report success.
+    */
+   @Test
+   void updateRefusesADataSourceThatIsNotTabular() throws Exception {
+      when(datasourcesService.checkDuplicate("folder/orders")).thenReturn(true);
+      JDBCDataSource jdbc = mock(JDBCDataSource.class);
+      when(jdbc.getType()).thenReturn(XDataSource.JDBC);
+      when(xrepository.getDataSource("folder/orders")).thenReturn(jdbc);
+
+      assertThrows(UnsupportedDatasourceException.class, () ->
+         controller.updateTabularDataSource("folder/orders", definition("orders"), principal));
+
+      verify(datasourcesService, never()).updateDataSource(anyString(), any(), any());
+   }
+
+   @Test
+   void updateRejectsAMissingName() throws Exception {
+      ResponseStatusException e = assertThrows(
+         ResponseStatusException.class, () -> controller.updateTabularDataSource(
+            "folder/mongo", definition(null), principal));
+
+      assertEquals(HttpStatus.BAD_REQUEST, e.getStatusCode());
+      verify(datasourcesService, never()).updateDataSource(anyString(), any(), any());
    }
 
    /*
@@ -178,7 +370,7 @@ class WizTabularControllerTest {
     * as 0 and every response would look current.
     */
    @Test
-   void refreshEchoesTheSequenceNumberBack() {
+   void refreshEchoesTheSequenceNumberBack() throws Exception {
       DataSourceDefinition sent = definition("mongo");
       sent.setSequenceNumber(7);
 
@@ -186,13 +378,78 @@ class WizTabularControllerTest {
       recomputed.setSequenceNumber(0);
       when(datasourcesService.refreshTabularView(sent)).thenReturn(recomputed);
 
-      assertEquals(7, controller.refreshTabularView(sent).getSequenceNumber());
+      assertEquals(7, controller.refreshTabularView(sent, principal).getSequenceNumber());
    }
 
    @Test
    void checkDuplicateAnswersInAnExtensibleShape() throws Exception {
       when(datasourcesService.checkDuplicate("mongo")).thenReturn(true);
 
-      assertEquals(Boolean.TRUE, controller.checkDuplicate("mongo").get("duplicate"));
+      assertEquals(Boolean.TRUE, controller.checkDuplicate("mongo", principal).get("duplicate"));
+   }
+
+   /*
+    * JDBC listings have no TabularView to render and belong to the databases editor, and the key is
+    * the stable getName() rather than the translated display name.
+    */
+   @Test
+   void listingsOfferTabularTypesOnly() throws Exception {
+      // Built before the static stubbing opens: mocking inside it would be read as an attempt to
+      // stub the static call itself.
+      List<DataSourceListing> offered =
+         List.of(listing("MongoDB", "NoSQL", true), listing("MySQL", "Database", false));
+
+      try(MockedStatic<DataSourceListingService> listings =
+             mockStatic(DataSourceListingService.class))
+      {
+         listings.when(() -> DataSourceListingService.getAllDataSourceListings(true))
+            .thenReturn(offered);
+
+         WizTabularListings result = controller.getTabularListings(principal);
+
+         assertEquals(List.of("MongoDB"), result.listings().stream()
+            .map(WizTabularListing::name).toList());
+         assertEquals(List.of("NoSQL"), result.categories());
+      }
+   }
+
+   @Test
+   void listingIsSeededFromTheStableNameAndLookedUpByTheDisplayName() throws Exception {
+      DataSourceDefinition seeded = definition("MongoDB");
+      List<DataSourceListing> offered = List.of(listing("MongoDB", "NoSQL", true));
+
+      try(MockedStatic<DataSourceListingService> listings =
+             mockStatic(DataSourceListingService.class))
+      {
+         listings.when(() -> DataSourceListingService.getAllDataSourceListings(true))
+            .thenReturn(offered);
+         when(datasourcesService.getDataSourceFromListing("MongoDB (translated)"))
+            .thenReturn(seeded);
+
+         assertSame(seeded, controller.getTabularListing("MongoDB", principal));
+      }
+   }
+
+   /*
+    * Measured: a JDBC name such as "MySQL" reached the service and came back as an opaque 500 with
+    * an empty body, logged as a server fault. Asking for a type that does not exist is the caller's
+    * mistake.
+    */
+   @Test
+   void listingAnswers404ForANameThatIsNotOffered() throws Exception {
+      List<DataSourceListing> offered = List.of(listing("MySQL", "Database", false));
+
+      try(MockedStatic<DataSourceListingService> listings =
+             mockStatic(DataSourceListingService.class))
+      {
+         listings.when(() -> DataSourceListingService.getAllDataSourceListings(true))
+            .thenReturn(offered);
+
+         ResponseStatusException e = assertThrows(
+            ResponseStatusException.class, () -> controller.getTabularListing("MySQL", principal));
+
+         assertEquals(HttpStatus.NOT_FOUND, e.getStatusCode());
+         verify(datasourcesService, never()).getDataSourceFromListing(anyString());
+      }
    }
 }


### PR DESCRIPTION
**Branch:** `feature-wiz-tabular-controller` · base `stylebi-wiz-main-rebase`

The StyleBI half of tabular data source create/edit.
[stylebi-wiz#1556](https://github.com/inetsoft-technology/stylebi-wiz/pull/1556) builds the portal
and wiz-services layers against these seven endpoints. **None of them existed** — I searched all 253
remote branches — so that PR currently calls routes that 404. This is the missing half; the two
should land together.

Built to the Layer-1 contract in that PR's own spec (`docs/superpowers/specs/2026-08-12-tabular-datasource-design.md`),
including its class name, package, injected dependencies and authorization rules.

```
GET  /api/wiz/tabular/listings              -> WizTabularListings
GET  /api/wiz/tabular/listing?name=         -> DataSourceDefinition   (pass-through)
GET  /api/wiz/tabular/definition?path=      -> DataSourceDefinition   (pass-through)
POST /api/wiz/tabular/refresh               -> DataSourceDefinition
POST /api/wiz/tabular/create                -> WizTabularSaveResult
POST /api/wiz/tabular/update?path=          -> WizTabularSaveResult
GET  /api/wiz/tabular/check-duplicate?name= -> { duplicate }
```

Separate from `WizDatabaseController` because tabular and JDBC are unrelated models. What they share
is the authorization stance.

## Decisions worth a reviewer's attention

**`DataSourceDefinition` and `TabularView` pass through unflattened** — the opposite of the JDBC
endpoints. `tabularView` *is* the UI description; there is no dimension to reduce, and trimming
removes something the renderer needs.

**Keys are not labels.** `getDisplayName()` is `getName()` run through a resource bundle for the
caller's locale, and StyleBI's own `getDataSourceListing` matches on the *display* name — so the
portal's key set shifts when the locale does. These endpoints key on the stable `getName()` and
translate only at the edge (`label`, `categoryLabel`), so a stored choice survives a locale switch.
`/tabular/listing?name=` resolves the stable name to a listing here and hands the service the
display name it expects.

**JDBC listings are excluded, and a null check would not have done it.** Measured against a running
server: a JDBC listing seeds a `tabularView` with **zero views** — an empty form, not `null` —
while Cassandra gives 10, MongoDB REST 12, REST JSON 21. The discriminator is therefore
`TabularDataSource`, which means instantiating each listing's data source. They are plain objects
with default fields, not connections. A listing that cannot be instantiated costs its own entry in
the picker rather than failing the whole request.

**Refresh echoes the sequence number back.** The caller increments it before each refresh and
discards any response carrying a lower one. Drop the echo and the field returns 0, every response
looks current, and a slow one silently overwrites a newer form. The portal does the same; there is a
test for it.

**Duplicate names are checked before writing, not inferred from the failure.** `MessageException`
carries a Catalog-translated sentence, and string-matching it breaks in any other locale. Only
`INVALID_FOLDER` still rests on that comparison — deliberately the last one that does. Anything
unrecognized becomes `UNKNOWN` and is logged verbatim rather than swallowed.

**Authorization is at the entry point**, not left to the service: WRITE on the path for
`definition`/`update`, the folder rule (with the root fallback to `CREATE_DATA_SOURCE`) for
`create`, and no path gate on `refresh`, which touches no stored data and recomputes from a
caller-supplied definition. No local `@ExceptionHandler` — it would take precedence over
`WizControllerErrorHandler` and degrade a 403 into a 400.

## Verification

**10 JUnit tests**, all passing, `mvn -pl community/core test` BUILD SUCCESS. They cover the paths
where a wrong answer is worst — a client branches on `reason` and cannot see the sentence behind it:

- create: saved path; duplicate rejected *without writing*; unrecognized refusal → `UNKNOWN`;
  permission denial leaves as `SecurityException` (so it becomes a 403) and writes nothing
- update: `DATASOURCE_LOST` when it vanished; rename returns the new path; rename onto an existing
  name rejected; saving under its own name is **not** a duplicate of itself
- refresh: sequence number echoed

Endpoint shapes were checked against a live server through the portal's equivalent routes: MySQL
(jdbc) 0 views, Apache Cassandra 10, MongoDB REST 12, REST JSON 21.

## Not verified

`/tabular/listings` cannot be exercised without a running server — `DataSourceListingService`
requires the Spring context, so it fails in a unit test. That means the tabular/JDBC classification
and the listing sort are covered by reasoning and by the live seed evidence above, not by a test.
**Worth an integration check before merge**, especially that the picker is not empty: an empty type
picker looks exactly like a deployment with no data source plugins installed.

Confirming these routes end to end also needs a rebuilt container image, which was not done — the
local one predates `WizDatabaseController`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
