### PR TITLE
Add form-check-input class to Analyze MV table checkboxes

### DIFF
--- a/web/projects/portal/src/app/portal/dialog/analyze-mv/analyze-mv-view/analyze-mv-pane.component.html
+++ b/web/projects/portal/src/app/portal/dialog/analyze-mv/analyze-mv-view/analyze-mv-pane.component.html
@@ -22,7 +22,7 @@
       <thead class="thead-light">
         <tr>
           <th class="table-header text-center align-middle">
-            <input type="checkbox"
+            <input class="form-check-input" type="checkbox"
               [ngModel]="isModelAllSelected()" (ngModelChange)="selectionAll($event)">
           </th>
           @for (header of tableHeaders; track header.name) {
@@ -36,7 +36,7 @@
       <tbody>
         @for (model of models; track model.name; let i = $index) {
           <tr>
-            <td><input type="checkbox" [ngModel]="isModelSelected(model)" (ngModelChange)="selectionChanged($event, model)"></td>
+            <td><input class="form-check-input" type="checkbox" [ngModel]="isModelSelected(model)" (ngModelChange)="selectionChanged($event, model)"></td>
             @for (header of tableHeaders; track header.name) {
               <td>{{model[header.name]}}</td>
             }


### PR DESCRIPTION
## Summary
- Aligns the select-all and per-row model checkboxes in the Analyze MV pane with the app's shared `form-check-input` styling.

## Test plan
- [ ] Open the Analyze MV dialog and confirm the header select-all checkbox and per-row checkboxes render with standard checkbox styling and remain fully functional (select all / select individual rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)