### PR TITLE
Bug #75975, dispatch a real "loaded" DOM event from every Embed*Component

### DIFF
--- a/web/projects/portal/src/app/embed/chart/embed-chart.component.html
+++ b/web/projects/portal/src/app/embed/chart/embed-chart.component.html
@@ -28,7 +28,8 @@
       [appSize]="appSize"
       [container]="viewerRoot"
       [variableValues]="variableValuesFunction"
-      (contextmenu)="onOpenContextMenu($event)">
+      (contextmenu)="onOpenContextMenu($event)"
+      (onChartLoaded)="dispatchLoaded()">
     </vs-chart>
   }
   @if (showError) {

--- a/web/projects/portal/src/app/embed/chart/embed-chart.component.ts
+++ b/web/projects/portal/src/app/embed/chart/embed-chart.component.ts
@@ -280,6 +280,17 @@ export class EmbedChartComponent extends CommandProcessor implements OnInit, OnD
       );
    }
 
+   /**
+    * Dispatches a plain DOM CustomEvent on this component's own host element once the wrapped
+    * <vs-chart> reports it has actually finished rendering (see VSChart.onChartLoaded) - so a
+    * consumer embedding <inetsoft-chart> as a plain custom element (no Angular APIs available)
+    * can learn when the chart is done instead of guessing from unrelated DOM signals or a fixed
+    * timeout. See toggleWizFullscreen() above for the same host-dispatch pattern.
+    */
+   dispatchLoaded(): void {
+      this.elementRef.nativeElement.dispatchEvent(new CustomEvent("loaded", { bubbles: true, composed: true }));
+   }
+
    ngOnDestroy() {
       this.dialogService.ngOnDestroy();
       this.clearServerUpdateInterval();

--- a/web/projects/portal/src/app/embed/crosstab/embed-crosstab.component.spec.ts
+++ b/web/projects/portal/src/app/embed/crosstab/embed-crosstab.component.spec.ts
@@ -1,0 +1,98 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { TestUtils } from "../../common/test/test-utils";
+import { EmbedAssemblyContextProviderFactory } from "../../vsobjects/context-provider.service";
+import { AddVsObjectMode } from "../../vsobjects/command/add-vs-object-command";
+import { VSCrosstabModel } from "../../vsobjects/model/vs-crosstab-model";
+import { EmbedCrosstabComponent } from "./embed-crosstab.component";
+
+/**
+ * Regression coverage for the stylebi-side half of bug-75975: <inetsoft-crosstab> (like every
+ * other embed element) never dispatched any DOM event a consumer could use to learn when it
+ * actually finished rendering - a plain custom-element consumer had nothing but a fixed
+ * client-side timeout to fall back on. A crosstab has no async per-tile image loading of its own
+ * (its cells are plain DOM rendered synchronously from the model by Angular change detection),
+ * so "rendered" here is just "the model this command carried has been applied and change
+ * detection has run". Built off the prototype rather than through TestBed: EmbedCrosstabComponent
+ * is an Angular Elements custom element wired to a websocket client, and standing all of that up
+ * would test the DI setup instead of the dispatch - see embed-table.component.spec.ts for the
+ * same pattern.
+ */
+describe("EmbedCrosstabComponent.dispatchLoaded", () => {
+   let component: any;
+   let host: HTMLElement;
+   let crosstab: VSCrosstabModel;
+
+   beforeEach(() => {
+      crosstab = TestUtils.createMockVSCrosstabModel("Crosstab1");
+      host = document.createElement("div");
+      component = Object.create(EmbedCrosstabComponent.prototype);
+      component.assemblyName = "Crosstab1";
+      component.contextProvider = EmbedAssemblyContextProviderFactory();
+      component.miniToolbarService = { hiddenFreeze: vi.fn(), hiddenUnfreeze: vi.fn() };
+      component.cdRef = { detectChanges: vi.fn() };
+      component.elementRef = { nativeElement: host };
+      component.updateVSInfo = () => {};
+   });
+
+   it("dispatches a bubbling, composed 'loaded' CustomEvent on the host element", () => {
+      const listener = vi.fn();
+      host.addEventListener("loaded", listener);
+
+      component.dispatchLoaded();
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      const event: CustomEvent = listener.mock.calls[0][0];
+      expect(event.bubbles).toBe(true);
+      expect(event.composed).toBe(true);
+   });
+
+   it("dispatches 'loaded' after applying a fresh AddVSObjectCommand", () => {
+      const listener = vi.fn();
+      host.addEventListener("loaded", listener);
+
+      component.processAddVSObjectCommand({
+         name: "Crosstab1", mode: AddVsObjectMode.RUNTIME_MODE, model: crosstab, parent: null
+      });
+
+      expect(component.cdRef.detectChanges).toHaveBeenCalled();
+      expect(listener).toHaveBeenCalledTimes(1);
+   });
+
+   it("dispatches 'loaded' after applying a RefreshVSObjectCommand", () => {
+      const listener = vi.fn();
+      host.addEventListener("loaded", listener);
+      component.vsObject = crosstab;
+
+      component.processRefreshVSObjectCommand({ info: crosstab });
+
+      expect(component.cdRef.detectChanges).toHaveBeenCalled();
+      expect(listener).toHaveBeenCalledTimes(1);
+   });
+
+   it("does not dispatch 'loaded' for a command addressed to a different assembly", () => {
+      const listener = vi.fn();
+      host.addEventListener("loaded", listener);
+
+      component.processAddVSObjectCommand({
+         name: "SomeOtherCrosstab", mode: AddVsObjectMode.RUNTIME_MODE, model: crosstab, parent: null
+      });
+
+      expect(listener).not.toHaveBeenCalled();
+   });
+});

--- a/web/projects/portal/src/app/embed/crosstab/embed-crosstab.component.ts
+++ b/web/projects/portal/src/app/embed/crosstab/embed-crosstab.component.ts
@@ -275,6 +275,18 @@ export class EmbedCrosstabComponent extends CommandProcessor implements OnInit, 
       );
    }
 
