### PR TITLE
75876, pie slice hover issue during edit

### DIFF
--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
@@ -79,6 +79,14 @@ public class SVGAnimationDOMInjector {
       // class, which the radar hover rules never match), so this is a pre-existing design-time
       // limitation, not a regression introduced by the #75642 overlap fix.
       if(animHint.contains(":" + SVGSupport.ANIMATION_FLAG_NOANIM)) {
+         // The donut center-hole overlay is an inetsoft-bar group just like a slice, so the bar
+         // hover-dim rule fades it to HOVER_DIM_OPACITY and the full pie underneath shows through
+         // the middle. Reclassifying it (normally done by injectPieAnimation) is a hover concern,
+         // not an animation one, so it must run on design-time surfaces too.
+         if(SVGSupport.ANIMATION_PIE.equals(base)) {
+            preprocessDonutHoles(svgRoot);
+         }
+
          return;
       }
 

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
@@ -367,6 +367,31 @@ class SVGAnimationDOMInjectorTest {
                   "noanim hint must leave data-animated unset");
    }
 
+   /**
+    * A "pie:noanim" hint (donut in the binding/wizard pane) must still reclassify the center-hole
+    * overlay. The overlay is an inetsoft-bar group like any slice, so without the reclassification
+    * the bar hover-dim rule fades it out and the full pie underneath shows through the middle
+    * (bug #75876). No entrance animation may be injected.
+    */
+   @Test
+   void noAnimHintReclassifiesDonutHole() throws Exception {
+      Document doc = newDocument();
+      addPieSlice(doc, 180, 100, 80, 0, 1, 100, 180, 100, 100);
+      Element hole = addHoleOverlay(doc, 100, 100, 30);
+
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(),
+         SVGSupport.ANIMATION_PIE + ":" + SVGSupport.ANIMATION_FLAG_NOANIM);
+
+      assertEquals(SVGSupport.ANNOTATION_DONUT_HOLE, hole.getAttribute("class"),
+                   "noanim hint must still reclassify the donut center-hole overlay");
+      assertTrue(hole.getAttribute("style").contains("opacity:1!important"),
+                 "the donut hole must be pinned opaque so hover dim cannot fade it");
+      assertFalse(allStyleContent(doc.getDocumentElement()).contains("@keyframes"),
+                  "noanim hint must not inject any animation @keyframes");
+      assertFalse(doc.getDocumentElement().hasAttribute("data-animated"),
+                  "noanim hint must leave data-animated unset");
+   }
+
    // -------------------------------------------------------------------------
    // Treemap animation tests
    // -------------------------------------------------------------------------


### PR DESCRIPTION
Root Cause:
A donut chart is rendered as a full pie plus a background-colored center-hole overlay painted on top (the smaller pie measure that also carries the CENTER_FILL total label). That overlay is a BarVO, so it lands in the SVG as a <g class="inetsoft-bar"> group — indistinguishable, class-wise, from a slice.

The server-injected hover-dim rule
svg:has(.inetsoft-bar.inetsoft-active) .inetsoft-bar:not(.inetsoft-active){opacity:0.20!important} therefore dimmed the hole overlay itself on hover, letting the full pie underneath show through the middle.

In the viewer this is prevented by SVGAnimationDOMInjector.preprocessDonutHoles(), which reclassifies the overlay group to "inetsoft-bar-hole" and pins opacity:1!important on it. That method is only reached through injectPieAnimation(). Design-time surfaces (chart edit/binding pane and the VS wizard) receive the hint "pie:noanim" from VGraphPair, and injectAnimation() returns early on the noanim flag after injecting the hover CSS but before reaching injectPieAnimation() — so on those surfaces the hover dim was active while the hole protection was not.

Fix:
SVGAnimationDOMInjector.injectAnimation() now calls preprocessDonutHoles(svgRoot) in the noanim early-return branch when the base hint is "pie", so the center-hole overlay is reclassified and pinned opaque on design-time surfaces exactly as it already is in the viewer. The call is scoped to pie hints, and preprocessDonutHoles only touches a group whose sole shape descendant is a <circle> (no <path>/<rect>), so a flat non-donut pie and every other chart type are unaffected. Added regression test SVGAnimationDOMInjectorTest#noAnimHintReclassifiesDonutHole.