### PR TITLE
Add /api/wiz export and email endpoints

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/WizEmailController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizEmailController.java
@@ -1,0 +1,66 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.controller;
+
+import inetsoft.web.viewsheet.controller.dialog.EmailDialogServiceProxy;
+import inetsoft.web.viewsheet.model.dialog.EmailDialogModel;
+import inetsoft.web.viewsheet.model.dialog.MessageDialogModel;
+import inetsoft.web.viewsheet.service.LinkUri;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+/**
+ * Wraps the same EmailDialogService that backs the native /api/vs/email-dialog-model endpoints
+ * under wiz's own JWT-authenticated, CSRF-exempt /api/wiz namespace (see
+ * WizServiceAuthenticationFilter / CSRFFilter#isWizApi). The native POST endpoint requires the
+ * double-submit XSRF-TOKEN cookie/header dance; going through /api/wiz sidesteps that entirely,
+ * since this namespace is CSRF-exempt and JWT-authenticated instead of session-cookie-authenticated.
+ * No email-sending logic is reimplemented — emailViewsheet() already returns a MessageDialogModel
+ * with success/message set appropriately (including on SMTP failure), so this stays a thin proxy.
+ */
+@RestController
+@RequestMapping("/api/wiz")
+public class WizEmailController {
+   public WizEmailController(EmailDialogServiceProxy emailDialogServiceProxy) {
+      this.emailDialogServiceProxy = emailDialogServiceProxy;
+   }
+
+   @GetMapping("/viewsheet/email-dialog-model")
+   public EmailDialogModel getEmailDialogModel(@RequestParam("runtimeId") String runtimeId,
+                                               Principal principal) throws Exception
+   {
+      return emailDialogServiceProxy.getEmailDialogModel(runtimeId, principal);
+   }
+
+   @PostMapping("/viewsheet/email")
+   public MessageDialogModel emailViewsheet(@RequestParam("runtimeId") String runtimeId,
+                                            @RequestBody EmailDialogModel value,
+                                            Principal principal,
+                                            @LinkUri String linkUri) throws Exception
+   {
+      return emailDialogServiceProxy.emailViewsheet(runtimeId, value, principal, linkUri);
+   }
+
+   private final EmailDialogServiceProxy emailDialogServiceProxy;
+}

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizExportController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizExportController.java
@@ -37,6 +37,8 @@ import inetsoft.web.viewsheet.service.VSExportService;
 import inetsoft.web.wiz.model.ExportViewsheetRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -86,10 +88,12 @@ public class WizExportController {
       return assemblyImageServiceProxy.checkExporting(runtimeId, principal);
    }
 
