### PR TITLE
feat(wiz): add WizShareController for the Share Link config gate

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/WizShareController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizShareController.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.controller;
+
+import inetsoft.sree.SreeEnv;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+/**
+ * Mirrors the "link" channel of the native {@code /api/share/config} endpoint
+ * (ShareController.getConfig()'s linkEnabled computation — no share logic is reimplemented
+ * here) under wiz's own JWT-authenticated, CSRF-exempt /api/wiz namespace.
+ *
+ * <p>Unlike export/email, generating the shareable URL itself needs no backend call: StyleBI's
+ * own Share-link dialog (ShareService.getViewsheetLink() in the Angular app) builds it purely
+ * client-side from the asset entry identifier (global/&lt;path&gt; or user/&lt;name&gt;/&lt;path&gt;
+ * under viewer/view/), so wiz replicates that same string-building logic in its own frontend
+ * instead of wrapping a link-generation service that doesn't exist server-side. This controller
+ * only exposes the admin-configurable on/off switch so wiz can hide the Share button consistently
+ * with however the deployment has "Share via Link" configured.
+ */
+@RestController
+@RequestMapping("/api/wiz")
+public class WizShareController {
+   public WizShareController(SecurityEngine securityEngine) {
+      this.securityEngine = securityEngine;
+   }
+
+   @GetMapping("/viewsheet/share-link-enabled")
+   public boolean isShareLinkEnabled(Principal principal) {
+      return "true".equals(SreeEnv.getProperty("share.link.enabled")) &&
+         checkLinkPermission(principal);
+   }
+
+   private boolean checkLinkPermission(Principal principal) {
+      try {
+         return securityEngine.checkPermission(
+            principal, ResourceType.SHARE, "link", ResourceAction.ACCESS);
+      }
+      catch(Exception e) {
+         LOG.warn("Failed to check share-link permission", e);
+         return false;
+      }
+   }
+
+   private final SecurityEngine securityEngine;
+
+   private static final Logger LOG = LoggerFactory.getLogger(WizShareController.class);
+}

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizShareControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizShareControllerTest.java
@@ -1,0 +1,105 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.controller;
+
+import inetsoft.sree.SreeEnv;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class WizShareControllerTest {
+   private MockedStatic<SreeEnv> sreeEnv;
+
+   @BeforeEach
+   void setUp() {
+      sreeEnv = mockStatic(SreeEnv.class, withSettings().lenient());
+   }
+
+   @AfterEach
+   void tearDown() {
+      sreeEnv.close();
+   }
+
+   private void configureLinkEnabledProperty(String value) {
+      sreeEnv.when(() -> SreeEnv.getProperty("share.link.enabled")).thenReturn(value);
+   }
+
+   @Test
+   void enabledWhenPropertyTrueAndPermissionGranted() throws Exception {
+      configureLinkEnabledProperty("true");
+      SecurityEngine sec = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+      when(sec.checkPermission(eq(principal), eq(ResourceType.SHARE), eq("link"),
+         eq(ResourceAction.ACCESS))).thenReturn(true);
+
+      WizShareController ctrl = new WizShareController(sec);
+
+      assertTrue(ctrl.isShareLinkEnabled(principal));
+   }
+
+   @Test
+   void disabledWhenPropertyFalse() throws Exception {
+      configureLinkEnabledProperty("false");
+      SecurityEngine sec = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+      when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
+
+      WizShareController ctrl = new WizShareController(sec);
+
+      assertFalse(ctrl.isShareLinkEnabled(principal));
+   }
+
+   @Test
+   void disabledWhenPermissionDenied() throws Exception {
+      configureLinkEnabledProperty("true");
+      SecurityEngine sec = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+      when(sec.checkPermission(eq(principal), eq(ResourceType.SHARE), eq("link"),
+         eq(ResourceAction.ACCESS))).thenReturn(false);
+
+      WizShareController ctrl = new WizShareController(sec);
+
+      assertFalse(ctrl.isShareLinkEnabled(principal));
+   }
+
+   @Test
+   void disabledWhenPermissionCheckThrows() throws Exception {
+      configureLinkEnabledProperty("true");
+      SecurityEngine sec = mock(SecurityEngine.class);
+      Principal principal = mock(Principal.class);
+      when(sec.checkPermission(any(), any(), anyString(), any()))
+         .thenThrow(new SecurityException("not logged in"));
+
+      WizShareController ctrl = new WizShareController(sec);
+
+      assertFalse(ctrl.isShareLinkEnabled(principal));
+   }
+}


### PR DESCRIPTION
## Summary
- Adds `WizShareController` (`GET /api/wiz/viewsheet/share-link-enabled`) under `inetsoft.web.wiz.controller`, backing wiz's upcoming Share Link feature on VizCard.
- Mirrors `ShareController.getConfig()`'s `linkEnabled` computation (`SreeEnv "share.link.enabled"` + the `ResourceType.SHARE`/`"link"` permission) — no share logic is reimplemented, just exposed under wiz's JWT-authenticated, CSRF-exempt `/api/wiz` namespace so wiz can respect however "Share via Link" is configured, without calling StyleBI's native `/api/share/config` controller directly.
- **Unlike export/email, this is the only endpoint needed.** Traced `ShareService.getViewsheetLink()` (the Angular app's own Share-link dialog) and confirmed it builds the shareable URL purely client-side from the asset entry identifier — there's no server-side link-generation service to proxy. wiz's frontend replicates that same string-building logic itself.

## Test plan
- [x] `mvn -pl core test -Dtest=WizShareControllerTest` — 4/4 pass (enabled, disabled-by-property, disabled-by-permission, fails closed on a permission-check exception) on a clean build.
- [ ] Manual verification in a real browser against a live StyleBI instance, alongside the wiz-side companion PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)