### PR TITLE
Broaden parentFolder to match currentFolder's selection handling

### DIFF
--- a/web/projects/portal/src/app/portal/schedule/schedule-task-list/schedule-task-list.component.ts
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-list/schedule-task-list.component.ts
@@ -458,8 +458,12 @@ export class ScheduleTaskListComponent implements OnInit, OnDestroy, AfterConten
    }
 
    get parentFolder(): AssetEntry {
-      if(!this.showTasksAsList && this.selectedNodes.length == 1) {
+      if(!this.showTasksAsList && this.selectedNodes.length > 0) {
          return this.selectedNodes[0].data;
+      }
+
+      if(!this.showTasksAsList && !!this.rootNode) {
+         return this.rootNode.data;
       }
 
       return null;


### PR DESCRIPTION
## Summary
- `parentFolder` previously required `selectedNodes.length == 1`, which is stricter than `currentFolder` (`selectedNodes.length > 0`) — the getter that actually decides which folder's tasks the list displays. Move now works with the same selection rule as the rest of the page: any non-empty selection uses `selectedNodes[0]`.
- Falls back to the root folder when no tree node is selected at all, instead of leaving Move unusable until a folder is explicitly picked.

## Test plan
- [ ] Move tasks with a single folder selected in the tree (existing behavior, should still work)
- [ ] Move tasks with multiple folders selected (ctrl/shift-click) — should now use the first selected node instead of disabling Move
- [ ] Move tasks with no folder selected — should default to the root folder instead of disabling Move

🤖 Generated with [Claude Code](https://claude.com/claude-code)