+   /**
+    * Dispatches a plain DOM CustomEvent on this component's own host element right after a
+    * model update has been applied via detectChanges(). Unlike chart/gauge/image, a crosstab has
+    * no async per-tile image loading of its own - its cells are plain DOM rendered synchronously
+    * from the model by Angular change detection - so "rendered" here just means "the model this
+    * command carried has been applied and change detection has run", with nothing further to
+    * wait for. See toggleWizFullscreen() above for the same host-dispatch pattern.
+    */
+   dispatchLoaded(): void {
+      this.elementRef.nativeElement.dispatchEvent(new CustomEvent("loaded", { bubbles: true, composed: true }));
+   }
+
    ngOnDestroy() {
       this.dialogService.ngOnDestroy();
       this.clearServerUpdateInterval();
@@ -348,6 +360,7 @@ export class EmbedCrosstabComponent extends CommandProcessor implements OnInit, 
          () => this.wizMaximized, () => this.toggleWizFullscreen());
       // Force change detection: as an Angular Elements custom element, this view is not refreshed by the zone tick that wraps websocket command processing, so the embedded object would otherwise never render on open.
       this.cdRef.detectChanges();
+      this.dispatchLoaded();
    }
 
    // noinspection JSUnusedGlobalSymbols
@@ -369,6 +382,7 @@ export class EmbedCrosstabComponent extends CommandProcessor implements OnInit, 
          () => this.wizMaximized, () => this.toggleWizFullscreen());
       // Force change detection: as an Angular Elements custom element, this view is not refreshed by the zone tick that wraps websocket command processing, so the embedded object would otherwise never render on open.
       this.cdRef.detectChanges();
+      this.dispatchLoaded();
    }
 
    // noinspection JSUnusedGlobalSymbols

--- a/web/projects/portal/src/app/embed/gauge/embed-gauge.component.html
+++ b/web/projects/portal/src/app/embed/gauge/embed-gauge.component.html
@@ -26,7 +26,8 @@
     <vs-gauge
             [vsInfo]="vsInfo" [model]="vsObject" [actions]="vsObjectActions"
             [container]="viewerRoot"
