### PR TITLE
fix(chart): dashboard color-frame sync crashes when charts have differently-named color dimensions

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/graph/VSFrameVisitor.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/VSFrameVisitor.java
@@ -614,7 +614,16 @@ public class VSFrameVisitor {
       // if a dimension is bound to both x and color, the sorting order of x dimension will
       // be used in VSDataSet since it comes first, and the aesthetic dimension sorting is
       // ignored. we find and apply the aesthetic dimension sorting here. (43336)
-      if(aref != null && aref.getRTDataRef() instanceof ChartDimensionRef) {
+      //
+      // Guarded on dataset.indexOfHeader(field, true) >= 0: when multiple charts share one
+      // dashboard-wide color-frame sync pass, `dataset` here is not guaranteed to be THIS
+      // dimension's own chart's data (see VSDimensionRef#createComparator's analogous guard for
+      // the same underlying issue). Without this check, `new SortedDataSet(dataset, field)`'s
+      // constructor -> addSortColumn() throws MessageException("Column not found: <field>") and
+      // aborts the entire export/render instead of just skipping this aesthetic-dimension sort.
+      if(aref != null && aref.getRTDataRef() instanceof ChartDimensionRef &&
+         dataset.indexOfHeader(field, true) >= 0)
+      {
          Comparator comp = ((ChartDimensionRef) aref.getRTDataRef()).createComparator(data);
          Comparator comp0 = dataset.getComparator(field);
 

--- a/core/src/main/java/inetsoft/uql/viewsheet/VSDimensionRef.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/VSDimensionRef.java
@@ -840,7 +840,17 @@ public class VSDimensionRef extends AbstractDataRef implements ContentObject, XD
       int order = getOrder();
       boolean string = XSchema.STRING.equals(getDataType());
 
-      if(data != null) {
+      // Prefer the runtime data set's actual column type over the declared one -- but only when
+      // this dimension's column is actually PRESENT in `data`. When multiple charts are composed
+      // into one dashboard viewsheet (WizDashboardService#composeDashboard, or an ordinary
+      // Composer-built dashboard with several charts), `data` passed to createComparator() during
+      // categorical color-frame sync (VSFrameVisitor#syncColors -> sortValues) is not guaranteed
+      // to be THIS dimension's own chart's data set -- e.g. a shared/cloned CategoricalColorFrame
+      // context carried over from a sibling chart. Calling getType() unconditionally then throws
+      // ColumnNotFoundException (e.g. "Column not found: project_name in
+      // date_type,None(event_month),work_package_count") and aborts the entire export/render
+      // instead of just this one dimension falling back to its already-computed declared type.
+      if(data != null && data.indexOfHeader(getFullName(), true) >= 0) {
          string = data.getType(getFullName()) == String.class;
       }
 

--- a/core/src/test/java/inetsoft/uql/viewsheet/VSDimensionRefCreateComparatorTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/VSDimensionRefCreateComparatorTest.java
@@ -1,0 +1,101 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.viewsheet;
+
+import inetsoft.graph.data.DataSet;
+import inetsoft.graph.data.DefaultDataSet;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.schema.XSchema;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Comparator;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression test for a dashboard-compose crash: {@link VSDimensionRef#createComparator} used to
+ * call {@code data.getType(getFullName())} unconditionally whenever a non-null {@link DataSet}
+ * was supplied, even when that data set did not actually contain this dimension's column. That
+ * throws {@link inetsoft.uql.viewsheet.ColumnNotFoundException} ("Column not found: project_name
+ * in date_type,None(event_month),work_package_count", reproduced via VSFrameVisitor#syncColors ->
+ * sortValues -> createComparator when composing two charts with differently-named categorical
+ * color dimensions into one dashboard viewsheet), aborting the entire export/render instead of
+ * this one dimension simply falling back to its own declared data type.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class VSDimensionRefCreateComparatorTest {
+
+   private VSDimensionRef stringRef(String name) {
+      VSDimensionRef ref = new VSDimensionRef();
+      ref.setDataRef(new AttributeRef(name));
+      ref.setDataType(XSchema.STRING);
+      return ref;
+   }
+
+   @Test
+   void doesNotThrowWhenTheDimensionsColumnIsAbsentFromTheDataSet() {
+      // "project_name" is bound to this dimension, but the supplied data set (standing in for a
+      // sibling chart's data, as happens when two charts share a dashboard-wide color-frame sync
+      // pass) only has "date_type" and "work_package_count".
+      VSDimensionRef projectName = stringRef("project_name");
+      DataSet siblingChartData = new DefaultDataSet(new Object[][]{
+         {"date_type", "work_package_count"},
+         {"Planned Start", 42.0},
+         {"Due Date", 37.0},
+      });
+
+      Comparator comparator = assertDoesNotThrow(() -> projectName.createComparator(siblingChartData));
+      assertNotNull(comparator);
+   }
+
+   @Test
+   void stillConsultsTheDataSetsActualColumnTypeWhenTheColumnIsPresent() {
+      // Regression guard on the fix itself: when the column IS present, behavior must be
+      // unchanged from before -- still resolve via the live data set, not just fall back to the
+      // declared type on every call.
+      VSDimensionRef category = stringRef("category");
+      DataSet ownChartData = new DefaultDataSet(new Object[][]{
+         {"category", "amount"},
+         {"A", 10.0},
+         {"B", 20.0},
+      });
+
+      Comparator comparator = assertDoesNotThrow(() -> category.createComparator(ownChartData));
+      assertNotNull(comparator);
+   }
+
+   @Test
+   void fallsBackGracefullyWithNoDataSetAtAll() {
+      // The pre-existing null-data path (data == null) must remain unaffected by the fix.
+      VSDimensionRef projectName = stringRef("project_name");
+      Comparator comparator = assertDoesNotThrow(() -> projectName.createComparator(null));
+      assertNotNull(comparator);
+   }
+}


### PR DESCRIPTION
## Summary

Composing two charts with differently-named categorical color dimensions (e.g. `date_type` and `project_name`) into one dashboard viewsheet crashes StyleBI's cross-chart color-legend synchronization, leaving the second chart's plot area blank (title/caption render fine, but the chart body doesn't) in both the live dashboard viewer and PDF/PPTX export.

Two adjacent unguarded assumptions in the same code path, both fixed:

1. **`VSDimensionRef#createComparator(DataSet data)`** called `data.getType(getFullName())` unconditionally whenever a non-null `DataSet` was supplied, even when that dataset didn't actually contain this dimension's own column — throwing `ColumnNotFoundException` instead of falling back to the already-computed declared type.

2. **`VSFrameVisitor#getVisualDataSet(String, AestheticRef, DataSet)`** — after fixing #1, this second, adjacent bug surfaced: it unconditionally wrapped the dataset in `new SortedDataSet(dataset, field)` whenever the aesthetic ref was a `ChartDimensionRef`, even when `field` wasn't actually a column of `dataset` — `SortedDataSet`'s constructor throws `MessageException("Column not found: <field>")` in that case.

Both are reached via `VSFrameVisitor#syncColors -> sortValues -> createComparator` (crash #1) and `VSFrameVisitor#createVisualFrame -> initFrame -> getVisualDataSet` (crash #2) during the dashboard's cross-chart color-frame sync pass, whenever the dataset a dimension's comparator/sort gets evaluated against isn't guaranteed to be that dimension's own chart's data.

## Repro

1. Create two charts on separate worksheets, each with a categorical color dimension of a **different name** (e.g. chart A colors by `date_type`, chart B colors by `project_name`).
2. Compose both into one dashboard (`WizDashboardService#composeDashboard`, or an ordinary Composer-built multi-chart dashboard).
3. Open the dashboard live, or export it to PDF/PPTX.
4. Before this fix: `ColumnNotFoundException: Column not found: project_name in date_type,None(event_month),work_package_count`, and the affected chart renders with title/caption only, no plot content.

## Fix

Guard both call sites on the column actually being present before using it (`data.indexOfHeader(getFullName(), true) >= 0` / `dataset.indexOfHeader(field, true) >= 0`), falling back to graceful degradation (the already-computed declared type; skipping just this aesthetic-dimension sort) instead of aborting the whole export/render.

## Test plan
- [x] New regression test `VSDimensionRefCreateComparatorTest` (3 cases) for crash #1 — confirmed it **fails** with the exact production exception against the pre-fix code, and passes with the fix.
- [x] `mvnw compile -pl core` clean for both fixes.
- [x] End-to-end verified against a live server: full rebuild (Java + Angular + Docker image), redeployed the running container, recomposed the dashboard and re-exported to PDF three times as each fix landed. Final state: the previously-blank chart now renders with full content (all axis tick labels, both panel scales, legend) and zero new ERROR-level log entries, vs. a title-only blank page and the exception stack trace before.
- Crash #2 (`VSFrameVisitor#getVisualDataSet`, a private method deep in a class requiring substantial fixture construction — `ChartInfo`/`VSFrameStrategy`/`FrameInitializer`) is verified via the live end-to-end test above rather than a unit test; no existing `VSFrameVisitorTest` fixture exists to build on affordably within scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)