### PR TITLE
Stop a null property value reading as "no such property"

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/ai/AdminPropertiesController.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminPropertiesController.java
@@ -105,21 +105,35 @@ public class AdminPropertiesController {
    private PropertyView view(AdminPropertyName name, CatalogEntry entry) {
       AdminRiskClassifier.RiskClassification risk = classifier.classify(name);
       String description = entry == null ? null : entry.description();
-      String current;
+      boolean secret = AdminPropertyCatalog.isSecret(name.baseName());
+      // A secret's value is not read AT ALL, not merely omitted from the response - see the test
+      // that asserts SreeEnv is never called for one. Determining existence by reading it would
+      // trade that invariant for a signal the catalog supplies properly, so the secret path stays
+      // blind and reports what it actually knows.
+      //
+      // orgScope=false so the value shown is the one an apply would actually change.
+      String stored = secret ? null : SreeEnv.getProperty(name.key(), false, false);
 
       // Secret properties (e.g. password.encryption.key) are still LISTED - an operator
       // legitimately needs to know the property exists - but the value is withheld rather than
       // forwarded to the model provider that this endpoint's caller relays responses through. Not
       // a 403: the same operator role can already read this unmasked via PropertiesController, so
       // refusing to even acknowledge the property's existence would just be confusing.
-      if(AdminPropertyCatalog.isSecret(name.baseName())) {
-         current = null;
-         description = "Value withheld: secret properties are not exposed through admin-chat.";
+      //
+      // The old phrasing said "Value withheld", which asserts there is a value to withhold. This
+      // branch is reached on nothing more than a name match, so an invented name ending .key came
+      // back claiming a secret had been withheld - manufacturing evidence that the property exists
+      // out of a string suffix.
+      if(secret) {
+         description = "Secret property: admin-chat can neither read nor change it. Its value is "
+            + "not read here at all, so this says nothing about whether one is set.";
       }
-      else {
-         // orgScope=false so the value shown is the one an apply would actually change.
-         current = SreeEnv.getProperty(name.key(), false, false);
-      }
+
+      // A catalogued name is authoritative; a stored value is proof by demonstration, and covers
+      // anything declared in defaults.properties, since the defaults chain resolves through
+      // getProperty. Neither means the server cannot say whether the name is real - which is
+      // always the case for a secret, since this path deliberately never looks.
+      boolean confirmed = entry != null || stored != null;
 
       return new PropertyView(name.key(),
          entry == null ? List.of() : (entry.aliases() == null ? List.of() : entry.aliases()),
@@ -129,8 +143,19 @@ public class AdminPropertiesController {
          entry == null ? null : entry.min(),
          entry == null ? null : entry.max(),
          description,
-         risk.risk(), risk.snapshotScope(), current, risk.recognized());
+         risk.risk(), risk.snapshotScope(), stored, risk.recognized(),
+         confirmed ? PropertyView.EXISTS_CONFIRMED : PropertyView.EXISTS_UNKNOWN,
+         confirmed ? null : UNKNOWN_GUIDANCE);
    }
+
+   private static final String UNKNOWN_GUIDANCE =
+      "admin-chat cannot tell whether this property exists: it is not in the admin catalog and has "
+      + "no stored value, and a real property that nobody has set yet looks exactly like a "
+      + "misspelled name. Do NOT conclude from this that the setting is stored somewhere other "
+      + "than server properties. Confirm the spelling against the property reference "
+      + "(search_product_docs with corpus \"properties\") before including it in a change: an "
+      + "unrecognised name is written verbatim, so a typo becomes an inert property that nothing "
+      + "reads, while the change reports success.";
 
    /** See {@code AdminAiController.requireSiteAdmin} for why both checks are needed. */
    private void requireSiteAdmin(Principal user) {

--- a/core/src/main/java/inetsoft/web/admin/ai/AdminPropertiesController.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminPropertiesController.java
@@ -124,9 +124,15 @@ public class AdminPropertiesController {
       // branch is reached on nothing more than a name match, so an invented name ending .key came
       // back claiming a secret had been withheld - manufacturing evidence that the property exists
       // out of a string suffix.
+      //
+      // The replacement is worded about the NAME rather than the property for the same reason. A
+      // name match is all that is known here, so "Secret property: ..." would still assert the
+      // category, and a caller who stopped reading at the colon would take it as confirmation the
+      // property exists - the very inference `exists` was added to prevent.
       if(secret) {
-         description = "Secret property: admin-chat can neither read nor change it. Its value is "
-            + "not read here at all, so this says nothing about whether one is set.";
+         description = "This name matches admin-chat's secret pattern, so its value is neither "
+            + "read nor changed here - not even read to test whether one is present, so this says "
+            + "nothing about whether the property exists or is set.";
       }
 
       // A catalogued name is authoritative; a stored value is proof by demonstration, and covers

--- a/core/src/main/java/inetsoft/web/admin/ai/PropertyView.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/PropertyView.java
@@ -19,10 +19,29 @@ package inetsoft.web.admin.ai;
 
 import java.util.List;
 
-/** Catalog metadata plus the current value, for plugin/agent discovery. */
+/**
+ * Catalog metadata plus the current value, for plugin/agent discovery.
+ *
+ * @param exists   whether the property demonstrably exists in StyleBI: {@code confirmed} when it is
+ *                 catalogued or has a stored value, {@code unknown} otherwise. Two distinct things
+ *                 produce a null {@code currentValue} on an uncatalogued property — a real property
+ *                 nobody has set yet, and a name that does not exist at all — and the server cannot
+ *                 tell them apart, because the only evidence a bare {@code SreeEnv} property exists
+ *                 is a read site in Java source. Reporting that ambiguity is the point: a caller
+ *                 that reads a null value as "no such property" will conclude the setting lives
+ *                 somewhere else, and a caller that reads it as "exists, unset" will happily write a
+ *                 typo. Both have happened.
+ * @param guidance what to do about an {@code unknown} property; null when {@code exists} is
+ *                 {@code confirmed}.
+ */
 public record PropertyView(String name, List<String> aliases, String type,
                            List<String> allowedValues, Integer min, Integer max,
                            String description, String risk, String snapshotScope,
-                           String currentValue, boolean recognized)
+                           String currentValue, boolean recognized,
+                           String exists, String guidance)
 {
+   /** The property is catalogued, or holds a value; either way it is real. */
+   public static final String EXISTS_CONFIRMED = "confirmed";
+   /** Uncatalogued and unset — indistinguishable from a name that does not exist. */
+   public static final String EXISTS_UNKNOWN = "unknown";
 }

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminPropertiesControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminPropertiesControllerTest.java
@@ -186,6 +186,10 @@ class AdminPropertiesControllerTest {
       assertEquals(PropertyView.EXISTS_UNKNOWN, invented.exists());
       assertNotNull(invented.guidance());
       assertFalse(invented.description().contains("Value withheld"));
+      // The description must be about the NAME, not the property: a caller who stops reading at
+      // the first clause must not come away with "this exists and is a secret".
+      assertFalse(invented.description().startsWith("Secret property"));
+      assertTrue(invented.description().contains("name"));
       sreeEnv.verify(
          () -> SreeEnv.getProperty("openid.completely.made.up.key", false, false), never());
    }

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminPropertiesControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminPropertiesControllerTest.java
@@ -142,6 +142,71 @@ class AdminPropertiesControllerTest {
    }
 
    @Test
+   void confirmsExistenceOfACataloguedProperty() {
+      sreeEnv.when(() -> SreeEnv.getProperty("query.runtime.maxrow", false, false))
+         .thenReturn(null);
+      PropertyView view = controller.get("query.runtime.maxrow", principal);
+      // Catalogued but unset: the catalog alone settles that the name is real.
+      assertEquals(PropertyView.EXISTS_CONFIRMED, view.exists());
+      assertNull(view.guidance());
+   }
+
+   @Test
+   void confirmsExistenceOfAnUncataloguedPropertyThatHoldsAValue() {
+      // Covers anything declared in defaults.properties: the defaults chain resolves through
+      // getProperty, so a declared-but-never-set property still reads non-null.
+      sreeEnv.when(() -> SreeEnv.getProperty("role.administrator", false, false))
+         .thenReturn("Administrator");
+      PropertyView view = controller.get("role.administrator", principal);
+      assertFalse(view.recognized());
+      assertEquals(PropertyView.EXISTS_CONFIRMED, view.exists());
+      assertNull(view.guidance());
+   }
+
+   @Test
+   void reportsExistenceAsUnknownWhenUncataloguedAndUnset() {
+      // The regression this whole field exists for. openid.client.id is a real property with a
+      // read site in OpenIDConfig, but on a server where SSO has never been configured it is
+      // unset and uncatalogued - byte-identical to a name that does not exist. An agent read that
+      // as "OIDC settings are not stored in server properties" and abandoned the task.
+      sreeEnv.when(() -> SreeEnv.getProperty("openid.client.id", false, false)).thenReturn(null);
+      PropertyView view = controller.get("openid.client.id", principal);
+      assertFalse(view.recognized());
+      assertNull(view.currentValue());
+      assertEquals(PropertyView.EXISTS_UNKNOWN, view.exists());
+      assertNotNull(view.guidance());
+   }
+
+   @Test
+   void doesNotClaimAValueWasWithheldForANameThatMerelyLooksSecret() {
+      // isSecret matches on the name alone, so an invented name ending .key took the secret
+      // branch and came back asserting a secret had been withheld - inventing evidence that the
+      // property exists out of a string suffix. It must report that it does not know instead.
+      PropertyView invented = controller.get("openid.completely.made.up.key", principal);
+      assertEquals(PropertyView.EXISTS_UNKNOWN, invented.exists());
+      assertNotNull(invented.guidance());
+      assertFalse(invented.description().contains("Value withheld"));
+      sreeEnv.verify(
+         () -> SreeEnv.getProperty("openid.completely.made.up.key", false, false), never());
+   }
+
+   @Test
+   void distinguishesARealUnsetPropertyFromAnInventedOneOnlyByGuidance() {
+      // Both are unknown - the server genuinely cannot tell them apart, and the fix is to say so
+      // rather than to guess. This pins that the ambiguity is reported, not silently resolved.
+      sreeEnv.when(() -> SreeEnv.getProperty("openid.issuer", false, false)).thenReturn(null);
+      sreeEnv.when(() -> SreeEnv.getProperty("openid.not.a.real.property", false, false))
+         .thenReturn(null);
+
+      PropertyView real = controller.get("openid.issuer", principal);
+      PropertyView invented = controller.get("openid.not.a.real.property", principal);
+
+      assertEquals(PropertyView.EXISTS_UNKNOWN, real.exists());
+      assertEquals(PropertyView.EXISTS_UNKNOWN, invented.exists());
+      assertEquals(real.guidance(), invented.guidance());
+   }
+
+   @Test
    void refusesANonSiteAdmin() {
       when(orgManager.isSiteAdmin(principal)).thenReturn(false);
       assertEquals(HttpStatus.FORBIDDEN, assertThrows(ResponseStatusException.class,


### PR DESCRIPTION
`get_property` returned `currentValue: null` and `recognized: false` both for a real property nobody has set and for a name that does not exist. The two responses were byte-identical, and the only evidence a bare `SreeEnv` property exists is a read site in Java source, which the server cannot consult.

## How it surfaced

An agent configuring OIDC SSO from scratch, running with only the admin-chat plugin's tools, probed several `openid.*` names. Every one was unset, so every probe returned null. It concluded StyleBI's SSO settings *"are stored in a separate structured settings object, not in the flat sree.properties-style store admin-chat manages"* and abandoned the task, emitting hand-entry instructions instead. They are ordinary `SreeEnv` properties.

Its caution was correct — it refused to guess names into `preview_changes`, since a wrong key writes an inert property while reporting success — but the tool gave it nothing to confirm a name against.

## The change

`PropertyView` gains `exists`, plus `guidance` when it is unknown:

| | |
|---|---|
| `confirmed` | catalogued, or holds a value — proof by demonstration, and covers anything declared in `defaults.properties` since the defaults chain resolves through `getProperty` |
| `unknown` | uncatalogued **and** unset — genuinely indistinguishable from a name that does not exist, so the response says so rather than letting the caller infer |

It also stops `isSecret` manufacturing evidence. That branch is reached on a name match alone, so an invented name ending `.key` came back *"Value withheld: secret properties are not exposed through admin-chat"* — asserting a secret existed to withhold, out of a string suffix. It now states the rule without claiming a value is there.

The secret path still never reads `SreeEnv` at all. An earlier draft determined existence by reading the value and discarding it, which broke the test asserting exactly that; existence is a signal the catalog supplies properly, and buying it by reading the password-encryption master key is the wrong trade. A secret therefore reports `unknown` unless catalogued, which is honest.

## Verification

Tests 9 → 14, including the `openid.client.id` / `openid.completely.made.up.key` pair that produced the wrong conclusion. Full `admin.ai` suite (129 tests) green.

Verified live against a running server: `openid.client.id` now returns `exists: "unknown"` with guidance, and re-running the same agent task produced a correct seven-property plan instead of abandoning it.

Paired with inetsoft-technology/stylebi-wiz#PENDING, which teaches the model how to read the field.