-            (contextmenu)="onOpenContextMenu($event)">
+            (contextmenu)="onOpenContextMenu($event)"
+            (onLoad)="dispatchLoaded()">
     </vs-gauge>
   }
   @if (showError) {

--- a/web/projects/portal/src/app/embed/gauge/embed-gauge.component.ts
+++ b/web/projects/portal/src/app/embed/gauge/embed-gauge.component.ts
@@ -134,7 +134,8 @@ export class EmbedGaugeComponent extends CommandProcessor implements OnInit, OnD
                private shadowDomService: ShadowDomService,
                private showHyperlinkService: ShowHyperlinkService,
                private debounceService: DebounceService,
-               private cdRef: ChangeDetectorRef)
+               private cdRef: ChangeDetectorRef,
+               private elementRef: ElementRef)
    {
       super(viewsheetClient, zone, true);
       shadowDomService.addShadowRootHost(injector, viewContainerRef.element?.nativeElement);
@@ -151,6 +152,16 @@ export class EmbedGaugeComponent extends CommandProcessor implements OnInit, OnD
 
    getAssemblyName(): string {
       return null;
+   }
+
+   /**
+    * Dispatches a plain DOM CustomEvent on this component's own host element once the wrapped
+    * <vs-gauge> reports it has actually finished rendering (see AbstractImageComponent.onLoad) -
+    * so a consumer embedding <inetsoft-gauge> as a plain custom element (no Angular APIs
+    * available) can learn when the gauge is done instead of guessing.
+    */
+   dispatchLoaded(): void {
+      this.elementRef.nativeElement.dispatchEvent(new CustomEvent("loaded", { bubbles: true, composed: true }));
    }
 
    ngOnInit(): void {

--- a/web/projects/portal/src/app/embed/image/embed-image.component.html
+++ b/web/projects/portal/src/app/embed/image/embed-image.component.html
@@ -26,7 +26,8 @@
     <vs-image
             [vsInfo]="vsInfo" [model]="vsObject" [actions]="vsObjectActions"
             [container]="viewerRoot"
-            (contextmenu)="onOpenContextMenu($event)">
+            (contextmenu)="onOpenContextMenu($event)"
+            (onLoad)="dispatchLoaded()">
     </vs-image>
   }
   @if (showError) {

--- a/web/projects/portal/src/app/embed/image/embed-image.component.ts
+++ b/web/projects/portal/src/app/embed/image/embed-image.component.ts
@@ -134,7 +134,8 @@ export class EmbedImageComponent extends CommandProcessor implements OnInit, OnD
                private shadowDomService: ShadowDomService,
                private showHyperlinkService: ShowHyperlinkService,
                private debounceService: DebounceService,
-               private cdRef: ChangeDetectorRef)
+               private cdRef: ChangeDetectorRef,
+               private elementRef: ElementRef)
    {
       super(viewsheetClient, zone, true);
       shadowDomService.addShadowRootHost(injector, viewContainerRef.element?.nativeElement);
@@ -151,6 +152,16 @@ export class EmbedImageComponent extends CommandProcessor implements OnInit, OnD
 
    getAssemblyName(): string {
       return null;
+   }
+
+   /**
+    * Dispatches a plain DOM CustomEvent on this component's own host element once the wrapped
+    * <vs-image> reports it has actually finished rendering (see AbstractImageComponent.onLoad) -
+    * so a consumer embedding <inetsoft-image> as a plain custom element (no Angular APIs
+    * available) can learn when the image is done instead of guessing.
+    */
+   dispatchLoaded(): void {
+      this.elementRef.nativeElement.dispatchEvent(new CustomEvent("loaded", { bubbles: true, composed: true }));
    }
 
    ngOnInit(): void {

--- a/web/projects/portal/src/app/embed/table/embed-table.component.spec.ts
+++ b/web/projects/portal/src/app/embed/table/embed-table.component.spec.ts
@@ -18,6 +18,7 @@
 import { AssemblyActionGroup } from "../../common/action/assembly-action-group";
 import { TestUtils } from "../../common/test/test-utils";
 import { EmbedAssemblyContextProviderFactory } from "../../vsobjects/context-provider.service";
+import { AddVsObjectMode } from "../../vsobjects/command/add-vs-object-command";
 import { VSTableModel } from "../../vsobjects/model/vs-table-model";
 import { EmbedTableActions } from "./embed-table-actions";
 import { EmbedTableComponent } from "./embed-table.component";
@@ -73,5 +74,79 @@ describe("EmbedTableComponent.onOpenContextMenu", () => {
       // The browser's own context menu stays suppressed either way - having nothing of our own
       // to show is not a reason to offer the embedding page's users Reload/Save As.
       expect(event.preventDefault).toHaveBeenCalled();
+   });
+});
+
+/**
+ * Regression coverage for the stylebi-side half of bug-75975: <inetsoft-table> (like every other
+ * embed element) never dispatched any DOM event a consumer could use to learn when it actually
+ * finished rendering - a plain custom-element consumer had nothing but a fixed client-side
+ * timeout to fall back on. A table has no async per-tile image loading of its own (its cells are
+ * plain DOM rendered synchronously from the model by Angular change detection), so "rendered"
+ * here is just "the model this command carried has been applied and change detection has run".
+ * Built off the prototype for the same reason as the suite above: standing up the full DI graph
+ * would test the websocket wiring instead of the dispatch.
+ */
+describe("EmbedTableComponent.dispatchLoaded", () => {
+   let component: any;
+   let host: HTMLElement;
+   let table: VSTableModel;
+
+   beforeEach(() => {
+      table = TestUtils.createMockVSTableModel("Table1");
+      host = document.createElement("div");
+      component = Object.create(EmbedTableComponent.prototype);
+      component.assemblyName = "Table1";
+      component.contextProvider = EmbedAssemblyContextProviderFactory();
+      component.miniToolbarService = { hiddenFreeze: vi.fn(), hiddenUnfreeze: vi.fn() };
+      component.cdRef = { detectChanges: vi.fn() };
+      component.elementRef = { nativeElement: host };
+      component.updateVSInfo = () => {};
+   });
+
+   it("dispatches a bubbling, composed 'loaded' CustomEvent on the host element", () => {
+      const listener = vi.fn();
+      host.addEventListener("loaded", listener);
+
+      component.dispatchLoaded();
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      const event: CustomEvent = listener.mock.calls[0][0];
+      expect(event.bubbles).toBe(true);
+      expect(event.composed).toBe(true);
+   });
+
+   it("dispatches 'loaded' after applying a fresh AddVSObjectCommand", () => {
+      const listener = vi.fn();
+      host.addEventListener("loaded", listener);
+
+      component.processAddVSObjectCommand({
+         name: "Table1", mode: AddVsObjectMode.RUNTIME_MODE, model: table, parent: null
+      });
+
+      expect(component.cdRef.detectChanges).toHaveBeenCalled();
+      expect(listener).toHaveBeenCalledTimes(1);
+   });
+
+   it("dispatches 'loaded' after applying a RefreshVSObjectCommand", () => {
+      const listener = vi.fn();
+      host.addEventListener("loaded", listener);
+      component.vsObject = table;
+
+      component.processRefreshVSObjectCommand({ info: table });
+
+      expect(component.cdRef.detectChanges).toHaveBeenCalled();
+      expect(listener).toHaveBeenCalledTimes(1);
+   });
+
+   it("does not dispatch 'loaded' for a command addressed to a different assembly", () => {
+      const listener = vi.fn();
+      host.addEventListener("loaded", listener);
+
+      component.processAddVSObjectCommand({
+         name: "SomeOtherTable", mode: AddVsObjectMode.RUNTIME_MODE, model: table, parent: null
+      });
+
+      expect(listener).not.toHaveBeenCalled();
    });
 });

