### PR TITLE
75875, box plot outliers not correctly dimming with rest of box plot areas

### DIFF
--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
@@ -3431,8 +3431,12 @@ public class SVGAnimationDOMInjector {
          // must dim the other's non-active elements — a same-class-only rule left the outliers at
          // full opacity while their boxes faded. The hovered box's OWN outliers (and an outlier's
          // own box) are kept undimmed by ChartInlineSvgDirective, which activates them via the
-         // shared data-group key. These selectors can only match in a document containing both
-         // classes, i.e. a box plot; a point-only chart has no .inetsoft-box to dim.
+         // shared data-group key. Correlating by class alone is safe: .inetsoft-point is generic
+         // (every PointVO gets it), but Box Plot is a merged graph type (GraphTypes.isMergedGraphType),
+         // so GraphTypes.supportsMultiStyles() excludes it and ChangeChartTypeProcessor.process()
+         // forces setMultiStyles(false) whenever it is selected — even per-measure. A box and a plain
+         // (non-outlier) point therefore never appear in the same graph, and a point-only chart has
+         // no .inetsoft-box to dim.
          "svg.ready:has(.inetsoft-box.inetsoft-active) .inetsoft-box:not(.inetsoft-active)," +
          "svg.ready:has(.inetsoft-box.inetsoft-active) .inetsoft-point:not(.inetsoft-active)," +
          "svg.ready:has(.inetsoft-point.inetsoft-active) .inetsoft-box:not(.inetsoft-active)" +

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
@@ -3426,8 +3426,16 @@ public class SVGAnimationDOMInjector {
          // Candlestick dimming.
          "svg.ready:has(.inetsoft-candle.inetsoft-active) .inetsoft-candle:not(.inetsoft-active)" +
          "{opacity:" + dim + "!important}" +
-         // Box-plot dimming.
-         "svg.ready:has(.inetsoft-box.inetsoft-active) .inetsoft-box:not(.inetsoft-active)" +
+         // Box-plot dimming. A box plot draws two kinds of annotation group over one BoxDataSet:
+         // the box/whisker glyph (.inetsoft-box) and the outlier markers (.inetsoft-point), so each
+         // must dim the other's non-active elements — a same-class-only rule left the outliers at
+         // full opacity while their boxes faded. The hovered box's OWN outliers (and an outlier's
+         // own box) are kept undimmed by ChartInlineSvgDirective, which activates them via the
+         // shared data-group key. These selectors can only match in a document containing both
+         // classes, i.e. a box plot; a point-only chart has no .inetsoft-box to dim.
+         "svg.ready:has(.inetsoft-box.inetsoft-active) .inetsoft-box:not(.inetsoft-active)," +
+         "svg.ready:has(.inetsoft-box.inetsoft-active) .inetsoft-point:not(.inetsoft-active)," +
+         "svg.ready:has(.inetsoft-point.inetsoft-active) .inetsoft-box:not(.inetsoft-active)" +
          "{opacity:" + dim + "!important}" +
          // Treemap + label dimming.
          "svg.ready:has(.inetsoft-treemap.inetsoft-active) .inetsoft-treemap:not(.inetsoft-active)," +

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
@@ -248,6 +248,16 @@ class SVGAnimationDOMInjectorTest {
          css.contains(".inetsoft-box.inetsoft-active") &&
          css.contains(".inetsoft-box:not(.inetsoft-active)"),
          "hover CSS must contain box :has() dim rule");
+      // A box plot's outlier markers are .inetsoft-point groups, so an active box must dim them
+      // too (and an active outlier must dim the boxes) or they stay at full opacity.
+      assertTrue(
+         css.contains("svg.ready:has(.inetsoft-box.inetsoft-active) " +
+                         ".inetsoft-point:not(.inetsoft-active)"),
+         "hover CSS must dim outlier points when a box is active");
+      assertTrue(
+         css.contains("svg.ready:has(.inetsoft-point.inetsoft-active) " +
+                         ".inetsoft-box:not(.inetsoft-active)"),
+         "hover CSS must dim boxes when an outlier point is active");
       // HOVER_DIM_OPACITY = 0.20 formatted as "%.2f" produces "0.20"
       String expectedOpacity = "opacity:" +
          String.format(java.util.Locale.US, "%.2f", AnimationConstants.HOVER_DIM_OPACITY) +

--- a/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.spec.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.spec.ts
@@ -231,6 +231,73 @@ describe("ChartInlineSvgDirective cross-tile dim", () => {
       });
    });
 
