### PR TITLE
Viewsheet agent backend, and a capturing dispatcher for headless composer calls

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/WorksheetEngine.java
+++ b/core/src/main/java/inetsoft/report/composition/WorksheetEngine.java
@@ -549,6 +549,25 @@ public abstract class WorksheetEngine extends SheetLibraryEngine implements Work
     * @param touch <code>true</code> to update the access time and heartbeat.
     * @return the runtime sheet if any.
     */
+   /**
+    * Whether a principal may act on a runtime sheet owned by a different session.
+    *
+    * <p>Two cases, both narrow and both opt-in on the principal itself:
+    * {@code supportLogin} for a support-staff login, and {@code pairedAgent} for an AI agent that
+    * has paired with the runtime. The pairing path sets the latter only after confirming the
+    * runtime's owner is the same logical user (see {@code SheetRuntimeAccess}), so this widens
+    * access to another <em>session</em> of that user, never to another user.
+    *
+    * <p>The agent case is needed because the wiz layer resolves a paired sheet without the owner
+    * check, but then delegates to composer services that re-resolve through this method with the
+    * agent's own principal — which can never be {@code equals} to the browser session's.
+    */
+   private static boolean mayActForOwner(Principal user) {
+      return user instanceof SRPrincipal p &&
+         (Boolean.TRUE.toString().equals(p.getProperty("supportLogin")) ||
+          Boolean.TRUE.toString().equals(p.getProperty("pairedAgent")));
+   }
+
    public final RuntimeSheet getSheet(String id, Principal user, boolean touch) {
       if(!isLocal(id)) {
          LOG.error("Getting sheet from non-owner: {}", id, new Exception("Stack trace"));
@@ -563,9 +582,7 @@ public abstract class WorksheetEngine extends SheetLibraryEngine implements Work
       }
 
       if(rs.getUser() != null && user != null && !rs.matches(user)) {
-         if(!(user instanceof SRPrincipal &&
-            Boolean.TRUE.toString().equals(((SRPrincipal) user).getProperty("supportLogin"))))
-         {
+         if(!mayActForOwner(user)) {
             throw new InvalidUserException(
                catalog.getString("common.invalidUser", user, rs.getUser()),
                LogLevel.INFO, false, rs.getUser());
@@ -789,10 +806,7 @@ public abstract class WorksheetEngine extends SheetLibraryEngine implements Work
          boolean isSchedulerSheet = rsheet.getEntry() != null &&
             "true".equals(rsheet.getEntry().getProperty("_scheduler_"));
 
-         if(!isSchedulerSheet &&
-            !(user instanceof SRPrincipal &&
-            Boolean.TRUE.toString().equals(((SRPrincipal) user).getProperty("supportLogin"))))
-         {
+         if(!isSchedulerSheet && !mayActForOwner(user)) {
             throw new InvalidUserException(Catalog.getCatalog().
                getString("common.invalidUser", user, rsheet.getUser()),
                                            rsheet.getUser());

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartPlotResizeService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartPlotResizeService.java
@@ -73,7 +73,12 @@ public class VSChartPlotResizeService extends VSChartControllerService<VSChartPl
 
             if(heightResized || square) {
                chartInfo.setUnitHeightRatio(sizeRatio);
-               chartInfo.setUnitWidthRatioPercent(sizeRatio / chartInfo.getInitialHeightRatio());
+               // Height branch sets the HEIGHT percent. It set the width percent, overwriting the
+               // value the width branch had just computed on a square resize, and leaving the
+               // height percent unset — which matters because VGraphPair recomputes
+               // unitHeightRatio only when getUnitHeightRatioPercent() >= 1, so a height resize
+               // was dropped on the next recompute.
+               chartInfo.setUnitHeightRatioPercent(sizeRatio / chartInfo.getInitialHeightRatio());
                chartInfo.setHeightResized(true);
             }
          }

--- a/core/src/main/java/inetsoft/web/wiz/WizControllerErrorHandler.java
+++ b/core/src/main/java/inetsoft/web/wiz/WizControllerErrorHandler.java
@@ -19,6 +19,7 @@ package inetsoft.web.wiz;
 
 import inetsoft.util.Catalog;
 import inetsoft.util.InvalidUserException;
+import inetsoft.web.wiz.dispatch.CommandErrorException;
 import inetsoft.web.wiz.service.UnsupportedDatasourceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -201,6 +202,29 @@ public class WizControllerErrorHandler {
                   "The request body could not be read: " +
                   (newline < 0 ? detail : detail.substring(0, newline)));
       return new ResponseEntity<>(payload, null, HttpStatus.BAD_REQUEST);
+   }
+
+   /**
+    * Maps a captured composer error to 409, carrying every message.
+    *
+    * <p>{@code CommandErrorException} extends {@code Exception} and had no handler, so the
+    * mechanism this whole feature exists to add — turning a composer ERROR that is only
+    * <em>dispatched</em> into something the caller can see — captured the text and then lost it to
+    * a generic 500 reading "Internal Server Error". The capture worked; the delivery did not.
+    *
+    * <p>409 rather than 400 because the request was well-formed and the composer refused it: a
+    * conflict with the sheet's state, not a malformed call. {@code getErrors()} is surfaced as its
+    * own field as well as joined into {@code error}, since the composer often reports several and
+    * joining them alone loses the boundaries.
+    */
+   @ExceptionHandler(CommandErrorException.class)
+   public ResponseEntity<Map<String, Object>> handleCommandError(CommandErrorException e) {
+      LOG.warn("Composer reported an error to the wiz agent: {}", e.getMessage());
+
+      Map<String, Object> payload = new HashMap<>();
+      payload.put("error", e.getMessage());
+      payload.put("errors", e.getErrors());
+      return new ResponseEntity<>(payload, null, HttpStatus.CONFLICT);
    }
 
    private static final Logger LOG = LoggerFactory.getLogger(WizControllerErrorHandler.class);

--- a/core/src/main/java/inetsoft/web/wiz/WizControllerErrorHandler.java
+++ b/core/src/main/java/inetsoft/web/wiz/WizControllerErrorHandler.java
@@ -80,5 +80,29 @@ public class WizControllerErrorHandler {
       return new ResponseEntity<>(payload, null, HttpStatus.UNPROCESSABLE_ENTITY);
    }
 
+   /**
+    * Maps an input-validation failure to 400 <em>carrying its message</em>.
+    *
+    * <p>The wiz agent services express every bad-request condition as an
+    * {@code IllegalArgumentException} with a caller-facing message — ~75 sites in
+    * {@code inetsoft.web.wiz.viewsheet} alone ({@code ViewsheetEditService},
+    * {@code PropertyPath}, {@code ConditionVocabulary}, {@code DateComparisonService}, …). Without
+    * this handler every one of them fell through as a generic 500 with the message discarded, so a
+    * caller saw "Request failed with status code 500" for a fixable bad request and had no way to
+    * learn which field was wrong. That made correct validation indistinguishable from a server bug.
+    *
+    * <p>The message goes in the {@code error} key deliberately: that is the field wiz-services'
+    * {@code handleError} extracts, so the text reaches the agent rather than being replaced by a
+    * bare status code.
+    */
+   @ExceptionHandler(IllegalArgumentException.class)
+   public ResponseEntity<Map<String, String>> handleIllegalArgument(IllegalArgumentException e) {
+      LOG.warn("Invalid wiz request: {}", e.getMessage());
+
+      Map<String, String> payload = new HashMap<>();
+      payload.put("error", e.getMessage());
+      return new ResponseEntity<>(payload, null, HttpStatus.BAD_REQUEST);
+   }
+
    private static final Logger LOG = LoggerFactory.getLogger(WizControllerErrorHandler.class);
 }

--- a/core/src/main/java/inetsoft/web/wiz/WizControllerErrorHandler.java
+++ b/core/src/main/java/inetsoft/web/wiz/WizControllerErrorHandler.java
@@ -22,6 +22,8 @@ import inetsoft.util.InvalidUserException;
 import inetsoft.web.wiz.service.UnsupportedDatasourceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.ResponseEntity;
@@ -44,6 +46,19 @@ import java.util.Map;
  * specific local {@code SecurityException} handler, since a local handler takes precedence over a
  * {@code @ControllerAdvice} and their catch-all would otherwise intercept the denial first (as 400).
  */
+/*
+ * Ordered ahead of every other advice, for the wiz packages only.
+ *
+ * GlobalExceptionHandler extends ResponseEntityExceptionHandler, which carries a built-in handler
+ * for the Spring MVC exceptions -- HttpMessageNotReadableException among them -- and answers with
+ * the default empty body. With neither advice ordered, that one won, so a body Jackson could not
+ * read came back as a bare 400 no matter what this class said about it.
+ *
+ * This was invisible to the unit tests: standaloneSetup registers only the advice under test, so
+ * the handler looked correct in isolation and did nothing in the running application. Found by
+ * calling the tool after the fix and getting the same empty 400 as before.
+ */
+@Order(Ordered.HIGHEST_PRECEDENCE)
 @ControllerAdvice(basePackages = "inetsoft.web.wiz")
 public class WizControllerErrorHandler {
    @ExceptionHandler({ inetsoft.sree.security.SecurityException.class, java.lang.SecurityException.class })

--- a/core/src/main/java/inetsoft/web/wiz/WizControllerErrorHandler.java
+++ b/core/src/main/java/inetsoft/web/wiz/WizControllerErrorHandler.java
@@ -23,6 +23,7 @@ import inetsoft.web.wiz.service.UnsupportedDatasourceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -154,6 +155,37 @@ public class WizControllerErrorHandler {
       Map<String, String> payload = new HashMap<>();
       payload.put("error", e.getMessage());
       return new ResponseEntity<>(payload, null, HttpStatus.NOT_IMPLEMENTED);
+   }
+
+   /**
+    * Maps a body the converter could not read to 400 <em>saying so</em>.
+    *
+    * <p>Spring retries an unmatched exception against its cause, so a {@code @JsonCreator} that
+    * throws {@code IllegalArgumentException} is already answered with its message by the handler
+    * above. A failure raised by <em>Jackson</em> is not: a field given the wrong shape produced a
+    * bodyless 400, and the caller saw "Request failed with status code 400" and nothing else —
+    * which is indistinguishable from a broken tool, and sends an investigation looking at the
+    * server rather than at the request.
+    *
+    * <p>Jackson's own text is verbose and names internal classes, so only its first line is
+    * passed on: it is the line that names the offending field, which is the part a caller can act
+    * on.
+    */
+   @ExceptionHandler(HttpMessageNotReadableException.class)
+   public ResponseEntity<Map<String, String>> handleUnreadableBody(
+      HttpMessageNotReadableException e)
+   {
+      LOG.warn("Unreadable wiz request body: {}", e.getMessage());
+
+      Throwable cause = e.getMostSpecificCause();
+      String detail = cause == null || cause.getMessage() == null ? "" : cause.getMessage();
+      int newline = detail.indexOf('\n');
+
+      Map<String, String> payload = new HashMap<>();
+      payload.put("error",
+                  "The request body could not be read: " +
+                  (newline < 0 ? detail : detail.substring(0, newline)));
+      return new ResponseEntity<>(payload, null, HttpStatus.BAD_REQUEST);
    }
 
    private static final Logger LOG = LoggerFactory.getLogger(WizControllerErrorHandler.class);

--- a/core/src/main/java/inetsoft/web/wiz/WizControllerErrorHandler.java
+++ b/core/src/main/java/inetsoft/web/wiz/WizControllerErrorHandler.java
@@ -18,6 +18,7 @@
 package inetsoft.web.wiz;
 
 import inetsoft.util.Catalog;
+import inetsoft.util.InvalidUserException;
 import inetsoft.web.wiz.service.UnsupportedDatasourceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -102,6 +103,36 @@ public class WizControllerErrorHandler {
       Map<String, String> payload = new HashMap<>();
       payload.put("error", e.getMessage());
       return new ResponseEntity<>(payload, null, HttpStatus.BAD_REQUEST);
+   }
+
+   /**
+    * Maps a stale pairing session to 409 with an instruction the agent can act on.
+    *
+    * <p>When the principal behind a pairing session no longer owns the runtime sheet — the user
+    * logged out and back in, or the container restarted and they re-opened the sheet in a new
+    * browser session — {@code WorksheetEngine.getSheet} throws {@code InvalidUserException}. It
+    * arrived here as a bare 500 HTML page with no message, so an agent saw an opaque server error
+    * and its only sensible response was to retry, which fails identically every time.
+    *
+    * <p>The failure is especially misleading because <em>reads keep working</em>: those resolve the
+    * sheet through the pairing lookup, which does not check ownership, while every mutation goes
+    * through {@code getSheet} and is refused. So the session reports healthy and renders images
+    * right up to the first write.
+    *
+    * <p>The raw message names two client session ids and nothing else, which tells the agent
+    * nothing — hence a rewritten message rather than a passthrough. Kept as its own status so
+    * "re-pair" is distinguishable from the 400 that means "fix your input".
+    */
+   @ExceptionHandler(InvalidUserException.class)
+   public ResponseEntity<Map<String, String>> handleInvalidUser(InvalidUserException e) {
+      LOG.warn("Pairing session no longer owns the sheet: {}", e.getMessage());
+
+      Map<String, String> payload = new HashMap<>();
+      payload.put("error",
+                  "This pairing session no longer owns the sheet — the StyleBI login that opened " +
+                  "it has been replaced. Ask the user for a fresh pairing code and connect again. " +
+                  "Reads may still succeed on this session; writes will not.");
+      return new ResponseEntity<>(payload, null, HttpStatus.CONFLICT);
    }
 
    private static final Logger LOG = LoggerFactory.getLogger(WizControllerErrorHandler.class);

--- a/core/src/main/java/inetsoft/web/wiz/WizControllerErrorHandler.java
+++ b/core/src/main/java/inetsoft/web/wiz/WizControllerErrorHandler.java
@@ -135,5 +135,26 @@ public class WizControllerErrorHandler {
       return new ResponseEntity<>(payload, null, HttpStatus.CONFLICT);
    }
 
+   /**
+    * Maps a capability that is declared but not wired up to 501, carrying its message.
+    *
+    * <p>Some tools exist ahead of the mechanism they need — {@code set_column_labels} is the
+    * first: renaming a header requires a {@code TableDataPath} cell override that is not built
+    * yet, and writing the label anywhere else stores it where nothing reads. Such a tool must
+    * refuse rather than report a success that did not happen, and the refusal must not arrive as
+    * a 500, which reads as a bug and invites a retry that will fail identically.
+    *
+    * <p>501 says the request was fine and the feature is absent — which is exactly what an agent
+    * needs in order to surface a gap instead of working around it.
+    */
+   @ExceptionHandler(UnsupportedOperationException.class)
+   public ResponseEntity<Map<String, String>> handleUnsupported(UnsupportedOperationException e) {
+      LOG.warn("Unimplemented wiz capability: {}", e.getMessage());
+
+      Map<String, String> payload = new HashMap<>();
+      payload.put("error", e.getMessage());
+      return new ResponseEntity<>(payload, null, HttpStatus.NOT_IMPLEMENTED);
+   }
+
    private static final Logger LOG = LoggerFactory.getLogger(WizControllerErrorHandler.class);
 }

--- a/core/src/main/java/inetsoft/web/wiz/binding/AestheticChannels.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/AestheticChannels.java
@@ -38,8 +38,8 @@ public final class AestheticChannels {
    public static final List<String> FRAME_CHANNELS =
       List.of("color", "shape", "size", "line", "texture");
 
-   /** Frame channels this phase can write. The rest arrive in Phase 2. */
-   public static final List<String> SUPPORTED_FRAME_CHANNELS = List.of("color");
+   /** Frame channels that can be written. Every frame channel is supported since 2c Phase 2. */
+   public static final List<String> SUPPORTED_FRAME_CHANNELS = FRAME_CHANNELS;
 
    private AestheticChannels() {
    }

--- a/core/src/main/java/inetsoft/web/wiz/binding/AestheticChannels.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/AestheticChannels.java
@@ -1,0 +1,92 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import java.util.List;
+
+/**
+ * The aesthetic channel vocabulary.
+ *
+ * <p><b>Field channels and frame channels are not the same set</b>, and this class exposes
+ * that asymmetry rather than hiding it. There are field bindings for colour, shape, size and
+ * text; there are frames for colour, shape, size, line and texture. {@code line} and
+ * {@code texture} have frames but no field binding, so a caller asking to bind a field to
+ * {@code line} gets told why instead of a shrug.
+ *
+ * <p>Node channels belong to relation charts and arrive with spec 2c Phase 3.
+ */
+public final class AestheticChannels {
+   /** Channels that accept a field binding. */
+   public static final List<String> FIELD_CHANNELS = List.of("color", "shape", "size", "text");
+
+   /** Channels that accept a visual frame. */
+   public static final List<String> FRAME_CHANNELS =
+      List.of("color", "shape", "size", "line", "texture");
+
+   /** Frame channels this phase can write. The rest arrive in Phase 2. */
+   public static final List<String> SUPPORTED_FRAME_CHANNELS = List.of("color");
+
+   private AestheticChannels() {
+   }
+
+   public static String normalize(String channel) {
+      return channel == null ? "" : channel.trim().toLowerCase();
+   }
+
+   public static String requireFieldChannel(String channel) {
+      String name = normalize(channel);
+
+      if(FIELD_CHANNELS.contains(name)) {
+         return name;
+      }
+
+      if(FRAME_CHANNELS.contains(name)) {
+         throw new IllegalArgumentException(
+            "Channel '" + channel + "' takes a visual frame but no field binding. Use " +
+            "set_visual_frame for it. Field channels: " + String.join(", ", FIELD_CHANNELS) + ".");
+      }
+
+      throw new IllegalArgumentException(
+         "Unknown aesthetic channel '" + channel + "'. Field channels: " +
+         String.join(", ", FIELD_CHANNELS) + ".");
+   }
+
+   public static String requireFrameChannel(String channel) {
+      String name = normalize(channel);
+
+      if(SUPPORTED_FRAME_CHANNELS.contains(name)) {
+         return name;
+      }
+
+      if(FRAME_CHANNELS.contains(name)) {
+         throw new IllegalArgumentException(
+            "Channel '" + channel + "' has visual frames, but only " +
+            String.join(", ", SUPPORTED_FRAME_CHANNELS) + " frames are supported yet.");
+      }
+
+      if(FIELD_CHANNELS.contains(name)) {
+         throw new IllegalArgumentException(
+            "Channel '" + channel + "' accepts a field binding but has no visual frame. Use " +
+            "set_aesthetic_field for it.");
+      }
+
+      throw new IllegalArgumentException(
+         "Unknown aesthetic channel '" + channel + "'. Frame channels: " +
+         String.join(", ", FRAME_CHANNELS) + ".");
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindableColumns.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindableColumns.java
@@ -1,0 +1,87 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.web.wiz.binding.model.BindableTable;
+import inetsoft.web.wiz.binding.model.FieldRef;
+
+import java.util.*;
+
+/**
+ * Checks that a field being bound names a column the assembly can actually bind.
+ *
+ * <p>Without this, a column the source does not have was accepted in silence. The shelf stored it,
+ * the call reported success, and the assembly rendered with that grouping simply missing — a
+ * crosstab with no rows at all, which reads as "the data is empty" rather than "that column does
+ * not exist". Verified live by binding {@code NO_SUCH_COLUMN_XYZ}, and hit for real by binding a
+ * column belonging to a different worksheet than the one the assembly was pointed at.
+ *
+ * <p>The check is deliberately lenient about <em>where</em> a column lives: the listing groups
+ * columns by table and the same name can appear in several, so matching on the name alone across
+ * every table is enough to catch a name that exists nowhere without rejecting a legitimate one.
+ */
+public final class BindableColumns {
+   private BindableColumns() {
+   }
+
+   /**
+    * @throws IllegalArgumentException naming the column and what is available, if a field names a
+    *                                  column that appears in no bindable table.
+    */
+   public static void require(List<BindableTable> tables, String assembly, FieldRef... fields) {
+      require(tables, assembly, fields == null ? List.of() : Arrays.asList(fields));
+   }
+
+   public static void require(List<BindableTable> tables, String assembly,
+                              Collection<FieldRef> fields)
+   {
+      if(fields == null || fields.isEmpty()) {
+         return;
+      }
+
+      Set<String> available = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+
+      for(BindableTable table : tables == null ? List.<BindableTable>of() : tables) {
+         for(var field : table.fields()) {
+            if(field.column() != null) {
+               available.add(field.column());
+            }
+         }
+      }
+
+      // No listing at all means the tree could not be read — a different failure, and refusing
+      // every column on the strength of it would turn a read problem into a write problem.
+      if(available.isEmpty()) {
+         return;
+      }
+
+      for(FieldRef field : fields) {
+         if(field == null || field.column() == null || field.column().isBlank()) {
+            continue;
+         }
+
+         if(!available.contains(field.column())) {
+            throw new IllegalArgumentException(
+               "'" + field.column() + "' is not a column " + assembly + " can bind. Available: " +
+               String.join(", ", available) +
+               ". A column the source does not have binds cleanly and then renders nothing, so " +
+               "it is refused here rather than left to look like empty data.");
+         }
+      }
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindableFieldsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindableFieldsService.java
@@ -1,0 +1,87 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.web.binding.drm.DataRefModel;
+import inetsoft.web.binding.service.VSBindingTreeService;
+import inetsoft.web.composer.model.TreeNodeModel;
+import inetsoft.web.wiz.binding.model.BindableField;
+import inetsoft.web.wiz.binding.model.BindableTable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Projects the Composer's binding tree into a flat table/column list.
+ *
+ * <p>{@code TreeNodeModel} is a UI tree — icon, expandedIcon, toggleCollapsedIcon, tooltip,
+ * organization, expand state. An agent needs the structure, not the chrome, so this keeps
+ * names and data types and discards the rest.
+ */
+@Service
+public class BindableFieldsService {
+   @Autowired
+   public BindableFieldsService(VSBindingTreeService tree) {
+      this.tree = tree;
+   }
+
+   public List<BindableTable> list(String runtimeId, String assembly, Principal user)
+      throws Exception
+   {
+      TreeNodeModel root = tree.getBinding(runtimeId, assembly, false, user);
+      List<BindableTable> tables = new ArrayList<>();
+
+      if(root != null) {
+         collect(root, tables);
+      }
+
+      return tables;
+   }
+
+   /**
+    * A node with leaf children is a table; anything else is a folder to descend into. Keeping
+    * the rule structural rather than depth-based means the projection does not care how
+    * deeply the Composer nests its tree.
+    */
+   private void collect(TreeNodeModel node, List<BindableTable> tables) {
+      List<BindableField> fields = new ArrayList<>();
+
+      for(TreeNodeModel child : node.children()) {
+         if(child.leaf()) {
+            fields.add(new BindableField(child.label(), dataTypeOf(child), null));
+         }
+         else {
+            collect(child, tables);
+         }
+      }
+
+      if(!fields.isEmpty()) {
+         tables.add(new BindableTable(node.label(), fields));
+      }
+   }
+
+   /** A column node carries its {@link DataRefModel} in {@code data()}. */
+   private String dataTypeOf(TreeNodeModel node) {
+      return node.data() instanceof DataRefModel ref ? ref.getDataType() : null;
+   }
+
+   private final VSBindingTreeService tree;
+}

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
@@ -57,7 +57,8 @@ public class BindingAgentController {
                                  BindingReadService readService,
                                  ChartBindingService chartService,
                                  ChartAestheticService aestheticService,
-                                 TableBindingService tableService)
+                                 TableBindingService tableService,
+                                 CalcTableService calcService)
    {
       this.feature = feature;
       this.joinService = joinService;
@@ -68,6 +69,7 @@ public class BindingAgentController {
       this.chartService = chartService;
       this.aestheticService = aestheticService;
       this.tableService = tableService;
+      this.calcService = calcService;
    }
 
    public record JoinRequest(String code) {}
@@ -271,6 +273,55 @@ public class BindingAgentController {
                              request.toShelf(), request.column(), request.position());
    }
 
+   public record CellBindingRequest(String assembly, Integer row, Integer col,
+                                    Map<String, Object> binding) {}
+
+   @GetMapping("/api/wiz/v1/agent/binding/{sessionToken}/calc/layout")
+   public Map<String, Object> calcLayout(@PathVariable String sessionToken,
+                                         @RequestParam String assembly,
+                                         Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return calcService.readLayout(sessionToken, user, assembly);
+   }
+
+   @GetMapping("/api/wiz/v1/agent/binding/{sessionToken}/calc/cell")
+   public Map<String, Object> calcCell(@PathVariable String sessionToken,
+                                       @RequestParam String assembly,
+                                       @RequestParam int row,
+                                       @RequestParam int col,
+                                       Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return calcService.readCell(sessionToken, user, assembly, row, col);
+   }
+
+   @GetMapping("/api/wiz/v1/agent/binding/{sessionToken}/calc/vocabulary")
+   public Map<String, Object> calcVocabulary(@PathVariable String sessionToken, Principal user) {
+      requireEnabled();
+      return calcService.vocabulary();
+   }
+
+   @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/calc/cell")
+   public void setCalcCell(@PathVariable String sessionToken,
+                           @RequestBody CellBindingRequest request,
+                           Principal user)
+      throws Exception
+   {
+      requireEnabled();
+
+      if(request.row() == null || request.col() == null) {
+         throw new IllegalArgumentException(
+            "set_cell_binding requires 'row' and 'col' — calc-table cells are addressed by " +
+            "coordinate.");
+      }
+
+      calcService.setCellBinding(sessionToken, user, request.assembly(), request.row(),
+                                 request.col(), request.binding());
+   }
+
    @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/detach")
    public void detach(@PathVariable String sessionToken, Principal user) {
       sessionService.close(sessionToken);
@@ -308,4 +359,5 @@ public class BindingAgentController {
    private final ChartBindingService chartService;
    private final ChartAestheticService aestheticService;
    private final TableBindingService tableService;
+   private final CalcTableService calcService;
 }

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
@@ -322,6 +322,69 @@ public class BindingAgentController {
                                  request.col(), request.binding());
    }
 
+   public record TableSortRequest(String assembly, String shelf, String column, String direction,
+                                  String sortByField, List<String> manualOrder) {}
+   public record TableRankingRequest(String assembly, String shelf, String column, String mode,
+                                     Integer n, String measure, Boolean others) {}
+   public record TableLabelRequest(String assembly, Map<String, String> labels) {}
+   public record TableOptionRequest(String assembly, Map<String, Object> options) {}
+
+   @GetMapping("/api/wiz/v1/agent/binding/{sessionToken}/table/options")
+   public Map<String, Object> tableOptionVocabulary(@PathVariable String sessionToken,
+                                                    Principal user)
+   {
+      requireEnabled();
+      return tableService.optionVocabulary();
+   }
+
+   @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/table/sort")
+   public void setTableSort(@PathVariable String sessionToken,
+                            @RequestBody TableSortRequest request,
+                            Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      tableService.setSort(sessionToken, user, request.assembly(), request.shelf(),
+                           request.column(),
+                           new DimensionSortRanking.Sort(request.direction(),
+                                                         request.sortByField(),
+                                                         request.manualOrder()));
+   }
+
+   @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/table/ranking")
+   public void setTableRanking(@PathVariable String sessionToken,
+                               @RequestBody TableRankingRequest request,
+                               Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      tableService.setRanking(sessionToken, user, request.assembly(), request.shelf(),
+                              request.column(),
+                              new DimensionSortRanking.Ranking(request.mode(), request.n(),
+                                                               request.measure(),
+                                                               request.others()));
+   }
+
+   @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/table/labels")
+   public void setTableLabels(@PathVariable String sessionToken,
+                              @RequestBody TableLabelRequest request,
+                              Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      tableService.setColumnLabels(sessionToken, user, request.assembly(), request.labels());
+   }
+
+   @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/table/option")
+   public void setTableOptions(@PathVariable String sessionToken,
+                               @RequestBody TableOptionRequest request,
+                               Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      tableService.setOptions(sessionToken, user, request.assembly(), request.options());
+   }
+
    @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/detach")
    public void detach(@PathVariable String sessionToken, Principal user) {
       sessionService.close(sessionToken);

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
@@ -1,0 +1,128 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.web.wiz.binding.model.AssemblyBinding;
+import inetsoft.web.wiz.binding.model.BindableTable;
+import inetsoft.web.wiz.pairing.*;
+import inetsoft.web.wiz.viewsheet.ViewsheetSessionService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.security.Principal;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * REST surface for agent-driven binding discovery and reads.
+ *
+ * <p>Pairs against a VIEWSHEET runtime exactly as {@code ViewsheetAgentController} does. The
+ * {@code /join} endpoint here is a second door to the same {@link SheetJoinService}, not a
+ * second session model — it exists so the binding plugin can be installed and paired on its
+ * own, without the viewsheet plugin.
+ *
+ * <p>Phase 1 is read-only: every endpoint below is a pure read, so none of them takes a
+ * capturing dispatcher, adds a checkpoint, or broadcasts.
+ */
+@RestController
+public class BindingAgentController {
+   @Autowired
+   public BindingAgentController(SheetAgentFeature feature,
+                                 SheetJoinService joinService,
+                                 SheetSessionService sessionService,
+                                 ViewsheetSessionService sessions,
+                                 BindableFieldsService fieldsService,
+                                 BindingReadService readService)
+   {
+      this.feature = feature;
+      this.joinService = joinService;
+      this.sessionService = sessionService;
+      this.sessions = sessions;
+      this.fieldsService = fieldsService;
+      this.readService = readService;
+   }
+
+   public record JoinRequest(String code) {}
+   public record JoinResponse(String sessionToken, String runtimeId, String ownerIdentity) {}
+
+   @PostMapping("/api/wiz/v1/agent/binding/join")
+   public JoinResponse join(@RequestBody JoinRequest body, Principal user) throws PairingException {
+      requireEnabled();
+      JoinSession session = joinService.join(body.code(), user);
+      return new JoinResponse(session.sessionToken(), session.runtimeId(), session.ownerIdentity());
+   }
+
+   @GetMapping("/api/wiz/v1/agent/binding/{sessionToken}/fields")
+   public List<BindableTable> fields(@PathVariable String sessionToken,
+                                     @RequestParam(required = false) String assembly,
+                                     Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return fieldsService.list(sessions.runtimeId(sessionToken, user), assembly, user);
+   }
+
+   @GetMapping("/api/wiz/v1/agent/binding/{sessionToken}/binding")
+   public AssemblyBinding binding(@PathVariable String sessionToken,
+                                  @RequestParam String assembly,
+                                  Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return readService.read(sessions.resolve(sessionToken, user), assembly);
+   }
+
+   @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/detach")
+   public void detach(@PathVariable String sessionToken, Principal user) {
+      sessionService.close(sessionToken);
+   }
+
+   private void requireEnabled() {
+      if(!feature.isEnabled()) {
+         throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                                           "Sheet agent pairing is disabled");
+      }
+   }
+
+   @ExceptionHandler(PairingException.class)
+   public ResponseEntity<Map<String, String>> handlePairingException(PairingException e) {
+      HttpStatus status = switch(e.getKind()) {
+         case SESSION_EXPIRED -> HttpStatus.NOT_FOUND;
+         case USER_MISMATCH, FEATURE_DISABLED -> HttpStatus.FORBIDDEN;
+         case RATE_LIMITED -> HttpStatus.TOO_MANY_REQUESTS;
+         case INTERNAL -> HttpStatus.INTERNAL_SERVER_ERROR;
+         default -> HttpStatus.BAD_REQUEST;
+      };
+
+      Map<String, String> body = new LinkedHashMap<>();
+      body.put("error", e.getMessage());
+      body.put("errorCode", e.getKind().name());
+      return ResponseEntity.status(status).body(body);
+   }
+
+   private final SheetAgentFeature feature;
+   private final SheetJoinService joinService;
+   private final SheetSessionService sessionService;
+   private final ViewsheetSessionService sessions;
+   private final BindableFieldsService fieldsService;
+   private final BindingReadService readService;
+}

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
@@ -119,6 +119,22 @@ public class BindingAgentController {
                             request.fields(), linkUri);
    }
 
+   /** {@code field} may be null, which clears the shelf. */
+   public record SingleShelfRequest(String assembly, String shelf, FieldRef field) {}
+
+   @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/chart/single-shelf")
+   public void setChartSingleShelf(@PathVariable String sessionToken,
+                                   @RequestBody SingleShelfRequest request,
+                                   @RequestParam(required = false, defaultValue = "")
+                                   String linkUri,
+                                   Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      chartService.setSingleShelf(sessionToken, user, request.assembly(), request.shelf(),
+                                  request.field(), linkUri);
+   }
+
    @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/chart/type")
    public void setChartType(@PathVariable String sessionToken,
                             @RequestBody ChartTypeRequest request,
@@ -213,6 +229,9 @@ public class BindingAgentController {
    }
 
    public record TableShelfRequest(String assembly, String shelf, List<FieldRef> fields) {}
+
+   /** {@code force} discards fields already bound to the old source; absent means false. */
+   public record TableSourceRequest(String assembly, String table, Boolean force) {}
    public record TableFieldRequest(String assembly, String shelf, FieldRef field,
                                    Integer position) {}
    public record TableRemoveRequest(String assembly, String shelf, String column) {}
@@ -238,6 +257,17 @@ public class BindingAgentController {
       requireEnabled();
       tableService.setShelf(sessionToken, user, request.assembly(), request.shelf(),
                             request.fields());
+   }
+
+   @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/table/source")
+   public void setTableSource(@PathVariable String sessionToken,
+                              @RequestBody TableSourceRequest request,
+                              Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      tableService.setSource(sessionToken, user, request.assembly(), request.table(),
+                             Boolean.TRUE.equals(request.force()));
    }
 
    @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/table/field/add")
@@ -302,6 +332,29 @@ public class BindingAgentController {
    public Map<String, Object> calcVocabulary(@PathVariable String sessionToken, Principal user) {
       requireEnabled();
       return calcService.vocabulary();
+   }
+
+   @GetMapping("/api/wiz/v1/agent/binding/{sessionToken}/calc/cell/script")
+   public Map<String, Object> calcCellScript(@PathVariable String sessionToken,
+                                             @RequestParam String assembly,
+                                             @RequestParam int row,
+                                             @RequestParam int col,
+                                             Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return calcService.cellScript(sessionToken, user, assembly, row, col);
+   }
+
+   @GetMapping("/api/wiz/v1/agent/binding/{sessionToken}/calc/named-groups")
+   public Map<String, Object> calcNamedGroups(@PathVariable String sessionToken,
+                                              @RequestParam String assembly,
+                                              @RequestParam(required = false) String column,
+                                              Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return calcService.namedGroups(sessionToken, user, assembly, column);
    }
 
    @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/calc/cell")

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
@@ -56,7 +56,8 @@ public class BindingAgentController {
                                  BindableFieldsService fieldsService,
                                  BindingReadService readService,
                                  ChartBindingService chartService,
-                                 ChartAestheticService aestheticService)
+                                 ChartAestheticService aestheticService,
+                                 TableBindingService tableService)
    {
       this.feature = feature;
       this.joinService = joinService;
@@ -66,6 +67,7 @@ public class BindingAgentController {
       this.readService = readService;
       this.chartService = chartService;
       this.aestheticService = aestheticService;
+      this.tableService = tableService;
    }
 
    public record JoinRequest(String code) {}
@@ -208,6 +210,67 @@ public class BindingAgentController {
                                 request.frame(), linkUri);
    }
 
+   public record TableShelfRequest(String assembly, String shelf, List<FieldRef> fields) {}
+   public record TableFieldRequest(String assembly, String shelf, FieldRef field,
+                                   Integer position) {}
+   public record TableRemoveRequest(String assembly, String shelf, String column) {}
+   public record TableMoveRequest(String assembly, String fromShelf, String toShelf,
+                                  String column, Integer position) {}
+
+   @GetMapping("/api/wiz/v1/agent/binding/{sessionToken}/table/binding")
+   public Map<String, Object> tableBinding(@PathVariable String sessionToken,
+                                           @RequestParam String assembly,
+                                           Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return tableService.read(sessionToken, user, assembly);
+   }
+
+   @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/table/fields")
+   public void setTableFields(@PathVariable String sessionToken,
+                              @RequestBody TableShelfRequest request,
+                              Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      tableService.setShelf(sessionToken, user, request.assembly(), request.shelf(),
+                            request.fields());
+   }
+
+   @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/table/field/add")
+   public void addTableField(@PathVariable String sessionToken,
+                             @RequestBody TableFieldRequest request,
+                             Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      tableService.addField(sessionToken, user, request.assembly(), request.shelf(),
+                            request.field(), request.position());
+   }
+
+   @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/table/field/remove")
+   public void removeTableField(@PathVariable String sessionToken,
+                                @RequestBody TableRemoveRequest request,
+                                Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      tableService.removeField(sessionToken, user, request.assembly(), request.shelf(),
+                               request.column());
+   }
+
+   @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/table/field/move")
+   public void moveTableField(@PathVariable String sessionToken,
+                              @RequestBody TableMoveRequest request,
+                              Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      tableService.moveField(sessionToken, user, request.assembly(), request.fromShelf(),
+                             request.toShelf(), request.column(), request.position());
+   }
+
    @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/detach")
    public void detach(@PathVariable String sessionToken, Principal user) {
       sessionService.close(sessionToken);
@@ -244,4 +307,5 @@ public class BindingAgentController {
    private final BindingReadService readService;
    private final ChartBindingService chartService;
    private final ChartAestheticService aestheticService;
+   private final TableBindingService tableService;
 }

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
@@ -380,10 +380,11 @@ public class BindingAgentController {
                                  request.col(), request.binding());
    }
 
-   public record TableSortRequest(String assembly, String shelf, String column, String direction,
-                                  String sortByField, List<String> manualOrder) {}
-   public record TableRankingRequest(String assembly, String shelf, String column, String mode,
-                                     Integer n, String measure, Boolean others) {}
+   public record TableSortRequest(String assembly, String shelf, String column, Integer index,
+                                  String direction, String sortByField,
+                                  List<String> manualOrder) {}
+   public record TableRankingRequest(String assembly, String shelf, String column, Integer index,
+                                     String mode, Integer n, String measure, Boolean others) {}
    public record TableLabelRequest(String assembly, Map<String, String> labels) {}
    public record TableOptionRequest(String assembly, Map<String, Object> options) {}
 
@@ -403,7 +404,7 @@ public class BindingAgentController {
    {
       requireEnabled();
       tableService.setSort(sessionToken, user, request.assembly(), request.shelf(),
-                           request.column(),
+                           request.column(), request.index(),
                            new DimensionSortRanking.Sort(request.direction(),
                                                          request.sortByField(),
                                                          request.manualOrder()));
@@ -417,7 +418,7 @@ public class BindingAgentController {
    {
       requireEnabled();
       tableService.setRanking(sessionToken, user, request.assembly(), request.shelf(),
-                              request.column(),
+                              request.column(), request.index(),
                               new DimensionSortRanking.Ranking(request.mode(), request.n(),
                                                                request.measure(),
                                                                request.others()));

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
@@ -385,6 +385,56 @@ public class BindingAgentController {
       tableService.setOptions(sessionToken, user, request.assembly(), request.options());
    }
 
+   public record CalcLayoutRequest(String assembly, String op, Integer row, Integer col,
+                                   Integer rows, Integer cols, Integer n) {}
+   public record CalcCopyRequest(String assembly, String op, Integer row, Integer col,
+                                 Integer rows, Integer cols, Integer targetRow,
+                                 Integer targetCol) {}
+
+   @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/calc/layout")
+   public Map<String, Object> modifyCalcLayout(@PathVariable String sessionToken,
+                                               @RequestBody CalcLayoutRequest request,
+                                               Principal user)
+      throws Exception
+   {
+      requireEnabled();
+
+      if(request.row() == null || request.col() == null) {
+         throw new IllegalArgumentException(
+            "modify_calc_layout requires 'row' and 'col' — the anchor the operation applies at.");
+      }
+
+      return calcService.modifyLayout(sessionToken, user, request.assembly(), request.op(),
+                                      request.row(), request.col(), request.rows(),
+                                      request.cols(), request.n());
+   }
+
+   @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/calc/cells/copy")
+   public Map<String, Object> copyCalcCells(@PathVariable String sessionToken,
+                                            @RequestBody CalcCopyRequest request,
+                                            Principal user)
+      throws Exception
+   {
+      requireEnabled();
+
+      if(request.row() == null || request.col() == null) {
+         throw new IllegalArgumentException(
+            "copy_calc_cells requires 'row' and 'col' — the source range's top-left cell.");
+      }
+
+      java.awt.Rectangle source = new java.awt.Rectangle(
+         request.col(), request.row(),
+         request.cols() == null ? 1 : request.cols(),
+         request.rows() == null ? 1 : request.rows());
+      java.awt.Rectangle target = request.targetRow() == null || request.targetCol() == null
+         ? null
+         : new java.awt.Rectangle(request.targetCol(), request.targetRow(), source.width,
+                                  source.height);
+
+      return calcService.copyCells(sessionToken, user, request.assembly(), request.op(), source,
+                                   target);
+   }
+
    @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/detach")
    public void detach(@PathVariable String sessionToken, Principal user) {
       sessionService.close(sessionToken);

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
@@ -55,7 +55,8 @@ public class BindingAgentController {
                                  ViewsheetSessionService sessions,
                                  BindableFieldsService fieldsService,
                                  BindingReadService readService,
-                                 ChartBindingService chartService)
+                                 ChartBindingService chartService,
+                                 ChartAestheticService aestheticService)
    {
       this.feature = feature;
       this.joinService = joinService;
@@ -64,6 +65,7 @@ public class BindingAgentController {
       this.fieldsService = fieldsService;
       this.readService = readService;
       this.chartService = chartService;
+      this.aestheticService = aestheticService;
    }
 
    public record JoinRequest(String code) {}
@@ -143,6 +145,69 @@ public class BindingAgentController {
       chartService.swapAxes(sessionToken, user, request.assembly(), linkUri);
    }
 
+   public record AestheticFieldRequest(String assembly, String channel, FieldRef field) {}
+   public record AestheticFrameRequest(String assembly, String channel,
+                                       Map<String, Object> frame) {}
+
+   @GetMapping("/api/wiz/v1/agent/binding/{sessionToken}/chart/aesthetics")
+   public Map<String, Object> chartAesthetics(@PathVariable String sessionToken,
+                                              @RequestParam String assembly,
+                                              Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return aestheticService.read(sessionToken, user, assembly);
+   }
+
+   /**
+    * Chart-type-aware discovery arrives with Phase 2, when channel validity starts to depend
+    * on the chart type. Until then every supported channel applies to every chart, and saying
+    * so plainly beats a list that pretends to be filtered.
+    */
+   @GetMapping("/api/wiz/v1/agent/binding/{sessionToken}/chart/aesthetic-options")
+   public Map<String, Object> aestheticOptions(@PathVariable String sessionToken,
+                                               Principal user)
+   {
+      requireEnabled();
+      return aestheticService.options();
+   }
+
+   @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/chart/aesthetic-field")
+   public void setAestheticField(@PathVariable String sessionToken,
+                                 @RequestBody AestheticFieldRequest request,
+                                 @RequestParam(required = false, defaultValue = "") String linkUri,
+                                 Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      aestheticService.setField(sessionToken, user, request.assembly(), request.channel(),
+                                request.field(), linkUri);
+   }
+
+   @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/chart/aesthetic-field/clear")
+   public void clearAestheticField(@PathVariable String sessionToken,
+                                   @RequestBody AestheticFieldRequest request,
+                                   @RequestParam(required = false, defaultValue = "") String linkUri,
+                                   Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      aestheticService.clearField(sessionToken, user, request.assembly(), request.channel(),
+                                  linkUri);
+   }
+
+   @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/chart/frame")
+   public void setVisualFrame(@PathVariable String sessionToken,
+                              @RequestBody AestheticFrameRequest request,
+                              @RequestParam(required = false, defaultValue = "") String linkUri,
+                              Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      aestheticService.setFrame(sessionToken, user, request.assembly(), request.channel(),
+                                request.frame(), linkUri);
+   }
+
    @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/detach")
    public void detach(@PathVariable String sessionToken, Principal user) {
       sessionService.close(sessionToken);
@@ -178,4 +243,5 @@ public class BindingAgentController {
    private final BindableFieldsService fieldsService;
    private final BindingReadService readService;
    private final ChartBindingService chartService;
+   private final ChartAestheticService aestheticService;
 }

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
@@ -29,6 +29,9 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.security.Principal;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -255,6 +258,7 @@ public class BindingAgentController {
       throws Exception
    {
       requireEnabled();
+      requireBindableColumns(sessionToken, user, request.assembly(), request.fields());
       tableService.setShelf(sessionToken, user, request.assembly(), request.shelf(),
                             request.fields());
    }
@@ -277,6 +281,7 @@ public class BindingAgentController {
       throws Exception
    {
       requireEnabled();
+      requireBindableColumns(sessionToken, user, request.assembly(), List.of(request.field()));
       tableService.addField(sessionToken, user, request.assembly(), request.shelf(),
                             request.field(), request.position());
    }
@@ -520,6 +525,35 @@ public class BindingAgentController {
    private final SheetJoinService joinService;
    private final SheetSessionService sessionService;
    private final ViewsheetSessionService sessions;
+   /**
+    * Refuses a field naming a column the assembly cannot bind.
+    *
+    * <p>Such a column bound cleanly and rendered nothing — a crosstab with no rows, which reads as
+    * empty data rather than a bad column name. Checked here because the controller already holds
+    * the field listing; the alternative was injecting it into the service, which would change a
+    * constructor and so require a full reactor build for a validation fix.
+    *
+    * <p>A failure to read the listing is swallowed on purpose: it is a different problem, and
+    * turning it into a refusal would block writes whenever the tree happens to be unreadable.
+    */
+   private void requireBindableColumns(String sessionToken, Principal user, String assembly,
+                                       java.util.Collection<FieldRef> fields)
+   {
+      try {
+         BindableColumns.require(
+            fieldsService.list(sessions.runtimeId(sessionToken, user), assembly, user),
+            assembly, fields);
+      }
+      catch(IllegalArgumentException e) {
+         throw e;
+      }
+      catch(Exception e) {
+         LOG.debug("Could not list bindable columns for {}; skipping the check", assembly, e);
+      }
+   }
+
+   private static final Logger LOG = LoggerFactory.getLogger(BindingAgentController.class);
+
    private final BindableFieldsService fieldsService;
    private final BindingReadService readService;
    private final ChartBindingService chartService;

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
@@ -17,6 +17,8 @@
  */
 package inetsoft.web.wiz.binding;
 
+import inetsoft.uql.XPrincipal;
+import inetsoft.sree.security.IdentityID;
 import inetsoft.web.wiz.binding.model.AssemblyBinding;
 import inetsoft.web.wiz.binding.model.BindableTable;
 import inetsoft.web.wiz.binding.model.FieldRef;
@@ -496,7 +498,20 @@ public class BindingAgentController {
 
    @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/detach")
    public void detach(@PathVariable String sessionToken, Principal user) {
-      sessionService.close(sessionToken);
+      JoinSession session = sessionService.resolve(sessionToken, agentKey(user));
+
+      if(session != null) {
+         sessionService.close(sessionToken);
+      }
+   }
+
+   private static String agentKey(Principal agent) {
+      if(agent instanceof XPrincipal p) {
+         IdentityID id = IdentityID.getIdentityIDFromKey(p.getName());
+         return id != null ? id.convertToKey() : p.getName();
+      }
+
+      return agent != null ? agent.getName() : null;
    }
 
    private void requireEnabled() {

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
@@ -19,6 +19,7 @@ package inetsoft.web.wiz.binding;
 
 import inetsoft.web.wiz.binding.model.AssemblyBinding;
 import inetsoft.web.wiz.binding.model.BindableTable;
+import inetsoft.web.wiz.binding.model.FieldRef;
 import inetsoft.web.wiz.pairing.*;
 import inetsoft.web.wiz.viewsheet.ViewsheetSessionService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,15 +34,17 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * REST surface for agent-driven binding discovery and reads.
+ * REST surface for agent-driven binding discovery, reads, and chart data-binding writes.
  *
  * <p>Pairs against a VIEWSHEET runtime exactly as {@code ViewsheetAgentController} does. The
  * {@code /join} endpoint here is a second door to the same {@link SheetJoinService}, not a
  * second session model — it exists so the binding plugin can be installed and paired on its
  * own, without the viewsheet plugin.
  *
- * <p>Phase 1 is read-only: every endpoint below is a pure read, so none of them takes a
- * capturing dispatcher, adds a checkpoint, or broadcasts.
+ * <p>The discovery and read endpoints are pure reads — no dispatcher, checkpoint, or
+ * broadcast. The chart endpoints mutate, and each is exactly one
+ * {@code ViewsheetSessionService.mutate}, so one call is one undo checkpoint in the user's
+ * Composer.
  */
 @RestController
 public class BindingAgentController {
@@ -51,7 +54,8 @@ public class BindingAgentController {
                                  SheetSessionService sessionService,
                                  ViewsheetSessionService sessions,
                                  BindableFieldsService fieldsService,
-                                 BindingReadService readService)
+                                 BindingReadService readService,
+                                 ChartBindingService chartService)
    {
       this.feature = feature;
       this.joinService = joinService;
@@ -59,6 +63,7 @@ public class BindingAgentController {
       this.sessions = sessions;
       this.fieldsService = fieldsService;
       this.readService = readService;
+      this.chartService = chartService;
    }
 
    public record JoinRequest(String code) {}
@@ -89,6 +94,53 @@ public class BindingAgentController {
    {
       requireEnabled();
       return readService.read(sessions.resolve(sessionToken, user), assembly);
+   }
+
+   public record ShelfRequest(String assembly, String shelf, List<FieldRef> fields) {}
+   public record ChartTypeRequest(String assembly, Integer type, Boolean multi,
+                                  Boolean stackMeasures, Boolean separate) {}
+   public record SwapRequest(String assembly) {}
+
+   @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/chart/shelf")
+   public void setChartShelf(@PathVariable String sessionToken,
+                             @RequestBody ShelfRequest request,
+                             @RequestParam(required = false, defaultValue = "") String linkUri,
+                             Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      chartService.setShelf(sessionToken, user, request.assembly(), request.shelf(),
+                            request.fields(), linkUri);
+   }
+
+   @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/chart/type")
+   public void setChartType(@PathVariable String sessionToken,
+                            @RequestBody ChartTypeRequest request,
+                            @RequestParam(required = false, defaultValue = "") String linkUri,
+                            Principal user)
+      throws Exception
+   {
+      requireEnabled();
+
+      if(request.type() == null) {
+         throw new IllegalArgumentException(
+            "set_chart_type requires 'type' — the GraphTypes chart-type code.");
+      }
+
+      chartService.setChartType(sessionToken, user, request.assembly(), request.type(),
+                                request.multi(), request.stackMeasures(), request.separate(),
+                                linkUri);
+   }
+
+   @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/chart/swap-axes")
+   public void swapChartAxes(@PathVariable String sessionToken,
+                             @RequestBody SwapRequest request,
+                             @RequestParam(required = false, defaultValue = "") String linkUri,
+                             Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      chartService.swapAxes(sessionToken, user, request.assembly(), linkUri);
    }
 
    @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/detach")
@@ -125,4 +177,5 @@ public class BindingAgentController {
    private final ViewsheetSessionService sessions;
    private final BindableFieldsService fieldsService;
    private final BindingReadService readService;
+   private final ChartBindingService chartService;
 }

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
@@ -56,7 +56,7 @@ public class BindingAgentController {
                                  BindableFieldsService fieldsService,
                                  BindingReadService readService,
                                  ChartBindingService chartService,
-                                 ChartAestheticService aestheticService,
+                                 ChartAestheticAgentService aestheticService,
                                  TableBindingService tableService,
                                  CalcTableService calcService)
    {
@@ -470,7 +470,7 @@ public class BindingAgentController {
    private final BindableFieldsService fieldsService;
    private final BindingReadService readService;
    private final ChartBindingService chartService;
-   private final ChartAestheticService aestheticService;
+   private final ChartAestheticAgentService aestheticService;
    private final TableBindingService tableService;
    private final CalcTableService calcService;
 }

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingReadService.java
@@ -1,0 +1,108 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.CalcTableVSAssembly;
+import inetsoft.uql.viewsheet.VSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.binding.drm.DataRefModel;
+import inetsoft.web.binding.model.BindingModel;
+import inetsoft.web.binding.model.ChartBindingModel;
+import inetsoft.web.binding.model.table.CrosstabBindingModel;
+import inetsoft.web.binding.model.table.TableBindingModel;
+import inetsoft.web.binding.service.VSBindingService;
+import inetsoft.web.wiz.binding.model.AssemblyBinding;
+import inetsoft.web.wiz.binding.model.FieldRef;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Reads an assembly's binding into the shared {@link FieldRef} vocabulary.
+ *
+ * <p>A pure read: {@code VSBindingService.createModel} is a function of the assembly, so no
+ * dispatcher, checkpoint, or broadcast is involved.
+ */
+@Service
+public class BindingReadService {
+   @Autowired
+   public BindingReadService(VSBindingService binding) {
+      this.binding = binding;
+   }
+
+   public AssemblyBinding read(RuntimeViewsheet rvs, String assemblyName) {
+      Viewsheet vs = rvs == null ? null : rvs.getViewsheet();
+      VSAssembly assembly = vs == null ? null : vs.getAssembly(assemblyName);
+
+      if(assembly == null) {
+         throw new IllegalArgumentException("Unknown assembly '" + assemblyName + "'.");
+      }
+
+      // A calc table's binding is cell-structured and lives in its layout, not its binding
+      // model — CalcTableBindingModel adds no fields at all. See spec 2e.
+      if(assembly instanceof CalcTableVSAssembly) {
+         throw new IllegalArgumentException(
+            "'" + assemblyName + "' is a calc table. Its binding lives in its cell layout, " +
+            "not its binding model — read it with get_calc_layout instead.");
+      }
+
+      BindingModel model = binding.createModel(assembly);
+      Map<String, List<FieldRef>> shelves = new LinkedHashMap<>();
+
+      if(model instanceof ChartBindingModel chart) {
+         shelves.put("x", refs(chart.getXFields()));
+         shelves.put("y", refs(chart.getYFields()));
+         shelves.put("group", refs(chart.getGroupFields()));
+      }
+      else if(model instanceof CrosstabBindingModel crosstab) {
+         shelves.put("rows", refs(crosstab.getRows()));
+         shelves.put("cols", refs(crosstab.getCols()));
+         shelves.put("aggregates", refs(crosstab.getAggregates()));
+      }
+      else if(model instanceof TableBindingModel table) {
+         shelves.put("groups", refs(table.getGroups()));
+         shelves.put("details", refs(table.getDetails()));
+         shelves.put("aggregates", refs(table.getAggregates()));
+      }
+
+      return new AssemblyBinding(assemblyName,
+                                 assembly.getClass().getSimpleName(),
+                                 model == null || model.getSource() == null
+                                    ? null : model.getSource().getSource(),
+                                 shelves);
+   }
+
+   private static List<FieldRef> refs(List<? extends DataRefModel> models) {
+      List<FieldRef> refs = new ArrayList<>();
+
+      if(models != null) {
+         for(DataRefModel model : models) {
+            refs.add(FieldRefFactory.from(model));
+         }
+      }
+
+      return refs;
+   }
+
+   private final VSBindingService binding;
+}

--- a/core/src/main/java/inetsoft/web/wiz/binding/CalcCellVocabulary.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/CalcCellVocabulary.java
@@ -1,0 +1,232 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.report.CellBinding;
+import inetsoft.report.GroupableCellBinding;
+import inetsoft.web.binding.model.table.CellBindingInfo;
+
+import java.util.*;
+
+/**
+ * The agent-facing calc-table cell vocabulary.
+ *
+ * <p>Across this binding surface {@code type} now means five unrelated things:
+ * the object type on {@code BindingModel}; dimension-or-measure on a field ref;
+ * {@code BIND_TEXT}/{@code BIND_COLUMN}/{@code BIND_FORMULA} on a cell; sort direction on
+ * {@code OrderModel}; ranking mode on {@code TopNModel}. Three of those are reachable in one
+ * {@code set_cell_binding} call.
+ *
+ * <p>That is the {@code fieldType}-vs-{@code role} defect class at its worst — not one
+ * ambiguous key but a family of them, where a plausible wrong guess lands in a valid-looking
+ * field and produces a silently wrong table. <b>So this vocabulary does not expose
+ * {@code type} or {@code btype} at all</b>: the keys are {@code content}, {@code grouping} and
+ * {@code expand}, and supplying any of the ambiguous spellings fails loud naming the right one.
+ *
+ * <p>{@code role} is refused for the same reason rather than adopted as an alias: it is the
+ * wrong key in the recorded {@code fieldConfigs} defect, and giving it a new meaning inside the
+ * same plugin family would be its own trap.
+ *
+ * <p>Integer constants never appear in either direction.
+ */
+public final class CalcCellVocabulary {
+   private static final Map<String, Integer> CONTENT = Map.of(
+      "text", CellBinding.BIND_TEXT,
+      "column", CellBinding.BIND_COLUMN,
+      "formula", CellBinding.BIND_FORMULA);
+
+   private static final Map<String, Integer> GROUPING = Map.of(
+      "group", CellBinding.GROUP,
+      "detail", CellBinding.DETAIL,
+      "summary", CellBinding.SUMMARY);
+
+   private static final Map<String, Integer> EXPAND = Map.of(
+      "none", GroupableCellBinding.EXPAND_NONE,
+      "vertical", GroupableCellBinding.EXPAND_V,
+      "v", GroupableCellBinding.EXPAND_V,
+      "horizontal", GroupableCellBinding.EXPAND_H,
+      "h", GroupableCellBinding.EXPAND_H);
+
+   /** Keys that mean something else here, mapped to the key the caller meant. */
+   private static final Map<String, String> REJECTED = Map.of(
+      "type", "content",
+      "btype", "grouping",
+      "expansion", "expand",
+      "role", "content' or 'grouping");
+
+   private CalcCellVocabulary() {
+   }
+
+   public static int content(String token) {
+      return resolve(CONTENT, token, "content");
+   }
+
+   public static int grouping(String token) {
+      return resolve(GROUPING, token, "grouping");
+   }
+
+   public static int expand(String token) {
+      return resolve(EXPAND, token, "expand");
+   }
+
+   /**
+    * Checks a cell-binding spec before anything is written.
+    *
+    * <p>An incomplete binding is refused rather than applied: a cell bound to nothing renders
+    * blank, which reads as a data problem rather than as the binding error it is.
+    */
+   public static void validate(Map<String, Object> spec) {
+      Map<String, Object> cell = spec == null ? Map.of() : spec;
+
+      for(Map.Entry<String, String> rejected : REJECTED.entrySet()) {
+         if(cell.containsKey(rejected.getKey())) {
+            throw new IllegalArgumentException(
+               "'" + rejected.getKey() + "' is not a calc-table cell key — it means something " +
+               "else elsewhere in this plugin, which is exactly why it is refused here. Use '" +
+               rejected.getValue() + "'. Cell keys are: content, grouping, expand, field, " +
+               "value, formula.");
+         }
+      }
+
+      String contentToken = str(cell, "content");
+
+      if(contentToken == null) {
+         throw new IllegalArgumentException(
+            "A cell binding needs a 'content' of " + tokens(CONTENT) + ".");
+      }
+
+      int type = content(contentToken);
+
+      if(cell.get("grouping") != null) {
+         grouping(str(cell, "grouping"));
+      }
+
+      if(cell.get("expand") != null) {
+         expand(str(cell, "expand"));
+      }
+
+      if(type == CellBinding.BIND_COLUMN && cell.get("field") == null) {
+         throw new IllegalArgumentException(
+            "A cell with content 'column' needs a 'field' — {column, type}. A cell bound to " +
+            "nothing renders blank, which reads as missing data rather than a binding error.");
+      }
+
+      if(type == CellBinding.BIND_FORMULA && str(cell, "formula") == null) {
+         throw new IllegalArgumentException(
+            "A cell with content 'formula' needs a 'formula'. A cell bound to nothing renders " +
+            "blank, which reads as missing data rather than a binding error.");
+      }
+
+      if(type == CellBinding.BIND_TEXT && str(cell, "value") == null) {
+         throw new IllegalArgumentException(
+            "A cell with content 'text' needs a 'value' — the literal text to show.");
+      }
+   }
+
+   /** Renders a cell binding back in tokens. Never emits an integer constant or an alias key. */
+   public static Map<String, Object> describe(CellBindingInfo info) {
+      if(info == null) {
+         return null;
+      }
+
+      Map<String, Object> out = new LinkedHashMap<>();
+      out.put("content", tokenOf(CONTENT, info.getType()));
+      out.put("grouping", tokenOf(GROUPING, info.getBtype()));
+      out.put("expand", expandTokenOf(info.getExpansion()));
+      out.put("value", info.getValue());
+      out.put("formula", info.getFormula());
+      out.put("mergeCells", info.getMergeCells());
+      out.put("rowGroup", info.getRowGroup());
+      out.put("colGroup", info.getColGroup());
+      out.put("runtimeName", info.getRuntimeName());
+      return out;
+   }
+
+   public static List<String> contentTokens() {
+      return sorted(CONTENT);
+   }
+
+   public static List<String> groupingTokens() {
+      return sorted(GROUPING);
+   }
+
+   public static List<String> expandTokens() {
+      return List.of("none", "vertical", "horizontal");
+   }
+
+   // ── helpers ───────────────────────────────────────────────────────────────
+
+   private static int resolve(Map<String, Integer> table, String token, String key) {
+      String name = token == null ? "" : token.trim().toLowerCase();
+      Integer value = table.get(name);
+
+      if(value == null) {
+         throw new IllegalArgumentException(
+            "'" + token + "' is not a valid '" + key + "'. Valid values: " + tokens(table) +
+            ". Integer constants are not accepted — the words are the vocabulary.");
+      }
+
+      return value;
+   }
+
+   /**
+    * Reports an unrecognized constant as itself rather than guessing a token. A guess here
+    * would read as fact to whoever consumed it.
+    */
+   private static String tokenOf(Map<String, Integer> table, int value) {
+      for(Map.Entry<String, Integer> entry : table.entrySet()) {
+         if(entry.getValue() == value) {
+            return entry.getKey();
+         }
+      }
+
+      return "unknown(" + value + ")";
+   }
+
+   private static String expandTokenOf(int value) {
+      if(value == GroupableCellBinding.EXPAND_NONE) {
+         return "none";
+      }
+
+      if(value == GroupableCellBinding.EXPAND_V) {
+         return "vertical";
+      }
+
+      if(value == GroupableCellBinding.EXPAND_H) {
+         return "horizontal";
+      }
+
+      return "unknown(" + value + ")";
+   }
+
+   private static String tokens(Map<String, Integer> table) {
+      return String.join(", ", sorted(table));
+   }
+
+   private static List<String> sorted(Map<String, Integer> table) {
+      List<String> names = new ArrayList<>(table.keySet());
+      Collections.sort(names);
+      return names;
+   }
+
+   private static String str(Map<String, Object> spec, String key) {
+      Object value = spec == null ? null : spec.get(key);
+      String text = value == null ? "" : String.valueOf(value).trim();
+      return text.isEmpty() ? null : text;
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/binding/CalcCellVocabulary.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/CalcCellVocabulary.java
@@ -84,6 +84,11 @@ public final class CalcCellVocabulary {
       return resolve(EXPAND, token, "expand");
    }
 
+   /** Whether a resolved grouping constant is the aggregating one. */
+   public static boolean isSummary(int grouping) {
+      return grouping == CellBinding.SUMMARY;
+   }
+
    /**
     * Checks a cell-binding spec before anything is written.
     *

--- a/core/src/main/java/inetsoft/web/wiz/binding/CalcTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/CalcTableService.java
@@ -24,7 +24,13 @@ import inetsoft.uql.viewsheet.CalcTableVSAssembly;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.uql.viewsheet.internal.CalcTableVSAssemblyInfo;
+import inetsoft.report.internal.binding.AssetNamedGroupInfo;
+import inetsoft.web.binding.command.GetCellScriptCommand;
+import inetsoft.web.binding.command.GetPredefinedNamedGroupCommand;
 import inetsoft.web.binding.controller.VSTableLayoutService;
+import inetsoft.web.binding.event.GetCellScriptEvent;
+import inetsoft.web.binding.event.GetPredefinedNamedGroupEvent;
+import inetsoft.web.wiz.dispatch.CapturingCommandDispatcher;
 import inetsoft.web.binding.event.CopyCutCalcCellEvent;
 import inetsoft.web.binding.event.ModifyTableLayoutEvent;
 import inetsoft.web.binding.event.SetCellBindingEvent;
@@ -118,6 +124,106 @@ public class CalcTableService {
       out.put("binding",
               CalcCellVocabulary.describe(layoutService.getCellBindingInfo(assembly, row, col)));
       return out;
+   }
+
+   /**
+    * The script StyleBI evaluates for a cell.
+    *
+    * <p>Goes through {@code sessions.read} rather than {@code resolve} because
+    * {@code VSTableLayoutService.getCellScript} returns {@code Void} and delivers the script by
+    * <em>dispatching</em> a {@code GetCellScriptCommand}. A plain resolve has no dispatcher to
+    * capture it, and a mutate would open an undo checkpoint for a read.
+    */
+   public Map<String, Object> cellScript(String sessionToken, Principal user, String assemblyName,
+                                         int row, int col)
+      throws Exception
+   {
+      return sessions.read(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         CalcTableVSAssembly assembly = requireCalcTable(rvs, assemblyName);
+         requireInGrid(layoutOf(assembly), row, col);
+
+         GetCellScriptEvent event = new GetCellScriptEvent();
+         event.setName(assemblyName);
+         event.setRow(row);
+         event.setCol(col);
+         layoutService.getCellScript(runtimeId, event, user, dispatcher);
+
+         String script = null;
+
+         for(CapturingCommandDispatcher.Command command : dispatcher.getCapturedCommands()) {
+            if(command.getCommand() instanceof GetCellScriptCommand cellScript) {
+               script = cellScript.getScript();
+               break;
+            }
+         }
+
+         Map<String, Object> out = new LinkedHashMap<>();
+         out.put("assembly", assemblyName);
+         out.put("row", row);
+         out.put("col", col);
+         out.put("script", script);
+
+         if(script == null || script.isBlank()) {
+            out.put("note",
+                    "This cell has no script. A cell's own binding — content, grouping, expand — " +
+                    "is read with get_cell_binding; a script is the optional expression layered " +
+                    "on top of it.");
+         }
+
+         return out;
+      });
+   }
+
+   /**
+    * The predefined named groups a column offers, for a cell's {@code namedGroup}.
+    *
+    * <p>Same command-dispatch shape as {@link #cellScript}: {@code getNamedGroup} answers by
+    * dispatching a {@code GetPredefinedNamedGroupCommand}.
+    */
+   public Map<String, Object> namedGroups(String sessionToken, Principal user,
+                                          String assemblyName, String column)
+      throws Exception
+   {
+      if(column == null || column.isBlank()) {
+         throw new IllegalArgumentException(
+            "list_named_groups requires 'column' — named groups are defined per column. " +
+            "get_calc_layout reports which columns a cell is bound to.");
+      }
+
+      return sessions.read(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         requireCalcTable(rvs, assemblyName);
+
+         GetPredefinedNamedGroupEvent event = new GetPredefinedNamedGroupEvent();
+         event.setName(assemblyName);
+         event.setColumn(column);
+         layoutService.getNamedGroup(runtimeId, event, user, dispatcher);
+
+         // The command carries the group NAMES only — its constructor takes
+         // AssetNamedGroupInfo[] but keeps just getName() from each. The members are not on
+         // the wire, so this reports what StyleBI actually sends rather than inventing a shape.
+         List<String> groups = new ArrayList<>();
+
+         for(CapturingCommandDispatcher.Command command : dispatcher.getCapturedCommands()) {
+            if(command.getCommand() instanceof GetPredefinedNamedGroupCommand named &&
+               named.getNamedGroups() != null)
+            {
+               groups.addAll(List.of(named.getNamedGroups()));
+            }
+         }
+
+         Map<String, Object> out = new LinkedHashMap<>();
+         out.put("assembly", assemblyName);
+         out.put("column", column);
+         out.put("namedGroups", groups);
+
+         if(groups.isEmpty()) {
+            out.put("note",
+                    "No predefined named groups exist for this column. Named groups are defined " +
+                    "on the data source, not created here.");
+         }
+
+         return out;
+      });
    }
 
    /** Binds one cell. One {@code sessions.mutate}, so one undo checkpoint. */
@@ -314,6 +420,22 @@ public class CalcTableService {
 
       if(type == CellBinding.BIND_COLUMN) {
          info.setValue(columnOf(binding.get("field")));
+         // A summary cell is an aggregate, and an aggregate carries a formula. Binding a field
+         // requires content "column", so this branch has to accept one too — without it StyleBI
+         // threw `Cannot read field "formula" because "finfo" is null` from
+         // TableLayoutHandler.createAggregateField, making a summary column cell impossible.
+         String formula = str(binding, "formula");
+
+         if(CalcCellVocabulary.isSummary(info.getBtype()) &&
+            (formula == null || formula.isBlank()))
+         {
+            throw new IllegalArgumentException(
+               "A 'summary' cell aggregates its column, so it needs a 'formula' such as " +
+               "Sum, Count, Average, Max or Min. Without one StyleBI fails building the " +
+               "aggregate rather than rendering an unaggregated cell.");
+         }
+
+         info.setFormula(formula);
       }
       else if(type == CellBinding.BIND_FORMULA) {
          info.setFormula(str(binding, "formula"));

--- a/core/src/main/java/inetsoft/web/wiz/binding/CalcTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/CalcTableService.java
@@ -1,0 +1,271 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.report.CellBinding;
+import inetsoft.report.TableLayout;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.CalcTableVSAssembly;
+import inetsoft.uql.viewsheet.VSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.internal.CalcTableVSAssemblyInfo;
+import inetsoft.web.binding.controller.VSTableLayoutService;
+import inetsoft.web.binding.event.SetCellBindingEvent;
+import inetsoft.web.binding.model.table.CellBindingInfo;
+import inetsoft.web.binding.model.table.TableCell;
+import inetsoft.web.wiz.binding.model.FieldRef;
+import inetsoft.web.wiz.viewsheet.ViewsheetSessionService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.awt.*;
+import java.security.Principal;
+import java.util.*;
+import java.util.List;
+
+/**
+ * Freehand (calc) table authoring: the cell grid and per-cell bindings.
+ *
+ * <p><b>This service deliberately does not share the read-merge-write architecture</b> the
+ * chart, table and crosstab services use, and the reason is structural rather than incidental:
+ * {@code CalcTableBindingModel} extends {@code BaseTableBindingModel} and adds nothing at all.
+ * A calc table's binding does not live in the binding model — it lives in the layout, and
+ * StyleBI provides a dedicated cell-addressed endpoint family for it.
+ *
+ * <p>So this is cell-addressed rather than model-merged. It is a different architecture for a
+ * genuinely different object.
+ */
+@Service
+public class CalcTableService {
+   @Autowired
+   public CalcTableService(ViewsheetSessionService sessions, VSTableLayoutService layoutService) {
+      this.sessions = sessions;
+      this.layoutService = layoutService;
+   }
+
+   /**
+    * The grid: its dimensions and every cell's binding, in the token vocabulary.
+    *
+    * <p>The discovery call everything else depends on. Note that any layout operation shifts
+    * coordinates, so a layout read before one is stale afterwards.
+    */
+   public Map<String, Object> readLayout(String sessionToken, Principal user,
+                                         String assemblyName)
+      throws Exception
+   {
+      RuntimeViewsheet rvs = sessions.resolve(sessionToken, user);
+      CalcTableVSAssembly assembly = requireCalcTable(rvs, assemblyName);
+      TableLayout layout = layoutOf(assembly);
+      List<Map<String, Object>> cells = new ArrayList<>();
+
+      for(int row = 0; row < layout.getRowCount(); row++) {
+         for(int col = 0; col < layout.getColCount(); col++) {
+            Map<String, Object> cell = new LinkedHashMap<>();
+            cell.put("row", row);
+            cell.put("col", col);
+            Dimension span = layout.getSpan(row, col);
+
+            if(span != null) {
+               cell.put("spanRows", span.height);
+               cell.put("spanCols", span.width);
+            }
+
+            cell.put("binding",
+                     CalcCellVocabulary.describe(
+                        layoutService.getCellBindingInfo(assembly, row, col)));
+            cells.add(cell);
+         }
+      }
+
+      Map<String, Object> out = new LinkedHashMap<>();
+      out.put("assembly", assemblyName);
+      out.put("rowCount", layout.getRowCount());
+      out.put("colCount", layout.getColCount());
+      out.put("cells", cells);
+      return out;
+   }
+
+   /** One cell's binding, in the token vocabulary. */
+   public Map<String, Object> readCell(String sessionToken, Principal user, String assemblyName,
+                                       int row, int col)
+      throws Exception
+   {
+      RuntimeViewsheet rvs = sessions.resolve(sessionToken, user);
+      CalcTableVSAssembly assembly = requireCalcTable(rvs, assemblyName);
+      requireInGrid(layoutOf(assembly), row, col);
+
+      Map<String, Object> out = new LinkedHashMap<>();
+      out.put("row", row);
+      out.put("col", col);
+      out.put("binding",
+              CalcCellVocabulary.describe(layoutService.getCellBindingInfo(assembly, row, col)));
+      return out;
+   }
+
+   /** Binds one cell. One {@code sessions.mutate}, so one undo checkpoint. */
+   public void setCellBinding(String sessionToken, Principal user, String assemblyName,
+                              int row, int col, Map<String, Object> binding)
+      throws Exception
+   {
+      // Validated before the runtime is touched: an incomplete binding costs nothing to
+      // reject here, and opens no checkpoint the caller then has to undo.
+      CalcCellVocabulary.validate(binding);
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         CalcTableVSAssembly assembly = requireCalcTable(rvs, assemblyName);
+         requireInGrid(layoutOf(assembly), row, col);
+
+         SetCellBindingEvent event = new SetCellBindingEvent();
+         event.setName(assemblyName);
+         event.setSelectCells(new TableCell[]{ cellAt(row, col) });
+         event.setBinding(toCellBindingInfo(binding));
+         layoutService.setCellBinding(runtimeId, event, user, dispatcher);
+      });
+   }
+
+   /** The tokens this build accepts, so an agent can discover rather than guess. */
+   public Map<String, Object> vocabulary() {
+      return Map.of(
+         "content", CalcCellVocabulary.contentTokens(),
+         "grouping", CalcCellVocabulary.groupingTokens(),
+         "expand", CalcCellVocabulary.expandTokens());
+   }
+
+   // ── conversions ───────────────────────────────────────────────────────────
+
+   static CellBindingInfo toCellBindingInfo(Map<String, Object> binding) {
+      CellBindingInfo info = new CellBindingInfo();
+      int type = CalcCellVocabulary.content(str(binding, "content"));
+      info.setType(type);
+
+      if(binding.get("grouping") != null) {
+         info.setBtype(CalcCellVocabulary.grouping(str(binding, "grouping")));
+      }
+
+      if(binding.get("expand") != null) {
+         info.setExpansion(CalcCellVocabulary.expand(str(binding, "expand")));
+      }
+
+      if(type == CellBinding.BIND_COLUMN) {
+         info.setValue(columnOf(binding.get("field")));
+      }
+      else if(type == CellBinding.BIND_FORMULA) {
+         info.setFormula(str(binding, "formula"));
+         info.setValue(str(binding, "value"));
+      }
+      else {
+         info.setValue(str(binding, "value"));
+      }
+
+      if(binding.get("mergeCells") instanceof Boolean merge) {
+         info.setMergeCells(merge);
+      }
+
+      info.setRowGroup(str(binding, "rowGroup"));
+      info.setColGroup(str(binding, "colGroup"));
+      return info;
+   }
+
+   /**
+    * A cell's column binding is the column name. The nested field carries the shared
+    * vocabulary so it reads the same as everywhere else, and its type is required for the
+    * same reason it is required everywhere else.
+    */
+   private static String columnOf(Object field) {
+      if(field instanceof FieldRef ref) {
+         FieldRefFactory.requireType(ref);
+         return ref.column();
+      }
+
+      if(field instanceof Map<?, ?> map) {
+         Object column = map.get("column");
+         Object type = map.get("type");
+
+         if(column == null || String.valueOf(column).isBlank()) {
+            throw new IllegalArgumentException("A cell's 'field' needs a 'column'.");
+         }
+
+         FieldRefFactory.requireType(
+            new FieldRef(String.valueOf(column), type == null ? null : String.valueOf(type),
+                         null, null, null));
+         return String.valueOf(column);
+      }
+
+      throw new IllegalArgumentException(
+         "A cell's 'field' must be an object such as {column: \"Region\", type: \"dimension\"}.");
+   }
+
+   private static TableCell cellAt(int row, int col) {
+      TableCell cell = new TableCell();
+      cell.setRow(row);
+      cell.setCol(col);
+      return cell;
+   }
+
+   // ── guards ────────────────────────────────────────────────────────────────
+
+   private static TableLayout layoutOf(CalcTableVSAssembly assembly) {
+      CalcTableVSAssemblyInfo info = (CalcTableVSAssemblyInfo) assembly.getInfo();
+      TableLayout layout = info == null ? null : info.getTableLayout();
+
+      if(layout == null) {
+         throw new IllegalArgumentException(
+            "'" + assembly.getAbsoluteName() + "' has no cell layout yet.");
+      }
+
+      return layout;
+   }
+
+   private static void requireInGrid(TableLayout layout, int row, int col) {
+      if(row < 0 || col < 0 || row >= layout.getRowCount() || col >= layout.getColCount()) {
+         throw new IllegalArgumentException(
+            "Cell [" + row + "," + col + "] is outside the grid, which is " +
+            layout.getRowCount() + " row(s) by " + layout.getColCount() + " column(s). " +
+            "Coordinates read before a layout change are stale — re-read the layout.");
+      }
+   }
+
+   private static CalcTableVSAssembly requireCalcTable(RuntimeViewsheet rvs,
+                                                       String assemblyName)
+   {
+      Viewsheet vs = rvs == null ? null : rvs.getViewsheet();
+      VSAssembly assembly = vs == null ? null : vs.getAssembly(assemblyName);
+
+      if(assembly == null) {
+         throw new IllegalArgumentException("Unknown assembly '" + assemblyName + "'.");
+      }
+
+      if(!(assembly instanceof CalcTableVSAssembly calc)) {
+         throw new IllegalArgumentException(
+            "'" + assemblyName + "' is a " + assembly.getClass().getSimpleName() +
+            ", not a calc table. Its binding lives in shelves, not cells — use " +
+            "get_table_binding or get_binding instead.");
+      }
+
+      return calc;
+   }
+
+   private static String str(Map<String, Object> spec, String key) {
+      Object value = spec == null ? null : spec.get(key);
+      String text = value == null ? "" : String.valueOf(value).trim();
+      return text.isEmpty() ? null : text;
+   }
+
+   private final ViewsheetSessionService sessions;
+   private final VSTableLayoutService layoutService;
+}

--- a/core/src/main/java/inetsoft/web/wiz/binding/CalcTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/CalcTableService.java
@@ -25,6 +25,8 @@ import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.uql.viewsheet.internal.CalcTableVSAssemblyInfo;
 import inetsoft.web.binding.controller.VSTableLayoutService;
+import inetsoft.web.binding.event.CopyCutCalcCellEvent;
+import inetsoft.web.binding.event.ModifyTableLayoutEvent;
 import inetsoft.web.binding.event.SetCellBindingEvent;
 import inetsoft.web.binding.model.table.CellBindingInfo;
 import inetsoft.web.binding.model.table.TableCell;
@@ -36,6 +38,7 @@ import org.springframework.stereotype.Service;
 import java.awt.*;
 import java.security.Principal;
 import java.util.*;
+import java.awt.Rectangle;
 import java.util.List;
 
 /**
@@ -138,12 +141,160 @@ public class CalcTableService {
       });
    }
 
+   /**
+    * Layout operations. Op names are taken verbatim from {@code TableLayoutHandler} rather than
+    * renamed, so the tool surface and the Composer's own log messages agree.
+    *
+    * <p><b>Every one of these shifts coordinates</b> — inserting a row at 2 moves everything
+    * below it down by one. So this returns the <i>updated</i> layout, and an agent never has to
+    * re-read to stay correct or guess how the grid moved.
+    */
+   private static final Map<String, String> LAYOUT_OPS = layoutOps();
+
+   private static Map<String, String> layoutOps() {
+      Map<String, String> map = new LinkedHashMap<>();
+      map.put("insertrow", "insertRow");
+      map.put("insert_row", "insertRow");
+      map.put("appendrow", "appendRow");
+      map.put("append_row", "appendRow");
+      map.put("deleterow", "deleteRow");
+      map.put("delete_row", "deleteRow");
+      map.put("insertcol", "insertCol");
+      map.put("insert_col", "insertCol");
+      map.put("appendcol", "appendCol");
+      map.put("append_col", "appendCol");
+      map.put("deletecol", "deleteCol");
+      map.put("delete_col", "deleteCol");
+      map.put("mergecells", "mergeCells");
+      map.put("merge_cells", "mergeCells");
+      map.put("splitcells", "splitCells");
+      map.put("split_cells", "splitCells");
+      return Collections.unmodifiableMap(map);
+   }
+
+   /**
+    * Applies a layout operation and returns the layout it produced.
+    *
+    * @param rows how many rows/columns the selection spans; merge needs more than one cell
+    * @param n    how many rows/columns to insert or delete
+    */
+   public Map<String, Object> modifyLayout(String sessionToken, Principal user,
+                                           String assemblyName, String op, int row, int col,
+                                           Integer rows, Integer cols, Integer n)
+      throws Exception
+   {
+      String resolved = requireOp(op);
+      int spanRows = rows == null ? 1 : rows;
+      int spanCols = cols == null ? 1 : cols;
+      int count = n == null ? 1 : n;
+
+      if(count < 1) {
+         throw new IllegalArgumentException("'n' must be at least 1, got " + count + ".");
+      }
+
+      // Both of these are no-ops in the handler that would otherwise report success.
+      if("mergeCells".equals(resolved) && spanRows <= 1 && spanCols <= 1) {
+         throw new IllegalArgumentException(
+            "mergeCells needs a selection spanning more than one cell — pass 'rows' and/or " +
+            "'cols'. Merging a single cell does nothing and would report success.");
+      }
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         CalcTableVSAssembly assembly = requireCalcTable(rvs, assemblyName);
+         TableLayout layout = layoutOf(assembly);
+         requireInGrid(layout, row, col);
+
+         if("splitCells".equals(resolved)) {
+            Dimension span = layout.getSpan(row, col);
+
+            if(span == null || (span.width <= 1 && span.height <= 1)) {
+               throw new IllegalArgumentException(
+                  "Cell [" + row + "," + col + "] is not merged, so splitCells does nothing and " +
+                  "would report success.");
+            }
+         }
+
+         ModifyTableLayoutEvent event = new ModifyTableLayoutEvent();
+         event.setName(assemblyName);
+         event.setOp(resolved);
+         event.setNum(count);
+         event.setSelection(new Rectangle(col, row, spanCols, spanRows));
+         layoutService.modifyLayout(runtimeId, event, user, dispatcher);
+      });
+
+      // Returned rather than left to the caller: coordinates read before this call are stale.
+      Map<String, Object> updated = readLayout(sessionToken, user, assemblyName);
+      updated.put("note", "Coordinates read before this operation are stale — use this layout.");
+      return updated;
+   }
+
+   /**
+    * Copies, cuts or removes a cell range.
+    *
+    * @param target where a copy or cut lands; unused by {@code remove}
+    */
+   public Map<String, Object> copyCells(String sessionToken, Principal user, String assemblyName,
+                                        String op, Rectangle source, Rectangle target)
+      throws Exception
+   {
+      String resolved = switch(op == null ? "" : op.trim().toLowerCase()) {
+         case "copy" -> "copy";
+         case "cut" -> "cut";
+         case "remove" -> "remove";
+         default -> throw new IllegalArgumentException(
+            "'op' must be copy, cut or remove, got '" + op + "'.");
+      };
+
+      if(!"remove".equals(resolved) && target == null) {
+         throw new IllegalArgumentException(
+            "'" + resolved + "' needs a target — the cell the range lands on. Without one there " +
+            "is nowhere to paste and the operation would do nothing.");
+      }
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         CalcTableVSAssembly assembly = requireCalcTable(rvs, assemblyName);
+         TableLayout layout = layoutOf(assembly);
+         requireInGrid(layout, source.y, source.x);
+
+         if(target != null) {
+            requireInGrid(layout, target.y, target.x);
+         }
+
+         CopyCutCalcCellEvent event = new CopyCutCalcCellEvent();
+         event.setName(assemblyName);
+         event.setOp(resolved);
+         event.setSelections(target == null
+                                ? new Rectangle[]{ source, source }
+                                : new Rectangle[]{ source, target });
+         layoutService.copyCut(runtimeId, event, user, dispatcher);
+      });
+
+      Map<String, Object> updated = readLayout(sessionToken, user, assemblyName);
+      updated.put("note", "Coordinates read before this operation are stale — use this layout.");
+      return updated;
+   }
+
+   private static String requireOp(String op) {
+      String name = op == null ? "" : op.trim().toLowerCase();
+      String resolved = LAYOUT_OPS.get(name);
+
+      if(resolved == null) {
+         throw new IllegalArgumentException(
+            "Unknown layout op '" + op + "'. Valid ops: " +
+            new TreeSet<>(LAYOUT_OPS.values()) + ".");
+      }
+
+      return resolved;
+   }
+
    /** The tokens this build accepts, so an agent can discover rather than guess. */
    public Map<String, Object> vocabulary() {
       return Map.of(
          "content", CalcCellVocabulary.contentTokens(),
          "grouping", CalcCellVocabulary.groupingTokens(),
-         "expand", CalcCellVocabulary.expandTokens());
+         "expand", CalcCellVocabulary.expandTokens(),
+         "layoutOps", new TreeSet<>(LAYOUT_OPS.values()),
+         "copyOps", List.of("copy", "cut", "remove"));
    }
 
    // ── conversions ───────────────────────────────────────────────────────────

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticAgentService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticAgentService.java
@@ -47,9 +47,9 @@ import java.util.Map;
  * service instead would leave stale shared frames behind.
  */
 @Service
-public class ChartAestheticService {
+public class ChartAestheticAgentService {
    @Autowired
-   public ChartAestheticService(ViewsheetSessionService sessions,
+   public ChartAestheticAgentService(ViewsheetSessionService sessions,
                                 VSBindingService binding,
                                 ChangeChartAestheticService aestheticService)
    {

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticMutator.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.wiz.binding;
 
+import inetsoft.web.binding.model.BindingRefModel;
 import inetsoft.web.binding.model.ChartBindingModel;
 import inetsoft.web.binding.model.graph.AestheticInfo;
 import inetsoft.web.binding.model.graph.aesthetic.*;
@@ -102,11 +103,37 @@ public final class ChartAestheticMutator {
       AestheticInfo info = AestheticChannels.FIELD_CHANNELS.contains(channel)
          ? read(model, channel) : null;
 
-      view.put("field", info == null ? null : info.getFullName());
+      view.put("field", fieldNameOf(info));
       view.put("frame", VisualFrameAliases.describe(frameOf(model, channel)));
       view.put("acceptsField", AestheticChannels.FIELD_CHANNELS.contains(channel));
       view.put("acceptsFrame", AestheticChannels.FRAME_CHANNELS.contains(channel));
       return view;
+   }
+
+   /**
+    * The name of the field bound to a channel.
+    *
+    * <p>Read from the {@code dataInfo}, not from {@link AestheticInfo#getFullName()}. The read
+    * path — {@code AestheticRefModelFactory.createAestheticInfo} — sets only {@code dataInfo} and
+    * {@code frame}; nothing there ever sets the {@code AestheticInfo}'s own {@code fullName}. The
+    * only writer of that field is {@link #setField}, ours. So asking the {@code AestheticInfo} for
+    * its name reported {@code null} for every channel of every chart, while the aesthetic was
+    * visibly rendering — the write worked, the read lied.
+    *
+    * <p>{@code fullName} is kept only as a fallback, for the models our own writer built.
+    */
+   private static String fieldNameOf(AestheticInfo info) {
+      if(info == null) {
+         return null;
+      }
+
+      BindingRefModel dataInfo = info.getDataInfo();
+
+      if(dataInfo != null && dataInfo.getFullName() != null) {
+         return dataInfo.getFullName();
+      }
+
+      return info.getFullName();
    }
 
    private static VisualFrameModel frameOf(ChartBindingModel model, String channel) {

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticMutator.java
@@ -1,0 +1,142 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.web.binding.model.ChartBindingModel;
+import inetsoft.web.binding.model.graph.AestheticInfo;
+import inetsoft.web.binding.model.graph.aesthetic.*;
+import inetsoft.web.wiz.binding.model.FieldRef;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Read-modify-write over the thirteen aesthetic fields in {@link ChartBindingFields#AESTHETIC}.
+ *
+ * <p>The mirror image of {@link ChartBindingMutator}. {@code changeChartAesthetic} posts the
+ * same {@code ChangeChartRefEvent} carrying the entire {@code ChartBindingModel}, so the
+ * preservation obligation runs both ways: 2b must not disturb these fields, and this class
+ * must not disturb the shelves, chart type or options. Callers must pass the model
+ * {@code VSBindingService.createModel} returned and mutate it in place — a fresh model would
+ * silently drop everything neither class sets.
+ */
+public final class ChartAestheticMutator {
+   private ChartAestheticMutator() {
+   }
+
+   /** Binds a field to a channel. Replaces whatever that channel held; leaves the rest alone. */
+   public static void setField(ChartBindingModel model, String channel, FieldRef field) {
+      String name = AestheticChannels.requireFieldChannel(channel);
+
+      if(field == null) {
+         throw new IllegalArgumentException(
+            "Binding the " + name + " channel needs a field. To unbind it, use " +
+            "clear_aesthetic_field instead — an absent field is not the same request as an " +
+            "explicit clear.");
+      }
+
+      AestheticInfo info = new AestheticInfo();
+      info.setFullName(field.column());
+      info.setDataInfo(FieldRefFactory.toChartRef(field));
+      assign(model, name, info);
+   }
+
+   /** Unbinds a channel. */
+   public static void clearField(ChartBindingModel model, String channel) {
+      assign(model, AestheticChannels.requireFieldChannel(channel), null);
+   }
+
+   /** Sets a channel's visual frame from the agent vocabulary. */
+   public static void setFrame(ChartBindingModel model, String channel,
+                               Map<String, Object> spec)
+   {
+      String name = AestheticChannels.requireFrameChannel(channel);
+      VisualFrameModel frame = VisualFrameAliases.create(name, spec);
+
+      switch(name) {
+         case "color" -> model.setColorFrame((ColorFrameModel) frame);
+         case "shape" -> model.setShapeFrame((ShapeFrameModel) frame);
+         case "size" -> model.setSizeFrame((SizeFrameModel) frame);
+         case "line" -> model.setLineFrame((LineFrameModel) frame);
+         case "texture" -> model.setTextureFrame((TextureFrameModel) frame);
+         default -> throw new IllegalArgumentException("Unhandled frame channel '" + name + "'.");
+      }
+   }
+
+   /**
+    * Every channel the vocabulary knows, with what it currently holds. Channels are reported
+    * even when unbound, so an agent reading a chart learns what it *could* set rather than
+    * only what someone already set.
+    */
+   public static Map<String, Object> describe(ChartBindingModel model) {
+      Map<String, Object> out = new LinkedHashMap<>();
+
+      for(String channel : AestheticChannels.FIELD_CHANNELS) {
+         out.put(channel, channelView(model, channel));
+      }
+
+      for(String channel : AestheticChannels.FRAME_CHANNELS) {
+         out.computeIfAbsent(channel, name -> channelView(model, name));
+      }
+
+      return out;
+   }
+
+   private static Map<String, Object> channelView(ChartBindingModel model, String channel) {
+      Map<String, Object> view = new LinkedHashMap<>();
+      AestheticInfo info = AestheticChannels.FIELD_CHANNELS.contains(channel)
+         ? read(model, channel) : null;
+
+      view.put("field", info == null ? null : info.getFullName());
+      view.put("frame", VisualFrameAliases.describe(frameOf(model, channel)));
+      view.put("acceptsField", AestheticChannels.FIELD_CHANNELS.contains(channel));
+      view.put("acceptsFrame", AestheticChannels.FRAME_CHANNELS.contains(channel));
+      return view;
+   }
+
+   private static VisualFrameModel frameOf(ChartBindingModel model, String channel) {
+      return switch(channel) {
+         case "color" -> model.getColorFrame();
+         case "shape" -> model.getShapeFrame();
+         case "size" -> model.getSizeFrame();
+         case "line" -> model.getLineFrame();
+         case "texture" -> model.getTextureFrame();
+         default -> null;
+      };
+   }
+
+   private static AestheticInfo read(ChartBindingModel model, String channel) {
+      return switch(channel) {
+         case "color" -> model.getColorField();
+         case "shape" -> model.getShapeField();
+         case "size" -> model.getSizeField();
+         case "text" -> model.getTextField();
+         default -> null;
+      };
+   }
+
+   private static void assign(ChartBindingModel model, String channel, AestheticInfo info) {
+      switch(channel) {
+         case "color" -> model.setColorField(info);
+         case "shape" -> model.setShapeField(info);
+         case "size" -> model.setSizeField(info);
+         case "text" -> model.setTextField(info);
+         default -> throw new IllegalArgumentException("Unhandled field channel '" + channel + "'.");
+      }
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticService.java
@@ -1,0 +1,145 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.VSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.binding.controller.ChangeChartAestheticService;
+import inetsoft.web.binding.event.ChangeChartRefEvent;
+import inetsoft.web.binding.model.ChartBindingModel;
+import inetsoft.web.binding.service.VSBindingService;
+import inetsoft.web.wiz.binding.model.FieldRef;
+import inetsoft.web.wiz.viewsheet.ViewsheetSessionService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Chart aesthetic mutations: channel field bindings and visual frames.
+ *
+ * <p>Structurally identical to {@link ChartBindingService} — each public method is exactly one
+ * {@code sessions.mutate}, so it is one undo checkpoint in the user's Composer, driven through
+ * the capturing dispatcher and broadcast afterwards.
+ *
+ * <p>Writes go through {@code changeChartAesthetic} rather than {@code changeChartRef}: it
+ * posts the same {@code ChangeChartRefEvent}, but clears the viewsheet's shared frames when
+ * the colour or shape channel changes. Routing an aesthetic write through the data-binding
+ * service instead would leave stale shared frames behind.
+ */
+@Service
+public class ChartAestheticService {
+   @Autowired
+   public ChartAestheticService(ViewsheetSessionService sessions,
+                                VSBindingService binding,
+                                ChangeChartAestheticService aestheticService)
+   {
+      this.sessions = sessions;
+      this.binding = binding;
+      this.aestheticService = aestheticService;
+   }
+
+   public void setField(String sessionToken, Principal user, String assemblyName, String channel,
+                        FieldRef field, String linkUri) throws Exception
+   {
+      // Validated before the runtime is touched, so a bad channel costs nothing and does not
+      // open a checkpoint the caller then has to undo.
+      String name = AestheticChannels.requireFieldChannel(channel);
+
+      apply(sessionToken, user, assemblyName, name, linkUri,
+            model -> ChartAestheticMutator.setField(model, name, field));
+   }
+
+   public void clearField(String sessionToken, Principal user, String assemblyName,
+                          String channel, String linkUri) throws Exception
+   {
+      String name = AestheticChannels.requireFieldChannel(channel);
+
+      apply(sessionToken, user, assemblyName, name, linkUri,
+            model -> ChartAestheticMutator.clearField(model, name));
+   }
+
+   public void setFrame(String sessionToken, Principal user, String assemblyName, String channel,
+                        Map<String, Object> frame, String linkUri) throws Exception
+   {
+      String name = AestheticChannels.requireFrameChannel(channel);
+
+      apply(sessionToken, user, assemblyName, name, linkUri,
+            model -> ChartAestheticMutator.setFrame(model, name, frame));
+   }
+
+   /** Reads the channels without opening a checkpoint. */
+   public Map<String, Object> read(String sessionToken, Principal user, String assemblyName)
+      throws Exception
+   {
+      RuntimeViewsheet rvs = sessions.resolve(sessionToken, user);
+      ChartVSAssembly chart = requireChart(rvs, assemblyName);
+      return ChartAestheticMutator.describe((ChartBindingModel) binding.createModel(chart));
+   }
+
+   /** The channels and frame types available, so an agent can discover rather than guess. */
+   public Map<String, Object> options() {
+      return Map.of(
+         "fieldChannels", AestheticChannels.FIELD_CHANNELS,
+         "frameChannels", AestheticChannels.SUPPORTED_FRAME_CHANNELS,
+         "frameTypes", List.of("static", "categorical", "gradient", "palette"),
+         "palettes", List.copyOf(VisualFrameAliases.PALETTES.keySet()));
+   }
+
+   private void apply(String sessionToken, Principal user, String assemblyName, String channel,
+                      String linkUri, java.util.function.Consumer<ChartBindingModel> mutation)
+      throws Exception
+   {
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         ChartVSAssembly chart = requireChart(rvs, assemblyName);
+         ChartBindingModel model = (ChartBindingModel) binding.createModel(chart);
+         mutation.accept(model);
+
+         ChangeChartRefEvent event = new ChangeChartRefEvent();
+         event.setName(assemblyName);
+         event.setFieldType(channel);
+         event.setModel(model);
+         aestheticService.changeChartAesthetic(runtimeId, event, user, dispatcher, linkUri);
+      });
+   }
+
+   private static ChartVSAssembly requireChart(RuntimeViewsheet rvs, String assemblyName) {
+      Viewsheet vs = rvs == null ? null : rvs.getViewsheet();
+      VSAssembly assembly = vs == null ? null : vs.getAssembly(assemblyName);
+
+      if(assembly == null) {
+         throw new IllegalArgumentException("Unknown assembly '" + assemblyName + "'.");
+      }
+
+      if(!(assembly instanceof ChartVSAssembly chart)) {
+         throw new IllegalArgumentException(
+            "'" + assemblyName + "' is a " + assembly.getClass().getSimpleName() +
+            ", not a chart. Chart aesthetic tools only apply to charts.");
+      }
+
+      return chart;
+   }
+
+   private final ViewsheetSessionService sessions;
+   private final VSBindingService binding;
+   private final ChangeChartAestheticService aestheticService;
+}

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingFields.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingFields.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.web.binding.model.ChartBindingModel;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The 2b/2c ownership split over {@code ChartBindingModel}, declared once.
+ *
+ * <p>{@code ChangeChartRefEvent} demands the whole model, so every data-binding write
+ * round-trips the aesthetic fields spec 2c owns. Dropping or defaulting one silently destroys
+ * the user's styling, and it surfaces much later as a 2c bug rather than as a fault in the
+ * write that caused it. The merge logic and the preservation tests both read this list rather
+ * than each keeping their own copy, so they cannot drift apart.
+ *
+ * <p><b>Any future spec that writes {@code ChartBindingModel} must be added here.</b>
+ */
+public final class ChartBindingFields {
+   /** The thirteen fields spec 2c owns. Spec 2b must never write them. */
+   public static final List<String> AESTHETIC = List.of(
+      "colorField", "shapeField", "sizeField", "textField",
+      "colorFrame", "shapeFrame", "lineFrame", "textureFrame", "sizeFrame",
+      "nodeColorField", "nodeSizeField", "nodeColorFrame", "nodeSizeFrame");
+
+   private ChartBindingFields() {
+   }
+
+   /**
+    * Captures the aesthetic fields by identity so a test can assert a write left them
+    * untouched. Compared with {@code equals}, which for these model objects is reference
+    * equality — exactly what "the write did not replace them" means.
+    */
+   public static Map<String, Object> snapshotAesthetics(ChartBindingModel model) {
+      Map<String, Object> snapshot = new LinkedHashMap<>();
+      snapshot.put("colorField", model.getColorField());
+      snapshot.put("shapeField", model.getShapeField());
+      snapshot.put("sizeField", model.getSizeField());
+      snapshot.put("textField", model.getTextField());
+      snapshot.put("colorFrame", model.getColorFrame());
+      snapshot.put("shapeFrame", model.getShapeFrame());
+      snapshot.put("lineFrame", model.getLineFrame());
+      snapshot.put("textureFrame", model.getTextureFrame());
+      snapshot.put("sizeFrame", model.getSizeFrame());
+      snapshot.put("nodeColorField", model.getNodeColorField());
+      snapshot.put("nodeSizeField", model.getNodeSizeField());
+      snapshot.put("nodeColorFrame", model.getNodeColorFrame());
+      snapshot.put("nodeSizeFrame", model.getNodeSizeFrame());
+      return snapshot;
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingMutator.java
@@ -45,10 +45,18 @@ public final class ChartBindingMutator {
    public static void setShelf(ChartBindingModel model, String shelf, List<FieldRef> fields) {
       String name = shelf == null ? "" : shelf.trim().toLowerCase();
 
+      if(SINGLE_SHELVES.contains(name)) {
+         throw new IllegalArgumentException(
+            "'" + name + "' holds exactly one field, not a list — use set_chart_single_shelf " +
+            "for it. Passing a list here would bind only the first field and drop the rest " +
+            "without saying so.");
+      }
+
       if(!SHELVES.contains(name)) {
          throw new IllegalArgumentException(
             "Unknown chart shelf '" + shelf + "'. Valid shelves: " +
-            String.join(", ", SHELVES) + ".");
+            String.join(", ", SHELVES) + ". Single-field shelves (open, high, low, close, path, " +
+            "source, target, start, end, milestone) use set_chart_single_shelf.");
       }
 
       List<ChartRefModel> refs = new ArrayList<>();
@@ -62,5 +70,77 @@ public final class ChartBindingMutator {
       case "y" -> model.setYFields(refs);
       default -> model.setGroupFields(refs);
       }
+   }
+
+   /**
+    * Shelves that hold exactly <b>one</b> field rather than a list.
+    *
+    * <p>A candlestick has one close, a Gantt bar one start. Keeping them out of {@link #SHELVES}
+    * is deliberate: routing them through the list API would silently bind the first element of a
+    * list and drop the rest.
+    */
+   public static final List<String> SINGLE_SHELVES =
+      List.of("open", "high", "low", "close", "path", "source", "target",
+              "start", "end", "milestone");
+
+   /**
+    * Sets one single-field shelf. A null {@code field} clears it.
+    *
+    * <p>Which shelves a chart actually reads depends on its type — a candlestick uses
+    * open/high/low/close and ignores x/y, a Gantt uses start/end/milestone. Binding the wrong
+    * family for the current chart type renders an empty chart with no error anywhere, which is
+    * why {@code set_chart_type} and these belong in the same conversation.
+    */
+   public static void setSingleShelf(ChartBindingModel model, String shelf, FieldRef field) {
+      String name = requireSingleShelf(shelf);
+      ChartRefModel ref = field == null ? null : FieldRefFactory.toChartRef(field);
+
+      switch(name) {
+      case "open" -> model.setOpenField(ref);
+      case "high" -> model.setHighField(ref);
+      case "low" -> model.setLowField(ref);
+      case "close" -> model.setCloseField(ref);
+      case "path" -> model.setPathField(ref);
+      case "source" -> model.setSourceField(ref);
+      case "target" -> model.setTargetField(ref);
+      case "start" -> model.setStartField(ref);
+      case "end" -> model.setEndField(ref);
+      default -> model.setMilestoneField(ref);
+      }
+   }
+
+   /** Reads one single-field shelf, or null when nothing is bound to it. */
+   public static ChartRefModel readSingleShelf(ChartBindingModel model, String shelf) {
+      return switch(requireSingleShelf(shelf)) {
+         case "open" -> model.getOpenField();
+         case "high" -> model.getHighField();
+         case "low" -> model.getLowField();
+         case "close" -> model.getCloseField();
+         case "path" -> model.getPathField();
+         case "source" -> model.getSourceField();
+         case "target" -> model.getTargetField();
+         case "start" -> model.getStartField();
+         case "end" -> model.getEndField();
+         default -> model.getMilestoneField();
+      };
+   }
+
+   private static String requireSingleShelf(String shelf) {
+      String name = shelf == null ? "" : shelf.trim().toLowerCase();
+
+      if(SHELVES.contains(name)) {
+         throw new IllegalArgumentException(
+            "'" + name + "' holds a list of fields, not one — use set_chart_shelf for it. " +
+            "Single-field shelves: " + String.join(", ", SINGLE_SHELVES) + ".");
+      }
+
+      if(!SINGLE_SHELVES.contains(name)) {
+         throw new IllegalArgumentException(
+            "Unknown chart shelf '" + shelf + "'. Single-field shelves: " +
+            String.join(", ", SINGLE_SHELVES) + ". List shelves: " +
+            String.join(", ", SHELVES) + ".");
+      }
+
+      return name;
    }
 }

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingMutator.java
@@ -54,8 +54,7 @@ public final class ChartBindingMutator {
       List<ChartRefModel> refs = new ArrayList<>();
 
       for(FieldRef field : fields == null ? List.<FieldRef>of() : fields) {
-         FieldRefFactory.requireType(field);
-         refs.add(toChartRef(field));
+         refs.add(FieldRefFactory.toChartRef(field));
       }
 
       switch(name) {
@@ -63,29 +62,5 @@ public final class ChartBindingMutator {
       case "y" -> model.setYFields(refs);
       default -> model.setGroupFields(refs);
       }
-   }
-
-   private static ChartRefModel toChartRef(FieldRef field) {
-      if(FieldRefFactory.MEASURE.equalsIgnoreCase(field.type())) {
-         ChartAggregateRefModel ref = new ChartAggregateRefModel();
-         ref.setColumnValue(field.column());
-         ref.setName(field.column());
-
-         if(field.aggregate() != null) {
-            ref.setFormula(field.aggregate());
-         }
-
-         return ref;
-      }
-
-      ChartDimensionRefModel ref = new ChartDimensionRefModel();
-      ref.setColumnValue(field.column());
-      ref.setName(field.column());
-
-      if(field.dateLevel() != null) {
-         ref.setDateLevel(field.dateLevel());
-      }
-
-      return ref;
    }
 }

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingMutator.java
@@ -1,0 +1,91 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.web.binding.model.ChartBindingModel;
+import inetsoft.web.binding.model.graph.ChartAggregateRefModel;
+import inetsoft.web.binding.model.graph.ChartDimensionRefModel;
+import inetsoft.web.binding.model.graph.ChartRefModel;
+import inetsoft.web.wiz.binding.model.FieldRef;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Read-modify-write over {@code ChartBindingModel}.
+ *
+ * <p>Callers must pass the model returned by {@code VSBindingService.createModel} and mutate
+ * it in place. Constructing a fresh model would drop every field this class does not set —
+ * including the thirteen in {@link ChartBindingFields#AESTHETIC}, which
+ * {@code ChangeChartRefEvent} round-trips whether or not a data-binding write means to touch
+ * them.
+ */
+public final class ChartBindingMutator {
+   /** Shelves this phase writes. Chart's specialized shelves arrive in 2b Phase 2. */
+   public static final List<String> SHELVES = List.of("x", "y", "group");
+
+   private ChartBindingMutator() {
+   }
+
+   public static void setShelf(ChartBindingModel model, String shelf, List<FieldRef> fields) {
+      String name = shelf == null ? "" : shelf.trim().toLowerCase();
+
+      if(!SHELVES.contains(name)) {
+         throw new IllegalArgumentException(
+            "Unknown chart shelf '" + shelf + "'. Valid shelves: " +
+            String.join(", ", SHELVES) + ".");
+      }
+
+      List<ChartRefModel> refs = new ArrayList<>();
+
+      for(FieldRef field : fields == null ? List.<FieldRef>of() : fields) {
+         FieldRefFactory.requireType(field);
+         refs.add(toChartRef(field));
+      }
+
+      switch(name) {
+      case "x" -> model.setXFields(refs);
+      case "y" -> model.setYFields(refs);
+      default -> model.setGroupFields(refs);
+      }
+   }
+
+   private static ChartRefModel toChartRef(FieldRef field) {
+      if(FieldRefFactory.MEASURE.equalsIgnoreCase(field.type())) {
+         ChartAggregateRefModel ref = new ChartAggregateRefModel();
+         ref.setColumnValue(field.column());
+         ref.setName(field.column());
+
+         if(field.aggregate() != null) {
+            ref.setFormula(field.aggregate());
+         }
+
+         return ref;
+      }
+
+      ChartDimensionRefModel ref = new ChartDimensionRefModel();
+      ref.setColumnValue(field.column());
+      ref.setName(field.column());
+
+      if(field.dateLevel() != null) {
+         ref.setDateLevel(field.dateLevel());
+      }
+
+      return ref;
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingService.java
@@ -1,0 +1,134 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.VSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.binding.controller.ChangeChartRefService;
+import inetsoft.web.binding.controller.ChangeChartTypeService;
+import inetsoft.web.binding.controller.SwapXYBindingService;
+import inetsoft.web.binding.event.ChangeChartRefEvent;
+import inetsoft.web.binding.event.ChangeChartTypeEvent;
+import inetsoft.web.binding.event.ChangeSeparateStatusEvent;
+import inetsoft.web.binding.model.ChartBindingModel;
+import inetsoft.web.binding.service.VSBindingService;
+import inetsoft.web.wiz.binding.model.FieldRef;
+import inetsoft.web.wiz.viewsheet.ViewsheetSessionService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+import java.util.List;
+
+/**
+ * Chart data-binding mutations: shelves, chart type, and axis swap.
+ *
+ * <p>Each public method is exactly one {@code sessions.mutate}, so it is one undo checkpoint
+ * in the user's Composer, driven through the capturing dispatcher and broadcast afterwards.
+ *
+ * <p>Shelf writes are read-modify-write on the model {@code VSBindingService.createModel}
+ * returns. {@code ChangeChartRefEvent} carries the entire {@code ChartBindingModel}, so
+ * constructing a fresh one would silently discard the thirteen aesthetic fields in
+ * {@link ChartBindingFields#AESTHETIC} along with everything else this class does not set.
+ */
+@Service
+public class ChartBindingService {
+   @Autowired
+   public ChartBindingService(ViewsheetSessionService sessions,
+                              VSBindingService binding,
+                              ChangeChartRefService refService,
+                              ChangeChartTypeService typeService,
+                              SwapXYBindingService swapService)
+   {
+      this.sessions = sessions;
+      this.binding = binding;
+      this.refService = refService;
+      this.typeService = typeService;
+      this.swapService = swapService;
+   }
+
+   public void setShelf(String sessionToken, Principal user, String assemblyName, String shelf,
+                        List<FieldRef> fields, String linkUri) throws Exception
+   {
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         ChartVSAssembly chart = requireChart(rvs, assemblyName);
+         ChartBindingModel model = (ChartBindingModel) binding.createModel(chart);
+         ChartBindingMutator.setShelf(model, shelf, fields);
+
+         ChangeChartRefEvent event = new ChangeChartRefEvent();
+         event.setName(assemblyName);
+         event.setFieldType(shelf);
+         event.setModel(model);
+         refService.changeChartRef(runtimeId, event, user, dispatcher, linkUri);
+      });
+   }
+
+   public void setChartType(String sessionToken, Principal user, String assemblyName, int type,
+                            Boolean multi, Boolean stackMeasures, Boolean separate,
+                            String linkUri) throws Exception
+   {
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         requireChart(rvs, assemblyName);
+
+         ChangeChartTypeEvent event = new ChangeChartTypeEvent();
+         event.setName(assemblyName);
+         event.setType(type);
+         event.setMulti(Boolean.TRUE.equals(multi));
+         event.setStackMeasures(Boolean.TRUE.equals(stackMeasures));
+         event.setSeparate(!Boolean.FALSE.equals(separate));
+         typeService.changeChartType(runtimeId, event, user, dispatcher, linkUri);
+      });
+   }
+
+   public void swapAxes(String sessionToken, Principal user, String assemblyName, String linkUri)
+      throws Exception
+   {
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         requireChart(rvs, assemblyName);
+
+         ChangeSeparateStatusEvent event = new ChangeSeparateStatusEvent();
+         event.setName(assemblyName);
+         swapService.swapXYBinding(runtimeId, event, user, dispatcher, linkUri);
+      });
+   }
+
+   private static ChartVSAssembly requireChart(RuntimeViewsheet rvs, String assemblyName) {
+      Viewsheet vs = rvs == null ? null : rvs.getViewsheet();
+      VSAssembly assembly = vs == null ? null : vs.getAssembly(assemblyName);
+
+      if(assembly == null) {
+         throw new IllegalArgumentException("Unknown assembly '" + assemblyName + "'.");
+      }
+
+      if(!(assembly instanceof ChartVSAssembly chart)) {
+         throw new IllegalArgumentException(
+            "'" + assemblyName + "' is a " + assembly.getClass().getSimpleName() +
+            ", not a chart. Chart binding tools only apply to charts.");
+      }
+
+      return chart;
+   }
+
+   private final ViewsheetSessionService sessions;
+   private final VSBindingService binding;
+   private final ChangeChartRefService refService;
+   private final ChangeChartTypeService typeService;
+   private final SwapXYBindingService swapService;
+}

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingService.java
@@ -80,6 +80,29 @@ public class ChartBindingService {
       });
    }
 
+   /**
+    * Binds one of the single-field shelves — open/high/low/close, path, source/target,
+    * start/end/milestone. A null {@code field} clears it.
+    *
+    * <p>Goes through the same {@code changeChartRef} event as the list shelves, so the 13
+    * snapshotted aesthetic fields are preserved identically.
+    */
+   public void setSingleShelf(String sessionToken, Principal user, String assemblyName,
+                              String shelf, FieldRef field, String linkUri) throws Exception
+   {
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         ChartVSAssembly chart = requireChart(rvs, assemblyName);
+         ChartBindingModel model = (ChartBindingModel) binding.createModel(chart);
+         ChartBindingMutator.setSingleShelf(model, shelf, field);
+
+         ChangeChartRefEvent event = new ChangeChartRefEvent();
+         event.setName(assemblyName);
+         event.setFieldType(shelf);
+         event.setModel(model);
+         refService.changeChartRef(runtimeId, event, user, dispatcher, linkUri);
+      });
+   }
+
    public void setChartType(String sessionToken, Principal user, String assemblyName, int type,
                             Boolean multi, Boolean stackMeasures, Boolean separate,
                             String linkUri) throws Exception

--- a/core/src/main/java/inetsoft/web/wiz/binding/DateLevels.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/DateLevels.java
@@ -1,0 +1,112 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.uql.XConstants;
+
+import java.util.*;
+
+/**
+ * Turns a date grouping level into the number StyleBI stores.
+ *
+ * <p>The levels are {@link XConstants} constants whose values nobody can guess and which do not
+ * run in the order anyone would assume — year is 5, quarter 4, month 3, week 2, day 1, and none 0.
+ * So a caller naturally writes {@code dateLevel: "year"}.
+ *
+ * <p>That used to be stored verbatim. Nothing complained at the time; the binding simply held a
+ * level that is not a number, and the <em>next</em> write to that assembly — any write, on any
+ * shelf — failed with {@code For input string: "year"}, naming neither the field, nor the level,
+ * nor the call that poisoned it. The assembly stayed broken until the level was overwritten.
+ *
+ * <p>Hence both halves of the rule this codebase follows: forgiving where the intent is
+ * unambiguous — the names, in any case — and loud otherwise, rather than storing something that
+ * will fail later somewhere else.
+ */
+public final class DateLevels {
+   private DateLevels() {
+   }
+
+   /**
+    * The stored form of a date level, or null if none was given.
+    *
+    * @throws IllegalArgumentException if the value is neither a known name nor a known constant.
+    */
+   public static String normalize(String dateLevel) {
+      if(dateLevel == null || dateLevel.isBlank()) {
+         return null;
+      }
+
+      String token = dateLevel.trim().toLowerCase();
+
+      // StyleBI's own sentinel for "no date level": VSDimensionRef.setDateLevel maps -1 to null.
+      // Refs read back from a live binding carry it, so refusing it would break every round trip
+      // that reads a dimension and writes it somewhere else.
+      if(UNSET.equals(token)) {
+         return UNSET;
+      }
+
+      Integer named = BY_NAME.get(token);
+
+      if(named != null) {
+         return String.valueOf(named);
+      }
+
+      try {
+         int value = Integer.parseInt(token);
+
+         // A number outside the known set is exactly as poisonous as a word, and just as silent,
+         // so it is refused too rather than trusted for looking numeric.
+         if(VALUES.contains(value)) {
+            return String.valueOf(value);
+         }
+      }
+      catch(NumberFormatException ignored) {
+         // fall through to the shared refusal below
+      }
+
+      throw new IllegalArgumentException(
+         "'" + dateLevel + "' is not a date level. Accepted names: " +
+         String.join(", ", new TreeSet<>(BY_NAME.keySet())) +
+         ". The equivalent numbers are also accepted.");
+   }
+
+   /** StyleBI's sentinel for an unset level — see {@code VSDimensionRef.setDateLevel}. */
+   private static final String UNSET = "-1";
+
+   private static final Map<String, Integer> BY_NAME = byName();
+   private static final Set<Integer> VALUES = new HashSet<>(BY_NAME.values());
+
+   private static Map<String, Integer> byName() {
+      Map<String, Integer> levels = new LinkedHashMap<>();
+      levels.put("none", XConstants.NONE_DATE_GROUP);
+      levels.put("year", XConstants.YEAR_DATE_GROUP);
+      levels.put("quarter", XConstants.QUARTER_DATE_GROUP);
+      levels.put("month", XConstants.MONTH_DATE_GROUP);
+      levels.put("week", XConstants.WEEK_DATE_GROUP);
+      levels.put("day", XConstants.DAY_DATE_GROUP);
+      levels.put("hour", XConstants.HOUR_DATE_GROUP);
+      levels.put("minute", XConstants.MINUTE_DATE_GROUP);
+      levels.put("second", XConstants.SECOND_DATE_GROUP);
+      levels.put("millisecond", XConstants.MILLISECOND_DATE_GROUP);
+
+      // The "part" levels — quarter of year, month of year, day of week and so on — group by a
+      // component rather than truncating to it, which is a different question from this one and
+      // is not offered here rather than being half-supported under a similar name.
+      return levels;
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/binding/DateLevels.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/DateLevels.java
@@ -85,6 +85,28 @@ public final class DateLevels {
          ". The equivalent numbers are also accepted.");
    }
 
+   /**
+    * The name of a stored level, or the raw value if it names none.
+    *
+    * <p>For error messages: having told callers to write "quarter", reporting back "date level 4"
+    * asks them to translate a number this codebase deliberately hides.
+    */
+   public static String name(String dateLevel) {
+      if(dateLevel == null || dateLevel.isBlank()) {
+         return null;
+      }
+
+      String token = dateLevel.trim();
+
+      for(Map.Entry<String, Integer> level : BY_NAME.entrySet()) {
+         if(String.valueOf(level.getValue()).equals(token)) {
+            return level.getKey();
+         }
+      }
+
+      return token;
+   }
+
    /** StyleBI's sentinel for an unset level — see {@code VSDimensionRef.setDateLevel}. */
    private static final String UNSET = "-1";
 

--- a/core/src/main/java/inetsoft/web/wiz/binding/DimensionSortRanking.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/DimensionSortRanking.java
@@ -1,0 +1,269 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.uql.XCondition;
+import inetsoft.uql.XConstants;
+import inetsoft.web.binding.model.BDimensionRefModel;
+
+import java.util.*;
+
+/**
+ * Per-dimension sorting and ranking, in the agent vocabulary.
+ *
+ * <p><b>Columns are addressed by name, never by index.</b> {@code OrderModel.sortByCol} and
+ * {@code TopNModel.sumCol} are integer indices with name-valued twins, and an index is brittle
+ * under any shelf reorder: a stable index today is the wrong column tomorrow, and the failure is
+ * silent because the sort still "works", just on the wrong column. So this writes the name form
+ * only, and an integer supplied where a column name belongs is refused.
+ *
+ * <p>That is a deliberate narrowing — the raw escape hatch offered elsewhere in this plugin is
+ * withheld here, because there is no case where a caller legitimately knows the index but not the
+ * name.
+ *
+ * <p>Ranking spellings match what viz-chat already established, so an agent that has driven
+ * that surface does not have to relearn them here.
+ */
+public final class DimensionSortRanking {
+   /** Sort directions. {@code value_asc}/{@code value_desc} sort by an aggregate, not the label. */
+   private static final Map<String, Integer> SORTS = Map.of(
+      "none", XConstants.SORT_NONE,
+      "asc", XConstants.SORT_ASC,
+      "ascending", XConstants.SORT_ASC,
+      "desc", XConstants.SORT_DESC,
+      "descending", XConstants.SORT_DESC,
+      "value_asc", XConstants.SORT_VALUE_ASC,
+      "value_desc", XConstants.SORT_VALUE_DESC,
+      "manual", XConstants.SORT_SPECIFIC);
+
+   /** Ranking modes, spelled as viz-chat spells them. */
+   private static final Map<String, Integer> RANKINGS = Map.of(
+      "none", XCondition.NONE,
+      "top", XCondition.TOP_N,
+      "top_n", XCondition.TOP_N,
+      "bottom", XCondition.BOTTOM_N,
+      "bottom_n", XCondition.BOTTOM_N);
+
+   private DimensionSortRanking() {
+   }
+
+   /**
+    * @param direction   a token from {@link #sortTokens()}
+    * @param sortByField the measure to sort by, for {@code value_asc}/{@code value_desc}
+    * @param manualOrder the explicit value order, for {@code manual}
+    */
+   public record Sort(String direction, String sortByField, List<String> manualOrder) {}
+
+   /**
+    * @param mode    {@code top}, {@code bottom} or {@code none}
+    * @param n       how many
+    * @param measure the measure to rank by, by name
+    * @param others  group the remainder into an "Others" row
+    */
+   public record Ranking(String mode, Integer n, String measure, Boolean others) {}
+
+   public static void applySort(BDimensionRefModel dimension, Sort sort) {
+      String direction = require(SORTS, sort == null ? null : sort.direction(), "direction",
+                                 sortTokens());
+      int order = SORTS.get(direction);
+
+      // A by-value sort with nothing to sort by silently falls back to sorting by label, which
+      // looks like the request was honoured.
+      if((order == XConstants.SORT_VALUE_ASC || order == XConstants.SORT_VALUE_DESC) &&
+         blank(sort.sortByField()))
+      {
+         throw new IllegalArgumentException(
+            "'" + direction + "' sorts by an aggregate, so it needs 'sortByField' — the measure " +
+            "to sort on. Without it the sort falls back to the label, which looks like it worked.");
+      }
+
+      if(order == XConstants.SORT_SPECIFIC &&
+         (sort.manualOrder() == null || sort.manualOrder().isEmpty()))
+      {
+         throw new IllegalArgumentException(
+            "'manual' needs 'manualOrder' — the values in the order you want them.");
+      }
+
+      requireName(sort.sortByField(), "sortByField");
+      dimension.setOrder(order);
+
+      if(!blank(sort.sortByField())) {
+         dimension.setSortByCol(sort.sortByField());
+      }
+
+      if(sort.manualOrder() != null && !sort.manualOrder().isEmpty()) {
+         dimension.setManualOrder(new ArrayList<>(sort.manualOrder()));
+      }
+   }
+
+   public static void applyRanking(BDimensionRefModel dimension, Ranking ranking) {
+      String mode = require(RANKINGS, ranking == null ? null : ranking.mode(), "mode",
+                            rankingTokens());
+      int option = RANKINGS.get(mode);
+
+      if(option == XCondition.NONE) {
+         dimension.setRankingOption(String.valueOf(XCondition.NONE));
+         dimension.setRankingN(null);
+         dimension.setRankingCol(null);
+         return;
+      }
+
+      if(ranking.n() == null || ranking.n() < 1) {
+         throw new IllegalArgumentException(
+            "'" + mode + "' ranking needs an 'n' of at least 1, got " + ranking.n() + ".");
+      }
+
+      // Ranking by an unbound or unnamed measure produces an empty or arbitrary result rather
+      // than an error, so the measure is required by name.
+      if(blank(ranking.measure())) {
+         throw new IllegalArgumentException(
+            "'" + mode + "' ranking needs a 'measure' — the aggregate to rank by, by name. " +
+            "Ranking by nothing produces an arbitrary result rather than an error.");
+      }
+
+      requireName(ranking.measure(), "measure");
+      dimension.setRankingOption(String.valueOf(option));
+      dimension.setRankingN(String.valueOf(ranking.n()));
+      dimension.setRankingCol(ranking.measure());
+
+      if(ranking.others() != null) {
+         dimension.setOthers(ranking.others());
+      }
+   }
+
+   /** What a dimension is currently sorted and ranked by, in the agent vocabulary. */
+   public static Map<String, Object> describe(BDimensionRefModel dimension) {
+      Map<String, Object> out = new LinkedHashMap<>();
+
+      if(dimension == null) {
+         return out;
+      }
+
+      out.put("direction", sortToken(dimension.getOrder()));
+      out.put("sortByField", dimension.getSortByCol());
+      out.put("manualOrder", dimension.getManualOrder());
+      out.put("ranking", rankingToken(dimension.getRankingOption()));
+      out.put("rankingN", dimension.getRankingN());
+      out.put("rankingMeasure", dimension.getRankingCol());
+      out.put("others", dimension.isOthers());
+      return out;
+   }
+
+   public static List<String> sortTokens() {
+      return sorted(SORTS);
+   }
+
+   public static List<String> rankingTokens() {
+      return sorted(RANKINGS);
+   }
+
+   // ── the index refusal ─────────────────────────────────────────────────────
+
+   /**
+    * The deliberate narrowing. An all-digit value where a column name belongs is almost
+    * certainly an index, and an index silently sorts or ranks by the wrong column after any
+    * shelf reorder.
+    */
+   private static void requireName(String value, String key) {
+      if(blank(value)) {
+         return;
+      }
+
+      if(value.trim().matches("-?\\d+")) {
+         throw new IllegalArgumentException(
+            "'" + key + "' is '" + value + "', which looks like a column index. Columns are " +
+            "addressed by name here: an index is stable only until the shelf is reordered, and " +
+            "then it sorts or ranks by the wrong column without failing. Use the column's name.");
+      }
+   }
+
+   private static String require(Map<String, Integer> table, String token, String key,
+                                 List<String> valid)
+   {
+      String name = token == null ? "" : token.trim().toLowerCase();
+
+      if(!table.containsKey(name)) {
+         throw new IllegalArgumentException(
+            "'" + key + "' must be one of " + valid + ", got '" + token + "'.");
+      }
+
+      return name;
+   }
+
+   /** Canonical spellings, so a read never hands back an alias. */
+   private static String sortToken(int order) {
+      if(order == XConstants.SORT_VALUE_ASC) {
+         return "value_asc";
+      }
+
+      if(order == XConstants.SORT_VALUE_DESC) {
+         return "value_desc";
+      }
+
+      if(order == XConstants.SORT_ASC) {
+         return "asc";
+      }
+
+      if(order == XConstants.SORT_DESC) {
+         return "desc";
+      }
+
+      if(order == XConstants.SORT_SPECIFIC) {
+         return "manual";
+      }
+
+      if(order == XConstants.SORT_NONE) {
+         return "none";
+      }
+
+      return "unknown(" + order + ")";
+   }
+
+   private static String rankingToken(String option) {
+      if(blank(option)) {
+         return "none";
+      }
+
+      try {
+         int value = Integer.parseInt(option.trim());
+
+         if(value == XCondition.TOP_N) {
+            return "top";
+         }
+
+         if(value == XCondition.BOTTOM_N) {
+            return "bottom";
+         }
+
+         return value == XCondition.NONE ? "none" : "unknown(" + value + ")";
+      }
+      catch(NumberFormatException e) {
+         return "unknown(" + option + ")";
+      }
+   }
+
+   private static List<String> sorted(Map<String, Integer> table) {
+      List<String> names = new ArrayList<>(table.keySet());
+      Collections.sort(names);
+      return names;
+   }
+
+   private static boolean blank(String value) {
+      return value == null || value.isBlank();
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/binding/FieldRefFactory.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/FieldRefFactory.java
@@ -64,7 +64,7 @@ public final class FieldRefFactory {
       ref.setName(field.column());
 
       if(field.dateLevel() != null) {
-         ref.setDateLevel(field.dateLevel());
+         ref.setDateLevel(DateLevels.normalize(field.dateLevel()));
       }
 
       return ref;

--- a/core/src/main/java/inetsoft/web/wiz/binding/FieldRefFactory.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/FieldRefFactory.java
@@ -20,6 +20,9 @@ package inetsoft.web.wiz.binding;
 import inetsoft.web.binding.drm.DataRefModel;
 import inetsoft.web.binding.model.BAggregateRefModel;
 import inetsoft.web.binding.model.BDimensionRefModel;
+import inetsoft.web.binding.model.graph.ChartAggregateRefModel;
+import inetsoft.web.binding.model.graph.ChartDimensionRefModel;
+import inetsoft.web.binding.model.graph.ChartRefModel;
 import inetsoft.web.wiz.binding.model.FieldRef;
 
 import java.util.List;
@@ -32,6 +35,39 @@ public final class FieldRefFactory {
    private static final List<String> TYPES = List.of(DIMENSION, MEASURE);
 
    private FieldRefFactory() {
+   }
+
+   /**
+    * Builds the chart-side ref model a {@link FieldRef} describes.
+    *
+    * <p>Shared by 2b's shelf writes and 2c's aesthetic channels: both put the same kind of
+    * field in different places, and two copies of this would drift the moment one of them
+    * learned about a new field attribute.
+    */
+   public static ChartRefModel toChartRef(FieldRef field) {
+      requireType(field);
+
+      if(MEASURE.equalsIgnoreCase(field.type())) {
+         ChartAggregateRefModel ref = new ChartAggregateRefModel();
+         ref.setColumnValue(field.column());
+         ref.setName(field.column());
+
+         if(field.aggregate() != null) {
+            ref.setFormula(field.aggregate());
+         }
+
+         return ref;
+      }
+
+      ChartDimensionRefModel ref = new ChartDimensionRefModel();
+      ref.setColumnValue(field.column());
+      ref.setName(field.column());
+
+      if(field.dateLevel() != null) {
+         ref.setDateLevel(field.dateLevel());
+      }
+
+      return ref;
    }
 
    public static FieldRef from(DataRefModel ref) {

--- a/core/src/main/java/inetsoft/web/wiz/binding/FieldRefFactory.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/FieldRefFactory.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.web.binding.drm.DataRefModel;
+import inetsoft.web.binding.model.BAggregateRefModel;
+import inetsoft.web.binding.model.BDimensionRefModel;
+import inetsoft.web.wiz.binding.model.FieldRef;
+
+import java.util.List;
+
+/** Converts between StyleBI's ref models and the agent-facing {@link FieldRef}. */
+public final class FieldRefFactory {
+   public static final String DIMENSION = "dimension";
+   public static final String MEASURE = "measure";
+
+   private static final List<String> TYPES = List.of(DIMENSION, MEASURE);
+
+   private FieldRefFactory() {
+   }
+
+   public static FieldRef from(DataRefModel ref) {
+      if(ref instanceof BAggregateRefModel aggregate) {
+         return new FieldRef(aggregate.getColumnValue(), MEASURE, aggregate.getFormula(),
+                             null, null);
+      }
+
+      if(ref instanceof BDimensionRefModel dimension) {
+         return new FieldRef(dimension.getColumnValue(), DIMENSION, null,
+                             dimension.getDateLevel(),
+                             dimension.getNamedGroupInfo() == null
+                                ? null : dimension.getNamedGroupInfo().getName());
+      }
+
+      return new FieldRef(ref == null ? null : ref.getName(), null, null, null, null);
+   }
+
+   /**
+    * Fails loud when the discriminator is absent or unrecognized. Never defaults it: a ref
+    * with a guessed role lands on the wrong shelf and renders plausibly wrong, which is the
+    * failure this vocabulary exists to prevent.
+    */
+   public static void requireType(FieldRef ref) {
+      String type = ref == null || ref.type() == null ? null : ref.type().trim().toLowerCase();
+
+      if(type == null || !TYPES.contains(type)) {
+         throw new IllegalArgumentException(
+            "Field '" + (ref == null ? "?" : ref.column()) + "' needs a 'type' of " +
+            String.join(" or ", TYPES) + ", got '" +
+            (ref == null ? "null" : String.valueOf(ref.type())) + "'.");
+      }
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/binding/TableBindingMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/TableBindingMutator.java
@@ -629,6 +629,26 @@ public final class TableBindingMutator {
     * Percentage-by is positional and only meaningful when the shelf it refers to is populated.
     * By-column with no columns bound renders zeros rather than failing.
     */
+   /**
+    * The name of a stored percentage direction, for reporting.
+    *
+    * <p>Stored as an {@code XConstants} number — and {@code PERCENTAGE_BY_COL} is 1, which is also
+    * the default, so a fresh crosstab reads back {@code "1"}. That looks like a setting somebody
+    * chose, in a vocabulary ({@code none}/{@code row}/{@code col}) the number does not belong to.
+    */
+   public static String percentageByName(String stored) {
+      if(stored == null || stored.isBlank()) {
+         return null;
+      }
+
+      return switch(stored.trim()) {
+         case "0" -> "none";
+         case "1" -> "col";
+         case "2" -> "row";
+         default -> stored.trim();
+      };
+   }
+
    private static String percentageBy(Object raw, CrosstabBindingModel model) {
       String token = raw == null ? "" : String.valueOf(raw).trim().toLowerCase();
       int value = switch(token) {

--- a/core/src/main/java/inetsoft/web/wiz/binding/TableBindingMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/TableBindingMutator.java
@@ -461,19 +461,19 @@ public final class TableBindingMutator {
          }
       }
 
-      Map<String, String> merged = model.getName2Labels() == null
-         ? new LinkedHashMap<>() : new LinkedHashMap<>(model.getName2Labels());
-
-      for(Map.Entry<String, String> label : labels.entrySet()) {
-         if(label.getValue() == null || label.getValue().isEmpty()) {
-            merged.remove(label.getKey());
-         }
-         else {
-            merged.put(label.getKey(), label.getValue());
-         }
-      }
-
-      model.setName2Labels(merged);
+      // name2Labels is read and written by BaseTableBindingModel and by nothing else in the
+      // product. Writing here landed nowhere: the header kept its original text, columnLabels
+      // read back empty, and the tool still reported success -- the worst of the three possible
+      // outcomes, because the caller has no way to tell.
+      //
+      // A header rename is really a TableDataPath cell override, which needs the rendered table
+      // lens to find the header cell and differs between a crosstab and a table. Until that is
+      // built, refusing is the honest answer: an agent can then surface a missing capability
+      // rather than report a rename that did not happen.
+      throw new UnsupportedOperationException(
+         "Renaming column headers is not supported yet. The label would be stored somewhere " +
+         "nothing reads, so the header would keep its current text while this call reported " +
+         "success. Ask for it as a gap rather than working around it.");
    }
 
    // ── options (2d Phase 3) ──────────────────────────────────────────────────

--- a/core/src/main/java/inetsoft/web/wiz/binding/TableBindingMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/TableBindingMutator.java
@@ -1,0 +1,353 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.web.binding.drm.AttributeRefModel;
+import inetsoft.web.binding.drm.ColumnRefModel;
+import inetsoft.web.binding.drm.DataRefModel;
+import inetsoft.web.binding.model.BAggregateRefModel;
+import inetsoft.web.binding.model.BDimensionRefModel;
+import inetsoft.web.binding.model.table.BaseTableBindingModel;
+import inetsoft.web.binding.model.table.CrosstabBindingModel;
+import inetsoft.web.binding.model.table.TableBindingModel;
+import inetsoft.web.wiz.binding.model.FieldRef;
+
+import java.util.*;
+
+/**
+ * Read-modify-write over a crosstab's or table's shelves.
+ *
+ * <p>Five shelves against the chart's fifteen, so this is the simplest of the binding
+ * mutators — but the shelves are <b>not interchangeable between the two object types</b>, and
+ * the refusals say which type has which rather than just "unknown shelf".
+ *
+ * <p>Callers must pass the model {@code VSBindingService.createModel} returned and mutate it
+ * in place: {@code setbinding} carries the whole {@code BindingModel}, so a fresh one would
+ * drop {@code source}, {@code allRows}, {@code name2Labels}, the option info, and everything
+ * else no tool here touches.
+ */
+public final class TableBindingMutator {
+   /** Shelves holding dimensions, per object type. */
+   private static final List<String> CROSSTAB_DIMENSION_SHELVES = List.of("rows", "cols");
+   private static final List<String> TABLE_DIMENSION_SHELVES = List.of("groups");
+
+   /**
+    * Natural spellings an agent is likely to reach for. The canonical names match
+    * {@code CrosstabConstants} rather than inventing new ones.
+    */
+   private static final Map<String, String> ALIASES = Map.of(
+      "rowheaders", "rows",
+      "row", "rows",
+      "columnheaders", "cols",
+      "columns", "cols",
+      "col", "cols",
+      "column", "cols",
+      "aggregate", "aggregates",
+      "measures", "aggregates",
+      "group", "groups",
+      "detail", "details");
+
+   private TableBindingMutator() {
+   }
+
+   /** Canonical shelf names valid for the given model, in the order the UI presents them. */
+   public static List<String> shelvesOf(BaseTableBindingModel model) {
+      if(model instanceof CrosstabBindingModel) {
+         return List.of("rows", "cols", "aggregates");
+      }
+
+      if(model instanceof TableBindingModel) {
+         return List.of("groups", "details", "aggregates");
+      }
+
+      throw new IllegalArgumentException(
+         "Not a table or crosstab binding: " +
+         (model == null ? "null" : model.getClass().getSimpleName()) + ".");
+   }
+
+   public static String requireShelf(BaseTableBindingModel model, String shelf) {
+      String raw = shelf == null ? "" : shelf.trim().toLowerCase();
+      String name = ALIASES.getOrDefault(raw, raw);
+      List<String> valid = shelvesOf(model);
+
+      if(!valid.contains(name)) {
+         String type = model instanceof CrosstabBindingModel ? "crosstab" : "table";
+         throw new IllegalArgumentException(
+            "Unknown shelf '" + shelf + "' for a " + type + ". Its shelves are: " +
+            String.join(", ", valid) + ".");
+      }
+
+      return name;
+   }
+
+   public static void setShelf(BaseTableBindingModel model, String shelf, List<FieldRef> fields) {
+      String name = requireShelf(model, shelf);
+      List<FieldRef> refs = fields == null ? List.of() : fields;
+
+      for(FieldRef field : refs) {
+         requireCompatible(name, field);
+      }
+
+      switch(name) {
+         case "rows" -> ((CrosstabBindingModel) model).setRows(dimensions(refs));
+         case "cols" -> ((CrosstabBindingModel) model).setCols(dimensions(refs));
+         case "groups" -> ((TableBindingModel) model).setGroups(dimensions(refs));
+         case "details" -> ((TableBindingModel) model).setDetails(details(refs));
+         default -> model.setAggregates(aggregates(refs));
+      }
+
+      pruneOrphanedSuppression(model);
+   }
+
+   public static void addField(BaseTableBindingModel model, String shelf, FieldRef field,
+                               Integer position)
+   {
+      String name = requireShelf(model, shelf);
+      requireCompatible(name, field);
+      List<FieldRef> current = new ArrayList<>(read(model, name));
+      int index = position == null ? current.size() : position;
+
+      if(index < 0 || index > current.size()) {
+         throw new IllegalArgumentException(
+            "Position " + position + " is outside the " + name + " shelf, which holds " +
+            current.size() + " field(s). Valid positions are 0 to " + current.size() + ".");
+      }
+
+      current.add(index, field);
+      setShelf(model, name, current);
+   }
+
+   public static void removeField(BaseTableBindingModel model, String shelf, String column) {
+      String name = requireShelf(model, shelf);
+      List<FieldRef> current = new ArrayList<>(read(model, name));
+      boolean removed = current.removeIf(
+         field -> field.column() != null && field.column().equalsIgnoreCase(column));
+
+      if(!removed) {
+         throw new IllegalArgumentException(
+            "'" + column + "' is not on the " + name + " shelf. It holds: " +
+            (current.isEmpty() ? "(nothing)" : columns(current)) + ".");
+      }
+
+      setShelf(model, name, current);
+   }
+
+   /**
+    * Moves a field between shelves in one write.
+    *
+    * <p>Its own operation rather than remove-then-add because pivoting a crosstab is the most
+    * common table edit, and two calls would mean two checkpoints and an intermediate state
+    * the browser renders. Validation happens before either side is touched, so a rejected
+    * move leaves the field where it was rather than dropping it.
+    */
+   public static void moveField(BaseTableBindingModel model, String fromShelf, String toShelf,
+                                String column, Integer position)
+   {
+      String from = requireShelf(model, fromShelf);
+      String to = requireShelf(model, toShelf);
+      FieldRef field = read(model, from).stream()
+         .filter(ref -> ref.column() != null && ref.column().equalsIgnoreCase(column))
+         .findFirst()
+         .orElseThrow(() -> new IllegalArgumentException(
+            "'" + column + "' is not on the " + from + " shelf."));
+
+      requireCompatible(to, field);
+
+      List<FieldRef> source = new ArrayList<>(read(model, from));
+      source.removeIf(ref -> ref.column() != null && ref.column().equalsIgnoreCase(column));
+      List<FieldRef> target = new ArrayList<>(read(model, to));
+      int index = position == null ? target.size() : position;
+
+      if(index < 0 || index > target.size()) {
+         throw new IllegalArgumentException(
+            "Position " + position + " is outside the " + to + " shelf, which holds " +
+            target.size() + " field(s).");
+      }
+
+      target.add(index, field);
+      setShelf(model, from, source);
+      setShelf(model, to, target);
+   }
+
+   /** What a shelf currently holds, in the shared vocabulary. */
+   public static List<FieldRef> read(BaseTableBindingModel model, String shelf) {
+      String name = requireShelf(model, shelf);
+      List<? extends DataRefModel> refs = switch(name) {
+         case "rows" -> ((CrosstabBindingModel) model).getRows();
+         case "cols" -> ((CrosstabBindingModel) model).getCols();
+         case "groups" -> ((TableBindingModel) model).getGroups();
+         case "details" -> ((TableBindingModel) model).getDetails();
+         default -> model.getAggregates();
+      };
+
+      List<FieldRef> out = new ArrayList<>();
+
+      if(refs != null) {
+         for(DataRefModel ref : refs) {
+            out.add(fieldOf(ref, name));
+         }
+      }
+
+      return out;
+   }
+
+   // ── validation ────────────────────────────────────────────────────────────
+
+   /**
+    * A shelf holds one kind of thing, and putting the wrong kind on it is the mistake that
+    * renders plausibly wrong rather than failing — a measure dropped into rows becomes a
+    * grouping column, which produces a real-looking table of the wrong shape.
+    */
+   private static void requireCompatible(String shelf, FieldRef field) {
+      FieldRefFactory.requireType(field);
+      boolean measure = FieldRefFactory.MEASURE.equalsIgnoreCase(field.type());
+
+      if("aggregates".equals(shelf) && !measure) {
+         throw new IllegalArgumentException(
+            "Field '" + field.column() + "' is a dimension, and the aggregates shelf holds " +
+            "measures. Put it on a dimension shelf, or set its type to measure with an " +
+            "aggregate.");
+      }
+
+      if(!"aggregates".equals(shelf) && measure) {
+         throw new IllegalArgumentException(
+            "Field '" + field.column() + "' is a measure, and the " + shelf + " shelf holds " +
+            "dimensions. Measures belong on the aggregates shelf.");
+      }
+
+      // A detail row is ungrouped raw data, so an aggregate on it is a category error rather
+      // than a value to drop. See docs/superpowers/plans/2026-08-13-needs-your-input.md.
+      if("details".equals(shelf) && field.aggregate() != null) {
+         throw new IllegalArgumentException(
+            "Field '" + field.column() + "' carries an aggregate, and the details shelf holds " +
+            "ungrouped columns. Put it on the aggregates shelf instead.");
+      }
+   }
+
+   // ── conversions ───────────────────────────────────────────────────────────
+
+   private static List<BDimensionRefModel> dimensions(List<FieldRef> fields) {
+      List<BDimensionRefModel> out = new ArrayList<>();
+
+      for(FieldRef field : fields) {
+         BDimensionRefModel ref = new BDimensionRefModel();
+         ref.setName(field.column());
+         ref.setColumnValue(field.column());
+
+         if(field.dateLevel() != null) {
+            ref.setDateLevel(field.dateLevel());
+         }
+
+         out.add(ref);
+      }
+
+      return out;
+   }
+
+   private static List<BAggregateRefModel> aggregates(List<FieldRef> fields) {
+      List<BAggregateRefModel> out = new ArrayList<>();
+
+      for(FieldRef field : fields) {
+         BAggregateRefModel ref = new BAggregateRefModel();
+         ref.setName(field.column());
+         ref.setColumnValue(field.column());
+
+         if(field.aggregate() != null) {
+            ref.setFormula(field.aggregate());
+         }
+
+         out.add(ref);
+      }
+
+      return out;
+   }
+
+   /**
+    * Detail columns are {@code ColumnRefModel} wrapping an attribute ref — a plainer shape
+    * than every other shelf in the plugin.
+    */
+   private static List<DataRefModel> details(List<FieldRef> fields) {
+      List<DataRefModel> out = new ArrayList<>();
+
+      for(FieldRef field : fields) {
+         AttributeRefModel attribute = new AttributeRefModel();
+         attribute.setName(field.column());
+         attribute.setAttribute(field.column());
+
+         ColumnRefModel column = new ColumnRefModel();
+         column.setName(field.column());
+         column.setAttribute(field.column());
+         column.setDataRefModel(attribute);
+         column.setVisible(true);
+         out.add(column);
+      }
+
+      return out;
+   }
+
+   private static FieldRef fieldOf(DataRefModel ref, String shelf) {
+      FieldRef field = FieldRefFactory.from(ref);
+
+      // A detail column is neither dimension nor measure on the wire, but the shared
+      // vocabulary requires a type, so it reads back as the dimension it behaves like.
+      if("details".equals(shelf) && field.type() == null) {
+         return new FieldRef(field.column(), FieldRefFactory.DIMENSION, null, null, null);
+      }
+
+      return field;
+   }
+
+   private static String columns(List<FieldRef> fields) {
+      List<String> names = new ArrayList<>();
+
+      for(FieldRef field : fields) {
+         names.add(field.column());
+      }
+
+      return String.join(", ", names);
+   }
+
+   /**
+    * {@code suppressGroupTotal} is keyed by field name and nothing prunes it, so a removed
+    * field leaves an entry that grows the map unboundedly and can resurrect suppression if
+    * the name is ever reused. Every write prunes what is no longer bound.
+    */
+   private static void pruneOrphanedSuppression(BaseTableBindingModel model) {
+      if(!(model instanceof CrosstabBindingModel crosstab)) {
+         return;
+      }
+
+      Hashtable<String, Boolean> suppression = crosstab.getSuppressGroupTotal();
+
+      if(suppression == null || suppression.isEmpty()) {
+         return;
+      }
+
+      Set<String> bound = new HashSet<>();
+
+      for(String shelf : shelvesOf(model)) {
+         for(FieldRef field : read(model, shelf)) {
+            if(field.column() != null) {
+               bound.add(field.column());
+            }
+         }
+      }
+
+      suppression.keySet().removeIf(key -> !bound.contains(key));
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/binding/TableBindingMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/TableBindingMutator.java
@@ -458,10 +458,10 @@ public final class TableBindingMutator {
          StringBuilder candidates = new StringBuilder();
 
          for(Map.Entry<Integer, BDimensionRefModel> match : matches.entrySet()) {
-            String level = match.getValue().getDateLevel();
+            String level = DateLevels.name(match.getValue().getDateLevel());
             candidates.append(candidates.isEmpty() ? "" : ", ")
                .append("index ").append(match.getKey())
-               .append(level == null || level.isBlank() ? "" : " (date level " + level + ")");
+               .append(level == null || level.isBlank() ? "" : " (" + level + ")");
          }
 
          throw new IllegalArgumentException(

--- a/core/src/main/java/inetsoft/web/wiz/binding/TableBindingMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/TableBindingMutator.java
@@ -253,7 +253,7 @@ public final class TableBindingMutator {
          ref.setColumnValue(field.column());
 
          if(field.dateLevel() != null) {
-            ref.setDateLevel(field.dateLevel());
+            ref.setDateLevel(DateLevels.normalize(field.dateLevel()));
          }
 
          out.add(ref);

--- a/core/src/main/java/inetsoft/web/wiz/binding/TableBindingMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/TableBindingMutator.java
@@ -22,7 +22,10 @@ import inetsoft.web.binding.drm.ColumnRefModel;
 import inetsoft.web.binding.drm.DataRefModel;
 import inetsoft.web.binding.model.BAggregateRefModel;
 import inetsoft.web.binding.model.BDimensionRefModel;
+import inetsoft.uql.XConstants;
 import inetsoft.web.binding.model.table.BaseTableBindingModel;
+import inetsoft.web.binding.model.table.CrosstabOptionInfo;
+import inetsoft.web.binding.model.table.TableOptionInfo;
 import inetsoft.web.binding.model.table.CrosstabBindingModel;
 import inetsoft.web.binding.model.table.TableBindingModel;
 import inetsoft.web.wiz.binding.model.FieldRef;
@@ -349,5 +352,295 @@ public final class TableBindingMutator {
       }
 
       suppression.keySet().removeIf(key -> !bound.contains(key));
+   }
+
+   // ── sorting and ranking (2d Phase 2) ──────────────────────────────────────
+
+   /**
+    * Applies a sort to one dimension on a shelf.
+    *
+    * <p>The dimension is found by column name, not by index, for the same reason the sort's own
+    * column reference is a name — see {@link DimensionSortRanking}.
+    */
+   public static void setSort(BaseTableBindingModel model, String shelf, String column,
+                              DimensionSortRanking.Sort sort)
+   {
+      DimensionSortRanking.applySort(requireDimension(model, shelf, column), sort);
+   }
+
+   public static void setRanking(BaseTableBindingModel model, String shelf, String column,
+                                 DimensionSortRanking.Ranking ranking)
+   {
+      DimensionSortRanking.applyRanking(requireDimension(model, shelf, column), ranking);
+   }
+
+   /** The sort and ranking on every dimension of a shelf. */
+   public static Map<String, Object> describeSorts(BaseTableBindingModel model, String shelf) {
+      String name = requireShelf(model, shelf);
+      Map<String, Object> out = new LinkedHashMap<>();
+
+      for(BDimensionRefModel dimension : dimensionsOf(model, name)) {
+         out.put(dimension.getColumnValue() == null
+                    ? dimension.getName() : dimension.getColumnValue(),
+                 DimensionSortRanking.describe(dimension));
+      }
+
+      return out;
+   }
+
+   private static BDimensionRefModel requireDimension(BaseTableBindingModel model, String shelf,
+                                                      String column)
+   {
+      String name = requireShelf(model, shelf);
+
+      if("aggregates".equals(name) || "details".equals(name)) {
+         throw new IllegalArgumentException(
+            "Sorting and ranking apply to dimension shelves. The " + name + " shelf holds " +
+            (("aggregates".equals(name)) ? "measures" : "ungrouped columns") + ".");
+      }
+
+      List<String> present = new ArrayList<>();
+
+      for(BDimensionRefModel dimension : dimensionsOf(model, name)) {
+         String value = dimension.getColumnValue() == null
+            ? dimension.getName() : dimension.getColumnValue();
+         present.add(value);
+
+         if(value != null && value.equalsIgnoreCase(column)) {
+            return dimension;
+         }
+      }
+
+      throw new IllegalArgumentException(
+         "'" + column + "' is not on the " + name + " shelf. It holds: " +
+         (present.isEmpty() ? "(nothing)" : String.join(", ", present)) + ".");
+   }
+
+   private static List<BDimensionRefModel> dimensionsOf(BaseTableBindingModel model,
+                                                        String shelf)
+   {
+      List<BDimensionRefModel> dimensions = switch(shelf) {
+         case "rows" -> ((CrosstabBindingModel) model).getRows();
+         case "cols" -> ((CrosstabBindingModel) model).getCols();
+         case "groups" -> ((TableBindingModel) model).getGroups();
+         default -> List.of();
+      };
+
+      return dimensions == null ? List.of() : dimensions;
+   }
+
+   // ── column labels (2d Phase 2) ────────────────────────────────────────────
+
+   /**
+    * Header aliases. A label for a column that is not bound would sit in {@code name2Labels}
+    * doing nothing, so it is refused with the bound columns listed.
+    */
+   public static void setColumnLabels(BaseTableBindingModel model, Map<String, String> labels) {
+      if(labels == null || labels.isEmpty()) {
+         throw new IllegalArgumentException(
+            "set_column_labels needs at least one label. To remove one, pass it with an empty " +
+            "string.");
+      }
+
+      Set<String> bound = new LinkedHashSet<>();
+
+      for(String shelf : shelvesOf(model)) {
+         for(FieldRef field : read(model, shelf)) {
+            if(field.column() != null) {
+               bound.add(field.column());
+            }
+         }
+      }
+
+      for(Map.Entry<String, String> label : labels.entrySet()) {
+         if(bound.stream().noneMatch(column -> column.equalsIgnoreCase(label.getKey()))) {
+            throw new IllegalArgumentException(
+               "'" + label.getKey() + "' is not bound on this assembly, so a label for it would " +
+               "never be shown. Bound columns: " +
+               (bound.isEmpty() ? "(none)" : String.join(", ", bound)) + ".");
+         }
+      }
+
+      Map<String, String> merged = model.getName2Labels() == null
+         ? new LinkedHashMap<>() : new LinkedHashMap<>(model.getName2Labels());
+
+      for(Map.Entry<String, String> label : labels.entrySet()) {
+         if(label.getValue() == null || label.getValue().isEmpty()) {
+            merged.remove(label.getKey());
+         }
+         else {
+            merged.put(label.getKey(), label.getValue());
+         }
+      }
+
+      model.setName2Labels(merged);
+   }
+
+   // ── options (2d Phase 3) ──────────────────────────────────────────────────
+
+   /**
+    * Crosstab and table options.
+    *
+    * <p><b>The crosstab totals are string-typed booleans</b> — {@code rowTotalVisibleValue} and
+    * friends are dynamic-value strings, not booleans, and StyleBI reads anything that is not
+    * {@code "true"} as false. So a caller passing {@code "yes"} would silently turn the total
+    * <i>off</i>. Real booleans are normalized to the string form, and any other spelling is
+    * refused rather than coerced.
+    */
+   public static void setOptions(BaseTableBindingModel model, Map<String, Object> options) {
+      if(options == null || options.isEmpty()) {
+         throw new IllegalArgumentException("set_table_options needs at least one option.");
+      }
+
+      if(model instanceof CrosstabBindingModel crosstab) {
+         setCrosstabOptions(crosstab, options);
+      }
+      else if(model instanceof TableBindingModel table) {
+         setTableOptions(table, options);
+      }
+   }
+
+   private static void setCrosstabOptions(CrosstabBindingModel model,
+                                          Map<String, Object> options)
+   {
+      CrosstabOptionInfo info = model.getOption();
+
+      if(info == null) {
+         info = new CrosstabOptionInfo();
+         model.setOption(info);
+      }
+
+      requireKnown(options, List.of("rowTotals", "colTotals", "percentageBy",
+                                    "summarySideBySide", "suppressGroupTotal"));
+
+      if(options.containsKey("rowTotals")) {
+         info.setRowTotalVisibleValue(stringBoolean(options.get("rowTotals"), "rowTotals"));
+      }
+
+      if(options.containsKey("colTotals")) {
+         info.setColTotalVisibleValue(stringBoolean(options.get("colTotals"), "colTotals"));
+      }
+
+      if(options.containsKey("percentageBy")) {
+         info.setPercentageByValue(percentageBy(options.get("percentageBy"), model));
+      }
+
+      if(options.containsKey("summarySideBySide")) {
+         info.setSummarySideBySide(
+            Boolean.parseBoolean(stringBoolean(options.get("summarySideBySide"),
+                                               "summarySideBySide")));
+      }
+
+      if(options.get("suppressGroupTotal") instanceof Map<?, ?> suppression) {
+         for(Map.Entry<?, ?> entry : suppression.entrySet()) {
+            model.getSuppressGroupTotal().put(
+               String.valueOf(entry.getKey()),
+               Boolean.parseBoolean(stringBoolean(entry.getValue(), "suppressGroupTotal")));
+         }
+
+         pruneOrphanedSuppression(model);
+      }
+   }
+
+   private static void setTableOptions(TableBindingModel model, Map<String, Object> options) {
+      TableOptionInfo info = model.getOption();
+
+      if(info == null) {
+         info = new TableOptionInfo();
+         model.setOption(info);
+      }
+
+      requireKnown(options, List.of("grandTotal", "distinct"));
+
+      if(options.containsKey("grandTotal")) {
+         info.setGrandTotal(
+            Boolean.parseBoolean(stringBoolean(options.get("grandTotal"), "grandTotal")));
+      }
+
+      if(options.containsKey("distinct")) {
+         info.setDistinct(
+            Boolean.parseBoolean(stringBoolean(options.get("distinct"), "distinct")));
+      }
+   }
+
+   /**
+    * Percentage-by is positional and only meaningful when the shelf it refers to is populated.
+    * By-column with no columns bound renders zeros rather than failing.
+    */
+   private static String percentageBy(Object raw, CrosstabBindingModel model) {
+      String token = raw == null ? "" : String.valueOf(raw).trim().toLowerCase();
+      int value = switch(token) {
+         case "none" -> XConstants.PERCENTAGE_NONE;
+         case "col", "column", "columns" -> XConstants.PERCENTAGE_BY_COL;
+         case "row", "rows" -> XConstants.PERCENTAGE_BY_ROW;
+         default -> throw new IllegalArgumentException(
+            "'percentageBy' must be none, row or col, got '" + raw + "'.");
+      };
+
+      if(value == XConstants.PERCENTAGE_BY_COL &&
+         (model.getCols() == null || model.getCols().isEmpty()))
+      {
+         throw new IllegalArgumentException(
+            "'percentageBy: col' needs at least one field on the cols shelf. With none bound the " +
+            "crosstab renders zeros rather than failing.");
+      }
+
+      if(value == XConstants.PERCENTAGE_BY_ROW &&
+         (model.getRows() == null || model.getRows().isEmpty()))
+      {
+         throw new IllegalArgumentException(
+            "'percentageBy: row' needs at least one field on the rows shelf. With none bound the " +
+            "crosstab renders zeros rather than failing.");
+      }
+
+      return String.valueOf(value);
+   }
+
+   /**
+    * A dynamic-value string that StyleBI reads as a boolean. Anything but "true" reads as false,
+    * so "yes" would silently turn a total off — refused rather than coerced.
+    */
+   private static String stringBoolean(Object raw, String key) {
+      if(raw instanceof Boolean value) {
+         return String.valueOf(value);
+      }
+
+      String text = raw == null ? "" : String.valueOf(raw).trim();
+
+      if("true".equalsIgnoreCase(text) || "false".equalsIgnoreCase(text)) {
+         return text.toLowerCase();
+      }
+
+      throw new IllegalArgumentException(
+         "'" + key + "' must be true or false, got '" + raw + "'. This setting is stored as a " +
+         "string that StyleBI reads as a boolean, so a spelling like \"yes\" would read as " +
+         "false and silently turn the setting off.");
+   }
+
+   private static void requireKnown(Map<String, Object> options, List<String> known) {
+      List<String> unknown = new ArrayList<>();
+
+      for(String key : options.keySet()) {
+         if(!known.contains(key)) {
+            unknown.add(key);
+         }
+      }
+
+      if(!unknown.isEmpty()) {
+         throw new IllegalArgumentException(
+            "Unknown option(s) " + unknown + " for this object type. Valid options: " + known +
+            ". An unknown option would be accepted and do nothing.");
+      }
+   }
+
+   /** The option vocabulary, so a caller does not guess which type takes which. */
+   public static Map<String, Object> optionVocabulary() {
+      return Map.of(
+         "crosstab", List.of("rowTotals", "colTotals", "percentageBy", "summarySideBySide",
+                             "suppressGroupTotal"),
+         "table", List.of("grandTotal", "distinct"),
+         "percentageBy", List.of("none", "row", "col"),
+         "sortDirections", DimensionSortRanking.sortTokens(),
+         "rankingModes", DimensionSortRanking.rankingTokens());
    }
 }

--- a/core/src/main/java/inetsoft/web/wiz/binding/TableBindingMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/TableBindingMutator.java
@@ -363,15 +363,15 @@ public final class TableBindingMutator {
     * column reference is a name — see {@link DimensionSortRanking}.
     */
    public static void setSort(BaseTableBindingModel model, String shelf, String column,
-                              DimensionSortRanking.Sort sort)
+                              Integer index, DimensionSortRanking.Sort sort)
    {
-      DimensionSortRanking.applySort(requireDimension(model, shelf, column), sort);
+      DimensionSortRanking.applySort(requireDimension(model, shelf, column, index), sort);
    }
 
    public static void setRanking(BaseTableBindingModel model, String shelf, String column,
-                                 DimensionSortRanking.Ranking ranking)
+                                 Integer index, DimensionSortRanking.Ranking ranking)
    {
-      DimensionSortRanking.applyRanking(requireDimension(model, shelf, column), ranking);
+      DimensionSortRanking.applyRanking(requireDimension(model, shelf, column, index), ranking);
    }
 
    /** The sort and ranking on every dimension of a shelf. */
@@ -379,17 +379,45 @@ public final class TableBindingMutator {
       String name = requireShelf(model, shelf);
       Map<String, Object> out = new LinkedHashMap<>();
 
-      for(BDimensionRefModel dimension : dimensionsOf(model, name)) {
-         out.put(dimension.getColumnValue() == null
-                    ? dimension.getName() : dimension.getColumnValue(),
+      List<BDimensionRefModel> dimensions = dimensionsOf(model, name);
+
+      for(int i = 0; i < dimensions.size(); i++) {
+         BDimensionRefModel dimension = dimensions.get(i);
+         String column = dimension.getColumnValue() == null
+            ? dimension.getName() : dimension.getColumnValue();
+
+         // A crosstab binds the same column twice on purpose (Year then Quarter), and keying by
+         // name alone let the second overwrite the first, so one of the two was simply invisible.
+         // The index is appended only when it is needed, to keep the common shape unchanged.
+         out.put(occurrences(dimensions, column) > 1 ? column + " [" + i + "]" : column,
                  DimensionSortRanking.describe(dimension));
       }
 
       return out;
    }
 
+   private static long occurrences(List<BDimensionRefModel> dimensions, String column) {
+      return dimensions.stream()
+         .map(d -> d.getColumnValue() == null ? d.getName() : d.getColumnValue())
+         .filter(value -> value != null && value.equalsIgnoreCase(column))
+         .count();
+   }
+
+   /**
+    * The dimension a call means.
+    *
+    * <p>A crosstab binds the same column more than once by design — dropping a date column twice
+    * is how a Year › Quarter drill is built, and the Composer auto-advances the level on the
+    * second drop. Sort and ranking are fields on each ref, so the product itself never addresses
+    * a dimension by name; this layer does, and it used to return the FIRST match. Sorting "the
+    * quarter one" then quietly sorted the year one and reported success.
+    *
+    * <p>So a name matching several refs now requires {@code index} — the position on the shelf,
+    * which is what {@code suppressGroupTotal} already keys on ({@code ORDER_DATE:rows0}). A name
+    * matching exactly one still needs nothing, so the common call is unchanged.
+    */
    private static BDimensionRefModel requireDimension(BaseTableBindingModel model, String shelf,
-                                                      String column)
+                                                      String column, Integer index)
    {
       String name = requireShelf(model, shelf);
 
@@ -400,15 +428,49 @@ public final class TableBindingMutator {
       }
 
       List<String> present = new ArrayList<>();
+      List<BDimensionRefModel> dimensions = dimensionsOf(model, name);
+      Map<Integer, BDimensionRefModel> matches = new LinkedHashMap<>();
 
-      for(BDimensionRefModel dimension : dimensionsOf(model, name)) {
+      for(int i = 0; i < dimensions.size(); i++) {
+         BDimensionRefModel dimension = dimensions.get(i);
          String value = dimension.getColumnValue() == null
             ? dimension.getName() : dimension.getColumnValue();
          present.add(value);
 
          if(value != null && value.equalsIgnoreCase(column)) {
-            return dimension;
+            matches.put(i, dimension);
          }
+      }
+
+      if(index != null) {
+         BDimensionRefModel chosen = matches.get(index);
+
+         if(chosen == null) {
+            throw new IllegalArgumentException(
+               "index " + index + " is not a position of '" + column + "' on the " + name +
+               " shelf. It is bound at: " + matches.keySet() + ".");
+         }
+
+         return chosen;
+      }
+
+      if(matches.size() > 1) {
+         StringBuilder candidates = new StringBuilder();
+
+         for(Map.Entry<Integer, BDimensionRefModel> match : matches.entrySet()) {
+            String level = match.getValue().getDateLevel();
+            candidates.append(candidates.isEmpty() ? "" : ", ")
+               .append("index ").append(match.getKey())
+               .append(level == null || level.isBlank() ? "" : " (date level " + level + ")");
+         }
+
+         throw new IllegalArgumentException(
+            "'" + column + "' is bound " + matches.size() + " times on the " + name +
+            " shelf, so this call is ambiguous. Pass 'index' to say which: " + candidates + ".");
+      }
+
+      if(matches.size() == 1) {
+         return matches.values().iterator().next();
       }
 
       throw new IllegalArgumentException(

--- a/core/src/main/java/inetsoft/web/wiz/binding/TableBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/TableBindingService.java
@@ -1,0 +1,168 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.*;
+import inetsoft.web.binding.controller.VSBindingModelService;
+import inetsoft.web.binding.event.ApplyVSAssemblyInfoEvent;
+import inetsoft.web.binding.model.BindingModel;
+import inetsoft.web.binding.model.table.BaseTableBindingModel;
+import inetsoft.web.binding.model.table.CrosstabBindingModel;
+import inetsoft.web.binding.model.table.TableBindingModel;
+import inetsoft.web.binding.service.VSBindingService;
+import inetsoft.web.wiz.binding.model.FieldRef;
+import inetsoft.web.wiz.viewsheet.ViewsheetSessionService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+import java.util.*;
+import java.util.function.Consumer;
+
+/**
+ * Crosstab and table shelf mutations.
+ *
+ * <p>Unlike charts, tables have no dedicated write endpoint: they go through the generic
+ * {@code setbinding}, which takes the whole polymorphic {@code BindingModel}. That endpoint
+ * carries a trap flag, defaulting on, so a binding that would produce a cartesian result is
+ * reported rather than quietly applied. It is deliberately not disabled to make a call
+ * succeed.
+ *
+ * <p>Each public method is exactly one {@code sessions.mutate} — one undo checkpoint. That is
+ * why {@code moveField} exists rather than asking callers to remove then add: a crosstab pivot
+ * as two calls would be two checkpoints, with an intermediate state the browser renders.
+ */
+@Service
+public class TableBindingService {
+   @Autowired
+   public TableBindingService(ViewsheetSessionService sessions,
+                              VSBindingService binding,
+                              VSBindingModelService bindingModelService)
+   {
+      this.sessions = sessions;
+      this.binding = binding;
+      this.bindingModelService = bindingModelService;
+   }
+
+   public void setShelf(String sessionToken, Principal user, String assemblyName, String shelf,
+                        List<FieldRef> fields) throws Exception
+   {
+      apply(sessionToken, user, assemblyName,
+            model -> TableBindingMutator.setShelf(model, shelf, fields));
+   }
+
+   public void addField(String sessionToken, Principal user, String assemblyName, String shelf,
+                        FieldRef field, Integer position) throws Exception
+   {
+      apply(sessionToken, user, assemblyName,
+            model -> TableBindingMutator.addField(model, shelf, field, position));
+   }
+
+   public void removeField(String sessionToken, Principal user, String assemblyName,
+                           String shelf, String column) throws Exception
+   {
+      apply(sessionToken, user, assemblyName,
+            model -> TableBindingMutator.removeField(model, shelf, column));
+   }
+
+   public void moveField(String sessionToken, Principal user, String assemblyName,
+                         String fromShelf, String toShelf, String column, Integer position)
+      throws Exception
+   {
+      apply(sessionToken, user, assemblyName,
+            model -> TableBindingMutator.moveField(model, fromShelf, toShelf, column, position));
+   }
+
+   /** The shelves, their contents, and the object type — without opening a checkpoint. */
+   public Map<String, Object> read(String sessionToken, Principal user, String assemblyName)
+      throws Exception
+   {
+      RuntimeViewsheet rvs = sessions.resolve(sessionToken, user);
+      BaseTableBindingModel model = requireTableBinding(rvs, assemblyName);
+      Map<String, Object> shelves = new LinkedHashMap<>();
+
+      for(String shelf : TableBindingMutator.shelvesOf(model)) {
+         shelves.put(shelf, TableBindingMutator.read(model, shelf));
+      }
+
+      Map<String, Object> out = new LinkedHashMap<>();
+      out.put("assembly", assemblyName);
+      out.put("objectType", model instanceof CrosstabBindingModel ? "crosstab" : "table");
+      out.put("source", model.getSource() == null ? null : model.getSource().getSource());
+      out.put("shelves", shelves);
+      out.put("columnLabels", model.getName2Labels());
+
+      if(model instanceof CrosstabBindingModel crosstab) {
+         out.put("suppressGroupTotal", crosstab.getSuppressGroupTotal());
+      }
+      else if(model instanceof TableBindingModel table) {
+         // Read-only for now: writing it turns an embedded table into a bound one, which is
+         // closer to a data-loss operation than a binding edit.
+         out.put("embedded", table.getEmbedded());
+      }
+
+      return out;
+   }
+
+   private void apply(String sessionToken, Principal user, String assemblyName,
+                      Consumer<BaseTableBindingModel> mutation) throws Exception
+   {
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         BaseTableBindingModel model = requireTableBinding(rvs, assemblyName);
+         mutation.accept(model);
+
+         ApplyVSAssemblyInfoEvent event = new ApplyVSAssemblyInfoEvent();
+         event.setName(assemblyName);
+         event.setBinding(model);
+         // Left at its default of true. A trap means the binding produces a cartesian or
+         // otherwise invalid result, and turning it off to make the call succeed would be
+         // trading a reported problem for an unreported one.
+         bindingModelService.setBinding(runtimeId, event, user, dispatcher);
+      });
+   }
+
+   private BaseTableBindingModel requireTableBinding(RuntimeViewsheet rvs, String assemblyName) {
+      Viewsheet vs = rvs == null ? null : rvs.getViewsheet();
+      VSAssembly assembly = vs == null ? null : vs.getAssembly(assemblyName);
+
+      if(assembly == null) {
+         throw new IllegalArgumentException("Unknown assembly '" + assemblyName + "'.");
+      }
+
+      if(assembly instanceof CalcTableVSAssembly) {
+         throw new IllegalArgumentException(
+            "'" + assemblyName + "' is a calc table. Its binding lives in its cell layout, " +
+            "not its shelves — use the calc-table tools instead.");
+      }
+
+      BindingModel model = binding.createModel(assembly);
+
+      if(!(model instanceof BaseTableBindingModel table)) {
+         throw new IllegalArgumentException(
+            "'" + assemblyName + "' is a " + assembly.getClass().getSimpleName() +
+            ", not a table or crosstab. Use the chart binding tools for charts.");
+      }
+
+      return table;
+   }
+
+   private final ViewsheetSessionService sessions;
+   private final VSBindingService binding;
+   private final VSBindingModelService bindingModelService;
+}

--- a/core/src/main/java/inetsoft/web/wiz/binding/TableBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/TableBindingService.java
@@ -287,7 +287,9 @@ public class TableBindingService {
       if(model instanceof CrosstabBindingModel crosstab && crosstab.getOption() != null) {
          out.put("rowTotals", crosstab.getOption().getRowTotalVisibleValue());
          out.put("colTotals", crosstab.getOption().getColTotalVisibleValue());
-         out.put("percentageBy", crosstab.getOption().getPercentageByValue());
+         out.put("percentageBy",
+                 TableBindingMutator.percentageByName(
+                    crosstab.getOption().getPercentageByValue()));
          out.put("summarySideBySide", crosstab.getOption().isSummarySideBySide());
       }
       else if(model instanceof TableBindingModel table && table.getOption() != null) {

--- a/core/src/main/java/inetsoft/web/wiz/binding/TableBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/TableBindingService.java
@@ -89,6 +89,38 @@ public class TableBindingService {
             model -> TableBindingMutator.moveField(model, fromShelf, toShelf, column, position));
    }
 
+   public void setSort(String sessionToken, Principal user, String assemblyName, String shelf,
+                       String column, DimensionSortRanking.Sort sort) throws Exception
+   {
+      apply(sessionToken, user, assemblyName,
+            model -> TableBindingMutator.setSort(model, shelf, column, sort));
+   }
+
+   public void setRanking(String sessionToken, Principal user, String assemblyName, String shelf,
+                          String column, DimensionSortRanking.Ranking ranking) throws Exception
+   {
+      apply(sessionToken, user, assemblyName,
+            model -> TableBindingMutator.setRanking(model, shelf, column, ranking));
+   }
+
+   public void setColumnLabels(String sessionToken, Principal user, String assemblyName,
+                               Map<String, String> labels) throws Exception
+   {
+      apply(sessionToken, user, assemblyName,
+            model -> TableBindingMutator.setColumnLabels(model, labels));
+   }
+
+   public void setOptions(String sessionToken, Principal user, String assemblyName,
+                          Map<String, Object> options) throws Exception
+   {
+      apply(sessionToken, user, assemblyName,
+            model -> TableBindingMutator.setOptions(model, options));
+   }
+
+   public Map<String, Object> optionVocabulary() {
+      return TableBindingMutator.optionVocabulary();
+   }
+
    /** The shelves, their contents, and the object type — without opening a checkpoint. */
    public Map<String, Object> read(String sessionToken, Principal user, String assemblyName)
       throws Exception
@@ -107,6 +139,16 @@ public class TableBindingService {
       out.put("source", model.getSource() == null ? null : model.getSource().getSource());
       out.put("shelves", shelves);
       out.put("columnLabels", model.getName2Labels());
+      Map<String, Object> sorts = new LinkedHashMap<>();
+
+      for(String shelf : TableBindingMutator.shelvesOf(model)) {
+         if(!"aggregates".equals(shelf) && !"details".equals(shelf)) {
+            sorts.putAll(TableBindingMutator.describeSorts(model, shelf));
+         }
+      }
+
+      out.put("sorts", sorts);
+      out.put("options", describeOptions(model));
 
       if(model instanceof CrosstabBindingModel crosstab) {
          out.put("suppressGroupTotal", crosstab.getSuppressGroupTotal());
@@ -115,6 +157,23 @@ public class TableBindingService {
          // Read-only for now: writing it turns an embedded table into a bound one, which is
          // closer to a data-loss operation than a binding edit.
          out.put("embedded", table.getEmbedded());
+      }
+
+      return out;
+   }
+
+   private static Map<String, Object> describeOptions(BaseTableBindingModel model) {
+      Map<String, Object> out = new LinkedHashMap<>();
+
+      if(model instanceof CrosstabBindingModel crosstab && crosstab.getOption() != null) {
+         out.put("rowTotals", crosstab.getOption().getRowTotalVisibleValue());
+         out.put("colTotals", crosstab.getOption().getColTotalVisibleValue());
+         out.put("percentageBy", crosstab.getOption().getPercentageByValue());
+         out.put("summarySideBySide", crosstab.getOption().isSummarySideBySide());
+      }
+      else if(model instanceof TableBindingModel table && table.getOption() != null) {
+         out.put("grandTotal", table.getOption().getGrandTotal());
+         out.put("distinct", table.getOption().getDistinct());
       }
 
       return out;

--- a/core/src/main/java/inetsoft/web/wiz/binding/TableBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/TableBindingService.java
@@ -196,17 +196,19 @@ public class TableBindingService {
    }
 
    public void setSort(String sessionToken, Principal user, String assemblyName, String shelf,
-                       String column, DimensionSortRanking.Sort sort) throws Exception
+                       String column, Integer index, DimensionSortRanking.Sort sort)
+      throws Exception
    {
       apply(sessionToken, user, assemblyName,
-            model -> TableBindingMutator.setSort(model, shelf, column, sort));
+            model -> TableBindingMutator.setSort(model, shelf, column, index, sort));
    }
 
    public void setRanking(String sessionToken, Principal user, String assemblyName, String shelf,
-                          String column, DimensionSortRanking.Ranking ranking) throws Exception
+                          String column, Integer index, DimensionSortRanking.Ranking ranking)
+      throws Exception
    {
       apply(sessionToken, user, assemblyName,
-            model -> TableBindingMutator.setRanking(model, shelf, column, ranking));
+            model -> TableBindingMutator.setRanking(model, shelf, column, index, ranking));
    }
 
    public void setColumnLabels(String sessionToken, Principal user, String assemblyName,

--- a/core/src/main/java/inetsoft/web/wiz/binding/TableBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/TableBindingService.java
@@ -21,8 +21,10 @@ import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.web.binding.controller.VSBindingModelService;
 import inetsoft.web.binding.event.ApplyVSAssemblyInfoEvent;
+import inetsoft.web.binding.model.SourceInfo;
 import inetsoft.web.binding.model.BindingModel;
 import inetsoft.web.binding.model.table.BaseTableBindingModel;
+import inetsoft.web.binding.model.table.CalcTableBindingModel;
 import inetsoft.web.binding.model.table.CrosstabBindingModel;
 import inetsoft.web.binding.model.table.TableBindingModel;
 import inetsoft.web.binding.service.VSBindingService;
@@ -65,6 +67,110 @@ public class TableBindingService {
    {
       apply(sessionToken, user, assemblyName,
             model -> TableBindingMutator.setShelf(model, shelf, fields));
+   }
+
+   /**
+    * Points a crosstab or table at a source table.
+    *
+    * <p>An assembly added in the Composer starts with no source. Its shelves can be populated —
+    * {@code set_table_fields} reports success — and it renders nothing at all, because shelves
+    * with no source have nothing to query. Nothing else here assigns one: the mutators
+    * <em>preserve</em> {@code source} through a read-modify-write, which is not the same as
+    * being able to set it.
+    *
+    * <p>Repointing a bound assembly discards every field on its shelves, since the columns
+    * belong to the old source. That is refused unless {@code force} is set, rather than done
+    * silently on one call.
+    */
+   public void setSource(String sessionToken, Principal user, String assemblyName,
+                         String table, boolean force) throws Exception
+   {
+      if(table == null || table.isBlank()) {
+         throw new IllegalArgumentException(
+            "set_table_source requires 'table' — the source table's name. " +
+            "list_bindable_fields reports what this assembly can bind to.");
+      }
+
+      apply(sessionToken, user, assemblyName, model -> {
+         String resolved = resolveTable(model, table, assemblyName);
+
+         if(!force) {
+            requireNoBoundFields(model, assemblyName, resolved);
+         }
+
+         // Only type, prefix and source survive the trip back: VSBindingService.updateSourceInfo
+         // calls SourceInfo.toSourceAttr, which rebuilds the asset source from exactly those
+         // three. Setting them directly rather than through the SourceInfo(uql.SourceInfo)
+         // convenience constructor also avoids that constructor's toView() call, which drags in
+         // VSUtil for a display string nothing here reads.
+         SourceInfo source = new SourceInfo();
+         source.setType(inetsoft.uql.asset.SourceInfo.ASSET);
+         source.setSource(resolved);
+         source.setView(resolved);
+         model.setSource(source);
+      }, true);
+   }
+
+   /** Matches a requested table against what the assembly can actually bind to. */
+   private static String resolveTable(BaseTableBindingModel model, String table,
+                                      String assemblyName)
+   {
+      List<BindingModel.SourceTable> tables = model.getTables();
+      List<String> names = new ArrayList<>();
+
+      if(tables != null) {
+         for(BindingModel.SourceTable candidate : tables) {
+            if(candidate.getName() != null) {
+               names.add(candidate.getName());
+
+               if(candidate.getName().equalsIgnoreCase(table)) {
+                  return candidate.getName();
+               }
+            }
+         }
+      }
+
+      throw new IllegalArgumentException(
+         "'" + assemblyName + "' cannot bind to '" + table + "'. Available: " + names + ". " +
+         "A source the assembly cannot see binds nothing and renders an empty assembly.");
+   }
+
+   /**
+    * Refuses to discard bound fields. The columns on a shelf belong to the source that was set
+    * when they were added, so repointing invalidates all of them.
+    */
+   private static void requireNoBoundFields(BaseTableBindingModel model, String assemblyName,
+                                            String table)
+   {
+      SourceInfo current = model.getSource();
+
+      if(current != null && table.equalsIgnoreCase(current.getSource())) {
+         return;
+      }
+
+      // A calc table has no shelves to discard — its binding lives in its cells, which keep
+      // referring to their columns by name. Nothing to warn about, and shelvesOf would refuse it.
+      if(model instanceof CalcTableBindingModel) {
+         return;
+      }
+
+      List<String> populated = new ArrayList<>();
+
+      for(String shelf : TableBindingMutator.shelvesOf(model)) {
+         int count = TableBindingMutator.read(model, shelf).size();
+
+         if(count > 0) {
+            populated.add(count + " on " + shelf);
+         }
+      }
+
+      if(!populated.isEmpty()) {
+         throw new IllegalArgumentException(
+            "'" + assemblyName + "' already has fields bound (" + String.join(", ", populated) +
+            "). Changing its source would discard them, because those columns belong to the " +
+            "old source. Clear the shelves first, or pass force:true to discard them " +
+            "deliberately.");
+      }
    }
 
    public void addField(String sessionToken, Principal user, String assemblyName, String shelf,
@@ -137,6 +243,17 @@ public class TableBindingService {
       out.put("assembly", assemblyName);
       out.put("objectType", model instanceof CrosstabBindingModel ? "crosstab" : "table");
       out.put("source", model.getSource() == null ? null : model.getSource().getSource());
+
+      // A sourceless assembly accepts shelf writes and renders nothing, with no error anywhere
+      // to say why. Saying so on the read every caller is told to make first is the cheapest
+      // place to stop that.
+      if(model.getSource() == null) {
+         out.put("note",
+                 "This assembly has no source table, so it renders empty whatever is on its " +
+                 "shelves. Point it at one with set_table_source — list_bindable_fields " +
+                 "reports the names it accepts.");
+      }
+
       out.put("shelves", shelves);
       out.put("columnLabels", model.getName2Labels());
       Map<String, Object> sorts = new LinkedHashMap<>();
@@ -182,8 +299,15 @@ public class TableBindingService {
    private void apply(String sessionToken, Principal user, String assemblyName,
                       Consumer<BaseTableBindingModel> mutation) throws Exception
    {
+      apply(sessionToken, user, assemblyName, mutation, false);
+   }
+
+   private void apply(String sessionToken, Principal user, String assemblyName,
+                      Consumer<BaseTableBindingModel> mutation, boolean allowCalcTable)
+      throws Exception
+   {
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
-         BaseTableBindingModel model = requireTableBinding(rvs, assemblyName);
+         BaseTableBindingModel model = requireTableBinding(rvs, assemblyName, allowCalcTable);
          mutation.accept(model);
 
          ApplyVSAssemblyInfoEvent event = new ApplyVSAssemblyInfoEvent();
@@ -197,11 +321,35 @@ public class TableBindingService {
    }
 
    private BaseTableBindingModel requireTableBinding(RuntimeViewsheet rvs, String assemblyName) {
+      return requireTableBinding(rvs, assemblyName, false);
+   }
+
+   /**
+    * @param allowCalcTable calc tables are refused for <b>shelf</b> operations, because their
+    *                       binding lives in their cell layout. Assigning a <b>source</b> is not a
+    *                       shelf operation: a {@code CalcTableVSAssembly} is a
+    *                       {@code TableDataVSAssembly} and carries a source like any other, and
+    *                       without one a freehand table renders empty however its cells are bound.
+    */
+   private BaseTableBindingModel requireTableBinding(RuntimeViewsheet rvs, String assemblyName,
+                                                     boolean allowCalcTable)
+   {
       Viewsheet vs = rvs == null ? null : rvs.getViewsheet();
       VSAssembly assembly = vs == null ? null : vs.getAssembly(assemblyName);
 
       if(assembly == null) {
          throw new IllegalArgumentException("Unknown assembly '" + assemblyName + "'.");
+      }
+
+      if(allowCalcTable && assembly instanceof CalcTableVSAssembly) {
+         BindingModel calcModel = binding.createModel(assembly);
+
+         if(calcModel instanceof BaseTableBindingModel calcTable) {
+            return calcTable;
+         }
+
+         throw new IllegalArgumentException(
+            "'" + assemblyName + "' is a calc table whose binding model cannot carry a source.");
       }
 
       if(assembly instanceof CalcTableVSAssembly) {

--- a/core/src/main/java/inetsoft/web/wiz/binding/VisualFrameAliases.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/VisualFrameAliases.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.wiz.binding;
 
+import inetsoft.web.binding.model.ColorMapModel;
 import inetsoft.web.binding.model.graph.aesthetic.*;
 
 import java.util.*;
@@ -59,18 +60,48 @@ public final class VisualFrameAliases {
       "gradient", GradientColorModel.class);
 
    /**
+    * The fieldless frames, whose only behaviour is which visual frame they create. Mapped here
+    * so {@link #describe} names them and the coverage test sees them as reachable.
+    */
+   private static final Map<Class<?>, String> BEHAVIOURAL = behavioural();
+
+   /**
     * Subclasses deliberately not reachable through an alias, each with its reason. The
     * coverage test reads this list, so excluding something is a recorded decision rather than
     * an oversight.
     */
    private static final Map<Class<?>, String> EXCLUDED = Map.of(
-      HSLColorModel.class, "abstract base of Brightness and Saturation",
-      BrightnessColorModel.class, "Phase 2 — behavioural colour frames",
-      SaturationColorModel.class, "Phase 2 — behavioural colour frames",
-      BipolarColorModel.class, "Phase 2 — behavioural colour frames",
-      CircularColorModel.class, "Phase 2 — behavioural colour frames",
-      RainbowColorModel.class, "Phase 2 — behavioural colour frames",
-      HeatColorModel.class, "Phase 2 — behavioural colour frames");
+      HSLColorModel.class, "abstract base of Brightness and Saturation, reached through those",
+      TextFrameModel.class, "abstract base; text frames have no configurable variety",
+      DefaultTextFrameModel.class, "the only text frame; nothing to choose",
+      ColorFrameModel.class, "abstract base",
+      ShapeFrameModel.class, "abstract base",
+      SizeFrameModel.class, "abstract base",
+      LineFrameModel.class, "abstract base",
+      TextureFrameModel.class, "abstract base");
+
+   private static Map<Class<?>, String> behavioural() {
+      Map<Class<?>, String> map = new LinkedHashMap<>();
+      map.put(BipolarColorModel.class, "bipolar");
+      map.put(CircularColorModel.class, "circular");
+      map.put(RainbowColorModel.class, "rainbow");
+      map.put(HeatColorModel.class, "heat");
+      map.put(FillShapeModel.class, "fill");
+      map.put(OrientationShapeModel.class, "orientation");
+      map.put(OvalShapeModel.class, "oval");
+      map.put(PolygonShapeModel.class, "polygon");
+      map.put(TriangleShapeModel.class, "triangle");
+      map.put(LinearSizeModel.class, "linear");
+      map.put(CategoricalSizeModel.class, "categorical");
+      map.put(LinearLineModel.class, "linear");
+      map.put(CategoricalLineModel.class, "categorical");
+      map.put(CategoricalTextureModel.class, "categorical");
+      map.put(GridTextureModel.class, "grid");
+      map.put(LeftTiltTextureModel.class, "left_tilt");
+      map.put(RightTiltTextureModel.class, "right_tilt");
+      map.put(OrientationTextureModel.class, "orientation");
+      return Collections.unmodifiableMap(map);
+   }
 
    private VisualFrameAliases() {
    }
@@ -92,18 +123,89 @@ public final class VisualFrameAliases {
       if(type == null) {
          throw new IllegalArgumentException(
             "A visual frame needs a 'type'. Valid types for the " + name + " channel: " +
-            String.join(", ", colorTypeNames()) + ".");
+            String.join(", ", typeNames(name)) + ".");
       }
 
-      // Only the colour channel is supported this phase, so any frame reaching here is a
-      // colour frame; requireFrameChannel has already refused the others.
-      return switch(type) {
-         case "static" -> staticColor(spec);
-         case "categorical" -> categoricalColor(spec);
-         case "gradient" -> gradientColor(spec);
-         case "palette" -> palette(spec);
-         default -> throw unknownType(name, type);
+      // Every frame channel now accepts a `categorical` and a `static`, so a spec meant for one
+      // channel is structurally valid on another and its value keys would simply be ignored:
+      // {type: "categorical", colors: [...]} on `size` would build a categorical size frame with
+      // no colours and report success. So a key the chosen channel and type do not consume is
+      // refused, naming both.
+      requireNoUnusedKeys(name, type, spec);
+
+      return switch(name) {
+         case "color" -> colorFrame(spec, type);
+         case "shape" -> shapeFrame(spec, type);
+         case "size" -> sizeFrame(spec, type);
+         case "line" -> lineFrame(spec, type);
+         default -> textureFrame(spec, type);
       };
+   }
+
+   /** The value keys a given channel and frame type actually read. */
+   private static Set<String> consumedKeys(String channel, String type) {
+      Set<String> keys = new LinkedHashSet<>(List.of("type"));
+
+      switch(channel) {
+         case "color" -> {
+            switch(type) {
+               case "static", "brightness", "saturation" -> keys.add("color");
+               case "categorical" -> keys.addAll(List.of("colors", "mapping", "useGlobal"));
+               case "gradient" -> keys.addAll(List.of("from", "to"));
+               case "palette" -> keys.add("palette");
+               default -> { /* fieldless */ }
+            }
+         }
+         case "shape" -> {
+            switch(type) {
+               case "static" -> keys.add("shape");
+               case "categorical" -> keys.add("shapes");
+               default -> { /* fieldless */ }
+            }
+         }
+         case "size" -> {
+            if("static".equals(type)) {
+               keys.add("size");
+            }
+         }
+         case "line" -> {
+            if("static".equals(type)) {
+               keys.add("line");
+            }
+         }
+         default -> {
+            if("static".equals(type)) {
+               keys.add("texture");
+            }
+         }
+      }
+
+      return keys;
+   }
+
+   private static void requireNoUnusedKeys(String channel, String type,
+                                           Map<String, Object> spec)
+   {
+      if(spec == null) {
+         return;
+      }
+
+      Set<String> consumed = consumedKeys(channel, type);
+      List<String> unused = new ArrayList<>();
+
+      for(String key : spec.keySet()) {
+         if(!consumed.contains(key)) {
+            unused.add(key);
+         }
+      }
+
+      if(!unused.isEmpty()) {
+         throw new IllegalArgumentException(
+            "A '" + type + "' frame on the " + channel + " channel does not use " + unused +
+            ". It reads " + consumed + ". Passing a key it ignores would report success while " +
+            "that value went nowhere — most often it means the spec was written for a " +
+            "different channel.");
+      }
    }
 
    /** Renders a frame back in the agent vocabulary. Never emits {@code clazz}. */
@@ -124,6 +226,19 @@ public final class VisualFrameAliases {
          out.put("type", "categorical");
          out.put("colors", model.getColors() == null
             ? List.of() : Arrays.asList(model.getColors()));
+         Map<String, Object> mapping = new LinkedHashMap<>();
+
+         for(ColorMapModel map : model.getColorMaps() == null
+            ? new ColorMapModel[0] : model.getColorMaps())
+         {
+            if(map != null && map.getOption() != null) {
+               mapping.put(map.getOption(), map.getColor());
+            }
+         }
+
+         out.put("mapping", mapping);
+         // Reported because a true here means any mapping above is stored but not rendered.
+         out.put("useGlobal", model.isUseGlobal());
          return out;
       }
 
@@ -131,6 +246,50 @@ public final class VisualFrameAliases {
          out.put("type", "gradient");
          out.put("from", model.getFromColor());
          out.put("to", model.getToColor());
+         return out;
+      }
+
+      if(frame instanceof HSLColorModel model) {
+         out.put("type", frame instanceof SaturationColorModel ? "saturation" : "brightness");
+         out.put("color", model.getColor());
+         return out;
+      }
+
+      if(frame instanceof StaticShapeModel model) {
+         out.put("type", "static");
+         out.put("shape", model.getShape());
+         return out;
+      }
+
+      if(frame instanceof CategoricalShapeModel model) {
+         out.put("type", "categorical");
+         out.put("shapes", model.getShapes() == null
+            ? List.of() : Arrays.asList(model.getShapes()));
+         return out;
+      }
+
+      if(frame instanceof StaticSizeModel model) {
+         out.put("type", "static");
+         out.put("size", model.getSize());
+         return out;
+      }
+
+      if(frame instanceof StaticLineModel model) {
+         out.put("type", "static");
+         out.put("line", model.getLine());
+         return out;
+      }
+
+      if(frame instanceof StaticTextureModel model) {
+         out.put("type", "static");
+         out.put("texture", model.getTexture());
+         return out;
+      }
+
+      String behavioural = BEHAVIOURAL.get(frame.getClass());
+
+      if(behavioural != null) {
+         out.put("type", behavioural);
          return out;
       }
 
@@ -182,16 +341,25 @@ public final class VisualFrameAliases {
 
    // ── the coverage test's view ──────────────────────────────────────────────
 
-   /** Every concrete {@code ColorFrameModel} subclass the vocabulary must account for. */
+   /** Every frame subclass the vocabulary must account for, across all five channels. */
    public static Collection<Class<?>> colorFrameSubclasses() {
       List<Class<?>> all = new ArrayList<>(PALETTES.values());
       all.addAll(COLOR_TYPES.values());
+      all.addAll(BEHAVIOURAL.keySet());
       all.addAll(EXCLUDED.keySet());
+      all.addAll(List.of(StaticShapeModel.class, CategoricalShapeModel.class,
+                         StaticSizeModel.class, StaticLineModel.class,
+                         StaticTextureModel.class, BrightnessColorModel.class,
+                         SaturationColorModel.class));
       return all;
    }
 
    public static boolean isMapped(Class<?> subclass) {
-      return COLOR_TYPES.containsValue(subclass) || PALETTES.containsValue(subclass);
+      return COLOR_TYPES.containsValue(subclass) || PALETTES.containsValue(subclass) ||
+         BEHAVIOURAL.containsKey(subclass) ||
+         List.of(StaticShapeModel.class, CategoricalShapeModel.class, StaticSizeModel.class,
+                 StaticLineModel.class, StaticTextureModel.class, BrightnessColorModel.class,
+                 SaturationColorModel.class).contains(subclass);
    }
 
    public static boolean isExcluded(Class<?> subclass) {
@@ -199,6 +367,159 @@ public final class VisualFrameAliases {
    }
 
    // ── builders ──────────────────────────────────────────────────────────────
+
+   private static VisualFrameModel colorFrame(Map<String, Object> spec, String type) {
+      return switch(type) {
+         case "static" -> staticColor(spec);
+         case "categorical" -> categoricalColor(spec);
+         case "gradient" -> gradientColor(spec);
+         case "palette" -> palette(spec);
+         case "brightness" -> tinted(spec, new BrightnessColorModel());
+         case "saturation" -> tinted(spec, new SaturationColorModel());
+         case "bipolar" -> new BipolarColorModel();
+         case "circular" -> new CircularColorModel();
+         case "rainbow" -> new RainbowColorModel();
+         case "heat" -> new HeatColorModel();
+         default -> throw unknownType("color", type);
+      };
+   }
+
+   /** Brightness and saturation derive a ramp from one base colour. */
+   private static VisualFrameModel tinted(Map<String, Object> spec, HSLColorModel model) {
+      String color = str(spec, "color");
+
+      if(color == null) {
+         throw new IllegalArgumentException(
+            "A brightness or saturation colour frame needs a 'color' to derive its ramp from.");
+      }
+
+      model.setColor(normalizeColor(color));
+      return model;
+   }
+
+   private static VisualFrameModel shapeFrame(Map<String, Object> spec, String type) {
+      return switch(type) {
+         case "static" -> staticShape(spec);
+         case "categorical" -> categoricalShape(spec);
+         case "fill" -> new FillShapeModel();
+         case "orientation" -> new OrientationShapeModel();
+         case "oval" -> new OvalShapeModel();
+         case "polygon" -> new PolygonShapeModel();
+         case "triangle" -> new TriangleShapeModel();
+         default -> throw unknownType("shape", type);
+      };
+   }
+
+   private static VisualFrameModel staticShape(Map<String, Object> spec) {
+      String shape = str(spec, "shape");
+
+      if(shape == null) {
+         throw new IllegalArgumentException(
+            "A static shape frame needs a 'shape', e.g. {type: \"static\", shape: \"circle\"}.");
+      }
+
+      StaticShapeModel model = new StaticShapeModel();
+      model.setShape(shape);
+      return model;
+   }
+
+   private static VisualFrameModel categoricalShape(Map<String, Object> spec) {
+      List<String> shapes = strList(spec, "shapes");
+
+      if(shapes.isEmpty()) {
+         throw new IllegalArgumentException(
+            "A categorical shape frame needs a non-empty 'shapes' list.");
+      }
+
+      CategoricalShapeModel model = new CategoricalShapeModel();
+      model.setShapes(shapes.toArray(new String[0]));
+      return model;
+   }
+
+   private static VisualFrameModel sizeFrame(Map<String, Object> spec, String type) {
+      return switch(type) {
+         case "static" -> staticSize(spec);
+         case "linear" -> new LinearSizeModel();
+         case "categorical" -> new CategoricalSizeModel();
+         default -> throw unknownType("size", type);
+      };
+   }
+
+   private static VisualFrameModel staticSize(Map<String, Object> spec) {
+      Double size = number(spec, "size");
+
+      if(size == null) {
+         throw new IllegalArgumentException(
+            "A static size frame needs a numeric 'size', e.g. {type: \"static\", size: 8}.");
+      }
+
+      StaticSizeModel model = new StaticSizeModel();
+      model.setSize(size);
+      return model;
+   }
+
+   private static VisualFrameModel lineFrame(Map<String, Object> spec, String type) {
+      return switch(type) {
+         case "static" -> staticLine(spec);
+         case "linear" -> new LinearLineModel();
+         case "categorical" -> new CategoricalLineModel();
+         default -> throw unknownType("line", type);
+      };
+   }
+
+   private static VisualFrameModel staticLine(Map<String, Object> spec) {
+      Double line = number(spec, "line");
+
+      if(line == null) {
+         throw new IllegalArgumentException(
+            "A static line frame needs a numeric 'line' — the StyleBI line-style code.");
+      }
+
+      StaticLineModel model = new StaticLineModel();
+      model.setLine(line.intValue());
+      return model;
+   }
+
+   private static VisualFrameModel textureFrame(Map<String, Object> spec, String type) {
+      return switch(type) {
+         case "static" -> staticTexture(spec);
+         case "categorical" -> new CategoricalTextureModel();
+         case "grid" -> new GridTextureModel();
+         case "left_tilt" -> new LeftTiltTextureModel();
+         case "right_tilt" -> new RightTiltTextureModel();
+         case "orientation" -> new OrientationTextureModel();
+         default -> throw unknownType("texture", type);
+      };
+   }
+
+   private static VisualFrameModel staticTexture(Map<String, Object> spec) {
+      Double texture = number(spec, "texture");
+
+      if(texture == null) {
+         throw new IllegalArgumentException(
+            "A static texture frame needs a numeric 'texture' — the StyleBI texture code.");
+      }
+
+      StaticTextureModel model = new StaticTextureModel();
+      model.setTexture(texture.intValue());
+      return model;
+   }
+
+   private static Double number(Map<String, Object> spec, String key) {
+      String text = str(spec, key);
+
+      if(text == null) {
+         return null;
+      }
+
+      try {
+         return Double.parseDouble(text);
+      }
+      catch(NumberFormatException e) {
+         throw new IllegalArgumentException(
+            "'" + key + "' must be a number, got '" + text + "'.");
+      }
+   }
 
    private static VisualFrameModel staticColor(Map<String, Object> spec) {
       String color = str(spec, "color");
@@ -213,19 +534,120 @@ public final class VisualFrameAliases {
       return model;
    }
 
+   /**
+    * A categorical colour frame, optionally with per-value colour mapping.
+    *
+    * <p><b>The {@code useGlobal} footgun lives here.</b> {@code CategoricalColorModel} defaults
+    * {@code useGlobal} and {@code shareColors} to {@code true}, and while {@code useGlobal} is set
+    * the automatic palette wins: an explicit per-value colour is accepted, stored, and never
+    * rendered. That is a recorded defect, and it is invisible — the model round-trips perfectly
+    * and the chart shows something else.
+    *
+    * <p>So supplying a mapping clears {@code useGlobal}, because supplying one <i>is</i> the
+    * intent to override the automatic palette. Asking for {@code useGlobal: true} alongside a
+    * mapping is refused rather than honoured, since that combination cannot render what was
+    * asked for.
+    */
    private static VisualFrameModel categoricalColor(Map<String, Object> spec) {
       List<String> colors = strList(spec, "colors");
+      Map<String, Object> mapping = mapping(spec);
 
-      if(colors.isEmpty()) {
+      if(colors.isEmpty() && mapping.isEmpty()) {
          throw new IllegalArgumentException(
-            "A categorical colour frame needs a non-empty 'colors' list, e.g. " +
-            "{type: \"categorical\", colors: [\"#4E79A7\", \"#F28E2C\"]}.");
+            "A categorical colour frame needs a non-empty 'colors' list, or a 'mapping' of " +
+            "value to colour, e.g. {type: \"categorical\", mapping: {\"East\": \"#4E79A7\"}}.");
+      }
+
+      Boolean useGlobal = bool(spec, "useGlobal");
+
+      if(Boolean.TRUE.equals(useGlobal) && !mapping.isEmpty()) {
+         throw new IllegalArgumentException(
+            "'useGlobal: true' cannot be combined with a 'mapping'. While useGlobal is set the " +
+            "automatic palette wins, so the mapped colours would be stored and never rendered — " +
+            "the model would round-trip perfectly and the chart would show something else. Drop " +
+            "useGlobal to apply the mapping, or drop the mapping to keep the automatic palette.");
       }
 
       CategoricalColorModel model = new CategoricalColorModel();
-      model.setColors(colors.stream().map(VisualFrameAliases::normalizeColor)
-                         .toArray(String[]::new));
+
+      if(!colors.isEmpty()) {
+         model.setColors(colors.stream().map(VisualFrameAliases::normalizeColor)
+                            .toArray(String[]::new));
+      }
+
+      if(!mapping.isEmpty()) {
+         List<ColorMapModel> maps = new ArrayList<>();
+
+         for(Map.Entry<String, Object> entry : mapping.entrySet()) {
+            ColorMapModel map = new ColorMapModel();
+            map.setOption(entry.getKey());
+            map.setColor(normalizeColor(String.valueOf(entry.getValue())));
+            maps.add(map);
+         }
+
+         model.setColorMaps(maps.toArray(new ColorMapModel[0]));
+         // Supplying a mapping IS the intent to override the automatic palette.
+         model.setUseGlobal(false);
+         model.setShareColors(false);
+      }
+      else if(useGlobal != null) {
+         model.setUseGlobal(useGlobal);
+      }
+
       return model;
+   }
+
+   @SuppressWarnings("unchecked")
+   private static Map<String, Object> mapping(Map<String, Object> spec) {
+      Object raw = spec == null ? null : spec.get("mapping");
+
+      if(raw == null) {
+         return Map.of();
+      }
+
+      if(!(raw instanceof Map<?, ?> map)) {
+         throw new IllegalArgumentException(
+            "'mapping' must be an object of value to colour, e.g. {\"East\": \"#4E79A7\"}.");
+      }
+
+      Map<String, Object> out = new LinkedHashMap<>();
+
+      for(Map.Entry<?, ?> entry : map.entrySet()) {
+         if(entry.getKey() != null && entry.getValue() != null) {
+            out.put(String.valueOf(entry.getKey()), entry.getValue());
+         }
+      }
+
+      if(out.isEmpty()) {
+         throw new IllegalArgumentException("'mapping' is empty; omit it or give it entries.");
+      }
+
+      return out;
+   }
+
+   private static Boolean bool(Map<String, Object> spec, String key) {
+      Object raw = spec == null ? null : spec.get(key);
+
+      if(raw == null) {
+         return null;
+      }
+
+      if(raw instanceof Boolean value) {
+         return value;
+      }
+
+      String text = String.valueOf(raw).trim();
+
+      if("true".equalsIgnoreCase(text)) {
+         return Boolean.TRUE;
+      }
+
+      if("false".equalsIgnoreCase(text)) {
+         return Boolean.FALSE;
+      }
+
+      throw new IllegalArgumentException(
+         "'" + key + "' must be true or false, got '" + raw + "'.");
    }
 
    private static VisualFrameModel gradientColor(Map<String, Object> spec) {
@@ -285,7 +707,7 @@ public final class VisualFrameAliases {
    }
 
    private static IllegalArgumentException unknownType(String channel, String type) {
-      List<String> valid = colorTypeNames();
+      List<String> valid = typeNames(channel);
       String nearest = nearestMatch(type, valid);
       String hint = nearest == null ? "" : " Did you mean '" + nearest + "'?";
 
@@ -341,9 +763,19 @@ public final class VisualFrameAliases {
       return previous[b.length()];
    }
 
-   private static List<String> colorTypeNames() {
-      List<String> names = new ArrayList<>(COLOR_TYPES.keySet());
-      names.add("palette");
+   /** The frame types valid for a channel, for discovery and for error messages. */
+   public static List<String> typeNames(String channel) {
+      List<String> names = new ArrayList<>(switch(AestheticChannels.normalize(channel)) {
+         case "color" -> List.of("static", "categorical", "gradient", "palette", "brightness",
+                                 "saturation", "bipolar", "circular", "rainbow", "heat");
+         case "shape" -> List.of("static", "categorical", "fill", "orientation", "oval",
+                                 "polygon", "triangle");
+         case "size" -> List.of("static", "linear", "categorical");
+         case "line" -> List.of("static", "linear", "categorical");
+         case "texture" -> List.of("static", "categorical", "grid", "left_tilt", "right_tilt",
+                                   "orientation");
+         default -> List.<String>of();
+      });
       Collections.sort(names);
       return names;
    }

--- a/core/src/main/java/inetsoft/web/wiz/binding/VisualFrameAliases.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/VisualFrameAliases.java
@@ -1,0 +1,420 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.web.binding.model.graph.aesthetic.*;
+
+import java.util.*;
+
+/**
+ * The agent-facing visual-frame vocabulary.
+ *
+ * <p>{@code VisualFrameModel} discriminates its subtypes by fully-qualified Java class name:
+ *
+ * <pre>{@code @JsonTypeInfo(use = Id.CLASS, ..., property = "clazz")}</pre>
+ *
+ * <p>No agent should be asked to produce {@code
+ * inetsoft.web.binding.model.graph.aesthetic.CategoricalColorModel}, and any that guesses will
+ * guess wrong. This table is the only way in, and {@link #describe} is the only way out — an
+ * FQCN never reaches the caller in either direction.
+ *
+ * <p>The 64 classes in {@code model/graph/aesthetic} are mostly not distinct behaviour: 27 of
+ * them are named colour ramps that declare no fields at all and differ only in
+ * {@code createVisualFrame()}. Those collapse to one alias — {@code {type: "palette", palette:
+ * "<name>"}} — leaving a handful of real frame types.
+ *
+ * <p><b>Classes are referenced by class literal, never by name string</b>, so an upstream
+ * rename or repackage breaks the build rather than surfacing as a runtime resolution failure
+ * against a live viewsheet.
+ */
+public final class VisualFrameAliases {
+   /**
+    * The 27 named colour ramps. Each is a fieldless subclass, so the whole family needs one
+    * alias plus this registry to make the names discoverable rather than guessable.
+    */
+   public static final Map<String, Class<? extends ColorFrameModel>> PALETTES = palettes();
+
+   /**
+    * Behavioural colour frames this phase builds. The remaining ones — HSL, brightness,
+    * saturation, bipolar, circular, rainbow, heat — arrive in Phase 2.
+    */
+   private static final Map<String, Class<? extends ColorFrameModel>> COLOR_TYPES = Map.of(
+      "static", StaticColorModel.class,
+      "categorical", CategoricalColorModel.class,
+      "gradient", GradientColorModel.class);
+
+   /**
+    * Subclasses deliberately not reachable through an alias, each with its reason. The
+    * coverage test reads this list, so excluding something is a recorded decision rather than
+    * an oversight.
+    */
+   private static final Map<Class<?>, String> EXCLUDED = Map.of(
+      HSLColorModel.class, "abstract base of Brightness and Saturation",
+      BrightnessColorModel.class, "Phase 2 — behavioural colour frames",
+      SaturationColorModel.class, "Phase 2 — behavioural colour frames",
+      BipolarColorModel.class, "Phase 2 — behavioural colour frames",
+      CircularColorModel.class, "Phase 2 — behavioural colour frames",
+      RainbowColorModel.class, "Phase 2 — behavioural colour frames",
+      HeatColorModel.class, "Phase 2 — behavioural colour frames");
+
+   private VisualFrameAliases() {
+   }
+
+   /**
+    * Builds a frame from the agent vocabulary.
+    *
+    * @param channel the aesthetic channel the frame is destined for; a colour frame on the
+    *                size channel is a caller error worth naming, not something to coerce
+    * @param spec    {@code {type, ...}} in the alias vocabulary
+    */
+   public static VisualFrameModel create(String channel, Map<String, Object> spec) {
+      // The type is read before the channel is validated so a mismatch can name both. Being
+      // told "the size channel is not supported" when you asked for a categorical colour
+      // frame leaves you guessing which half of the call was wrong.
+      String type = str(spec, "type");
+      String name = requireFrameChannelFor(channel, type);
+
+      if(type == null) {
+         throw new IllegalArgumentException(
+            "A visual frame needs a 'type'. Valid types for the " + name + " channel: " +
+            String.join(", ", colorTypeNames()) + ".");
+      }
+
+      // Only the colour channel is supported this phase, so any frame reaching here is a
+      // colour frame; requireFrameChannel has already refused the others.
+      return switch(type) {
+         case "static" -> staticColor(spec);
+         case "categorical" -> categoricalColor(spec);
+         case "gradient" -> gradientColor(spec);
+         case "palette" -> palette(spec);
+         default -> throw unknownType(name, type);
+      };
+   }
+
+   /** Renders a frame back in the agent vocabulary. Never emits {@code clazz}. */
+   public static Map<String, Object> describe(VisualFrameModel frame) {
+      if(frame == null) {
+         return null;
+      }
+
+      Map<String, Object> out = new LinkedHashMap<>();
+
+      if(frame instanceof StaticColorModel model) {
+         out.put("type", "static");
+         out.put("color", model.getColor());
+         return out;
+      }
+
+      if(frame instanceof CategoricalColorModel model) {
+         out.put("type", "categorical");
+         out.put("colors", model.getColors() == null
+            ? List.of() : Arrays.asList(model.getColors()));
+         return out;
+      }
+
+      if(frame instanceof GradientColorModel model) {
+         out.put("type", "gradient");
+         out.put("from", model.getFromColor());
+         out.put("to", model.getToColor());
+         return out;
+      }
+
+      String paletteName = paletteNameOf(frame.getClass());
+
+      if(paletteName != null) {
+         out.put("type", "palette");
+         out.put("palette", paletteName);
+         return out;
+      }
+
+      // A frame outside the vocabulary is reported as what it is rather than silently
+      // flattened to something wrong. The caller can still see it; they just cannot rebuild
+      // it with set_visual_frame yet.
+      out.put("type", "unsupported");
+      out.put("detail", frame.getClass().getSimpleName());
+      return out;
+   }
+
+   /** Normalizes {@code #RGB} / {@code #RRGGBB}, with or without {@code #}, to {@code #RRGGBB}. */
+   public static String normalizeColor(String color) {
+      String value = color == null ? "" : color.trim();
+
+      if(value.startsWith("#")) {
+         value = value.substring(1);
+      }
+
+      if(!value.matches("(?i)[0-9a-f]{3}|[0-9a-f]{6}")) {
+         throw new IllegalArgumentException(
+            "'" + color + "' is not a colour this tool accepts. Use #RRGGBB or #RGB (the '#' " +
+            "is optional). Named CSS colours are not supported — half-supporting them would " +
+            "mean some names silently rendering as something else.");
+      }
+
+      value = value.toUpperCase();
+
+      if(value.length() == 3) {
+         StringBuilder expanded = new StringBuilder();
+
+         for(char c : value.toCharArray()) {
+            expanded.append(c).append(c);
+         }
+
+         value = expanded.toString();
+      }
+
+      return "#" + value;
+   }
+
+   // ── the coverage test's view ──────────────────────────────────────────────
+
+   /** Every concrete {@code ColorFrameModel} subclass the vocabulary must account for. */
+   public static Collection<Class<?>> colorFrameSubclasses() {
+      List<Class<?>> all = new ArrayList<>(PALETTES.values());
+      all.addAll(COLOR_TYPES.values());
+      all.addAll(EXCLUDED.keySet());
+      return all;
+   }
+
+   public static boolean isMapped(Class<?> subclass) {
+      return COLOR_TYPES.containsValue(subclass) || PALETTES.containsValue(subclass);
+   }
+
+   public static boolean isExcluded(Class<?> subclass) {
+      return EXCLUDED.containsKey(subclass);
+   }
+
+   // ── builders ──────────────────────────────────────────────────────────────
+
+   private static VisualFrameModel staticColor(Map<String, Object> spec) {
+      String color = str(spec, "color");
+
+      if(color == null) {
+         throw new IllegalArgumentException(
+            "A static colour frame needs a 'color', e.g. {type: \"static\", color: \"#4E79A7\"}.");
+      }
+
+      StaticColorModel model = new StaticColorModel();
+      model.setColor(normalizeColor(color));
+      return model;
+   }
+
+   private static VisualFrameModel categoricalColor(Map<String, Object> spec) {
+      List<String> colors = strList(spec, "colors");
+
+      if(colors.isEmpty()) {
+         throw new IllegalArgumentException(
+            "A categorical colour frame needs a non-empty 'colors' list, e.g. " +
+            "{type: \"categorical\", colors: [\"#4E79A7\", \"#F28E2C\"]}.");
+      }
+
+      CategoricalColorModel model = new CategoricalColorModel();
+      model.setColors(colors.stream().map(VisualFrameAliases::normalizeColor)
+                         .toArray(String[]::new));
+      return model;
+   }
+
+   private static VisualFrameModel gradientColor(Map<String, Object> spec) {
+      String from = str(spec, "from");
+      String to = str(spec, "to");
+
+      if(from == null || to == null) {
+         throw new IllegalArgumentException(
+            "A gradient colour frame needs both 'from' and 'to', e.g. " +
+            "{type: \"gradient\", from: \"#EEEEFF\", to: \"#005599\"}.");
+      }
+
+      GradientColorModel model = new GradientColorModel();
+      model.setFromColor(normalizeColor(from));
+      model.setToColor(normalizeColor(to));
+      return model;
+   }
+
+   private static VisualFrameModel palette(Map<String, Object> spec) {
+      String requested = str(spec, "palette");
+
+      if(requested == null) {
+         throw new IllegalArgumentException(
+            "A palette frame needs a 'palette' name. Available: " + paletteNames() + ".");
+      }
+
+      for(Map.Entry<String, Class<? extends ColorFrameModel>> entry : PALETTES.entrySet()) {
+         if(entry.getKey().equalsIgnoreCase(requested)) {
+            try {
+               return entry.getValue().getDeclaredConstructor().newInstance();
+            }
+            catch(ReflectiveOperationException e) {
+               throw new IllegalStateException(
+                  "Palette '" + entry.getKey() + "' could not be instantiated.", e);
+            }
+         }
+      }
+
+      throw new IllegalArgumentException(
+         "Unknown palette '" + requested + "'. Available: " + paletteNames() + ".");
+   }
+
+   // ── helpers ───────────────────────────────────────────────────────────────
+
+   private static String requireFrameChannelFor(String channel, String type) {
+      try {
+         return AestheticChannels.requireFrameChannel(channel);
+      }
+      catch(IllegalArgumentException e) {
+         if(type == null) {
+            throw e;
+         }
+
+         throw new IllegalArgumentException(
+            e.getMessage() + " (the requested frame type was '" + type + "')", e);
+      }
+   }
+
+   private static IllegalArgumentException unknownType(String channel, String type) {
+      List<String> valid = colorTypeNames();
+      String nearest = nearestMatch(type, valid);
+      String hint = nearest == null ? "" : " Did you mean '" + nearest + "'?";
+
+      return new IllegalArgumentException(
+         "Unknown frame type '" + type + "' for the " + channel + " channel." + hint +
+         " Valid types: " + String.join(", ", valid) + ". A frame is never substituted with a " +
+         "default — that would look like the tool worked.");
+   }
+
+   /**
+    * Cheap edit-distance-1-ish match: good enough to catch a typo like "categorial", and it
+    * never guesses on the caller's behalf — the near match is only ever a suggestion in an
+    * error message.
+    */
+   private static String nearestMatch(String typed, List<String> candidates) {
+      String best = null;
+      int bestDistance = Integer.MAX_VALUE;
+
+      for(String candidate : candidates) {
+         int distance = editDistance(typed.toLowerCase(), candidate);
+
+         if(distance < bestDistance) {
+            bestDistance = distance;
+            best = candidate;
+         }
+      }
+
+      return bestDistance <= Math.max(2, typed.length() / 3) ? best : null;
+   }
+
+   private static int editDistance(String a, String b) {
+      int[] previous = new int[b.length() + 1];
+      int[] current = new int[b.length() + 1];
+
+      for(int j = 0; j <= b.length(); j++) {
+         previous[j] = j;
+      }
+
+      for(int i = 1; i <= a.length(); i++) {
+         current[0] = i;
+
+         for(int j = 1; j <= b.length(); j++) {
+            int cost = a.charAt(i - 1) == b.charAt(j - 1) ? 0 : 1;
+            current[j] = Math.min(Math.min(current[j - 1] + 1, previous[j] + 1),
+                                  previous[j - 1] + cost);
+         }
+
+         int[] swap = previous;
+         previous = current;
+         current = swap;
+      }
+
+      return previous[b.length()];
+   }
+
+   private static List<String> colorTypeNames() {
+      List<String> names = new ArrayList<>(COLOR_TYPES.keySet());
+      names.add("palette");
+      Collections.sort(names);
+      return names;
+   }
+
+   private static String paletteNames() {
+      return String.join(", ", PALETTES.keySet());
+   }
+
+   private static String paletteNameOf(Class<?> type) {
+      for(Map.Entry<String, Class<? extends ColorFrameModel>> entry : PALETTES.entrySet()) {
+         if(entry.getValue().equals(type)) {
+            return entry.getKey();
+         }
+      }
+
+      return null;
+   }
+
+   private static String str(Map<String, Object> spec, String key) {
+      Object value = spec == null ? null : spec.get(key);
+      String text = value == null ? "" : String.valueOf(value).trim();
+      return text.isEmpty() ? null : text;
+   }
+
+   private static List<String> strList(Map<String, Object> spec, String key) {
+      Object value = spec == null ? null : spec.get(key);
+
+      if(!(value instanceof Collection<?> collection)) {
+         return List.of();
+      }
+
+      List<String> out = new ArrayList<>();
+
+      for(Object item : collection) {
+         if(item != null) {
+            out.add(String.valueOf(item));
+         }
+      }
+
+      return out;
+   }
+
+   private static Map<String, Class<? extends ColorFrameModel>> palettes() {
+      Map<String, Class<? extends ColorFrameModel>> map = new LinkedHashMap<>();
+      map.put("Blues", BluesColorModel.class);
+      map.put("BrBG", BrBGColorModel.class);
+      map.put("BuGn", BuGnColorModel.class);
+      map.put("BuPu", BuPuColorModel.class);
+      map.put("GnBu", GnBuColorModel.class);
+      map.put("Greens", GreensColorModel.class);
+      map.put("Greys", GreysColorModel.class);
+      map.put("OrRd", OrRdColorModel.class);
+      map.put("Oranges", OrangesColorModel.class);
+      map.put("PRGn", PRGnColorModel.class);
+      map.put("PiYG", PiYGColorModel.class);
+      map.put("PuBu", PuBuColorModel.class);
+      map.put("PuBuGn", PuBuGnColorModel.class);
+      map.put("PuOr", PuOrColorModel.class);
+      map.put("PuRd", PuRdColorModel.class);
+      map.put("Purples", PurplesColorModel.class);
+      map.put("RdBu", RdBuColorModel.class);
+      map.put("RdGy", RdGyColorModel.class);
+      map.put("RdPu", RdPuColorModel.class);
+      map.put("RdYlBu", RdYlBuColorModel.class);
+      map.put("RdYlGn", RdYlGnColorModel.class);
+      map.put("Reds", RedsColorModel.class);
+      map.put("Spectral", SpectralColorModel.class);
+      map.put("YlGn", YlGnColorModel.class);
+      map.put("YlGnBu", YlGnBuColorModel.class);
+      map.put("YlOrBr", YlOrBrColorModel.class);
+      map.put("YlOrRd", YlOrRdColorModel.class);
+      return Collections.unmodifiableMap(map);
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/binding/model/AssemblyBinding.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/model/AssemblyBinding.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding.model;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An assembly's current binding, keyed by shelf name.
+ *
+ * <p>Chart shelves are {@code x}, {@code y}, {@code group}; crosstab are {@code rows},
+ * {@code cols}, {@code aggregates}; table are {@code groups}, {@code details},
+ * {@code aggregates}. Calc tables are not represented here — their binding lives in the cell
+ * layout, per spec 2e.
+ */
+public record AssemblyBinding(String assembly, String objectType, String source,
+                              Map<String, List<FieldRef>> shelves) {}

--- a/core/src/main/java/inetsoft/web/wiz/binding/model/BindableField.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/model/BindableField.java
@@ -1,0 +1,21 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding.model;
+
+/** One bindable column. {@code role} is "dimension", "measure", or null when the tree does not say. */
+public record BindableField(String column, String dataType, String role) {}

--- a/core/src/main/java/inetsoft/web/wiz/binding/model/BindableTable.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/model/BindableTable.java
@@ -1,0 +1,23 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding.model;
+
+import java.util.List;
+
+/** One source table and the columns it offers. */
+public record BindableTable(String name, List<BindableField> fields) {}

--- a/core/src/main/java/inetsoft/web/wiz/binding/model/FieldRef.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/model/FieldRef.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding.model;
+
+/**
+ * The agent-facing shape of one bound field, shared by every binding spec (2a–2e) and
+ * embedded by highlights in spec #4.
+ *
+ * <p>{@code type} is the mandatory discriminator — {@code "dimension"} or {@code "measure"}.
+ * A reference without it is exactly the input that gets coerced onto the wrong shelf and
+ * renders plausibly wrong, so it is never defaulted.
+ *
+ * @param column     the column name, as it appears in the binding tree
+ * @param type       "dimension" or "measure"
+ * @param aggregate  aggregate formula, measures only (e.g. "Sum", "Count")
+ * @param dateLevel  date grouping level, dimensions only
+ * @param namedGroup named-group name, dimensions only
+ */
+public record FieldRef(String column, String type, String aggregate, String dateLevel,
+                       String namedGroup) {}

--- a/core/src/main/java/inetsoft/web/wiz/dispatch/CapturingCommandDispatcher.java
+++ b/core/src/main/java/inetsoft/web/wiz/dispatch/CapturingCommandDispatcher.java
@@ -1,0 +1,201 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.dispatch;
+
+import inetsoft.web.messaging.MessageAttributes;
+import inetsoft.web.messaging.MessageContextHolder;
+import inetsoft.web.viewsheet.command.MessageCommand;
+import inetsoft.web.viewsheet.command.ViewsheetCommand;
+import inetsoft.web.viewsheet.service.CommandDispatcher;
+import inetsoft.web.viewsheet.service.CommandDispatcherService;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.GenericMessage;
+
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A {@link CommandDispatcher} for agent-driven, browser-less calls into composer services that
+ * <em>captures</em> dispatched commands instead of discarding them.
+ *
+ * <p>Composer services do not signal failure by throwing. They send a
+ * {@code MessageCommand} of {@code Type.ERROR} through the dispatcher and then return
+ * normally — see {@code VSObjectPropertyService.editObjectProperty}, which does this for a
+ * rename dependency cycle, a missing assembly, and an invalid input list. Because
+ * {@link CommandDispatcher#withDummyDispatcher} overrides {@code sendCommand} to a no-op,
+ * those failures vanish and the caller observes a clean return.
+ *
+ * <p>This dispatcher keeps the commands so a caller can inspect what actually happened. It
+ * transmits nothing: like the dummy dispatcher it is meant for callers with no browser
+ * session, and the wiz pairing layer broadcasts to the browser separately.
+ */
+public final class CapturingCommandDispatcher extends CommandDispatcher {
+   private CapturingCommandDispatcher(StompHeaderAccessor headerAccessor,
+                                      CommandDispatcherService dispatcherService)
+   {
+      super(headerAccessor, dispatcherService, null);
+   }
+
+   /**
+    * Run {@code fn} with a capturing dispatcher, mirroring
+    * {@link CommandDispatcher#withDummyDispatcher}'s message-context handling so composer
+    * services see the thread state they expect.
+    */
+   public static <T> T withCapturingDispatcher(Principal principal, CapturingTask<T> fn)
+      throws Exception
+   {
+      GenericMessage<String> message = new GenericMessage<>("captured");
+      MessageAttributes messageAttributes = new MessageAttributes(message);
+      StompHeaderAccessor headerAccessor = messageAttributes.getHeaderAccessor();
+      headerAccessor.setUser(principal);
+
+      SimpMessagingTemplate messagingTemplate = new SimpMessagingTemplate(new MessageChannel() {
+         @Override
+         public boolean send(Message<?> message) {
+            return true;
+         }
+
+         @Override
+         public boolean send(Message<?> message, long timeout) {
+            return true;
+         }
+      });
+
+      // Save the previous message attributes so we can restore them, as withDummyDispatcher does.
+      MessageAttributes previousAttributes = MessageContextHolder.getMessageAttributes();
+      MessageContextHolder.setMessageAttributes(messageAttributes);
+
+      // Null cluster is deliberate. This service is constructed by hand rather than managed by
+      // Spring, so its @PostConstruct (the only place the cluster is used) never runs, and the
+      // class already guards for a null cluster. Nothing is transmitted through it in any case.
+      // Taking Cluster.getInstance() here would make this dispatcher unusable outside a live
+      // Spring context for no benefit.
+      CommandDispatcherService service =
+         new CommandDispatcherService(messagingTemplate, null)
+      {
+         @Override
+         public void convertAndSendToUser(String user, String destination, Object payload,
+                                          Map<String, Object> headers) throws MessagingException
+         {
+            // NO-OP — nothing is transmitted.
+         }
+      };
+
+      CapturingCommandDispatcher dispatcher =
+         new CapturingCommandDispatcher(headerAccessor, service);
+
+      try {
+         T result = fn.apply(dispatcher);
+         List<String> errors = dispatcher.getErrors();
+
+         if(!errors.isEmpty()) {
+            throw new CommandErrorException(errors);
+         }
+
+         return result;
+      }
+      finally {
+         MessageContextHolder.setMessageAttributes(previousAttributes);
+      }
+   }
+
+   /**
+    * Messages from captured {@code MessageCommand}s of {@code Type.ERROR}, in dispatch order.
+    */
+   public List<String> getErrors() {
+      return messagesOfType(MessageCommand.Type.ERROR);
+   }
+
+   /**
+    * Messages from captured {@code MessageCommand}s of {@code Type.WARNING}, in dispatch order.
+    * Warnings do not fail the call — the caller decides whether to relay them.
+    */
+   public List<String> getWarnings() {
+      return messagesOfType(MessageCommand.Type.WARNING);
+   }
+
+   private List<String> messagesOfType(MessageCommand.Type type) {
+      List<String> messages = new ArrayList<>();
+
+      for(Command command : captured) {
+         if(command.getCommand() instanceof MessageCommand message && message.getType() == type) {
+            messages.add(message.getMessage());
+         }
+      }
+
+      return messages;
+   }
+
+   /**
+    * Captures the command rather than transmitting it. Deliberately does not call
+    * {@code super}, which would engage the debounce/flush machinery that needs a real STOMP
+    * session.
+    */
+   @Override
+   public void sendCommand(String assemblyName, ViewsheetCommand command) {
+      captured.add(new Command(assemblyName, commandTypeOf(command), command));
+   }
+
+   @Override
+   public void flush() {
+      // NO-OP — nothing is transmitted, so there is nothing to flush.
+   }
+
+   /** Every command the wrapped call dispatched, in order. */
+   public List<Command> getCapturedCommands() {
+      return Collections.unmodifiableList(captured);
+   }
+
+   /**
+    * Mirrors {@code CommandDispatcher}'s Immutable-stripping so a captured command's type
+    * reads the way the browser would have seen it.
+    */
+   private static String commandTypeOf(ViewsheetCommand command) {
+      Class<?> commandClass = command.getClass();
+      String commandType = commandClass.getSimpleName();
+
+      if(commandType.startsWith("Immutable")) {
+         Class<?> baseClass = commandClass.getSuperclass();
+
+         if(baseClass != null) {
+            com.fasterxml.jackson.databind.annotation.JsonSerialize annotation =
+               baseClass.getAnnotation(com.fasterxml.jackson.databind.annotation.JsonSerialize.class);
+
+            if(annotation != null && commandClass.equals(annotation.as())) {
+               commandType = baseClass.getSimpleName();
+            }
+         }
+      }
+
+      return commandType;
+   }
+
+   @FunctionalInterface
+   public interface CapturingTask<T> {
+      T apply(CapturingCommandDispatcher dispatcher) throws Exception;
+   }
+
+   private final List<Command> captured = new ArrayList<>();
+}

--- a/core/src/main/java/inetsoft/web/wiz/dispatch/CapturingCommandDispatcher.java
+++ b/core/src/main/java/inetsoft/web/wiz/dispatch/CapturingCommandDispatcher.java
@@ -158,6 +158,44 @@ public final class CapturingCommandDispatcher extends CommandDispatcher {
       captured.add(new Command(assemblyName, commandTypeOf(command), command));
    }
 
+   /**
+    * Stays capturing when detached.
+    *
+    * <p>{@code CommandDispatcher.detach()} returns a copy of the base class, so anything sent
+    * through it was neither captured nor inspected — the hole this class exists to close.
+    * {@code CoreLifecycleService.createList} calls {@code detach()}, which puts it on the add,
+    * remove, group and rename paths; an ERROR dispatched during that refresh was dropped and the
+    * op reported success.
+    *
+    * <p>Returning {@code this} rather than a copy is safe precisely because this dispatcher never
+    * transmits: {@code send} and {@code convertAndSendToUser} are both no-ops, so there is no
+    * message-thread state a detached copy would need to shed — and one captured list is what the
+    * caller actually wants to inspect.
+    */
+   @Override
+   public CommandDispatcher detach() {
+      return this;
+   }
+
+   /**
+    * Iterates what was captured.
+    *
+    * <p>{@code sendCommand} deliberately skips {@code super}, so the base {@code commands} list
+    * stays empty and the inherited {@code iterator()}/{@code stream()} returned nothing. Framework
+    * code reads exactly those — {@code CoreLifecycleService} decides {@code checkMVHandled} from
+    * {@code stream()}, which being always false re-sent {@code CheckMVEvent} and added a SECOND
+    * checkpoint, breaking the one-checkpoint-per-call promise {@code mutate} makes.
+    */
+   @Override
+   public java.util.Iterator<Command> iterator() {
+      return Collections.unmodifiableList(captured).iterator();
+   }
+
+   @Override
+   public java.util.stream.Stream<Command> stream() {
+      return List.copyOf(captured).stream();
+   }
+
    @Override
    public void flush() {
       // NO-OP — nothing is transmitted, so there is nothing to flush.

--- a/core/src/main/java/inetsoft/web/wiz/dispatch/CapturingCommandDispatcher.java
+++ b/core/src/main/java/inetsoft/web/wiz/dispatch/CapturingCommandDispatcher.java
@@ -88,7 +88,11 @@ public final class CapturingCommandDispatcher extends CommandDispatcher {
       MessageContextHolder.setMessageAttributes(messageAttributes);
 
       // Null cluster is deliberate. This service is constructed by hand rather than managed by
-      // Spring, so its @PostConstruct (the only place the cluster is used) never runs, and the
+      // Spring, so its @PostConstruct never runs. The cluster is used elsewhere in that service
+      // (convertAndSendToUser and the session-state paths), so the null is safe for a different
+      // reason than "nothing reads it": every method that would touch it is overridden below to a
+      // no-op, because this dispatcher never transmits. A later change that leans on the wrong
+      // reason would NPE, which is why the right one is written down. The
       // class already guards for a null cluster. Nothing is transmitted through it in any case.
       // Taking Cluster.getInstance() here would make this dispatcher unusable outside a live
       // Spring context for no benefit.

--- a/core/src/main/java/inetsoft/web/wiz/dispatch/CommandErrorException.java
+++ b/core/src/main/java/inetsoft/web/wiz/dispatch/CommandErrorException.java
@@ -33,6 +33,16 @@ public class CommandErrorException extends Exception {
       this.errors = List.copyOf(errors);
    }
 
+   /**
+    * Adds a note to the message while leaving {@link #getErrors()} exactly as the service
+    * reported it — the note is ours, not the composer's, and folding it into the list would make
+    * a caller iterating the errors read it as one.
+    */
+   public CommandErrorException(List<String> errors, String note) {
+      super(String.join("; ", errors) + " — " + note);
+      this.errors = List.copyOf(errors);
+   }
+
    /** The individual error messages, in the order the service reported them. */
    public List<String> getErrors() {
       return Collections.unmodifiableList(errors);

--- a/core/src/main/java/inetsoft/web/wiz/dispatch/CommandErrorException.java
+++ b/core/src/main/java/inetsoft/web/wiz/dispatch/CommandErrorException.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.dispatch;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Raised when a composer service reported failure by dispatching one or more
+ * {@code MessageCommand}s of {@code Type.ERROR} and then returning normally.
+ *
+ * <p>Without this, such a failure is invisible to an agent-driven caller: the service returns,
+ * nothing throws, and the tool reports success while nothing changed.
+ */
+public class CommandErrorException extends Exception {
+   public CommandErrorException(List<String> errors) {
+      super(String.join("; ", errors));
+      this.errors = List.copyOf(errors);
+   }
+
+   /** The individual error messages, in the order the service reported them. */
+   public List<String> getErrors() {
+      return Collections.unmodifiableList(errors);
+   }
+
+   private final List<String> errors;
+}

--- a/core/src/main/java/inetsoft/web/wiz/pairing/SheetRuntimeAccess.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/SheetRuntimeAccess.java
@@ -19,6 +19,7 @@ package inetsoft.web.wiz.pairing;
 
 import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.report.composition.*;
+import inetsoft.uql.XPrincipal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -87,11 +88,61 @@ public class SheetRuntimeAccess {
                                            Principal agentUser)
       throws PairingException
    {
-      return switch (sheetType) {
+      RuntimeSheet sheet = switch (sheetType) {
          case WORKSHEET -> getWorksheetForPairing(runtimeId, agentUser);
          case VIEWSHEET -> getViewsheetForPairing(runtimeId, agentUser);
       };
+
+      grantOwnershipBypass(sheet, runtimeId, agentUser);
+      return sheet;
    }
+
+   /**
+    * Marks the agent principal so {@code WorksheetEngine.getSheet} will accept it for this runtime.
+    *
+    * <p>Bypassing {@code matches()} here is not enough on its own. A wiz service that delegates to
+    * a <em>composer</em> service passes it {@code runtimeId} plus the agent principal, and that
+    * service re-resolves the sheet through {@code getSheet}, which enforces
+    * {@code rs.matches(user)} — full {@code Principal} equality, session id included. The agent
+    * principal is rebuilt from the JWT while the owner is the browser-session principal, so the two
+    * are never equal objects. The result was that reads worked and every write failed with
+    * {@code InvalidUserException}, which made a paired session look healthy right up to the first
+    * mutation.
+    *
+    * <p>The flag is set here rather than where the principal is built, so it is granted only to an
+    * agent that has resolved a specific runtime it demonstrably shares a logical identity with —
+    * not to every wiz request. It mirrors the existing {@code supportLogin} hatch, which is read in
+    * exactly the same two ownership checks and nothing else.
+    *
+    * <p>A null owner earns no bypass: it cannot be verified, and {@code getSheet} only enforces
+    * ownership when the runtime has a user, so there is nothing to bypass.
+    */
+   private void grantOwnershipBypass(RuntimeSheet sheet, String runtimeId, Principal agentUser)
+      throws PairingException
+   {
+      Principal owner = sheet == null ? null : sheet.getUser();
+
+      if(owner == null || !(agentUser instanceof XPrincipal agent)) {
+         return;
+      }
+
+      if(!PairingUtil.sameLogicalUser(owner, agentUser)) {
+         LOG.warn("Pairing runtime access: runtime not owned by agent (id={}, agent={})",
+                  runtimeId, agentUser.getName());
+         throw new PairingException(PairingException.Kind.USER_MISMATCH,
+                                    "Pairing code does not belong to this user");
+      }
+
+      agent.setProperty(PAIRED_AGENT, "true");
+   }
+
+   /**
+    * Property name recognised by {@code WorksheetEngine}'s ownership checks, alongside
+    * {@code supportLogin}. Kept distinct from {@code supportLogin} so an agent bypass is never
+    * confused with a support-staff login, and so anything gated on the latter does not silently
+    * apply to agents.
+    */
+   public static final String PAIRED_AGENT = "pairedAgent";
 
    /**
     * Return the owner principal of the runtime with the given id on this node, or null if the

--- a/core/src/main/java/inetsoft/web/wiz/pairing/SheetRuntimeAccess.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/SheetRuntimeAccess.java
@@ -93,8 +93,24 @@ public class SheetRuntimeAccess {
          case VIEWSHEET -> getViewsheetForPairing(runtimeId, agentUser);
       };
 
-      grantOwnershipBypass(sheet, runtimeId, agentUser);
+      grantOwnershipBypass(sheet == null ? null : sheet.getUser(), runtimeId, agentUser);
       return sheet;
+   }
+
+   /**
+    * Grants the same bypass from a runtime id alone, for callers that never resolve the sheet.
+    *
+    * <p>Several wiz services take {@code runtimeId} straight from the pairing session and hand it
+    * to a composer service, which re-resolves it and enforces ownership. Those paths need the flag
+    * just as much as the resolving ones, and marking only inside {@link #getSheetForPairing} left
+    * them broken — chart region properties still failed while chart aesthetics worked.
+    *
+    * <p>The owner lookup is side-effect free, so this does not touch or audit the runtime.
+    */
+   public void grantOwnershipBypass(SheetType sheetType, String runtimeId, Principal agentUser)
+      throws PairingException
+   {
+      grantOwnershipBypass(getRuntimeOwner(sheetType, runtimeId), runtimeId, agentUser);
    }
 
    /**
@@ -117,11 +133,9 @@ public class SheetRuntimeAccess {
     * <p>A null owner earns no bypass: it cannot be verified, and {@code getSheet} only enforces
     * ownership when the runtime has a user, so there is nothing to bypass.
     */
-   private void grantOwnershipBypass(RuntimeSheet sheet, String runtimeId, Principal agentUser)
+   private void grantOwnershipBypass(Principal owner, String runtimeId, Principal agentUser)
       throws PairingException
    {
-      Principal owner = sheet == null ? null : sheet.getUser();
-
       if(owner == null || !(agentUser instanceof XPrincipal agent)) {
          return;
       }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AnnotationFamily.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AnnotationFamily.java
@@ -1,0 +1,106 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.uql.viewsheet.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.viewsheet.internal.AnnotationRectangleVSAssemblyInfo;
+import inetsoft.uql.viewsheet.internal.AnnotationVSAssemblyInfo;
+
+/**
+ * An annotation is <b>three assemblies</b> — {@link AnnotationVSAssembly}, its line, and its
+ * rectangle — linked by name, with the content held on the rectangle.
+ *
+ * <p>Two consequences the rest of the plugin has to respect:
+ *
+ * <ol>
+ *   <li>Listed flat, the three read as unrelated assemblies with nothing to say they are one
+ *       object. The read model groups them.</li>
+ *   <li>Removing one part directly <b>orphans the others</b>: the surviving
+ *       {@code AnnotationVSAssemblyInfo} then references a name that no longer resolves. So
+ *       the structural {@code remove} op refuses on any of the three.</li>
+ * </ol>
+ *
+ * <p>This holds whether or not the annotation tools exist yet — annotations already exist in
+ * the viewsheets this plugin edits, so the orphaning hazard is present from day one.
+ */
+public final class AnnotationFamily {
+   private AnnotationFamily() {
+   }
+
+   public static boolean isPart(VSAssembly assembly) {
+      return assembly instanceof AnnotationVSAssembly ||
+         assembly instanceof AnnotationLineVSAssembly ||
+         assembly instanceof AnnotationRectangleVSAssembly;
+   }
+
+   /** The line and rectangle belong to an annotation; the annotation itself is the root. */
+   public static boolean isSubordinatePart(VSAssembly assembly) {
+      return assembly instanceof AnnotationLineVSAssembly ||
+         assembly instanceof AnnotationRectangleVSAssembly;
+   }
+
+   /** The rectangle's text, which is what a reader means by "the annotation". */
+   public static String contentOf(Viewsheet vs, VSAssembly annotation) {
+      if(vs == null || !(annotation instanceof AnnotationVSAssembly) ||
+         !(annotation.getVSAssemblyInfo() instanceof AnnotationVSAssemblyInfo info) ||
+         info.getRectangle() == null)
+      {
+         return null;
+      }
+
+      Assembly rectangle = vs.getAssembly(info.getRectangle());
+
+      return rectangle instanceof AnnotationRectangleVSAssembly rect &&
+         rect.getVSAssemblyInfo() instanceof AnnotationRectangleVSAssemblyInfo rectInfo
+         ? rectInfo.getContent() : null;
+   }
+
+   /** The names of the line and rectangle an annotation owns, for grouping in the read model. */
+   public static List<String> partsOf(VSAssembly annotation) {
+      if(!(annotation instanceof AnnotationVSAssembly) ||
+         !(annotation.getVSAssemblyInfo() instanceof AnnotationVSAssemblyInfo info))
+      {
+         return List.of();
+      }
+
+      List<String> parts = new ArrayList<>();
+
+      if(info.getLine() != null) {
+         parts.add(info.getLine());
+      }
+
+      if(info.getRectangle() != null) {
+         parts.add(info.getRectangle());
+      }
+
+      return parts;
+   }
+
+   /** The refusal the structural {@code remove} op raises on any annotation part. */
+   public static IllegalArgumentException removeRefusal(String assemblyName) {
+      return new IllegalArgumentException(
+         "'" + assemblyName + "' is part of an annotation, which is three linked assemblies " +
+         "— the annotation, its line, and its rectangle. Removing one directly orphans the " +
+         "others: the survivors reference a name that no longer resolves. Remove the " +
+         "annotation as a whole instead.");
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyConditionService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyConditionService.java
@@ -1,0 +1,189 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.web.binding.drm.DataRefModel;
+import inetsoft.web.composer.model.vs.VSConditionDialogModel;
+import inetsoft.web.composer.vs.dialog.VSConditionDialogService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+import java.util.*;
+
+/**
+ * Assembly-level conditions — filtering what an assembly shows.
+ *
+ * <p>Wraps the Composer's own condition dialog rather than reusing wiz's {@code apply_filter}.
+ * That was a deliberate decision: the wiz path is <b>copy-then-apply</b>, duplicating the target
+ * so a chat conversation accumulates parallel versions. A Composer user editing their own
+ * viewsheet expects the change to land in place, and a parallel copy appearing instead would be
+ * a silent wrong result rather than an error.
+ *
+ * <p>The condition list itself is built by {@link ConditionVocabulary}, which owns the
+ * alternating-array hazard. This class only reads the model, swaps the list, and writes it back —
+ * preserving {@code tableName} and {@code fields}, neither of which a caller supplies.
+ *
+ * <p><b>A condition changes what renders</b>, and one that matches nothing produces an empty but
+ * structurally valid assembly that returns cleanly. So the summary says to look, and the read
+ * side reports how many conditions are active.
+ */
+@Service
+public class AssemblyConditionService {
+   @Autowired
+   public AssemblyConditionService(ViewsheetSessionService sessions,
+                                   VSConditionDialogService conditionService)
+   {
+      this.sessions = sessions;
+      this.conditionService = conditionService;
+   }
+
+   /** The current conditions, in the flat vocabulary, plus what fields are filterable. */
+   public Map<String, Object> read(String sessionToken, Principal user, String assemblyName)
+      throws Exception
+   {
+      VSConditionDialogModel model = conditionService.getModel(
+         sessions.resolve(sessionToken, user).getID(), assemblyName, user);
+
+      Map<String, Object> out = new LinkedHashMap<>();
+      out.put("assembly", assemblyName);
+
+      if(model == null) {
+         out.put("conditions", List.of());
+         out.put("fields", List.of());
+         return out;
+      }
+
+      List<Map<String, Object>> conditions =
+         ConditionVocabulary.describe(model.getConditionList());
+      out.put("tableName", model.getTableName());
+      out.put("conditions", conditions);
+      out.put("conditionCount", conditions.size());
+      out.put("fields", fieldNames(model.getFields()));
+      return out;
+   }
+
+   /**
+    * Replaces the assembly's conditions. One {@code sessions.mutate}, so one undo checkpoint.
+    *
+    * <p>The clauses are validated against the model's own {@code fields[]}, which means the
+    * model has to be read first — a condition naming a column the assembly cannot filter on is
+    * the recorded cause of a downstream cast failure.
+    */
+   public int set(String sessionToken, Principal user, String assemblyName,
+                  List<ConditionVocabulary.Clause> clauses, String linkUri) throws Exception
+   {
+      int[] applied = new int[1];
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         VSConditionDialogModel model = conditionService.getModel(runtimeId, assemblyName, user);
+
+         if(model == null) {
+            throw new IllegalArgumentException(
+               "'" + assemblyName + "' has no condition dialog — it is not an assembly that " +
+               "can be filtered. Charts, tables, crosstabs and selection assemblies can.");
+         }
+
+         Object[] conditionList = ConditionVocabulary.toConditionList(clauses, model.getFields());
+         model.setConditionList(conditionList);
+         applied[0] = clauses == null ? 0 : clauses.size();
+         conditionService.setModel(runtimeId, assemblyName, model, linkUri, user, dispatcher);
+      });
+
+      return applied[0];
+   }
+
+   /** Clears every condition. Distinct from setting an empty list only in what it reads like. */
+   public void clear(String sessionToken, Principal user, String assemblyName, String linkUri)
+      throws Exception
+   {
+      set(sessionToken, user, assemblyName, List.of(), linkUri);
+   }
+
+   /**
+    * The values a column actually holds, so a condition is not written against a guess.
+    *
+    * <p>{@code browseData} wants the column's {@code DataRefModel}, not its name, so the model is
+    * read first and the name resolved against its {@code fields[]}. That also means an unknown
+    * column fails here with the available list rather than returning an empty browse that reads
+    * as "this column has no values".
+    */
+   public Object browseValues(String sessionToken, Principal user, String assemblyName,
+                              String columnName) throws Exception
+   {
+      if(columnName == null || columnName.isBlank()) {
+         throw new IllegalArgumentException(
+            "browse_condition_values needs a 'column' — the column whose values to list.");
+      }
+
+      String runtimeId = sessions.resolve(sessionToken, user).getID();
+      VSConditionDialogModel model = conditionService.getModel(runtimeId, assemblyName, user);
+      DataRefModel field = model == null ? null : find(model.getFields(), columnName);
+
+      if(field == null) {
+         throw new IllegalArgumentException(
+            "'" + columnName + "' is not a field of '" + assemblyName + "'. Available: " +
+            (model == null ? "(none)" : String.join(", ", fieldNames(model.getFields()))) +
+            ". Browsing an unknown column would return nothing, which reads as an empty column " +
+            "rather than a wrong name.");
+      }
+
+      return conditionService.browseData(runtimeId, model.getTableName(), assemblyName, false,
+                                        field, user);
+   }
+
+   private static DataRefModel find(DataRefModel[] fields, String columnName) {
+      if(fields != null) {
+         for(DataRefModel field : fields) {
+            if(field != null && field.getName() != null &&
+               field.getName().equalsIgnoreCase(columnName))
+            {
+               return field;
+            }
+         }
+      }
+
+      return null;
+   }
+
+   /** The built-in date ranges usable with the date_in operator. */
+   public Object dateRanges(String sessionToken, Principal user) throws Exception {
+      return conditionService.getDateRanges(sessions.resolve(sessionToken, user).getID(), user);
+   }
+
+   public Map<String, Object> vocabulary() {
+      return ConditionVocabulary.vocabulary();
+   }
+
+   private static List<String> fieldNames(DataRefModel[] fields) {
+      List<String> names = new ArrayList<>();
+
+      if(fields != null) {
+         for(DataRefModel field : fields) {
+            if(field != null && field.getName() != null) {
+               names.add(field.getName());
+            }
+         }
+      }
+
+      return names;
+   }
+
+   private final ViewsheetSessionService sessions;
+   private final VSConditionDialogService conditionService;
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightService.java
@@ -1,0 +1,277 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.web.wiz.binding.VisualFrameAliases;
+import inetsoft.web.composer.model.vs.HighlightDialogModel;
+import inetsoft.web.composer.model.vs.HighlightModel;
+import inetsoft.web.composer.model.vs.VSConditionDialogModel;
+import inetsoft.web.composer.vs.dialog.HighlightDialogService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+import java.util.*;
+
+/**
+ * Highlights — conditional formatting on an assembly.
+ *
+ * <p>Each {@code HighlightModel} embeds a full {@code VSConditionDialogModel}, so highlights
+ * inherit the alternating-array hazard wholesale. They therefore use {@link ConditionVocabulary}
+ * unchanged: one implementation, two callers. A caller who has written a condition for
+ * {@code set_condition} already knows how to write one here.
+ *
+ * <p><b>{@code usedHighlightNames} exists to stop name collisions, and this honours it.</b> A
+ * duplicate name silently replaces an existing highlight, so adding one under a name already in
+ * use is refused; updating requires saying so, which makes the destructive case explicit rather
+ * than accidental.
+ *
+ * <p>Region-addressed like hyperlinks: a highlight applies to a cell, an axis or a text element,
+ * not to the assembly as a whole.
+ */
+@Service
+public class AssemblyHighlightService {
+   @Autowired
+   public AssemblyHighlightService(ViewsheetSessionService sessions,
+                                   HighlightDialogService highlightService)
+   {
+      this.sessions = sessions;
+      this.highlightService = highlightService;
+   }
+
+   /** Where a highlight lives. All-defaults means the assembly itself. */
+   public record Region(Integer row, Integer col, String colName, boolean axis, boolean text) {
+      public static Region whole() {
+         return new Region(null, null, null, false, false);
+      }
+   }
+
+   /** One highlight in the agent vocabulary. Colours are {@code #RRGGBB}. */
+   public record Highlight(String name, String foreground, String background,
+                           List<ConditionVocabulary.Clause> conditions, boolean applyRow) {}
+
+   public Map<String, Object> list(String sessionToken, Principal user, String assemblyName,
+                                   Region region) throws Exception
+   {
+      HighlightDialogModel model = read(sessions.resolve(sessionToken, user).getID(),
+                                       assemblyName, region, user);
+
+      Map<String, Object> out = new LinkedHashMap<>();
+      out.put("assembly", assemblyName);
+
+      if(model == null) {
+         out.put("highlights", List.of());
+         return out;
+      }
+
+      List<Map<String, Object>> highlights = new ArrayList<>();
+
+      for(HighlightModel highlight : model.getHighlights() == null
+         ? new HighlightModel[0] : model.getHighlights())
+      {
+         highlights.add(describe(highlight));
+      }
+
+      out.put("highlights", highlights);
+      out.put("usedNames", model.getUsedHighlightNames() == null
+         ? List.of() : Arrays.asList(model.getUsedHighlightNames()));
+      out.put("fields", fieldNames(model));
+      out.put("appliesToRow", model.isShowRow());
+      return out;
+   }
+
+   /**
+    * Adds a highlight, or updates one by name when {@code replace} is set.
+    *
+    * <p>One {@code sessions.mutate}, so one undo checkpoint.
+    */
+   public void set(String sessionToken, Principal user, String assemblyName, Region region,
+                   Highlight highlight, boolean replace, String linkUri) throws Exception
+   {
+      requireName(highlight);
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         HighlightDialogModel model = read(runtimeId, assemblyName, region, user);
+
+         if(model == null) {
+            throw new IllegalArgumentException(
+               "'" + assemblyName + "' has no highlight dialog — it is not an assembly that " +
+               "supports conditional formatting.");
+         }
+
+         List<HighlightModel> highlights = new ArrayList<>();
+         boolean found = false;
+
+         for(HighlightModel existing : model.getHighlights() == null
+            ? new HighlightModel[0] : model.getHighlights())
+         {
+            if(existing != null && highlight.name().equalsIgnoreCase(existing.getName())) {
+               found = true;
+
+               // Silently replacing is the recorded hazard usedHighlightNames exists to
+               // prevent, so overwriting has to be asked for.
+               if(!replace) {
+                  throw new IllegalArgumentException(
+                     "A highlight named '" + highlight.name() + "' already exists on '" +
+                     assemblyName + "'. Adding another under the same name would silently " +
+                     "replace it. Pass replace:true to update it deliberately, or choose a " +
+                     "different name.");
+               }
+
+               highlights.add(build(highlight, model));
+            }
+            else {
+               highlights.add(existing);
+            }
+         }
+
+         if(!found) {
+            highlights.add(build(highlight, model));
+         }
+
+         model.setHighlights(highlights.toArray(new HighlightModel[0]));
+         highlightService.setHighlightDialogModel(runtimeId, assemblyName, model, linkUri, user,
+                                                 dispatcher);
+      });
+   }
+
+   /** Removes one highlight by name. Removing one that is not there is an error, not a no-op. */
+   public void delete(String sessionToken, Principal user, String assemblyName, Region region,
+                      String name, String linkUri) throws Exception
+   {
+      if(name == null || name.isBlank()) {
+         throw new IllegalArgumentException("delete_highlight needs the highlight's 'name'.");
+      }
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         HighlightDialogModel model = read(runtimeId, assemblyName, region, user);
+         HighlightModel[] existing = model == null || model.getHighlights() == null
+            ? new HighlightModel[0] : model.getHighlights();
+         List<HighlightModel> kept = new ArrayList<>();
+         List<String> names = new ArrayList<>();
+
+         for(HighlightModel highlight : existing) {
+            if(highlight == null) {
+               continue;
+            }
+
+            names.add(highlight.getName());
+
+            if(!name.equalsIgnoreCase(highlight.getName())) {
+               kept.add(highlight);
+            }
+         }
+
+         if(kept.size() == existing.length) {
+            throw new IllegalArgumentException(
+               "'" + assemblyName + "' has no highlight named '" + name + "'. It has: " +
+               (names.isEmpty() ? "(none)" : String.join(", ", names)) + ".");
+         }
+
+         model.setHighlights(kept.toArray(new HighlightModel[0]));
+         highlightService.setHighlightDialogModel(runtimeId, assemblyName, model, linkUri, user,
+                                                 dispatcher);
+      });
+   }
+
+   // ── conversions ───────────────────────────────────────────────────────────
+
+   private static void requireName(Highlight highlight) {
+      if(highlight == null || highlight.name() == null || highlight.name().isBlank()) {
+         throw new IllegalArgumentException(
+            "A highlight needs a 'name' — it is how the highlight is addressed for updates and " +
+            "deletion.");
+      }
+
+      if(highlight.foreground() == null && highlight.background() == null) {
+         throw new IllegalArgumentException(
+            "Highlight '" + highlight.name() + "' sets no colour. A highlight with no " +
+            "foreground and no background is stored and renders nothing, which reads as a " +
+            "condition that never matched.");
+      }
+   }
+
+   private static HighlightModel build(Highlight highlight, HighlightDialogModel model) {
+      HighlightModel out = new HighlightModel();
+      out.setName(highlight.name());
+
+      if(highlight.foreground() != null) {
+         out.setForeground(VisualFrameAliases.normalizeColor(highlight.foreground()));
+      }
+
+      if(highlight.background() != null) {
+         out.setBackground(VisualFrameAliases.normalizeColor(highlight.background()));
+      }
+
+      out.setApplyRow(highlight.applyRow());
+
+      // The embedded condition model reuses spec #4's vocabulary rather than a parallel one,
+      // and is validated against the highlight dialog's own fields.
+      VSConditionDialogModel condition = new VSConditionDialogModel();
+      condition.setTableName(model.getTableName());
+      condition.setFields(model.getFields());
+      condition.setConditionList(
+         ConditionVocabulary.toConditionList(highlight.conditions(), model.getFields()));
+      out.setVsConditionDialogModel(condition);
+      return out;
+   }
+
+   private static Map<String, Object> describe(HighlightModel highlight) {
+      Map<String, Object> out = new LinkedHashMap<>();
+
+      if(highlight == null) {
+         return out;
+      }
+
+      out.put("name", highlight.getName());
+      out.put("foreground", highlight.getForeground());
+      out.put("background", highlight.getBackground());
+      out.put("applyRow", highlight.isApplyRow());
+      out.put("conditions", highlight.getVsConditionDialogModel() == null
+         ? List.of()
+         : ConditionVocabulary.describe(
+            highlight.getVsConditionDialogModel().getConditionList()));
+      return out;
+   }
+
+   private HighlightDialogModel read(String runtimeId, String assemblyName, Region region,
+                                     Principal user) throws Exception
+   {
+      Region target = region == null ? Region.whole() : region;
+      return highlightService.getHighlightDialogModel(runtimeId, assemblyName, target.row(),
+                                                      target.col(), target.colName(),
+                                                      target.axis(), target.text(), user);
+   }
+
+   private static List<String> fieldNames(HighlightDialogModel model) {
+      List<String> names = new ArrayList<>();
+
+      if(model.getFields() != null) {
+         for(var field : model.getFields()) {
+            if(field != null && field.getName() != null) {
+               names.add(field.getName());
+            }
+         }
+      }
+
+      return names;
+   }
+
+   private final ViewsheetSessionService sessions;
+   private final HighlightDialogService highlightService;
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightService.java
@@ -56,8 +56,26 @@ public class AssemblyHighlightService {
 
    /** Where a highlight lives. All-defaults means the assembly itself. */
    public record Region(Integer row, Integer col, String colName, boolean axis, boolean text) {
+      /**
+       * Normalizes a null row/col to <b>0</b> — on every construction path.
+       *
+       * <p>For a table-type assembly {@code HighlightDialogService.getHighlightDialogModel} calls
+       * {@code lens.getTableDataPath(row, col)}, which NPEs on null, so highlights were unusable
+       * on every table, crosstab and calc table (a chart never reaches that branch). Zero is what
+       * the rest of that same method already assumes: a few lines later it reads
+       * {@code row == null ? 0 : row}.
+       *
+       * <p>This lives in the compact constructor rather than in {@link #whole()} because the
+       * controller builds a Region straight from its nullable {@code @RequestParam}s and never
+       * calls the factory — normalizing only there fixed nothing on the live path.
+       */
+      public Region {
+         row = row == null ? 0 : row;
+         col = col == null ? 0 : col;
+      }
+
       public static Region whole() {
-         return new Region(null, null, null, false, false);
+         return new Region(0, 0, null, false, false);
       }
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHyperlinkService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHyperlinkService.java
@@ -66,8 +66,27 @@ public class AssemblyHyperlinkService {
     */
    public record Region(Integer row, Integer col, String colName, boolean axis, boolean text,
                         boolean titleLink, boolean emptyPlotLink) {
+      /**
+       * Normalizes a null row/col to <b>0</b> — on every construction path.
+       *
+       * <p>{@code HyperlinkDialogService.getHyperlinkDialogModel} dereferences row as an int
+       * (through {@code getFields}), so nulls threw
+       * {@code NullPointerException: … because "row" is null} and made set_hyperlink unusable at
+       * assembly level for every assembly type. The Composer never sends null — its controller
+       * declares {@code @RequestParam(value = "row", required = false, defaultValue = "0")} — so
+       * calling the service directly means supplying that default ourselves.
+       *
+       * <p>This lives in the compact constructor rather than in {@link #whole()} because the
+       * agent controller builds a Region straight from its nullable {@code @RequestParam}s and
+       * never calls the factory — normalizing only there fixed nothing on the live path.
+       */
+      public Region {
+         row = row == null ? 0 : row;
+         col = col == null ? 0 : col;
+      }
+
       public static Region whole() {
-         return new Region(null, null, null, false, false, false, false);
+         return new Region(0, 0, null, false, false, false, false);
       }
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHyperlinkService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHyperlinkService.java
@@ -1,0 +1,243 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.Hyperlink;
+import inetsoft.web.composer.model.vs.HyperlinkDialogModel;
+import inetsoft.web.composer.vs.dialog.HyperlinkDialogService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+import java.util.*;
+
+/**
+ * An assembly's hyperlink.
+ *
+ * <p>Unlike the property engine, this is <b>region-addressed</b>: a hyperlink hangs off a cell,
+ * an axis, a title, or the empty plot area rather than off the assembly as a whole. So it takes
+ * a region selector instead of a dotted path, and gets its own tools.
+ *
+ * <p>{@code linkType} is an integer constant on the wire — 1 web, 8 viewsheet, 16 message — and
+ * appears here as a token. Which value field matters depends on the type, and a link whose type
+ * and value disagree is accepted by the dialog and then does nothing when clicked, so this
+ * refuses the combination instead.
+ *
+ * <p><b>Highlights are deliberately not here.</b> {@code HighlightDialogModel} carries
+ * {@code HighlightModel[]}, each with a condition list, and conditions are spec #4's
+ * vocabulary. A second condition vocabulary in this class would put those semantics in two
+ * places, which is the drift the property design exists to prevent — so highlights wait for #4.
+ */
+@Service
+public class AssemblyHyperlinkService {
+   /** Agent-facing link types. The integers never appear in either direction. */
+   private static final Map<String, Integer> LINK_TYPES = Map.of(
+      "none", 0,
+      "web", Hyperlink.WEB_LINK,
+      "viewsheet", Hyperlink.VIEWSHEET_LINK,
+      "message", Hyperlink.MESSAGE_LINK);
+
+   @Autowired
+   public AssemblyHyperlinkService(ViewsheetSessionService sessions,
+                                   HyperlinkDialogService hyperlinkService)
+   {
+      this.sessions = sessions;
+      this.hyperlinkService = hyperlinkService;
+   }
+
+   /**
+    * A region within an assembly. All-defaults addresses the assembly itself, which is what a
+    * caller naming only the assembly means.
+    */
+   public record Region(Integer row, Integer col, String colName, boolean axis, boolean text,
+                        boolean titleLink, boolean emptyPlotLink) {
+      public static Region whole() {
+         return new Region(null, null, null, false, false, false, false);
+      }
+   }
+
+   public Map<String, Object> read(String sessionToken, Principal user, String assemblyName,
+                                   Region region) throws Exception
+   {
+      Region target = region == null ? Region.whole() : region;
+      HyperlinkDialogModel model = hyperlinkService.getHyperlinkDialogModel(
+         sessions.resolve(sessionToken, user).getID(), assemblyName, target.row(), target.col(),
+         target.colName(), target.axis(), target.text(), target.titleLink(),
+         target.emptyPlotLink(), user);
+
+      return describe(assemblyName, model);
+   }
+
+   /** One {@code sessions.mutate}, so one undo checkpoint. */
+   public void set(String sessionToken, Principal user, String assemblyName, Region region,
+                   Map<String, Object> link, String linkUri) throws Exception
+   {
+      // Validated before the runtime is touched: a link whose type and value disagree costs
+      // nothing to refuse here, and opens no checkpoint the caller then has to undo.
+      String type = requireType(link);
+      requireValueForType(type, link);
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         Region target = region == null ? Region.whole() : region;
+         HyperlinkDialogModel model = hyperlinkService.getHyperlinkDialogModel(
+            runtimeId, assemblyName, target.row(), target.col(), target.colName(),
+            target.axis(), target.text(), target.titleLink(), target.emptyPlotLink(), user);
+
+         apply(model, type, link);
+         hyperlinkService.setHyperlinkDialogModel(runtimeId, assemblyName, model, linkUri, user,
+                                                 dispatcher);
+      });
+   }
+
+   public Map<String, Object> linkTypes() {
+      List<String> names = new ArrayList<>(LINK_TYPES.keySet());
+      Collections.sort(names);
+      return Map.of("linkTypes", names);
+   }
+
+   // ── vocabulary ────────────────────────────────────────────────────────────
+
+   private static String requireType(Map<String, Object> link) {
+      Object raw = link == null ? null : link.get("linkType");
+      String type = raw == null ? "" : String.valueOf(raw).trim().toLowerCase();
+
+      if(!LINK_TYPES.containsKey(type)) {
+         throw new IllegalArgumentException(
+            "'linkType' must be one of " + new TreeSet<>(LINK_TYPES.keySet()) + ", got '" +
+            raw + "'. Integer constants are not accepted — the words are the vocabulary.");
+      }
+
+      return type;
+   }
+
+   /**
+    * Which field carries the destination depends on the type. A link with a type but no
+    * matching value is accepted by the dialog and then does nothing when clicked, which reads
+    * as a broken report rather than a bad call.
+    */
+   private static void requireValueForType(String type, Map<String, Object> link) {
+      switch(type) {
+         case "web" -> require(link, "webLink", type);
+         case "viewsheet" -> require(link, "assetLinkPath", type);
+         case "message" -> require(link, "webLink", type);
+         default -> { /* none clears the link, so it needs no destination */ }
+      }
+   }
+
+   private static void require(Map<String, Object> link, String field, String type) {
+      if(str(link, field) == null) {
+         throw new IllegalArgumentException(
+            "A '" + type + "' hyperlink needs '" + field + "'. Without it the link is stored " +
+            "and then does nothing when clicked, which reads as a broken report rather than a " +
+            "bad call.");
+      }
+   }
+
+   private static void apply(HyperlinkDialogModel model, String type,
+                             Map<String, Object> link)
+   {
+      model.setLinkType(LINK_TYPES.get(type));
+
+      if("none".equals(type)) {
+         model.setWebLink(null);
+         model.setAssetLinkPath(null);
+         model.setAssetLinkId(null);
+         return;
+      }
+
+      if(link.containsKey("webLink")) {
+         model.setWebLink(str(link, "webLink"));
+      }
+
+      if(link.containsKey("assetLinkPath")) {
+         model.setAssetLinkPath(str(link, "assetLinkPath"));
+      }
+
+      if(link.containsKey("bookmark")) {
+         model.setBookmark(str(link, "bookmark"));
+      }
+
+      if(link.containsKey("targetFrame")) {
+         model.setTargetFrame(str(link, "targetFrame"));
+      }
+
+      if(link.containsKey("tooltip")) {
+         model.setTooltip(str(link, "tooltip"));
+      }
+
+      if(link.get("self") instanceof Boolean self) {
+         model.setSelf(self);
+      }
+
+      if(link.get("sendViewsheetParameters") instanceof Boolean send) {
+         model.setSendViewsheetParameters(send);
+      }
+
+      if(link.get("sendSelectionsAsParameters") instanceof Boolean send) {
+         model.setSendSelectionsAsParameters(send);
+      }
+
+      if(link.get("disableParameterPrompt") instanceof Boolean disable) {
+         model.setDisableParameterPrompt(disable);
+      }
+   }
+
+   private static Map<String, Object> describe(String assemblyName, HyperlinkDialogModel model) {
+      Map<String, Object> out = new LinkedHashMap<>();
+      out.put("assembly", assemblyName);
+
+      if(model == null) {
+         out.put("linkType", "none");
+         return out;
+      }
+
+      out.put("linkType", tokenOf(model.getLinkType()));
+      out.put("webLink", model.getWebLink());
+      out.put("assetLinkPath", model.getAssetLinkPath());
+      out.put("bookmark", model.getBookmark());
+      out.put("targetFrame", model.getTargetFrame());
+      out.put("tooltip", model.getTooltip());
+      out.put("self", model.isSelf());
+      out.put("sendViewsheetParameters", model.isSendViewsheetParameters());
+      out.put("sendSelectionsAsParameters", model.isSendSelectionsAsParameters());
+      out.put("row", model.getRow());
+      out.put("col", model.getCol());
+      out.put("colName", model.getColName());
+      return out;
+   }
+
+   /** An unrecognized constant reads back as itself rather than as a guessed token. */
+   private static String tokenOf(int value) {
+      for(Map.Entry<String, Integer> entry : LINK_TYPES.entrySet()) {
+         if(entry.getValue() == value) {
+            return entry.getKey();
+         }
+      }
+
+      return "unknown(" + value + ")";
+   }
+
+   private static String str(Map<String, Object> link, String key) {
+      Object value = link == null ? null : link.get(key);
+      String text = value == null ? "" : String.valueOf(value).trim();
+      return text.isEmpty() ? null : text;
+   }
+
+   private final ViewsheetSessionService sessions;
+   private final HyperlinkDialogService hyperlinkService;
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
@@ -1,0 +1,241 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.composer.vs.dialog.GaugePropertyDialogService;
+import inetsoft.web.composer.vs.dialog.TextPropertyDialogService;
+import inetsoft.web.viewsheet.service.CommandDispatcher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.security.Principal;
+import java.util.*;
+
+/**
+ * Reads and writes assembly properties through the Composer's own property-dialog services.
+ *
+ * <p>Going through the dialog services rather than writing {@code VSAssemblyInfo} directly
+ * keeps their validation and normalization, which is the whole reason the Phase 0 gate asked
+ * whether they could be driven headlessly.
+ *
+ * <p><b>Dispatch is by naming convention</b> — every service exposes
+ * {@code get<Type>PropertyDialogModel(runtimeId, objectId, principal)} and
+ * {@code set<Type>PropertyDialogModel(runtimeId, objectId, model, linkUri, principal,
+ * dispatcher)}. That convention is asserted by {@code AssemblyPropertyServiceTest} against
+ * every registered service, so a break surfaces at build time rather than against a live
+ * viewsheet. The alternative — 25 hand-written bindings — was rejected as more code guarding
+ * the same convention less legibly. See docs/superpowers/plans/2026-08-13-needs-your-input.md.
+ *
+ * <p>A patch is validated <b>whole</b> before anything is applied, so a typo in the fourth key
+ * does not leave the first three written.
+ */
+@Service
+public class AssemblyPropertyService {
+   @Autowired
+   public AssemblyPropertyService(ViewsheetSessionService sessions,
+                                  GaugePropertyDialogService gaugeService,
+                                  TextPropertyDialogService textService)
+   {
+      this.sessions = sessions;
+      this.services = Map.of("gauge", gaugeService, "text", textService);
+   }
+
+   /** The alias vocabulary for an assembly's type, with its current values. */
+   public Map<String, Object> list(String sessionToken, Principal user, String assemblyName)
+      throws Exception
+   {
+      RuntimeViewsheet rvs = sessions.resolve(sessionToken, user);
+      String type = typeOf(rvs, assemblyName);
+      PropertyAliases.TypeAliases entry = PropertyAliases.forType(type);
+      Object model = readModel(rvs, type, assemblyName, user);
+      List<Map<String, Object>> properties = new ArrayList<>();
+
+      for(Map.Entry<String, String> alias : entry.aliases().entrySet()) {
+         Map<String, Object> property = new LinkedHashMap<>();
+         property.put("name", alias.getKey());
+         property.put("path", alias.getValue());
+         property.put("type",
+                      PropertyPath.typeOf(entry.modelClass(), alias.getValue()).getSimpleName());
+         property.put("value", PropertyPath.get(model, alias.getValue()));
+         properties.add(property);
+      }
+
+      Map<String, Object> out = new LinkedHashMap<>();
+      out.put("assembly", assemblyName);
+      out.put("assemblyType", type);
+      out.put("properties", properties);
+      return out;
+   }
+
+   /** Current values, by alias. {@code raw} returns the whole dialog model instead. */
+   public Object get(String sessionToken, Principal user, String assemblyName, boolean raw)
+      throws Exception
+   {
+      RuntimeViewsheet rvs = sessions.resolve(sessionToken, user);
+      String type = typeOf(rvs, assemblyName);
+      Object model = readModel(rvs, type, assemblyName, user);
+
+      if(raw) {
+         return model;
+      }
+
+      PropertyAliases.TypeAliases entry = PropertyAliases.forType(type);
+      Map<String, Object> values = new LinkedHashMap<>();
+
+      for(Map.Entry<String, String> alias : entry.aliases().entrySet()) {
+         values.put(alias.getKey(), PropertyPath.get(model, alias.getValue()));
+      }
+
+      return values;
+   }
+
+   /** Applies a patch of aliases and/or raw paths. One {@code mutate}, so one checkpoint. */
+   public void set(String sessionToken, Principal user, String assemblyName,
+                   Map<String, Object> patch, String linkUri) throws Exception
+   {
+      if(patch == null || patch.isEmpty()) {
+         throw new IllegalArgumentException(
+            "set_assembly_properties needs at least one property to set.");
+      }
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         String type = typeOf(rvs, assemblyName);
+         Object model = readModel(rvs, type, assemblyName, user);
+
+         // Resolved whole before anything is written: a typo in the fourth key must not
+         // leave the first three applied, which would be a partial edit the caller has no
+         // way to detect from the error alone.
+         Map<String, String> resolved = new LinkedHashMap<>();
+
+         for(String key : patch.keySet()) {
+            resolved.put(key, PropertyAliases.resolve(type, key));
+         }
+
+         for(Map.Entry<String, String> entry : resolved.entrySet()) {
+            PropertyPath.set(model, entry.getValue(), patch.get(entry.getKey()));
+         }
+
+         writeModel(runtimeId, type, assemblyName, model, linkUri, user, dispatcher);
+      });
+   }
+
+   // ── convention dispatch ───────────────────────────────────────────────────
+
+   private Object readModel(RuntimeViewsheet rvs, String type, String assemblyName,
+                            Principal user)
+   {
+      Object service = serviceFor(type);
+      Method getter = method(service, "get" + capitalize(type) + "PropertyDialogModel", 3);
+
+      try {
+         return getter.invoke(service, rvs.getID(), assemblyName, user);
+      }
+      catch(IllegalAccessException | InvocationTargetException e) {
+         throw new IllegalArgumentException(
+            "Reading " + type + " properties of '" + assemblyName + "' failed: " +
+            rootMessage(e), e);
+      }
+   }
+
+   private void writeModel(String runtimeId, String type, String assemblyName, Object model,
+                           String linkUri, Principal user, CommandDispatcher dispatcher)
+   {
+      Object service = serviceFor(type);
+      Method setter = method(service, "set" + capitalize(type) + "PropertyDialogModel", 6);
+
+      try {
+         setter.invoke(service, runtimeId, assemblyName, model, linkUri, user, dispatcher);
+      }
+      catch(IllegalAccessException | InvocationTargetException e) {
+         throw new IllegalArgumentException(
+            "Setting " + type + " properties of '" + assemblyName + "' failed: " +
+            rootMessage(e), e);
+      }
+   }
+
+   Object serviceFor(String type) {
+      Object service = services.get(type);
+
+      if(service == null) {
+         throw new IllegalArgumentException(
+            "No property service wired for assembly type '" + type + "'. Wired types: " +
+            String.join(", ", new TreeSet<>(services.keySet())) + ".");
+      }
+
+      return service;
+   }
+
+   /** Package-visible so the convention test can assert every wired service satisfies it. */
+   static Method method(Object service, String name, int parameterCount) {
+      for(Method candidate : service.getClass().getMethods()) {
+         if(candidate.getName().equals(name) && candidate.getParameterCount() == parameterCount) {
+            return candidate;
+         }
+      }
+
+      throw new IllegalStateException(
+         service.getClass().getSimpleName() + " has no " + name + " taking " + parameterCount +
+         " arguments. The property dispatch relies on that naming convention; if the composer " +
+         "has changed it, this service needs an explicit binding.");
+   }
+
+   Map<String, Object> wiredServices() {
+      return services;
+   }
+
+   private String typeOf(RuntimeViewsheet rvs, String assemblyName) {
+      Viewsheet vs = rvs == null ? null : rvs.getViewsheet();
+      Object assembly = vs == null ? null : vs.getAssembly(assemblyName);
+
+      if(assembly == null) {
+         throw new IllegalArgumentException("Unknown assembly '" + assemblyName + "'.");
+      }
+
+      String simple = assembly.getClass().getSimpleName();
+      String type = simple.endsWith("VSAssembly")
+         ? simple.substring(0, simple.length() - "VSAssembly".length()) : simple;
+      String normalized = type.toLowerCase();
+
+      if(!PropertyAliases.covers(normalized)) {
+         throw new IllegalArgumentException(
+            "'" + assemblyName + "' is a " + type + ", whose properties are not covered yet. " +
+            "Covered types: " + String.join(", ", new TreeSet<>(PropertyAliases.coveredTypes())) +
+            ".");
+      }
+
+      return normalized;
+   }
+
+   private static String rootMessage(Exception e) {
+      Throwable cause = e instanceof InvocationTargetException invocation &&
+         invocation.getCause() != null ? invocation.getCause() : e;
+      return cause.getMessage() == null ? cause.getClass().getSimpleName() : cause.getMessage();
+   }
+
+   private static String capitalize(String value) {
+      return value.isEmpty() ? value
+         : Character.toUpperCase(value.charAt(0)) + value.substring(1);
+   }
+
+   private final ViewsheetSessionService sessions;
+   private final Map<String, Object> services;
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
@@ -20,6 +20,7 @@ package inetsoft.web.wiz.viewsheet;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.composer.vs.dialog.*;
+import inetsoft.web.viewsheet.service.VSInputService;
 import inetsoft.web.viewsheet.service.CommandDispatcher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -59,8 +60,24 @@ import java.util.*;
  */
 @Service
 public class AssemblyPropertyService {
-   /** One assembly type's dialog service and the two method names it actually uses. */
-   record Binding(Object service, String getter, String setter) {}
+   /**
+    * One assembly type's dialog service and the two method names it actually uses.
+    *
+    * <p>{@code extraGetterArgs} covers the getters that take more than
+    * {@code (runtimeId, objectId, principal)} — calc table's wants a scroll offset between
+    * {@code objectId} and {@code principal}. Declared per binding rather than guessed, since
+    * inserting an argument on a hunch is how a reflective call silently targets the wrong
+    * overload.
+    */
+   record Binding(Object service, String getter, String setter, Object... extraGetterArgs) {
+      Binding(Object service, String getter, String setter) {
+         this(service, getter, setter, new Object[0]);
+      }
+
+      int getterArity() {
+         return 3 + extraGetterArgs.length;
+      }
+   }
 
    @Autowired
    public AssemblyPropertyService(ViewsheetSessionService sessions,
@@ -70,24 +87,75 @@ public class AssemblyPropertyService {
                                   TableViewPropertyDialogService tableService,
                                   CrosstabPropertyDialogService crosstabService,
                                   SelectionListPropertyDialogService selectionListService,
-                                  SelectionTreePropertyDialogService selectionTreeService)
+                                  SelectionTreePropertyDialogService selectionTreeService,
+                                  VSInputService inputService,
+                                  RangeSliderPropertyDialogService rangeSliderService,
+                                  CalendarPropertyDialogService calendarService,
+                                  TabPropertyDialogService tabService,
+                                  CalcTablePropertyDialogService calcTableService,
+                                  GroupContainerPropertyDialogService groupContainerService,
+                                  LinePropertyDialogService lineService,
+                                  OvalPropertyDialogService ovalService,
+                                  RectanglePropertyDialogService rectangleService,
+                                  SelectionContainerPropertyDialogService containerService,
+                                  SubmitPropertyDialogService submitService)
    {
       this.sessions = sessions;
-      this.bindings = Map.of(
-         "gauge", new Binding(gaugeService, "getGaugePropertyDialogModel",
-                              "setGaugePropertyDialogModel"),
-         "text", new Binding(textService, "getTextPropertyDialogModel",
-                             "setTextPropertyDialogModel"),
-         "chart", new Binding(chartService, "getChartPropertyDialogModel",
-                              "setChartPropertyModel"),
-         "table", new Binding(tableService, "getTableViewPropertyDialogModel",
-                              "setTablePropertyModel"),
-         "crosstab", new Binding(crosstabService, "getCrosstabPropertyDialogModel",
-                                 "setCrosstabPropertyModel"),
-         "selectionlist", new Binding(selectionListService, "getSelectionListPropertyModel",
-                                      "setSelectionListPropertyModel"),
-         "selectiontree", new Binding(selectionTreeService, "getSelectionTreePropertyModel",
-                                      "setSelectionTreePropertyModel"));
+      Map<String, Binding> map = new LinkedHashMap<>();
+      map.put("gauge", new Binding(gaugeService, "getGaugePropertyDialogModel",
+                                   "setGaugePropertyDialogModel"));
+      map.put("text", new Binding(textService, "getTextPropertyDialogModel",
+                                  "setTextPropertyDialogModel"));
+      map.put("chart", new Binding(chartService, "getChartPropertyDialogModel",
+                                   "setChartPropertyModel"));
+      map.put("table", new Binding(tableService, "getTableViewPropertyDialogModel",
+                                   "setTablePropertyModel"));
+      map.put("crosstab", new Binding(crosstabService, "getCrosstabPropertyDialogModel",
+                                      "setCrosstabPropertyModel"));
+      map.put("selectionlist", new Binding(selectionListService, "getSelectionListPropertyModel",
+                                           "setSelectionListPropertyModel"));
+      map.put("selectiontree", new Binding(selectionTreeService, "getSelectionTreePropertyModel",
+                                           "setSelectionTreePropertyModel"));
+      // The six input assemblies all live on one shared service. Note checkbox:
+      // the getter capitalizes the B and the setter does not.
+      map.put("checkbox", new Binding(inputService, "getCheckBoxPropertyModel",
+                                      "setCheckboxPropertyModel"));
+      map.put("combobox", new Binding(inputService, "getComboboxPropertyDialogModel",
+                                      "setComboboxPropertyDialogModel"));
+      map.put("radiobutton", new Binding(inputService, "getRadioButtonPropertyModel",
+                                         "setRadioButtonPropertyModel"));
+      map.put("slider", new Binding(inputService, "getSliderPropertyDialogModel",
+                                    "setSliderPropertyDialogModel"));
+      map.put("spinner", new Binding(inputService, "getSpinnerPropertyDialogModel",
+                                     "setSpinnerPropertyDialogModel"));
+      map.put("textinput", new Binding(inputService, "getTextInputPropertyDialogModel",
+                                       "setTextInputPropertyDialogModel"));
+      // The assembly class is TimeSliderVSAssembly; the dialog calls it a range slider.
+      map.put("timeslider", new Binding(rangeSliderService, "getRangeSliderPropertyModel",
+                                        "setRangeSliderPropertyModel"));
+      map.put("calendar", new Binding(calendarService, "getCalendarPropertyModel",
+                                      "setCalendarPropertyModel"));
+      map.put("tab", new Binding(tabService, "getTabPropertyDialogModel",
+                                 "setTabPropertyDialogModel"));
+      // Calc table's getter wants a scroll offset that only the browser has a real value for;
+      // 0 is the top of the sheet, which is what a headless read should see.
+      map.put("calctable", new Binding(calcTableService, "getCalcTablePropertyDialogModel",
+                                      "setCalcTablePropertyModel", 0d));
+      map.put("groupcontainer",
+              new Binding(groupContainerService, "getGroupContainerPropertyDialogModel",
+                          "setGroupContainerPropertyDialogModel"));
+      map.put("line", new Binding(lineService, "getLinePropertyDialogModel",
+                                  "setLinePropertyDialogModel"));
+      map.put("oval", new Binding(ovalService, "getOvalPropertyDialogModel",
+                                  "setOvalPropertyDialogModel"));
+      map.put("rectangle", new Binding(rectangleService, "getRectanglePropertyDialogModel",
+                                       "setRectanglePropertyDialogModel"));
+      map.put("selectioncontainer",
+              new Binding(containerService, "getSelectionContainerPropertyModel",
+                          "setSelectionContainerPropertyModel"));
+      map.put("submit", new Binding(submitService, "getSubmitPropertyDialogModel",
+                                    "setSubmitPropertyDialogModel"));
+      this.bindings = Collections.unmodifiableMap(map);
    }
 
    /** The alias vocabulary for an assembly's type, with its current values. */
@@ -175,10 +243,16 @@ public class AssemblyPropertyService {
                             Principal user)
    {
       Binding binding = bindingFor(type);
-      Method getter = method(binding.service(), binding.getter(), 3);
+      Method getter = method(binding.service(), binding.getter(), binding.getterArity());
+      Object[] args = new Object[binding.getterArity()];
+      args[0] = rvs.getID();
+      args[1] = assemblyName;
+      System.arraycopy(binding.extraGetterArgs(), 0, args, 2,
+                       binding.extraGetterArgs().length);
+      args[args.length - 1] = user;
 
       try {
-         return getter.invoke(binding.service(), rvs.getID(), assemblyName, user);
+         return getter.invoke(binding.service(), args);
       }
       catch(IllegalAccessException | InvocationTargetException e) {
          throw new IllegalArgumentException(

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
@@ -82,6 +82,7 @@ public class AssemblyPropertyService {
    @Autowired
    public AssemblyPropertyService(ViewsheetSessionService sessions,
                                   GaugePropertyDialogService gaugeService,
+                                  ImagePropertyDialogService imageService,
                                   TextPropertyDialogService textService,
                                   ChartPropertyDialogService chartService,
                                   TableViewPropertyDialogService tableService,
@@ -104,6 +105,9 @@ public class AssemblyPropertyService {
       Map<String, Binding> map = new LinkedHashMap<>();
       map.put("gauge", new Binding(gaugeService, "getGaugePropertyDialogModel",
                                    "setGaugePropertyDialogModel"));
+      // Immutables model — reachable since PropertyPath learned withX rebuilding.
+      map.put("image", new Binding(imageService, "getImagePropertyDialogModel",
+                                   "setImagePropertyDialogModel"));
       map.put("text", new Binding(textService, "getTextPropertyDialogModel",
                                   "setTextPropertyDialogModel"));
       map.put("chart", new Binding(chartService, "getChartPropertyDialogModel",

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
@@ -19,8 +19,7 @@ package inetsoft.web.wiz.viewsheet;
 
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.viewsheet.Viewsheet;
-import inetsoft.web.composer.vs.dialog.GaugePropertyDialogService;
-import inetsoft.web.composer.vs.dialog.TextPropertyDialogService;
+import inetsoft.web.composer.vs.dialog.*;
 import inetsoft.web.viewsheet.service.CommandDispatcher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -37,26 +36,58 @@ import java.util.*;
  * keeps their validation and normalization, which is the whole reason the Phase 0 gate asked
  * whether they could be driven headlessly.
  *
- * <p><b>Dispatch is by naming convention</b> — every service exposes
- * {@code get<Type>PropertyDialogModel(runtimeId, objectId, principal)} and
- * {@code set<Type>PropertyDialogModel(runtimeId, objectId, model, linkUri, principal,
- * dispatcher)}. That convention is asserted by {@code AssemblyPropertyServiceTest} against
- * every registered service, so a break surfaces at build time rather than against a live
- * viewsheet. The alternative — 25 hand-written bindings — was rejected as more code guarding
- * the same convention less legibly. See docs/superpowers/plans/2026-08-13-needs-your-input.md.
+ * <p><b>Dispatch names both methods explicitly per type</b>, because the convention they
+ * appear to follow does not actually hold. The signatures are uniform — getters take
+ * {@code (runtimeId, objectId, principal)}, setters take
+ * {@code (runtimeId, objectId, model, linkUri, principal, dispatcher)} — but the names are not:
+ *
+ * <pre>
+ *   gauge          getGaugePropertyDialogModel      setGaugePropertyDialogModel
+ *   chart          getChartPropertyDialogModel      setChartPropertyModel        (no "Dialog")
+ *   table          getTableViewPropertyDialogModel  setTablePropertyModel        (View / no View)
+ *   selectionlist  getSelectionListPropertyModel    setSelectionListPropertyModel(no "Dialog")
+ * </pre>
+ *
+ * <p>Deriving the names from the assembly type worked for gauge and text and would have failed
+ * on every type added after them — silently for the getter, since a missing method would only
+ * surface on the first live call. So each binding states both names, and
+ * {@code AssemblyPropertyServiceTest} resolves every one of them reflectively, which turns a
+ * composer rename into a build failure.
  *
  * <p>A patch is validated <b>whole</b> before anything is applied, so a typo in the fourth key
  * does not leave the first three written.
  */
 @Service
 public class AssemblyPropertyService {
+   /** One assembly type's dialog service and the two method names it actually uses. */
+   record Binding(Object service, String getter, String setter) {}
+
    @Autowired
    public AssemblyPropertyService(ViewsheetSessionService sessions,
                                   GaugePropertyDialogService gaugeService,
-                                  TextPropertyDialogService textService)
+                                  TextPropertyDialogService textService,
+                                  ChartPropertyDialogService chartService,
+                                  TableViewPropertyDialogService tableService,
+                                  CrosstabPropertyDialogService crosstabService,
+                                  SelectionListPropertyDialogService selectionListService,
+                                  SelectionTreePropertyDialogService selectionTreeService)
    {
       this.sessions = sessions;
-      this.services = Map.of("gauge", gaugeService, "text", textService);
+      this.bindings = Map.of(
+         "gauge", new Binding(gaugeService, "getGaugePropertyDialogModel",
+                              "setGaugePropertyDialogModel"),
+         "text", new Binding(textService, "getTextPropertyDialogModel",
+                             "setTextPropertyDialogModel"),
+         "chart", new Binding(chartService, "getChartPropertyDialogModel",
+                              "setChartPropertyModel"),
+         "table", new Binding(tableService, "getTableViewPropertyDialogModel",
+                              "setTablePropertyModel"),
+         "crosstab", new Binding(crosstabService, "getCrosstabPropertyDialogModel",
+                                 "setCrosstabPropertyModel"),
+         "selectionlist", new Binding(selectionListService, "getSelectionListPropertyModel",
+                                      "setSelectionListPropertyModel"),
+         "selectiontree", new Binding(selectionTreeService, "getSelectionTreePropertyModel",
+                                      "setSelectionTreePropertyModel"));
    }
 
    /** The alias vocabulary for an assembly's type, with its current values. */
@@ -143,11 +174,11 @@ public class AssemblyPropertyService {
    private Object readModel(RuntimeViewsheet rvs, String type, String assemblyName,
                             Principal user)
    {
-      Object service = serviceFor(type);
-      Method getter = method(service, "get" + capitalize(type) + "PropertyDialogModel", 3);
+      Binding binding = bindingFor(type);
+      Method getter = method(binding.service(), binding.getter(), 3);
 
       try {
-         return getter.invoke(service, rvs.getID(), assemblyName, user);
+         return getter.invoke(binding.service(), rvs.getID(), assemblyName, user);
       }
       catch(IllegalAccessException | InvocationTargetException e) {
          throw new IllegalArgumentException(
@@ -159,11 +190,12 @@ public class AssemblyPropertyService {
    private void writeModel(String runtimeId, String type, String assemblyName, Object model,
                            String linkUri, Principal user, CommandDispatcher dispatcher)
    {
-      Object service = serviceFor(type);
-      Method setter = method(service, "set" + capitalize(type) + "PropertyDialogModel", 6);
+      Binding binding = bindingFor(type);
+      Method setter = method(binding.service(), binding.setter(), 6);
 
       try {
-         setter.invoke(service, runtimeId, assemblyName, model, linkUri, user, dispatcher);
+         setter.invoke(binding.service(), runtimeId, assemblyName, model, linkUri, user,
+                       dispatcher);
       }
       catch(IllegalAccessException | InvocationTargetException e) {
          throw new IllegalArgumentException(
@@ -172,16 +204,16 @@ public class AssemblyPropertyService {
       }
    }
 
-   Object serviceFor(String type) {
-      Object service = services.get(type);
+   Binding bindingFor(String type) {
+      Binding binding = bindings.get(type);
 
-      if(service == null) {
+      if(binding == null) {
          throw new IllegalArgumentException(
             "No property service wired for assembly type '" + type + "'. Wired types: " +
-            String.join(", ", new TreeSet<>(services.keySet())) + ".");
+            String.join(", ", new TreeSet<>(bindings.keySet())) + ".");
       }
 
-      return service;
+      return binding;
    }
 
    /** Package-visible so the convention test can assert every wired service satisfies it. */
@@ -194,12 +226,12 @@ public class AssemblyPropertyService {
 
       throw new IllegalStateException(
          service.getClass().getSimpleName() + " has no " + name + " taking " + parameterCount +
-         " arguments. The property dispatch relies on that naming convention; if the composer " +
-         "has changed it, this service needs an explicit binding.");
+         " arguments. The binding for this type names that method explicitly; if the composer " +
+         "has renamed it, update the binding.");
    }
 
-   Map<String, Object> wiredServices() {
-      return services;
+   Map<String, Binding> wiredBindings() {
+      return bindings;
    }
 
    private String typeOf(RuntimeViewsheet rvs, String assemblyName) {
@@ -231,11 +263,7 @@ public class AssemblyPropertyService {
       return cause.getMessage() == null ? cause.getClass().getSimpleName() : cause.getMessage();
    }
 
-   private static String capitalize(String value) {
-      return value.isEmpty() ? value
-         : Character.toUpperCase(value.charAt(0)) + value.substring(1);
-   }
 
    private final ViewsheetSessionService sessions;
-   private final Map<String, Object> services;
+   private final Map<String, Binding> bindings;
 }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartElementService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartElementService.java
@@ -1,0 +1,270 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.VSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.web.viewsheet.controller.chart.*;
+import inetsoft.web.viewsheet.event.chart.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+import java.util.*;
+
+/**
+ * A chart's sub-elements: axis, legend and title visibility, and plot sizing.
+ *
+ * <p>These are authoring operations rather than runtime exploration — they clone
+ * {@code ChartVSAssemblyInfo} and mutate its descriptors, the same shape as every other
+ * property write — so they belong with the viewsheet plugin rather than being excluded as
+ * interactive analysis.
+ *
+ * <p><b>The underlying events have a footgun this class hides.</b> {@code isHide()} does not
+ * mean "hide it": on the titles event, {@code hide=true} with {@code titleType="chart-title"}
+ * hides the chart title, {@code hide=true} with {@code titleType="chart-title-true"}
+ * <i>shows</i> it, and {@code hide=false} shows <i>all</i> titles regardless of which one you
+ * named. An agent asked to "show the y axis title" that set {@code hide=false} would silently
+ * un-hide every title the user had deliberately hidden.
+ *
+ * <p>So the agent-facing surface is {@code (element, target, visible)} and this class maps it
+ * onto whatever combination the event actually needs.
+ *
+ * <p><b>The events are built with Jackson, not setters.</b> They expose getters over private
+ * fields and declare no setters at all — Jackson reaches the field once the getter reveals the
+ * property, which is exactly how the STOMP layer populates them in production. Building them
+ * any other way would either need reflection or a parallel constructor this package does not
+ * own. {@code ChartElementServiceTest} asserts the conversion actually lands its values,
+ * because an all-default titles event means "show every title", which is the destructive case.
+ */
+@Service
+public class ChartElementService {
+   /** Titles addressable by name, mapped to the descriptor token the event expects. */
+   private static final Map<String, String> AXIS_TITLES = Map.of(
+      "x", "x_title",
+      "x2", "x2_title",
+      "y", "y_title",
+      "y2", "y2_title");
+
+   @Autowired
+   public ChartElementService(ViewsheetSessionService sessions,
+                              ObjectMapper objectMapper,
+                              VSChartAxesVisibilityService axesService,
+                              VSChartLegendsVisibilityService legendsService,
+                              VSChartTitlesVisibilityService titlesService,
+                              VSChartPlotResizeService plotResizeService)
+   {
+      this.sessions = sessions;
+      this.objectMapper = objectMapper;
+      this.axesService = axesService;
+      this.legendsService = legendsService;
+      this.titlesService = titlesService;
+      this.plotResizeService = plotResizeService;
+   }
+
+   /**
+    * Shows or hides one of a chart's sub-elements.
+    *
+    * @param element {@code axis}, {@code legend} or {@code title}
+    * @param target  which one — an axis column name, a legend field, or an axis title
+    *                ({@code x}, {@code x2}, {@code y}, {@code y2}) or {@code chart} for the
+    *                chart title. Null means all of that element.
+    */
+   public void setVisibility(String sessionToken, Principal user, String assemblyName,
+                             String element, String target, boolean visible, String linkUri)
+      throws Exception
+   {
+      String kind = requireElement(element);
+
+      // Resolved before the runtime is touched: "show the y title" and "show every title" are
+      // different requests, and the event cannot express the first one, so a caller naming a
+      // target it cannot honour has to be told rather than quietly given the second.
+      if(visible && target != null && !"title".equals(kind)) {
+         throw new IllegalArgumentException(
+            "Showing a single " + kind + " is not supported by the Composer — showing restores " +
+            "all of them at once. Call this without 'target' to show every " + kind + ", or " +
+            "hide the ones you do not want.");
+      }
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         requireChart(rvs, assemblyName);
+
+         switch(kind) {
+            case "axis" -> axesService.eventHandler(
+               runtimeId,
+               event(Map.of("chartName", assemblyName, "hide", !visible), "columnName", target,
+                     VSChartAxesVisibilityEvent.class),
+               linkUri, user, dispatcher);
+            case "legend" -> legendsService.eventHandler(
+               runtimeId,
+               event(Map.of("chartName", assemblyName, "hide", !visible), "field", target,
+                     VSChartLegendsVisibilityEvent.class),
+               linkUri, user, dispatcher);
+            default -> titlesService.eventHandler(
+               runtimeId,
+               convert(titleFields(assemblyName, target, visible),
+                       VSChartTitlesVisibilityEvent.class),
+               linkUri, user, dispatcher);
+         }
+      });
+   }
+
+   /**
+    * Resizes the plot area, or resets it.
+    *
+    * @param ratio    the plot's share of the assembly, 0 exclusive to 1 inclusive
+    * @param vertical true to resize the height, false the width
+    */
+   public void resizePlot(String sessionToken, Principal user, String assemblyName, Double ratio,
+                          boolean vertical, boolean reset, String linkUri) throws Exception
+   {
+      if(!reset && (ratio == null || ratio <= 0 || ratio > 1)) {
+         throw new IllegalArgumentException(
+            "resize_plot needs a 'ratio' greater than 0 and at most 1 — the plot's share of " +
+            "the assembly. Got " + ratio + ". Pass reset:true to restore the default instead.");
+      }
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         requireChart(rvs, assemblyName);
+
+         Map<String, Object> fields = new LinkedHashMap<>();
+         fields.put("chartName", assemblyName);
+         fields.put("reset", reset);
+         fields.put("heightResized", vertical);
+         fields.put("sizeRatio", reset || ratio == null ? 0d : ratio);
+         plotResizeService.eventHandler(runtimeId, convert(fields, VSChartPlotResizeEvent.class),
+                                        linkUri, user, dispatcher);
+      });
+   }
+
+   public Map<String, Object> vocabulary() {
+      return Map.of(
+         "elements", List.of("axis", "legend", "title"),
+         "titleTargets", List.of("x", "x2", "y", "y2", "chart"),
+         "note", "An axis target is a column name and a legend target is a field name; call " +
+            "get_binding for those. Showing a single axis or legend is not supported — " +
+            "showing restores all of them.");
+   }
+
+   // ── the titles footgun, contained ─────────────────────────────────────────
+
+   /**
+    * Translates {@code (target, visible)} into the event's own idiom.
+    *
+    * <p>{@code hide=false} means "show every title", so it is only ever used when the caller
+    * asked for exactly that. Showing one title goes through the event's
+    * {@code chart-title-true} special case, and showing a single <i>axis</i> title has no
+    * expression at all — which the caller is told rather than silently given all of them.
+    */
+   static Map<String, Object> titleFields(String assemblyName, String target, boolean visible) {
+      Map<String, Object> fields = new LinkedHashMap<>();
+      fields.put("chartName", assemblyName);
+
+      if(target == null) {
+         fields.put("hide", !visible);
+
+         if(!visible) {
+            fields.put("titleType", "chart-title");
+         }
+
+         return fields;
+      }
+
+      String name = target.trim().toLowerCase();
+
+      if("chart".equals(name)) {
+         // The event expresses "show the chart title" as hide=true plus this token, which is
+         // why the agent-facing surface never exposes `hide`.
+         fields.put("hide", true);
+         fields.put("titleType", visible ? "chart-title-true" : "chart-title");
+         return fields;
+      }
+
+      String axisTitle = AXIS_TITLES.get(name);
+
+      if(axisTitle == null) {
+         throw new IllegalArgumentException(
+            "Unknown title target '" + target + "'. Valid targets: " +
+            new TreeSet<>(AXIS_TITLES.keySet()) + ", or 'chart' for the chart title.");
+      }
+
+      if(visible) {
+         throw new IllegalArgumentException(
+            "Showing a single axis title is not supported by the Composer — showing restores " +
+            "all titles at once. Call this without 'target' to show every title, or hide the " +
+            "ones you do not want.");
+      }
+
+      fields.put("hide", true);
+      fields.put("titleType", axisTitle);
+      return fields;
+   }
+
+   private <T> T event(Map<String, Object> base, String targetField, String target,
+                       Class<T> type)
+   {
+      Map<String, Object> fields = new LinkedHashMap<>(base);
+
+      if(target != null) {
+         fields.put(targetField, target);
+      }
+
+      return convert(fields, type);
+   }
+
+   private <T> T convert(Map<String, Object> fields, Class<T> type) {
+      return objectMapper.convertValue(fields, type);
+   }
+
+   private static String requireElement(String element) {
+      String kind = element == null ? "" : element.trim().toLowerCase();
+
+      if(!List.of("axis", "legend", "title").contains(kind)) {
+         throw new IllegalArgumentException(
+            "'element' must be axis, legend or title, got '" + element + "'.");
+      }
+
+      return kind;
+   }
+
+   private static void requireChart(inetsoft.report.composition.RuntimeViewsheet rvs,
+                                    String assemblyName)
+   {
+      Viewsheet vs = rvs == null ? null : rvs.getViewsheet();
+      VSAssembly assembly = vs == null ? null : vs.getAssembly(assemblyName);
+
+      if(assembly == null) {
+         throw new IllegalArgumentException("Unknown assembly '" + assemblyName + "'.");
+      }
+
+      if(!(assembly instanceof ChartVSAssembly)) {
+         throw new IllegalArgumentException(
+            "'" + assemblyName + "' is a " + assembly.getClass().getSimpleName() +
+            ", not a chart. Axes, legends and titles only exist on charts.");
+      }
+   }
+
+   private final ViewsheetSessionService sessions;
+   private final ObjectMapper objectMapper;
+   private final VSChartAxesVisibilityService axesService;
+   private final VSChartLegendsVisibilityService legendsService;
+   private final VSChartTitlesVisibilityService titlesService;
+   private final VSChartPlotResizeService plotResizeService;
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartElementService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartElementService.java
@@ -129,16 +129,28 @@ public class ChartElementService {
    /**
     * Resizes the plot area, or resets it.
     *
-    * @param ratio    the plot's share of the assembly, 0 exclusive to 1 inclusive
+    * <p>The ratio <em>scales the plot's minimum size</em> — {@code VGraphPair} applies it as
+    * {@code minPlotHeight *= heightRatio} — so above 1 enlarges the plot and makes the assembly
+    * scroll, 1 is the default, and below 1 lowers a minimum the plot already exceeds and so
+    * usually changes nothing visible.
+    *
+    * <p>This was originally documented and validated as "the plot's share of the assembly, 0 to
+    * 1", which is not what the underlying event does. Because the validation enforced that range,
+    * the only values the tool accepted were the ones that do nothing — the tool returned success
+    * and never changed a pixel.
+    *
+    * @param ratio    scale for the plot's minimum size; above 1 enlarges it
     * @param vertical true to resize the height, false the width
     */
    public void resizePlot(String sessionToken, Principal user, String assemblyName, Double ratio,
                           boolean vertical, boolean reset, String linkUri) throws Exception
    {
-      if(!reset && (ratio == null || ratio <= 0 || ratio > 1)) {
+      if(!reset && (ratio == null || ratio <= 0 || ratio > MAX_PLOT_RATIO)) {
          throw new IllegalArgumentException(
-            "resize_plot needs a 'ratio' greater than 0 and at most 1 — the plot's share of " +
-            "the assembly. Got " + ratio + ". Pass reset:true to restore the default instead.");
+            "resize_plot needs a 'ratio' greater than 0 and at most " + (int) MAX_PLOT_RATIO +
+            " — it scales the plot's minimum size, so a value above 1 enlarges the plot and makes " +
+            "it scroll, while 1 or less usually changes nothing visible. Got " + ratio +
+            ". Pass reset:true to restore the default instead.");
       }
 
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
@@ -158,9 +170,14 @@ public class ChartElementService {
       return Map.of(
          "elements", List.of("axis", "legend", "title"),
          "titleTargets", List.of("x", "x2", "y", "y2", "chart"),
-         "note", "An axis target is a column name and a legend target is a field name; call " +
-            "get_binding for those. Showing a single axis or legend is not supported — " +
-            "showing restores all of them.");
+         // Spelled out because the same word means two things across two tools: here a target
+         // names the column whose axis is hidden, while set_chart_region_properties takes the
+         // axis TYPE (y, y2, x, x2). Following this note over there addressed no axis at all.
+         "note", "For hiding and showing, an axis target is a column name and a legend target is " +
+            "a field name; call get_binding for those. Showing a single axis or legend is not " +
+            "supported — showing restores all of them. Note that " +
+            "set_chart_region_properties addresses an axis by TYPE (y, y2, x, x2) instead, not " +
+            "by column — it takes the column separately, as 'field'.");
    }
 
    // ── the titles footgun, contained ─────────────────────────────────────────
@@ -266,5 +283,12 @@ public class ChartElementService {
    private final VSChartAxesVisibilityService axesService;
    private final VSChartLegendsVisibilityService legendsService;
    private final VSChartTitlesVisibilityService titlesService;
+   /**
+    * Upper bound on the plot scale. The underlying ratio multiplies the plot's minimum size with
+    * no ceiling of its own, so an absurd value would ask for an enormous graph — worth refusing
+    * outright in a tool a model drives, where a stray 500 is a plausible typo for 5.
+    */
+   private static final double MAX_PLOT_RATIO = 10d;
+
    private final VSChartPlotResizeService plotResizeService;
 }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyService.java
@@ -1,0 +1,261 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.web.composer.vs.dialog.RegionPropertyDialogService;
+import inetsoft.web.graph.model.dialog.AxisPropertyDialogModel;
+import inetsoft.web.graph.model.dialog.LegendFormatDialogModel;
+import inetsoft.web.graph.model.dialog.TitleFormatDialogModel;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+import java.util.*;
+
+/**
+ * Properties of a chart's <b>sub-elements</b>: its axes, legends and titles.
+ *
+ * <p>These are the three dialogs {@code AssemblyPropertyService} could not reach. Every property
+ * it handles is addressed by assembly alone; these are addressed by assembly <em>and a region
+ * within it</em> — an axis by its type, a legend by its index, a title by which title it is. That
+ * extra key is the whole reason they were deferred.
+ *
+ * <p>Everything else is deliberately the same as the assembly property engine: names resolve
+ * through an alias table onto {@link PropertyPath} paths, values coerce the same way, and the
+ * patch is validated whole before any of it is applied — so one bad key does not leave the others
+ * written.
+ */
+@Service
+public class ChartRegionPropertyService {
+   @Autowired
+   public ChartRegionPropertyService(ViewsheetSessionService sessions,
+                                     RegionPropertyDialogService regions)
+   {
+      this.sessions = sessions;
+      this.regions = regions;
+   }
+
+   /** The regions and what each one's {@code target} means. */
+   public Map<String, Object> vocabulary() {
+      return Map.of(
+         "regions", List.of("axis", "legend", "title"),
+         "target", Map.of(
+            "axis", "the axis type — y, y2, x, x2 — as reported by list_chart_elements",
+            "legend", "the legend's 0-based index",
+            "title", "which title — x, x2, y, y2 or chart"),
+         "note", "An axis may also need 'field' when a chart has more than one axis of a type.");
+   }
+
+   /** Property names for a region, with their current values. */
+   public Map<String, Object> list(String sessionToken, Principal user, String assembly,
+                                   String region, String target, String field)
+      throws Exception
+   {
+      String name = requireRegion(region);
+      String key = requireTarget(target, name);
+      Object model = readModel(sessionToken, user, assembly, name, key, field);
+      Map<String, String> aliases = aliasesFor(name);
+      List<Map<String, Object>> properties = new ArrayList<>();
+
+      for(Map.Entry<String, String> alias : aliases.entrySet()) {
+         Map<String, Object> one = new LinkedHashMap<>();
+         one.put("name", alias.getKey());
+         one.put("path", alias.getValue());
+         one.put("value", PropertyPath.get(model, alias.getValue()));
+         properties.add(one);
+      }
+
+      Map<String, Object> out = new LinkedHashMap<>();
+      out.put("assembly", assembly);
+      out.put("region", name);
+      out.put("target", key);
+      out.put("properties", properties);
+      return out;
+   }
+
+   /**
+    * Applies a patch to one region.
+    *
+    * <p>Validated whole before anything is written, so a typo in one key does not leave the rest
+    * applied — the same rule the assembly properties follow, and for the same reason: a partly
+    * applied patch is worse than a rejected one because nothing reports it.
+    */
+   public void set(String sessionToken, Principal user, String assembly, String region,
+                   String target, String field, Map<String, Object> properties, String linkUri)
+      throws Exception
+   {
+      String name = requireRegion(region);
+      String key = requireTarget(target, name);
+
+      if(properties == null || properties.isEmpty()) {
+         throw new IllegalArgumentException(
+            "set_chart_region_properties needs at least one property. " +
+            "list_chart_region_properties reports the names this region accepts.");
+      }
+
+      Object model = readModel(sessionToken, user, assembly, name, key, field);
+      Map<String, String> aliases = aliasesFor(name);
+      Map<String, Object> resolved = new LinkedHashMap<>();
+
+      for(Map.Entry<String, Object> property : properties.entrySet()) {
+         String path = property.getKey() != null && property.getKey().contains(".")
+            ? property.getKey()
+            : aliases.get(property.getKey());
+
+         if(path == null) {
+            throw new IllegalArgumentException(
+               "'" + property.getKey() + "' is not a property of a chart " + name + ". Known " +
+               "names: " + String.join(", ", new TreeSet<>(aliases.keySet())) +
+               ". A raw model path (containing a '.') is also accepted.");
+         }
+
+         resolved.put(path, property.getValue());
+      }
+
+      // Write onto the model only after every key resolved.
+      for(Map.Entry<String, Object> one : resolved.entrySet()) {
+         PropertyPath.set(model, one.getKey(), one.getValue());
+      }
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         switch(name) {
+         case "axis" -> regions.setAxisPropertyDialogModel(
+            runtimeId, assembly, key, 0, field, (AxisPropertyDialogModel) model, linkUri, user,
+            dispatcher);
+         case "legend" -> regions.setLegendFormatDialogModel(
+            runtimeId, assembly, indexOf(key), (LegendFormatDialogModel) model, linkUri, user,
+            dispatcher);
+         default -> regions.setTitleFormatDialogModel(
+            runtimeId, assembly, key, (TitleFormatDialogModel) model, linkUri, user, dispatcher);
+         }
+      });
+   }
+
+   private Object readModel(String sessionToken, Principal user, String assembly, String region,
+                            String target, String field)
+      throws Exception
+   {
+      String runtimeId = sessions.runtimeId(sessionToken, user);
+
+      return switch(region) {
+         case "axis" -> regions.getAxisPropertyDialogModel(runtimeId, assembly, target, "0", field,
+                                                           "", user);
+         case "legend" -> regions.getLegendFormatDialogModel(runtimeId, assembly, target, "", user);
+         default -> regions.getTitleFormatDialogModel(runtimeId, assembly, target, "", user);
+      };
+   }
+
+   private static int indexOf(String target) {
+      try {
+         return Integer.parseInt(target.trim());
+      }
+      catch(NumberFormatException e) {
+         throw new IllegalArgumentException(
+            "A legend is addressed by its 0-based index, got '" + target + "'.");
+      }
+   }
+
+   private static String requireRegion(String region) {
+      String name = region == null ? "" : region.trim().toLowerCase();
+
+      if(!REGIONS.contains(name)) {
+         throw new IllegalArgumentException(
+            "Unknown chart region '" + region + "'. Valid regions: " +
+            String.join(", ", REGIONS) + ".");
+      }
+
+      return name;
+   }
+
+   private static String requireTarget(String target, String region) {
+      if(target == null || target.isBlank()) {
+         throw new IllegalArgumentException(
+            "A chart " + region + " needs a 'target' — " +
+            switch(region) {
+               case "axis" -> "the axis type, such as y or x.";
+               case "legend" -> "the legend's 0-based index.";
+               default -> "which title: x, x2, y, y2 or chart.";
+            });
+      }
+
+      String trimmed = target.trim();
+
+      // Validated here rather than only at write time: the composer service parses the index
+      // itself while READING the model, so a non-numeric target surfaced as a raw
+      // `For input string: "..."` from inside StyleBI before the write-side guard was reached.
+      if("legend".equals(region)) {
+         indexOf(trimmed);
+      }
+
+      return trimmed;
+   }
+
+   private static Map<String, String> aliasesFor(String region) {
+      return switch(region) {
+         case "axis" -> AXIS;
+         case "legend" -> LEGEND;
+         default -> TITLE;
+      };
+   }
+
+   private static final List<String> REGIONS = List.of("axis", "legend", "title");
+
+   private static final Map<String, String> AXIS = axis();
+   private static final Map<String, String> LEGEND = legend();
+   private static final Map<String, String> TITLE = title();
+
+   private static Map<String, String> axis() {
+      Map<String, String> aliases = new LinkedHashMap<>();
+      aliases.put("showAxisLine", "axisLinePaneModel.showAxisLine");
+      aliases.put("lineColor", "axisLinePaneModel.lineColor");
+      aliases.put("showTicks", "axisLinePaneModel.showTicks");
+      aliases.put("logarithmicScale", "axisLinePaneModel.logarithmicScale");
+      aliases.put("reverse", "axisLinePaneModel.reverse");
+      aliases.put("shared", "axisLinePaneModel.shared");
+      aliases.put("ignoreNull", "axisLinePaneModel.ignoreNull");
+      aliases.put("truncate", "axisLinePaneModel.truncate");
+      aliases.put("minimum", "axisLinePaneModel.minimum");
+      aliases.put("maximum", "axisLinePaneModel.maximum");
+      aliases.put("increment", "axisLinePaneModel.increment");
+      aliases.put("minorIncrement", "axisLinePaneModel.minorIncrement");
+      aliases.put("showAxisLabel", "axisLabelPaneModel.showAxisLabel");
+      aliases.put("labelOnSecondaryAxis", "axisLabelPaneModel.labelOnSecondaryAxis");
+      return aliases;
+   }
+
+   private static Map<String, String> legend() {
+      Map<String, String> aliases = new LinkedHashMap<>();
+      aliases.put("title", "legendFormatGeneralPaneModel.title");
+      aliases.put("visible", "legendFormatGeneralPaneModel.visible");
+      aliases.put("position", "legendFormatGeneralPaneModel.position");
+      aliases.put("fillColor", "legendFormatGeneralPaneModel.fillColor");
+      aliases.put("style", "legendFormatGeneralPaneModel.style");
+      aliases.put("notShowNull", "legendFormatGeneralPaneModel.notShowNull");
+      aliases.put("symbolSize", "legendFormatGeneralPaneModel.symbolSize");
+      return aliases;
+   }
+
+   private static Map<String, String> title() {
+      Map<String, String> aliases = new LinkedHashMap<>();
+      aliases.put("title", "titleFormatPaneModel.title");
+      return aliases;
+   }
+
+   private final ViewsheetSessionService sessions;
+   private final RegionPropertyDialogService regions;
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyService.java
@@ -202,6 +202,24 @@ public class ChartRegionPropertyService {
          indexOf(trimmed);
       }
 
+      // Same reasoning, worse symptom. ChartRegionHandler.getAxisArea returns null for a type it
+      // does not recognise, and neither side reports it: the read returned the same full, plausible
+      // property list for "PAID" or "zzzznonsense" as for "y", and the write threw
+      // NullPointerException: axisArea is null. So an unrecognised axis silently read as a real one
+      // and then failed with a message naming nothing the caller passed.
+      if("axis".equals(region)) {
+         String normalized = trimmed.toLowerCase();
+
+         if(!AXIS_TARGETS.contains(normalized)) {
+            throw new IllegalArgumentException(
+               "'" + target + "' does not name an axis. Valid targets: " +
+               String.join(", ", AXIS_TARGETS) + ". To address one of several axes of the same " +
+               "type, keep the axis type here and pass the column name as 'field'.");
+         }
+
+         return normalized;
+      }
+
       return trimmed;
    }
 
@@ -214,6 +232,15 @@ public class ChartRegionPropertyService {
    }
 
    private static final List<String> REGIONS = List.of("axis", "legend", "title");
+
+   /**
+    * The axis types {@code ChartRegionHandler.getAxisArea} recognises — the short title forms and
+    * the long area forms, both accepted there and so both accepted here. Any other value yields a
+    * null axis area, which is the whole reason this list is enforced.
+    */
+   private static final List<String> AXIS_TARGETS =
+      List.of("x", "x2", "y", "y2",
+              "bottom_x_axis", "top_x_axis", "left_y_axis", "right_y_axis");
 
    private static final Map<String, String> AXIS = axis();
    private static final Map<String, String> LEGEND = legend();

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ConditionVocabulary.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ConditionVocabulary.java
@@ -1,0 +1,349 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.uql.JunctionOperator;
+import inetsoft.uql.XCondition;
+import inetsoft.web.binding.drm.DataRefModel;
+import inetsoft.web.composer.model.condition.*;
+
+import java.util.*;
+
+/**
+ * The agent-facing condition vocabulary, and the builder for StyleBI's alternating condition
+ * list.
+ *
+ * <p>{@code VSConditionDialogModel.conditionList} is an {@code Object[]} that alternates
+ * condition items and junction operators:
+ *
+ * <pre>[condition, junction, condition, junction, condition]</pre>
+ *
+ * <p>Get the alternation wrong — two conditions adjacent, a trailing junction, a junction first
+ * — and the result is an orphaned junction that either crashes downstream as a cast exception or,
+ * worse, silently evaluates differently than intended. This is the most defect-prone shape on the
+ * whole Composer surface, and its history proves it: orphaned-junction cast crashes,
+ * flat-versus-nested shape drops, and multi-value filters normalizing to the wrong operator have
+ * all been fixed here before.
+ *
+ * <p><b>So the agent never writes {@code conditionList}.</b> It writes a flat, homogeneous list
+ * where each condition carries its junction to the <i>next</i> one, and this class builds the
+ * array. There is deliberately no raw escape hatch: unlike a deep property path, there is no case
+ * where a caller legitimately needs to hand-build the alternating form.
+ *
+ * <p>Highlights embed a full condition model, so this same vocabulary serves both — one
+ * implementation, two callers.
+ */
+public final class ConditionVocabulary {
+   /** Operator tokens, with the aliases an agent naturally reaches for. */
+   private static final Map<String, Integer> OPERATORS = operators();
+
+   /** Operators that take no values at all. */
+   private static final Set<String> VALUELESS = Set.of("null");
+
+   /** Operators that take exactly two. */
+   private static final Set<String> PAIRED = Set.of("between");
+
+   private ConditionVocabulary() {
+   }
+
+   /** One condition in the flat vocabulary. {@code junction} points at the *next* condition. */
+   public record Clause(String field, String operator, List<Object> values, String junction,
+                        boolean negated) {}
+
+   /**
+    * Builds the alternating array.
+    *
+    * @param clauses   the flat list, each carrying its junction to the next
+    * @param available the model's own {@code fields[]}; a condition on a column absent from it
+    *                  is the recorded cast-crash trigger, so it is refused here
+    */
+   public static Object[] toConditionList(List<Clause> clauses, DataRefModel[] available) {
+      if(clauses == null || clauses.isEmpty()) {
+         return new Object[0];
+      }
+
+      Map<String, DataRefModel> fields = index(available);
+      List<Object> out = new ArrayList<>();
+
+      for(int i = 0; i < clauses.size(); i++) {
+         Clause clause = clauses.get(i);
+         boolean last = i == clauses.size() - 1;
+
+         // Arity is checked before anything is built, so a malformed list never becomes a
+         // half-built array that a later cast turns into a crash.
+         requireJunctionArity(clause, i, last);
+         out.add(condition(clause, i, fields));
+
+         if(!last) {
+            out.add(junction(clause.junction(), i));
+         }
+      }
+
+      return out.toArray();
+   }
+
+   /** Renders an alternating array back into the flat vocabulary. */
+   public static List<Map<String, Object>> describe(Object[] conditionList) {
+      List<Map<String, Object>> out = new ArrayList<>();
+
+      if(conditionList == null) {
+         return out;
+      }
+
+      for(int i = 0; i < conditionList.length; i++) {
+         Object item = conditionList[i];
+
+         if(item instanceof ConditionModel condition) {
+            Map<String, Object> clause = new LinkedHashMap<>();
+            clause.put("field", condition.getField() == null
+               ? null : condition.getField().getName());
+            clause.put("operator", operatorToken(condition.getOperation()));
+            clause.put("values", values(condition.getValues()));
+            clause.put("negated", condition.isNegated());
+            clause.put("junction", junctionAfter(conditionList, i));
+            out.add(clause);
+         }
+      }
+
+      return out;
+   }
+
+   public static Map<String, Object> vocabulary() {
+      return Map.of(
+         "operators", new TreeSet<>(OPERATORS.keySet()),
+         "junctions", List.of("and", "or"),
+         "note", "Each condition carries the junction to the NEXT one, so the last condition " +
+            "must not have a junction and every earlier one must. The alternating array " +
+            "StyleBI stores is built for you and cannot be written directly.");
+   }
+
+   // ── the arity invariant ───────────────────────────────────────────────────
+
+   /**
+    * The invariant the raw shape cannot express: exactly one fewer junction than conditions.
+    * Both failure directions are named by index, because "junction arity mismatch" alone leaves
+    * the caller counting.
+    */
+   private static void requireJunctionArity(Clause clause, int index, boolean last) {
+      boolean has = clause.junction() != null && !clause.junction().isBlank();
+
+      if(last && has) {
+         throw new IllegalArgumentException(
+            "Condition " + index + " is the last one and must not carry a 'junction' — a " +
+            "junction joins a condition to the NEXT one, and a trailing junction becomes an " +
+            "orphan that fails downstream.");
+      }
+
+      if(!last && !has) {
+         throw new IllegalArgumentException(
+            "Condition " + index + " needs a 'junction' of and/or to join it to condition " +
+            (index + 1) + ". Every condition but the last carries one.");
+      }
+   }
+
+   // ── builders ──────────────────────────────────────────────────────────────
+
+   private static ConditionModel condition(Clause clause, int index,
+                                           Map<String, DataRefModel> fields)
+   {
+      String name = clause.field() == null ? "" : clause.field().trim();
+
+      if(name.isEmpty()) {
+         throw new IllegalArgumentException("Condition " + index + " needs a 'field'.");
+      }
+
+      DataRefModel field = fields.get(name.toLowerCase());
+
+      if(field == null) {
+         throw new IllegalArgumentException(
+            "Condition " + index + " names '" + clause.field() + "', which this assembly " +
+            "cannot filter on. Available fields: " +
+            (fields.isEmpty() ? "(none)" : String.join(", ", new TreeSet<>(names(fields)))) +
+            ". A condition on an unknown column is the recorded cause of a downstream cast " +
+            "failure, so it is refused here.");
+      }
+
+      String operator = requireOperator(clause.operator(), index);
+      List<Object> values = clause.values() == null ? List.of() : clause.values();
+      requireValueArity(operator, values, index);
+
+      ConditionModel condition = new ConditionModel();
+      condition.setField(field);
+      condition.setOperation(OPERATORS.get(operator));
+      condition.setNegated(clause.negated());
+      condition.setLevel(0);
+      condition.setValues(values.stream().map(ConditionVocabulary::value)
+                             .toArray(ConditionValueModel[]::new));
+      return condition;
+   }
+
+   private static ConditionValueModel value(Object raw) {
+      ConditionValueModel value = new ConditionValueModel();
+      value.setValue(raw);
+      value.setType("value");
+      return value;
+   }
+
+   private static JunctionOperatorModel junction(String token, int index) {
+      String name = token.trim().toLowerCase();
+      int type = switch(name) {
+         case "and", "&&" -> JunctionOperator.AND;
+         case "or", "||" -> JunctionOperator.OR;
+         default -> throw new IllegalArgumentException(
+            "Condition " + index + " has junction '" + token + "'; valid junctions are and, or.");
+      };
+
+      JunctionOperatorModel junction = new JunctionOperatorModel();
+      junction.setType(type);
+      junction.setLevel(0);
+      return junction;
+   }
+
+   private static String requireOperator(String operator, int index) {
+      String name = operator == null ? "" : operator.trim().toLowerCase();
+
+      if(!OPERATORS.containsKey(name)) {
+         throw new IllegalArgumentException(
+            "Condition " + index + " has operator '" + operator + "'. Valid operators: " +
+            new TreeSet<>(OPERATORS.keySet()) + ".");
+      }
+
+      return name;
+   }
+
+   /**
+    * A value-arity mismatch is the other silent case: {@code between} with one value, or
+    * {@code one_of} with none, is accepted by the model and then evaluates as something the
+    * caller did not ask for.
+    */
+   private static void requireValueArity(String operator, List<Object> values, int index) {
+      if(VALUELESS.contains(operator)) {
+         if(!values.isEmpty()) {
+            throw new IllegalArgumentException(
+               "Condition " + index + " uses '" + operator + "', which takes no values.");
+         }
+
+         return;
+      }
+
+      if(values.isEmpty()) {
+         throw new IllegalArgumentException(
+            "Condition " + index + " uses '" + operator + "' and needs at least one value.");
+      }
+
+      if(PAIRED.contains(operator) && values.size() != 2) {
+         throw new IllegalArgumentException(
+            "Condition " + index + " uses 'between', which needs exactly two values, got " +
+            values.size() + ".");
+      }
+   }
+
+   // ── read direction ────────────────────────────────────────────────────────
+
+   private static String junctionAfter(Object[] conditionList, int index) {
+      if(index + 1 < conditionList.length &&
+         conditionList[index + 1] instanceof JunctionOperatorModel junction)
+      {
+         return junction.getType() == JunctionOperator.OR ? "or" : "and";
+      }
+
+      return null;
+   }
+
+   private static List<Object> values(ConditionValueModel[] values) {
+      List<Object> out = new ArrayList<>();
+
+      if(values != null) {
+         for(ConditionValueModel value : values) {
+            out.add(value == null ? null : value.getValue());
+         }
+      }
+
+      return out;
+   }
+
+   /** An unmapped operation reads back as itself rather than as a guessed token. */
+   private static String operatorToken(int operation) {
+      for(Map.Entry<String, Integer> entry : OPERATORS.entrySet()) {
+         if(entry.getValue() == operation && !isAlias(entry.getKey())) {
+            return entry.getKey();
+         }
+      }
+
+      return "unknown(" + operation + ")";
+   }
+
+   private static boolean isAlias(String token) {
+      return !CANONICAL.contains(token);
+   }
+
+   // ── tables ────────────────────────────────────────────────────────────────
+
+   /** The canonical spelling per operation, used when reading back. */
+   private static final Set<String> CANONICAL = Set.of(
+      "equals", "one_of", "less_than", "greater_than", "between", "starts_with", "contains",
+      "null", "top_n", "date_in", "like");
+
+   private static Map<String, Integer> operators() {
+      Map<String, Integer> map = new LinkedHashMap<>();
+      map.put("equals", XCondition.EQUAL_TO);
+      map.put("=", XCondition.EQUAL_TO);
+      map.put("==", XCondition.EQUAL_TO);
+      map.put("one_of", XCondition.ONE_OF);
+      map.put("oneof", XCondition.ONE_OF);
+      map.put("in", XCondition.ONE_OF);
+      map.put("less_than", XCondition.LESS_THAN);
+      map.put("<", XCondition.LESS_THAN);
+      map.put("greater_than", XCondition.GREATER_THAN);
+      map.put(">", XCondition.GREATER_THAN);
+      map.put("between", XCondition.BETWEEN);
+      map.put("starts_with", XCondition.STARTING_WITH);
+      map.put("startswith", XCondition.STARTING_WITH);
+      map.put("contains", XCondition.CONTAINS);
+      map.put("null", XCondition.NULL);
+      map.put("is_null", XCondition.NULL);
+      map.put("top_n", XCondition.TOP_N);
+      map.put("date_in", XCondition.DATE_IN);
+      map.put("like", XCondition.LIKE);
+      return Collections.unmodifiableMap(map);
+   }
+
+   private static Map<String, DataRefModel> index(DataRefModel[] available) {
+      Map<String, DataRefModel> fields = new LinkedHashMap<>();
+
+      if(available != null) {
+         for(DataRefModel field : available) {
+            if(field != null && field.getName() != null) {
+               fields.put(field.getName().toLowerCase(), field);
+            }
+         }
+      }
+
+      return fields;
+   }
+
+   private static Collection<String> names(Map<String, DataRefModel> fields) {
+      List<String> names = new ArrayList<>();
+
+      for(DataRefModel field : fields.values()) {
+         names.add(field.getName());
+      }
+
+      return names;
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
@@ -138,6 +138,19 @@ public class DateComparisonService {
 
       boolean hasEnd = comparison.endDate() != null && !comparison.endDate().isBlank();
 
+      // The anchor is only required when the period is actually being set. Demanding it on every
+      // call meant a caller who wanted nothing but useFacet:true had to invent a period, and the
+      // call then rewrote the one already there.
+      if(!setsPeriod(comparison)) {
+         if(hasEnd || comparison.endToday()) {
+            throw new IllegalArgumentException(
+               "An end anchor was given without any period to anchor. Pass 'periods' and 'level' " +
+               "to set the period, or drop 'endDate'/'endToday' to leave it alone.");
+         }
+
+         return;
+      }
+
       if(hasEnd && comparison.endToday()) {
          throw new IllegalArgumentException(
             "'endDate' and 'endToday' cannot both be set. When the range anchors on today the " +
@@ -158,6 +171,15 @@ public class DateComparisonService {
       }
    }
 
+   /** Whether the call asks for any period change at all. */
+   private static boolean setsPeriod(Comparison comparison) {
+      return comparison.periods() != null
+         || comparison.level() != null
+         || (comparison.endDate() != null && !comparison.endDate().isBlank())
+         || comparison.endToday()
+         || comparison.interval() != null;
+   }
+
    private static void apply(DateComparisonPaneModel model, Comparison comparison) {
       if(comparison.useFacet() != null) {
          model.setUseFacet(comparison.useFacet());
@@ -176,6 +198,20 @@ public class DateComparisonService {
       if(periods == null) {
          throw new IllegalArgumentException(
             "This assembly's date comparison has no period pane, so the period cannot be set.");
+      }
+
+      // Nothing period-related was asked for, so the period is left exactly as it is. This block
+      // used to run unconditionally, which is how a call setting only useFacet converted a custom
+      // period to standard and discarded it.
+      if(!setsPeriod(comparison)) {
+         return;
+      }
+
+      if(periods.isCustom()) {
+         throw new IllegalArgumentException(
+            "This assembly uses a custom date-comparison period, and setting a standard period " +
+            "here would discard it with no way back. Clear the comparison first if that is what " +
+            "you want; setting a custom period is not supported by this tool yet.");
       }
 
       periods.setCustom(false);

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
@@ -1,0 +1,266 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.web.composer.model.vs.*;
+import inetsoft.web.composer.vs.dialog.DateComparisonDialogService;
+import inetsoft.web.wiz.binding.VisualFrameAliases;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+import java.util.*;
+
+/**
+ * Date comparison — period-over-period analysis on an assembly.
+ *
+ * <p><b>The central guard is the end date.</b> A standard period carries both
+ * {@code toDayAsEndDay} and an explicit {@code endDay}, and when the flag is set the range
+ * anchors on <i>today</i> and the supplied end date is <b>silently discarded</b>. That is a
+ * recorded defect: a caller comparing on a due-date or any forward-looking field asked for a
+ * range ending at a specific date, got one ending today, and nothing said so. So supplying an
+ * end date here clears the flag, and supplying neither is refused rather than defaulted.
+ *
+ * <p>The read side deliberately does <b>not</b> echo the raw cell format. A date-comparison cell
+ * once serialized a 67 KB timezone table into the response; the normalized shape here carries
+ * only what a caller can act on.
+ *
+ * <p>{@code DateComparisonPaneModel} also carries a {@code VisualFrameModel}, so it reuses spec
+ * 2c's frame vocabulary rather than a parallel one.
+ */
+@Service
+public class DateComparisonService {
+   @Autowired
+   public DateComparisonService(ViewsheetSessionService sessions,
+                                DateComparisonDialogService comparisonService)
+   {
+      this.sessions = sessions;
+      this.comparisonService = comparisonService;
+   }
+
+   /**
+    * A date-comparison request in the agent vocabulary.
+    *
+    * @param periods  how many periods back to compare
+    * @param level    the period level — the date level token, e.g. year, quarter, month
+    * @param endDate  the range end. Required unless {@code endToday} is set.
+    * @param endToday anchor the range on today instead of an explicit end
+    */
+   public record Comparison(Integer periods, String level, String endDate, boolean endToday,
+                            String interval, Boolean useFacet, Boolean onlyShowMostRecentDate,
+                            Map<String, Object> frame) {}
+
+   /** The current settings, normalized. Never echoes the raw cell format. */
+   public Map<String, Object> read(String sessionToken, Principal user, String assemblyName)
+      throws Exception
+   {
+      DateComparisonPaneModel model = comparisonService.getDateComparison(
+         sessions.resolve(sessionToken, user).getID(), assemblyName, user);
+
+      Map<String, Object> out = new LinkedHashMap<>();
+      out.put("assembly", assemblyName);
+
+      if(model == null) {
+         out.put("enabled", false);
+         return out;
+      }
+
+      out.put("enabled", true);
+      out.put("comparisonOption", model.getComparisonOption());
+      out.put("useFacet", model.isUseFacet());
+      out.put("onlyShowMostRecentDate", model.isOnlyShowMostRecentDate());
+      out.put("period", describePeriod(model.getPeriodPaneModel()));
+      out.put("interval", describeInterval(model.getIntervalPaneModel()));
+      // The frame is described through 2c's vocabulary, so no FQCN reaches the caller.
+      out.put("frame", VisualFrameAliases.describe(model.getVisualFrameModel()));
+      return out;
+   }
+
+   /** Applies a comparison. One {@code sessions.mutate}, so one undo checkpoint. */
+   public void set(String sessionToken, Principal user, String assemblyName,
+                   Comparison comparison, String linkUri) throws Exception
+   {
+      requireEndAnchor(comparison);
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         DateComparisonPaneModel model =
+            comparisonService.getDateComparison(runtimeId, assemblyName, user);
+
+         if(model == null) {
+            throw new IllegalArgumentException(
+               "'" + assemblyName + "' does not support date comparison. It needs a date " +
+               "dimension in its binding.");
+         }
+
+         apply(model, comparison);
+         comparisonService.setDateComparison(runtimeId, assemblyName,
+                                            model.toDateComparisonInfo(), null, linkUri, user,
+                                            dispatcher);
+      });
+   }
+
+   public void clear(String sessionToken, Principal user, String assemblyName, String linkUri)
+      throws Exception
+   {
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) ->
+         comparisonService.clearDateComparison(runtimeId, assemblyName, linkUri, user,
+                                               dispatcher));
+   }
+
+   // ── the end-date guard ────────────────────────────────────────────────────
+
+   /**
+    * The recorded defect, refused at the boundary.
+    *
+    * <p>An explicit end date and "anchor on today" are mutually exclusive, and asking for both
+    * is how the end date came to be discarded. Asking for neither is refused too: defaulting to
+    * today is exactly the behaviour that produced a wrong range for a forward-looking field.
+    */
+   static void requireEndAnchor(Comparison comparison) {
+      if(comparison == null) {
+         throw new IllegalArgumentException("set_date_comparison needs a comparison.");
+      }
+
+      boolean hasEnd = comparison.endDate() != null && !comparison.endDate().isBlank();
+
+      if(hasEnd && comparison.endToday()) {
+         throw new IllegalArgumentException(
+            "'endDate' and 'endToday' cannot both be set. When the range anchors on today the " +
+            "end date is discarded, which is how a comparison silently ended today instead of " +
+            "where you asked. Pick one.");
+      }
+
+      if(!hasEnd && !comparison.endToday()) {
+         throw new IllegalArgumentException(
+            "set_date_comparison needs either an 'endDate' or endToday:true. It is not " +
+            "defaulted, because defaulting to today gives a forward-looking field — a due date, " +
+            "say — a range that ends before the data does, and nothing reports it.");
+      }
+
+      if(comparison.periods() != null && comparison.periods() < 1) {
+         throw new IllegalArgumentException(
+            "'periods' must be at least 1, got " + comparison.periods() + ".");
+      }
+   }
+
+   private static void apply(DateComparisonPaneModel model, Comparison comparison) {
+      if(comparison.useFacet() != null) {
+         model.setUseFacet(comparison.useFacet());
+      }
+
+      if(comparison.onlyShowMostRecentDate() != null) {
+         model.setOnlyShowMostRecentDate(comparison.onlyShowMostRecentDate());
+      }
+
+      if(comparison.frame() != null) {
+         model.setVisualFrameModel(VisualFrameAliases.create("color", comparison.frame()));
+      }
+
+      PeriodPaneModel periods = model.getPeriodPaneModel();
+
+      if(periods == null) {
+         throw new IllegalArgumentException(
+            "This assembly's date comparison has no period pane, so the period cannot be set.");
+      }
+
+      periods.setCustom(false);
+      StandardPeriodPaneModel standard = periods.getStandardPeriodPaneModel();
+
+      if(standard == null) {
+         throw new IllegalArgumentException(
+            "This assembly's date comparison has no standard period pane.");
+      }
+
+      if(comparison.periods() != null) {
+         setDynamic(standard.getPreCount(), String.valueOf(comparison.periods()));
+      }
+
+      if(comparison.level() != null) {
+         setDynamic(standard.getDateLevel(), comparison.level());
+      }
+
+      // Setting the end date clears the today anchor, because leaving it set is what discarded
+      // the date.
+      if(comparison.endToday()) {
+         standard.setToDayAsEndDay(true);
+      }
+      else {
+         standard.setToDayAsEndDay(false);
+         setDynamic(standard.getEndDay(), comparison.endDate());
+      }
+
+      IntervalPaneModel interval = model.getIntervalPaneModel();
+
+      if(comparison.interval() != null && interval != null) {
+         setDynamic(interval.getLevel(), comparison.interval());
+      }
+   }
+
+   private static void setDynamic(DynamicValueModel target, String value) {
+      if(target == null) {
+         throw new IllegalArgumentException(
+            "This assembly's date comparison does not expose that setting.");
+      }
+
+      target.setValue(value);
+   }
+
+   // ── read normalization ────────────────────────────────────────────────────
+
+   private static Map<String, Object> describePeriod(PeriodPaneModel periods) {
+      Map<String, Object> out = new LinkedHashMap<>();
+
+      if(periods == null) {
+         return out;
+      }
+
+      out.put("custom", periods.isCustom());
+      StandardPeriodPaneModel standard = periods.getStandardPeriodPaneModel();
+
+      if(standard != null) {
+         out.put("periods", value(standard.getPreCount()));
+         out.put("level", value(standard.getDateLevel()));
+         out.put("endToday", standard.isToDayAsEndDay());
+         out.put("endDate", standard.isToDayAsEndDay() ? null : value(standard.getEndDay()));
+         out.put("inclusive", standard.isInclusive());
+      }
+
+      return out;
+   }
+
+   private static Map<String, Object> describeInterval(IntervalPaneModel interval) {
+      Map<String, Object> out = new LinkedHashMap<>();
+
+      if(interval == null) {
+         return out;
+      }
+
+      out.put("level", value(interval.getLevel()));
+      out.put("granularity", value(interval.getGranularity()));
+      out.put("endDayAsToDate", interval.isEndDayAsToDate());
+      out.put("inclusive", interval.isInclusive());
+      return out;
+   }
+
+   private static Object value(DynamicValueModel model) {
+      return model == null ? null : model.getValue();
+   }
+
+   private final ViewsheetSessionService sessions;
+   private final DateComparisonDialogService comparisonService;
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/EditRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/EditRequest.java
@@ -1,0 +1,40 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import java.util.List;
+
+/**
+ * One structural edit. {@code op} is the discriminator; the remaining fields are populated
+ * per op and validated by {@link ViewsheetEditService}, which fails loud rather than
+ * defaulting a missing value.
+ */
+public record EditRequest(String op,
+                          String assembly,
+                          Integer x,
+                          Integer y,
+                          Integer width,
+                          Integer height,
+                          Integer zIndex,
+                          String title,
+                          Boolean locked,
+                          String container,
+                          List<String> assemblies,
+                          String newName,
+                          Integer type,
+                          String axis) {}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
@@ -157,6 +157,32 @@ public final class PropertyAliases {
                selectionList());
       register(registry, "selectiontree", SelectionTreePropertyDialogModel.class,
                selectionTree());
+
+      // Phase 3 batch a — the input assemblies, all on VSInputService, plus range slider,
+      // calendar and tab.
+      register(registry, "checkbox", CheckboxPropertyDialogModel.class,
+               listInput("checkboxGeneralPaneModel", true));
+      register(registry, "combobox", ComboboxPropertyDialogModel.class,
+               listInput("comboboxGeneralPaneModel", false));
+      register(registry, "radiobutton", RadioButtonPropertyDialogModel.class,
+               listInput("radioButtonGeneralPaneModel", true));
+      register(registry, "slider", SliderPropertyDialogModel.class, slider());
+      register(registry, "spinner", SpinnerPropertyDialogModel.class, spinner());
+      register(registry, "textinput", TextInputPropertyDialogModel.class, textInput());
+      register(registry, "timeslider", RangeSliderPropertyDialogModel.class, rangeSlider());
+      register(registry, "calendar", CalendarPropertyDialogModel.class, calendar());
+      register(registry, "tab", TabPropertyDialogModel.class, tab());
+
+      // Phase 3 batch b — containers, shapes, submit, calc table.
+      register(registry, "calctable", CalcTablePropertyDialogModel.class, calcTable());
+      register(registry, "groupcontainer", GroupContainerPropertyDialogModel.class,
+               groupContainer());
+      register(registry, "line", LinePropertyDialogModel.class, shape());
+      register(registry, "oval", OvalPropertyDialogModel.class, shape());
+      register(registry, "rectangle", RectanglePropertyDialogModel.class, shape());
+      register(registry, "selectioncontainer", SelectionContainerPropertyDialogModel.class,
+               selectionContainer());
+      register(registry, "submit", SubmitPropertyDialogModel.class, submit());
       return Collections.unmodifiableMap(registry);
    }
 
@@ -181,6 +207,18 @@ public final class PropertyAliases {
     */
    private static void dataGeneral(Map<String, String> aliases, String prefix) {
       basicGeneral(aliases, prefix + ".generalPropPaneModel");
+   }
+
+   /**
+    * Shapes — line, oval, rectangle — hold {@code basicGeneralPaneModel} directly, with no
+    * {@code generalPropPaneModel} between. A third shape, one level shallower than data
+    * assemblies and two shallower than output ones.
+    */
+   private static void shapeGeneral(Map<String, String> aliases, String prefix) {
+      String basic = prefix + ".basicGeneralPaneModel";
+      aliases.put("name", basic + ".name");
+      aliases.put("visible", basic + ".visible");
+      aliases.put("primary", basic + ".primary");
    }
 
    private static void basicGeneral(Map<String, String> aliases, String generalPrefix) {
@@ -294,5 +332,123 @@ public final class PropertyAliases {
       aliases.put("singleSelection", "selectionGeneralPaneModel.singleSelection");
       aliases.put("submitOnChange", "selectionGeneralPaneModel.submitOnChange");
       aliases.put("suppressBlank", "selectionGeneralPaneModel.suppressBlank");
+   }
+
+   // ── Phase 3 batch a ───────────────────────────────────────────────────────
+
+   /** Check box, combo box and radio button share a list-values general pane. */
+   private static Map<String, String> listInput(String prefix, boolean hasTitle) {
+      Map<String, String> aliases = new LinkedHashMap<>();
+      dataGeneral(aliases, prefix);
+      sizePosition(aliases, prefix);
+
+      if(hasTitle) {
+         title(aliases, prefix);
+      }
+
+      return aliases;
+   }
+
+   private static Map<String, String> slider() {
+      Map<String, String> aliases = new LinkedHashMap<>();
+      dataGeneral(aliases, "sliderGeneralPaneModel");
+      sizePosition(aliases, "sliderGeneralPaneModel");
+      numericRange(aliases, "sliderGeneralPaneModel");
+      aliases.put("snap", "sliderAdvancedPaneModel.snap");
+      return aliases;
+   }
+
+   private static Map<String, String> spinner() {
+      Map<String, String> aliases = new LinkedHashMap<>();
+      dataGeneral(aliases, "spinnerGeneralPaneModel");
+      sizePosition(aliases, "spinnerGeneralPaneModel");
+      numericRange(aliases, "spinnerGeneralPaneModel");
+      return aliases;
+   }
+
+   private static Map<String, String> textInput() {
+      Map<String, String> aliases = new LinkedHashMap<>();
+      dataGeneral(aliases, "textInputGeneralPaneModel");
+      sizePosition(aliases, "textInputGeneralPaneModel");
+      return aliases;
+   }
+
+   private static Map<String, String> rangeSlider() {
+      Map<String, String> aliases = new LinkedHashMap<>();
+      dataGeneral(aliases, "rangeSliderGeneralPaneModel");
+      sizePosition(aliases, "rangeSliderGeneralPaneModel");
+      title(aliases, "rangeSliderGeneralPaneModel");
+      return aliases;
+   }
+
+   private static Map<String, String> calendar() {
+      Map<String, String> aliases = new LinkedHashMap<>();
+      dataGeneral(aliases, "calendarGeneralPaneModel");
+      sizePosition(aliases, "calendarGeneralPaneModel");
+      title(aliases, "calendarGeneralPaneModel");
+      return aliases;
+   }
+
+   private static Map<String, String> tab() {
+      Map<String, String> aliases = new LinkedHashMap<>();
+      dataGeneral(aliases, "tabGeneralPaneModel");
+      sizePosition(aliases, "tabGeneralPaneModel");
+      return aliases;
+   }
+
+   private static void numericRange(Map<String, String> aliases, String prefix) {
+      // The pane is numericRangePaneModel here and numberRangePaneModel on a gauge, with
+      // maximum/minimum rather than max/min. The short names hide that.
+      aliases.put("min", prefix + ".numericRangePaneModel.minimum");
+      aliases.put("max", prefix + ".numericRangePaneModel.maximum");
+      aliases.put("increment", prefix + ".numericRangePaneModel.increment");
+   }
+
+   // ── Phase 3 batch b ───────────────────────────────────────────────────────
+
+   private static Map<String, String> calcTable() {
+      Map<String, String> aliases = new LinkedHashMap<>();
+      dataGeneral(aliases, "tableViewGeneralPaneModel");
+      sizePosition(aliases, "tableViewGeneralPaneModel");
+      title(aliases, "tableViewGeneralPaneModel");
+      aliases.put("shrink", "calcTableAdvancedPaneModel.shrink");
+      aliases.put("fillBlankWithZero", "calcTableAdvancedPaneModel.fillBlankWithZero");
+      aliases.put("sortOthersLast", "calcTableAdvancedPaneModel.sortOthersLast");
+      aliases.put("headerRowCount", "calcTableAdvancedPaneModel.headerRowCount");
+      aliases.put("headerColCount", "calcTableAdvancedPaneModel.headerColCount");
+      return aliases;
+   }
+
+   private static Map<String, String> groupContainer() {
+      Map<String, String> aliases = new LinkedHashMap<>();
+      // Note the pane accessor is groupContainerGeneralPane — no "Model" suffix, unlike every
+      // other type. Another reason these paths are declared rather than derived.
+      basicGeneral(aliases, "groupContainerGeneralPane.generalPropPane");
+      sizePosition(aliases, "groupContainerGeneralPane");
+      return aliases;
+   }
+
+   /** Line, oval and rectangle share {@code ShapeGeneralPaneModel}. */
+   private static Map<String, String> shape() {
+      Map<String, String> aliases = new LinkedHashMap<>();
+      shapeGeneral(aliases, "shapeGeneralPaneModel");
+      sizePosition(aliases, "shapeGeneralPaneModel");
+      return aliases;
+   }
+
+   private static Map<String, String> selectionContainer() {
+      Map<String, String> aliases = new LinkedHashMap<>();
+      dataGeneral(aliases, "selectionContainerGeneralPaneModel");
+      sizePosition(aliases, "selectionContainerGeneralPaneModel");
+      title(aliases, "selectionContainerGeneralPaneModel");
+      return aliases;
+   }
+
+   private static Map<String, String> submit() {
+      Map<String, String> aliases = new LinkedHashMap<>();
+      dataGeneral(aliases, "submitGeneralPaneModel");
+      sizePosition(aliases, "submitGeneralPaneModel");
+      aliases.put("label", "submitGeneralPaneModel.labelPropPaneModel.label");
+      return aliases;
    }
 }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
@@ -150,6 +150,11 @@ public final class PropertyAliases {
       Map<String, TypeAliases> registry = new LinkedHashMap<>();
       register(registry, "gauge", GaugePropertyDialogModel.class, gauge());
       register(registry, "text", TextPropertyDialogModel.class, text());
+      // Immutables models. These were "not covered" until PropertyPath learned to read a bare
+      // Immutables accessor and to rebuild immutable levels through withX — the paths below run
+      // through two immutable levels into a mutable OutputGeneralPaneModel.
+      register(registry, "image", ImagePropertyDialogModel.class, image());
+
       register(registry, "chart", ChartPropertyDialogModel.class, chart());
       register(registry, "table", TableViewPropertyDialogModel.class, table());
       register(registry, "crosstab", CrosstabPropertyDialogModel.class, crosstab());
@@ -267,6 +272,18 @@ public final class PropertyAliases {
       return aliases;
    }
 
+   /**
+    * The image assembly. Its dialog model and general pane are both Immutables, so every path
+    * here crosses at least one immutable level — {@code PropertyPath} rebuilds them through
+    * {@code withX} on the way back up.
+    */
+   private static Map<String, String> image() {
+      Map<String, String> aliases = new LinkedHashMap<>();
+      outputGeneral(aliases, "imageGeneralPaneModel");
+      sizePosition(aliases, "imageGeneralPaneModel");
+      return aliases;
+   }
+
    private static Map<String, String> chart() {
       Map<String, String> aliases = new LinkedHashMap<>();
       dataGeneral(aliases, "chartGeneralPaneModel");
@@ -275,6 +292,28 @@ public final class PropertyAliases {
       aliases.put("enableAdhocEditing", "chartAdvancedPaneModel.enableAdhocEditing");
       aliases.put("glossyEffect", "chartAdvancedPaneModel.glossyEffect");
       aliases.put("sparkline", "chartAdvancedPaneModel.sparkline");
+
+      // The line pane — trend lines, grid lines, facet grid. What a user means by "add a trend
+      // line" lives here, one pane below the general/advanced panes.
+      //
+      // Deliberately absent: pointLine and the word-cloud font scale are PlotDescriptor fields
+      // that ChartPropertyDialogModel never surfaces, so there is no path to alias. They are not
+      // reachable through this engine, and claiming otherwise would be worse than the gap.
+      aliases.put("gridLineVisible", "chartLinePaneModel.gridLineVisible");
+      aliases.put("innerLineVisible", "chartLinePaneModel.innerLineVisible");
+      aliases.put("trendLineType", "chartLinePaneModel.trendLineType");
+      aliases.put("trendLineStyle", "chartLinePaneModel.trendLineStyle");
+      aliases.put("trendLineColor", "chartLinePaneModel.trendLineColor");
+      aliases.put("trendLineVisible", "chartLinePaneModel.trendLineVisible");
+      aliases.put("trendPerColor", "chartLinePaneModel.trendPerColor");
+      aliases.put("projectForward", "chartLinePaneModel.projectForward");
+      aliases.put("facetGrid", "chartLinePaneModel.facetGrid");
+      aliases.put("facetGridColor", "chartLinePaneModel.facetGridColor");
+      aliases.put("facetGridVisible", "chartLinePaneModel.facetGridVisible");
+      aliases.put("diagonalLineStyle", "chartLinePaneModel.diagonalLineStyle");
+      aliases.put("diagonalLineColor", "chartLinePaneModel.diagonalLineColor");
+      aliases.put("quadrantGridLineStyle", "chartLinePaneModel.quadrantGridLineStyle");
+      aliases.put("quadrantGridLineColor", "chartLinePaneModel.quadrantGridLineColor");
       return aliases;
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
@@ -1,0 +1,202 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.web.composer.model.vs.*;
+
+import java.util.*;
+
+/**
+ * Short names for the deep dialog-model paths.
+ *
+ * <p>Setting one boolean on a gauge otherwise means writing
+ * {@code gaugeGeneralPaneModel.outputGeneralPaneModel.generalPropPaneModel.basicGeneralPaneModel.visible}.
+ * That depth is the entire reason this layer exists.
+ *
+ * <p>Two invariants hold this honest:
+ *
+ * <ol>
+ *   <li><b>Every declared alias resolves.</b> {@code PropertyAliasesTest} reflects over this
+ *       registry and asserts each path exists on its model class. When the composer renames a
+ *       pane field the build breaks rather than production.</li>
+ *   <li><b>Aliases never widen the surface.</b> An alias is only ever a shorter name for a
+ *       path that already exists — nothing here computes, combines, or defaults a value. That
+ *       would put property semantics in two places, which is the drift this design prevents.</li>
+ * </ol>
+ *
+ * <p>Resolution order is exact alias → raw dotted path → error. A key that is neither is never
+ * dropped.
+ */
+public final class PropertyAliases {
+   /** One assembly type's dialog model and its alias vocabulary. */
+   public record TypeAliases(String assemblyType, Class<?> modelClass,
+                             Map<String, String> aliases) {}
+
+   private static final Map<String, TypeAliases> REGISTRY = registry();
+
+   private PropertyAliases() {
+   }
+
+   public static TypeAliases forType(String assemblyType) {
+      TypeAliases entry = REGISTRY.get(normalize(assemblyType));
+
+      if(entry == null) {
+         throw new IllegalArgumentException(
+            "No property vocabulary for assembly type '" + assemblyType + "' yet. Types " +
+            "covered: " + String.join(", ", new TreeSet<>(REGISTRY.keySet())) + ". Raw dotted " +
+            "paths are not available for uncovered types either, because the dialog model is " +
+            "not known.");
+      }
+
+      return entry;
+   }
+
+   public static boolean covers(String assemblyType) {
+      return REGISTRY.containsKey(normalize(assemblyType));
+   }
+
+   public static Set<String> coveredTypes() {
+      return Collections.unmodifiableSet(REGISTRY.keySet());
+   }
+
+   /**
+    * Resolves an agent-supplied key to a model path: exact alias first, then the key as a raw
+    * dotted path. A key that is neither throws with near-matches — it is never dropped.
+    */
+   public static String resolve(String assemblyType, String key) {
+      TypeAliases entry = forType(assemblyType);
+      String alias = entry.aliases().get(key);
+
+      if(alias != null) {
+         return alias;
+      }
+
+      if(key != null && key.contains(".")) {
+         // A dotted key is the documented raw escape hatch. PropertyPath validates it and
+         // fails loud if it does not resolve, so nothing silently no-ops here.
+         return key;
+      }
+
+      throw new IllegalArgumentException(
+         "'" + key + "' is not a property of " + entry.assemblyType() + "." +
+         nearest(key, entry.aliases().keySet()) +
+         " Known names: " + String.join(", ", new TreeSet<>(entry.aliases().keySet())) +
+         ". A raw model path (containing a '.') is also accepted.");
+   }
+
+   private static String nearest(String key, Set<String> candidates) {
+      String best = null;
+      int bestDistance = Integer.MAX_VALUE;
+
+      for(String candidate : candidates) {
+         int distance = distance(key == null ? "" : key.toLowerCase(), candidate.toLowerCase());
+
+         if(distance < bestDistance) {
+            bestDistance = distance;
+            best = candidate;
+         }
+      }
+
+      return best != null && bestDistance <= 3 ? " Did you mean '" + best + "'?" : "";
+   }
+
+   private static int distance(String a, String b) {
+      int[] previous = new int[b.length() + 1];
+      int[] current = new int[b.length() + 1];
+
+      for(int j = 0; j <= b.length(); j++) {
+         previous[j] = j;
+      }
+
+      for(int i = 1; i <= a.length(); i++) {
+         current[0] = i;
+
+         for(int j = 1; j <= b.length(); j++) {
+            int cost = a.charAt(i - 1) == b.charAt(j - 1) ? 0 : 1;
+            current[j] = Math.min(Math.min(current[j - 1] + 1, previous[j] + 1),
+                                  previous[j - 1] + cost);
+         }
+
+         int[] swap = previous;
+         previous = current;
+         current = swap;
+      }
+
+      return previous[b.length()];
+   }
+
+   private static String normalize(String assemblyType) {
+      return assemblyType == null ? "" : assemblyType.trim().toLowerCase();
+   }
+
+   // ── the registry ──────────────────────────────────────────────────────────
+
+   private static Map<String, TypeAliases> registry() {
+      Map<String, TypeAliases> registry = new LinkedHashMap<>();
+      register(registry, "gauge", GaugePropertyDialogModel.class, gauge());
+      register(registry, "text", TextPropertyDialogModel.class, text());
+      return Collections.unmodifiableMap(registry);
+   }
+
+   private static void register(Map<String, TypeAliases> registry, String type,
+                                Class<?> modelClass, Map<String, String> aliases)
+   {
+      registry.put(type, new TypeAliases(type, modelClass, Collections.unmodifiableMap(aliases)));
+   }
+
+   /** The general pane every output assembly shares, under a given prefix. */
+   private static void outputGeneral(Map<String, String> aliases, String prefix) {
+      String basic = prefix + ".outputGeneralPaneModel.generalPropPaneModel.basicGeneralPaneModel";
+      aliases.put("name", basic + ".name");
+      aliases.put("visible", basic + ".visible");
+      aliases.put("enabled", basic + ".enabled");
+      aliases.put("shadow", basic + ".shadow");
+      aliases.put("primary", basic + ".primary");
+      aliases.put("refresh", basic + ".refresh");
+   }
+
+   private static void sizePosition(Map<String, String> aliases, String prefix) {
+      String size = prefix + ".sizePositionPaneModel";
+      aliases.put("top", size + ".top");
+      aliases.put("left", size + ".left");
+      aliases.put("width", size + ".width");
+      aliases.put("height", size + ".height");
+      aliases.put("locked", size + ".locked");
+   }
+
+   private static Map<String, String> gauge() {
+      Map<String, String> aliases = new LinkedHashMap<>();
+      outputGeneral(aliases, "gaugeGeneralPaneModel");
+      sizePosition(aliases, "gaugeGeneralPaneModel");
+      aliases.put("min", "gaugeGeneralPaneModel.numberRangePaneModel.min");
+      aliases.put("max", "gaugeGeneralPaneModel.numberRangePaneModel.max");
+      aliases.put("majorIncrement", "gaugeGeneralPaneModel.numberRangePaneModel.majorIncrement");
+      aliases.put("minorIncrement", "gaugeGeneralPaneModel.numberRangePaneModel.minorIncrement");
+      aliases.put("showValue", "gaugeAdvancedPaneModel.showValue");
+      return aliases;
+   }
+
+   private static Map<String, String> text() {
+      Map<String, String> aliases = new LinkedHashMap<>();
+      outputGeneral(aliases, "textGeneralPaneModel");
+      sizePosition(aliases, "textGeneralPaneModel");
+      aliases.put("alpha", "textGeneralPaneModel.alpha");
+      aliases.put("popComponent", "textGeneralPaneModel.popComponent");
+      return aliases;
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
@@ -150,6 +150,13 @@ public final class PropertyAliases {
       Map<String, TypeAliases> registry = new LinkedHashMap<>();
       register(registry, "gauge", GaugePropertyDialogModel.class, gauge());
       register(registry, "text", TextPropertyDialogModel.class, text());
+      register(registry, "chart", ChartPropertyDialogModel.class, chart());
+      register(registry, "table", TableViewPropertyDialogModel.class, table());
+      register(registry, "crosstab", CrosstabPropertyDialogModel.class, crosstab());
+      register(registry, "selectionlist", SelectionListPropertyDialogModel.class,
+               selectionList());
+      register(registry, "selectiontree", SelectionTreePropertyDialogModel.class,
+               selectionTree());
       return Collections.unmodifiableMap(registry);
    }
 
@@ -159,15 +166,37 @@ public final class PropertyAliases {
       registry.put(type, new TypeAliases(type, modelClass, Collections.unmodifiableMap(aliases)));
    }
 
-   /** The general pane every output assembly shares, under a given prefix. */
+   /**
+    * The general pane an <i>output</i> assembly shares — gauge, text and friends nest it one
+    * level deeper, under {@code outputGeneralPaneModel}.
+    */
    private static void outputGeneral(Map<String, String> aliases, String prefix) {
-      String basic = prefix + ".outputGeneralPaneModel.generalPropPaneModel.basicGeneralPaneModel";
+      basicGeneral(aliases, prefix + ".outputGeneralPaneModel.generalPropPaneModel");
+   }
+
+   /**
+    * The general pane a <i>data</i> assembly shares — chart, table, crosstab and the selection
+    * assemblies hold {@code generalPropPaneModel} directly. The two shapes differ by exactly
+    * one level, which is the kind of near-miss the invariant test exists to catch.
+    */
+   private static void dataGeneral(Map<String, String> aliases, String prefix) {
+      basicGeneral(aliases, prefix + ".generalPropPaneModel");
+   }
+
+   private static void basicGeneral(Map<String, String> aliases, String generalPrefix) {
+      String basic = generalPrefix + ".basicGeneralPaneModel";
       aliases.put("name", basic + ".name");
       aliases.put("visible", basic + ".visible");
       aliases.put("enabled", basic + ".enabled");
       aliases.put("shadow", basic + ".shadow");
       aliases.put("primary", basic + ".primary");
       aliases.put("refresh", basic + ".refresh");
+   }
+
+   /** Title bar, on the assemblies that have one. */
+   private static void title(Map<String, String> aliases, String prefix) {
+      aliases.put("titleVisible", prefix + ".titlePropPaneModel.visible");
+      aliases.put("title", prefix + ".titlePropPaneModel.title");
    }
 
    private static void sizePosition(Map<String, String> aliases, String prefix) {
@@ -198,5 +227,72 @@ public final class PropertyAliases {
       aliases.put("alpha", "textGeneralPaneModel.alpha");
       aliases.put("popComponent", "textGeneralPaneModel.popComponent");
       return aliases;
+   }
+
+   private static Map<String, String> chart() {
+      Map<String, String> aliases = new LinkedHashMap<>();
+      dataGeneral(aliases, "chartGeneralPaneModel");
+      sizePosition(aliases, "chartGeneralPaneModel");
+      title(aliases, "chartGeneralPaneModel");
+      aliases.put("enableAdhocEditing", "chartAdvancedPaneModel.enableAdhocEditing");
+      aliases.put("glossyEffect", "chartAdvancedPaneModel.glossyEffect");
+      aliases.put("sparkline", "chartAdvancedPaneModel.sparkline");
+      return aliases;
+   }
+
+   private static Map<String, String> table() {
+      Map<String, String> aliases = new LinkedHashMap<>();
+      dataGeneral(aliases, "tableViewGeneralPaneModel");
+      sizePosition(aliases, "tableViewGeneralPaneModel");
+      title(aliases, "tableViewGeneralPaneModel");
+      aliases.put("maxRows", "tableViewGeneralPaneModel.maxRows");
+      aliases.put("submitOnChange", "tableViewGeneralPaneModel.submitOnChange");
+      aliases.put("shrink", "tableAdvancedPaneModel.shrink");
+      aliases.put("form", "tableAdvancedPaneModel.form");
+      aliases.put("enableAdhoc", "tableAdvancedPaneModel.enableAdhoc");
+      return aliases;
+   }
+
+   private static Map<String, String> crosstab() {
+      Map<String, String> aliases = new LinkedHashMap<>();
+      dataGeneral(aliases, "tableViewGeneralPaneModel");
+      sizePosition(aliases, "tableViewGeneralPaneModel");
+      title(aliases, "tableViewGeneralPaneModel");
+      aliases.put("maxRows", "tableViewGeneralPaneModel.maxRows");
+      aliases.put("fillBlankWithZero", "crosstabAdvancedPaneModel.fillBlankWithZero");
+      aliases.put("summarySideBySide", "crosstabAdvancedPaneModel.summarySideBySide");
+      aliases.put("mergeSpan", "crosstabAdvancedPaneModel.mergeSpan");
+      aliases.put("shrink", "crosstabAdvancedPaneModel.shrink");
+      aliases.put("drillEnabled", "crosstabAdvancedPaneModel.drillEnabled");
+      return aliases;
+   }
+
+   private static Map<String, String> selectionList() {
+      Map<String, String> aliases = new LinkedHashMap<>();
+      dataGeneral(aliases, "selectionGeneralPaneModel");
+      sizePosition(aliases, "selectionGeneralPaneModel");
+      title(aliases, "selectionGeneralPaneModel");
+      selectionGeneral(aliases);
+      return aliases;
+   }
+
+   private static Map<String, String> selectionTree() {
+      Map<String, String> aliases = new LinkedHashMap<>();
+      dataGeneral(aliases, "selectionGeneralPaneModel");
+      sizePosition(aliases, "selectionGeneralPaneModel");
+      title(aliases, "selectionGeneralPaneModel");
+      selectionGeneral(aliases);
+      aliases.put("selectChildren", "selectionTreePaneModel.selectChildren");
+      aliases.put("mode", "selectionTreePaneModel.mode");
+      return aliases;
+   }
+
+   private static void selectionGeneral(Map<String, String> aliases) {
+      aliases.put("showType", "selectionGeneralPaneModel.showType");
+      aliases.put("listHeight", "selectionGeneralPaneModel.listHeight");
+      aliases.put("sortType", "selectionGeneralPaneModel.sortType");
+      aliases.put("singleSelection", "selectionGeneralPaneModel.singleSelection");
+      aliases.put("submitOnChange", "selectionGeneralPaneModel.submitOnChange");
+      aliases.put("suppressBlank", "selectionGeneralPaneModel.suppressBlank");
    }
 }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyPath.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyPath.java
@@ -1,0 +1,315 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.*;
+
+/**
+ * Reads and writes a dotted path on a property-dialog model.
+ *
+ * <p>The dialog models nest deeply — setting one boolean on a gauge means
+ * {@code gaugeGeneralPaneModel.outputGeneralPaneModel.generalPropPaneModel.basicGeneralPaneModel.visible}
+ * — which is why the alias layer exists on top of this. This class is the layer underneath:
+ * the raw escape hatch, and what every alias ultimately resolves to.
+ *
+ * <p><b>Nothing here is ever silently skipped.</b> An unresolvable segment throws and names
+ * both the segment and what was available at that level. A path that quietly no-ops is the
+ * exact defect this plugin family exists to avoid — it reports success while changing nothing.
+ */
+public final class PropertyPath {
+   private PropertyPath() {
+   }
+
+   /** Reads a dotted path, returning null if an intermediate object is absent. */
+   public static Object get(Object root, String path) {
+      String[] segments = segments(path);
+      Object current = root;
+
+      for(int i = 0; i < segments.length; i++) {
+         if(current == null) {
+            return null;
+         }
+
+         current = readOne(current, segments[i], path, i);
+      }
+
+      return current;
+   }
+
+   /**
+    * Writes a dotted path.
+    *
+    * <p>An absent intermediate is an error rather than something to instantiate: the dialog
+    * models are populated by the composer service, so a null pane means the property does not
+    * apply to this assembly, and filling one in would fabricate a shape the service never
+    * produced.
+    */
+   public static void set(Object root, String path, Object value) {
+      String[] segments = segments(path);
+      Object current = root;
+
+      for(int i = 0; i < segments.length - 1; i++) {
+         Object next = readOne(current, segments[i], path, i);
+
+         if(next == null) {
+            throw new IllegalArgumentException(
+               "Cannot set '" + path + "': '" + segments[i] + "' is not present on this " +
+               "assembly, so the rest of the path does not exist. That usually means the " +
+               "property does not apply to this assembly type.");
+         }
+
+         current = next;
+      }
+
+      String leaf = segments[segments.length - 1];
+      Method setter = setterFor(current.getClass(), leaf);
+
+      if(setter == null) {
+         throw new IllegalArgumentException(
+            "Cannot set '" + path + "': '" + leaf + "' is not a writable property of " +
+            simpleName(current.getClass()) + ". " + available(current.getClass()));
+      }
+
+      Class<?> target = setter.getParameterTypes()[0];
+
+      try {
+         setter.invoke(current, coerce(value, target, path));
+      }
+      catch(IllegalAccessException | InvocationTargetException e) {
+         throw new IllegalArgumentException(
+            "Setting '" + path + "' failed: " + rootMessage(e), e);
+      }
+   }
+
+   /** The type a path expects, so a registry test can assert the alias declares it correctly. */
+   public static Class<?> typeOf(Class<?> rootType, String path) {
+      String[] segments = segments(path);
+      Class<?> current = rootType;
+
+      for(String segment : segments) {
+         Method getter = getterFor(current, segment);
+
+         if(getter == null) {
+            throw new IllegalArgumentException(
+               "'" + segment + "' does not exist on " + simpleName(current) +
+               " (resolving '" + path + "'). " + available(current));
+         }
+
+         current = getter.getReturnType();
+      }
+
+      return current;
+   }
+
+   /** Readable property names at a level, for error messages and discovery. */
+   public static List<String> propertiesOf(Class<?> type) {
+      Set<String> names = new TreeSet<>();
+
+      for(Method method : type.getMethods()) {
+         if(method.getParameterCount() != 0 || method.getDeclaringClass() == Object.class) {
+            continue;
+         }
+
+         String name = method.getName();
+
+         if(name.startsWith("get") && name.length() > 3) {
+            names.add(decapitalize(name.substring(3)));
+         }
+         else if(name.startsWith("is") && name.length() > 2) {
+            names.add(decapitalize(name.substring(2)));
+         }
+      }
+
+      return new ArrayList<>(names);
+   }
+
+   /**
+    * Coerces a JSON-shaped value onto the setter's type.
+    *
+    * <p>Forgiving where the intent is unambiguous — {@code "true"} for a boolean, a numeric
+    * string for a number, an enum token in any case — and loud otherwise. An LLM writing JSON
+    * produces these spellings constantly, and rejecting them would be pedantry; guessing at
+    * anything beyond them would not.
+    */
+   static Object coerce(Object value, Class<?> target, String path) {
+      if(value == null) {
+         if(target.isPrimitive()) {
+            throw new IllegalArgumentException(
+               "'" + path + "' is a " + target.getName() + " and cannot be set to null.");
+         }
+
+         return null;
+      }
+
+      if(target.isInstance(value) && !(value instanceof Number && target != value.getClass())) {
+         return value;
+      }
+
+      String text = String.valueOf(value).trim();
+
+      if(target == boolean.class || target == Boolean.class) {
+         if("true".equalsIgnoreCase(text)) {
+            return Boolean.TRUE;
+         }
+
+         if("false".equalsIgnoreCase(text)) {
+            return Boolean.FALSE;
+         }
+
+         throw new IllegalArgumentException(
+            "'" + path + "' is a boolean; '" + value + "' is not true or false. Spellings " +
+            "like \"yes\" are refused rather than guessed at, because guessing wrong here " +
+            "renders a setting that looks applied and is not.");
+      }
+
+      try {
+         if(target == int.class || target == Integer.class) {
+            return (int) Double.parseDouble(text);
+         }
+
+         if(target == long.class || target == Long.class) {
+            return (long) Double.parseDouble(text);
+         }
+
+         if(target == double.class || target == Double.class) {
+            return Double.parseDouble(text);
+         }
+
+         if(target == float.class || target == Float.class) {
+            return (float) Double.parseDouble(text);
+         }
+      }
+      catch(NumberFormatException e) {
+         throw new IllegalArgumentException(
+            "'" + path + "' is a " + simpleName(target) + "; '" + value + "' is not a number.");
+      }
+
+      if(target == String.class) {
+         return text;
+      }
+
+      if(target.isEnum()) {
+         for(Object constant : target.getEnumConstants()) {
+            if(String.valueOf(constant).equalsIgnoreCase(text)) {
+               return constant;
+            }
+         }
+
+         throw new IllegalArgumentException(
+            "'" + path + "' does not accept '" + value + "'. Valid values: " +
+            Arrays.toString(target.getEnumConstants()) + ".");
+      }
+
+      throw new IllegalArgumentException(
+         "'" + path + "' expects " + simpleName(target) + ", which '" + value + "' is not.");
+   }
+
+   // ── reflection helpers ────────────────────────────────────────────────────
+
+   private static String[] segments(String path) {
+      if(path == null || path.isBlank()) {
+         throw new IllegalArgumentException("A property path cannot be empty.");
+      }
+
+      return path.split("\\.");
+   }
+
+   private static Object readOne(Object target, String segment, String path, int index) {
+      Method getter = getterFor(target.getClass(), segment);
+
+      if(getter == null) {
+         throw new IllegalArgumentException(
+            "'" + segment + "' (in '" + path + "', segment " + (index + 1) + ") is not a " +
+            "property of " + simpleName(target.getClass()) + ". " +
+            available(target.getClass()));
+      }
+
+      try {
+         return getter.invoke(target);
+      }
+      catch(IllegalAccessException | InvocationTargetException e) {
+         throw new IllegalArgumentException("Reading '" + path + "' failed: " + rootMessage(e), e);
+      }
+   }
+
+   private static Method getterFor(Class<?> type, String property) {
+      String suffix = capitalize(property);
+
+      for(Method method : type.getMethods()) {
+         if(method.getParameterCount() != 0) {
+            continue;
+         }
+
+         if(method.getName().equals("get" + suffix) || method.getName().equals("is" + suffix)) {
+            return method;
+         }
+      }
+
+      return null;
+   }
+
+   private static Method setterFor(Class<?> type, String property) {
+      String name = "set" + capitalize(property);
+
+      for(Method method : type.getMethods()) {
+         if(method.getParameterCount() == 1 && method.getName().equals(name)) {
+            return method;
+         }
+      }
+
+      return null;
+   }
+
+   /** Names the nearest properties, since a wrong segment is nearly always a near miss. */
+   private static String available(Class<?> type) {
+      List<String> properties = propertiesOf(type);
+
+      if(properties.isEmpty()) {
+         return "It has no readable properties.";
+      }
+
+      if(properties.size() > 25) {
+         return "It has " + properties.size() + " properties; call list_assembly_properties " +
+            "for the vocabulary.";
+      }
+
+      return "Available: " + String.join(", ", properties) + ".";
+   }
+
+   private static String rootMessage(Exception e) {
+      Throwable cause = e instanceof InvocationTargetException invocation && invocation.getCause() != null
+         ? invocation.getCause() : e;
+      return cause.getMessage() == null ? cause.getClass().getSimpleName() : cause.getMessage();
+   }
+
+   private static String simpleName(Class<?> type) {
+      return type.getSimpleName();
+   }
+
+   private static String capitalize(String value) {
+      return value.isEmpty() ? value
+         : Character.toUpperCase(value.charAt(0)) + value.substring(1);
+   }
+
+   private static String decapitalize(String value) {
+      return value.isEmpty() ? value
+         : Character.toLowerCase(value.charAt(0)) + value.substring(1);
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyPath.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyPath.java
@@ -62,41 +62,100 @@ public final class PropertyPath {
     * produced.
     */
    public static void set(Object root, String path, Object value) {
-      String[] segments = segments(path);
-      Object current = root;
+      REBUILT_CHILD.remove();
 
-      for(int i = 0; i < segments.length - 1; i++) {
-         Object next = readOne(current, segments[i], path, i);
+      try {
+         writeInto(root, segments(path), 0, path, value);
+      }
+      finally {
+         REBUILT_CHILD.remove();
+      }
+   }
 
-         if(next == null) {
+   /**
+    * Writes {@code value} at {@code segments[depth..]}, rebuilding immutable levels on the way
+    * back up.
+    *
+    * <p>A mutable owner takes {@code setX} and the write stops there. An <b>immutable</b> owner
+    * has no setter — only {@code withX} returning a new instance — so the new instance has to be
+    * written back into <em>its</em> owner, which may itself be immutable. Hence the recursion:
+    * the rebuild propagates upward exactly as far as the immutability does, and stops at the
+    * first mutable holder.
+    */
+   private static void writeInto(Object owner, String[] segments, int depth, String path,
+                                 Object value)
+   {
+      String segment = segments[depth];
+      boolean leaf = depth == segments.length - 1;
+      Object toWrite = value;
+
+      if(!leaf) {
+         Object child = readOne(owner, segment, path, depth);
+
+         if(child == null) {
             throw new IllegalArgumentException(
-               "Cannot set '" + path + "': '" + segments[i] + "' is not present on this " +
+               "Cannot set '" + path + "': '" + segment + "' is not present on this " +
                "assembly, so the rest of the path does not exist. That usually means the " +
                "property does not apply to this assembly type.");
          }
 
-         current = next;
+         Object before = child;
+         writeInto(child, segments, depth + 1, path, value);
+         Object after = readOne(owner, segment, path, depth);
+
+         // A mutable child was updated in place, so there is nothing to write back. An
+         // immutable one is unchanged here — REBUILT_CHILD holds the new instance instead.
+         if(REBUILT_CHILD.get() == null || after != before) {
+            REBUILT_CHILD.remove();
+            return;
+         }
+
+         toWrite = REBUILT_CHILD.get();
+         REBUILT_CHILD.remove();
       }
 
-      String leaf = segments[segments.length - 1];
-      Method setter = setterFor(current.getClass(), leaf);
+      Method setter = setterFor(owner.getClass(), segment);
 
-      if(setter == null) {
+      if(setter != null) {
+         try {
+            setter.invoke(owner, leaf ? coerce(toWrite, setter.getParameterTypes()[0], path)
+                                      : toWrite);
+            return;
+         }
+         catch(IllegalAccessException | InvocationTargetException e) {
+            throw new IllegalArgumentException(
+               "Setting '" + path + "' failed: " + rootMessage(e), e);
+         }
+      }
+
+      Method wither = witherFor(owner.getClass(), segment);
+
+      if(wither == null) {
          throw new IllegalArgumentException(
-            "Cannot set '" + path + "': '" + leaf + "' is not a writable property of " +
-            simpleName(current.getClass()) + ". " + available(current.getClass()));
+            "Cannot set '" + path + "': '" + segment + "' is not a writable property of " +
+            simpleName(owner.getClass()) + ". " + available(owner.getClass()));
       }
-
-      Class<?> target = setter.getParameterTypes()[0];
 
       try {
-         setter.invoke(current, coerce(value, target, path));
+         Object rebuilt = wither.invoke(
+            owner, leaf ? coerce(toWrite, wither.getParameterTypes()[0], path) : toWrite);
+         // Hand the new instance to the caller one level up, which writes it into its own owner.
+         REBUILT_CHILD.set(rebuilt);
       }
       catch(IllegalAccessException | InvocationTargetException e) {
          throw new IllegalArgumentException(
             "Setting '" + path + "' failed: " + rootMessage(e), e);
       }
    }
+
+   /**
+    * Carries a rebuilt immutable instance from a recursion level to its parent.
+    *
+    * <p>A thread-local rather than a return value because {@code writeInto} is also the public
+    * entry point's recursion, and threading an out-parameter through every level would obscure
+    * the mutable case, which is by far the common one.
+    */
+   private static final ThreadLocal<Object> REBUILT_CHILD = new ThreadLocal<>();
 
    /** The type a path expects, so a registry test can assert the alias declares it correctly. */
    public static Class<?> typeOf(Class<?> rootType, String path) {
@@ -158,11 +217,15 @@ public final class PropertyPath {
          return null;
       }
 
+      String text = String.valueOf(value).trim();
+
+      // Checked before the pass-through below, which would otherwise hand a String straight to a
+      // String setter without ever consulting the value domain.
+      requireAllowedValue(text, value, target, path);
+
       if(target.isInstance(value) && !(value instanceof Number && target != value.getClass())) {
          return value;
       }
-
-      String text = String.valueOf(value).trim();
 
       if(target == boolean.class || target == Boolean.class) {
          if("true".equalsIgnoreCase(text)) {
@@ -249,15 +312,41 @@ public final class PropertyPath {
       }
    }
 
+   /**
+    * Finds a reader: {@code getX()}, {@code isX()}, or the bare {@code x()} an Immutables model
+    * generates. Without the bare form the five Immutables dialog models — image, presenter,
+    * table layout, and both viewsheet-level ones — could not be read at all.
+    */
    private static Method getterFor(Class<?> type, String property) {
       String suffix = capitalize(property);
+      Method bare = null;
 
       for(Method method : type.getMethods()) {
-         if(method.getParameterCount() != 0) {
+         if(method.getParameterCount() != 0 || method.getDeclaringClass() == Object.class) {
             continue;
          }
 
          if(method.getName().equals("get" + suffix) || method.getName().equals("is" + suffix)) {
+            return method;
+         }
+
+         if(method.getName().equals(property)) {
+            bare = method;
+         }
+      }
+
+      return bare;
+   }
+
+   /**
+    * Finds an Immutables wither: {@code withX(value)} returning a <b>new</b> instance rather
+    * than mutating this one.
+    */
+   private static Method witherFor(Class<?> type, String property) {
+      String name = "with" + capitalize(property);
+
+      for(Method method : type.getMethods()) {
+         if(method.getParameterCount() == 1 && method.getName().equals(name)) {
             return method;
          }
       }
@@ -312,4 +401,46 @@ public final class PropertyPath {
       return value.isEmpty() ? value
          : Character.toLowerCase(value.charAt(0)) + value.substring(1);
    }
+
+   /**
+    * Refuses a value outside a String property's closed domain.
+    *
+    * <p>Some String-typed properties are enums in disguise: StyleBI maps a recognised token to a
+    * constant and silently keeps the default for anything else. Passing the raw text through
+    * produces the worst outcome available — a clean "ok" for a setting that was never applied.
+    * Live, {@code visible: "no"} stored "no" and left the assembly on screen.
+    */
+   private static void requireAllowedValue(String text, Object value, Class<?> target,
+                                           String path)
+   {
+      if(target != String.class) {
+         return;
+      }
+
+      Set<String> allowed = CONSTRAINED_STRINGS.get(leafName(path));
+
+      if(allowed != null && allowed.stream().noneMatch(v -> v.equalsIgnoreCase(text))) {
+         throw new IllegalArgumentException(
+            "'" + path + "' accepts only " + new TreeSet<>(allowed) + "; '" + value + "' is not " +
+            "one of them. StyleBI ignores an unrecognised value and keeps the default, so this " +
+            "would have reported success without changing anything.");
+      }
+   }
+
+   /** The last segment of a dotted path — the property's own name. */
+   private static String leafName(String path) {
+      int dot = path.lastIndexOf('.');
+      return dot < 0 ? path : path.substring(dot + 1);
+   }
+
+   /**
+    * String-typed properties whose value domain is closed.
+    *
+    * <p>{@code visible} is declared in {@code VSAssemblyInfo} as a {@code DynamicValue} over
+    * {@code {"true","show","false","hide","hide on print and export"}}; an unrecognised token is
+    * not an error there, it simply leaves the default in place. Without this check the tool
+    * reported success for {@code visible: "no"} and the assembly stayed on screen.
+    */
+   private static final Map<String, Set<String>> CONSTRAINED_STRINGS = Map.of(
+      "visible", Set.of("true", "show", "false", "hide", "hide on print and export"));
 }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAgentController.java
@@ -25,7 +25,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
+import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.XPrincipal;
+import inetsoft.uql.asset.AssetEntry;
 import inetsoft.web.wiz.script.ScriptImageService;
 
 import java.security.Principal;
@@ -50,7 +54,9 @@ public class ViewsheetAgentController {
                                    ViewsheetReadService readService,
                                    ViewsheetEditService editService,
                                    ViewsheetFormatService formatService,
-                                   ScriptImageService imageService)
+                                   ScriptImageService imageService,
+                                   ViewsheetService viewsheetService,
+                                   SheetAgentBroadcastService broadcast)
    {
       this.feature = feature;
       this.joinService = joinService;
@@ -60,6 +66,8 @@ public class ViewsheetAgentController {
       this.editService = editService;
       this.formatService = formatService;
       this.imageService = imageService;
+      this.viewsheetService = viewsheetService;
+      this.broadcast = broadcast;
    }
 
    public record JoinRequest(String code) {}
@@ -123,6 +131,66 @@ public class ViewsheetAgentController {
                                image.width(), image.height(), image.note());
    }
 
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/save")
+   public void save(@PathVariable String sessionToken, Principal user) throws PairingException {
+      requireEnabled();
+      RuntimeViewsheet rvs = sessions.resolve(sessionToken, user);
+      AssetEntry entry = rvs.getEntry();
+
+      if(entry.getScope() == AssetRepository.TEMPORARY_SCOPE) {
+         throw new PairingException(
+            "Viewsheet is unsaved (\"" + entry.toView() + "\"). Save it with a name in the " +
+            "StyleBI Composer first — there is no save-as through this tool — then call " +
+            "save_viewsheet again.");
+      }
+
+      if(!(user instanceof XPrincipal xp)) {
+         throw new PairingException("Cannot save: agent principal is not an XPrincipal (" +
+                                    user.getClass().getName() + ")");
+      }
+
+      try {
+         viewsheetService.setViewsheet(rvs.getViewsheet(), entry, xp, true, true);
+         rvs.setSavePoint(rvs.getCurrent());
+      }
+      catch(Exception e) {
+         throw new PairingException("Failed to save viewsheet: " + e.getMessage(), e);
+      }
+
+      broadcast.broadcastSave(rvs, rvs.getID(), user);
+   }
+
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/undo")
+   public Map<String, Object> undo(@PathVariable String sessionToken, Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      RuntimeViewsheet rvs = sessions.resolve(sessionToken, user);
+      boolean undone = rvs.undo(null);
+      broadcast.broadcastRefresh(rvs, SheetType.VIEWSHEET, rvs.getID(), user);
+      return undoState("undone", undone, rvs);
+   }
+
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/redo")
+   public Map<String, Object> redo(@PathVariable String sessionToken, Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      RuntimeViewsheet rvs = sessions.resolve(sessionToken, user);
+      boolean redone = rvs.redo(null);
+      broadcast.broadcastRefresh(rvs, SheetType.VIEWSHEET, rvs.getID(), user);
+      return undoState("redone", redone, rvs);
+   }
+
+   private static Map<String, Object> undoState(String key, boolean applied, RuntimeViewsheet rvs) {
+      Map<String, Object> state = new LinkedHashMap<>();
+      state.put(key, applied);
+      state.put("checkpoint", rvs.getCurrent());
+      state.put("total", rvs.size());
+      state.put("savePoint", rvs.getSavePoint());
+      return state;
+   }
+
    @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/detach")
    public void detach(@PathVariable String sessionToken, Principal user) {
       sessionService.close(sessionToken);
@@ -159,4 +227,6 @@ public class ViewsheetAgentController {
    private final ViewsheetEditService editService;
    private final ViewsheetFormatService formatService;
    private final ScriptImageService imageService;
+   private final ViewsheetService viewsheetService;
+   private final SheetAgentBroadcastService broadcast;
 }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAgentController.java
@@ -25,7 +25,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.web.wiz.script.ScriptImageService;
+
 import java.security.Principal;
+import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -44,7 +48,9 @@ public class ViewsheetAgentController {
                                    SheetSessionService sessionService,
                                    ViewsheetSessionService sessions,
                                    ViewsheetReadService readService,
-                                   ViewsheetEditService editService)
+                                   ViewsheetEditService editService,
+                                   ViewsheetFormatService formatService,
+                                   ScriptImageService imageService)
    {
       this.feature = feature;
       this.joinService = joinService;
@@ -52,6 +58,8 @@ public class ViewsheetAgentController {
       this.sessions = sessions;
       this.readService = readService;
       this.editService = editService;
+      this.formatService = formatService;
+      this.imageService = imageService;
    }
 
    public record JoinRequest(String code) {}
@@ -81,6 +89,38 @@ public class ViewsheetAgentController {
    {
       requireEnabled();
       editService.apply(sessionToken, user, request, linkUri);
+   }
+
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/format")
+   public void format(@PathVariable String sessionToken,
+                      @RequestBody ViewsheetFormatService.FormatRequest request,
+                      @RequestParam(required = false, defaultValue = "") String linkUri,
+                      Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      formatService.setFormat(sessionToken, user, request, linkUri);
+   }
+
+   public record ImageResponse(String image, String format, int width, int height, String note) {}
+
+   @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/image")
+   public ImageResponse image(@PathVariable String sessionToken,
+                              @RequestParam(required = false) String target,
+                              @RequestParam(required = false) Integer width,
+                              @RequestParam(required = false) Integer height,
+                              Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      RuntimeViewsheet rvs = sessions.resolve(sessionToken, user);
+      ScriptImageService.ChartImage image = target == null || target.isBlank()
+         ? imageService.getViewsheetImage(rvs, width, height, user)
+         : imageService.getAssemblyImage(rvs, target, width, height, user);
+
+      return new ImageResponse(Base64.getEncoder().encodeToString(image.pngBytes()),
+                               image.isPng() ? "png" : "svg",
+                               image.width(), image.height(), image.note());
    }
 
    @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/detach")
@@ -117,4 +157,6 @@ public class ViewsheetAgentController {
    private final ViewsheetSessionService sessions;
    private final ViewsheetReadService readService;
    private final ViewsheetEditService editService;
+   private final ViewsheetFormatService formatService;
+   private final ScriptImageService imageService;
 }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAgentController.java
@@ -43,13 +43,15 @@ public class ViewsheetAgentController {
                                    SheetJoinService joinService,
                                    SheetSessionService sessionService,
                                    ViewsheetSessionService sessions,
-                                   ViewsheetReadService readService)
+                                   ViewsheetReadService readService,
+                                   ViewsheetEditService editService)
    {
       this.feature = feature;
       this.joinService = joinService;
       this.sessionService = sessionService;
       this.sessions = sessions;
       this.readService = readService;
+      this.editService = editService;
    }
 
    public record JoinRequest(String code) {}
@@ -68,6 +70,17 @@ public class ViewsheetAgentController {
    {
       requireEnabled();
       return readService.read(sessions.resolve(sessionToken, user));
+   }
+
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/edit")
+   public void edit(@PathVariable String sessionToken,
+                    @RequestBody EditRequest request,
+                    @RequestParam(required = false, defaultValue = "") String linkUri,
+                    Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      editService.apply(sessionToken, user, request, linkUri);
    }
 
    @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/detach")
@@ -103,4 +116,5 @@ public class ViewsheetAgentController {
    private final SheetSessionService sessionService;
    private final ViewsheetSessionService sessions;
    private final ViewsheetReadService readService;
+   private final ViewsheetEditService editService;
 }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAgentController.java
@@ -1,0 +1,106 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.web.wiz.pairing.*;
+import inetsoft.web.wiz.viewsheet.model.ViewsheetModel;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.security.Principal;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * REST surface for agent-driven viewsheet layout editing.
+ *
+ * <p>Validation and delegation only — every mutation goes through the Composer's own services
+ * via {@link ViewsheetSessionService}, which supplies the capturing dispatcher, the checkpoint,
+ * and the browser broadcast.
+ */
+@RestController
+public class ViewsheetAgentController {
+   @Autowired
+   public ViewsheetAgentController(SheetAgentFeature feature,
+                                   SheetJoinService joinService,
+                                   SheetSessionService sessionService,
+                                   ViewsheetSessionService sessions,
+                                   ViewsheetReadService readService)
+   {
+      this.feature = feature;
+      this.joinService = joinService;
+      this.sessionService = sessionService;
+      this.sessions = sessions;
+      this.readService = readService;
+   }
+
+   public record JoinRequest(String code) {}
+   public record JoinResponse(String sessionToken, String runtimeId, String ownerIdentity) {}
+
+   @PostMapping("/api/wiz/v1/agent/viewsheet/join")
+   public JoinResponse join(@RequestBody JoinRequest body, Principal user) throws PairingException {
+      requireEnabled();
+      JoinSession session = joinService.join(body.code(), user);
+      return new JoinResponse(session.sessionToken(), session.runtimeId(), session.ownerIdentity());
+   }
+
+   @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/model")
+   public ViewsheetModel model(@PathVariable String sessionToken, Principal user)
+      throws PairingException
+   {
+      requireEnabled();
+      return readService.read(sessions.resolve(sessionToken, user));
+   }
+
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/detach")
+   public void detach(@PathVariable String sessionToken, Principal user) {
+      sessionService.close(sessionToken);
+   }
+
+   private void requireEnabled() {
+      if(!feature.isEnabled()) {
+         throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                                           "Sheet agent pairing is disabled");
+      }
+   }
+
+   @ExceptionHandler(PairingException.class)
+   public ResponseEntity<Map<String, String>> handlePairingException(PairingException e) {
+      HttpStatus status = switch(e.getKind()) {
+         case SESSION_EXPIRED -> HttpStatus.NOT_FOUND;
+         case USER_MISMATCH, FEATURE_DISABLED -> HttpStatus.FORBIDDEN;
+         case RATE_LIMITED -> HttpStatus.TOO_MANY_REQUESTS;
+         case INTERNAL -> HttpStatus.INTERNAL_SERVER_ERROR;
+         default -> HttpStatus.BAD_REQUEST;
+      };
+
+      Map<String, String> body = new LinkedHashMap<>();
+      body.put("error", e.getMessage());
+      body.put("errorCode", e.getKind().name());
+      return ResponseEntity.status(status).body(body);
+   }
+
+   private final SheetAgentFeature feature;
+   private final SheetJoinService joinService;
+   private final SheetSessionService sessionService;
+   private final ViewsheetSessionService sessions;
+   private final ViewsheetReadService readService;
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -55,6 +55,7 @@ public class ViewsheetAssemblyAgentController {
                                    ViewsheetEditService editService,
                                    ViewsheetFormatService formatService,
                                    ScriptImageService imageService,
+                                   AssemblyPropertyService propertyService,
                                    ViewsheetService viewsheetService,
                                    SheetAgentBroadcastService broadcast)
    {
@@ -66,6 +67,7 @@ public class ViewsheetAssemblyAgentController {
       this.editService = editService;
       this.formatService = formatService;
       this.imageService = imageService;
+      this.propertyService = propertyService;
       this.viewsheetService = viewsheetService;
       this.broadcast = broadcast;
    }
@@ -129,6 +131,40 @@ public class ViewsheetAssemblyAgentController {
       return new ImageResponse(Base64.getEncoder().encodeToString(image.pngBytes()),
                                image.isPng() ? "png" : "svg",
                                image.width(), image.height(), image.note());
+   }
+
+   public record PropertyPatchRequest(String assembly, Map<String, Object> properties) {}
+
+   @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/properties/list")
+   public Map<String, Object> listAssemblyProperties(@PathVariable String sessionToken,
+                                                     @RequestParam String assembly,
+                                                     Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return propertyService.list(sessionToken, user, assembly);
+   }
+
+   @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/properties")
+   public Object getAssemblyProperties(@PathVariable String sessionToken,
+                                       @RequestParam String assembly,
+                                       @RequestParam(required = false) boolean raw,
+                                       Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return propertyService.get(sessionToken, user, assembly, raw);
+   }
+
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/properties")
+   public void setAssemblyProperties(@PathVariable String sessionToken,
+                                     @RequestBody PropertyPatchRequest request,
+                                     @RequestParam(required = false, defaultValue = "") String linkUri,
+                                     Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      propertyService.set(sessionToken, user, request.assembly(), request.properties(), linkUri);
    }
 
    @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/save")
@@ -227,6 +263,7 @@ public class ViewsheetAssemblyAgentController {
    private final ViewsheetEditService editService;
    private final ViewsheetFormatService formatService;
    private final ScriptImageService imageService;
+   private final AssemblyPropertyService propertyService;
    private final ViewsheetService viewsheetService;
    private final SheetAgentBroadcastService broadcast;
 }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -57,6 +57,7 @@ public class ViewsheetAssemblyAgentController {
                                    ScriptImageService imageService,
                                    AssemblyPropertyService propertyService,
                                    AssemblyHyperlinkService hyperlinkService,
+                                   ChartElementService chartElementService,
                                    ViewsheetService viewsheetService,
                                    SheetAgentBroadcastService broadcast)
    {
@@ -70,6 +71,7 @@ public class ViewsheetAssemblyAgentController {
       this.imageService = imageService;
       this.propertyService = propertyService;
       this.hyperlinkService = hyperlinkService;
+      this.chartElementService = chartElementService;
       this.viewsheetService = viewsheetService;
       this.broadcast = broadcast;
    }
@@ -213,6 +215,52 @@ public class ViewsheetAssemblyAgentController {
                            request.link(), linkUri);
    }
 
+   public record ElementVisibilityRequest(String assembly, String element, String target,
+                                          Boolean visible) {}
+   public record PlotResizeRequest(String assembly, Double ratio, Boolean vertical,
+                                   Boolean reset) {}
+
+   @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/chart/elements")
+   public Map<String, Object> chartElementVocabulary(@PathVariable String sessionToken,
+                                                     Principal user)
+   {
+      requireEnabled();
+      return chartElementService.vocabulary();
+   }
+
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/chart/element-visibility")
+   public void setChartElementVisibility(
+      @PathVariable String sessionToken,
+      @RequestBody ElementVisibilityRequest request,
+      @RequestParam(required = false, defaultValue = "") String linkUri,
+      Principal user) throws Exception
+   {
+      requireEnabled();
+
+      if(request.visible() == null) {
+         throw new IllegalArgumentException(
+            "set_chart_element_visibility requires 'visible' — true to show, false to hide. " +
+            "Defaulting it either way would guess at the caller's intent.");
+      }
+
+      chartElementService.setVisibility(sessionToken, user, request.assembly(),
+                                        request.element(), request.target(), request.visible(),
+                                        linkUri);
+   }
+
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/chart/plot-size")
+   public void resizeChartPlot(@PathVariable String sessionToken,
+                               @RequestBody PlotResizeRequest request,
+                               @RequestParam(required = false, defaultValue = "") String linkUri,
+                               Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      chartElementService.resizePlot(sessionToken, user, request.assembly(), request.ratio(),
+                                     Boolean.TRUE.equals(request.vertical()),
+                                     Boolean.TRUE.equals(request.reset()), linkUri);
+   }
+
    @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/save")
    public void save(@PathVariable String sessionToken, Principal user) throws PairingException {
       requireEnabled();
@@ -311,6 +359,7 @@ public class ViewsheetAssemblyAgentController {
    private final ScriptImageService imageService;
    private final AssemblyPropertyService propertyService;
    private final AssemblyHyperlinkService hyperlinkService;
+   private final ChartElementService chartElementService;
    private final ViewsheetService viewsheetService;
    private final SheetAgentBroadcastService broadcast;
 }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.wiz.viewsheet;
 
+import inetsoft.sree.security.IdentityID;
 import inetsoft.web.wiz.pairing.*;
 import inetsoft.web.wiz.viewsheet.model.ViewsheetModel;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -207,8 +208,14 @@ public class ViewsheetAssemblyAgentController {
    }
 
    @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/hyperlink/types")
-   public Map<String, Object> hyperlinkTypes(@PathVariable String sessionToken, Principal user) {
+   public Map<String, Object> hyperlinkTypes(@PathVariable String sessionToken, Principal user)
+      throws Exception
+   {
       requireEnabled();
+      // Static data, so nothing is exposed by skipping this -- but an agent that gets a clean
+      // answer here while every other call reports SESSION_EXPIRED has a contradictory picture of
+      // its own session to reason from.
+      sessions.resolve(sessionToken, user);
       return hyperlinkService.linkTypes();
    }
 
@@ -232,8 +239,10 @@ public class ViewsheetAssemblyAgentController {
    @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/chart/elements")
    public Map<String, Object> chartElementVocabulary(@PathVariable String sessionToken,
                                                      Principal user)
+      throws Exception
    {
       requireEnabled();
+      sessions.resolve(sessionToken, user);
       return chartElementService.vocabulary();
    }
 
@@ -335,8 +344,10 @@ public class ViewsheetAssemblyAgentController {
    @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/condition/vocabulary")
    public Map<String, Object> conditionVocabulary(@PathVariable String sessionToken,
                                                   Principal user)
+      throws Exception
    {
       requireEnabled();
+      sessions.resolve(sessionToken, user);
       return conditionService.vocabulary();
    }
 
@@ -557,9 +568,31 @@ public class ViewsheetAssemblyAgentController {
       return state;
    }
 
+   /**
+    * Closes the caller's own pairing session.
+    *
+    * <p>Resolves the token against the caller first. Without that, this endpoint took a session
+    * token and nothing else, so any authenticated caller holding or guessing another user's token
+    * could terminate their pairing -- {@code Principal} was accepted and ignored while every other
+    * endpoint binds the token through {@code resolve}. Skipping {@code requireEnabled()} is
+    * deliberate and stays: disconnecting is always allowed.
+    */
    @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/detach")
    public void detach(@PathVariable String sessionToken, Principal user) {
-      sessionService.close(sessionToken);
+      JoinSession session = sessionService.resolve(sessionToken, agentKey(user));
+
+      if(session != null) {
+         sessionService.close(sessionToken);
+      }
+   }
+
+   private static String agentKey(Principal agent) {
+      if(agent instanceof XPrincipal p) {
+         IdentityID id = IdentityID.getIdentityIDFromKey(p.getName());
+         return id != null ? id.convertToKey() : p.getName();
+      }
+
+      return agent != null ? agent.getName() : null;
    }
 
    private void requireEnabled() {

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -59,6 +59,7 @@ public class ViewsheetAssemblyAgentController {
                                    AssemblyPropertyService propertyService,
                                    AssemblyHyperlinkService hyperlinkService,
                                    ChartElementService chartElementService,
+                                   ChartRegionPropertyService chartRegionService,
                                    AssemblyConditionService conditionService,
                                    AssemblyHighlightService highlightService,
                                    DateComparisonService comparisonService,
@@ -76,6 +77,7 @@ public class ViewsheetAssemblyAgentController {
       this.propertyService = propertyService;
       this.hyperlinkService = hyperlinkService;
       this.chartElementService = chartElementService;
+      this.chartRegionService = chartRegionService;
       this.conditionService = conditionService;
       this.highlightService = highlightService;
       this.comparisonService = comparisonService;
@@ -234,6 +236,44 @@ public class ViewsheetAssemblyAgentController {
       requireEnabled();
       return chartElementService.vocabulary();
    }
+
+   @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/chart/regions")
+   public Map<String, Object> chartRegionVocabulary(@PathVariable String sessionToken,
+                                                    Principal user)
+   {
+      requireEnabled();
+      return chartRegionService.vocabulary();
+   }
+
+   @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/chart/region-properties")
+   public Map<String, Object> listChartRegionProperties(@PathVariable String sessionToken,
+                                                        @RequestParam String assembly,
+                                                        @RequestParam String region,
+                                                        @RequestParam String target,
+                                                        @RequestParam(required = false)
+                                                        String field,
+                                                        Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return chartRegionService.list(sessionToken, user, assembly, region, target, field);
+   }
+
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/chart/region-properties")
+   public void setChartRegionProperties(@PathVariable String sessionToken,
+                                        @RequestBody RegionPropertiesRequest request,
+                                        @RequestParam(required = false, defaultValue = "")
+                                        String linkUri,
+                                        Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      chartRegionService.set(sessionToken, user, request.assembly(), request.region(),
+                             request.target(), request.field(), request.properties(), linkUri);
+   }
+
+   public record RegionPropertiesRequest(String assembly, String region, String target,
+                                         String field, Map<String, Object> properties) {}
 
    @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/chart/element-visibility")
    public void setChartElementVisibility(
@@ -556,6 +596,7 @@ public class ViewsheetAssemblyAgentController {
    private final AssemblyPropertyService propertyService;
    private final AssemblyHyperlinkService hyperlinkService;
    private final ChartElementService chartElementService;
+   private final ChartRegionPropertyService chartRegionService;
    private final AssemblyConditionService conditionService;
    private final AssemblyHighlightService highlightService;
    private final DateComparisonService comparisonService;

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -60,6 +60,7 @@ public class ViewsheetAssemblyAgentController {
                                    AssemblyHyperlinkService hyperlinkService,
                                    ChartElementService chartElementService,
                                    AssemblyConditionService conditionService,
+                                   AssemblyHighlightService highlightService,
                                    ViewsheetService viewsheetService,
                                    SheetAgentBroadcastService broadcast)
    {
@@ -75,6 +76,7 @@ public class ViewsheetAssemblyAgentController {
       this.hyperlinkService = hyperlinkService;
       this.chartElementService = chartElementService;
       this.conditionService = conditionService;
+      this.highlightService = highlightService;
       this.viewsheetService = viewsheetService;
       this.broadcast = broadcast;
    }
@@ -349,6 +351,67 @@ public class ViewsheetAssemblyAgentController {
       conditionService.clear(sessionToken, user, request.assembly(), linkUri);
    }
 
+   public record HighlightRequest(String assembly, Integer row, Integer col, String colName,
+                                  String name, String foreground, String background,
+                                  List<ConditionClause> conditions, Boolean applyRow,
+                                  Boolean replace) {
+      AssemblyHighlightService.Region region() {
+         return new AssemblyHighlightService.Region(row, col, colName, false, false);
+      }
+
+      AssemblyHighlightService.Highlight highlight() {
+         List<ConditionVocabulary.Clause> clauses = new java.util.ArrayList<>();
+
+         if(conditions != null) {
+            for(ConditionClause clause : conditions) {
+               clauses.add(clause.toClause());
+            }
+         }
+
+         return new AssemblyHighlightService.Highlight(name, foreground, background, clauses,
+                                                       Boolean.TRUE.equals(applyRow));
+      }
+   }
+
+   @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/highlights")
+   public Map<String, Object> listHighlights(@PathVariable String sessionToken,
+                                             @RequestParam String assembly,
+                                             @RequestParam(required = false) Integer row,
+                                             @RequestParam(required = false) Integer col,
+                                             @RequestParam(required = false) String colName,
+                                             Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return highlightService.list(sessionToken, user, assembly,
+                                   new AssemblyHighlightService.Region(row, col, colName, false,
+                                                                       false));
+   }
+
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/highlights")
+   public void setHighlight(@PathVariable String sessionToken,
+                            @RequestBody HighlightRequest request,
+                            @RequestParam(required = false, defaultValue = "") String linkUri,
+                            Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      highlightService.set(sessionToken, user, request.assembly(), request.region(),
+                           request.highlight(), Boolean.TRUE.equals(request.replace()), linkUri);
+   }
+
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/highlights/delete")
+   public void deleteHighlight(@PathVariable String sessionToken,
+                               @RequestBody HighlightRequest request,
+                               @RequestParam(required = false, defaultValue = "") String linkUri,
+                               Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      highlightService.delete(sessionToken, user, request.assembly(), request.region(),
+                              request.name(), linkUri);
+   }
+
    @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/save")
    public void save(@PathVariable String sessionToken, Principal user) throws PairingException {
       requireEnabled();
@@ -449,6 +512,7 @@ public class ViewsheetAssemblyAgentController {
    private final AssemblyHyperlinkService hyperlinkService;
    private final ChartElementService chartElementService;
    private final AssemblyConditionService conditionService;
+   private final AssemblyHighlightService highlightService;
    private final ViewsheetService viewsheetService;
    private final SheetAgentBroadcastService broadcast;
 }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -61,6 +61,7 @@ public class ViewsheetAssemblyAgentController {
                                    ChartElementService chartElementService,
                                    AssemblyConditionService conditionService,
                                    AssemblyHighlightService highlightService,
+                                   DateComparisonService comparisonService,
                                    ViewsheetService viewsheetService,
                                    SheetAgentBroadcastService broadcast)
    {
@@ -77,6 +78,7 @@ public class ViewsheetAssemblyAgentController {
       this.chartElementService = chartElementService;
       this.conditionService = conditionService;
       this.highlightService = highlightService;
+      this.comparisonService = comparisonService;
       this.viewsheetService = viewsheetService;
       this.broadcast = broadcast;
    }
@@ -412,6 +414,49 @@ public class ViewsheetAssemblyAgentController {
                               request.name(), linkUri);
    }
 
+   public record DateComparisonRequest(String assembly, Integer periods, String level,
+                                       String endDate, Boolean endToday, String interval,
+                                       Boolean useFacet, Boolean onlyShowMostRecentDate,
+                                       Map<String, Object> frame) {
+      DateComparisonService.Comparison comparison() {
+         return new DateComparisonService.Comparison(
+            periods, level, endDate, Boolean.TRUE.equals(endToday), interval, useFacet,
+            onlyShowMostRecentDate, frame);
+      }
+   }
+
+   @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/date-comparison")
+   public Map<String, Object> getDateComparison(@PathVariable String sessionToken,
+                                                @RequestParam String assembly,
+                                                Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return comparisonService.read(sessionToken, user, assembly);
+   }
+
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/date-comparison")
+   public void setDateComparison(
+      @PathVariable String sessionToken,
+      @RequestBody DateComparisonRequest request,
+      @RequestParam(required = false, defaultValue = "") String linkUri,
+      Principal user) throws Exception
+   {
+      requireEnabled();
+      comparisonService.set(sessionToken, user, request.assembly(), request.comparison(), linkUri);
+   }
+
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/date-comparison/clear")
+   public void clearDateComparison(
+      @PathVariable String sessionToken,
+      @RequestBody DateComparisonRequest request,
+      @RequestParam(required = false, defaultValue = "") String linkUri,
+      Principal user) throws Exception
+   {
+      requireEnabled();
+      comparisonService.clear(sessionToken, user, request.assembly(), linkUri);
+   }
+
    @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/save")
    public void save(@PathVariable String sessionToken, Principal user) throws PairingException {
       requireEnabled();
@@ -513,6 +558,7 @@ public class ViewsheetAssemblyAgentController {
    private final ChartElementService chartElementService;
    private final AssemblyConditionService conditionService;
    private final AssemblyHighlightService highlightService;
+   private final DateComparisonService comparisonService;
    private final ViewsheetService viewsheetService;
    private final SheetAgentBroadcastService broadcast;
 }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -45,9 +45,9 @@ import java.util.Map;
  * and the browser broadcast.
  */
 @RestController
-public class ViewsheetAgentController {
+public class ViewsheetAssemblyAgentController {
    @Autowired
-   public ViewsheetAgentController(SheetAgentFeature feature,
+   public ViewsheetAssemblyAgentController(SheetAgentFeature feature,
                                    SheetJoinService joinService,
                                    SheetSessionService sessionService,
                                    ViewsheetSessionService sessions,

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -34,6 +34,7 @@ import inetsoft.web.wiz.script.ScriptImageService;
 
 import java.security.Principal;
 import java.util.Base64;
+import java.util.List;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -58,6 +59,7 @@ public class ViewsheetAssemblyAgentController {
                                    AssemblyPropertyService propertyService,
                                    AssemblyHyperlinkService hyperlinkService,
                                    ChartElementService chartElementService,
+                                   AssemblyConditionService conditionService,
                                    ViewsheetService viewsheetService,
                                    SheetAgentBroadcastService broadcast)
    {
@@ -72,6 +74,7 @@ public class ViewsheetAssemblyAgentController {
       this.propertyService = propertyService;
       this.hyperlinkService = hyperlinkService;
       this.chartElementService = chartElementService;
+      this.conditionService = conditionService;
       this.viewsheetService = viewsheetService;
       this.broadcast = broadcast;
    }
@@ -261,6 +264,91 @@ public class ViewsheetAssemblyAgentController {
                                      Boolean.TRUE.equals(request.reset()), linkUri);
    }
 
+   /**
+    * One clause in the flat condition vocabulary. {@code junction} joins it to the NEXT clause,
+    * so the last clause must not carry one — {@link ConditionVocabulary} enforces that.
+    */
+   public record ConditionClause(String field, String operator, List<Object> values,
+                                 String junction, Boolean negated) {
+      ConditionVocabulary.Clause toClause() {
+         return new ConditionVocabulary.Clause(field, operator, values, junction,
+                                               Boolean.TRUE.equals(negated));
+      }
+   }
+
+   public record ConditionRequest(String assembly, List<ConditionClause> conditions) {}
+
+   @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/condition")
+   public Map<String, Object> getCondition(@PathVariable String sessionToken,
+                                           @RequestParam String assembly,
+                                           Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return conditionService.read(sessionToken, user, assembly);
+   }
+
+   @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/condition/vocabulary")
+   public Map<String, Object> conditionVocabulary(@PathVariable String sessionToken,
+                                                  Principal user)
+   {
+      requireEnabled();
+      return conditionService.vocabulary();
+   }
+
+   @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/condition/values")
+   public Object browseConditionValues(@PathVariable String sessionToken,
+                                       @RequestParam String assembly,
+                                       @RequestParam String column,
+                                       Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return conditionService.browseValues(sessionToken, user, assembly, column);
+   }
+
+   @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/condition/date-ranges")
+   public Object conditionDateRanges(@PathVariable String sessionToken, Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return conditionService.dateRanges(sessionToken, user);
+   }
+
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/condition")
+   public Map<String, Object> setCondition(
+      @PathVariable String sessionToken,
+      @RequestBody ConditionRequest request,
+      @RequestParam(required = false, defaultValue = "") String linkUri,
+      Principal user) throws Exception
+   {
+      requireEnabled();
+      List<ConditionVocabulary.Clause> clauses = new java.util.ArrayList<>();
+
+      if(request.conditions() != null) {
+         for(ConditionClause clause : request.conditions()) {
+            clauses.add(clause.toClause());
+         }
+      }
+
+      int applied = conditionService.set(sessionToken, user, request.assembly(), clauses, linkUri);
+      Map<String, Object> out = new LinkedHashMap<>();
+      out.put("ok", true);
+      out.put("conditionCount", applied);
+      return out;
+   }
+
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/condition/clear")
+   public void clearCondition(@PathVariable String sessionToken,
+                              @RequestBody ConditionRequest request,
+                              @RequestParam(required = false, defaultValue = "") String linkUri,
+                              Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      conditionService.clear(sessionToken, user, request.assembly(), linkUri);
+   }
+
    @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/save")
    public void save(@PathVariable String sessionToken, Principal user) throws PairingException {
       requireEnabled();
@@ -360,6 +448,7 @@ public class ViewsheetAssemblyAgentController {
    private final AssemblyPropertyService propertyService;
    private final AssemblyHyperlinkService hyperlinkService;
    private final ChartElementService chartElementService;
+   private final AssemblyConditionService conditionService;
    private final ViewsheetService viewsheetService;
    private final SheetAgentBroadcastService broadcast;
 }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -56,6 +56,7 @@ public class ViewsheetAssemblyAgentController {
                                    ViewsheetFormatService formatService,
                                    ScriptImageService imageService,
                                    AssemblyPropertyService propertyService,
+                                   AssemblyHyperlinkService hyperlinkService,
                                    ViewsheetService viewsheetService,
                                    SheetAgentBroadcastService broadcast)
    {
@@ -68,6 +69,7 @@ public class ViewsheetAssemblyAgentController {
       this.formatService = formatService;
       this.imageService = imageService;
       this.propertyService = propertyService;
+      this.hyperlinkService = hyperlinkService;
       this.viewsheetService = viewsheetService;
       this.broadcast = broadcast;
    }
@@ -167,6 +169,50 @@ public class ViewsheetAssemblyAgentController {
       propertyService.set(sessionToken, user, request.assembly(), request.properties(), linkUri);
    }
 
+   public record HyperlinkRequest(String assembly, Integer row, Integer col, String colName,
+                                  Boolean axis, Boolean text, Boolean titleLink,
+                                  Boolean emptyPlotLink, Map<String, Object> link) {
+      AssemblyHyperlinkService.Region region() {
+         return new AssemblyHyperlinkService.Region(
+            row, col, colName, Boolean.TRUE.equals(axis), Boolean.TRUE.equals(text),
+            Boolean.TRUE.equals(titleLink), Boolean.TRUE.equals(emptyPlotLink));
+      }
+   }
+
+   @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/hyperlink")
+   public Map<String, Object> getHyperlink(@PathVariable String sessionToken,
+                                           @RequestParam String assembly,
+                                           @RequestParam(required = false) Integer row,
+                                           @RequestParam(required = false) Integer col,
+                                           @RequestParam(required = false) String colName,
+                                           @RequestParam(required = false) boolean titleLink,
+                                           Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return hyperlinkService.read(
+         sessionToken, user, assembly,
+         new AssemblyHyperlinkService.Region(row, col, colName, false, false, titleLink, false));
+   }
+
+   @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/hyperlink/types")
+   public Map<String, Object> hyperlinkTypes(@PathVariable String sessionToken, Principal user) {
+      requireEnabled();
+      return hyperlinkService.linkTypes();
+   }
+
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/hyperlink")
+   public void setHyperlink(@PathVariable String sessionToken,
+                            @RequestBody HyperlinkRequest request,
+                            @RequestParam(required = false, defaultValue = "") String linkUri,
+                            Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      hyperlinkService.set(sessionToken, user, request.assembly(), request.region(),
+                           request.link(), linkUri);
+   }
+
    @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/save")
    public void save(@PathVariable String sessionToken, Principal user) throws PairingException {
       requireEnabled();
@@ -264,6 +310,7 @@ public class ViewsheetAssemblyAgentController {
    private final ViewsheetFormatService formatService;
    private final ScriptImageService imageService;
    private final AssemblyPropertyService propertyService;
+   private final AssemblyHyperlinkService hyperlinkService;
    private final ViewsheetService viewsheetService;
    private final SheetAgentBroadcastService broadcast;
 }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetEditService.java
@@ -27,6 +27,7 @@ import inetsoft.web.composer.vs.objects.controller.VSObjectPropertyService;
 import inetsoft.web.composer.vs.objects.event.*;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.web.wiz.viewsheet.model.AssemblyNode;
+import inetsoft.web.wiz.viewsheet.model.ViewsheetModel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -199,6 +200,8 @@ public class ViewsheetEditService {
       requireAssembly(request);
 
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         requireExisting(rvs, request.assembly());
+
          // An annotation is three linked assemblies. Removing one leaves the survivors
          // pointing at a name that no longer resolves, and nothing reports the orphaning.
          Viewsheet vs = rvs == null ? null : rvs.getViewsheet();
@@ -229,6 +232,10 @@ public class ViewsheetEditService {
       }
 
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         // Through the shared guard, so the message lists the names that do exist and every op
+         // reports a bad name the same way.
+         requireExisting(rvs, request.assembly());
+
          Viewsheet vs = rvs.getViewsheet();
          VSAssembly assembly = vs == null ? null : (VSAssembly) vs.getAssembly(request.assembly());
 
@@ -280,6 +287,8 @@ public class ViewsheetEditService {
       }
 
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         requireExisting(rvs, request.assembly());
+
          ChangeVSObjectLayerEvent event = new ChangeVSObjectLayerEvent();
          event.setName(request.assembly());
          event.setzIndex(request.zIndex());
@@ -298,6 +307,8 @@ public class ViewsheetEditService {
       }
 
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         requireExisting(rvs, request.assembly());
+
          LockVSObjectEvent event = new LockVSObjectEvent();
          event.setName(request.assembly());
          event.setLocked(request.locked());
@@ -315,6 +326,8 @@ public class ViewsheetEditService {
       }
 
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         requireExisting(rvs, request.assembly());
+
          ChangeVSObjectTextEvent event = new ChangeVSObjectTextEvent();
          event.setName(request.assembly());
          event.setText(request.title());
@@ -343,8 +356,10 @@ public class ViewsheetEditService {
    {
       requireAssembly(request);
 
-      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) ->
-         groups.ungroup(runtimeId, request.assembly(), linkUri, user, dispatcher));
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         requireExisting(rvs, request.assembly());
+         groups.ungroup(runtimeId, request.assembly(), linkUri, user, dispatcher);
+      });
    }
 
    private void moveFromContainer(String sessionToken, Principal user, EditRequest request,
@@ -354,6 +369,8 @@ public class ViewsheetEditService {
       requireValues(request.op(), "x", request.x(), "y", request.y());
 
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         requireExisting(rvs, request.assembly());
+
          MoveVSObjectEvent event = new MoveVSObjectEvent();
          event.setName(request.assembly());
          event.setxOffset(request.x());
@@ -505,8 +522,9 @@ public class ViewsheetEditService {
     */
    private AssemblyNode requireExisting(RuntimeViewsheet rvs, String name) {
       Map<String, AssemblyNode> byName = new LinkedHashMap<>();
+      ViewsheetModel model = reader.read(rvs);
 
-      for(AssemblyNode node : reader.read(rvs).assemblies()) {
+      for(AssemblyNode node : model == null ? List.<AssemblyNode>of() : model.assemblies()) {
          byName.put(node.name(), node);
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetEditService.java
@@ -1,0 +1,132 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.web.composer.vs.objects.controller.ComposerObjectService;
+import inetsoft.web.composer.vs.objects.event.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+import java.util.List;
+
+/**
+ * Applies structural edits by delegating to the Composer's own services.
+ *
+ * <p>Each {@code apply} call is exactly one {@code mutate}, so it is one undo checkpoint in
+ * the human's Composer — matching what a single Composer action does.
+ */
+@Service
+public class ViewsheetEditService {
+   @Autowired
+   public ViewsheetEditService(ViewsheetSessionService sessions, ComposerObjectService objects) {
+      this.sessions = sessions;
+      this.objects = objects;
+   }
+
+   /** Ops this service understands, named in the error when an unknown one arrives. */
+   static final List<String> OPS = List.of("move", "resize", "resize_title");
+
+   public void apply(String sessionToken, Principal user, EditRequest request, String linkUri)
+      throws Exception
+   {
+      String op = request.op() == null ? "" : request.op().trim().toLowerCase();
+
+      switch(op) {
+      case "move" -> move(sessionToken, user, request, linkUri);
+      case "resize" -> resize(sessionToken, user, request, linkUri);
+      case "resize_title" -> resizeTitle(sessionToken, user, request, linkUri);
+      default -> throw new IllegalArgumentException(
+         "Unknown edit op '" + request.op() + "'. Supported ops: " + String.join(", ", OPS) + ".");
+      }
+   }
+
+   private void move(String sessionToken, Principal user, EditRequest request, String linkUri)
+      throws Exception
+   {
+      requireAssembly(request);
+      requireValues(request.op(), "x", request.x(), "y", request.y());
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         MoveVSObjectEvent move = new MoveVSObjectEvent();
+         move.setName(request.assembly());
+         move.setxOffset(request.x());
+         move.setyOffset(request.y());
+
+         MultiMoveVsObjectEvent event = new MultiMoveVsObjectEvent();
+         event.setEvents(new MoveVSObjectEvent[]{ move });
+         objects.moveObjects(runtimeId, event, user, dispatcher, linkUri);
+      });
+   }
+
+   private void resize(String sessionToken, Principal user, EditRequest request, String linkUri)
+      throws Exception
+   {
+      requireAssembly(request);
+      requireValues(request.op(), "width", request.width(), "height", request.height());
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         ResizeVSObjectEvent event = new ResizeVSObjectEvent();
+         event.setName(request.assembly());
+         event.setWidth(request.width());
+         event.setHeight(request.height());
+         objects.resizeObject(runtimeId, event, user, dispatcher, linkUri);
+      });
+   }
+
+   /**
+    * Resizes an assembly's title bar. {@code ResizeVSObjectTitleEvent} carries a title height
+    * rather than a width/height pair, so this op reads {@code height} alone.
+    */
+   private void resizeTitle(String sessionToken, Principal user, EditRequest request,
+                            String linkUri) throws Exception
+   {
+      requireAssembly(request);
+
+      if(request.height() == null) {
+         throw new IllegalArgumentException(
+            "Edit op 'resize_title' requires 'height' — the new title-bar height in pixels.");
+      }
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         ResizeVSObjectTitleEvent event = new ResizeVSObjectTitleEvent();
+         event.setName(request.assembly());
+         event.setTitleHeight(request.height());
+         objects.resizeObjectTitle(runtimeId, event, user, dispatcher, linkUri);
+      });
+   }
+
+   private static void requireAssembly(EditRequest request) {
+      if(request.assembly() == null || request.assembly().isBlank()) {
+         throw new IllegalArgumentException(
+            "Edit op '" + request.op() + "' requires 'assembly' — the assembly name.");
+      }
+   }
+
+   private static void requireValues(String op, String firstName, Object first,
+                                     String secondName, Object second)
+   {
+      if(first == null || second == null) {
+         throw new IllegalArgumentException(
+            "Edit op '" + op + "' requires both '" + firstName + "' and '" + secondName + "'.");
+      }
+   }
+
+   private final ViewsheetSessionService sessions;
+   private final ComposerObjectService objects;
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetEditService.java
@@ -172,8 +172,18 @@ public class ViewsheetEditService {
    {
       requireAssembly(request);
 
-      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) ->
-         objects.removeObject(runtimeId, request.assembly(), linkUri, user, dispatcher));
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         // An annotation is three linked assemblies. Removing one leaves the survivors
+         // pointing at a name that no longer resolves, and nothing reports the orphaning.
+         Viewsheet vs = rvs == null ? null : rvs.getViewsheet();
+         VSAssembly target = vs == null ? null : vs.getAssembly(request.assembly());
+
+         if(target != null && AnnotationFamily.isPart(target)) {
+            throw AnnotationFamily.removeRefusal(request.assembly());
+         }
+
+         objects.removeObject(runtimeId, request.assembly(), linkUri, user, dispatcher);
+      });
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetEditService.java
@@ -374,7 +374,20 @@ public class ViewsheetEditService {
       requireValues(request.op(), "x", request.x(), "y", request.y());
 
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
-         requireExisting(rvs, request.assembly());
+         AssemblyNode current = requireExisting(rvs, request.assembly());
+
+         // 'container' was accepted and never read -- the Composer service infers the parent from
+         // the assembly, so naming the wrong container, or one the assembly is not in, returned
+         // ok. Checking it makes the parameter mean something instead of being decoration.
+         if(request.container() != null && !request.container().isBlank() &&
+            !request.container().equals(current.container()))
+         {
+            throw new IllegalArgumentException(
+               "'" + request.assembly() + "' is not in container '" + request.container() +
+               "'. It is " + (current.container() == null
+                  ? "not in any container" : "in '" + current.container() + "'") +
+               ". Omit 'container' to move it out of whichever container it is in.");
+         }
 
          MoveVSObjectEvent event = new MoveVSObjectEvent();
          event.setName(request.assembly());

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetEditService.java
@@ -21,14 +21,20 @@ import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.composer.vs.event.CopyVSObjectsEvent;
 import inetsoft.web.composer.vs.objects.controller.ClipboardControllerService;
+import inetsoft.web.composer.vs.objects.controller.ComposerGroupService;
 import inetsoft.web.composer.vs.objects.controller.ComposerObjectService;
 import inetsoft.web.composer.vs.objects.controller.VSObjectPropertyService;
 import inetsoft.web.composer.vs.objects.event.*;
+import inetsoft.web.wiz.viewsheet.model.AssemblyNode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.security.Principal;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Applies structural edits by delegating to the Composer's own services.
@@ -42,17 +48,23 @@ public class ViewsheetEditService {
    public ViewsheetEditService(ViewsheetSessionService sessions,
                                ComposerObjectService objects,
                                ClipboardControllerService clipboard,
-                               VSObjectPropertyService propertyService)
+                               VSObjectPropertyService propertyService,
+                               ViewsheetReadService reader,
+                               ComposerGroupService groups)
    {
       this.sessions = sessions;
       this.objects = objects;
       this.clipboard = clipboard;
       this.propertyService = propertyService;
+      this.reader = reader;
+      this.groups = groups;
    }
 
    /** Ops this service understands, named in the error when an unknown one arrives. */
    static final List<String> OPS = List.of(
-      "move", "resize", "resize_title", "add", "remove", "rename", "copy", "paste");
+      "move", "resize", "resize_title", "add", "remove", "rename", "copy", "cut", "paste",
+      "set_z_index", "set_lock", "set_title", "group", "ungroup", "move_from_container",
+      "align", "distribute");
 
    public void apply(String sessionToken, Principal user, EditRequest request, String linkUri)
       throws Exception
@@ -68,6 +80,13 @@ public class ViewsheetEditService {
       case "rename" -> rename(sessionToken, user, request, linkUri);
       case "copy", "cut" -> copyOrCut(sessionToken, user, request, linkUri, "cut".equals(op));
       case "paste" -> paste(sessionToken, user, request, linkUri);
+      case "set_z_index" -> setZIndex(sessionToken, user, request);
+      case "set_lock" -> setLock(sessionToken, user, request);
+      case "set_title" -> setTitle(sessionToken, user, request);
+      case "group" -> group(sessionToken, user, request, linkUri);
+      case "ungroup" -> ungroup(sessionToken, user, request, linkUri);
+      case "move_from_container" -> moveFromContainer(sessionToken, user, request, linkUri);
+      case "align", "distribute" -> arrange(sessionToken, user, request, linkUri, op);
       default -> throw new IllegalArgumentException(
          "Unknown edit op '" + request.op() + "'. Supported ops: " + String.join(", ", OPS) + ".");
       }
@@ -215,6 +234,216 @@ public class ViewsheetEditService {
          clipboard.pasteObject(runtimeId, request.x(), request.y(), user, dispatcher, linkUri));
    }
 
+   private void setZIndex(String sessionToken, Principal user, EditRequest request)
+      throws Exception
+   {
+      requireAssembly(request);
+
+      if(request.zIndex() == null) {
+         throw new IllegalArgumentException("Edit op 'set_z_index' requires 'zIndex'.");
+      }
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         ChangeVSObjectLayerEvent event = new ChangeVSObjectLayerEvent();
+         event.setName(request.assembly());
+         event.setzIndex(request.zIndex());
+         objects.changeZIndex(runtimeId, event, user, dispatcher);
+      });
+   }
+
+   private void setLock(String sessionToken, Principal user, EditRequest request)
+      throws Exception
+   {
+      requireAssembly(request);
+
+      if(request.locked() == null) {
+         throw new IllegalArgumentException(
+            "Edit op 'set_lock' requires 'locked' (true to lock, false to unlock).");
+      }
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         LockVSObjectEvent event = new LockVSObjectEvent();
+         event.setName(request.assembly());
+         event.setLocked(request.locked());
+         objects.changeLockState(runtimeId, event, user, dispatcher);
+      });
+   }
+
+   private void setTitle(String sessionToken, Principal user, EditRequest request)
+      throws Exception
+   {
+      requireAssembly(request);
+
+      if(request.title() == null) {
+         throw new IllegalArgumentException("Edit op 'set_title' requires 'title'.");
+      }
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         ChangeVSObjectTextEvent event = new ChangeVSObjectTextEvent();
+         event.setName(request.assembly());
+         event.setText(request.title());
+         objects.changeTitle(runtimeId, event, user, dispatcher);
+      });
+   }
+
+   private void group(String sessionToken, Principal user, EditRequest request, String linkUri)
+      throws Exception
+   {
+      List<String> names = request.assemblies();
+
+      if(names == null || names.size() < 2) {
+         throw new IllegalArgumentException(
+            "Edit op 'group' requires 'assemblies' with at least two assembly names.");
+      }
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) ->
+         groups.groupComponents(runtimeId,
+                                GroupVSObjectsEvent.builder().objects(names).build(),
+                                linkUri, user, dispatcher));
+   }
+
+   private void ungroup(String sessionToken, Principal user, EditRequest request, String linkUri)
+      throws Exception
+   {
+      requireAssembly(request);
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) ->
+         groups.ungroup(runtimeId, request.assembly(), linkUri, user, dispatcher));
+   }
+
+   private void moveFromContainer(String sessionToken, Principal user, EditRequest request,
+                                  String linkUri) throws Exception
+   {
+      requireAssembly(request);
+      requireValues(request.op(), "x", request.x(), "y", request.y());
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         MoveVSObjectEvent event = new MoveVSObjectEvent();
+         event.setName(request.assembly());
+         event.setxOffset(request.x());
+         event.setyOffset(request.y());
+         objects.moveFromContainer(runtimeId, event, user, dispatcher, linkUri);
+      });
+   }
+
+   /**
+    * Align and distribute have no Composer service — they are position arithmetic. Compute the
+    * targets from the current layout, then issue ONE move event so the whole arrangement is a
+    * single undo checkpoint rather than one per assembly.
+    */
+   private void arrange(String sessionToken, Principal user, EditRequest request,
+                        String linkUri, String op) throws Exception
+   {
+      List<String> names = request.assemblies();
+
+      if(names == null || names.size() < 2) {
+         throw new IllegalArgumentException(
+            "Edit op '" + op + "' requires 'assemblies' with at least two assembly names.");
+      }
+
+      String axis = request.axis() == null ? "" : request.axis().trim().toLowerCase();
+      List<String> valid = "align".equals(op)
+         ? List.of("left", "right", "top", "bottom")
+         : List.of("horizontal", "vertical");
+
+      if(!valid.contains(axis)) {
+         throw new IllegalArgumentException(
+            "Edit op '" + op + "' requires 'axis' to be one of: " + String.join(", ", valid) +
+            ". Got '" + request.axis() + "'.");
+      }
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         Map<String, AssemblyNode> byName = new LinkedHashMap<>();
+
+         for(AssemblyNode node : reader.read(rvs).assemblies()) {
+            byName.put(node.name(), node);
+         }
+
+         List<AssemblyNode> targets = new ArrayList<>();
+
+         for(String name : names) {
+            AssemblyNode node = byName.get(name);
+
+            if(node == null) {
+               throw new IllegalArgumentException(
+                  "Unknown assembly '" + name + "'. Available: " + byName.keySet() + ".");
+            }
+
+            targets.add(node);
+         }
+
+         MoveVSObjectEvent[] moves = "align".equals(op)
+            ? alignMoves(targets, axis)
+            : distributeMoves(targets, axis);
+
+         MultiMoveVsObjectEvent event = new MultiMoveVsObjectEvent();
+         event.setEvents(moves);
+         objects.moveObjects(runtimeId, event, user, dispatcher, linkUri);
+      });
+   }
+
+   private static MoveVSObjectEvent[] alignMoves(List<AssemblyNode> targets, String axis) {
+      int edge = switch(axis) {
+         case "left" -> targets.stream().mapToInt(AssemblyNode::x).min().orElseThrow();
+         case "right" -> targets.stream().mapToInt(n -> n.x() + n.width()).max().orElseThrow();
+         case "top" -> targets.stream().mapToInt(AssemblyNode::y).min().orElseThrow();
+         default -> targets.stream().mapToInt(n -> n.y() + n.height()).max().orElseThrow();
+      };
+
+      MoveVSObjectEvent[] moves = new MoveVSObjectEvent[targets.size()];
+
+      for(int i = 0; i < targets.size(); i++) {
+         AssemblyNode node = targets.get(i);
+         moves[i] = move(node.name(),
+                         switch(axis) {
+                            case "left" -> edge;
+                            case "right" -> edge - node.width();
+                            default -> node.x();
+                         },
+                         switch(axis) {
+                            case "top" -> edge;
+                            case "bottom" -> edge - node.height();
+                            default -> node.y();
+                         });
+      }
+
+      return moves;
+   }
+
+   /**
+    * Spreads the assemblies evenly between the first and last along {@code axis}, ordered by
+    * their current position so the two outermost stay put and only the middle ones move.
+    */
+   private static MoveVSObjectEvent[] distributeMoves(List<AssemblyNode> targets, String axis) {
+      boolean horizontal = "horizontal".equals(axis);
+      List<AssemblyNode> ordered = new ArrayList<>(targets);
+      ordered.sort(Comparator.comparingInt(horizontal ? AssemblyNode::x : AssemblyNode::y));
+
+      int first = horizontal ? ordered.get(0).x() : ordered.get(0).y();
+      AssemblyNode lastNode = ordered.get(ordered.size() - 1);
+      int last = horizontal ? lastNode.x() : lastNode.y();
+      int gaps = ordered.size() - 1;
+      MoveVSObjectEvent[] moves = new MoveVSObjectEvent[ordered.size()];
+
+      for(int i = 0; i < ordered.size(); i++) {
+         AssemblyNode node = ordered.get(i);
+         int position = first + Math.round((float) (last - first) * i / gaps);
+         moves[i] = horizontal
+            ? move(node.name(), position, node.y())
+            : move(node.name(), node.x(), position);
+      }
+
+      return moves;
+   }
+
+   private static MoveVSObjectEvent move(String name, int x, int y) {
+      MoveVSObjectEvent event = new MoveVSObjectEvent();
+      event.setName(name);
+      event.setxOffset(x);
+      event.setyOffset(y);
+      return event;
+   }
+
    private static void requireAssembly(EditRequest request) {
       if(request.assembly() == null || request.assembly().isBlank()) {
          throw new IllegalArgumentException(
@@ -235,4 +464,6 @@ public class ViewsheetEditService {
    private final ComposerObjectService objects;
    private final ClipboardControllerService clipboard;
    private final VSObjectPropertyService propertyService;
+   private final ViewsheetReadService reader;
+   private final ComposerGroupService groups;
 }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetEditService.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.wiz.viewsheet;
 
+import inetsoft.uql.viewsheet.TitledVSAssembly;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.composer.vs.event.CopyVSObjectsEvent;
@@ -327,6 +328,7 @@ public class ViewsheetEditService {
 
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          requireExisting(rvs, request.assembly());
+         requireTitled(rvs, request.assembly());
 
          ChangeVSObjectTextEvent event = new ChangeVSObjectTextEvent();
          event.setName(request.assembly());
@@ -520,6 +522,30 @@ public class ViewsheetEditService {
     * {@code instanceof} guard and returns normally — so a misspelled name produced a cheerful
     * "ok" on every op. Nothing downstream will ever complain, so we complain here.
     */
+   /**
+    * Refuses set_title on an assembly that has no title bar.
+    *
+    * <p>{@code ComposerObjectService.changeTitle} casts to {@code TitledVSAssembly}, so a Text or
+    * a shape produced a raw {@code ClassCastException} as a bare 500 — an internal type name, with
+    * no hint that the op simply does not apply here.
+    *
+    * <p>Tested with {@code instanceof} rather than a list of type names so it cannot drift from
+    * whatever actually implements the interface. Charts, tables, crosstabs, selections and
+    * calendars have titles; text, images and shapes do not — they ARE their content, so what
+    * looks like a title on a Text is set through its own value, not this op.
+    */
+   private void requireTitled(RuntimeViewsheet rvs, String name) {
+      Viewsheet vs = rvs == null ? null : rvs.getViewsheet();
+      VSAssembly assembly = vs == null ? null : vs.getAssembly(name);
+
+      if(assembly != null && !(assembly instanceof TitledVSAssembly)) {
+         throw new IllegalArgumentException(
+            "'" + name + "' has no title bar, so 'set_title' does not apply to it. Charts, " +
+            "tables, crosstabs, selections and calendars have titles; text, images and shapes " +
+            "do not — a text assembly's visible text is its own content, not a title.");
+      }
+   }
+
    private AssemblyNode requireExisting(RuntimeViewsheet rvs, String name) {
       Map<String, AssemblyNode> byName = new LinkedHashMap<>();
       ViewsheetModel model = reader.read(rvs);

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetEditService.java
@@ -25,6 +25,7 @@ import inetsoft.web.composer.vs.objects.controller.ComposerGroupService;
 import inetsoft.web.composer.vs.objects.controller.ComposerObjectService;
 import inetsoft.web.composer.vs.objects.controller.VSObjectPropertyService;
 import inetsoft.web.composer.vs.objects.event.*;
+import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.web.wiz.viewsheet.model.AssemblyNode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -99,10 +100,18 @@ public class ViewsheetEditService {
       requireValues(request.op(), "x", request.x(), "y", request.y());
 
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         requireExisting(rvs, request.assembly());
+
          MoveVSObjectEvent move = new MoveVSObjectEvent();
          move.setName(request.assembly());
          move.setxOffset(request.x());
          move.setyOffset(request.y());
+
+         // moveObject is what actually repositions the assembly. moveObjects (plural) only calls
+         // updateAnchoredLines — it is the post-move fix-up hook, not the move itself, so calling
+         // it alone returns cleanly and changes nothing. ComposerObjectController does both, in
+         // this order; so must we.
+         objects.moveObject(runtimeId, move, user, dispatcher, linkUri);
 
          MultiMoveVsObjectEvent event = new MultiMoveVsObjectEvent();
          event.setEvents(new MoveVSObjectEvent[]{ move });
@@ -115,12 +124,20 @@ public class ViewsheetEditService {
    {
       requireAssembly(request);
       requireValues(request.op(), "width", request.width(), "height", request.height());
+      requirePositive(request.op(), "width", request.width(), "height", request.height());
 
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         AssemblyNode current = requireExisting(rvs, request.assembly());
+
          ResizeVSObjectEvent event = new ResizeVSObjectEvent();
          event.setName(request.assembly());
          event.setWidth(request.width());
          event.setHeight(request.height());
+         // resizeObject also *moves* the assembly to the event's offset
+         // (`new Point(max(0, xOffset), max(0, yOffset))` then `move(...)`), so leaving these unset
+         // silently teleports it to 0,0. Seed them from the assembly's current position.
+         event.setxOffset(current.x());
+         event.setyOffset(current.y());
          objects.resizeObject(runtimeId, event, user, dispatcher, linkUri);
       });
    }
@@ -140,9 +157,18 @@ public class ViewsheetEditService {
       }
 
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         AssemblyNode current = requireExisting(rvs, request.assembly());
+
          ResizeVSObjectTitleEvent event = new ResizeVSObjectTitleEvent();
          event.setName(request.assembly());
          event.setTitleHeight(request.height());
+         // resizeObjectTitle delegates to resizeObject, which reads width/height/offset off this
+         // same event. Setting only the title height left them at 0, so a "make the title taller"
+         // call collapsed the whole assembly to 1x1 at 0,0. Seed the current geometry.
+         event.setWidth(current.width());
+         event.setHeight(current.height());
+         event.setxOffset(current.x());
+         event.setyOffset(current.y());
          objects.resizeObjectTitle(runtimeId, event, user, dispatcher, linkUri);
       });
    }
@@ -386,6 +412,13 @@ public class ViewsheetEditService {
             ? alignMoves(targets, axis)
             : distributeMoves(targets, axis);
 
+         // Same two-step contract as move(): moveObject actually repositions each assembly,
+         // moveObjects afterwards only fixes up anchored lines. Calling the fix-up alone made
+         // align and distribute no-ops that reported success.
+         for(MoveVSObjectEvent each : moves) {
+            objects.moveObject(runtimeId, each, user, dispatcher, linkUri);
+         }
+
          MultiMoveVsObjectEvent event = new MultiMoveVsObjectEvent();
          event.setEvents(moves);
          objects.moveObjects(runtimeId, event, user, dispatcher, linkUri);
@@ -458,6 +491,47 @@ public class ViewsheetEditService {
       if(request.assembly() == null || request.assembly().isBlank()) {
          throw new IllegalArgumentException(
             "Edit op '" + request.op() + "' requires 'assembly' — the assembly name.");
+      }
+   }
+
+   /**
+    * Resolves an assembly by name, failing loud if it does not exist, and returns its current
+    * geometry so callers can seed Composer events that read position/size.
+    *
+    * <p>This check cannot be delegated to the composer layer. {@code ComposerObjectService} looks
+    * the assembly up with {@code viewsheet.getAssembly(name)}, gets null, falls through every
+    * {@code instanceof} guard and returns normally — so a misspelled name produced a cheerful
+    * "ok" on every op. Nothing downstream will ever complain, so we complain here.
+    */
+   private AssemblyNode requireExisting(RuntimeViewsheet rvs, String name) {
+      Map<String, AssemblyNode> byName = new LinkedHashMap<>();
+
+      for(AssemblyNode node : reader.read(rvs).assemblies()) {
+         byName.put(node.name(), node);
+      }
+
+      AssemblyNode node = byName.get(name);
+
+      if(node == null) {
+         throw new IllegalArgumentException(
+            "Unknown assembly '" + name + "'. Available: " + byName.keySet() + ".");
+      }
+
+      return node;
+   }
+
+   /**
+    * Rejects non-positive dimensions. StyleBI clamps them to 1x1 rather than refusing, so
+    * {@code resize -50 -20} silently destroyed the assembly's geometry and reported success.
+    */
+   private static void requirePositive(String op, String firstName, Integer first,
+                                       String secondName, Integer second)
+   {
+      if(first != null && first <= 0 || second != null && second <= 0) {
+         throw new IllegalArgumentException(
+            "Edit op '" + op + "' requires '" + firstName + "' and '" + secondName +
+            "' to be greater than zero — got " + first + " and " + second +
+            ". Non-positive sizes are clamped to 1x1 rather than refused.");
       }
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetEditService.java
@@ -17,7 +17,12 @@
  */
 package inetsoft.web.wiz.viewsheet;
 
+import inetsoft.uql.viewsheet.VSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.composer.vs.event.CopyVSObjectsEvent;
+import inetsoft.web.composer.vs.objects.controller.ClipboardControllerService;
 import inetsoft.web.composer.vs.objects.controller.ComposerObjectService;
+import inetsoft.web.composer.vs.objects.controller.VSObjectPropertyService;
 import inetsoft.web.composer.vs.objects.event.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -34,13 +39,20 @@ import java.util.List;
 @Service
 public class ViewsheetEditService {
    @Autowired
-   public ViewsheetEditService(ViewsheetSessionService sessions, ComposerObjectService objects) {
+   public ViewsheetEditService(ViewsheetSessionService sessions,
+                               ComposerObjectService objects,
+                               ClipboardControllerService clipboard,
+                               VSObjectPropertyService propertyService)
+   {
       this.sessions = sessions;
       this.objects = objects;
+      this.clipboard = clipboard;
+      this.propertyService = propertyService;
    }
 
    /** Ops this service understands, named in the error when an unknown one arrives. */
-   static final List<String> OPS = List.of("move", "resize", "resize_title");
+   static final List<String> OPS = List.of(
+      "move", "resize", "resize_title", "add", "remove", "rename", "copy", "paste");
 
    public void apply(String sessionToken, Principal user, EditRequest request, String linkUri)
       throws Exception
@@ -51,6 +63,11 @@ public class ViewsheetEditService {
       case "move" -> move(sessionToken, user, request, linkUri);
       case "resize" -> resize(sessionToken, user, request, linkUri);
       case "resize_title" -> resizeTitle(sessionToken, user, request, linkUri);
+      case "add" -> add(sessionToken, user, request, linkUri);
+      case "remove" -> remove(sessionToken, user, request, linkUri);
+      case "rename" -> rename(sessionToken, user, request, linkUri);
+      case "copy", "cut" -> copyOrCut(sessionToken, user, request, linkUri, "cut".equals(op));
+      case "paste" -> paste(sessionToken, user, request, linkUri);
       default -> throw new IllegalArgumentException(
          "Unknown edit op '" + request.op() + "'. Supported ops: " + String.join(", ", OPS) + ".");
       }
@@ -111,6 +128,93 @@ public class ViewsheetEditService {
       });
    }
 
+   private void add(String sessionToken, Principal user, EditRequest request, String linkUri)
+      throws Exception
+   {
+      if(request.type() == null) {
+         throw new IllegalArgumentException(
+            "Edit op 'add' requires 'type' — the AbstractSheet asset code for the assembly " +
+            "(e.g. 111 text, 112 image, 125 line, 126 rectangle, 127 oval).");
+      }
+
+      requireValues(request.op(), "x", request.x(), "y", request.y());
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         AddNewVSObjectEvent event = new AddNewVSObjectEvent();
+         event.setType(request.type());
+         event.setxOffset(request.x());
+         event.setyOffset(request.y());
+         objects.addNewObject(runtimeId, event, user, dispatcher, linkUri);
+      });
+   }
+
+   private void remove(String sessionToken, Principal user, EditRequest request, String linkUri)
+      throws Exception
+   {
+      requireAssembly(request);
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) ->
+         objects.removeObject(runtimeId, request.assembly(), linkUri, user, dispatcher));
+   }
+
+   /**
+    * Renames through the Composer's own property path, which also requalifies references to
+    * the old name. The capturing dispatcher matters most here: a rename that the service
+    * refuses — a dependency cycle, say — is reported as an ERROR command and a normal return,
+    * so without capture it would look like success.
+    */
+   private void rename(String sessionToken, Principal user, EditRequest request, String linkUri)
+      throws Exception
+   {
+      requireAssembly(request);
+
+      if(request.newName() == null || request.newName().isBlank()) {
+         throw new IllegalArgumentException(
+            "Edit op 'rename' requires 'newName' — the new assembly name.");
+      }
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         Viewsheet vs = rvs.getViewsheet();
+         VSAssembly assembly = vs == null ? null : (VSAssembly) vs.getAssembly(request.assembly());
+
+         if(assembly == null) {
+            throw new IllegalArgumentException(
+               "Unknown assembly '" + request.assembly() + "'.");
+         }
+
+         propertyService.editObjectProperty(rvs, assembly.getVSAssemblyInfo(),
+                                            request.assembly(), request.newName(),
+                                            linkUri, user, dispatcher);
+      });
+   }
+
+   private void copyOrCut(String sessionToken, Principal user, EditRequest request,
+                          String linkUri, boolean cut) throws Exception
+   {
+      List<String> names = request.assemblies();
+
+      if(names == null || names.isEmpty()) {
+         throw new IllegalArgumentException(
+            "Edit op '" + request.op() + "' requires 'assemblies' with at least one name.");
+      }
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         CopyVSObjectsEvent event = new CopyVSObjectsEvent();
+         event.setObjects(names.toArray(new String[0]));
+         event.setCut(cut);
+         clipboard.copyOrCut(runtimeId, event, user, dispatcher, linkUri);
+      });
+   }
+
+   private void paste(String sessionToken, Principal user, EditRequest request, String linkUri)
+      throws Exception
+   {
+      requireValues(request.op(), "x", request.x(), "y", request.y());
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) ->
+         clipboard.pasteObject(runtimeId, request.x(), request.y(), user, dispatcher, linkUri));
+   }
+
    private static void requireAssembly(EditRequest request) {
       if(request.assembly() == null || request.assembly().isBlank()) {
          throw new IllegalArgumentException(
@@ -129,4 +233,6 @@ public class ViewsheetEditService {
 
    private final ViewsheetSessionService sessions;
    private final ComposerObjectService objects;
+   private final ClipboardControllerService clipboard;
+   private final VSObjectPropertyService propertyService;
 }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetEditService.java
@@ -100,6 +100,9 @@ public class ViewsheetEditService {
    {
       requireAssembly(request);
       requireValues(request.op(), "x", request.x(), "y", request.y());
+      // Nothing else stops an assembly being parked off-canvas, where the user can neither see
+      // nor select it to put it back.
+      requireNonNegative(request.op(), "x", request.x(), "y", request.y());
 
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          requireExisting(rvs, request.assembly());
@@ -481,18 +484,32 @@ public class ViewsheetEditService {
       List<AssemblyNode> ordered = new ArrayList<>(targets);
       ordered.sort(Comparator.comparingInt(horizontal ? AssemblyNode::x : AssemblyNode::y));
 
-      int first = horizontal ? ordered.get(0).x() : ordered.get(0).y();
+      // Equal GAPS, not equal edges. Spreading the left/top positions evenly looks correct only
+      // when every assembly is the same size; with mixed sizes the visible spacing comes out
+      // uneven, which is neither what Composer's distribute does nor what a caller asking to
+      // "distribute horizontally" means. So the free space between the bounding boxes is what
+      // gets divided.
+      AssemblyNode firstNode = ordered.get(0);
       AssemblyNode lastNode = ordered.get(ordered.size() - 1);
-      int last = horizontal ? lastNode.x() : lastNode.y();
+      int start = horizontal ? firstNode.x() : firstNode.y();
+      int end = horizontal ? lastNode.x() + lastNode.width() : lastNode.y() + lastNode.height();
+      int occupied = ordered.stream()
+         .mapToInt(node -> horizontal ? node.width() : node.height())
+         .sum();
       int gaps = ordered.size() - 1;
+      float gap = (end - start - occupied) / (float) gaps;
       MoveVSObjectEvent[] moves = new MoveVSObjectEvent[ordered.size()];
+      float cursor = start;
 
       for(int i = 0; i < ordered.size(); i++) {
          AssemblyNode node = ordered.get(i);
-         int position = first + Math.round((float) (last - first) * i / gaps);
+         int position = i == 0 ? start
+            : (i == gaps ? end - (horizontal ? node.width() : node.height())
+                         : Math.round(cursor));
          moves[i] = horizontal
             ? move(node.name(), position, node.y())
             : move(node.name(), node.x(), position);
+         cursor = position + (horizontal ? node.width() : node.height()) + gap;
       }
 
       return moves;
@@ -504,6 +521,17 @@ public class ViewsheetEditService {
       event.setxOffset(x);
       event.setyOffset(y);
       return event;
+   }
+
+   private static void requireNonNegative(String op, String firstName, Integer first,
+                                          String secondName, Integer second)
+   {
+      if(first != null && first < 0 || second != null && second < 0) {
+         throw new IllegalArgumentException(
+            "Edit op '" + op + "' needs '" + firstName + "' and '" + secondName +
+            "' to be zero or more, got " + first + " and " + second +
+            ". A negative offset puts the assembly off-canvas, where it cannot be selected.");
+      }
    }
 
    private static void requireAssembly(EditRequest request) {

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetFormatService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetFormatService.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.web.composer.model.vs.VSObjectFormatInfoModel;
+import inetsoft.web.composer.vs.controller.FormatPainterService;
+import inetsoft.web.composer.vs.objects.event.FormatVSObjectEvent;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+import java.util.List;
+
+/**
+ * Applies assembly-level formatting through the Composer's own format service.
+ *
+ * <p>{@code VSObjectFormatInfoModel} is CSS-shaped — {@code color}, {@code backgroundColor},
+ * {@code font}, {@code align}, {@code format}/{@code formatSpec}, and the four border sides —
+ * so it passes straight through without an alias layer.
+ */
+@Service
+public class ViewsheetFormatService {
+   @Autowired
+   public ViewsheetFormatService(ViewsheetSessionService sessions, FormatPainterService painter) {
+      this.sessions = sessions;
+      this.painter = painter;
+   }
+
+   /**
+    * @param assemblies the assemblies to format; at least one
+    * @param format     the format to apply; may be null only when {@code reset} is true
+    * @param reset      clear formatting back to the default rather than applying {@code format}
+    */
+   public record FormatRequest(List<String> assemblies,
+                               VSObjectFormatInfoModel format,
+                               boolean reset) {}
+
+   public void setFormat(String sessionToken, Principal user, FormatRequest request,
+                         String linkUri) throws Exception
+   {
+      if(request.assemblies() == null || request.assemblies().isEmpty()) {
+         throw new IllegalArgumentException(
+            "set_format requires 'assemblies' with at least one assembly name.");
+      }
+
+      if(request.format() == null && !request.reset()) {
+         throw new IllegalArgumentException(
+            "set_format requires 'format' unless 'reset' is true.");
+      }
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         FormatVSObjectEvent event = new FormatVSObjectEvent();
+         event.setObjects(request.assemblies().toArray(new String[0]));
+         event.setFormat(request.format());
+         event.setReset(request.reset());
+         painter.setFormat(runtimeId, event, user, dispatcher, linkUri);
+      });
+   }
+
+   private final ViewsheetSessionService sessions;
+   private final FormatPainterService painter;
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetFormatService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetFormatService.java
@@ -86,6 +86,7 @@ public class ViewsheetFormatService {
 
          ObjectNode object = ((ObjectNode) format).deepCopy();
          object.put("type", VSObjectFormatInfoModel.class.getName());
+         coerceAlign(object);
 
          try {
             return MAPPER.treeToValue(object, VSObjectFormatInfoModel.class);
@@ -94,6 +95,51 @@ public class ViewsheetFormatService {
             throw new IllegalArgumentException(
                "set_format could not read 'format': " + e.getOriginalMessage(), e);
          }
+      }
+
+      /**
+       * Lets {@code align} be written as a word.
+       *
+       * <p>This API documents its format as CSS-shaped and lists {@code align} beside
+       * {@code color} and {@code backgroundColor}, so a caller writes {@code align: "center"}.
+       * Underneath it is an {@code AlignmentInfo} with {@code halign}/{@code valign}, and Jackson
+       * threw on the string — during body conversion, where Spring wraps the failure in
+       * {@code HttpMessageNotReadableException} and answers with a **bodyless 400**. So the
+       * documented usage failed with no message at all.
+       *
+       * <p>Accepting the word is the right half of the fix: "center" has one sensible meaning, and
+       * the alternative is asking callers to learn an internal model this API exists to hide. Both
+       * axes are accepted, together or separately, and the object form still works.
+       */
+      private static void coerceAlign(ObjectNode object) {
+         JsonNode align = object.get("align");
+
+         if(align == null || !align.isTextual()) {
+            return;
+         }
+
+         ObjectNode alignment = object.objectNode();
+
+         for(String word : align.asText().trim().toLowerCase().split("\\s+")) {
+            if(word.isEmpty()) {
+               continue;
+            }
+
+            switch(word) {
+            case "left" -> alignment.put("halign", "Left");
+            case "center" -> alignment.put("halign", "Center");
+            case "right" -> alignment.put("halign", "Right");
+            case "top" -> alignment.put("valign", "Top");
+            case "middle" -> alignment.put("valign", "Middle");
+            case "bottom" -> alignment.put("valign", "Bottom");
+            default -> throw new IllegalArgumentException(
+               "set_format could not read 'align': '" + word + "' is not an alignment. " +
+               "Horizontal: left, center, right. Vertical: top, middle, bottom. " +
+               "Both may be given together, as \"center middle\".");
+            }
+         }
+
+         object.set("align", alignment);
       }
 
       private static final ObjectMapper MAPPER = new ObjectMapper();

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetFormatService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetFormatService.java
@@ -17,6 +17,12 @@
  */
 package inetsoft.web.wiz.viewsheet;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import inetsoft.web.composer.model.vs.VSObjectFormatInfoModel;
 import inetsoft.web.composer.vs.controller.FormatPainterService;
 import inetsoft.web.composer.vs.objects.event.FormatVSObjectEvent;
@@ -48,7 +54,50 @@ public class ViewsheetFormatService {
     */
    public record FormatRequest(List<String> assemblies,
                                VSObjectFormatInfoModel format,
-                               boolean reset) {}
+                               boolean reset)
+   {
+      /**
+       * Reads {@code format} as a plain object, supplying the polymorphic type id ourselves.
+       *
+       * <p>{@code FormatInfoModel} is annotated {@code @JsonTypeInfo(use = Id.CLASS,
+       * property = "type")}, so Jackson rejected any format that did not carry
+       * {@code "type": "inetsoft.web.composer.model.vs.VSObjectFormatInfoModel"}. Every documented
+       * usage of set_format failed with a 400 — an empty {@code {}} included — and the only way to
+       * succeed was for the caller to name an internal Java class, precisely the leak this API
+       * exists to prevent.
+       *
+       * <p>Taking the value as a {@code JsonNode} is what actually bypasses the resolver. Neither
+       * {@code @JsonTypeInfo(use = Id.NONE)} nor {@code @JsonDeserialize(using = …)} on the record
+       * component works: for a polymorphic property Jackson runs the {@code TypeDeserializer}
+       * before either one gets a say.
+       */
+      @JsonCreator
+      public static FormatRequest fromJson(@JsonProperty("assemblies") List<String> assemblies,
+                                           @JsonProperty("format") JsonNode format,
+                                           @JsonProperty("reset") boolean reset)
+      {
+         return new FormatRequest(assemblies, toModel(format), reset);
+      }
+
+      private static VSObjectFormatInfoModel toModel(JsonNode format) {
+         if(format == null || format.isNull()) {
+            return null;
+         }
+
+         ObjectNode object = ((ObjectNode) format).deepCopy();
+         object.put("type", VSObjectFormatInfoModel.class.getName());
+
+         try {
+            return MAPPER.treeToValue(object, VSObjectFormatInfoModel.class);
+         }
+         catch(JsonProcessingException e) {
+            throw new IllegalArgumentException(
+               "set_format could not read 'format': " + e.getOriginalMessage(), e);
+         }
+      }
+
+      private static final ObjectMapper MAPPER = new ObjectMapper();
+   }
 
    public void setFormat(String sessionToken, Principal user, FormatRequest request,
                          String linkUri) throws Exception
@@ -68,6 +117,12 @@ public class ViewsheetFormatService {
          event.setObjects(request.assemblies().toArray(new String[0]));
          event.setFormat(request.format());
          event.setReset(request.reset());
+         // FormatPainterService iterates `event.getCharts().length` unguarded, so a null here is an
+         // immediate NPE — every set_format call, format or reset alike, failed with a 500. An
+         // empty array is the correct value for assembly-level formatting: the chart-region
+         // branches that read getColumnNames()/getIndexes()/getRegions() all live inside that
+         // loop, so they never execute for these requests.
+         event.setCharts(new String[0]);
          painter.setFormat(runtimeId, event, user, dispatcher, linkUri);
       });
    }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetFormatService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetFormatService.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import inetsoft.report.StyleConstants;
 import inetsoft.web.composer.model.vs.VSObjectFormatInfoModel;
 import inetsoft.web.composer.vs.controller.FormatPainterService;
 import inetsoft.web.composer.vs.objects.event.FormatVSObjectEvent;
@@ -87,6 +88,7 @@ public class ViewsheetFormatService {
          ObjectNode object = ((ObjectNode) format).deepCopy();
          object.put("type", VSObjectFormatInfoModel.class.getName());
          coerceAlign(object);
+         coerceBorderStyles(object);
 
          try {
             return MAPPER.treeToValue(object, VSObjectFormatInfoModel.class);
@@ -141,6 +143,50 @@ public class ViewsheetFormatService {
 
          object.set("align", alignment);
       }
+
+      /**
+       * Lets the four border styles be written as CSS words.
+       *
+       * <p>The underlying model is asymmetric: {@code FormatInfoModel.getBorderStyle} <em>reads</em>
+       * "solid"/"dashed"/"dotted"/"double", while the write goes through
+       * {@code FormatPainterService}, which does {@code Integer.parseInt} on the same field. So the
+       * word this API documents — and the word that comes back out of it — could never be written,
+       * and failed with a raw {@code For input string: "solid"} naming no field at all.
+       *
+       * <p>A number still passes through untouched, for a caller that already has the constant.
+       */
+      private static void coerceBorderStyles(ObjectNode object) {
+         for(String side : BORDER_STYLES) {
+            JsonNode style = object.get(side);
+
+            if(style == null || !style.isTextual()) {
+               continue;
+            }
+
+            String word = style.asText().trim().toLowerCase();
+
+            if(word.chars().allMatch(Character::isDigit)) {
+               continue;
+            }
+
+            object.put(side, String.valueOf(switch(word) {
+               case "none" -> StyleConstants.NO_BORDER;
+               case "solid", "thin" -> StyleConstants.THIN_LINE;
+               case "medium" -> StyleConstants.MEDIUM_LINE;
+               case "thick" -> StyleConstants.THICK_LINE;
+               case "dashed" -> StyleConstants.DASH_LINE;
+               case "dotted" -> StyleConstants.DOT_LINE;
+               case "double" -> StyleConstants.DOUBLE_LINE;
+               default -> throw new IllegalArgumentException(
+                  "set_format could not read '" + side + "': '" + word + "' is not a border " +
+                  "style. Accepted: none, solid, dashed, dotted, double, thin, medium, thick. " +
+                  "A StyleBI line constant is accepted as a number.");
+            }));
+         }
+      }
+
+      private static final List<String> BORDER_STYLES =
+         List.of("borderTopStyle", "borderLeftStyle", "borderBottomStyle", "borderRightStyle");
 
       private static final ObjectMapper MAPPER = new ObjectMapper();
    }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetReadService.java
@@ -43,18 +43,25 @@ public class ViewsheetReadService {
       List<AssemblyNode> nodes = new ArrayList<>();
 
       for(Assembly assembly : vs.getAssemblies()) {
-         if(assembly instanceof VSAssembly vsAssembly) {
-            nodes.add(toNode(vsAssembly));
+         // The line and rectangle are reported under their annotation rather than beside it.
+         // Flat, the three read as unrelated assemblies with nothing to say they are one
+         // object, and an agent asked to "remove the annotation" would remove a third of it.
+         if(assembly instanceof VSAssembly vsAssembly &&
+            !AnnotationFamily.isSubordinatePart(vsAssembly))
+         {
+            nodes.add(toNode(vs, vsAssembly));
          }
       }
 
       return new ViewsheetModel(vs.getName(), nodes);
    }
 
-   private AssemblyNode toNode(VSAssembly assembly) {
+   private AssemblyNode toNode(Viewsheet vs, VSAssembly assembly) {
       Point offset = assembly.getPixelOffset();
       Dimension size = assembly.getPixelSize();
       Assembly container = assembly.getContainer();
+
+      List<String> parts = AnnotationFamily.partsOf(assembly);
 
       return new AssemblyNode(
          assembly.getAbsoluteName(),
@@ -65,7 +72,9 @@ public class ViewsheetReadService {
          size == null ? 0 : size.height,
          assembly.getVSAssemblyInfo() == null ? 0 : assembly.getVSAssemblyInfo().getZIndex(),
          container == null ? null : container.getName(),
-         assembly.isVisible());
+         assembly.isVisible(),
+         parts.isEmpty() ? null : parts,
+         AnnotationFamily.contentOf(vs, assembly));
    }
 
    /** "GaugeVSAssembly" reads as "Gauge" — the name the user sees in the Composer. */

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetReadService.java
@@ -1,0 +1,78 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.viewsheet.VSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.wiz.viewsheet.model.AssemblyNode;
+import inetsoft.web.wiz.viewsheet.model.ViewsheetModel;
+import org.springframework.stereotype.Service;
+
+import java.awt.Dimension;
+import java.awt.Point;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Builds the agent-facing layout model from a live viewsheet runtime. */
+@Service
+public class ViewsheetReadService {
+   public ViewsheetModel read(RuntimeViewsheet rvs) {
+      Viewsheet vs = rvs == null ? null : rvs.getViewsheet();
+
+      if(vs == null) {
+         return new ViewsheetModel(null, List.of());
+      }
+
+      List<AssemblyNode> nodes = new ArrayList<>();
+
+      for(Assembly assembly : vs.getAssemblies()) {
+         if(assembly instanceof VSAssembly vsAssembly) {
+            nodes.add(toNode(vsAssembly));
+         }
+      }
+
+      return new ViewsheetModel(vs.getName(), nodes);
+   }
+
+   private AssemblyNode toNode(VSAssembly assembly) {
+      Point offset = assembly.getPixelOffset();
+      Dimension size = assembly.getPixelSize();
+      Assembly container = assembly.getContainer();
+
+      return new AssemblyNode(
+         assembly.getAbsoluteName(),
+         typeName(assembly),
+         offset == null ? 0 : offset.x,
+         offset == null ? 0 : offset.y,
+         size == null ? 0 : size.width,
+         size == null ? 0 : size.height,
+         assembly.getVSAssemblyInfo() == null ? 0 : assembly.getVSAssemblyInfo().getZIndex(),
+         container == null ? null : container.getName(),
+         assembly.isVisible());
+   }
+
+   /** "GaugeVSAssembly" reads as "Gauge" — the name the user sees in the Composer. */
+   private String typeName(VSAssembly assembly) {
+      String simple = assembly.getClass().getSimpleName();
+      return simple.endsWith("VSAssembly")
+         ? simple.substring(0, simple.length() - "VSAssembly".length())
+         : simple;
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetSessionService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetSessionService.java
@@ -1,0 +1,138 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.sree.security.IdentityID;
+import inetsoft.uql.XPrincipal;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.wiz.dispatch.CapturingCommandDispatcher;
+import inetsoft.web.wiz.pairing.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+
+/**
+ * Resolves a pairing session to a live viewsheet runtime and runs mutations against it.
+ *
+ * <p>Mirrors {@code ScriptEditService.resolve}, including the socket-session plumbing that
+ * makes broadcasts reach the browser.
+ *
+ * <p>Mutations run under a {@link CapturingCommandDispatcher} rather than a dummy one:
+ * composer services report failure by dispatching a {@code MessageCommand} of
+ * {@code Type.ERROR} and returning normally, so a dispatcher that drops commands turns every
+ * such failure into a silent success.
+ */
+@Service
+public class ViewsheetSessionService {
+   @Autowired
+   public ViewsheetSessionService(SheetSessionService sessions,
+                                  SheetRuntimeAccess runtimeAccess,
+                                  SheetAgentBroadcastService broadcast)
+   {
+      this.sessions = sessions;
+      this.runtimeAccess = runtimeAccess;
+      this.broadcast = broadcast;
+   }
+
+   public JoinSession requireSession(String sessionToken, Principal agent) throws PairingException {
+      JoinSession session = sessions.resolve(sessionToken, agentKey(agent));
+
+      if(session == null) {
+         throw new PairingException(
+            PairingException.Kind.SESSION_EXPIRED,
+            "Invalid or expired viewsheet session: " + sessionToken +
+            ". Ask the user for a fresh pairing code and run connect_viewsheet again.");
+      }
+
+      return session;
+   }
+
+   public RuntimeViewsheet resolve(String sessionToken, Principal agent) throws PairingException {
+      JoinSession session = requireSession(sessionToken, agent);
+      RuntimeViewsheet rvs = (RuntimeViewsheet) runtimeAccess.getSheetForPairing(
+         SheetType.VIEWSHEET, session.runtimeId(), agent);
+      applySocketSession(rvs, session);
+      return rvs;
+   }
+
+   public String runtimeId(String sessionToken, Principal agent) throws PairingException {
+      return requireSession(sessionToken, agent).runtimeId();
+   }
+
+   /**
+    * Resolve, run the mutation under a capturing dispatcher, checkpoint, broadcast.
+    *
+    * <p>One checkpoint per call, matching what a single Composer dialog OK does, so the
+    * human's Ctrl+Z steps back through agent edits one at a time.
+    */
+   public void mutate(String sessionToken, Principal agent, Mutation mutation) throws Exception {
+      JoinSession session = requireSession(sessionToken, agent);
+      RuntimeViewsheet rvs = (RuntimeViewsheet) runtimeAccess.getSheetForPairing(
+         SheetType.VIEWSHEET, session.runtimeId(), agent);
+      applySocketSession(rvs, session);
+
+      CapturingCommandDispatcher.withCapturingDispatcher(agent, dispatcher -> {
+         mutation.run(rvs, session.runtimeId(), dispatcher);
+         return null;
+      });
+
+      Viewsheet vs = rvs.getViewsheet();
+
+      if(vs != null) {
+         rvs.addCheckpoint(vs.prepareCheckpoint());
+      }
+
+      broadcast.broadcastRefresh(rvs, SheetType.VIEWSHEET, session.runtimeId(), agent);
+   }
+
+   @FunctionalInterface
+   public interface Mutation {
+      void run(RuntimeViewsheet rvs, String runtimeId, CapturingCommandDispatcher dispatcher)
+         throws Exception;
+   }
+
+   /**
+    * Carry the browser's socket session onto the runtime. Without this
+    * {@code SheetAgentBroadcastService} finds no socket session and skips the broadcast, so
+    * the human's Composer never reflects the agent's edits.
+    */
+   private void applySocketSession(RuntimeViewsheet rvs, JoinSession session) {
+      if(session.socketSessionId() != null && rvs.getSocketSessionId() == null) {
+         rvs.setSocketSessionId(session.socketSessionId());
+      }
+
+      if(rvs.getSocketUserName() == null && session.socketUserName() != null) {
+         rvs.setSocketUserName(session.socketUserName());
+      }
+   }
+
+   private String agentKey(Principal agent) {
+      if(agent instanceof XPrincipal p) {
+         IdentityID id = IdentityID.getIdentityIDFromKey(p.getName());
+         return id != null ? id.convertToKey() : p.getName();
+      }
+
+      return agent != null ? agent.getName() : null;
+   }
+
+   private final SheetSessionService sessions;
+   private final SheetRuntimeAccess runtimeAccess;
+   private final SheetAgentBroadcastService broadcast;
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetSessionService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetSessionService.java
@@ -102,9 +102,38 @@ public class ViewsheetSessionService {
       broadcast.broadcastRefresh(rvs, SheetType.VIEWSHEET, session.runtimeId(), agent);
    }
 
+   /**
+    * Resolve and run a <b>read</b> under a capturing dispatcher — no checkpoint, no broadcast.
+    *
+    * <p>Some composer services return their result by <em>dispatching a command</em> rather than
+    * returning a value: {@code VSTableLayoutService.getCellScript} and {@code getNamedGroup} both
+    * do. Reading those needs the capturing dispatcher, which {@link #resolve} does not supply.
+    *
+    * <p>{@link #mutate} would supply one, but it also opens a checkpoint and broadcasts — so
+    * using it for a read would put a stray Ctrl+Z step in the user's history for having
+    * <em>looked</em> at something, and tell their Composer to refresh for a change that never
+    * happened. Hence a third entry point rather than a flag on the second.
+    */
+   public <T> T read(String sessionToken, Principal agent, Read<T> read) throws Exception {
+      JoinSession session = requireSession(sessionToken, agent);
+      RuntimeViewsheet rvs = (RuntimeViewsheet) runtimeAccess.getSheetForPairing(
+         SheetType.VIEWSHEET, session.runtimeId(), agent);
+      applySocketSession(rvs, session);
+
+      return CapturingCommandDispatcher.withCapturingDispatcher(
+         agent, dispatcher -> read.run(rvs, session.runtimeId(), dispatcher));
+   }
+
    @FunctionalInterface
    public interface Mutation {
       void run(RuntimeViewsheet rvs, String runtimeId, CapturingCommandDispatcher dispatcher)
+         throws Exception;
+   }
+
+   /** A read that needs the capturing dispatcher to see a command-delivered result. */
+   @FunctionalInterface
+   public interface Read<T> {
+      T run(RuntimeViewsheet rvs, String runtimeId, CapturingCommandDispatcher dispatcher)
          throws Exception;
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetSessionService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetSessionService.java
@@ -72,8 +72,19 @@ public class ViewsheetSessionService {
       return rvs;
    }
 
+   /**
+    * The runtime id for a paired session.
+    *
+    * <p>Grants the ownership bypass as a side effect, because every caller of this method hands the
+    * id to a <em>composer</em> service, which re-resolves the sheet and enforces ownership against
+    * the agent's principal. Without it those services fail with {@code InvalidUserException} while
+    * the ones that go through {@link #resolve} or {@link #mutate} succeed — an inconsistency with
+    * no visible cause, since both look like ordinary reads from the outside.
+    */
    public String runtimeId(String sessionToken, Principal agent) throws PairingException {
-      return requireSession(sessionToken, agent).runtimeId();
+      String runtimeId = requireSession(sessionToken, agent).runtimeId();
+      runtimeAccess.grantOwnershipBypass(SheetType.VIEWSHEET, runtimeId, agent);
+      return runtimeId;
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetSessionService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetSessionService.java
@@ -22,6 +22,7 @@ import inetsoft.sree.security.IdentityID;
 import inetsoft.uql.XPrincipal;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.wiz.dispatch.CapturingCommandDispatcher;
+import inetsoft.web.wiz.dispatch.CommandErrorException;
 import inetsoft.web.wiz.pairing.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -99,18 +100,34 @@ public class ViewsheetSessionService {
          SheetType.VIEWSHEET, session.runtimeId(), agent);
       applySocketSession(rvs, session);
 
-      CapturingCommandDispatcher.withCapturingDispatcher(agent, dispatcher -> {
-         mutation.run(rvs, session.runtimeId(), dispatcher);
-         return null;
-      });
-
-      Viewsheet vs = rvs.getViewsheet();
-
-      if(vs != null) {
-         rvs.addCheckpoint(vs.prepareCheckpoint());
+      // The checkpoint and the broadcast happen even when the mutation fails. A composer service
+      // partially applies before it ERRORs -- that is precisely why it ERRORs rather than throwing
+      // -- so on failure the runtime holds a half-applied edit. Letting the exception escape first
+      // meant no checkpoint and no broadcast: the human's Composer kept rendering pre-edit state
+      // while the runtime had moved, the next agent edit built on that divergence, and Ctrl+Z had
+      // no step for the partial change. The partial edit is real, so it gets an undo step and the
+      // browser is told about it.
+      try {
+         CapturingCommandDispatcher.withCapturingDispatcher(agent, dispatcher -> {
+            mutation.run(rvs, session.runtimeId(), dispatcher);
+            return null;
+         });
       }
+      catch(CommandErrorException e) {
+         throw new CommandErrorException(
+            e.getErrors(),
+            "the edit may be partially applied; the runtime and your Composer have been " +
+            "refreshed to match, and one undo step covers whatever was applied");
+      }
+      finally {
+         Viewsheet vs = rvs.getViewsheet();
 
-      broadcast.broadcastRefresh(rvs, SheetType.VIEWSHEET, session.runtimeId(), agent);
+         if(vs != null) {
+            rvs.addCheckpoint(vs.prepareCheckpoint());
+         }
+
+         broadcast.broadcastRefresh(rvs, SheetType.VIEWSHEET, session.runtimeId(), agent);
+      }
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/model/AssemblyNode.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/model/AssemblyNode.java
@@ -1,0 +1,22 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet.model;
+
+/** One assembly's placement in a viewsheet, as the agent sees it. */
+public record AssemblyNode(String name, String type, int x, int y, int width, int height,
+                           int zIndex, String container, boolean visible) {}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/model/AssemblyNode.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/model/AssemblyNode.java
@@ -17,6 +17,22 @@
  */
 package inetsoft.web.wiz.viewsheet.model;
 
-/** One assembly's placement in a viewsheet, as the agent sees it. */
+import java.util.List;
+
+/**
+ * One assembly's placement in a viewsheet, as the agent sees it.
+ *
+ * <p>{@code annotationParts} is populated only on an annotation, naming the line and
+ * rectangle it owns. An annotation is three linked assemblies, and listed flat they read as
+ * three unrelated ones — so the read model groups them and the subordinate parts are omitted
+ * from the top level.
+ */
 public record AssemblyNode(String name, String type, int x, int y, int width, int height,
-                           int zIndex, String container, boolean visible) {}
+                           int zIndex, String container, boolean visible,
+                           List<String> annotationParts, String annotationContent) {
+   public AssemblyNode(String name, String type, int x, int y, int width, int height,
+                       int zIndex, String container, boolean visible)
+   {
+      this(name, type, x, y, width, height, zIndex, container, visible, null, null);
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/model/ViewsheetModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/model/ViewsheetModel.java
@@ -1,0 +1,23 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet.model;
+
+import java.util.List;
+
+/** The agent-facing shape of a viewsheet's layout. */
+public record ViewsheetModel(String name, List<AssemblyNode> assemblies) {}

--- a/core/src/test/java/inetsoft/web/wiz/WizControllerErrorHandlerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/WizControllerErrorHandlerTest.java
@@ -153,6 +153,28 @@ class WizControllerErrorHandlerTest {
                  "and must name the field Jackson choked on, got: [" + content + "]");
    }
 
+   /**
+    * The captured composer error must reach the caller. {@code CommandErrorException} extends
+    * {@code Exception} and had no handler, so the mechanism this whole feature exists to add —
+    * turning a silently-dispatched composer ERROR into something the caller can see — captured
+    * the text and then lost it to a generic 500 reading "Internal Server Error".
+    *
+    * <p>409 rather than 400: the request was well-formed and the composer refused it, which is a
+    * conflict with the sheet's state, not a malformed call. {@code getErrors()} is surfaced as its
+    * own field because the composer often reports several and joining them loses the boundaries.
+    */
+   @Test
+   void commandErrorExceptionReportsTheCapturedComposerErrors() throws Exception {
+      String content = mvc.perform(get("/wiz-test/throw").param("type", "commanderror"))
+         .andExpect(status().isConflict())
+         .andReturn().getResponse().getContentAsString();
+
+      assertTrue(content.contains("dependency cycle"),
+                 "the captured composer text must reach the caller, got: [" + content + "]");
+      assertTrue(content.contains("name is already in use"),
+                 "every captured error must survive, got: [" + content + "]");
+   }
+
    @RestController
    private static class ThrowingController {
       @GetMapping("/wiz-test/throw")
@@ -167,6 +189,11 @@ class WizControllerErrorHandlerTest {
 
          if("illegal".equals(type)) {
             throw new IllegalArgumentException("Edit op 'resize_title' requires 'height'.");
+         }
+
+         if("commanderror".equals(type)) {
+            throw new inetsoft.web.wiz.dispatch.CommandErrorException(
+               java.util.List.of("dependency cycle", "name is already in use"));
          }
 
          if("unreadable".equals(type)) {

--- a/core/src/test/java/inetsoft/web/wiz/WizControllerErrorHandlerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/WizControllerErrorHandlerTest.java
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -126,6 +127,32 @@ class WizControllerErrorHandlerTest {
          .andExpect(content().string(containsString("not supported yet")));
    }
 
+   /**
+    * A body Jackson cannot read at all.
+    *
+    * <p>Spring's resolver retries an unmatched exception against its <em>cause</em>, so a
+    * {@code @JsonCreator} that throws {@code IllegalArgumentException} is already answered with
+    * its message by the handler above — the first version of this test asserted exactly that and
+    * passed without any new code, which is what gave it away.
+    *
+    * <p>The real gap is a failure raised by Jackson itself: a field given the wrong shape, whose
+    * cause is a {@code JsonProcessingException} and matches nothing. That returned a **bodyless
+    * 400**, so the caller saw "Request failed with status code 400" and nothing else —
+    * indistinguishable from a bug in the tool. Found live on local-1201, where the documented
+    * {@code align: "center"} hit precisely this.
+    */
+   @Test
+   void anUnreadableBodyReportsWhyRatherThanAnEmpty400() throws Exception {
+      String content = mvc.perform(get("/wiz-test/throw").param("type", "unreadable"))
+         .andExpect(status().isBadRequest())
+         .andReturn().getResponse().getContentAsString();
+
+      assertTrue(content.contains("could not be read"),
+                 "the 400 must say the body was unreadable, got: [" + content + "]");
+      assertTrue(content.contains("align"),
+                 "and must name the field Jackson choked on, got: [" + content + "]");
+   }
+
    @RestController
    private static class ThrowingController {
       @GetMapping("/wiz-test/throw")
@@ -140,6 +167,18 @@ class WizControllerErrorHandlerTest {
 
          if("illegal".equals(type)) {
             throw new IllegalArgumentException("Edit op 'resize_title' requires 'height'.");
+         }
+
+         if("unreadable".equals(type)) {
+            // Jackson's own failure, not ours: nothing in the cause chain is an
+            // IllegalArgumentException, so no handler matched and the 400 came back empty.
+            throw new org.springframework.http.converter.HttpMessageNotReadableException(
+               "JSON parse error",
+               com.fasterxml.jackson.databind.exc.MismatchedInputException.from(
+                  (com.fasterxml.jackson.core.JsonParser) null, String.class,
+                  "Cannot construct instance of AlignmentInfo from String value 'center' " +
+                  "(field \"align\")"),
+               new org.springframework.mock.http.MockHttpInputMessage(new byte[0]));
          }
 
          if("unsupported-op".equals(type)) {

--- a/core/src/test/java/inetsoft/web/wiz/WizControllerErrorHandlerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/WizControllerErrorHandlerTest.java
@@ -81,6 +81,20 @@ class WizControllerErrorHandlerTest {
          .andExpect(content().string(containsString("Mongo")));
    }
 
+   /**
+    * The wiz agent services express every input-validation failure as an
+    * {@code IllegalArgumentException} carrying a caller-facing message (~75 sites across
+    * {@code inetsoft.web.wiz.viewsheet} alone). Without a handler those fall through to a generic
+    * 500 and the message is lost, so an agent driving the tools sees only
+    * "Request failed with status code 500" for what is really a fixable bad request.
+    */
+   @Test
+   void illegalArgumentExceptionMapsToBadRequestCarryingTheMessage() throws Exception {
+      mvc.perform(get("/wiz-test/throw").param("type", "illegal"))
+         .andExpect(status().isBadRequest())
+         .andExpect(content().string(containsString("requires 'height'")));
+   }
+
    @RestController
    private static class ThrowingController {
       @GetMapping("/wiz-test/throw")
@@ -91,6 +105,10 @@ class WizControllerErrorHandlerTest {
 
          if("unsupported".equals(type)) {
             throw new UnsupportedDatasourceException("MongoDB REST", "Mongo");
+         }
+
+         if("illegal".equals(type)) {
+            throw new IllegalArgumentException("Edit op 'resize_title' requires 'height'.");
          }
 
          throw new java.lang.SecurityException("denied");

--- a/core/src/test/java/inetsoft/web/wiz/WizControllerErrorHandlerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/WizControllerErrorHandlerTest.java
@@ -113,6 +113,19 @@ class WizControllerErrorHandlerTest {
          .andExpect(content().string(containsString("pairing code")));
    }
 
+   /**
+    * A capability that is declared but not wired up must say so, not 500. Without this the
+    * refusal added to set_column_labels would reach the caller as an opaque server error, which
+    * reads as a bug rather than a missing feature — and the whole point of refusing was to let an
+    * agent surface the gap.
+    */
+   @Test
+   void unsupportedOperationMapsToNotImplementedCarryingTheMessage() throws Exception {
+      mvc.perform(get("/wiz-test/throw").param("type", "unsupported-op"))
+         .andExpect(status().isNotImplemented())
+         .andExpect(content().string(containsString("not supported yet")));
+   }
+
    @RestController
    private static class ThrowingController {
       @GetMapping("/wiz-test/throw")
@@ -127,6 +140,11 @@ class WizControllerErrorHandlerTest {
 
          if("illegal".equals(type)) {
             throw new IllegalArgumentException("Edit op 'resize_title' requires 'height'.");
+         }
+
+         if("unsupported-op".equals(type)) {
+            throw new UnsupportedOperationException(
+               "Renaming column headers is not supported yet.");
          }
 
          if("invaliduser".equals(type)) {

--- a/core/src/test/java/inetsoft/web/wiz/WizControllerErrorHandlerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/WizControllerErrorHandlerTest.java
@@ -95,6 +95,24 @@ class WizControllerErrorHandlerTest {
          .andExpect(content().string(containsString("requires 'height'")));
    }
 
+   /**
+    * A pairing session whose principal no longer owns the runtime sheet. StyleBI throws
+    * {@code InvalidUserException} from {@code WorksheetEngine.getSheet}, naming two client session
+    * ids — unreadable, and it surfaced as a bare Tomcat 500 HTML page with no message at all.
+    *
+    * <p>Worth its own status because the remedy is specific and the agent can act on it: re-pair.
+    * A 500 tells it to retry, which will fail identically forever. Found live: reads kept working
+    * (they resolve the sheet through the pairing lookup) while every write failed, so the session
+    * looked healthy right up to the point of the first mutation.
+    */
+   @Test
+   void invalidUserExceptionMapsToConflictTellingTheAgentToRepair() throws Exception {
+      mvc.perform(get("/wiz-test/throw").param("type", "invaliduser"))
+         .andExpect(status().isConflict())
+         .andExpect(content().string(containsString("no longer owns")))
+         .andExpect(content().string(containsString("pairing code")));
+   }
+
    @RestController
    private static class ThrowingController {
       @GetMapping("/wiz-test/throw")
@@ -109,6 +127,12 @@ class WizControllerErrorHandlerTest {
 
          if("illegal".equals(type)) {
             throw new IllegalArgumentException("Edit op 'resize_title' requires 'height'.");
+         }
+
+         if("invaliduser".equals(type)) {
+            throw new inetsoft.util.InvalidUserException(
+               "Invalid user found: Principal[Client[admin@172.18.0.1@a2f160d8]] instead of " +
+               "Principal[Client[admin@172.18.0.1@ab0096b3]]", () -> "admin");
          }
 
          throw new java.lang.SecurityException("denied");

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindableColumnsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindableColumnsTest.java
@@ -1,0 +1,94 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.web.wiz.binding.model.BindableField;
+import inetsoft.web.wiz.binding.model.BindableTable;
+import inetsoft.web.wiz.binding.model.FieldRef;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * A column the source does not have used to bind cleanly. The shelf stored it, the call reported
+ * success, and the crosstab rendered with no rows at all — which reads as "the data is empty"
+ * rather than "that column does not exist". Found live on local-1200 by binding a column from a
+ * different worksheet than the one the assembly pointed at, and confirmed with a nonsense name.
+ */
+@Tag("core")
+class BindableColumnsTest {
+   private static final List<BindableTable> TABLES = List.of(
+      new BindableTable("Query1", List.of(new BindableField("PRICE", null, null),
+                                          new BindableField("QUANTITY", null, null))),
+      new BindableTable("Products", List.of(new BindableField("PRODUCT_NAME", null, null))));
+
+   private static FieldRef dim(String column) {
+      return new FieldRef(column, "dimension", null, null, null);
+   }
+
+   @Test
+   void refusesAColumnThatAppearsInNoBindableTable() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> BindableColumns.require(TABLES, "Crosstab1", dim("NO_SUCH_COLUMN_XYZ")));
+
+      assertTrue(thrown.getMessage().contains("NO_SUCH_COLUMN_XYZ"));
+      assertTrue(thrown.getMessage().contains("PRICE"), "the message must list what is available");
+   }
+
+   /** The listing groups by table, and a column only has to exist in one of them. */
+   @Test
+   void acceptsAColumnFromAnyBindableTable() {
+      assertDoesNotThrow(() -> BindableColumns.require(TABLES, "Crosstab1", dim("PRODUCT_NAME")));
+      assertDoesNotThrow(() -> BindableColumns.require(TABLES, "Crosstab1", dim("PRICE")));
+   }
+
+   @Test
+   void isCaseInsensitiveRatherThanRejectingAKnownColumnOnItsSpelling() {
+      assertDoesNotThrow(() -> BindableColumns.require(TABLES, "Crosstab1", dim("price")));
+   }
+
+   /**
+    * An empty listing means the binding tree could not be read — a different failure. Refusing
+    * every column on the strength of it would turn a read problem into a write problem.
+    */
+   @Test
+   void staysOutOfTheWayWhenNothingCouldBeListed() {
+      assertDoesNotThrow(() -> BindableColumns.require(List.of(), "Crosstab1", dim("ANYTHING")));
+      assertDoesNotThrow(() -> BindableColumns.require(null, "Crosstab1", dim("ANYTHING")));
+   }
+
+   @Test
+   void ignoresAnAbsentOrBlankColumn() {
+      assertDoesNotThrow(() -> BindableColumns.require(TABLES, "Crosstab1", dim(null)));
+      assertDoesNotThrow(() -> BindableColumns.require(TABLES, "Crosstab1", dim("  ")));
+      assertDoesNotThrow(() -> BindableColumns.require(TABLES, "Crosstab1", List.of()));
+   }
+
+   @Test
+   void checksEveryFieldNotJustTheFirst() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> BindableColumns.require(TABLES, "Crosstab1", dim("PRICE"), dim("MADE_UP")));
+
+      assertTrue(thrown.getMessage().contains("MADE_UP"));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindableFieldsServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindableFieldsServiceTest.java
@@ -1,0 +1,85 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.web.binding.drm.DataRefModel;
+import inetsoft.web.binding.service.VSBindingTreeService;
+import inetsoft.web.composer.model.TreeNodeModel;
+import inetsoft.web.wiz.binding.model.BindableTable;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class BindableFieldsServiceTest {
+   @Test
+   void flattensTheTreeIntoTablesAndColumnsAndDropsTheUiChrome() throws Exception {
+      DataRefModel ref = mock(DataRefModel.class);
+      when(ref.getDataType()).thenReturn("double");
+
+      TreeNodeModel column = TreeNodeModel.builder()
+         .label("Sales").leaf(true).data(ref)
+         .icon("column-icon").tooltip("a tooltip").build();
+      TreeNodeModel table = TreeNodeModel.builder()
+         .label("Orders").addChildren(column).build();
+      TreeNodeModel root = TreeNodeModel.builder().label("root").addChildren(table).build();
+
+      List<BindableTable> tables = serviceReturning(root).list("rt1", null, principal());
+
+      assertEquals(1, tables.size());
+      assertEquals("Orders", tables.get(0).name());
+      assertEquals(1, tables.get(0).fields().size());
+      assertEquals("Sales", tables.get(0).fields().get(0).column());
+      assertEquals("double", tables.get(0).fields().get(0).dataType());
+   }
+
+   @Test
+   void descendsThroughFolderLevelsSoNestingDepthDoesNotMatter() throws Exception {
+      TreeNodeModel column = TreeNodeModel.builder().label("Qty").leaf(true).build();
+      TreeNodeModel table = TreeNodeModel.builder().label("Items").addChildren(column).build();
+      TreeNodeModel folder = TreeNodeModel.builder().label("Folder").addChildren(table).build();
+      TreeNodeModel root = TreeNodeModel.builder().label("root").addChildren(folder).build();
+
+      List<BindableTable> tables = serviceReturning(root).list("rt1", null, principal());
+
+      assertEquals(1, tables.size(), "the folder level must not become a table");
+      assertEquals("Items", tables.get(0).name());
+   }
+
+   @Test
+   void returnsNoTablesRatherThanFailingWhenTheTreeIsEmpty() throws Exception {
+      assertTrue(serviceReturning(null).list("rt1", null, principal()).isEmpty());
+   }
+
+   private static BindableFieldsService serviceReturning(TreeNodeModel root) throws Exception {
+      VSBindingTreeService tree = mock(VSBindingTreeService.class);
+      when(tree.getBinding(eq("rt1"), any(), anyBoolean(), any(Principal.class)))
+         .thenReturn(root);
+      return new BindableFieldsService(tree);
+   }
+
+   private static Principal principal() {
+      return () -> "admin";
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
@@ -1,0 +1,83 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.web.wiz.pairing.*;
+import inetsoft.web.wiz.viewsheet.ViewsheetSessionService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.security.Principal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class BindingAgentControllerTest {
+   @Test
+   void fieldsRefusesWhenTheFeatureIsDisabled() {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      when(feature.isEnabled()).thenReturn(false);
+
+      assertThrows(ResponseStatusException.class,
+                   () -> controllerWith(feature, mock(ViewsheetSessionService.class),
+                                        mock(BindableFieldsService.class))
+                      .fields("tok", null, principal()));
+   }
+
+   @Test
+   void joinRefusesWhenTheFeatureIsDisabled() {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      when(feature.isEnabled()).thenReturn(false);
+
+      assertThrows(ResponseStatusException.class,
+                   () -> controllerWith(feature, mock(ViewsheetSessionService.class),
+                                        mock(BindableFieldsService.class))
+                      .join(new BindingAgentController.JoinRequest("ABCD2345"), principal()));
+   }
+
+   @Test
+   void fieldsListsTheDiscoveredTablesForTheSessionRuntime() throws Exception {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      when(feature.isEnabled()).thenReturn(true);
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      when(sessions.runtimeId(eq("tok"), any(Principal.class))).thenReturn("rt1");
+      BindableFieldsService fields = mock(BindableFieldsService.class);
+      when(fields.list(eq("rt1"), any(), any(Principal.class))).thenReturn(List.of());
+
+      assertTrue(controllerWith(feature, sessions, fields)
+                    .fields("tok", null, principal()).isEmpty());
+      verify(fields).list(eq("rt1"), any(), any(Principal.class));
+   }
+
+   private static BindingAgentController controllerWith(SheetAgentFeature feature,
+                                                        ViewsheetSessionService sessions,
+                                                        BindableFieldsService fields)
+   {
+      return new BindingAgentController(feature, mock(SheetJoinService.class),
+                                        mock(SheetSessionService.class), sessions, fields,
+                                        mock(BindingReadService.class));
+   }
+
+   private static Principal principal() {
+      return () -> "admin";
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
@@ -76,7 +76,7 @@ class BindingAgentControllerTest {
                                         mock(SheetSessionService.class), sessions, fields,
                                         mock(BindingReadService.class),
                                         mock(ChartBindingService.class),
-                                        mock(ChartAestheticService.class),
+                                        mock(ChartAestheticAgentService.class),
                                         mock(TableBindingService.class),
                                         mock(CalcTableService.class));
    }

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
@@ -74,7 +74,8 @@ class BindingAgentControllerTest {
    {
       return new BindingAgentController(feature, mock(SheetJoinService.class),
                                         mock(SheetSessionService.class), sessions, fields,
-                                        mock(BindingReadService.class));
+                                        mock(BindingReadService.class),
+                                        mock(ChartBindingService.class));
    }
 
    private static Principal principal() {

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
@@ -76,7 +76,8 @@ class BindingAgentControllerTest {
                                         mock(SheetSessionService.class), sessions, fields,
                                         mock(BindingReadService.class),
                                         mock(ChartBindingService.class),
-                                        mock(ChartAestheticService.class));
+                                        mock(ChartAestheticService.class),
+                                        mock(TableBindingService.class));
    }
 
    private static Principal principal() {

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
@@ -75,7 +75,8 @@ class BindingAgentControllerTest {
       return new BindingAgentController(feature, mock(SheetJoinService.class),
                                         mock(SheetSessionService.class), sessions, fields,
                                         mock(BindingReadService.class),
-                                        mock(ChartBindingService.class));
+                                        mock(ChartBindingService.class),
+                                        mock(ChartAestheticService.class));
    }
 
    private static Principal principal() {

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
@@ -77,7 +77,8 @@ class BindingAgentControllerTest {
                                         mock(BindingReadService.class),
                                         mock(ChartBindingService.class),
                                         mock(ChartAestheticService.class),
-                                        mock(TableBindingService.class));
+                                        mock(TableBindingService.class),
+                                        mock(CalcTableService.class));
    }
 
    private static Principal principal() {

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindingReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindingReadServiceTest.java
@@ -1,0 +1,79 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.CalcTableVSAssembly;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.VSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.binding.model.ChartBindingModel;
+import inetsoft.web.binding.service.VSBindingService;
+import inetsoft.web.wiz.binding.model.AssemblyBinding;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class BindingReadServiceTest {
+   @Test
+   void readsAChartsShelvesIntoTheSharedVocabulary() {
+      VSBindingService binding = mock(VSBindingService.class);
+      when(binding.createModel(any())).thenReturn(new ChartBindingModel());
+
+      AssemblyBinding result = new BindingReadService(binding)
+         .read(runtimeWith("Chart1", mock(ChartVSAssembly.class)), "Chart1");
+
+      assertEquals("Chart1", result.assembly());
+      assertTrue(result.shelves().containsKey("x"), "a chart exposes an x shelf");
+      assertTrue(result.shelves().containsKey("y"));
+      assertTrue(result.shelves().containsKey("group"));
+   }
+
+   @Test
+   void refusesACalcTablePointingAtTheLayoutTool() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> new BindingReadService(mock(VSBindingService.class))
+            .read(runtimeWith("Calc1", mock(CalcTableVSAssembly.class)), "Calc1"));
+
+      assertTrue(thrown.getMessage().contains("get_calc_layout"),
+                 "must point at the calc-table tool, got: " + thrown.getMessage());
+   }
+
+   @Test
+   void namesTheUnknownAssemblyRatherThanReturningAnEmptyBinding() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> new BindingReadService(mock(VSBindingService.class))
+            .read(runtimeWith("Ghost", null), "Ghost"));
+
+      assertTrue(thrown.getMessage().contains("Ghost"));
+   }
+
+   private static RuntimeViewsheet runtimeWith(String name, VSAssembly assembly) {
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssembly(name)).thenReturn(assembly);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      return rvs;
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/binding/CalcCellVocabularyTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/CalcCellVocabularyTest.java
@@ -1,0 +1,231 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.report.CellBinding;
+import inetsoft.report.GroupableCellBinding;
+import inetsoft.web.binding.model.table.CellBindingInfo;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+class CalcCellVocabularyTest {
+   private static Map<String, Object> spec(Object... pairs) {
+      Map<String, Object> spec = new LinkedHashMap<>();
+
+      for(int i = 0; i < pairs.length; i += 2) {
+         spec.put((String) pairs[i], pairs[i + 1]);
+      }
+
+      return spec;
+   }
+
+   // ── content ───────────────────────────────────────────────────────────────
+
+   @Test
+   void mapsTheContentTokensToCellBindingConstants() {
+      assertEquals(CellBinding.BIND_TEXT, CalcCellVocabulary.content("text"));
+      assertEquals(CellBinding.BIND_COLUMN, CalcCellVocabulary.content("column"));
+      assertEquals(CellBinding.BIND_FORMULA, CalcCellVocabulary.content("formula"));
+   }
+
+   @Test
+   void mapsTheGroupingTokens() {
+      assertEquals(CellBinding.GROUP, CalcCellVocabulary.grouping("group"));
+      assertEquals(CellBinding.DETAIL, CalcCellVocabulary.grouping("detail"));
+      assertEquals(CellBinding.SUMMARY, CalcCellVocabulary.grouping("summary"));
+   }
+
+   @Test
+   void mapsTheExpansionTokensIncludingTheShortSpellings() {
+      assertEquals(GroupableCellBinding.EXPAND_NONE, CalcCellVocabulary.expand("none"));
+      assertEquals(GroupableCellBinding.EXPAND_V, CalcCellVocabulary.expand("vertical"));
+      assertEquals(GroupableCellBinding.EXPAND_V, CalcCellVocabulary.expand("v"));
+      assertEquals(GroupableCellBinding.EXPAND_H, CalcCellVocabulary.expand("horizontal"));
+      assertEquals(GroupableCellBinding.EXPAND_H, CalcCellVocabulary.expand("h"));
+   }
+
+   @Test
+   void matchesTokensCaseInsensitively() {
+      assertEquals(CellBinding.BIND_COLUMN, CalcCellVocabulary.content("  Column "));
+      assertEquals(CellBinding.SUMMARY, CalcCellVocabulary.grouping("SUMMARY"));
+   }
+
+   // ── the naming hazard: five different `type` fields ───────────────────────
+
+   /**
+    * {@code type} means five unrelated things across this binding surface. Accepting it here
+    * with any of those meanings is how a plausible wrong guess lands in a valid-looking field
+    * and renders a silently wrong table.
+    */
+   @Test
+   void refusesTypeAtTheCellLevelNamingTheCorrectKey() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> CalcCellVocabulary.validate(spec("type", "column")));
+
+      assertTrue(thrown.getMessage().contains("type"));
+      assertTrue(thrown.getMessage().contains("content"),
+                 "the refusal must name the key that was meant");
+   }
+
+   @Test
+   void refusesBtypeNamingGrouping() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> CalcCellVocabulary.validate(spec("btype", "group")));
+
+      assertTrue(thrown.getMessage().contains("btype"));
+      assertTrue(thrown.getMessage().contains("grouping"));
+   }
+
+   @Test
+   void refusesExpansionNamingExpand() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> CalcCellVocabulary.validate(spec("expansion", "vertical")));
+
+      assertTrue(thrown.getMessage().contains("expand"));
+   }
+
+   /**
+    * `role` is excluded deliberately: it is the wrong key in the recorded fieldConfigs defect,
+    * and giving it a new meaning inside the same plugin family would be its own trap.
+    */
+   @Test
+   void refusesRoleRatherThanGivingItANewMeaning() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> CalcCellVocabulary.validate(spec("role", "group")));
+
+      assertTrue(thrown.getMessage().contains("role"));
+   }
+
+   @Test
+   void acceptsTheCanonicalKeys() {
+      assertDoesNotThrow(() -> CalcCellVocabulary.validate(
+         spec("content", "column", "grouping", "group", "expand", "vertical",
+              "field", Map.of("column", "Region", "type", "dimension"))));
+   }
+
+   // ── integer constants never appear ────────────────────────────────────────
+
+   @Test
+   void refusesAnIntegerWhereATokenIsExpected() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class, () -> CalcCellVocabulary.content("2"));
+
+      assertTrue(thrown.getMessage().contains("2"));
+      assertTrue(thrown.getMessage().contains("column"),
+                 "list the tokens rather than accepting the raw constant");
+   }
+
+   @Test
+   void refusesAnUnknownToken() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class, () -> CalcCellVocabulary.grouping("aggregate"));
+
+      assertTrue(thrown.getMessage().contains("aggregate"));
+      assertTrue(thrown.getMessage().contains("summary"));
+   }
+
+   @Test
+   void refusesAMissingToken() {
+      assertThrows(IllegalArgumentException.class, () -> CalcCellVocabulary.content(null));
+   }
+
+   // ── the read direction ────────────────────────────────────────────────────
+
+   @Test
+   void describesACellBackInTokensNeverIntegers() {
+      CellBindingInfo info = new CellBindingInfo();
+      info.setType(CellBinding.BIND_COLUMN);
+      info.setBtype(CellBinding.GROUP);
+      info.setExpansion(GroupableCellBinding.EXPAND_V);
+      info.setValue("Region");
+
+      Map<String, Object> described = CalcCellVocabulary.describe(info);
+
+      assertEquals("column", described.get("content"));
+      assertEquals("group", described.get("grouping"));
+      assertEquals("vertical", described.get("expand"));
+      assertEquals("Region", described.get("value"));
+      assertFalse(described.containsKey("type"), "the ambiguous keys must not come back out");
+      assertFalse(described.containsKey("btype"));
+   }
+
+   @Test
+   void describesNullAsNull() {
+      assertNull(CalcCellVocabulary.describe(null));
+   }
+
+   @Test
+   void describesAnUnrecognizedConstantWithoutInventingAToken() {
+      CellBindingInfo info = new CellBindingInfo();
+      info.setType(99);
+
+      Map<String, Object> described = CalcCellVocabulary.describe(info);
+
+      assertEquals("unknown(99)", described.get("content"),
+                   "reporting the raw constant beats guessing a token that would read as fact");
+   }
+
+   // ── binding completeness ──────────────────────────────────────────────────
+
+   /**
+    * A cell bound to nothing renders blank, which reads as a data problem rather than a
+    * binding error — so an incomplete binding is refused at the boundary.
+    */
+   @Test
+   void refusesColumnContentWithNoField() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> CalcCellVocabulary.validate(spec("content", "column")));
+
+      assertTrue(thrown.getMessage().contains("field"));
+   }
+
+   @Test
+   void refusesFormulaContentWithNoFormula() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> CalcCellVocabulary.validate(spec("content", "formula")));
+
+      assertTrue(thrown.getMessage().contains("formula"));
+   }
+
+   @Test
+   void refusesTextContentWithNoValue() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> CalcCellVocabulary.validate(spec("content", "text")));
+
+      assertTrue(thrown.getMessage().contains("value"));
+   }
+
+   @Test
+   void acceptsTextContentWithAValue() {
+      assertDoesNotThrow(
+         () -> CalcCellVocabulary.validate(spec("content", "text", "value", "Total")));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/binding/CalcTableServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/CalcTableServiceTest.java
@@ -17,6 +17,13 @@
  */
 package inetsoft.web.wiz.binding;
 
+import inetsoft.web.wiz.dispatch.CapturingCommandDispatcher;
+import inetsoft.web.viewsheet.service.CommandDispatcher;
+import inetsoft.web.binding.event.GetPredefinedNamedGroupEvent;
+import inetsoft.web.binding.event.GetCellScriptEvent;
+import inetsoft.web.binding.command.GetPredefinedNamedGroupCommand;
+import inetsoft.web.binding.command.GetCellScriptCommand;
+import inetsoft.report.internal.binding.AssetNamedGroupInfo;
 import inetsoft.report.CellBinding;
 import inetsoft.report.GroupableCellBinding;
 import inetsoft.report.TableLayout;
@@ -105,6 +112,48 @@ class CalcTableServiceTest {
       assertEquals(1, event.getSelectCells()[0].getCol());
       assertEquals(CellBinding.BIND_COLUMN, event.getBinding().getType());
       assertEquals("Region", event.getBinding().getValue());
+   }
+
+   /**
+    * A <b>summary</b> cell is an aggregate, and an aggregate needs a formula — but a cell that
+    * binds a field must use {@code content: "column"}, and that branch never set one. StyleBI then
+    * threw {@code NullPointerException: Cannot read field "formula" because "finfo" is null} from
+    * {@code TableLayoutHandler.createAggregateField}, which made a summary column cell impossible
+    * to create through this tool at all.
+    */
+   @Test
+   void carriesTheFormulaOnASummaryColumnCellBecauseAnAggregateNeedsOne() throws Exception {
+      Harness h = harness(3, 3);
+
+      h.service.setCellBinding("tok", principal(), "Calc1", 1, 1,
+                               spec("content", "column", "grouping", "summary",
+                                    "expand", "none", "formula", "Sum",
+                                    "field", Map.of("column", "PAID", "type", "measure")));
+
+      ArgumentCaptor<SetCellBindingEvent> captor =
+         ArgumentCaptor.forClass(SetCellBindingEvent.class);
+      verify(h.layoutService).setCellBinding(eq("rt1"), captor.capture(), any(Principal.class),
+                                             any());
+      assertEquals("Sum", captor.getValue().getBinding().getFormula());
+      assertEquals("PAID", captor.getValue().getBinding().getValue());
+   }
+
+   /**
+    * Without a formula the aggregate NPEs deep in StyleBI. Refusing here names the missing key
+    * instead of surfacing a 500 the caller cannot act on.
+    */
+   @Test
+   void refusesASummaryCellWithNoFormula() {
+      Harness h = harness(3, 3);
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> h.service.setCellBinding("tok", principal(), "Calc1", 1, 1,
+                                        spec("content", "column", "grouping", "summary",
+                                             "expand", "none",
+                                             "field", Map.of("column", "PAID",
+                                                             "type", "measure"))));
+      assertTrue(thrown.getMessage().contains("formula"));
    }
 
    @Test
@@ -221,6 +270,15 @@ class CalcTableServiceTest {
             return null;
          }).when(sessions).mutate(anyString(), any(Principal.class), any());
          when(sessions.resolve(anyString(), any(Principal.class))).thenReturn(rvs);
+
+         // The read entry point supplies a capturing dispatcher without a checkpoint. Composer
+         // services that answer by dispatching a command need it; the test double runs the read
+         // against a real CapturingCommandDispatcher so captured commands can be asserted.
+         doAnswer(invocation -> {
+            ViewsheetSessionService.Read<?> read = invocation.getArgument(2);
+            return CapturingCommandDispatcher.withCapturingDispatcher(
+               principal(), dispatcher -> read.run(rvs, "rt1", dispatcher));
+         }).when(sessions).read(anyString(), any(Principal.class), any());
       }
       catch(Exception e) {
          throw new IllegalStateException(e);
@@ -232,6 +290,73 @@ class CalcTableServiceTest {
 
    private static Principal principal() {
       return () -> "admin";
+   }
+
+   // ── cell scripts and named groups (2e Phase 3) ────────────────────────────
+   //
+   // Both composer services return their result by DISPATCHING a command rather than returning
+   // it, which is why these need the read-only capturing entry point rather than resolve().
+
+   @Test
+   void readsACellScriptOutOfTheDispatchedCommand() throws Exception {
+      Harness h = harness(3, 3);
+      doAnswer(invocation -> {
+         CommandDispatcher dispatcher = invocation.getArgument(3);
+         dispatcher.sendCommand("Calc1", new GetCellScriptCommand("sum(PAID)"));
+         return null;
+      }).when(h.layoutService).getCellScript(anyString(), any(GetCellScriptEvent.class),
+                                             any(Principal.class), any());
+
+      Map<String, Object> read = h.service.cellScript("tok", principal(), "Calc1", 1, 1);
+
+      assertEquals("sum(PAID)", read.get("script"));
+      assertEquals(1, read.get("row"));
+      assertEquals(1, read.get("col"));
+   }
+
+   @Test
+   void reportsNoScriptRatherThanNullWhenACellHasNone() throws Exception {
+      Harness h = harness(3, 3);
+
+      Map<String, Object> read = h.service.cellScript("tok", principal(), "Calc1", 0, 0);
+
+      assertNull(read.get("script"));
+      assertNotNull(read.get("note"), "say that no script came back rather than looking empty");
+   }
+
+   /**
+    * The command carries the group NAMES only: its constructor takes
+    * {@code AssetNamedGroupInfo[]} but keeps just {@code getName()} from each, so the members
+    * never reach the wire. This asserts what StyleBI actually sends.
+    */
+   @Test
+   void readsNamedGroupNamesOutOfTheDispatchedCommand() throws Exception {
+      Harness h = harness(3, 3);
+      GetPredefinedNamedGroupCommand command = new GetPredefinedNamedGroupCommand(
+         new AssetNamedGroupInfo[0]);
+      command.setNamedGroups(new String[]{ "Regions", "Tiers" });
+      doAnswer(invocation -> {
+         CommandDispatcher dispatcher = invocation.getArgument(3);
+         dispatcher.sendCommand("Calc1", command);
+         return null;
+      }).when(h.layoutService).getNamedGroup(anyString(),
+                                             any(GetPredefinedNamedGroupEvent.class),
+                                             any(Principal.class), any());
+
+      Map<String, Object> read = h.service.namedGroups("tok", principal(), "Calc1", "REGION");
+
+      assertEquals(List.of("Regions", "Tiers"), read.get("namedGroups"));
+      assertEquals("REGION", read.get("column"));
+   }
+
+   @Test
+   void namedGroupsNeedsAColumn() {
+      Harness h = harness(3, 3);
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> h.service.namedGroups("tok", principal(), "Calc1", "  "));
+      assertTrue(thrown.getMessage().contains("column"));
    }
 
    // ── layout operations (2e Phase 2) ────────────────────────────────────────

--- a/core/src/test/java/inetsoft/web/wiz/binding/CalcTableServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/CalcTableServiceTest.java
@@ -24,6 +24,8 @@ import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.CalcTableVSAssemblyInfo;
 import inetsoft.web.binding.controller.VSTableLayoutService;
+import inetsoft.web.binding.event.CopyCutCalcCellEvent;
+import inetsoft.web.binding.event.ModifyTableLayoutEvent;
 import inetsoft.web.binding.event.SetCellBindingEvent;
 import inetsoft.web.binding.model.table.CellBindingInfo;
 import inetsoft.web.wiz.viewsheet.ViewsheetSessionService;
@@ -230,5 +232,184 @@ class CalcTableServiceTest {
 
    private static Principal principal() {
       return () -> "admin";
+   }
+
+   // ── layout operations (2e Phase 2) ────────────────────────────────────────
+
+   @Test
+   void insertsARowAndReturnsTheUpdatedLayout() throws Exception {
+      Harness h = harness(3, 3);
+
+      Map<String, Object> updated =
+         h.service.modifyLayout("tok", principal(), "Calc1", "insertRow", 1, 0, null, null, 1);
+
+      ArgumentCaptor<ModifyTableLayoutEvent> captor =
+         ArgumentCaptor.forClass(ModifyTableLayoutEvent.class);
+      verify(h.layoutService).modifyLayout(eq("rt1"), captor.capture(), any(Principal.class),
+                                           any());
+      assertEquals("insertRow", captor.getValue().getOp());
+      assertEquals(1, captor.getValue().getNum());
+      assertEquals(1, captor.getValue().getSelection().y);
+      assertNotNull(updated.get("cells"), "the updated layout comes back with the response");
+   }
+
+   /**
+    * Coordinates read before a layout op are stale afterwards, so the response says so rather
+    * than leaving the caller to remember.
+    */
+   @Test
+   void theResponseWarnsThatEarlierCoordinatesAreStale() throws Exception {
+      Harness h = harness(3, 3);
+
+      Map<String, Object> updated =
+         h.service.modifyLayout("tok", principal(), "Calc1", "insertRow", 1, 0, null, null, 1);
+
+      assertTrue(String.valueOf(updated.get("note")).contains("stale"));
+   }
+
+   @Test
+   void acceptsTheOpNameSpellings() throws Exception {
+      for(String op : List.of("insertRow", "insert_row", "insertrow")) {
+         Harness h = harness(3, 3);
+         h.service.modifyLayout("tok", principal(), "Calc1", op, 0, 0, null, null, 1);
+         ArgumentCaptor<ModifyTableLayoutEvent> captor =
+            ArgumentCaptor.forClass(ModifyTableLayoutEvent.class);
+         verify(h.layoutService).modifyLayout(anyString(), captor.capture(), any(Principal.class),
+                                              any());
+         assertEquals("insertRow", captor.getValue().getOp(), "'" + op + "' should resolve");
+      }
+   }
+
+   @Test
+   void refusesAnUnknownLayoutOpListingTheValid() {
+      Harness h = harness(3, 3);
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> h.service.modifyLayout("tok", principal(), "Calc1", "explode", 0, 0, null, null,
+                                      1));
+
+      assertTrue(thrown.getMessage().contains("explode"));
+      assertTrue(thrown.getMessage().contains("mergeCells"));
+   }
+
+   /** Merging one cell is a handler no-op that would otherwise report success. */
+   @Test
+   void refusesMergingASingleCell() {
+      Harness h = harness(3, 3);
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> h.service.modifyLayout("tok", principal(), "Calc1", "mergeCells", 0, 0, 1, 1, 1));
+
+      assertTrue(thrown.getMessage().contains("report success"));
+   }
+
+   @Test
+   void acceptsMergingASpanningSelection() throws Exception {
+      Harness h = harness(3, 3);
+
+      h.service.modifyLayout("tok", principal(), "Calc1", "mergeCells", 0, 0, 2, 2, 1);
+
+      ArgumentCaptor<ModifyTableLayoutEvent> captor =
+         ArgumentCaptor.forClass(ModifyTableLayoutEvent.class);
+      verify(h.layoutService).modifyLayout(anyString(), captor.capture(), any(Principal.class),
+                                           any());
+      assertEquals(2, captor.getValue().getSelection().width);
+      assertEquals(2, captor.getValue().getSelection().height);
+   }
+
+   /** Splitting an unmerged cell is the other handler no-op. */
+   @Test
+   void refusesSplittingAnUnmergedCell() {
+      Harness h = harness(3, 3);
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> h.service.modifyLayout("tok", principal(), "Calc1", "splitCells", 0, 0, null,
+                                      null, 1));
+
+      assertTrue(thrown.getMessage().contains("not merged"));
+   }
+
+   @Test
+   void refusesAnNBelowOne() {
+      Harness h = harness(3, 3);
+
+      assertThrows(Exception.class,
+                   () -> h.service.modifyLayout("tok", principal(), "Calc1", "insertRow", 0, 0,
+                                                null, null, 0));
+   }
+
+   @Test
+   void refusesALayoutOpOutsideTheGrid() {
+      Harness h = harness(2, 2);
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> h.service.modifyLayout("tok", principal(), "Calc1", "insertRow", 9, 0, null, null,
+                                      1));
+
+      assertTrue(thrown.getMessage().contains("stale"));
+   }
+
+   // ── copy / cut / remove (2e Phase 2) ──────────────────────────────────────
+
+   @Test
+   void copiesARangeToATarget() throws Exception {
+      Harness h = harness(4, 4);
+
+      h.service.copyCells("tok", principal(), "Calc1", "copy",
+                          new java.awt.Rectangle(0, 0, 2, 1),
+                          new java.awt.Rectangle(0, 2, 2, 1));
+
+      ArgumentCaptor<CopyCutCalcCellEvent> captor =
+         ArgumentCaptor.forClass(CopyCutCalcCellEvent.class);
+      verify(h.layoutService).copyCut(eq("rt1"), captor.capture(), any(Principal.class), any());
+      assertEquals("copy", captor.getValue().getOp());
+      assertEquals(2, captor.getValue().getSelections().length);
+   }
+
+   @Test
+   void removeNeedsNoTarget() throws Exception {
+      Harness h = harness(4, 4);
+
+      h.service.copyCells("tok", principal(), "Calc1", "remove",
+                          new java.awt.Rectangle(0, 0, 1, 1), null);
+
+      verify(h.layoutService).copyCut(anyString(), any(CopyCutCalcCellEvent.class),
+                                      any(Principal.class), any());
+   }
+
+   /** Without a target there is nowhere to paste and the operation would do nothing. */
+   @Test
+   void refusesACopyWithNoTarget() {
+      Harness h = harness(4, 4);
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> h.service.copyCells("tok", principal(), "Calc1", "copy",
+                                   new java.awt.Rectangle(0, 0, 1, 1), null));
+
+      assertTrue(thrown.getMessage().contains("nowhere to paste"));
+   }
+
+   @Test
+   void refusesAnUnknownCopyOp() {
+      Harness h = harness(4, 4);
+
+      assertThrows(Exception.class,
+                   () -> h.service.copyCells("tok", principal(), "Calc1", "duplicate",
+                                             new java.awt.Rectangle(0, 0, 1, 1), null));
+   }
+
+   @Test
+   void vocabularyListsTheLayoutAndCopyOps() {
+      Harness h = harness(1, 1);
+
+      Map<String, Object> vocabulary = h.service.vocabulary();
+
+      assertTrue(String.valueOf(vocabulary.get("layoutOps")).contains("appendCol"));
+      assertTrue(String.valueOf(vocabulary.get("copyOps")).contains("remove"));
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/binding/CalcTableServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/CalcTableServiceTest.java
@@ -1,0 +1,234 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.report.CellBinding;
+import inetsoft.report.GroupableCellBinding;
+import inetsoft.report.TableLayout;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.internal.CalcTableVSAssemblyInfo;
+import inetsoft.web.binding.controller.VSTableLayoutService;
+import inetsoft.web.binding.event.SetCellBindingEvent;
+import inetsoft.web.binding.model.table.CellBindingInfo;
+import inetsoft.web.wiz.viewsheet.ViewsheetSessionService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.security.Principal;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class CalcTableServiceTest {
+   private static Map<String, Object> spec(Object... pairs) {
+      Map<String, Object> spec = new LinkedHashMap<>();
+
+      for(int i = 0; i < pairs.length; i += 2) {
+         spec.put((String) pairs[i], pairs[i + 1]);
+      }
+
+      return spec;
+   }
+
+   private static Map<String, Object> columnCell(String column) {
+      return spec("content", "column", "grouping", "group", "expand", "vertical",
+                  "field", Map.of("column", column, "type", "dimension"));
+   }
+
+   @Test
+   void readsTheGridDimensionsAndEveryCell() throws Exception {
+      Harness h = harness(2, 3);
+
+      Map<String, Object> layout = h.service.readLayout("tok", principal(), "Calc1");
+
+      assertEquals(2, layout.get("rowCount"));
+      assertEquals(3, layout.get("colCount"));
+      @SuppressWarnings("unchecked")
+      List<Object> cells = (List<Object>) layout.get("cells");
+      assertEquals(6, cells.size());
+      verify(h.sessions, never()).mutate(anyString(), any(Principal.class), any());
+   }
+
+   @Test
+   void readsACellInTheTokenVocabulary() throws Exception {
+      Harness h = harness(2, 2);
+      CellBindingInfo info = new CellBindingInfo();
+      info.setType(CellBinding.BIND_COLUMN);
+      info.setBtype(CellBinding.GROUP);
+      info.setExpansion(GroupableCellBinding.EXPAND_V);
+      when(h.layoutService.getCellBindingInfo(any(), eq(1), eq(0))).thenReturn(info);
+
+      Map<String, Object> read = h.service.readCell("tok", principal(), "Calc1", 1, 0);
+
+      @SuppressWarnings("unchecked")
+      Map<String, Object> binding = (Map<String, Object>) read.get("binding");
+      assertEquals("column", binding.get("content"));
+      assertEquals("group", binding.get("grouping"));
+      assertEquals("vertical", binding.get("expand"));
+   }
+
+   @Test
+   void setsACellBindingThroughTheCellAddressedEndpoint() throws Exception {
+      Harness h = harness(3, 3);
+
+      h.service.setCellBinding("tok", principal(), "Calc1", 2, 1, columnCell("Region"));
+
+      ArgumentCaptor<SetCellBindingEvent> captor =
+         ArgumentCaptor.forClass(SetCellBindingEvent.class);
+      verify(h.layoutService).setCellBinding(eq("rt1"), captor.capture(), any(Principal.class),
+                                             any());
+      SetCellBindingEvent event = captor.getValue();
+      assertEquals("Calc1", event.getName());
+      assertEquals(2, event.getSelectCells()[0].getRow());
+      assertEquals(1, event.getSelectCells()[0].getCol());
+      assertEquals(CellBinding.BIND_COLUMN, event.getBinding().getType());
+      assertEquals("Region", event.getBinding().getValue());
+   }
+
+   @Test
+   void eachBindIsExactlyOneCheckpoint() throws Exception {
+      Harness h = harness(3, 3);
+
+      h.service.setCellBinding("tok", principal(), "Calc1", 0, 0, columnCell("Region"));
+
+      verify(h.sessions, times(1)).mutate(anyString(), any(Principal.class), any());
+   }
+
+   /**
+    * A coordinate outside the grid must be refused with the grid's real dimensions, since the
+    * usual cause is a coordinate read before a layout change.
+    */
+   @Test
+   void refusesACoordinateOutsideTheGridReportingItsSize() {
+      Harness h = harness(2, 2);
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> h.service.setCellBinding("tok", principal(), "Calc1", 5, 0,
+                                        columnCell("Region")));
+
+      assertTrue(thrown.getMessage().contains("2 row"));
+      assertTrue(thrown.getMessage().contains("stale"));
+   }
+
+   @Test
+   void validatesTheBindingBeforeTouchingTheRuntime() {
+      Harness h = harness(3, 3);
+
+      assertThrows(Exception.class,
+                   () -> h.service.setCellBinding("tok", principal(), "Calc1", 0, 0,
+                                                  spec("type", "column")));
+
+      verifyNoInteractions(h.sessions);
+   }
+
+   @Test
+   void refusesAColumnCellWhoseFieldHasNoType() {
+      Harness h = harness(3, 3);
+
+      assertThrows(Exception.class,
+                   () -> h.service.setCellBinding(
+                      "tok", principal(), "Calc1", 0, 0,
+                      spec("content", "column", "field", Map.of("column", "Region"))));
+   }
+
+   @Test
+   void bindsATextCellFromItsLiteralValue() throws Exception {
+      Harness h = harness(2, 2);
+
+      h.service.setCellBinding("tok", principal(), "Calc1", 0, 0,
+                               spec("content", "text", "value", "Total"));
+
+      ArgumentCaptor<SetCellBindingEvent> captor =
+         ArgumentCaptor.forClass(SetCellBindingEvent.class);
+      verify(h.layoutService).setCellBinding(eq("rt1"), captor.capture(), any(Principal.class),
+                                             any());
+      assertEquals(CellBinding.BIND_TEXT, captor.getValue().getBinding().getType());
+      assertEquals("Total", captor.getValue().getBinding().getValue());
+   }
+
+   @Test
+   void refusesANonCalcAssemblyPointingAtTheShelfTools() {
+      Harness h = harnessFor(mock(CrosstabVSAssembly.class), 0, 0);
+
+      Exception thrown = assertThrows(
+         Exception.class, () -> h.service.readLayout("tok", principal(), "Crosstab1"));
+
+      assertTrue(thrown.getMessage().contains("Crosstab1"));
+      assertTrue(thrown.getMessage().contains("get_table_binding"));
+   }
+
+   @Test
+   void vocabularyListsTheTokensRatherThanConstants() {
+      Harness h = harness(1, 1);
+
+      Map<String, Object> vocabulary = h.service.vocabulary();
+
+      assertTrue(String.valueOf(vocabulary.get("content")).contains("formula"));
+      assertTrue(String.valueOf(vocabulary.get("expand")).contains("vertical"));
+   }
+
+   // ── harness ───────────────────────────────────────────────────────────────
+
+   private record Harness(CalcTableService service, ViewsheetSessionService sessions,
+                          VSTableLayoutService layoutService) {}
+
+   private static Harness harness(int rows, int cols) {
+      CalcTableVSAssembly assembly = mock(CalcTableVSAssembly.class);
+      CalcTableVSAssemblyInfo info = mock(CalcTableVSAssemblyInfo.class);
+      TableLayout layout = mock(TableLayout.class);
+      when(layout.getRowCount()).thenReturn(rows);
+      when(layout.getColCount()).thenReturn(cols);
+      when(info.getTableLayout()).thenReturn(layout);
+      when(assembly.getInfo()).thenReturn(info);
+      return harnessFor(assembly, rows, cols);
+   }
+
+   private static Harness harnessFor(VSAssembly assembly, int rows, int cols) {
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssembly(anyString())).thenReturn(assembly);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+
+      try {
+         doAnswer(invocation -> {
+            ViewsheetSessionService.Mutation mutation = invocation.getArgument(2);
+            mutation.run(rvs, "rt1", null);
+            return null;
+         }).when(sessions).mutate(anyString(), any(Principal.class), any());
+         when(sessions.resolve(anyString(), any(Principal.class))).thenReturn(rvs);
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(e);
+      }
+
+      VSTableLayoutService layoutService = mock(VSTableLayoutService.class);
+      return new Harness(new CalcTableService(sessions, layoutService), sessions, layoutService);
+   }
+
+   private static Principal principal() {
+      return () -> "admin";
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticAgentServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticAgentServiceTest.java
@@ -39,7 +39,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @Tag("core")
-class ChartAestheticServiceTest {
+class ChartAestheticAgentServiceTest {
    private static Map<String, Object> spec(Object... pairs) {
       Map<String, Object> spec = new LinkedHashMap<>();
 
@@ -140,7 +140,7 @@ class ChartAestheticServiceTest {
    @Test
    void eachMutationIsExactlyOneCheckpoint() throws Exception {
       ViewsheetSessionService sessions = sessionsFor(mock(ChartVSAssembly.class));
-      ChartAestheticService service = serviceWith(sessions, new ChartBindingModel(),
+      ChartAestheticAgentService service = serviceWith(sessions, new ChartBindingModel(),
                                                   mock(ChangeChartAestheticService.class));
 
       service.setField("tok", principal(), "Chart1", "color",
@@ -155,7 +155,7 @@ class ChartAestheticServiceTest {
       ChartAestheticMutator.setField(existing, "color",
                                      new FieldRef("Region", "dimension", null, null, null));
       ViewsheetSessionService sessions = sessionsFor(mock(ChartVSAssembly.class));
-      ChartAestheticService service = serviceWith(sessions, existing,
+      ChartAestheticAgentService service = serviceWith(sessions, existing,
                                                   mock(ChangeChartAestheticService.class));
 
       Map<String, Object> read = service.read("tok", principal(), "Chart1");
@@ -168,7 +168,7 @@ class ChartAestheticServiceTest {
 
    @Test
    void refusesANonChartAssemblyNamingIt() {
-      ChartAestheticService service = serviceWith(
+      ChartAestheticAgentService service = serviceWith(
          sessionsFor(mock(TextVSAssembly.class)), new ChartBindingModel(),
          mock(ChangeChartAestheticService.class));
 
@@ -182,7 +182,7 @@ class ChartAestheticServiceTest {
    @Test
    void refusesAnUnknownChannelBeforeTouchingTheRuntime() {
       ViewsheetSessionService sessions = sessionsFor(mock(ChartVSAssembly.class));
-      ChartAestheticService service = serviceWith(sessions, new ChartBindingModel(),
+      ChartAestheticAgentService service = serviceWith(sessions, new ChartBindingModel(),
                                                   mock(ChangeChartAestheticService.class));
 
       assertThrows(Exception.class,
@@ -203,7 +203,7 @@ class ChartAestheticServiceTest {
       return captor.getValue();
    }
 
-   private static ChartAestheticService harness(ChartBindingModel model,
+   private static ChartAestheticAgentService harness(ChartBindingModel model,
                                                 ChangeChartAestheticService aesthetics)
    {
       return serviceWith(sessionsFor(mock(ChartVSAssembly.class)), model, aesthetics);
@@ -236,13 +236,13 @@ class ChartAestheticServiceTest {
       return sessions;
    }
 
-   private static ChartAestheticService serviceWith(ViewsheetSessionService sessions,
+   private static ChartAestheticAgentService serviceWith(ViewsheetSessionService sessions,
                                                     ChartBindingModel model,
                                                     ChangeChartAestheticService aesthetics)
    {
       VSBindingService binding = mock(VSBindingService.class);
       when(binding.createModel(any())).thenReturn(model);
-      return new ChartAestheticService(sessions, binding, aesthetics);
+      return new ChartAestheticAgentService(sessions, binding, aesthetics);
    }
 
    private static Principal principal() {

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticMutatorTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticMutatorTest.java
@@ -1,0 +1,263 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.web.binding.model.ChartBindingModel;
+import inetsoft.web.binding.model.graph.*;
+import inetsoft.web.binding.model.graph.aesthetic.*;
+import inetsoft.web.wiz.binding.model.FieldRef;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+class ChartAestheticMutatorTest {
+   private static FieldRef dimension(String column) {
+      return new FieldRef(column, "dimension", null, null, null);
+   }
+
+   private static FieldRef measure(String column, String aggregate) {
+      return new FieldRef(column, "measure", aggregate, null, null);
+   }
+
+   private static Map<String, Object> spec(Object... pairs) {
+      Map<String, Object> spec = new LinkedHashMap<>();
+
+      for(int i = 0; i < pairs.length; i += 2) {
+         spec.put((String) pairs[i], pairs[i + 1]);
+      }
+
+      return spec;
+   }
+
+   /**
+    * The mirror of {@link ChartBindingMutatorTest}'s preservation test. 2b must not disturb
+    * the aesthetics; 2c must not disturb the shelves, chart type or options. Two specs write
+    * the same model through the same event, so both directions need the assertion.
+    */
+   private static Map<String, Object> snapshotNonAesthetics(ChartBindingModel model) {
+      Map<String, Object> snapshot = new LinkedHashMap<>();
+      snapshot.put("xFields", model.getXFields());
+      snapshot.put("yFields", model.getYFields());
+      snapshot.put("groupFields", model.getGroupFields());
+      snapshot.put("chartType", model.getChartType());
+      snapshot.put("multiStyles", model.isMultiStyles());
+      snapshot.put("separated", model.isSeparated());
+      return snapshot;
+   }
+
+   // ── field channels ────────────────────────────────────────────────────────
+
+   @Test
+   void bindsADimensionToTheColourChannel() {
+      ChartBindingModel model = new ChartBindingModel();
+
+      ChartAestheticMutator.setField(model, "color", dimension("Region"));
+
+      AestheticInfo info = model.getColorField();
+      assertNotNull(info);
+      assertEquals("Region", info.getFullName());
+      assertInstanceOf(ChartDimensionRefModel.class, info.getDataInfo());
+   }
+
+   @Test
+   void bindsAMeasureToTheSizeChannelCarryingItsAggregate() {
+      ChartBindingModel model = new ChartBindingModel();
+
+      ChartAestheticMutator.setField(model, "size", measure("Sales", "Sum"));
+
+      AestheticInfo info = model.getSizeField();
+      assertNotNull(info);
+      ChartAggregateRefModel ref =
+         assertInstanceOf(ChartAggregateRefModel.class, info.getDataInfo());
+      assertEquals("Sum", ref.getFormula());
+   }
+
+   @Test
+   void bindsToTheShapeAndTextChannels() {
+      ChartBindingModel model = new ChartBindingModel();
+
+      ChartAestheticMutator.setField(model, "shape", dimension("Category"));
+      ChartAestheticMutator.setField(model, "text", dimension("Label"));
+
+      assertNotNull(model.getShapeField());
+      assertNotNull(model.getTextField());
+   }
+
+   @Test
+   void clearingAChannelUnbindsIt() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setField(model, "color", dimension("Region"));
+
+      ChartAestheticMutator.clearField(model, "color");
+
+      assertNull(model.getColorField());
+   }
+
+   @Test
+   void matchesAChannelNameCaseInsensitively() {
+      ChartBindingModel model = new ChartBindingModel();
+
+      ChartAestheticMutator.setField(model, "  Color  ", dimension("Region"));
+
+      assertNotNull(model.getColorField());
+   }
+
+   // ── frame channels ────────────────────────────────────────────────────────
+
+   @Test
+   void setsAStaticColourFrame() {
+      ChartBindingModel model = new ChartBindingModel();
+
+      ChartAestheticMutator.setFrame(model, "color", spec("type", "static", "color", "#4e79a7"));
+
+      StaticColorModel frame = assertInstanceOf(StaticColorModel.class, model.getColorFrame());
+      assertEquals("#4E79A7", frame.getColor());
+   }
+
+   @Test
+   void setsANamedPaletteFrame() {
+      ChartBindingModel model = new ChartBindingModel();
+
+      ChartAestheticMutator.setFrame(model, "color", spec("type", "palette", "palette", "Blues"));
+
+      assertInstanceOf(BluesColorModel.class, model.getColorFrame());
+   }
+
+   // ── preservation, both ways ───────────────────────────────────────────────
+
+   @Test
+   void aFieldBindingLeavesTheNonAestheticModelUntouched() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(model, "x", List.of(dimension("Region")));
+      Map<String, Object> before = snapshotNonAesthetics(model);
+
+      ChartAestheticMutator.setField(model, "color", dimension("Category"));
+
+      assertEquals(before, snapshotNonAesthetics(model),
+                   "an aesthetic write must not disturb the shelves spec 2b owns");
+   }
+
+   @Test
+   void aFrameWriteLeavesTheNonAestheticModelUntouched() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(model, "y", List.of(measure("Sales", "Sum")));
+      Map<String, Object> before = snapshotNonAesthetics(model);
+
+      ChartAestheticMutator.setFrame(model, "color", spec("type", "static", "color", "#000"));
+
+      assertEquals(before, snapshotNonAesthetics(model));
+   }
+
+   @Test
+   void writingOneAestheticChannelLeavesTheOthersUntouched() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setField(model, "shape", dimension("Category"));
+      AestheticInfo shapeBefore = model.getShapeField();
+
+      ChartAestheticMutator.setField(model, "color", dimension("Region"));
+
+      assertSame(shapeBefore, model.getShapeField(),
+                 "writing the colour channel must not replace the shape channel");
+   }
+
+   // ── refusals ──────────────────────────────────────────────────────────────
+
+   @Test
+   void refusesAFieldOnAChannelThatOnlyTakesAFrame() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartAestheticMutator.setField(new ChartBindingModel(), "texture",
+                                              dimension("Region")));
+
+      assertTrue(thrown.getMessage().contains("texture"));
+      assertTrue(thrown.getMessage().contains("set_visual_frame"));
+   }
+
+   @Test
+   void refusesAnUnknownChannel() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartAestheticMutator.setField(new ChartBindingModel(), "colour",
+                                              dimension("Region")));
+
+      assertTrue(thrown.getMessage().contains("colour"));
+   }
+
+   @Test
+   void refusesAFieldWithNoType() {
+      assertThrows(IllegalArgumentException.class,
+                   () -> ChartAestheticMutator.setField(
+                      new ChartBindingModel(), "color",
+                      new FieldRef("Region", null, null, null, null)));
+   }
+
+   @Test
+   void refusesANullField() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartAestheticMutator.setField(new ChartBindingModel(), "color", null));
+
+      assertTrue(thrown.getMessage().contains("field"));
+   }
+
+   // ── the read direction ────────────────────────────────────────────────────
+
+   @Test
+   void describesTheBoundChannelsInTheAgentVocabulary() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setField(model, "color", dimension("Region"));
+      ChartAestheticMutator.setFrame(model, "color", spec("type", "palette", "palette", "Reds"));
+
+      Map<String, Object> described = ChartAestheticMutator.describe(model);
+      @SuppressWarnings("unchecked")
+      Map<String, Object> color = (Map<String, Object>) described.get("color");
+
+      assertEquals("Region", color.get("field"));
+      @SuppressWarnings("unchecked")
+      Map<String, Object> frame = (Map<String, Object>) color.get("frame");
+      assertEquals("palette", frame.get("type"));
+      assertEquals("Reds", frame.get("palette"));
+   }
+
+   @Test
+   void describesAnUnboundChannelWithNulls() {
+      Map<String, Object> described = ChartAestheticMutator.describe(new ChartBindingModel());
+      @SuppressWarnings("unchecked")
+      Map<String, Object> shape = (Map<String, Object>) described.get("shape");
+
+      assertNull(shape.get("field"));
+      assertNull(shape.get("frame"));
+   }
+
+   @Test
+   void describesEveryChannelSoAnAgentSeesWhatIsAvailable() {
+      Map<String, Object> described = ChartAestheticMutator.describe(new ChartBindingModel());
+
+      for(String channel : AestheticChannels.FIELD_CHANNELS) {
+         assertTrue(described.containsKey(channel), "missing channel " + channel);
+      }
+
+      for(String channel : AestheticChannels.FRAME_CHANNELS) {
+         assertTrue(described.containsKey(channel), "missing channel " + channel);
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticMutatorTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticMutatorTest.java
@@ -238,6 +238,57 @@ class ChartAestheticMutatorTest {
       assertEquals("Reds", frame.get("palette"));
    }
 
+   /**
+    * The read path builds its own {@link AestheticInfo} and never sets {@code fullName} —
+    * {@code AestheticRefModelFactory.createAestheticInfo} sets only {@code dataInfo} and
+    * {@code frame}. So reading the channel name off {@code AestheticInfo.getFullName()} reported
+    * {@code field: null} for every channel of every chart, even while the aesthetic was visibly
+    * rendering its legend.
+    *
+    * <p>The test above this one could not catch it: it builds the model with
+    * {@code ChartAestheticMutator.setField}, the one place that <em>does</em> set {@code fullName},
+    * so it round-trips through our own writer and never exercises a real read. This one builds the
+    * model the way the read path does — {@code dataInfo} populated, {@code fullName} absent.
+    */
+   @Test
+   void describesAChannelBuiltTheWayTheReadPathBuildsIt() {
+      ChartDimensionRefModel dataInfo = new ChartDimensionRefModel();
+      dataInfo.setFullName("Region");
+
+      AestheticInfo info = new AestheticInfo();
+      info.setDataInfo(dataInfo);   // exactly what createAestheticInfo does — no setFullName
+
+      ChartBindingModel model = new ChartBindingModel();
+      model.setColorField(info);
+
+      @SuppressWarnings("unchecked")
+      Map<String, Object> color =
+         (Map<String, Object>) ChartAestheticMutator.describe(model).get("color");
+
+      assertEquals("Region", color.get("field"),
+                   "a bound channel must report its field, not null");
+   }
+
+   /** A bound channel whose name cannot be resolved must not be indistinguishable from an empty one. */
+   @Test
+   void prefersTheDataInfoNameOverAStaleFullName() {
+      ChartDimensionRefModel dataInfo = new ChartDimensionRefModel();
+      dataInfo.setFullName("Region");
+
+      AestheticInfo info = new AestheticInfo();
+      info.setFullName("Stale");
+      info.setDataInfo(dataInfo);
+
+      ChartBindingModel model = new ChartBindingModel();
+      model.setColorField(info);
+
+      @SuppressWarnings("unchecked")
+      Map<String, Object> color =
+         (Map<String, Object>) ChartAestheticMutator.describe(model).get("color");
+
+      assertEquals("Region", color.get("field"));
+   }
+
    @Test
    void describesAnUnboundChannelWithNulls() {
       Map<String, Object> described = ChartAestheticMutator.describe(new ChartBindingModel());

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticServiceTest.java
@@ -1,0 +1,251 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.*;
+import inetsoft.web.binding.controller.ChangeChartAestheticService;
+import inetsoft.web.binding.event.ChangeChartRefEvent;
+import inetsoft.web.binding.model.ChartBindingModel;
+import inetsoft.web.binding.model.graph.aesthetic.BluesColorModel;
+import inetsoft.web.binding.model.graph.aesthetic.StaticColorModel;
+import inetsoft.web.binding.service.VSBindingService;
+import inetsoft.web.wiz.binding.model.FieldRef;
+import inetsoft.web.wiz.viewsheet.ViewsheetSessionService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.security.Principal;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class ChartAestheticServiceTest {
+   private static Map<String, Object> spec(Object... pairs) {
+      Map<String, Object> spec = new LinkedHashMap<>();
+
+      for(int i = 0; i < pairs.length; i += 2) {
+         spec.put((String) pairs[i], pairs[i + 1]);
+      }
+
+      return spec;
+   }
+
+   @Test
+   void setFieldPostsTheModelItReadRatherThanAFreshOne() throws Exception {
+      ChartBindingModel existing = new ChartBindingModel();
+      // A value only the read model carries. If the service constructs a fresh model this is
+      // lost — the same failure that would silently discard the user's shelves.
+      existing.setChartType(42);
+      ChangeChartAestheticService aesthetics = mock(ChangeChartAestheticService.class);
+
+      harness(existing, aesthetics)
+         .setField("tok", principal(), "Chart1", "color",
+                   new FieldRef("Region", "dimension", null, null, null), "");
+
+      ChangeChartRefEvent event = captureEvent(aesthetics);
+      assertEquals(42, event.getModel().getChartType(),
+                   "the posted model must be the one read, not a fresh construction");
+      assertEquals("Region", event.getModel().getColorField().getFullName());
+      assertEquals("Chart1", event.getName());
+   }
+
+   /**
+    * {@code ChangeChartAestheticService} branches on the field type — colour and shape clear
+    * the viewsheet's shared frames. Posting the wrong one leaves stale shared frames behind.
+    */
+   @Test
+   void setFieldTellsTheBackendWhichChannelChanged() throws Exception {
+      ChangeChartAestheticService aesthetics = mock(ChangeChartAestheticService.class);
+
+      harness(new ChartBindingModel(), aesthetics)
+         .setField("tok", principal(), "Chart1", "color",
+                   new FieldRef("Region", "dimension", null, null, null), "");
+
+      assertEquals("color", captureEvent(aesthetics).getFieldType());
+   }
+
+   @Test
+   void setFieldLeavesTheShelvesUntouched() throws Exception {
+      ChartBindingModel existing = new ChartBindingModel();
+      ChartBindingMutator.setShelf(
+         existing, "x", List.of(new FieldRef("Region", "dimension", null, null, null)));
+      Object shelfBefore = existing.getXFields();
+      ChangeChartAestheticService aesthetics = mock(ChangeChartAestheticService.class);
+
+      harness(existing, aesthetics)
+         .setField("tok", principal(), "Chart1", "color",
+                   new FieldRef("Category", "dimension", null, null, null), "");
+
+      assertSame(shelfBefore, captureEvent(aesthetics).getModel().getXFields(),
+                 "an aesthetic write must not disturb the shelves spec 2b owns");
+   }
+
+   @Test
+   void clearFieldUnbindsTheChannel() throws Exception {
+      ChartBindingModel existing = new ChartBindingModel();
+      ChartAestheticMutator.setField(existing, "color",
+                                     new FieldRef("Region", "dimension", null, null, null));
+      ChangeChartAestheticService aesthetics = mock(ChangeChartAestheticService.class);
+
+      harness(existing, aesthetics).clearField("tok", principal(), "Chart1", "color", "");
+
+      assertNull(captureEvent(aesthetics).getModel().getColorField());
+   }
+
+   @Test
+   void setFrameAppliesAStaticColour() throws Exception {
+      ChangeChartAestheticService aesthetics = mock(ChangeChartAestheticService.class);
+
+      harness(new ChartBindingModel(), aesthetics)
+         .setFrame("tok", principal(), "Chart1", "color",
+                   spec("type", "static", "color", "#4e79a7"), "");
+
+      StaticColorModel frame = assertInstanceOf(
+         StaticColorModel.class, captureEvent(aesthetics).getModel().getColorFrame());
+      assertEquals("#4E79A7", frame.getColor());
+   }
+
+   @Test
+   void setFrameAppliesANamedPalette() throws Exception {
+      ChangeChartAestheticService aesthetics = mock(ChangeChartAestheticService.class);
+
+      harness(new ChartBindingModel(), aesthetics)
+         .setFrame("tok", principal(), "Chart1", "color",
+                   spec("type", "palette", "palette", "Blues"), "");
+
+      assertInstanceOf(BluesColorModel.class,
+                       captureEvent(aesthetics).getModel().getColorFrame());
+   }
+
+   @Test
+   void eachMutationIsExactlyOneCheckpoint() throws Exception {
+      ViewsheetSessionService sessions = sessionsFor(mock(ChartVSAssembly.class));
+      ChartAestheticService service = serviceWith(sessions, new ChartBindingModel(),
+                                                  mock(ChangeChartAestheticService.class));
+
+      service.setField("tok", principal(), "Chart1", "color",
+                       new FieldRef("Region", "dimension", null, null, null), "");
+
+      verify(sessions, times(1)).mutate(anyString(), any(Principal.class), any());
+   }
+
+   @Test
+   void readDescribesTheChannelsWithoutMutating() throws Exception {
+      ChartBindingModel existing = new ChartBindingModel();
+      ChartAestheticMutator.setField(existing, "color",
+                                     new FieldRef("Region", "dimension", null, null, null));
+      ViewsheetSessionService sessions = sessionsFor(mock(ChartVSAssembly.class));
+      ChartAestheticService service = serviceWith(sessions, existing,
+                                                  mock(ChangeChartAestheticService.class));
+
+      Map<String, Object> read = service.read("tok", principal(), "Chart1");
+
+      @SuppressWarnings("unchecked")
+      Map<String, Object> color = (Map<String, Object>) read.get("color");
+      assertEquals("Region", color.get("field"));
+      verify(sessions, never()).mutate(anyString(), any(Principal.class), any());
+   }
+
+   @Test
+   void refusesANonChartAssemblyNamingIt() {
+      ChartAestheticService service = serviceWith(
+         sessionsFor(mock(TextVSAssembly.class)), new ChartBindingModel(),
+         mock(ChangeChartAestheticService.class));
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> service.setField("tok", principal(), "Text1", "color",
+                                new FieldRef("Region", "dimension", null, null, null), ""));
+      assertTrue(thrown.getMessage().contains("Text1"));
+   }
+
+   @Test
+   void refusesAnUnknownChannelBeforeTouchingTheRuntime() {
+      ViewsheetSessionService sessions = sessionsFor(mock(ChartVSAssembly.class));
+      ChartAestheticService service = serviceWith(sessions, new ChartBindingModel(),
+                                                  mock(ChangeChartAestheticService.class));
+
+      assertThrows(Exception.class,
+                   () -> service.setField("tok", principal(), "Chart1", "colour",
+                                          new FieldRef("Region", "dimension", null, null, null),
+                                          ""));
+   }
+
+   // ── harness ───────────────────────────────────────────────────────────────
+
+   private static ChangeChartRefEvent captureEvent(ChangeChartAestheticService aesthetics)
+      throws Exception
+   {
+      ArgumentCaptor<ChangeChartRefEvent> captor =
+         ArgumentCaptor.forClass(ChangeChartRefEvent.class);
+      verify(aesthetics).changeChartAesthetic(eq("rt1"), captor.capture(), any(Principal.class),
+                                              any(), anyString());
+      return captor.getValue();
+   }
+
+   private static ChartAestheticService harness(ChartBindingModel model,
+                                                ChangeChartAestheticService aesthetics)
+   {
+      return serviceWith(sessionsFor(mock(ChartVSAssembly.class)), model, aesthetics);
+   }
+
+   /**
+    * A session service whose mutate() runs the mutation immediately against runtime "rt1", so
+    * these tests exercise the read-modify-write without a live runtime.
+    */
+   private static ViewsheetSessionService sessionsFor(VSAssembly assembly) {
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssembly(anyString())).thenReturn(assembly);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+
+      try {
+         doAnswer(invocation -> {
+            ViewsheetSessionService.Mutation mutation = invocation.getArgument(2);
+            mutation.run(rvs, "rt1", null);
+            return null;
+         }).when(sessions).mutate(anyString(), any(Principal.class), any());
+         when(sessions.resolve(anyString(), any(Principal.class))).thenReturn(rvs);
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(e);
+      }
+
+      return sessions;
+   }
+
+   private static ChartAestheticService serviceWith(ViewsheetSessionService sessions,
+                                                    ChartBindingModel model,
+                                                    ChangeChartAestheticService aesthetics)
+   {
+      VSBindingService binding = mock(VSBindingService.class);
+      when(binding.createModel(any())).thenReturn(model);
+      return new ChartAestheticService(sessions, binding, aesthetics);
+   }
+
+   private static Principal principal() {
+      return () -> "admin";
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingMutatorTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingMutatorTest.java
@@ -95,6 +95,73 @@ class ChartBindingMutatorTest {
       assertTrue(model.getXFields().isEmpty());
    }
 
+   // ── specialized shelves (2b Phase 2) ──────────────────────────────────────
+   //
+   // These hold ONE field each, not a list: a candlestick has one close, a Gantt one start.
+   // They are separate from x/y/group because a chart type that uses them ignores those, and
+   // binding to the wrong family renders an empty chart with no error.
+
+   @Test
+   void setsEachSingleFieldShelf() {
+      for(String shelf : List.of("open", "high", "low", "close", "path", "source", "target",
+                                 "start", "end", "milestone"))
+      {
+         ChartBindingModel model = new ChartBindingModel();
+
+         ChartBindingMutator.setSingleShelf(
+            model, shelf, new FieldRef("Price", "measure", "Sum", null, null));
+
+         assertNotNull(ChartBindingMutator.readSingleShelf(model, shelf),
+                       shelf + " must be readable after being set");
+      }
+   }
+
+   @Test
+   void clearsASingleFieldShelfWithAnExplicitNull() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setSingleShelf(
+         model, "close", new FieldRef("Price", "measure", "Sum", null, null));
+
+      ChartBindingMutator.setSingleShelf(model, "close", null);
+
+      assertNull(ChartBindingMutator.readSingleShelf(model, "close"));
+   }
+
+   @Test
+   void rejectsAnUnknownSingleShelfNamingTheValidOnes() {
+      ChartBindingModel model = new ChartBindingModel();
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartBindingMutator.setSingleShelf(
+            model, "volume", new FieldRef("V", "measure", "Sum", null, null)));
+      assertTrue(thrown.getMessage().contains("volume"));
+      assertTrue(thrown.getMessage().contains("close"), "list the shelves that do exist");
+   }
+
+   /**
+    * x/y/group hold lists; the specialized shelves hold one field. Routing a single-field shelf
+    * through set_chart_shelf would silently bind only the first of a list, so the two families
+    * refuse each other by name.
+    */
+   @Test
+   void theTwoShelfFamiliesRefuseEachOther() {
+      ChartBindingModel model = new ChartBindingModel();
+
+      Exception listOnSingle = assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartBindingMutator.setShelf(
+            model, "close", List.of(new FieldRef("Price", "measure", "Sum", null, null))));
+      assertTrue(listOnSingle.getMessage().contains("close"));
+      assertTrue(listOnSingle.getMessage().contains("set_chart_single_shelf"));
+
+      Exception singleOnList = assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartBindingMutator.setSingleShelf(
+            model, "x", new FieldRef("Region", "dimension", null, null, null)));
+      assertTrue(singleOnList.getMessage().contains("set_chart_shelf"));
+   }
+
    @Test
    void theDeclaredAestheticSplitCoversThirteenFields() {
       assertEquals(13, ChartBindingFields.AESTHETIC.size(),

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingMutatorTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingMutatorTest.java
@@ -1,0 +1,103 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.web.binding.model.ChartBindingModel;
+import inetsoft.web.binding.model.graph.ChartAggregateRefModel;
+import inetsoft.web.binding.model.graph.ChartDimensionRefModel;
+import inetsoft.web.wiz.binding.model.FieldRef;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+class ChartBindingMutatorTest {
+   @Test
+   void setsTheXShelfFromFieldRefs() {
+      ChartBindingModel model = new ChartBindingModel();
+
+      ChartBindingMutator.setShelf(model, "x",
+                                   List.of(new FieldRef("Region", "dimension", null, null, null)));
+
+      assertEquals(1, model.getXFields().size());
+      assertInstanceOf(ChartDimensionRefModel.class, model.getXFields().get(0));
+   }
+
+   @Test
+   void setsAMeasureOnTheYShelfCarryingItsAggregate() {
+      ChartBindingModel model = new ChartBindingModel();
+
+      ChartBindingMutator.setShelf(model, "y",
+                                   List.of(new FieldRef("Sales", "measure", "Sum", null, null)));
+
+      assertEquals(1, model.getYFields().size());
+      assertInstanceOf(ChartAggregateRefModel.class, model.getYFields().get(0));
+   }
+
+   @Test
+   void leavesEveryAestheticFieldUntouched() {
+      ChartBindingModel model = new ChartBindingModel();
+      Map<String, Object> before = ChartBindingFields.snapshotAesthetics(model);
+
+      ChartBindingMutator.setShelf(model, "x",
+                                   List.of(new FieldRef("Region", "dimension", null, null, null)));
+
+      assertEquals(before, ChartBindingFields.snapshotAesthetics(model),
+                   "a shelf write must not disturb the aesthetic fields spec 2c owns");
+   }
+
+   @Test
+   void rejectsAnUnknownShelfNamingTheValidOnes() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartBindingMutator.setShelf(new ChartBindingModel(), "z", List.of()));
+      assertTrue(thrown.getMessage().contains("z"));
+      assertTrue(thrown.getMessage().contains("x"));
+   }
+
+   @Test
+   void rejectsAFieldWithoutATypeNamingTheField() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartBindingMutator.setShelf(
+            new ChartBindingModel(), "x",
+            List.of(new FieldRef("Region", null, null, null, null))));
+      assertTrue(thrown.getMessage().contains("Region"));
+   }
+
+   @Test
+   void clearsAShelfWhenGivenNoFields() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(model, "x",
+                                   List.of(new FieldRef("Region", "dimension", null, null, null)));
+
+      ChartBindingMutator.setShelf(model, "x", List.of());
+
+      assertTrue(model.getXFields().isEmpty());
+   }
+
+   @Test
+   void theDeclaredAestheticSplitCoversThirteenFields() {
+      assertEquals(13, ChartBindingFields.AESTHETIC.size(),
+                   "the 2b/2c split is declared once; changing it changes both sides");
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingServiceTest.java
@@ -1,0 +1,178 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.TextVSAssembly;
+import inetsoft.uql.viewsheet.VSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.binding.controller.ChangeChartRefService;
+import inetsoft.web.binding.controller.ChangeChartTypeService;
+import inetsoft.web.binding.controller.SwapXYBindingService;
+import inetsoft.web.binding.event.ChangeChartRefEvent;
+import inetsoft.web.binding.event.ChangeChartTypeEvent;
+import inetsoft.web.binding.event.ChangeSeparateStatusEvent;
+import inetsoft.web.binding.model.ChartBindingModel;
+import inetsoft.web.binding.service.VSBindingService;
+import inetsoft.web.wiz.binding.model.FieldRef;
+import inetsoft.web.wiz.viewsheet.ViewsheetSessionService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class ChartBindingServiceTest {
+   @Test
+   void setShelfPostsTheModelItReadRatherThanAFreshOne() throws Exception {
+      ChartBindingModel existing = new ChartBindingModel();
+      // A value only the read model carries. If the service constructs a fresh model, this
+      // is lost — which is exactly how the thirteen aesthetic fields would be lost too.
+      existing.setChartType(42);
+      ChangeChartRefService refs = mock(ChangeChartRefService.class);
+
+      harness(existing, refs, mock(ChangeChartTypeService.class), mock(SwapXYBindingService.class))
+         .setShelf("tok", principal(), "Chart1", "x",
+                   List.of(new FieldRef("Region", "dimension", null, null, null)), "");
+
+      ArgumentCaptor<ChangeChartRefEvent> captor =
+         ArgumentCaptor.forClass(ChangeChartRefEvent.class);
+      verify(refs).changeChartRef(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                  anyString());
+      assertEquals(42, captor.getValue().getModel().getChartType(),
+                   "the posted model must be the one read, not a fresh construction");
+      assertEquals(1, captor.getValue().getModel().getXFields().size());
+      assertEquals("Chart1", captor.getValue().getName());
+   }
+
+   @Test
+   void setShelfLeavesTheAestheticFieldsUntouched() throws Exception {
+      ChartBindingModel existing = new ChartBindingModel();
+      Map<String, Object> before = ChartBindingFields.snapshotAesthetics(existing);
+      ChangeChartRefService refs = mock(ChangeChartRefService.class);
+
+      harness(existing, refs, mock(ChangeChartTypeService.class), mock(SwapXYBindingService.class))
+         .setShelf("tok", principal(), "Chart1", "y",
+                   List.of(new FieldRef("Sales", "measure", "Sum", null, null)), "");
+
+      ArgumentCaptor<ChangeChartRefEvent> captor =
+         ArgumentCaptor.forClass(ChangeChartRefEvent.class);
+      verify(refs).changeChartRef(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                  anyString());
+      assertEquals(before, ChartBindingFields.snapshotAesthetics(captor.getValue().getModel()),
+                   "a shelf write must not disturb the aesthetic fields spec 2c owns");
+   }
+
+   @Test
+   void setChartTypeDelegatesTheType() throws Exception {
+      ChangeChartTypeService types = mock(ChangeChartTypeService.class);
+
+      harness(new ChartBindingModel(), mock(ChangeChartRefService.class), types,
+              mock(SwapXYBindingService.class))
+         .setChartType("tok", principal(), "Chart1", 3, null, null, null, "");
+
+      ArgumentCaptor<ChangeChartTypeEvent> captor =
+         ArgumentCaptor.forClass(ChangeChartTypeEvent.class);
+      verify(types).changeChartType(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                    anyString());
+      assertEquals(3, captor.getValue().getType());
+      assertEquals("Chart1", captor.getValue().getName());
+   }
+
+   @Test
+   void swapAxesDelegatesTheAssemblyName() throws Exception {
+      SwapXYBindingService swap = mock(SwapXYBindingService.class);
+
+      harness(new ChartBindingModel(), mock(ChangeChartRefService.class),
+              mock(ChangeChartTypeService.class), swap)
+         .swapAxes("tok", principal(), "Chart1", "");
+
+      ArgumentCaptor<ChangeSeparateStatusEvent> captor =
+         ArgumentCaptor.forClass(ChangeSeparateStatusEvent.class);
+      verify(swap).swapXYBinding(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                 anyString());
+      assertEquals("Chart1", captor.getValue().getName());
+   }
+
+   @Test
+   void refusesANonChartAssemblyNamingIt() {
+      ChartBindingService service = harnessWithAssembly(
+         mock(TextVSAssembly.class), new ChartBindingModel(),
+         mock(ChangeChartRefService.class), mock(ChangeChartTypeService.class),
+         mock(SwapXYBindingService.class));
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> service.swapAxes("tok", principal(), "Text1", ""));
+      assertTrue(thrown.getMessage().contains("Text1"));
+   }
+
+   private static ChartBindingService harness(ChartBindingModel model,
+                                              ChangeChartRefService refs,
+                                              ChangeChartTypeService types,
+                                              SwapXYBindingService swap)
+   {
+      return harnessWithAssembly(mock(ChartVSAssembly.class), model, refs, types, swap);
+   }
+
+   /**
+    * A session service whose mutate() runs the mutation immediately against runtime "rt1",
+    * so these tests exercise the read-modify-write without a live runtime.
+    */
+   private static ChartBindingService harnessWithAssembly(VSAssembly assembly,
+                                                          ChartBindingModel model,
+                                                          ChangeChartRefService refs,
+                                                          ChangeChartTypeService types,
+                                                          SwapXYBindingService swap)
+   {
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssembly(anyString())).thenReturn(assembly);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+
+      try {
+         doAnswer(invocation -> {
+            ViewsheetSessionService.Mutation mutation = invocation.getArgument(2);
+            mutation.run(rvs, "rt1", null);
+            return null;
+         }).when(sessions).mutate(anyString(), any(Principal.class), any());
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(e);
+      }
+
+      VSBindingService binding = mock(VSBindingService.class);
+      when(binding.createModel(any())).thenReturn(model);
+
+      return new ChartBindingService(sessions, binding, refs, types, swap);
+   }
+
+   private static Principal principal() {
+      return () -> "admin";
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/binding/DimensionSortRankingTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/DimensionSortRankingTest.java
@@ -1,0 +1,243 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.uql.XCondition;
+import inetsoft.uql.XConstants;
+import inetsoft.web.binding.model.BDimensionRefModel;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+class DimensionSortRankingTest {
+   private static DimensionSortRanking.Sort sort(String direction, String by,
+                                                 List<String> manual)
+   {
+      return new DimensionSortRanking.Sort(direction, by, manual);
+   }
+
+   private static DimensionSortRanking.Ranking ranking(String mode, Integer n, String measure) {
+      return new DimensionSortRanking.Ranking(mode, n, measure, null);
+   }
+
+   // ── sorting ───────────────────────────────────────────────────────────────
+
+   @Test
+   void sortsAscendingAndDescending() {
+      BDimensionRefModel dimension = new BDimensionRefModel();
+
+      DimensionSortRanking.applySort(dimension, sort("asc", null, null));
+      assertEquals(XConstants.SORT_ASC, dimension.getOrder());
+
+      DimensionSortRanking.applySort(dimension, sort("descending", null, null));
+      assertEquals(XConstants.SORT_DESC, dimension.getOrder());
+   }
+
+   @Test
+   void sortsByAnAggregateUsingTheNameForm() {
+      BDimensionRefModel dimension = new BDimensionRefModel();
+
+      DimensionSortRanking.applySort(dimension, sort("value_desc", "Sales", null));
+
+      assertEquals(XConstants.SORT_VALUE_DESC, dimension.getOrder());
+      assertEquals("Sales", dimension.getSortByCol());
+   }
+
+   /** A by-value sort with nothing to sort by falls back to the label and looks honoured. */
+   @Test
+   void refusesAByValueSortWithNoField() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> DimensionSortRanking.applySort(new BDimensionRefModel(),
+                                              sort("value_asc", null, null)));
+
+      assertTrue(thrown.getMessage().contains("sortByField"));
+      assertTrue(thrown.getMessage().contains("looks like it worked"));
+   }
+
+   @Test
+   void appliesAManualOrder() {
+      BDimensionRefModel dimension = new BDimensionRefModel();
+
+      DimensionSortRanking.applySort(dimension,
+                                     sort("manual", null, List.of("East", "West", "North")));
+
+      assertEquals(XConstants.SORT_SPECIFIC, dimension.getOrder());
+      assertEquals(3, dimension.getManualOrder().size());
+   }
+
+   @Test
+   void refusesManualWithNoOrder() {
+      assertThrows(IllegalArgumentException.class,
+                   () -> DimensionSortRanking.applySort(new BDimensionRefModel(),
+                                                        sort("manual", null, List.of())));
+   }
+
+   @Test
+   void refusesAnUnknownDirectionListingTheValid() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> DimensionSortRanking.applySort(new BDimensionRefModel(),
+                                              sort("sideways", null, null)));
+
+      assertTrue(thrown.getMessage().contains("sideways"));
+      assertTrue(thrown.getMessage().contains("value_desc"));
+   }
+
+   // ── the index refusal, the deliberate narrowing ───────────────────────────
+
+   /**
+    * An index is stable only until the shelf is reordered, and then it sorts by the wrong column
+    * without failing. There is no raw escape hatch for this on purpose.
+    */
+   @Test
+   void refusesAColumnIndexWhereASortFieldNameBelongs() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> DimensionSortRanking.applySort(new BDimensionRefModel(),
+                                              sort("value_asc", "2", null)));
+
+      assertTrue(thrown.getMessage().contains("index"));
+      assertTrue(thrown.getMessage().contains("reordered"),
+                 "the refusal has to say why the index is unsafe");
+   }
+
+   @Test
+   void refusesAColumnIndexWhereARankingMeasureBelongs() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> DimensionSortRanking.applyRanking(new BDimensionRefModel(),
+                                                 ranking("top", 5, "0")));
+
+      assertTrue(thrown.getMessage().contains("index"));
+   }
+
+   @Test
+   void refusesANegativeIndexToo() {
+      assertThrows(IllegalArgumentException.class,
+                   () -> DimensionSortRanking.applyRanking(new BDimensionRefModel(),
+                                                           ranking("top", 5, "-1")));
+   }
+
+   @Test
+   void acceptsAColumnNameThatMerelyContainsDigits() {
+      BDimensionRefModel dimension = new BDimensionRefModel();
+
+      assertDoesNotThrow(() -> DimensionSortRanking.applyRanking(
+         dimension, ranking("top", 5, "Q1 Sales")));
+      assertEquals("Q1 Sales", dimension.getRankingCol());
+   }
+
+   // ── ranking ───────────────────────────────────────────────────────────────
+
+   @Test
+   void appliesTopNByMeasureName() {
+      BDimensionRefModel dimension = new BDimensionRefModel();
+
+      DimensionSortRanking.applyRanking(dimension, ranking("top", 10, "Sales"));
+
+      assertEquals(String.valueOf(XCondition.TOP_N), dimension.getRankingOption());
+      assertEquals("10", dimension.getRankingN());
+      assertEquals("Sales", dimension.getRankingCol());
+   }
+
+   @Test
+   void appliesBottomN() {
+      BDimensionRefModel dimension = new BDimensionRefModel();
+
+      DimensionSortRanking.applyRanking(dimension, ranking("bottom_n", 3, "Sales"));
+
+      assertEquals(String.valueOf(XCondition.BOTTOM_N), dimension.getRankingOption());
+   }
+
+   @Test
+   void clearingRankingNeedsNothingElse() {
+      BDimensionRefModel dimension = new BDimensionRefModel();
+      DimensionSortRanking.applyRanking(dimension, ranking("top", 5, "Sales"));
+
+      DimensionSortRanking.applyRanking(dimension, ranking("none", null, null));
+
+      assertNull(dimension.getRankingN());
+      assertNull(dimension.getRankingCol());
+   }
+
+   @Test
+   void refusesRankingWithNoN() {
+      assertThrows(IllegalArgumentException.class,
+                   () -> DimensionSortRanking.applyRanking(new BDimensionRefModel(),
+                                                           ranking("top", null, "Sales")));
+      assertThrows(IllegalArgumentException.class,
+                   () -> DimensionSortRanking.applyRanking(new BDimensionRefModel(),
+                                                           ranking("top", 0, "Sales")));
+   }
+
+   /** Ranking by nothing produces an arbitrary result rather than an error. */
+   @Test
+   void refusesRankingWithNoMeasure() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> DimensionSortRanking.applyRanking(new BDimensionRefModel(),
+                                                 ranking("top", 5, null)));
+
+      assertTrue(thrown.getMessage().contains("arbitrary"));
+   }
+
+   @Test
+   void carriesTheOthersFlag() {
+      BDimensionRefModel dimension = new BDimensionRefModel();
+
+      DimensionSortRanking.applyRanking(
+         dimension, new DimensionSortRanking.Ranking("top", 5, "Sales", true));
+
+      assertTrue(dimension.isOthers());
+   }
+
+   // ── read back ─────────────────────────────────────────────────────────────
+
+   @Test
+   void readsBackCanonicalTokensNeverAliases() {
+      BDimensionRefModel dimension = new BDimensionRefModel();
+      DimensionSortRanking.applySort(dimension, sort("descending", null, null));
+      DimensionSortRanking.applyRanking(dimension, ranking("top_n", 5, "Sales"));
+
+      Map<String, Object> described = DimensionSortRanking.describe(dimension);
+
+      assertEquals("desc", described.get("direction"), "an alias must not come back out");
+      assertEquals("top", described.get("ranking"));
+      assertEquals("Sales", described.get("rankingMeasure"));
+   }
+
+   @Test
+   void describesAnUnsortedDimension() {
+      Map<String, Object> described =
+         DimensionSortRanking.describe(new BDimensionRefModel());
+
+      assertEquals("none", described.get("ranking"));
+   }
+
+   @Test
+   void listsItsTokens() {
+      assertTrue(DimensionSortRanking.sortTokens().contains("value_asc"));
+      assertTrue(DimensionSortRanking.rankingTokens().contains("bottom"));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/binding/FieldRefFactoryTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/FieldRefFactoryTest.java
@@ -1,0 +1,87 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.web.binding.model.BAggregateRefModel;
+import inetsoft.web.binding.model.BDimensionRefModel;
+import inetsoft.web.wiz.binding.model.FieldRef;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Guards the shared field-reference vocabulary. Specs 2b–2e inherit it and spec #4's
+ * highlights embed it, so its shape and its fail-loud discriminator are the deliverable.
+ */
+@Tag("core")
+class FieldRefFactoryTest {
+   @Test
+   void readsADimensionAsItsColumnAndDateLevel() {
+      BDimensionRefModel model = new BDimensionRefModel();
+      model.setColumnValue("Order Date");
+      model.setDateLevel("5");
+
+      FieldRef ref = FieldRefFactory.from(model);
+
+      assertEquals("Order Date", ref.column());
+      assertEquals("dimension", ref.type());
+      assertEquals("5", ref.dateLevel());
+      assertNull(ref.aggregate(), "a dimension has no aggregate");
+   }
+
+   @Test
+   void readsAMeasureAsItsColumnAndFormula() {
+      BAggregateRefModel model = new BAggregateRefModel();
+      model.setColumnValue("Sales");
+      model.setFormula("Sum");
+
+      FieldRef ref = FieldRefFactory.from(model);
+
+      assertEquals("Sales", ref.column());
+      assertEquals("measure", ref.type());
+      assertEquals("Sum", ref.aggregate());
+      assertNull(ref.dateLevel(), "a measure has no date level");
+   }
+
+   @Test
+   void requireTypeRejectsAMissingDiscriminatorNamingTheField() {
+      FieldRef ref = new FieldRef("Sales", null, null, null, null);
+
+      Exception thrown = assertThrows(IllegalArgumentException.class,
+                                      () -> FieldRefFactory.requireType(ref));
+      assertTrue(thrown.getMessage().contains("Sales"));
+      assertTrue(thrown.getMessage().contains("type"));
+   }
+
+   @Test
+   void requireTypeRejectsAnUnrecognizedDiscriminator() {
+      FieldRef ref = new FieldRef("Sales", "metric", null, null, null);
+
+      Exception thrown = assertThrows(IllegalArgumentException.class,
+                                      () -> FieldRefFactory.requireType(ref));
+      assertTrue(thrown.getMessage().contains("metric"),
+                 "the error must name what was supplied, got: " + thrown.getMessage());
+   }
+
+   @Test
+   void requireTypeAcceptsBothValidDiscriminatorsCaseInsensitively() {
+      FieldRefFactory.requireType(new FieldRef("A", "DIMENSION", null, null, null));
+      FieldRefFactory.requireType(new FieldRef("B", "measure", null, null, null));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/binding/FieldRefFactoryTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/FieldRefFactoryTest.java
@@ -31,6 +31,60 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 @Tag("core")
 class FieldRefFactoryTest {
+   /**
+    * The date level is an {@code XConstants} number whose mapping nobody can guess — year is 5,
+    * quarter 4, month 3, week 2, day 1 — so a caller naturally writes {@code dateLevel: "year"}.
+    * That was stored verbatim, and the binding then threw {@code For input string: "year"} on the
+    * NEXT unrelated write to the same assembly, naming neither the field nor the level nor the
+    * call that poisoned it. Found live on local-1199 while binding a crosstab for case 29.
+    */
+   @Test
+   void normalizesNamedDateLevelsToTheirConstants() {
+      assertEquals("5", DateLevels.normalize("year"));
+      assertEquals("4", DateLevels.normalize("QUARTER"));
+      assertEquals("3", DateLevels.normalize("Month"));
+      assertEquals("2", DateLevels.normalize("week"));
+      assertEquals("1", DateLevels.normalize("day"));
+      assertEquals("0", DateLevels.normalize("none"));
+   }
+
+   @Test
+   void passesANumericDateLevelThrough() {
+      assertEquals("5", DateLevels.normalize("5"));
+      assertEquals("0", DateLevels.normalize("0"));
+   }
+
+   @Test
+   void refusesADateLevelItCannotResolveRatherThanStoringIt() {
+      Exception thrown = assertThrows(IllegalArgumentException.class,
+                                      () -> DateLevels.normalize("fortnight"));
+
+      assertTrue(thrown.getMessage().contains("fortnight"));
+      assertTrue(thrown.getMessage().contains("year"), "the message must list what is accepted");
+   }
+
+   /** A number outside the known set is as poisonous as a word, and just as silent. */
+   @Test
+   void refusesAnUnknownNumericDateLevel() {
+      assertThrows(IllegalArgumentException.class, () -> DateLevels.normalize("99"));
+   }
+
+   /**
+    * -1 is StyleBI's own sentinel for "no date level" — {@code VSDimensionRef.setDateLevel} maps
+    * it to null — so refs read back from a live binding carry it. The first version of this guard
+    * refused it and broke every round trip that reads a dimension and writes it elsewhere; five
+    * existing tests caught that immediately.
+    */
+   @Test
+   void acceptsTheUnsetSentinel() {
+      assertEquals("-1", DateLevels.normalize("-1"));
+   }
+
+   @Test
+   void leavesAnAbsentDateLevelAlone() {
+      assertNull(DateLevels.normalize(null));
+   }
+
    @Test
    void readsADimensionAsItsColumnAndDateLevel() {
       BDimensionRefModel model = new BDimensionRefModel();

--- a/core/src/test/java/inetsoft/web/wiz/binding/TableBindingMutatorTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/TableBindingMutatorTest.java
@@ -345,6 +345,10 @@ class TableBindingMutatorTest {
       assertTrue(thrown.getMessage().contains("index"), thrown.getMessage());
       assertTrue(thrown.getMessage().contains("0"), "the message must name the positions");
       assertTrue(thrown.getMessage().contains("1"));
+      // Having told callers to write "quarter", reporting "date level 4" back asks them to
+      // translate a number this codebase deliberately hides.
+      assertTrue(thrown.getMessage().contains("year"), thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("quarter"), thrown.getMessage());
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/binding/TableBindingMutatorTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/TableBindingMutatorTest.java
@@ -1,0 +1,309 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.web.binding.drm.ColumnRefModel;
+import inetsoft.web.binding.model.table.CrosstabBindingModel;
+import inetsoft.web.binding.model.table.TableBindingModel;
+import inetsoft.web.wiz.binding.model.FieldRef;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+class TableBindingMutatorTest {
+   private static FieldRef dim(String column) {
+      return new FieldRef(column, "dimension", null, null, null);
+   }
+
+   private static FieldRef measure(String column, String aggregate) {
+      return new FieldRef(column, "measure", aggregate, null, null);
+   }
+
+   // ── crosstab shelves ──────────────────────────────────────────────────────
+
+   @Test
+   void setsCrosstabRows() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+
+      TableBindingMutator.setShelf(model, "rows", List.of(dim("Region")));
+
+      assertEquals(1, model.getRows().size());
+      assertEquals("Region", model.getRows().get(0).getColumnValue());
+   }
+
+   @Test
+   void setsCrosstabColsAndAggregates() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+
+      TableBindingMutator.setShelf(model, "cols", List.of(dim("Year")));
+      TableBindingMutator.setShelf(model, "aggregates", List.of(measure("Sales", "Sum")));
+
+      assertEquals(1, model.getCols().size());
+      assertEquals(1, model.getAggregates().size());
+      assertEquals("Sum", model.getAggregates().get(0).getFormula());
+   }
+
+   @Test
+   void acceptsTheNaturalShelfAliases() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+
+      TableBindingMutator.setShelf(model, "rowHeaders", List.of(dim("Region")));
+      TableBindingMutator.setShelf(model, "columns", List.of(dim("Year")));
+
+      assertEquals(1, model.getRows().size());
+      assertEquals(1, model.getCols().size());
+   }
+
+   @Test
+   void clearsAShelfOnAnEmptyList() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows", List.of(dim("Region")));
+
+      TableBindingMutator.setShelf(model, "rows", List.of());
+
+      assertTrue(model.getRows().isEmpty());
+   }
+
+   // ── table shelves ─────────────────────────────────────────────────────────
+
+   @Test
+   void setsTableGroupsAndAggregates() {
+      TableBindingModel model = new TableBindingModel();
+
+      TableBindingMutator.setShelf(model, "groups", List.of(dim("Region")));
+      TableBindingMutator.setShelf(model, "aggregates", List.of(measure("Sales", "Sum")));
+
+      assertEquals(1, model.getGroups().size());
+      assertEquals(1, model.getAggregates().size());
+   }
+
+   /**
+    * Every other shelf holds a dimension or aggregate ref; {@code details} holds a plain
+    * {@code ColumnRefModel}. See the note in docs/superpowers/plans/2026-08-13-needs-your-input.md.
+    */
+   @Test
+   void setsTableDetailsAsPlainColumns() {
+      TableBindingModel model = new TableBindingModel();
+
+      TableBindingMutator.setShelf(model, "details", List.of(dim("OrderID")));
+
+      assertEquals(1, model.getDetails().size());
+      ColumnRefModel detail = assertInstanceOf(ColumnRefModel.class, model.getDetails().get(0));
+      assertEquals("OrderID", detail.getName());
+      assertNotNull(detail.getDataRefModel(), "a detail column wraps an attribute ref");
+   }
+
+   @Test
+   void refusesAnAggregateOnDetailsPointingAtTheAggregatesShelf() {
+      TableBindingModel model = new TableBindingModel();
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> TableBindingMutator.setShelf(model, "details",
+                                            List.of(measure("Sales", "Sum"))));
+
+      assertTrue(thrown.getMessage().contains("aggregates"));
+   }
+
+   // ── shelf validity is per object type ─────────────────────────────────────
+
+   @Test
+   void refusesACrosstabShelfOnATableNamingBoth() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> TableBindingMutator.setShelf(new TableBindingModel(), "rows", List.of()));
+
+      assertTrue(thrown.getMessage().contains("rows"));
+      assertTrue(thrown.getMessage().contains("groups"),
+                 "the refusal should list the shelves this object type does have");
+   }
+
+   @Test
+   void refusesATableShelfOnACrosstab() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> TableBindingMutator.setShelf(new CrosstabBindingModel(), "details", List.of()));
+
+      assertTrue(thrown.getMessage().contains("details"));
+      assertTrue(thrown.getMessage().contains("rows"));
+   }
+
+   @Test
+   void refusesAMeasureOnADimensionShelfPointingAtTheAggregatesShelf() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> TableBindingMutator.setShelf(new CrosstabBindingModel(), "rows",
+                                            List.of(measure("Sales", "Sum"))));
+
+      assertTrue(thrown.getMessage().contains("Sales"));
+      assertTrue(thrown.getMessage().contains("aggregates"));
+   }
+
+   @Test
+   void refusesADimensionOnTheAggregatesShelf() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> TableBindingMutator.setShelf(new CrosstabBindingModel(), "aggregates",
+                                            List.of(dim("Region"))));
+
+      assertTrue(thrown.getMessage().contains("Region"));
+   }
+
+   @Test
+   void refusesAnUnknownShelf() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> TableBindingMutator.setShelf(new CrosstabBindingModel(), "z", List.of()));
+
+      assertTrue(thrown.getMessage().contains("z"));
+   }
+
+   // ── add / remove / move ───────────────────────────────────────────────────
+
+   @Test
+   void appendsToAShelf() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows", List.of(dim("Region")));
+
+      TableBindingMutator.addField(model, "rows", dim("Category"), null);
+
+      assertEquals(2, model.getRows().size());
+      assertEquals("Category", model.getRows().get(1).getColumnValue());
+   }
+
+   @Test
+   void insertsAtAPosition() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows", List.of(dim("Region"), dim("Category")));
+
+      TableBindingMutator.addField(model, "rows", dim("Year"), 0);
+
+      assertEquals("Year", model.getRows().get(0).getColumnValue());
+      assertEquals(3, model.getRows().size());
+   }
+
+   @Test
+   void refusesAPositionPastTheEndRatherThanClamping() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows", List.of(dim("Region")));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> TableBindingMutator.addField(model, "rows", dim("Year"), 9));
+
+      assertTrue(thrown.getMessage().contains("9"));
+   }
+
+   @Test
+   void removesAFieldByColumnName() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows", List.of(dim("Region"), dim("Category")));
+
+      TableBindingMutator.removeField(model, "rows", "Region");
+
+      assertEquals(1, model.getRows().size());
+      assertEquals("Category", model.getRows().get(0).getColumnValue());
+   }
+
+   @Test
+   void refusesToRemoveAFieldThatIsNotOnTheShelf() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows", List.of(dim("Region")));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> TableBindingMutator.removeField(model, "rows", "Nope"));
+
+      assertTrue(thrown.getMessage().contains("Nope"));
+      assertTrue(thrown.getMessage().contains("Region"), "list what is actually on the shelf");
+   }
+
+   /** The rows↔cols pivot: the single most common crosstab edit, and one checkpoint. */
+   @Test
+   void movesAFieldBetweenShelves() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows", List.of(dim("Region"), dim("Year")));
+
+      TableBindingMutator.moveField(model, "rows", "cols", "Year", null);
+
+      assertEquals(1, model.getRows().size());
+      assertEquals(1, model.getCols().size());
+      assertEquals("Year", model.getCols().get(0).getColumnValue());
+   }
+
+   @Test
+   void aMoveKeepsTheFieldWhenTheDestinationIsInvalid() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows", List.of(dim("Region")));
+
+      assertThrows(IllegalArgumentException.class,
+                   () -> TableBindingMutator.moveField(model, "rows", "details", "Region", null));
+      assertEquals(1, model.getRows().size(),
+                   "a rejected move must not have already removed the field");
+   }
+
+   @Test
+   void movingAMeasureOntoADimensionShelfIsRefusedAndLeavesTheSourceIntact() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "aggregates", List.of(measure("Sales", "Sum")));
+
+      assertThrows(IllegalArgumentException.class,
+                   () -> TableBindingMutator.moveField(model, "aggregates", "rows", "Sales",
+                                                       null));
+      assertEquals(1, model.getAggregates().size());
+   }
+
+   // ── preservation ──────────────────────────────────────────────────────────
+
+   @Test
+   void aShelfWriteLeavesTheOtherShelvesAndOptionsUntouched() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "cols", List.of(dim("Year")));
+      Object colsBefore = model.getCols();
+      model.getSuppressGroupTotal().put("Year", Boolean.TRUE);
+
+      TableBindingMutator.setShelf(model, "rows", List.of(dim("Region")));
+
+      assertSame(colsBefore, model.getCols());
+      assertEquals(Boolean.TRUE, model.getSuppressGroupTotal().get("Year"),
+                   "suppressGroupTotal is keyed by field name and must survive an unrelated write");
+   }
+
+   /**
+    * {@code suppressGroupTotal} is a Hashtable keyed by field name that nothing prunes, so a
+    * removed field leaves an entry behind. It grows unboundedly across edits, and can
+    * resurrect suppression if the name is ever reused. See spec 2d risk 1.
+    */
+   @Test
+   void prunesSuppressGroupTotalEntriesForFieldsNoLongerBound() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows", List.of(dim("Region"), dim("Year")));
+      model.getSuppressGroupTotal().put("Region", Boolean.TRUE);
+      model.getSuppressGroupTotal().put("Year", Boolean.TRUE);
+
+      TableBindingMutator.setShelf(model, "rows", List.of(dim("Region")));
+
+      assertEquals(Boolean.TRUE, model.getSuppressGroupTotal().get("Region"));
+      assertNull(model.getSuppressGroupTotal().get("Year"),
+                 "an orphaned suppression entry must be pruned, not left to resurrect later");
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/binding/TableBindingMutatorTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/TableBindingMutatorTest.java
@@ -500,6 +500,21 @@ class TableBindingMutatorTest {
    // ── options (2d Phase 3) ──────────────────────────────────────────────────
 
    /**
+    * percentageBy is stored as an XConstants number, and PERCENTAGE_BY_COL is 1 — which is also
+    * the default. So a fresh crosstab read back {@code percentageBy: "1"}, a value in no
+    * vocabulary this tool accepts, looking like a setting somebody had chosen. Found live on
+    * local-1201: setting it to "col" appeared to do nothing because it was already col.
+    */
+   @Test
+   void reportsThePercentageDirectionByNameNotItsConstant() {
+      assertEquals("none", TableBindingMutator.percentageByName("0"));
+      assertEquals("col", TableBindingMutator.percentageByName("1"));
+      assertEquals("row", TableBindingMutator.percentageByName("2"));
+      assertNull(TableBindingMutator.percentageByName(null));
+   }
+
+
+   /**
     * The crosstab totals are dynamic-value strings that StyleBI reads as booleans, so anything
     * but "true" reads as false. A real boolean has to normalize to the string form.
     */

--- a/core/src/test/java/inetsoft/web/wiz/binding/TableBindingMutatorTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/TableBindingMutatorTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -305,5 +306,212 @@ class TableBindingMutatorTest {
       assertEquals(Boolean.TRUE, model.getSuppressGroupTotal().get("Region"));
       assertNull(model.getSuppressGroupTotal().get("Year"),
                  "an orphaned suppression entry must be pruned, not left to resurrect later");
+   }
+
+   // ── sorting and ranking (2d Phase 2) ──────────────────────────────────────
+
+   @Test
+   void sortsADimensionOnTheRowsShelf() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows", List.of(dim("Region")));
+
+      TableBindingMutator.setSort(model, "rows", "Region",
+                                  new DimensionSortRanking.Sort("desc", null, null));
+
+      assertEquals(inetsoft.uql.XConstants.SORT_DESC, model.getRows().get(0).getOrder());
+   }
+
+   @Test
+   void ranksADimensionByAMeasureName() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows", List.of(dim("Region")));
+
+      TableBindingMutator.setRanking(model, "rows", "Region",
+                                     new DimensionSortRanking.Ranking("top", 5, "Sales", null));
+
+      assertEquals("5", model.getRows().get(0).getRankingN());
+      assertEquals("Sales", model.getRows().get(0).getRankingCol());
+   }
+
+   @Test
+   void refusesToSortAColumnThatIsNotOnTheShelf() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows", List.of(dim("Region")));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> TableBindingMutator.setSort(model, "rows", "Nope",
+                                           new DimensionSortRanking.Sort("asc", null, null)));
+
+      assertTrue(thrown.getMessage().contains("Nope"));
+      assertTrue(thrown.getMessage().contains("Region"));
+   }
+
+   @Test
+   void refusesToSortTheAggregatesOrDetailsShelf() {
+      CrosstabBindingModel crosstab = new CrosstabBindingModel();
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> TableBindingMutator.setSort(crosstab, "aggregates", "Sales",
+                                           new DimensionSortRanking.Sort("asc", null, null)));
+
+      assertTrue(thrown.getMessage().contains("measures"));
+   }
+
+   @Test
+   void describesTheSortsOnAShelf() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows", List.of(dim("Region")));
+      TableBindingMutator.setRanking(model, "rows", "Region",
+                                     new DimensionSortRanking.Ranking("top", 5, "Sales", null));
+
+      Map<String, Object> described = TableBindingMutator.describeSorts(model, "rows");
+
+      assertTrue(described.containsKey("Region"));
+   }
+
+   // ── column labels (2d Phase 2) ────────────────────────────────────────────
+
+   @Test
+   void setsAColumnLabelForABoundColumn() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows", List.of(dim("Region")));
+
+      TableBindingMutator.setColumnLabels(model, Map.of("Region", "Sales Region"));
+
+      assertEquals("Sales Region", model.getName2Labels().get("Region"));
+   }
+
+   /** A label for an unbound column would sit in name2Labels doing nothing. */
+   @Test
+   void refusesALabelForAColumnThatIsNotBound() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows", List.of(dim("Region")));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> TableBindingMutator.setColumnLabels(model, Map.of("Profit", "P")));
+
+      assertTrue(thrown.getMessage().contains("never be shown"));
+   }
+
+   @Test
+   void anEmptyLabelRemovesIt() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows", List.of(dim("Region")));
+      TableBindingMutator.setColumnLabels(model, Map.of("Region", "Sales Region"));
+
+      TableBindingMutator.setColumnLabels(model, Map.of("Region", ""));
+
+      assertFalse(model.getName2Labels().containsKey("Region"));
+   }
+
+   @Test
+   void refusesAnEmptyLabelMap() {
+      assertThrows(IllegalArgumentException.class,
+                   () -> TableBindingMutator.setColumnLabels(new CrosstabBindingModel(),
+                                                             Map.of()));
+   }
+
+   // ── options (2d Phase 3) ──────────────────────────────────────────────────
+
+   /**
+    * The crosstab totals are dynamic-value strings that StyleBI reads as booleans, so anything
+    * but "true" reads as false. A real boolean has to normalize to the string form.
+    */
+   @Test
+   void normalizesARealBooleanToTheStringForm() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+
+      TableBindingMutator.setOptions(model, Map.of("rowTotals", true, "colTotals", false));
+
+      assertEquals("true", model.getOption().getRowTotalVisibleValue());
+      assertEquals("false", model.getOption().getColTotalVisibleValue());
+   }
+
+   @Test
+   void acceptsTheStringSpellingsToo() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+
+      TableBindingMutator.setOptions(model, Map.of("rowTotals", "TRUE"));
+
+      assertEquals("true", model.getOption().getRowTotalVisibleValue());
+   }
+
+   /** "yes" reads as false downstream, so it would silently turn the total off. */
+   @Test
+   void refusesAnAmbiguousBooleanSpellingRatherThanTurningTheSettingOff() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> TableBindingMutator.setOptions(new CrosstabBindingModel(),
+                                              Map.of("rowTotals", "yes")));
+
+      assertTrue(thrown.getMessage().contains("silently turn the setting off"));
+   }
+
+   @Test
+   void setsPercentageByOnlyWhenTheShelfItNeedsIsPopulated() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "cols", List.of(dim("Year")));
+
+      TableBindingMutator.setOptions(model, Map.of("percentageBy", "col"));
+
+      assertEquals(String.valueOf(inetsoft.uql.XConstants.PERCENTAGE_BY_COL),
+                   model.getOption().getPercentageByValue());
+   }
+
+   /** By-column with no columns bound renders zeros rather than failing. */
+   @Test
+   void refusesPercentageByColWithNoColumnsBound() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> TableBindingMutator.setOptions(new CrosstabBindingModel(),
+                                              Map.of("percentageBy", "col")));
+
+      assertTrue(thrown.getMessage().contains("zeros"));
+   }
+
+   @Test
+   void refusesAnUnknownPercentageByToken() {
+      assertThrows(IllegalArgumentException.class,
+                   () -> TableBindingMutator.setOptions(new CrosstabBindingModel(),
+                                                        Map.of("percentageBy", "diagonal")));
+   }
+
+   @Test
+   void setsTableOptions() {
+      TableBindingModel model = new TableBindingModel();
+
+      TableBindingMutator.setOptions(model, Map.of("grandTotal", true, "distinct", false));
+
+      assertTrue(model.getOption().getGrandTotal());
+      assertFalse(model.getOption().getDistinct());
+   }
+
+   /** An option belonging to the other object type would be accepted and do nothing. */
+   @Test
+   void refusesACrosstabOptionOnATable() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> TableBindingMutator.setOptions(new TableBindingModel(),
+                                              Map.of("rowTotals", true)));
+
+      assertTrue(thrown.getMessage().contains("rowTotals"));
+      assertTrue(thrown.getMessage().contains("grandTotal"), "list what this type does take");
+   }
+
+   @Test
+   void refusesAnEmptyOptionMap() {
+      assertThrows(IllegalArgumentException.class,
+                   () -> TableBindingMutator.setOptions(new CrosstabBindingModel(), Map.of()));
+   }
+
+   @Test
+   void optionVocabularySeparatesTheTwoObjectTypes() {
+      Map<String, Object> vocabulary = TableBindingMutator.optionVocabulary();
+
+      assertTrue(String.valueOf(vocabulary.get("crosstab")).contains("rowTotals"));
+      assertTrue(String.valueOf(vocabulary.get("table")).contains("distinct"));
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/binding/TableBindingMutatorTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/TableBindingMutatorTest.java
@@ -315,10 +315,82 @@ class TableBindingMutatorTest {
       CrosstabBindingModel model = new CrosstabBindingModel();
       TableBindingMutator.setShelf(model, "rows", List.of(dim("Region")));
 
-      TableBindingMutator.setSort(model, "rows", "Region",
+      TableBindingMutator.setSort(model, "rows", "Region", null,
                                   new DimensionSortRanking.Sort("desc", null, null));
 
       assertEquals(inetsoft.uql.XConstants.SORT_DESC, model.getRows().get(0).getOrder());
+   }
+
+   /**
+    * A crosstab binds the same date column twice on purpose — that is how a Year › Quarter drill
+    * is built, and {@code VSCrosstabBindingHandler.setDateLevel} auto-advances the level on the
+    * second drop. Sort and ranking live on each ref, so the product never addresses a dimension
+    * by name; this layer does, and with duplicates it silently took the FIRST match.
+    *
+    * <p>So a caller sorting "the quarter one" quietly sorted the year one, and the model reported
+    * a single sort entry for both. Found live on local-1200 running case 29 step 5.
+    */
+   @Test
+   void refusesAnAmbiguousColumnRatherThanSortingTheFirstMatch() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows",
+                                   List.of(dated("ORDER_DATE", "year"),
+                                           dated("ORDER_DATE", "quarter")));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> TableBindingMutator.setSort(model, "rows", "ORDER_DATE", null,
+                                           new DimensionSortRanking.Sort("desc", null, null)));
+
+      assertTrue(thrown.getMessage().contains("index"), thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("0"), "the message must name the positions");
+      assertTrue(thrown.getMessage().contains("1"));
+   }
+
+   @Test
+   void sortsTheDimensionNamedByIndexWhenAColumnIsBoundTwice() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows",
+                                   List.of(dated("ORDER_DATE", "year"),
+                                           dated("ORDER_DATE", "quarter")));
+
+      TableBindingMutator.setSort(model, "rows", "ORDER_DATE", 1,
+                                  new DimensionSortRanking.Sort("desc", null, null));
+
+      assertEquals(inetsoft.uql.XConstants.SORT_DESC, model.getRows().get(1).getOrder(),
+                   "index 1 must be the second ref");
+      assertNotEquals(inetsoft.uql.XConstants.SORT_DESC, model.getRows().get(0).getOrder(),
+                      "the first ref must be untouched");
+   }
+
+   @Test
+   void refusesAnIndexThatNamesNoRefOfThatColumn() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows",
+                                   List.of(dated("ORDER_DATE", "year"),
+                                           dated("ORDER_DATE", "quarter")));
+
+      assertThrows(IllegalArgumentException.class,
+                   () -> TableBindingMutator.setSort(model, "rows", "ORDER_DATE", 7,
+                                                     new DimensionSortRanking.Sort("desc", null,
+                                                                                   null)));
+   }
+
+   /** Read side of the same bug: one key for two refs meant one of them was invisible. */
+   @Test
+   void describesBothRefsWhenAColumnIsBoundTwice() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows",
+                                   List.of(dated("ORDER_DATE", "year"),
+                                           dated("ORDER_DATE", "quarter")));
+
+      Map<String, Object> sorts = TableBindingMutator.describeSorts(model, "rows");
+
+      assertEquals(2, sorts.size(), "both refs must be reported, got: " + sorts.keySet());
+   }
+
+   private static FieldRef dated(String column, String level) {
+      return new FieldRef(column, "dimension", null, level, null);
    }
 
    @Test
@@ -326,7 +398,7 @@ class TableBindingMutatorTest {
       CrosstabBindingModel model = new CrosstabBindingModel();
       TableBindingMutator.setShelf(model, "rows", List.of(dim("Region")));
 
-      TableBindingMutator.setRanking(model, "rows", "Region",
+      TableBindingMutator.setRanking(model, "rows", "Region", null,
                                      new DimensionSortRanking.Ranking("top", 5, "Sales", null));
 
       assertEquals("5", model.getRows().get(0).getRankingN());
@@ -340,7 +412,7 @@ class TableBindingMutatorTest {
 
       Exception thrown = assertThrows(
          IllegalArgumentException.class,
-         () -> TableBindingMutator.setSort(model, "rows", "Nope",
+         () -> TableBindingMutator.setSort(model, "rows", "Nope", null,
                                            new DimensionSortRanking.Sort("asc", null, null)));
 
       assertTrue(thrown.getMessage().contains("Nope"));
@@ -353,7 +425,7 @@ class TableBindingMutatorTest {
 
       Exception thrown = assertThrows(
          IllegalArgumentException.class,
-         () -> TableBindingMutator.setSort(crosstab, "aggregates", "Sales",
+         () -> TableBindingMutator.setSort(crosstab, "aggregates", "Sales", null,
                                            new DimensionSortRanking.Sort("asc", null, null)));
 
       assertTrue(thrown.getMessage().contains("measures"));
@@ -363,7 +435,7 @@ class TableBindingMutatorTest {
    void describesTheSortsOnAShelf() {
       CrosstabBindingModel model = new CrosstabBindingModel();
       TableBindingMutator.setShelf(model, "rows", List.of(dim("Region")));
-      TableBindingMutator.setRanking(model, "rows", "Region",
+      TableBindingMutator.setRanking(model, "rows", "Region", null,
                                      new DimensionSortRanking.Ranking("top", 5, "Sales", null));
 
       Map<String, Object> described = TableBindingMutator.describeSorts(model, "rows");

--- a/core/src/test/java/inetsoft/web/wiz/binding/TableBindingMutatorTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/TableBindingMutatorTest.java
@@ -373,19 +373,36 @@ class TableBindingMutatorTest {
 
    // ── column labels (2d Phase 2) ────────────────────────────────────────────
 
+   /**
+    * The label never reached the header. {@code name2Labels} is read and written by
+    * {@code BaseTableBindingModel} and by nothing else in the product — a dead field — so the
+    * write landed nowhere, {@code columnLabels} read back empty, and the tool still reported
+    * "Relabelled 1 column(s)". Verified live on local-1200: the header stayed "Sum(PAID)".
+    *
+    * <p>The tests here asserted on {@code getName2Labels()}, so they passed while the feature did
+    * nothing — they checked that we wrote to the dead field, which is exactly what was wrong.
+    *
+    * <p>Renaming a header really means a {@code TableDataPath} cell override, which needs the
+    * rendered table lens to locate the header cell and differs between crosstab and table. That
+    * is a design job, not a patch. Until it exists the tool refuses, so an agent surfaces a
+    * missing capability instead of believing the header changed.
+    */
    @Test
-   void setsAColumnLabelForABoundColumn() {
+   void refusesBecauseTheLabelWouldNeverReachTheHeader() {
       CrosstabBindingModel model = new CrosstabBindingModel();
       TableBindingMutator.setShelf(model, "rows", List.of(dim("Region")));
 
-      TableBindingMutator.setColumnLabels(model, Map.of("Region", "Sales Region"));
+      Exception thrown = assertThrows(
+         UnsupportedOperationException.class,
+         () -> TableBindingMutator.setColumnLabels(model, Map.of("Region", "Sales Region")));
 
-      assertEquals("Sales Region", model.getName2Labels().get("Region"));
+      assertTrue(thrown.getMessage().toLowerCase().contains("not supported"),
+                 "the message must say the capability is missing, got: " + thrown.getMessage());
    }
 
-   /** A label for an unbound column would sit in name2Labels doing nothing. */
+   /** The unbound-column check still runs first: a wrong name is a different mistake. */
    @Test
-   void refusesALabelForAColumnThatIsNotBound() {
+   void stillNamesAnUnboundColumnBeforeReportingTheGap() {
       CrosstabBindingModel model = new CrosstabBindingModel();
       TableBindingMutator.setShelf(model, "rows", List.of(dim("Region")));
 
@@ -396,16 +413,6 @@ class TableBindingMutatorTest {
       assertTrue(thrown.getMessage().contains("never be shown"));
    }
 
-   @Test
-   void anEmptyLabelRemovesIt() {
-      CrosstabBindingModel model = new CrosstabBindingModel();
-      TableBindingMutator.setShelf(model, "rows", List.of(dim("Region")));
-      TableBindingMutator.setColumnLabels(model, Map.of("Region", "Sales Region"));
-
-      TableBindingMutator.setColumnLabels(model, Map.of("Region", ""));
-
-      assertFalse(model.getName2Labels().containsKey("Region"));
-   }
 
    @Test
    void refusesAnEmptyLabelMap() {

--- a/core/src/test/java/inetsoft/web/wiz/binding/TableBindingServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/TableBindingServiceTest.java
@@ -1,0 +1,202 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.*;
+import inetsoft.web.binding.controller.VSBindingModelService;
+import inetsoft.web.binding.event.ApplyVSAssemblyInfoEvent;
+import inetsoft.web.binding.model.BindingModel;
+import inetsoft.web.binding.model.table.CrosstabBindingModel;
+import inetsoft.web.binding.model.table.TableBindingModel;
+import inetsoft.web.binding.service.VSBindingService;
+import inetsoft.web.wiz.binding.model.FieldRef;
+import inetsoft.web.wiz.viewsheet.ViewsheetSessionService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class TableBindingServiceTest {
+   private static FieldRef dim(String column) {
+      return new FieldRef(column, "dimension", null, null, null);
+   }
+
+   @Test
+   void setShelfPostsTheModelItReadRatherThanAFreshOne() throws Exception {
+      CrosstabBindingModel existing = new CrosstabBindingModel();
+      existing.getName2Labels().put("Region", "Sales Region");
+      VSBindingModelService bindings = mock(VSBindingModelService.class);
+
+      harness(mock(CrosstabVSAssembly.class), existing, bindings)
+         .setShelf("tok", principal(), "Crosstab1", "rows", List.of(dim("Region")));
+
+      ApplyVSAssemblyInfoEvent event = capture(bindings);
+      CrosstabBindingModel posted = (CrosstabBindingModel) event.getBinding();
+      assertEquals("Sales Region", posted.getName2Labels().get("Region"),
+                   "column labels must survive a shelf write no tool here touches");
+      assertEquals(1, posted.getRows().size());
+      assertEquals("Crosstab1", event.getName());
+   }
+
+   /**
+    * The trap flag reports a binding that would produce a cartesian result. Turning it off to
+    * make a call succeed trades a reported problem for an unreported one.
+    */
+   @Test
+   void leavesTrapCheckingOn() throws Exception {
+      VSBindingModelService bindings = mock(VSBindingModelService.class);
+
+      harness(mock(CrosstabVSAssembly.class), new CrosstabBindingModel(), bindings)
+         .setShelf("tok", principal(), "Crosstab1", "rows", List.of(dim("Region")));
+
+      assertTrue(capture(bindings).isCheckTrap());
+   }
+
+   @Test
+   void aPivotIsOneCheckpointNotTwo() throws Exception {
+      CrosstabBindingModel existing = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(existing, "rows", List.of(dim("Region"), dim("Year")));
+      ViewsheetSessionService sessions = sessionsFor(mock(CrosstabVSAssembly.class));
+      VSBindingModelService bindings = mock(VSBindingModelService.class);
+
+      serviceWith(sessions, existing, bindings)
+         .moveField("tok", principal(), "Crosstab1", "rows", "cols", "Year", null);
+
+      verify(sessions, times(1)).mutate(anyString(), any(Principal.class), any());
+      CrosstabBindingModel posted = (CrosstabBindingModel) capture(bindings).getBinding();
+      assertEquals(1, posted.getRows().size());
+      assertEquals(1, posted.getCols().size());
+   }
+
+   @Test
+   void addAndRemoveDelegate() throws Exception {
+      CrosstabBindingModel existing = new CrosstabBindingModel();
+      VSBindingModelService bindings = mock(VSBindingModelService.class);
+
+      harness(mock(CrosstabVSAssembly.class), existing, bindings)
+         .addField("tok", principal(), "Crosstab1", "rows", dim("Region"), null);
+
+      assertEquals(1, ((CrosstabBindingModel) capture(bindings).getBinding()).getRows().size());
+   }
+
+   @Test
+   void readReportsTheObjectTypeAndShelvesWithoutMutating() throws Exception {
+      TableBindingModel existing = new TableBindingModel();
+      TableBindingMutator.setShelf(existing, "groups", List.of(dim("Region")));
+      ViewsheetSessionService sessions = sessionsFor(mock(TableVSAssembly.class));
+
+      Map<String, Object> read = serviceWith(sessions, existing,
+                                             mock(VSBindingModelService.class))
+         .read("tok", principal(), "Table1");
+
+      assertEquals("table", read.get("objectType"));
+      @SuppressWarnings("unchecked")
+      Map<String, Object> shelves = (Map<String, Object>) read.get("shelves");
+      assertTrue(shelves.containsKey("groups"));
+      assertTrue(shelves.containsKey("details"));
+      assertFalse(shelves.containsKey("rows"), "a table has no rows shelf");
+      verify(sessions, never()).mutate(anyString(), any(Principal.class), any());
+   }
+
+   @Test
+   void refusesAChartNamingIt() {
+      TableBindingService service = serviceWith(
+         sessionsFor(mock(ChartVSAssembly.class)),
+         new inetsoft.web.binding.model.ChartBindingModel(), mock(VSBindingModelService.class));
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> service.setShelf("tok", principal(), "Chart1", "rows", List.of(dim("Region"))));
+      assertTrue(thrown.getMessage().contains("Chart1"));
+      assertTrue(thrown.getMessage().contains("chart"));
+   }
+
+   @Test
+   void refusesACalcTablePointingAtItsCellLayout() {
+      TableBindingService service = serviceWith(
+         sessionsFor(mock(CalcTableVSAssembly.class)), new CrosstabBindingModel(),
+         mock(VSBindingModelService.class));
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> service.read("tok", principal(), "Calc1"));
+      assertTrue(thrown.getMessage().contains("cell layout"));
+   }
+
+   // ── harness ───────────────────────────────────────────────────────────────
+
+   private static ApplyVSAssemblyInfoEvent capture(VSBindingModelService bindings)
+      throws Exception
+   {
+      ArgumentCaptor<ApplyVSAssemblyInfoEvent> captor =
+         ArgumentCaptor.forClass(ApplyVSAssemblyInfoEvent.class);
+      verify(bindings).setBinding(eq("rt1"), captor.capture(), any(Principal.class), any());
+      return captor.getValue();
+   }
+
+   private static TableBindingService harness(VSAssembly assembly, BindingModel model,
+                                              VSBindingModelService bindings)
+   {
+      return serviceWith(sessionsFor(assembly), model, bindings);
+   }
+
+   private static ViewsheetSessionService sessionsFor(VSAssembly assembly) {
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssembly(anyString())).thenReturn(assembly);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+
+      try {
+         doAnswer(invocation -> {
+            ViewsheetSessionService.Mutation mutation = invocation.getArgument(2);
+            mutation.run(rvs, "rt1", null);
+            return null;
+         }).when(sessions).mutate(anyString(), any(Principal.class), any());
+         when(sessions.resolve(anyString(), any(Principal.class))).thenReturn(rvs);
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(e);
+      }
+
+      return sessions;
+   }
+
+   private static TableBindingService serviceWith(ViewsheetSessionService sessions,
+                                                  BindingModel model,
+                                                  VSBindingModelService bindings)
+   {
+      VSBindingService binding = mock(VSBindingService.class);
+      when(binding.createModel(any())).thenReturn(model);
+      return new TableBindingService(sessions, binding, bindings);
+   }
+
+   private static Principal principal() {
+      return () -> "admin";
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/binding/TableBindingServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/TableBindingServiceTest.java
@@ -22,6 +22,8 @@ import inetsoft.uql.viewsheet.*;
 import inetsoft.web.binding.controller.VSBindingModelService;
 import inetsoft.web.binding.event.ApplyVSAssemblyInfoEvent;
 import inetsoft.web.binding.model.BindingModel;
+import inetsoft.web.binding.model.table.BaseTableBindingModel;
+import inetsoft.web.binding.model.table.CalcTableBindingModel;
 import inetsoft.web.binding.model.table.CrosstabBindingModel;
 import inetsoft.web.binding.model.table.TableBindingModel;
 import inetsoft.web.binding.service.VSBindingService;
@@ -32,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.security.Principal;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -148,6 +151,121 @@ class TableBindingServiceTest {
    }
 
    // ── harness ───────────────────────────────────────────────────────────────
+
+   // ── set_table_source ──────────────────────────────────────────────────────
+   //
+   // A crosstab or table added in the Composer starts with no source. Its shelves can be
+   // populated — set_table_fields reports success — and it renders nothing at all, because
+   // shelves with no source have nothing to query. Nothing in the plugin could assign one.
+
+   @Test
+   void setSourceAssignsAnAssetSourceByName() throws Exception {
+      CrosstabBindingModel existing = withTables("ORDERS", "CUSTOMERS");
+      VSBindingModelService bindings = mock(VSBindingModelService.class);
+
+      harness(mock(CrosstabVSAssembly.class), existing, bindings)
+         .setSource("tok", principal(), "Crosstab1", "ORDERS", false);
+
+      CrosstabBindingModel posted = (CrosstabBindingModel) capture(bindings).getBinding();
+      assertNotNull(posted.getSource(), "the model must carry a source after the write");
+      assertEquals("ORDERS", posted.getSource().getSource());
+      assertEquals(inetsoft.uql.asset.SourceInfo.ASSET, posted.getSource().getType(),
+                   "worksheet tables bind as ASSET — the form used everywhere else");
+   }
+
+   @Test
+   void setSourceRefusesATableTheAssemblyCannotSee() {
+      CrosstabBindingModel existing = withTables("ORDERS", "CUSTOMERS");
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> harness(mock(CrosstabVSAssembly.class), existing, mock(VSBindingModelService.class))
+            .setSource("tok", principal(), "Crosstab1", "NOPE", false));
+
+      assertTrue(thrown.getMessage().contains("NOPE"));
+      assertTrue(thrown.getMessage().contains("ORDERS"), "list what it can bind to");
+   }
+
+   /**
+    * Repointing a bound assembly discards every field on its shelves, because the columns
+    * belong to the old source. Doing that silently on one call is the failure mode this whole
+    * plugin family exists to avoid.
+    */
+   @Test
+   void setSourceRefusesToDiscardBoundFieldsUnlessForced() {
+      CrosstabBindingModel existing = withTables("ORDERS", "CUSTOMERS");
+      existing.setRows(List.of(new inetsoft.web.binding.model.BDimensionRefModel()));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> harness(mock(CrosstabVSAssembly.class), existing, mock(VSBindingModelService.class))
+            .setSource("tok", principal(), "Crosstab1", "CUSTOMERS", false));
+
+      assertTrue(thrown.getMessage().contains("force"), "name the way through");
+   }
+
+   @Test
+   void setSourceProceedsWhenForced() throws Exception {
+      CrosstabBindingModel existing = withTables("ORDERS", "CUSTOMERS");
+      existing.setRows(List.of(new inetsoft.web.binding.model.BDimensionRefModel()));
+      VSBindingModelService bindings = mock(VSBindingModelService.class);
+
+      harness(mock(CrosstabVSAssembly.class), existing, bindings)
+         .setSource("tok", principal(), "Crosstab1", "CUSTOMERS", true);
+
+      CrosstabBindingModel posted = (CrosstabBindingModel) capture(bindings).getBinding();
+      assertEquals("CUSTOMERS", posted.getSource().getSource());
+   }
+
+   /**
+    * A calc table has a source like any other data assembly — {@code CalcTableVSAssembly} extends
+    * {@code TableDataVSAssembly} and {@code CalcTableBindingModel} extends
+    * {@code BaseTableBindingModel}. The blanket calc-table refusal exists because *shelves* do not
+    * apply to it, but assigning a source is not a shelf operation, and without this a freehand
+    * table can never be pointed at data: its cells bind, and it renders empty forever.
+    */
+   @Test
+   void setSourceAcceptsACalcTableBecauseSourceIsNotAShelfOperation() throws Exception {
+      CalcTableBindingModel existing = new CalcTableBindingModel();
+      List<BindingModel.SourceTable> tables = new ArrayList<>();
+      BindingModel.SourceTable table = new BindingModel.SourceTable();
+      table.setName("ORDERS");
+      tables.add(table);
+      existing.setTables(tables);
+      VSBindingModelService bindings = mock(VSBindingModelService.class);
+
+      harness(mock(CalcTableVSAssembly.class), existing, bindings)
+         .setSource("tok", principal(), "Calc1", "ORDERS", false);
+
+      BaseTableBindingModel posted = (BaseTableBindingModel) capture(bindings).getBinding();
+      assertEquals("ORDERS", posted.getSource().getSource());
+   }
+
+   @Test
+   void shelfWritesStillRefuseACalcTable() {
+      TableBindingService service = serviceWith(
+         sessionsFor(mock(CalcTableVSAssembly.class)), new CalcTableBindingModel(),
+         mock(VSBindingModelService.class));
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> service.setShelf("tok", principal(), "Calc1", "rows", List.of(dim("Region"))));
+      assertTrue(thrown.getMessage().contains("cell layout"));
+   }
+
+   private static CrosstabBindingModel withTables(String... names) {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      List<BindingModel.SourceTable> tables = new ArrayList<>();
+
+      for(String name : names) {
+         BindingModel.SourceTable table = new BindingModel.SourceTable();
+         table.setName(name);
+         tables.add(table);
+      }
+
+      model.setTables(tables);
+      return model;
+   }
 
    private static ApplyVSAssemblyInfoEvent capture(VSBindingModelService bindings)
       throws Exception

--- a/core/src/test/java/inetsoft/web/wiz/binding/VisualFrameAliasesTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/VisualFrameAliasesTest.java
@@ -136,15 +136,137 @@ class VisualFrameAliasesTest {
       assertTrue(thrown.getMessage().contains("Blues"));
    }
 
+   /**
+    * Every channel now accepts a {@code categorical} and a {@code static}, so a spec written for
+    * one channel is structurally valid on another and its value keys would simply be ignored —
+    * a categorical size frame with no colours, reported as success. The unused-key guard is what
+    * catches that.
+    */
    @Test
-   void refusesAColourFrameOnTheSizeChannelNamingBoth() {
+   void refusesAColourSpecOnTheSizeChannelNamingBoth() {
       Exception thrown = assertThrows(
          IllegalArgumentException.class,
          () -> VisualFrameAliases.create("size", spec("type", "categorical",
                                                       "colors", java.util.List.of("#fff"))));
 
       assertTrue(thrown.getMessage().contains("size"));
-      assertTrue(thrown.getMessage().contains("categorical"));
+      assertTrue(thrown.getMessage().contains("colors"));
+   }
+
+   @Test
+   void refusesAKeyTheFrameTypeDoesNotRead() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> VisualFrameAliases.create("color", spec("type", "static", "color", "#fff",
+                                                       "palette", "Blues")));
+
+      assertTrue(thrown.getMessage().contains("palette"));
+   }
+
+   // ── the rest of the taxonomy (2c Phase 2) ─────────────────────────────────
+
+   @Test
+   void buildsTheBehaviouralColourFrames() {
+      assertInstanceOf(BipolarColorModel.class,
+                       VisualFrameAliases.create("color", spec("type", "bipolar")));
+      assertInstanceOf(RainbowColorModel.class,
+                       VisualFrameAliases.create("color", spec("type", "rainbow")));
+      assertInstanceOf(HeatColorModel.class,
+                       VisualFrameAliases.create("color", spec("type", "heat")));
+      assertInstanceOf(CircularColorModel.class,
+                       VisualFrameAliases.create("color", spec("type", "circular")));
+   }
+
+   @Test
+   void buildsBrightnessAndSaturationFromABaseColour() {
+      BrightnessColorModel brightness = assertInstanceOf(
+         BrightnessColorModel.class,
+         VisualFrameAliases.create("color", spec("type", "brightness", "color", "#4e79a7")));
+      assertEquals("#4E79A7", brightness.getColor());
+      assertInstanceOf(SaturationColorModel.class,
+                       VisualFrameAliases.create("color", spec("type", "saturation",
+                                                               "color", "#abc")));
+   }
+
+   @Test
+   void refusesBrightnessWithNoBaseColour() {
+      assertThrows(IllegalArgumentException.class,
+                   () -> VisualFrameAliases.create("color", spec("type", "brightness")));
+   }
+
+   @Test
+   void buildsShapeFrames() {
+      StaticShapeModel shape = assertInstanceOf(
+         StaticShapeModel.class,
+         VisualFrameAliases.create("shape", spec("type", "static", "shape", "circle")));
+      assertEquals("circle", shape.getShape());
+
+      CategoricalShapeModel categorical = assertInstanceOf(
+         CategoricalShapeModel.class,
+         VisualFrameAliases.create("shape", spec("type", "categorical", "shapes",
+                                                 java.util.List.of("circle", "square"))));
+      assertArrayEquals(new String[]{ "circle", "square" }, categorical.getShapes());
+
+      assertInstanceOf(TriangleShapeModel.class,
+                       VisualFrameAliases.create("shape", spec("type", "triangle")));
+   }
+
+   @Test
+   void buildsSizeFrames() {
+      StaticSizeModel size = assertInstanceOf(
+         StaticSizeModel.class,
+         VisualFrameAliases.create("size", spec("type", "static", "size", 8)));
+      assertEquals(8d, size.getSize());
+      assertInstanceOf(LinearSizeModel.class,
+                       VisualFrameAliases.create("size", spec("type", "linear")));
+   }
+
+   @Test
+   void buildsLineAndTextureFrames() {
+      assertInstanceOf(StaticLineModel.class,
+                       VisualFrameAliases.create("line", spec("type", "static", "line", 1)));
+      assertInstanceOf(LinearLineModel.class,
+                       VisualFrameAliases.create("line", spec("type", "linear")));
+      assertInstanceOf(StaticTextureModel.class,
+                       VisualFrameAliases.create("texture", spec("type", "static",
+                                                                 "texture", 3)));
+      assertInstanceOf(GridTextureModel.class,
+                       VisualFrameAliases.create("texture", spec("type", "grid")));
+   }
+
+   @Test
+   void refusesANonNumericSize() {
+      assertThrows(IllegalArgumentException.class,
+                   () -> VisualFrameAliases.create("size", spec("type", "static",
+                                                                "size", "large")));
+   }
+
+   @Test
+   void refusesAFrameTypeThatBelongsToAnotherChannel() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> VisualFrameAliases.create("size", spec("type", "gradient", "from", "#eee",
+                                                      "to", "#059")));
+
+      assertTrue(thrown.getMessage().contains("size"));
+   }
+
+   @Test
+   void describesEveryFamilyBackInTokens() {
+      assertEquals("bipolar",
+                   VisualFrameAliases.describe(new BipolarColorModel()).get("type"));
+      assertEquals("grid", VisualFrameAliases.describe(new GridTextureModel()).get("type"));
+      assertEquals("linear", VisualFrameAliases.describe(new LinearSizeModel()).get("type"));
+      assertEquals("triangle",
+                   VisualFrameAliases.describe(new TriangleShapeModel()).get("type"));
+   }
+
+   @Test
+   void listsTypeNamesPerChannel() {
+      assertTrue(VisualFrameAliases.typeNames("color").contains("rainbow"));
+      assertTrue(VisualFrameAliases.typeNames("texture").contains("left_tilt"));
+      assertFalse(VisualFrameAliases.typeNames("size").contains("gradient"),
+                  "a channel must not advertise another channel's types");
    }
 
    @Test
@@ -222,5 +344,86 @@ class VisualFrameAliasesTest {
    @Test
    void describesNullAsNull() {
       assertNull(VisualFrameAliases.describe(null));
+   }
+
+   // ── per-value colour mapping, and the useGlobal footgun (2c Phase 3) ──────
+
+   /**
+    * The recorded defect: while {@code useGlobal} is set the automatic palette wins, so a mapped
+    * colour is stored and never rendered — the model round-trips perfectly and the chart shows
+    * something else. Supplying a mapping must clear the flag.
+    */
+   @Test
+   void aColourMappingClearsUseGlobalSoItActuallyRenders() {
+      CategoricalColorModel frame = assertInstanceOf(
+         CategoricalColorModel.class,
+         VisualFrameAliases.create("color", spec("type", "categorical", "mapping",
+                                                 Map.of("East", "#4e79a7"))));
+
+      assertFalse(frame.isUseGlobal(),
+                  "leaving useGlobal set is what made the mapped colour never render");
+      assertFalse(frame.isShareColors());
+      assertEquals(1, frame.getColorMaps().length);
+      assertEquals("East", frame.getColorMaps()[0].getOption());
+      assertEquals("#4E79A7", frame.getColorMaps()[0].getColor());
+   }
+
+   @Test
+   void refusesUseGlobalTogetherWithAMapping() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> VisualFrameAliases.create("color", spec("type", "categorical", "useGlobal", true,
+                                                       "mapping", Map.of("East", "#fff"))));
+
+      assertTrue(thrown.getMessage().contains("never rendered"),
+                 "the refusal has to say what would have happened, or it reads as arbitrary");
+   }
+
+   @Test
+   void acceptsUseGlobalOnItsOwn() {
+      CategoricalColorModel frame = assertInstanceOf(
+         CategoricalColorModel.class,
+         VisualFrameAliases.create("color", spec("type", "categorical", "useGlobal", true,
+                                                 "colors", java.util.List.of("#fff"))));
+
+      assertTrue(frame.isUseGlobal());
+   }
+
+   @Test
+   void acceptsAMappingWithNoExplicitColourList() {
+      assertDoesNotThrow(() -> VisualFrameAliases.create(
+         "color", spec("type", "categorical", "mapping", Map.of("East", "abc"))));
+   }
+
+   @Test
+   void refusesAMappingThatIsNotAnObject() {
+      assertThrows(IllegalArgumentException.class,
+                   () -> VisualFrameAliases.create("color", spec("type", "categorical",
+                                                                 "mapping", "East")));
+   }
+
+   @Test
+   void refusesAnEmptyMappingRatherThanIgnoringIt() {
+      assertThrows(IllegalArgumentException.class,
+                   () -> VisualFrameAliases.create("color", spec("type", "categorical",
+                                                                 "mapping", Map.of())));
+   }
+
+   @Test
+   void refusesACategoricalFrameWithNeitherColoursNorMapping() {
+      assertThrows(IllegalArgumentException.class,
+                   () -> VisualFrameAliases.create("color", spec("type", "categorical")));
+   }
+
+   /** useGlobal is reported on read, because a true there means any mapping is inert. */
+   @Test
+   void reportsUseGlobalAndTheMappingOnRead() {
+      VisualFrameModel frame = VisualFrameAliases.create(
+         "color", spec("type", "categorical", "mapping", Map.of("East", "#4e79a7")));
+
+      Map<String, Object> described = VisualFrameAliases.describe(frame);
+
+      assertEquals(false, described.get("useGlobal"));
+      assertEquals(Map.of("East", "#4E79A7"), described.get("mapping"));
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/binding/VisualFrameAliasesTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/VisualFrameAliasesTest.java
@@ -1,0 +1,226 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.web.binding.model.graph.aesthetic.*;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+class VisualFrameAliasesTest {
+   private static Map<String, Object> spec(Object... pairs) {
+      Map<String, Object> spec = new LinkedHashMap<>();
+
+      for(int i = 0; i < pairs.length; i += 2) {
+         spec.put((String) pairs[i], pairs[i + 1]);
+      }
+
+      return spec;
+   }
+
+   // ── the four Phase 1 colour frames ────────────────────────────────────────
+
+   @Test
+   void buildsAStaticColorFrame() {
+      VisualFrameModel frame = VisualFrameAliases.create("color", spec("type", "static",
+                                                                      "color", "#4e79a7"));
+
+      assertInstanceOf(StaticColorModel.class, frame);
+      assertEquals("#4E79A7", ((StaticColorModel) frame).getColor());
+   }
+
+   @Test
+   void buildsACategoricalColorFrameFromAColourList() {
+      VisualFrameModel frame = VisualFrameAliases.create(
+         "color", spec("type", "categorical", "colors", java.util.List.of("#4e79a7", "f28e2c")));
+
+      CategoricalColorModel categorical = assertInstanceOf(CategoricalColorModel.class, frame);
+      assertArrayEquals(new String[]{ "#4E79A7", "#F28E2C" }, categorical.getColors());
+   }
+
+   @Test
+   void buildsAGradientColorFrameFromAndTo() {
+      VisualFrameModel frame = VisualFrameAliases.create(
+         "color", spec("type", "gradient", "from", "#eef", "to", "#059"));
+
+      GradientColorModel gradient = assertInstanceOf(GradientColorModel.class, frame);
+      assertEquals("#EEEEFF", gradient.getFromColor());
+      assertEquals("#005599", gradient.getToColor());
+   }
+
+   @Test
+   void buildsANamedPaletteFrame() {
+      VisualFrameModel frame = VisualFrameAliases.create(
+         "color", spec("type", "palette", "palette", "Blues"));
+
+      assertInstanceOf(BluesColorModel.class, frame);
+   }
+
+   @Test
+   void matchesAPaletteNameCaseInsensitively() {
+      assertInstanceOf(RdYlGnColorModel.class,
+                       VisualFrameAliases.create("color", spec("type", "palette",
+                                                               "palette", "rdylgn")));
+   }
+
+   // ── the vocabulary stays honest ───────────────────────────────────────────
+
+   @Test
+   void everyRegisteredPaletteIsInstantiable() {
+      assertEquals(27, VisualFrameAliases.PALETTES.size(),
+                   "the palette registry should carry every named colour ramp");
+
+      for(String name : VisualFrameAliases.PALETTES.keySet()) {
+         assertNotNull(VisualFrameAliases.create("color", spec("type", "palette",
+                                                               "palette", name)),
+                       "palette '" + name + "' does not resolve");
+      }
+   }
+
+   /**
+    * The test that keeps the vocabulary honest as upstream adds palettes. A new
+    * {@code ColorFrameModel} subclass that nothing maps is silently unreachable — nothing
+    * errors, the option simply never exists.
+    */
+   @Test
+   void everyColorFrameSubclassIsMappedOrExplicitlyExcluded() {
+      for(Class<?> subclass : VisualFrameAliases.colorFrameSubclasses()) {
+         assertTrue(VisualFrameAliases.isMapped(subclass) ||
+                    VisualFrameAliases.isExcluded(subclass),
+                    subclass.getSimpleName() + " is neither mapped to an alias nor explicitly " +
+                    "excluded. Add it to VisualFrameAliases, or to its exclusion list with a " +
+                    "reason.");
+      }
+   }
+
+   // ── refusals ──────────────────────────────────────────────────────────────
+
+   @Test
+   void refusesAnUnknownFrameTypeAndSuggestsNearMatches() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> VisualFrameAliases.create("color", spec("type", "categorial")));
+
+      assertTrue(thrown.getMessage().contains("categorial"));
+      assertTrue(thrown.getMessage().contains("categorical"),
+                 "an unknown type should point at the near match, not just list everything");
+   }
+
+   @Test
+   void refusesAnUnknownPaletteListingTheAvailableOnes() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> VisualFrameAliases.create("color", spec("type", "palette", "palette", "Viridis")));
+
+      assertTrue(thrown.getMessage().contains("Viridis"));
+      assertTrue(thrown.getMessage().contains("Blues"));
+   }
+
+   @Test
+   void refusesAColourFrameOnTheSizeChannelNamingBoth() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> VisualFrameAliases.create("size", spec("type", "categorical",
+                                                      "colors", java.util.List.of("#fff"))));
+
+      assertTrue(thrown.getMessage().contains("size"));
+      assertTrue(thrown.getMessage().contains("categorical"));
+   }
+
+   @Test
+   void refusesAStaticFrameWithNoColour() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> VisualFrameAliases.create("color", spec("type", "static")));
+
+      assertTrue(thrown.getMessage().contains("color"));
+   }
+
+   @Test
+   void refusesACategoricalFrameWithNoColours() {
+      assertThrows(IllegalArgumentException.class,
+                   () -> VisualFrameAliases.create("color", spec("type", "categorical",
+                                                                 "colors", java.util.List.of())));
+   }
+
+   @Test
+   void refusesAMissingType() {
+      Exception thrown = assertThrows(IllegalArgumentException.class,
+                                      () -> VisualFrameAliases.create("color", spec()));
+
+      assertTrue(thrown.getMessage().contains("type"));
+   }
+
+   // ── colour normalization ──────────────────────────────────────────────────
+
+   @Test
+   void normalizesTheAcceptedColourSpellings() {
+      assertEquals("#4E79A7", VisualFrameAliases.normalizeColor("#4e79a7"));
+      assertEquals("#4E79A7", VisualFrameAliases.normalizeColor("4e79a7"));
+      assertEquals("#4E79A7", VisualFrameAliases.normalizeColor("  #4E79A7  "));
+      assertEquals("#AABBCC", VisualFrameAliases.normalizeColor("#abc"));
+      assertEquals("#AABBCC", VisualFrameAliases.normalizeColor("abc"));
+   }
+
+   @Test
+   void rejectsANamedCssColourRatherThanHalfSupportingIt() {
+      Exception thrown = assertThrows(IllegalArgumentException.class,
+                                      () -> VisualFrameAliases.normalizeColor("rebeccapurple"));
+
+      assertTrue(thrown.getMessage().contains("rebeccapurple"));
+      assertTrue(thrown.getMessage().contains("#RRGGBB"));
+   }
+
+   @Test
+   void rejectsAColourOfTheWrongLength() {
+      assertThrows(IllegalArgumentException.class,
+                   () -> VisualFrameAliases.normalizeColor("#12345"));
+   }
+
+   // ── the read direction ────────────────────────────────────────────────────
+
+   @Test
+   void describesAStaticFrameBackInTheAgentVocabulary() {
+      StaticColorModel model = new StaticColorModel();
+      model.setColor("#4E79A7");
+
+      Map<String, Object> described = VisualFrameAliases.describe(model);
+
+      assertEquals("static", described.get("type"));
+      assertEquals("#4E79A7", described.get("color"));
+      assertFalse(described.containsKey("clazz"), "an FQCN must never reach the agent");
+   }
+
+   @Test
+   void describesAPaletteFrameByItsName() {
+      Map<String, Object> described = VisualFrameAliases.describe(new BluesColorModel());
+
+      assertEquals("palette", described.get("type"));
+      assertEquals("Blues", described.get("palette"));
+   }
+
+   @Test
+   void describesNullAsNull() {
+      assertNull(VisualFrameAliases.describe(null));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/dispatch/CapturingCommandDispatcherTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/dispatch/CapturingCommandDispatcherTest.java
@@ -50,6 +50,58 @@ class CapturingCommandDispatcherTest {
       assertSame(info, captured.get(0).getCommand());
    }
 
+   /**
+    * {@code CommandDispatcher.detach()} returns a copy of the BASE class, so anything sent
+    * through it is neither captured nor inspected — the exact hole this class exists to close.
+    * It is reached in practice, not hypothetically: {@code CoreLifecycleService.createList} calls
+    * {@code detach()}, and that is on the add, remove, group and rename paths — rename being the
+    * op this feature's own description calls out as the one where capture matters most. An ERROR
+    * dispatched during that refresh was dropped and the op reported success.
+    *
+    * <p>This dispatcher never transmits — {@code send} and {@code convertAndSendToUser} are both
+    * no-ops — so returning itself is safe and keeps one captured list rather than a copy nobody
+    * reads.
+    */
+   @Test
+   void detachStaysCapturingSoRefreshErrorsAreNotDropped() {
+      CommandErrorException thrown = assertThrows(CommandErrorException.class, () ->
+         CapturingCommandDispatcher.withCapturingDispatcher(principal(), dispatcher -> {
+            dispatcher.detach().sendCommand(message(MessageCommand.Type.ERROR, "from refresh"));
+            return null;
+         }));
+
+      assertTrue(thrown.getErrors().contains("from refresh"),
+                 "an error sent through the detached copy must still be captured, got: " +
+                 thrown.getErrors());
+   }
+
+   /**
+    * The base {@code commands} list stays empty because {@code sendCommand} deliberately skips
+    * {@code super}, so the inherited {@code iterator()}/{@code stream()} saw nothing. Framework
+    * code reads exactly those: {@code CoreLifecycleService} uses {@code stream()} to decide
+    * {@code checkMVHandled} — always false here, which re-sends {@code CheckMVEvent} and adds a
+    * SECOND checkpoint, breaking the one-checkpoint-per-call promise {@code mutate} makes — and
+    * iterates the dispatcher to detect {@code InitGridCommand}.
+    */
+   @Test
+   void theDispatcherIteratesItsOwnCapturedCommands() throws Exception {
+      long[] counts = CapturingCommandDispatcher.withCapturingDispatcher(principal(), d -> {
+         d.sendCommand(message(MessageCommand.Type.INFO, "one"));
+         d.sendCommand(message(MessageCommand.Type.INFO, "two"));
+
+         long iterated = 0;
+
+         for(CommandDispatcher.Command ignored : d) {
+            iterated++;
+         }
+
+         return new long[]{ iterated, d.stream().count() };
+      });
+
+      assertEquals(2, counts[0], "iterator() must see the captured commands");
+      assertEquals(2, counts[1], "stream() must see the captured commands");
+   }
+
    @Test
    void throwsWhenTheWrappedCallReportedAnError() {
       CommandErrorException thrown = assertThrows(CommandErrorException.class, () ->

--- a/core/src/test/java/inetsoft/web/wiz/dispatch/CapturingCommandDispatcherTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/dispatch/CapturingCommandDispatcherTest.java
@@ -1,0 +1,92 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.dispatch;
+
+import inetsoft.web.viewsheet.command.MessageCommand;
+import inetsoft.web.viewsheet.service.CommandDispatcher;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Guards the Phase 0 spike finding: composer services report failure by SENDING a
+ * MessageCommand of Type.ERROR and returning normally, never by throwing. Under
+ * {@code CommandDispatcher.withDummyDispatcher} those commands are dropped, so every failure
+ * becomes a silent success. This dispatcher captures instead of dropping so the failure can be
+ * surfaced.
+ */
+@Tag("core")
+class CapturingCommandDispatcherTest {
+   @Test
+   void capturesSentCommandInsteadOfDiscardingIt() throws Exception {
+      MessageCommand info = message(MessageCommand.Type.INFO, "hello");
+
+      List<CommandDispatcher.Command> captured =
+         CapturingCommandDispatcher.withCapturingDispatcher(principal(), dispatcher -> {
+            dispatcher.sendCommand(info);
+            return dispatcher.getCapturedCommands();
+         });
+
+      assertEquals(1, captured.size(), "the command should have been captured, not dropped");
+      assertSame(info, captured.get(0).getCommand());
+   }
+
+   @Test
+   void throwsWhenTheWrappedCallReportedAnError() {
+      CommandErrorException thrown = assertThrows(CommandErrorException.class, () ->
+         CapturingCommandDispatcher.withCapturingDispatcher(principal(), dispatcher -> {
+            // Exactly what a composer service does on failure: send an ERROR, then return
+            // normally. Under withDummyDispatcher this is indistinguishable from success.
+            dispatcher.sendCommand(message(MessageCommand.Type.ERROR, "dependency cycle"));
+            return "service returned normally";
+         }));
+
+      assertTrue(thrown.getMessage().contains("dependency cycle"),
+                 "the reported failure should reach the caller, got: " + thrown.getMessage());
+   }
+
+   @Test
+   void surfacesWarningsWithoutFailingTheCall() throws Exception {
+      List<String> warnings =
+         CapturingCommandDispatcher.withCapturingDispatcher(principal(), dispatcher -> {
+            dispatcher.sendCommand(message(MessageCommand.Type.WARNING, "ranking is global"));
+            return dispatcher.getWarnings();
+         });
+
+      assertEquals(List.of("ranking is global"), warnings);
+   }
+
+   private static MessageCommand message(MessageCommand.Type type, String text) {
+      MessageCommand command = new MessageCommand();
+      command.setType(type);
+      command.setMessage(text);
+      return command;
+   }
+
+   /**
+    * A minimal principal. {@code SRPrincipal} pulls in the Spring context via
+    * {@code XSessionService}, and the dispatcher only ever reads {@code getName()}.
+    */
+   private static Principal principal() {
+      return () -> "admin";
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/dispatch/HeadlessDialogServiceProbeTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/dispatch/HeadlessDialogServiceProbeTest.java
@@ -1,0 +1,121 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.dispatch;
+
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.IntegrationTestConfiguration;
+import inetsoft.test.SreeHome;
+import inetsoft.web.binding.handler.VSAssemblyInfoHandler;
+import inetsoft.web.composer.vs.objects.controller.VSObjectPropertyService;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Phase 0 empirical probe, step 1: can the real composer service graph be instantiated in a
+ * test context at all?
+ *
+ * <p><b>Answer so far: not with this harness.</b> {@code WebConfig} scans {@code inetsoft.web}
+ * with {@code lazyInit = true}, so requesting one bean should build only its transitive
+ * closure. But component-scanning {@code inetsoft.web} also drags in the real
+ * {@code @Configuration} classes that {@link BaseTestConfiguration} and
+ * {@link IntegrationTestConfiguration} exist to replace, and they override the test doubles:
+ *
+ * <ol>
+ *   <li>Scanning {@code inetsoft.web} pulls in {@code inetsoft.web.factory.EngineConfiguration},
+ *       whose {@code cluster} / {@code viewsheetEngine} beans displace the test ones.</li>
+ *   <li>Excluding {@code inetsoft.web.factory} moves the failure to
+ *       {@code inetsoft.storage.StorageConfiguration}, imported transitively, whose
+ *       {@code keyValueEngine} displaces {@code BaseTestConfiguration}'s
+ *       {@code TestKeyValueEngine} and then cannot resolve {@code InetsoftConfig}.</li>
+ * </ol>
+ *
+ * <p>Each exclusion reveals the next conflict. The harness is built for tests that mock their
+ * collaborators, not for booting the real graph, so this is a harness-design mismatch rather
+ * than a missing bean.
+ *
+ * <p><b>Recommendation:</b> do not build a bespoke context for this. The plugin controller
+ * specified in the viewsheet-editing design runs inside the real Spring context, so this probe
+ * should become that plugin's first integration test during Phase 1, where the wiring exists
+ * for free. What it must still verify:
+ *
+ * <ul>
+ *   <li>a real {@code GaugePropertyDialogService} write mutates {@code VSAssemblyInfo};</li>
+ *   <li>a rename does not break the browser's assembly tracking;</li>
+ *   <li>{@code @ClusterProxy} routing works bean-to-bean;</li>
+ *   <li>broadcast + {@code addCheckpoint} leave the human's undo coherent.</li>
+ * </ul>
+ *
+ * <p>The dispatcher question itself is already settled: see
+ * {@link CapturingCommandDispatcherTest} and the Phase 0 spike result in the design doc.
+ */
+@Disabled("Phase 0 probe: harness cannot boot the real composer graph — see class javadoc. " +
+          "Reinstate as the plugin's first integration test in Phase 1.")
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(
+   classes = {
+      BaseTestConfiguration.class,
+      IntegrationTestConfiguration.class,
+      HeadlessDialogServiceProbeTest.ComposerScan.class
+   },
+   initializers = ConfigurationContextInitializer.class
+)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome()
+@Tag("core")
+@Tag("integration")
+class HeadlessDialogServiceProbeTest {
+   /**
+    * Scans the composer/binding graph but excludes {@code inetsoft.web.factory}, whose
+    * {@code EngineConfiguration} defines the very beans (cluster, viewsheetEngine) that
+    * BaseTestConfiguration and IntegrationTestConfiguration exist to replace.
+    */
+   @Configuration
+   @ComponentScan(
+      basePackages = "inetsoft.web",
+      lazyInit = true,
+      excludeFilters = @ComponentScan.Filter(
+         type = FilterType.REGEX,
+         pattern = "inetsoft\\.web\\.factory\\..*")
+   )
+   static class ComposerScan {
+   }
+
+   @Test
+   void realComposerBeansCanBeInstantiated() {
+      assertNotNull(vsObjectPropertyService, "VSObjectPropertyService should resolve");
+      assertNotNull(assemblyInfoHandler, "VSAssemblyInfoHandler should resolve");
+   }
+
+   @Autowired
+   private VSObjectPropertyService vsObjectPropertyService;
+
+   @Autowired
+   private VSAssemblyInfoHandler assemblyInfoHandler;
+}

--- a/core/src/test/java/inetsoft/web/wiz/pairing/SheetRuntimeAccessTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/pairing/SheetRuntimeAccessTest.java
@@ -18,6 +18,7 @@
 package inetsoft.web.wiz.pairing;
 
 import inetsoft.report.composition.*;
+import inetsoft.uql.XPrincipal;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -115,6 +116,75 @@ class SheetRuntimeAccessTest {
       assertThrows(PairingException.class,
          () -> access(wsMock, vsMock)
             .getSheetForPairing(SheetType.VIEWSHEET, "VS/GONE", ALICE));
+   }
+
+   // ------------------------------------------------------- paired-agent ownership bypass
+
+   /**
+    * A paired agent must be able to MUTATE the runtime, not only read it.
+    *
+    * <p>The pairing path resolves the sheet here, bypassing the owner check deliberately. But a
+    * wiz service that delegates to a composer service hands it {@code runtimeId} + the agent
+    * principal, and that service re-resolves through {@code WorksheetEngine.getSheet}, which
+    * enforces {@code rs.matches(user)} — full {@code Principal} equality, session id included. The
+    * agent principal is rebuilt from the JWT and the owner is the browser-session principal, so
+    * they are never equal objects and every write failed with {@code InvalidUserException} while
+    * every read succeeded.
+    *
+    * <p>Marking the principal here — after confirming the runtime's owner is the same logical
+    * user — lets {@code getSheet} accept it, mirroring the {@code supportLogin} hatch. Found live
+    * on local-1193, not by unit test.
+    */
+   @Test
+   void marksTheAgentPrincipalWhenTheRuntimeOwnerIsTheSameLogicalUser() throws Exception {
+      SheetDirectAccessor wsMock = mock(SheetDirectAccessor.class);
+      SheetDirectAccessor vsMock = mock(SheetDirectAccessor.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      // a DIFFERENT principal object for the same logical user — the browser session
+      when(rvs.getUser()).thenReturn(TestPrincipals.user("alice", "org"));
+      when(vsMock.getSheetDirect("VS/456")).thenReturn(rvs);
+
+      Principal agent = TestPrincipals.user("alice", "org");
+      access(wsMock, vsMock).getSheetForPairing(SheetType.VIEWSHEET, "VS/456", agent);
+
+      assertEquals("true", ((XPrincipal) agent).getProperty("pairedAgent"),
+                   "a paired agent must be allowed to mutate a runtime its own login opened " +
+                   "in another session");
+   }
+
+   /** The bypass is granted only to the owner's own logical user — never to anyone else. */
+   @Test
+   void refusesToMarkWhenTheRuntimeBelongsToADifferentUser() {
+      SheetDirectAccessor wsMock = mock(SheetDirectAccessor.class);
+      SheetDirectAccessor vsMock = mock(SheetDirectAccessor.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getUser()).thenReturn(TestPrincipals.user("bob", "org"));
+      when(vsMock.getSheetDirect("VS/456")).thenReturn(rvs);
+
+      Principal agent = TestPrincipals.user("alice", "org");
+
+      assertThrows(PairingException.class,
+         () -> access(wsMock, vsMock).getSheetForPairing(SheetType.VIEWSHEET, "VS/456", agent));
+      assertNull(((XPrincipal) agent).getProperty("pairedAgent"),
+                 "a rejected agent must not carry the bypass flag");
+   }
+
+   /**
+    * A null owner cannot be verified, so no bypass is granted. Harmless: {@code getSheet} only
+    * enforces ownership when {@code rs.getUser() != null}, so there is nothing to bypass.
+    */
+   @Test
+   void doesNotMarkWhenTheRuntimeHasNoOwner() throws Exception {
+      SheetDirectAccessor wsMock = mock(SheetDirectAccessor.class);
+      SheetDirectAccessor vsMock = mock(SheetDirectAccessor.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getUser()).thenReturn(null);
+      when(vsMock.getSheetDirect("VS/456")).thenReturn(rvs);
+
+      Principal agent = TestPrincipals.user("alice", "org");
+      access(wsMock, vsMock).getSheetForPairing(SheetType.VIEWSHEET, "VS/456", agent);
+
+      assertNull(((XPrincipal) agent).getProperty("pairedAgent"));
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/pairing/SheetRuntimeAccessTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/pairing/SheetRuntimeAccessTest.java
@@ -187,6 +187,45 @@ class SheetRuntimeAccessTest {
       assertNull(((XPrincipal) agent).getProperty("pairedAgent"));
    }
 
+   /**
+    * Some wiz services never resolve the sheet — they take {@code runtimeId} from the session and
+    * hand it straight to a composer service, which re-resolves it and enforces ownership. Those
+    * paths need the same bypass, so it must be grantable from the id alone.
+    *
+    * <p>Missed by the first version of this fix, which only marked inside
+    * {@code getSheetForPairing}: chart region properties then still failed while chart aesthetics
+    * worked, because only the latter resolves the sheet. Found live on local-1195.
+    */
+   @Test
+   void grantsTheBypassFromARuntimeIdAloneWithoutResolvingTheSheet() throws Exception {
+      SheetDirectAccessor wsMock = mock(SheetDirectAccessor.class);
+      SheetDirectAccessor vsMock = mock(SheetDirectAccessor.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getUser()).thenReturn(TestPrincipals.user("alice", "org"));
+      when(vsMock.getSheetDirect("VS/456")).thenReturn(rvs);
+
+      Principal agent = TestPrincipals.user("alice", "org");
+      access(wsMock, vsMock).grantOwnershipBypass(SheetType.VIEWSHEET, "VS/456", agent);
+
+      assertEquals("true", ((XPrincipal) agent).getProperty("pairedAgent"));
+   }
+
+   @Test
+   void refusesToGrantFromARuntimeIdOwnedByADifferentUser() {
+      SheetDirectAccessor wsMock = mock(SheetDirectAccessor.class);
+      SheetDirectAccessor vsMock = mock(SheetDirectAccessor.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getUser()).thenReturn(TestPrincipals.user("bob", "org"));
+      when(vsMock.getSheetDirect("VS/456")).thenReturn(rvs);
+
+      Principal agent = TestPrincipals.user("alice", "org");
+
+      assertThrows(PairingException.class,
+         () -> access(wsMock, vsMock)
+            .grantOwnershipBypass(SheetType.VIEWSHEET, "VS/456", agent));
+      assertNull(((XPrincipal) agent).getProperty("pairedAgent"));
+   }
+
    @Test
    void wrongTypeForViewsheetThrowsPairingException() {
       SheetDirectAccessor wsMock = mock(SheetDirectAccessor.class);

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AnnotationFamilyTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AnnotationFamilyTest.java
@@ -1,0 +1,114 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.internal.AnnotationRectangleVSAssemblyInfo;
+import inetsoft.uql.viewsheet.internal.AnnotationVSAssemblyInfo;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class AnnotationFamilyTest {
+   /**
+    * The infos are mocked rather than constructed: {@code VSAssemblyInfo}'s constructor reads
+    * {@code SreeEnv}, which needs a Spring context these unit tests deliberately do without.
+    */
+   private static AnnotationVSAssembly annotation(String line, String rectangle) {
+      AnnotationVSAssemblyInfo info = mock(AnnotationVSAssemblyInfo.class);
+      when(info.getLine()).thenReturn(line);
+      when(info.getRectangle()).thenReturn(rectangle);
+      AnnotationVSAssembly assembly = mock(AnnotationVSAssembly.class);
+      when(assembly.getVSAssemblyInfo()).thenReturn(info);
+      return assembly;
+   }
+
+   @Test
+   void recognizesAllThreeParts() {
+      assertTrue(AnnotationFamily.isPart(mock(AnnotationVSAssembly.class)));
+      assertTrue(AnnotationFamily.isPart(mock(AnnotationLineVSAssembly.class)));
+      assertTrue(AnnotationFamily.isPart(mock(AnnotationRectangleVSAssembly.class)));
+   }
+
+   @Test
+   void doesNotClaimAnUnrelatedAssembly() {
+      assertFalse(AnnotationFamily.isPart(mock(TextVSAssembly.class)));
+      assertFalse(AnnotationFamily.isSubordinatePart(mock(TextVSAssembly.class)));
+   }
+
+   /** The annotation itself stays in the flat listing; only its line and rectangle fold in. */
+   @Test
+   void treatsOnlyTheLineAndRectangleAsSubordinate() {
+      assertFalse(AnnotationFamily.isSubordinatePart(mock(AnnotationVSAssembly.class)));
+      assertTrue(AnnotationFamily.isSubordinatePart(mock(AnnotationLineVSAssembly.class)));
+      assertTrue(AnnotationFamily.isSubordinatePart(mock(AnnotationRectangleVSAssembly.class)));
+   }
+
+   @Test
+   void namesThePartsAnAnnotationOwns() {
+      List<String> parts = AnnotationFamily.partsOf(annotation("Line1", "Rect1"));
+
+      assertEquals(List.of("Line1", "Rect1"), parts);
+   }
+
+   @Test
+   void reportsNoPartsForAnUnrelatedAssembly() {
+      assertTrue(AnnotationFamily.partsOf(mock(TextVSAssembly.class)).isEmpty());
+   }
+
+   @Test
+   void toleratesAnAnnotationMissingAPartRatherThanEmittingNull() {
+      assertEquals(List.of("Rect1"), AnnotationFamily.partsOf(annotation(null, "Rect1")));
+   }
+
+   @Test
+   void readsTheContentFromTheRectangleWhereItActuallyLives() {
+      AnnotationRectangleVSAssemblyInfo rectInfo = mock(AnnotationRectangleVSAssemblyInfo.class);
+      when(rectInfo.getContent()).thenReturn("<p>Check this spike</p>");
+      AnnotationRectangleVSAssembly rectangle = mock(AnnotationRectangleVSAssembly.class);
+      when(rectangle.getVSAssemblyInfo()).thenReturn(rectInfo);
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssembly("Rect1")).thenReturn(rectangle);
+
+      assertEquals("<p>Check this spike</p>",
+                   AnnotationFamily.contentOf(vs, annotation("Line1", "Rect1")));
+   }
+
+   @Test
+   void reportsNoContentWhenTheRectangleIsMissing() {
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssembly(anyString())).thenReturn(null);
+
+      assertNull(AnnotationFamily.contentOf(vs, annotation("Line1", "Rect1")));
+   }
+
+   @Test
+   void theRemovalRefusalExplainsTheOrphaning() {
+      Exception thrown = AnnotationFamily.removeRefusal("Rect1");
+
+      assertTrue(thrown.getMessage().contains("Rect1"));
+      assertTrue(thrown.getMessage().contains("orphan"),
+                 "the refusal has to say why, or it reads as an arbitrary restriction");
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyConditionServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyConditionServiceTest.java
@@ -1,0 +1,246 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.binding.drm.DataRefModel;
+import inetsoft.web.composer.model.condition.ConditionModel;
+import inetsoft.web.composer.model.condition.JunctionOperatorModel;
+import inetsoft.web.composer.model.vs.VSConditionDialogModel;
+import inetsoft.web.composer.vs.dialog.VSConditionDialogService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class AssemblyConditionServiceTest {
+   private static DataRefModel field(String name) {
+      DataRefModel field = mock(DataRefModel.class);
+      when(field.getName()).thenReturn(name);
+      return field;
+   }
+
+   private static VSConditionDialogModel model() {
+      VSConditionDialogModel model = new VSConditionDialogModel();
+      model.setTableName("Orders");
+      model.setFields(new DataRefModel[]{ field("Region"), field("Revenue") });
+      return model;
+   }
+
+   private static ConditionVocabulary.Clause clause(String f, String op, List<Object> v,
+                                                    String junction)
+   {
+      return new ConditionVocabulary.Clause(f, op, v, junction, false);
+   }
+
+   @Test
+   void writesTheAlternatingArrayIntoTheModelItRead() throws Exception {
+      Harness h = harness(model());
+
+      int applied = h.service.set("tok", principal(), "Chart1",
+                                  List.of(clause("Region", "one_of", List.of("East"), "and"),
+                                          clause("Revenue", ">", List.of(1000), null)), "");
+
+      assertEquals(2, applied);
+      VSConditionDialogModel posted = capture(h.conditions);
+      assertEquals(3, posted.getConditionList().length);
+      assertInstanceOf(ConditionModel.class, posted.getConditionList()[0]);
+      assertInstanceOf(JunctionOperatorModel.class, posted.getConditionList()[1]);
+   }
+
+   /** tableName and fields are model state no caller supplies; losing them breaks the dialog. */
+   @Test
+   void preservesTheModelStateTheCallerNeverSupplies() throws Exception {
+      Harness h = harness(model());
+
+      h.service.set("tok", principal(), "Chart1",
+                    List.of(clause("Region", "equals", List.of("East"), null)), "");
+
+      VSConditionDialogModel posted = capture(h.conditions);
+      assertEquals("Orders", posted.getTableName());
+      assertEquals(2, posted.getFields().length);
+   }
+
+   @Test
+   void eachWriteIsExactlyOneCheckpoint() throws Exception {
+      Harness h = harness(model());
+
+      h.service.set("tok", principal(), "Chart1",
+                    List.of(clause("Region", "equals", List.of("East"), null)), "");
+
+      verify(h.sessions, times(1)).mutate(anyString(), any(Principal.class), any());
+   }
+
+   @Test
+   void clearingWritesAnEmptyArray() throws Exception {
+      Harness h = harness(model());
+
+      h.service.clear("tok", principal(), "Chart1", "");
+
+      assertEquals(0, capture(h.conditions).getConditionList().length);
+   }
+
+   @Test
+   void validatesFieldsAgainstTheModelSoAnUnknownColumnNeverReachesTheBackend() {
+      Harness h = harness(model());
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> h.service.set("tok", principal(), "Chart1",
+                             List.of(clause("Profit", "equals", List.of(1), null)), ""));
+
+      assertTrue(thrown.getMessage().contains("Profit"));
+      assertTrue(thrown.getMessage().contains("Region"));
+   }
+
+   @Test
+   void refusesAnAssemblyWithNoConditionDialog() {
+      Harness h = harness(null);
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> h.service.set("tok", principal(), "Text1",
+                             List.of(clause("Region", "equals", List.of(1), null)), ""));
+
+      assertTrue(thrown.getMessage().contains("Text1"));
+      assertTrue(thrown.getMessage().contains("filtered"));
+   }
+
+   // ── the read side ─────────────────────────────────────────────────────────
+
+   @Test
+   void readsConditionsBackInTheFlatVocabularyWithACount() throws Exception {
+      VSConditionDialogModel existing = model();
+      existing.setConditionList(ConditionVocabulary.toConditionList(
+         List.of(clause("Region", "one_of", List.of("East"), "and"),
+                 clause("Revenue", ">", List.of(1), null)),
+         existing.getFields()));
+      Harness h = harness(existing);
+
+      Map<String, Object> read = h.service.read("tok", principal(), "Chart1");
+
+      assertEquals(2, read.get("conditionCount"));
+      assertEquals(List.of("Region", "Revenue"), read.get("fields"));
+      verify(h.sessions, never()).mutate(anyString(), any(Principal.class), any());
+   }
+
+   @Test
+   void readsAnAssemblyWithNoDialogAsUnfiltered() throws Exception {
+      Map<String, Object> read = harness(null).service.read("tok", principal(), "Text1");
+
+      assertEquals(List.of(), read.get("conditions"));
+   }
+
+   // ── value browsing ────────────────────────────────────────────────────────
+
+   @Test
+   void resolvesTheColumnToItsRefBeforeBrowsing() throws Exception {
+      Harness h = harness(model());
+
+      h.service.browseValues("tok", principal(), "Chart1", "Region");
+
+      ArgumentCaptor<DataRefModel> captor = ArgumentCaptor.forClass(DataRefModel.class);
+      verify(h.conditions).browseData(eq("rt1"), eq("Orders"), eq("Chart1"), eq(false),
+                                      captor.capture(), any(Principal.class));
+      assertEquals("Region", captor.getValue().getName());
+   }
+
+   /**
+    * Browsing an unknown column returns nothing, which reads as "this column has no values"
+    * rather than "you named it wrong".
+    */
+   @Test
+   void refusesToBrowseAnUnknownColumn() throws Exception {
+      Harness h = harness(model());
+
+      Exception thrown = assertThrows(
+         Exception.class, () -> h.service.browseValues("tok", principal(), "Chart1", "Profit"));
+
+      assertTrue(thrown.getMessage().contains("Profit"));
+      assertTrue(thrown.getMessage().contains("Region"));
+      verify(h.conditions, never()).browseData(anyString(), any(), anyString(), any(), any(),
+                                               any(Principal.class));
+   }
+
+   @Test
+   void refusesToBrowseWithNoColumn() {
+      Harness h = harness(model());
+
+      assertThrows(Exception.class,
+                   () -> h.service.browseValues("tok", principal(), "Chart1", "  "));
+   }
+
+   @Test
+   void vocabularyComesFromTheSharedConditionVocabulary() {
+      assertEquals(ConditionVocabulary.vocabulary().get("operators"),
+                   harness(model()).service.vocabulary().get("operators"));
+   }
+
+   // ── harness ───────────────────────────────────────────────────────────────
+
+   private record Harness(AssemblyConditionService service, ViewsheetSessionService sessions,
+                          VSConditionDialogService conditions) {}
+
+   private static VSConditionDialogModel capture(VSConditionDialogService conditions)
+      throws Exception
+   {
+      ArgumentCaptor<VSConditionDialogModel> captor =
+         ArgumentCaptor.forClass(VSConditionDialogModel.class);
+      verify(conditions).setModel(eq("rt1"), anyString(), captor.capture(), anyString(),
+                                  any(Principal.class), any());
+      return captor.getValue();
+   }
+
+   private static Harness harness(VSConditionDialogModel model) {
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(mock(Viewsheet.class));
+      when(rvs.getID()).thenReturn("rt1");
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      VSConditionDialogService conditions = mock(VSConditionDialogService.class);
+
+      try {
+         when(sessions.resolve(anyString(), any(Principal.class))).thenReturn(rvs);
+         doAnswer(invocation -> {
+            ViewsheetSessionService.Mutation mutation = invocation.getArgument(2);
+            mutation.run(rvs, "rt1", null);
+            return null;
+         }).when(sessions).mutate(anyString(), any(Principal.class), any());
+         when(conditions.getModel(anyString(), anyString(), any(Principal.class)))
+            .thenReturn(model);
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(e);
+      }
+
+      return new Harness(new AssemblyConditionService(sessions, conditions), sessions, conditions);
+   }
+
+   private static Principal principal() {
+      return () -> "admin";
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightServiceTest.java
@@ -1,0 +1,318 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.binding.drm.DataRefModel;
+import inetsoft.web.composer.model.vs.HighlightDialogModel;
+import inetsoft.web.composer.model.vs.HighlightModel;
+import inetsoft.web.composer.vs.dialog.HighlightDialogService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class AssemblyHighlightServiceTest {
+   private static DataRefModel field(String name) {
+      DataRefModel field = mock(DataRefModel.class);
+      when(field.getName()).thenReturn(name);
+      return field;
+   }
+
+   private static HighlightDialogModel model(HighlightModel... existing) {
+      HighlightDialogModel model = new HighlightDialogModel();
+      model.setFields(new DataRefModel[]{ field("Region"), field("Revenue") });
+      model.setTableName("Orders");
+      model.setHighlights(existing);
+      return model;
+   }
+
+   private static HighlightModel existing(String name) {
+      HighlightModel highlight = new HighlightModel();
+      highlight.setName(name);
+      highlight.setBackground("#FF0000");
+      return highlight;
+   }
+
+   private static AssemblyHighlightService.Highlight highlight(String name) {
+      return new AssemblyHighlightService.Highlight(
+         name, null, "#ff0000",
+         List.of(new ConditionVocabulary.Clause("Revenue", ">", List.of(1000), null, false)),
+         false);
+   }
+
+   @Test
+   void addsAHighlightWithItsConditionBuiltByTheSharedVocabulary() throws Exception {
+      Harness h = harness(model());
+
+      h.service.set("tok", principal(), "Table1", null, highlight("HighRevenue"), false, "");
+
+      HighlightDialogModel posted = capture(h.highlights);
+      assertEquals(1, posted.getHighlights().length);
+      HighlightModel added = posted.getHighlights()[0];
+      assertEquals("HighRevenue", added.getName());
+      assertEquals("#FF0000", added.getBackground(), "colours normalize to #RRGGBB");
+      assertNotNull(added.getVsConditionDialogModel());
+      assertEquals(1, added.getVsConditionDialogModel().getConditionList().length);
+   }
+
+   @Test
+   void carriesTheDialogsTableAndFieldsIntoTheEmbeddedCondition() throws Exception {
+      Harness h = harness(model());
+
+      h.service.set("tok", principal(), "Table1", null, highlight("HighRevenue"), false, "");
+
+      HighlightModel added = capture(h.highlights).getHighlights()[0];
+      assertEquals("Orders", added.getVsConditionDialogModel().getTableName());
+      assertEquals(2, added.getVsConditionDialogModel().getFields().length);
+   }
+
+   @Test
+   void keepsExistingHighlightsWhenAddingANewOne() throws Exception {
+      Harness h = harness(model(existing("Old")));
+
+      h.service.set("tok", principal(), "Table1", null, highlight("New"), false, "");
+
+      assertEquals(2, capture(h.highlights).getHighlights().length);
+   }
+
+   /**
+    * A duplicate name silently replaces an existing highlight, which is what
+    * usedHighlightNames exists to prevent. Overwriting has to be asked for.
+    */
+   @Test
+   void refusesADuplicateNameUnlessReplaceWasAskedFor() {
+      Harness h = harness(model(existing("HighRevenue")));
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> h.service.set("tok", principal(), "Table1", null, highlight("HighRevenue"), false,
+                             ""));
+
+      assertTrue(thrown.getMessage().contains("HighRevenue"));
+      assertTrue(thrown.getMessage().contains("replace:true"));
+   }
+
+   @Test
+   void replacesInPlaceWhenAsked() throws Exception {
+      Harness h = harness(model(existing("HighRevenue"), existing("Other")));
+
+      h.service.set("tok", principal(), "Table1", null, highlight("HighRevenue"), true, "");
+
+      HighlightDialogModel posted = capture(h.highlights);
+      assertEquals(2, posted.getHighlights().length, "replacing must not add a second entry");
+      assertNotNull(posted.getHighlights()[0].getVsConditionDialogModel(),
+                    "the replaced one is the rebuilt highlight, in its original position");
+   }
+
+   @Test
+   void matchesAnExistingNameCaseInsensitively() {
+      Harness h = harness(model(existing("HighRevenue")));
+
+      assertThrows(Exception.class,
+                   () -> h.service.set("tok", principal(), "Table1", null,
+                                       highlight("highrevenue"), false, ""));
+   }
+
+   // ── refusals ──────────────────────────────────────────────────────────────
+
+   @Test
+   void refusesAHighlightWithNoName() {
+      Harness h = harness(model());
+
+      assertThrows(Exception.class,
+                   () -> h.service.set("tok", principal(), "Table1", null, highlight("  "), false,
+                                       ""));
+   }
+
+   /** A highlight with no colour is stored and renders nothing — indistinguishable from a
+    * condition that never matched. */
+   @Test
+   void refusesAHighlightThatSetsNoColour() {
+      Harness h = harness(model());
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> h.service.set("tok", principal(), "Table1", null,
+                             new AssemblyHighlightService.Highlight("Nothing", null, null,
+                                                                    List.of(), false),
+                             false, ""));
+
+      assertTrue(thrown.getMessage().contains("colour"));
+   }
+
+   @Test
+   void refusesAConditionOnAFieldTheAssemblyDoesNotHave() {
+      Harness h = harness(model());
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> h.service.set("tok", principal(), "Table1", null,
+                             new AssemblyHighlightService.Highlight(
+                                "Bad", null, "#fff",
+                                List.of(new ConditionVocabulary.Clause("Profit", ">",
+                                                                       List.of(1), null, false)),
+                                false),
+                             false, ""));
+
+      assertTrue(thrown.getMessage().contains("Profit"));
+   }
+
+   @Test
+   void refusesAnAssemblyWithNoHighlightDialog() {
+      Harness h = harness(null);
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> h.service.set("tok", principal(), "Text1", null, highlight("X"), false, ""));
+
+      assertTrue(thrown.getMessage().contains("Text1"));
+   }
+
+   // ── delete ────────────────────────────────────────────────────────────────
+
+   @Test
+   void deletesByName() throws Exception {
+      Harness h = harness(model(existing("Old"), existing("Keep")));
+
+      h.service.delete("tok", principal(), "Table1", null, "Old", "");
+
+      HighlightDialogModel posted = capture(h.highlights);
+      assertEquals(1, posted.getHighlights().length);
+      assertEquals("Keep", posted.getHighlights()[0].getName());
+   }
+
+   @Test
+   void deletingSomethingAbsentIsAnErrorNotANoOp() {
+      Harness h = harness(model(existing("Keep")));
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> h.service.delete("tok", principal(), "Table1", null, "Nope", ""));
+
+      assertTrue(thrown.getMessage().contains("Nope"));
+      assertTrue(thrown.getMessage().contains("Keep"), "list what is actually there");
+   }
+
+   @Test
+   void deletingNeedsAName() {
+      Harness h = harness(model());
+
+      assertThrows(Exception.class,
+                   () -> h.service.delete("tok", principal(), "Table1", null, null, ""));
+   }
+
+   // ── read ──────────────────────────────────────────────────────────────────
+
+   @Test
+   void listsHighlightsWithTheirConditionsAndUsedNames() throws Exception {
+      HighlightDialogModel existing = model();
+      existing.setUsedHighlightNames(new String[]{ "Taken" });
+      Harness h = harness(existing);
+      h.service.set("tok", principal(), "Table1", null, highlight("HighRevenue"), false, "");
+      HighlightDialogModel posted = capture(h.highlights);
+      when(h.highlights.getHighlightDialogModel(anyString(), anyString(), any(), any(), any(),
+                                                anyBoolean(), anyBoolean(), any(Principal.class)))
+         .thenReturn(posted);
+
+      Map<String, Object> listed = h.service.list("tok", principal(), "Table1", null);
+
+      @SuppressWarnings("unchecked")
+      List<Map<String, Object>> highlights =
+         (List<Map<String, Object>>) listed.get("highlights");
+      assertEquals("HighRevenue", highlights.get(0).get("name"));
+      assertEquals(1, ((List<?>) highlights.get(0).get("conditions")).size());
+      assertEquals(List.of("Taken"), listed.get("usedNames"));
+   }
+
+   @Test
+   void passesARegionThrough() throws Exception {
+      Harness h = harness(model());
+
+      h.service.list("tok", principal(), "Table1",
+                     new AssemblyHighlightService.Region(2, 1, "Sales", false, false));
+
+      verify(h.highlights).getHighlightDialogModel(eq("rt1"), eq("Table1"), eq(2), eq(1),
+                                                   eq("Sales"), eq(false), eq(false),
+                                                   any(Principal.class));
+   }
+
+   @Test
+   void eachWriteIsOneCheckpoint() throws Exception {
+      Harness h = harness(model());
+
+      h.service.set("tok", principal(), "Table1", null, highlight("X"), false, "");
+
+      verify(h.sessions, times(1)).mutate(anyString(), any(Principal.class), any());
+   }
+
+   // ── harness ───────────────────────────────────────────────────────────────
+
+   private record Harness(AssemblyHighlightService service, ViewsheetSessionService sessions,
+                          HighlightDialogService highlights) {}
+
+   private static HighlightDialogModel capture(HighlightDialogService highlights)
+      throws Exception
+   {
+      ArgumentCaptor<HighlightDialogModel> captor =
+         ArgumentCaptor.forClass(HighlightDialogModel.class);
+      verify(highlights).setHighlightDialogModel(eq("rt1"), anyString(), captor.capture(),
+                                                 anyString(), any(Principal.class), any());
+      return captor.getValue();
+   }
+
+   private static Harness harness(HighlightDialogModel model) {
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(mock(Viewsheet.class));
+      when(rvs.getID()).thenReturn("rt1");
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      HighlightDialogService highlights = mock(HighlightDialogService.class);
+
+      try {
+         when(sessions.resolve(anyString(), any(Principal.class))).thenReturn(rvs);
+         doAnswer(invocation -> {
+            ViewsheetSessionService.Mutation mutation = invocation.getArgument(2);
+            mutation.run(rvs, "rt1", null);
+            return null;
+         }).when(sessions).mutate(anyString(), any(Principal.class), any());
+         when(highlights.getHighlightDialogModel(anyString(), anyString(), any(), any(), any(),
+                                                 anyBoolean(), anyBoolean(),
+                                                 any(Principal.class)))
+            .thenReturn(model);
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(e);
+      }
+
+      return new Harness(new AssemblyHighlightService(sessions, highlights), sessions, highlights);
+   }
+
+   private static Principal principal() {
+      return () -> "admin";
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightServiceTest.java
@@ -249,6 +249,44 @@ class AssemblyHighlightServiceTest {
       assertEquals(List.of("Taken"), listed.get("usedNames"));
    }
 
+   /**
+    * Addressing the whole assembly means row/col <b>0</b>, not null.
+    *
+    * <p>For a table-type assembly {@code HighlightDialogService.getHighlightDialogModel} calls
+    * {@code lens.getTableDataPath(row, col)}, which NPEs on null — so list_highlights and
+    * set_highlight were unusable on every table, crosstab and calc table, while working fine on a
+    * chart (which never enters that branch). Zero is what the rest of that same method already
+    * assumes: a few lines later it reads {@code row == null ? 0 : row}.
+    */
+   @Test
+   void addressesTheWholeAssemblyWithZerosBecauseTableLookupNPEsOnNull() throws Exception {
+      Harness h = harness(model());
+
+      h.service.list("tok", principal(), "Table1", null);
+
+      verify(h.highlights).getHighlightDialogModel(eq("rt1"), eq("Table1"), eq(0), eq(0),
+                                                   isNull(), eq(false), eq(false),
+                                                   any(Principal.class));
+   }
+
+   /**
+    * The controller builds a Region straight from its nullable {@code @RequestParam}s rather than
+    * calling {@link AssemblyHighlightService.Region#whole()}, so normalizing only in the factory
+    * left the live path still passing nulls — and still NPEing. The record itself must normalize,
+    * on every construction path.
+    */
+   @Test
+   void aRegionBuiltDirectlyWithNullsStillAddressesRowAndColZero() throws Exception {
+      Harness h = harness(model());
+
+      h.service.list("tok", principal(), "Table1",
+                     new AssemblyHighlightService.Region(null, null, null, false, false));
+
+      verify(h.highlights).getHighlightDialogModel(eq("rt1"), eq("Table1"), eq(0), eq(0),
+                                                   isNull(), eq(false), eq(false),
+                                                   any(Principal.class));
+   }
+
    @Test
    void passesARegionThrough() throws Exception {
       Harness h = harness(model());

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHyperlinkServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHyperlinkServiceTest.java
@@ -150,13 +150,43 @@ class AssemblyHyperlinkServiceTest {
 
    // ── region addressing ─────────────────────────────────────────────────────
 
+   /**
+    * Addressing the whole assembly means row/col <b>0</b>, not null.
+    *
+    * <p>{@code HyperlinkDialogService.getHyperlinkDialogModel} dereferences row as an int
+    * (via {@code getFields}), so nulls threw
+    * {@code NullPointerException: Cannot invoke "java.lang.Integer.intValue()" because "row" is
+    * null} for every assembly type — set_hyperlink was unusable at assembly level. The Composer
+    * never sends null: its controller declares
+    * {@code @RequestParam(value = "row", required = false, defaultValue = "0")}.
+    *
+    * <p>This test previously asserted {@code isNull(), isNull()} and so certified the crash.
+    */
    @Test
-   void addressesTheWholeAssemblyWhenNoRegionIsGiven() throws Exception {
+   void addressesTheWholeAssemblyWithZerosBecauseNullRowNPEs() throws Exception {
       Harness h = harness(new HyperlinkDialogModel());
 
       h.service.read("tok", principal(), "Chart1", null);
 
-      verify(h.links).getHyperlinkDialogModel(eq("rt1"), eq("Chart1"), isNull(), isNull(),
+      verify(h.links).getHyperlinkDialogModel(eq("rt1"), eq("Chart1"), eq(0), eq(0),
+                                              isNull(), eq(false), eq(false), eq(false),
+                                              eq(false), any(Principal.class));
+   }
+
+   /**
+    * The controller builds a Region straight from its nullable {@code @RequestParam}s rather than
+    * calling {@code Region.whole()}, so normalizing only in the factory left the live path still
+    * passing nulls — and still NPEing. The record itself must normalize.
+    */
+   @Test
+   void aRegionBuiltDirectlyWithNullsStillAddressesRowAndColZero() throws Exception {
+      Harness h = harness(new HyperlinkDialogModel());
+
+      h.service.read("tok", principal(), "Chart1",
+                     new AssemblyHyperlinkService.Region(null, null, null, false, false, false,
+                                                         false));
+
+      verify(h.links).getHyperlinkDialogModel(eq("rt1"), eq("Chart1"), eq(0), eq(0),
                                               isNull(), eq(false), eq(false), eq(false),
                                               eq(false), any(Principal.class));
    }
@@ -182,7 +212,10 @@ class AssemblyHyperlinkServiceTest {
                      new AssemblyHyperlinkService.Region(null, null, null, false, false, true,
                                                          false));
 
-      verify(h.links).getHyperlinkDialogModel(anyString(), anyString(), isNull(), isNull(),
+      // Row/col normalize to 0 here too: a title link addresses the assembly, and the dialog
+      // service dereferences them as ints whatever the region flags say. This previously
+      // asserted isNull(), isNull() — the values that NPE live.
+      verify(h.links).getHyperlinkDialogModel(anyString(), anyString(), eq(0), eq(0),
                                               isNull(), eq(false), eq(false), eq(true),
                                               eq(false), any(Principal.class));
    }

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHyperlinkServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHyperlinkServiceTest.java
@@ -1,0 +1,264 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.Hyperlink;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.composer.model.vs.HyperlinkDialogModel;
+import inetsoft.web.composer.vs.dialog.HyperlinkDialogService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.security.Principal;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class AssemblyHyperlinkServiceTest {
+   private static Map<String, Object> link(Object... pairs) {
+      Map<String, Object> link = new LinkedHashMap<>();
+
+      for(int i = 0; i < pairs.length; i += 2) {
+         link.put((String) pairs[i], pairs[i + 1]);
+      }
+
+      return link;
+   }
+
+   @Test
+   void setsAWebLink() throws Exception {
+      Harness h = harness(new HyperlinkDialogModel());
+
+      h.service.set("tok", principal(), "Chart1", null,
+                    link("linkType", "web", "webLink", "https://example.com"), "");
+
+      HyperlinkDialogModel posted = capture(h.links);
+      assertEquals(Hyperlink.WEB_LINK, posted.getLinkType());
+      assertEquals("https://example.com", posted.getWebLink());
+   }
+
+   @Test
+   void setsAViewsheetLink() throws Exception {
+      Harness h = harness(new HyperlinkDialogModel());
+
+      h.service.set("tok", principal(), "Chart1", null,
+                    link("linkType", "viewsheet", "assetLinkPath", "Reports/Detail"), "");
+
+      assertEquals(Hyperlink.VIEWSHEET_LINK, capture(h.links).getLinkType());
+   }
+
+   @Test
+   void eachWriteIsExactlyOneCheckpoint() throws Exception {
+      Harness h = harness(new HyperlinkDialogModel());
+
+      h.service.set("tok", principal(), "Chart1", null,
+                    link("linkType", "web", "webLink", "https://example.com"), "");
+
+      verify(h.sessions, times(1)).mutate(anyString(), any(Principal.class), any());
+   }
+
+   /** Clearing is its own type rather than an empty value, so intent is never inferred. */
+   @Test
+   void clearingALinkNeedsNoDestination() throws Exception {
+      HyperlinkDialogModel model = new HyperlinkDialogModel();
+      model.setWebLink("https://old.example.com");
+      Harness h = harness(model);
+
+      h.service.set("tok", principal(), "Chart1", null, link("linkType", "none"), "");
+
+      HyperlinkDialogModel posted = capture(h.links);
+      assertEquals(0, posted.getLinkType());
+      assertNull(posted.getWebLink(), "clearing the type must clear the destination with it");
+   }
+
+   /**
+    * A link with a type but no matching destination is accepted by the dialog and then does
+    * nothing when clicked, which reads as a broken report rather than a bad call.
+    */
+   @Test
+   void refusesAWebLinkWithNoUrl() {
+      Harness h = harness(new HyperlinkDialogModel());
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> h.service.set("tok", principal(), "Chart1", null, link("linkType", "web"), ""));
+
+      assertTrue(thrown.getMessage().contains("webLink"));
+   }
+
+   @Test
+   void refusesAViewsheetLinkWithNoPath() {
+      Harness h = harness(new HyperlinkDialogModel());
+
+      assertThrows(Exception.class,
+                   () -> h.service.set("tok", principal(), "Chart1", null,
+                                       link("linkType", "viewsheet"), ""));
+   }
+
+   @Test
+   void validatesBeforeTouchingTheRuntime() {
+      Harness h = harness(new HyperlinkDialogModel());
+
+      assertThrows(Exception.class,
+                   () -> h.service.set("tok", principal(), "Chart1", null,
+                                       link("linkType", "web"), ""));
+
+      verifyNoInteractions(h.sessions);
+   }
+
+   @Test
+   void refusesAnIntegerLinkTypeListingTheTokens() {
+      Harness h = harness(new HyperlinkDialogModel());
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> h.service.set("tok", principal(), "Chart1", null,
+                             link("linkType", 1, "webLink", "https://x"), ""));
+
+      assertTrue(thrown.getMessage().contains("web"));
+   }
+
+   @Test
+   void refusesAMissingLinkType() {
+      Harness h = harness(new HyperlinkDialogModel());
+
+      assertThrows(Exception.class,
+                   () -> h.service.set("tok", principal(), "Chart1", null,
+                                       link("webLink", "https://x"), ""));
+   }
+
+   // ── region addressing ─────────────────────────────────────────────────────
+
+   @Test
+   void addressesTheWholeAssemblyWhenNoRegionIsGiven() throws Exception {
+      Harness h = harness(new HyperlinkDialogModel());
+
+      h.service.read("tok", principal(), "Chart1", null);
+
+      verify(h.links).getHyperlinkDialogModel(eq("rt1"), eq("Chart1"), isNull(), isNull(),
+                                              isNull(), eq(false), eq(false), eq(false),
+                                              eq(false), any(Principal.class));
+   }
+
+   @Test
+   void passesARegionThrough() throws Exception {
+      Harness h = harness(new HyperlinkDialogModel());
+
+      h.service.read("tok", principal(), "Table1",
+                     new AssemblyHyperlinkService.Region(2, 1, "Sales", false, false, false,
+                                                         false));
+
+      verify(h.links).getHyperlinkDialogModel(eq("rt1"), eq("Table1"), eq(2), eq(1),
+                                              eq("Sales"), eq(false), eq(false), eq(false),
+                                              eq(false), any(Principal.class));
+   }
+
+   @Test
+   void addressesATitleLink() throws Exception {
+      Harness h = harness(new HyperlinkDialogModel());
+
+      h.service.read("tok", principal(), "Chart1",
+                     new AssemblyHyperlinkService.Region(null, null, null, false, false, true,
+                                                         false));
+
+      verify(h.links).getHyperlinkDialogModel(anyString(), anyString(), isNull(), isNull(),
+                                              isNull(), eq(false), eq(false), eq(true),
+                                              eq(false), any(Principal.class));
+   }
+
+   // ── the read direction ────────────────────────────────────────────────────
+
+   @Test
+   void readsBackATokenNeverAnInteger() throws Exception {
+      HyperlinkDialogModel model = new HyperlinkDialogModel();
+      model.setLinkType(Hyperlink.WEB_LINK);
+      model.setWebLink("https://example.com");
+
+      Map<String, Object> read = harness(model).service.read("tok", principal(), "Chart1", null);
+
+      assertEquals("web", read.get("linkType"));
+      assertEquals("https://example.com", read.get("webLink"));
+   }
+
+   @Test
+   void reportsAnUnrecognizedConstantAsItself() throws Exception {
+      HyperlinkDialogModel model = new HyperlinkDialogModel();
+      model.setLinkType(99);
+
+      Map<String, Object> read = harness(model).service.read("tok", principal(), "Chart1", null);
+
+      assertEquals("unknown(99)", read.get("linkType"));
+   }
+
+   @Test
+   void listsTheLinkTypesForDiscovery() {
+      Map<String, Object> types = harness(new HyperlinkDialogModel()).service.linkTypes();
+
+      assertTrue(String.valueOf(types.get("linkTypes")).contains("viewsheet"));
+   }
+
+   // ── harness ───────────────────────────────────────────────────────────────
+
+   private record Harness(AssemblyHyperlinkService service, ViewsheetSessionService sessions,
+                          HyperlinkDialogService links) {}
+
+   private static HyperlinkDialogModel capture(HyperlinkDialogService links) throws Exception {
+      ArgumentCaptor<HyperlinkDialogModel> captor =
+         ArgumentCaptor.forClass(HyperlinkDialogModel.class);
+      verify(links).setHyperlinkDialogModel(eq("rt1"), anyString(), captor.capture(),
+                                            anyString(), any(Principal.class), any());
+      return captor.getValue();
+   }
+
+   private static Harness harness(HyperlinkDialogModel model) {
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(mock(Viewsheet.class));
+      when(rvs.getID()).thenReturn("rt1");
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      HyperlinkDialogService links = mock(HyperlinkDialogService.class);
+
+      try {
+         when(sessions.resolve(anyString(), any(Principal.class))).thenReturn(rvs);
+         doAnswer(invocation -> {
+            ViewsheetSessionService.Mutation mutation = invocation.getArgument(2);
+            mutation.run(rvs, "rt1", null);
+            return null;
+         }).when(sessions).mutate(anyString(), any(Principal.class), any());
+         when(links.getHyperlinkDialogModel(anyString(), anyString(), any(), any(), any(),
+                                            anyBoolean(), anyBoolean(), anyBoolean(),
+                                            anyBoolean(), any(Principal.class)))
+            .thenReturn(model);
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(e);
+      }
+
+      return new Harness(new AssemblyHyperlinkService(sessions, links), sessions, links);
+   }
+
+   private static Principal principal() {
+      return () -> "admin";
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
@@ -1,0 +1,177 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.*;
+import inetsoft.web.composer.model.vs.GaugePropertyDialogModel;
+import inetsoft.web.composer.vs.dialog.GaugePropertyDialogService;
+import inetsoft.web.composer.vs.dialog.TextPropertyDialogService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class AssemblyPropertyServiceTest {
+   /**
+    * <b>The convention guard.</b> Dispatch is by method name rather than 25 hand-written
+    * bindings, so this asserts every wired service actually satisfies the convention. If the
+    * composer renames a method, this fails at build time instead of against a live viewsheet.
+    */
+   @Test
+   void everyWiredServiceSatisfiesTheNamingConvention() {
+      AssemblyPropertyService service = serviceWith(mock(GaugeVSAssembly.class), null);
+
+      for(Map.Entry<String, Object> wired : service.wiredServices().entrySet()) {
+         String type = wired.getKey();
+         String suffix = Character.toUpperCase(type.charAt(0)) + type.substring(1);
+
+         assertNotNull(
+            AssemblyPropertyService.method(
+               wired.getValue(), "get" + suffix + "PropertyDialogModel", 3),
+            type + "'s service has no 3-argument get" + suffix + "PropertyDialogModel");
+         assertNotNull(
+            AssemblyPropertyService.method(
+               wired.getValue(), "set" + suffix + "PropertyDialogModel", 6),
+            type + "'s service has no 6-argument set" + suffix + "PropertyDialogModel");
+      }
+   }
+
+   @Test
+   void everyCoveredTypeHasAWiredService() {
+      AssemblyPropertyService service = serviceWith(mock(GaugeVSAssembly.class), null);
+
+      for(String type : PropertyAliases.coveredTypes()) {
+         assertDoesNotThrow(() -> service.serviceFor(type),
+                            "'" + type + "' has aliases but no property service wired, so " +
+                            "every call for it would fail at runtime");
+      }
+   }
+
+   @Test
+   void listsTheAliasVocabularyWithCurrentValues() throws Exception {
+      GaugePropertyDialogModel model = new GaugePropertyDialogModel();
+      AssemblyPropertyService service = serviceWith(mock(GaugeVSAssembly.class), model);
+
+      Map<String, Object> listed = service.list("tok", principal(), "Gauge1");
+
+      assertEquals("gauge", listed.get("assemblyType"));
+      assertNotNull(listed.get("properties"));
+   }
+
+   @Test
+   void refusesAnUnknownAssembly() {
+      AssemblyPropertyService service = serviceWith(null, null);
+
+      Exception thrown = assertThrows(
+         Exception.class, () -> service.list("tok", principal(), "Nope"));
+
+      assertTrue(thrown.getMessage().contains("Nope"));
+   }
+
+   /** A type with no alias vocabulary yet must say so, not fail obscurely. */
+   @Test
+   void refusesAnUncoveredAssemblyTypeNamingWhatIsCovered() {
+      AssemblyPropertyService service = serviceWith(mock(SubmitVSAssembly.class), null);
+
+      Exception thrown = assertThrows(
+         Exception.class, () -> service.list("tok", principal(), "Submit1"));
+
+      assertTrue(thrown.getMessage().contains("Submit"));
+      assertTrue(thrown.getMessage().contains("gauge"));
+   }
+
+   @Test
+   void refusesAnEmptyPatchRatherThanOpeningACheckpointForNothing() {
+      AssemblyPropertyService service = serviceWith(mock(GaugeVSAssembly.class), null);
+
+      assertThrows(Exception.class,
+                   () -> service.set("tok", principal(), "Gauge1", Map.of(), ""));
+   }
+
+   /**
+    * A typo in the fourth key must not leave the first three applied — a partial edit the
+    * caller cannot detect from the error alone.
+    */
+   @Test
+   void appliesNothingWhenAnyKeyInThePatchIsBad() throws Exception {
+      GaugePropertyDialogModel model = new GaugePropertyDialogModel();
+      AssemblyPropertyService service = serviceWith(mock(GaugeVSAssembly.class), model);
+      Map<String, Object> patch = new LinkedHashMap<>();
+      patch.put("max", "100");
+      patch.put("nonsense", "x");
+
+      assertThrows(Exception.class,
+                   () -> service.set("tok", principal(), "Gauge1", patch, ""));
+
+      assertNull(model.getGaugeGeneralPaneModel() == null
+                    ? null : model.getGaugeGeneralPaneModel().getNumberRangePaneModel().getMax(),
+                 "the valid key must not have been written before the bad one was found");
+   }
+
+   // ── harness ───────────────────────────────────────────────────────────────
+
+   private static AssemblyPropertyService serviceWith(VSAssembly assembly, Object model) {
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssembly(anyString())).thenReturn(assembly);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(rvs.getID()).thenReturn("rt1");
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+
+      try {
+         when(sessions.resolve(anyString(), any(Principal.class))).thenReturn(rvs);
+         doAnswer(invocation -> {
+            ViewsheetSessionService.Mutation mutation = invocation.getArgument(2);
+            mutation.run(rvs, "rt1", null);
+            return null;
+         }).when(sessions).mutate(anyString(), any(Principal.class), any());
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(e);
+      }
+
+      GaugePropertyDialogService gauge = mock(GaugePropertyDialogService.class);
+
+      if(model instanceof GaugePropertyDialogModel gaugeModel) {
+         try {
+            when(gauge.getGaugePropertyDialogModel(anyString(), anyString(),
+                                                   any(Principal.class)))
+               .thenReturn(gaugeModel);
+         }
+         catch(Exception e) {
+            throw new IllegalStateException(e);
+         }
+      }
+
+      return new AssemblyPropertyService(sessions, gauge,
+                                         mock(TextPropertyDialogService.class));
+   }
+
+   private static Principal principal() {
+      return () -> "admin";
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
@@ -20,8 +20,7 @@ package inetsoft.web.wiz.viewsheet;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.web.composer.model.vs.GaugePropertyDialogModel;
-import inetsoft.web.composer.vs.dialog.GaugePropertyDialogService;
-import inetsoft.web.composer.vs.dialog.TextPropertyDialogService;
+import inetsoft.web.composer.vs.dialog.*;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -36,27 +35,45 @@ import static org.mockito.Mockito.*;
 @Tag("core")
 class AssemblyPropertyServiceTest {
    /**
-    * <b>The convention guard.</b> Dispatch is by method name rather than 25 hand-written
-    * bindings, so this asserts every wired service actually satisfies the convention. If the
-    * composer renames a method, this fails at build time instead of against a live viewsheet.
+    * <b>The binding guard.</b> Every binding names its two methods explicitly, because the
+    * convention they look like they follow does not hold — {@code setChartPropertyModel} has no
+    * "Dialog", {@code getTableViewPropertyDialogModel} has a "View" its setter does not, and the
+    * selection services drop "Dialog" from both. This resolves every declared name reflectively,
+    * so a composer rename fails the build rather than the first live call.
     */
    @Test
-   void everyWiredServiceSatisfiesTheNamingConvention() {
+   void everyDeclaredMethodNameResolvesOnItsService() {
       AssemblyPropertyService service = serviceWith(mock(GaugeVSAssembly.class), null);
 
-      for(Map.Entry<String, Object> wired : service.wiredServices().entrySet()) {
-         String type = wired.getKey();
-         String suffix = Character.toUpperCase(type.charAt(0)) + type.substring(1);
+      for(Map.Entry<String, AssemblyPropertyService.Binding> wired :
+          service.wiredBindings().entrySet())
+      {
+         AssemblyPropertyService.Binding binding = wired.getValue();
 
          assertNotNull(
-            AssemblyPropertyService.method(
-               wired.getValue(), "get" + suffix + "PropertyDialogModel", 3),
-            type + "'s service has no 3-argument get" + suffix + "PropertyDialogModel");
+            AssemblyPropertyService.method(binding.service(), binding.getter(), 3),
+            wired.getKey() + "'s service has no 3-argument " + binding.getter());
          assertNotNull(
-            AssemblyPropertyService.method(
-               wired.getValue(), "set" + suffix + "PropertyDialogModel", 6),
-            type + "'s service has no 6-argument set" + suffix + "PropertyDialogModel");
+            AssemblyPropertyService.method(binding.service(), binding.setter(), 6),
+            wired.getKey() + "'s service has no 6-argument " + binding.setter());
       }
+   }
+
+   /**
+    * The names really are irregular. If someone later "tidies" the bindings by deriving them
+    * from the type, this fails and says why.
+    */
+   @Test
+   void theMethodNamesAreNotDerivableFromTheAssemblyType() {
+      AssemblyPropertyService service = serviceWith(mock(GaugeVSAssembly.class), null);
+
+      assertEquals("setChartPropertyModel", service.bindingFor("chart").setter(),
+                   "chart's setter has no 'Dialog' — do not derive these names");
+      assertEquals("getTableViewPropertyDialogModel", service.bindingFor("table").getter(),
+                   "table's getter says TableView while its setter says Table");
+      assertEquals("getSelectionListPropertyModel",
+                   service.bindingFor("selectionlist").getter(),
+                   "the selection services drop 'Dialog' from both names");
    }
 
    @Test
@@ -64,7 +81,7 @@ class AssemblyPropertyServiceTest {
       AssemblyPropertyService service = serviceWith(mock(GaugeVSAssembly.class), null);
 
       for(String type : PropertyAliases.coveredTypes()) {
-         assertDoesNotThrow(() -> service.serviceFor(type),
+         assertDoesNotThrow(() -> service.bindingFor(type),
                             "'" + type + "' has aliases but no property service wired, so " +
                             "every call for it would fail at runtime");
       }
@@ -167,8 +184,12 @@ class AssemblyPropertyServiceTest {
          }
       }
 
-      return new AssemblyPropertyService(sessions, gauge,
-                                         mock(TextPropertyDialogService.class));
+      return new AssemblyPropertyService(
+         sessions, gauge, mock(TextPropertyDialogService.class),
+         mock(ChartPropertyDialogService.class), mock(TableViewPropertyDialogService.class),
+         mock(CrosstabPropertyDialogService.class),
+         mock(SelectionListPropertyDialogService.class),
+         mock(SelectionTreePropertyDialogService.class));
    }
 
    private static Principal principal() {

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
@@ -120,18 +120,27 @@ class AssemblyPropertyServiceTest {
    }
 
    /**
-    * An uncovered type must say so, not fail obscurely. Image is the case that matters:
-    * its dialog model is immutable, so it is uncovered by necessity rather than backlog.
+    * An uncovered type must say so, not fail obscurely.
+    *
+    * <p>This used to use <b>image</b>, which was uncovered "by necessity rather than backlog"
+    * because its dialog model is Immutables. That necessity is gone: PropertyPath now reads bare
+    * Immutables accessors and rebuilds immutable levels through {@code withX}, so image is wired
+    * and covered. An assembly type genuinely outside the registry is used instead.
     */
    @Test
    void refusesAnUncoveredAssemblyTypeNamingWhatIsCovered() {
-      AssemblyPropertyService service = serviceWith(mock(ImageVSAssembly.class), null);
+      AssemblyPropertyService service = serviceWith(mock(AnnotationVSAssembly.class), null);
 
       Exception thrown = assertThrows(
-         Exception.class, () -> service.list("tok", principal(), "Image1"));
+         Exception.class, () -> service.list("tok", principal(), "Annotation1"));
 
-      assertTrue(thrown.getMessage().contains("Image"));
-      assertTrue(thrown.getMessage().contains("gauge"));
+      assertTrue(thrown.getMessage().contains("gauge"), "name what is covered");
+   }
+
+   /** Image is covered now — the Immutables write path is what made it reachable. */
+   @Test
+   void coversTheImageAssembly() {
+      assertTrue(PropertyAliases.covers("image"));
    }
 
    @Test
@@ -199,7 +208,8 @@ class AssemblyPropertyServiceTest {
       }
 
       return new AssemblyPropertyService(
-         sessions, gauge, mock(TextPropertyDialogService.class),
+         sessions, gauge, mock(ImagePropertyDialogService.class),
+         mock(TextPropertyDialogService.class),
          mock(ChartPropertyDialogService.class), mock(TableViewPropertyDialogService.class),
          mock(CrosstabPropertyDialogService.class),
          mock(SelectionListPropertyDialogService.class),

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
@@ -51,8 +51,10 @@ class AssemblyPropertyServiceTest {
          AssemblyPropertyService.Binding binding = wired.getValue();
 
          assertNotNull(
-            AssemblyPropertyService.method(binding.service(), binding.getter(), 3),
-            wired.getKey() + "'s service has no 3-argument " + binding.getter());
+            AssemblyPropertyService.method(binding.service(), binding.getter(),
+                                           binding.getterArity()),
+            wired.getKey() + "'s service has no " + binding.getterArity() + "-argument " +
+            binding.getter());
          assertNotNull(
             AssemblyPropertyService.method(binding.service(), binding.setter(), 6),
             wired.getKey() + "'s service has no 6-argument " + binding.setter());
@@ -74,6 +76,15 @@ class AssemblyPropertyServiceTest {
       assertEquals("getSelectionListPropertyModel",
                    service.bindingFor("selectionlist").getter(),
                    "the selection services drop 'Dialog' from both names");
+   }
+
+   /** Calc table's getter takes a scroll offset, so the arity is not uniform either. */
+   @Test
+   void carriesTheExtraGetterArgumentCalcTableNeeds() {
+      AssemblyPropertyService service = serviceWith(mock(GaugeVSAssembly.class), null);
+
+      assertEquals(4, service.bindingFor("calctable").getterArity());
+      assertEquals(3, service.bindingFor("gauge").getterArity());
    }
 
    @Test
@@ -108,15 +119,18 @@ class AssemblyPropertyServiceTest {
       assertTrue(thrown.getMessage().contains("Nope"));
    }
 
-   /** A type with no alias vocabulary yet must say so, not fail obscurely. */
+   /**
+    * An uncovered type must say so, not fail obscurely. Image is the case that matters:
+    * its dialog model is immutable, so it is uncovered by necessity rather than backlog.
+    */
    @Test
    void refusesAnUncoveredAssemblyTypeNamingWhatIsCovered() {
-      AssemblyPropertyService service = serviceWith(mock(SubmitVSAssembly.class), null);
+      AssemblyPropertyService service = serviceWith(mock(ImageVSAssembly.class), null);
 
       Exception thrown = assertThrows(
-         Exception.class, () -> service.list("tok", principal(), "Submit1"));
+         Exception.class, () -> service.list("tok", principal(), "Image1"));
 
-      assertTrue(thrown.getMessage().contains("Submit"));
+      assertTrue(thrown.getMessage().contains("Image"));
       assertTrue(thrown.getMessage().contains("gauge"));
    }
 
@@ -189,7 +203,16 @@ class AssemblyPropertyServiceTest {
          mock(ChartPropertyDialogService.class), mock(TableViewPropertyDialogService.class),
          mock(CrosstabPropertyDialogService.class),
          mock(SelectionListPropertyDialogService.class),
-         mock(SelectionTreePropertyDialogService.class));
+         mock(SelectionTreePropertyDialogService.class),
+         mock(inetsoft.web.viewsheet.service.VSInputService.class),
+         mock(RangeSliderPropertyDialogService.class),
+         mock(CalendarPropertyDialogService.class), mock(TabPropertyDialogService.class),
+         mock(CalcTablePropertyDialogService.class),
+         mock(GroupContainerPropertyDialogService.class),
+         mock(LinePropertyDialogService.class), mock(OvalPropertyDialogService.class),
+         mock(RectanglePropertyDialogService.class),
+         mock(SelectionContainerPropertyDialogService.class),
+         mock(SubmitPropertyDialogService.class));
    }
 
    private static Principal principal() {

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartElementServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartElementServiceTest.java
@@ -1,0 +1,324 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.*;
+import inetsoft.web.viewsheet.controller.chart.*;
+import inetsoft.web.viewsheet.event.chart.*;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class ChartElementServiceTest {
+   /**
+    * <b>The construction guard.</b> These events declare no setters — only getters over private
+    * fields — so they are built with Jackson, the same way the STOMP layer builds them. If that
+    * ever stops landing values, every event would arrive all-default, and an all-default titles
+    * event means "show every title": it would silently un-hide titles the user had hidden. So
+    * this asserts the conversion works rather than trusting it.
+    */
+   @Test
+   void jacksonActuallyPopulatesTheSetterlessEvents() {
+      ObjectMapper mapper = new ObjectMapper();
+
+      VSChartTitlesVisibilityEvent titles = mapper.convertValue(
+         ChartElementService.titleFields("Chart1", "y", false),
+         VSChartTitlesVisibilityEvent.class);
+
+      assertEquals("Chart1", titles.getChartName(), "chartName comes from the superclass");
+      assertTrue(titles.isHide(), "a private boolean with no setter must still be populated");
+      assertEquals("y_title", titles.getTitleType());
+   }
+
+   @Test
+   void aDefaultTitlesEventWouldMeanShowEverything() {
+      VSChartTitlesVisibilityEvent empty = new ObjectMapper()
+         .convertValue(java.util.Map.of(), VSChartTitlesVisibilityEvent.class);
+
+      assertFalse(empty.isHide(),
+                  "hide defaults to false, which this event reads as show-all-titles — which " +
+                  "is why the construction guard above matters");
+   }
+
+   @Test
+   void hidesOneAxisByColumnName() throws Exception {
+      Harness h = harness(mock(ChartVSAssembly.class));
+
+      h.service.setVisibility("tok", principal(), "Chart1", "axis", "Region", false, "");
+
+      ArgumentCaptor<VSChartAxesVisibilityEvent> captor =
+         ArgumentCaptor.forClass(VSChartAxesVisibilityEvent.class);
+      verify(h.axes).eventHandler(eq("rt1"), captor.capture(), anyString(),
+                                  any(Principal.class), any());
+      assertEquals("Chart1", captor.getValue().getChartName());
+      assertEquals("Region", captor.getValue().getColumnName());
+      assertTrue(captor.getValue().isHide());
+   }
+
+   @Test
+   void showsAllAxes() throws Exception {
+      Harness h = harness(mock(ChartVSAssembly.class));
+
+      h.service.setVisibility("tok", principal(), "Chart1", "axis", null, true, "");
+
+      ArgumentCaptor<VSChartAxesVisibilityEvent> captor =
+         ArgumentCaptor.forClass(VSChartAxesVisibilityEvent.class);
+      verify(h.axes).eventHandler(eq("rt1"), captor.capture(), anyString(),
+                                  any(Principal.class), any());
+      assertFalse(captor.getValue().isHide());
+   }
+
+   @Test
+   void hidesOneLegendByField() throws Exception {
+      Harness h = harness(mock(ChartVSAssembly.class));
+
+      h.service.setVisibility("tok", principal(), "Chart1", "legend", "Category", false, "");
+
+      ArgumentCaptor<VSChartLegendsVisibilityEvent> captor =
+         ArgumentCaptor.forClass(VSChartLegendsVisibilityEvent.class);
+      verify(h.legends).eventHandler(eq("rt1"), captor.capture(), anyString(),
+                                     any(Principal.class), any());
+      assertEquals("Category", captor.getValue().getField());
+      assertTrue(captor.getValue().isHide());
+   }
+
+   // ── the titles footgun ────────────────────────────────────────────────────
+
+   @Test
+   void hidesAnAxisTitleWithTheDescriptorToken() throws Exception {
+      Harness h = harness(mock(ChartVSAssembly.class));
+
+      h.service.setVisibility("tok", principal(), "Chart1", "title", "y", false, "");
+
+      VSChartTitlesVisibilityEvent event = captureTitle(h);
+      assertEquals("y_title", event.getTitleType());
+      assertTrue(event.isHide());
+   }
+
+   /**
+    * The event expresses "show the chart title" as {@code hide=true} plus a special token. An
+    * agent that set {@code hide=false} would show every title instead, including ones the user
+    * had deliberately hidden.
+    */
+   @Test
+   void showsTheChartTitleThroughTheEventsOwnSpecialCase() throws Exception {
+      Harness h = harness(mock(ChartVSAssembly.class));
+
+      h.service.setVisibility("tok", principal(), "Chart1", "title", "chart", true, "");
+
+      VSChartTitlesVisibilityEvent event = captureTitle(h);
+      assertTrue(event.isHide(), "hide=true is how this event says 'show the chart title'");
+      assertEquals("chart-title-true", event.getTitleType());
+   }
+
+   @Test
+   void hidesTheChartTitle() throws Exception {
+      Harness h = harness(mock(ChartVSAssembly.class));
+
+      h.service.setVisibility("tok", principal(), "Chart1", "title", "chart", false, "");
+
+      VSChartTitlesVisibilityEvent event = captureTitle(h);
+      assertEquals("chart-title", event.getTitleType());
+   }
+
+   @Test
+   void showsAllTitlesOnlyWhenNoTargetWasNamed() throws Exception {
+      Harness h = harness(mock(ChartVSAssembly.class));
+
+      h.service.setVisibility("tok", principal(), "Chart1", "title", null, true, "");
+
+      assertFalse(captureTitle(h).isHide(), "hide=false is the event's show-everything case");
+   }
+
+   /**
+    * The Composer cannot show one axis title on its own, and answering the request with
+    * show-everything would un-hide titles the user deliberately hid.
+    */
+   @Test
+   void refusesToShowASingleAxisTitleRatherThanShowingThemAll() {
+      Harness h = harness(mock(ChartVSAssembly.class));
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> h.service.setVisibility("tok", principal(), "Chart1", "title", "y", true, ""));
+
+      assertTrue(thrown.getMessage().contains("all titles"));
+   }
+
+   @Test
+   void refusesToShowASingleAxisOrLegend() {
+      Harness h = harness(mock(ChartVSAssembly.class));
+
+      assertThrows(Exception.class,
+                   () -> h.service.setVisibility("tok", principal(), "Chart1", "axis", "Region",
+                                                 true, ""));
+      assertThrows(Exception.class,
+                   () -> h.service.setVisibility("tok", principal(), "Chart1", "legend", "Cat",
+                                                 true, ""));
+      verifyNoInteractions(h.sessions);
+   }
+
+   @Test
+   void refusesAnUnknownTitleTarget() {
+      Harness h = harness(mock(ChartVSAssembly.class));
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> h.service.setVisibility("tok", principal(), "Chart1", "title", "z", false, ""));
+
+      assertTrue(thrown.getMessage().contains("z"));
+   }
+
+   @Test
+   void refusesAnUnknownElement() {
+      Harness h = harness(mock(ChartVSAssembly.class));
+
+      assertThrows(Exception.class,
+                   () -> h.service.setVisibility("tok", principal(), "Chart1", "gridline", null,
+                                                 false, ""));
+   }
+
+   @Test
+   void refusesANonChartAssembly() {
+      Harness h = harness(mock(TextVSAssembly.class));
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> h.service.setVisibility("tok", principal(), "Text1", "axis", null, true, ""));
+
+      assertTrue(thrown.getMessage().contains("Text1"));
+   }
+
+   // ── plot sizing ───────────────────────────────────────────────────────────
+
+   @Test
+   void resizesThePlotVertically() throws Exception {
+      Harness h = harness(mock(ChartVSAssembly.class));
+
+      h.service.resizePlot("tok", principal(), "Chart1", 0.6, true, false, "");
+
+      ArgumentCaptor<VSChartPlotResizeEvent> captor =
+         ArgumentCaptor.forClass(VSChartPlotResizeEvent.class);
+      verify(h.plot).eventHandler(eq("rt1"), captor.capture(), anyString(),
+                                  any(Principal.class), any());
+      assertEquals(0.6, captor.getValue().getSizeRatio());
+      assertTrue(captor.getValue().isHeightResized());
+      assertFalse(captor.getValue().isReset());
+   }
+
+   @Test
+   void resetsThePlotWithoutARatio() throws Exception {
+      Harness h = harness(mock(ChartVSAssembly.class));
+
+      h.service.resizePlot("tok", principal(), "Chart1", null, false, true, "");
+
+      ArgumentCaptor<VSChartPlotResizeEvent> captor =
+         ArgumentCaptor.forClass(VSChartPlotResizeEvent.class);
+      verify(h.plot).eventHandler(eq("rt1"), captor.capture(), anyString(),
+                                  any(Principal.class), any());
+      assertTrue(captor.getValue().isReset());
+   }
+
+   @Test
+   void refusesARatioOutsideTheUnitRange() {
+      Harness h = harness(mock(ChartVSAssembly.class));
+
+      assertThrows(Exception.class,
+                   () -> h.service.resizePlot("tok", principal(), "Chart1", 0d, true, false, ""));
+      assertThrows(Exception.class,
+                   () -> h.service.resizePlot("tok", principal(), "Chart1", 1.5, true, false, ""));
+      assertThrows(Exception.class,
+                   () -> h.service.resizePlot("tok", principal(), "Chart1", null, true, false,
+                                              ""));
+      verifyNoInteractions(h.sessions);
+   }
+
+   @Test
+   void eachVisibilityChangeIsOneCheckpoint() throws Exception {
+      Harness h = harness(mock(ChartVSAssembly.class));
+
+      h.service.setVisibility("tok", principal(), "Chart1", "axis", "Region", false, "");
+
+      verify(h.sessions, times(1)).mutate(anyString(), any(Principal.class), any());
+   }
+
+   @Test
+   void vocabularyNamesTheTitleTargets() {
+      Harness h = harness(mock(ChartVSAssembly.class));
+
+      assertTrue(String.valueOf(h.service.vocabulary().get("titleTargets")).contains("y2"));
+   }
+
+   // ── harness ───────────────────────────────────────────────────────────────
+
+   private record Harness(ChartElementService service, ViewsheetSessionService sessions,
+                          VSChartAxesVisibilityService axes,
+                          VSChartLegendsVisibilityService legends,
+                          VSChartTitlesVisibilityService titles,
+                          VSChartPlotResizeService plot) {}
+
+   private static VSChartTitlesVisibilityEvent captureTitle(Harness h) throws Exception {
+      ArgumentCaptor<VSChartTitlesVisibilityEvent> captor =
+         ArgumentCaptor.forClass(VSChartTitlesVisibilityEvent.class);
+      verify(h.titles).eventHandler(eq("rt1"), captor.capture(), anyString(),
+                                    any(Principal.class), any());
+      return captor.getValue();
+   }
+
+   private static Harness harness(VSAssembly assembly) {
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssembly(anyString())).thenReturn(assembly);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+
+      try {
+         doAnswer(invocation -> {
+            ViewsheetSessionService.Mutation mutation = invocation.getArgument(2);
+            mutation.run(rvs, "rt1", null);
+            return null;
+         }).when(sessions).mutate(anyString(), any(Principal.class), any());
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(e);
+      }
+
+      VSChartAxesVisibilityService axes = mock(VSChartAxesVisibilityService.class);
+      VSChartLegendsVisibilityService legends = mock(VSChartLegendsVisibilityService.class);
+      VSChartTitlesVisibilityService titles = mock(VSChartTitlesVisibilityService.class);
+      VSChartPlotResizeService plot = mock(VSChartPlotResizeService.class);
+
+      return new Harness(new ChartElementService(sessions, new ObjectMapper(), axes,
+                                                legends, titles, plot),
+                         sessions, axes, legends, titles, plot);
+   }
+
+   private static Principal principal() {
+      return () -> "admin";
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartElementServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartElementServiceTest.java
@@ -243,14 +243,42 @@ class ChartElementServiceTest {
       assertTrue(captor.getValue().isReset());
    }
 
+   /**
+    * The ratio scales the plot's MINIMUM size — {@code VGraphPair} does
+    * {@code minPlotHeight *= heightRatio} — so a value above 1 enlarges the plot and makes it
+    * scrollable, and a value at or below 1 usually changes nothing visible because the plot
+    * already fills the space.
+    *
+    * <p>This test previously asserted that 1.5 was <em>refused</em>, which certified the tool's
+    * original contract: "the plot's share of the assembly, 0 to 1". That contract was wrong, and
+    * because the validation enforced it, the tool could only ever be handed values from the
+    * ineffective range — which is why it looked inert. Found live on local-1196.
+    */
    @Test
-   void refusesARatioOutsideTheUnitRange() {
+   void acceptsARatioAboveOneBecauseThatIsTheRangeThatDoesAnything() throws Exception {
+      Harness h = harness(mock(ChartVSAssembly.class));
+
+      h.service.resizePlot("tok", principal(), "Chart1", 1.5, true, false, "");
+
+      ArgumentCaptor<VSChartPlotResizeEvent> captor =
+         ArgumentCaptor.forClass(VSChartPlotResizeEvent.class);
+      verify(h.plot).eventHandler(eq("rt1"), captor.capture(), anyString(),
+                                  any(Principal.class), any());
+      assertEquals(1.5, captor.getValue().getSizeRatio());
+   }
+
+   @Test
+   void refusesANonPositiveOrAbsurdRatio() {
       Harness h = harness(mock(ChartVSAssembly.class));
 
       assertThrows(Exception.class,
                    () -> h.service.resizePlot("tok", principal(), "Chart1", 0d, true, false, ""));
       assertThrows(Exception.class,
-                   () -> h.service.resizePlot("tok", principal(), "Chart1", 1.5, true, false, ""));
+                   () -> h.service.resizePlot("tok", principal(), "Chart1", -1d, true, false, ""));
+      // An unbounded multiplier on the minimum plot size is an allocation risk for a tool driven
+      // by a model, so absurd values are refused rather than attempted.
+      assertThrows(Exception.class,
+                   () -> h.service.resizePlot("tok", principal(), "Chart1", 500d, true, false, ""));
       assertThrows(Exception.class,
                    () -> h.service.resizePlot("tok", principal(), "Chart1", null, true, false,
                                               ""));

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyServiceTest.java
@@ -1,0 +1,228 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.web.composer.vs.dialog.RegionPropertyDialogService;
+import inetsoft.web.graph.model.dialog.*;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.security.Principal;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Chart sub-element properties: axis, legend and title.
+ *
+ * <p>These are the three dialogs the assembly property registry could not reach, because they are
+ * scoped by a <b>region</b> within the chart rather than by the assembly alone — an axis is
+ * identified by its type and field, a legend by its index, a title by which title it is.
+ */
+@Tag("core")
+class ChartRegionPropertyServiceTest {
+   @Test
+   void listsTheAxisPropertiesWithTheirCurrentValues() throws Exception {
+      Harness h = harness();
+      AxisPropertyDialogModel model = axisModel();
+      model.getAxisLinePaneModel().setShowAxisLine(true);
+      when(h.regions.getAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyString(),
+                                                any(), anyString(), any(Principal.class)))
+         .thenReturn(model);
+
+      Map<String, Object> listed = h.service.list("tok", principal(), "Chart1", "axis", "y", null);
+
+      assertEquals("axis", listed.get("region"));
+      @SuppressWarnings("unchecked")
+      java.util.List<Map<String, Object>> props =
+         (java.util.List<Map<String, Object>>) listed.get("properties");
+      assertTrue(props.stream().anyMatch(p -> "showAxisLine".equals(p.get("name"))),
+                 "the axis line properties must be discoverable by name");
+   }
+
+   @Test
+   void writesAnAxisPropertyThroughTheWholePatchRule() throws Exception {
+      Harness h = harness();
+      when(h.regions.getAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyString(),
+                                                any(), anyString(), any(Principal.class)))
+         .thenReturn(axisModel());
+
+      h.service.set("tok", principal(), "Chart1", "axis", "y", null,
+                    Map.of("showAxisLine", false, "logarithmicScale", true), "");
+
+      ArgumentCaptor<AxisPropertyDialogModel> captor =
+         ArgumentCaptor.forClass(AxisPropertyDialogModel.class);
+      verify(h.regions).setAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyInt(),
+                                                   any(), captor.capture(), anyString(),
+                                                   any(Principal.class), any());
+      assertFalse(captor.getValue().getAxisLinePaneModel().isShowAxisLine());
+      assertTrue(captor.getValue().getAxisLinePaneModel().isLogarithmicScale());
+   }
+
+   /** One bad key rejects the whole patch, exactly as set_assembly_properties does. */
+   @Test
+   void refusesTheWholePatchWhenOneKeyIsUnknown() throws Exception {
+      Harness h = harness();
+      when(h.regions.getAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyString(),
+                                                any(), anyString(), any(Principal.class)))
+         .thenReturn(axisModel());
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> h.service.set("tok", principal(), "Chart1", "axis", "y", null,
+                             Map.of("showAxisLine", false, "nonsense", 1), ""));
+
+      assertTrue(thrown.getMessage().contains("nonsense"));
+      verify(h.regions, never()).setAxisPropertyDialogModel(anyString(), anyString(), anyString(),
+                                                            anyInt(), any(), any(), anyString(),
+                                                            any(Principal.class), any());
+   }
+
+   @Test
+   void writesALegendPropertyAddressedByIndex() throws Exception {
+      Harness h = harness();
+      when(h.regions.getLegendFormatDialogModel(anyString(), anyString(), anyString(), anyString(),
+                                                any(Principal.class)))
+         .thenReturn(legendModel());
+
+      h.service.set("tok", principal(), "Chart1", "legend", "0", null,
+                    Map.of("visible", false), "");
+
+      ArgumentCaptor<LegendFormatDialogModel> captor =
+         ArgumentCaptor.forClass(LegendFormatDialogModel.class);
+      verify(h.regions).setLegendFormatDialogModel(anyString(), anyString(), anyInt(),
+                                                   captor.capture(), anyString(),
+                                                   any(Principal.class), any());
+      assertFalse(captor.getValue().getLegendFormatGeneralPaneModel().isVisible());
+   }
+
+   @Test
+   void writesATitleProperty() throws Exception {
+      Harness h = harness();
+      when(h.regions.getTitleFormatDialogModel(anyString(), anyString(), anyString(), anyString(),
+                                               any(Principal.class)))
+         .thenReturn(titleModel());
+
+      h.service.set("tok", principal(), "Chart1", "title", "y", null,
+                    Map.of("title", "Revenue"), "");
+
+      ArgumentCaptor<TitleFormatDialogModel> captor =
+         ArgumentCaptor.forClass(TitleFormatDialogModel.class);
+      verify(h.regions).setTitleFormatDialogModel(anyString(), anyString(), anyString(),
+                                                  captor.capture(), anyString(),
+                                                  any(Principal.class), any());
+      assertEquals("Revenue", captor.getValue().getTitleFormatPaneModel().getTitle());
+   }
+
+   @Test
+   void refusesAnUnknownRegionNamingTheThree() {
+      Harness h = harness();
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> h.service.list("tok", principal(), "Chart1", "plot", "y", null));
+      assertTrue(thrown.getMessage().contains("plot"));
+      assertTrue(thrown.getMessage().contains("axis"));
+      assertTrue(thrown.getMessage().contains("legend"));
+   }
+
+   /**
+    * The composer service parses the legend index while READING the model, so a non-numeric
+    * target surfaced as a raw {@code For input string: "..."} from inside StyleBI before the
+    * write-side guard was reached. Validating the target up front is what makes the message
+    * useful. Found live, not by unit test.
+    */
+   @Test
+   void refusesANonNumericLegendTargetBeforeTouchingTheComposerService() throws Exception {
+      Harness h = harness();
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> h.service.list("tok", principal(), "Chart1", "legend", "notanumber", null));
+
+      assertTrue(thrown.getMessage().contains("0-based index"));
+      assertTrue(thrown.getMessage().contains("notanumber"));
+      verify(h.regions, never()).getLegendFormatDialogModel(anyString(), anyString(), anyString(),
+                                                            anyString(), any(Principal.class));
+   }
+
+   @Test
+   void refusesAMissingTarget() {
+      Harness h = harness();
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> h.service.list("tok", principal(), "Chart1", "axis", "  ", null));
+      assertTrue(thrown.getMessage().contains("target"));
+   }
+
+   /**
+    * The composer service returns a fully-populated dialog model; a bare {@code new} leaves its
+    * panes null, and PropertyPath deliberately refuses to instantiate an absent intermediate
+    * (a null pane means "this property does not apply here"). So the fixtures populate them.
+    */
+   private static AxisPropertyDialogModel axisModel() {
+      AxisPropertyDialogModel model = new AxisPropertyDialogModel();
+      model.setAxisLinePaneModel(new AxisLinePaneModel());
+      model.setAxisLabelPaneModel(new AxisLabelPaneModel());
+      return model;
+   }
+
+   private static LegendFormatDialogModel legendModel() {
+      LegendFormatDialogModel model = new LegendFormatDialogModel();
+      model.setLegendFormatGeneralPaneModel(new LegendFormatGeneralPaneModel());
+      return model;
+   }
+
+   private static TitleFormatDialogModel titleModel() {
+      TitleFormatDialogModel model = new TitleFormatDialogModel();
+      model.setTitleFormatPaneModel(new TitleFormatPaneModel());
+      return model;
+   }
+
+   private record Harness(ChartRegionPropertyService service, RegionPropertyDialogService regions) {}
+
+   private static Harness harness() {
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+
+      try {
+         when(sessions.resolve(anyString(), any(Principal.class))).thenReturn(rvs);
+         when(sessions.runtimeId(anyString(), any(Principal.class))).thenReturn("rt1");
+         doAnswer(invocation -> {
+            ViewsheetSessionService.Mutation mutation = invocation.getArgument(2);
+            mutation.run(rvs, "rt1", null);
+            return null;
+         }).when(sessions).mutate(anyString(), any(Principal.class), any());
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(e);
+      }
+
+      RegionPropertyDialogService regions = mock(RegionPropertyDialogService.class);
+      return new Harness(new ChartRegionPropertyService(sessions, regions), regions);
+   }
+
+   private static Principal principal() {
+      return () -> "admin";
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyServiceTest.java
@@ -165,6 +165,59 @@ class ChartRegionPropertyServiceTest {
                                                             anyString(), any(Principal.class));
    }
 
+   /**
+    * An axis target that names no axis was accepted in silence on the read path — {@code "PAID"}
+    * and {@code "zzzznonsense"} both returned the same full, plausible property list as
+    * {@code "y"} — and blew up with {@code NullPointerException: axisArea is null} on the write
+    * path. Both come from {@code ChartRegionHandler.getAxisArea} returning null for an unrecognised
+    * type.
+    *
+    * <p>A column name is the specific wrong value worth predicting: {@code list_chart_elements}
+    * describes an axis target as a column name (true for element visibility, not for this tool),
+    * so an agent following it lands here. This tool takes the column in {@code field}, so the
+    * message says so rather than only listing the valid types. Found live on local-1196.
+    */
+   @Test
+   void refusesAnAxisTargetThatNamesNoAxis() {
+      Harness h = harness();
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> h.service.list("tok", principal(), "Chart1", "axis", "PAID", null));
+
+      assertTrue(thrown.getMessage().contains("PAID"));
+      assertTrue(thrown.getMessage().contains("y2"), "the message must list the valid axis types");
+      assertTrue(thrown.getMessage().contains("field"),
+                 "a column name belongs in 'field' — say so, since that is the likely mistake");
+   }
+
+   /** The long forms the composer itself uses are equally valid and must not be refused. */
+   @Test
+   void acceptsTheLongAxisFormsToo() throws Exception {
+      Harness h = harness();
+      when(h.regions.getAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyString(),
+                                                any(), anyString(), any(Principal.class)))
+         .thenReturn(axisModel());
+
+      Map<String, Object> listed =
+         h.service.list("tok", principal(), "Chart1", "axis", "left_y_axis", null);
+
+      assertEquals("left_y_axis", listed.get("target"));
+   }
+
+   /** Forgiving where the intent is unambiguous: case is normalised rather than refused. */
+   @Test
+   void normalisesAxisTargetCase() throws Exception {
+      Harness h = harness();
+      when(h.regions.getAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyString(),
+                                                any(), anyString(), any(Principal.class)))
+         .thenReturn(axisModel());
+
+      Map<String, Object> listed = h.service.list("tok", principal(), "Chart1", "axis", "Y2", null);
+
+      assertEquals("y2", listed.get("target"));
+   }
+
    @Test
    void refusesAMissingTarget() {
       Harness h = harness();

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ConditionVocabularyTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ConditionVocabularyTest.java
@@ -1,0 +1,325 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.uql.JunctionOperator;
+import inetsoft.uql.XCondition;
+import inetsoft.web.binding.drm.DataRefModel;
+import inetsoft.web.composer.model.condition.ConditionModel;
+import inetsoft.web.composer.model.condition.JunctionOperatorModel;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class ConditionVocabularyTest {
+   private static DataRefModel field(String name) {
+      DataRefModel field = mock(DataRefModel.class);
+      when(field.getName()).thenReturn(name);
+      return field;
+   }
+
+   private static final DataRefModel[] FIELDS =
+      { field("Region"), field("Revenue"), field("OrderDate") };
+
+   private static ConditionVocabulary.Clause clause(String field, String operator,
+                                                    List<Object> values, String junction)
+   {
+      return new ConditionVocabulary.Clause(field, operator, values, junction, false);
+   }
+
+   // ── the alternating array ─────────────────────────────────────────────────
+
+   @Test
+   void buildsASingleConditionWithNoJunction() {
+      Object[] list = ConditionVocabulary.toConditionList(
+         List.of(clause("Region", "equals", List.of("East"), null)), FIELDS);
+
+      assertEquals(1, list.length);
+      ConditionModel condition = assertInstanceOf(ConditionModel.class, list[0]);
+      assertEquals(XCondition.EQUAL_TO, condition.getOperation());
+   }
+
+   @Test
+   void alternatesConditionJunctionCondition() {
+      Object[] list = ConditionVocabulary.toConditionList(
+         List.of(clause("Region", "one_of", List.of("East", "West"), "and"),
+                 clause("Revenue", ">", List.of(10000), null)),
+         FIELDS);
+
+      assertEquals(3, list.length);
+      assertInstanceOf(ConditionModel.class, list[0]);
+      assertInstanceOf(JunctionOperatorModel.class, list[1]);
+      assertInstanceOf(ConditionModel.class, list[2]);
+   }
+
+   @Test
+   void buildsThreeConditionsWithTwoJunctions() {
+      Object[] list = ConditionVocabulary.toConditionList(
+         List.of(clause("Region", "equals", List.of("East"), "or"),
+                 clause("Revenue", ">", List.of(1), "and"),
+                 clause("OrderDate", "null", List.of(), null)),
+         FIELDS);
+
+      assertEquals(5, list.length);
+      assertInstanceOf(JunctionOperatorModel.class, list[1]);
+      assertInstanceOf(JunctionOperatorModel.class, list[3]);
+   }
+
+   @Test
+   void mapsTheJunctionTokens() {
+      Object[] and = ConditionVocabulary.toConditionList(
+         List.of(clause("Region", "equals", List.of("E"), "and"),
+                 clause("Revenue", ">", List.of(1), null)), FIELDS);
+      Object[] or = ConditionVocabulary.toConditionList(
+         List.of(clause("Region", "equals", List.of("E"), "or"),
+                 clause("Revenue", ">", List.of(1), null)), FIELDS);
+
+      assertEquals(JunctionOperator.AND, ((JunctionOperatorModel) and[1]).getType());
+      assertEquals(JunctionOperator.OR, ((JunctionOperatorModel) or[1]).getType());
+   }
+
+   @Test
+   void anEmptyListBuildsAnEmptyArray() {
+      assertEquals(0, ConditionVocabulary.toConditionList(List.of(), FIELDS).length);
+      assertEquals(0, ConditionVocabulary.toConditionList(null, FIELDS).length);
+   }
+
+   // ── the arity invariant: the highest-value guard here ─────────────────────
+
+   @Test
+   void refusesATrailingJunctionNamingTheIndex() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ConditionVocabulary.toConditionList(
+            List.of(clause("Region", "equals", List.of("East"), "and")), FIELDS));
+
+      assertTrue(thrown.getMessage().contains("0"));
+      assertTrue(thrown.getMessage().contains("orphan"),
+                 "the refusal should say what a trailing junction becomes");
+   }
+
+   @Test
+   void refusesAMissingMiddleJunctionNamingTheIndex() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ConditionVocabulary.toConditionList(
+            List.of(clause("Region", "equals", List.of("East"), null),
+                    clause("Revenue", ">", List.of(1), null)),
+            FIELDS));
+
+      assertTrue(thrown.getMessage().contains("0"));
+      assertTrue(thrown.getMessage().contains("1"), "name the condition it should join to");
+   }
+
+   @Test
+   void refusesABlankJunctionAsIfItWereMissing() {
+      assertThrows(IllegalArgumentException.class,
+                   () -> ConditionVocabulary.toConditionList(
+                      List.of(clause("Region", "equals", List.of("E"), "  "),
+                              clause("Revenue", ">", List.of(1), null)),
+                      FIELDS));
+   }
+
+   @Test
+   void refusesAnUnknownJunction() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ConditionVocabulary.toConditionList(
+            List.of(clause("Region", "equals", List.of("E"), "xor"),
+                    clause("Revenue", ">", List.of(1), null)),
+            FIELDS));
+
+      assertTrue(thrown.getMessage().contains("xor"));
+   }
+
+   /** Nothing may be built before the whole list is checked, or a cast finds a half-array. */
+   @Test
+   void validatesTheWholeListBeforeBuildingAnyOfIt() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ConditionVocabulary.toConditionList(
+            List.of(clause("Region", "equals", List.of("E"), "and"),
+                    clause("Nope", ">", List.of(1), null)),
+            FIELDS));
+
+      assertTrue(thrown.getMessage().contains("Nope"));
+   }
+
+   // ── the recorded cast-crash trigger ───────────────────────────────────────
+
+   @Test
+   void refusesAFieldTheAssemblyCannotFilterOnListingWhatItCan() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ConditionVocabulary.toConditionList(
+            List.of(clause("Profit", "equals", List.of(1), null)), FIELDS));
+
+      assertTrue(thrown.getMessage().contains("Profit"));
+      assertTrue(thrown.getMessage().contains("Region"), "list the fields that do exist");
+      assertTrue(thrown.getMessage().contains("cast"),
+                 "say why, since this is a recorded downstream crash");
+   }
+
+   @Test
+   void matchesAFieldNameCaseInsensitively() {
+      assertDoesNotThrow(() -> ConditionVocabulary.toConditionList(
+         List.of(clause("region", "equals", List.of("East"), null)), FIELDS));
+   }
+
+   @Test
+   void refusesAMissingField() {
+      assertThrows(IllegalArgumentException.class,
+                   () -> ConditionVocabulary.toConditionList(
+                      List.of(clause(null, "equals", List.of(1), null)), FIELDS));
+   }
+
+   // ── operator aliases, from the recorded multi-value defect ────────────────
+
+   @Test
+   void resolvesTheOneOfAliases() {
+      for(String token : List.of("one_of", "oneOf", "IN", "in")) {
+         Object[] list = ConditionVocabulary.toConditionList(
+            List.of(clause("Region", token, List.of("E", "W"), null)), FIELDS);
+         assertEquals(XCondition.ONE_OF, ((ConditionModel) list[0]).getOperation(),
+                      "'" + token + "' should resolve to ONE_OF");
+      }
+   }
+
+   @Test
+   void resolvesTheComparisonAliases() {
+      assertEquals(XCondition.EQUAL_TO, operationOf("="));
+      assertEquals(XCondition.EQUAL_TO, operationOf("equals"));
+      assertEquals(XCondition.LESS_THAN, operationOf("<"));
+      assertEquals(XCondition.GREATER_THAN, operationOf(">"));
+      assertEquals(XCondition.CONTAINS, operationOf("contains"));
+      assertEquals(XCondition.STARTING_WITH, operationOf("startsWith"));
+   }
+
+   @Test
+   void refusesAnUnknownOperatorListingTheValid() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class, () -> operationOf("=~"));
+
+      assertTrue(thrown.getMessage().contains("=~"));
+      assertTrue(thrown.getMessage().contains("contains"));
+   }
+
+   // ── value arity ───────────────────────────────────────────────────────────
+
+   @Test
+   void refusesBetweenWithoutTwoValues() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ConditionVocabulary.toConditionList(
+            List.of(clause("Revenue", "between", List.of(1), null)), FIELDS));
+
+      assertTrue(thrown.getMessage().contains("two"));
+   }
+
+   @Test
+   void acceptsBetweenWithExactlyTwo() {
+      assertDoesNotThrow(() -> ConditionVocabulary.toConditionList(
+         List.of(clause("Revenue", "between", List.of(1, 100), null)), FIELDS));
+   }
+
+   @Test
+   void refusesAValuedOperatorWithNoValues() {
+      assertThrows(IllegalArgumentException.class,
+                   () -> ConditionVocabulary.toConditionList(
+                      List.of(clause("Region", "one_of", List.of(), null)), FIELDS));
+   }
+
+   @Test
+   void acceptsNullWithNoValues() {
+      assertDoesNotThrow(() -> ConditionVocabulary.toConditionList(
+         List.of(clause("Region", "null", List.of(), null)), FIELDS));
+   }
+
+   @Test
+   void refusesNullWithValues() {
+      assertThrows(IllegalArgumentException.class,
+                   () -> ConditionVocabulary.toConditionList(
+                      List.of(clause("Region", "null", List.of("x"), null)), FIELDS));
+   }
+
+   // ── round trip ────────────────────────────────────────────────────────────
+
+   @Test
+   void readsBackTheFlatVocabularyIncludingJunctions() {
+      Object[] list = ConditionVocabulary.toConditionList(
+         List.of(clause("Region", "one_of", List.of("East", "West"), "and"),
+                 clause("Revenue", ">", List.of(10000), null)),
+         FIELDS);
+
+      List<Map<String, Object>> described = ConditionVocabulary.describe(list);
+
+      assertEquals(2, described.size());
+      assertEquals("Region", described.get(0).get("field"));
+      assertEquals("one_of", described.get(0).get("operator"));
+      assertEquals(List.of("East", "West"), described.get(0).get("values"));
+      assertEquals("and", described.get(0).get("junction"));
+      assertNull(described.get(1).get("junction"), "the last condition carries no junction");
+   }
+
+   @Test
+   void readsBackACanonicalOperatorRatherThanAnAlias() {
+      Object[] list = ConditionVocabulary.toConditionList(
+         List.of(clause("Revenue", ">", List.of(1), null)), FIELDS);
+
+      assertEquals("greater_than", ConditionVocabulary.describe(list).get(0).get("operator"),
+                   "reading back an alias would make the round trip lossy in appearance");
+   }
+
+   @Test
+   void describesAnEmptyOrNullListAsEmpty() {
+      assertTrue(ConditionVocabulary.describe(null).isEmpty());
+      assertTrue(ConditionVocabulary.describe(new Object[0]).isEmpty());
+   }
+
+   @Test
+   void aBuiltListRoundTripsBackToItself() {
+      List<ConditionVocabulary.Clause> clauses = List.of(
+         clause("Region", "one_of", List.of("East"), "or"),
+         clause("Revenue", "between", List.of(1, 2), "and"),
+         clause("OrderDate", "null", List.of(), null));
+
+      List<Map<String, Object>> described =
+         ConditionVocabulary.describe(ConditionVocabulary.toConditionList(clauses, FIELDS));
+
+      assertEquals(3, described.size());
+      assertEquals("or", described.get(0).get("junction"));
+      assertEquals("and", described.get(1).get("junction"));
+      assertNull(described.get(2).get("junction"));
+   }
+
+   @Test
+   void vocabularyExplainsTheJunctionRule() {
+      assertTrue(String.valueOf(ConditionVocabulary.vocabulary().get("note")).contains("NEXT"));
+   }
+
+   private static int operationOf(String operator) {
+      Object[] list = ConditionVocabulary.toConditionList(
+         List.of(clause("Region", operator, List.of("x", "y"), null)), FIELDS);
+      return ((ConditionModel) list[0]).getOperation();
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
@@ -61,6 +61,44 @@ class DateComparisonServiceTest {
                                                   null);
    }
 
+   /**
+    * {@code apply} ran {@code periods.setCustom(false)} unconditionally, and {@code validate}
+    * demanded an end anchor on every call. So a caller who only wanted {@code useFacet: true} had
+    * to supply a period anyway, and the call converted an assembly configured with a CUSTOM period
+    * to standard — discarding it with no error and no warning, moments after {@code read} had
+    * happily reported that custom period.
+    */
+   @Test
+   void aNonPeriodChangeNeedsNoEndAnchorAndLeavesThePeriodAlone() throws Exception {
+      DateComparisonPaneModel model = model();
+      model.getPeriodPaneModel().setCustom(true);
+      Harness h = harness(model);
+
+      h.service.set("tok", principal(), "Chart1", facetOnly(), "");
+
+      assertTrue(model.getPeriodPaneModel().isCustom(),
+                 "a call that sets no period field must not convert a custom period to standard");
+      assertTrue(model.isUseFacet(), "the change that WAS asked for must still be applied");
+   }
+
+   /** Setting a period over a custom one is refused rather than silently replacing it. */
+   @Test
+   void refusesToReplaceACustomPeriodWithoutSayingSo() {
+      DateComparisonPaneModel model = model();
+      model.getPeriodPaneModel().setCustom(true);
+      Harness h = harness(model);
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> h.service.set("tok", principal(), "Chart1", comparison("2026-03-31", false), ""));
+
+      assertTrue(thrown.getMessage().toLowerCase().contains("custom"), thrown.getMessage());
+   }
+
+   private static DateComparisonService.Comparison facetOnly() {
+      return new DateComparisonService.Comparison(null, null, null, false, null, true, null, null);
+   }
+
    // ── the recorded defect ───────────────────────────────────────────────────
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
@@ -1,0 +1,272 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.composer.model.vs.*;
+import inetsoft.web.composer.vs.dialog.DateComparisonDialogService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class DateComparisonServiceTest {
+   private static DynamicValueModel dynamic() {
+      return new DynamicValueModel();
+   }
+
+   private static DateComparisonPaneModel model() {
+      StandardPeriodPaneModel standard = new StandardPeriodPaneModel();
+      standard.setPreCount(dynamic());
+      standard.setDateLevel(dynamic());
+      standard.setEndDay(dynamic());
+      standard.setToDayAsEndDay(true);
+
+      PeriodPaneModel periods = new PeriodPaneModel();
+      periods.setStandardPeriodPaneModel(standard);
+
+      IntervalPaneModel interval = new IntervalPaneModel();
+      interval.setLevel(dynamic());
+
+      DateComparisonPaneModel model = mock(DateComparisonPaneModel.class, CALLS_REAL_METHODS);
+      when(model.getPeriodPaneModel()).thenReturn(periods);
+      when(model.getIntervalPaneModel()).thenReturn(interval);
+      return model;
+   }
+
+   private static DateComparisonService.Comparison comparison(String endDate, boolean endToday) {
+      return new DateComparisonService.Comparison(4, "year", endDate, endToday, null, null, null,
+                                                  null);
+   }
+
+   // ── the recorded defect ───────────────────────────────────────────────────
+
+   /**
+    * When {@code toDayAsEndDay} is set the range anchors on today and the supplied end date is
+    * discarded. Setting an explicit end date must clear the flag, or the date goes nowhere.
+    */
+   @Test
+   void anExplicitEndDateClearsTheTodayAnchor() throws Exception {
+      DateComparisonPaneModel model = model();
+      Harness h = harness(model);
+
+      h.service.set("tok", principal(), "Chart1", comparison("2026-03-31", false), "");
+
+      StandardPeriodPaneModel standard =
+         model.getPeriodPaneModel().getStandardPeriodPaneModel();
+      assertFalse(standard.isToDayAsEndDay(),
+                  "leaving the today anchor set is what discarded the end date");
+      assertEquals("2026-03-31", standard.getEndDay().getValue());
+   }
+
+   @Test
+   void endTodaySetsTheAnchorAndLeavesNoStaleDate() throws Exception {
+      DateComparisonPaneModel model = model();
+      Harness h = harness(model);
+
+      h.service.set("tok", principal(), "Chart1", comparison(null, true), "");
+
+      assertTrue(model.getPeriodPaneModel().getStandardPeriodPaneModel().isToDayAsEndDay());
+   }
+
+   @Test
+   void refusesBothAnEndDateAndTheTodayAnchor() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> DateComparisonService.requireEndAnchor(comparison("2026-03-31", true)));
+
+      assertTrue(thrown.getMessage().contains("discarded"),
+                 "the refusal should say what would have happened");
+   }
+
+   /**
+    * Defaulting to today is the behaviour that gave a forward-looking field a range ending
+    * before its data does, with nothing reporting it.
+    */
+   @Test
+   void refusesNeitherRatherThanDefaultingToToday() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> DateComparisonService.requireEndAnchor(comparison(null, false)));
+
+      assertTrue(thrown.getMessage().contains("due date"),
+                 "the refusal should name the case it protects");
+   }
+
+   @Test
+   void refusesABlankEndDateAsIfItWereAbsent() {
+      assertThrows(IllegalArgumentException.class,
+                   () -> DateComparisonService.requireEndAnchor(comparison("  ", false)));
+   }
+
+   @Test
+   void refusesAPeriodCountBelowOne() {
+      assertThrows(IllegalArgumentException.class,
+                   () -> DateComparisonService.requireEndAnchor(
+                      new DateComparisonService.Comparison(0, "year", null, true, null, null,
+                                                           null, null)));
+   }
+
+   @Test
+   void validatesBeforeTouchingTheRuntime() {
+      Harness h = harness(model());
+
+      assertThrows(Exception.class,
+                   () -> h.service.set("tok", principal(), "Chart1", comparison(null, false), ""));
+
+      verifyNoInteractions(h.sessions);
+   }
+
+   // ── the rest of the write ─────────────────────────────────────────────────
+
+   @Test
+   void setsThePeriodCountAndLevel() throws Exception {
+      DateComparisonPaneModel model = model();
+
+      harness(model).service.set("tok", principal(), "Chart1", comparison("2026-03-31", false), "");
+
+      StandardPeriodPaneModel standard =
+         model.getPeriodPaneModel().getStandardPeriodPaneModel();
+      assertEquals("4", standard.getPreCount().getValue());
+      assertEquals("year", standard.getDateLevel().getValue());
+   }
+
+   @Test
+   void convertsThePaneModelBeforePostingIt() throws Exception {
+      Harness h = harness(model());
+
+      h.service.set("tok", principal(), "Chart1", comparison("2026-03-31", false), "");
+
+      verify(h.comparisons).setDateComparison(eq("rt1"), eq("Chart1"), any(), isNull(),
+                                              anyString(), any(Principal.class), any());
+   }
+
+   @Test
+   void eachWriteIsOneCheckpoint() throws Exception {
+      Harness h = harness(model());
+
+      h.service.set("tok", principal(), "Chart1", comparison("2026-03-31", false), "");
+
+      verify(h.sessions, times(1)).mutate(anyString(), any(Principal.class), any());
+   }
+
+   @Test
+   void refusesAnAssemblyWithoutDateComparison() {
+      Harness h = harness(null);
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> h.service.set("tok", principal(), "Text1", comparison(null, true), ""));
+
+      assertTrue(thrown.getMessage().contains("date dimension"));
+   }
+
+   @Test
+   void clearDelegates() throws Exception {
+      Harness h = harness(model());
+
+      h.service.clear("tok", principal(), "Chart1", "");
+
+      verify(h.comparisons).clearDateComparison(eq("rt1"), eq("Chart1"), anyString(),
+                                                any(Principal.class), any());
+   }
+
+   // ── the read side ─────────────────────────────────────────────────────────
+
+   @Test
+   void readsTheNormalizedShape() throws Exception {
+      Map<String, Object> read = harness(model()).service.read("tok", principal(), "Chart1");
+
+      assertEquals(true, read.get("enabled"));
+      @SuppressWarnings("unchecked")
+      Map<String, Object> period = (Map<String, Object>) read.get("period");
+      assertEquals(true, period.get("endToday"));
+   }
+
+   /**
+    * A date-comparison cell once serialized a 67 KB timezone table into the response. The
+    * normalized shape carries only what a caller can act on, so nothing like that can ride along.
+    */
+   @Test
+   void theReadShapeStaysSmallAndCarriesNoCellFormat() throws Exception {
+      Map<String, Object> read = harness(model()).service.read("tok", principal(), "Chart1");
+
+      assertFalse(read.containsKey("format"),
+                  "a cell format must not be echoed — that is the 67KB timezone-table regression");
+      assertTrue(read.toString().length() < 2000,
+                 "the normalized response should be small; got " + read.toString().length());
+   }
+
+   @Test
+   void reportsAnAssemblyWithNoComparisonAsDisabled() throws Exception {
+      Map<String, Object> read = harness(null).service.read("tok", principal(), "Text1");
+
+      assertEquals(false, read.get("enabled"));
+   }
+
+   @Test
+   void hidesTheEndDateWhenTheRangeAnchorsOnToday() throws Exception {
+      Map<String, Object> read = harness(model()).service.read("tok", principal(), "Chart1");
+
+      @SuppressWarnings("unchecked")
+      Map<String, Object> period = (Map<String, Object>) read.get("period");
+      assertNull(period.get("endDate"),
+                 "reporting a stale end date beside endToday would read as the range's real end");
+   }
+
+   // ── harness ───────────────────────────────────────────────────────────────
+
+   private record Harness(DateComparisonService service, ViewsheetSessionService sessions,
+                          DateComparisonDialogService comparisons) {}
+
+   private static Harness harness(DateComparisonPaneModel model) {
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(mock(Viewsheet.class));
+      when(rvs.getID()).thenReturn("rt1");
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      DateComparisonDialogService comparisons = mock(DateComparisonDialogService.class);
+
+      try {
+         when(sessions.resolve(anyString(), any(Principal.class))).thenReturn(rvs);
+         doAnswer(invocation -> {
+            ViewsheetSessionService.Mutation mutation = invocation.getArgument(2);
+            mutation.run(rvs, "rt1", null);
+            return null;
+         }).when(sessions).mutate(anyString(), any(Principal.class), any());
+         when(comparisons.getDateComparison(anyString(), anyString(), any(Principal.class)))
+            .thenReturn(model);
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(e);
+      }
+
+      return new Harness(new DateComparisonService(sessions, comparisons), sessions, comparisons);
+   }
+
+   private static Principal principal() {
+      return () -> "admin";
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyAliasesTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyAliasesTest.java
@@ -1,0 +1,133 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+class PropertyAliasesTest {
+   /**
+    * <b>The highest-value test in this band.</b> It reflects over every declared alias and
+    * asserts the path exists on its dialog model. When the composer renames a pane field, this
+    * breaks the build instead of letting the plugin ship an alias that silently resolves to
+    * nothing in production.
+    */
+   @Test
+   void everyDeclaredAliasResolvesOnItsDialogModel() {
+      for(String type : PropertyAliases.coveredTypes()) {
+         PropertyAliases.TypeAliases entry = PropertyAliases.forType(type);
+
+         for(Map.Entry<String, String> alias : entry.aliases().entrySet()) {
+            assertDoesNotThrow(
+               () -> PropertyPath.typeOf(entry.modelClass(), alias.getValue()),
+               "alias '" + alias.getKey() + "' on " + type + " points at '" +
+               alias.getValue() + "', which does not exist on " +
+               entry.modelClass().getSimpleName());
+         }
+      }
+   }
+
+   /**
+    * An alias is only ever a shorter name for a path that already exists. If one ever mapped
+    * to something computed, property semantics would live in two places — the drift this
+    * design exists to prevent.
+    */
+   @Test
+   void noAliasIsAnEmptyOrSelfReferentialPath() {
+      for(String type : PropertyAliases.coveredTypes()) {
+         PropertyAliases.TypeAliases entry = PropertyAliases.forType(type);
+
+         for(Map.Entry<String, String> alias : entry.aliases().entrySet()) {
+            assertFalse(alias.getValue().isBlank(), alias.getKey() + " maps to nothing");
+            assertTrue(alias.getValue().contains("."),
+                       alias.getKey() + " maps to '" + alias.getValue() + "', which is not a " +
+                       "model path — an alias must name a real nested field");
+         }
+      }
+   }
+
+   @Test
+   void coversTheTypesItClaimsTo() {
+      assertTrue(PropertyAliases.covers("gauge"));
+      assertTrue(PropertyAliases.covers("Gauge"), "type matching is case-insensitive");
+      assertTrue(PropertyAliases.covers("text"));
+   }
+
+   @Test
+   void resolvesAnAliasToItsPath() {
+      assertEquals(
+         "gaugeGeneralPaneModel.numberRangePaneModel.max",
+         PropertyAliases.resolve("gauge", "max"));
+   }
+
+   @Test
+   void resolvesTheDeepVisibilityPathThatMotivatesTheWholeLayer() {
+      assertEquals(
+         "gaugeGeneralPaneModel.outputGeneralPaneModel.generalPropPaneModel." +
+         "basicGeneralPaneModel.visible",
+         PropertyAliases.resolve("gauge", "visible"));
+   }
+
+   /** The documented raw escape hatch: a dotted key passes through for PropertyPath to check. */
+   @Test
+   void passesADottedRawPathThrough() {
+      assertEquals("gaugeAdvancedPaneModel.rangePaneModel.rangeGradient",
+                   PropertyAliases.resolve("gauge", "gaugeAdvancedPaneModel.rangePaneModel." +
+                                                    "rangeGradient"));
+   }
+
+   @Test
+   void refusesAnUnknownKeyAndSuggestsTheNearMatch() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class, () -> PropertyAliases.resolve("gauge", "maxx"));
+
+      assertTrue(thrown.getMessage().contains("maxx"));
+      assertTrue(thrown.getMessage().contains("'max'"), "a near miss should be offered");
+   }
+
+   @Test
+   void refusesAnUnknownKeyByListingTheKnownOnes() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class, () -> PropertyAliases.resolve("gauge", "wobble"));
+
+      assertTrue(thrown.getMessage().contains("visible"));
+   }
+
+   @Test
+   void refusesAnUncoveredAssemblyTypeListingWhatIsCovered() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class, () -> PropertyAliases.forType("submit"));
+
+      assertTrue(thrown.getMessage().contains("submit"));
+      assertTrue(thrown.getMessage().contains("gauge"));
+   }
+
+   /**
+    * `min` on a Text is the spec's own example of a property that belongs to another type.
+    * It has to fail, not land somewhere harmless.
+    */
+   @Test
+   void refusesAPropertyThatBelongsToADifferentType() {
+      assertThrows(IllegalArgumentException.class, () -> PropertyAliases.resolve("text", "min"));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyAliasesTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyAliasesTest.java
@@ -113,12 +113,17 @@ class PropertyAliasesTest {
       assertTrue(thrown.getMessage().contains("visible"));
    }
 
+   /**
+    * `image` is the standing example of an uncovered type, and not for lack of curation:
+    * {@code ImagePropertyDialogModel} is an Immutables class with no setters, so the path
+    * engine cannot write it at all. Four other dialog models share that shape.
+    */
    @Test
    void refusesAnUncoveredAssemblyTypeListingWhatIsCovered() {
       Exception thrown = assertThrows(
-         IllegalArgumentException.class, () -> PropertyAliases.forType("submit"));
+         IllegalArgumentException.class, () -> PropertyAliases.forType("image"));
 
-      assertTrue(thrown.getMessage().contains("submit"));
+      assertTrue(thrown.getMessage().contains("image"));
       assertTrue(thrown.getMessage().contains("gauge"));
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyAliasesTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyAliasesTest.java
@@ -73,6 +73,27 @@ class PropertyAliasesTest {
       assertTrue(PropertyAliases.covers("text"));
    }
 
+   /**
+    * The chart's line pane — trend lines, grid lines, facet grid. These are the properties a
+    * user means by "add a trend line", and they live one pane below the general/advanced panes
+    * the first pass covered.
+    *
+    * <p>Note what is deliberately absent: {@code pointLine} and the word-cloud font scale are
+    * {@code PlotDescriptor} fields that the chart property dialog never surfaces, so there is no
+    * path to alias. They are not reachable through this engine at all.
+    */
+   @Test
+   void coversTheChartLinePaneProperties() {
+      for(String alias : java.util.List.of("gridLineVisible", "innerLineVisible",
+                                           "trendLineType", "trendLineStyle", "trendLineColor",
+                                           "trendLineVisible", "projectForward",
+                                           "facetGrid", "facetGridColor", "facetGridVisible"))
+      {
+         assertTrue(PropertyAliases.forType("chart").aliases().containsKey(alias),
+                    "chart should expose '" + alias + "'");
+      }
+   }
+
    @Test
    void resolvesAnAliasToItsPath() {
       assertEquals(
@@ -114,17 +135,30 @@ class PropertyAliasesTest {
    }
 
    /**
-    * `image` is the standing example of an uncovered type, and not for lack of curation:
-    * {@code ImagePropertyDialogModel} is an Immutables class with no setters, so the path
-    * engine cannot write it at all. Four other dialog models share that shape.
+    * An uncovered type must still fail loudly, naming what is covered.
+    *
+    * <p>This used to assert that `image` was uncovered — it was the standing example, because
+    * {@code ImagePropertyDialogModel} is an Immutables class with no setters and the path engine
+    * could not write it. That is no longer true: {@code PropertyPath} now reads bare Immutables
+    * accessors and rebuilds immutable levels through {@code withX}, so image is covered and this
+    * test needed a genuinely unsupported type instead.
     */
    @Test
    void refusesAnUncoveredAssemblyTypeListingWhatIsCovered() {
       Exception thrown = assertThrows(
-         IllegalArgumentException.class, () -> PropertyAliases.forType("image"));
+         IllegalArgumentException.class, () -> PropertyAliases.forType("nosuchassembly"));
 
-      assertTrue(thrown.getMessage().contains("image"));
+      assertTrue(thrown.getMessage().contains("nosuchassembly"));
       assertTrue(thrown.getMessage().contains("gauge"));
+   }
+
+   /** The Immutables model that motivated the builder write path. */
+   @Test
+   void coversTheImageAssemblyNowThatImmutablesCanBeWritten() {
+      assertTrue(PropertyAliases.covers("image"));
+      assertEquals("imageGeneralPaneModel.outputGeneralPaneModel.generalPropPaneModel." +
+                   "basicGeneralPaneModel.visible",
+                   PropertyAliases.resolve("image", "visible"));
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyPathTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyPathTest.java
@@ -1,0 +1,270 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+class PropertyPathTest {
+   public enum Alignment { LEFT, CENTER, RIGHT }
+
+   public static class Leaf {
+      public boolean isVisible() { return visible; }
+      public void setVisible(boolean visible) { this.visible = visible; }
+      public String getTitle() { return title; }
+      public void setTitle(String title) { this.title = title; }
+      public int getMax() { return max; }
+      public void setMax(int max) { this.max = max; }
+      public double getRatio() { return ratio; }
+      public void setRatio(double ratio) { this.ratio = ratio; }
+      public Alignment getAlign() { return align; }
+      public void setAlign(Alignment align) { this.align = align; }
+      public String getReadOnly() { return "fixed"; }
+
+      private boolean visible;
+      private String title;
+      private int max;
+      private double ratio;
+      private Alignment align;
+   }
+
+   public static class Middle {
+      public Leaf getLeaf() { return leaf; }
+      public void setLeaf(Leaf leaf) { this.leaf = leaf; }
+
+      private Leaf leaf = new Leaf();
+   }
+
+   public static class Root {
+      public Middle getMiddle() { return middle; }
+      public void setMiddle(Middle middle) { this.middle = middle; }
+      public Middle getAbsent() { return null; }
+
+      private Middle middle = new Middle();
+   }
+
+   // ── reading ───────────────────────────────────────────────────────────────
+
+   @Test
+   void readsANestedPath() {
+      Root root = new Root();
+      root.getMiddle().getLeaf().setTitle("Sales");
+
+      assertEquals("Sales", PropertyPath.get(root, "middle.leaf.title"));
+   }
+
+   @Test
+   void readsABooleanThroughItsIsGetter() {
+      Root root = new Root();
+      root.getMiddle().getLeaf().setVisible(true);
+
+      assertEquals(Boolean.TRUE, PropertyPath.get(root, "middle.leaf.visible"));
+   }
+
+   @Test
+   void readsNullWhenAnIntermediateIsAbsent() {
+      assertNull(PropertyPath.get(new Root(), "absent.leaf.title"));
+   }
+
+   // ── writing ───────────────────────────────────────────────────────────────
+
+   @Test
+   void writesANestedPath() {
+      Root root = new Root();
+
+      PropertyPath.set(root, "middle.leaf.title", "Revenue");
+
+      assertEquals("Revenue", root.getMiddle().getLeaf().getTitle());
+   }
+
+   /**
+    * The whole point of this class: a path that quietly no-ops reports success while changing
+    * nothing, which is the defect the plugin family exists to avoid.
+    */
+   @Test
+   void refusesAnUnknownLeafRatherThanSilentlyDoingNothing() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> PropertyPath.set(new Root(), "middle.leaf.nope", "x"));
+
+      assertTrue(thrown.getMessage().contains("nope"));
+      assertTrue(thrown.getMessage().contains("title"), "name what was available instead");
+   }
+
+   @Test
+   void refusesAnUnknownIntermediateNamingTheSegment() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> PropertyPath.set(new Root(), "middel.leaf.title", "x"));
+
+      assertTrue(thrown.getMessage().contains("middel"));
+   }
+
+   /**
+    * An absent pane means the property does not apply to this assembly. Instantiating one
+    * would fabricate a shape the composer service never produced.
+    */
+   @Test
+   void refusesToFabricateAnAbsentIntermediate() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> PropertyPath.set(new Root(), "absent.leaf.title", "x"));
+
+      assertTrue(thrown.getMessage().contains("does not apply"));
+   }
+
+   @Test
+   void refusesAReadOnlyProperty() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> PropertyPath.set(new Root(), "middle.leaf.readOnly", "x"));
+
+      assertTrue(thrown.getMessage().contains("readOnly"));
+   }
+
+   @Test
+   void refusesAnEmptyPath() {
+      assertThrows(IllegalArgumentException.class, () -> PropertyPath.set(new Root(), "", "x"));
+   }
+
+   // ── coercion: forgiving where unambiguous ─────────────────────────────────
+
+   @Test
+   void acceptsAStringSpellingOfABoolean() {
+      Root root = new Root();
+
+      PropertyPath.set(root, "middle.leaf.visible", "true");
+
+      assertTrue(root.getMiddle().getLeaf().isVisible());
+   }
+
+   @Test
+   void acceptsARealBoolean() {
+      Root root = new Root();
+
+      PropertyPath.set(root, "middle.leaf.visible", Boolean.TRUE);
+
+      assertTrue(root.getMiddle().getLeaf().isVisible());
+   }
+
+   @Test
+   void acceptsANumericString() {
+      Root root = new Root();
+
+      PropertyPath.set(root, "middle.leaf.max", "100");
+
+      assertEquals(100, root.getMiddle().getLeaf().getMax());
+   }
+
+   @Test
+   void narrowsAJsonDoubleOntoAnIntField() {
+      Root root = new Root();
+
+      PropertyPath.set(root, "middle.leaf.max", 100.0);
+
+      assertEquals(100, root.getMiddle().getLeaf().getMax());
+   }
+
+   @Test
+   void widensAnIntOntoADoubleField() {
+      Root root = new Root();
+
+      PropertyPath.set(root, "middle.leaf.ratio", 2);
+
+      assertEquals(2.0, root.getMiddle().getLeaf().getRatio());
+   }
+
+   @Test
+   void matchesAnEnumTokenInAnyCase() {
+      Root root = new Root();
+
+      PropertyPath.set(root, "middle.leaf.align", "center");
+
+      assertEquals(Alignment.CENTER, root.getMiddle().getLeaf().getAlign());
+   }
+
+   // ── coercion: loud otherwise ──────────────────────────────────────────────
+
+   @Test
+   void refusesAnAmbiguousBooleanSpellingRatherThanGuessing() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> PropertyPath.set(new Root(), "middle.leaf.visible", "yes"));
+
+      assertTrue(thrown.getMessage().contains("yes"));
+      assertTrue(thrown.getMessage().contains("true"));
+   }
+
+   @Test
+   void refusesANonNumericStringForANumber() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> PropertyPath.set(new Root(), "middle.leaf.max", "lots"));
+
+      assertTrue(thrown.getMessage().contains("lots"));
+   }
+
+   @Test
+   void refusesAnUnknownEnumTokenListingTheValid() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> PropertyPath.set(new Root(), "middle.leaf.align", "middle"));
+
+      assertTrue(thrown.getMessage().contains("CENTER"));
+   }
+
+   @Test
+   void refusesNullForAPrimitive() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> PropertyPath.set(new Root(), "middle.leaf.visible", null));
+
+      assertTrue(thrown.getMessage().contains("null"));
+   }
+
+   // ── introspection, used by the registry's invariant test ──────────────────
+
+   @Test
+   void reportsThePathsDeclaredType() {
+      assertEquals(boolean.class, PropertyPath.typeOf(Root.class, "middle.leaf.visible"));
+      assertEquals(String.class, PropertyPath.typeOf(Root.class, "middle.leaf.title"));
+   }
+
+   @Test
+   void typeOfRefusesAPathThatDoesNotExist() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> PropertyPath.typeOf(Root.class, "middle.leaf.nope"));
+
+      assertTrue(thrown.getMessage().contains("nope"));
+   }
+
+   @Test
+   void listsReadablePropertiesForDiscovery() {
+      List<String> properties = PropertyPath.propertiesOf(Leaf.class);
+
+      assertTrue(properties.contains("visible"));
+      assertTrue(properties.contains("title"));
+      assertFalse(properties.contains("class"), "Object's own getters are not properties");
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyPathTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyPathTest.java
@@ -101,6 +101,130 @@ class PropertyPathTest {
     * The whole point of this class: a path that quietly no-ops reports success while changing
     * nothing, which is the defect the plugin family exists to avoid.
     */
+   /**
+    * `visible` is a String-typed enum in disguise. {@code VSAssemblyInfo} declares its whole domain
+    * as {@code {"true","show","false","hide","hide on print and export"}} and maps anything else to
+    * the default — so {@code visible: "no"} returned ok, stored "no", and left the assembly on
+    * screen. The boolean guard in coerce never fired because the target type is String.
+    */
+   public static class StringVisible {
+      public String getVisible() { return visible; }
+      public void setVisible(String visible) { this.visible = visible; }
+
+      private String visible = "show";
+   }
+
+   @Test
+   void refusesAnAmbiguousVisibleTokenRatherThanLettingStyleBIIgnoreIt() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> PropertyPath.set(new StringVisible(), "visible", "no"));
+
+      assertTrue(thrown.getMessage().contains("visible"), "name the property");
+      assertTrue(thrown.getMessage().contains("hide"), "list the tokens that do work");
+   }
+
+   @Test
+   void acceptsEveryVisibleTokenStyleBIUnderstands() {
+      for(String token : new String[]{ "show", "hide", "true", "false",
+                                       "hide on print and export" })
+      {
+         StringVisible target = new StringVisible();
+         PropertyPath.set(target, "visible", token);
+         assertEquals(token, target.getVisible(), token + " is a documented value");
+      }
+   }
+
+   @Test
+   void normalizesABooleanOntoTheStringTypedVisibleProperty() {
+      StringVisible target = new StringVisible();
+      PropertyPath.set(target, "visible", false);
+      assertEquals("false", target.getVisible());
+   }
+
+   // ── Immutables support ────────────────────────────────────────────────────
+   //
+   // Five dialog models are Immutables: accessors are bare (imageGeneralPaneModel(), no "get")
+   // and there are no setters, only withX() returning a NEW instance. PropertyPath read get/is
+   // and wrote setX, so it could not touch them at all — which is why image and VS-level
+   // properties were "not covered". Writing a leaf means rebuilding every immutable level above
+   // it, from the leaf upward.
+
+   /** Immutable leaf: no setter, only a wither returning a new instance. */
+   public static final class ImmutableLeaf {
+      ImmutableLeaf(String title, boolean visible) {
+         this.title = title;
+         this.visible = visible;
+      }
+
+      public String title() { return title; }
+      public boolean visible() { return visible; }
+      public ImmutableLeaf withTitle(String value) { return new ImmutableLeaf(value, visible); }
+      public ImmutableLeaf withVisible(boolean value) { return new ImmutableLeaf(title, value); }
+
+      private final String title;
+      private final boolean visible;
+   }
+
+   /** Immutable middle holding an immutable leaf. */
+   public static final class ImmutableMiddle {
+      ImmutableMiddle(ImmutableLeaf leaf) { this.leaf = leaf; }
+
+      public ImmutableLeaf leaf() { return leaf; }
+      public ImmutableMiddle withLeaf(ImmutableLeaf value) { return new ImmutableMiddle(value); }
+
+      private final ImmutableLeaf leaf;
+   }
+
+   /** Mutable root — the realistic shape: a mutable holder of an immutable tree. */
+   public static class MutableRoot {
+      public ImmutableMiddle getMiddle() { return middle; }
+      public void setMiddle(ImmutableMiddle middle) { this.middle = middle; }
+
+      private ImmutableMiddle middle =
+         new ImmutableMiddle(new ImmutableLeaf("original", false));
+   }
+
+   @Test
+   void readsThroughABareImmutablesAccessor() {
+      MutableRoot root = new MutableRoot();
+
+      assertEquals("original", PropertyPath.get(root, "middle.leaf.title"));
+      assertEquals(false, PropertyPath.get(root, "middle.leaf.visible"));
+   }
+
+   @Test
+   void writesAnImmutableLeafByRebuildingEveryLevelAboveIt() {
+      MutableRoot root = new MutableRoot();
+
+      PropertyPath.set(root, "middle.leaf.title", "rebuilt");
+
+      assertEquals("rebuilt", PropertyPath.get(root, "middle.leaf.title"),
+                   "the rebuilt instances must be stored back up the chain");
+      assertEquals(false, PropertyPath.get(root, "middle.leaf.visible"),
+                   "rebuilding one field must not reset its siblings");
+   }
+
+   @Test
+   void coercesOntoAnImmutableWither() {
+      MutableRoot root = new MutableRoot();
+
+      PropertyPath.set(root, "middle.leaf.visible", "true");
+
+      assertEquals(true, PropertyPath.get(root, "middle.leaf.visible"),
+                   "a wither takes the same coercion as a setter");
+   }
+
+   @Test
+   void refusesAnUnknownLeafOnAnImmutableOwnerNamingWhatExists() {
+      MutableRoot root = new MutableRoot();
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> PropertyPath.set(root, "middle.leaf.nope", "x"));
+      assertTrue(thrown.getMessage().contains("nope"));
+   }
+
    @Test
    void refusesAnUnknownLeafRatherThanSilentlyDoingNothing() {
       Exception thrown = assertThrows(

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAgentControllerTest.java
@@ -1,0 +1,76 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.web.wiz.pairing.*;
+import inetsoft.web.wiz.viewsheet.model.ViewsheetModel;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.security.Principal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class ViewsheetAgentControllerTest {
+   @Test
+   void joinRefusesWhenTheFeatureIsDisabled() {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      when(feature.isEnabled()).thenReturn(false);
+
+      ViewsheetAgentController controller = controllerWith(feature,
+                                                           mock(ViewsheetSessionService.class),
+                                                           mock(ViewsheetReadService.class));
+
+      assertThrows(ResponseStatusException.class, () ->
+         controller.join(new ViewsheetAgentController.JoinRequest("ABCD2345"), principal()));
+   }
+
+   @Test
+   void modelReturnsTheReadServiceResult() throws Exception {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      when(feature.isEnabled()).thenReturn(true);
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      ViewsheetReadService reader = mock(ViewsheetReadService.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      ViewsheetModel expected = new ViewsheetModel("vs1", List.of());
+      when(sessions.resolve(eq("tok"), any(Principal.class))).thenReturn(rvs);
+      when(reader.read(rvs)).thenReturn(expected);
+
+      ViewsheetAgentController controller = controllerWith(feature, sessions, reader);
+
+      assertSame(expected, controller.model("tok", principal()));
+   }
+
+   private static ViewsheetAgentController controllerWith(SheetAgentFeature feature,
+                                                          ViewsheetSessionService sessions,
+                                                          ViewsheetReadService reader)
+   {
+      return new ViewsheetAgentController(feature, mock(SheetJoinService.class),
+                                          mock(SheetSessionService.class), sessions, reader);
+   }
+
+   private static Principal principal() {
+      return () -> "admin";
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAgentControllerTest.java
@@ -67,7 +67,8 @@ class ViewsheetAgentControllerTest {
                                                           ViewsheetReadService reader)
    {
       return new ViewsheetAgentController(feature, mock(SheetJoinService.class),
-                                          mock(SheetSessionService.class), sessions, reader);
+                                          mock(SheetSessionService.class), sessions, reader,
+                                          mock(ViewsheetEditService.class));
    }
 
    private static Principal principal() {

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAgentControllerTest.java
@@ -68,7 +68,9 @@ class ViewsheetAgentControllerTest {
    {
       return new ViewsheetAgentController(feature, mock(SheetJoinService.class),
                                           mock(SheetSessionService.class), sessions, reader,
-                                          mock(ViewsheetEditService.class));
+                                          mock(ViewsheetEditService.class),
+                                          mock(ViewsheetFormatService.class),
+                                          mock(inetsoft.web.wiz.script.ScriptImageService.class));
    }
 
    private static Principal principal() {

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAgentControllerTest.java
@@ -70,7 +70,9 @@ class ViewsheetAgentControllerTest {
                                           mock(SheetSessionService.class), sessions, reader,
                                           mock(ViewsheetEditService.class),
                                           mock(ViewsheetFormatService.class),
-                                          mock(inetsoft.web.wiz.script.ScriptImageService.class));
+                                          mock(inetsoft.web.wiz.script.ScriptImageService.class),
+                                          mock(inetsoft.analytic.composition.ViewsheetService.class),
+                                          mock(SheetAgentBroadcastService.class));
    }
 
    private static Principal principal() {

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -62,12 +62,58 @@ class ViewsheetAgentControllerTest {
       assertSame(expected, controller.model("tok", principal()));
    }
 
+   /**
+    * detach took the session token and nothing else, so any authenticated caller holding or
+    * guessing another user's token could terminate their pairing session. Every other endpoint
+    * binds the token to the caller through {@code sessions.resolve(token, user)}; this one
+    * accepted {@code Principal} and ignored it. The script controller — which this was clearly
+    * copied from — resolves first and only closes on a hit.
+    */
+   @Test
+   void detachRefusesASessionThatIsNotTheCallersOwn() {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      SheetSessionService sessionService = mock(SheetSessionService.class);
+      when(sessionService.resolve(anyString(), anyString())).thenReturn(null);
+
+      ViewsheetAssemblyAgentController controller =
+         controllerWith(feature, mock(ViewsheetSessionService.class),
+                        mock(ViewsheetReadService.class), sessionService);
+
+      controller.detach("someone-elses-token", principal());
+
+      verify(sessionService, never()).close(anyString());
+   }
+
+   @Test
+   void detachClosesTheCallersOwnSession() {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      SheetSessionService sessionService = mock(SheetSessionService.class);
+      when(sessionService.resolve(anyString(), anyString()))
+         .thenReturn(mock(JoinSession.class));
+
+      ViewsheetAssemblyAgentController controller =
+         controllerWith(feature, mock(ViewsheetSessionService.class),
+                        mock(ViewsheetReadService.class), sessionService);
+
+      controller.detach("my-token", principal());
+
+      verify(sessionService).close("my-token");
+   }
+
    private static ViewsheetAssemblyAgentController controllerWith(SheetAgentFeature feature,
                                                           ViewsheetSessionService sessions,
                                                           ViewsheetReadService reader)
    {
+      return controllerWith(feature, sessions, reader, mock(SheetSessionService.class));
+   }
+
+   private static ViewsheetAssemblyAgentController controllerWith(SheetAgentFeature feature,
+                                                          ViewsheetSessionService sessions,
+                                                          ViewsheetReadService reader,
+                                                          SheetSessionService sessionService)
+   {
       return new ViewsheetAssemblyAgentController(feature, mock(SheetJoinService.class),
-                                          mock(SheetSessionService.class), sessions, reader,
+                                          sessionService, sessions, reader,
                                           mock(ViewsheetEditService.class),
                                           mock(ViewsheetFormatService.class),
                                           mock(inetsoft.web.wiz.script.ScriptImageService.class),

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -72,6 +72,7 @@ class ViewsheetAgentControllerTest {
                                           mock(ViewsheetFormatService.class),
                                           mock(inetsoft.web.wiz.script.ScriptImageService.class),
                                           mock(AssemblyPropertyService.class),
+                                          mock(AssemblyHyperlinkService.class),
                                           mock(inetsoft.analytic.composition.ViewsheetService.class),
                                           mock(SheetAgentBroadcastService.class));
    }

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -76,6 +76,7 @@ class ViewsheetAgentControllerTest {
                                           mock(ChartElementService.class),
                                           mock(AssemblyConditionService.class),
                                           mock(AssemblyHighlightService.class),
+                                          mock(DateComparisonService.class),
                                           mock(inetsoft.analytic.composition.ViewsheetService.class),
                                           mock(SheetAgentBroadcastService.class));
    }

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -74,6 +74,7 @@ class ViewsheetAgentControllerTest {
                                           mock(AssemblyPropertyService.class),
                                           mock(AssemblyHyperlinkService.class),
                                           mock(ChartElementService.class),
+                                          mock(AssemblyConditionService.class),
                                           mock(inetsoft.analytic.composition.ViewsheetService.class),
                                           mock(SheetAgentBroadcastService.class));
    }

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -71,6 +71,7 @@ class ViewsheetAgentControllerTest {
                                           mock(ViewsheetEditService.class),
                                           mock(ViewsheetFormatService.class),
                                           mock(inetsoft.web.wiz.script.ScriptImageService.class),
+                                          mock(AssemblyPropertyService.class),
                                           mock(inetsoft.analytic.composition.ViewsheetService.class),
                                           mock(SheetAgentBroadcastService.class));
    }

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -38,12 +38,12 @@ class ViewsheetAgentControllerTest {
       SheetAgentFeature feature = mock(SheetAgentFeature.class);
       when(feature.isEnabled()).thenReturn(false);
 
-      ViewsheetAgentController controller = controllerWith(feature,
+      ViewsheetAssemblyAgentController controller = controllerWith(feature,
                                                            mock(ViewsheetSessionService.class),
                                                            mock(ViewsheetReadService.class));
 
       assertThrows(ResponseStatusException.class, () ->
-         controller.join(new ViewsheetAgentController.JoinRequest("ABCD2345"), principal()));
+         controller.join(new ViewsheetAssemblyAgentController.JoinRequest("ABCD2345"), principal()));
    }
 
    @Test
@@ -57,16 +57,16 @@ class ViewsheetAgentControllerTest {
       when(sessions.resolve(eq("tok"), any(Principal.class))).thenReturn(rvs);
       when(reader.read(rvs)).thenReturn(expected);
 
-      ViewsheetAgentController controller = controllerWith(feature, sessions, reader);
+      ViewsheetAssemblyAgentController controller = controllerWith(feature, sessions, reader);
 
       assertSame(expected, controller.model("tok", principal()));
    }
 
-   private static ViewsheetAgentController controllerWith(SheetAgentFeature feature,
+   private static ViewsheetAssemblyAgentController controllerWith(SheetAgentFeature feature,
                                                           ViewsheetSessionService sessions,
                                                           ViewsheetReadService reader)
    {
-      return new ViewsheetAgentController(feature, mock(SheetJoinService.class),
+      return new ViewsheetAssemblyAgentController(feature, mock(SheetJoinService.class),
                                           mock(SheetSessionService.class), sessions, reader,
                                           mock(ViewsheetEditService.class),
                                           mock(ViewsheetFormatService.class),

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -74,6 +74,7 @@ class ViewsheetAgentControllerTest {
                                           mock(AssemblyPropertyService.class),
                                           mock(AssemblyHyperlinkService.class),
                                           mock(ChartElementService.class),
+                                          mock(ChartRegionPropertyService.class),
                                           mock(AssemblyConditionService.class),
                                           mock(AssemblyHighlightService.class),
                                           mock(DateComparisonService.class),

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -73,6 +73,7 @@ class ViewsheetAgentControllerTest {
                                           mock(inetsoft.web.wiz.script.ScriptImageService.class),
                                           mock(AssemblyPropertyService.class),
                                           mock(AssemblyHyperlinkService.class),
+                                          mock(ChartElementService.class),
                                           mock(inetsoft.analytic.composition.ViewsheetService.class),
                                           mock(SheetAgentBroadcastService.class));
    }

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -75,6 +75,7 @@ class ViewsheetAgentControllerTest {
                                           mock(AssemblyHyperlinkService.class),
                                           mock(ChartElementService.class),
                                           mock(AssemblyConditionService.class),
+                                          mock(AssemblyHighlightService.class),
                                           mock(inetsoft.analytic.composition.ViewsheetService.class),
                                           mock(SheetAgentBroadcastService.class));
    }

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetEditServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetEditServiceTest.java
@@ -26,6 +26,11 @@ import inetsoft.web.composer.vs.objects.event.AddNewVSObjectEvent;
 import inetsoft.web.composer.vs.objects.event.ChangeVSObjectLayerEvent;
 import inetsoft.web.composer.vs.objects.event.LockVSObjectEvent;
 import inetsoft.web.composer.vs.objects.event.MoveVSObjectEvent;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.TextVSAssembly;
+import inetsoft.uql.viewsheet.VSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.wiz.viewsheet.model.AssemblyNode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -452,6 +457,51 @@ class ViewsheetEditServiceTest {
                  op + " must name the assembly it could not find, got: " + thrown.getMessage());
    }
 
+   /**
+    * Not every assembly has a title bar. {@code ComposerObjectService.changeTitle} casts to
+    * {@code TitledVSAssembly}, so set_title on a Text produced a raw
+    * {@code ClassCastException: TextVSAssembly cannot be cast to TitledVSAssembly} as a bare 500 —
+    * an internal type name, and no hint that the op simply does not apply to this assembly.
+    *
+    * <p>Checked with {@code instanceof} rather than a list of type names, so it cannot drift from
+    * whatever actually implements the interface. Found live on local-1198.
+    */
+   @Test
+   void setTitleOnAnAssemblyWithNoTitleBarSaysSoRatherThanThrowingAClassCastException() {
+      RuntimeViewsheet rvs = runtimeWith("Text1", mock(TextVSAssembly.class));
+      ViewsheetEditService service = serviceWithRuntime(rvs, readerReturning(
+         new AssemblyNode("Text1", "Text", 140, 440, 100, 20, 0, null, true)));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> service.apply("tok", principal(), full("set_title", "Text1"), ""));
+
+      assertTrue(thrown.getMessage().contains("Text1"));
+      assertFalse(thrown.getMessage().contains("TitledVSAssembly"),
+                  "an internal interface name is not an explanation, got: " + thrown.getMessage());
+   }
+
+   /** A titled assembly still goes through. */
+   @Test
+   void setTitleStillWorksOnAnAssemblyThatHasATitle() throws Exception {
+      ComposerObjectService objects = mock(ComposerObjectService.class);
+      RuntimeViewsheet rvs = runtimeWith("Chart1", mock(ChartVSAssembly.class));
+      ViewsheetEditService service = serviceWithRuntime(rvs, readerReturning(
+         new AssemblyNode("Chart1", "Chart", 240, 100, 400, 240, 0, null, true)), objects);
+
+      service.apply("tok", principal(), full("set_title", "Chart1"), "");
+
+      verify(objects).changeTitle(eq("rt1"), any(), any(Principal.class), any());
+   }
+
+   private static RuntimeViewsheet runtimeWith(String name, VSAssembly assembly) {
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(vs.getAssembly(name)).thenReturn(assembly);
+      return rvs;
+   }
+
    /** Every field populated, so an op fails on the missing assembly rather than a missing field. */
    private static EditRequest full(String op, String assembly) {
       return new EditRequest(op, assembly, 10, 10, 100, 100, 2, "A title", true, "Container1",
@@ -520,6 +570,35 @@ class ViewsheetEditServiceTest {
    {
       return serviceWith(objects, clipboard, mock(ViewsheetReadService.class),
                          mock(ComposerGroupService.class));
+   }
+
+   /** Runs the mutation against a supplied runtime, for the guards that inspect the assembly. */
+   private static ViewsheetEditService serviceWithRuntime(RuntimeViewsheet rvs,
+                                                          ViewsheetReadService reader)
+   {
+      return serviceWithRuntime(rvs, reader, mock(ComposerObjectService.class));
+   }
+
+   private static ViewsheetEditService serviceWithRuntime(RuntimeViewsheet rvs,
+                                                          ViewsheetReadService reader,
+                                                          ComposerObjectService objects)
+   {
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+
+      try {
+         doAnswer(invocation -> {
+            ViewsheetSessionService.Mutation mutation = invocation.getArgument(2);
+            mutation.run(rvs, "rt1", null);
+            return null;
+         }).when(sessions).mutate(anyString(), any(Principal.class), any());
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(e);
+      }
+
+      return new ViewsheetEditService(sessions, objects, mock(ClipboardControllerService.class),
+                                      mock(VSObjectPropertyService.class), reader,
+                                      mock(ComposerGroupService.class));
    }
 
    private static ViewsheetEditService serviceWith(ComposerObjectService objects,

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetEditServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetEditServiceTest.java
@@ -44,10 +44,18 @@ import static org.mockito.Mockito.*;
 
 @Tag("core")
 class ViewsheetEditServiceTest {
+   /**
+    * Covers only the second half of the move contract — the anchored-line fix-up. This test used to
+    * be named "moveDelegatesTheNewPosition…" and was the sole move test, which is how the missing
+    * {@code moveObject} call survived: {@code moveObjects} is a fix-up hook that moves nothing, so
+    * asserting it alone certified a no-op. The actual move is covered by
+    * {@link #moveCallsMoveObjectBecauseMoveObjectsOnlyUpdatesAnchoredLines()}.
+    */
    @Test
-   void moveDelegatesTheNewPositionToComposerObjectService() throws Exception {
+   void moveAlsoTriggersTheAnchoredLineFixUp() throws Exception {
       ComposerObjectService objects = mock(ComposerObjectService.class);
-      ViewsheetEditService service = serviceWith(objects);
+      ViewsheetEditService service = serviceWith(objects, readerReturning(
+         new AssemblyNode("Gauge1", "Gauge", 340, 440, 140, 140, 0, null, true)));
 
       service.apply("tok", principal(), edit("move", "Gauge1", 120, 240), "");
 
@@ -63,7 +71,8 @@ class ViewsheetEditServiceTest {
    @Test
    void resizeDelegatesTheNewSize() throws Exception {
       ComposerObjectService objects = mock(ComposerObjectService.class);
-      ViewsheetEditService service = serviceWith(objects);
+      ViewsheetEditService service = serviceWith(objects, readerReturning(
+         new AssemblyNode("Gauge1", "Gauge", 340, 440, 140, 140, 0, null, true)));
 
       EditRequest request = request("resize", "Gauge1");
       request = new EditRequest(request.op(), request.assembly(), null, null, 300, 150,
@@ -81,7 +90,8 @@ class ViewsheetEditServiceTest {
    @Test
    void resizeTitleDelegatesTheTitleHeight() throws Exception {
       ComposerObjectService objects = mock(ComposerObjectService.class);
-      ViewsheetEditService service = serviceWith(objects);
+      ViewsheetEditService service = serviceWith(objects, readerReturning(
+         new AssemblyNode("Table1", "Table", 10, 20, 300, 150, 0, null, true)));
 
       EditRequest request = new EditRequest("resize_title", "Table1", null, null, null, 28,
                                             null, null, null, null, null, null, null, null);
@@ -325,6 +335,105 @@ class ViewsheetEditServiceTest {
       verify(objects).moveObjects(eq("rt1"), captor.capture(), any(Principal.class), any(),
                                   anyString());
       return captor.getValue().getEvents();
+   }
+
+   // ------------------------------------------------------------------------------------------
+   // Regression tests for the "partially-populated Composer event" defect class.
+   //
+   // ComposerObjectService reads fields off these events that the caller must fill in. Populating
+   // only the fields the op is "about" leaves the rest at 0, and the service applies those zeroes
+   // as real values. Live symptoms: move did nothing, resize teleported the assembly to 0,0, and
+   // resize_title collapsed it to 1x1 at 0,0 — each returning ok.
+   //
+   // Note these assert the CONTENT of the event, not merely which method was called. The previous
+   // move test asserted `verify(objects).moveObjects(...)` and so certified the broken call.
+   // ------------------------------------------------------------------------------------------
+
+   @Test
+   void moveCallsMoveObjectBecauseMoveObjectsOnlyUpdatesAnchoredLines() throws Exception {
+      ComposerObjectService objects = mock(ComposerObjectService.class);
+      ViewsheetReadService reader = readerReturning(
+         new AssemblyNode("Gauge1", "Gauge", 340, 440, 140, 140, 0, null, true));
+      ViewsheetEditService service = serviceWith(objects, reader);
+
+      service.apply("tok", principal(), edit("move", "Gauge1", 380, 480), "");
+
+      ArgumentCaptor<MoveVSObjectEvent> captor = ArgumentCaptor.forClass(MoveVSObjectEvent.class);
+      verify(objects).moveObject(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                 anyString());
+      assertEquals("Gauge1", captor.getValue().getName());
+      assertEquals(380, captor.getValue().getxOffset());
+      assertEquals(480, captor.getValue().getyOffset());
+   }
+
+   @Test
+   void resizeCarriesTheCurrentPositionSoTheAssemblyIsNotTeleportedToTheOrigin() throws Exception {
+      ComposerObjectService objects = mock(ComposerObjectService.class);
+      ViewsheetReadService reader = readerReturning(
+         new AssemblyNode("Chart1", "Chart", 240, 100, 400, 240, 0, null, true));
+      ViewsheetEditService service = serviceWith(objects, reader);
+
+      service.apply("tok", principal(), sized("resize", "Chart1", 420, 260), "");
+
+      ArgumentCaptor<ResizeVSObjectEvent> captor =
+         ArgumentCaptor.forClass(ResizeVSObjectEvent.class);
+      verify(objects).resizeObject(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                   anyString());
+      assertEquals(420, captor.getValue().getWidth());
+      assertEquals(260, captor.getValue().getHeight());
+      assertEquals(240, captor.getValue().getxOffset(), "resize must preserve x");
+      assertEquals(100, captor.getValue().getyOffset(), "resize must preserve y");
+   }
+
+   @Test
+   void resizeTitleCarriesTheCurrentSizeSoTheAssemblyIsNotCollapsed() throws Exception {
+      ComposerObjectService objects = mock(ComposerObjectService.class);
+      ViewsheetReadService reader = readerReturning(
+         new AssemblyNode("Chart1", "Chart", 240, 100, 400, 240, 0, null, true));
+      ViewsheetEditService service = serviceWith(objects, reader);
+
+      service.apply("tok", principal(),
+                    new EditRequest("resize_title", "Chart1", null, null, null, 40, null, null,
+                                    null, null, null, null, null, null), "");
+
+      ArgumentCaptor<ResizeVSObjectTitleEvent> captor =
+         ArgumentCaptor.forClass(ResizeVSObjectTitleEvent.class);
+      verify(objects).resizeObjectTitle(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                        anyString());
+      assertEquals(40, captor.getValue().getTitleHeight());
+      assertEquals(400, captor.getValue().getWidth(), "resize_title must preserve width");
+      assertEquals(240, captor.getValue().getHeight(), "resize_title must preserve height");
+      assertEquals(240, captor.getValue().getxOffset(), "resize_title must preserve x");
+      assertEquals(100, captor.getValue().getyOffset(), "resize_title must preserve y");
+   }
+
+   @Test
+   void editOnAnUnknownAssemblyFailsLoudRatherThanSilentlyDoingNothing() {
+      ViewsheetReadService reader = readerReturning(
+         new AssemblyNode("Chart1", "Chart", 240, 100, 400, 240, 0, null, true));
+      ViewsheetEditService service = serviceWith(mock(ComposerObjectService.class), reader);
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> service.apply("tok", principal(), sized("resize", "NoSuchAssembly1", 120, 80), ""));
+      assertTrue(thrown.getMessage().contains("NoSuchAssembly1"));
+   }
+
+   @Test
+   void resizeRejectsNonPositiveDimensionsRatherThanCollapsingTheAssembly() {
+      ViewsheetReadService reader = readerReturning(
+         new AssemblyNode("Text1", "Text", 140, 440, 100, 20, 0, null, true));
+      ViewsheetEditService service = serviceWith(mock(ComposerObjectService.class), reader);
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> service.apply("tok", principal(), sized("resize", "Text1", -50, -20), ""));
+      assertTrue(thrown.getMessage().contains("width"));
+   }
+
+   private static EditRequest sized(String op, String assembly, Integer width, Integer height) {
+      return new EditRequest(op, assembly, null, null, width, height, null, null, null, null,
+                             null, null, null, null);
    }
 
    private static ViewsheetReadService readerReturning(AssemblyNode... nodes) {

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetEditServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetEditServiceTest.java
@@ -1,0 +1,141 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.web.composer.vs.objects.controller.ComposerObjectService;
+import inetsoft.web.composer.vs.objects.event.MultiMoveVsObjectEvent;
+import inetsoft.web.composer.vs.objects.event.ResizeVSObjectEvent;
+import inetsoft.web.composer.vs.objects.event.ResizeVSObjectTitleEvent;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class ViewsheetEditServiceTest {
+   @Test
+   void moveDelegatesTheNewPositionToComposerObjectService() throws Exception {
+      ComposerObjectService objects = mock(ComposerObjectService.class);
+      ViewsheetEditService service = serviceWith(objects);
+
+      service.apply("tok", principal(), edit("move", "Gauge1", 120, 240), "");
+
+      ArgumentCaptor<MultiMoveVsObjectEvent> captor =
+         ArgumentCaptor.forClass(MultiMoveVsObjectEvent.class);
+      verify(objects).moveObjects(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                  anyString());
+      assertEquals("Gauge1", captor.getValue().getEvents()[0].getName());
+      assertEquals(120, captor.getValue().getEvents()[0].getxOffset());
+      assertEquals(240, captor.getValue().getEvents()[0].getyOffset());
+   }
+
+   @Test
+   void resizeDelegatesTheNewSize() throws Exception {
+      ComposerObjectService objects = mock(ComposerObjectService.class);
+      ViewsheetEditService service = serviceWith(objects);
+
+      EditRequest request = request("resize", "Gauge1");
+      request = new EditRequest(request.op(), request.assembly(), null, null, 300, 150,
+                                null, null, null, null, null, null, null, null);
+      service.apply("tok", principal(), request, "");
+
+      ArgumentCaptor<ResizeVSObjectEvent> captor =
+         ArgumentCaptor.forClass(ResizeVSObjectEvent.class);
+      verify(objects).resizeObject(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                   anyString());
+      assertEquals(300, captor.getValue().getWidth());
+      assertEquals(150, captor.getValue().getHeight());
+   }
+
+   @Test
+   void resizeTitleDelegatesTheTitleHeight() throws Exception {
+      ComposerObjectService objects = mock(ComposerObjectService.class);
+      ViewsheetEditService service = serviceWith(objects);
+
+      EditRequest request = new EditRequest("resize_title", "Table1", null, null, null, 28,
+                                            null, null, null, null, null, null, null, null);
+      service.apply("tok", principal(), request, "");
+
+      ArgumentCaptor<ResizeVSObjectTitleEvent> captor =
+         ArgumentCaptor.forClass(ResizeVSObjectTitleEvent.class);
+      verify(objects).resizeObjectTitle(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                        anyString());
+      assertEquals(28, captor.getValue().getTitleHeight());
+   }
+
+   @Test
+   void unknownOpFailsLoudNamingTheOp() {
+      ViewsheetEditService service = serviceWith(mock(ComposerObjectService.class));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> service.apply("tok", principal(), request("teleport", "Gauge1"), ""));
+      assertTrue(thrown.getMessage().contains("teleport"),
+                 "the error should name the rejected op, got: " + thrown.getMessage());
+   }
+
+   @Test
+   void moveWithoutCoordinatesFailsLoudRatherThanMovingToTheOrigin() {
+      ViewsheetEditService service = serviceWith(mock(ComposerObjectService.class));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> service.apply("tok", principal(), request("move", "Gauge1"), ""));
+      assertTrue(thrown.getMessage().contains("x"));
+   }
+
+   private static EditRequest request(String op, String assembly) {
+      return new EditRequest(op, assembly, null, null, null, null, null, null, null, null,
+                             null, null, null, null);
+   }
+
+   private static EditRequest edit(String op, String assembly, Integer x, Integer y) {
+      return new EditRequest(op, assembly, x, y, null, null, null, null, null, null,
+                             null, null, null, null);
+   }
+
+   private static Principal principal() {
+      return () -> "admin";
+   }
+
+   /**
+    * A session service whose mutate() runs the mutation immediately against runtime "rt1",
+    * so these tests exercise op dispatch and validation without a live runtime.
+    */
+   private static ViewsheetEditService serviceWith(ComposerObjectService objects) {
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+
+      try {
+         doAnswer(invocation -> {
+            ViewsheetSessionService.Mutation mutation = invocation.getArgument(2);
+            mutation.run(null, "rt1", null);
+            return null;
+         }).when(sessions).mutate(anyString(), any(Principal.class), any());
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(e);
+      }
+
+      return new ViewsheetEditService(sessions, objects);
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetEditServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetEditServiceTest.java
@@ -27,6 +27,8 @@ import inetsoft.web.composer.vs.objects.event.ChangeVSObjectLayerEvent;
 import inetsoft.web.composer.vs.objects.event.LockVSObjectEvent;
 import inetsoft.web.composer.vs.objects.event.MoveVSObjectEvent;
 import inetsoft.web.wiz.viewsheet.model.AssemblyNode;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import inetsoft.web.wiz.viewsheet.model.ViewsheetModel;
 import inetsoft.web.composer.vs.objects.event.MultiMoveVsObjectEvent;
 import inetsoft.web.composer.vs.objects.event.ResizeVSObjectEvent;
@@ -128,7 +130,8 @@ class ViewsheetEditServiceTest {
    @Test
    void removeDelegatesTheAssemblyNameToComposerObjectService() throws Exception {
       ComposerObjectService objects = mock(ComposerObjectService.class);
-      ViewsheetEditService service = serviceWith(objects);
+      ViewsheetEditService service = serviceWith(objects, readerReturning(
+         new AssemblyNode("Gauge1", "Gauge", 340, 440, 140, 140, 0, null, true)));
 
       service.apply("tok", principal(), request("remove", "Gauge1"), "");
 
@@ -288,7 +291,8 @@ class ViewsheetEditServiceTest {
    @Test
    void setZIndexDelegatesTheLayerChange() throws Exception {
       ComposerObjectService objects = mock(ComposerObjectService.class);
-      ViewsheetEditService service = serviceWith(objects);
+      ViewsheetEditService service = serviceWith(objects, readerReturning(
+         new AssemblyNode("Gauge1", "Gauge", 340, 440, 140, 140, 0, null, true)));
       EditRequest request = new EditRequest("set_z_index", "Gauge1", null, null, null, null,
                                             7, null, null, null, null, null, null, null);
 
@@ -303,7 +307,8 @@ class ViewsheetEditServiceTest {
    @Test
    void setLockDelegatesTheLockState() throws Exception {
       ComposerObjectService objects = mock(ComposerObjectService.class);
-      ViewsheetEditService service = serviceWith(objects);
+      ViewsheetEditService service = serviceWith(objects, readerReturning(
+         new AssemblyNode("Rect1", "Rectangle", 10, 10, 80, 40, 0, null, true)));
       EditRequest request = new EditRequest("set_lock", "Rect1", null, null, null, null,
                                             null, null, Boolean.TRUE, null, null, null,
                                             null, null);
@@ -320,7 +325,9 @@ class ViewsheetEditServiceTest {
       ComposerGroupService groups = mock(ComposerGroupService.class);
       ViewsheetEditService service = serviceWith(mock(ComposerObjectService.class),
                                                  mock(ClipboardControllerService.class),
-                                                 mock(ViewsheetReadService.class), groups);
+                                                 readerReturning(new AssemblyNode(
+                                                    "Group1", "GroupContainer", 0, 0, 200, 200,
+                                                    0, null, true)), groups);
 
       service.apply("tok", principal(), request("ungroup", "Group1"), "");
 
@@ -417,6 +424,38 @@ class ViewsheetEditServiceTest {
          IllegalArgumentException.class,
          () -> service.apply("tok", principal(), sized("resize", "NoSuchAssembly1", 120, 80), ""));
       assertTrue(thrown.getMessage().contains("NoSuchAssembly1"));
+   }
+
+   /**
+    * The same guard belongs on <em>every</em> op that addresses an existing assembly, not just the
+    * three geometry ones. It was wired into move, resize and resize_title only, so renaming
+    * Text1 and then calling set_title on "Text1" returned a cheerful ok — the composer layer looks
+    * the assembly up, gets null, falls through every instanceof guard and returns normally.
+    *
+    * <p>That is the worst shape of failure for an agent: the rename succeeded, the follow-up
+    * silently did nothing, and both reported success, so the caller believes the title was set.
+    * Found live on local-1197 while testing rename tracking.
+    */
+   @ParameterizedTest
+   @ValueSource(strings = { "set_title", "set_z_index", "set_lock", "remove", "rename",
+                            "ungroup", "move_from_container" })
+   void everyOpAddressingAnAssemblyFailsLoudOnAnUnknownName(String op) {
+      ViewsheetReadService reader = readerReturning(
+         new AssemblyNode("Chart1", "Chart", 240, 100, 400, 240, 0, null, true));
+      ViewsheetEditService service = serviceWith(mock(ComposerObjectService.class), reader);
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> service.apply("tok", principal(), full(op, "NoSuchAssembly1"), ""),
+         op + " must refuse an assembly that does not exist");
+      assertTrue(thrown.getMessage().contains("NoSuchAssembly1"),
+                 op + " must name the assembly it could not find, got: " + thrown.getMessage());
+   }
+
+   /** Every field populated, so an op fails on the missing assembly rather than a missing field. */
+   private static EditRequest full(String op, String assembly) {
+      return new EditRequest(op, assembly, 10, 10, 100, 100, 2, "A title", true, "Container1",
+                             List.of(assembly), "NewName1", 111, "left");
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetEditServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetEditServiceTest.java
@@ -44,6 +44,7 @@ import org.mockito.ArgumentCaptor;
 
 import java.security.Principal;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -258,6 +259,55 @@ class ViewsheetEditServiceTest {
       assertEquals(0, moves[0].getxOffset(), "the first assembly anchors");
       assertEquals(50, moves[1].getxOffset(), "the middle one sits halfway");
       assertEquals(100, moves[2].getxOffset(), "the last assembly anchors");
+   }
+
+   /**
+    * Distribute must equalize the GAPS, not the left edges. Spreading positions evenly looks right
+    * only when every assembly is the same width; with mixed widths the visible spacing comes out
+    * uneven, which is neither what Composer's distribute does nor what "distribute horizontally"
+    * means to anyone asking for it.
+    *
+    * <p>Widths 100, 300, 100 across 0..600: edges-even would put the middle at 250 (gaps of 150
+    * and 50). Gap-even puts it at 200, for equal gaps of 100.
+    */
+   @Test
+   void distributeEqualizesTheGapsNotTheEdges() throws Exception {
+      ComposerObjectService objects = mock(ComposerObjectService.class);
+      ViewsheetEditService service = serviceWith(objects, readerReturning(
+         new AssemblyNode("A", "Text", 0, 10, 100, 20, 0, null, true),
+         new AssemblyNode("B", "Text", 250, 10, 300, 20, 0, null, true),
+         new AssemblyNode("C", "Text", 600, 10, 100, 20, 0, null, true)));
+
+      service.apply("tok", principal(),
+                    arrange("distribute", List.of("A", "B", "C"), "horizontal"), "");
+
+      ArgumentCaptor<MoveVSObjectEvent> captor = ArgumentCaptor.forClass(MoveVSObjectEvent.class);
+      verify(objects, times(3)).moveObject(eq("rt1"), captor.capture(), any(Principal.class),
+                                           any(), anyString());
+      Map<String, Integer> byName = new java.util.HashMap<>();
+
+      for(MoveVSObjectEvent move : captor.getAllValues()) {
+         byName.put(move.getName(), move.getxOffset());
+      }
+
+      assertEquals(0, byName.get("A"), "the first assembly anchors the range");
+      assertEquals(600, byName.get("C"), "the last assembly anchors the range");
+      assertEquals(200, byName.get("B"),
+                   "equal gaps put B at 200 (gap 100 either side); 250 would be edge-even");
+   }
+
+   /** Nothing stopped an agent parking an assembly off-canvas where the user cannot select it. */
+   @Test
+   void moveRejectsNegativeCoordinatesRatherThanHidingTheAssembly() {
+      ViewsheetEditService service = serviceWith(mock(ComposerObjectService.class),
+                                                 readerReturning(
+         new AssemblyNode("Gauge1", "Gauge", 340, 440, 140, 140, 0, null, true)));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> service.apply("tok", principal(), edit("move", "Gauge1", -50, 20), ""));
+
+      assertTrue(thrown.getMessage().contains("-50"), thrown.getMessage());
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetEditServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetEditServiceTest.java
@@ -310,6 +310,45 @@ class ViewsheetEditServiceTest {
       assertTrue(thrown.getMessage().contains("-50"), thrown.getMessage());
    }
 
+   /**
+    * {@code container} was in the tool schema and in {@code EditRequest}, and nothing read it:
+    * {@code moveFromContainer} builds the event from name/x/y and lets the Composer infer the
+    * parent. So an agent could name the wrong container, or one the assembly is not in, and get
+    * {@code ok: true} — the accepted-and-ignored shape CLAUDE.md calls out by name.
+    */
+   @Test
+   void moveFromContainerRefusesAContainerTheAssemblyIsNotIn() {
+      ViewsheetEditService service = serviceWith(mock(ComposerObjectService.class),
+                                                 readerReturning(
+         new AssemblyNode("Text1", "Text", 10, 10, 100, 20, 0, "Group1", true)));
+      EditRequest request = new EditRequest("move_from_container", "Text1", 20, 30, null, null,
+                                            null, null, null, "SomeOtherGroup", null, null,
+                                            null, null);
+
+      Exception thrown = assertThrows(IllegalArgumentException.class,
+                                      () -> service.apply("tok", principal(), request, ""));
+
+      assertTrue(thrown.getMessage().contains("SomeOtherGroup"), thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("Group1"),
+                 "the message must name the container it is actually in, got: " +
+                 thrown.getMessage());
+   }
+
+   /** Naming the right container is accepted, so the parameter is worth passing. */
+   @Test
+   void moveFromContainerAcceptsTheContainerTheAssemblyIsActuallyIn() throws Exception {
+      ComposerObjectService objects = mock(ComposerObjectService.class);
+      ViewsheetEditService service = serviceWith(objects, readerReturning(
+         new AssemblyNode("Text1", "Text", 10, 10, 100, 20, 0, "Group1", true)));
+      EditRequest request = new EditRequest("move_from_container", "Text1", 20, 30, null, null,
+                                            null, null, null, "Group1", null, null, null, null);
+
+      service.apply("tok", principal(), request, "");
+
+      verify(objects).moveFromContainer(eq("rt1"), any(), any(Principal.class), any(),
+                                        anyString());
+   }
+
    @Test
    void alignRejectsAnUnknownAxis() {
       ViewsheetEditService service = serviceWith(mock(ComposerObjectService.class));

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetEditServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetEditServiceTest.java
@@ -17,7 +17,11 @@
  */
 package inetsoft.web.wiz.viewsheet;
 
+import inetsoft.web.composer.vs.event.CopyVSObjectsEvent;
+import inetsoft.web.composer.vs.objects.controller.ClipboardControllerService;
 import inetsoft.web.composer.vs.objects.controller.ComposerObjectService;
+import inetsoft.web.composer.vs.objects.controller.VSObjectPropertyService;
+import inetsoft.web.composer.vs.objects.event.AddNewVSObjectEvent;
 import inetsoft.web.composer.vs.objects.event.MultiMoveVsObjectEvent;
 import inetsoft.web.composer.vs.objects.event.ResizeVSObjectEvent;
 import inetsoft.web.composer.vs.objects.event.ResizeVSObjectTitleEvent;
@@ -26,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.security.Principal;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -104,6 +109,83 @@ class ViewsheetEditServiceTest {
       assertTrue(thrown.getMessage().contains("x"));
    }
 
+   @Test
+   void removeDelegatesTheAssemblyNameToComposerObjectService() throws Exception {
+      ComposerObjectService objects = mock(ComposerObjectService.class);
+      ViewsheetEditService service = serviceWith(objects);
+
+      service.apply("tok", principal(), request("remove", "Gauge1"), "");
+
+      verify(objects).removeObject(eq("rt1"), eq("Gauge1"), anyString(), any(Principal.class),
+                                   any());
+   }
+
+   @Test
+   void addRequiresATypeAndFailsLoudWithoutOne() {
+      ViewsheetEditService service = serviceWith(mock(ComposerObjectService.class));
+      EditRequest request = new EditRequest("add", null, 10, 10, null, null, null, null,
+                                            null, null, null, null, null, null);
+
+      Exception thrown = assertThrows(IllegalArgumentException.class,
+                                      () -> service.apply("tok", principal(), request, ""));
+      assertTrue(thrown.getMessage().contains("type"));
+   }
+
+   @Test
+   void addDelegatesTheAssetTypeAndPosition() throws Exception {
+      ComposerObjectService objects = mock(ComposerObjectService.class);
+      ViewsheetEditService service = serviceWith(objects);
+      EditRequest request = new EditRequest("add", null, 40, 60, null, null, null, null,
+                                            null, null, null, null, 111, null);
+
+      service.apply("tok", principal(), request, "");
+
+      ArgumentCaptor<AddNewVSObjectEvent> captor =
+         ArgumentCaptor.forClass(AddNewVSObjectEvent.class);
+      verify(objects).addNewObject(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                   anyString());
+      assertEquals(111, captor.getValue().getType());
+      assertEquals(40, captor.getValue().getxOffset());
+   }
+
+   @Test
+   void renameRequiresANewNameAndFailsLoudWithoutOne() {
+      ViewsheetEditService service = serviceWith(mock(ComposerObjectService.class));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> service.apply("tok", principal(), request("rename", "Gauge1"), ""));
+      assertTrue(thrown.getMessage().contains("newName"));
+   }
+
+   @Test
+   void copyDelegatesTheAssemblyNames() throws Exception {
+      ClipboardControllerService clipboard = mock(ClipboardControllerService.class);
+      ViewsheetEditService service = serviceWith(mock(ComposerObjectService.class), clipboard);
+      EditRequest request = new EditRequest("copy", null, null, null, null, null, null, null,
+                                            null, null, List.of("Gauge1", "Text1"), null,
+                                            null, null);
+
+      service.apply("tok", principal(), request, "");
+
+      ArgumentCaptor<CopyVSObjectsEvent> captor =
+         ArgumentCaptor.forClass(CopyVSObjectsEvent.class);
+      verify(clipboard).copyOrCut(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                  anyString());
+      assertArrayEquals(new String[]{ "Gauge1", "Text1" }, captor.getValue().getObjects());
+   }
+
+   @Test
+   void pasteDelegatesTheTargetPosition() throws Exception {
+      ClipboardControllerService clipboard = mock(ClipboardControllerService.class);
+      ViewsheetEditService service = serviceWith(mock(ComposerObjectService.class), clipboard);
+
+      service.apply("tok", principal(), edit("paste", null, 15, 25), "");
+
+      verify(clipboard).pasteObject(eq("rt1"), eq(15), eq(25), any(Principal.class), any(),
+                                    anyString());
+   }
+
    private static EditRequest request(String op, String assembly) {
       return new EditRequest(op, assembly, null, null, null, null, null, null, null, null,
                              null, null, null, null);
@@ -123,6 +205,12 @@ class ViewsheetEditServiceTest {
     * so these tests exercise op dispatch and validation without a live runtime.
     */
    private static ViewsheetEditService serviceWith(ComposerObjectService objects) {
+      return serviceWith(objects, mock(ClipboardControllerService.class));
+   }
+
+   private static ViewsheetEditService serviceWith(ComposerObjectService objects,
+                                                   ClipboardControllerService clipboard)
+   {
       ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
 
       try {
@@ -136,6 +224,7 @@ class ViewsheetEditServiceTest {
          throw new IllegalStateException(e);
       }
 
-      return new ViewsheetEditService(sessions, objects);
+      return new ViewsheetEditService(sessions, objects, clipboard,
+                                     mock(VSObjectPropertyService.class));
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetEditServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetEditServiceTest.java
@@ -21,7 +21,13 @@ import inetsoft.web.composer.vs.event.CopyVSObjectsEvent;
 import inetsoft.web.composer.vs.objects.controller.ClipboardControllerService;
 import inetsoft.web.composer.vs.objects.controller.ComposerObjectService;
 import inetsoft.web.composer.vs.objects.controller.VSObjectPropertyService;
+import inetsoft.web.composer.vs.objects.controller.ComposerGroupService;
 import inetsoft.web.composer.vs.objects.event.AddNewVSObjectEvent;
+import inetsoft.web.composer.vs.objects.event.ChangeVSObjectLayerEvent;
+import inetsoft.web.composer.vs.objects.event.LockVSObjectEvent;
+import inetsoft.web.composer.vs.objects.event.MoveVSObjectEvent;
+import inetsoft.web.wiz.viewsheet.model.AssemblyNode;
+import inetsoft.web.wiz.viewsheet.model.ViewsheetModel;
 import inetsoft.web.composer.vs.objects.event.MultiMoveVsObjectEvent;
 import inetsoft.web.composer.vs.objects.event.ResizeVSObjectEvent;
 import inetsoft.web.composer.vs.objects.event.ResizeVSObjectTitleEvent;
@@ -186,6 +192,152 @@ class ViewsheetEditServiceTest {
                                     anyString());
    }
 
+   @Test
+   void alignLeftMovesEveryAssemblyToTheLeftmostEdge() throws Exception {
+      ComposerObjectService objects = mock(ComposerObjectService.class);
+      ViewsheetReadService reader = readerReturning(
+         new AssemblyNode("A", "Text", 50, 10, 100, 20, 0, null, true),
+         new AssemblyNode("B", "Text", 20, 60, 100, 20, 0, null, true));
+      ViewsheetEditService service = serviceWith(objects, reader);
+
+      service.apply("tok", principal(), arrange("align", List.of("A", "B"), "left"), "");
+
+      MoveVSObjectEvent[] moves = capturedMoves(objects);
+      assertEquals(2, moves.length);
+      assertEquals(20, moves[0].getxOffset());
+      assertEquals(20, moves[1].getxOffset());
+      assertEquals(10, moves[0].getyOffset(), "align left must not change y");
+   }
+
+   @Test
+   void alignRightUsesTheRightmostEdgeAndAccountsForWidth() throws Exception {
+      ComposerObjectService objects = mock(ComposerObjectService.class);
+      ViewsheetReadService reader = readerReturning(
+         new AssemblyNode("A", "Text", 50, 10, 100, 20, 0, null, true),
+         new AssemblyNode("B", "Text", 20, 60, 40, 20, 0, null, true));
+      ViewsheetEditService service = serviceWith(objects, reader);
+
+      service.apply("tok", principal(), arrange("align", List.of("A", "B"), "right"), "");
+
+      MoveVSObjectEvent[] moves = capturedMoves(objects);
+      assertEquals(50, moves[0].getxOffset(), "A already ends at the rightmost edge 150");
+      assertEquals(110, moves[1].getxOffset(), "B must end at 150, so x = 150 - 40");
+   }
+
+   @Test
+   void distributeHorizontallySpreadsTheMiddleAssembliesEvenly() throws Exception {
+      ComposerObjectService objects = mock(ComposerObjectService.class);
+      ViewsheetReadService reader = readerReturning(
+         new AssemblyNode("A", "Text", 0, 0, 10, 10, 0, null, true),
+         new AssemblyNode("B", "Text", 5, 0, 10, 10, 0, null, true),
+         new AssemblyNode("C", "Text", 100, 0, 10, 10, 0, null, true));
+      ViewsheetEditService service = serviceWith(objects, reader);
+
+      service.apply("tok", principal(),
+                    arrange("distribute", List.of("A", "B", "C"), "horizontal"), "");
+
+      MoveVSObjectEvent[] moves = capturedMoves(objects);
+      assertEquals(0, moves[0].getxOffset(), "the first assembly anchors");
+      assertEquals(50, moves[1].getxOffset(), "the middle one sits halfway");
+      assertEquals(100, moves[2].getxOffset(), "the last assembly anchors");
+   }
+
+   @Test
+   void alignRejectsAnUnknownAxis() {
+      ViewsheetEditService service = serviceWith(mock(ComposerObjectService.class));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> service.apply("tok", principal(),
+                             arrange("align", List.of("A", "B"), "sideways"), ""));
+      assertTrue(thrown.getMessage().contains("sideways"));
+   }
+
+   @Test
+   void alignRejectsFewerThanTwoAssemblies() {
+      ViewsheetEditService service = serviceWith(mock(ComposerObjectService.class));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> service.apply("tok", principal(), arrange("align", List.of("A"), "left"), ""));
+      assertTrue(thrown.getMessage().contains("assemblies"));
+   }
+
+   @Test
+   void alignNamesTheUnknownAssemblyRatherThanSkippingIt() {
+      ViewsheetReadService reader = readerReturning(
+         new AssemblyNode("A", "Text", 0, 0, 10, 10, 0, null, true));
+      ViewsheetEditService service = serviceWith(mock(ComposerObjectService.class), reader);
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> service.apply("tok", principal(), arrange("align", List.of("A", "Ghost"), "left"), ""));
+      assertTrue(thrown.getMessage().contains("Ghost"));
+   }
+
+   @Test
+   void setZIndexDelegatesTheLayerChange() throws Exception {
+      ComposerObjectService objects = mock(ComposerObjectService.class);
+      ViewsheetEditService service = serviceWith(objects);
+      EditRequest request = new EditRequest("set_z_index", "Gauge1", null, null, null, null,
+                                            7, null, null, null, null, null, null, null);
+
+      service.apply("tok", principal(), request, "");
+
+      ArgumentCaptor<ChangeVSObjectLayerEvent> captor =
+         ArgumentCaptor.forClass(ChangeVSObjectLayerEvent.class);
+      verify(objects).changeZIndex(eq("rt1"), captor.capture(), any(Principal.class), any());
+      assertEquals(7, captor.getValue().getzIndex());
+   }
+
+   @Test
+   void setLockDelegatesTheLockState() throws Exception {
+      ComposerObjectService objects = mock(ComposerObjectService.class);
+      ViewsheetEditService service = serviceWith(objects);
+      EditRequest request = new EditRequest("set_lock", "Rect1", null, null, null, null,
+                                            null, null, Boolean.TRUE, null, null, null,
+                                            null, null);
+
+      service.apply("tok", principal(), request, "");
+
+      ArgumentCaptor<LockVSObjectEvent> captor = ArgumentCaptor.forClass(LockVSObjectEvent.class);
+      verify(objects).changeLockState(eq("rt1"), captor.capture(), any(Principal.class), any());
+      assertTrue(captor.getValue().isLocked());
+   }
+
+   @Test
+   void ungroupDelegatesTheContainerName() throws Exception {
+      ComposerGroupService groups = mock(ComposerGroupService.class);
+      ViewsheetEditService service = serviceWith(mock(ComposerObjectService.class),
+                                                 mock(ClipboardControllerService.class),
+                                                 mock(ViewsheetReadService.class), groups);
+
+      service.apply("tok", principal(), request("ungroup", "Group1"), "");
+
+      verify(groups).ungroup(eq("rt1"), eq("Group1"), anyString(), any(Principal.class), any());
+   }
+
+   private static MoveVSObjectEvent[] capturedMoves(ComposerObjectService objects)
+      throws Exception
+   {
+      ArgumentCaptor<MultiMoveVsObjectEvent> captor =
+         ArgumentCaptor.forClass(MultiMoveVsObjectEvent.class);
+      verify(objects).moveObjects(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                  anyString());
+      return captor.getValue().getEvents();
+   }
+
+   private static ViewsheetReadService readerReturning(AssemblyNode... nodes) {
+      ViewsheetReadService reader = mock(ViewsheetReadService.class);
+      when(reader.read(any())).thenReturn(new ViewsheetModel("vs", List.of(nodes)));
+      return reader;
+   }
+
+   private static EditRequest arrange(String op, List<String> assemblies, String axis) {
+      return new EditRequest(op, null, null, null, null, null, null, null, null, null,
+                             assemblies, null, null, axis);
+   }
+
    private static EditRequest request(String op, String assembly) {
       return new EditRequest(op, assembly, null, null, null, null, null, null, null, null,
                              null, null, null, null);
@@ -209,7 +361,23 @@ class ViewsheetEditServiceTest {
    }
 
    private static ViewsheetEditService serviceWith(ComposerObjectService objects,
+                                                   ViewsheetReadService reader)
+   {
+      return serviceWith(objects, mock(ClipboardControllerService.class), reader,
+                         mock(ComposerGroupService.class));
+   }
+
+   private static ViewsheetEditService serviceWith(ComposerObjectService objects,
                                                    ClipboardControllerService clipboard)
+   {
+      return serviceWith(objects, clipboard, mock(ViewsheetReadService.class),
+                         mock(ComposerGroupService.class));
+   }
+
+   private static ViewsheetEditService serviceWith(ComposerObjectService objects,
+                                                   ClipboardControllerService clipboard,
+                                                   ViewsheetReadService reader,
+                                                   ComposerGroupService groups)
    {
       ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
 
@@ -225,6 +393,6 @@ class ViewsheetEditServiceTest {
       }
 
       return new ViewsheetEditService(sessions, objects, clipboard,
-                                     mock(VSObjectPropertyService.class));
+                                     mock(VSObjectPropertyService.class), reader, groups);
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetFormatServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetFormatServiceTest.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.wiz.viewsheet;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import inetsoft.web.composer.model.vs.VSObjectFormatInfoModel;
 import inetsoft.web.composer.vs.controller.FormatPainterService;
 import inetsoft.web.composer.vs.objects.event.FormatVSObjectEvent;
@@ -49,6 +50,50 @@ class ViewsheetFormatServiceTest {
                                 anyString());
       assertArrayEquals(new String[]{ "Gauge1" }, captor.getValue().getObjects());
       assertEquals("#333333", captor.getValue().getFormat().getColor());
+   }
+
+   /**
+    * {@code FormatPainterService.setFormat} dereferences {@code event.getCharts().length}, so
+    * leaving the array null made every set_format call fail with
+    * "Cannot read the array length because the return value of
+    * FormatVSObjectEvent.getCharts() is null" — a 500 for both a format and a reset.
+    */
+   @Test
+   void populatesTheChartsArraySoThePainterDoesNotDereferenceNull() throws Exception {
+      FormatPainterService painter = mock(FormatPainterService.class);
+      VSObjectFormatInfoModel format = new VSObjectFormatInfoModel();
+
+      serviceWith(painter).setFormat(
+         "tok", principal(),
+         new ViewsheetFormatService.FormatRequest(List.of("Gauge1"), format, false), "");
+
+      ArgumentCaptor<FormatVSObjectEvent> captor =
+         ArgumentCaptor.forClass(FormatVSObjectEvent.class);
+      verify(painter).setFormat(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                anyString());
+      assertNotNull(captor.getValue().getCharts(), "charts must not be null");
+   }
+
+   /**
+    * {@code FormatInfoModel} is annotated {@code @JsonTypeInfo(use = Id.CLASS, property = "type")},
+    * so Jackson refused any format object that did not carry
+    * {@code "type": "inetsoft.web.composer.model.vs.VSObjectFormatInfoModel"} — a 400 for every
+    * documented usage, including an empty {@code {}}. Requiring a caller to name a Java class is
+    * exactly the internals leak this API is meant to avoid, so the endpoint must accept a plain
+    * format object.
+    */
+   @Test
+   void acceptsAPlainFormatObjectWithoutAJavaClassDiscriminator() throws Exception {
+      ObjectMapper mapper = new ObjectMapper();
+
+      ViewsheetFormatService.FormatRequest request = mapper.readValue(
+         "{\"assemblies\":[\"Text1\"],\"format\":{\"color\":\"#CC0000\"," +
+         "\"backgroundColor\":\"#FFEEAA\"},\"reset\":false}",
+         ViewsheetFormatService.FormatRequest.class);
+
+      assertNotNull(request.format(), "format must deserialize without a 'type' discriminator");
+      assertEquals("#CC0000", request.format().getColor());
+      assertEquals("#FFEEAA", request.format().getBackgroundColor());
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetFormatServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetFormatServiceTest.java
@@ -171,6 +171,58 @@ class ViewsheetFormatServiceTest {
       assertTrue(thrown.getMessage().contains("sideways"), thrown.getMessage());
    }
 
+   /**
+    * The border style is asymmetric in the underlying model: reading emits CSS words
+    * ({@code FormatInfoModel.getBorderStyle} returns "solid"/"dashed"/"dotted"/"double"), while
+    * writing goes through {@code FormatPainterService}, which does
+    * {@code Integer.parseInt(topBorder)}. So the CSS word this API documents could never be
+    * written, and produced a raw {@code For input string: "solid"} naming no field. Found live on
+    * local-1203 running case 7.
+    */
+   @Test
+   void acceptsBorderStylesAsCssWordsBecauseThatIsWhatReadsBack() throws Exception {
+      ObjectMapper mapper = new ObjectMapper();
+
+      ViewsheetFormatService.FormatRequest request = mapper.readValue(
+         "{\"assemblies\":[\"Text1\"],\"format\":{\"borderTopStyle\":\"solid\"," +
+         "\"borderLeftStyle\":\"dashed\",\"borderBottomStyle\":\"none\"},\"reset\":false}",
+         ViewsheetFormatService.FormatRequest.class);
+
+      assertEquals(String.valueOf(inetsoft.report.StyleConstants.THIN_LINE),
+                   request.format().getBorderTopStyle());
+      assertEquals(String.valueOf(inetsoft.report.StyleConstants.DASH_LINE),
+                   request.format().getBorderLeftStyle());
+      assertEquals("0", request.format().getBorderBottomStyle());
+   }
+
+   /** A number still passes through, for anyone who already knows the constant. */
+   @Test
+   void leavesANumericBorderStyleAlone() throws Exception {
+      ObjectMapper mapper = new ObjectMapper();
+
+      ViewsheetFormatService.FormatRequest request = mapper.readValue(
+         "{\"assemblies\":[\"Text1\"],\"format\":{\"borderTopStyle\":\"4097\"}," +
+         "\"reset\":false}",
+         ViewsheetFormatService.FormatRequest.class);
+
+      assertEquals("4097", request.format().getBorderTopStyle());
+   }
+
+   @Test
+   void refusesABorderStyleItCannotResolve() {
+      ObjectMapper mapper = new ObjectMapper();
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> mapper.readValue(
+            "{\"assemblies\":[\"Text1\"],\"format\":{\"borderTopStyle\":\"wiggly\"}," +
+            "\"reset\":false}",
+            ViewsheetFormatService.FormatRequest.class));
+
+      assertTrue(thrown.getMessage().contains("wiggly"), thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("borderTopStyle"), thrown.getMessage());
+   }
+
    @Test
    void requiresAtLeastOneAssembly() {
       Exception thrown = assertThrows(

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetFormatServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetFormatServiceTest.java
@@ -96,6 +96,81 @@ class ViewsheetFormatServiceTest {
       assertEquals("#FFEEAA", request.format().getBackgroundColor());
    }
 
+   /**
+    * The tool documents the format as CSS-shaped and lists `align` beside `color` and
+    * `backgroundColor`, so a caller writes {@code align: "center"}. But align is an
+    * {@code AlignmentInfo} object with {@code halign}/{@code valign}, so Jackson threw during
+    * body conversion — and Spring wraps that in {@code HttpMessageNotReadableException}, which
+    * returns a **bodyless 400**. The caller saw "Request failed with status code 400" and nothing
+    * else. Found live on local-1201 running case 7.
+    *
+    * <p>Accepting the word is the fix rather than documenting the object: the documented usage
+    * should work, and "center" has exactly one sensible meaning here.
+    */
+   @Test
+   void acceptsAlignAsAWordBecauseThatIsWhatTheToolDocuments() throws Exception {
+      ObjectMapper mapper = new ObjectMapper();
+
+      ViewsheetFormatService.FormatRequest request = mapper.readValue(
+         "{\"assemblies\":[\"Text1\"],\"format\":{\"align\":\"center\"},\"reset\":false}",
+         ViewsheetFormatService.FormatRequest.class);
+
+      assertNotNull(request.format().getAlign(), "align must survive as an AlignmentInfo");
+      assertEquals("Center", request.format().getAlign().getHalign());
+   }
+
+   @Test
+   void acceptsAVerticalAlignWordToo() throws Exception {
+      ObjectMapper mapper = new ObjectMapper();
+
+      ViewsheetFormatService.FormatRequest request = mapper.readValue(
+         "{\"assemblies\":[\"Text1\"],\"format\":{\"align\":\"middle\"},\"reset\":false}",
+         ViewsheetFormatService.FormatRequest.class);
+
+      assertEquals("Middle", request.format().getAlign().getValign());
+   }
+
+   /** Both axes at once, since a caller wanting one often wants the other. */
+   @Test
+   void acceptsBothAlignmentsInOneValue() throws Exception {
+      ObjectMapper mapper = new ObjectMapper();
+
+      ViewsheetFormatService.FormatRequest request = mapper.readValue(
+         "{\"assemblies\":[\"Text1\"],\"format\":{\"align\":\"center middle\"}," +
+         "\"reset\":false}",
+         ViewsheetFormatService.FormatRequest.class);
+
+      assertEquals("Center", request.format().getAlign().getHalign());
+      assertEquals("Middle", request.format().getAlign().getValign());
+   }
+
+   /** The object form still works — this widens the contract rather than replacing it. */
+   @Test
+   void stillAcceptsTheObjectForm() throws Exception {
+      ObjectMapper mapper = new ObjectMapper();
+
+      ViewsheetFormatService.FormatRequest request = mapper.readValue(
+         "{\"assemblies\":[\"Text1\"],\"format\":{\"align\":{\"halign\":\"Right\"}}," +
+         "\"reset\":false}",
+         ViewsheetFormatService.FormatRequest.class);
+
+      assertEquals("Right", request.format().getAlign().getHalign());
+   }
+
+   @Test
+   void refusesAnAlignWordItCannotResolve() {
+      ObjectMapper mapper = new ObjectMapper();
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> mapper.readValue(
+            "{\"assemblies\":[\"Text1\"],\"format\":{\"align\":\"sideways\"}," +
+            "\"reset\":false}",
+            ViewsheetFormatService.FormatRequest.class));
+
+      assertTrue(thrown.getMessage().contains("sideways"), thrown.getMessage());
+   }
+
    @Test
    void requiresAtLeastOneAssembly() {
       Exception thrown = assertThrows(

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetFormatServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetFormatServiceTest.java
@@ -1,0 +1,110 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.web.composer.model.vs.VSObjectFormatInfoModel;
+import inetsoft.web.composer.vs.controller.FormatPainterService;
+import inetsoft.web.composer.vs.objects.event.FormatVSObjectEvent;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.security.Principal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class ViewsheetFormatServiceTest {
+   @Test
+   void appliesTheFormatToTheNamedAssemblies() throws Exception {
+      FormatPainterService painter = mock(FormatPainterService.class);
+      VSObjectFormatInfoModel format = new VSObjectFormatInfoModel();
+      format.setColor("#333333");
+
+      serviceWith(painter).setFormat(
+         "tok", principal(),
+         new ViewsheetFormatService.FormatRequest(List.of("Gauge1"), format, false), "");
+
+      ArgumentCaptor<FormatVSObjectEvent> captor =
+         ArgumentCaptor.forClass(FormatVSObjectEvent.class);
+      verify(painter).setFormat(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                anyString());
+      assertArrayEquals(new String[]{ "Gauge1" }, captor.getValue().getObjects());
+      assertEquals("#333333", captor.getValue().getFormat().getColor());
+   }
+
+   @Test
+   void requiresAtLeastOneAssembly() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> serviceWith(mock(FormatPainterService.class)).setFormat(
+            "tok", principal(),
+            new ViewsheetFormatService.FormatRequest(List.of(), new VSObjectFormatInfoModel(),
+                                                     false), ""));
+      assertTrue(thrown.getMessage().contains("assemblies"));
+   }
+
+   @Test
+   void requiresAFormatUnlessResetting() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> serviceWith(mock(FormatPainterService.class)).setFormat(
+            "tok", principal(),
+            new ViewsheetFormatService.FormatRequest(List.of("Gauge1"), null, false), ""));
+      assertTrue(thrown.getMessage().contains("format"));
+   }
+
+   @Test
+   void resetNeedsNoFormat() throws Exception {
+      FormatPainterService painter = mock(FormatPainterService.class);
+
+      serviceWith(painter).setFormat(
+         "tok", principal(),
+         new ViewsheetFormatService.FormatRequest(List.of("Gauge1"), null, true), "");
+
+      ArgumentCaptor<FormatVSObjectEvent> captor =
+         ArgumentCaptor.forClass(FormatVSObjectEvent.class);
+      verify(painter).setFormat(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                anyString());
+      assertTrue(captor.getValue().isReset());
+   }
+
+   private static ViewsheetFormatService serviceWith(FormatPainterService painter) {
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+
+      try {
+         doAnswer(invocation -> {
+            ViewsheetSessionService.Mutation mutation = invocation.getArgument(2);
+            mutation.run(null, "rt1", null);
+            return null;
+         }).when(sessions).mutate(anyString(), any(Principal.class), any());
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(e);
+      }
+
+      return new ViewsheetFormatService(sessions, painter);
+   }
+
+   private static Principal principal() {
+      return () -> "admin";
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetReadServiceTest.java
@@ -1,0 +1,84 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.viewsheet.GaugeVSAssembly;
+import inetsoft.uql.viewsheet.TextVSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.wiz.viewsheet.model.AssemblyNode;
+import inetsoft.web.wiz.viewsheet.model.ViewsheetModel;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.awt.Point;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Constructing a real {@link Viewsheet} runs {@code VSAssemblyInfo}'s constructor, which reads
+ * {@code SreeEnv} and therefore needs a Spring context — hence the harness annotations, which
+ * mirror {@code ClipboardControllerServiceTest}.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class },
+                      initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome()
+@Tag("core")
+class ViewsheetReadServiceTest {
+   @Test
+   void readsEveryAssemblyWithItsPositionAndType() {
+      Viewsheet vs = new Viewsheet();
+      GaugeVSAssembly gauge = new GaugeVSAssembly(vs, "Gauge1");
+      gauge.setPixelOffset(new Point(10, 20));
+      vs.addAssembly(gauge);
+      TextVSAssembly text = new TextVSAssembly(vs, "Text1");
+      text.setPixelOffset(new Point(30, 40));
+      vs.addAssembly(text);
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      ViewsheetModel model = new ViewsheetReadService().read(rvs);
+
+      assertEquals(2, model.assemblies().size());
+      AssemblyNode first = model.assemblies().stream()
+         .filter(a -> "Gauge1".equals(a.name())).findFirst().orElseThrow();
+      assertEquals("Gauge", first.type());
+      assertEquals(10, first.x());
+      assertEquals(20, first.y());
+   }
+
+   @Test
+   void reportsAnEmptyViewsheetAsNoAssembliesRatherThanFailing() {
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(new Viewsheet());
+
+      assertTrue(new ViewsheetReadService().read(rvs).assemblies().isEmpty());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetSessionServiceReadTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetSessionServiceReadTest.java
@@ -68,6 +68,51 @@ class ViewsheetSessionServiceReadTest {
                    () -> service.read("bad", principal(), (rvs, runtimeId, dispatcher) -> null));
    }
 
+   /**
+    * A composer service partially applies before it ERRORs — that is precisely why it ERRORs
+    * instead of throwing. When {@code mutate} let the resulting {@code CommandErrorException}
+    * escape, no checkpoint was taken and no broadcast was sent, so the runtime held a half-applied
+    * edit while the human's Composer kept rendering pre-edit state. The next agent edit then built
+    * on that divergence, and the user's Ctrl+Z had no checkpoint for the partial change.
+    *
+    * <p>So the checkpoint and the broadcast happen either way: the partial edit is real, it
+    * deserves an undo step, and the browser should show what is actually there.
+    */
+   @Test
+   void aFailedMutationStillCheckpointsAndBroadcastsSoTheBrowserMatchesTheRuntime()
+      throws Exception
+   {
+      Harness h = harness();
+
+      assertThrows(Exception.class, () ->
+         h.service.mutate("tok", principal(), (rvs, runtimeId, dispatcher) ->
+            dispatcher.sendCommand(errorCommand())));
+
+      verify(h.rvs).addCheckpoint(any());
+      verify(h.broadcast).broadcastRefresh(any(), any(), anyString(), any(Principal.class));
+   }
+
+   /** The message must say the edit may be half-applied, since the caller cannot tell. */
+   @Test
+   void theFailureSaysTheEditMayBePartiallyApplied() throws Exception {
+      Harness h = harness();
+
+      Exception thrown = assertThrows(Exception.class, () ->
+         h.service.mutate("tok", principal(), (rvs, runtimeId, dispatcher) ->
+            dispatcher.sendCommand(errorCommand())));
+
+      assertTrue(thrown.getMessage().toLowerCase().contains("partially applied"),
+                 "got: " + thrown.getMessage());
+   }
+
+   private static inetsoft.web.viewsheet.command.MessageCommand errorCommand() {
+      inetsoft.web.viewsheet.command.MessageCommand command =
+         new inetsoft.web.viewsheet.command.MessageCommand();
+      command.setMessage("dependency cycle");
+      command.setType(inetsoft.web.viewsheet.command.MessageCommand.Type.ERROR);
+      return command;
+   }
+
    private record Harness(ViewsheetSessionService service, RuntimeViewsheet rvs,
                           SheetAgentBroadcastService broadcast) {}
 

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetSessionServiceReadTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetSessionServiceReadTest.java
@@ -1,0 +1,96 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.wiz.pairing.*;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * The read-only capturing entry point.
+ *
+ * <p>Some composer services return their result by <em>dispatching a command</em> rather than
+ * returning a value — {@code VSTableLayoutService.getCellScript} and {@code getNamedGroup} are
+ * the ones that matter here. Reading those needs a capturing dispatcher, which previously only
+ * {@code mutate} supplied. Using {@code mutate} for a read would add a checkpoint to the user's
+ * undo history for having <em>looked</em> at something, and broadcast a refresh for a change
+ * that never happened.
+ */
+@Tag("core")
+class ViewsheetSessionServiceReadTest {
+   @Test
+   void readSuppliesACapturingDispatcherWithoutCheckpointingOrBroadcasting() throws Exception {
+      Harness h = harness();
+
+      String seen = h.service.read("tok", principal(), (rvs, runtimeId, dispatcher) -> {
+         assertNotNull(dispatcher, "a read needs the capturing dispatcher to see command results");
+         assertEquals("rt1", runtimeId);
+         return "read-result";
+      });
+
+      assertEquals("read-result", seen, "the value the read produced must come back");
+      verify(h.rvs, never()).addCheckpoint(any());
+      verify(h.broadcast, never()).broadcastRefresh(any(), any(), anyString(),
+                                                    any(Principal.class));
+   }
+
+   @Test
+   void readStillFailsLoudOnAnInvalidSession() {
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      when(sessions.resolve(anyString(), anyString())).thenReturn(null);
+      ViewsheetSessionService service = new ViewsheetSessionService(
+         sessions, mock(SheetRuntimeAccess.class), mock(SheetAgentBroadcastService.class));
+
+      assertThrows(PairingException.class,
+                   () -> service.read("bad", principal(), (rvs, runtimeId, dispatcher) -> null));
+   }
+
+   private record Harness(ViewsheetSessionService service, RuntimeViewsheet rvs,
+                          SheetAgentBroadcastService broadcast) {}
+
+   private static Harness harness() throws Exception {
+      JoinSession session = new JoinSession("tok", "rt1", "admin", SheetType.VIEWSHEET,
+                                            Long.MAX_VALUE / 2, Long.MAX_VALUE / 2,
+                                            JoinSession.ConnectionMode.PAIRED, null, null);
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      when(sessions.resolve(anyString(), anyString())).thenReturn(session);
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(mock(Viewsheet.class));
+
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(runtimeAccess.getSheetForPairing(any(), anyString(), any(Principal.class)))
+         .thenReturn(rvs);
+
+      SheetAgentBroadcastService broadcast = mock(SheetAgentBroadcastService.class);
+      return new Harness(new ViewsheetSessionService(sessions, runtimeAccess, broadcast), rvs,
+                         broadcast);
+   }
+
+   private static Principal principal() {
+      return () -> "admin";
+   }
+}


### PR DESCRIPTION
Backend for the viewsheet layout plugin: a new `inetsoft/web/wiz/viewsheet/` package exposing `/api/wiz/v1/agent/viewsheet/**`, plus a dispatcher fix that closes a silent-failure defect.

**Base branch:** `feature-76074-server-fixes`, not `main` — the `wiz/pairing` package and `ScriptImageService` this builds on do not exist on main yet.

## The defect this fixes first

Composer services **do not throw on failure.** They dispatch a `MessageCommand` of `Type.ERROR` and return normally:

```java
// VSObjectPropertyService.editObjectProperty
this.coreLifecycleService.sendMessage(
   Catalog.getCatalog().getString("common.dependencyCycle"),
   MessageCommand.Type.ERROR, commandDispatcher);
return;                                    // caller sees a normal return
```

`sendMessage` routes to `dispatcher.sendCommand`, and `CommandDispatcher.withDummyDispatcher` overrides that to a no-op. So for any browser-less caller — the seven existing `withDummyDispatcher` sites included — every one of the **56 `MessageCommand.Type.ERROR` sites across `composer/` and `binding/`** becomes a silent success.

`CapturingCommandDispatcher` captures dispatched commands instead of discarding them, and `withCapturingDispatcher` throws `CommandErrorException` when any ERROR was reported. Warnings surface separately and do not fail the call. It transmits nothing, matching the dummy dispatcher's intent — the pairing layer broadcasts to the browser separately.

## The plugin backend

| Class | Responsibility |
|---|---|
| `ViewsheetAgentController` | REST surface; validation and delegation only |
| `ViewsheetSessionService` | Pairing session → `RuntimeViewsheet`; capturing dispatcher, checkpoint, broadcast |
| `ViewsheetReadService` | Agent-facing layout model |
| `ViewsheetEditService` | 16 structural ops onto Composer services |
| `ViewsheetFormatService` | Format via `FormatPainterService` |

Every mutation delegates to the Composer's own services rather than reimplementing them, so their validation and fixups apply. Each tool call is exactly one `addCheckpoint`, matching a single Composer action, so the user's Ctrl+Z steps back one edit at a time.

## Worth reviewer attention

- **`align` and `distribute` have no Composer service.** They are position arithmetic here, issuing one `MultiMoveVsObjectEvent` so an alignment stays a single checkpoint rather than N.
- **`applySocketSession` is load-bearing.** Without carrying the browser's socket id onto the runtime, `SheetAgentBroadcastService` finds no session and silently skips — the user's Composer would never reflect an agent edit, with no error anywhere.
- **`CapturingCommandDispatcher` passes a null cluster deliberately.** It is hand-constructed rather than Spring-managed, so its `@PostConstruct` never runs; the class already guards for null; and nothing is transmitted. Taking `Cluster.getInstance()` would make it unusable outside a live Spring context for no benefit.

## Testing

1,014 tests pass across `inetsoft.web.wiz.**`, of which 28 are new.

`HeadlessDialogServiceProbeTest` is included `@Disabled`, documenting why the real Composer bean graph cannot be booted in the current test harness — component-scanning `inetsoft.web` drags in the `@Configuration` classes the harness exists to replace. It belongs as this controller's first integration test, and should verify: a real property write mutates `VSAssemblyInfo`; a rename does not break browser tracking; `@ClusterProxy` routing works bean-to-bean; broadcast plus checkpoint leave undo coherent.

---

## Update — the first live run against a Composer, and what it found

The disabled probe test above asks four questions no unit test can answer. They have now been
answered by running the thing, and the run found a family of defects that all reported success.

**`@ClusterProxy` routing works.** The first live failure — `edit move` returning `ok` and changing
nothing — looked exactly like broken routing, and the test plan says that signature means routing.
It does not. `moveObjects` (plural) reached the real service across the proxy and ran; it is the
anchored-line **fix-up hook**, not the move. The actual move is `moveObject`, which the real
controller calls first. Same shape sank `resize` (repositioned to 0,0), `resize_title` (**collapsed
the assembly to 1×1**), `align`, `distribute` and `set_format`: the plugin fabricated Composer
events and populated only the fields each op was "about", while the services read fields it left
null or zero.

**A real property write does mutate `VSAssemblyInfo`**, verified by image and by reload.

**Broadcast plus checkpoint leave undo coherent**: two tool calls needed exactly two Ctrl+Z presses
and restored the original geometry precisely. And the new read-only entry point adds none — measured,
three reads left the checkpoint total unchanged.

### The change that made the rest diagnosable

`WizControllerErrorHandler` had no `IllegalArgumentException` handler, so the ~75 validation sites
across `inetsoft/web/wiz/**` all surfaced as bare 500s with their messages discarded. Correct
validation was indistinguishable from a server fault. `PairingException` — the one type that *did*
have a handler — was the only source of readable errors in the whole run, which is what pointed at
the cause.

### New capabilities

`set_table_source` exists because an assembly added in the Composer had no way to be pointed at
data. The four deferred roadmap items are also in: a read-only capturing dispatcher (so
`getCellScript`/`getNamedGroup`, which answer by *dispatching* a command, can be read without an
undo step), the ten single-field chart shelves (a real candlestick renders), chart axis/legend/title
properties addressed by region, and Immutables support in `PropertyPath` — bare accessors plus
`withX` rebuilding from the leaf up, which is what finally makes image and VS-level properties
reachable.

### Worth flagging for review

Three tests were found asserting the wrong collaborator on a mock and thereby certifying the bugs
above — `moveDelegatesTheNewPosition…`, `addressesTheWholeAssemblyWhenNoRegionIsGiven`,
`addressesATitleLink`. One of them was mine, and its fix was dead code because the controller builds
the region directly and never calls the factory I normalized. The lesson is in the commits: a mock
test proves you called what you meant to call, not that it does anything.

Gates: **1380** Java wiz tests, 0 failures.

## Second pass: 20 defects found by driving the tools against a live Composer

Everything above was written before any of it had run outside a unit test. Running the plan
against a live server found the following, each fixed with a regression test. Several were found
only by *rendering the result* — the model said the right thing in most of them.

**Silent success — the tool reported a change it did not make**

| Defect | Cause |
|---|---|
| `get_chart_aesthetics` reported `field: null` on every channel, always | Read `AestheticInfo.getFullName()`, which the read path never sets. The name was on `dataInfo`. |
| `set_title` on a stale name after a rename returned ok | `requireExisting` was wired into 3 of 10 ops; the composer layer returns normally for an unknown assembly |
| Binding a column the source does not have | Accepted, stored, rendered nothing — reads as "empty data", not "no such column" |
| `set_column_labels` reported "Relabelled 1 column(s)" | Wrote `name2Labels`, a field nothing in the product reads. Now **501**, since a real rename needs a `TableDataPath` cell override |
| Sorting a column bound twice sorted the wrong one | A crosstab binds the same date column twice **by design** (Year › Quarter); name-only addressing took the first match. Now `index`, with an ambiguity refusal |
| An axis target naming no axis | Read returned a full plausible property list; write threw `NPE: axisArea is null` |

**Poisoned state — the bad call succeeded and a later innocent one failed**

`dateLevel: "year"` was stored verbatim. The *next* write to that assembly, on any shelf, failed
with `For input string: "year"`, naming neither the field nor the call that caused it. The levels
are `XConstants` numbers running in an order nobody expects — year 5, quarter 4, month 3, day 1 —
so `DateLevels` now takes the names, takes the numbers, and refuses anything else.

**Pairing could not write at all**

Every write through a paired session failed `InvalidUserException` while every read succeeded, so a
session looked healthy right up to the first mutation. The wiz layer resolves a paired sheet
without the owner check, then hands `runtimeId` to a composer service that re-resolves it and
enforces `Principal` equality — which the JWT-rebuilt agent principal can never satisfy.
`WorksheetEngine` already had `supportLogin` for exactly this shape; this adds a sibling
`pairedAgent`, granted only after confirming the runtime's owner is the same logical user — a check
that path previously did not do **at all**.

**Reported honestly rather than fixed**

- `resize_chart_plot` is **still inert** after four real fixes (contract wrong in all three tiers,
  plus a copy-paste bug where the height branch set the *width* ratio percent). Four hypotheses are
  ruled out in the findings doc; the next step is instrumentation, not a fifth guess.
- `percentageBy` sets the direction only. Rendering percentages needs a percent calculation on the
  aggregate, which no tool can set — surfaced as a gap.

**Eight tests were found asserting the wrong thing**, in addition to the three already noted above.
Three separate suites — Java, plugin, and wiz-services — each asserted `resize_chart_plot` refused
`ratio: 1.5`, so all three stayed green while the tool could only ever be handed values that do
nothing. `set_column_labels`' tests asserted on the dead field. The recurring shape: a test that
writes with our writer and reads with our reader proves only that the two agree.

**A CSS vocabulary over a model that stores integers**

Three fields documented one vocabulary and required another, each failing with a raw parse error
naming no field: `dateLevel: "year"` (an `XConstants` number where year is 5 and day is 1),
`align: "center"` (an `AlignmentInfo` object), and `borderTopStyle: "solid"` — which is the clearest
bug of the three, because `FormatInfoModel.getBorderStyle` *reads back* `"solid"` while the write
path does `Integer.parseInt` on the same field. The API hands you a value it cannot accept. All
three now coerce the documented word and refuse an unknown one by name.

If a fourth turns up, the right answer is probably one translation layer rather than a fourth
special case.

**An error handler that was dead code in production**

A body Jackson could not read returned a bodyless 400 — `"Request failed with status code 400"` and
nothing else, indistinguishable from a broken tool. The handler added for it did nothing, because
`GlobalExceptionHandler extends ResponseEntityExceptionHandler`, which carries a built-in handler
for the Spring MVC exceptions, and with neither advice ordered that one won. The unit test could
not see it: `standaloneSetup` registers only the advice under test, so the handler was correct in
isolation and unreachable in the running application. Caught by calling the tool again after the
"fix" and getting the identical empty 400. The wiz advice is now `HIGHEST_PRECEDENCE`, with the
reasoning in the class comment so the annotation is not later removed as noise.

Gates: **1427** Java wiz tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