--- a/web/projects/portal/src/app/embed/table/embed-table.component.ts
+++ b/web/projects/portal/src/app/embed/table/embed-table.component.ts
@@ -276,6 +276,18 @@ export class EmbedTableComponent extends CommandProcessor implements OnInit, OnD
       );
    }
 
+   /**
+    * Dispatches a plain DOM CustomEvent on this component's own host element right after a
+    * model update has been applied via detectChanges(). Unlike chart/gauge/image, a table has no
+    * async per-tile image loading of its own - its cells are plain DOM rendered synchronously
+    * from the model by Angular change detection - so "rendered" here just means "the model this
+    * command carried has been applied and change detection has run", with nothing further to
+    * wait for. See toggleWizFullscreen() above for the same host-dispatch pattern.
+    */
+   dispatchLoaded(): void {
+      this.elementRef.nativeElement.dispatchEvent(new CustomEvent("loaded", { bubbles: true, composed: true }));
+   }
+
    ngOnDestroy() {
       this.dialogService.ngOnDestroy();
       this.clearServerUpdateInterval();
@@ -349,6 +361,7 @@ export class EmbedTableComponent extends CommandProcessor implements OnInit, OnD
          () => this.wizMaximized, () => this.toggleWizFullscreen());
       // Force change detection: as an Angular Elements custom element, this view is not refreshed by the zone tick that wraps websocket command processing, so the embedded object would otherwise never render on open.
       this.cdRef.detectChanges();
+      this.dispatchLoaded();
    }
 
    // noinspection JSUnusedGlobalSymbols
@@ -370,6 +383,7 @@ export class EmbedTableComponent extends CommandProcessor implements OnInit, OnD
          () => this.wizMaximized, () => this.toggleWizFullscreen());
       // Force change detection: as an Angular Elements custom element, this view is not refreshed by the zone tick that wraps websocket command processing, so the embedded object would otherwise never render on open.
       this.cdRef.detectChanges();
+      this.dispatchLoaded();
    }
 
    // noinspection JSUnusedGlobalSymbols

