### PR TITLE
feat(wiz): expand WizShareController to full multi-channel share

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/WizShareController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizShareController.java
@@ -17,56 +17,73 @@
  */
 package inetsoft.web.wiz.controller;
 
-import inetsoft.sree.SreeEnv;
-import inetsoft.sree.security.ResourceAction;
-import inetsoft.sree.security.ResourceType;
-import inetsoft.sree.security.SecurityEngine;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import inetsoft.web.share.ShareConfig;
+import inetsoft.web.share.ShareController;
+import inetsoft.web.share.ShareMessage;
+import inetsoft.web.wiz.model.ShareMessageRequest;
+import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
 
 /**
- * Mirrors the "link" channel of the native {@code /api/share/config} endpoint
- * (ShareController.getConfig()'s linkEnabled computation — no share logic is reimplemented
- * here) under wiz's own JWT-authenticated, CSRF-exempt /api/wiz namespace.
+ * Wraps the same {@code ShareController} that backs StyleBI's native {@code /api/share/*}
+ * endpoints — no share logic is reimplemented here — under wiz's own JWT-authenticated,
+ * CSRF-exempt {@code /api/wiz} namespace, so wiz's browser never needs to talk to StyleBI's
+ * session/CSRF-protected controller directly.
  *
- * <p>Unlike export/email, generating the shareable URL itself needs no backend call: StyleBI's
- * own Share-link dialog (ShareService.getViewsheetLink() in the Angular app) builds it purely
- * client-side from the asset entry identifier (global/&lt;path&gt; or user/&lt;name&gt;/&lt;path&gt;
- * under viewer/view/), so wiz replicates that same string-building logic in its own frontend
- * instead of wrapping a link-generation service that doesn't exist server-side. This controller
- * only exposes the admin-configurable on/off switch so wiz can hide the Share button consistently
- * with however the deployment has "Share via Link" configured.
+ * <p>Unlike export/email, there is no separate {@code *Service}/{@code *ServiceProxy} bean for
+ * share's email/Slack/Google Chat sending — that logic lives directly in {@code ShareController}
+ * itself — so this proxies the controller bean directly rather than a service tier.
+ *
+ * <p>The Link channel has no endpoint here at all: it was dropped from wiz's Share menu entirely
+ * (product decision — the Share icon is for sending a chart to someone/somewhere, not for
+ * grabbing a bare URL), and even where it existed it needed no backend call —
+ * {@code ShareService.getViewsheetLink()} (the Angular app's own Share-link dialog) builds the
+ * shareable URL purely client-side.
+ *
+ * <p>{@code getConfig}'s {@code orgId} param is passed as {@code null} here: it only matters for
+ * the "expose default-org viewsheets to every org" multi-tenant feature (an explicit cross-org
+ * query), which wiz's frontend never sends — matching how the Angular app itself only supplies
+ * an {@code orgId} for that specific case.
  */
 @RestController
 @RequestMapping("/api/wiz")
 public class WizShareController {
-   public WizShareController(SecurityEngine securityEngine) {
-      this.securityEngine = securityEngine;
+   public WizShareController(ShareController shareController) {
+      this.shareController = shareController;
    }
 
-   @GetMapping("/viewsheet/share-link-enabled")
-   public boolean isShareLinkEnabled(Principal principal) {
-      return "true".equals(SreeEnv.getProperty("share.link.enabled")) &&
-         checkLinkPermission(principal);
+   @GetMapping("/viewsheet/share-config")
+   public ShareConfig getShareConfig(Principal principal) throws Exception {
+      return shareController.getConfig(null, principal);
    }
 
-   private boolean checkLinkPermission(Principal principal) {
-      try {
-         return securityEngine.checkPermission(
-            principal, ResourceType.SHARE, "link", ResourceAction.ACCESS);
-      }
-      catch(Exception e) {
-         LOG.warn("Failed to check share-link permission", e);
-         return false;
-      }
+   @PostMapping("/viewsheet/share-email")
+   public void shareEmail(@RequestBody ShareMessageRequest request, Principal principal) throws Exception {
+      shareController.sendEmailMessage(toShareMessage(request), principal);
    }
 
-   private final SecurityEngine securityEngine;
+   @PostMapping("/viewsheet/share-slack")
+   public void shareSlack(@RequestBody ShareMessageRequest request, Principal principal) throws Exception {
+      shareController.sendSlackMessage(toShareMessage(request), principal);
+   }
 
-   private static final Logger LOG = LoggerFactory.getLogger(WizShareController.class);
+   @PostMapping("/viewsheet/share-google-chat")
+   public void shareGoogleChat(@RequestBody ShareMessageRequest request, Principal principal) throws Exception {
+      shareController.sendGoogleChatMessage(toShareMessage(request), principal);
+   }
+
+   private ShareMessage toShareMessage(ShareMessageRequest request) {
+      return ShareMessage.builder()
+         .viewsheetId(request.getViewsheetId())
+         .link(request.getLink())
+         .message(request.getMessage())
+         .subject(request.getSubject())
+         .recipients(request.getRecipients())
+         .ccs(request.getCcs())
+         .bccs(request.getBccs())
+         .build();
+   }
+
+   private final ShareController shareController;
 }

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizShareController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizShareController.java
@@ -21,6 +21,7 @@ import inetsoft.web.share.ShareConfig;
 import inetsoft.web.share.ShareController;
 import inetsoft.web.share.ShareMessage;
 import inetsoft.web.wiz.model.ShareMessageRequest;
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
@@ -59,17 +60,17 @@ public class WizShareController {
    }
 
    @PostMapping("/viewsheet/share-email")
-   public void shareEmail(@RequestBody ShareMessageRequest request, Principal principal) throws Exception {
+   public void shareEmail(@Valid @RequestBody ShareMessageRequest request, Principal principal) throws Exception {
       shareController.sendEmailMessage(toShareMessage(request), principal);
    }
 
    @PostMapping("/viewsheet/share-slack")
-   public void shareSlack(@RequestBody ShareMessageRequest request, Principal principal) throws Exception {
+   public void shareSlack(@Valid @RequestBody ShareMessageRequest request, Principal principal) throws Exception {
       shareController.sendSlackMessage(toShareMessage(request), principal);
    }
 
    @PostMapping("/viewsheet/share-google-chat")
-   public void shareGoogleChat(@RequestBody ShareMessageRequest request, Principal principal) throws Exception {
+   public void shareGoogleChat(@Valid @RequestBody ShareMessageRequest request, Principal principal) throws Exception {
       shareController.sendGoogleChatMessage(toShareMessage(request), principal);
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/model/ShareMessageRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/ShareMessageRequest.java
@@ -18,6 +18,7 @@
 package inetsoft.web.wiz.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.validation.constraints.NotBlank;
 
 import java.util.List;
 
@@ -30,6 +31,13 @@ import java.util.List;
  *
  * <p>Only {@code link} and {@code message} are used by the Slack/Google Chat channels;
  * {@code viewsheetId}/{@code subject}/{@code recipients}/{@code ccs}/{@code bccs} are Email-only.
+ *
+ * <p>{@code link}/{@code message} are {@code @NotBlank}: they back {@code ShareMessage.link()}/
+ * {@code message()}, which are non-{@code @Nullable} Immutables attributes. Without this
+ * validation, an omitted {@code link}/{@code message} would reach the Immutables builder in
+ * {@code WizShareController.toShareMessage()} and throw an unhandled {@code NullPointerException}
+ * (surfacing as a generic 500) instead of the clean 400 that {@code @Valid} +
+ * {@code GlobalExceptionHandler}'s default {@code MethodArgumentNotValidException} handling gives.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ShareMessageRequest {
@@ -90,7 +98,9 @@ public class ShareMessageRequest {
    }
 
    private String viewsheetId;
+   @NotBlank
    private String link;
+   @NotBlank
    private String message;
    private String subject;
    private List<String> recipients;

--- a/core/src/main/java/inetsoft/web/wiz/model/ShareMessageRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/ShareMessageRequest.java
@@ -1,0 +1,99 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+/**
+ * Request body shared by {@code POST /api/wiz/viewsheet/share-email}, {@code share-slack} and
+ * {@code share-google-chat} — a plain, JSON-friendly stand-in for {@code inetsoft.web.share.
+ * ShareMessage} (an Immutables interface, awkward to bind directly from a controller method).
+ * {@code WizShareController} converts one of these into a real {@code ShareMessage} via its
+ * builder before delegating to the corresponding {@code ShareController} method.
+ *
+ * <p>Only {@code link} and {@code message} are used by the Slack/Google Chat channels;
+ * {@code viewsheetId}/{@code subject}/{@code recipients}/{@code ccs}/{@code bccs} are Email-only.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ShareMessageRequest {
+   public String getViewsheetId() {
+      return viewsheetId;
+   }
+
+   public void setViewsheetId(String viewsheetId) {
+      this.viewsheetId = viewsheetId;
+   }
+
+   public String getLink() {
+      return link;
+   }
+
+   public void setLink(String link) {
+      this.link = link;
+   }
+
+   public String getMessage() {
+      return message;
+   }
+
+   public void setMessage(String message) {
+      this.message = message;
+   }
+
+   public String getSubject() {
+      return subject;
+   }
+
+   public void setSubject(String subject) {
+      this.subject = subject;
+   }
+
+   public List<String> getRecipients() {
+      return recipients;
+   }
+
+   public void setRecipients(List<String> recipients) {
+      this.recipients = recipients;
+   }
+
+   public List<String> getCcs() {
+      return ccs;
+   }
+
+   public void setCcs(List<String> ccs) {
+      this.ccs = ccs;
+   }
+
+   public List<String> getBccs() {
+      return bccs;
+   }
+
+   public void setBccs(List<String> bccs) {
+      this.bccs = bccs;
+   }
+
+   private String viewsheetId;
+   private String link;
+   private String message;
+   private String subject;
+   private List<String> recipients;
+   private List<String> ccs;
+   private List<String> bccs;
+}

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizShareControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizShareControllerTest.java
@@ -17,18 +17,15 @@
  */
 package inetsoft.web.wiz.controller;
 
-import inetsoft.sree.SreeEnv;
-import inetsoft.sree.security.ResourceAction;
-import inetsoft.sree.security.ResourceType;
-import inetsoft.sree.security.SecurityEngine;
-import inetsoft.sree.security.SecurityException;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import inetsoft.web.share.ShareConfig;
+import inetsoft.web.share.ShareController;
+import inetsoft.web.share.ShareMessage;
+import inetsoft.web.wiz.model.ShareMessageRequest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
 
 import java.security.Principal;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -36,70 +33,84 @@ import static org.mockito.Mockito.*;
 
 @Tag("core")
 class WizShareControllerTest {
-   private MockedStatic<SreeEnv> sreeEnv;
 
-   @BeforeEach
-   void setUp() {
-      sreeEnv = mockStatic(SreeEnv.class, withSettings().lenient());
-   }
+   @Test
+   void getShareConfigDelegatesToShareController() throws Exception {
+      ShareController shareController = mock(ShareController.class);
+      Principal principal = mock(Principal.class);
+      ShareConfig config = ShareConfig.builder()
+         .emailEnabled(true).facebookEnabled(false).googleChatEnabled(true)
+         .linkedinEnabled(false).slackEnabled(true).twitterEnabled(false).linkEnabled(true)
+         .build();
+      when(shareController.getConfig(isNull(), eq(principal))).thenReturn(config);
 
-   @AfterEach
-   void tearDown() {
-      sreeEnv.close();
-   }
+      WizShareController ctrl = new WizShareController(shareController);
 
-   private void configureLinkEnabledProperty(String value) {
-      sreeEnv.when(() -> SreeEnv.getProperty("share.link.enabled")).thenReturn(value);
+      assertSame(config, ctrl.getShareConfig(principal));
    }
 
    @Test
-   void enabledWhenPropertyTrueAndPermissionGranted() throws Exception {
-      configureLinkEnabledProperty("true");
-      SecurityEngine sec = mock(SecurityEngine.class);
+   void shareEmailBuildsShareMessageAndDelegates() throws Exception {
+      ShareController shareController = mock(ShareController.class);
       Principal principal = mock(Principal.class);
-      when(sec.checkPermission(eq(principal), eq(ResourceType.SHARE), eq("link"),
-         eq(ResourceAction.ACCESS))).thenReturn(true);
 
-      WizShareController ctrl = new WizShareController(sec);
+      ShareMessageRequest request = new ShareMessageRequest();
+      request.setViewsheetId("1^4^admin^visualizations-593.../abc^host-org");
+      request.setLink("/sree/viewer/view/global/visualizations-593.../abc");
+      request.setMessage("Check this out");
+      request.setSubject("A chart");
+      request.setRecipients(List.of("a@b.com"));
+      request.setCcs(List.of("c@d.com"));
+      request.setBccs(List.of("e@f.com"));
 
-      assertTrue(ctrl.isShareLinkEnabled(principal));
+      WizShareController ctrl = new WizShareController(shareController);
+      ctrl.shareEmail(request, principal);
+
+      verify(shareController).sendEmailMessage(argThat((ShareMessage m) ->
+         "1^4^admin^visualizations-593.../abc^host-org".equals(m.viewsheetId()) &&
+         "/sree/viewer/view/global/visualizations-593.../abc".equals(m.link()) &&
+         "Check this out".equals(m.message()) &&
+         "A chart".equals(m.subject()) &&
+         List.of("a@b.com").equals(m.recipients()) &&
+         List.of("c@d.com").equals(m.ccs()) &&
+         List.of("e@f.com").equals(m.bccs())
+      ), eq(principal));
    }
 
    @Test
-   void disabledWhenPropertyFalse() throws Exception {
-      configureLinkEnabledProperty("false");
-      SecurityEngine sec = mock(SecurityEngine.class);
+   void shareSlackBuildsShareMessageAndDelegates() throws Exception {
+      ShareController shareController = mock(ShareController.class);
       Principal principal = mock(Principal.class);
-      when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
 
-      WizShareController ctrl = new WizShareController(sec);
+      ShareMessageRequest request = new ShareMessageRequest();
+      request.setLink("/sree/viewer/view/global/visualizations-593.../abc");
+      request.setMessage("Check this out");
 
-      assertFalse(ctrl.isShareLinkEnabled(principal));
+      WizShareController ctrl = new WizShareController(shareController);
+      ctrl.shareSlack(request, principal);
+
+      verify(shareController).sendSlackMessage(argThat((ShareMessage m) ->
+         "/sree/viewer/view/global/visualizations-593.../abc".equals(m.link()) &&
+         "Check this out".equals(m.message()) &&
+         m.viewsheetId() == null
+      ), eq(principal));
    }
 
    @Test
-   void disabledWhenPermissionDenied() throws Exception {
-      configureLinkEnabledProperty("true");
-      SecurityEngine sec = mock(SecurityEngine.class);
+   void shareGoogleChatBuildsShareMessageAndDelegates() throws Exception {
+      ShareController shareController = mock(ShareController.class);
       Principal principal = mock(Principal.class);
-      when(sec.checkPermission(eq(principal), eq(ResourceType.SHARE), eq("link"),
-         eq(ResourceAction.ACCESS))).thenReturn(false);
 
-      WizShareController ctrl = new WizShareController(sec);
+      ShareMessageRequest request = new ShareMessageRequest();
+      request.setLink("/sree/viewer/view/global/visualizations-593.../abc");
+      request.setMessage("Check this out");
 
-      assertFalse(ctrl.isShareLinkEnabled(principal));
-   }
+      WizShareController ctrl = new WizShareController(shareController);
+      ctrl.shareGoogleChat(request, principal);
 
-   @Test
-   void disabledWhenPermissionCheckThrows() throws Exception {
-      configureLinkEnabledProperty("true");
-      SecurityEngine sec = mock(SecurityEngine.class);
-      Principal principal = mock(Principal.class);
-      when(sec.checkPermission(any(), any(), anyString(), any()))
-         .thenThrow(new SecurityException("not logged in"));
-
-      WizShareController ctrl = new WizShareController(sec);
-
-      assertFalse(ctrl.isShareLinkEnabled(principal));
+      verify(shareController).sendGoogleChatMessage(argThat((ShareMessage m) ->
+         "/sree/viewer/view/global/visualizations-593.../abc".equals(m.link()) &&
+         "Check this out".equals(m.message())
+      ), eq(principal));
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/model/ShareMessageRequestTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/model/ShareMessageRequestTest.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * {@code link}/{@code message} back {@code ShareMessage.link()}/{@code message()}
+ * (non-{@code @Nullable} Immutables attributes) — omitting either from the JSON body must fail
+ * validation with a clean 400 (via {@code @Valid} in {@code WizShareController} +
+ * {@code GlobalExceptionHandler}'s default {@code MethodArgumentNotValidException} handling)
+ * instead of reaching {@code toShareMessage()} and throwing an unhandled
+ * {@code NullPointerException} from the Immutables builder.
+ */
+@Tag("core")
+class ShareMessageRequestTest {
+   @Test
+   void linkIsRequired() {
+      ShareMessageRequest request = new ShareMessageRequest();
+      request.setMessage("Check this out");
+
+      Set<ConstraintViolation<ShareMessageRequest>> violations = VALIDATOR.validate(request);
+
+      assertTrue(violations.stream().anyMatch(v -> "link".equals(v.getPropertyPath().toString())));
+   }
+
+   @Test
+   void messageIsRequired() {
+      ShareMessageRequest request = new ShareMessageRequest();
+      request.setLink("/sree/viewer/view/global/visualizations-593.../abc");
+
+      Set<ConstraintViolation<ShareMessageRequest>> violations = VALIDATOR.validate(request);
+
+      assertTrue(violations.stream().anyMatch(v -> "message".equals(v.getPropertyPath().toString())));
+   }
+
+   @Test
+   void validWhenLinkAndMessagePresent() {
+      ShareMessageRequest request = new ShareMessageRequest();
+      request.setLink("/sree/viewer/view/global/visualizations-593.../abc");
+      request.setMessage("Check this out");
+
+      assertTrue(VALIDATOR.validate(request).isEmpty());
+   }
+
+   // ParameterMessageInterpolator sidesteps the default interpolator's jakarta.el requirement,
+   // which isn't on this module's classpath — irrelevant here since violation messages aren't asserted.
+   private static final Validator VALIDATOR = Validation.byDefaultProvider().configure()
+      .messageInterpolator(new ParameterMessageInterpolator())
+      .buildValidatorFactory().getValidator();
+}


### PR DESCRIPTION
## Summary
- Extends `WizShareController` (previously only `share-link-enabled`, merged in #4601) to full StyleBI Share parity for wiz's VizCard Share menu:
  - `GET /api/wiz/viewsheet/share-config` — all 7 `ShareConfig` flags (email/facebook/googleChat/linkedin/slack/twitter/link), delegating to `ShareController.getConfig()`.
  - `POST /api/wiz/viewsheet/share-email` / `share-slack` / `share-google-chat` — each delegates directly to the injected `ShareController` bean's `sendEmailMessage()`/`sendSlackMessage()`/`sendGoogleChatMessage()`. No share logic is reimplemented: unlike export/email, there's no separate `*Service`/`*ServiceProxy` tier for these three channels — the sending logic lives directly on `ShareController` itself, so this proxies the controller bean directly rather than inventing a service to wrap.
- **Removed** the old `share-link-enabled` endpoint entirely — wiz's Share menu dropped the Link channel as a product decision (the icon is for sending a chart to someone/somewhere, not grabbing a bare URL), so nothing calls it anymore.
- Added `ShareMessageRequest` (`inetsoft.web.wiz.model`) — a plain, JSON-friendly stand-in for `ShareMessage` (an Immutables interface, awkward to bind directly from a controller method). `WizShareController` converts one into a real `ShareMessage` via its builder before delegating.

## Companion wiz-side change
[inetsoft-technology/stylebi-wiz#1603](https://github.com/inetsoft-technology/stylebi-wiz/pull/1603) is the frontend consumer — a `ShareMenu` dropdown (Email/Slack/Google Chat/Facebook/LinkedIn/Twitter, each with its own small dialog or immediate popup) replacing the single-click "copy link" the earlier round of this feature shipped.

## Test plan
- [x] `mvn -pl core clean test -Dtest=WizShareControllerTest` — 4/4 pass on a clean build.
- [x] `mvn -pl core compile` — clean.
- [ ] Manual verification in a real browser against a live StyleBI instance, alongside the wiz-side companion PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)