-   // request is an unannotated bean parameter — Spring binds it implicitly from the same query
-   // params the old per-field @RequestParam list declared (see ExportViewsheetRequest's own doc).
-   @GetMapping("/viewsheet/export")
-   public void exportViewsheet(ExportViewsheetRequest request, Principal principal,
+   // POST + @RequestBody (not GET + query params) to match the established convention for every
+   // other multi-field wiz request in inetsoft.web.wiz.model — see GeoApplyRequest/ChartFormatRequest.
+   // The wiz frontend fetches the exported file as a blob and downloads it via an object URL
+   // rather than navigating the browser directly to this URL (which POST wouldn't support).
+   @PostMapping("/viewsheet/export")
+   public void exportViewsheet(@RequestBody ExportViewsheetRequest request, Principal principal,
                                HttpServletResponse response) throws Exception
    {
       if(!securityEngine.checkPermission(principal, ResourceType.VIEWSHEET_TOOLBAR_ACTION,

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizExportController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizExportController.java
@@ -22,6 +22,7 @@ import inetsoft.sree.security.ResourceAction;
 import inetsoft.sree.security.ResourceType;
 import inetsoft.sree.security.SecurityEngine;
 import inetsoft.sree.security.SecurityException;
+import inetsoft.uql.viewsheet.FileFormatInfo;
 import inetsoft.util.cachefs.BinaryTransfer;
 import inetsoft.web.composer.vs.controller.ExportControllerService;
 import inetsoft.web.composer.vs.controller.ExportControllerServiceProxy;
@@ -108,6 +109,13 @@ public class WizExportController {
       String[] bookmarks = bookmarksParam.isEmpty() ? new String[0] : bookmarksParam.split(",");
       String[] tables = tableAssembliesParam.isEmpty() ? new String[0] : tableAssembliesParam.split(",");
 
+      // Mirrors ExportController.exportViewsheet0()'s override: CSV data must always be fully
+      // expanded rather than clipped to the on-screen layout, regardless of what the caller asked
+      // for via `match`.
+      if(format == FileFormatInfo.EXPORT_TYPE_CSV) {
+         match = false;
+      }
+
       CSVConfig csvConfig = new CSVConfig();
 
       if(delimiter != null) {
@@ -122,6 +130,8 @@ public class WizExportController {
       csvConfig.setTabDelimited(tabDelimited);
       csvConfig.setExportAssemblies(Arrays.asList(tables));
 
+      // type=null (no output-extension override), matchesAssetIdFormat=false (see class doc),
+      // previewPrintLayout=false, print=false — wiz never sets either of the last two.
       ExportControllerService.ViewsheetExportResult result = exportControllerServiceProxy.exportViewsheet(
          runtimeId, format, null, false, match, expandSelections, current, false, false,
          bookmarks, onlyDataComponents, exportAllTabbedTables, csvConfig, principal);

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizExportController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizExportController.java
@@ -102,11 +102,16 @@ public class WizExportController {
          throw new SecurityException("Permission denied: viewsheet export");
       }
 
-      // The individual @RequestParam("runtimeId") this replaced was required (no defaultValue),
-      // so Spring 400'd automatically on a missing value; the implicit-bean binding above does
-      // not, so that same "fail loud on a missing required param" guarantee has to be explicit.
+      // runtimeId and format were both individually @RequestParam-required (no defaultValue), so
+      // Spring 400'd automatically on a missing value; @RequestBody's JSON binding does not, so
+      // that same "fail loud on a missing required field" guarantee has to be explicit here (see
+      // ExportViewsheetRequest's class doc).
       if(Tool.isEmptyString(request.getRuntimeId())) {
          throw new IllegalArgumentException("Missing required parameter: runtimeId");
+      }
+
+      if(request.getFormat() == null) {
+         throw new IllegalArgumentException("Missing required parameter: format");
       }
 
       String bookmarksParam = request.getBookmarks();

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizExportController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizExportController.java
@@ -1,0 +1,140 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.controller;
+
+import inetsoft.report.io.csv.CSVConfig;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
+import inetsoft.util.cachefs.BinaryTransfer;
+import inetsoft.web.composer.vs.controller.ExportControllerService;
+import inetsoft.web.composer.vs.controller.ExportControllerServiceProxy;
+import inetsoft.web.service.BinaryTransferService;
+import inetsoft.web.viewsheet.command.MessageCommand;
+import inetsoft.web.viewsheet.controller.AssemblyImageServiceProxy;
+import inetsoft.web.viewsheet.controller.dialog.ExportDialogServiceProxy;
+import inetsoft.web.viewsheet.model.dialog.ExportDialogModel;
+import inetsoft.web.viewsheet.service.ExportResponse;
+import inetsoft.web.viewsheet.service.VSExportService;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+import java.util.Arrays;
+
+/**
+ * Wraps the same services that back the native /api/vs/export-dialog-model and
+ * /export/viewsheet endpoints (ExportDialogService, ExportControllerService — no export logic
+ * is reimplemented here) under wiz's own JWT-authenticated, CSRF-exempt /api/wiz namespace
+ * (see WizServiceAuthenticationFilter / CSRFFilter#isWizApi), so wiz's browser never needs to
+ * talk to StyleBI's session/CSRF-protected controllers directly, or replicate StyleBI's
+ * ~_hex_~ runtime-id path escaping (Tool.byteEncode) for a plain query parameter.
+ *
+ * runtimeId here is always one wiz already has open (via ViewsheetRuntimeController), never an
+ * asset path to resolve — mirrors ExportController's own "path doesn't parse as an asset entry"
+ * fallback branch, so matchesAssetIdFormat is always false.
+ */
+@RestController
+@RequestMapping("/api/wiz")
+public class WizExportController {
+   public WizExportController(ExportDialogServiceProxy exportDialogServiceProxy,
+                              ExportControllerServiceProxy exportControllerServiceProxy,
+                              AssemblyImageServiceProxy assemblyImageServiceProxy,
+                              BinaryTransferService binaryTransferService,
+                              SecurityEngine securityEngine)
+   {
+      this.exportDialogServiceProxy = exportDialogServiceProxy;
+      this.exportControllerServiceProxy = exportControllerServiceProxy;
+      this.assemblyImageServiceProxy = assemblyImageServiceProxy;
+      this.binaryTransferService = binaryTransferService;
+      this.securityEngine = securityEngine;
+   }
+
+   @GetMapping("/viewsheet/export-dialog-model")
+   public ExportDialogModel getExportDialogModel(@RequestParam("runtimeId") String runtimeId,
+                                                 Principal principal) throws Exception
+   {
+      return exportDialogServiceProxy.getExportDialogModel(runtimeId, principal);
+   }
+
+   @GetMapping("/viewsheet/export-check")
+   public MessageCommand checkExporting(@RequestParam("runtimeId") String runtimeId,
+                                        Principal principal) throws Exception
+   {
+      return assemblyImageServiceProxy.checkExporting(runtimeId, principal);
+   }
+
+   @GetMapping("/viewsheet/export")
+   public void exportViewsheet(@RequestParam("runtimeId") String runtimeId,
+                               @RequestParam("format") int format,
+                               @RequestParam(value = "match", defaultValue = "true") boolean match,
+                               @RequestParam(value = "expandSelections", defaultValue = "false") boolean expandSelections,
+                               @RequestParam(value = "current", defaultValue = "true") boolean current,
+                               @RequestParam(value = "bookmarks", defaultValue = "") String bookmarksParam,
+                               @RequestParam(value = "onlyDataComponents", defaultValue = "false") boolean onlyDataComponents,
+                               @RequestParam(value = "exportAllTabbedTables", defaultValue = "false") boolean exportAllTabbedTables,
+                               @RequestParam(value = "delimiter", required = false) String delimiter,
+                               @RequestParam(value = "quote", required = false) String quote,
+                               @RequestParam(value = "keepHeader", defaultValue = "true") boolean keepHeader,
+                               @RequestParam(value = "tabDelimited", defaultValue = "false") boolean tabDelimited,
+                               @RequestParam(value = "tableAssemblies", defaultValue = "") String tableAssembliesParam,
+                               Principal principal, HttpServletResponse response) throws Exception
+   {
+      if(!securityEngine.checkPermission(principal, ResourceType.VIEWSHEET_TOOLBAR_ACTION,
+         "Export", ResourceAction.READ))
+      {
+         throw new SecurityException("Permission denied: viewsheet export");
+      }
+
+      String[] bookmarks = bookmarksParam.isEmpty() ? new String[0] : bookmarksParam.split(",");
+      String[] tables = tableAssembliesParam.isEmpty() ? new String[0] : tableAssembliesParam.split(",");
+
+      CSVConfig csvConfig = new CSVConfig();
+
+      if(delimiter != null) {
+         csvConfig.setDelimiter(delimiter);
+      }
+
+      if(quote != null) {
+         csvConfig.setQuote(quote);
+      }
+
+      csvConfig.setKeepHeader(keepHeader);
+      csvConfig.setTabDelimited(tabDelimited);
+      csvConfig.setExportAssemblies(Arrays.asList(tables));
+
+      ExportControllerService.ViewsheetExportResult result = exportControllerServiceProxy.exportViewsheet(
+         runtimeId, format, null, false, match, expandSelections, current, false, false,
+         bookmarks, onlyDataComponents, exportAllTabbedTables, csvConfig, principal);
+
+      VSExportService.setResponseHeader(new ExportResponse(response), result.getSuffix(),
+         "attachment", result.getFileName(), result.getMime());
+      BinaryTransfer data = result.getData();
+      binaryTransferService.writeData(data, response.getOutputStream());
+   }
+
+   private final ExportDialogServiceProxy exportDialogServiceProxy;
+   private final ExportControllerServiceProxy exportControllerServiceProxy;
+   private final AssemblyImageServiceProxy assemblyImageServiceProxy;
+   private final BinaryTransferService binaryTransferService;
+   private final SecurityEngine securityEngine;
+}

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizExportController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizExportController.java
@@ -23,6 +23,7 @@ import inetsoft.sree.security.ResourceType;
 import inetsoft.sree.security.SecurityEngine;
 import inetsoft.sree.security.SecurityException;
 import inetsoft.uql.viewsheet.FileFormatInfo;
+import inetsoft.util.Tool;
 import inetsoft.util.cachefs.BinaryTransfer;
 import inetsoft.web.composer.vs.controller.ExportControllerService;
 import inetsoft.web.composer.vs.controller.ExportControllerServiceProxy;
@@ -33,6 +34,7 @@ import inetsoft.web.viewsheet.controller.dialog.ExportDialogServiceProxy;
 import inetsoft.web.viewsheet.model.dialog.ExportDialogModel;
 import inetsoft.web.viewsheet.service.ExportResponse;
 import inetsoft.web.viewsheet.service.VSExportService;
+import inetsoft.web.wiz.model.ExportViewsheetRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -84,21 +86,11 @@ public class WizExportController {
       return assemblyImageServiceProxy.checkExporting(runtimeId, principal);
    }
 
+   // request is an unannotated bean parameter — Spring binds it implicitly from the same query
+   // params the old per-field @RequestParam list declared (see ExportViewsheetRequest's own doc).
    @GetMapping("/viewsheet/export")
-   public void exportViewsheet(@RequestParam("runtimeId") String runtimeId,
-                               @RequestParam("format") int format,
-                               @RequestParam(value = "match", defaultValue = "true") boolean match,
-                               @RequestParam(value = "expandSelections", defaultValue = "false") boolean expandSelections,
-                               @RequestParam(value = "current", defaultValue = "true") boolean current,
-                               @RequestParam(value = "bookmarks", defaultValue = "") String bookmarksParam,
-                               @RequestParam(value = "onlyDataComponents", defaultValue = "false") boolean onlyDataComponents,
-                               @RequestParam(value = "exportAllTabbedTables", defaultValue = "false") boolean exportAllTabbedTables,
-                               @RequestParam(value = "delimiter", required = false) String delimiter,
-                               @RequestParam(value = "quote", required = false) String quote,
-                               @RequestParam(value = "keepHeader", defaultValue = "true") boolean keepHeader,
-                               @RequestParam(value = "tabDelimited", defaultValue = "false") boolean tabDelimited,
-                               @RequestParam(value = "tableAssemblies", defaultValue = "") String tableAssembliesParam,
-                               Principal principal, HttpServletResponse response) throws Exception
+   public void exportViewsheet(ExportViewsheetRequest request, Principal principal,
+                               HttpServletResponse response) throws Exception
    {
       if(!securityEngine.checkPermission(principal, ResourceType.VIEWSHEET_TOOLBAR_ACTION,
          "Export", ResourceAction.READ))
@@ -106,8 +98,20 @@ public class WizExportController {
          throw new SecurityException("Permission denied: viewsheet export");
       }
 
+      // The individual @RequestParam("runtimeId") this replaced was required (no defaultValue),
+      // so Spring 400'd automatically on a missing value; the implicit-bean binding above does
+      // not, so that same "fail loud on a missing required param" guarantee has to be explicit.
+      if(Tool.isEmptyString(request.getRuntimeId())) {
+         throw new IllegalArgumentException("Missing required parameter: runtimeId");
+      }
+
+      String bookmarksParam = request.getBookmarks();
+      String tableAssembliesParam = request.getTableAssemblies();
       String[] bookmarks = bookmarksParam.isEmpty() ? new String[0] : bookmarksParam.split(",");
       String[] tables = tableAssembliesParam.isEmpty() ? new String[0] : tableAssembliesParam.split(",");
+
+      int format = request.getFormat();
+      boolean match = request.isMatch();
 
       // Mirrors ExportController.exportViewsheet0()'s override: CSV data must always be fully
       // expanded rather than clipped to the on-screen layout, regardless of what the caller asked
@@ -118,23 +122,24 @@ public class WizExportController {
 
       CSVConfig csvConfig = new CSVConfig();
 
-      if(delimiter != null) {
-         csvConfig.setDelimiter(delimiter);
+      if(request.getDelimiter() != null) {
+         csvConfig.setDelimiter(request.getDelimiter());
       }
 
-      if(quote != null) {
-         csvConfig.setQuote(quote);
+      if(request.getQuote() != null) {
+         csvConfig.setQuote(request.getQuote());
       }
 
-      csvConfig.setKeepHeader(keepHeader);
-      csvConfig.setTabDelimited(tabDelimited);
+      csvConfig.setKeepHeader(request.isKeepHeader());
+      csvConfig.setTabDelimited(request.isTabDelimited());
       csvConfig.setExportAssemblies(Arrays.asList(tables));
 
       // type=null (no output-extension override), matchesAssetIdFormat=false (see class doc),
       // previewPrintLayout=false, print=false — wiz never sets either of the last two.
       ExportControllerService.ViewsheetExportResult result = exportControllerServiceProxy.exportViewsheet(
-         runtimeId, format, null, false, match, expandSelections, current, false, false,
-         bookmarks, onlyDataComponents, exportAllTabbedTables, csvConfig, principal);
+         request.getRuntimeId(), format, null, false, match, request.isExpandSelections(),
+         request.isCurrent(), false, false, bookmarks, request.isOnlyDataComponents(),
+         request.isExportAllTabbedTables(), csvConfig, principal);
 
       VSExportService.setResponseHeader(new ExportResponse(response), result.getSuffix(),
          "attachment", result.getFileName(), result.getMime());

--- a/core/src/main/java/inetsoft/web/wiz/model/ExportViewsheetRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/ExportViewsheetRequest.java
@@ -17,19 +17,20 @@
  */
 package inetsoft.web.wiz.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 /**
- * Query parameters for {@code GET /api/wiz/viewsheet/export}.
- *
- * <p>An unannotated bean parameter on a {@code @GetMapping} method is bound by Spring's implicit
- * {@code ModelAttribute} resolution from request parameters of the same name — no
- * {@code @RequestBody}/JSON involved, and the wire format (plain query string) is unchanged, so
- * this stays a simple GET the browser can navigate to / download from directly.
+ * Request body for {@code POST /api/wiz/viewsheet/export}, replacing what used to be 13
+ * individual {@code @RequestParam}-annotated primitives on the controller method — matches the
+ * established {@code inetsoft.web.wiz.model.*Request} convention used elsewhere in this package
+ * (see {@link GeoApplyRequest}, {@link ChartFormatRequest}).
  *
  * <p>The field initializers below reproduce the {@code defaultValue} each replaced
- * {@code @RequestParam} used to declare: Spring's data binder only overwrites a property when a
- * matching request parameter is actually present, so an absent query param keeps the value
- * initialized here.
+ * {@code @RequestParam} used to declare: Jackson only overwrites a property when the
+ * corresponding JSON key is actually present, so an absent field keeps the value initialized
+ * here.
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ExportViewsheetRequest {
    public String getRuntimeId() {
       return runtimeId;

--- a/core/src/main/java/inetsoft/web/wiz/model/ExportViewsheetRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/ExportViewsheetRequest.java
@@ -1,0 +1,151 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+/**
+ * Query parameters for {@code GET /api/wiz/viewsheet/export}.
+ *
+ * <p>An unannotated bean parameter on a {@code @GetMapping} method is bound by Spring's implicit
+ * {@code ModelAttribute} resolution from request parameters of the same name — no
+ * {@code @RequestBody}/JSON involved, and the wire format (plain query string) is unchanged, so
+ * this stays a simple GET the browser can navigate to / download from directly.
+ *
+ * <p>The field initializers below reproduce the {@code defaultValue} each replaced
+ * {@code @RequestParam} used to declare: Spring's data binder only overwrites a property when a
+ * matching request parameter is actually present, so an absent query param keeps the value
+ * initialized here.
+ */
+public class ExportViewsheetRequest {
+   public String getRuntimeId() {
+      return runtimeId;
+   }
+
+   public void setRuntimeId(String runtimeId) {
+      this.runtimeId = runtimeId;
+   }
+
+   public int getFormat() {
+      return format;
+   }
+
+   public void setFormat(int format) {
+      this.format = format;
+   }
+
+   public boolean isMatch() {
+      return match;
+   }
+
+   public void setMatch(boolean match) {
+      this.match = match;
+   }
+
+   public boolean isExpandSelections() {
+      return expandSelections;
+   }
+
+   public void setExpandSelections(boolean expandSelections) {
+      this.expandSelections = expandSelections;
+   }
+
+   public boolean isCurrent() {
+      return current;
+   }
+
+   public void setCurrent(boolean current) {
+      this.current = current;
+   }
+
+   public String getBookmarks() {
+      return bookmarks;
+   }
+
+   public void setBookmarks(String bookmarks) {
+      this.bookmarks = bookmarks;
+   }
+
+   public boolean isOnlyDataComponents() {
+      return onlyDataComponents;
+   }
+
+   public void setOnlyDataComponents(boolean onlyDataComponents) {
+      this.onlyDataComponents = onlyDataComponents;
+   }
+
+   public boolean isExportAllTabbedTables() {
+      return exportAllTabbedTables;
+   }
+
+   public void setExportAllTabbedTables(boolean exportAllTabbedTables) {
+      this.exportAllTabbedTables = exportAllTabbedTables;
+   }
+
+   public String getDelimiter() {
+      return delimiter;
+   }
+
+   public void setDelimiter(String delimiter) {
+      this.delimiter = delimiter;
+   }
+
+   public String getQuote() {
+      return quote;
+   }
+
+   public void setQuote(String quote) {
+      this.quote = quote;
+   }
+
+   public boolean isKeepHeader() {
+      return keepHeader;
+   }
+
+   public void setKeepHeader(boolean keepHeader) {
+      this.keepHeader = keepHeader;
+   }
+
+   public boolean isTabDelimited() {
+      return tabDelimited;
+   }
+
+   public void setTabDelimited(boolean tabDelimited) {
+      this.tabDelimited = tabDelimited;
+   }
+
+   public String getTableAssemblies() {
+      return tableAssemblies;
+   }
+
+   public void setTableAssemblies(String tableAssemblies) {
+      this.tableAssemblies = tableAssemblies;
+   }
+
+   private String runtimeId;
+   private int format;
+   private boolean match = true;
+   private boolean expandSelections = false;
+   private boolean current = true;
+   private String bookmarks = "";
+   private boolean onlyDataComponents = false;
+   private boolean exportAllTabbedTables = false;
+   private String delimiter;
+   private String quote;
+   private boolean keepHeader = true;
+   private boolean tabDelimited = false;
+   private String tableAssemblies = "";
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/ExportViewsheetRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/ExportViewsheetRequest.java
@@ -28,7 +28,11 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  * <p>The field initializers below reproduce the {@code defaultValue} each replaced
  * {@code @RequestParam} used to declare: Jackson only overwrites a property when the
  * corresponding JSON key is actually present, so an absent field keeps the value initialized
- * here.
+ * here. {@code runtimeId} and {@code format} are the two exceptions — both used to be declared
+ * with no {@code defaultValue} (i.e. required, auto-rejected by Spring with a 400 when missing),
+ * so they are left unset (null) here and explicitly checked in
+ * {@link inetsoft.web.wiz.controller.WizExportController#exportViewsheet} instead, to reproduce
+ * that same fail-fast behavior rather than silently proceeding with a null/zero value.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ExportViewsheetRequest {
@@ -40,11 +44,11 @@ public class ExportViewsheetRequest {
       this.runtimeId = runtimeId;
    }
 
-   public int getFormat() {
+   public Integer getFormat() {
       return format;
    }
 
-   public void setFormat(int format) {
+   public void setFormat(Integer format) {
       this.format = format;
    }
 
@@ -137,7 +141,7 @@ public class ExportViewsheetRequest {
    }
 
    private String runtimeId;
-   private int format;
+   private Integer format;
    private boolean match = true;
    private boolean expandSelections = false;
    private boolean current = true;

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizEmailControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizEmailControllerTest.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.controller;
+
+import inetsoft.web.viewsheet.controller.dialog.EmailDialogServiceProxy;
+import inetsoft.web.viewsheet.model.dialog.EmailDialogModel;
+import inetsoft.web.viewsheet.model.dialog.MessageDialogModel;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@Tag("core")
+class WizEmailControllerTest {
+
+   @Test
+   void getEmailDialogModelDelegatesToProxy() throws Exception {
+      EmailDialogServiceProxy proxy = mock(EmailDialogServiceProxy.class);
+      Principal principal = mock(Principal.class);
+      EmailDialogModel model = mock(EmailDialogModel.class);
+      when(proxy.getEmailDialogModel("rt1", principal)).thenReturn(model);
+
+      WizEmailController ctrl = new WizEmailController(proxy);
+
+      assertSame(model, ctrl.getEmailDialogModel("rt1", principal));
+   }
+
+   @Test
+   void emailViewsheetDelegatesToProxyWithRuntimeIdBodyPrincipalAndLinkUri() throws Exception {
+      EmailDialogServiceProxy proxy = mock(EmailDialogServiceProxy.class);
+      Principal principal = mock(Principal.class);
+      EmailDialogModel body = mock(EmailDialogModel.class);
+      MessageDialogModel expected = mock(MessageDialogModel.class);
+      when(proxy.emailViewsheet("rt1", body, principal, "http://host/link")).thenReturn(expected);
+
+      WizEmailController ctrl = new WizEmailController(proxy);
+
+      assertSame(expected, ctrl.emailViewsheet("rt1", body, principal, "http://host/link"));
+   }
+
+   @Test
+   void emailViewsheetReturnsTheProxysFailureResultUnchangedOnSmtpFailure() throws Exception {
+      // EmailDialogService.emailViewsheet() already catches SMTP/send failures internally and
+      // returns a MessageDialogModel with success=false rather than throwing -- this controller
+      // must not swallow or reinterpret that, just pass it straight through.
+      EmailDialogServiceProxy proxy = mock(EmailDialogServiceProxy.class);
+      Principal principal = mock(Principal.class);
+      EmailDialogModel body = mock(EmailDialogModel.class);
+      MessageDialogModel failure = mock(MessageDialogModel.class);
+      when(failure.success()).thenReturn(false);
+      when(proxy.emailViewsheet("rt1", body, principal, "http://host/link")).thenReturn(failure);
+
+      WizEmailController ctrl = new WizEmailController(proxy);
+
+      MessageDialogModel result = ctrl.emailViewsheet("rt1", body, principal, "http://host/link");
+      assertSame(failure, result);
+      assertFalse(result.success());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizExportControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizExportControllerTest.java
@@ -67,8 +67,8 @@ class WizExportControllerTest {
    }
 
    /** Mirrors the field defaults ExportViewsheetRequest itself declares (i.e. what an absent
-    *  query param would leave in place), so each test only sets what it actually cares about. */
-   private static ExportViewsheetRequest request(String runtimeId, int format) {
+    *  JSON field would leave in place), so each test only sets what it actually cares about. */
+   private static ExportViewsheetRequest request(String runtimeId, Integer format) {
       ExportViewsheetRequest request = new ExportViewsheetRequest();
       request.setRuntimeId(runtimeId);
       request.setFormat(format);
@@ -253,6 +253,27 @@ class WizExportControllerTest {
 
       assertThrows(IllegalArgumentException.class, () -> ctrl.exportViewsheet(
          request(null, FileFormatInfo.EXPORT_TYPE_EXCEL), principal, mock(HttpServletResponse.class)));
+
+      verifyNoInteractions(exportControllerServiceProxy);
+   }
+
+   @Test
+   void throwsWhenFormatIsMissing() throws Exception {
+      // Same category of regression as throwsWhenRuntimeIdIsMissing: format used to be
+      // @RequestParam("format") int format with no defaultValue (required, auto-400 on missing).
+      // ExportViewsheetRequest.format must reject a missing value just as loudly instead of
+      // silently defaulting to 0 (FileFormatInfo.EXPORT_TYPE_EXCEL) and exporting the wrong format.
+      SecurityEngine sec = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+      when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
+      ExportControllerServiceProxy exportControllerServiceProxy = mock(ExportControllerServiceProxy.class);
+
+      WizExportController ctrl = new WizExportController(
+         mock(ExportDialogServiceProxy.class), exportControllerServiceProxy,
+         mock(AssemblyImageServiceProxy.class), mock(BinaryTransferService.class), sec);
+
+      assertThrows(IllegalArgumentException.class, () -> ctrl.exportViewsheet(
+         request("rt1", null), principal, mock(HttpServletResponse.class)));
 
       verifyNoInteractions(exportControllerServiceProxy);
    }

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizExportControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizExportControllerTest.java
@@ -31,6 +31,7 @@ import inetsoft.web.viewsheet.command.MessageCommand;
 import inetsoft.web.viewsheet.controller.AssemblyImageServiceProxy;
 import inetsoft.web.viewsheet.controller.dialog.ExportDialogServiceProxy;
 import inetsoft.web.viewsheet.model.dialog.ExportDialogModel;
+import inetsoft.web.wiz.model.ExportViewsheetRequest;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.WriteListener;
 import jakarta.servlet.http.HttpServletResponse;
@@ -63,6 +64,15 @@ class WizExportControllerTest {
             sink.write(b);
          }
       };
+   }
+
+   /** Mirrors the field defaults ExportViewsheetRequest itself declares (i.e. what an absent
+    *  query param would leave in place), so each test only sets what it actually cares about. */
+   private static ExportViewsheetRequest request(String runtimeId, int format) {
+      ExportViewsheetRequest request = new ExportViewsheetRequest();
+      request.setRuntimeId(runtimeId);
+      request.setFormat(format);
+      return request;
    }
 
    @Test
@@ -107,9 +117,7 @@ class WizExportControllerTest {
          mock(AssemblyImageServiceProxy.class), mock(BinaryTransferService.class), sec);
 
       assertThrows(SecurityException.class, () -> ctrl.exportViewsheet(
-         "rt1", FileFormatInfo.EXPORT_TYPE_EXCEL, true, false, true, "",
-         false, false, null, null, true, false, "",
-         principal, mock(HttpServletResponse.class)));
+         request("rt1", FileFormatInfo.EXPORT_TYPE_EXCEL), principal, mock(HttpServletResponse.class)));
 
       verifyNoInteractions(exportControllerServiceProxy);
    }
@@ -142,8 +150,11 @@ class WizExportControllerTest {
          mock(AssemblyImageServiceProxy.class), mock(BinaryTransferService.class), sec);
 
       // match=true is explicitly requested, but format=CSV must override it to false.
-      ctrl.exportViewsheet("rt1", FileFormatInfo.EXPORT_TYPE_CSV, true, false, true, "",
-         false, false, ",", "\"", true, false, "", principal, response);
+      ExportViewsheetRequest request = request("rt1", FileFormatInfo.EXPORT_TYPE_CSV);
+      request.setMatch(true);
+      request.setDelimiter(",");
+      request.setQuote("\"");
+      ctrl.exportViewsheet(request, principal, response);
 
       verify(exportControllerServiceProxy).exportViewsheet(
          eq("rt1"), eq(FileFormatInfo.EXPORT_TYPE_CSV), isNull(), eq(false), eq(false),
@@ -177,8 +188,9 @@ class WizExportControllerTest {
 
       // match=true (Match Layout) requested for a non-CSV format must reach the service
       // unchanged -- only CSV forces an override to false, so this must NOT be flipped.
-      ctrl.exportViewsheet("rt1", FileFormatInfo.EXPORT_TYPE_EXCEL, true, false, true, "",
-         false, false, null, null, true, false, "", principal, response);
+      ExportViewsheetRequest request = request("rt1", FileFormatInfo.EXPORT_TYPE_EXCEL);
+      request.setMatch(true);
+      ctrl.exportViewsheet(request, principal, response);
 
       verify(exportControllerServiceProxy).exportViewsheet(
          eq("rt1"), eq(FileFormatInfo.EXPORT_TYPE_EXCEL), isNull(), eq(false), eq(true),
@@ -210,9 +222,12 @@ class WizExportControllerTest {
          mock(ExportDialogServiceProxy.class), exportControllerServiceProxy,
          mock(AssemblyImageServiceProxy.class), mock(BinaryTransferService.class), sec);
 
-      ctrl.exportViewsheet("rt1", FileFormatInfo.EXPORT_TYPE_CSV, true, false, true,
-         "(Home),My Bookmark", false, false, ",", "\"", true, false,
-         "Table1,Table2", principal, response);
+      ExportViewsheetRequest request = request("rt1", FileFormatInfo.EXPORT_TYPE_CSV);
+      request.setBookmarks("(Home),My Bookmark");
+      request.setDelimiter(",");
+      request.setQuote("\"");
+      request.setTableAssemblies("Table1,Table2");
+      ctrl.exportViewsheet(request, principal, response);
 
       verify(exportControllerServiceProxy).exportViewsheet(
          eq("rt1"), anyInt(), any(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(),
@@ -220,5 +235,25 @@ class WizExportControllerTest {
          eq(new String[] { "(Home)", "My Bookmark" }), anyBoolean(), anyBoolean(),
          argThat(cfg -> cfg.getExportAssemblies().equals(java.util.List.of("Table1", "Table2"))),
          eq(principal));
+   }
+
+   @Test
+   void throwsWhenRuntimeIdIsMissing() throws Exception {
+      // Switching from individual @RequestParam("runtimeId") (required, auto-400) to a single
+      // bound request object loses Spring's automatic "missing required parameter" rejection --
+      // this must fail just as loudly instead of silently calling the proxy with a null runtimeId.
+      SecurityEngine sec = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+      when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
+      ExportControllerServiceProxy exportControllerServiceProxy = mock(ExportControllerServiceProxy.class);
+
+      WizExportController ctrl = new WizExportController(
+         mock(ExportDialogServiceProxy.class), exportControllerServiceProxy,
+         mock(AssemblyImageServiceProxy.class), mock(BinaryTransferService.class), sec);
+
+      assertThrows(IllegalArgumentException.class, () -> ctrl.exportViewsheet(
+         request(null, FileFormatInfo.EXPORT_TYPE_EXCEL), principal, mock(HttpServletResponse.class)));
+
+      verifyNoInteractions(exportControllerServiceProxy);
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizExportControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizExportControllerTest.java
@@ -1,0 +1,224 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.controller;
+
+import inetsoft.report.io.csv.CSVConfig;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
+import inetsoft.uql.viewsheet.FileFormatInfo;
+import inetsoft.util.cachefs.BinaryTransfer;
+import inetsoft.web.composer.vs.controller.ExportControllerService;
+import inetsoft.web.composer.vs.controller.ExportControllerServiceProxy;
+import inetsoft.web.service.BinaryTransferService;
+import inetsoft.web.viewsheet.command.MessageCommand;
+import inetsoft.web.viewsheet.controller.AssemblyImageServiceProxy;
+import inetsoft.web.viewsheet.controller.dialog.ExportDialogServiceProxy;
+import inetsoft.web.viewsheet.model.dialog.ExportDialogModel;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class WizExportControllerTest {
+
+   private static ServletOutputStream capturingOutputStream(ByteArrayOutputStream sink) {
+      return new ServletOutputStream() {
+         @Override
+         public boolean isReady() {
+            return true;
+         }
+
+         @Override
+         public void setWriteListener(WriteListener writeListener) {
+         }
+
+         @Override
+         public void write(int b) {
+            sink.write(b);
+         }
+      };
+   }
+
+   @Test
+   void getExportDialogModelDelegatesToProxy() throws Exception {
+      ExportDialogServiceProxy exportDialogServiceProxy = mock(ExportDialogServiceProxy.class);
+      Principal principal = mock(Principal.class);
+      ExportDialogModel model = mock(ExportDialogModel.class);
+      when(exportDialogServiceProxy.getExportDialogModel("rt1", principal)).thenReturn(model);
+
+      WizExportController ctrl = new WizExportController(
+         exportDialogServiceProxy, mock(ExportControllerServiceProxy.class),
+         mock(AssemblyImageServiceProxy.class), mock(BinaryTransferService.class),
+         mock(SecurityEngine.class));
+
+      assertSame(model, ctrl.getExportDialogModel("rt1", principal));
+   }
+
+   @Test
+   void checkExportingDelegatesToProxy() throws Exception {
+      AssemblyImageServiceProxy assemblyImageServiceProxy = mock(AssemblyImageServiceProxy.class);
+      Principal principal = mock(Principal.class);
+      MessageCommand command = mock(MessageCommand.class);
+      when(assemblyImageServiceProxy.checkExporting("rt1", principal)).thenReturn(command);
+
+      WizExportController ctrl = new WizExportController(
+         mock(ExportDialogServiceProxy.class), mock(ExportControllerServiceProxy.class),
+         assemblyImageServiceProxy, mock(BinaryTransferService.class), mock(SecurityEngine.class));
+
+      assertSame(command, ctrl.checkExporting("rt1", principal));
+   }
+
+   @Test
+   void deniesExportWhenPermissionMissing() throws Exception {
+      ExportControllerServiceProxy exportControllerServiceProxy = mock(ExportControllerServiceProxy.class);
+      SecurityEngine sec = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+      when(sec.checkPermission(eq(principal), eq(ResourceType.VIEWSHEET_TOOLBAR_ACTION),
+         eq("Export"), eq(ResourceAction.READ))).thenReturn(false);
+
+      WizExportController ctrl = new WizExportController(
+         mock(ExportDialogServiceProxy.class), exportControllerServiceProxy,
+         mock(AssemblyImageServiceProxy.class), mock(BinaryTransferService.class), sec);
+
+      assertThrows(SecurityException.class, () -> ctrl.exportViewsheet(
+         "rt1", FileFormatInfo.EXPORT_TYPE_EXCEL, true, false, true, "",
+         false, false, null, null, true, false, "",
+         principal, mock(HttpServletResponse.class)));
+
+      verifyNoInteractions(exportControllerServiceProxy);
+   }
+
+   @Test
+   void csvFormatForcesMatchFalseRegardlessOfRequestedMatch() throws Exception {
+      // Regression test: mirrors ExportController.exportViewsheet0()'s
+      // `if(format == EXPORT_TYPE_CSV) { match = false; }` override, which this controller
+      // originally omitted -- a caller-supplied match=true for CSV must still reach the service
+      // as false, or CSV exports come back clipped to the on-screen layout instead of expanded.
+      ExportControllerServiceProxy exportControllerServiceProxy = mock(ExportControllerServiceProxy.class);
+      SecurityEngine sec = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+      when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
+
+      BinaryTransfer data = mock(BinaryTransfer.class);
+      ExportControllerService.ViewsheetExportResult result =
+         new ExportControllerService.ViewsheetExportResult(data, "export.csv", "text/csv", "csv");
+      when(exportControllerServiceProxy.exportViewsheet(
+         eq("rt1"), eq(FileFormatInfo.EXPORT_TYPE_CSV), isNull(), eq(false), eq(false),
+         anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), any(String[].class),
+         anyBoolean(), anyBoolean(), any(CSVConfig.class), eq(principal)))
+         .thenReturn(result);
+
+      HttpServletResponse response = mock(HttpServletResponse.class);
+      when(response.getOutputStream()).thenReturn(capturingOutputStream(new ByteArrayOutputStream()));
+
+      WizExportController ctrl = new WizExportController(
+         mock(ExportDialogServiceProxy.class), exportControllerServiceProxy,
+         mock(AssemblyImageServiceProxy.class), mock(BinaryTransferService.class), sec);
+
+      // match=true is explicitly requested, but format=CSV must override it to false.
+      ctrl.exportViewsheet("rt1", FileFormatInfo.EXPORT_TYPE_CSV, true, false, true, "",
+         false, false, ",", "\"", true, false, "", principal, response);
+
+      verify(exportControllerServiceProxy).exportViewsheet(
+         eq("rt1"), eq(FileFormatInfo.EXPORT_TYPE_CSV), isNull(), eq(false), eq(false),
+         anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), any(String[].class),
+         anyBoolean(), anyBoolean(), any(CSVConfig.class), eq(principal));
+   }
+
+   @Test
+   void nonCsvFormatPassesRequestedMatchThrough() throws Exception {
+      ExportControllerServiceProxy exportControllerServiceProxy = mock(ExportControllerServiceProxy.class);
+      SecurityEngine sec = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+      when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
+
+      BinaryTransfer data = mock(BinaryTransfer.class);
+      ExportControllerService.ViewsheetExportResult result = new ExportControllerService.ViewsheetExportResult(
+         data, "export.xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "xlsx");
+      when(exportControllerServiceProxy.exportViewsheet(
+         eq("rt1"), eq(FileFormatInfo.EXPORT_TYPE_EXCEL), isNull(), eq(false), eq(true),
+         anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), any(String[].class),
+         anyBoolean(), anyBoolean(), any(CSVConfig.class), eq(principal)))
+         .thenReturn(result);
+
+      HttpServletResponse response = mock(HttpServletResponse.class);
+      when(response.getOutputStream()).thenReturn(capturingOutputStream(new ByteArrayOutputStream()));
+
+      BinaryTransferService binaryTransferService = mock(BinaryTransferService.class);
+      WizExportController ctrl = new WizExportController(
+         mock(ExportDialogServiceProxy.class), exportControllerServiceProxy,
+         mock(AssemblyImageServiceProxy.class), binaryTransferService, sec);
+
+      // match=true (Match Layout) requested for a non-CSV format must reach the service
+      // unchanged -- only CSV forces an override to false, so this must NOT be flipped.
+      ctrl.exportViewsheet("rt1", FileFormatInfo.EXPORT_TYPE_EXCEL, true, false, true, "",
+         false, false, null, null, true, false, "", principal, response);
+
+      verify(exportControllerServiceProxy).exportViewsheet(
+         eq("rt1"), eq(FileFormatInfo.EXPORT_TYPE_EXCEL), isNull(), eq(false), eq(true),
+         anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), any(String[].class),
+         anyBoolean(), anyBoolean(), any(CSVConfig.class), eq(principal));
+      verify(binaryTransferService).writeData(eq(data), any());
+   }
+
+   @Test
+   void bookmarksAndTableAssembliesAreSplitOnComma() throws Exception {
+      ExportControllerServiceProxy exportControllerServiceProxy = mock(ExportControllerServiceProxy.class);
+      SecurityEngine sec = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+      when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
+
+      BinaryTransfer data = mock(BinaryTransfer.class);
+      ExportControllerService.ViewsheetExportResult result =
+         new ExportControllerService.ViewsheetExportResult(data, "export.csv", "text/csv", "csv");
+      when(exportControllerServiceProxy.exportViewsheet(
+         any(), anyInt(), any(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(),
+         anyBoolean(), anyBoolean(), any(String[].class), anyBoolean(), anyBoolean(),
+         any(CSVConfig.class), any()))
+         .thenReturn(result);
+
+      HttpServletResponse response = mock(HttpServletResponse.class);
+      when(response.getOutputStream()).thenReturn(capturingOutputStream(new ByteArrayOutputStream()));
+
+      WizExportController ctrl = new WizExportController(
+         mock(ExportDialogServiceProxy.class), exportControllerServiceProxy,
+         mock(AssemblyImageServiceProxy.class), mock(BinaryTransferService.class), sec);
+
+      ctrl.exportViewsheet("rt1", FileFormatInfo.EXPORT_TYPE_CSV, true, false, true,
+         "(Home),My Bookmark", false, false, ",", "\"", true, false,
+         "Table1,Table2", principal, response);
+
+      verify(exportControllerServiceProxy).exportViewsheet(
+         eq("rt1"), anyInt(), any(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(),
+         anyBoolean(), anyBoolean(),
+         eq(new String[] { "(Home)", "My Bookmark" }), anyBoolean(), anyBoolean(),
+         argThat(cfg -> cfg.getExportAssemblies().equals(java.util.List.of("Table1", "Table2"))),
+         eq(principal));
+   }
+}


### PR DESCRIPTION
## Summary
- Adds `WizExportController` and `WizEmailController` under `inetsoft.web.wiz.controller`, wrapping the same services that already back StyleBI's native `/api/vs/export-dialog-model`, `/export/viewsheet`, `/export/check` and `/api/vs/email-dialog-model` endpoints (`ExportDialogService`, `ExportControllerService`, `AssemblyImageService.checkExporting`, `EmailDialogService`) — no export/email logic is reimplemented, these are thin proxies.
- Motivation: wiz's frontend previously called StyleBI's native, session/CSRF-protected controllers directly, which required replicating StyleBI's `Tool.byteEncode` runtime-id path-escaping scheme and (for the email POST) the double-submit `XSRF-TOKEN` cookie/header dance. Routing through `/api/wiz` instead means:
  - `runtimeId` travels as a plain query parameter (no path-escaping needed).
  - The namespace is JWT-authenticated (`WizServiceAuthenticationFilter`) and CSRF-exempt (`CSRFFilter#isWizApi`), so the email POST needs no CSRF handling.
- `WizExportController` explicitly checks the `VIEWSHEET_TOOLBAR_ACTION`/`Export` permission before exporting (mirrors `ExportController`'s own check, which lives in the controller rather than the service).

## Endpoints added
- `GET /api/wiz/viewsheet/export-dialog-model?runtimeId=`
- `GET /api/wiz/viewsheet/export?runtimeId=&format=&match=&...`
- `GET /api/wiz/viewsheet/export-check?runtimeId=`
- `GET /api/wiz/viewsheet/email-dialog-model?runtimeId=`
- `POST /api/wiz/viewsheet/email?runtimeId=` (body: `EmailDialogModel`)

## Test plan
- [x] `mvn -pl core compile` — compiles cleanly against the real service/proxy signatures (verified directly against the generated `ExportControllerServiceProxy`/`ExportDialogServiceProxy`/`EmailDialogServiceProxy`/`AssemblyImageServiceProxy` classes, not guessed).
- [ ] Manual verification against a live StyleBI instance from the wiz frontend (which already calls these paths — see the corresponding wiz-side PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)