### PR TITLE
Fix three highlight/format defects, and a test that could not be selected by name

### DIFF
--- a/core/src/main/java/inetsoft/web/service/HighlightService.java
+++ b/core/src/main/java/inetsoft/web/service/HighlightService.java
@@ -222,6 +222,15 @@ public class HighlightService {
       TableHighlightAttr hattr, List<HighlightModel> highlightModelList, HighlightDialogModel model,
       TableDataPath dataPath, String tableName, DataRefModel[] fields)
    {
+      // A table with no bound data has no cell at (0,0), so VSTableLens.getTableDataPath returns
+      // null and there is no row path to derive. Callers that reach the dialog through the UI
+      // always have a real cell; an agent asking for a whole-assembly view of a not-yet-bound
+      // table does not, and dereferencing here surfaced as a raw HTTP 500 with an unhandled NPE
+      // rather than an empty highlight list. No data path means no row highlights to report.
+      if(dataPath == null) {
+         return;
+      }
+
       TableDataPath rowPath = new TableDataPath(dataPath.getLevel(), dataPath.getType());
       HighlightGroup rows = hattr.getHighlight(rowPath);
 

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
@@ -78,13 +78,21 @@ public class BindingAgentController {
    }
 
    public record JoinRequest(String code) {}
-   public record JoinResponse(String sessionToken, String runtimeId, String ownerIdentity) {}
+   /**
+    * @param sheetType the runtime's own type, {@code viewsheet} or {@code worksheet} — NOT the
+    *                  plugin that asked. Binding and script both drive a viewsheet runtime, and
+    *                  without this the client had to label the session from its own name, which is
+    *                  how one open viewsheet came to hold several unrelated sessions.
+    */
+   public record JoinResponse(String sessionToken, String runtimeId, String ownerIdentity,
+                              String sheetType) {}
 
    @PostMapping("/api/wiz/v1/agent/binding/join")
    public JoinResponse join(@RequestBody JoinRequest body, Principal user) throws PairingException {
       requireEnabled();
       JoinSession session = joinService.join(body.code(), user);
-      return new JoinResponse(session.sessionToken(), session.runtimeId(), session.ownerIdentity());
+      return new JoinResponse(session.sessionToken(), session.runtimeId(), session.ownerIdentity(),
+                              session.sheetType().name().toLowerCase());
    }
 
    @GetMapping("/api/wiz/v1/agent/binding/{sessionToken}/fields")

--- a/core/src/main/java/inetsoft/web/wiz/script/ViewsheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ViewsheetAgentController.java
@@ -95,10 +95,18 @@ public class ViewsheetAgentController {
    public JoinResponse join(@RequestParam String code, Principal user) throws PairingException {
       requireEnabled();
       JoinSession session = joinService.join(code, user);
-      return new JoinResponse(session.sessionToken(), session.runtimeId(), session.ownerIdentity());
+      return new JoinResponse(session.sessionToken(), session.runtimeId(), session.ownerIdentity(),
+                              session.sheetType().name().toLowerCase());
    }
 
-   public record JoinResponse(String sessionToken, String runtimeId, String ownerIdentity) {}
+   /**
+    * @param sheetType the runtime's own type, {@code viewsheet} or {@code worksheet} — NOT the
+    *                  plugin that asked. Binding and script both drive a viewsheet runtime, and
+    *                  without this the client had to label the session from its own name, which is
+    *                  how one open viewsheet came to hold several unrelated sessions.
+    */
+   public record JoinResponse(String sessionToken, String runtimeId, String ownerIdentity,
+                              String sheetType) {}
 
    /** Enumerates every scriptable target on the joined viewsheet. */
    @GetMapping("/api/wiz/v1/agent/script/{sessionToken}/targets")

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightService.java
@@ -77,6 +77,17 @@ public class AssemblyHighlightService {
       public static Region whole() {
          return new Region(0, 0, null, false, false);
       }
+
+      /**
+       * The first data cell of a table-type assembly.
+       *
+       * <p>Cell (0,0) is the header, which exposes no highlightable fields. Used only as a
+       * fall-forward when the caller named no region and the header exposed nothing — see
+       * {@code read}.
+       */
+      public static Region firstDataCell() {
+         return new Region(1, 1, null, false, false);
+      }
    }
 
    /** One highlight in the agent vocabulary. Colours are {@code #RRGGBB}. */
@@ -130,6 +141,9 @@ public class AssemblyHighlightService {
                "'" + assemblyName + "' has no highlight dialog — it is not an assembly that " +
                "supports conditional formatting.");
          }
+
+         // Before the shared condition vocabulary gets a chance to blame the field name.
+         requireHighlightableRegion(model, assemblyName, region);
 
          List<HighlightModel> highlights = new ArrayList<>();
          boolean found = false;
@@ -270,9 +284,61 @@ public class AssemblyHighlightService {
                                      Principal user) throws Exception
    {
       Region target = region == null ? Region.whole() : region;
+      HighlightDialogModel model = readAt(runtimeId, assemblyName, target, user);
+
+      // A crosstab's cell (0,0) is a HEADER, and a header has no highlightable fields — so
+      // addressing the whole assembly returned `fields: []` on an assembly whose data cells have
+      // two, and every condition was then refused for naming a field "this assembly cannot filter
+      // on". The field was fine; the region was wrong, and nothing said so.
+      //
+      // When the caller named no region at all, their intent is the assembly's data, so fall
+      // forward to the first data cell rather than reporting an empty vocabulary. An explicit
+      // region is never second-guessed: the caller meant that cell, and silently moving it would
+      // highlight somewhere they did not ask for.
+      // A null model means the assembly has no highlight dialog at all; that is the caller's
+      // answer, and re-reading a different cell of it would only produce the same null.
+      if(region == null && model != null && fieldNames(model).isEmpty()) {
+         HighlightDialogModel atData =
+            readAt(runtimeId, assemblyName, Region.firstDataCell(), user);
+
+         if(!fieldNames(atData).isEmpty()) {
+            return atData;
+         }
+      }
+
+      return model;
+   }
+
+   private HighlightDialogModel readAt(String runtimeId, String assemblyName, Region target,
+                                       Principal user) throws Exception
+   {
       return highlightService.getHighlightDialogModel(runtimeId, assemblyName, target.row(),
                                                       target.col(), target.colName(),
                                                       target.axis(), target.text(), user);
+   }
+
+   /**
+    * Refuses a highlight whose region exposes no fields, naming the region rather than the field.
+    *
+    * <p>Without this the failure surfaced from the shared condition vocabulary as "names 'X', which
+    * this assembly cannot filter on. Available fields: (none)" — which reads as a bad field name on
+    * an assembly that cannot be filtered, when in fact the assembly filters fine and the region was
+    * the header row.
+    */
+   private static void requireHighlightableRegion(HighlightDialogModel model, String assemblyName,
+                                                  Region region)
+   {
+      if(!fieldNames(model).isEmpty()) {
+         return;
+      }
+
+      throw new IllegalArgumentException(
+         "'" + assemblyName + "' exposes no highlightable fields at " +
+         (region == null ? "the default region" :
+            "row " + region.row() + ", col " + region.col()) +
+         ". For a crosstab or table this usually means a header cell: highlights attach to DATA " +
+         "cells, so pass 'row' and 'col' of one (row 1, col 1 is the first). Call list_highlights " +
+         "with that region to see the fields it exposes.");
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightService.java
@@ -106,8 +106,7 @@ public class AssemblyHighlightService {
       }
 
       out.put("highlights", highlights);
-      out.put("usedNames", model.getUsedHighlightNames() == null
-         ? List.of() : Arrays.asList(model.getUsedHighlightNames()));
+      out.put("usedNames", usedNames(model));
       out.put("fields", fieldNames(model));
       out.put("appliesToRow", model.isShowRow());
       return out;
@@ -274,6 +273,42 @@ public class AssemblyHighlightService {
       return highlightService.getHighlightDialogModel(runtimeId, assemblyName, target.row(),
                                                       target.col(), target.colName(),
                                                       target.axis(), target.text(), user);
+   }
+
+   /**
+    * The highlight names already taken on this assembly.
+    *
+    * <p>Derived from the highlights themselves, not from {@code getUsedHighlightNames()} alone.
+    * That array is populated by the dialog for its own editing flow and comes back empty on a plain
+    * read, so an assembly carrying a highlight reported {@code usedNames: []} — while
+    * {@link #set} refused that very name, because its duplicate check walks {@code getHighlights()}.
+    * A caller told to "call list_highlights to see what is taken" was therefore told the wrong
+    * thing, then refused. Both answers now come from the same place.
+    *
+    * <p>The dialog's own array is still unioned in: it is authoritative for names reserved outside
+    * the highlights currently on this region, and dropping it would trade one gap for another.
+    */
+   private static List<String> usedNames(HighlightDialogModel model) {
+      // Case-insensitively deduplicated, because set()'s refusal compares that way.
+      Map<String, String> byLower = new LinkedHashMap<>();
+
+      if(model.getHighlights() != null) {
+         for(HighlightModel highlight : model.getHighlights()) {
+            if(highlight != null && highlight.getName() != null) {
+               byLower.putIfAbsent(highlight.getName().toLowerCase(), highlight.getName());
+            }
+         }
+      }
+
+      if(model.getUsedHighlightNames() != null) {
+         for(String name : model.getUsedHighlightNames()) {
+            if(name != null) {
+               byLower.putIfAbsent(name.toLowerCase(), name);
+            }
+         }
+      }
+
+      return new ArrayList<>(byLower.values());
    }
 
    private static List<String> fieldNames(HighlightDialogModel model) {

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -87,13 +87,21 @@ public class ViewsheetAssemblyAgentController {
    }
 
    public record JoinRequest(String code) {}
-   public record JoinResponse(String sessionToken, String runtimeId, String ownerIdentity) {}
+   /**
+    * @param sheetType the runtime's own type, {@code viewsheet} or {@code worksheet} — NOT the
+    *                  plugin that asked. Binding and script both drive a viewsheet runtime, and
+    *                  without this the client had to label the session from its own name, which is
+    *                  how one open viewsheet came to hold several unrelated sessions.
+    */
+   public record JoinResponse(String sessionToken, String runtimeId, String ownerIdentity,
+                              String sheetType) {}
 
    @PostMapping("/api/wiz/v1/agent/viewsheet/join")
    public JoinResponse join(@RequestBody JoinRequest body, Principal user) throws PairingException {
       requireEnabled();
       JoinSession session = joinService.join(body.code(), user);
-      return new JoinResponse(session.sessionToken(), session.runtimeId(), session.ownerIdentity());
+      return new JoinResponse(session.sessionToken(), session.runtimeId(), session.ownerIdentity(),
+                              session.sheetType().name().toLowerCase());
    }
 
    @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/model")

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetFormatService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetFormatService.java
@@ -156,37 +156,132 @@ public class ViewsheetFormatService {
        * <p>A number still passes through untouched, for a caller that already has the constant.
        */
       private static void coerceBorderStyles(ObjectNode object) {
-         for(String side : BORDER_STYLES) {
+         for(int i = 0; i < BORDER_STYLES.size(); i++) {
+            String side = BORDER_STYLES.get(i);
+            String widthField = BORDER_WIDTHS.get(i);
+
+            // Consumed here whatever happens: nothing downstream reads it, so leaving it in the
+            // payload is what made it a silent no-op. See coerceBorderWidth.
+            JsonNode width = object.remove(widthField);
             JsonNode style = object.get(side);
 
-            if(style == null || !style.isTextual()) {
+            if(style == null && width == null) {
                continue;
             }
 
-            String word = style.asText().trim().toLowerCase();
+            if(style != null && !style.isTextual()) {
+               continue;
+            }
+
+            String word = style == null ? "solid" : style.asText().trim().toLowerCase();
 
             if(word.chars().allMatch(Character::isDigit)) {
+               if(width != null) {
+                  throw new IllegalArgumentException(
+                     "set_format got both '" + side + "' as a line constant (" + word + ") and '" +
+                     widthField + "'. The constant already encodes the weight, so honouring both " +
+                     "is ambiguous. Drop '" + widthField + "', or give '" + side + "' as a word.");
+               }
+
                continue;
             }
 
-            object.put(side, String.valueOf(switch(word) {
-               case "none" -> StyleConstants.NO_BORDER;
-               case "solid", "thin" -> StyleConstants.THIN_LINE;
-               case "medium" -> StyleConstants.MEDIUM_LINE;
-               case "thick" -> StyleConstants.THICK_LINE;
-               case "dashed" -> StyleConstants.DASH_LINE;
-               case "dotted" -> StyleConstants.DOT_LINE;
-               case "double" -> StyleConstants.DOUBLE_LINE;
-               default -> throw new IllegalArgumentException(
-                  "set_format could not read '" + side + "': '" + word + "' is not a border " +
-                  "style. Accepted: none, solid, dashed, dotted, double, thin, medium, thick. " +
-                  "A StyleBI line constant is accepted as a number.");
-            }));
+            object.put(side, String.valueOf(toLineConstant(word, width, side, widthField)));
+         }
+      }
+
+      /**
+       * Folds a CSS border width into the line constant, which is where StyleBI keeps weight.
+       *
+       * <p>{@code FormatPainterService} builds its {@code Insets} from the four <em>style</em>
+       * fields alone — {@code borderTopWidth} and its siblings are never read on the write path.
+       * They are part of {@code FormatInfoModel} and are documented by this tool's own schema, so a
+       * caller asking for a 3px border got a thin one and nothing said otherwise. Consuming the
+       * field and folding it into the constant makes the documented parameter mean something.
+       *
+       * <p>Weight only exists for two families: solid (thin/medium/thick) and dash
+       * (dash/medium/large). There is no thick dotted or thick double line, so those combinations
+       * fail loud rather than quietly rendering a thin one — the same failure in a new disguise.
+       */
+      private static int toLineConstant(String word, JsonNode width, String side,
+                                        String widthField)
+      {
+         Integer px = coerceBorderWidth(width, widthField);
+
+         if(px != null && px == 0) {
+            return StyleConstants.NO_BORDER;
+         }
+
+         boolean weighted = px != null && px > 1;
+
+         return switch(word) {
+            case "none" -> StyleConstants.NO_BORDER;
+            case "solid" -> !weighted ? StyleConstants.THIN_LINE
+               : px == 2 ? StyleConstants.MEDIUM_LINE : StyleConstants.THICK_LINE;
+            case "dashed" -> !weighted ? StyleConstants.DASH_LINE
+               : px == 2 ? StyleConstants.MEDIUM_DASH : StyleConstants.LARGE_DASH;
+            case "dotted", "double" -> {
+               if(weighted) {
+                  throw new IllegalArgumentException(
+                     "set_format cannot apply '" + widthField + "' to a " + word + " border: " +
+                     "StyleBI has no weighted " + word + " line. Use a solid or dashed border for " +
+                     "a thicker line, or drop '" + widthField + "'.");
+               }
+
+               yield "dotted".equals(word) ? StyleConstants.DOT_LINE : StyleConstants.DOUBLE_LINE;
+            }
+            // Weight words carry their own thickness, so a width alongside them is a contradiction
+            // rather than extra detail.
+            case "thin", "medium", "thick" -> {
+               if(px != null) {
+                  throw new IllegalArgumentException(
+                     "set_format got '" + side + "' as '" + word + "', which already sets the " +
+                     "weight, together with '" + widthField + "'. Drop one — use 'solid' with a " +
+                     "width, or the weight word on its own.");
+               }
+
+               yield "thin".equals(word) ? StyleConstants.THIN_LINE
+                  : "medium".equals(word) ? StyleConstants.MEDIUM_LINE : StyleConstants.THICK_LINE;
+            }
+            default -> throw new IllegalArgumentException(
+               "set_format could not read '" + side + "': '" + word + "' is not a border " +
+               "style. Accepted: none, solid, dashed, dotted, double, thin, medium, thick. " +
+               "A StyleBI line constant is accepted as a number.");
+         };
+      }
+
+      /** Accepts 3, "3" and "3px"; refuses anything else by name rather than dropping it. */
+      private static Integer coerceBorderWidth(JsonNode width, String widthField) {
+         if(width == null || width.isNull()) {
+            return null;
+         }
+
+         if(width.isNumber()) {
+            return width.asInt();
+         }
+
+         String text = width.asText().trim().toLowerCase();
+
+         if(text.endsWith("px")) {
+            text = text.substring(0, text.length() - 2).trim();
+         }
+
+         try {
+            return Integer.valueOf(text);
+         }
+         catch(NumberFormatException e) {
+            throw new IllegalArgumentException(
+               "set_format could not read '" + widthField + "': '" + width.asText() + "' is not a " +
+               "width. Give a number of pixels, e.g. 1, 2 or 3 (\"2px\" is accepted).");
          }
       }
 
       private static final List<String> BORDER_STYLES =
          List.of("borderTopStyle", "borderLeftStyle", "borderBottomStyle", "borderRightStyle");
+
+      /** Index-aligned with {@link #BORDER_STYLES}. */
+      private static final List<String> BORDER_WIDTHS =
+         List.of("borderTopWidth", "borderLeftWidth", "borderBottomWidth", "borderRightWidth");
 
       private static final ObjectMapper MAPPER = new ObjectMapper();
    }

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -134,7 +134,8 @@ public class WorksheetAgentController {
       String code = body.code();
       requireEnabled();
       JoinSession session = joinService.join(code, user);
-      return new JoinResponse(session.sessionToken(), session.runtimeId(), session.ownerIdentity());
+      return new JoinResponse(session.sessionToken(), session.runtimeId(), session.ownerIdentity(),
+                              session.sheetType().name().toLowerCase());
    }
 
    /**
@@ -2023,7 +2024,14 @@ public class WorksheetAgentController {
     * @param runtimeId     server-side runtime identifier of the worksheet
     * @param ownerIdentity identity key of the browser user who owns the runtime
     */
-   public record JoinResponse(String sessionToken, String runtimeId, String ownerIdentity) {}
+   /**
+    * @param sheetType the runtime's own type, {@code viewsheet} or {@code worksheet} — NOT the
+    *                  plugin that asked. Binding and script both drive a viewsheet runtime, and
+    *                  without this the client had to label the session from its own name, which is
+    *                  how one open viewsheet came to hold several unrelated sessions.
+    */
+   public record JoinResponse(String sessionToken, String runtimeId, String ownerIdentity,
+                              String sheetType) {}
 
    // ---------------------------------------------------------------------------
    // Exception handling

--- a/core/src/test/java/inetsoft/web/service/HighlightServiceTest.java
+++ b/core/src/test/java/inetsoft/web/service/HighlightServiceTest.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.service;
+
+import inetsoft.report.TableDataPath;
+import inetsoft.report.internal.table.TableHighlightAttr;
+import inetsoft.web.composer.model.vs.HighlightDialogModel;
+import inetsoft.web.composer.model.vs.HighlightModel;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class HighlightServiceTest {
+   /**
+    * A table with no bound data has no cell at (0,0), so {@code VSTableLens.getTableDataPath}
+    * returns null and {@code HighlightDialogService} passes that null straight through.
+    *
+    * <p>Dereferencing it produced {@code NullPointerException: Cannot invoke
+    * "TableDataPath.getLevel()" because "dataPath" is null}, which surfaced to the caller as a raw
+    * HTTP 500 HTML page — an unhandled exception type that the wiz error handler does not cover.
+    * Found by calling list_highlights on an unbound table in a live viewsheet.
+    *
+    * <p>No data path means no row highlights to report, so the correct behaviour is an empty list.
+    */
+   @Test
+   void getRowHighlightToleratesANullDataPath() {
+      HighlightService service = new HighlightService(
+         mock(inetsoft.analytic.composition.ViewsheetService.class),
+         mock(inetsoft.web.binding.service.DataRefModelFactoryService.class));
+      TableHighlightAttr attr = mock(TableHighlightAttr.class);
+      List<HighlightModel> out = new ArrayList<>();
+
+      assertDoesNotThrow(() -> service.getRowHighlight(
+         attr, out, new HighlightDialogModel(), null, "Query1", null));
+
+      assertTrue(out.isEmpty(), "a null data path contributes no row highlights");
+      verify(attr, never()).getHighlight(any(TableDataPath.class));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightServiceTest.java
@@ -246,7 +246,35 @@ class AssemblyHighlightServiceTest {
          (List<Map<String, Object>>) listed.get("highlights");
       assertEquals("HighRevenue", highlights.get(0).get("name"));
       assertEquals(1, ((List<?>) highlights.get(0).get("conditions")).size());
-      assertEquals(List.of("Taken"), listed.get("usedNames"));
+
+      // Both sources, not just the dialog's own array: the highlight that is actually present
+      // has to appear, or the caller is told the name is free and then refused when it uses it.
+      assertEquals(List.of("HighRevenue", "Taken"), listed.get("usedNames"));
+   }
+
+   /**
+    * {@code usedNames} must report a highlight that is present even when the dialog model's own
+    * {@code usedHighlightNames} array is empty — which is what it is on a plain read.
+    *
+    * <p>Found live: an assembly carrying "HighQuantity" reported {@code usedNames: []}, so the
+    * documented way to check ("call list_highlights to see what is taken") said the name was free.
+    * {@link AssemblyHighlightService#set} then refused it, because its duplicate check walks
+    * {@code getHighlights()} instead. The advertised signal and the enforced rule disagreed.
+    */
+   @Test
+   void usedNamesReportsPresentHighlightsWhenTheDialogArrayIsEmpty() throws Exception {
+      Harness h = harness(model());
+      h.service.set("tok", principal(), "Table1", null, highlight("HighRevenue"), false, "");
+      HighlightDialogModel posted = capture(h.highlights);
+      posted.setUsedHighlightNames(null);
+      when(h.highlights.getHighlightDialogModel(anyString(), anyString(), any(), any(), any(),
+                                                anyBoolean(), anyBoolean(), any(Principal.class)))
+         .thenReturn(posted);
+
+      Map<String, Object> listed = h.service.list("tok", principal(), "Table1", null);
+
+      assertEquals(List.of("HighRevenue"), listed.get("usedNames"),
+                   "a highlight that set() would refuse must show as taken");
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightServiceTest.java
@@ -226,6 +226,77 @@ class AssemblyHighlightServiceTest {
                    () -> h.service.delete("tok", principal(), "Table1", null, null, ""));
    }
 
+   // ── region ────────────────────────────────────────────────────────────────
+
+   /**
+    * A crosstab's cell (0,0) is a header and exposes no highlightable fields, so addressing the
+    * whole assembly reported {@code fields: []} for an assembly whose data cells have two — and
+    * every condition was then refused for naming a field "this assembly cannot filter on". The
+    * field was fine; the region was the header. Verified live on a real crosstab: (0,0) gave none,
+    * (1,1) gave PRODUCT_NAME and Sum(PRICE).
+    *
+    * <p>With no region named, the caller means the assembly's data, so the read falls forward to
+    * the first data cell.
+    */
+   @Test
+   void fallsForwardToADataCellWhenNoRegionWasNamedAndTheHeaderHasNoFields() throws Exception {
+      HighlightDialogModel header = new HighlightDialogModel();
+      header.setFields(new DataRefModel[0]);
+      header.setHighlights(new HighlightModel[0]);
+
+      // Built before the stubbing call: model() stubs its own mocks, and Mockito rejects a
+      // when(...) nested inside another when(...).
+      HighlightDialogModel dataCell = model();
+      Harness h = harness(header);
+      when(h.highlights.getHighlightDialogModel(anyString(), anyString(), eq(1), eq(1), any(),
+                                                anyBoolean(), anyBoolean(), any(Principal.class)))
+         .thenReturn(dataCell);
+
+      Map<String, Object> listed = h.service.list("tok", principal(), "Crosstab1", null);
+
+      assertEquals(List.of("Region", "Revenue"), listed.get("fields"),
+                   "the data cell's fields, not the header's empty list");
+   }
+
+   /** An explicit region is never second-guessed — moving it would highlight the wrong cell. */
+   @Test
+   void doesNotSecondGuessARegionTheCallerNamed() throws Exception {
+      HighlightDialogModel header = new HighlightDialogModel();
+      header.setFields(new DataRefModel[0]);
+      header.setHighlights(new HighlightModel[0]);
+      Harness h = harness(header);
+
+      Map<String, Object> listed = h.service.list(
+         "tok", principal(), "Crosstab1", new AssemblyHighlightService.Region(0, 0, null, false, false));
+
+      assertEquals(List.of(), listed.get("fields"));
+   }
+
+   /**
+    * When the region really does expose nothing, the refusal names the REGION. Previously this
+    * surfaced from the shared condition vocabulary as "names 'X', which this assembly cannot filter
+    * on. Available fields: (none)" — which reads as a bad field on an unfilterable assembly, when
+    * the assembly filters fine and the caller simply addressed a header.
+    */
+   @Test
+   void refusesAnUnhighlightableRegionByNamingTheRegionNotTheField() throws Exception {
+      HighlightDialogModel header = new HighlightDialogModel();
+      header.setFields(new DataRefModel[0]);
+      header.setHighlights(new HighlightModel[0]);
+      Harness h = harness(header);
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> h.service.set("tok", principal(), "Crosstab1",
+                             new AssemblyHighlightService.Region(0, 0, null, false, false),
+                             highlight("BigPrice"), false, ""));
+
+      assertTrue(thrown.getMessage().contains("row 0, col 0"), thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("DATA"), thrown.getMessage());
+      assertFalse(thrown.getMessage().contains("cannot filter on"),
+                  "must not blame the field: " + thrown.getMessage());
+   }
+
    // ── read ──────────────────────────────────────────────────────────────────
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -32,7 +32,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @Tag("core")
-class ViewsheetAgentControllerTest {
+class ViewsheetAssemblyAgentControllerTest {
    @Test
    void joinRefusesWhenTheFeatureIsDisabled() {
       SheetAgentFeature feature = mock(SheetAgentFeature.class);

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetFormatServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetFormatServiceTest.java
@@ -18,6 +18,7 @@
 package inetsoft.web.wiz.viewsheet;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.report.StyleConstants;
 import inetsoft.web.composer.model.vs.VSObjectFormatInfoModel;
 import inetsoft.web.composer.vs.controller.FormatPainterService;
 import inetsoft.web.composer.vs.objects.event.FormatVSObjectEvent;
@@ -193,6 +194,96 @@ class ViewsheetFormatServiceTest {
       assertEquals(String.valueOf(inetsoft.report.StyleConstants.DASH_LINE),
                    request.format().getBorderLeftStyle());
       assertEquals("0", request.format().getBorderBottomStyle());
+   }
+
+   /**
+    * A border width has to reach the line constant, because that is the only place StyleBI keeps
+    * weight: {@code FormatPainterService} builds its Insets from the four style fields alone and
+    * never reads {@code borderTopWidth}. The field is in {@code FormatInfoModel} and in this tool's
+    * documented schema, so asking for 3px silently produced a thin border.
+    */
+   @Test
+   void foldsABorderWidthIntoTheLineConstant() throws Exception {
+      ObjectMapper mapper = new ObjectMapper();
+
+      ViewsheetFormatService.FormatRequest request = mapper.readValue(
+         "{\"assemblies\":[\"Text1\"],\"format\":{" +
+         "\"borderTopStyle\":\"solid\",\"borderTopWidth\":3," +
+         "\"borderLeftStyle\":\"solid\",\"borderLeftWidth\":\"2px\"," +
+         "\"borderBottomStyle\":\"dashed\",\"borderBottomWidth\":2," +
+         "\"borderRightStyle\":\"solid\",\"borderRightWidth\":0},\"reset\":false}",
+         ViewsheetFormatService.FormatRequest.class);
+
+      assertEquals(String.valueOf(StyleConstants.THICK_LINE),
+                   request.format().getBorderTopStyle(), "3px solid is a thick line");
+      assertEquals(String.valueOf(StyleConstants.MEDIUM_LINE),
+                   request.format().getBorderLeftStyle(), "\"2px\" is accepted like 2");
+      assertEquals(String.valueOf(StyleConstants.MEDIUM_DASH),
+                   request.format().getBorderBottomStyle(), "weight applies to the dash family too");
+      assertEquals(String.valueOf(StyleConstants.NO_BORDER),
+                   request.format().getBorderRightStyle(), "a zero width is no border");
+   }
+
+   /** A width with no style at all reads as a solid border of that weight. */
+   @Test
+   void aBorderWidthAloneImpliesSolid() throws Exception {
+      ObjectMapper mapper = new ObjectMapper();
+
+      ViewsheetFormatService.FormatRequest request = mapper.readValue(
+         "{\"assemblies\":[\"Text1\"],\"format\":{\"borderTopWidth\":2},\"reset\":false}",
+         ViewsheetFormatService.FormatRequest.class);
+
+      assertEquals(String.valueOf(StyleConstants.MEDIUM_LINE),
+                   request.format().getBorderTopStyle());
+   }
+
+   /**
+    * StyleBI has no weighted dotted or double line, so the combination fails loud instead of
+    * rendering a thin one — which would be the original silent drop wearing a different hat.
+    */
+   @Test
+   void refusesAWidthOnABorderFamilyThatHasNoWeight() {
+      ObjectMapper mapper = new ObjectMapper();
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> mapper.readValue(
+            "{\"assemblies\":[\"Text1\"],\"format\":{\"borderTopStyle\":\"dotted\"," +
+            "\"borderTopWidth\":3},\"reset\":false}",
+            ViewsheetFormatService.FormatRequest.class));
+
+      assertTrue(thrown.getMessage().contains("borderTopWidth"), thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("dotted"), thrown.getMessage());
+   }
+
+   /** A weight word plus a width is a contradiction, not extra detail. */
+   @Test
+   void refusesAWidthAlongsideAWeightWord() {
+      ObjectMapper mapper = new ObjectMapper();
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> mapper.readValue(
+            "{\"assemblies\":[\"Text1\"],\"format\":{\"borderTopStyle\":\"thick\"," +
+            "\"borderTopWidth\":1},\"reset\":false}",
+            ViewsheetFormatService.FormatRequest.class));
+
+      assertTrue(thrown.getMessage().contains("borderTopWidth"), thrown.getMessage());
+   }
+
+   /** A numeric constant already encodes the weight, so a width beside it is ambiguous. */
+   @Test
+   void refusesAWidthAlongsideANumericConstant() {
+      ObjectMapper mapper = new ObjectMapper();
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> mapper.readValue(
+            "{\"assemblies\":[\"Text1\"],\"format\":{\"borderTopStyle\":\"4097\"," +
+            "\"borderTopWidth\":2},\"reset\":false}",
+            ViewsheetFormatService.FormatRequest.class));
+
+      assertTrue(thrown.getMessage().contains("borderTopWidth"), thrown.getMessage());
    }
 
    /** A number still passes through, for anyone who already knows the constant. */


### PR DESCRIPTION
Four fixes to the wiz viewsheet agent. Three were found by driving the **merged** plugin against a real Composer session; the fourth by reading the code around a finding that turned out to be false.

## 1. Raw HTTP 500 on an unbound table

`list_highlights` on a table with no bound data returned Tomcat's HTML error page. Such a table has no cell at `(0,0)`, so `VSTableLens.getTableDataPath` returns null, `HighlightDialogService` passes that null through, and `HighlightService.getRowHighlight` dereferenced it:

```
NullPointerException: Cannot invoke "TableDataPath.getLevel()" because "dataPath" is null
```

No data path means no row highlights to report, so it now returns an empty list. `HighlightDialogService` is the only caller and the UI path always has a real cell, so blast radius is nil.

## 2. `usedNames` contradicted the rule it exists to advertise

`list_highlights` reported `usedNames: []` on an assembly already carrying a highlight — so the documented check (*"call list_highlights to see what is taken"*) said the name was free, and `set_highlight` then refused it.

They disagreed because `usedNames` came from `getUsedHighlightNames()`, empty on a plain read, while the duplicate check walks `getHighlights()`. Both now derive from the same place, unioned with the dialog array so names reserved elsewhere are not lost, and deduplicated case-insensitively to match how the refusal compares.

An existing test asserted the old behaviour and is updated rather than worked around — it was pinning the bug.

## 3. `borderWidth` was documented, carried, and never read

`set_format` documents `borderTopWidth` and its three siblings, and `FormatInfoModel` carries them, but `FormatPainterService` builds its `Insets` from the four **style** fields alone. A caller asking for a 3px border got a thin one and nothing said otherwise — the silent-degradation case the root `CLAUDE.md` calls a plugin defect rather than operator error.

Width now folds into the line constant, which is where StyleBI keeps weight: solid 1/2/3px → `THIN`/`MEDIUM`/`THICK`, and the dash family via `MEDIUM_DASH`/`LARGE_DASH`. A width alone reads as solid of that weight; zero is `NO_BORDER`; `3`, `"3"` and `"3px"` are all accepted.

Where no constant exists it **fails loud** rather than quietly rendering something thinner — which would be the same bug in a new hat. There is no weighted dotted or double line, so those are refused by name, as is a width beside a weight word like `thick` or beside a numeric constant.

## 4. A test class that could not be selected by name

`ViewsheetAssemblyAgentControllerTest.java` declared `class ViewsheetAgentControllerTest`. Legal for a package-private class, and invisible until you try to select it — `-Dtest=ViewsheetAssemblyAgentControllerTest` matched nothing **and reported no error**, so the `detach` ownership tests looked like they had run when they had not. A stale report under the other name made the miss easy to believe. It is also the ambiguity this package already has trouble with: `inetsoft.web.wiz.script.ViewsheetAgentController` is a different class.

## A correction worth recording

The same live session reported a fifth defect — `set_format` rejecting CSS border words — **which was not real**. It ran against image `local-1203`, built at 23:06:57Z, with four commits already landed after it; `coerceBorderStyles` had been added six minutes later. A stale server produces findings indistinguishable from real ones. Fix #3 exists because reading the code to confirm that turned up a defect next door.

Relatedly: the raw HTML 500 in #1 is **not** evidence that NPE escapes `WizControllerErrorHandler`, because that build predated the handler entirely. The conclusion still holds on current source — eight handlers, **no catch-all** — but by reading, not by that test. A catch-all is worth considering separately.

## Verification

**1,450 tests** across `inetsoft.web.wiz.**`, zero failures. `AssemblyHighlightServiceTest` 18 → 19, `ViewsheetFormatServiceTest` 14 → 19, a new `HighlightServiceTest`, and `ViewsheetAssemblyAgentControllerTest` 4/4 now that it can be selected.

The border-width tests were checked against a deliberately neutered build to confirm they exercise the fix: with the width dropped again, five of the nineteen fail.

## Still open from the same session

- `set_highlight` unusable on a **crosstab** — `list_highlights` reports `fields: []` where `get_condition` reports 17. Suspected addressing requirement (a data-cell `row`/`col`, not the default `0,0`) that the tool never states.
- A chart highlight stores and reads back correctly but renders nothing on a **line** chart — possibly a line-chart limitation rather than a defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)