### PR TITLE
fix(wiz): reject a physical-table column the source does not have

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -417,9 +417,10 @@ public class WorksheetTableService {
          " column(s) but its query produces only " + produced.size() + ": " +
          (dropped.isEmpty() ? String.join(", ", produced)
             : "the query cannot produce " + String.join(", ", dropped)) +
-         ". A column the source does not have is dropped from the query instead of failing it, so " +
-         "this table would render as an empty or partial result. Check the column names against " +
-         "the source (a derived value belongs in expressionColumns, not columns).");
+         ". A column the query cannot resolve is dropped from it instead of failing it, so this " +
+         "table would render as an empty or partial result. Check each column resolves against " +
+         "what this table is built on — the source table for a physical table, the SELECT list for " +
+         "a sql query table, the base table for a mirror or join.");
    }
 
    /** The columns this table promises its callers — exactly what {@link #extractColumnsFromSelection} reports. */
@@ -498,7 +499,8 @@ public class WorksheetTableService {
          return Set.of();
       }
 
-      String upper = name.toUpperCase();
+      // Locale.ROOT: these are datasource/lens identifiers, not display text.
+      String upper = name.toUpperCase(Locale.ROOT);
       int dot = upper.lastIndexOf('.');
 
       return dot > 0 && dot < upper.length() - 1