--- a/web/projects/portal/src/app/embed/text/embed-text.component.spec.ts
+++ b/web/projects/portal/src/app/embed/text/embed-text.component.spec.ts
@@ -1,0 +1,98 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { TestUtils } from "../../common/test/test-utils";
+import { EmbedAssemblyContextProviderFactory } from "../../vsobjects/context-provider.service";
+import { AddVsObjectMode } from "../../vsobjects/command/add-vs-object-command";
+import { VSTextModel } from "../../vsobjects/model/output/vs-text-model";
+import { EmbedTextComponent } from "./embed-text.component";
+
+/**
+ * Regression coverage for the stylebi-side half of bug-75975: <inetsoft-text> (like every other
+ * embed element) never dispatched any DOM event a consumer could use to learn when it actually
+ * finished rendering - a plain custom-element consumer had nothing but a fixed client-side
+ * timeout to fall back on. A text assembly has no async loading of its own (its content is
+ * plain DOM - innerHTML - rendered synchronously from the model by Angular change detection), so
+ * "rendered" here is just "the model this command carried has been applied and change detection
+ * has run". Built off the prototype rather than through TestBed: EmbedTextComponent is an
+ * Angular Elements custom element wired to a websocket client, and standing all of that up would
+ * test the DI setup instead of the dispatch - see embed-table.component.spec.ts for the same
+ * pattern.
+ */
+describe("EmbedTextComponent.dispatchLoaded", () => {
+   let component: any;
+   let host: HTMLElement;
+   let text: VSTextModel;
+
+   beforeEach(() => {
+      text = TestUtils.createMockVSTextModel("Text1");
+      host = document.createElement("div");
+      component = Object.create(EmbedTextComponent.prototype);
+      component.assemblyName = "Text1";
+      component.contextProvider = EmbedAssemblyContextProviderFactory();
+      component.miniToolbarService = { hiddenFreeze: vi.fn(), hiddenUnfreeze: vi.fn() };
+      component.cdRef = { detectChanges: vi.fn() };
+      component.elementRef = { nativeElement: host };
+      component.updateVSInfo = () => {};
+   });
+
+   it("dispatches a bubbling, composed 'loaded' CustomEvent on the host element", () => {
+      const listener = vi.fn();
+      host.addEventListener("loaded", listener);
+
+      component.dispatchLoaded();
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      const event: CustomEvent = listener.mock.calls[0][0];
+      expect(event.bubbles).toBe(true);
+      expect(event.composed).toBe(true);
+   });
+
+   it("dispatches 'loaded' after applying a fresh AddVSObjectCommand", () => {
+      const listener = vi.fn();
+      host.addEventListener("loaded", listener);
+
+      component.processAddVSObjectCommand({
+         name: "Text1", mode: AddVsObjectMode.RUNTIME_MODE, model: text, parent: null
+      });
+
+      expect(component.cdRef.detectChanges).toHaveBeenCalled();
+      expect(listener).toHaveBeenCalledTimes(1);
+   });
+
+   it("dispatches 'loaded' after applying a RefreshVSObjectCommand", () => {
+      const listener = vi.fn();
+      host.addEventListener("loaded", listener);
+      component.vsObject = text;
+
+      component.processRefreshVSObjectCommand({ info: text });
+
+      expect(component.cdRef.detectChanges).toHaveBeenCalled();
+      expect(listener).toHaveBeenCalledTimes(1);
+   });
+
+   it("does not dispatch 'loaded' for a command addressed to a different assembly", () => {
+      const listener = vi.fn();
+      host.addEventListener("loaded", listener);
+
+      component.processAddVSObjectCommand({
+         name: "SomeOtherText", mode: AddVsObjectMode.RUNTIME_MODE, model: text, parent: null
+      });
+
+      expect(listener).not.toHaveBeenCalled();
+   });
+});

--- a/web/projects/portal/src/app/embed/text/embed-text.component.ts
+++ b/web/projects/portal/src/app/embed/text/embed-text.component.ts
@@ -134,7 +134,8 @@ export class EmbedTextComponent extends CommandProcessor implements OnInit, OnDe
                private shadowDomService: ShadowDomService,
                private showHyperlinkService: ShowHyperlinkService,
                private debounceService: DebounceService,
-               private cdRef: ChangeDetectorRef)
+               private cdRef: ChangeDetectorRef,
+               private elementRef: ElementRef)
    {
       super(viewsheetClient, zone, true);
       shadowDomService.addShadowRootHost(injector, viewContainerRef.element?.nativeElement);
@@ -151,6 +152,17 @@ export class EmbedTextComponent extends CommandProcessor implements OnInit, OnDe
 
    getAssemblyName(): string {
       return null;
+   }
+
+   /**
+    * Dispatches a plain DOM CustomEvent on this component's own host element right after a
+    * model update has been applied via detectChanges(). A text assembly has no async loading of
+    * its own - its content is plain DOM (innerHTML) rendered synchronously from the model by
+    * Angular change detection - so "rendered" here just means "the model this command carried
+    * has been applied and change detection has run", with nothing further to wait for.
+    */
+   dispatchLoaded(): void {
+      this.elementRef.nativeElement.dispatchEvent(new CustomEvent("loaded", { bubbles: true, composed: true }));
    }
 
    ngOnInit(): void {
@@ -286,6 +298,7 @@ export class EmbedTextComponent extends CommandProcessor implements OnInit, OnDe
          this.contextProvider, false, null, null, null, this.miniToolbarService);
       // Force change detection: as an Angular Elements custom element, this view is not refreshed by the zone tick that wraps websocket command processing, so the embedded object would otherwise never render on open.
       this.cdRef.detectChanges();
+      this.dispatchLoaded();
    }
 
    processRefreshVSObjectCommand(command: RefreshVSObjectCommand): void {
@@ -305,6 +318,7 @@ export class EmbedTextComponent extends CommandProcessor implements OnInit, OnDe
          this.contextProvider, false, null, null, null, this.miniToolbarService);
       // Force change detection: as an Angular Elements custom element, this view is not refreshed by the zone tick that wraps websocket command processing, so the embedded object would otherwise never render on open.
       this.cdRef.detectChanges();
