### PR TITLE
Bug #76064, resolve the login page theme against the requested organization

### DIFF
--- a/core/src/main/java/inetsoft/web/GlobalStyleController.java
+++ b/core/src/main/java/inetsoft/web/GlobalStyleController.java
@@ -22,6 +22,7 @@ import inetsoft.sree.SreeEnv;
 import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.portal.*;
 import inetsoft.sree.security.*;
+import inetsoft.util.ThreadContext;
 import inetsoft.util.Tool;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -73,7 +74,7 @@ public class GlobalStyleController implements ApplicationContextAware {
          }
       }
 
-      StyleResource resource = getResource(path, user);
+      StyleResource resource = getResource(path, user, getRequestOrgID(request));
 
       // use max-age caching for static resources to minimize the number of requests to load the
       // application
@@ -99,6 +100,46 @@ public class GlobalStyleController implements ApplicationContextAware {
    @Override
    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
       this.context = applicationContext;
+   }
+
+   /**
+    * Resolves the organization that an unauthenticated request belongs to. The login page and the
+    * style sheets it pulls in are served without a principal, so OrganizationManager falls back to
+    * the default organization and a tenant's login page ends up styled with the host organization's
+    * theme. The organization the browser actually asked for is encoded in the request (sub-domain
+    * or path, depending on security.login.orgLocation), which is how the login flow reads it too.
+    *
+    * @return the organization to resolve the theme against, or {@code null} to leave the current
+    *         organization alone (authenticated request, single tenant, or unknown organization).
+    */
+   private String getRequestOrgID(HttpServletRequest request) {
+      if(!SUtil.isMultiTenant() || ThreadContext.getContextPrincipal() != null ||
+         OrganizationContextHolder.getCurrentOrgId() != null)
+      {
+         return null;
+      }
+
+      // returns null unless the host/path names an existing organization
+      return SUtil.getLoginOrganization(request);
+   }
+
+   private StyleResource getResource(String path, Principal user, String requestOrgID)
+      throws IOException
+   {
+      if(requestOrgID == null) {
+         return getResource(path, user);
+      }
+
+      // make the organization named by the request current for the duration of the lookup so that
+      // the theme, the organization record and the resource cache all agree on it
+      OrganizationContextHolder.setCurrentOrgId(requestOrgID);
+
+      try {
+         return getResource(path, user);
+      }
+      finally {
+         OrganizationContextHolder.clear();
+      }
    }
 
    private synchronized StyleResource getResource(String path, Principal user) throws IOException {

--- a/core/src/main/java/inetsoft/web/portal/controller/LoginController.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/LoginController.java
@@ -24,6 +24,7 @@ import inetsoft.sree.SreeEnv;
 import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.portal.*;
 import inetsoft.sree.security.*;
+import inetsoft.util.ThreadContext;
 import inetsoft.util.Tool;
 import inetsoft.web.portal.model.LocaleModel;
 import inetsoft.web.portal.model.LoginBannerModel;
@@ -90,9 +91,7 @@ public class LoginController {
       // this page, but the subsequent requests will be unauthenticated, so if the current user has
       // a theme assigned, it will end up trying to load theme-variables.css from the "default"
       // theme, which doesn't exist. To avoid this, just check if the global theme is custom.
-      boolean isCustomTheme = !Tool.isEmptyString(customThemesManager.getSelectedTheme()) &&
-                              !"default".equals(customThemesManager.getSelectedTheme());
-      model.addObject("customTheme", isCustomTheme);
+      model.addObject("customTheme", isCustomTheme(request));
 
       if(welcomePage != null) {
          LoginBannerModel loginBanner = new LoginBannerModel();
@@ -180,6 +179,39 @@ public class LoginController {
       String recordedOrgName = recordedOrgID == null ? null : securityEngine.getSecurityProvider().getOrgNameFromID(recordedOrgID);
 
       return recordedOrgName == null  || Tool.equals(recordedOrgName, Organization.getDefaultOrganizationName());
+   }
+
+   /**
+    * Checks whether a custom theme applies to the organization this login page is being served
+    * for, which controls whether theme-variables.css is linked. The request is unauthenticated, so
+    * without pinning the organization named by the request the flag would be resolved against the
+    * default organization instead.
+    *
+    * Resolves the <i>organization</i> under the same conditions GlobalStyleController applies when
+    * it serves the style sheet, so both agree on whose theme is being asked for. They can still
+    * pick different themes within that organization: this only consults the selected-theme pointer
+    * chain (see the Bug #53246 note at the call site), while GlobalStyleController prefers
+    * Organization.theme when it names an existing theme. That predates this method and is why
+    * GlobalStyleController falls back to the "default" theme for an unknown id.
+    */
+   private boolean isCustomTheme(HttpServletRequest request) {
+      String orgID = SUtil.isMultiTenant() ? SUtil.getLoginOrganization(request) : null;
+      boolean pinned = orgID != null && ThreadContext.getContextPrincipal() == null &&
+         OrganizationContextHolder.getCurrentOrgId() == null;
+
+      if(pinned) {
+         OrganizationContextHolder.setCurrentOrgId(orgID);
+      }
+
+      try {
+         String theme = customThemesManager.getSelectedTheme();
+         return !Tool.isEmptyString(theme) && !"default".equals(theme);
+      }
+      finally {
+         if(pinned) {
+            OrganizationContextHolder.clear();
+         }
+      }
    }
 
    private String getRecordedOrgId(HttpServletRequest request) {

--- a/core/src/test/java/inetsoft/web/GlobalStyleControllerTest.java
+++ b/core/src/test/java/inetsoft/web/GlobalStyleControllerTest.java
@@ -1,0 +1,195 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web;
+
+/*
+ * Test strategy
+ *
+ * Class type: behavioral — resolves which theme a style sheet request is served from.
+ *
+ * The login page and the style sheets it pulls in are requested without a principal, so
+ * OrganizationManager falls back to the default organization. A tenant reaching its own login page
+ * (organization0.localhost/...) would then be styled with the host organization's theme; only the
+ * organization named by the request itself identifies the right theme before login.
+ *
+ * --- getStyle() organization resolution ---
+ *
+ *  ├─ [A] unauthenticated + request names an organization → that org's theme is served
+ *  ├─ [B] unauthenticated + request names no organization → current (default) org's theme
+ *  ├─ [C] authenticated                                   → current org's theme, request ignored
+ *  └─ [D] any of the above                                → org context is left clean afterwards
+ */
+
+import inetsoft.sree.internal.SUtil;
+import inetsoft.sree.portal.CustomTheme;
+import inetsoft.sree.portal.CustomThemesManager;
+import inetsoft.sree.security.*;
+import inetsoft.uql.XPrincipal;
+import inetsoft.util.ThreadContext;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.io.Resource;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.io.ByteArrayInputStream;
+import java.security.Principal;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class GlobalStyleControllerTest {
+   @Mock private SecurityEngine securityEngine;
+   @Mock private SecurityProvider securityProvider;
+   @Mock private CustomThemesManager customThemesManager;
+   @Mock private OrganizationManager organizationManager;
+   @Mock private ApplicationContext context;
+   @Mock private Resource resource;
+
+   private MockedStatic<SUtil> sUtilStatic;
+   private MockedStatic<OrganizationManager> organizationManagerStatic;
+   private MockedStatic<ThreadContext> threadContextStatic;
+   private GlobalStyleController controller;
+
+   private static final String CSS_PATH = "/app/theme-variables.css";
+   private static final String HOST_ORG = "host-org";
+   private static final String TENANT_ORG = "organization0";
+   private static final String HOST_ORG_THEME = "def2";
+   private static final String TENANT_ORG_THEME = "test2";
+
+   @BeforeEach
+   void setUp() throws Exception {
+      sUtilStatic = mockStatic(SUtil.class);
+      threadContextStatic = mockStatic(ThreadContext.class);
+      organizationManagerStatic = mockStatic(OrganizationManager.class);
+      organizationManagerStatic.when(OrganizationManager::getInstance).thenReturn(organizationManager);
+      // mirrors the real implementation: the principal's org, else the org pinned on the thread,
+      // else the default organization
+      lenient().when(organizationManager.getCurrentOrgID()).thenAnswer(invocation -> {
+         String pinned = OrganizationContextHolder.getCurrentOrgId();
+         return pinned != null ? pinned : HOST_ORG;
+      });
+
+      sUtilStatic.when(SUtil::isMultiTenant).thenReturn(true);
+      lenient().when(securityEngine.getSecurityProvider()).thenReturn(securityProvider);
+      Organization hostOrg = organization(HOST_ORG_THEME);
+      Organization tenantOrg = organization(TENANT_ORG_THEME);
+      lenient().when(securityProvider.getOrganization(HOST_ORG)).thenReturn(hostOrg);
+      lenient().when(securityProvider.getOrganization(TENANT_ORG)).thenReturn(tenantOrg);
+      lenient().when(customThemesManager.getCustomThemes())
+         .thenReturn(Set.of(theme(HOST_ORG_THEME), theme(TENANT_ORG_THEME)));
+
+      lenient().when(resource.lastModified()).thenReturn(1L);
+      lenient().when(resource.getFilename()).thenReturn("theme-variables.css");
+      lenient().when(resource.getInputStream())
+         .thenAnswer(invocation -> new ByteArrayInputStream(new byte[] { 'x' }));
+      lenient().when(context.getResource(anyString())).thenReturn(resource);
+
+      controller = new GlobalStyleController(securityEngine, customThemesManager);
+      controller.setApplicationContext(context);
+   }
+
+   @AfterEach
+   void tearDown() {
+      if(sUtilStatic != null) { sUtilStatic.close(); }
+      if(organizationManagerStatic != null) { organizationManagerStatic.close(); }
+      if(threadContextStatic != null) { threadContextStatic.close(); }
+      OrganizationContextHolder.clear();
+   }
+
+   // [Path A] pre-login request for a tenant: the org in the request URL decides the theme, not the
+   // default org that OrganizationManager falls back to when there is no principal
+   @Test
+   void getStyle_unauthenticatedTenantRequest_servesRequestOrgTheme() throws Exception {
+      threadContextStatic.when(ThreadContext::getContextPrincipal).thenReturn(null);
+      sUtilStatic.when(() -> SUtil.getLoginOrganization(any())).thenReturn(TENANT_ORG);
+
+      getStyle(null);
+
+      assertEquals("theme:" + TENANT_ORG_THEME + "/inetsoft/web/resources" + CSS_PATH,
+                   capturedLocation());
+   }
+
+   // [Path B] the host/path names no organization -> current (default) organization is kept
+   @Test
+   void getStyle_unauthenticatedRequestWithoutOrg_servesDefaultOrgTheme() throws Exception {
+      threadContextStatic.when(ThreadContext::getContextPrincipal).thenReturn(null);
+      sUtilStatic.when(() -> SUtil.getLoginOrganization(any())).thenReturn(null);
+
+      getStyle(null);
+
+      assertEquals("theme:" + HOST_ORG_THEME + "/inetsoft/web/resources" + CSS_PATH,
+                   capturedLocation());
+   }
+
+   // [Path C] an authenticated user's organization always wins over the requested host
+   @Test
+   void getStyle_authenticatedRequest_ignoresRequestOrg() throws Exception {
+      threadContextStatic.when(ThreadContext::getContextPrincipal).thenReturn(mock(XPrincipal.class));
+      lenient().when(customThemesManager.getSelectedTheme(any())).thenReturn(HOST_ORG_THEME);
+
+      getStyle(mock(Principal.class));
+
+      assertEquals("theme:" + HOST_ORG_THEME + "/inetsoft/web/resources" + CSS_PATH,
+                   capturedLocation());
+      sUtilStatic.verify(() -> SUtil.getLoginOrganization(any()), never());
+   }
+
+   // [Path D] the pinned organization must not leak to the next request on this thread
+   @Test
+   void getStyle_unauthenticatedTenantRequest_clearsPinnedOrgContext() throws Exception {
+      threadContextStatic.when(ThreadContext::getContextPrincipal).thenReturn(null);
+      sUtilStatic.when(() -> SUtil.getLoginOrganization(any())).thenReturn(TENANT_ORG);
+
+      getStyle(null);
+
+      assertNull(OrganizationContextHolder.getCurrentOrgId());
+   }
+
+   private void getStyle(Principal user) throws Exception {
+      MockHttpServletRequest request = new MockHttpServletRequest("GET", CSS_PATH);
+      request.setServletPath(CSS_PATH);
+      controller.getStyle(request, new MockHttpServletResponse(), user);
+   }
+
+   private String capturedLocation() {
+      ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+      verify(context).getResource(captor.capture());
+      return captor.getValue();
+   }
+
+   private static Organization organization(String themeId) {
+      Organization org = mock(Organization.class);
+      lenient().when(org.getTheme()).thenReturn(themeId);
+      return org;
+   }
+
+   private static CustomTheme theme(String id) {
+      CustomTheme theme = new CustomTheme();
+      theme.setId(id);
+      theme.setName(id);
+      return theme;
+   }
+}


### PR DESCRIPTION
## Problem

A tenant reaching its own login page (`organization0.localhost/sree/login.html`) was styled with the **host organization's** theme. Because both themes shared a JAR the base colors looked correct, so the only visible symptom was the host theme's `--inet-text-color` override bleeding through as green text.

The login page and the style sheets it links (`app/global.css`, `app/theme-variables.css`) are requested **before authentication**, so there is no principal and `OrganizationManager.getCurrentOrgID()` falls back to `Organization.getDefaultOrganizationID()`. `GlobalStyleController.getResource()` then read `provider.getOrganization("host-org").getTheme()`. The organization in the URL was never consulted — `AbstractSecurityFilter.authenticateAnonymous()` only reads the `X-INETSOFT-ORGID` cookie and also defaults to the host org, so a first visit to a tenant URL has no org context at all.

## Fix

**`GlobalStyleController`**

- `getRequestOrgID(request)` returns the organization named by the request, or `null` to leave the current one alone. It bails out on single-tenant, on any request that has a principal, and when an org is already pinned on the thread, so the change is strictly additive. It delegates to `SUtil.getLoginOrganization()`, which reads the sub-domain or path per `security.login.orgLocation` and already returns `null` unless the value names a real organization.
- A `getResource(path, user, requestOrgID)` overload wraps the existing lookup in `OrganizationContextHolder.setCurrentOrgId(...)` with `clear()` in a `finally` (request threads are pooled). Pinning through the holder is the fallback `getCurrentOrgID(principal)` already consults, so one change makes the theme lookup, the `Organization` record lookup and the per-org resource cache key all agree — no signature churn through the resolution chain.

**`LoginController`**

- `isCustomTheme(request)` resolves the `customTheme` flag the same way. That flag controls whether `theme-variables.css` is linked at all, so if it resolved against a different organization than the controller serving the file, a tenant with a custom theme on a host org without one would never request its variables.

An authenticated user's own organization still wins in both places.

## Scope notes

The flag and the served style sheet now agree on the *organization*; they can still pick different themes within it, since the flag uses only the selected-theme pointer chain while `GlobalStyleController` prefers `Organization.theme` when it names an existing theme. That split predates this change and is why the resource loader falls back to the `"default"` theme for an unknown id.

`LoginController` also resolves `customLogo` from `getCurrentOrgID()` — the same pre-login defect for the login logo. Left out of scope here.

## Testing

New `GlobalStyleControllerTest` (4 tests) covers: request names an organization → that org's theme; request names none → default org; authenticated → request ignored; pinned context cleared afterwards. On unpatched code it fails with `expected: <theme:test2/...> but was: <theme:def2/...>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)