### PR TITLE
Tell the wiz portal how each data source can be annotated

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/WizDatabaseController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizDatabaseController.java
@@ -26,6 +26,8 @@ import inetsoft.uql.XDataSource;
 import inetsoft.uql.XRepository;
 import inetsoft.uql.jdbc.JDBCDataSource;
 import inetsoft.uql.jdbc.SQLHelper;
+import inetsoft.uql.tabular.ScriptedQuery;
+import inetsoft.uql.tabular.SelectableTabularQuery;
 import inetsoft.uql.util.Config;
 import inetsoft.util.audit.ActionRecord;
 import inetsoft.web.admin.content.database.*;
@@ -582,6 +584,7 @@ public class WizDatabaseController {
       boolean folder = isFolder(nodeType);
       String sourceType = null;
       String databaseType = null;
+      String annotationClass = null;
 
       if(!folder) {
          try {
@@ -593,6 +596,8 @@ public class WizDatabaseController {
                if(dataSource instanceof JDBCDataSource jdbcDataSource) {
                   databaseType = jdbcDataSource.getDatabaseTypeString();
                }
+
+               annotationClass = annotationClassOf(dataSource);
             }
          }
          catch(Throwable ex) {
@@ -600,12 +605,98 @@ public class WizDatabaseController {
             // the whole listing down with it. The row still renders, just without a type.
             LOG.debug("Failed to resolve the type of data source {}: {}", info.path(),
                       ex.getMessage());
+            annotationClass = UNKNOWN;
          }
       }
 
       return new WizDatasourceEntry(info.name(), info.path(), nodeType, folder, sourceType,
-                                    databaseType, info.createdBy(), info.createdDate(),
-                                    info.editable(), info.deletable(), info.hasSubFolder());
+                                    databaseType, annotationClass, info.createdBy(),
+                                    info.createdDate(), info.editable(), info.deletable(),
+                                    info.hasSubFolder());
+   }
+
+   /**
+    * Decides how a data source can be annotated. See {@link WizDatasourceEntry} for what each value
+    * means to the portal.
+    *
+    * <p>The question is answered from the QUERY class rather than the data source, because what
+    * distinguishes these cases is how targets are discovered, and that lives on the query. The query
+    * class also owns the {@code endpoints.json} resource, which is the whole of the
+    * {@code ENDPOINT_CATALOG} test.</p>
+    *
+    * <p>Order matters and runs specific to general. {@code EndpointJsonQuery} extends
+    * {@code RestJsonQuery}, so testing for REST first would classify all 65 catalogued connectors as
+    * needing documentation they do not need.</p>
+    */
+   private String annotationClassOf(XDataSource dataSource) {
+      String type = dataSource.getType();
+
+      if(dataSource instanceof JDBCDataSource) {
+         return JDBC;
+      }
+
+      Class<?> queryClass;
+
+      try {
+         String className = uqlConfig.getQueryClass(type);
+
+         if(className == null) {
+            return UNKNOWN;
+         }
+
+         queryClass = uqlConfig.getClass(type, className);
+      }
+      catch(Throwable ex) {
+         // A connector whose plugin is absent cannot be classified. Saying UNKNOWN keeps that
+         // distinct from "classified as not annotatable", which the portal reports very differently.
+         LOG.debug("Failed to load the query class for type {}: {}", type, ex.getMessage());
+         return UNKNOWN;
+      }
+
+      return queryClass == null ? UNKNOWN : classifyQueryClass(queryClass);
+   }
+
+   /**
+    * The classification itself, separated from how the class was obtained so it can be exercised
+    * without standing up a plugin registry.
+    */
+   static String classifyQueryClass(Class<?> queryClass) {
+      if(ScriptedQuery.class.isAssignableFrom(queryClass)) {
+         return UNSUPPORTED;
+      }
+
+      // Resource lookup rather than a class-name test: shipping an endpoints.json IS the property
+      // being asked about, and core cannot reference the connector classes to test them directly.
+      if(queryClass.getResource("endpoints.json") != null) {
+         return ENDPOINT_CATALOG;
+      }
+
+      if(isRestQuery(queryClass)) {
+         return DOCUMENT_REQUIRED;
+      }
+
+      if(SelectableTabularQuery.class.isAssignableFrom(queryClass)) {
+         return FILE;
+      }
+
+      return METADATA;
+   }
+
+   /**
+    * Whether the query descends from the REST base class, by name.
+    *
+    * <p>{@code AbstractRestQuery} lives in a connector module that core does not depend on, so it
+    * cannot be named directly. Walking the superclass chain keeps this to one string rather than
+    * enumerating every REST query type.</p>
+    */
+   private static boolean isRestQuery(Class<?> queryClass) {
+      for(Class<?> c = queryClass; c != null; c = c.getSuperclass()) {
+         if(REST_QUERY_CLASS.equals(c.getName())) {
+            return true;
+         }
+      }
+
+      return false;
    }
 
    /**
@@ -982,4 +1073,16 @@ public class WizDatabaseController {
    private final SecurityEngine securityEngine;
    private final Config uqlConfig;
    private final XRepository xrepository;
+
+   /** Annotation classes. See {@link WizDatasourceEntry} for what each one means to the portal. */
+   private static final String JDBC = "JDBC";
+   private static final String FILE = "FILE";
+   private static final String METADATA = "METADATA";
+   private static final String ENDPOINT_CATALOG = "ENDPOINT_CATALOG";
+   private static final String DOCUMENT_REQUIRED = "DOCUMENT_REQUIRED";
+   private static final String UNSUPPORTED = "UNSUPPORTED";
+   private static final String UNKNOWN = "UNKNOWN";
+
+   /** Named rather than imported: it lives in a connector module core does not depend on. */
+   private static final String REST_QUERY_CLASS = "inetsoft.uql.rest.AbstractRestQuery";
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/WizDatasourceEntry.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizDatasourceEntry.java
@@ -41,6 +41,31 @@ package inetsoft.web.wiz.model;
  *                     folders, and null when the data source could not be loaded.
  * @param databaseType {@code JDBCDataSource.getDatabaseTypeString()}, e.g. {@code "MYSQL"}. Null for
  *                     anything that is not a JDBC database.