+      this.dispatchLoaded();
    }
 
    processCollectParametersCommand(command: CollectParametersCommand): void {

--- a/web/projects/portal/src/app/vsobjects/objects/chart/vs-chart.component.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/chart/vs-chart.component.spec.ts
@@ -261,4 +261,49 @@ describe("VSChart Tests", () => {
             expect(action.action).not.toHaveBeenCalled();
       });
    });
+
+   // Regression coverage for the stylebi-side half of bug-75975: a consumer embedding
+   // <inetsoft-chart> as a plain custom element (e.g. wiz) had no DOM event to learn when the
+   // chart actually finished rendering, only a fixed client-side timeout. onChartLoaded is the
+   // new @Output that makes clearChartLoading()'s existing "tiles have settled" signal (already
+   // driving this component's own chartLoading/chartLoadingIcon state) observable from outside.
+   //
+   // clearChartLoading() calls this.detectChanges(), which forces a real
+   // ChangeDetectorRef.detectChanges() - triggering the SAME broken template render every other
+   // test in this suite is .skip'd for (VSDataTipDirective.ngOnInit needs a real Observable on
+   // the stubbed dataTipService.scrolled, which isn't set up here). That gap is pre-existing and
+   // orthogonal to onChartLoaded, so it's stubbed out here rather than fixing the whole suite's
+   // template-rendering setup.
+   it("emits onChartLoaded when clearChartLoading transitions loading to not-loading", () => {
+      let fixture = TestBed.createComponent(VSChart);
+      // Stub BEFORE setting .model: the model setter itself calls showChartLoading(), which
+      // calls detectChanges() synchronously - this must be in place first or that earlier call
+      // hits the same template-rendering gap.
+      vi.spyOn(fixture.componentInstance as any, "detectChanges").mockImplementation(() => {});
+      fixture.componentInstance.model = TestUtils.createMockVSChartModel("Chart1");
+      let spy = vi.fn();
+      fixture.componentInstance.onChartLoaded.subscribe(spy);
+
+      fixture.componentInstance.chartLoading = true;
+      fixture.componentInstance.clearChartLoading();
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(fixture.componentInstance.chartLoading).toBe(false);
+   });
+
+   it("does not emit onChartLoaded when clearChartLoading runs while already not loading", () => {
+      let fixture = TestBed.createComponent(VSChart);
+      // Stub BEFORE setting .model: the model setter itself calls showChartLoading(), which
+      // calls detectChanges() synchronously - this must be in place first or that earlier call
+      // hits the same template-rendering gap.
+      vi.spyOn(fixture.componentInstance as any, "detectChanges").mockImplementation(() => {});
+      fixture.componentInstance.model = TestUtils.createMockVSChartModel("Chart1");
+      let spy = vi.fn();
+      fixture.componentInstance.onChartLoaded.subscribe(spy);
+
+      fixture.componentInstance.chartLoading = false;
+      fixture.componentInstance.clearChartLoading();
+
+      expect(spy).not.toHaveBeenCalled();
+   });
 });

--- a/web/projects/portal/src/app/vsobjects/objects/chart/vs-chart.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/chart/vs-chart.component.ts
@@ -161,6 +161,13 @@ export class VSChart extends AbstractVSObject<VSChartModel>
    @Output() public maxModeChange = new EventEmitter<{assembly: string, maxMode: boolean}>();
    @Output() public onOpenFormatPane = new EventEmitter<VSChartModel>();
    @Output() public onLoadFormatModel = new EventEmitter<VSChartModel>();
+   // Fires whenever clearChartLoading() actually transitions loading -> not-loading, i.e. the
+   // chart's tiles (or its no-data/retry-exhausted/timeout fallback path) have settled. This is
+   // the same signal chartLoading/chartLoadingIcon already drive for this component's own
+   // template; it exists as an @Output so a consumer embedding this component (e.g.
+   // EmbedChartComponent, wrapped as a plain custom element with no Angular APIs available) can
+   // learn when the chart has actually finished rendering instead of guessing.
+   @Output() public onChartLoaded = new EventEmitter<void>();
    @ViewChild("chartContainer") chartContainer: ElementRef;
    @ViewChild("chartArea") chartArea: ChartArea;
    public scrollTop = 0;
@@ -1130,6 +1137,7 @@ export class VSChart extends AbstractVSObject<VSChartModel>
          this.loadingStateChanged(this.chartLoading);
          this.clearChartSnapshot();
          this.detectChanges();
+         this.onChartLoaded.emit();
       }
    }
 

--- a/web/projects/portal/src/app/vsobjects/objects/output/abstract-image.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/output/abstract-image.ts
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { Directive, Input, NgZone, OnDestroy } from "@angular/core";
+import { Directive, EventEmitter, Input, NgZone, OnDestroy, Output } from "@angular/core";
 import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
 import { Subscription } from "rxjs";
 import { Tool } from "../../../../../../shared/util/tool";
