### PR TITLE
Fix Data Sources/Physical Model editor bugs found during manual testing

### DIFF
--- a/core/src/main/java/inetsoft/uql/erm/XPartition.java
+++ b/core/src/main/java/inetsoft/uql/erm/XPartition.java
@@ -1420,8 +1420,13 @@ public class XPartition implements Cloneable, Serializable, XMLSerializable, XML
    }
 
    /**
-    * Checks for any unjoined tables in the view. Returns the first pair of
-    * unjoined tables that are found.
+    * Checks for any unjoined tables in the view. Groups all tables into
+    * connected components and, if more than one exists, returns a
+    * representative of the largest (main) component paired with a
+    * representative of the smallest component. This ensures the reported
+    * table names always include an actual disconnected table, rather than
+    * an arbitrary table (which may itself belong to a minor component)
+    * used as a fixed comparison anchor.
     *
     * @return the names of the unjoined tables or <code>null</code> if no
     *         unjoined tables are found.
@@ -1430,22 +1435,46 @@ public class XPartition implements Cloneable, Serializable, XMLSerializable, XML
     */
    public String[] getUnjoinedTables() {
       Enumeration e = getTables();
-      String[] tables = new String[getTableCount()];
+      List<String> tableList = new ArrayList<>();
 
-      for(int i = 0; e.hasMoreElements(); i++) {
+      while(e.hasMoreElements()) {
          PartitionTable temp = (PartitionTable) e.nextElement();
-         tables[i] = temp.getName();
+         tableList.add(temp.getName());
       }
 
-      // check for missing joins
-      for(int i = 1; i < tables.length; i++) {
-         if(findJoinPath(tables[0], tables[i], null, new ArrayList<>(), false) == null)
-         {
-            return new String[] { tables[0], tables[i] };
+      if(tableList.size() < 2) {
+         return null;
+      }
+
+      List<List<String>> components = new ArrayList<>();
+
+      for(String table : tableList) {
+         List<String> matched = null;
+
+         for(List<String> component : components) {
+            if(findJoinPath(component.get(0), table, null, new ArrayList<>(), false) != null) {
+               matched = component;
+               break;
+            }
+         }
+
+         if(matched != null) {
+            matched.add(table);
+         }
+         else {
+            List<String> component = new ArrayList<>();
+            component.add(table);
+            components.add(component);
          }
       }
 
-      return null;
+      if(components.size() <= 1) {
+         return null;
+      }
+
+      components.sort((a, b) -> b.size() - a.size());
+
+      return new String[] { components.get(0).get(0), components.get(1).get(0) };
    }
 
    /**

--- a/core/src/main/resources/inetsoft/util/srinter.properties
+++ b/core/src/main/resources/inetsoft/util/srinter.properties
@@ -3869,6 +3869,7 @@ data.logicalmodel.confirmRemoveAllDrills=Are you sure you want to remove all aut
 data.logicalmodel.confirmRemoveDrill=Are you sure you want to remove the selected auto drill(s)?
 data.logicalmodel.confirmRemoveElements=Are you sure you want to remove selected elements?
 data.logicalmodel.confirmRemoveModel=Are you sure you want to remove this logical model\: {0}? This action cannot be reversed.
+data.logicalmodel.confirmRemoveParam=Are you sure you want to remove this parameter?
 data.logicalmodel.confirmRemoveParams=Are you sure you want to remove all Parameters?
 data.logicalmodel.drillCleanParameters=Clear Parameters
 data.logicalmodel.drillDeleteParameter=Delete Parameter

--- a/web/projects/em/src/app/settings/presentation/presentation-themes-view/theme-css-view/theme-css-view.component.ts
+++ b/web/projects/em/src/app/settings/presentation/presentation-themes-view/theme-css-view/theme-css-view.component.ts
@@ -117,6 +117,8 @@ export class ThemeCssViewComponent implements OnInit, OnDestroy, OnChanges {
       {name: "_#(js:em.presentation.lookAndFeel.css.heading.font)", heading: true},
       {name: "--inet-font-size-base"},
       {name: "--inet-font-family"},
+      {name: "--inet-feedback-font-size"},
+      {name: "--inet-badge-font-size"},
       {name: "--inet-text-color", color: true},
       {name: "--inet-text-strong-color", color: true},
       {name: "--inet-text-muted-color", color: true},
@@ -155,7 +157,10 @@ export class ThemeCssViewComponent implements OnInit, OnDestroy, OnChanges {
       {name: "--inet-hover-primary-bg-color", color: true},
       {name: "--inet-hover-secondary-bg-color", color: true},
       {name: "--inet-hover-text-color", color: true},
+      {name: "--inet-ui-neutral-color", color: true},
+      {name: "--inet-ui-neutral-border-color", color: true},
       {name: "--inet-ui-neutral-hover-bg-color", color: true},
+      {name: "--inet-ui-neutral-hover-color", color: true},
 
       // selected items
       {name: "_#(js:em.presentation.lookAndFeel.css.heading.selItems)", heading: true},

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/logical-model/attribute-editor/auto-drill-dialog/data-auto-drill-dialog.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/logical-model/attribute-editor/auto-drill-dialog/data-auto-drill-dialog.component.ts
@@ -594,7 +594,16 @@ export class AutoDrillDialog implements OnInit, AfterViewInit {
     * @param index
     */
    removeParameter(index: number): void {
-      this.editDrill.params.splice(index, 1);
+      const title: string = "_#(js:data.logicalmodel.drillDeleteParameter)";
+      const message: string = "_#(js:data.logicalmodel.confirmRemoveParam)";
+
+      ComponentTool.showConfirmDialog(this.modalService, title, message)
+         .then((result: string) => {
+            if(result == "ok") {
+               this.editDrill.params.splice(index, 1);
+            }
+         },
+         () => {});
    }
 
    /**

--- a/web/projects/portal/src/app/portal/data/data-navigation-tree/data-sources-tree-view.component.ts
+++ b/web/projects/portal/src/app/portal/data/data-navigation-tree/data-sources-tree-view.component.ts
@@ -1875,8 +1875,13 @@ export class DataSourcesTreeViewComponent extends CommandProcessor implements On
                parentPath = this.getParentPath0(node.data.path);
             }
 
+            // the top-level "Data Model" node's scope is assigned by the server and can
+            // differ from the hardcoded GLOBAL_SCOPE used for its data model folder/model
+            // tree nodes, so don't gate this lookup on scope equality when targeting it.
+            const isDataModelParent = parentPath != null && parentPath.endsWith("/Data Model");
             let parentNode = GuiTool.findNode(root, (n) =>
-               !!n.data && n.data.path === parentPath && n.data.scope === node.data.scope);
+               !!n.data && n.data.path === parentPath &&
+               (isDataModelParent || n.data.scope === node.data.scope));
             selectedNode = !!parentNode ? parentNode : root;
 
             if(selectedNode?.type === PortalDataType.DATA_MODEL ||

--- a/web/projects/portal/src/app/widget/dialog/script-pane/script-pane.component.ts
+++ b/web/projects/portal/src/app/widget/dialog/script-pane/script-pane.component.ts
@@ -50,6 +50,7 @@ import { VirtualScrollTreeComponent } from "../../tree/virtual-scroll-tree/virtu
 
 
 const LINT_MARKERS = "CodeMirror-lint-markers";
+const DUPLICATE_CLICK_THRESHOLD = 500;
 
 @Component({
     selector: "script-pane",
@@ -96,6 +97,8 @@ export class ScriptPane implements AfterViewInit, AfterViewChecked, OnInit, OnDe
    private _operatorTreeRoot: TreeNodeModel;
    private _analysisResults: AnalysisResult[] = [];
    private cursorTop: boolean = false;
+   private lastClickedNode: TreeNodeModel = null;
+   private lastClickedTime: number = 0;
    @Input() showHelp: boolean = true;
    helpURL = "";
    needUseVirtualScroll: boolean = true;
@@ -611,6 +614,21 @@ export class ScriptPane implements AfterViewInit, AfterViewChecked, OnInit, OnDe
    }
 
    itemClicked(node: TreeNodeModel, target: string): void {
+      // tree selection fires on mousedown, so a double-click (two mousedowns) on the
+      // same leaf reaches here twice and would insert the field text twice.
+      // Collapse those into a single insertion.
+      const now = Date.now();
+
+      if(node === this.lastClickedNode &&
+         now - this.lastClickedTime < DUPLICATE_CLICK_THRESHOLD)
+      {
+         this.lastClickedTime = now;
+         return;
+      }
+
+      this.lastClickedNode = node;
+      this.lastClickedTime = now;
+
       // make sure focus is on text area
       setTimeout(() => this.codemirrorInstance.focus(), 200);
 

--- a/web/projects/portal/src/app/widget/modal-header/modal-header.component.html
+++ b/web/projects/portal/src/app/widget/modal-header/modal-header.component.html
@@ -41,7 +41,12 @@
       </button>
     }
     @if (showHelpLink) {
-      <i [helpLink]="cshid" class="mx-1" tabindex="0" aria-label="_#(Help Information)" role="link" enterClick></i>
+      @if (cshid) {
+        <i [helpLink]="cshid" class="mx-1" tabindex="0" aria-label="_#(Help Information)" role="link" enterClick></i>
+      } @else {
+        <i class="help-question-mark-icon cursor-pointer mx-1" tabindex="0" title="_#(js:Help)"
+           aria-label="_#(Help Information)" role="link" enterClick (click)="openHelpURL()"></i>
+      }
     }
     <button type="button" class="btn-close" (click)="onCancel.emit($event)" aria-label="_#(Close)" title="_#(Close)"></button>
   </div>


### PR DESCRIPTION
## Summary
Five independent, small bug fixes found during manual testing of the Data Sources and Physical/Logical Model editors. Stacked on #4600.

- **modal-header**: fall back to a dialog's own `helpURL` when no `cshid` is bound, instead of always rendering the `cshid` help-link icon. Fixes the Add Expression dialog's help icon opening an empty anchor (falls back to the docs homepage) instead of the script-help docs.
- **script-pane**: collapse the duplicate insertion caused by tree selection firing on both mousedowns of a native double-click, which previously inserted the clicked field/function twice into the expression editor.
- **data-auto-drill-dialog**: show a confirmation before deleting a single Auto Drill parameter, matching the existing confirm-before-delete pattern already used for removing a drill or all parameters.
- **data-sources-tree-view**: fix post-delete/rename/move navigation landing on the Data Sources root instead of the Data Model listing, caused by a scope mismatch between the "Data Model" node (server-assigned scope) and its folder/model children (hardcoded `GLOBAL_SCOPE`).
- **XPartition**: replace the single-arbitrary-anchor unjoined-table check with real connected-component grouping, so the reported "unjoined tables" warning always names an actual disconnected table instead of whichever table happened to be enumerated first.

## Test plan
- [x] Add Expression help icon opens the script-help doc URL instead of an empty anchor (verified live)
- [x] Double-clicking a column/function tree item inserts it once; two separate slower clicks still insert twice (verified live)
- [x] Deleting a single Auto Drill parameter now prompts for confirmation; Cancel preserves it, OK deletes it (verified live)
- [x] Self-deleting the currently-open Data Model folder now lands on the Data Model listing instead of the Data Sources root (verified live)
- [x] Removing a join to isolate a table now reports that table by name in the cross-join warning instead of an unrelated one (verified live)
- [x] `core` module compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)