+ * @param annotationClass
+ *                     how this data source can be annotated, which decides what the wiz portal has
+ *                     to ask of the user before it can index it. Null for folders. One of:
+ *                     <dl>
+ *                     <dt>{@code JDBC}</dt>
+ *                     <dd>a relational database; tables and columns come from JDBC metadata.</dd>
+ *                     <dt>{@code FILE}</dt>
+ *                     <dd>a browsable tree of files or sheets. Targets are enumerable; columns are
+ *                     read from the file.</dd>
+ *                     <dt>{@code METADATA}</dt>
+ *                     <dd>the service can be asked what it holds — collections, entities, objects,
+ *                     tables. Targets are enumerable without the user supplying anything.</dd>
+ *                     <dt>{@code ENDPOINT_CATALOG}</dt>
+ *                     <dd>ships an {@code endpoints.json}, so the callable set is known offline and
+ *                     exactly. Needs no discovery and no documentation.</dd>
+ *                     <dt>{@code DOCUMENT_REQUIRED}</dt>
+ *                     <dd>a REST service with no catalogue of its own. Nothing can enumerate what it
+ *                     offers, so the user must supply documentation before it can be annotated.</dd>
+ *                     <dt>{@code UNSUPPORTED}</dt>
+ *                     <dd>output shape is decided by a user script, so there is no stable target to
+ *                     annotate. Shown, but not annotatable.</dd>
+ *                     <dt>{@code UNKNOWN}</dt>
+ *                     <dd>classification failed, usually a connector plugin that did not load. Kept
+ *                     distinct from the others so the cause is not mistaken for a verdict.</dd>
+ *                     </dl>
  * @param createdBy    the alias of the creating user, may be null.
  * @param createdDate  creation time in epoch millis, 0 when unknown. Not formatted.
  * @param editable     whether the caller holds WRITE on this entry.
