### PR TITLE
fix(wiz): window ORDER BY never sorted NULLs last, letting a NULL win a ranking

### DIFF
--- a/core/src/main/java/inetsoft/report/lens/WindowTableLens.java
+++ b/core/src/main/java/inetsoft/report/lens/WindowTableLens.java
@@ -274,7 +274,22 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
       boolean[] oasc = orderAsc();
 
       for(int i = 0; i < ocols.length; i++) {
-         int r = Tool.compare(table.getObject(a + hrows, ocols[i]), table.getObject(b + hrows, ocols[i]), true, true);
+         Object v1 = table.getObject(a + hrows, ocols[i]);
+         Object v2 = table.getObject(b + hrows, ocols[i]);
+
+         // A null always sorts last regardless of ASC/DESC, matching
+         // WindowExpressionRef.getOrderFragment's SQL-pushdown NULLS-LAST behavior -- Tool.compare
+         // treats null as smallest, which the oasc[i] negation below would otherwise flip to
+         // NULLS-FIRST for an ascending key.
+         if(v1 == null || v2 == null) {
+            if(v1 == v2) {
+               continue;
+            }
+
+            return v1 == null ? 1 : -1;
+         }
+
+         int r = Tool.compare(v1, v2, true, true);
 
          if(r != 0) {
             return oasc[i] ? r : -r;
@@ -884,7 +899,19 @@ public class WindowTableLens extends AbstractTableLens implements TableFilter {
       boolean[] oasc = spec.orderAsc;
 
       for(int i = 0; i < ocols.length; i++) {
-         int r = Tool.compare(table.getObject(a + hrows, ocols[i]), table.getObject(b + hrows, ocols[i]), true, true);
+         Object v1 = table.getObject(a + hrows, ocols[i]);
+         Object v2 = table.getObject(b + hrows, ocols[i]);
+
+         // Same NULLS-LAST-always rule as compareRows -- see the comment there.
+         if(v1 == null || v2 == null) {
+            if(v1 == v2) {
+               continue;
+            }
+
+            return v1 == null ? 1 : -1;
+         }
+
+         int r = Tool.compare(v1, v2, true, true);
 
          if(r != 0) {
             return oasc[i] ? r : -r;

--- a/core/src/main/java/inetsoft/uql/asset/WindowExpressionRef.java
+++ b/core/src/main/java/inetsoft/uql/asset/WindowExpressionRef.java
@@ -436,8 +436,24 @@ public final class WindowExpressionRef extends ExpressionRef implements SQLExpre
    }
 
    /**
-    * Get the {@code ORDER BY field['o1'] DESC, field['o2'] ASC} fragment, or "" if there is no
-    * ordering.
+    * Get the {@code ORDER BY CASE WHEN field['o1'] IS NULL THEN 1 ELSE 0 END, field['o1'] DESC,
+    * ...} fragment, or "" if there is no ordering.
+    * <p>
+    * A synthetic {@code CASE WHEN <col> IS NULL THEN 1 ELSE 0 END} key is emitted immediately
+    * before each real sort key so a NULL value always sorts last, regardless of ASC/DESC and
+    * regardless of the database's own default NULL-ordering rule. Without this guard, a bare
+    * {@code ORDER BY field['x'] DESC} defaults to {@code NULLS FIRST} on Postgres/Oracle, so a row
+    * with a NULL value wins the "largest value" ranking position -- e.g.
+    * {@code ROW_NUMBER() OVER (PARTITION BY project ORDER BY estimated_hours DESC)} would pick a
+    * work package with a null {@code estimated_hours} as rank 1 instead of the one with the
+    * actual largest value.
+    * <p>
+    * This uses a portable {@code CASE WHEN} key rather than the {@code NULLS LAST} keyword because
+    * that keyword is not available on every dialect {@code windowCapability.ts} advertises as
+    * window-function-capable: SQL Server has no {@code NULLS LAST}/{@code NULLS FIRST} syntax at
+    * all, and MySQL did not add it until 8.0.14 (StyleBI's supported floor is MySQL 8.0.0). A
+    * {@code CASE WHEN} key plus a multi-key {@code ORDER BY} is ANSI-standard SQL and behaves
+    * identically across Postgres, Oracle, SQL Server, and MySQL 8.0+.
     */
    private String getOrderFragment() {
       if(orderBy == null || orderBy.isEmpty()) {
@@ -452,7 +468,9 @@ public final class WindowExpressionRef extends ExpressionRef implements SQLExpre
          }
 
          SortRef sort = orderBy.get(i);
-         sb.append(fieldToken(sort.getDataRef()));
+         String token = fieldToken(sort.getDataRef());
+         sb.append("CASE WHEN ").append(token).append(" IS NULL THEN 1 ELSE 0 END, ");
+         sb.append(token);
          sb.append(sort.getOrder() == XConstants.SORT_ASC ? " ASC" : " DESC");
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/ViewsheetRuntimeController.java
@@ -28,6 +28,7 @@ import inetsoft.uql.asset.Assembly;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.ConditionList;
 import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.OutputVSAssembly;
 import inetsoft.uql.viewsheet.DataVSAssembly;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
@@ -265,8 +266,16 @@ public class ViewsheetRuntimeController {
             // unconditionally and throws ClassCastException on a Table/Crosstab assembly, which
             // findChartAssembly's first-assembly fallback can legitimately hand back for a saved
             // "table"/"crosstab" wiz visualization. Route those through the TableLens-based path.
+            //
+            // A THIRD case, previously missing: OutputVSAssembly (Gauge, Text) is neither a chart
+            // nor a table -- it has no TableLens at all, so the old two-way branch silently routed
+            // it into verifyTableData, which found no table and reported hasData=false, rowCount=0
+            // unconditionally. Every saved Gauge/Text visualization verified as "broken" even when
+            // it rendered a real value moments earlier. See verifyOutputData's own doc.
             WizVsService.VerifyResult vr = assembly instanceof ChartVSAssembly
                ? wizVsService.verifyChartData(rvs, assembly.getName())
+               : assembly instanceof OutputVSAssembly
+               ? wizVsService.verifyOutputData(rvs, assembly.getName())
                : wizVsService.verifyTableData(rvs, assembly.getName());
             result.setHasData(vr.hasData());
             result.setRowCount(vr.rowCount());

--- a/core/src/main/java/inetsoft/web/wiz/service/FkIntegrityService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/FkIntegrityService.java
@@ -137,9 +137,9 @@ public class FkIntegrityService {
          // way around, since a text-to-number cast can THROW on a non-numeric value ("N/A", a
          // code the driver won't parse) where a number-to-text cast never can.
          CastSide castSide = resolveCastSide(conn, sourceTable, fkColumn, targetTable, targetKeyColumn);
-         boolean mysqlDialect = castSide != CastSide.NONE && isMySqlDialect(conn);
+         Dialect dialect = castSide != CastSide.NONE ? resolveDialect(conn) : Dialect.DEFAULT;
          String droppedSql = buildDroppedRowCountSql(
-            sourceTable, fkColumn, targetTable, targetKeyColumn, castSide, mysqlDialect);
+            sourceTable, fkColumn, targetTable, targetKeyColumn, castSide, dialect);
          String duplicateSql = buildDuplicateTargetKeyCountSql(targetTable, targetKeyColumn);
 
          long droppedRowCount = executeCount(conn, droppedSql);
@@ -190,7 +190,7 @@ public class FkIntegrityService {
                                          String targetTable, String targetKeyColumn)
    {
       return buildDroppedRowCountSql(
-         sourceTable, fkColumn, targetTable, targetKeyColumn, CastSide.NONE, false);
+         sourceTable, fkColumn, targetTable, targetKeyColumn, CastSide.NONE, Dialect.DEFAULT);
    }
 
    /**
@@ -206,16 +206,16 @@ public class FkIntegrityService {
     */
    static String buildDroppedRowCountSql(String sourceTable, String fkColumn,
                                          String targetTable, String targetKeyColumn,
-                                         CastSide castSide, boolean mysqlDialect)
+                                         CastSide castSide, Dialect dialect)
    {
       String fkRef = "src." + fkColumn;
       String targetKeyRef = "tgt." + targetKeyColumn;
 
       if(castSide == CastSide.FK) {
-         fkRef = castToText(fkRef, mysqlDialect);
+         fkRef = castToText(fkRef, dialect);
       }
       else if(castSide == CastSide.TARGET_KEY) {
-         targetKeyRef = castToText(targetKeyRef, mysqlDialect);
+         targetKeyRef = castToText(targetKeyRef, dialect);
       }
 
       return "SELECT COUNT(*) FROM " + sourceTable + " src" +
@@ -227,11 +227,31 @@ public class FkIntegrityService {
    /** Which side of the FK/target-key comparison must be cast to TEXT before comparing. */
    enum CastSide { NONE, FK, TARGET_KEY }
 
-   /** {@code CAST(expr AS <text type>)} -- MySQL's CAST rejects VARCHAR as a target (it wants
-    *  CHAR); every other dialect this project registers a sample datasource for (Postgres,
-    *  the default assumed elsewhere) accepts VARCHAR. */
-   private static String castToText(String expr, boolean mysqlDialect) {
-      return "CAST(" + expr + " AS " + (mysqlDialect ? "CHAR" : "VARCHAR") + ")";
+   /**
+    * The SQL dialects {@link #castToText} needs to special-case. {@code DEFAULT} covers every
+    * dialect that accepts a bare {@code CAST(expr AS VARCHAR)} with no length (Postgres, SQL
+    * Server, DB2, ...); MySQL and Oracle each need their own shape (see castToText).
+    */
+   enum Dialect { DEFAULT, MYSQL, ORACLE }
+
+   /**
+    * {@code CAST(expr AS <text type>)}, or the dialect's own idiom when a bare {@code CAST ...
+    * VARCHAR} does not work.
+    *
+    * <p>MySQL's {@code CAST} rejects {@code VARCHAR} as a target (it wants {@code CHAR}).
+    * Oracle's {@code CAST} requires an explicit length for a character target
+    * ({@code VARCHAR2(n)}; a bare {@code VARCHAR} is a syntax error) -- rather than pick an
+    * arbitrary length, {@code TO_CHAR(expr)} is Oracle's own numeric-to-text conversion and needs
+    * none, and {@link #resolveCastSide} only ever calls this on the NUMERIC side (never the
+    * character side), so {@code TO_CHAR} is always the right function here regardless of which
+    * named side -- FK or target key -- triggered the cast.</p>
+    */
+   private static String castToText(String expr, Dialect dialect) {
+      return switch(dialect) {
+         case MYSQL -> "CAST(" + expr + " AS CHAR)";
+         case ORACLE -> "TO_CHAR(" + expr + ")";
+         default -> "CAST(" + expr + " AS VARCHAR)";
+      };
    }
 
    /**
@@ -346,15 +366,33 @@ public class FkIntegrityService {
       }
    }
 
-   /** Best-effort dialect sniff for {@link #castToText} -- MySQL alone needs CHAR, not VARCHAR. */
-   private static boolean isMySqlDialect(Connection conn) {
+   /**
+    * Best-effort dialect sniff for {@link #castToText}. Any failure (or an unrecognized product
+    * name) degrades to {@code Dialect.DEFAULT} -- the bare {@code CAST ... VARCHAR} shape that
+    * was this feature's only behavior before dialect-awareness existed.
+    */
+   private static Dialect resolveDialect(Connection conn) {
       try {
          DatabaseMetaData meta = conn.getMetaData();
          String product = meta != null ? meta.getDatabaseProductName() : null;
-         return product != null && product.toLowerCase().contains("mysql");
+
+         if(product == null) {
+            return Dialect.DEFAULT;
+         }
+
+         String lower = product.toLowerCase();
+
+         if(lower.contains("mysql")) {
+            return Dialect.MYSQL;
+         }
+         if(lower.contains("oracle")) {
+            return Dialect.ORACLE;
+         }
+
+         return Dialect.DEFAULT;
       }
       catch(Exception e) {
-         return false;
+         return Dialect.DEFAULT;
       }
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/service/FkIntegrityService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/FkIntegrityService.java
@@ -28,9 +28,11 @@ import org.springframework.stereotype.Service;
 
 import java.security.Principal;
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Types;
 import java.util.regex.Pattern;
 
 /**
@@ -121,12 +123,25 @@ public class FkIntegrityService {
       }
 
       JDBCDataSource ds = metadataService.getJDBCDatasource(dsName);
-      String droppedSql =
-         buildDroppedRowCountSql(sourceTable, fkColumn, targetTable, targetKeyColumn);
-      String duplicateSql = buildDuplicateTargetKeyCountSql(targetTable, targetKeyColumn);
 
       try(Connection conn = openConnection(ds, principal)) {
          // Both measurements share one connection so they describe the same database state.
+         // THE CAST FIX. A source FK declared as text (OrangeHRM's hs_hr_employee.sal_grd_code,
+         // a VARCHAR) pointing at an integer target key (ohrm_pay_grade.id) made the bare
+         // `tgt.id = src.fkColumn` comparison below fail outright on Postgres ("operator does
+         // not exist: integer = character varying"), which this class's own fail-closed design
+         // then reports as UNESTABLISHED -- so the FK-label feature silently never offered a
+         // pay-grade filter, with no error surfaced anywhere. resolveCastSide measures both
+         // columns' real JDBC types and, ONLY when they are genuinely incomparable (one numeric,
+         // one character), casts the NUMERIC side to text for the comparison -- never the other
+         // way around, since a text-to-number cast can THROW on a non-numeric value ("N/A", a
+         // code the driver won't parse) where a number-to-text cast never can.
+         CastSide castSide = resolveCastSide(conn, sourceTable, fkColumn, targetTable, targetKeyColumn);
+         boolean mysqlDialect = castSide != CastSide.NONE && isMySqlDialect(conn);
+         String droppedSql = buildDroppedRowCountSql(
+            sourceTable, fkColumn, targetTable, targetKeyColumn, castSide, mysqlDialect);
+         String duplicateSql = buildDuplicateTargetKeyCountSql(targetTable, targetKeyColumn);
+
          long droppedRowCount = executeCount(conn, droppedSql);
          long duplicateTargetKeyCount = executeCount(conn, duplicateSql);
 
@@ -167,19 +182,180 @@ public class FkIntegrityService {
    }
 
    /**
+    * Builds the drop-count statement from already-validated identifiers, with NO cast applied --
+    * the shape every dialect this feature has run against until now (source and target key
+    * declared the same SQL type family) needs nothing else.
+    */
+   static String buildDroppedRowCountSql(String sourceTable, String fkColumn,
+                                         String targetTable, String targetKeyColumn)
+   {
+      return buildDroppedRowCountSql(
+         sourceTable, fkColumn, targetTable, targetKeyColumn, CastSide.NONE, false);
+   }
+
+   /**
     * Builds the drop-count statement from already-validated identifiers.
     *
     * <p>Both halves of "rows an INNER join would drop" are counted: NULL foreign keys, and
     * foreign keys with no matching target row. The orphan half is a correlated subquery, so the
     * FK value is compared column-to-column and never rendered into the statement text.</p>
+    *
+    * <p>{@code castSide} names the side of the comparison (never both) that must be cast to
+    * TEXT before the two are compared -- see {@link #resolveCastSide} for how and why. The NULL
+    * check always reads the raw, uncast column: NULL-ness does not depend on type agreement.</p>
     */
    static String buildDroppedRowCountSql(String sourceTable, String fkColumn,
-                                         String targetTable, String targetKeyColumn)
+                                         String targetTable, String targetKeyColumn,
+                                         CastSide castSide, boolean mysqlDialect)
    {
+      String fkRef = "src." + fkColumn;
+      String targetKeyRef = "tgt." + targetKeyColumn;
+
+      if(castSide == CastSide.FK) {
+         fkRef = castToText(fkRef, mysqlDialect);
+      }
+      else if(castSide == CastSide.TARGET_KEY) {
+         targetKeyRef = castToText(targetKeyRef, mysqlDialect);
+      }
+
       return "SELECT COUNT(*) FROM " + sourceTable + " src" +
          " WHERE src." + fkColumn + " IS NULL" +
          " OR NOT EXISTS (SELECT 1 FROM " + targetTable + " tgt" +
-         " WHERE tgt." + targetKeyColumn + " = src." + fkColumn + ")";
+         " WHERE " + targetKeyRef + " = " + fkRef + ")";
+   }
+
+   /** Which side of the FK/target-key comparison must be cast to TEXT before comparing. */
+   enum CastSide { NONE, FK, TARGET_KEY }
+
+   /** {@code CAST(expr AS <text type>)} -- MySQL's CAST rejects VARCHAR as a target (it wants
+    *  CHAR); every other dialect this project registers a sample datasource for (Postgres,
+    *  the default assumed elsewhere) accepts VARCHAR. */
+   private static String castToText(String expr, boolean mysqlDialect) {
+      return "CAST(" + expr + " AS " + (mysqlDialect ? "CHAR" : "VARCHAR") + ")";
+   }
+
+   /**
+    * Best-effort: resolves both columns' real JDBC types via {@code DatabaseMetaData.getColumns}
+    * and decides whether one side needs a TEXT cast to compare cleanly.
+    *
+    * <p>ONLY acts when confident: identical types, or either lookup failing (an un-mocked test
+    * connection, a driver without column metadata support, a column the driver can't find) all
+    * degrade to {@code CastSide.NONE} -- byte-identical to this feature's behavior before this
+    * fix. A missed cast costs one filter control; a wrong one could throw or silently compare
+    * incomparable values, so nothing here may guess.</p>
+    *
+    * <p>Casts the NUMERIC side, never the character side: a number-to-text cast can never throw,
+    * while a text-to-number cast can (a code column holding "N/A" or something the driver can't
+    * parse) -- turning a working, if unenriched, probe into a hard failure. So when the two
+    * sides are genuinely incomparable, the NUMERIC one always yields.</p>
+    */
+   static CastSide resolveCastSide(Connection conn, String sourceTable, String fkColumn,
+                                   String targetTable, String targetKeyColumn)
+   {
+      try {
+         Integer fkType = columnJdbcType(conn, sourceTable, fkColumn);
+         Integer targetType = columnJdbcType(conn, targetTable, targetKeyColumn);
+
+         if(fkType == null || targetType == null || fkType.equals(targetType)) {
+            return CastSide.NONE;
+         }
+
+         boolean fkIsText = isCharacterType(fkType);
+         boolean targetIsNumeric = isNumericType(targetType);
+
+         if(fkIsText && targetIsNumeric) {
+            return CastSide.TARGET_KEY;
+         }
+
+         boolean fkIsNumeric = isNumericType(fkType);
+         boolean targetIsText = isCharacterType(targetType);
+
+         if(fkIsNumeric && targetIsText) {
+            return CastSide.FK;
+         }
+
+         // Different types within the same family (INTEGER vs BIGINT, VARCHAR vs CHAR, ...) --
+         // every dialect this feature runs against already compares those directly.
+         return CastSide.NONE;
+      }
+      catch(Exception e) {
+         return CastSide.NONE;
+      }
+   }
+
+   /**
+    * The JDBC {@code java.sql.Types} code for one column, or {@code null} when it cannot be
+    * established (no metadata, column not found, driver quirk) -- never a guessed default.
+    */
+   private static Integer columnJdbcType(Connection conn, String tableIdentifier, String column)
+      throws SQLException
+   {
+      String schema = null;
+      String table = tableIdentifier;
+      int dot = tableIdentifier.indexOf('.');
+
+      if(dot >= 0) {
+         schema = tableIdentifier.substring(0, dot);
+         table = tableIdentifier.substring(dot + 1);
+      }
+
+      DatabaseMetaData meta = conn.getMetaData();
+
+      if(meta == null) {
+         return null;
+      }
+
+      try(ResultSet rs = meta.getColumns(conn.getCatalog(), schema, table, column)) {
+         if(rs != null && rs.next()) {
+            int type = rs.getInt("DATA_TYPE");
+            return rs.wasNull() ? null : type;
+         }
+      }
+
+      return null;
+   }
+
+   private static boolean isCharacterType(int jdbcType) {
+      switch(jdbcType) {
+         case Types.CHAR:
+         case Types.VARCHAR:
+         case Types.LONGVARCHAR:
+         case Types.NCHAR:
+         case Types.NVARCHAR:
+         case Types.LONGNVARCHAR:
+            return true;
+         default:
+            return false;
+      }
+   }
+
+   private static boolean isNumericType(int jdbcType) {
+      switch(jdbcType) {
+         case Types.TINYINT:
+         case Types.SMALLINT:
+         case Types.INTEGER:
+         case Types.BIGINT:
+         case Types.FLOAT:
+         case Types.REAL:
+         case Types.DOUBLE:
+         case Types.NUMERIC:
+         case Types.DECIMAL:
+            return true;
+         default:
+            return false;
+      }
+   }
+
+   /** Best-effort dialect sniff for {@link #castToText} -- MySQL alone needs CHAR, not VARCHAR. */
+   private static boolean isMySqlDialect(Connection conn) {
+      try {
+         DatabaseMetaData meta = conn.getMetaData();
+         String product = meta != null ? meta.getDatabaseProductName() : null;
+         return product != null && product.toLowerCase().contains("mysql");
+      }
+      catch(Exception e) {
+         return false;
+      }
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -2814,6 +2814,50 @@ public class WizVsService {
    }
 
    /**
+    * Execute a Gauge/Text (OutputVSAssembly) assembly's scalar value to verify the saved
+    * visualization actually renders, without materializing a table.
+    *
+    * <p>THE BUG THIS FIXES. The controller's dispatch used to be a two-way branch --
+    * {@code ChartVSAssembly ? verifyChartData : verifyTableData} -- on the unstated assumption
+    * that "not a chart" means "table or crosstab". An OutputVSAssembly (Gauge, Text -- the same
+    * shape {@link #verifyChartData}'s own sibling {@link #verifyTableData} was added to handle
+    * for table/crosstab) is NEITHER: it falls into the {@code verifyTableData} branch, which
+    * calls {@link ViewsheetSandbox#getTableData}, and a Gauge/Text assembly has no TableLens at
+    * all -- {@code getTableData} returns {@code null}, so verifyTableData reports
+    * {@code hasData=false, rowCount=0} unconditionally. Every saved Gauge/Text visualization was
+    * therefore reported as a "silently-broken save" even when it rendered a real value, live,
+    * moments earlier -- reproduced on orangehrm: a headcount gauge (value 251, or 39 filtered)
+    * verified as 0 rows / no data every time.
+    *
+    * <p>Mirrors {@link #extractOutputAssemblyData}'s own execute-then-read pattern (the ONE place
+    * in this class that already correctly reads a Gauge/Text's computed value for
+    * create_viewsheet's response), rather than inventing a second implementation of it.
+    */
+   public VerifyResult verifyOutputData(RuntimeViewsheet rvs, String assemblyName) throws Exception {
+      Optional<ViewsheetSandbox> boxOpt = rvs.getViewsheetSandbox();
+
+      if(boxOpt.isEmpty()) {
+         return new VerifyResult(false, 0);
+      }
+
+      ViewsheetSandbox box = boxOpt.get();
+      VSAssembly vsAssembly = rvs.getViewsheet().getAssembly(assemblyName);
+
+      if(!(vsAssembly instanceof OutputVSAssembly outputAssembly)) {
+         return new VerifyResult(false, 0);
+      }
+
+      // executeOutput runs the scalar query via getData() and then calls assembly.setValue(),
+      // which is required before getValue() returns the computed result -- see
+      // extractOutputAssemblyData's identical call for why.
+      box.executeOutput(outputAssembly.getAssemblyEntry());
+
+      Object value = outputAssembly.getValue();
+
+      return value == null ? new VerifyResult(false, 0) : new VerifyResult(true, 1);
+   }
+
+   /**
     * Extracts tabular data from a Table or Crosstab assembly via its TableLens.
     * Row 0 through headerRowCount-1 are header rows; data begins at headerRowCount.
     * <p>

--- a/core/src/test/java/inetsoft/report/lens/WindowTableLensTest.java
+++ b/core/src/test/java/inetsoft/report/lens/WindowTableLensTest.java
@@ -539,6 +539,58 @@ class WindowTableLensTest {
                  "error should name the null-order-value cause: " + ex.getMessage());
    }
 
+   // ── NULLS-LAST parity with WindowExpressionRef.getOrderFragment's SQL-pushdown path ─────────
+
+   @Test
+   void rowNumber_ascOrder_nullSortsLast_notFirst() {
+      // ORDER BY amount ASC with a null value. Tool.compare treats null as smallest, so before
+      // the fix compareRows put the null row FIRST for ascending order -- inconsistent with the
+      // SQL-pushdown path, which now forces NULLS LAST regardless of direction. Base rows stay in
+      // ORIGINAL order (see rowNumber_perPartition_orderedDesc above); only rn reflects the sorted
+      // position. Original order here is 10, null, 20; ASC+nulls-last sorted order is 10, 20, null.
+      Object[][] data = {{"amount"}, {10.0}, {null}, {20.0}};
+      DefaultTableLens t = new DefaultTableLens(data); t.setHeaderRowCount(1);
+      WindowTableLens.Spec spec = new WindowTableLens.Spec(
+         "rn", "ROW_NUMBER", -1, 0, new int[0], new int[]{0}, new boolean[]{true});
+      WindowTableLens lens = new WindowTableLens(t, new WindowTableLens.Spec[]{spec});
+      assertEquals(10.0, cell(lens, 0, 0)); assertEquals(1, cell(lens, 0, 1)); // 10 -> rn 1
+      assertNull(cell(lens, 1, 0));         assertEquals(3, cell(lens, 1, 1)); // null -> rn 3 (last)
+      assertEquals(20.0, cell(lens, 2, 0)); assertEquals(2, cell(lens, 2, 1)); // 20 -> rn 2
+   }
+
+   @Test
+   void rowNumber_descOrder_nullStillSortsLast() {
+      // DESC happened to come out right before the fix too (negation flips it), pinned here so a
+      // future change can't regress the direction that already worked. Sorted DESC+nulls-last
+      // order is 20, 10, null.
+      Object[][] data = {{"amount"}, {10.0}, {null}, {20.0}};
+      DefaultTableLens t = new DefaultTableLens(data); t.setHeaderRowCount(1);
+      WindowTableLens.Spec spec = new WindowTableLens.Spec(
+         "rn", "ROW_NUMBER", -1, 0, new int[0], new int[]{0}, new boolean[]{false});
+      WindowTableLens lens = new WindowTableLens(t, new WindowTableLens.Spec[]{spec});
+      assertEquals(10.0, cell(lens, 0, 0)); assertEquals(2, cell(lens, 0, 1)); // 10 -> rn 2
+      assertNull(cell(lens, 1, 0));         assertEquals(3, cell(lens, 1, 1)); // null -> rn 3 (last)
+      assertEquals(20.0, cell(lens, 2, 0)); assertEquals(1, cell(lens, 2, 1)); // 20 -> rn 1
+   }
+
+   @Test
+   void rank_ascOrder_nullGetsHighestRank_notTiedForFirst() {
+      // RANK's own per-spec tie-counting goes through orderKeyCompare, a separate method from
+      // compareRows with the identical pre-fix bug. Before the fix a null could tie for rank 1
+      // under ASC (Tool.compare's "null is smallest" reading it as the least value) even though
+      // compareRows had already physically sorted it last -- the two methods disagreeing on
+      // null's place is exactly the inconsistency this fix removes. No ties here, so RANK equals
+      // ROW_NUMBER's sorted position: 10 -> 1, 20 -> 2, null -> 3.
+      Object[][] data = {{"amount"}, {10.0}, {null}, {20.0}};
+      DefaultTableLens t = new DefaultTableLens(data); t.setHeaderRowCount(1);
+      WindowTableLens.Spec spec = new WindowTableLens.Spec(
+         "rk", "RANK", -1, 0, new int[0], new int[]{0}, new boolean[]{true});
+      WindowTableLens lens = new WindowTableLens(t, new WindowTableLens.Spec[]{spec});
+      assertEquals(10.0, cell(lens, 0, 0)); assertEquals(1, cell(lens, 0, 1));
+      assertNull(cell(lens, 1, 0));         assertEquals(3, cell(lens, 1, 1));
+      assertEquals(20.0, cell(lens, 2, 0)); assertEquals(2, cell(lens, 2, 1));
+   }
+
    @Test
    void columnIdentifier_delegatesBaseColumnsToUnderlyingTable() {
       // Regression: WindowTableLens must expose its pass-through (base) columns' identifiers by

--- a/core/src/test/java/inetsoft/uql/asset/WindowExpressionRefTest.java
+++ b/core/src/test/java/inetsoft/uql/asset/WindowExpressionRefTest.java
@@ -64,8 +64,10 @@ class WindowExpressionRefTest {
          List.of(new AttributeRef("stage")),
          List.of(sort("amount", XConstants.SORT_DESC)));
 
-      assertEquals("ROW_NUMBER() OVER (PARTITION BY field['stage'] ORDER BY field['amount'] DESC)",
-                   ref.getExpression());
+      assertEquals(
+         "ROW_NUMBER() OVER (PARTITION BY field['stage'] ORDER BY "
+         + "CASE WHEN field['amount'] IS NULL THEN 1 ELSE 0 END, field['amount'] DESC)",
+         ref.getExpression());
    }
 
    @Test
@@ -75,7 +77,10 @@ class WindowExpressionRefTest {
          List.of(),
          List.of(sort("amount", XConstants.SORT_DESC)));
 
-      assertEquals("NTILE(4) OVER (ORDER BY field['amount'] DESC)", ref.getExpression());
+      assertEquals(
+         "NTILE(4) OVER (ORDER BY "
+         + "CASE WHEN field['amount'] IS NULL THEN 1 ELSE 0 END, field['amount'] DESC)",
+         ref.getExpression());
    }
 
    @Test
@@ -85,7 +90,10 @@ class WindowExpressionRefTest {
          List.of(),
          List.of(sort("t", XConstants.SORT_ASC)));
 
-      assertEquals("LAG(field['amount'], 1) OVER (ORDER BY field['t'] ASC)", ref.getExpression());
+      assertEquals(
+         "LAG(field['amount'], 1) OVER (ORDER BY "
+         + "CASE WHEN field['t'] IS NULL THEN 1 ELSE 0 END, field['t'] ASC)",
+         ref.getExpression());
    }
 
    @Test
@@ -113,7 +121,53 @@ class WindowExpressionRefTest {
          List.of(),
          List.of(sort("t", XConstants.SORT_ASC)));
 
-      assertEquals("LAG(field['amount']) OVER (ORDER BY field['t'] ASC)", ref.getExpression());
+      assertEquals(
+         "LAG(field['amount']) OVER (ORDER BY "
+         + "CASE WHEN field['t'] IS NULL THEN 1 ELSE 0 END, field['t'] ASC)",
+         ref.getExpression());
+   }
+
+   // ---- getOrderFragment() nulls-last guard (J6 regression) ------------------------------------
+
+   @Test
+   void orderBy_emitsNullsLastGuard_regardlessOfDirection() {
+      // Root cause: on Postgres/Oracle, a bare "ORDER BY x DESC" defaults to NULLS FIRST, so a
+      // NULL value wins a "largest value" window ranking -- e.g. ROW_NUMBER() OVER (PARTITION BY
+      // project_name ORDER BY estimated_hours DESC) picked a work package with a null
+      // estimated_hours as rank 1 instead of the row with the actual largest value. The fix
+      // prepends a portable CASE WHEN key (not the NULLS LAST keyword, which SQL Server never
+      // supports and MySQL only gained in 8.0.14) so NULL always sorts last on every dialect
+      // windowCapability.ts advertises as window-function-capable, regardless of ASC/DESC.
+      WindowExpressionRef desc = new WindowExpressionRef(
+         "ROW_NUMBER", null, 0, List.of(new AttributeRef("project_name")),
+         List.of(sort("estimated_hours", XConstants.SORT_DESC)));
+      assertEquals(
+         "ROW_NUMBER() OVER (PARTITION BY field['project_name'] ORDER BY "
+         + "CASE WHEN field['estimated_hours'] IS NULL THEN 1 ELSE 0 END, "
+         + "field['estimated_hours'] DESC)",
+         desc.getExpression());
+
+      WindowExpressionRef asc = new WindowExpressionRef(
+         "ROW_NUMBER", null, 0, List.of(new AttributeRef("project_name")),
+         List.of(sort("estimated_hours", XConstants.SORT_ASC)));
+      assertEquals(
+         "ROW_NUMBER() OVER (PARTITION BY field['project_name'] ORDER BY "
+         + "CASE WHEN field['estimated_hours'] IS NULL THEN 1 ELSE 0 END, "
+         + "field['estimated_hours'] ASC)",
+         asc.getExpression());
+   }
+
+   @Test
+   void orderBy_multipleKeys_eachGetsOwnNullsLastGuard() {
+      WindowExpressionRef ref = new WindowExpressionRef(
+         "ROW_NUMBER", null, 0, List.of(),
+         List.of(sort("stage", XConstants.SORT_ASC), sort("amount", XConstants.SORT_DESC)));
+
+      assertEquals(
+         "ROW_NUMBER() OVER (ORDER BY "
+         + "CASE WHEN field['stage'] IS NULL THEN 1 ELSE 0 END, field['stage'] ASC, "
+         + "CASE WHEN field['amount'] IS NULL THEN 1 ELSE 0 END, field['amount'] DESC)",
+         ref.getExpression());
    }
 
    // ---- isSQL() ------------------------------------------------------------------------------
@@ -303,7 +357,8 @@ class WindowExpressionRefTest {
          List.of(sort("t", XConstants.SORT_ASC)));
       ref.setFrame("PRECEDING", 2, "CURRENT_ROW", 0);
       assertEquals(
-         "SUM(field['amount']) OVER (PARTITION BY field['stage'] ORDER BY field['t'] ASC "
+         "SUM(field['amount']) OVER (PARTITION BY field['stage'] ORDER BY "
+         + "CASE WHEN field['t'] IS NULL THEN 1 ELSE 0 END, field['t'] ASC "
          + "ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)",
          ref.getExpression());
    }
@@ -314,7 +369,8 @@ class WindowExpressionRefTest {
          "LAST_VALUE", new AttributeRef("amount"), 0, List.of(new AttributeRef("stage")),
          List.of(sort("t", XConstants.SORT_ASC)));
       assertEquals(
-         "LAST_VALUE(field['amount']) OVER (PARTITION BY field['stage'] ORDER BY field['t'] ASC "
+         "LAST_VALUE(field['amount']) OVER (PARTITION BY field['stage'] ORDER BY "
+         + "CASE WHEN field['t'] IS NULL THEN 1 ELSE 0 END, field['t'] ASC "
          + "ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)",
          ref.getExpression());
    }
@@ -325,7 +381,8 @@ class WindowExpressionRefTest {
          "FIRST_VALUE", new AttributeRef("amount"), 0, List.of(new AttributeRef("stage")),
          List.of(sort("t", XConstants.SORT_ASC)));
       assertEquals(
-         "FIRST_VALUE(field['amount']) OVER (PARTITION BY field['stage'] ORDER BY field['t'] ASC)",
+         "FIRST_VALUE(field['amount']) OVER (PARTITION BY field['stage'] ORDER BY "
+         + "CASE WHEN field['t'] IS NULL THEN 1 ELSE 0 END, field['t'] ASC)",
          ref.getExpression());
    }
 
@@ -335,7 +392,8 @@ class WindowExpressionRefTest {
          "SUM", new AttributeRef("amount"), 0, List.of(new AttributeRef("stage")),
          List.of(sort("t", XConstants.SORT_ASC)));
       assertEquals(
-         "SUM(field['amount']) OVER (PARTITION BY field['stage'] ORDER BY field['t'] ASC)",
+         "SUM(field['amount']) OVER (PARTITION BY field['stage'] ORDER BY "
+         + "CASE WHEN field['t'] IS NULL THEN 1 ELSE 0 END, field['t'] ASC)",
          ref.getExpression());
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/controller/ViewsheetRuntimeControllerVerifyDispatchTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/ViewsheetRuntimeControllerVerifyDispatchTest.java
@@ -26,6 +26,7 @@ import inetsoft.uql.asset.Assembly;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.asset.AssetRepository;
 import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.GaugeVSAssembly;
 import inetsoft.uql.viewsheet.TableVSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.wiz.model.VerifyViewsheetResult;
@@ -135,5 +136,43 @@ class ViewsheetRuntimeControllerVerifyDispatchTest {
       assertEquals(29, result.getRowCount());
       verify(wizVsService).verifyChartData(rvs, "Chart1");
       verify(wizVsService, never()).verifyTableData(any(), any());
+   }
+
+   /**
+    * THE BUG THIS PINS DOWN. Before {@code verifyOutputData} existed, the dispatch was a two-way
+    * branch on the unstated assumption that "not a chart" means "table or crosstab". A Gauge/Text
+    * (OutputVSAssembly) is neither: it fell into {@code verifyTableData}, which calls
+    * {@code getTableData} — there is no TableLens for a Gauge/Text at all, so that always
+    * returned null and reported {@code hasData=false, rowCount=0}. Every saved Gauge/Text
+    * visualization verified as a "silently-broken save" even when it rendered a real value,
+    * live, moments earlier. Reproduced on orangehrm: a headcount gauge (value 251) verified as
+    * 0 rows / no data every time.
+    */
+   @Test
+   void routesOutputAssemblyThroughVerifyOutputDataNotVerifyTableData() throws Exception {
+      Principal principal = mock(Principal.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      GaugeVSAssembly gauge = mock(GaugeVSAssembly.class);
+      when(gauge.getName()).thenReturn("Gauge1");
+      when(vs.getAssemblies()).thenReturn(new Assembly[] { gauge });
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      ViewsheetService vsService = grantedViewsheetService(principal, "rt3", rvs);
+      SecurityEngine securityEngine = grantedSecurityEngine(principal);
+      WizVsService wizVsService = mock(WizVsService.class);
+      when(wizVsService.verifyOutputData(rvs, "Gauge1"))
+         .thenReturn(new WizVsService.VerifyResult(true, 1));
+
+      ViewsheetRuntimeController controller =
+         new ViewsheetRuntimeController(vsService, wizVsService, securityEngine);
+
+      VerifyViewsheetResult result = controller.verifyViewsheet(managedIdentifier(), null, principal);
+
+      assertTrue(result.isHasData(), "gauge assembly with a real value should report hasData");
+      assertEquals(1, result.getRowCount());
+      verify(wizVsService).verifyOutputData(rvs, "Gauge1");
+      verify(wizVsService, never()).verifyTableData(any(), any());
+      verify(wizVsService, never()).verifyChartData(any(), any());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/FkIntegrityServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/FkIntegrityServiceTest.java
@@ -32,9 +32,11 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.security.Principal;
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Types;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -216,6 +218,202 @@ class FkIntegrityServiceTest {
       assertTrue(sql.contains("GROUP BY id"), sql);
       assertTrue(sql.contains("HAVING COUNT(*) > 1"), sql);
       assertFalse(sql.contains("'"), "the statement must contain no string literals: " + sql);
+   }
+
+   // ------------------------------------------------------------------
+   // THE CAST FIX — a text FK pointing at a numeric target key
+   // ------------------------------------------------------------------
+   //
+   // Reproduced live on orangehrm: hs_hr_employee.sal_grd_code is a VARCHAR, genuinely FK to
+   // ohrm_pay_grade.id (an integer PK). The bare `tgt.id = src.sal_grd_code` comparison this
+   // class always used to emit fails outright on Postgres ("operator does not exist: integer =
+   // character varying"), which propagates as a SQLException and is reported upstream as
+   // UNESTABLISHED -- so the FK-label feature silently never offered a pay-grade filter, with no
+   // error anywhere a caller could see. These tests pin resolveCastSide's classification and the
+   // SQL it produces; the end-to-end checkIntegrity test pins that the cast actually reaches the
+   // statement that gets executed.
+
+   @Test
+   void resolveCastSide_castsTheNumericTargetWhenFkIsText() throws Exception {
+      Connection conn = columnTypedConnection("sal_grd_code", Types.VARCHAR, "id", Types.INTEGER);
+
+      assertEquals(FkIntegrityService.CastSide.TARGET_KEY,
+         FkIntegrityService.resolveCastSide(conn, "public.hs_hr_employee", "sal_grd_code",
+            "public.ohrm_pay_grade", "id"));
+   }
+
+   @Test
+   void resolveCastSide_castsTheNumericFkWhenTargetIsText() throws Exception {
+      Connection conn = columnTypedConnection("partner_id", Types.INTEGER, "code", Types.VARCHAR);
+
+      assertEquals(FkIntegrityService.CastSide.FK,
+         FkIntegrityService.resolveCastSide(conn, "public.sale_order", "partner_id",
+            "public.res_partner", "code"));
+   }
+
+   @Test
+   void resolveCastSide_isNoneWhenBothSidesAgree() throws Exception {
+      Connection conn = columnTypedConnection("partner_id", Types.INTEGER, "id", Types.INTEGER);
+
+      assertEquals(FkIntegrityService.CastSide.NONE,
+         FkIntegrityService.resolveCastSide(conn, "public.sale_order", "partner_id",
+            "public.res_partner", "id"));
+   }
+
+   @Test
+   void resolveCastSide_isNoneForDifferentNumericFamiliesInTheSameCategory() throws Exception {
+      // INTEGER vs BIGINT: different java.sql.Types codes, but every dialect this feature runs
+      // against already compares them directly -- casting would be pure churn.
+      Connection conn = columnTypedConnection("partner_id", Types.INTEGER, "id", Types.BIGINT);
+
+      assertEquals(FkIntegrityService.CastSide.NONE,
+         FkIntegrityService.resolveCastSide(conn, "public.sale_order", "partner_id",
+            "public.res_partner", "id"));
+   }
+
+   @Test
+   void resolveCastSide_isNoneWhenColumnMetadataCannotBeEstablished() throws Exception {
+      // getMetaData() answers null -- an un-mocked/minimal connection, exactly what every OTHER
+      // test in this file already uses. Must degrade to NONE, never throw and never guess.
+      Connection conn = mock(Connection.class);
+
+      assertEquals(FkIntegrityService.CastSide.NONE,
+         FkIntegrityService.resolveCastSide(conn, "public.sale_order", "partner_id",
+            "public.res_partner", "id"));
+   }
+
+   @Test
+   void resolveCastSide_isNoneWhenGetColumnsThrows() throws Exception {
+      Connection conn = mock(Connection.class);
+      DatabaseMetaData meta = mock(DatabaseMetaData.class);
+      when(conn.getMetaData()).thenReturn(meta);
+      when(meta.getColumns(any(), any(), any(), any()))
+         .thenThrow(new SQLException("driver does not support getColumns"));
+
+      assertEquals(FkIntegrityService.CastSide.NONE,
+         FkIntegrityService.resolveCastSide(conn, "public.sale_order", "partner_id",
+            "public.res_partner", "id"));
+   }
+
+   @Test
+   void buildDroppedRowCountSql_castsTheTargetKeyToTextWhenDirected() {
+      String sql = FkIntegrityService.buildDroppedRowCountSql(
+         "public.hs_hr_employee", "sal_grd_code", "public.ohrm_pay_grade", "id",
+         FkIntegrityService.CastSide.TARGET_KEY, false);
+
+      assertTrue(sql.contains("CAST(tgt.id AS VARCHAR) = src.sal_grd_code"), sql);
+      // The NULL check must stay on the RAW column -- NULL-ness does not depend on type agreement.
+      assertTrue(sql.contains("src.sal_grd_code IS NULL"), sql);
+   }
+
+   @Test
+   void buildDroppedRowCountSql_castsTheFkToTextWhenDirected() {
+      String sql = FkIntegrityService.buildDroppedRowCountSql(
+         "public.sale_order", "partner_id", "public.res_partner", "code",
+         FkIntegrityService.CastSide.FK, false);
+
+      assertTrue(sql.contains("tgt.code = CAST(src.partner_id AS VARCHAR)"), sql);
+   }
+
+   @Test
+   void buildDroppedRowCountSql_usesCharNotVarcharOnMySql() {
+      // MySQL's CAST rejects VARCHAR as a target type outright; it wants CHAR.
+      String sql = FkIntegrityService.buildDroppedRowCountSql(
+         "public.hs_hr_employee", "sal_grd_code", "public.ohrm_pay_grade", "id",
+         FkIntegrityService.CastSide.TARGET_KEY, true);
+
+      assertTrue(sql.contains("CAST(tgt.id AS CHAR)"), sql);
+      assertFalse(sql.contains("VARCHAR"), sql);
+   }
+
+   @Test
+   void buildDroppedRowCountSql_fourArgOverloadAppliesNoCast() {
+      // The pre-existing 4-arg overload must stay byte-identical to before this fix -- every
+      // caller that never resolves a cast side (or can't) gets exactly the old SQL.
+      assertEquals(DROP_SQL, FkIntegrityService.buildDroppedRowCountSql(
+         "public.sale_order", "partner_id", "public.res_partner", "id"));
+   }
+
+   /** End-to-end: the cast actually reaches the statement checkIntegrity executes. */
+   @Test
+   void checkIntegrity_castsTheTargetKeyWhenTheFkIsTextAndTheTargetIsNumeric() throws Exception {
+      Harness harness = new Harness();
+      harness.request.setSourceTable("public.hs_hr_employee");
+      harness.request.setFkColumn("sal_grd_code");
+      harness.request.setTargetTable("public.ohrm_pay_grade");
+      harness.request.setTargetKeyColumn("id");
+      harness.stubColumnTypes(Types.VARCHAR, Types.INTEGER);
+
+      String expectedDrop =
+         "SELECT COUNT(*) FROM public.hs_hr_employee src WHERE src.sal_grd_code IS NULL " +
+         "OR NOT EXISTS (SELECT 1 FROM public.ohrm_pay_grade tgt " +
+         "WHERE CAST(tgt.id AS VARCHAR) = src.sal_grd_code)";
+      String expectedDuplicate =
+         "SELECT COUNT(*) FROM (SELECT id FROM public.ohrm_pay_grade GROUP BY id " +
+         "HAVING COUNT(*) > 1) d";
+      doReturn(harness.dropStatement).when(harness.connection).prepareStatement(expectedDrop);
+      doReturn(harness.duplicateStatement).when(harness.connection)
+         .prepareStatement(expectedDuplicate);
+
+      FkIntegrityResponse response =
+         harness.service.checkIntegrity(harness.request, harness.principal);
+
+      assertEquals(0L, response.droppedRowCount());
+      verify(harness.connection).prepareStatement(expectedDrop);
+   }
+
+   /** Same shape, but on a MySQL connection -- CHAR, not VARCHAR. */
+   @Test
+   void checkIntegrity_usesCharOnMySqlWhenCasting() throws Exception {
+      Harness harness = new Harness();
+      harness.request.setSourceTable("public.hs_hr_employee");
+      harness.request.setFkColumn("sal_grd_code");
+      harness.request.setTargetTable("public.ohrm_pay_grade");
+      harness.request.setTargetKeyColumn("id");
+      harness.stubColumnTypes(Types.VARCHAR, Types.INTEGER);
+      when(harness.databaseMetaData.getDatabaseProductName()).thenReturn("MySQL");
+
+      String expectedDrop =
+         "SELECT COUNT(*) FROM public.hs_hr_employee src WHERE src.sal_grd_code IS NULL " +
+         "OR NOT EXISTS (SELECT 1 FROM public.ohrm_pay_grade tgt " +
+         "WHERE CAST(tgt.id AS CHAR) = src.sal_grd_code)";
+      String expectedDuplicate =
+         "SELECT COUNT(*) FROM (SELECT id FROM public.ohrm_pay_grade GROUP BY id " +
+         "HAVING COUNT(*) > 1) d";
+      doReturn(harness.dropStatement).when(harness.connection).prepareStatement(expectedDrop);
+      doReturn(harness.duplicateStatement).when(harness.connection)
+         .prepareStatement(expectedDuplicate);
+
+      harness.service.checkIntegrity(harness.request, harness.principal);
+
+      verify(harness.connection).prepareStatement(expectedDrop);
+   }
+
+   /**
+    * Wires a mocked {@code DatabaseMetaData.getColumns(...)} call so {@code resolveCastSide} can
+    * classify both columns without a live database -- routed EXPLICITLY by each column's own
+    * name (never by position or by exclusion), so a test naming two columns that happen to share
+    * a name with another test's fixture can never cross-contaminate.
+    */
+   private static Connection columnTypedConnection(
+      String fkColumnName, int fkJdbcType, String targetColumnName, int targetJdbcType)
+      throws SQLException
+   {
+      Connection conn = mock(Connection.class);
+      DatabaseMetaData meta = mock(DatabaseMetaData.class);
+      when(conn.getMetaData()).thenReturn(meta);
+
+      ResultSet fkRs = mock(ResultSet.class);
+      when(fkRs.next()).thenReturn(true, false);
+      when(fkRs.getInt("DATA_TYPE")).thenReturn(fkJdbcType);
+      when(meta.getColumns(any(), any(), any(), eq(fkColumnName))).thenReturn(fkRs);
+
+      ResultSet targetRs = mock(ResultSet.class);
+      when(targetRs.next()).thenReturn(true, false);
+      when(targetRs.getInt("DATA_TYPE")).thenReturn(targetJdbcType);
+      when(meta.getColumns(any(), any(), any(), eq(targetColumnName))).thenReturn(targetRs);
+
+      return conn;
    }
 
    // ------------------------------------------------------------------
@@ -516,15 +714,41 @@ class FkIntegrityServiceTest {
          when(duplicateResultSet.getLong(1)).thenReturn(count);
       }
 
+      /**
+       * Wires {@code connection.getMetaData()} so {@code resolveCastSide} can classify
+       * {@code request}'s fkColumn/targetKeyColumn without a live database. Call AFTER setting
+       * {@code request}'s column names -- the routing is by column name, matching how
+       * {@code columnJdbcType} actually calls {@code getColumns}.
+       */
+      void stubColumnTypes(int fkJdbcType, int targetJdbcType) throws SQLException {
+         when(connection.getMetaData()).thenReturn(databaseMetaData);
+         // Default product name so isMySqlDialect degrades to "not MySQL" unless a test overrides it.
+         when(databaseMetaData.getDatabaseProductName()).thenReturn("PostgreSQL");
+
+         ResultSet fkRs = mock(ResultSet.class);
+         when(fkRs.next()).thenReturn(true, false);
+         when(fkRs.getInt("DATA_TYPE")).thenReturn(fkJdbcType);
+         ResultSet targetRs = mock(ResultSet.class);
+         when(targetRs.next()).thenReturn(true, false);
+         when(targetRs.getInt("DATA_TYPE")).thenReturn(targetJdbcType);
+
+         when(databaseMetaData.getColumns(any(), any(), any(), eq(request.getFkColumn())))
+            .thenReturn(fkRs);
+         when(databaseMetaData.getColumns(any(), any(), any(), eq(request.getTargetKeyColumn())))
+            .thenReturn(targetRs);
+      }
+
       final MetadataApiService metadataService = mock(MetadataApiService.class);
       final DataSourceService dataSourceService = mock(DataSourceService.class);
       final JDBCDataSource dataSource = mock(JDBCDataSource.class);
       final Connection connection = mock(Connection.class);
+      final DatabaseMetaData databaseMetaData = mock(DatabaseMetaData.class);
       final PreparedStatement dropStatement = mock(PreparedStatement.class);
       final PreparedStatement duplicateStatement = mock(PreparedStatement.class);
       final ResultSet dropResultSet = mock(ResultSet.class);
       final ResultSet duplicateResultSet = mock(ResultSet.class);
       final Principal principal = mock(Principal.class);
+      final FkIntegrityRequest request = request();
       final FkIntegrityService service;
       int connectionsOpened;
    }

--- a/core/src/test/java/inetsoft/web/wiz/service/FkIntegrityServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/FkIntegrityServiceTest.java
@@ -299,7 +299,7 @@ class FkIntegrityServiceTest {
    void buildDroppedRowCountSql_castsTheTargetKeyToTextWhenDirected() {
       String sql = FkIntegrityService.buildDroppedRowCountSql(
          "public.hs_hr_employee", "sal_grd_code", "public.ohrm_pay_grade", "id",
-         FkIntegrityService.CastSide.TARGET_KEY, false);
+         FkIntegrityService.CastSide.TARGET_KEY, FkIntegrityService.Dialect.DEFAULT);
 
       assertTrue(sql.contains("CAST(tgt.id AS VARCHAR) = src.sal_grd_code"), sql);
       // The NULL check must stay on the RAW column -- NULL-ness does not depend on type agreement.
@@ -310,7 +310,7 @@ class FkIntegrityServiceTest {
    void buildDroppedRowCountSql_castsTheFkToTextWhenDirected() {
       String sql = FkIntegrityService.buildDroppedRowCountSql(
          "public.sale_order", "partner_id", "public.res_partner", "code",
-         FkIntegrityService.CastSide.FK, false);
+         FkIntegrityService.CastSide.FK, FkIntegrityService.Dialect.DEFAULT);
 
       assertTrue(sql.contains("tgt.code = CAST(src.partner_id AS VARCHAR)"), sql);
    }
@@ -320,9 +320,26 @@ class FkIntegrityServiceTest {
       // MySQL's CAST rejects VARCHAR as a target type outright; it wants CHAR.
       String sql = FkIntegrityService.buildDroppedRowCountSql(
          "public.hs_hr_employee", "sal_grd_code", "public.ohrm_pay_grade", "id",
-         FkIntegrityService.CastSide.TARGET_KEY, true);
+         FkIntegrityService.CastSide.TARGET_KEY, FkIntegrityService.Dialect.MYSQL);
 
       assertTrue(sql.contains("CAST(tgt.id AS CHAR)"), sql);
+      assertFalse(sql.contains("VARCHAR"), sql);
+   }
+
+   /**
+    * Oracle's CAST requires an explicit length for a character target (VARCHAR2(n)) -- a bare
+    * "CAST(... AS VARCHAR)" is a SYNTAX ERROR on Oracle, not merely the wrong keyword. TO_CHAR
+    * needs no length and is Oracle's own numeric-to-text conversion, which is always what this
+    * cast means: resolveCastSide only ever directs the NUMERIC side to be cast.
+    */
+   @Test
+   void buildDroppedRowCountSql_usesToCharOnOracle() {
+      String sql = FkIntegrityService.buildDroppedRowCountSql(
+         "public.hs_hr_employee", "sal_grd_code", "public.ohrm_pay_grade", "id",
+         FkIntegrityService.CastSide.TARGET_KEY, FkIntegrityService.Dialect.ORACLE);
+
+      assertTrue(sql.contains("TO_CHAR(tgt.id) = src.sal_grd_code"), sql);
+      assertFalse(sql.contains("CAST"), sql);
       assertFalse(sql.contains("VARCHAR"), sql);
    }
 
@@ -377,6 +394,33 @@ class FkIntegrityServiceTest {
          "SELECT COUNT(*) FROM public.hs_hr_employee src WHERE src.sal_grd_code IS NULL " +
          "OR NOT EXISTS (SELECT 1 FROM public.ohrm_pay_grade tgt " +
          "WHERE CAST(tgt.id AS CHAR) = src.sal_grd_code)";
+      String expectedDuplicate =
+         "SELECT COUNT(*) FROM (SELECT id FROM public.ohrm_pay_grade GROUP BY id " +
+         "HAVING COUNT(*) > 1) d";
+      doReturn(harness.dropStatement).when(harness.connection).prepareStatement(expectedDrop);
+      doReturn(harness.duplicateStatement).when(harness.connection)
+         .prepareStatement(expectedDuplicate);
+
+      harness.service.checkIntegrity(harness.request, harness.principal);
+
+      verify(harness.connection).prepareStatement(expectedDrop);
+   }
+
+   /** Same shape, but on an Oracle connection -- TO_CHAR, not CAST ... VARCHAR (a syntax error there). */
+   @Test
+   void checkIntegrity_usesToCharOnOracleWhenCasting() throws Exception {
+      Harness harness = new Harness();
+      harness.request.setSourceTable("public.hs_hr_employee");
+      harness.request.setFkColumn("sal_grd_code");
+      harness.request.setTargetTable("public.ohrm_pay_grade");
+      harness.request.setTargetKeyColumn("id");
+      harness.stubColumnTypes(Types.VARCHAR, Types.INTEGER);
+      when(harness.databaseMetaData.getDatabaseProductName()).thenReturn("Oracle");
+
+      String expectedDrop =
+         "SELECT COUNT(*) FROM public.hs_hr_employee src WHERE src.sal_grd_code IS NULL " +
+         "OR NOT EXISTS (SELECT 1 FROM public.ohrm_pay_grade tgt " +
+         "WHERE TO_CHAR(tgt.id) = src.sal_grd_code)";
       String expectedDuplicate =
          "SELECT COUNT(*) FROM (SELECT id FROM public.ohrm_pay_grade GROUP BY id " +
          "HAVING COUNT(*) > 1) d";
@@ -722,7 +766,7 @@ class FkIntegrityServiceTest {
        */
       void stubColumnTypes(int fkJdbcType, int targetJdbcType) throws SQLException {
          when(connection.getMetaData()).thenReturn(databaseMetaData);
-         // Default product name so isMySqlDialect degrades to "not MySQL" unless a test overrides it.
+         // Default product name so resolveDialect degrades to DEFAULT unless a test overrides it.
          when(databaseMetaData.getDatabaseProductName()).thenReturn("PostgreSQL");
 
          ResultSet fkRs = mock(ResultSet.class);

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceWindowColumnsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceWindowColumnsTest.java
@@ -98,7 +98,8 @@ class WorksheetTableServiceWindowColumnsTest {
 
       WindowExpressionRef winRef = (WindowExpressionRef) colRef.getDataRef();
       assertEquals(
-         "ROW_NUMBER() OVER (PARTITION BY field['stage'] ORDER BY field['amount'] DESC)",
+         "ROW_NUMBER() OVER (PARTITION BY field['stage'] ORDER BY "
+         + "CASE WHEN field['amount'] IS NULL THEN 1 ELSE 0 END, field['amount'] DESC)",
          winRef.getExpression());
       assertTrue(winRef.isSQL());
    }


### PR DESCRIPTION
## Root cause

`WindowExpressionRef.getOrderFragment()` built a bare `ORDER BY field['col'] ASC|DESC` with no null-ordering directive. On Postgres/Oracle, `DESC` defaults to `NULLS FIRST`, so a row with a NULL sort value would win a "largest value" window ranking — e.g.

```
ROW_NUMBER() OVER (PARTITION BY project_name ORDER BY estimated_hours DESC)
```

would pick a work package with a null `estimated_hours` as rank 1 instead of the row with the actual largest value.

Found during a wiz-chat plugin exercise sweep of the `openproject` datasource (defect J6): a `windowColumns` ranking of `estimated_hours DESC` per project surfaced a NULL-valued row as the "top" row for several projects.

## Fix

Prepend a portable `CASE WHEN field['col'] IS NULL THEN 1 ELSE 0 END` synthetic sort key immediately before each real `ORDER BY` key, so NULL always sorts last regardless of `ASC`/`DESC`.

This uses only ANSI-standard `CASE WHEN` + multi-key `ORDER BY` rather than the `NULLS LAST` keyword, because that keyword is not available on every dialect wiz-services' `windowCapability.ts` advertises as window-function-capable:
- SQL Server has no `NULLS LAST`/`NULLS FIRST` syntax at all.
- MySQL didn't add it until 8.0.14 — StyleBI's supported floor is MySQL 8.0.0.

`wiz-services`' `windowColumns.ts` is validation-only (its `overClause()` builder exists only to exercise the same guards that used to emit SQL text; the return value is discarded per its own comment) — `WindowExpressionRef` is the sole generator of the `OVER (...)` SQL, so no `wiz-services` change was needed for this fix.

## Testing

- Updated every pinned `getExpression()`/exact-string assertion across `WindowExpressionRefTest` and `WorksheetTableServiceWindowColumnsTest` to the new generated SQL shape.
- Added two new regression tests pinning the null-ordering guard itself: `orderBy_emitsNullsLastGuard_regardlessOfDirection` (single key, both ASC and DESC) and `orderBy_multipleKeys_eachGetsOwnNullsLastGuard` (multi-key ORDER BY, each key gets its own guard).
- `WindowExpressionRefTest` (34), `WorksheetTableServiceWindowColumnsTest` (24), `WindowRoutingTest` (21), `WindowExpressionDetectionTest` (6) — all pass, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)