@@ -58,6 +58,13 @@ extends AbstractVSObject<T> implements OnDestroy
    private _actions: AbstractVSActions<T>;
    private _selected: boolean;
    loading: boolean = false;
+
+   // Fires whenever the assembly's underlying <img> (see getSrc()) finishes loading, successfully
+   // or not. This is the same signal `loading` already drives for this component's own template;
+   // it exists as an @Output so a consumer embedding this component (e.g. EmbedGaugeComponent /
+   // EmbedImageComponent, wrapped as a plain custom element with no Angular APIs available) can
+   // learn when the image has actually finished rendering instead of guessing.
+   @Output() onLoad = new EventEmitter<boolean>();
 
    @Input()
    set actions(actions: AbstractVSActions<T>) {
@@ -152,5 +159,6 @@ extends AbstractVSObject<T> implements OnDestroy
 
    loaded(success: boolean) {
       this.loading = false;
+      this.onLoad.emit(success);
    }
 }

--- a/web/projects/portal/src/app/vsobjects/objects/output/gauge/vs-gauge.component.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/output/gauge/vs-gauge.component.spec.ts
@@ -221,4 +221,30 @@ describe("VSGauge", () => {
       let gauge = fixture.nativeElement.querySelector("img.vs-gauge__image");
       expect(gauge.style["opacity"]).toBe("0.3");
    });
+
+   // Regression coverage for the stylebi-side half of bug-75975: a consumer embedding
+   // <inetsoft-gauge> as a plain custom element (e.g. wiz) had no DOM event to learn when the
+   // gauge's underlying <img> (see getSrc()) actually finished loading, only a fixed client-side
+   // timeout. AbstractImageComponent.onLoad is the new @Output that makes loaded()'s existing
+   // "image settled" signal (already driving this component's own `loading` state) observable
+   // from outside.
+   it("emits onLoad with the load outcome when the underlying image finishes loading", () => {
+      let fixture = TestBed.createComponent(VSGauge);
+      fixture.componentInstance.model = model;
+      fixture.componentInstance.vsInfo = new ViewsheetInfo([], "/link/");
+      fixture.detectChanges();
+
+      let successSpy = vi.fn();
+      let failureSpy = vi.fn();
+      fixture.componentInstance.onLoad.subscribe((success: boolean) => {
+         (success ? successSpy : failureSpy)(success);
+      });
+
+      fixture.componentInstance.loaded(true);
+      expect(successSpy).toHaveBeenCalledWith(true);
+      expect(fixture.componentInstance.loading).toBe(false);
+
+      fixture.componentInstance.loaded(false);
+      expect(failureSpy).toHaveBeenCalledWith(false);
+   });
 });

--- a/web/projects/portal/src/app/vsobjects/objects/output/image/vs-image.component.display.tl.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/output/image/vs-image.component.display.tl.spec.ts
@@ -28,7 +28,9 @@
  *                       scaling, border subtraction
  *   Group 4 [Risk 2] — hasPopComponentChange: popComponent value diffing
  *   Group 5 [Risk 1] — isForceTab: composer-context boolean getter
- *   Group 6 [Risk 1] — finishLoad: loading cleared + change detection
+ *   Group 6 [Risk 1] — finishLoad: loading cleared + change detection + onLoad emission
+ *                       (bug #75975 follow-up: VSImage doesn't route through the base class's
+ *                       loaded(), so finishLoad() must emit onLoad itself)
  *   Group 7 [Risk 1] — isPopupOrDataTipSource: pop-source boolean getter
  *   Group 8 [Risk 3] — Legacy DOM regressions ported verbatim from vs-image.component.spec.ts
  *                       (bugs #17807, #17228, #20755): uses a real TestBed render (not direct
@@ -302,6 +304,33 @@ describe("VSImage — Pass 3: Display", () => {
 
          expect(comp.loading).toBe(false);
          expect(changeDetectorRef.detectChanges).toHaveBeenCalled();
+      });
+
+      // Bug #75975 follow-up: unlike VSGauge, VSImage doesn't route its <img> load/error through
+      // the base AbstractImageComponent.loaded() - it manages `loading` directly, so finishLoad()
+      // must emit the inherited onLoad @Output itself (defaulting to success=true, matching every
+      // pre-existing no-arg call site: onImageLoad()'s own success path, and the tiled-image
+      // immediate-completion paths in ngOnInit/modelChanged). Otherwise EmbedImageComponent's
+      // (onLoad)="dispatchLoaded()" binding never fires and <inetsoft-image> embeds never
+      // dispatch the "loaded" DOM event this PR is meant to add.
+      it("should emit onLoad(true) by default", () => {
+         const { comp } = createImageComponent();
+         const spy = vi.fn();
+         comp.onLoad.subscribe(spy);
+
+         comp.finishLoad();
+
+         expect(spy).toHaveBeenCalledWith(true);
+      });
+
+      it("should emit onLoad(false) when called from the <img> error handler", () => {
+         const { comp } = createImageComponent();
+         const spy = vi.fn();
+         comp.onLoad.subscribe(spy);
+
+         comp.finishLoad(false);
+
+         expect(spy).toHaveBeenCalledWith(false);
       });
    });
 

