### PR TITLE
Let admin-chat set the OIDC client secret

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/ai/AdminChangePlanService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminChangePlanService.java
@@ -18,6 +18,7 @@
 package inetsoft.web.admin.ai;
 
 import inetsoft.sree.SreeEnv;
+import inetsoft.util.Tool;
 import inetsoft.util.audit.AdminChangeRecord;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -74,14 +75,35 @@ public class AdminChangePlanService {
                "changes: duplicate entry for " + name.key() + "; list each property once");
          }
 
+         boolean credential = AdminPropertyCatalog.isEncryptedCredential(name.baseName());
+
          // Unlike the read path in AdminPropertiesController (which withholds the value but still
          // shows the property exists), a change is refused outright: this service exists to WRITE
          // a value, and blanking a secret through it would make every stored encrypted credential
          // undecryptable. See AdminPropertyCatalog.isSecret for why this is an egress/blast-radius
          // control rather than a privilege boundary.
-         if(AdminPropertyCatalog.isSecret(name.baseName())) {
+         //
+         // The exception is the small allow-list of application credentials whose accessors
+         // encrypt at rest: those are written through SreeEnv.setPassword, which encrypts exactly
+         // as the Enterprise Manager field does. Reading them is still refused - the egress
+         // rationale is about values LEAVING the host, and is untouched by letting one in.
+         if(AdminPropertyCatalog.isSecret(name.baseName()) && !credential) {
             throw new IllegalArgumentException(
                name.key() + ": secret properties cannot be changed through admin-chat");
+         }
+
+         // With cloud secrets configured, these properties hold the NAME of a secret rather than a
+         // secret - getPassword resolves it through Tool.loadCredentials and reads a client_secret
+         // field out of the JSON. Enterprise Manager swaps its Client Secret field for a Secret ID
+         // one in that mode for exactly this reason. An agent handed a literal secret would store
+         // it where a reference belongs, and nothing downstream could resolve it, so refuse rather
+         // than write a value that cannot work.
+         if(credential && Tool.isCloudSecrets()) {
+            throw new IllegalArgumentException(
+               name.key() + ": this deployment uses cloud secrets, so this property holds the ID "
+               + "of a secret rather than the secret itself. Set it from Enterprise Manager's "
+               + "Settings > Security > SSO page, whose Secret ID field writes the reference "
+               + "correctly.");
          }
 
          CatalogEntry entry = catalog.getEntry(name);
@@ -94,7 +116,16 @@ public class AdminChangePlanService {
          requireHashSafe("property", name.key());
          requireHashSafe("value", proposed);
 
-         String currentValue = SreeEnv.getProperty(name.key(), false, false);
+         // A credential's stored form is ciphertext, and the plan is relayed to a model provider by
+         // the caller. Ciphertext is not the secret, but there is no reason to ship it either, and
+         // an operator reading the plan is served better by whether one is already set than by a
+         // base64 blob. Note the consequence for the drift gate: replacing one secret with a
+         // different one is not detected between preview and apply, only set <-> unset is. That is
+         // tolerable here because the human approved "set this property to the value I supplied",
+         // which is what executes either way.
+         String currentValue = credential
+            ? (SreeEnv.getProperty(name.key(), false, false) == null ? "(not set)" : "(set)")
+            : SreeEnv.getProperty(name.key(), false, false);
          requireHashSafe("currentValue", currentValue);
 
          changes.add(new PlanChange(name.key(), name.orgId(),

--- a/core/src/main/java/inetsoft/web/admin/ai/AdminChangePlanService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminChangePlanService.java
@@ -106,6 +106,21 @@ public class AdminChangePlanService {
                + "correctly.");
          }
 
+         // Every other property in this service takes "" as an explicit set-to-empty, with null
+         // meaning reset-to-default. A credential cannot honour that: SreeEnv.setPassword guards
+         // on Tool.isEmptyString and returns without writing, so "" would leave the existing
+         // secret in place. That does fail safe - the read-back verify compares the old secret
+         // against "" and reports FAILED - but an operator trying to blank a secret would get a
+         // bare failure and no idea why, having asked for something this path cannot do. Refuse it
+         // here, where the message can say what to use instead. An empty client secret is not a
+         // valid credential in any case, so nothing legitimate is being turned away.
+         if(credential && "".equals(requested.getValue())) {
+            throw new IllegalArgumentException(
+               name.key() + ": an empty value cannot be written to a credential - the property "
+               + "would keep its current secret. Pass a null value to reset the property to its "
+               + "default, or a non-empty value to change it.");
+         }
+
          CatalogEntry entry = catalog.getEntry(name);
          // An uncatalogued property cannot be validated or canonicalized, so its value passes
          // through verbatim; the classifier marks it high risk so review flags it.

--- a/core/src/main/java/inetsoft/web/admin/ai/AdminChangePlanService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminChangePlanService.java
@@ -123,6 +123,21 @@ public class AdminChangePlanService {
          // different one is not detected between preview and apply, only set <-> unset is. That is
          // tolerable here because the human approved "set this property to the value I supplied",
          // which is what executes either way.
+         //
+         // proposedValue is deliberately NOT masked, and the asymmetry with currentValue is the
+         // point rather than an oversight. Masking a value only helps if withholding it keeps it
+         // from somewhere it would otherwise reach. currentValue qualifies: it is read off the
+         // server here and would reach the caller for the first time. proposedValue does not - it
+         // arrived IN this request, and apply requires the caller to send the identical changes
+         // array back, because the request body is the plan and the hash is recomputed from it. So
+         // the caller necessarily holds the plaintext before and after this response, and blanking
+         // it in between would remove nothing while destroying the operator's ability to see WHICH
+         // secret a plan writes, which is what the review gate exists to show them.
+         //
+         // That reasoning depends on the value always arriving through the request. If an
+         // out-of-band channel is ever added - a placeholder the server resolves from somewhere
+         // the caller never sees - then echoing the resolved value here WOULD be a new disclosure,
+         // and this must be revisited along with it.
          String currentValue = credential
             ? (SreeEnv.getProperty(name.key(), false, false) == null ? "(not set)" : "(set)")
             : SreeEnv.getProperty(name.key(), false, false);

--- a/core/src/main/java/inetsoft/web/admin/ai/AdminChangeService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminChangeService.java
@@ -83,8 +83,16 @@ public class AdminChangeService {
          // above, i.e. already ciphertext, and re-encrypting it would double-encrypt and restore
          // something that never decrypts back to the original secret. The action is what separates
          // the two: only an apply carries a plaintext value.
+         //
+         // Written as "is APPLY" rather than "is not ROLLBACK" deliberately. requireValidAction
+         // also accepts RESTORE, which nothing issues today but which would, by its name, replay a
+         // stored value exactly as rollback does - so excluding only ROLLBACK would encrypt it and
+         // reintroduce the double-encryption this branch exists to prevent, in a path with no test
+         // to catch it. Naming the one action that carries plaintext fails closed for RESTORE and
+         // for any action added later; the deny-list spelling failed open for both. That is the
+         // same argument as isEncryptedCredential being an allow-list, applied to actions.
          boolean encryptOnWrite = AdminPropertyCatalog.isEncryptedCredential(name.baseName())
-            && !AdminChangeRecord.ACTION_ROLLBACK.equals(req.getAction());
+            && AdminChangeRecord.ACTION_APPLY.equals(req.getAction());
 
          // AdminChangePlanService refuses a credential under cloud secrets, but a plan is approved
          // at preview and executed later, so that check is not the one that protects the write.

--- a/core/src/main/java/inetsoft/web/admin/ai/AdminChangeService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminChangeService.java
@@ -75,11 +75,25 @@ public class AdminChangeService {
          // (beforeRead stays false) - see AdminChangeResult.isBeforeRead().
          result.setBeforeRead(true);
 
+         // An allow-listed credential is stored encrypted, so an apply must write it through
+         // setPassword - the same encryption the Enterprise Manager field applies - or the store
+         // would hold plaintext where every reader calls Tool.decryptPassword.
+         //
+         // A ROLLBACK must not. Its value is the stored form captured by the getProperty read
+         // above, i.e. already ciphertext, and re-encrypting it would double-encrypt and restore
+         // something that never decrypts back to the original secret. The action is what separates
+         // the two: only an apply carries a plaintext value.
+         boolean encryptOnWrite = AdminPropertyCatalog.isEncryptedCredential(name.baseName())
+            && !AdminChangeRecord.ACTION_ROLLBACK.equals(req.getAction());
+
          if(desired == null) {
             // Side-effect hooks match exact literals (e.g. "security.exposedefaultorgtoall"), so
             // they must receive the base name; an org-qualified name would silently never fire.
             sideEffects.applyPreRemoveSideEffects(name.baseName());
             SreeEnv.remove(name.key());
+         }
+         else if(encryptOnWrite) {
+            SreeEnv.setPassword(name.key(), desired);
          }
          else {
             SreeEnv.setProperty(name.key(), desired);
@@ -94,9 +108,20 @@ public class AdminChangeService {
             sideEffects.applyEditSideEffects(name.baseName());
          }
 
+         // beforeValue and afterValue stay the STORED form on every path - ciphertext for a
+         // credential. That is deliberate and load-bearing, not an oversight: the changeset apply
+         // service replays getBeforeValue() as the rollback value, so masking or decrypting either
+         // one would break rollback. Ciphertext is not the secret, so nothing sensitive is
+         // recorded by keeping it.
          String after = SreeEnv.getProperty(name.key(), false, false);
          result.setAfterValue(after);
-         status = Objects.equals(after, desired)
+
+         // The comparison has to speak the same language as the write. An encrypting write stores
+         // ciphertext while `desired` is plaintext, so comparing the raw read would report FAILED
+         // for every successful credential write and roll it straight back; getPassword reverses
+         // the encryption so like is compared with like.
+         String verified = encryptOnWrite ? SreeEnv.getPassword(name.key()) : after;
+         status = Objects.equals(verified, desired)
             ? AdminChangeRecord.STATUS_VERIFIED : AdminChangeRecord.STATUS_FAILED;
       }
       catch(Exception ex) {

--- a/core/src/main/java/inetsoft/web/admin/ai/AdminChangeService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminChangeService.java
@@ -86,6 +86,20 @@ public class AdminChangeService {
          boolean encryptOnWrite = AdminPropertyCatalog.isEncryptedCredential(name.baseName())
             && !AdminChangeRecord.ACTION_ROLLBACK.equals(req.getAction());
 
+         // AdminChangePlanService refuses a credential under cloud secrets, but a plan is approved
+         // at preview and executed later, so that check is not the one that protects the write.
+         // Cloud secrets turning on in between would leave setPassword skipping encryption and
+         // writing the literal secret into a property everything downstream reads as a
+         // secret-manager reference - succeeding silently, which is the exact failure this class
+         // otherwise refuses to leave open. Re-check at the point of the write.
+         if(encryptOnWrite && desired != null && Tool.isCloudSecrets()) {
+            throw new IllegalStateException(
+               name.key() + ": this deployment uses cloud secrets, so this property holds the ID "
+               + "of a secret rather than the secret itself. Set it from Enterprise Manager's "
+               + "Settings > Security > SSO page, whose Secret ID field writes the reference "
+               + "correctly.");
+         }
+
          if(desired == null) {
             // Side-effect hooks match exact literals (e.g. "security.exposedefaultorgtoall"), so
             // they must receive the base name; an org-qualified name would silently never fire.

--- a/core/src/main/java/inetsoft/web/admin/ai/AdminPropertyCatalog.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminPropertyCatalog.java
@@ -239,9 +239,24 @@ public class AdminPropertyCatalog {
     * <p>So membership is not inferable from the name, and every entry must be verified against its
     * accessor before it is added - the same discipline this class's javadoc requires of a catalog
     * entry, and for the same reason: the failure is silent. Both current entries were checked:
-    * {@code OpenIDConfig.setClientSecret} and
-    * {@code StyleBIGoogleOpenIDConfig.setClientSecret} each write
-    * {@code encryptPassword(...)} and their getters reverse it with {@code Tool.decryptPassword}.
+    *
+    * <ul>
+    *   <li>{@code openid.client.secret} - {@code inetsoft.web.admin.security.OpenIDConfig}, in this
+    *       module. {@code setClientSecret} writes {@code encryptPassword(...)} and
+    *       {@code getClientSecret} reverses it with {@code Tool.decryptPassword}.</li>
+    *   <li>{@code stylebi.google.openid.client.secret} - {@code StyleBIGoogleOpenIDConfig}, at
+    *       {@code enterprise/src/main/java/inetsoft/enterprise/sso/} in the <b>enterprise</b>
+    *       superproject, which is NOT part of this repository. Same shape:
+    *       {@code setClientSecret} writes
+    *       {@code PasswordEncryption.newInstance().encryptPassword(...)} and
+    *       {@code getClientSecret} reverses it. A reader who greps only this repository will not
+    *       find that class and should not conclude the entry is unverified - note also that
+    *       {@code SreeEnv.getPassword} carries a case-sensitive literal check for this property's
+    *       cloud-secrets branch, which is the only trace of it visible from here.</li>
+    * </ul>
+    *
+    * <p>An entry whose accessor lives in the enterprise superproject is still correct to list here:
+    * on a Community build the property is simply never written, because nothing reads it.</p>
     *
     * <p>Reading these is still refused - see {@link #isSecret} for the egress rationale, which is
     * unaffected. This governs the write path alone.

--- a/core/src/main/java/inetsoft/web/admin/ai/AdminPropertyCatalog.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminPropertyCatalog.java
@@ -221,6 +221,38 @@ public class AdminPropertyCatalog {
          lower.contains("credential") || lower.endsWith(".key") || lower.startsWith("license.");
    }
 
+   /**
+    * True when {@code baseName} names an application credential whose accessors encrypt on write
+    * and decrypt on read, so admin-chat can set it through {@code SreeEnv.setPassword}.
+    *
+    * <p>An <b>allow-list, deliberately not a pattern.</b> {@link #isSecret} matches sixteen
+    * properties and they do not behave alike: {@code log.fluentd.security.password},
+    * {@code google.maps.key}, {@code sso.rsa.public.key} and {@code auth0.client.secret} are all
+    * read with a plain {@code SreeEnv.getProperty}, so an encrypting write would hand each of them
+    * ciphertext where they expect a literal - a broken deployment that still reports success.
+    * {@code enable.changepassword} is not a secret at all; it matches on the substring
+    * "password" and holds a boolean. And {@code password.encryption.key},
+    * {@code password.hash.key}, {@code jwt.signing.key}, {@code sso.rsa.private.key} and the
+    * {@code license.*} keys are generated or licensed material that must not be written here on
+    * any path.
+    *
+    * <p>So membership is not inferable from the name, and every entry must be verified against its
+    * accessor before it is added - the same discipline this class's javadoc requires of a catalog
+    * entry, and for the same reason: the failure is silent. Both current entries were checked:
+    * {@code OpenIDConfig.setClientSecret} and
+    * {@code StyleBIGoogleOpenIDConfig.setClientSecret} each write
+    * {@code encryptPassword(...)} and their getters reverse it with {@code Tool.decryptPassword}.
+    *
+    * <p>Reading these is still refused - see {@link #isSecret} for the egress rationale, which is
+    * unaffected. This governs the write path alone.
+    */
+   public static boolean isEncryptedCredential(String baseName) {
+      return baseName != null && ENCRYPTED_CREDENTIALS.contains(baseName.toLowerCase());
+   }
+
+   private static final Set<String> ENCRYPTED_CREDENTIALS = Set.of(
+      "openid.client.secret", "stylebi.google.openid.client.secret");
+
    private static final String RESOURCE = "admin-property-catalog.json";
    private final List<CatalogEntry> entries;
    private final Map<String, CatalogEntry> byKey;

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminChangePlanServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminChangePlanServiceTest.java
@@ -318,4 +318,23 @@ class AdminChangePlanServiceTest {
          assertTrue(ex.getMessage().contains("cloud secrets"));
       }
    }
+
+   @Test void refusesAnEmptyValueForACredentialAndSaysWhatToUseInstead() {
+      // "" is an explicit set-to-empty everywhere else, but SreeEnv.setPassword guards on
+      // isEmptyString and returns without writing, so it would silently leave the old secret in
+      // place. Refused here so the message can point at null, rather than surfacing as a bare
+      // FAILED from the read-back verify at apply time.
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("blank it", "openid.client.secret", "")));
+      assertTrue(ex.getMessage().contains("openid.client.secret"));
+      assertTrue(ex.getMessage().contains("null"));
+   }
+
+   @Test void stillAllowsResettingACredentialWithANullValue() {
+      // Reset goes through SreeEnv.remove, not setPassword, so it is unaffected by the guard above
+      // and remains the supported way to clear a credential.
+      ResolvedPlan plan = service.resolve(request("clear it", "openid.client.secret", null));
+      assertEquals(1, plan.changes().size());
+      assertNull(plan.changes().get(0).proposedValue());
+   }
 }

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminChangePlanServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminChangePlanServiceTest.java
@@ -18,6 +18,7 @@
 package inetsoft.web.admin.ai;
 
 import inetsoft.sree.SreeEnv;
+import inetsoft.util.Tool;
 import org.junit.jupiter.api.*;
 import org.mockito.MockedStatic;
 import org.mockito.quality.Strictness;
@@ -270,5 +271,51 @@ class AdminChangePlanServiceTest {
 
       sreeEnv.when(() -> SreeEnv.getProperty("mail.smtp.host", false, false)).thenReturn("null");
       assertNotEquals(unsetHash, service.resolve(request("t", "mail.smtp.host", "x")).planHash());
+   }
+
+   @Test void allowsAnAllowListedCredentialIntoThePlan() {
+      // The change that unblocks configuring OIDC SSO end to end. Reading it is still refused;
+      // this is the write path only.
+      PlanRequest req = request("set the OIDC client secret",
+                                    "openid.client.secret", "s3cret");
+      ResolvedPlan plan = service.resolve(req);
+      assertEquals(1, plan.changes().size());
+      assertEquals("s3cret", plan.changes().get(0).proposedValue());
+   }
+
+   @Test void masksACredentialsCurrentValueInThePlan() {
+      // The plan is relayed to a model provider. Ciphertext is not the secret, but there is no
+      // reason to ship it, and "(set)" is what actually helps an operator reading the diff.
+      sreeEnv.when(() -> SreeEnv.getProperty("openid.client.secret", false, false))
+             .thenReturn("ENC(cipher)");
+      ResolvedPlan plan = service.resolve(
+         request("rotate it", "openid.client.secret", "new"));
+      assertEquals("(set)", plan.changes().get(0).currentValue());
+   }
+
+   @Test void stillRefusesASecretThatIsNotAnAllowListedCredential() {
+      // password.encryption.key is the master key; log.fluentd.security.password is read with a
+      // plain getProperty. Neither may be written here, and the allow-list is why.
+      for(String prop : new String[] { "password.encryption.key", "jwt.signing.key",
+                                       "log.fluentd.security.password", "license.key" })
+      {
+         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> service.resolve(request("try it", prop, "x")));
+         assertTrue(ex.getMessage().contains(prop), "expected the error to name " + prop);
+      }
+   }
+
+   @Test void refusesACredentialWhenCloudSecretsAreConfigured() {
+      // In that mode the property holds the NAME of a secret, not the secret, so writing a literal
+      // value would store something nothing downstream can resolve. Scoped to this test: a
+      // class-wide Tool mock would silently change every other test's environment.
+      try(MockedStatic<Tool> tool = mockStatic(Tool.class, withSettings().strictness(
+             Strictness.LENIENT)))
+      {
+         tool.when(Tool::isCloudSecrets).thenReturn(true);
+         IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> service.resolve(request("set it", "openid.client.secret", "s3cret")));
+         assertTrue(ex.getMessage().contains("cloud secrets"));
+      }
    }
 }

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminChangeServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminChangeServiceTest.java
@@ -337,4 +337,37 @@ class AdminChangeServiceTest {
       sreeEnv.verify(() -> SreeEnv.setProperty("log.fluentd.security.password", "literal"));
       sreeEnv.verify(() -> SreeEnv.setPassword(anyString(), anyString()), never());
    }
+
+   @Test void refusesToWriteACredentialAtApplyTimeWhenCloudSecretsAreOn() {
+      // The plan service refuses this at preview, but a plan is approved then executed later. If
+      // cloud secrets came on in between, setPassword would skip encryption and write the literal
+      // secret into a property everything downstream reads as a secret-manager reference - and
+      // report success. The apply path re-checks for that reason.
+      toolStatic.when(Tool::isCloudSecrets).thenReturn(true);
+      sreeEnv.when(() -> SreeEnv.getProperty("openid.client.secret", false, false))
+             .thenReturn(null);
+
+      AdminChangeResult res = service.applyChange(req("openid.client.secret", "s3cret"), principal);
+
+      assertEquals(AdminChangeRecord.STATUS_FAILED, res.getStatus());
+      assertTrue(res.getError().contains("cloud secrets"));
+      sreeEnv.verify(() -> SreeEnv.setPassword(anyString(), anyString()), never());
+      sreeEnv.verify(() -> SreeEnv.setProperty(eq("openid.client.secret"), anyString()), never());
+   }
+
+   @Test void stillRollsBackACredentialUnderCloudSecrets() {
+      // A rollback writes the stored form verbatim and never encrypts, so the cloud-secrets hazard
+      // does not apply to it - and blocking it would strand a half-applied changeset.
+      toolStatic.when(Tool::isCloudSecrets).thenReturn(true);
+      AdminChangeRequest r = req("openid.client.secret", "secret-ref");
+      r.setAction(AdminChangeRecord.ACTION_ROLLBACK);
+      sreeEnv.when(() -> SreeEnv.getProperty("openid.client.secret", false, false))
+             .thenReturn("other-ref")
+             .thenReturn("secret-ref");
+
+      AdminChangeResult res = service.applyChange(r, principal);
+
+      assertEquals(AdminChangeRecord.STATUS_VERIFIED, res.getStatus());
+      sreeEnv.verify(() -> SreeEnv.setProperty("openid.client.secret", "secret-ref"));
+   }
 }

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminChangeServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminChangeServiceTest.java
@@ -370,4 +370,22 @@ class AdminChangeServiceTest {
       assertEquals(AdminChangeRecord.STATUS_VERIFIED, res.getStatus());
       sreeEnv.verify(() -> SreeEnv.setProperty("openid.client.secret", "secret-ref"));
    }
+
+   @Test void doesNotReEncryptACredentialOnRestoreEither() {
+      // RESTORE is accepted by requireValidAction and issued by nothing today, but by its name it
+      // replays a stored value the way rollback does. encryptOnWrite therefore names APPLY rather
+      // than excluding ROLLBACK: a deny-list would encrypt this and double-encrypt the credential,
+      // in a path with no caller to notice.
+      AdminChangeRequest r = req("openid.client.secret", "ENC(fromBackup)");
+      r.setAction(AdminChangeRecord.ACTION_RESTORE);
+      sreeEnv.when(() -> SreeEnv.getProperty("openid.client.secret", false, false))
+             .thenReturn("ENC(current)")
+             .thenReturn("ENC(fromBackup)");
+
+      AdminChangeResult res = service.applyChange(r, principal);
+
+      sreeEnv.verify(() -> SreeEnv.setProperty("openid.client.secret", "ENC(fromBackup)"));
+      sreeEnv.verify(() -> SreeEnv.setPassword(anyString(), anyString()), never());
+      assertEquals(AdminChangeRecord.STATUS_VERIFIED, res.getStatus());
+   }
 }

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminChangeServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminChangeServiceTest.java
@@ -276,4 +276,65 @@ class AdminChangeServiceTest {
       assertEquals(ActionRecord.OBJECT_TYPE_EMPROPERTY, record.getObjectType());
       assertEquals("host-1", record.getServerHostName());
    }
+
+   @Test void writesAnAllowListedCredentialThroughSetPasswordSoItIsEncryptedAtRest() {
+      // openid.client.secret is read by OpenIDConfig.getClientSecret via Tool.decryptPassword, so
+      // a raw setProperty would leave plaintext where every reader expects ciphertext.
+      sreeEnv.when(() -> SreeEnv.getProperty("openid.client.secret", false, false))
+             .thenReturn(null)              // before
+             .thenReturn("ENC(cipher)");    // after read-back, stored form
+      sreeEnv.when(() -> SreeEnv.getPassword("openid.client.secret")).thenReturn("s3cret");
+
+      AdminChangeResult res = service.applyChange(req("openid.client.secret", "s3cret"), principal);
+
+      sreeEnv.verify(() -> SreeEnv.setPassword("openid.client.secret", "s3cret"));
+      sreeEnv.verify(() -> SreeEnv.setProperty("openid.client.secret", "s3cret"), never());
+      assertEquals(AdminChangeRecord.STATUS_VERIFIED, res.getStatus());
+   }
+
+   @Test void verifiesACredentialThroughGetPasswordNotTheRawStoredValue() {
+      // Comparing the ciphertext read-back against the plaintext desired value would mark every
+      // successful credential write FAILED and roll it straight back.
+      sreeEnv.when(() -> SreeEnv.getProperty("openid.client.secret", false, false))
+             .thenReturn(null)
+             .thenReturn("ENC(cipher)");
+      sreeEnv.when(() -> SreeEnv.getPassword("openid.client.secret")).thenReturn("s3cret");
+
+      AdminChangeResult res = service.applyChange(req("openid.client.secret", "s3cret"), principal);
+
+      assertEquals(AdminChangeRecord.STATUS_VERIFIED, res.getStatus());
+      // The stored form is what is reported and audited, because rollback replays it verbatim.
+      assertEquals("ENC(cipher)", res.getAfterValue());
+   }
+
+   @Test void rollingBackACredentialWritesTheStoredFormVerbatimWithoutReEncrypting() {
+      // The rollback value came from a getProperty read, so it is ALREADY ciphertext. Sending it
+      // through setPassword would encrypt it a second time and restore something that never
+      // decrypts back to the original secret.
+      AdminChangeRequest r = req("openid.client.secret", "ENC(previous)");
+      r.setAction(AdminChangeRecord.ACTION_ROLLBACK);
+      sreeEnv.when(() -> SreeEnv.getProperty("openid.client.secret", false, false))
+             .thenReturn("ENC(cipher)")
+             .thenReturn("ENC(previous)");
+
+      AdminChangeResult res = service.applyChange(r, principal);
+
+      sreeEnv.verify(() -> SreeEnv.setProperty("openid.client.secret", "ENC(previous)"));
+      sreeEnv.verify(() -> SreeEnv.setPassword(anyString(), anyString()), never());
+      assertEquals(AdminChangeRecord.STATUS_VERIFIED, res.getStatus());
+   }
+
+   @Test void writesASecretNamedPropertyThatIsNotAnAllowListedCredentialVerbatim() {
+      // log.fluentd.security.password matches isSecret but is read with a plain getProperty.
+      // Encrypting it would hand the fluentd client ciphertext as its password. (The plan service
+      // refuses this property outright; this pins the write path regardless of how it is reached.)
+      sreeEnv.when(() -> SreeEnv.getProperty("log.fluentd.security.password", false, false))
+             .thenReturn(null)
+             .thenReturn("literal");
+
+      service.applyChange(req("log.fluentd.security.password", "literal"), principal);
+
+      sreeEnv.verify(() -> SreeEnv.setProperty("log.fluentd.security.password", "literal"));
+      sreeEnv.verify(() -> SreeEnv.setPassword(anyString(), anyString()), never());
+   }
 }


### PR DESCRIPTION
Follows inetsoft-technology/stylebi#4587. Configuring OIDC SSO end to end died one property short: everything else previewed cleanly and `openid.client.secret` had to be typed into Enterprise Manager by hand.

The refusal was justified as an egress control, but egress is about values *leaving* the host — by the time a write is proposed the value is already in the caller's context, so refusing it protected nothing and only stopped the task completing.

## Not a relaxed predicate

`isSecret` matches sixteen properties and they do not behave alike:

| | |
|---|---|
| **encrypting accessors** | `openid.client.secret`, `stylebi.google.openid.client.secret` — `setClientSecret` writes `encryptPassword(...)`, the getter reverses it with `Tool.decryptPassword` |
| **plain accessors** | `log.fluentd.security.password`, `google.maps.key`, `sso.rsa.public.key`, `auth0.client.secret` — all read with a bare `getProperty` |
| **not a secret** | `enable.changepassword` — matches on the substring "password", holds a boolean |
| **key material** | `password.encryption.key`, `password.hash.key`, `jwt.signing.key`, `sso.rsa.private.key`, `license.*` |

A blanket `if(isSecret) setPassword` would have handed ciphertext to four properties that expect a literal — silently, while reporting success. So membership is an **allow-list verified against each accessor**, currently two entries, with the same discipline `AdminPropertyCatalog`'s javadoc already requires of a catalog entry and for the same reason: the failure is silent.

## Three interactions that each needed handling

- **Verify reads back through `getPassword`.** Comparing the stored ciphertext against the plaintext `desired` would mark every successful credential write `FAILED` and roll it straight back.
- **Rollback must not re-encrypt.** Its value came from a `getProperty` read and is already ciphertext; `ACTION_ROLLBACK` separates it from an apply. Double-encrypting would restore something that never decrypts to the original secret.
- **`beforeValue`/`afterValue` stay the stored form.** This is load-bearing rather than an oversight: `AdminChangesetApplyService` replays `getBeforeValue()` as the rollback value, so masking or decrypting either would break rollback. Ciphertext is not the secret, so nothing sensitive is recorded by keeping it.

## Scope of what is allowed

Cloud secrets are refused outright — there these properties hold the *name* of a secret, which is why Enterprise Manager swaps in a **Secret ID** field, and a literal value would store something nothing downstream can resolve.

**Reading stays refused.** The egress rationale is about values leaving the host and is untouched by letting one in. The plan shows `(set)`/`(not set)` rather than shipping ciphertext to a model provider; the cost is that swapping one secret for a different one is not seen by the drift gate, which is tolerable because what the human approved is "set this property to the value I supplied", and that executes either way.

## Verification

Plan tests 21 → 25, change-service tests 15 → 19. Full `admin.ai` suite green (147 tests) on the post-#4587 base.

Tests cover each direction that would corrupt data if reversed: an allow-listed credential goes through `setPassword`, verification uses `getPassword`, a rollback writes verbatim without re-encrypting, and a secret-named property that is *not* allow-listed is written verbatim.