### PR TITLE
Redesign schedule action deliver/save content-as options

### DIFF
--- a/web/projects/em/src/app/settings/schedule/task-action-pane/delivery-emails/delivery-emails.component.html
+++ b/web/projects/em/src/app/settings/schedule/task-action-pane/delivery-emails/delivery-emails.component.html
@@ -71,32 +71,43 @@
           <mat-error *ngIf="form.controls.format?.errors?.required">_#(em.schedule.action.formatRequired)</mat-error>
         </mat-form-field>
         @if (dataSizeOptionVisible) {
-          <mat-radio-group class="flex-col left-padding" formControlName="emailMatchLayout"
-            (change)="fireDeliveryChanged()">
-            <mat-radio-button [value]="true">_#(Match Layout)</mat-radio-button>
-            <mat-radio-button [value]="false"
-            [disabled]="!expandEnabled">_#(Expand Components)</mat-radio-button>
-          </mat-radio-group>
-        }
-        <div class="full-width">
-          @if (dataSizeOptionVisible) {
-            <mat-checkbox class="left-padding"
-              formControlName="emailExpandSelections"
+          <div class="option-group">
+            <div class="group-label left-padding">_#(Deliver content as)</div>
+            <mat-radio-group class="flex-col left-padding"
+              formControlName="emailMatchLayout"
               (change)="fireDeliveryChanged()">
-              _#(Expand Selection List/Tree)
-            </mat-checkbox>
-          }
-          @if (type == 'viewsheet' && format == 'Excel') {
-            <mat-checkbox class="left-padding"
-              formControlName="emailOnlyDataComponents"
-              (change)="fireDeliveryChanged()">_#(Only Data Elements)
-            </mat-checkbox>
-          }
-        </div>
-        @if (type == 'viewsheet' && format == 'Excel') {
-          <mat-checkbox class="left-padding"
-            formControlName="exportAllTabbedTables"
-          (change)="fireDeliveryChanged()">_#(Export All Tabbed Tables)</mat-checkbox>
+              <mat-radio-button [value]="true">_#(Match Layout)</mat-radio-button>
+              <div class="option-row">
+                <mat-radio-button [value]="false"
+                [disabled]="!expandEnabled">_#(Expand Components)</mat-radio-button>
+                @if (emailLayoutReason) {
+                  <span class="option-reason">{{ emailLayoutReason }}</span>
+                }
+              </div>
+            </mat-radio-group>
+            <div class="option-indent left-padding">
+              <div class="option-row">
+                <mat-checkbox formControlName="emailExpandSelections" (change)="fireDeliveryChanged()">
+                  _#(Expand Selection List/Tree)
+                </mat-checkbox>
+                @if (emailExpandSelectionsReason) {
+                  <span class="option-reason">{{ emailExpandSelectionsReason }}</span>
+                }
+              </div>
+              <div class="option-row">
+                <mat-checkbox formControlName="emailOnlyDataComponents" (change)="fireDeliveryChanged()">_#(Only Data Elements)</mat-checkbox>
+                @if (emailOnlyDataReason) {
+                  <span class="option-reason">{{ emailOnlyDataReason }}</span>
+                }
+              </div>
+              <div class="option-row">
+                <mat-checkbox formControlName="exportAllTabbedTables" (change)="fireDeliveryChanged()">_#(Export All Tabbed Tables)</mat-checkbox>
+                @if (emailTabbedTablesDisabled) {
+                  <span class="option-reason">_#(Excel only)</span>
+                }
+              </div>
+            </div>
+          </div>
         }
         <mat-checkbox class="left-padding"
           formControlName="bundledAsZip"

--- a/web/projects/em/src/app/settings/schedule/task-action-pane/delivery-emails/delivery-emails.component.scss
+++ b/web/projects/em/src/app/settings/schedule/task-action-pane/delivery-emails/delivery-emails.component.scss
@@ -71,6 +71,41 @@
       .left-padding {
         padding-left: 24px;
       }
+
+      .group-label {
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: rgba(0, 0, 0, .6);
+      }
+
+      .option-group {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
+        width: 100%;
+      }
+
+      .option-indent {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 4px;
+        margin-left: 26px;
+      }
+
+      .option-row {
+        display: flex;
+        align-items: center;
+        gap: 9px;
+      }
+
+      .option-reason {
+        font-size: 12px;
+        color: rgba(0, 0, 0, .6);
+      }
     }
   }
 

