### PR TITLE
Catalogue the SSO area

### DIFF
--- a/core/src/main/resources/inetsoft/web/admin/ai/admin-property-catalog.json
+++ b/core/src/main/resources/inetsoft/web/admin/ai/admin-property-catalog.json
@@ -1,7 +1,11 @@
 [
   {
     "name": "query.runtime.maxrow",
-    "aliases": ["max.rows", "max.row", "query.max.rows"],
+    "aliases": [
+      "max.rows",
+      "max.row",
+      "query.max.rows"
+    ],
     "type": "int",
     "min": 0,
     "max": 10000000,
@@ -11,16 +15,27 @@
   },
   {
     "name": "log.detail.level",
-    "aliases": ["log.level", "logging.level"],
+    "aliases": [
+      "log.level",
+      "logging.level"
+    ],
     "type": "enum",
-    "allowedValues": ["debug", "info", "warn", "error", "off"],
+    "allowedValues": [
+      "debug",
+      "info",
+      "warn",
+      "error",
+      "off"
+    ],
     "description": "Global log detail level. 'debug' is verbose and can grow log storage quickly; 'off' disables logging.",
     "risk": "low",
     "snapshotScope": "value"
   },
   {
     "name": "mail.smtp.host",
-    "aliases": ["smtp.host"],
+    "aliases": [
+      "smtp.host"
+    ],
     "type": "string",
     "description": "Outgoing SMTP host used for scheduled reports and alerts. A wrong value fails delivery silently until the next send.",
     "risk": "high",
@@ -28,10 +43,362 @@
   },
   {
     "name": "security.exposedefaultorgtoall",
-    "aliases": ["expose.default.org"],
+    "aliases": [
+      "expose.default.org"
+    ],
     "type": "boolean",
     "description": "Exposes the default organization's assets to all users. Changing it fires repository side effects and alters what every user can see.",
     "risk": "high",
     "snapshotScope": "storage"
+  },
+  {
+    "name": "openid.audience",
+    "aliases": [],
+    "type": "string",
+    "description": "openid.audience is the expected aud claim value that OpenIDFilterBaseFilter.createSessionFromToken requires on every verified ID token, and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "openid.authorization.endpoint",
+    "aliases": [],
+    "type": "string",
+    "description": "openid.authorization.endpoint is the URL of the identity provider's OAuth 2.0 authorization endpoint \u2014 the address a user's browser is redirected to first, to begin an OpenID Connect login \u2014 and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "openid.callback.url",
+    "aliases": [],
+    "type": "string",
+    "description": "openid.callback.url is not a URL on the identity provider at all \u2014 it is the context-relative path on this StyleBI server that receives the provider's redirect after login, and defaults, when unset, to /openid/login.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "openid.client.id",
+    "aliases": [],
+    "type": "string",
+    "description": "openid.client.id is the client identifier StyleBI registered with the identity provider for this OpenID application, and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "openid.client.secret",
+    "aliases": [],
+    "type": "string",
+    "description": "openid.client.secret is the client secret StyleBI presents to the identity provider's token endpoint, and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "openid.group.claim",
+    "aliases": [],
+    "type": "string",
+    "description": "openid.group.claim names the ID-token claim StyleBI reads to assign StyleBI groups to a logging-in user, and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "openid.issuer",
+    "aliases": [],
+    "type": "string",
+    "description": "openid.issuer is the identity provider's issuer identifier, checked against the returned ID token's iss claim after the token is already parsed \u2014 unlike the endpoint properties, it never builds a URL StyleBI calls \u2014 and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "openid.jwk.cert",
+    "aliases": [],
+    "type": "string",
+    "description": "openid.jwk.cert holds a PEM-encoded certificate StyleBI parses into a local signature-verification key, used only as a fallback when openid.jwks.uri is unset, and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "openid.jwks.uri",
+    "aliases": [],
+    "type": "string",
+    "description": "openid.jwks.uri is the URL of the identity provider's JSON Web Key Set \u2014 fetched only after a token comes back, to verify the token's signature, not to start the login \u2014 and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "openid.name.claim",
+    "aliases": [],
+    "type": "string",
+    "description": "openid.name.claim names the ID-token claim StyleBI reads as the logging-in user's identity, and defaults, when unset, to email.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "openid.orgid.claim",
+    "aliases": [],
+    "type": "string",
+    "description": "openid.orgid.claim names the ID-token claim StyleBI reads to place a logging-in user in a StyleBI organization, and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "openid.postprocessor",
+    "aliases": [],
+    "type": "string",
+    "description": "openid.postprocessor is meant to name a class StyleBI instantiates to adjust the SRPrincipal built from an OpenID login, given the token's claims, and is unset by default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "openid.property.provider",
+    "aliases": [],
+    "type": "string",
+    "description": "openid.property.provider names a class StyleBI instantiates to compute the OpenID configuration for each request, overriding the stored OpenIDConfig values, and is unset by default, so no override runs.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "openid.role.claim",
+    "aliases": [],
+    "type": "string",
+    "description": "openid.role.claim names the ID-token claim StyleBI reads to assign StyleBI roles to a logging-in user, and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "openid.scopes",
+    "aliases": [],
+    "type": "string",
+    "description": "openid.scopes is the space-separated list of OAuth scopes StyleBI requests in the authorization redirect \u2014 a request parameter sent alongside the endpoint URLs, not an address or key of its own \u2014 and defaults, when unset, to openid email.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "openid.token.endpoint",
+    "aliases": [],
+    "type": "string",
+    "description": "openid.token.endpoint is the URL of the identity provider's OAuth 2.0 token endpoint \u2014 the address this StyleBI server itself calls, server to server, to exchange an authorization code for an ID token \u2014 and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "double.sso",
+    "aliases": [],
+    "type": "boolean",
+    "description": "double.sso is the Allow Default Form Login checkbox on Enterprise Manager's Settings > Security > SSO page \u2014 it keeps StyleBI's own login form reachable while single sign-on is active, instead of every request being handed to the SSO provider.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "sso.custom.class",
+    "aliases": [],
+    "type": "string",
+    "description": "sso.custom.class is the fully-qualified Java class name of a custom Filter implementation, and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "sso.default.roles",
+    "aliases": [],
+    "type": "string",
+    "description": "sso.default.roles is a comma-separated list of role names granted to every user on their first SSO login, and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "sso.heartbeat.url",
+    "aliases": [],
+    "type": "string",
+    "description": "sso.heartbeat.url is a URL the client is told to poll to detect that an SSO session has ended elsewhere, and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "sso.logout.path",
+    "aliases": [],
+    "type": "string",
+    "description": "sso.logout.path is the application path the identity provider's own single sign-out request targets, and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "sso.logout.url",
+    "aliases": [],
+    "type": "string",
+    "description": "sso.logout.url is the Single Sign-Out URL the portal's and EM's Log Out control sends the browser to, and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "sso.protocol.type",
+    "aliases": [],
+    "type": "enum",
+    "allowedValues": [
+      "None",
+      "SAML",
+      "OpenID",
+      "Custom"
+    ],
+    "description": "sso.protocol.type selects the active SSO mechanism. Unset or unrecognised reads as NONE, so a typo silently disables single sign-on; this catalog entry rejects one instead.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "sso.rsa.private.key",
+    "aliases": [],
+    "type": "string",
+    "description": "sso.rsa.private.key is the Base64-encoded, master-key-encrypted RSA private key SSOTokenService uses to sign cross-app SSO JWTs, and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "sso.rsa.public.key",
+    "aliases": [],
+    "type": "string",
+    "description": "sso.rsa.public.key is the Base64-encoded RSA public key paired with sso.rsa.private.key, and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "stylebi.google.openid.client.id",
+    "aliases": [],
+    "type": "string",
+    "description": "stylebi.google.openid.client.id is the Client ID field on Enterprise Manager's Settings > Security > Sign In With Google page \u2014 the OAuth client ID StyleBI was issued when its Google project was registered \u2014 and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "stylebi.google.openid.scopes",
+    "aliases": [],
+    "type": "string",
+    "description": "stylebi.google.openid.scopes is the Scopes field on Enterprise Manager's Settings > Security > Sign In With Google page \u2014 the OAuth scopes StyleBI asks Google for when a visitor signs in \u2014 and defaults to openid email profile.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "onelogin.saml2.idp.entityid",
+    "aliases": [],
+    "type": "string",
+    "description": "onelogin.saml2.idp.entityid is the identity provider's SAML entity ID, checked as the issuer of every incoming SAML message, and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "onelogin.saml2.idp.single_logout_service.url",
+    "aliases": [],
+    "type": "string",
+    "description": "onelogin.saml2.idp.single_logout_service.url is the identity provider's Single Logout Service endpoint \u2014 where this server sends a SAML LogoutRequest on logout \u2014 and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "onelogin.saml2.idp.single_sign_on_service.url",
+    "aliases": [],
+    "type": "string",
+    "description": "onelogin.saml2.idp.single_sign_on_service.url is the identity provider's Single Sign-On Service endpoint \u2014 where this server redirects a user to start SAML login \u2014 and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "onelogin.saml2.idp.x509cert",
+    "aliases": [],
+    "type": "string",
+    "description": "onelogin.saml2.idp.x509cert is the identity provider's PEM-encoded signing certificate, used to verify every SAML response and logout message it signs, and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "onelogin.saml2.sp.assertion_consumer_service.url",
+    "aliases": [],
+    "type": "string",
+    "description": "onelogin.saml2.sp.assertion_consumer_service.url is the callback URL where the identity provider must POST the SAML response after login \u2014 the Assertion Consumer Service (ACS) URL \u2014 and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "onelogin.saml2.sp.entityid",
+    "aliases": [],
+    "type": "string",
+    "description": "onelogin.saml2.sp.entityid is this server's SAML Service Provider entity ID, sent to the identity provider, and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "saml.groups.attribute",
+    "aliases": [],
+    "type": "string",
+    "description": "saml.groups.attribute is the Group Claim field of the SAML form on Enterprise Manager's Settings > Security > SSO page \u2014 the name of the assertion attribute StyleBI reads to put a user logging in through SAML into groups \u2014 and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "saml.orgid.attribute",
+    "aliases": [],
+    "type": "string",
+    "description": "saml.orgid.attribute is the Organization Id Claim field of the SAML form on Enterprise Manager's Settings > Security > SSO page \u2014 the name of the assertion attribute StyleBI reads to decide which organization a user logging in through SAML belongs to \u2014 and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "saml.roles.attribute",
+    "aliases": [],
+    "type": "string",
+    "description": "saml.roles.attribute is the Role Claim field of the SAML form on Enterprise Manager's Settings > Security > SSO page \u2014 the name of the assertion attribute StyleBI reads to assign roles to a user logging in through SAML \u2014 and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "auth0.client.id",
+    "aliases": [],
+    "type": "string",
+    "description": "auth0.client.id is the OAuth client identifier a legacy Auth0 installation stored, and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "auth0.client.secret",
+    "aliases": [],
+    "type": "string",
+    "description": "auth0.client.secret is the OAuth client secret a legacy Auth0 installation stored, and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "auth0.domain",
+    "aliases": [],
+    "type": "string",
+    "description": "auth0.domain is the Auth0 tenant domain a legacy installation stored to build its Auth0 login endpoints, and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "auth0.jwk.url",
+    "aliases": [],
+    "type": "string",
+    "description": "auth0.jwk.url is the JWKS URL a legacy Auth0 installation stored, and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "auth0.jwt.claim",
+    "aliases": [],
+    "type": "string",
+    "description": "auth0.jwt.claim is the ID-token claim name a legacy Auth0 installation stored as the login identity, and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "auth0.logout.url",
+    "aliases": [],
+    "type": "string",
+    "description": "auth0.logout.url is the single sign-out URL a legacy Auth0 installation stored, and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
+  },
+  {
+    "name": "auth0.openid.scope",
+    "aliases": [],
+    "type": "string",
+    "description": "auth0.openid.scope is the space-separated OAuth scope list a legacy Auth0 installation stored, and has no declared default.",
+    "risk": "high",
+    "snapshotScope": "value"
   }
 ]

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminPropertiesControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminPropertiesControllerTest.java
@@ -165,12 +165,18 @@ class AdminPropertiesControllerTest {
 
    @Test
    void reportsExistenceAsUnknownWhenUncataloguedAndUnset() {
-      // The regression this whole field exists for. openid.client.id is a real property with a
-      // read site in OpenIDConfig, but on a server where SSO has never been configured it is
-      // unset and uncatalogued - byte-identical to a name that does not exist. An agent read that
+      // The regression this whole field exists for. It was openid.client.id: a real property with
+      // a read site in OpenIDConfig which, on a server where SSO had never been configured, was
+      // unset AND uncatalogued - byte-identical to a name that does not exist. An agent read that
       // as "OIDC settings are not stored in server properties" and abandoned the task.
-      sreeEnv.when(() -> SreeEnv.getProperty("openid.client.id", false, false)).thenReturn(null);
-      PropertyView view = controller.get("openid.client.id", principal);
+      //
+      // That property is catalogued now, so it reports confirmed and no longer demonstrates the
+      // case. permission.andcondition stands in: real, community, still uncatalogued, unset by
+      // default. If cataloguing ever reaches it this test will fail, and that failure is a prompt
+      // to move the example on - not a defect.
+      sreeEnv.when(() -> SreeEnv.getProperty("permission.andcondition", false, false))
+         .thenReturn(null);
+      PropertyView view = controller.get("permission.andcondition", principal);
       assertFalse(view.recognized());
       assertNull(view.currentValue());
       assertEquals(PropertyView.EXISTS_UNKNOWN, view.exists());
@@ -198,12 +204,13 @@ class AdminPropertiesControllerTest {
    void distinguishesARealUnsetPropertyFromAnInventedOneOnlyByGuidance() {
       // Both are unknown - the server genuinely cannot tell them apart, and the fix is to say so
       // rather than to guess. This pins that the ambiguity is reported, not silently resolved.
-      sreeEnv.when(() -> SreeEnv.getProperty("openid.issuer", false, false)).thenReturn(null);
-      sreeEnv.when(() -> SreeEnv.getProperty("openid.not.a.real.property", false, false))
+      sreeEnv.when(() -> SreeEnv.getProperty("permission.andcondition", false, false))
+         .thenReturn(null);
+      sreeEnv.when(() -> SreeEnv.getProperty("permission.notarealproperty", false, false))
          .thenReturn(null);
 
-      PropertyView real = controller.get("openid.issuer", principal);
-      PropertyView invented = controller.get("openid.not.a.real.property", principal);
+      PropertyView real = controller.get("permission.andcondition", principal);
+      PropertyView invented = controller.get("permission.notarealproperty", principal);
 
       assertEquals(PropertyView.EXISTS_UNKNOWN, real.exists());
       assertEquals(PropertyView.EXISTS_UNKNOWN, invented.exists());

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminPropertyCatalogTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminPropertyCatalogTest.java
@@ -17,6 +17,9 @@
  */
 package inetsoft.web.admin.ai;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -191,5 +194,71 @@ class AdminPropertyCatalogTest {
       assertTrue(AdminPropertyCatalog.isEncryptedCredential("mail.smtp.clientSecret"));
       assertTrue(AdminPropertyCatalog.isEncryptedCredential("styleBI.google.openid.client.secret"));
       assertTrue(AdminPropertyCatalog.isEncryptedCredential("log.fluentd.security.sharedKey"));
+   }
+
+   @Test
+   void everyCatalogueEntryIsWellFormed() {
+      // The class javadoc's hard rule: a catalogued name that does not exist in StyleBI would be
+      // snapshotted as null, applied, read back as null, and reported as success for a property
+      // nothing reads. That existence check cannot run here - it is a source-tree grep, done when
+      // entries are added - but the shape checks that CAN run should, because a malformed entry
+      // fails the same silent way.
+      AdminPropertyCatalog catalog = new AdminPropertyCatalog();
+      Set<String> seen = new HashSet<>();
+
+      for(CatalogEntry entry : catalog.entries()) {
+         String name = entry.name();
+         assertNotNull(name, "every entry needs a name");
+         assertEquals(name.toLowerCase(), name,
+                      name + ": catalogued names are looked up lowercased, so store them that way");
+         assertTrue(seen.add(name), name + ": duplicated catalog entry");
+         assertNotNull(entry.description(), name + ": needs a description; it is shown in the plan");
+         assertTrue(List.of("string", "int", "boolean", "enum").contains(entry.type()),
+                    name + ": type must be one AdminPropertyCatalog.canonicalizeValue handles");
+         assertTrue(List.of("low", "high").contains(entry.risk()), name + ": risk must be low/high");
+         assertTrue(List.of("value", "storage").contains(entry.snapshotScope()),
+                    name + ": snapshotScope must be value/storage");
+
+         if("enum".equals(entry.type())) {
+            assertNotNull(entry.allowedValues(), name + ": an enum needs allowedValues");
+            assertFalse(entry.allowedValues().isEmpty(),
+                        name + ": an enum with no allowed values rejects every value");
+         }
+      }
+   }
+
+   @Test
+   void theSsoAreaIsCataloguedAndClassifiedConsistently() {
+      // Catalogued so a from-scratch SSO setup reports exists:"confirmed" and gets its values
+      // validated, instead of every property looking indistinguishable from a typo.
+      AdminPropertyCatalog catalog = new AdminPropertyCatalog();
+
+      for(String name : new String[] { "sso.protocol.type", "openid.client.id", "openid.issuer",
+                                       "openid.jwks.uri", "openid.scopes", "openid.name.claim",
+                                       "saml.roles.attribute", "onelogin.saml2.sp.entityid" })
+      {
+         CatalogEntry entry = catalog.getEntry(AdminPropertyName.parse(name));
+         assertNotNull(entry, name + " should be catalogued");
+         // No property in this area appears in PropertyChangeSideEffects or
+         // PropertiesEngine.applyProperty, so a write reaches nothing beyond the value itself and
+         // does not need a Tier-2 storage snapshot.
+         assertEquals("value", entry.snapshotScope(), name + ": no side-effect channel reaches it");
+         // Under-classifying here would skip review on a change that can lock every user out.
+         assertEquals("high", entry.risk(), name + ": SSO changes govern who can log in");
+      }
+   }
+
+   @Test
+   void ssoProtocolTypeRejectsATypoThatWouldSilentlyDisableSso() {
+      // SSOType.forName folds anything unrecognised to NONE, so "OpenId Connect" would turn SSO
+      // off with no error. As an enum it is refused, and a recognised value is canonicalised to
+      // the exact casing - which matters, because EmNavBarController compares the raw string.
+      AdminPropertyCatalog catalog = new AdminPropertyCatalog();
+      CatalogEntry entry = catalog.getEntry(AdminPropertyName.parse("sso.protocol.type"));
+
+      assertEquals("OpenID", catalog.canonicalizeValue(entry, "openid"));
+      assertEquals("SAML", catalog.canonicalizeValue(entry, "  saml  "));
+      assertThrows(IllegalArgumentException.class,
+                   () -> catalog.canonicalizeValue(entry, "OpenId Connect"));
    }
 }


### PR DESCRIPTION
The admin property catalog held **four** entries, so a from-scratch SSO setup saw every property come back `recognized: false` — unvalidated, high risk, storage scope, and (before `exists`) indistinguishable from a typo. This adds the 43 SSO-area properties that can be verified from this repository.

Generated from the per-property reference corpus rather than written by hand, then checked: **every catalogued name was confirmed to occur in community source**, because this class's hard rule is that a catalogued name which does not exist would be snapshotted as `null`, applied, read back as `null`, and reported as success for a property nothing reads.

## What it removes

`snapshotScope` is `value` for all 43 — **verified, not assumed**. No property in this area appears in `PropertyChangeSideEffects` or `PropertiesEngine.applyProperty`, and the only listeners registered through `PropertiesEngine.addPropertyChangeListener` are `TableFormat`'s two. A write reaches nothing beyond the value itself, so it does not warrant a Tier-2 storage snapshot. That is the friction this removes.

## What it deliberately does not remove

`risk` is `high` for all 43. These properties collectively decide who can log in, and under-classifying would skip review on a change that can lock every user out. Sign-off is the automatic reviewer subagent, so the cost is small — the storage snapshot was the expensive part.

## Two entries that do more than describe

- **`sso.protocol.type`** is an `enum`. `SSOType.forName` folds anything unrecognised to `NONE`, so a typo silently disables single sign-on today. It is now rejected, and a recognised value is canonicalised to the exact casing that `EmNavBarController`'s raw string comparison depends on — `openid` becomes `OpenID`.
- **`double.sso`** is a `boolean` read as `"true".equals`, so every other value means off. A value like `yes` is refused rather than quietly meaning "no".

## Twelve left out, on purpose

The whole `styleBI.google.*` family plus `sso.login.url`, `sso.logout.parameter` and `saml.name.attribute` have accessors only in the **enterprise superproject**. On a Community build they do not exist, so cataloguing them here would be exactly the failure the rule guards against. Reaching them needs a second resource contributed by the enterprise module — a design change, not an entry, and worth deciding separately.

## Test churn worth reading

Two `AdminPropertiesControllerTest` cases used `openid.client.id` and `openid.issuer` as their examples of a *real but uncatalogued* property. Cataloguing them is what makes those tests fail — the regression that motivated the `exists` field is now fixed at its source. The examples moved to `permission.andcondition`, with a note that a future failure there is a prompt to move on again rather than a defect.

Catalog 4 → 47. Catalog tests 18 → 21, including a well-formedness check over every entry (lowercase name, no duplicates, description present, type/risk/scope in range, enums non-empty). Full `admin.ai` suite green: 171 tests.
