### PR TITLE
Bug #76083, custom shapes not deleted when resetting global presentation settings

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/graph/aesthetic/ImageShapes.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/graph/aesthetic/ImageShapes.java
@@ -70,6 +70,18 @@ public class ImageShapes {
    }
 
    /**
+    * Clear the cached shapes of all organizations. Should be used when the global shapes
+    * directory changes, since every organization falls back to it.
+    */
+   public static void clearAllShapes() {
+      synchronized(ImageShapes.class) {
+         singleton.cache.clear();
+         singleton.lastByOrg.clear();
+         SVGShape.clearCache();
+      }
+   }
+
+   /**
     * Get the named shape.
     */
    public static GShape getShape(String name) {

--- a/core/src/main/java/inetsoft/web/admin/content/dataspace/DataSpaceContentSettingsService.java
+++ b/core/src/main/java/inetsoft/web/admin/content/dataspace/DataSpaceContentSettingsService.java
@@ -230,9 +230,16 @@ public class DataSpaceContentSettingsService {
 
       dataSpace.delete(null, path);
 
-      if(path.startsWith("portal/" + OrganizationManager.getInstance().getCurrentOrgID() + "/shapes/") ||
-         path.startsWith("portal/shapes/"))
-      {
+      final String orgShapesDir = ImageShapes.getShapesDirectory();
+      final String globalShapesDir = ImageShapes.getGlobalShapesDirectory();
+
+      // the shapes directory itself is deleted when the presentation settings are reset, so the
+      // cache must be cleared for the directory as well as for files/folders under it
+      if(path.equals(globalShapesDir) || path.startsWith(globalShapesDir + "/")) {
+         // every organization falls back to the global shapes directory, clear all of them
+         ImageShapes.clearAllShapes();
+      }
+      else if(path.equals(orgShapesDir) || path.startsWith(orgShapesDir + "/")) {
          ImageShapes.clearShapes();
       }
 


### PR DESCRIPTION
## Problem

Re-test failure of #76034 (fixed in #4568). After uploading a custom shape in
**EM > Settings > Presentation > Look and Feel > Custom Shapes**, binding it to a chart,
and then clicking **Reset to Default**, the chart still renders the deleted shape instead
of falling back to the default circle.

## Cause

`PresentationSettingsController.resetSettings()` deletes the shapes directory itself
(`portal/shapes`), but `DataSpaceContentSettingsService.deleteDataSpaceNode()` only flushed
the `ImageShapes` cache when the deleted path was *inside* that directory:

```java
if(path.startsWith("portal/" + orgID + "/shapes/") || path.startsWith("portal/shapes/")) {
   ImageShapes.clearShapes();
}
```

`"portal/shapes"` has no trailing slash, so neither `startsWith` matched and the cache kept
the stale entry. `ShapeFrameWrapper.getGShape("3.gif")` then still resolved to the cached
`ImageShape` instead of `null`, so the point never fell back to the default shape.

This is why deleting a shape one-by-one from the Custom Shapes dialog worked (path is
`portal/shapes/3.gif`, which matches the prefix) while **Reset to Default** did not.

## Fix

- Match the shapes directory itself in addition to paths under it, and derive the paths from
  `ImageShapes` instead of hardcoding them (consistent with the upload-side check in
  `DataSpaceFolderSettingsController`).
- Add `ImageShapes.clearAllShapes()` and use it when the *global* shapes directory is removed —
  every organization falls back to `portal/shapes` in `ImageShapes.loadShapes()`, so clearing only
  the current organization left other organizations serving the deleted shape.

## Side effects

- Per-file/per-folder deletes from the Custom Shapes dialog and the Data Space tree behave as
  before (they still match the `startsWith(dir + "/")` branch).
- In non-multi-tenant mode `getShapesDirectory()` returns the global directory, so the first
  branch handles it and `clearAllShapes()` clears the single cache entry.
- `SUtil.isMultiTenant()` is newly reached here, but it is already called on the same request
  paths by `DataSpaceFolderSettingsController.checkUploadPermission()` and
  `DataSpaceTreeController.checkDeletePermission()`.

## Testing

- `./mvnw -pl core compile` passes.
- Manual: upload a custom shape, bind it to a chart, save, reset presentation settings, reopen the
  viewsheet in the portal — the point now renders as the default circle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
