### PR TITLE
Fix portal form binding regressions

### DIFF
--- a/web/projects/portal/src/app/portal/dialog/analyze-mv/analyze-mv-view/analyze-mv-pane.component.html
+++ b/web/projects/portal/src/app/portal/dialog/analyze-mv/analyze-mv-view/analyze-mv-pane.component.html
@@ -22,7 +22,7 @@
       <thead class="thead-light">
         <tr>
           <th class="table-header text-center align-middle">
-            <input type="checkbox"
+            <input class="form-check-input" type="checkbox"
               [ngModel]="isModelAllSelected()" (ngModelChange)="selectionAll($event)">
           </th>
           @for (header of tableHeaders; track header.name) {
@@ -36,7 +36,7 @@
       <tbody>
         @for (model of models; track model.name; let i = $index) {
           <tr>
-            <td><input type="checkbox" [ngModel]="isModelSelected(model)" (ngModelChange)="selectionChanged($event, model)"></td>
+            <td><input class="form-check-input" type="checkbox" [ngModel]="isModelSelected(model)" (ngModelChange)="selectionChanged($event, model)"></td>
             @for (header of tableHeaders; track header.name) {
               <td>{{model[header.name]}}</td>
             }

--- a/web/projects/portal/src/app/portal/dialog/arrange-dashboard-dialog.component.html
+++ b/web/projects/portal/src/app/portal/dialog/arrange-dashboard-dialog.component.html
@@ -57,7 +57,7 @@
                 <td>
                   <button type="button" class="btn btn-light-no-bg icon-hover-bg" (click)="moveDashboard(i, i - 1)"
                     [disabled]="!canMoveUp(i)">
-                    <i class="downward-icon" aria-hidden="true"></i>
+                    <i class="upward-icon" aria-hidden="true"></i>
                   </button>
                   <button type="button" class="btn btn-light-no-bg icon-hover-bg" (click)="moveDashboard(i, i + 1)"
                     [disabled]="!canMoveDown(i)">

--- a/web/projects/portal/src/app/portal/dialog/edit-dashboard-dialog.component.html
+++ b/web/projects/portal/src/app/portal/dialog/edit-dashboard-dialog.component.html
@@ -27,7 +27,7 @@
           @if (nameControl) {
             <div class="shell-form-group shell-form-row one-col-form-flex">
               <div class="form-floating col">
-                <input class="form-control dashboard_name_id" type="text" trim [(ngModel)]="name" [formControl]="nameControl"
+                <input class="form-control dashboard_name_id" type="text" trim [formControl]="nameControl"
                   placeholder="_#(Dashboard Name)"
                   defaultFocus [autoSelect]="false" aria-required="true"
                   [class.is-invalid]="!nameControl.valid && nameControl.dirty">

--- a/web/projects/portal/src/app/portal/dialog/edit-dashboard-dialog.component.ts
+++ b/web/projects/portal/src/app/portal/dialog/edit-dashboard-dialog.component.ts
@@ -121,7 +121,7 @@ export class EditDashboardDialog implements OnInit {
 
    okClicked(): void {
       let newDashboard = Tool.clone(this.dashboard);
-      newDashboard.name = this.name;
+      newDashboard.name = this.nameControl ? this.nameControl.value : this.name;
 
       // new dashboard
       if(this.isNew) {

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/action-accordian/action-accordion.component.html
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/action-accordian/action-accordion.component.html
@@ -164,8 +164,7 @@
                       [ngbTypeahead]="searchFrom"
                       [resultTemplate]="emailAutocompleteResult"
                       [inputFormatter]="formatEmails"
-                      title="_#(from.email.tooltip)"
-                      (ngModelChange)="updateFromEmails($event)">
+                      title="_#(from.email.tooltip)">
                     <label>_#(From)</label>
                   </div>
                 </div>
@@ -307,7 +306,6 @@
                     <div class="col-auto form-floating">
                       <input type="text" class="form-control" id="secretId"
                         formControlName="secretId"
-                        [(ngModel)]="action.secretId"
                         title="_#(schedule.zip.secretId)">
                       <label>_#(Secret ID)</label>
                     </div>
@@ -317,7 +315,6 @@
                       <input type="password" class="form-control" id="password"
                         formControlName="password"
                         [class.is-invalid]="form && form.hasError('passwordsDoNotMatch')"
-                        [(ngModel)]="action.password"
                         title="_#(schedule.zip.password)">
                       <label>_#(Password)</label>
                     </div>
@@ -325,7 +322,6 @@
                       <input type="password" class="form-control" id="confirmPassword"
                         formControlName="confirmPassword"
                         [class.is-invalid]="form && form.hasError('passwordsDoNotMatch')"
-                        [(ngModel)]="confirmPassword"
                         title="_#(confirm.zip.password)">
                       <label>_#(Confirm Password)</label>
                       @if (form && form.hasError('passwordsDoNotMatch')) {
@@ -415,7 +411,6 @@
                     <input type="text" class="form-control" id="attachmentName"
                       formControlName="attachmentName"
                       [class.is-invalid]="!form.controls['attachmentName'].valid"
-                      [(ngModel)]="action.attachmentName"
                       title="_#(Attachment name Tooltip)">
                     <label>_#(Attachment Name)</label>
                     @if (form && !!form.controls['attachmentName'] &&
@@ -433,12 +428,10 @@
                     @if (!isIE) {
                       <ckeditor-wrapper [(ngModel)]="deliveryMessage" [advanced]="true" [ngModelOptions]="{standalone: true}" class="schedule-delivery-message"></ckeditor-wrapper>
                     } @else {
-                      <textarea class="form-control" formControlName="deliveryMessage"
-                      (ngModelChange)="updateDeliverMessage($event)"></textarea>
+                      <textarea class="form-control" formControlName="deliveryMessage"></textarea>
                     }
                     <ng-template #plainTextArea>
-                      <textarea class="form-control" formControlName="deliveryMessage"
-                      (ngModelChange)="updateDeliverMessage($event)"></textarea>
+                      <textarea class="form-control" formControlName="deliveryMessage"></textarea>
                     </ng-template>
                     <label>_#(Message)</label>
                   </div>

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/action-accordian/action-accordion.component.ts
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/action-accordian/action-accordion.component.ts
@@ -1015,6 +1015,20 @@ export class ActionAccordion implements OnInit, OnChanges, OnDestroy {
          this.form.addControl("deliveryMessage", new UntypedFormControl(this.deliveryMessage));
       }
 
+      this.formSubscriptions.add(this.form.get("secretId").valueChanges.subscribe(value =>
+         this.action.secretId = value));
+      this.formSubscriptions.add(this.form.get("password").valueChanges.subscribe(value =>
+         this.action.password = value));
+      this.formSubscriptions.add(this.form.get("confirmPassword").valueChanges.subscribe(value =>
+         this.confirmPassword = value));
+      this.formSubscriptions.add(this.form.get("attachmentName").valueChanges.subscribe(value =>
+         this.action.attachmentName = value));
+
+      if(this.isIE) {
+         this.formSubscriptions.add(this.form.get("deliveryMessage").valueChanges.subscribe(value =>
+            this.updateDeliverMessage(value)));
+      }
+
       if(this.action.notificationEnabled) {
          this.updateNotificationStatus(true);
       }
@@ -1041,6 +1055,8 @@ export class ActionAccordion implements OnInit, OnChanges, OnDestroy {
       }
 
       if(this.model.emailDeliveryEnabled) {
+         this.formSubscriptions.add(this.form.get("from").valueChanges.subscribe(value =>
+            this.updateFromEmails(value)));
          this.formSubscriptions.add(this.form.get("cc").valueChanges.subscribe(value =>
             this.action.ccAddress = value));
          this.formSubscriptions.add(this.form.get("bcc").valueChanges.subscribe(value =>

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/task-action-pane.component.html
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/task-action-pane.component.html
@@ -25,17 +25,17 @@
               >
               <input class="form-control" id="dashboardLabel" readonly
                 placeholder="_#(Select a Dashboard)" aria-label="select a Dashboard"
-                [ngModel]="getSheetPath(generalActionModel.sheet)"  [ngModelOptions]="{standalone: true}"
+                [value]="getSheetPath(generalActionModel.sheet)"
                 [class.is-invalid]="selectSheetError"/>
               <input class="form-control d-none" id="dashboard" formControlName="dashboard" readonly
                 placeholder="_#(Select a Dashboard)" aria-label="select a Dashboard"
-                [ngModel]="getSheetPath(generalActionModel.sheet)" [class.is-invalid]="selectSheetError"/>
+                [class.is-invalid]="selectSheetError"/>
               <button type="button" class="btn btn-secondary" (click)="showSelectDashboardDialog()">
                 _#(Select)
               </button>
               <button type="button" class="btn btn-secondary"
                 [disabled]="!generalActionModel.sheet"
-                (click)="generalActionModel.sheet = null">
+                (click)="clearViewsheet()">
                 _#(Clear)
               </button>
             </div>

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/task-action-pane.component.ts
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/task-action-pane.component.ts
@@ -216,6 +216,8 @@ export class TaskActionPane implements OnInit {
    private changeViewsheet(sheet: string): void {
       this.clearHighlightConditions(sheet);
       (<GeneralActionModel>this.action).sheet = sheet;
+      this.form?.controls["dashboard"]?.setValue(sheet);
+      this.form?.controls["dashboard"]?.markAsDirty();
       this.dirtyFormByTs = true;
 
       if(!sheet) {
@@ -227,6 +229,10 @@ export class TaskActionPane implements OnInit {
       this.getHighlights();
       this.getParameters();
       this.getTableDataAssemblies();
+   }
+
+   clearViewsheet(): void {
+      this.changeViewsheet(null);
    }
 
    private getPrintLayout(sheet: string = null) {

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-list/schedule-task-list.component.ts
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-list/schedule-task-list.component.ts
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import { HttpClient, HttpParams } from "@angular/common/http";
+import { NgClass } from "@angular/common";
 import {
    AfterContentChecked,
    AfterViewInit,
@@ -106,7 +107,7 @@ declare const window: any;
     templateUrl: "./schedule-task-list.component.html",
     styleUrls: ["./schedule-task-list.component.scss"],
     providers: [ScheduleChangeService],
-    imports: [SplitPane, TreeComponent, ScrollableFlexTableDirective, FormsModule, SortColumnDirective]
+    imports: [SplitPane, TreeComponent, ScrollableFlexTableDirective, FormsModule, SortColumnDirective, NgClass]
 })
 export class ScheduleTaskListComponent implements OnInit, OnDestroy, AfterContentChecked, AfterViewInit {
    @ViewChild("tree") tree: TreeComponent;
@@ -196,7 +197,13 @@ export class ScheduleTaskListComponent implements OnInit, OnDestroy, AfterConten
    }
 
    get schedulerHealthPillClass(): string {
-      return this.schedulerHealth?.detailMessage ? "is-unavailable" : "is-ready";
+      const statusLabel = this.schedulerHealth?.statusLabel;
+
+      if(statusLabel === "_#(Unavailable)" || statusLabel === "Unavailable") {
+         return "is-unavailable";
+      }
+
+      return this.schedulerHealth?.detailMessage ? "is-warning" : "is-ready";
    }
 
    refreshSchedulerHealth(): void {

--- a/web/projects/portal/src/app/widget/schedule/start-time-editor.component.ts
+++ b/web/projects/portal/src/app/widget/schedule/start-time-editor.component.ts
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import { Component, EventEmitter, forwardRef, Input, OnInit, Output } from "@angular/core";
+import { NgIf } from "@angular/common";
 import { ControlValueAccessor, UntypedFormBuilder, UntypedFormGroup, NG_VALUE_ACCESSOR, ValidationErrors, Validators, FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { TimeRange } from "../../../../../shared/schedule/model/time-condition-model";
 import { CustomSelectOption, CustomSelectComponent } from "../custom-select/custom-select.component";
@@ -34,7 +35,7 @@ import { NgbTimepicker } from "@ng-bootstrap/ng-bootstrap";
             multi: true
         }
     ],
-    imports: [FormsModule, ReactiveFormsModule, NgbTimepicker, CustomSelectComponent]
+    imports: [NgIf, FormsModule, ReactiveFormsModule, NgbTimepicker, CustomSelectComponent]
 })
 export class StartTimeEditor implements OnInit, ControlValueAccessor {
    @Input() timeRanges: TimeRange[] = [];


### PR DESCRIPTION
Summary
Dashboard name field (edit-dashboard-dialog) was bound via both [(ngModel)] and [formControl] simultaneously; removed the redundant ngModel and read the value from nameControl on save so edits are actually persisted.
Several schedule action fields (secretId, password, confirmPassword, attachmentName, delivery message, from-email) mixed ngModel/ngModelChange with formControlName on the same input, causing dirty-state and value tracking to conflict. Replaced with valueChanges subscriptions that sync the corresponding model fields, removing the duplicate template bindings.
task-action-pane's dashboard-select input used ngModel purely for display; switched to a plain [value] binding, and added a clearViewsheet() handler so the "Clear" button updates the reactive form control (previously it only mutated the model directly, leaving the form out of sync).
Fixed the arrange-dashboard "move up" button using the wrong icon class (downward-icon instead of upward-icon).
Refined the scheduler health pill: it now distinguishes an explicit "Unavailable" status from a general warning (detailMessage present but not unavailable) instead of collapsing both into is-unavailable.
Added missing NgClass/NgIf imports to schedule-task-list and start-time-editor standalone component imports arrays (required after switching those templates to use directives not previously declared).
Why
These editors were using mixed template-driven (ngModel) and reactive-form (formControl/formControlName) bindings on the same inputs. Angular allows this without error, but the two mechanisms fight over the control's value/dirty state, so user edits could silently fail to persist or dirty tracking would be wrong (e.g., save button staying disabled, or saving stale values).

Test plan
 Edit a dashboard's name in the Edit Dashboard dialog and save — confirm the new name persists.
 In a schedule task's email/zip action, edit Secret ID, Password, Confirm Password, Attachment Name, and delivery message — save and reopen, confirm all values persist.
 Select and then Clear a dashboard in the Select Dashboard action pane — confirm the field clears and the save button reflects the dirty state correctly.
 In Arrange Dashboards, confirm the "move up" button shows an upward-pointing icon.
 With the scheduler in a degraded (non-fatal) state vs. fully unavailable, confirm the health pill shows "warning" vs. "unavailable" styling correctly.