--- a/web/projects/em/src/app/settings/schedule/task-action-pane/delivery-emails/delivery-emails.component.ts
+++ b/web/projects/em/src/app/settings/schedule/task-action-pane/delivery-emails/delivery-emails.component.ts
@@ -265,8 +265,59 @@ export class DeliveryEmailsComponent implements OnInit, OnChanges {
    }
 
    get dataSizeOptionVisible(): boolean {
-      return this.type === "viewsheet" && this.format !== "HTML" && this.format !== "CSV" &&
-         (this.format != "PDF" || !this.hasPrintLayout);
+      return this.type === "viewsheet" && (this.format != "PDF" || !this.hasPrintLayout);
+   }
+
+   get emailLayoutUnavailable(): boolean {
+      return this.format === DashboardOptions.HTML || this.format === "CSV";
+   }
+
+   get emailLayoutReason(): string {
+      if(this.format === DashboardOptions.HTML) {
+         return "_#(js:Not applied to HTML)";
+      }
+
+      if(this.format === "CSV") {
+         return "_#(js:Not applied to CSV)";
+      }
+
+      return "";
+   }
+
+   private get emailExpandActive(): boolean {
+      return !this.emailLayoutUnavailable && !this.emailMatchLayout;
+   }
+
+   get emailExpandSelectionsReason(): string {
+      if(!this.expandEnabled) {
+         return "_#(js:Requires Expand Components permission)";
+      }
+
+      if(!this.emailExpandActive) {
+         return "_#(js:Needs Expand components)";
+      }
+
+      if(this.format === "Excel" && this.emailOnlyDataComponents) {
+         return "_#(js:Not used with data-only export)";
+      }
+
+      return "";
+   }
+
+   get emailOnlyDataReason(): string {
+      if(this.format !== "Excel") {
+         return "_#(js:Excel only)";
+      }
+
+      if(!this.emailExpandActive) {
+         return "_#(js:Needs Expand components)";
+      }
+
+      return "";
+   }
+
+   get emailTabbedTablesDisabled(): boolean {
+      return this.format !== "Excel";
    }
 
    form: UntypedFormGroup;