@@ -820,7 +822,9 @@ public class WorksheetTableService {
 
       if(request.getColumns() != null && !request.getColumns().isEmpty()) {
          // Explicit column list from the LLM — reconciled against the source's real columns so a
-         // name the table does not have fails loud here (see resolveRequestedColumns).
+         // name the table does not have fails loud here (see resolveRequestedColumns). A name this
+         // same request derives is dropped from the result: applyExpressionColumns /
+         // applyWindowColumns below contribute the real derived column.
          List<WorksheetTable.ColumnInfo> cols = resolveRequestedColumns(
             request.getColumns(), sourceColumnNames(metaData), derivedColumnNames(request));
          ColumnSelection cs = buildColumnSelection(cols);
@@ -1169,7 +1173,9 @@ public class WorksheetTableService {
     * The names (and aliases) of the columns this same request DERIVES rather than reads from the
     * source — {@code expressionColumns} and {@code windowColumns}. A request that also lists a
     * derived column in {@code columns} is naming something the source's metadata cannot know about,
-    * so it is exempt from source reconciliation.
+    * so {@link #resolveRequestedColumns} neither rejects it nor keeps it: the entry is dropped and
+    * the real derived column is contributed by {@link #applyExpressionColumns} /
+    * {@link #applyWindowColumns}.
     */
    private static Set<String> derivedColumnNames(WorksheetTable request) {
       Set<String> names = new HashSet<>();
@@ -1223,7 +1229,8 @@ public class WorksheetTableService {
     * @param sourceColumns   the source table's real column names; empty means "metadata unavailable",
     *                        which skips reconciliation rather than failing the create
     * @param derivedColumns  columns this request derives itself (see {@link #derivedColumnNames})
-    * @return {@code requested}, with every name canonicalized to the source's spelling
+    * @return the source-backed subset of {@code requested}, each name canonicalized to the source's
+    *         spelling — a name only this request derives is DROPPED, not passed through
     * @throws IllegalArgumentException if any name cannot be resolved to a source column
     */
    // Package-private for unit testing (WorksheetTableServiceColumnValidationTest).
@@ -1238,13 +1245,24 @@ public class WorksheetTableService {
       }
 
       // Upper-cased name → the source's exact spelling. First spelling wins, so a source that
-      // reports two columns differing only in case keeps the one it listed first.
+      // reports two columns differing only in case keeps the one it listed first. Locale.ROOT
+      // because these are datasource identifiers, not display text — a Turkish default locale
+      // would otherwise fold "i" to "İ" and break the match for any column containing an i.
       Map<String, String> canonical = new HashMap<>();
 
       for(String name : sourceColumns) {
-         canonical.putIfAbsent(name.toUpperCase(), name);
+         canonical.putIfAbsent(name.toUpperCase(Locale.ROOT), name);
       }
 
+      // Case-insensitive: the caller can spell a derived column differently in `columns` than in
+      // `expressionColumns`, and reporting that as "not found in source" would misdirect.
+      Set<String> derived = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+
+      if(derivedColumns != null) {
+         derived.addAll(derivedColumns);
+      }
+
+      List<WorksheetTable.ColumnInfo> resolved = new ArrayList<>(requested.size());
       List<String> unresolved = new ArrayList<>();
 
       for(WorksheetTable.ColumnInfo col : requested) {
@@ -1255,26 +1273,40 @@ public class WorksheetTableService {
             continue;
          }
 
-         // Derived by this same request — the source's metadata cannot know it.
-         if(derivedColumns.contains(name)) {
-            continue;
-         }
-
-         String match = canonical.get(name.toUpperCase());
+         String match = canonical.get(name.toUpperCase(Locale.ROOT));
          int dot = name.lastIndexOf('.');
 
          // "ORDERS.ORDER_AMOUNT" — a table-qualified name. Unqualify ONLY when the exact name is
          // not itself a column, so a source column whose own name contains a dot still wins.
          if(match == null && dot > 0 && dot < name.length() - 1) {
-            match = canonical.get(name.substring(dot + 1).toUpperCase());
+            match = canonical.get(name.substring(dot + 1).toUpperCase(Locale.ROOT));
          }
 
          if(match == null) {
+            // Derived by this same request — the source's metadata cannot know it, so it is not an
+            // unresolvable name. It is DROPPED here rather than passed through: the derived column
+            // is contributed by applyExpressionColumns / applyWindowColumns, and a plain
+            // AttributeRef of the same name reaching the selection first would SHADOW it —
+            // ColumnSelection.addAttribute is exclusive and ColumnRef equality is by name alone
+            // (AbstractDataRef.equals), so the real expression would be silently discarded and the
+            // phantom attribute then dropped from the query by validateColumnSelection.
+            //
+            // Only a derived name the source does NOT have takes this branch, so a derived column
+            // that shadows a real source column keeps resolving to the source column, exactly as
+            // before.
+            if(derived.contains(name)) {
+               continue;
+            }
+
             unresolved.add(name);
+            continue;
          }
-         else if(!match.equals(name)) {
+
+         if(!match.equals(name)) {
             col.setName(match);
          }
+
+         resolved.add(col);
       }
 
       if(!unresolved.isEmpty()) {
@@ -1286,7 +1318,7 @@ public class WorksheetTableService {
             "in columns.");
       }
 
-      return requested;
+      return resolved;
    }
 
    private ColumnSelection buildColumnSelectionFromMeta(OsiDataset metaData) {

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -353,7 +353,9 @@ public class WorksheetTableService {
     * {@code getTableLens} (LIVE re-swallows it at doGetTableLens), so {@code checkFailedQuery} must
     * be called actively.
     */
-   private void probeExecutable(Worksheet worksheet, Assembly table, Principal user) throws Exception {
+   private void probeExecutable(Worksheet worksheet, AbstractTableAssembly table, Principal user)
+      throws Exception
+   {
       AssetQuerySandbox box = new AssetQuerySandbox(worksheet);
       box.setBaseUser(user);
 
@@ -371,11 +373,136 @@ public class WorksheetTableService {
             // message, which would misdirect for a raw SQL query table or an infra error.
             // WizVsService is in this same package.
             WizVsService.checkFailedQuery(lens, false);
+
+            // A query that runs is not yet a query that produces what this table promises — see
+            // checkProducedColumns.
+            checkProducedColumns(table, lens);
          }
       }
       finally {
          box.dispose();
       }
+   }
+
+   /**
+    * Fail when the probe's query produces FEWER columns than the table assembly advertises.
+    *
+    * <p>{@link #probeExecutable} on its own only answers "did the query run". It cannot see a column
+    * quietly going missing, because that is not an error anywhere in the query layer:
+    * {@code PreAssetQuery.validateColumnSelection} REMOVES a column the source does not have and
+    * carries on, so the generated SQL stays valid and the probe passes. The assembly still holds the
+    * removed column in its stored selection, so every read-back this API serves ({@code /ws/table}'s
+    * response, {@code /ws/structure}) keeps advertising a column no query can ever produce — a chart
+    * bound to it renders empty with no error, and the column disappears from the worksheet as soon as
+    * Composer refreshes it.
+    *
+    * <p>This is the backstop for that class of silent loss in general. The known cause — an explicit
+    * {@code columns} entry the physical source does not have — is rejected up front by
+    * {@link #resolveRequestedColumns}; this catches whatever else reaches the same end state
+    * (a stale mirror base, an expression referencing a vanished column) for the tables that are
+    * probed at all.
+    */
+   private void checkProducedColumns(AbstractTableAssembly table, TableLens lens) {
+      List<String> advertised = advertisedColumnNames(table);
+      List<String> produced = producedColumnNames(lens);
+
+      if(produced.size() >= advertised.size()) {
+         return;
+      }
+
+      List<String> dropped = droppedColumns(advertised, produced);
+
+      throw new IllegalArgumentException(
+         "Table '" + table.getName() + "' advertises " + advertised.size() +
+         " column(s) but its query produces only " + produced.size() + ": " +
+         (dropped.isEmpty() ? String.join(", ", produced)
+            : "the query cannot produce " + String.join(", ", dropped)) +
+         ". A column the source does not have is dropped from the query instead of failing it, so " +
+         "this table would render as an empty or partial result. Check the column names against " +
+         "the source (a derived value belongs in expressionColumns, not columns).");
+   }
+
+   /** The columns this table promises its callers — exactly what {@link #extractColumnsFromSelection} reports. */
+   private static List<String> advertisedColumnNames(AbstractTableAssembly table) {
+      ColumnSelection cs = table.getColumnSelection(true);
+      List<String> names = new ArrayList<>();
+
+      for(int i = 0; cs != null && i < cs.getAttributeCount(); i++) {
+         if(cs.getAttribute(i) instanceof ColumnRef cr && cr.isVisible()) {
+            names.add(cr.getName());
+         }
+      }
+
+      return names;
+   }
+
+   /**
+    * The columns the executed query actually produced. {@code AssetQuery} only stamps a column
+    * identifier when it differs from the header (see {@code AssetQuery.getMetaDataTableLens}), so the
+    * header is the fallback, not a second-class source.
+    */
+   private static List<String> producedColumnNames(TableLens lens) {
+      List<String> names = new ArrayList<>();
+
+      for(int col = 0; col < Math.max(0, lens.getColCount()); col++) {
+         String id = lens.getColumnIdentifier(col);
+
+         if(id == null || id.isBlank()) {
+            Object header = lens.getObject(0, col);
+            id = header == null ? null : header.toString();
+         }
+
+         names.add(id);
+      }
+
+      return names;
+   }
+
+   /**
+    * The {@code advertised} columns absent from {@code produced}.
+    *
+    * <p>Called only once the counts prove something was dropped, so a mere spelling difference
+    * between a {@code ColumnRef}'s name and a lens header can never by itself fail a create — at
+    * worst it makes this list empty and the caller reports the counts instead.
+    */
+   // Package-private for unit testing (WorksheetTableServiceProducedColumnsTest).
+   static List<String> droppedColumns(List<String> advertised, List<String> produced) {
+      Set<String> producedKeys = new HashSet<>();
+
+      for(String name : produced) {
+         producedKeys.addAll(matchKeys(name));
+      }
+
+      List<String> dropped = new ArrayList<>();
+
+      for(String name : advertised) {
+         Set<String> keys = matchKeys(name);
+
+         // A nameless advertised column cannot be matched either way, so it is no evidence — the
+         // caller's count-based message covers it rather than this list naming a "null" column.
+         if(!keys.isEmpty() && Collections.disjoint(keys, producedKeys)) {
+            dropped.add(name);
+         }
+      }
+
+      return dropped;
+   }
+
+   /**
+    * The forms a column name may be matched by: its own spelling, case-insensitively, plus the bare
+    * attribute after the last dot — a lens reports a mirror's column bare where the assembly's
+    * {@code ColumnRef} names it {@code BaseTable.col}.
+    */
+   private static Set<String> matchKeys(String name) {
+      if(name == null || name.isBlank()) {
+         return Set.of();
+      }
+
+      String upper = name.toUpperCase();
+      int dot = upper.lastIndexOf('.');
+
+      return dot > 0 && dot < upper.length() - 1
+         ? Set.of(upper, upper.substring(dot + 1)) : Set.of(upper);
    }
 
    // Delete tables.
@@ -687,20 +814,20 @@ public class WorksheetTableService {
       sinfo.setProperty(SourceInfo.TABLE_TYPE, (String) tableMetaData.getAttribute("type"));
       table.setSourceInfo(sinfo);
 
-      // Build column selection.
+      // Build column selection. Both branches need the source's real columns — the explicit branch
+      // to reconcile the caller's list against them, the implicit branch to build the list from them.
+      OsiDataset metaData = fetchSourceMetaData(src, user);
+
       if(request.getColumns() != null && !request.getColumns().isEmpty()) {
-         // Explicit column list from the LLM.
-         ColumnSelection cs = buildColumnSelection(request.getColumns());
+         // Explicit column list from the LLM — reconciled against the source's real columns so a
+         // name the table does not have fails loud here (see resolveRequestedColumns).
+         List<WorksheetTable.ColumnInfo> cols = resolveRequestedColumns(
+            request.getColumns(), sourceColumnNames(metaData), derivedColumnNames(request));
+         ColumnSelection cs = buildColumnSelection(cols);
          table.setColumnSelection(cs);
       }
       else {
-         // No explicit columns → fetch all from datasource metadata.
-         GetDatabaseTableMetaRequest metaReq = new GetDatabaseTableMetaRequest();
-         metaReq.setDsName(src.getDatasourcePath());
-         metaReq.setCatalog(src.getCatalog());
-         metaReq.setSchema(src.getSchema());
-         metaReq.setTableName(src.getTableName());
-         OsiDataset metaData = metadataApiService.getMetaData(metaReq, user);
+         // No explicit columns → take all of them from datasource metadata.
          ColumnSelection cs = buildColumnSelectionFromMeta(metaData);
          table.setColumnSelection(cs);
       }
@@ -1002,6 +1129,164 @@ public class WorksheetTableService {
       }
 
       return cs;
+   }
+
+   /**
+    * The source table's metadata (column names + types), as {@link #buildColumnSelectionFromMeta}
+    * consumes it. A failure propagates: building a physical table on column names that were never
+    * reconciled against the source is exactly the silent-phantom-column failure
+    * {@link #resolveRequestedColumns} exists to prevent.
+    */
+   private OsiDataset fetchSourceMetaData(WorksheetTable.PhysicalSource src, Principal user)
+      throws Exception
+   {
+      GetDatabaseTableMetaRequest metaReq = new GetDatabaseTableMetaRequest();
+      metaReq.setDsName(src.getDatasourcePath());
+      metaReq.setCatalog(src.getCatalog());
+      metaReq.setSchema(src.getSchema());
+      metaReq.setTableName(src.getTableName());
+      return metadataApiService.getMetaData(metaReq, user);
+   }
+
+   /** The source table's real column names, in metadata order. */
+   private static List<String> sourceColumnNames(OsiDataset metaData) {
+      if(metaData == null || metaData.getFields() == null) {
+         return Collections.emptyList();
+      }
+
+      List<String> names = new ArrayList<>();
+
+      for(OsiField field : metaData.getFields()) {
+         if(field != null && !Tool.isEmptyString(field.getName())) {
+            names.add(field.getName());
+         }
+      }
+
+      return names;
+   }
+
+   /**
+    * The names (and aliases) of the columns this same request DERIVES rather than reads from the
+    * source — {@code expressionColumns} and {@code windowColumns}. A request that also lists a
+    * derived column in {@code columns} is naming something the source's metadata cannot know about,
+    * so it is exempt from source reconciliation.
+    */
+   private static Set<String> derivedColumnNames(WorksheetTable request) {
+      Set<String> names = new HashSet<>();
+
+      if(request.getExpressionColumns() != null) {
+         for(WorksheetTable.ExpressionColumnInfo col : request.getExpressionColumns()) {
+            if(col == null) {
+               continue;
+            }
+
+            if(!Tool.isEmptyString(col.getName())) {
+               names.add(col.getName());
+            }
+
+            if(!Tool.isEmptyString(col.getAlias())) {
+               names.add(col.getAlias());
+            }
+         }
+      }
+
+      if(request.getWindowColumns() != null) {
+         for(WorksheetTable.WindowColumnInfo col : request.getWindowColumns()) {
+            if(col != null && !Tool.isEmptyString(col.getName())) {
+               names.add(col.getName());
+            }
+         }
+      }
+
+      return names;
+   }
+
+   /**
+    * Reconcile a caller-declared {@code columns} list against the source table's real column names,
+    * canonicalizing each name to the source's exact spelling.
+    *
+    * <p>Forgiving where the intent is unambiguous: a case-only difference, or a name qualified with
+    * a table prefix ({@code ORDERS.ORDER_AMOUNT}) whose remainder is a real column, resolves to the
+    * source's spelling. Fail loud otherwise — and the error names both the unresolvable columns and
+    * the ones the table does have, so a caller (LLM or human) can correct itself in one step.
+    *
+    * <p>Why this must fail rather than pass through: {@link #buildColumnSelection} turns any string
+    * into an {@link AttributeRef}, so a column the source does not have used to enter the assembly's
+    * stored column selection unchallenged, and every read-back this API serves ({@code /ws/table}'s
+    * response, {@code /ws/structure}) then advertised the phantom column as real. Nothing failed
+    * later either: at query time {@code PreAssetQuery.validateColumnSelection} silently REMOVES
+    * columns the source does not have, so the generated SQL is valid and even the execution probe
+    * passes. The caller binds a chart to a column no query can ever produce and gets an empty chart
+    * with no error, and the column disappears from the worksheet as soon as Composer refreshes it.
+    *
+    * @param requested       the caller's column list; resolvable names are canonicalized in place
+    * @param sourceColumns   the source table's real column names; empty means "metadata unavailable",
+    *                        which skips reconciliation rather than failing the create
+    * @param derivedColumns  columns this request derives itself (see {@link #derivedColumnNames})
+    * @return {@code requested}, with every name canonicalized to the source's spelling
+    * @throws IllegalArgumentException if any name cannot be resolved to a source column
+    */
+   // Package-private for unit testing (WorksheetTableServiceColumnValidationTest).
+   List<WorksheetTable.ColumnInfo> resolveRequestedColumns(
+      List<WorksheetTable.ColumnInfo> requested, List<String> sourceColumns,
+      Set<String> derivedColumns)
+   {
+      if(sourceColumns == null || sourceColumns.isEmpty()) {
+         LOG.warn("No source metadata to reconcile the requested columns against; " +
+                  "accepting them as declared.");
+         return requested;
+      }
+
+      // Upper-cased name → the source's exact spelling. First spelling wins, so a source that
+      // reports two columns differing only in case keeps the one it listed first.
+      Map<String, String> canonical = new HashMap<>();
+
+      for(String name : sourceColumns) {
+         canonical.putIfAbsent(name.toUpperCase(), name);
+      }
+
+      List<String> unresolved = new ArrayList<>();
+
+      for(WorksheetTable.ColumnInfo col : requested) {
+         String name = col == null ? null : col.getName();
+
+         if(name == null || name.isBlank()) {
+            unresolved.add("<empty>");
+            continue;
+         }
+
+         // Derived by this same request — the source's metadata cannot know it.
+         if(derivedColumns.contains(name)) {
+            continue;
+         }
+
+         String match = canonical.get(name.toUpperCase());
+         int dot = name.lastIndexOf('.');
+
+         // "ORDERS.ORDER_AMOUNT" — a table-qualified name. Unqualify ONLY when the exact name is
+         // not itself a column, so a source column whose own name contains a dot still wins.
+         if(match == null && dot > 0 && dot < name.length() - 1) {
+            match = canonical.get(name.substring(dot + 1).toUpperCase());
+         }
+
+         if(match == null) {
+            unresolved.add(name);
+         }
+         else if(!match.equals(name)) {
+            col.setName(match);
+         }
+      }
+
+      if(!unresolved.isEmpty()) {
+         throw new IllegalArgumentException(
+            "Column(s) not found in source table: " + String.join(", ", unresolved) +
+            ". Available columns: " + String.join(", ", sourceColumns) +
+            ". Use the exact column names the datasource reports; a value the source does not " +
+            "store must be derived in expressionColumns (on a mirror of this table), not listed " +
+            "in columns.");
+      }
+
+      return requested;
    }
 
    private ColumnSelection buildColumnSelectionFromMeta(OsiDataset metaData) {

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceColumnValidationTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceColumnValidationTest.java
@@ -144,7 +144,7 @@ class WorksheetTableServiceColumnValidationTest {
    }
 
    @Test
-   void aColumnTheRequestDerivesItselfIsExempt() throws Exception {
+   void aColumnTheRequestDerivesItselfIsNeitherRejectedNorKept() throws Exception {
       WorksheetTable req = request("""
          {
            "tableName": "t", "tableType": "physical table",
@@ -157,10 +157,48 @@ class WorksheetTableServiceColumnValidationTest {
          }
          """);
 
-      // discount_status is derived by this same request, so the source's metadata cannot know it.
-      assertEquals(List.of("ORDER_ID", "discount_status"),
+      // discount_status is derived by this same request, so the source's metadata cannot know it —
+      // it must not be reported as missing. It must ALSO not be returned: buildColumnSelection would
+      // turn it into a plain AttributeRef, and ColumnSelection.addAttribute is exclusive with
+      // ColumnRef equality by name, so that attribute would shadow the ExpressionRef that
+      // applyExpressionColumns adds next — silently discarding the expression and leaving a phantom
+      // column that validateColumnSelection then drops from the query.
+      assertEquals(List.of("ORDER_ID"),
                    names(service().resolveRequestedColumns(
                       req.getColumns(), ORDERS_COLUMNS, Set.of("discount_status"))));
+   }
+
+   @Test
+   void aDerivedColumnIsRecognizedRegardlessOfSpelling() {
+      // The caller may spell it differently in columns than in expressionColumns; reporting that as
+      // "not found in source table" would misdirect.
+      List<WorksheetTable.ColumnInfo> requested = columns("ORDER_ID", "Discount_Status");
+
+      assertEquals(List.of("ORDER_ID"),
+                   names(service().resolveRequestedColumns(
+                      requested, ORDERS_COLUMNS, Set.of("discount_status"))));
+   }
+
+   @Test
+   void aDerivedNameThatIsAlsoARealSourceColumnStillResolvesToTheSourceColumn() {
+      // The derived branch is reached ONLY when the source has no such column, so an expression
+      // named after a real column leaves the existing resolution untouched.
+      List<WorksheetTable.ColumnInfo> requested = columns("ORDER_ID", "discount");
+
+      assertEquals(List.of("ORDER_ID", "DISCOUNT"),
+                   names(service().resolveRequestedColumns(
+                      requested, ORDERS_COLUMNS, Set.of("DISCOUNT"))));
+   }
+
+   @Test
+   void aHallucinatedColumnIsStillReportedWhenTheRequestDerivesOtherColumns() {
+      List<WorksheetTable.ColumnInfo> requested = columns("ORDER_AMOUNT", "discount_status");
+
+      IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () ->
+         service().resolveRequestedColumns(requested, ORDERS_COLUMNS, Set.of("discount_status")));
+
+      assertTrue(e.getMessage().contains("ORDER_AMOUNT"), e.getMessage());
+      assertFalse(e.getMessage().contains("discount_status"), e.getMessage());
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceColumnValidationTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceColumnValidationTest.java
@@ -1,0 +1,185 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.web.wiz.model.WorksheetTable;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression tests for {@link WorksheetTableService#resolveRequestedColumns}.
+ *
+ * <p>The bug: a {@code physical table} request's explicit {@code columns} list was turned into
+ * {@code AttributeRef}s verbatim, with no reconciliation against the source table's real columns.
+ * A hallucinated name (ORDER_AMOUNT on a table that has no such column) entered the assembly's
+ * stored column selection, and every read-back — {@code /ws/table}'s response and
+ * {@code /ws/structure} — then advertised it as real, so the whole downstream chain bound a chart
+ * to it. Nothing failed loud: {@code PreAssetQuery.validateColumnSelection} silently removes
+ * columns the source does not have, so the generated SQL stayed valid and the execution probe
+ * passed. The result was an empty chart with no error, plus a column that vanished from the
+ * worksheet the next time Composer refreshed it.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WorksheetTableServiceColumnValidationTest {
+   private static final ObjectMapper MAPPER = new ObjectMapper();
+
+   /** The real Examples/Orders ORDERS columns — note there is no ORDER_AMOUNT. */
+   private static final List<String> ORDERS_COLUMNS =
+      List.of("ORDER_ID", "CUSTOMER_ID", "EMPLOYEE_ID", "ORDER_DATE", "DISCOUNT", "PAID");
+
+   private static WorksheetTableService service() {
+      // resolveRequestedColumns reads only its parameters, never instance state.
+      return new WorksheetTableService(null, null, null, null, null, null, null, null, null);
+   }
+
+   private static WorksheetTable request(String json) throws Exception {
+      return MAPPER.readValue(json, WorksheetTable.class);
+   }
+
+   private static List<WorksheetTable.ColumnInfo> columns(String... names) {
+      List<WorksheetTable.ColumnInfo> cols = new ArrayList<>();
+
+      for(String name : names) {
+         WorksheetTable.ColumnInfo col = new WorksheetTable.ColumnInfo();
+         col.setName(name);
+         cols.add(col);
+      }
+
+      return cols;
+   }
+
+   private static List<String> names(List<WorksheetTable.ColumnInfo> cols) {
+      return cols.stream().map(WorksheetTable.ColumnInfo::getName).toList();
+   }
+
+   @Test
+   void hallucinatedColumnFailsLoud() {
+      List<WorksheetTable.ColumnInfo> requested = columns("ORDER_ID", "DISCOUNT", "ORDER_AMOUNT");
+
+      IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () ->
+         service().resolveRequestedColumns(requested, ORDERS_COLUMNS, Set.of()));
+
+      // The offending column and the real ones are both named, so the caller can self-correct.
+      assertTrue(e.getMessage().contains("ORDER_AMOUNT"), e.getMessage());
+      assertTrue(e.getMessage().contains("ORDER_DATE"), e.getMessage());
+      // A column that DOES exist must not be reported as missing.
+      assertFalse(e.getMessage().startsWith("Column(s) not found in source table: ORDER_ID"),
+                  e.getMessage());
+   }
+
+   @Test
+   void everyUnresolvableColumnIsReportedTogether() {
+      List<WorksheetTable.ColumnInfo> requested = columns("ORDER_AMOUNT", "DISCOUNT_RATE");
+
+      IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () ->
+         service().resolveRequestedColumns(requested, ORDERS_COLUMNS, Set.of()));
+
+      assertTrue(e.getMessage().contains("ORDER_AMOUNT"), e.getMessage());
+      assertTrue(e.getMessage().contains("DISCOUNT_RATE"), e.getMessage());
+   }
+
+   @Test
+   void exactNamesPassThroughUnchanged() {
+      List<WorksheetTable.ColumnInfo> requested = columns("ORDER_ID", "DISCOUNT");
+
+      assertEquals(List.of("ORDER_ID", "DISCOUNT"),
+                   names(service().resolveRequestedColumns(requested, ORDERS_COLUMNS, Set.of())));
+   }
+
+   @Test
+   void caseOnlyDifferenceIsCanonicalizedToTheSourceSpelling() {
+      List<WorksheetTable.ColumnInfo> requested = columns("order_id", "Discount");
+
+      assertEquals(List.of("ORDER_ID", "DISCOUNT"),
+                   names(service().resolveRequestedColumns(requested, ORDERS_COLUMNS, Set.of())));
+   }
+
+   @Test
+   void tableQualifiedNameIsUnqualified() {
+      List<WorksheetTable.ColumnInfo> requested = columns("ORDERS.ORDER_ID", "SA.ORDERS.DISCOUNT");
+
+      assertEquals(List.of("ORDER_ID", "DISCOUNT"),
+                   names(service().resolveRequestedColumns(requested, ORDERS_COLUMNS, Set.of())));
+   }
+
+   @Test
+   void aSourceColumnWhoseOwnNameContainsADotWinsOverUnqualifying() {
+      List<String> source = List.of("A.B", "B");
+      List<WorksheetTable.ColumnInfo> requested = columns("A.B");
+
+      // "A.B" is itself a column, so it must NOT be unqualified to "B".
+      assertEquals(List.of("A.B"),
+                   names(service().resolveRequestedColumns(requested, source, Set.of())));
+   }
+
+   @Test
+   void aColumnTheRequestDerivesItselfIsExempt() throws Exception {
+      WorksheetTable req = request("""
+         {
+           "tableName": "t", "tableType": "physical table",
+           "columns": [ { "name": "ORDER_ID" }, { "name": "discount_status" } ],
+           "expressionColumns": [
+             { "name": "discount_status", "alias": "discount_status",
+               "expression": "CASE WHEN DISCOUNT > 0 THEN 'Has Discount' ELSE 'No Discount' END",
+               "type": "string", "sql": true }
+           ]
+         }
+         """);
+
+      // discount_status is derived by this same request, so the source's metadata cannot know it.
+      assertEquals(List.of("ORDER_ID", "discount_status"),
+                   names(service().resolveRequestedColumns(
+                      req.getColumns(), ORDERS_COLUMNS, Set.of("discount_status"))));
+   }
+
+   @Test
+   void unavailableSourceMetadataSkipsReconciliationRatherThanFailingTheCreate() {
+      List<WorksheetTable.ColumnInfo> requested = columns("ORDER_AMOUNT");
+
+      assertEquals(List.of("ORDER_AMOUNT"),
+                   names(service().resolveRequestedColumns(requested, List.of(), Set.of())));
+      assertEquals(List.of("ORDER_AMOUNT"),
+                   names(service().resolveRequestedColumns(requested, null, Set.of())));
+   }
+
+   @Test
+   void blankColumnNameIsReported() {
+      List<WorksheetTable.ColumnInfo> requested = columns("   ");
+
+      IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () ->
+         service().resolveRequestedColumns(requested, ORDERS_COLUMNS, Set.of()));
+
+      assertTrue(e.getMessage().contains("<empty>"), e.getMessage());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceProducedColumnsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceProducedColumnsTest.java
@@ -1,0 +1,122 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression tests for {@link WorksheetTableService#droppedColumns} — the name-matching half of the
+ * execution probe's dropped-column backstop.
+ *
+ * <p>The bug: the probe only answered "did the query run". A column the source does not have is
+ * REMOVED by {@code PreAssetQuery.validateColumnSelection} rather than failing the query, so the SQL
+ * stayed valid and the probe passed, while the assembly kept advertising the column to every
+ * read-back. The chart bound to it rendered empty with no error.
+ *
+ * <p>The matcher deliberately runs only after a count comparison has already proven columns went
+ * missing, so these tests fix the two behaviours that matter: a genuinely absent column is named,
+ * and a name that merely SPELLS differently between the assembly and the lens is not.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WorksheetTableServiceProducedColumnsTest {
+   @Test
+   void aColumnTheQueryDidNotProduceIsNamed() {
+      List<String> advertised = List.of("ORDER_ID", "DISCOUNT", "ORDER_AMOUNT", "discount_status");
+      List<String> produced = List.of("ORDER_ID", "DISCOUNT", "discount_status");
+
+      assertEquals(List.of("ORDER_AMOUNT"),
+                   WorksheetTableService.droppedColumns(advertised, produced));
+   }
+
+   @Test
+   void everyMissingColumnIsNamed() {
+      List<String> advertised = List.of("A", "B", "C", "D");
+      List<String> produced = List.of("B");
+
+      assertEquals(List.of("A", "C", "D"),
+                   WorksheetTableService.droppedColumns(advertised, produced));
+   }
+
+   @Test
+   void nothingMissingWhenEveryColumnWasProduced() {
+      List<String> names = List.of("ORDER_ID", "DISCOUNT");
+
+      assertTrue(WorksheetTableService.droppedColumns(names, names).isEmpty());
+   }
+
+   @Test
+   void aMirrorsQualifiedColumnNameMatchesTheLensBareHeader() {
+      // The assembly names a mirror's inherited columns "BaseTable.col"; the lens reports them bare.
+      // Treating that spelling difference as a dropped column would fail a perfectly good table.
+      List<String> advertised = List.of("ORDERS_physical_1.ORDER_ID", "ORDERS_physical_1.DISCOUNT");
+      List<String> produced = List.of("ORDER_ID", "DISCOUNT");
+
+      assertTrue(WorksheetTableService.droppedColumns(advertised, produced).isEmpty());
+   }
+
+   @Test
+   void theQualifiedMatchWorksInBothDirections() {
+      List<String> advertised = List.of("ORDER_ID");
+      List<String> produced = List.of("ORDERS_physical_1.ORDER_ID");
+
+      assertTrue(WorksheetTableService.droppedColumns(advertised, produced).isEmpty());
+   }
+
+   @Test
+   void matchingIsCaseInsensitive() {
+      List<String> advertised = List.of("Order_Id", "discount");
+      List<String> produced = List.of("ORDER_ID", "DISCOUNT");
+
+      assertTrue(WorksheetTableService.droppedColumns(advertised, produced).isEmpty());
+   }
+
+   @Test
+   void aQualifiedColumnIsStillMissedWhenOnlyItsPrefixDiffersAndTheAttributeIsAbsent() {
+      List<String> advertised = List.of("T.ORDER_AMOUNT");
+      List<String> produced = List.of("T.ORDER_ID");
+
+      assertEquals(List.of("T.ORDER_AMOUNT"),
+                   WorksheetTableService.droppedColumns(advertised, produced));
+   }
+
+   @Test
+   void aNullLensColumnNameNeitherMatchesNorCrashes() {
+      List<String> advertised = new ArrayList<>(Arrays.asList("A", null));
+      List<String> produced = new ArrayList<>(Arrays.asList((String) null));
+
+      // A null on either side carries no match key, so the real column is reported and the null
+      // advertised entry is not — an unnamed lens column is no evidence about a named one.
+      assertEquals(List.of("A"), WorksheetTableService.droppedColumns(advertised, produced));
+   }
+}


### PR DESCRIPTION
## Problem

A `/ws/table` physical-table request's explicit `columns` list was turned into `AttributeRef`s verbatim, with **no reconciliation against the source table's real columns**. A name the table does not have entered the assembly's stored column selection unchallenged, and every read-back this API serves — `/ws/table`'s own response and `/ws/structure` — then advertised the phantom column as real.

Nothing failed later either. At query time `PreAssetQuery.validateColumnSelection` **removes** columns the source does not have and carries on, so the generated SQL stays valid and even the execution probe passes. The caller binds a chart to a column no query can ever produce, gets an empty chart with no error, and the column disappears from the worksheet as soon as Composer refreshes it.

Observed end to end: an agent asked for `ORDER_AMOUNT` on `Examples/Orders.ORDERS`, which has no such column (`ORDER_ID, CUSTOMER_ID, EMPLOYEE_ID, ORDER_DATE, DISCOUNT, PAID`). Creation returned `success: true` with `ORDER_AMOUNT` in the response, `/ws/structure` reported it, the chart bound `Average(ORDER_AMOUNT)` and rendered with no data, and the column was absent when the worksheet was opened in Composer.

## Fix

**`buildPhysicalTable` reconciles the requested columns against the source's metadata** — which it already fetches to resolve the qualified table name, so the authority was in hand and unused.

- *Forgiving where the intent is unambiguous*: a case-only difference (`order_id` → `ORDER_ID`) or a table-qualified name whose remainder is a real column (`ORDERS.ORDER_ID`, `SA.ORDERS.DISCOUNT`) canonicalizes to the source's spelling. Unqualifying happens only when the full name is not itself a column, so a source column whose own name contains a dot still wins.
- *Fail loud otherwise*: the error names both the unresolvable columns and the ones the table does have, so a caller can correct itself in one step. `addOneTable`'s existing rollback turns it into `success: false` + `errorMessage`.
- Columns the same request **derives** (`expressionColumns` / `windowColumns`) are exempt — the source's metadata cannot know them.
- A metadata gap (no columns reported) logs a warning and skips reconciliation rather than failing the create.

**The execution probe gained a dropped-column backstop** for the same end state reached by any other path (a stale mirror base, an expression over a vanished column). `probeExecutable` only answered "did the query run"; it now also compares what the table advertises against what its query actually produced.

- *Count-guarded on purpose*: name matching runs only once the counts prove columns went missing, so a mere spelling difference between a `ColumnRef`'s name and a lens header can never by itself fail a create. If the names cannot be matched, the error reports the counts instead.
- Matching tolerates the mirror naming difference (assembly says `BaseTable.col`, the lens reports it bare) in both directions, case-insensitively.

## Behaviour change

A physical-table create that passes explicit `columns` now always reads the source's column metadata (one extra `MetadataApiService.getMetaData` call; the provider caches). If that read fails, the create now fails where it previously succeeded — intentional, since building a table on unreconciled column names is exactly the failure this fixes.

`shouldProbe` is unchanged: pure physical / mirror / join tables with no derived columns are still not probed (zero added latency). The backstop covers the tables that are probed at all; the known cause is rejected up front by the reconciliation.

## Tests

Two new test classes, both following the existing pure-logic pattern (`WorksheetTableServiceShouldProbeTest`):

- `WorksheetTableServiceColumnValidationTest` (9) — hallucinated column fails loud, every unresolvable column reported together, exact names pass through, case canonicalization, table-prefix unqualifying, dotted source name wins, derived column exempt, metadata gap passes through, blank name reported.
- `WorksheetTableServiceProducedColumnsTest` (8) — a column the query did not produce is named, all missing named, nothing missing when all produced, mirror qualified-vs-bare match in both directions, case-insensitive match, a genuinely absent qualified attribute is still caught, null lens column neither matches nor crashes.

```
WorksheetTableService*Test (10 classes)   Tests run: 78,  Failures: 0
inetsoft.web.wiz (whole package)          Tests run: 992, Failures: 0
```

Not verified end to end against a live datasource: the reconciliation now blocks the phantom column at creation, so exercising the probe backstop needs a different silent-drop path plus a running server. Its matching logic is unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)