### PR TITLE
Bug #76091, fix brushed chart drawing raw values instead of change-from-previous

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/graph/calc/ValueOfColumn.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/calc/ValueOfColumn.java
@@ -472,7 +472,7 @@ public class ValueOfColumn extends AbstractColumn {
          DataSet lookupData = data;
 
          if(lookupData instanceof DataSetFilter && (ndimIsPartDate || !ndim.equals(innerDim))) {
-            lookupData = ((DataSetFilter) lookupData).getRootDataSet();
+            lookupData = getLookupRoot(lookupData);
          }
 
          DataSet sub = getSubDataSet(lookupData, cond);
@@ -484,6 +484,31 @@ public class ValueOfColumn extends AbstractColumn {
 
          return sub.getData(field, (ctype == ValueOfCalc.PREVIOUS) ? rcnt - 1 : 0);
       }
+   }
+
+   /**
+    * Unwrap the filter chain toward the root so rows belonging to another facet can be found,
+    * but stop at the last dataset that still contains the measure column being looked up.
+    *
+    * In a brushed chart the all-data columns (__all__xxx) are created by BrushDataSet and do
+    * not exist on the datasets below it. Unwrapping all the way to the root would make
+    * sub.getData(field, ...) return null for every row, which silently turns a
+    * change-from-previous value into the raw aggregate value.
+    */
+   private DataSet getLookupRoot(DataSet data) {
+      DataSet lookup = data;
+
+      while(lookup instanceof DataSetFilter) {
+         DataSet base = ((DataSetFilter) lookup).getDataSet();
+
+         if(base == null || base.indexOfHeader(field) < 0) {
+            break;
+         }
+
+         lookup = base;
+      }
+
+      return lookup;
    }
 
    // Extract the base column name from a date function expression, e.g. "MonthOfYear(Date)" -> "Date".

--- a/core/src/test/java/inetsoft/report/composition/graph/calc/ChangeColumnTest.java
+++ b/core/src/test/java/inetsoft/report/composition/graph/calc/ChangeColumnTest.java
@@ -25,8 +25,10 @@ import inetsoft.report.filter.CrossFilter;
 import inetsoft.report.filter.CrossTabFilter;
 import inetsoft.report.lens.DefaultTableLens;
 import inetsoft.test.*;
+import inetsoft.uql.XConstants;
 import inetsoft.uql.viewsheet.VSDataRef;
 import inetsoft.uql.viewsheet.VSDimensionRef;