--- a/web/projects/portal/src/app/vsobjects/objects/output/image/vs-image.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/output/image/vs-image.component.html
@@ -48,7 +48,7 @@
           @if (!model.scaleInfo.tiled) {
             <img #imageElement class="image-content"
               (click)="clicked($event)"
-              (load)="onImageLoad()" (error)="finishLoad()"
+              (load)="onImageLoad()" (error)="finishLoad(false)"
               [class.image-content-shadow]="model.shadow && model.animateGif"
               [style.width.px]="imageSize.width"
               [style.height.px]="imageSize.height"

--- a/web/projects/portal/src/app/vsobjects/objects/output/image/vs-image.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/output/image/vs-image.component.ts
@@ -269,11 +269,16 @@ export class VSImage extends AbstractImageComponent<VSImageModel>
          this.imageSize = size;
       }
 
-      this.finishLoad();
+      this.finishLoad(true);
    }
 
-   finishLoad() {
+   finishLoad(success: boolean = true) {
       this.loading = false;
+      // Unlike VSGauge, VSImage doesn't route its <img> load/error through the base
+      // AbstractImageComponent.loaded() - it manages `loading` directly, so it must emit onLoad
+      // itself too, or EmbedImageComponent's (onLoad)="dispatchLoaded()" binding never fires and
+      // <inetsoft-image> embeds never dispatch the "loaded" DOM event. (Bug #75975 follow-up.)
+      this.onLoad.emit(success);
       this.changeRef.detectChanges();
    }
 


### PR DESCRIPTION
## Summary
- Companion fix to wiz's bug-75975 (portal PR #1577): every `<inetsoft-chart>`/`<inetsoft-crosstab>`/`<inetsoft-table>`/`<inetsoft-gauge>`/`<inetsoft-text>`/`<inetsoft-image>` custom element gave a plain custom-element consumer (e.g. wiz's chat card) no DOM event for "I have actually finished rendering" — only a fixed client-side timeout to fall back on. That made every embed mount/refresh look exactly as slow as the consumer's timeout, regardless of how fast the underlying render actually was.
- Adds a genuine per-type "rendered" signal and dispatches it as `CustomEvent("loaded", {bubbles: true, composed: true})` on each `Embed*Component`'s own host element, reusing the same manual-dispatch pattern already used for `"wizfullscreen"`:
  - **Chart**: `VSChart` gets a new `onChartLoaded` `@Output`, emitted from the existing `clearChartLoading()` — the same "tiles have settled" signal that already drives this component's own `chartLoading`/`chartLoadingIcon` state (retries, no-data, and its own internal timeout fallback are already handled there).
  - **Gauge/Image**: `AbstractImageComponent`'s existing `loaded(success)` callback (already wired to the underlying `<img>`'s `load`/`error`) now also emits a new `onLoad` `@Output`.
  - **Crosstab/Table/Text**: no async per-tile loading of their own — content is plain DOM rendered synchronously from the model by Angular change detection — so the embed wrapper dispatches `"loaded"` right after applying an Add/RefreshVSObjectCommand's `detectChanges()`.
- Deliberately does **not** reuse `AbstractVSObject`'s existing `onLoadingStateChanged`: tracing `AssemblyLoadingCommand`/`ClearAssemblyLoadingCommand` into `CoreLifecycleService` shows that pair only brackets server-side model recomputation, well before the browser even requests a chart's tile images — wiring it through would trade "signals too late" for "signals too early".

## Test plan
- [x] New/extended unit tests: `vs-chart.component.spec.ts` (`onChartLoaded` fires on the loading→not-loading transition, not on a no-op call), `vs-gauge.component.spec.ts` (`onLoad` emits the load outcome), `embed-table.component.spec.ts` (host dispatch + wiring through `processAddVSObjectCommand`/`processRefreshVSObjectCommand`, including the "wrong assembly name" no-op case).
- [x] `ng test portal` (full suite): 195 files / 1018 tests passing.
- [x] `ng run portal:test-tl` (large-test suite): 403 files / 8165 tests, 3 pre-existing failures unrelated to any file touched here (composer-selection-container-children, datasources-datasource-editor — Angular TestBed module-compile ordering / a timeout, reproducible on this branch's base commit too).
- [ ] Manual verification against a real embed page once this lands, alongside the wiz-side consumer switching over to this event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)