@@ -349,8 +400,17 @@ export class DeliveryEmailsComponent implements OnInit, OnChanges {
    }
 
    private updateEnable(): void {
+      if(this.form.get("emailMatchLayout")) {
+         if(this.emailLayoutUnavailable) {
+            this.form.get("emailMatchLayout").disable({ emitEvent: false });
+         }
+         else {
+            this.form.get("emailMatchLayout").enable({ emitEvent: false });
+         }
+      }
+
       if(this.form.get("emailExpandSelections")) {
-         if(!this.expandEnabled || this.emailMatchLayout || (this.emailOnlyDataComponents && this.format == "Excel")) {
+         if(!this.expandEnabled || !this.emailExpandActive || (this.emailOnlyDataComponents && this.format == "Excel")) {
             this.form.get("emailExpandSelections").disable({ emitEvent: false });
          }
          else {
@@ -359,11 +419,20 @@ export class DeliveryEmailsComponent implements OnInit, OnChanges {
       }
 
       if(this.form.get("emailOnlyDataComponents")) {
-         if(!this.expandEnabled || this.emailMatchLayout) {
+         if(this.format !== "Excel" || !this.emailExpandActive) {
             this.form.get("emailOnlyDataComponents").disable({ emitEvent: false });
          }
          else {
             this.form.get("emailOnlyDataComponents").enable({ emitEvent: false });
+         }
+      }
+
+      if(this.form.get("exportAllTabbedTables")) {
+         if(this.emailTabbedTablesDisabled) {
+            this.form.get("exportAllTabbedTables").disable({ emitEvent: false });
+         }
+         else {
+            this.form.get("exportAllTabbedTables").enable({ emitEvent: false });
          }
       }
    }
@@ -399,14 +468,8 @@ export class DeliveryEmailsComponent implements OnInit, OnChanges {
    changeFormat() {
       this.bundledAsZip = !this.bundledDisabled && this.bundledAsZip;
 
-      if(this.form.get("format").value === DashboardOptions.HTML) {
-         this.form.get("emailMatchLayout").disable();
-      }
-      else if(this.form.get("format").value === ReportOptions.CSV && this.type === "viewsheet") {
+      if(this.form.get("format").value === ReportOptions.CSV && this.type === "viewsheet") {
          this.bundledAsZip = true;
-      }
-      else {
-         this.form.get("emailMatchLayout").enable();
       }
 
       this.togglePasswordForm(true);

--- a/web/projects/em/src/app/settings/schedule/task-action-pane/server-save/server-save.component.html
+++ b/web/projects/em/src/app/settings/schedule/task-action-pane/server-save/server-save.component.html
@@ -140,28 +140,38 @@
         <mat-icon fontSet="ineticons" fontIcon="shape-plus-icon"></mat-icon>
       </button>
       @if (showMatchAndExpand) {
-        <div class="full-width">
+        <div class="option-group">
+          <div class="group-label left-padding">_#(Save content as)</div>
           <mat-radio-group [(ngModel)]="matchLayout" class="flex-col left-padding" (change)="fireServerSaveChanged()">
             <mat-radio-button [value]="true">_#(Match Layout)</mat-radio-button>
             <mat-radio-button [value]="false" [disabled]="!expandEnabled">_#(Expand Components)</mat-radio-button>
           </mat-radio-group>
-          <mat-checkbox class="left-padding" [(ngModel)]="expandSelections" [disabled]="matchLayout || saveOnlyDataComponents" (change)="fireServerSaveChanged()">
-          _#(Expand Selection List/Tree)</mat-checkbox>
-          @if (hasExcelFormat) {
-            <mat-checkbox class="left-padding" [(ngModel)]="saveOnlyDataComponents" [disabled]="matchLayout" (change)="fireServerSaveChanged()">
-            _#(Only Data Elements)</mat-checkbox>
-          }
-          <div class="flex-col">
-            @if (hasExcelFormat) {
-              <mat-checkbox class="left-padding" [(ngModel)]="saveExportAllTabbedTables" (change)="fireServerSaveChanged()">
-              _#(Export All Tabbed Tables)</mat-checkbox>
-            }
-          </div>
-          @if (showHtmlMatchMessage) {
-            <div class="left-padding match-massage">
-              <span>_#(schedule.task.action.htmlFileFormat.doNotApplyMatch)<br>_#(schedule.task.action.excelFileFormat.justApplyTabbedTable)</span>
+          <div class="option-indent left-padding">
+            <div class="option-row">
+              <mat-checkbox [(ngModel)]="expandSelections" [disabled]="!expandEnabled || matchLayout || saveOnlyDataComponents" (change)="fireServerSaveChanged()">
+                _#(Expand Selection List/Tree)
+              </mat-checkbox>
+              @if (saveExpandSelectionsReason) {
+                <span class="option-reason">{{ saveExpandSelectionsReason }}</span>
+              }
             </div>
-          }
+            <div class="option-row">
+              <mat-checkbox [(ngModel)]="saveOnlyDataComponents" [disabled]="!hasExcelFormat || matchLayout" (change)="fireServerSaveChanged()">
+                _#(Only Data Elements)
+              </mat-checkbox>
+              @if (saveOnlyDataReason) {
+                <span class="option-reason">{{ saveOnlyDataReason }}</span>
+              }
+            </div>
+            <div class="option-row">
+              <mat-checkbox [(ngModel)]="saveExportAllTabbedTables" [disabled]="saveTabbedTablesDisabled" (change)="fireServerSaveChanged()">
+                _#(Export All Tabbed Tables)
+              </mat-checkbox>
+              @if (saveTabbedTablesDisabled) {
+                <span class="option-reason">_#(Excel only)</span>
+              }
+            </div>
+          </div>
         </div>
       }
       @if (hasCSVFormat && enabled) {

--- a/web/projects/em/src/app/settings/schedule/task-action-pane/server-save/server-save.component.scss
+++ b/web/projects/em/src/app/settings/schedule/task-action-pane/server-save/server-save.component.scss
@@ -105,8 +105,39 @@
         padding-left: 24px;
       }
 
-      .match-massage {
-         margin-top: 1em;
+      .group-label {
+        font-size: 12px;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: rgba(0, 0, 0, .6);
+      }
+
+      .option-group {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
+        width: 100%;
+      }
+
+      .option-indent {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 4px;
+        margin-left: 26px;
+      }
+
+      .option-row {
+        display: flex;
+        align-items: center;
+        gap: 9px;
+      }
+
+      .option-reason {
+        font-size: 12px;
+        color: rgba(0, 0, 0, .6);
       }
 
       .mat-mdc-mini-fab {

--- a/web/projects/em/src/app/settings/schedule/task-action-pane/server-save/server-save.component.ts
+++ b/web/projects/em/src/app/settings/schedule/task-action-pane/server-save/server-save.component.ts
@@ -152,31 +152,41 @@ export class ServerSaveComponent implements OnInit {
       });
    }
 
-   get showHtmlMatchMessage() {
-      let hasHtmlOrCsv = false;
-      let hasOther = false;
-
-      if(!this._files) {
-         return false;
-      }
-
-      this._files.forEach((file) => {
-         if(this.isHtmlFormat(file.format) ||
-            (this.isDashboard && this.isVSCSVFormat(file.format)))
-         {
-            hasHtmlOrCsv = true;
-         }
-         else {
-            hasOther = true;
-         }
-      });
-
-      return hasHtmlOrCsv && hasOther;
-   }
-
    get hasExcelFormat(): boolean {
       // 0 is Excel
       return this.saveFormats.includes("0");
+   }
+
+   get saveExpandSelectionsReason(): string {
+      if(!this.expandEnabled) {
+         return "_#(js:Requires Expand Components permission)";
+      }
+
+      if(this.matchLayout) {
+         return "_#(js:Needs Expand components)";
+      }
+
+      if(this.saveOnlyDataComponents) {
+         return "_#(js:Not used with data-only export)";
+      }
+
+      return "";
+   }
+
+   get saveOnlyDataReason(): string {
+      if(!this.hasExcelFormat) {
+         return "_#(js:Excel only)";
+      }
+
+      if(this.matchLayout) {
+         return "_#(js:Needs Expand components)";
+      }
+
+      return "";
+   }
+
+   get saveTabbedTablesDisabled(): boolean {
+      return !this.hasExcelFormat;
    }
 
    get hasCSVFormat(): boolean {

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/action-accordian/action-accordion.component.display.tl.spec.ts
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/action-accordian/action-accordion.component.display.tl.spec.ts
@@ -264,7 +264,7 @@ describe("ActionAccordion — Match Layout / Expand Components radios (email sec
       expect(document.getElementById("onlyDataComponents")).not.toBeNull();
    });
 
-   it("'Only Data Elements' checkbox is absent when format=PDF", async () => {
+   it("'Only Data Elements' checkbox is present but disabled with an 'Excel only' reason when format=PDF", async () => {
       const action = makeAction({
          actionType: "ViewsheetAction",
          deliverEmailsEnabled: true,
@@ -275,7 +275,10 @@ describe("ActionAccordion — Match Layout / Expand Components radios (email sec
          vsMailFormats: [{ type: "PDF", label: "PDF" }],
       });
       await renderActionAccordion({ action, model });
-      expect(document.getElementById("onlyDataComponents")).toBeNull();
+      const checkbox = document.getElementById("onlyDataComponents") as HTMLInputElement;
+      expect(checkbox).not.toBeNull();
+      expect(checkbox.disabled).toBe(true);
+      expect(checkbox.closest(".action-accordion__option-row")?.textContent).toContain("_#(js:Excel only)");
    });
 });
 
@@ -415,13 +418,12 @@ describe("ActionAccordion — showMatchAndExpand radios (Save section)", () => {
    });
 });
 
-// ── Group 9: showMatchMessage HTML warning ────────────────────────────────────
+// ── Group 9: post-save warning replaced by inline per-control reasons ─────────
 
-describe("ActionAccordion — .html-match-message visibility", () => {
+describe("ActionAccordion — .html-match-message removed in favor of inline reasons", () => {
 
-   it("html-match-message is visible when saveFormats mixes HTML and non-HTML entries", async () => {
+   it("the old combined html-match-message warning never renders", async () => {
       // FileTypes.HTML=5 → "5"; Excel save format → "0"
-      // hasHtml=true + hasOther=true → showMatchMessage=true
       const action = makeAction({
          actionType: "ViewsheetAction",
          saveToServerEnabled: true,
@@ -433,22 +435,31 @@ describe("ActionAccordion — .html-match-message visibility", () => {
          ],
       });
       await renderActionAccordion({ action });
-      expect(document.querySelector(".html-match-message")).not.toBeNull();
+      expect(document.querySelector(".html-match-message")).toBeNull();
    });
 
-   it("html-match-message is absent when saveFormats has only Excel entries", async () => {
+   it("'Only Data Elements' / 'Export All Tabbed Tables' are present but disabled with an 'Excel only' reason when saveFormats has no Excel entries", async () => {
+      // "5" = HTML, "9" = PDF (neither is Excel's "0"); mixing them keeps showMatchAndExpand
+      // true (not every format is HTML/CSV) while hasExcelFormat() stays false.
       const action = makeAction({
          actionType: "ViewsheetAction",
          saveToServerEnabled: true,
-         saveFormats: ["0"],
-         filePaths: ["r.xlsx"],
-         serverFilePaths: [{
-            path: "r.xlsx", ftp: false, useCredential: false,
-            secretId: null, username: null, password: null, oldFormat: -1,
-         }],
+         saveFormats: ["5", "9"],
+         filePaths: ["r.html", "r.pdf"],
+         serverFilePaths: [
+            { path: "r.html", ftp: false, useCredential: false, secretId: null, username: null, password: null, oldFormat: -1 },
+            { path: "r.pdf", ftp: false, useCredential: false, secretId: null, username: null, password: null, oldFormat: -1 },
+         ],
       });
       await renderActionAccordion({ action });
-      expect(document.querySelector(".html-match-message")).toBeNull();
+      const onlyData = document.getElementById("onlyDataComponents2") as HTMLInputElement;
+      const tabbedTables = document.getElementById("saveExportAllTabbedTables") as HTMLInputElement;
+      expect(onlyData).not.toBeNull();
+      expect(onlyData.disabled).toBe(true);
+      expect(onlyData.closest(".action-accordion__option-row")?.textContent).toContain("_#(js:Excel only)");
+      expect(tabbedTables).not.toBeNull();
+      expect(tabbedTables.disabled).toBe(true);
+      expect(tabbedTables.closest(".action-accordion__option-row")?.textContent).toContain("_#(Excel only)");
    });
 });
 

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/action-accordian/action-accordion.component.html
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/action-accordian/action-accordion.component.html
@@ -345,65 +345,84 @@
                   </div>
                 </div>
                 @if (dataSizeOptionVisible) {
-                  <div class="form-check mb-2 flex-wrap">
-                    <div class="col-auto emailSpacing">
-                      <input class="form-check-input" type="radio" id="match" name="emailMatch"
-                        [ngModelOptions]="{standalone: true}"
-                        [(ngModel)]="action.emailMatchLayout"
-                        [value]="true" (ngModelChange)="updateEmailDataOnlyFormat()">
-                      <label class="form-check-label match-layout-id" for="match">
-                        _#(Match Layout)
-                      </label>
-                    </div>
-                    <div class="col-auto emailSpacing">
-                      <input class="form-check-input" type="radio" id="expand" name="emailMatch"
-                        [attr.disabled]="model.expandEnabled ? null : ''"
-                        [ngModelOptions]="{standalone: true}"
-                        [(ngModel)]="action.emailMatchLayout"
-                        [value]="false">
-                      <label class="form-check-label expand-tables-and-charts-id" for="expand">
-                        _#(Expand Components)
-                      </label>
-                    </div>
-                    <div class="col-auto emailSpacing">
-                      <div class="form-check form-switch action-accordion__section-toggle">
-                        <input type="checkbox" class="form-check-input"
-                          id="expandSelections"
-                          [disabled]="!model.expandEnabled || action.emailMatchLayout || action.emailOnlyDataComponents"
-                          [ngModelOptions]="{standalone: true}"
-                          [(ngModel)]="action.emailExpandSelections">
-                        <label class="form-check-label" for="expandSelections">
-                          _#(Expand Selection List/Tree)
-                        </label>
+                  <div class="action-accordion__option-group">
+                    <div class="action-accordion__group-label">_#(Deliver content as)</div>
+                    <div class="action-accordion__option-group action-accordion__option-group--radios">
+                      <div class="action-accordion__option-row">
+                        <div class="form-check">
+                          <input class="form-check-input" type="radio" id="match" name="emailMatch"
+                            [disabled]="emailLayoutUnavailable"
+                            [ngModelOptions]="{standalone: true}"
+                            [(ngModel)]="action.emailMatchLayout"
+                            [value]="true" (ngModelChange)="updateEmailDataOnlyFormat()">
+                          <label class="form-check-label match-layout-id" for="match">
+                            _#(Match Layout)
+                          </label>
+                        </div>
+                      </div>
+                      <div class="action-accordion__option-row">
+                        <div class="form-check">
+                          <input class="form-check-input" type="radio" id="expand" name="emailMatch"
+                            [disabled]="emailLayoutUnavailable || !model.expandEnabled"
+                            [ngModelOptions]="{standalone: true}"
+                            [(ngModel)]="action.emailMatchLayout"
+                            [value]="false">
+                          <label class="form-check-label expand-tables-and-charts-id" for="expand">
+                            _#(Expand Components)
+                          </label>
+                        </div>
+                        @if (emailLayoutReason) {
+                          <span class="action-accordion__option-reason">{{ emailLayoutReason }}</span>
+                        }
                       </div>
                     </div>
-                    @if (action.format === 'Excel') {
-                      <div class="col-auto emailSpacing">
-                        <div class="form-check form-switch action-accordion__section-toggle">
+                    <div class="action-accordion__option-indent">
+                      <div class="action-accordion__option-row">
+                        <div class="form-check">
+                          <input type="checkbox" class="form-check-input"
+                            id="expandSelections"
+                            [disabled]="emailExpandSelectionsDisabled"
+                            [ngModelOptions]="{standalone: true}"
+                            [(ngModel)]="action.emailExpandSelections">
+                          <label class="form-check-label" for="expandSelections">
+                            _#(Expand Selection List/Tree)
+                          </label>
+                        </div>
+                        @if (emailExpandSelectionsReason) {
+                          <span class="action-accordion__option-reason">{{ emailExpandSelectionsReason }}</span>
+                        }
+                      </div>
+                      <div class="action-accordion__option-row">
+                        <div class="form-check">
                           <input type="checkbox" class="form-check-input"
                             id="onlyDataComponents"
-                            [disabled]="!model.expandEnabled || action.emailMatchLayout"
+                            [disabled]="emailOnlyDataDisabled"
                             [ngModelOptions]="{standalone: true}"
                             [(ngModel)]="action.emailOnlyDataComponents">
                           <label class="form-check-label" for="onlyDataComponents">
                             _#(Only Data Elements)
                           </label>
                         </div>
+                        @if (emailOnlyDataReason) {
+                          <span class="action-accordion__option-reason">{{ emailOnlyDataReason }}</span>
+                        }
                       </div>
-                    }
-                    @if (action.format === 'Excel') {
-                      <div class="col-auto emailSpacing">
-                        <div class="form-check form-switch action-accordion__section-toggle">
+                      <div class="action-accordion__option-row">
+                        <div class="form-check">
                           <input type="checkbox" class="form-check-input"
                             id="exportAllTabbedTables"
+                            [disabled]="emailTabbedTablesDisabled"
                             [ngModelOptions]="{standalone: true}"
                             [(ngModel)]="action.exportAllTabbedTables">
                           <label class="form-check-label" for="exportAllTabbedTables">
                             _#(Export All Tabbed Tables)
                           </label>
                         </div>
+                        @if (emailTabbedTablesDisabled) {
+                          <span class="action-accordion__option-reason">_#(Excel only)</span>
+                        }
                       </div>
-                    }
+                    </div>
                   </div>
                 }
                 <div class="action-accordion__row row">
@@ -596,70 +615,80 @@
                   </div>
                 </div>
                 @if (showMatchAndExpand) {
-                  <div class="row">
-                    <div class="col-auto">
-                      <input class="form-check-input" type="radio" id="match2" name="saveMatch"
-                        [ngModelOptions]="{standalone: true}"
-                        [(ngModel)]="action.saveMatchLayout"
-                        [value]="true" (ngModelChange)="updateDataOnlyFormat()">
-                      <label class="form-check-label match-layout-id" for="match2">
-                        _#(Match Layout)
-                      </label>
-                    </div>
-                    <div class="col-auto">
-                      <input class="form-check-input" type="radio" id="expand2" name="saveMatch"
-                        [attr.disabled]="model.expandEnabled ? null : ''"
-                        [ngModelOptions]="{standalone: true}"
-                        [(ngModel)]="action.saveMatchLayout"
-                        [value]="false">
-                      <label class="form-check-label expand-tables-and-charts-id" for="expand2">
-                        _#(Expand Components)
-                      </label>
-                    </div>
-                    <div class="col-auto">
-                      <div class="form-check form-switch action-accordion__section-toggle">
-                        <input type="checkbox" class="form-check-input"
-                          id="expandSelections2"
-                          [disabled]="!model.expandEnabled || action.saveMatchLayout || action.saveOnlyDataComponents"
-                          [ngModelOptions]="{standalone: true}"
-                          [(ngModel)]="action.saveExpandSelections">
-                        <label class="form-check-label" for="expandSelections2">
-                          _#(Expand Selection List/Tree)
-                        </label>
+                  <div class="action-accordion__option-group">
+                    <div class="action-accordion__group-label">_#(Save content as)</div>
+                    <div class="action-accordion__option-group action-accordion__option-group--radios">
+                      <div class="action-accordion__option-row">
+                        <div class="form-check">
+                          <input class="form-check-input" type="radio" id="match2" name="saveMatch"
+                            [ngModelOptions]="{standalone: true}"
+                            [(ngModel)]="action.saveMatchLayout"
+                            [value]="true" (ngModelChange)="updateDataOnlyFormat()">
+                          <label class="form-check-label match-layout-id" for="match2">
+                            _#(Match Layout)
+                          </label>
+                        </div>
+                      </div>
+                      <div class="action-accordion__option-row">
+                        <div class="form-check">
+                          <input class="form-check-input" type="radio" id="expand2" name="saveMatch"
+                            [attr.disabled]="model.expandEnabled ? null : ''"
+                            [ngModelOptions]="{standalone: true}"
+                            [(ngModel)]="action.saveMatchLayout"
+                            [value]="false">
+                          <label class="form-check-label expand-tables-and-charts-id" for="expand2">
+                            _#(Expand Components)
+                          </label>
+                        </div>
                       </div>
                     </div>
-                    @if (hasExcelFormat()) {
-                      <div class="col-auto">
-                        <div class="form-check form-switch action-accordion__section-toggle">
+                    <div class="action-accordion__option-indent">
+                      <div class="action-accordion__option-row">
+                        <div class="form-check">
+                          <input type="checkbox" class="form-check-input"
+                            id="expandSelections2"
+                            [disabled]="saveExpandSelectionsDisabled"
+                            [ngModelOptions]="{standalone: true}"
+                            [(ngModel)]="action.saveExpandSelections">
+                          <label class="form-check-label" for="expandSelections2">
+                            _#(Expand Selection List/Tree)
+                          </label>
+                        </div>
+                        @if (saveExpandSelectionsReason) {
+                          <span class="action-accordion__option-reason">{{ saveExpandSelectionsReason }}</span>
+                        }
+                      </div>
+                      <div class="action-accordion__option-row">
+                        <div class="form-check">
                           <input type="checkbox" class="form-check-input"
                             id="onlyDataComponents2"
-                            [disabled]="!model.expandEnabled || action.saveMatchLayout"
+                            [disabled]="saveOnlyDataDisabled"
                             [ngModelOptions]="{standalone: true}"
                             [(ngModel)]="action.saveOnlyDataComponents">
                           <label class="form-check-label" for="onlyDataComponents2">
                             _#(Only Data Elements)
                           </label>
                         </div>
+                        @if (saveOnlyDataReason) {
+                          <span class="action-accordion__option-reason">{{ saveOnlyDataReason }}</span>
+                        }
                       </div>
-                    }
-                    @if (hasExcelFormat()) {
-                      <div class="col-auto">
-                        <div class="form-check form-switch action-accordion__section-toggle">
+                      <div class="action-accordion__option-row">
+                        <div class="form-check">
                           <input type="checkbox" class="form-check-input"
                             id="saveExportAllTabbedTables"
+                            [disabled]="saveTabbedTablesDisabled"
                             [ngModelOptions]="{standalone: true}"
                             [(ngModel)]="action.saveExportAllTabbedTables">
                           <label class="form-check-label" for="saveExportAllTabbedTables">
                             _#(Export All Tabbed Tables)
                           </label>
                         </div>
+                        @if (saveTabbedTablesDisabled) {
+                          <span class="action-accordion__option-reason">_#(Excel only)</span>
+                        }
                       </div>
-                    }
-                  </div>
-                }
-                @if (showMatchMessage) {
-                  <div class="row html-match-message">
-                    <span class="col-auto">_#(schedule.task.action.htmlFileFormat.doNotApplyMatch)<br>_#(schedule.task.action.excelFileFormat.justApplyTabbedTable)</span>
+                    </div>
                   </div>
                 }
               </fieldset>

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/action-accordian/action-accordion.component.interaction.tl.spec.ts
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/action-accordian/action-accordion.component.interaction.tl.spec.ts
@@ -493,11 +493,29 @@ describe("ActionAccordion — isDashboard, bundledDisabled, dataSizeOptionVisibl
       expect(comp.dataSizeOptionVisible).toBe(false);
    });
 
-   it("dataSizeOptionVisible is false for dashboard with HTML format", async () => {
+   it("dataSizeOptionVisible stays true for dashboard with HTML format (shown disabled, not hidden)", async () => {
       const { comp } = await renderActionAccordion({
          action: makeAction({ actionType: "ViewsheetAction", format: "HTML" }),
       });
-      expect(comp.dataSizeOptionVisible).toBe(false);
+      expect(comp.dataSizeOptionVisible).toBe(true);
+      expect(comp.emailLayoutUnavailable).toBe(true);
+      expect(comp.emailLayoutReason).toBe("_#(js:Not applied to HTML)");
+   });
+
+   it("emailLayoutReason reflects CSV format", async () => {
+      const { comp } = await renderActionAccordion({
+         action: makeAction({ actionType: "ViewsheetAction", format: "CSV" }),
+      });
+      expect(comp.emailLayoutUnavailable).toBe(true);
+      expect(comp.emailLayoutReason).toBe("_#(js:Not applied to CSV)");
+   });
+
+   it("emailLayoutReason is empty for a format the layout choice applies to", async () => {
+      const { comp } = await renderActionAccordion({
+         action: makeAction({ actionType: "ViewsheetAction", format: "Excel" }),
+      });
+      expect(comp.emailLayoutUnavailable).toBe(false);
+      expect(comp.emailLayoutReason).toBe("");
    });
 });
 

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/action-accordian/action-accordion.component.scss
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/action-accordian/action-accordion.component.scss
@@ -52,6 +52,15 @@
   flex-direction: column;
   gap: var(--inet-space-3);
   padding: 0;
+
+  // <fieldset> defaults to min-width: min-content in the UA stylesheet, and as a flex
+  // item its automatic minimum size falls back to that same content-based floor. With
+  // any unshrinkable descendant, that lets the fieldset (and everything stretched to
+  // its width) balloon far past the card — override it so the fieldset actually
+  // respects the flex column's width instead of sizing to its widest content.
+  > fieldset {
+    min-width: 0;
+  }
 }
 
 .action-accordion__row,
@@ -78,6 +87,11 @@
   margin-bottom: 0;
 }
 
+.action-accordion__section-toggle + fieldset,
+.action-accordion__section-toggle + .action-accordion-highlights {
+  margin-top: 0.75rem;
+}
+
 .action-accordion-highlights {
   margin-bottom: 0;
 }
@@ -90,6 +104,57 @@
 
 .action-accordion-bookmark-row {
   --bs-gutter-x: var(--inet-space-3);
+}
+
+// ── Deliver/Save content-as group (grouped radio + indented checkbox pattern) ──
+
+.action-accordion__group-label {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--inet-text-muted-color);
+}
+
+.action-accordion__option-group {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 0.75rem;
+  min-width: 0;
+  width: 100%;
+}
+
+.action-accordion__option-group--radios {
+  gap: 14px;
+}
+
+.action-accordion__option-indent {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+  margin: 2px 0 0 26px;
+}
+
+.action-accordion__option-row {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+  margin-bottom: 0;
+
+  // Keep Bootstrap's floated/negative-margin .form-check checkbox model isolated from
+  // this flex row — combining them on one element let the float's -1.5em margin blow
+  // out this row's (and its flex-column ancestors') measured width.
+  > .form-check {
+    min-width: 0;
+  }
+}
+
+.action-accordion__option-reason {
+  font-size: 12px;
+  color: var(--inet-text-muted-color);
 }
 
 .action-accordion-bookmark-select-col {

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/action-accordian/action-accordion.component.ts
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-editor/actions/action-accordian/action-accordion.component.ts
@@ -1313,8 +1313,112 @@ export class ActionAccordion implements OnInit, OnChanges, OnDestroy {
    }
 
    get dataSizeOptionVisible(): boolean {
-      return this.isDashboard && this.action.format !== "HTML" && this.action.format !== "CSV" &&
-         (this.action.format !== "PDF" || !this.hasPrintLayout);
+      return this.isDashboard && (this.action.format !== "PDF" || !this.hasPrintLayout);
+   }
+
+   get emailLayoutUnavailable(): boolean {
+      return this.action.format === "HTML" || this.action.format === "CSV";
+   }
+
+   get emailLayoutReason(): string {
+      if(this.action.format === "HTML") {
+         return "_#(js:Not applied to HTML)";
+      }
+
+      if(this.action.format === "CSV") {
+         return "_#(js:Not applied to CSV)";
+      }
+
+      return "";
+   }
+
+   private get emailExpandActive(): boolean {
+      return !this.emailLayoutUnavailable && !this.action.emailMatchLayout;
+   }
+
+   get emailExpandSelectionsDisabled(): boolean {
+      return !this.model.expandEnabled || !this.emailExpandActive ||
+         (this.action.format === "Excel" && this.action.emailOnlyDataComponents);
+   }
+
+   get emailExpandSelectionsReason(): string {
+      if(!this.model.expandEnabled) {
+         return "_#(js:Requires Expand Components permission)";
+      }
+
+      if(!this.emailExpandActive) {
+         return "_#(js:Needs Expand components)";
+      }
+
+      if(this.action.format === "Excel" && this.action.emailOnlyDataComponents) {
+         return "_#(js:Not used with data-only export)";
+      }
+
+      return "";
+   }
+
+   get emailOnlyDataDisabled(): boolean {
+      return this.action.format !== "Excel" || !this.emailExpandActive;
+   }
+
+   get emailOnlyDataReason(): string {
+      if(this.action.format !== "Excel") {
+         return "_#(js:Excel only)";
+      }
+
+      if(!this.emailExpandActive) {
+         return "_#(js:Needs Expand components)";
+      }
+
+      return "";
+   }
+
+   get emailTabbedTablesDisabled(): boolean {
+      return this.action.format !== "Excel";
+   }
+
+   get saveExpandActive(): boolean {
+      return !this.action.saveMatchLayout;
+   }
+
+   get saveExpandSelectionsDisabled(): boolean {
+      return !this.model.expandEnabled || this.action.saveMatchLayout || this.action.saveOnlyDataComponents;
+   }
+
+   get saveExpandSelectionsReason(): string {
+      if(!this.model.expandEnabled) {
+         return "_#(js:Requires Expand Components permission)";
+      }
+
+      if(this.action.saveMatchLayout) {
+         return "_#(js:Needs Expand components)";
+      }
+
+      if(this.action.saveOnlyDataComponents) {
+         return "_#(js:Not used with data-only export)";
+      }
+
+      return "";
+   }
+
+   get saveOnlyDataDisabled(): boolean {
+      return !this.hasExcelFormat() || this.action.saveMatchLayout;
+   }
+
+   get saveOnlyDataReason(): string {
+      if(!this.hasExcelFormat()) {
+         return "_#(js:Excel only)";
+      }
+
+      if(this.action.saveMatchLayout) {
+         return "_#(js:Needs Expand components)";
+      }
+
+      return "";
+   }
+
+   get saveTabbedTablesDisabled(): boolean {
+      return !this.hasExcelFormat();
    }
 
    private isHtmlFormat(format: string) {


### PR DESCRIPTION
## Summary
Replace the Deliver-to-email and Save-to-server "content as" row of toggle switches with a grouped radio (Match layout / Expand components) plus an indented block of checkboxes, per the approved 1B/2A design.

Key behavior change: controls no longer appear/disappear based on format. They stay visible, disabled, with an inline reason ("Excel only", "Needs Expand components", "Not used with data-only export", "Requires Expand Components permission", "Not applied to HTML/CSV") instead of being hidden or reported as a post-save warning. The old combined html-match-message warning is removed since its information is now conveyed per-control.

Applied identically to:
- portal `action-accordion.component` (email + save-to-server panes)
- EM `delivery-emails.component` and `server-save.component` (Angular Material radios/checkboxes, same grouping/indentation/reason pattern)

## Test plan
- [x] Verified live in browser: toggling Deliver to Emails, switching Match Layout / Expand Components, confirming Expand Selection List/Tree, Only Data Elements, and Export All Tabbed Tables show correct disabled state + reason text, and spacing before Attachment Name is clean (no overlap)
- [ ] Repeat the same check in EM's delivery-emails and server-save panes

🤖 Generated with [Claude Code](https://claude.com/claude-code)