### PR TITLE
Classify encrypted credentials by their writer

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/ai/AdminChangePlanService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminChangePlanService.java
@@ -100,10 +100,7 @@ public class AdminChangePlanService {
          // than write a value that cannot work.
          if(credential && Tool.isCloudSecrets()) {
             throw new IllegalArgumentException(
-               name.key() + ": this deployment uses cloud secrets, so this property holds the ID "
-               + "of a secret rather than the secret itself. Set it from Enterprise Manager's "
-               + "Settings > Security > SSO page, whose Secret ID field writes the reference "
-               + "correctly.");
+               AdminPropertyCatalog.cloudSecretsRefusal(name.key()));
          }
 
          // Every other property in this service takes "" as an explicit set-to-empty, with null

--- a/core/src/main/java/inetsoft/web/admin/ai/AdminChangeService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminChangeService.java
@@ -102,10 +102,7 @@ public class AdminChangeService {
          // otherwise refuses to leave open. Re-check at the point of the write.
          if(encryptOnWrite && desired != null && Tool.isCloudSecrets()) {
             throw new IllegalStateException(
-               name.key() + ": this deployment uses cloud secrets, so this property holds the ID "
-               + "of a secret rather than the secret itself. Set it from Enterprise Manager's "
-               + "Settings > Security > SSO page, whose Secret ID field writes the reference "
-               + "correctly.");
+               AdminPropertyCatalog.cloudSecretsRefusal(name.key()));
          }
 
          if(desired == null) {

--- a/core/src/main/java/inetsoft/web/admin/ai/AdminPropertyCatalog.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminPropertyCatalog.java
@@ -290,6 +290,26 @@ public class AdminPropertyCatalog {
       return baseName != null && ENCRYPTED_CREDENTIALS.contains(baseName.toLowerCase());
    }
 
+   /**
+    * The refusal both the plan and the apply path give when an encrypted credential is set on a
+    * deployment using cloud secrets.
+    *
+    * <p>Built here rather than written out at each site so the two cannot drift apart, and
+    * deliberately does NOT name an Enterprise Manager page. It used to say "Settings > Security >
+    * SSO", which was true while the allow-list held only the two OpenID credentials and became
+    * wrong the moment mail and logging credentials joined them - they are configured on entirely
+    * different pages. Sending an operator to the wrong page is worse than sending them to none,
+    * and a page-per-property mapping maintained here would be a second name-keyed table to drift
+    * out of date, which is the failure this class has already had once.
+    */
+   public static String cloudSecretsRefusal(String key) {
+      return key + ": this deployment uses cloud secrets, so this property holds the ID of a "
+         + "secret rather than the secret itself. Set it from the Enterprise Manager page that "
+         + "owns this setting - under cloud secrets those pages present a Secret ID field, which "
+         + "writes the reference correctly. admin-chat cannot, because it would store the literal "
+         + "value where nothing downstream can resolve it.";
+   }
+
    private static final Set<String> ENCRYPTED_CREDENTIALS = Set.of(
       "openid.client.secret", "stylebi.google.openid.client.secret",
       "mail.smtp.pass", "mail.smtp.clientsecret", "mail.smtp.accesstoken",

--- a/core/src/main/java/inetsoft/web/admin/ai/AdminPropertyCatalog.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminPropertyCatalog.java
@@ -225,48 +225,75 @@ public class AdminPropertyCatalog {
     * True when {@code baseName} names an application credential whose accessors encrypt on write
     * and decrypt on read, so admin-chat can set it through {@code SreeEnv.setPassword}.
     *
-    * <p>An <b>allow-list, deliberately not a pattern.</b> {@link #isSecret} matches sixteen
-    * properties and they do not behave alike: {@code log.fluentd.security.password},
-    * {@code google.maps.key}, {@code sso.rsa.public.key} and {@code auth0.client.secret} are all
-    * read with a plain {@code SreeEnv.getProperty}, so an encrypting write would hand each of them
-    * ciphertext where they expect a literal - a broken deployment that still reports success.
-    * {@code enable.changepassword} is not a secret at all; it matches on the substring
-    * "password" and holds a boolean. And {@code password.encryption.key},
-    * {@code password.hash.key}, {@code jwt.signing.key}, {@code sso.rsa.private.key} and the
-    * {@code license.*} keys are generated or licensed material that must not be written here on
-    * any path.
+    * <p><b>Classify by the WRITER, never by the reader.</b> An earlier version of this javadoc
+    * excluded {@code log.fluentd.security.password} on the grounds that it is "read with a plain
+    * {@code SreeEnv.getProperty}". That reasoning was wrong, even though the exclusion happened to
+    * be right. {@code LogSettingService} reads it with {@code getProperty} and then calls
+    * {@code Tool.decryptPassword} on the result two lines later - so by the reader it looks
+    * encrypted. It is not: the save path writes it with a bare {@code SreeEnv.setProperty}.
     *
-    * <p>So membership is not inferable from the name, and every entry must be verified against its
-    * accessor before it is added - the same discipline this class's javadoc requires of a catalog
-    * entry, and for the same reason: the failure is silent. Both current entries were checked:
+    * <p>The reader cannot settle this because {@code Tool.decryptPassword} passes an unrecognised
+    * (i.e. plaintext) value straight through - see {@code LocalPasswordEncryption.decryptPassword},
+    * whose final branch is literally {@code // clear text}. A defensive decrypt on read is
+    * therefore compatible with BOTH storage forms, usually because something wrote the value
+    * encrypted at some point in the past. Only the writer is authoritative.
+    *
+    * <p>An <b>allow-list, deliberately not a pattern</b>, because {@link #isSecret} sorts on the
+    * name and the name does not correlate with the storage form in either direction:
     *
     * <ul>
-    *   <li>{@code openid.client.secret} - {@code inetsoft.web.admin.security.OpenIDConfig}, in this
-    *       module. {@code setClientSecret} writes {@code encryptPassword(...)} and
-    *       {@code getClientSecret} reverses it with {@code Tool.decryptPassword}.</li>
-    *   <li>{@code stylebi.google.openid.client.secret} - {@code StyleBIGoogleOpenIDConfig}, at
-    *       {@code enterprise/src/main/java/inetsoft/enterprise/sso/} in the <b>enterprise</b>
-    *       superproject, which is NOT part of this repository. Same shape:
-    *       {@code setClientSecret} writes
-    *       {@code PasswordEncryption.newInstance().encryptPassword(...)} and
-    *       {@code getClientSecret} reverses it. A reader who greps only this repository will not
-    *       find that class and should not conclude the entry is unverified - note also that
-    *       {@code SreeEnv.getPassword} carries a case-sensitive literal check for this property's
-    *       cloud-secrets branch, which is the only trace of it visible from here.</li>
+    *   <li><b>Matched but plaintext</b> - {@code log.fluentd.security.password} (bare
+    *       {@code setProperty}), {@code google.maps.key}, {@code sso.rsa.public.key} (a PUBLIC
+    *       key), {@code auth0.client.secret} (read plain, then copied into
+    *       {@code openid.client.secret} by the legacy migration, which encrypts on the way).
+    *       Encrypting any of these would store ciphertext where a literal is expected.</li>
+    *   <li><b>Matched but not a secret at all</b> - {@code enable.changepassword} holds a boolean
+    *       and matches on the substring "password".</li>
+    *   <li><b>Matched and must never be written</b> - {@code password.encryption.key},
+    *       {@code password.hash.key}, {@code jwt.signing.key}, {@code sso.rsa.private.key} and
+    *       {@code license.*} are generated or licensed material.</li>
+    *   <li><b>NOT matched, yet genuinely encrypted</b> - {@code mail.smtp.pass},
+    *       {@code mail.smtp.accesstoken}, {@code mail.smtp.refreshtoken} and
+    *       {@code log.fluentd.security.sharedkey}. These are the dangerous direction: before they
+    *       were listed here, admin-chat wrote them with a plain {@code setProperty} while
+    *       Enterprise Manager writes them with {@code setPassword}, silently downgrading a stored
+    *       credential to plaintext at rest. It still "worked", because the defensive decrypt above
+    *       passes plaintext through.</li>
     * </ul>
     *
-    * <p>An entry whose accessor lives in the enterprise superproject is still correct to list here:
-    * on a Community build the property is simply never written, because nothing reads it.</p>
+    * <p>Every entry below was verified against its writer:
     *
-    * <p>Reading these is still refused - see {@link #isSecret} for the egress rationale, which is
-    * unaffected. This governs the write path alone.
+    * <ul>
+    *   <li>{@code openid.client.secret} - {@code OpenIDConfig.setClientSecret}, this module,
+    *       writes {@code encryptPassword(...)}.</li>
+    *   <li>{@code stylebi.google.openid.client.secret} - {@code StyleBIGoogleOpenIDConfig} at
+    *       {@code enterprise/src/main/java/inetsoft/enterprise/sso/} in the <b>enterprise</b>
+    *       superproject, which is NOT part of this repository, writes
+    *       {@code PasswordEncryption.newInstance().encryptPassword(...)}. A reader who greps only
+    *       this repository will not find that class and should not conclude the entry is
+    *       unverified; the only trace visible from here is the case-sensitive literal in
+    *       {@code SreeEnv.getPassword}'s cloud-secrets branch. Listing an enterprise-only property
+    *       is still correct - on a Community build nothing reads it, so nothing writes it.</li>
+    *   <li>{@code mail.smtp.pass}, {@code mail.smtp.clientsecret}, {@code mail.smtp.accesstoken},
+    *       {@code mail.smtp.refreshtoken} - {@code EmailSettingsService} writes all four with
+    *       {@code SreeEnv.setPassword}. Note {@code mail.smtp.tokenuri} sits beside them in the
+    *       same save block and is written with a plain {@code setProperty}, so it is NOT here.</li>
+    *   <li>{@code log.fluentd.security.sharedkey} - {@code LogSettingService} writes it through
+    *       its {@code toPassword} helper, which calls {@code Tool.encryptPassword}. Its sibling
+    *       {@code log.fluentd.security.password} does not, which is why one is listed and the
+    *       other is not despite the adjacent names.</li>
+    * </ul>
+    *
+    * <p>Reading is governed separately by {@link #isSecret} and is unaffected by this method.
     */
    public static boolean isEncryptedCredential(String baseName) {
       return baseName != null && ENCRYPTED_CREDENTIALS.contains(baseName.toLowerCase());
    }
 
    private static final Set<String> ENCRYPTED_CREDENTIALS = Set.of(
-      "openid.client.secret", "stylebi.google.openid.client.secret");
+      "openid.client.secret", "stylebi.google.openid.client.secret",
+      "mail.smtp.pass", "mail.smtp.clientsecret", "mail.smtp.accesstoken",
+      "mail.smtp.refreshtoken", "log.fluentd.security.sharedkey");
 
    private static final String RESOURCE = "admin-property-catalog.json";
    private final List<CatalogEntry> entries;

--- a/core/src/main/java/inetsoft/web/admin/ai/AdminPropertyCatalog.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminPropertyCatalog.java
@@ -294,20 +294,31 @@ public class AdminPropertyCatalog {
     * The refusal both the plan and the apply path give when an encrypted credential is set on a
     * deployment using cloud secrets.
     *
-    * <p>Built here rather than written out at each site so the two cannot drift apart, and
-    * deliberately does NOT name an Enterprise Manager page. It used to say "Settings > Security >
-    * SSO", which was true while the allow-list held only the two OpenID credentials and became
-    * wrong the moment mail and logging credentials joined them - they are configured on entirely
-    * different pages. Sending an operator to the wrong page is worse than sending them to none,
-    * and a page-per-property mapping maintained here would be a second name-keyed table to drift
-    * out of date, which is the failure this class has already had once.
+    * <p>Built here rather than written out at each site so the two cannot drift apart - they
+    * already did once, which is how an obsolete page name survived the change that invalidated it.
+    *
+    * <p><b>It describes what admin-chat will not do, and nothing about the Enterprise Manager
+    * UI.</b> Two rounds of review caught the same drift at successively finer grain: first it named
+    * "Settings > Security > SSO", true only while the list held the two OpenID credentials; then it
+    * promised "a Secret ID field", which exists for {@code openid.client.secret},
+    * {@code stylebi.google.openid.client.secret} and {@code mail.smtp.pass} - and for nothing else
+    * on the list. {@code EmailSettingsService} has no cloud-secrets branch for
+    * {@code mail.smtp.clientsecret}, {@code mail.smtp.accesstoken} or
+    * {@code mail.smtp.refreshtoken}, and {@code LogSettingService} does not mention
+    * {@code Tool.isCloudSecrets} at all.
+    *
+    * <p>The pattern is worth naming, because a third wording would fail the same way: any claim
+    * about how a property is configured elsewhere is a claim per property, and this method has one
+    * string for seven of them. Describing only this component's own behaviour is the wording that
+    * stays true as the list grows. If per-property guidance is ever wanted, the corpus already
+    * records {@code emBinding.page} for each - drive it from there rather than from a second
+    * name-keyed table maintained by hand beside {@link #ENCRYPTED_CREDENTIALS}.
     */
-   public static String cloudSecretsRefusal(String key) {
-      return key + ": this deployment uses cloud secrets, so this property holds the ID of a "
-         + "secret rather than the secret itself. Set it from the Enterprise Manager page that "
-         + "owns this setting - under cloud secrets those pages present a Secret ID field, which "
-         + "writes the reference correctly. admin-chat cannot, because it would store the literal "
-         + "value where nothing downstream can resolve it.";
+   static String cloudSecretsRefusal(String key) {
+      return key + ": this deployment uses cloud secrets, so a value stored under this property is "
+         + "resolved as a reference to a secret rather than used directly. admin-chat will not set "
+         + "it - it can only write the literal value it was given, which nothing downstream could "
+         + "resolve. Configure it through Enterprise Manager instead.";
    }
 
    private static final Set<String> ENCRYPTED_CREDENTIALS = Set.of(

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminChangePlanServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminChangePlanServiceTest.java
@@ -337,4 +337,26 @@ class AdminChangePlanServiceTest {
       assertEquals(1, plan.changes().size());
       assertNull(plan.changes().get(0).proposedValue());
    }
+
+   @Test void refusesAMailCredentialUnderCloudSecretsWithoutNamingTheSsoPage() {
+      // The guard became reachable for mail and logging credentials when they joined the
+      // allow-list. Its message used to say "Settings > Security > SSO", which is the wrong page
+      // for every one of them - and a wrong page is worse guidance than none.
+      try(MockedStatic<Tool> tool = mockStatic(Tool.class, withSettings().strictness(
+             Strictness.LENIENT)))
+      {
+         tool.when(Tool::isCloudSecrets).thenReturn(true);
+
+         for(String prop : new String[] { "mail.smtp.pass", "log.fluentd.security.sharedkey",
+                                          "openid.client.secret" })
+         {
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+               () -> service.resolve(request("set it", prop, "value")));
+            assertTrue(ex.getMessage().contains(prop), "message should name " + prop);
+            assertTrue(ex.getMessage().contains("cloud secrets"));
+            assertFalse(ex.getMessage().contains("Security > SSO"),
+                        "message must not name an SSO page for " + prop);
+         }
+      }
+   }
 }

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminChangePlanServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminChangePlanServiceTest.java
@@ -354,8 +354,14 @@ class AdminChangePlanServiceTest {
                () -> service.resolve(request("set it", prop, "value")));
             assertTrue(ex.getMessage().contains(prop), "message should name " + prop);
             assertTrue(ex.getMessage().contains("cloud secrets"));
+            // The message must describe only what admin-chat will not do. Every claim about how a
+            // property is configured elsewhere is a claim per property, and this is one string for
+            // seven of them - two review rounds caught exactly that, first the page name and then
+            // the Secret ID field, which only three of the seven actually have.
             assertFalse(ex.getMessage().contains("Security > SSO"),
                         "message must not name an SSO page for " + prop);
+            assertFalse(ex.getMessage().contains("Secret ID"),
+                        "message must not promise a Secret ID field for " + prop);
          }
       }
    }

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminChangeServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminChangeServiceTest.java
@@ -388,4 +388,35 @@ class AdminChangeServiceTest {
       sreeEnv.verify(() -> SreeEnv.setPassword(anyString(), anyString()), never());
       assertEquals(AdminChangeRecord.STATUS_VERIFIED, res.getStatus());
    }
+
+   @Test void encryptsAMailCredentialThatTheNamePredicateDoesNotMatch() {
+      // mail.smtp.pass is not caught by isSecret, so before it was allow-listed admin-chat wrote
+      // it with a plain setProperty while EmailSettingsService writes it with setPassword -
+      // storing the SMTP password unencrypted at rest, and "succeeding" because the defensive
+      // decrypt on read passes plaintext through.
+      sreeEnv.when(() -> SreeEnv.getProperty("mail.smtp.pass", false, false))
+             .thenReturn(null)
+             .thenReturn("ENC(cipher)");
+      sreeEnv.when(() -> SreeEnv.getPassword("mail.smtp.pass")).thenReturn("hunter2");
+
+      AdminChangeResult res = service.applyChange(req("mail.smtp.pass", "hunter2"), principal);
+
+      sreeEnv.verify(() -> SreeEnv.setPassword("mail.smtp.pass", "hunter2"));
+      sreeEnv.verify(() -> SreeEnv.setProperty(eq("mail.smtp.pass"), anyString()), never());
+      assertEquals(AdminChangeRecord.STATUS_VERIFIED, res.getStatus());
+   }
+
+   @Test void writesTheAdjacentPlaintextMailPropertyVerbatim() {
+      // mail.smtp.tokenuri sits in the same save block as the four encrypted ones and is written
+      // with a plain setProperty. Encrypting it would store ciphertext where a URL is expected.
+      sreeEnv.when(() -> SreeEnv.getProperty("mail.smtp.tokenuri", false, false))
+             .thenReturn(null)
+             .thenReturn("https://oauth2.example/token");
+
+      service.applyChange(req("mail.smtp.tokenuri", "https://oauth2.example/token"), principal);
+
+      sreeEnv.verify(() -> SreeEnv.setProperty("mail.smtp.tokenuri",
+                                               "https://oauth2.example/token"));
+      sreeEnv.verify(() -> SreeEnv.setPassword(anyString(), anyString()), never());
+   }
 }

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminPropertyCatalogTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminPropertyCatalogTest.java
@@ -148,4 +148,48 @@ class AdminPropertyCatalogTest {
       CatalogEntry entry = catalog.getEntry(AdminPropertyName.parse("query.runtime.maxrow"));
       assertNull(catalog.canonicalizeValue(entry, null));
    }
+
+   @Test
+   void classifiesEncryptedCredentialsByTheirWriterNotTheirName() {
+      // The four properties the name predicate does NOT match but which Enterprise Manager writes
+      // with setPassword. Before they were listed, admin-chat wrote them plain and silently
+      // downgraded a stored credential to plaintext at rest.
+      for(String name : new String[] { "mail.smtp.pass", "mail.smtp.clientsecret",
+                                       "mail.smtp.accesstoken", "mail.smtp.refreshtoken",
+                                       "log.fluentd.security.sharedkey",
+                                       "openid.client.secret",
+                                       "stylebi.google.openid.client.secret" })
+      {
+         assertTrue(AdminPropertyCatalog.isEncryptedCredential(name),
+                    name + " is written with setPassword/encryptPassword and must be listed");
+      }
+   }
+
+   @Test
+   void excludesAdjacentPropertiesWhoseWriterDoesNotEncrypt() {
+      // Each of these sits beside a listed property and reads like it belongs. None does.
+      //   mail.smtp.tokenuri              same save block as the four above, plain setProperty
+      //   log.fluentd.security.password   sibling of sharedkey, plain setProperty - its reader
+      //                                   calls decryptPassword, which proves nothing, because
+      //                                   decryptPassword passes plaintext straight through
+      //   auth0.client.secret             read plain; the legacy migration encrypts on the way out
+      //   sso.rsa.public.key              a PUBLIC key
+      for(String name : new String[] { "mail.smtp.tokenuri", "log.fluentd.security.password",
+                                       "auth0.client.secret", "sso.rsa.public.key",
+                                       "google.maps.key", "enable.changepassword",
+                                       "password.encryption.key", "jwt.signing.key" })
+      {
+         assertFalse(AdminPropertyCatalog.isEncryptedCredential(name),
+                     name + " is not written encrypted and must not be listed");
+      }
+   }
+
+   @Test
+   void matchesAnEncryptedCredentialRegardlessOfTheCasingTheCallerUses() {
+      // Source spells several of these camelCase (mail.smtp.clientSecret,
+      // styleBI.google.openid.client.secret); the store lowercases via computePropertyNameCase.
+      assertTrue(AdminPropertyCatalog.isEncryptedCredential("mail.smtp.clientSecret"));
+      assertTrue(AdminPropertyCatalog.isEncryptedCredential("styleBI.google.openid.client.secret"));
+      assertTrue(AdminPropertyCatalog.isEncryptedCredential("log.fluentd.security.sharedKey"));
+   }
 }


### PR DESCRIPTION
Follows inetsoft-technology/stylebi#4588. The allow-list added there held two entries, and the javadoc justified the omissions with the wrong evidence.

## The reasoning error

The javadoc said `log.fluentd.security.password` is *"read with a plain `SreeEnv.getProperty`"*, so encrypting it would corrupt it. The exclusion was right; the reasoning was not. `LogSettingService` reads it with `getProperty` and calls `Tool.decryptPassword` on the result two lines later — so **by the reader it looks encrypted**.

The reader cannot settle this. `Tool.decryptPassword` passes an unrecognised value straight through — `LocalPasswordEncryption`'s final branch is literally `// clear text` — so a defensive decrypt is compatible with *both* storage forms, typically because something wrote the value encrypted at some point in the past. **Only the writer is authoritative.** `log.fluentd.security.password` is written with a bare `setProperty`, so it stays out, now for the correct reason.

## What applying that rule found

Five properties missing, four of them in the dangerous direction:

| property | writer |
|---|---|
| `mail.smtp.pass` | `EmailSettingsService` → `SreeEnv.setPassword` |
| `mail.smtp.clientsecret` | `EmailSettingsService` → `SreeEnv.setPassword` |
| `mail.smtp.accesstoken` | `EmailSettingsService` → `SreeEnv.setPassword` |
| `mail.smtp.refreshtoken` | `EmailSettingsService` → `SreeEnv.setPassword` |
| `log.fluentd.security.sharedkey` | `LogSettingService.toPassword` → `Tool.encryptPassword` |

All but `mail.smtp.clientsecret` are invisible to `isSecret`, so admin-chat wrote them with a plain `setProperty` while Enterprise Manager writes them encrypted — **silently downgrading a stored credential to plaintext at rest**, and reporting success, because the same defensive decrypt reads plaintext back fine.

That is the SMTP password and the OAuth access and refresh tokens, on the *"configure the mail server"* path.

## The traps, now pinned by tests

The two properties that sit adjacent to these and do **not** belong are where the next edit will go wrong:

- `mail.smtp.tokenuri` — same save block as the four above, written plain. Encrypting it would store ciphertext where a URL is expected.
- `log.fluentd.security.password` — sibling of `sharedkey`, written plain despite the near-identical name.

## Scope

This fixes only **which accessor a write uses**. The read half of the same underlying defect — `isSecret` returning those same mail properties *unmasked* to the caller — is already filed as **#76006**, which also documents why the name predicate must be kept and unioned with the writer signal rather than replaced: replacing it would unmask fifteen properties in order to close three.

Catalog tests 15 → 18, change-service 22 → 24, full `admin.ai` suite green.
