### PR TITLE
fix(wiz): spell the icicle chart type correctly (icicle, not icircle)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -2381,7 +2381,7 @@ public class WizAutoBindingService {
          case GraphTypes.CHART_TREEMAP -> "treemap";
          case GraphTypes.CHART_SUNBURST -> "sunburst";
          case GraphTypes.CHART_CIRCLE_PACKING -> "circle_packing";
-         case GraphTypes.CHART_ICICLE -> "icircle";
+         case GraphTypes.CHART_ICICLE -> "icicle";
          case GraphTypes.CHART_MEKKO -> "marimekko";
          case GraphTypes.CHART_GANTT -> "gantt";
          case GraphTypes.CHART_FUNNEL -> "funnel";
@@ -2433,7 +2433,7 @@ public class WizAutoBindingService {
          case "treemap" -> GraphTypes.CHART_TREEMAP;
          case "sunburst" -> GraphTypes.CHART_SUNBURST;
          case "circle_packing" -> GraphTypes.CHART_CIRCLE_PACKING;
-         case "icircle" -> GraphTypes.CHART_ICICLE;
+         case "icicle" -> GraphTypes.CHART_ICICLE;
          case "marimekko" -> GraphTypes.CHART_MEKKO;
          case "gantt" -> GraphTypes.CHART_GANTT;
          case "funnel" -> GraphTypes.CHART_FUNNEL;

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -3659,7 +3659,7 @@ public class WizVsService {
          case "treemap" -> GraphTypes.CHART_TREEMAP;
          case "sunburst" -> GraphTypes.CHART_SUNBURST;
          case "circle_packing" -> GraphTypes.CHART_CIRCLE_PACKING;
-         case "icircle" -> GraphTypes.CHART_ICICLE;
+         case "icicle" -> GraphTypes.CHART_ICICLE;
          case "marimekko" -> GraphTypes.CHART_MEKKO;
          case "gantt" -> GraphTypes.CHART_GANTT;
          case "funnel" -> GraphTypes.CHART_FUNNEL;
@@ -3925,7 +3925,7 @@ public class WizVsService {
             }
          }
       }
-      // TreeMap group: Tree Map, Sun Burst, Circle Packing, ICircle
+      // TreeMap group: Tree Map, Sun Burst, Circle Packing, Icicle
       // x (dimension), y (measure), t (dimension hierarchy → added to X)
       else if(isTreeMapChartType(chartType)) {
          if(binding.getX() != null) {

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceChartTypeCandidatesTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceChartTypeCandidatesTest.java
@@ -194,4 +194,23 @@ class WizAutoBindingServiceChartTypeCandidatesTest {
 
       assertNull(WizAutoBindingService.selectedRecommendationType(rec));
    }
+
+   /**
+    * Regression: {@code getChartTypeString}/{@code graphTypeForName} used to spell
+    * {@link GraphTypes#CHART_ICICLE} as "icircle" — not StyleBI's own name for this chart type
+    * (every other surface, including this class's own {@link GraphTypes} javadoc and its catalog
+    * label "Icicle", spells it "icicle"). Found live from the wiz-services side, where a caller
+    * asking for an "icicle" chart got silently substituted with a different chart type because the
+    * bridge only recognized "icircle". Fixed at the source: this candidate menu (and the inverse
+    * name→type lookup it shares logic with) must use the same spelling as the rest of the product.
+    */
+   @Test
+   void spellsTheIcicleChartTypeCorrectly() {
+      List<ChartTypeCandidate> candidates = WizAutoBindingService.buildChartTypeCandidates(List.of(
+         chartRec(List.of(info(GraphTypes.CHART_ICICLE), info(GraphTypes.CHART_TREEMAP)), null)));
+
+      assertTrue(typesOf(candidates).contains("icicle"),
+                 "CHART_ICICLE must be spelled \"icicle\", not \"icircle\": " + typesOf(candidates));
+      assertFalse(typesOf(candidates).contains("icircle"));
+   }
 }


### PR DESCRIPTION
## What

`WizVsService.getChartType` and `WizAutoBindingService.getChartTypeString`/`graphTypeForName` spelled `GraphTypes.CHART_ICICLE` as `"icircle"` in the JSON wire contract with wiz-services.

## Why this is wrong

`"icircle"` was never StyleBI's own name for this chart type. `GraphTypes.java`'s own javadoc, its own UI catalog label (`"Icicle"`), `IcicleChartFilter.java`, and 25 other files across the product all correctly spell it `"icicle"`. `"icircle"` was a typo introduced only in this bridge, then copied into wiz-services' own `ComponentType` enum as though it were StyleBI's real name.

## How it was found

Found live sweeping the openproject datasource through the wiz-services plugin (E4: "icicle chart of work packages by project and type"). A request for the correctly-spelled chart type rendered a valid binding, then failed against this bridge (which only recognized `"icircle"`), and silently fell back to a materially different chart type with no indication `"icicle"` was ever a valid, renderable request.

## Fix

Both directions of the string↔`GraphTypes` mapping now spell it `"icicle"`. No backward-compatibility shim needed — this wiz integration has not shipped, so there is no persisted or external caller depending on the `"icircle"` spelling; StyleBI's own asset persistence stores chart type as the `GraphTypes` int constant (`0x44`), never as this JSON string.

## Testing

Added a regression test via `buildChartTypeCandidates` (the public path that shares `getChartTypeString`'s logic) confirming `CHART_ICICLE` now resolves to `"icicle"`, not `"icircle"`. Full `Wiz*Test` suite (393 tests) passes.

Companion fix in `stylebi-wiz` (wiz-services/wiz-portal side, same rename, no alias) ships alongside this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)