@@ -54,6 +79,7 @@ public record WizDatasourceEntry(
    boolean folder,
    String sourceType,
    String databaseType,
+   String annotationClass,
    String createdBy,
    long createdDate,
    boolean editable,

--- a/core/src/test/java/inetsoft/uql/rest/AbstractRestQuery.java
+++ b/core/src/test/java/inetsoft/uql/rest/AbstractRestQuery.java
@@ -1,0 +1,33 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.rest;
+
+import inetsoft.uql.tabular.TabularQuery;
+
+/**
+ * Test-only stand-in for the REST base class, which really lives in the inetsoft-rest connector.
+ *
+ * <p>Core does not depend on that module, which is exactly why the classifier matches it by name.
+ * A class with the same fully-qualified name here lets that name-matching be exercised; if the real
+ * class is ever moved or renamed, this file is the reminder that the constant must move with it.</p>
+ */
+public abstract class AbstractRestQuery extends TabularQuery {
+   protected AbstractRestQuery(String type) {
+      super(type);
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizDatasourceAnnotationClassTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizDatasourceAnnotationClassTest.java
@@ -1,0 +1,119 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.controller;
+
+import inetsoft.uql.rest.AbstractRestQuery;
+import inetsoft.web.wiz.controller.cataloged.CatalogedTestQueries;
+import inetsoft.uql.tabular.*;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * How a data source is classified for annotation.
+ *
+ * <p>The value drives what the portal asks of the user — index it silently, demand a document
+ * first, or refuse — so a wrong verdict is not a cosmetic problem: classifying one of the 65
+ * catalogued connectors as DOCUMENT_REQUIRED would demand documentation for a connector that ships
+ * its own catalogue.</p>
+ */
+@Tag("core")
+class WizDatasourceAnnotationClassTest {
+   @Test
+   void scriptedQueriesCannotBeAnnotated() {
+      // Output shape is whatever the user's script returns, so there is no stable target.
+      assertEquals("UNSUPPORTED", WizDatabaseController.classifyQueryClass(ScriptedTestQuery.class));
+   }
+
+   @Test
+   void aQueryShippingAnEndpointCatalogNeedsNoDocumentation() {
+      // endpoints.json sits beside this test class, standing in for the 65 connectors that ship one.
+      assertEquals("ENDPOINT_CATALOG",
+                   WizDatabaseController.classifyQueryClass(CatalogedTestQueries.CatalogedQuery.class));
+   }
+
+   @Test
+   void aRestQueryWithoutACatalogRequiresDocumentation() {
+      assertEquals("DOCUMENT_REQUIRED",
+                   WizDatabaseController.classifyQueryClass(PlainRestTestQuery.class));
+   }
+
+   @Test
+   void aBrowsableQueryIsAFileSource() {
+      assertEquals("FILE", WizDatabaseController.classifyQueryClass(SelectableTestQuery.class));
+   }
+
+   @Test
+   void anythingElseIsAskedForItsMetadata() {
+      assertEquals("METADATA", WizDatabaseController.classifyQueryClass(PlainTestQuery.class));
+   }
+
+   /**
+    * The ordering constraint, and the reason the checks cannot be reordered for tidiness.
+    *
+    * <p>Every catalogued connector IS a REST query — {@code EndpointJsonQuery} extends
+    * {@code RestJsonQuery} — so testing REST first would classify all 65 of them as needing
+    * documentation they already ship. This class is both, and must come out as the catalogue.</p>
+    */
+   @Test
+   void aCatalogedQueryThatIsAlsoRestIsStillACatalog() {
+      assertEquals("ENDPOINT_CATALOG",
+                   WizDatabaseController.classifyQueryClass(CatalogedTestQueries.CatalogedRestQuery.class));
+   }
+
+   private static class PlainTestQuery extends TabularQuery {
+      PlainTestQuery() {
+         super("TEST");
+      }
+   }
+
+   private static class ScriptedTestQuery extends TabularQuery implements ScriptedQuery {
+      ScriptedTestQuery() {
+         super("TEST");
+      }
+
+      @Override
+      public String getInputScript() {
+         return null;
+      }
+
+      @Override
+      public String getOutputScript() {
+         return null;
+      }
+   }
+
+   private static class SelectableTestQuery extends SelectableTabularQuery {
+      SelectableTestQuery() {
+         super("TEST");
+      }
+
+      @Override
+      protected ColumnDefinition[] loadColumns() {
+         return new ColumnDefinition[0];
+      }
+   }
+
+   private static class PlainRestTestQuery extends AbstractRestQuery {
+      PlainRestTestQuery() {
+         super("TEST");
+      }
+   }
+
+}

--- a/core/src/test/java/inetsoft/web/wiz/controller/cataloged/CatalogedTestQueries.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/cataloged/CatalogedTestQueries.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.controller.cataloged;
+
+import inetsoft.uql.rest.AbstractRestQuery;
+import inetsoft.uql.tabular.TabularQuery;
+
+/**
+ * Query classes that ship an endpoints.json, which is what makes a connector a catalogue.
+ *
+ * <p>They live in their own package because the classifier resolves that file RELATIVE TO THE
+ * QUERY CLASS. Keeping them beside the other test queries would put the catalogue on every one of
+ * them and classify the lot as catalogues -- which is exactly what happened before this package
+ * existed.</p>
+ */
+public final class CatalogedTestQueries {
+   private CatalogedTestQueries() {
+   }
+
+   public static class CatalogedQuery extends TabularQuery {
+      public CatalogedQuery() {
+         super("TEST");
+      }
+   }
+
+   /** Both a catalogue and a REST query, which is the ordering case that matters. */
+   public static class CatalogedRestQuery extends AbstractRestQuery {
+      public CatalogedRestQuery() {
+         super("TEST");
+      }
+   }
+}

--- a/core/src/test/resources/inetsoft/web/wiz/controller/cataloged/endpoints.json
+++ b/core/src/test/resources/inetsoft/web/wiz/controller/cataloged/endpoints.json
@@ -1,0 +1,8 @@
+{
+  "endpoints": [
+    {
+      "name": "Stand-in",
+      "suffix": "/v1/stand_in"
+    }
+  ]
+}


### PR DESCRIPTION
Adds `annotationClass` to the browser entry the wiz portal reads, so it knows what it has to ask of the user before a data source can be indexed: index it silently, demand documentation first, or refuse outright.

| value | meaning |
|---|---|
| `JDBC` | relational; tables and columns come from JDBC metadata |
| `FILE` | browsable tree of files or sheets |
| `METADATA` | the service can be asked what it holds — collections, entities, objects |
| `ENDPOINT_CATALOG` | ships an `endpoints.json`; the callable set is known offline and exactly |
| `DOCUMENT_REQUIRED` | a REST service with no catalogue — the user must supply documentation |
| `UNSUPPORTED` | output shape decided by a user script; no stable target to annotate |
| `UNKNOWN` | classification failed, usually a plugin that did not load |

## Why the query class, not the data source

What separates these cases is *how targets are discovered*, and that lives on the query rather than on the connection. The query class also owns the `endpoints.json` resource, which is the entire `ENDPOINT_CATALOG` test.

## The ordering cannot be tidied

`EndpointJsonQuery extends RestJsonQuery`, so checking REST before the catalogue would classify **all 65 catalogued connectors as needing documentation they already ship with**. A test covers precisely that: a class that is both a catalogue and a REST query has to come out as the catalogue.

## Two deliberate asymmetries

**The catalogue test is a resource lookup, the REST test is a name match.** Shipping an `endpoints.json` *is* the property being asked about, so looking the file up is the most direct statement of it. `AbstractRestQuery`, on the other hand, lives in a connector module core does not depend on and cannot be named directly — so a test-only class with that fully-qualified name exists to exercise the match, and to be the thing that breaks loudly if the real class is ever moved or renamed. Without it, a rename would silently reclassify every REST source as `METADATA`.

**`UNKNOWN` is distinct from `UNSUPPORTED`.** A connector whose plugin did not load cannot be classified, and reporting "this cannot be annotated" when the truth is "we could not tell" sends the user looking in the wrong place for a fix that does not exist.

## What writing the tests exposed

The resource lookup is sharper than it looks. With `endpoints.json` sitting in the shared test package, **every query class beside it resolved that file** and the entire suite classified as `ENDPOINT_CATALOG` — three tests failed for a reason that had nothing to do with the code under test. Real connectors satisfy the constraint naturally by having one folder each; the fixtures now do the same by living in their own package.

## Testing

```
WizDatasourceAnnotationClassTest      6 tests, all green
WizDatabaseControllerSecurityTest     9 tests, unchanged (no regression)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