+import inetsoft.uql.viewsheet.XDimensionRef;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -142,6 +144,60 @@ public class ChangeColumnTest {
       Object result = changeColumn.calculate(mockContext, pairN);
 
       assertEquals(-13.0, result);
+   }
+
+   /**
+    * Regression test: change-from-previous on the all-data (__all__) column of a brushed
+    * chart must produce the change, not the raw aggregate.
+    *
+    * The __all__ columns exist only on the BrushDataSet. When the previous-value lookup
+    * unwrapped the filter chain past it (done for PART_DATE_GROUP inner dims so cross-facet
+    * rows can be reached), the lookup returned null for every row; a null previous value is
+    * treated as 0, so the change collapsed to the raw value and the all-data area of a
+    * brushed chart grew to span the full measure range.
+    */
+   @Test
+   void testChangePreviousOnBrushAllDataColumnReturnsChangeNotRawValue() {
+      DefaultTableLens atb = new DefaultTableLens(new Object[][]{
+         { "MonthOfYear(Date)", "id" },
+         { 1, 10 },
+         { 2, 20 },
+         { 3, 40 }
+      });
+      DefaultTableLens tb = new DefaultTableLens(new Object[][]{
+         { "MonthOfYear(Date)", "id" },
+         { 1, 5 },
+         { 2, 7 },
+         { 3, 9 }
+      });
+
+      VSDimensionRef monthVsRef = mock(VSDimensionRef.class);
+      when(monthVsRef.getFullName()).thenReturn("MonthOfYear(Date)");
+      VSDimensionRef monthVsRef2 = mock(VSDimensionRef.class);
+      when(monthVsRef2.getFullName()).thenReturn("MonthOfYear(Date)");
+
+      // rows 0-2 are the brushed rows (id), rows 3-5 the all-data rows (__all__id)
+      BrushDataSet brushDataSet = new BrushDataSet(
+         new VSDataSet(atb, new VSDataRef[] { monthVsRef }),
+         new VSDataSet(tb, new VSDataRef[] { monthVsRef2 }));
+
+      changeColumn = new ChangeColumn(BrushDataSet.ALL_HEADER_PREFIX + "id",
+                                      BrushDataSet.ALL_HEADER_PREFIX + "sum(id)");
+      changeColumn.setAsPercent(false);
+      changeColumn.setChangeType(ValueOfCalc.PREVIOUS);
+      changeColumn.setDim("MonthOfYear(Date)");
+      changeColumn.setInnerDim("MonthOfYear(Date)");
+
+      XDimensionRef monthDimRef = mock(XDimensionRef.class);
+      when(monthDimRef.getFullName()).thenReturn("MonthOfYear(Date)");
+      when(monthDimRef.getDateLevel()).thenReturn(XConstants.MONTH_OF_YEAR_DATE_GROUP);
+      changeColumn.setDimensions(List.of(monthDimRef));
+
+      // row 4 = all-data month 2: 20 - 10 = 10 (regression returned the raw 20)
+      assertEquals(10.0, changeColumn.calculate(brushDataSet, 4, false, false));
+
+      // row 5 = all-data month 3: 40 - 20 = 20 (regression returned the raw 40)
+      assertEquals(20.0, changeColumn.calculate(brushDataSet, 5, false, false));
    }
 
    private VSDataSet createVSDataSet(DefaultTableLens tableLens, String name) {

--- a/core/src/test/java/inetsoft/report/composition/graph/calc/ValueOfColumnTest.java
+++ b/core/src/test/java/inetsoft/report/composition/graph/calc/ValueOfColumnTest.java
@@ -323,6 +323,65 @@ public class ValueOfColumnTest {
    }
 
    /**
+    * Regression test: PREVIOUS on an all-data (__all__) column of a brushed chart must find
+    * the value on the BrushDataSet, which is the only dataset in the chain that owns the
+    * __all__ columns.
+    *
+    * When the inner dimension is a PART_DATE_GROUP (e.g. MonthOfYear), the sub-dataset lookup
+    * unwraps the filter chain so cross-facet rows can be reached. Unwrapping all the way to
+    * the root skips past the BrushDataSet, where __all__ columns are created, so the lookup
+    * returns null for every row. ChangeColumn then treats the missing previous value as 0 and
+    * plots the raw aggregate instead of the change — the all-data area of a brushed chart
+    * suddenly spans the full measure range.
+    */
+   @Test
+   void testPreviousOnBrushAllDataColumnFindsValueOnBrushDataSet() {
+      // all data (not brushed)
+      DefaultTableLens atb = new DefaultTableLens(new Object[][]{
+         { "MonthOfYear(Date)", "id" },
+         { 1, 10 },
+         { 2, 20 },
+         { 3, 40 }
+      });
+      // brushed subset — same months, smaller values
+      DefaultTableLens tb = new DefaultTableLens(new Object[][]{
+         { "MonthOfYear(Date)", "id" },
+         { 1, 5 },
+         { 2, 7 },
+         { 3, 9 }
+      });
+
+      VSDimensionRef monthVsRef = mock(VSDimensionRef.class);
+      when(monthVsRef.getFullName()).thenReturn("MonthOfYear(Date)");
+      VSDimensionRef monthVsRef2 = mock(VSDimensionRef.class);
+      when(monthVsRef2.getFullName()).thenReturn("MonthOfYear(Date)");
+      VSDataSet adata = new VSDataSet(atb, new VSDataRef[] { monthVsRef });
+      VSDataSet data = new VSDataSet(tb, new VSDataRef[] { monthVsRef2 });
+
+      // rows 0-2 are the brushed rows (id), rows 3-5 the all-data rows (__all__id)
+      BrushDataSet brushDataSet = new BrushDataSet(adata, data);
+
+      valueOfColumn = new ValueOfColumn(BrushDataSet.ALL_HEADER_PREFIX + "id",
+                                        BrushDataSet.ALL_HEADER_PREFIX + "sum(id)");
+      valueOfColumn.setChangeType(ValueOfCalc.PREVIOUS);
+      valueOfColumn.setDim("MonthOfYear(Date)");
+      valueOfColumn.setInnerDim("MonthOfYear(Date)");
+
+      // MonthOfYear is a PART_DATE_GROUP dim, which triggers the root-dataset unwrap
+      XDimensionRef monthDimRef = mock(XDimensionRef.class);
+      when(monthDimRef.getFullName()).thenReturn("MonthOfYear(Date)");
+      when(monthDimRef.getDateLevel()).thenReturn(XConstants.MONTH_OF_YEAR_DATE_GROUP);
+      valueOfColumn.setDimensions(List.of(monthDimRef));
+
+      // Row 4 = all-data month 2. Previous month is 1, whose all-data value is 10.
+      // Regression: unwrapping past the BrushDataSet loses __all__id and returns null.
+      assertEquals(10, valueOfColumn.calculate(brushDataSet, 4, false, false));
+
+      // Row 3 = all-data month 1, the first month → no previous.
+      assertEquals(CalcColumn.INVALID, valueOfColumn.calculate(brushDataSet, 3, true, false));
+   }
+
+   /**
     * Regression test for Bug #75664 (ranking follow-up): PREVIOUS navigation on a
     * part-date-group dimension (e.g. HourOfDay) must use natural calendar order even when
     * the dimension has an explicit value-based sort comparator — as set by a Top-N/Bottom-N


### PR DESCRIPTION
## Issue

Import `stackvalue1.vso`, open it in the composer, and select "0" on chart1. The dimmed all-data area on the other charts jumps to span the full measure range instead of staying within the change-from-previous range.

## Root cause

`BrushDataSet` clones each calc column for the all-data element and rewrites its header/field to `__all__…`. Those columns exist **only on the `BrushDataSet`** — never on the datasets below it.

For a `PART_DATE_GROUP` inner dimension (the affected charts bind `MonthOfYear(Order:Date)` and `DayOfWeek(Order:Date)`), the previous-value lookup in `ValueOfColumn.getDataSetDynamicCalcValue()` unwrapped the filter chain with `getRootDataSet()` so cross-facet rows could be reached (added by #74367). That walk skips past the `BrushDataSet`, so `__all__Sum(...)` resolved to column index −1 and the lookup returned `null` for every row.

In `ChangeColumn.getValue()` a null previous value falls through to `cd = NULL` (0), so the result is `d − 0 = d` — the raw aggregate. Hence the all-data area suddenly spanning 0 → full measure range.

## Fix

Replace the `getRootDataSet()` call with `getLookupRoot()`, which unwraps toward the root but stops at the last dataset that still contains the measure column:

```java
if(base == null || base.indexOfHeader(field) < 0) {
   break;
}
```

For brushed all-data columns the walk halts on the `BrushDataSet`. Every other case reaches the same root as before, so the cross-facet behavior from #74367 / #74542 / #74582 is unchanged.

## Tests

- `ValueOfColumnTest#testPreviousOnBrushAllDataColumnFindsValueOnBrushDataSet` — the lookup on `__all__id` over a `MONTH_OF_YEAR_DATE_GROUP` inner dim returns the all-data previous value (10); the first month returns `INVALID`.
- `ChangeColumnTest#testChangePreviousOnBrushAllDataColumnReturnsChangeNotRawValue` — end-to-end symptom: change is 10 and 20, not the raw 20 and 40.

Both fail without the fix (`expected: <10> but was: <null>` and `expected: <10.0> but was: <20.0>`) and pass with it. All 63 tests in `inetsoft.report.composition.graph.calc` pass.

## Known adjacent limitation (not addressed)

For `NEXT` rather than `PREVIOUS`, the lookup takes index `0` of the matched subset, which in the brush row layout is a brow row where `__all__` columns are null. Fixing that requires brush-section awareness in the row selection — wider than this defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
