### PR TITLE
Fix schedule task editor UI regressions

### DIFF
--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/task-action-pane.component.html
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/task-action-pane.component.html
@@ -68,7 +68,7 @@
         [disabled]="!isValid()">
         _#(Multiple Actions)
       </button>
-      <button type="button" class="btn btn-secondary" (click)="save(true)"
+      <button type="button" class="btn btn-primary" (click)="save(true)"
       [disabled]="!isValid()">_#(Save)</button>
       <button type="button" class="btn btn-secondary" (click)="closeEditor.emit(model)">
         _#(Close)

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/conditions/task-condition-pane.component.scss
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/conditions/task-condition-pane.component.scss
@@ -55,7 +55,6 @@
       background-color: var(--inet-shell-surface-default);
       color: var(--inet-text-color);
       border-color: var(--inet-default-border-color);
-      box-shadow: inset 0 -2px 0 var(--inet-navbar-selected-border-color);
     }
   }
 
@@ -102,6 +101,7 @@
 .condition-edit-view__type-link:hover {
   background-color: var(--inet-ui-neutral-hover-bg-color);
   color: var(--inet-text-color);
+  text-decoration: none;
 }
 
 .condition-edit-view__card {
@@ -228,6 +228,19 @@
 
 .scheduler-form.input-group:focus-within .input-group-text {
   border-color: var(--inet-primary-color);
+}
+
+// custom-select draws its own complete focus ring around just the dropdown
+// (see custom-select.component.scss ':host(.is-focused)'), unlike number-stepper
+// which relies on this group-level ring. Suppress the group-level ring here so it
+// doesn't double up and bleed over the adjacent "day of the month" / "of the month" label.
+.scheduler-form.input-group.condition-edit-view__monthly-input-group:focus-within {
+  box-shadow: none;
+  outline: none;
+}
+
+.scheduler-form.input-group.condition-edit-view__monthly-input-group:focus-within .input-group-text {
+  border-color: var(--inet-input-border-color);
 }
 
 .sm-dropdown {

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/conditions/task-condition-pane.component.ts
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/conditions/task-condition-pane.component.ts
@@ -26,7 +26,7 @@ import {
    SimpleChanges
 } from "@angular/core";
 import { UntypedFormArray, UntypedFormControl, UntypedFormGroup, ValidationErrors, ValidatorFn, Validators, FormsModule, ReactiveFormsModule } from "@angular/forms";
-import { NgbDateStruct, NgbModal, NgbTimeStruct, NgbTimepicker, NgbInputDatepicker, NgbDatepicker } from "@ng-bootstrap/ng-bootstrap";
+import { NgbDateStruct, NgbModal, NgbTimeStruct, NgbTimepicker, NgbInputDatepicker, NgbDatepicker, NgbDatepickerMonth } from "@ng-bootstrap/ng-bootstrap";
 
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
@@ -67,7 +67,7 @@ dayjs.extend(utc);
     selector: "task-condition-pane",
     templateUrl: "./task-condition-pane.component.html",
     styleUrls: ["./task-condition-pane.component.scss"],
-    imports: [NgIf, NgFor, NgSwitch, NgSwitchCase, FormsModule, ReactiveFormsModule, StartTimeEditor, NgbTimepicker, NgbInputDatepicker, EditableTableComponent, CustomSelectComponent, NumberStepperComponent]
+    imports: [NgIf, NgFor, NgSwitch, NgSwitchCase, FormsModule, ReactiveFormsModule, StartTimeEditor, NgbTimepicker, NgbInputDatepicker, NgbDatepickerMonth, EditableTableComponent, CustomSelectComponent, NumberStepperComponent]
 })
 export class TaskConditionPane implements OnInit, OnChanges {
    private readonly defaultYearWindow: number = 10;

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/options/task-options-pane.component.ts
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/options/task-options-pane.component.ts
@@ -18,7 +18,7 @@
 import { HttpClient } from "@angular/common/http";
 import { Component, EventEmitter, Input, OnInit, Output } from "@angular/core";
 import { UntypedFormControl, UntypedFormGroup, FormsModule, ReactiveFormsModule } from "@angular/forms";
-import { NgbDateStruct, NgbModal, NgbInputDatepicker, NgbDatepicker } from "@ng-bootstrap/ng-bootstrap";
+import { NgbDateStruct, NgbModal, NgbInputDatepicker, NgbDatepicker, NgbDatepickerMonth } from "@ng-bootstrap/ng-bootstrap";
 import { IdentityIdWithLabel } from "../../../../../../../em/src/app/settings/security/users/idenity-id-with-label";
 import { IdentityId } from "../../../../../../../em/src/app/settings/security/users/identity-id";
 import { IdentityType } from "../../../../../../../shared/data/identity-type";
@@ -37,7 +37,7 @@ import { ScheduleTaskDialogModel } from "../../../../../../../shared/schedule/mo
     selector: "task-options-pane",
     templateUrl: "./task-options-pane.component.html",
     styleUrls: ["./task-options-pane.component.scss"],
-    imports: [FormsModule, ReactiveFormsModule, NgbInputDatepicker, CustomSelectComponent]
+    imports: [FormsModule, ReactiveFormsModule, NgbInputDatepicker, NgbDatepickerMonth, CustomSelectComponent]
 })
 export class TaskOptionsPane implements OnInit {
    private readonly defaultYearWindow: number = 10;

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-list/edit-task-folder-dialog/edit-task-folder-dialog.component.html
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-list/edit-task-folder-dialog/edit-task-folder-dialog.component.html
@@ -15,11 +15,8 @@
 ~ You should have received a copy of the GNU Affero General Public License
 ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -->
-<div class="modal-header">
-  <h3 class="modal-title">_#(em.schedule.task.folderEdit)</h3>
-  <button type="button" class="btn-close" (click)="cancel()" [attr.title]="'_#(Close)'" aria-label="Close">
-  </button>
-</div>
+<modal-header [title]="'_#(em.schedule.task.folderEdit)'" (onCancel)="cancel()">
+</modal-header>
 <div class="modal-body">
   <form class="container-fluid" [formGroup]="form">
     <div class="row">

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-list/edit-task-folder-dialog/edit-task-folder-dialog.component.ts
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-list/edit-task-folder-dialog/edit-task-folder-dialog.component.ts
@@ -33,6 +33,7 @@ import { HttpClient } from "@angular/common/http";
 import { Tool } from "../../../../../../../shared/util/tool";
 import { CheckDuplicateResponse } from "../../../data/commands/check-duplicate-response";
 import { FormValidators } from "../../../../../../../shared/util/form-validators";
+import { ModalHeaderComponent } from "../../../../widget/modal-header/modal-header.component";
 
 
 const TASK_FOLDER_CHECK_DUPLICATE_URI: string = "../api/portal/schedule/rename/checkDuplicate";
@@ -41,7 +42,7 @@ const TASK_FOLDER_CHECK_DUPLICATE_URI: string = "../api/portal/schedule/rename/c
     selector: "c-edit-task-folder-dialog",
     templateUrl: "./edit-task-folder-dialog.component.html",
     styleUrls: ["./edit-task-folder-dialog.component.scss"],
-    imports: [FormsModule, ReactiveFormsModule]
+    imports: [FormsModule, ReactiveFormsModule, ModalHeaderComponent]
 })
 export class EditTaskFolderDialog implements OnInit, OnChanges, AfterViewInit {
   @Input() model: EditTaskFolderDialogModel;

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-list/schedule-task-list.component.html
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-list/schedule-task-list.component.html
@@ -40,7 +40,7 @@
       <button type="button" class="btn btn-secondary" (click)="loadTasks(true)">_#(Refresh List)</button>
       <button type="button" class="btn btn-secondary"
               (click)="moveTasks()"
-              [disabled]="(showTasksAsList || !removeEnable())">
+              [disabled]="(showTasksAsList || !removeEnable() || !parentFolder)">
         _#(Move)
       </button>
       <button type="button" class="btn btn-secondary"

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-list/schedule-task-list.component.ts
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-list/schedule-task-list.component.ts
@@ -936,7 +936,7 @@ export class ScheduleTaskListComponent implements OnInit, OnDestroy, AfterConten
    }
 
    public moveTasks(): void {
-      if(this.showTasksAsList || !this.removeEnable()) {
+      if(this.showTasksAsList || !this.removeEnable() || !this.parentFolder) {
          return;
       }
 


### PR DESCRIPTION
## Summary
- Scope the monthly condition dropdown's focus ring to the custom-select itself instead of bleeding over the "day of the month"/"of the month" labels
- Remove the redundant orange inset box-shadow and stray underline on the selected/hovered condition-type tab
- Fix the Run Once and Options date pickers rendering with no calendar grid (`NgbDatepickerMonth` was missing from imports, so `<ngb-datepicker-month>` rendered as an inert unbound element)
- Fix the Action tab's Save button using `btn-secondary` instead of `btn-primary` like the Condition/Options tabs
- Fix a crash moving tasks when the folder tree selection isn't exactly one node (ctrl/shift-click) by disabling Move and guarding `moveTasks()` on the existing `parentFolder` getter
- Use the shared `<modal-header>` component in the edit task folder dialog instead of hand-rolled header markup

## Test plan
- [x] Verified live in browser: Monthly condition dropdown focus ring, tab hover/selected styling, Run Once + Options date pickers rendering full calendar grids, Deliver-to-email content-as options (see stacked PR on top of this one)
- [ ] Confirm Move button is disabled when the folder tree has 0 or >1 nodes selected, and enabled/functional with exactly 1 selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)