### PR TITLE
75878, circular network hover/animation issues in facet graph

### DIFF
--- a/core/src/main/java/inetsoft/graph/internal/GTool.java
+++ b/core/src/main/java/inetsoft/graph/internal/GTool.java
@@ -596,6 +596,29 @@ public final class GTool {
    }
 
    /**
+    * Get a key identifying the facet panel a coordinate belongs to, built from the facet
+    * dimension values assigned to it by the enclosing facet (e.g. {@code {Region=USA East}}).
+    *
+    * <p>Each facet panel gets its own coordinate instance, so this key differs between panels
+    * and is identical for every visual object drawn in one panel.  Returns {@code null} for a
+    * non-faceted chart (no parent values), so callers can omit the key entirely in that case.
+    */
+   public static String getFacetPanelId(Coordinate coord) {
+      if(coord == null) {
+         return null;
+      }
+
+      Map<String, Object> xvals = coord.getParentValues(true);
+      Map<String, Object> yvals = coord.getParentValues(false);
+
+      if(xvals.isEmpty() && yvals.isEmpty()) {
+         return null;
+      }
+
+      return xvals + "/" + yvals;
+   }
+
+   /**
     * Get the topmost VGraph.
     */
    public static VGraph getTopVGraph(Coordinate coord) {

--- a/core/src/main/java/inetsoft/graph/visual/RelationEdgeVO.java
+++ b/core/src/main/java/inetsoft/graph/visual/RelationEdgeVO.java
@@ -50,6 +50,9 @@ public class RelationEdgeVO extends ElementVO {
       setZIndex(GDefaults.VO_Z_INDEX - 1); // edges below nodes
       RelationEdgeGeometry obj = (RelationEdgeGeometry) gobj;
       this.edges = obj.getEdges();
+      // mxCell ids are only unique within a facet panel (each panel builds its own mxGraph),
+      // so the panel key is stamped alongside the source/target ids. Null when not faceted.
+      this.panelId = GTool.getFacetPanelId(coord);
    }
 
    /**
@@ -69,6 +72,10 @@ public class RelationEdgeVO extends ElementVO {
          if(cell != null && cell.getSource() != null && cell.getTarget() != null) {
             edgeAttrs.put(SVGSupport.ATTR_SOURCE, cell.getSource().getId());
             edgeAttrs.put(SVGSupport.ATTR_TARGET, cell.getTarget().getId());
+         }
+
+         if(panelId != null) {
+            edgeAttrs.put(SVGSupport.ATTR_PANEL, panelId);
          }
          svg.beginAnnotationGroup(g, SVGSupport.ANNOTATION_RELATION_EDGE, edgeAttrs);
       }
@@ -313,6 +320,7 @@ public class RelationEdgeVO extends ElementVO {
    }
 
    private List<Shape> edges = new ArrayList<>();
+   private final String panelId;
    private static final Color DEFAULT_LINE_COLOR = new Color(0xafafad);
 
 }

--- a/core/src/main/java/inetsoft/graph/visual/RelationVO.java
+++ b/core/src/main/java/inetsoft/graph/visual/RelationVO.java
@@ -52,6 +52,9 @@ public class RelationVO extends ElementVO {
       RelationElement elem = (RelationElement) obj.getElement();
 
       this.shape = obj.getShape();
+      // mxCell ids are only unique within a facet panel (each panel builds its own mxGraph),
+      // so the panel key is stamped alongside the id for hover matching. Null when not faceted.
+      this.panelId = GTool.getFacetPanelId(coord);
 
       // only add label on 'all'
       if(elem.getHint("overlay") == null) {
@@ -111,6 +114,11 @@ public class RelationVO extends ElementVO {
          nodeAttrs.put(SVGSupport.ATTR_ROW, String.valueOf(gobj.getRowIndex()));
          nodeAttrs.put(SVGSupport.ATTR_COL, String.valueOf(gobj.getColIndex()));
          nodeAttrs.put(SVGSupport.ATTR_NODE_ID, gobj.getMxCell().getId());
+
+         if(panelId != null) {
+            nodeAttrs.put(SVGSupport.ATTR_PANEL, panelId);
+         }
+
          nodeAttrs.put(SVGSupport.ATTR_Y, String.valueOf(b.getCenterY()));
          svg.beginAnnotationGroup(g, SVGSupport.ANNOTATION_RELATION, nodeAttrs);
       }
@@ -425,6 +433,7 @@ public class RelationVO extends ElementVO {
 
    private Shape shape;
    private VOText vtext;
+   private final String panelId;
 
    private static final Color DEFAULT_LINE_COLOR = new Color(0xafafad);
    private static final Logger LOG = LoggerFactory.getLogger(RelationVO.class);

--- a/core/src/main/java/inetsoft/util/graphics/SVGSupport.java
+++ b/core/src/main/java/inetsoft/util/graphics/SVGSupport.java
@@ -176,6 +176,10 @@ public interface SVGSupport {
    String ATTR_SOURCE = "source";
    /** {@code data-target} — target node's mxCell ID for relation/tree chart edges. */
    String ATTR_TARGET = "target";
+   /** {@code data-panel} — facet panel key for relation/tree chart nodes and edges.  Node ids are
+    *  only unique within a panel (each facet panel builds its own mxGraph), so hover matching must
+    *  pair the id with this key.  Absent on non-faceted charts. */
+   String ATTR_PANEL = "panel";
    /** {@code data-pareto} — {@code "true"} on the cumulative-% line in a Pareto chart. */
    String ATTR_PARETO = "pareto";
 

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
@@ -2205,15 +2205,17 @@ public class SVGAnimationDOMInjector {
       // the graph structure (orientation-independent) rather than screen geometry.
       List<Element> edgeGroups = collectAnnotationGroups(svgRoot, SVGSupport.ANNOTATION_RELATION_EDGE);
 
-      // Map node id → node index so both the depth computation and the edge/label passes can
-      // resolve a node from its stamped data-node-id.
+      // Map node key → node index so both the depth computation and the edge/label passes can
+      // resolve a node from its stamped data-id.  The key is panel-qualified: a faceted chart
+      // builds one mxGraph per panel, so the same id repeats in every panel and an id-only map
+      // would keep just the last panel's copy — merging the panels into one topology.
       Map<String, Integer> nodeIndexById = new HashMap<>();
 
       for(int i = 0; i < nodes.size(); i++) {
-         String id = nodes.get(i).getAttribute("data-" + SVGSupport.ATTR_NODE_ID);
+         String key = relationNodeKey(nodes.get(i), SVGSupport.ATTR_NODE_ID);
 
-         if(!id.isEmpty()) {
-            nodeIndexById.put(id, i);
+         if(key != null) {
+            nodeIndexById.put(key, i);
          }
       }
 
@@ -2291,26 +2293,27 @@ public class SVGAnimationDOMInjector {
             AnimationConstants.RELATION_FADE_DURATION, AnimationConstants.EASING, delayOf[i]));
       }
 
-      // Build node-ID → delay map so edges/labels inherit their node's exact delay and fade in
+      // Build node-key → delay map so edges/labels inherit their node's exact delay and fade in
       // together with it (not merely at the same depth band).
       Map<String, Double> delayByNodeId = new HashMap<>();
 
       for(int i = 0; i < nodes.size(); i++) {
-         String id = nodes.get(i).getAttribute("data-" + SVGSupport.ATTR_NODE_ID);
+         String key = relationNodeKey(nodes.get(i), SVGSupport.ATTR_NODE_ID);
 
-         if(!id.isEmpty()) {
-            delayByNodeId.put(id, delayOf[i]);
+         if(key != null) {
+            delayByNodeId.put(key, delayOf[i]);
          }
       }
 
       // Edge animation: each edge fades in with its target (child) node so the edge and
       // its destination appear together. Falls back to the source node's delay, then 0.
+      // An edge never spans panels, so both endpoints resolve against the edge's own panel.
       for(Element edgeG : edgeGroups) {
-         String targetId = edgeG.getAttribute("data-" + SVGSupport.ATTR_TARGET);
-         String sourceId = edgeG.getAttribute("data-" + SVGSupport.ATTR_SOURCE);
-         Double delay = delayByNodeId.get(targetId);
+         String targetId = relationNodeKey(edgeG, SVGSupport.ATTR_TARGET);
+         String sourceId = relationNodeKey(edgeG, SVGSupport.ATTR_SOURCE);
+         Double delay = targetId == null ? null : delayByNodeId.get(targetId);
 
-         if(delay == null) {
+         if(delay == null && sourceId != null) {
             delay = delayByNodeId.get(sourceId);
          }
 
@@ -2384,6 +2387,31 @@ public class SVGAnimationDOMInjector {
    }
 
    /**
+    * Build a panel-qualified key for a relation node reference, mirroring what the client-side
+    * hover handler does ({@code ChartInlineSvgDirective.relationKey}).  The two encodings are
+    * independent — the keys never cross between the animation and hover pipelines.
+    *
+    * <p>A relation/tree chart builds one mxGraph per facet panel, so the stamped mxCell ids
+    * ({@code data-id} on nodes, {@code data-source}/{@code data-target} on edges) repeat in every
+    * panel.  Pairing the id with {@link SVGSupport#ATTR_PANEL} keeps each panel's topology — and
+    * therefore its entrance cascade — independent.  {@code data-panel} is only stamped on faceted
+    * charts; elsewhere the panel half is empty and the key is equivalent to the bare id.
+    *
+    * @param el       the node or edge annotation group
+    * @param idAttr   the id attribute to read, without the {@code data-} prefix
+    * @return the key, or {@code null} when the id attribute is absent or empty
+    */
+   private static String relationNodeKey(Element el, String idAttr) {
+      String id = el.getAttribute("data-" + idAttr);
+
+      if(id.isEmpty()) {
+         return null;
+      }
+
+      return el.getAttribute("data-" + SVGSupport.ATTR_PANEL) + "\0" + id;
+   }
+
+   /**
     * Compute each relation node's tree depth (0 = root) from the edge source→target topology.
     *
     * <p>Depth comes from the graph structure, not screen geometry, so root-first ordering is
@@ -2412,10 +2440,11 @@ public class SVGAnimationDOMInjector {
       Set<String> hasIncoming = new HashSet<>();
 
       for(Element edgeG : edgeGroups) {
-         String source = edgeG.getAttribute("data-" + SVGSupport.ATTR_SOURCE);
-         String target = edgeG.getAttribute("data-" + SVGSupport.ATTR_TARGET);
+         String rawSource = edgeG.getAttribute("data-" + SVGSupport.ATTR_SOURCE);
+         String source = relationNodeKey(edgeG, SVGSupport.ATTR_SOURCE);
+         String target = relationNodeKey(edgeG, SVGSupport.ATTR_TARGET);
 
-         if(source.isEmpty() || target.isEmpty()) {
+         if(source == null || target == null) {
             continue;
          }
 
@@ -2424,7 +2453,9 @@ public class SVGAnimationDOMInjector {
          // An edge from that sentinel — or from any source dropped upstream (e.g. maxNodes
          // truncation) and thus unknown here — must NOT mark its target as having a real incoming
          // edge, so the actual root is detected as depth 0 rather than a child of the sentinel.
-         if("null".equals(source) || !nodeIndexById.containsKey(source)) {
+         // The sentinel test reads the raw id, not the panel-qualified key, which never equals
+         // "null" on a faceted chart.
+         if("null".equals(rawSource) || !nodeIndexById.containsKey(source)) {
             continue;
          }
 
@@ -2474,8 +2505,8 @@ public class SVGAnimationDOMInjector {
       int[] levelOf = new int[nodes.size()];
 
       for(int i = 0; i < nodes.size(); i++) {
-         String id = nodes.get(i).getAttribute("data-" + SVGSupport.ATTR_NODE_ID);
-         Integer d = id.isEmpty() ? null : depthById.get(id);
+         String key = relationNodeKey(nodes.get(i), SVGSupport.ATTR_NODE_ID);
+         Integer d = key == null ? null : depthById.get(key);
          // Nodes never reached by BFS — an isolated all-cyclic component while the rest of the
          // graph has a real root — intentionally default to depth 0 and fade in with the roots.
          // This is an accepted trade-off: the whole-graph cyclic case is already handled by the

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
@@ -2162,6 +2162,24 @@ class SVGAnimationDOMInjectorTest {
       return addAnnotGroup(doc, SVGSupport.ANNOTATION_RELATION_EDGE, attrs, 0, 0, 20, 2);
    }
 
+   /** Adds a relation node annotation group belonging to a named facet panel. */
+   private static Element relNode(Document doc, String id, double y, String panel) {
+      Map<String, String> attrs = new LinkedHashMap<>();
+      attrs.put(SVGSupport.ATTR_NODE_ID, id);
+      attrs.put(SVGSupport.ATTR_PANEL, panel);
+      attrs.put(SVGSupport.ATTR_Y, String.valueOf(y));
+      return addAnnotGroup(doc, SVGSupport.ANNOTATION_RELATION, attrs, 0, y, 20, 16);
+   }
+
+   /** Adds a relation edge annotation group inside a named facet panel. */
+   private static Element relEdge(Document doc, String source, String target, String panel) {
+      Map<String, String> attrs = new LinkedHashMap<>();
+      attrs.put(SVGSupport.ATTR_SOURCE, source);
+      attrs.put(SVGSupport.ATTR_TARGET, target);
+      attrs.put(SVGSupport.ATTR_PANEL, panel);
+      return addAnnotGroup(doc, SVGSupport.ANNOTATION_RELATION_EDGE, attrs, 0, 0, 20, 2);
+   }
+
    /**
     * A linear tree (root → child → grandchild, one node per depth) staggers strictly root-first:
     * delay grows by exactly {@link AnimationConstants#RELATION_LEVEL_STEP} per depth level.
@@ -2226,6 +2244,44 @@ class SVGAnimationDOMInjectorTest {
                  "real root stays depth 0 (delay < one step) despite the null-parent sentinel edge");
       assertEquals(step, parseDelay(firstChildStyle(child)), 0.001,
                    "child of the real root is depth 1");
+   }
+
+   /**
+    * Regression for Redmine #75878: a faceted relation chart builds one mxGraph per panel, so every
+    * panel stamps the same node ids.  Keyed on the bare id, the delay map kept only the last panel's
+    * entry per id, so EVERY panel's edges faded with the last panel's node — an edge arriving after
+    * the node it connects.  (Depth itself survived a symmetric facet, since all copies of an id read
+    * back the one merged depth; it breaks only when a shared id sits at different depths in
+    * different panels.)  Panel-qualifying the keys gives each panel its own topology and its own
+    * edge timing, while the shared per-depth counters keep the panels one intra-level spread apart
+    * — the "ripple" across the facet — rather than lengthening the total entrance.
+    */
+   @Test
+   void relationFacetPanelsCascadeIndependently() throws Exception {
+      Document doc = newDocument();
+      Element eastRoot = relNode(doc, "R_id", 100, "{Region=East}/{}");
+      Element eastChild = relNode(doc, "A_id", 200, "{Region=East}/{}");
+      Element westRoot = relNode(doc, "R_id", 100, "{Region=West}/{}");
+      Element westChild = relNode(doc, "A_id", 200, "{Region=West}/{}");
+      Element eastEdge = relEdge(doc, "R_id", "A_id", "{Region=East}/{}");
+      Element westEdge = relEdge(doc, "R_id", "A_id", "{Region=West}/{}");
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_RELATION);
+
+      double step = AnimationConstants.RELATION_LEVEL_STEP;
+      // Two nodes share each depth (one per panel), so the intra-level spread is index/2 of a step.
+      assertEquals(0.0, parseDelay(firstChildStyle(eastRoot)), 0.001, "east root → depth 0, first");
+      assertEquals(step / 2, parseDelay(firstChildStyle(westRoot)), 0.001,
+                   "west root → depth 0, one intra-level spread behind east (ripple)");
+      assertEquals(step, parseDelay(firstChildStyle(eastChild)), 0.001,
+                   "east child is depth 1 in its OWN panel");
+      assertEquals(step * 1.5, parseDelay(firstChildStyle(westChild)), 0.001, "west child → depth 1");
+
+      // Each edge fades with its own panel's target node, not with whichever panel was stamped last.
+      assertEquals(parseDelay(firstChildStyle(eastChild)), parseDelay(firstChildStyle(eastEdge)),
+                   0.001, "east edge follows east's target node");
+      assertEquals(parseDelay(firstChildStyle(westChild)), parseDelay(firstChildStyle(westEdge)),
+                   0.001, "west edge follows west's target node");
    }
 
    /**

--- a/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.spec.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.spec.ts
@@ -128,10 +128,16 @@ describe("ChartInlineSvgDirective cross-tile dim", () => {
          return Array.from(host.querySelectorAll(sel)).map(e => e.classList.contains("inetsoft-active"));
       }
 
+      // Node keys are panel-qualified (see ChartInlineSvgDirective.relationKey); an unfaceted
+      // chart stamps no data-panel, so the panel half is empty.
+      function key(id: string, panel = ""): string {
+         return JSON.stringify([panel, id]);
+      }
+
       it("activates the hovered node, its neighbours, incident edges and their labels", () => {
          const { dir, host } = makeDirective(html);
          (dir as any).svgRootEl = host;
-         dir.setExternalRelationHighlight(new Set(["B", "A", "C"]), "B");
+         dir.setExternalRelationHighlight(new Set([key("B"), key("A"), key("C")]), key("B"));
          expect(activeFlags(host, ".inetsoft-relation")).toEqual([true, true, true]);
          expect(activeFlags(host, ".inetsoft-relation-edge")).toEqual([true, true]);
          expect(activeFlags(host, ".inetsoft-relation-label")).toEqual([true, true]);
@@ -143,7 +149,7 @@ describe("ChartInlineSvgDirective cross-tile dim", () => {
             <div class="inetsoft-relation" data-id="X" data-row="0" data-col="0"></div>
             <div class="inetsoft-relation" data-id="Y" data-row="1" data-col="0"></div>`);
          (dir as any).svgRootEl = host;
-         dir.setExternalRelationHighlight(new Set(["A", "B"]), "A");
+         dir.setExternalRelationHighlight(new Set([key("A"), key("B")]), key("A"));
          expect(activeFlags(host, ".inetsoft-relation")).toEqual([false, false]);
          expect(host.classList.contains("inetsoft-dim-all")).toBe(true);
       });
@@ -156,7 +162,7 @@ describe("ChartInlineSvgDirective cross-tile dim", () => {
             <div class="inetsoft-relation" data-id="Q" data-row="0" data-col="0"></div>
             <div class="inetsoft-relation-edge" data-source="A" data-target="Z"></div>`);
          (dir as any).svgRootEl = host;
-         dir.setExternalRelationHighlight(new Set(["A", "Z"]), "A");
+         dir.setExternalRelationHighlight(new Set([key("A"), key("Z")]), key("A"));
          expect(host.querySelector(".inetsoft-relation")!.classList.contains("inetsoft-active")).toBe(false);
          expect(host.querySelector(".inetsoft-relation-edge")!.classList.contains("inetsoft-active")).toBe(true);
          expect(host.classList.contains("inetsoft-dim-all")).toBe(false);
@@ -165,12 +171,52 @@ describe("ChartInlineSvgDirective cross-tile dim", () => {
       it("clears all active classes and dim-all on null", () => {
          const { dir, host } = makeDirective(html);
          (dir as any).svgRootEl = host;
-         dir.setExternalRelationHighlight(new Set(["A", "B", "C"]), "B");
+         dir.setExternalRelationHighlight(new Set([key("A"), key("B"), key("C")]), key("B"));
          host.classList.add("inetsoft-dim-all");
          dir.setExternalRelationHighlight(null, null);
          expect(activeFlags(host, ".inetsoft-relation,.inetsoft-relation-edge,.inetsoft-relation-label")
             .some(Boolean)).toBe(false);
          expect(host.classList.contains("inetsoft-dim-all")).toBe(false);
+      });
+   });
+
+   describe("activateRelationNeighbors (facet panels)", () => {
+      // Redmine #75878: a relation chart builds one mxGraph per facet panel, so both panels stamp
+      // the same node ids ("R_id"/"N_id"). Hovering a node in the East panel must not light up the
+      // West panel's edge, which carries an identical data-source/data-target pair.
+      const html = `
+         <svg>
+            <g class="inetsoft-relation" data-id="R_id" data-panel="{Region=East}/{}" data-row="0" data-col="0"></g>
+            <g class="inetsoft-relation" data-id="N_id" data-panel="{Region=East}/{}" data-row="1" data-col="0"></g>
+            <g class="inetsoft-relation-edge" data-panel="{Region=East}/{}" data-source="R_id" data-target="N_id"></g>
+            <g class="inetsoft-relation" data-id="R_id" data-panel="{Region=West}/{}" data-row="2" data-col="0"></g>
+            <g class="inetsoft-relation" data-id="N_id" data-panel="{Region=West}/{}" data-row="3" data-col="0"></g>
+            <g class="inetsoft-relation-edge" data-panel="{Region=West}/{}" data-source="R_id" data-target="N_id"></g>
+         </svg>`;
+
+      function activeFlags(host: HTMLElement, sel: string): boolean[] {
+         return Array.from(host.querySelectorAll(sel)).map(e => e.classList.contains("inetsoft-active"));
+      }
+
+      it("activates only the hovered panel's edge and neighbour", () => {
+         const { dir, host } = makeDirective(html);
+         (dir as any).afterSvgInjected();
+         (dir as any).activateKeys(["0-0"]);
+         expect(activeFlags(host, ".inetsoft-relation")).toEqual([true, true, false, false]);
+         expect(activeFlags(host, ".inetsoft-relation-edge")).toEqual([true, false]);
+      });
+
+      it("still matches by id alone when no panel is stamped (unfaceted chart)", () => {
+         const { dir, host } = makeDirective(`
+            <svg>
+               <g class="inetsoft-relation" data-id="R_id" data-row="0" data-col="0"></g>
+               <g class="inetsoft-relation" data-id="N_id" data-row="1" data-col="0"></g>
+               <g class="inetsoft-relation-edge" data-source="R_id" data-target="N_id"></g>
+            </svg>`);
+         (dir as any).afterSvgInjected();
+         (dir as any).activateKeys(["0-0"]);
+         expect(activeFlags(host, ".inetsoft-relation")).toEqual([true, true]);
+         expect(activeFlags(host, ".inetsoft-relation-edge")).toEqual([true]);
       });
    });
 

--- a/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.ts
@@ -54,7 +54,8 @@ export class ChartInlineSvgDirective implements OnDestroy {
    /** Emits the data-color of the hovered area/line series (null on clear) so the parent can
     *  mirror the dim across sibling tiles of a split chart. Only emitted in cross-tile mode. */
    @Output() seriesDimChange = new EventEmitter<string | null>();
-   /** Emits the data-id of the hovered relation/tree node (null on clear). The parent resolves
+   /** Emits the panel-qualified key (see relationKey) of the hovered relation/tree node (null on
+    *  clear). The parent resolves
     *  neighbours from the merged cross-tile graph and drives every tile, since a node's neighbours
     *  may be rendered in sibling tiles this tile's connectivity maps can't see. Cross-tile only. */
    @Output() relationHover = new EventEmitter<string | null>();
@@ -100,9 +101,10 @@ export class ChartInlineSvgDirective implements OnDestroy {
    private retryHandle: ReturnType<typeof setTimeout> | null = null;
    /** Timer handle for adding .ready class to the SVG after animation completes. */
    private readyHandle: ReturnType<typeof setTimeout> | null = null;
-   /** Maps mxCell id → node Element for relation/tree charts. */
+   /** Maps panel-qualified node key → node Element for relation/tree charts (see relationKey). */
    private relationNodeIdMap = new Map<string, Element>();
-   /** Edge connectivity for relation/tree charts: each entry holds the element plus its source/target mxCell IDs. */
+   /** Edge connectivity for relation/tree charts: each entry holds the element plus its
+    *  panel-qualified source/target node keys (see relationKey). */
    private relationEdges: Array<{el: Element, sourceId: string, targetId: string}> = [];
    /** Elements activated as neighbors of the current relation node (cleared on deactivation). */
    private activeRelationNeighbors: Element[] = [];
@@ -420,7 +422,7 @@ export class ChartInlineSvgDirective implements OnDestroy {
             // neighbours from the merged graph and drive every tile via setExternalRelationHighlight.
             // (Relation hover is always single-key, so returning here is safe.)
             if(this.isRelationChart && this.crossTile) {
-               this.emitRelationHover(el.getAttribute("data-id"));
+               this.emitRelationHover(ChartInlineSvgDirective.relationKey(el, "data-id"));
                return;
             }
             el.classList.add("inetsoft-active");
@@ -509,12 +511,25 @@ export class ChartInlineSvgDirective implements OnDestroy {
       this.activeTreemapDescendants = [];
    }
 
+   /**
+    * Panel-qualified relation node key — a JSON-encoded [panel, id] pair, so no panel/id value can
+    * be confused with another pair through separator ambiguity. A relation/tree chart builds one
+    * mxGraph per facet panel, so the stamped mxCell ids (data-id on nodes, data-source/data-target
+    * on edges) repeat across panels — matching on the id alone lights up the sibling panel's edges
+    * too (#75878). data-panel is only stamped on faceted charts; the empty prefix on a single-panel
+    * chart keeps the key equivalent to the bare id. Returns null when the id attribute is absent.
+    */
+   private static relationKey(el: Element, idAttr: string): string | null {
+      const id = el.getAttribute(idAttr);
+      return id ? JSON.stringify([el.getAttribute("data-panel") ?? "", id]) : null;
+   }
+
    // Activates neighbor nodes, their connecting edges, and neighbor labels.
    // The hovered node's own label is activated separately by activateKeys() via labelGroupMap,
    // and cleared by deactivateCurrent(). Neighbor labels pushed into activeRelationNeighbors
    // are cleared by the activeRelationNeighbors loop in deactivateCurrent().
    private activateRelationNeighbors(nodeEl: Element): void {
-      const nodeId = nodeEl.getAttribute("data-id");
+      const nodeId = ChartInlineSvgDirective.relationKey(nodeEl, "data-id");
       if(!nodeId) return;
       this.activeRelationNeighbors = [];
 
@@ -790,14 +805,15 @@ export class ChartInlineSvgDirective implements OnDestroy {
          this.element.nativeElement.querySelectorAll(".inetsoft-relation") as NodeListOf<Element>);
       this.isRelationChart = relationNodes.length > 0;
       for(const n of relationNodes) {
-         const nodeId = n.getAttribute("data-id");
-         if(nodeId) this.relationNodeIdMap.set(nodeId, n);
+         const nodeKey = ChartInlineSvgDirective.relationKey(n, "data-id");
+         if(nodeKey) this.relationNodeIdMap.set(nodeKey, n);
       }
       const relationEdgeEls = Array.from(
          this.element.nativeElement.querySelectorAll(".inetsoft-relation-edge") as NodeListOf<Element>);
       for(const e of relationEdgeEls) {
-         const src = e.getAttribute("data-source");
-         const tgt = e.getAttribute("data-target");
+         // An edge never spans panels, so both endpoints take the edge's own panel key.
+         const src = ChartInlineSvgDirective.relationKey(e, "data-source");
+         const tgt = ChartInlineSvgDirective.relationKey(e, "data-target");
          if(src && tgt) this.relationEdges.push({el: e, sourceId: src, targetId: tgt});
       }
 
@@ -1374,16 +1390,17 @@ export class ChartInlineSvgDirective implements OnDestroy {
       }
    }
 
-   /** This tile's relation edges as source/target id pairs, for the parent to merge into the
-    *  cross-tile connectivity graph. */
+   /** This tile's relation edges as source/target key pairs (panel-qualified, see relationKey),
+    *  for the parent to merge into the cross-tile connectivity graph. */
    getRelationEdges(): { source: string, target: string }[] {
       return this.relationEdges.map(e => ({ source: e.sourceId, target: e.targetId }));
    }
 
    /**
     * Highlight this tile's share of a relation hover, driven by the parent so neighbours render
-    * correctly across a split chart's SVGs. Nodes whose data-id is in activeIds (the hovered node
-    * plus its neighbours) and edges incident to hoveredId get inetsoft-active; their labels too.
+    * correctly across a split chart's SVGs. Nodes whose panel-qualified key is in activeIds (the
+    * hovered node plus its neighbours) and edges incident to hoveredId get inetsoft-active; their
+    * labels too.
     * A tile with at least one active element relies on the server :has() rule to dim the rest; a
     * tile with none gets inetsoft-dim-all so it dims fully. Pass null to clear.
     */
@@ -1405,7 +1422,7 @@ export class ChartInlineSvgDirective implements OnDestroy {
       const activeRowCols = new Set<string>();
 
       for(const node of nodes) {
-         const id = node.getAttribute("data-id");
+         const id = ChartInlineSvgDirective.relationKey(node, "data-id");
          if(id != null && activeIds.has(id)) {
             node.classList.add("inetsoft-active");
             anyActive = true;
@@ -1418,7 +1435,8 @@ export class ChartInlineSvgDirective implements OnDestroy {
       }
 
       for(const edge of edges) {
-         const s = edge.getAttribute("data-source"), t = edge.getAttribute("data-target");
+         const s = ChartInlineSvgDirective.relationKey(edge, "data-source");
+         const t = ChartInlineSvgDirective.relationKey(edge, "data-target");
          if(hoveredId != null && (s === hoveredId || t === hoveredId)) {
             edge.classList.add("inetsoft-active");
             anyActive = true;


### PR DESCRIPTION
Root Cause:

A relation/network chart builds a separate mxGraph for every facet panel — GGraph.initGeometries() calls RelationElement.createGeometry() once per panel with that panel's sub-DataSet, and each call starts with "new mxGraph()". Node ids come from the node's value alone (RelationElement.getId returns the formatted value + "_id"), so they carry no facet qualifier and the same id string is emitted in every panel. Those ids are stamped into the SVG as data-id on nodes and data-source/data-target on edges.

The hover handler collected every relation edge in the SVG and matched them against the hovered node by bare id, so the sibling panel's edge — which carries an identical source/target pair — matched too and stayed highlighted while the rest of that panel dimmed. The nodes appeared to behave because the node lookup map was keyed by id and silently kept only one element per duplicate id; only the edges had no such deduplication, which is why the links stayed lit while the points dimmed.

The same id collision affected the entrance animation: the animation injector's delay map is keyed by bare id, so it retained only the last panel's entry and every panel's edges faded in with the last panel's nodes, making an edge arrive after the node it connects.

Fix:

Give each facet panel an identity and require it to match.

Backend
- New SVGSupport.ATTR_PANEL, emitted as a data-panel attribute.
- New GTool.getFacetPanelId(Coordinate): builds a key from the coordinate's facet parent values, and returns null when there are none, so a non-faceted chart emits no attribute and its DOM is unchanged.
- RelationVO and RelationEdgeVO stamp the key on their annotation groups. Each facet panel has its own coordinate instance, and VGraph.createVisuals passes that same instance to every geometry in the panel, so a panel's nodes and edges always agree on the key.

Frontend
- New relationKey(el, idAttr) helper in ChartInlineSvgDirective producing a panel-qualified node key. It is used everywhere relation identity is compared: the node map, the edge source/target entries, activateRelationNeighbors, the cross-tile hover emit, getRelationEdges and setExternalRelationHighlight. The matching logic itself is unchanged; only the key is wider. An edge never spans panels, so both of its endpoints resolve against the edge's own panel.

Entrance animation
- The node index map, the delay map, the edge delay lookup and the topological depth walk in SVGAnimationDOMInjector are panel-qualified the same way, so each panel now cascades root to leaf on its own topology and each edge fades with its own panel's target node. The "null" root sentinel check still reads the raw data-source, so root detection is unaffected.
- Per-depth stagger counters remain global, so the panels ripple one intra-level spread apart rather than firing in lockstep. Total entrance duration is unchanged, because the intra-level spread is normalised by the node count at that depth.

Tests
- Hover: two panels sharing node ids — hovering a node in one panel activates only that panel's edge and neighbour; a chart with no data-panel still matches by id alone.
- Animation: a two-panel facet pinning the exact per-panel delays and asserting each edge follows its own panel's target node.