+   describe("activateBoxGroup (box plot box + its outlier markers)", () => {
+      // Two box groups, each a .inetsoft-box glyph plus outlier .inetsoft-point markers drawn over
+      // it. Box and outliers are separate BoxDataSet rows (distinct data-row) tied together only by
+      // the server-stamped data-group key.
+      const html = `
+         <svg>
+            <g class="inetsoft-box" data-row="0" data-col="0" data-group="AK"></g>
+            <g class="inetsoft-point" data-row="1" data-col="0" data-group="AK"></g>
+            <g class="inetsoft-point" data-row="2" data-col="0" data-group="AK"></g>
+            <g class="inetsoft-box" data-row="3" data-col="0" data-group="NY"></g>
+            <g class="inetsoft-point" data-row="4" data-col="0" data-group="NY"></g>
+         </svg>`;
+
+      function isActive(host: HTMLElement, sel: string): boolean {
+         return host.querySelector(sel)!.classList.contains("inetsoft-active");
+      }
+
+      it("activates the hovered box's own outlier points so they are not dimmed", () => {
+         const { dir, host } = makeDirective(html);
+         (dir as any).afterSvgInjected();
+         dir.highlightElement(0, 0);
+         expect(isActive(host, "[data-row='0']")).toBe(true);
+         expect(isActive(host, "[data-row='1']")).toBe(true);
+         expect(isActive(host, "[data-row='2']")).toBe(true);
+         // The other group stays dimmable.
+         expect(isActive(host, "[data-row='3']")).toBe(false);
+         expect(isActive(host, "[data-row='4']")).toBe(false);
+      });
+
+      it("activates the owning box when an outlier point is hovered", () => {
+         const { dir, host } = makeDirective(html);
+         (dir as any).afterSvgInjected();
+         dir.highlightElement(4, 0);
+         expect(isActive(host, "[data-row='4']")).toBe(true);
+         expect(isActive(host, "[data-row='3']")).toBe(true);
+         expect(isActive(host, "[data-row='0']")).toBe(false);
+      });
+
+      it("clears the group's active classes when the hover ends", () => {
+         vi.useFakeTimers();
+
+         try {
+            const { dir, host } = makeDirective(html);
+            (dir as any).afterSvgInjected();
+            dir.highlightElement(0, 0);
+            dir.highlightElements([]);
+            vi.advanceTimersByTime(ChartInlineSvgDirective["CLEAR_DELAY_MS"]);
+            expect(host.querySelectorAll(".inetsoft-active").length).toBe(0);
+         }
+         finally {
+            vi.useRealTimers();
+         }
+      });
+
+      it("is a no-op for annotation groups carrying no data-group", () => {
+         const { dir, host } = makeDirective(`
+            <svg>
+               <g class="inetsoft-point" data-row="0" data-col="0"></g>
+               <g class="inetsoft-point" data-row="1" data-col="0"></g>
+            </svg>`);
+         (dir as any).afterSvgInjected();
+         dir.highlightElement(0, 0);
+         expect(isActive(host, "[data-row='0']")).toBe(true);
+         expect(isActive(host, "[data-row='1']")).toBe(false);
+      });
+   });
+
    describe("milestone point label activation (gantt)", () => {
       // <svg> sets svgRootEl; two milestone markers + labels keyed by data-row/col.
       const html = `

--- a/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.ts
@@ -437,6 +437,8 @@ export class ChartInlineSvgDirective implements OnDestroy {
                this.activateTreemapDescendants(el);
             }
             else {
+               // Called for every remaining hovered VO (bar, candle, point, box, ...); it self-guards
+               // on the data-group attribute, which is only stamped for box plots.
                this.activateBoxGroup(el);
             }
          }

--- a/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.ts
@@ -111,6 +111,12 @@ export class ChartInlineSvgDirective implements OnDestroy {
    private treemapGroups: Element[] = [];
    /** Treemap descendant nodes + labels activated for the current hover (cleared on deactivation). */
    private activeTreemapDescendants: Element[] = [];
+   /** Box-plot annotation groups (boxes and outlier markers) that carry a data-group key, indexed by
+    *  that key. A box and the outlier points drawn over it share the key, so hovering either can
+    *  keep the whole group undimmed. Empty for every chart type other than a box plot. */
+   private boxGroupMap = new Map<string, Element[]>();
+   /** Box-plot group members activated alongside the hovered box/outlier (cleared on deactivation). */
+   private activeBoxGroupMembers: Element[] = [];
    /** Ordered list of hover series; one entry per (panel, series) pair. fillGroup is null on a pure
     *  line chart (no area fills); points is empty on an area chart, whose markers are not part of
     *  the cursor-band hover. */
@@ -430,6 +436,9 @@ export class ChartInlineSvgDirective implements OnDestroy {
             else if(el.classList.contains("inetsoft-treemap")) {
                this.activateTreemapDescendants(el);
             }
+            else {
+               this.activateBoxGroup(el);
+            }
          }
 
          const glyphs = this.labelGroupMap.get(key);
@@ -507,6 +516,11 @@ export class ChartInlineSvgDirective implements OnDestroy {
          n.classList.remove("inetsoft-active");
       }
       this.activeTreemapDescendants = [];
+
+      for(const n of this.activeBoxGroupMembers) {
+         n.classList.remove("inetsoft-active");
+      }
+      this.activeBoxGroupMembers = [];
    }
 
    // Activates neighbor nodes, their connecting edges, and neighbor labels.
@@ -588,6 +602,27 @@ export class ChartInlineSvgDirective implements OnDestroy {
                });
             }
          }
+      }
+   }
+
+   // Keep a hovered box plot's box/whisker glyph and its outlier markers undimmed together. They are
+   // separate annotation groups (.inetsoft-box / .inetsoft-point) over one BoxDataSet with different
+   // data-rows, so activateKeys only marks the one under the cursor and the server dim rules — which
+   // now correlate the two classes — would fade the hovered box's own outliers. Members are matched
+   // by the shared data-group key stamped server-side for box plots only, so this is a no-op for
+   // every other chart type. Cleared by deactivateCurrent() via the activeBoxGroupMembers array.
+   private activateBoxGroup(el: Element): void {
+      const group = el.getAttribute("data-group");
+      if(!group) return; // not a box-plot box or outlier
+
+      const members = this.boxGroupMap.get(group);
+      if(!members) return;
+
+      for(const member of members) {
+         if(member === el) continue; // already activated by activateKeys
+
+         member.classList.add("inetsoft-active");
+         this.activeBoxGroupMembers.push(member);
       }
    }
 
@@ -673,6 +708,8 @@ export class ChartInlineSvgDirective implements OnDestroy {
       this.activeRelationNeighbors = [];
       this.treemapGroups = [];
       this.activeTreemapDescendants = [];
+      this.boxGroupMap.clear();
+      this.activeBoxGroupMembers = [];
       this._activeKeys = [];
       this.svgRootEl = this.element.nativeElement.querySelector("svg");
 
@@ -806,6 +843,21 @@ export class ChartInlineSvgDirective implements OnDestroy {
       // groups that the server :has() dim rule would otherwise dim along with unrelated nodes).
       this.treemapGroups = Array.from(
          this.element.nativeElement.querySelectorAll(".inetsoft-treemap") as NodeListOf<Element>);
+
+      // Index box-plot groups by their shared data-group key so activateBoxGroup can keep a hovered
+      // box and its outlier markers undimmed together. data-group is stamped only on box-plot boxes
+      // and outlier points, so this map stays empty for every other chart type.
+      const boxGroupEls = Array.from(this.element.nativeElement
+         .querySelectorAll(".inetsoft-box[data-group],.inetsoft-point[data-group]") as NodeListOf<Element>);
+
+      for(const el of boxGroupEls) {
+         const group = el.getAttribute("data-group");
+         if(!group) continue;
+
+         const arr = this.boxGroupMap.get(group);
+         if(arr) arr.push(el);
+         else this.boxGroupMap.set(group, [el]);
+      }
 
       // Build label map from server-annotated label elements for all chart types that have
       // external text groups matched to data elements (bar, point/gantt-milestone, treemap/sunburst/icicle, mekko).


### PR DESCRIPTION
Root Cause:
A box plot draws two different kinds of annotation group over one BoxDataSet: the box/whisker glyph (.inetsoft-box, from SchemaVO/BoxPainter) and the outlier markers (.inetsoft-point, from PointVO). Hover dimming is done with server-injected CSS :has() rules, and the box-plot rule only correlated elements of the same class:

svg.ready:has(.inetsoft-box.inetsoft-active) .inetsoft-box:not(.inetsoft-active) So hovering a box dimmed the other boxes but never selected the outlier point groups, which stayed at full opacity.

Fix:
1. SVGAnimationDOMInjector.appendHoverCSS() now correlates the two classes in both directions: an active .inetsoft-box also dims non-active .inetsoft-point, and an active .inetsoft-point also dims non-active .inetsoft-box. These selectors can only match in a document that contains both classes, i.e. a box plot, so no other chart type is affected.
2. So that the hovered box's OWN outliers stay bright, ChartInlineSvgDirective now indexes box-plot annotation groups by the data-group key that a box and its outliers already share (added for the entrance animation in #75643) and activates the whole group on hover (activateBoxGroup), cleared on hover end like the existing treemap/relation activation. data-group is stamped only for box plots, so this is a no-op for every other chart type.

Result: hovering a box keeps that box and its own outlier points bright; every other box and every other box's outliers dim. Hovering an outlier does the same from the other side.

Tests: SVGAnimationDOMInjectorTest asserts both new selectors; four new cases in chart-inline-svg.directive.spec.ts cover group activation, the outlier->box direction, cleanup on hover end, and the no-data-group no-op.