### PR TITLE
Viewsheet-level properties for the wiz agent API

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/ViewsheetPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/ViewsheetPropertyDialogService.java
@@ -455,11 +455,15 @@ public class ViewsheetPropertyDialogService {
 
       LocalizationPaneModel localizationPane = value.localizationPane();
 
-      for(String component: info.getLocalComponents()) {
-         info.removeLocalID(component, true);
-      }
-
+      // A null pane means "not supplied", not "clear everything". getViewsheetInfo populates it
+      // only for a site admin (or when security is off / single-tenant), so on any other principal
+      // a plain read-modify-write round trip arrived here with null -- and wiping first removed
+      // every localized text id on the sheet as a side effect of setting something unrelated.
       if(localizationPane != null) {
+         for(String component: info.getLocalComponents()) {
+            info.removeLocalID(component, true);
+         }
+
          for(LocalizationComponent component: localizationPane.getLocalized()) {
             info.setLocalID(component.getName(), component.getTextId());
          }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
@@ -230,7 +230,11 @@ public class AssemblyPropertyService {
          Map<String, String> resolved = new LinkedHashMap<>();
 
          for(String key : patch.keySet()) {
-            resolved.put(key, PropertyAliases.resolve(type, key));
+            // resolveForWrite, not resolve: its refusals are keyed by type and currently fire
+            // only for the sheet, so this is a no-op for every assembly today. Going through the
+            // write path anyway means a refusal added for an assembly type -- a script pane on
+            // some future assembly, say -- applies here without anyone remembering to route it.
+            resolved.put(key, PropertyAliases.resolveForWrite(type, key));
          }
 
          // PropertyPath.set returns the root the caller must keep using: if a future alias

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
@@ -233,8 +233,12 @@ public class AssemblyPropertyService {
             resolved.put(key, PropertyAliases.resolve(type, key));
          }
 
+         // PropertyPath.set returns the root the caller must keep using: if a future alias
+         // ever targets a direct top-level field of an Immutables dialog model (no nested pane
+         // to absorb the rebuild — see PropertyPath's own note), the wither produces a new
+         // instance and the original reference silently stops reflecting the write.
          for(Map.Entry<String, String> entry : resolved.entrySet()) {
-            PropertyPath.set(model, entry.getValue(), patch.get(entry.getKey()));
+            model = PropertyPath.set(model, entry.getValue(), patch.get(entry.getKey()));
          }
 
          writeModel(runtimeId, type, assemblyName, model, linkUri, user, dispatcher);

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyService.java
@@ -128,20 +128,30 @@ public class ChartRegionPropertyService {
       }
 
       // Write onto the model only after every key resolved.
+      //
+      // Keep the returned root. All three region dialog models are plain mutable classes today, so
+      // PropertyPath.set mutates in place and the assignment is a no-op — but if any of them (or a
+      // pane beneath one) becomes an Immutables model, a wither rebuilds rather than mutates and
+      // the write would vanish with no error and no compile failure. That is the same shape that
+      // made width/height/preview silently unwritable on the viewsheet's own dialog model.
+      Object rebuilt = model;
+
       for(Map.Entry<String, Object> one : resolved.entrySet()) {
-         PropertyPath.set(model, one.getKey(), one.getValue());
+         rebuilt = PropertyPath.set(rebuilt, one.getKey(), one.getValue());
       }
+
+      final Object written = rebuilt;
 
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          switch(name) {
          case "axis" -> regions.setAxisPropertyDialogModel(
-            runtimeId, assembly, key, 0, field, (AxisPropertyDialogModel) model, linkUri, user,
+            runtimeId, assembly, key, 0, field, (AxisPropertyDialogModel) written, linkUri, user,
             dispatcher);
          case "legend" -> regions.setLegendFormatDialogModel(
-            runtimeId, assembly, indexOf(key), (LegendFormatDialogModel) model, linkUri, user,
+            runtimeId, assembly, indexOf(key), (LegendFormatDialogModel) written, linkUri, user,
             dispatcher);
          default -> regions.setTitleFormatDialogModel(
-            runtimeId, assembly, key, (TitleFormatDialogModel) model, linkUri, user, dispatcher);
+            runtimeId, assembly, key, (TitleFormatDialogModel) written, linkUri, user, dispatcher);
          }
       });
    }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
@@ -602,11 +602,14 @@ public final class PropertyAliases {
       aliases.put("maxRowsWarning", "vsOptionsPane.maxRowsWarning");
       aliases.put("hideNotifications", "vsOptionsPane.hideNotifications");
       aliases.put("listOnPortalTree", "vsOptionsPane.listOnPortalTree");
-      // Read-only in v1 -- see resolveForWrite. Both are genuine top-level accessors, hence the
-      // bare (dot-free) path; noAliasIsAnEmptyOrSelfReferentialPath carves out this type for
-      // exactly that reason.
-      aliases.put("filtersPane", "filtersPane");
-      aliases.put("localizationPane", "localizationPane");
+      // filtersPane and localizationPane are deliberately NOT aliased.
+      //
+      // They are read-only, and they are whole object graphs rather than properties: aliasing them
+      // made every list/get response carry the entire localization component tree -- ~350 lines on
+      // a small sheet, and it grows with assembly count. That is a curated vocabulary paying a
+      // large cost for something it cannot even write. Reading them is still possible, and is what
+      // `raw: true` is for; resolveForWrite still refuses them by name, since it matches on the
+      // path rather than on membership in this map.
       aliases.put("width", "width");
       aliases.put("height", "height");
       aliases.put("preview", "preview");

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
@@ -43,6 +43,9 @@ import java.util.*;
  * dropped.
  */
 public final class PropertyAliases {
+   /** The viewsheet's own property vocabulary. Not "viewsheet" -- see the register call below. */
+   public static final String SHEET = "sheet";
+
    /** One assembly type's dialog model and its alias vocabulary. */
    public record TypeAliases(String assemblyType, Class<?> modelClass,
                              Map<String, String> aliases) {}
@@ -140,7 +143,7 @@ public final class PropertyAliases {
     * alias that happens to map onto it).
     */
    private static String viewsheetWriteRefusal(String normalizedType, String pathOrKey) {
-      if(!"viewsheet".equals(normalizedType) || pathOrKey == null) {
+      if(!SHEET.equals(normalizedType) || pathOrKey == null) {
          return null;
       }
 
@@ -270,7 +273,13 @@ public final class PropertyAliases {
       // dialog model above, ViewsheetPropertyDialogModel has genuine top-level scalar fields
       // (width, height, preview) with no general pane to nest them under, so several aliases
       // here are legitimately bare paths rather than dotted ones.
-      register(registry, "viewsheet", ViewsheetPropertyDialogModel.class, viewsheet());
+      // Keyed "sheet", not "viewsheet", because "viewsheet" is already an ASSEMBLY type name:
+      // Viewsheet implements VSAssembly, so AssemblyPropertyService.typeOf derives "viewsheet"
+      // from the class of an embedded-viewsheet assembly. Registering the sheet's own vocabulary
+      // under that name made covers("viewsheet") true and replaced the clear "'X' is a Viewsheet,
+      // whose properties are not covered yet" with "No property service wired for assembly type
+      // 'viewsheet'" -- which reads as an internal wiring bug rather than an unsupported assembly.
+      register(registry, SHEET, ViewsheetPropertyDialogModel.class, viewsheet());
       return Collections.unmodifiableMap(registry);
    }
 
@@ -596,7 +605,6 @@ public final class PropertyAliases {
       aliases.put("promptForParams", "vsOptionsPane.promptForParams");
       aliases.put("selectionAssociation", "vsOptionsPane.selectionAssociation");
       aliases.put("createMv", "vsOptionsPane.createMv");
-      aliases.put("onDemandMvEnabled", "vsOptionsPane.onDemandMvEnabled");
       aliases.put("serverSideUpdate", "vsOptionsPane.serverSideUpdate");
       aliases.put("touchInterval", "vsOptionsPane.touchInterval");
       aliases.put("maxRowsWarning", "vsOptionsPane.maxRowsWarning");
@@ -610,9 +618,15 @@ public final class PropertyAliases {
       // large cost for something it cannot even write. Reading them is still possible, and is what
       // `raw: true` is for; resolveForWrite still refuses them by name, since it matches on the
       // path rather than on membership in this map.
-      aliases.put("width", "width");
-      aliases.put("height", "height");
-      aliases.put("preview", "preview");
+      // width/height/preview are deliberately absent. They are not sheet state: getViewsheetInfo
+      // never populates them, so they read back as the Immutables defaults 0/0/false, and
+      // setViewsheetInfo reads them only to size a one-off refresh. Writing one reported success
+      // and changed nothing -- the silent no-op this layer exists to prevent -- and preview:true
+      // additionally reached VSEventUtil.clearScale, discarding assembly scaling as a side effect
+      // of "setting a property".
+      //
+      // onDemandMvEnabled is absent for the same reason: it is a capability flag computed in the
+      // getter from SreeEnv, never read by the setter. createMv is the real property.
       return aliases;
    }
 }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
@@ -75,6 +75,39 @@ public final class PropertyAliases {
    }
 
    /**
+    * Resolves a key for a <b>write</b>, on top of {@link #resolve}.
+    *
+    * <p>The viewsheet's own vocabulary has properties that are readable — they come back from
+    * {@code list_viewsheet_properties} / {@code get_viewsheet_properties} — but refuse to be
+    * <i>written</i> through a properties patch, because the write would be a hazard the
+    * ordinary "set a scalar" contract does not cover: authoring script through a second,
+    * ungoverned path, or replacing a structure that is relational to other assemblies in the
+    * sheet rather than a simple {@code info.setX}. {@code vsScriptPane} is refused outright —
+    * it is not even in the vocabulary, since it is never offered as something to set at all.
+    *
+    * <p>The refusal checks the <b>resolved path</b>, not just the input key, so the raw-dotted-
+    * path escape hatch cannot reach the same field under a different spelling — e.g.
+    * {@code vsScriptPane.onInit} is refused exactly like {@code vsScriptPane} is.
+    */
+   public static String resolveForWrite(String assemblyType, String key) {
+      String normalizedType = normalize(assemblyType);
+      String refusal = viewsheetWriteRefusal(normalizedType, key);
+
+      if(refusal != null) {
+         throw new IllegalArgumentException(refusal);
+      }
+
+      String path = resolve(assemblyType, key);
+      refusal = viewsheetWriteRefusal(normalizedType, path);
+
+      if(refusal != null) {
+         throw new IllegalArgumentException(refusal);
+      }
+
+      return path;
+   }
+
+   /**
     * Resolves an agent-supplied key to a model path: exact alias first, then the key as a raw
     * dotted path. A key that is neither throws with near-matches — it is never dropped.
     */
@@ -97,6 +130,50 @@ public final class PropertyAliases {
          nearest(key, entry.aliases().keySet()) +
          " Known names: " + String.join(", ", new TreeSet<>(entry.aliases().keySet())) +
          ". A raw model path (containing a '.') is also accepted.");
+   }
+
+   /**
+    * The viewsheet-level write refusals. Checked against both the input key (so
+    * {@code vsScriptPane}, which is not in the vocabulary at all, still gets a specific,
+    * explanatory refusal rather than a generic "unknown key") and the resolved path (so the
+    * same field cannot be reached by a different spelling — a raw dotted path, or a registered
+    * alias that happens to map onto it).
+    */
+   private static String viewsheetWriteRefusal(String normalizedType, String pathOrKey) {
+      if(!"viewsheet".equals(normalizedType) || pathOrKey == null) {
+         return null;
+      }
+
+      if(isOrUnder(pathOrKey, "vsScriptPane")) {
+         return "'vsScriptPane' is not settable through set_viewsheet_properties. It carries " +
+            "the viewsheet's onInit/onLoad script; writing it through a properties patch would " +
+            "be a second, ungoverned path to authoring viewsheet script. Use update_script " +
+            "instead. Reading it is fine — call get_viewsheet_properties with raw=true.";
+      }
+
+      if(isOrUnder(pathOrKey, "filtersPane")) {
+         return "'filtersPane' is read-only through set_viewsheet_properties in this version. " +
+            "Its filter-id assignments are relational to the sheet's own selection assemblies, " +
+            "not a simple scalar write.";
+      }
+
+      if(isOrUnder(pathOrKey, "localizationPane")) {
+         return "'localizationPane' is read-only through set_viewsheet_properties in this " +
+            "version. Its entries are keyed to the sheet's own component tree, not a simple " +
+            "scalar write.";
+      }
+
+      if(isOrUnder(pathOrKey, "screensPane")) {
+         return "'screensPane' is not settable through set_viewsheet_properties. Device " +
+            "layouts, print layout and screen sizing are their own capability, not a corner of " +
+            "a properties patch.";
+      }
+
+      return null;
+   }
+
+   private static boolean isOrUnder(String path, String prefix) {
+      return path.equals(prefix) || path.startsWith(prefix + ".");
    }
 
    private static String nearest(String key, Set<String> candidates) {
@@ -188,6 +265,12 @@ public final class PropertyAliases {
       register(registry, "selectioncontainer", SelectionContainerPropertyDialogModel.class,
                selectionContainer());
       register(registry, "submit", SubmitPropertyDialogModel.class, submit());
+
+      // The viewsheet's own properties -- the assembly-less target. Unlike every assembly
+      // dialog model above, ViewsheetPropertyDialogModel has genuine top-level scalar fields
+      // (width, height, preview) with no general pane to nest them under, so several aliases
+      // here are legitimately bare paths rather than dotted ones.
+      register(registry, "viewsheet", ViewsheetPropertyDialogModel.class, viewsheet());
       return Collections.unmodifiableMap(registry);
    }
 
@@ -488,6 +571,45 @@ public final class PropertyAliases {
       dataGeneral(aliases, "submitGeneralPaneModel");
       sizePosition(aliases, "submitGeneralPaneModel");
       aliases.put("label", "submitGeneralPaneModel.labelPropPaneModel.label");
+      return aliases;
+   }
+
+   // ── the viewsheet's own properties ────────────────────────────────────────
+
+   /**
+    * {@code VSOptionsPaneModel} has no name field of its own — {@code alias} is the viewsheet
+    * asset's display name, writable here exactly as {@code set_worksheet_properties} already
+    * exposes it for the sibling worksheet type. {@code screensPane} is excluded entirely: it
+    * reaches device layouts, print layout and screen sizing through {@code refLayoutName}, which
+    * is its own capability, not a corner of this one. {@code vsScriptPane} is excluded from the
+    * vocabulary the same way — see {@link #resolveForWrite} for why both write-refuse, and why
+    * {@code filtersPane}/{@code localizationPane} are listed here (readable) but still refuse a
+    * write.
+    */
+   private static Map<String, String> viewsheet() {
+      Map<String, String> aliases = new LinkedHashMap<>();
+      aliases.put("alias", "vsOptionsPane.alias");
+      aliases.put("desc", "vsOptionsPane.desc");
+      aliases.put("maxRows", "vsOptionsPane.maxRows");
+      aliases.put("snapGrid", "vsOptionsPane.snapGrid");
+      aliases.put("useMetaData", "vsOptionsPane.useMetaData");
+      aliases.put("promptForParams", "vsOptionsPane.promptForParams");
+      aliases.put("selectionAssociation", "vsOptionsPane.selectionAssociation");
+      aliases.put("createMv", "vsOptionsPane.createMv");
+      aliases.put("onDemandMvEnabled", "vsOptionsPane.onDemandMvEnabled");
+      aliases.put("serverSideUpdate", "vsOptionsPane.serverSideUpdate");
+      aliases.put("touchInterval", "vsOptionsPane.touchInterval");
+      aliases.put("maxRowsWarning", "vsOptionsPane.maxRowsWarning");
+      aliases.put("hideNotifications", "vsOptionsPane.hideNotifications");
+      aliases.put("listOnPortalTree", "vsOptionsPane.listOnPortalTree");
+      // Read-only in v1 -- see resolveForWrite. Both are genuine top-level accessors, hence the
+      // bare (dot-free) path; noAliasIsAnEmptyOrSelfReferentialPath carves out this type for
+      // exactly that reason.
+      aliases.put("filtersPane", "filtersPane");
+      aliases.put("localizationPane", "localizationPane");
+      aliases.put("width", "width");
+      aliases.put("height", "height");
+      aliases.put("preview", "preview");
       return aliases;
    }
 }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
@@ -269,10 +269,8 @@ public final class PropertyAliases {
                selectionContainer());
       register(registry, "submit", SubmitPropertyDialogModel.class, submit());
 
-      // The viewsheet's own properties -- the assembly-less target. Unlike every assembly
-      // dialog model above, ViewsheetPropertyDialogModel has genuine top-level scalar fields
-      // (width, height, preview) with no general pane to nest them under, so several aliases
-      // here are legitimately bare paths rather than dotted ones.
+      // The viewsheet's own properties -- the assembly-less target.
+      //
       // Keyed "sheet", not "viewsheet", because "viewsheet" is already an ASSEMBLY type name:
       // Viewsheet implements VSAssembly, so AssemblyPropertyService.typeOf derives "viewsheet"
       // from the class of an embedded-viewsheet assembly. Registering the sheet's own vocabulary

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyPath.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyPath.java
@@ -54,18 +54,30 @@ public final class PropertyPath {
    }
 
    /**
-    * Writes a dotted path.
+    * Writes a dotted path, and returns the root the caller must keep using afterward.
     *
     * <p>An absent intermediate is an error rather than something to instantiate: the dialog
     * models are populated by the composer service, so a null pane means the property does not
     * apply to this assembly, and filling one in would fabricate a shape the service never
     * produced.
+    *
+    * <p><b>The return value matters whenever the root itself is immutable.</b> Every other
+    * Immutables case this class handles nests the immutable level under a mutable holder, so a
+    * rebuilt child always has somewhere mutable to be written back into and {@code root} itself
+    * never changes identity. But a single-segment path directly on an immutable root — the
+    * viewsheet-level dialog model's own {@code width}/{@code height}/{@code preview} — has no
+    * such holder: the wither produces a genuinely new instance, and nothing above the root
+    * exists to absorb it. Returning {@code root} unconditionally would silently drop that write,
+    * which is exactly the defect this class exists to avoid. A caller that ignores the return
+    * value and keeps the original reference reproduces that defect regardless.
     */
-   public static void set(Object root, String path, Object value) {
+   public static Object set(Object root, String path, Object value) {
       REBUILT_CHILD.remove();
 
       try {
          writeInto(root, segments(path), 0, path, value);
+         Object rebuilt = REBUILT_CHILD.get();
+         return rebuilt != null ? rebuilt : root;
       }
       finally {
          REBUILT_CHILD.remove();

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/SheetPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/SheetPropertyService.java
@@ -129,7 +129,7 @@ public class SheetPropertyService {
       });
    }
 
-   private static final String VIEWSHEET = "viewsheet";
+   private static final String VIEWSHEET = PropertyAliases.SHEET;
 
    private final ViewsheetSessionService sessions;
    private final ViewsheetPropertyDialogService dialogService;

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/SheetPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/SheetPropertyService.java
@@ -59,7 +59,7 @@ public class SheetPropertyService {
    public Map<String, Object> list(String sessionToken, Principal user) throws Exception {
       RuntimeViewsheet rvs = sessions.resolve(sessionToken, user);
       ViewsheetPropertyDialogModel model = dialogService.getViewsheetInfo(rvs.getID(), user);
-      PropertyAliases.TypeAliases entry = PropertyAliases.forType(VIEWSHEET);
+      PropertyAliases.TypeAliases entry = PropertyAliases.forType(SHEET_TYPE);
       List<Map<String, Object>> properties = new ArrayList<>();
 
       for(Map.Entry<String, String> alias : entry.aliases().entrySet()) {
@@ -86,7 +86,7 @@ public class SheetPropertyService {
          return model;
       }
 
-      PropertyAliases.TypeAliases entry = PropertyAliases.forType(VIEWSHEET);
+      PropertyAliases.TypeAliases entry = PropertyAliases.forType(SHEET_TYPE);
       Map<String, Object> values = new LinkedHashMap<>();
 
       for(Map.Entry<String, String> alias : entry.aliases().entrySet()) {
@@ -111,15 +111,17 @@ public class SheetPropertyService {
       Map<String, String> resolved = new LinkedHashMap<>();
 
       for(String key : patch.keySet()) {
-         resolved.put(key, PropertyAliases.resolveForWrite(VIEWSHEET, key));
+         resolved.put(key, PropertyAliases.resolveForWrite(SHEET_TYPE, key));
       }
 
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          ViewsheetPropertyDialogModel model = dialogService.getViewsheetInfo(runtimeId, user);
 
-         // PropertyPath.set returns the root to keep using: width/height/preview live directly
-         // on this Immutables model with no nested pane to absorb a wither's rebuild, so the
-         // reassignment is load-bearing, not defensive boilerplate.
+         // Keep PropertyPath.set's returned root. Every alias in the vocabulary currently nests
+         // under a pane, which absorbs an Immutables wither's rebuild, so today this reassignment
+         // changes nothing. It guards the NEXT alias that targets a bare top-level field of this
+         // model: without it, the wither's new instance would be discarded and the write would
+         // vanish with no error and no compile failure.
          for(Map.Entry<String, String> entry : resolved.entrySet()) {
             model = (ViewsheetPropertyDialogModel)
                PropertyPath.set(model, entry.getValue(), patch.get(entry.getKey()));
@@ -129,7 +131,14 @@ public class SheetPropertyService {
       });
    }
 
-   private static final String VIEWSHEET = PropertyAliases.SHEET;
+   /**
+    * The vocabulary key for the sheet's own properties.
+    *
+    * <p>Deliberately not the string "viewsheet": that is already an assembly type name, derived
+    * from {@code Viewsheet implements VSAssembly}. This constant is the one place the distinction
+    * has to be stated, so it defers to {@link PropertyAliases#SHEET} rather than repeating it.
+    */
+   private static final String SHEET_TYPE = PropertyAliases.SHEET;
 
    private final ViewsheetSessionService sessions;
    private final ViewsheetPropertyDialogService dialogService;

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/SheetPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/SheetPropertyService.java
@@ -1,0 +1,136 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.web.composer.model.vs.ViewsheetPropertyDialogModel;
+import inetsoft.web.composer.vs.dialog.ViewsheetPropertyDialogService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+import java.util.*;
+
+/**
+ * Reads and writes the viewsheet's <b>own</b> properties — the settings behind the Composer's
+ * Viewsheet Property dialog — through {@link ViewsheetPropertyDialogService}.
+ *
+ * <p>A sibling to {@link AssemblyPropertyService} rather than an extension of it.
+ * {@code AssemblyPropertyService} reflects one signature onto every dialog service —
+ * {@code (runtimeId, objectId, principal)} / {@code (runtimeId, objectId, model, linkUri,
+ * principal, dispatcher)} — because every assembly dialog service actually shares it.
+ * {@code ViewsheetPropertyDialogService} does not: {@code getViewsheetInfo(runtimeId, principal)}
+ * and {@code setViewsheetInfo(runtimeId, value, principal, dispatcher, linkUri, refLayoutName)}
+ * take no assembly name, order their arguments differently, and add {@code refLayoutName} for
+ * the device-layout path this tool does not touch. There is also exactly one target, so the
+ * reflective per-type dispatch {@code AssemblyPropertyService} needs has nothing to dispatch
+ * over here — both methods are called directly.
+ *
+ * <p>{@code refLayoutName} is always passed as {@code null}: it exists so the dialog can report
+ * back which device layout tab moved when the caller was mid-edit on one, and this tool never
+ * touches the layout/{@code screensPane} path (see {@link PropertyAliases}).
+ */
+@Service
+public class SheetPropertyService {
+   @Autowired
+   public SheetPropertyService(ViewsheetSessionService sessions,
+                                ViewsheetPropertyDialogService dialogService)
+   {
+      this.sessions = sessions;
+      this.dialogService = dialogService;
+   }
+
+   /** The viewsheet's property vocabulary, with current values. */
+   public Map<String, Object> list(String sessionToken, Principal user) throws Exception {
+      RuntimeViewsheet rvs = sessions.resolve(sessionToken, user);
+      ViewsheetPropertyDialogModel model = dialogService.getViewsheetInfo(rvs.getID(), user);
+      PropertyAliases.TypeAliases entry = PropertyAliases.forType(VIEWSHEET);
+      List<Map<String, Object>> properties = new ArrayList<>();
+
+      for(Map.Entry<String, String> alias : entry.aliases().entrySet()) {
+         Map<String, Object> property = new LinkedHashMap<>();
+         property.put("name", alias.getKey());
+         property.put("path", alias.getValue());
+         property.put("type",
+                      PropertyPath.typeOf(entry.modelClass(), alias.getValue()).getSimpleName());
+         property.put("value", PropertyPath.get(model, alias.getValue()));
+         properties.add(property);
+      }
+
+      Map<String, Object> out = new LinkedHashMap<>();
+      out.put("properties", properties);
+      return out;
+   }
+
+   /** Current values, by alias. {@code raw} returns the whole dialog model instead. */
+   public Object get(String sessionToken, Principal user, boolean raw) throws Exception {
+      RuntimeViewsheet rvs = sessions.resolve(sessionToken, user);
+      ViewsheetPropertyDialogModel model = dialogService.getViewsheetInfo(rvs.getID(), user);
+
+      if(raw) {
+         return model;
+      }
+
+      PropertyAliases.TypeAliases entry = PropertyAliases.forType(VIEWSHEET);
+      Map<String, Object> values = new LinkedHashMap<>();
+
+      for(Map.Entry<String, String> alias : entry.aliases().entrySet()) {
+         values.put(alias.getKey(), PropertyPath.get(model, alias.getValue()));
+      }
+
+      return values;
+   }
+
+   /** Applies a patch of aliases and/or raw paths. One {@code mutate}, so one checkpoint. */
+   public void set(String sessionToken, Principal user, Map<String, Object> patch, String linkUri)
+      throws Exception
+   {
+      if(patch == null || patch.isEmpty()) {
+         throw new IllegalArgumentException(
+            "set_viewsheet_properties needs at least one property to set.");
+      }
+
+      // Resolved whole before anything is written, exactly as the assembly path is: a bad or
+      // refused key anywhere in the patch must not leave the properties before it applied,
+      // which would be a partial edit the caller has no way to detect from the error alone.
+      Map<String, String> resolved = new LinkedHashMap<>();
+
+      for(String key : patch.keySet()) {
+         resolved.put(key, PropertyAliases.resolveForWrite(VIEWSHEET, key));
+      }
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         ViewsheetPropertyDialogModel model = dialogService.getViewsheetInfo(runtimeId, user);
+
+         // PropertyPath.set returns the root to keep using: width/height/preview live directly
+         // on this Immutables model with no nested pane to absorb a wither's rebuild, so the
+         // reassignment is load-bearing, not defensive boilerplate.
+         for(Map.Entry<String, String> entry : resolved.entrySet()) {
+            model = (ViewsheetPropertyDialogModel)
+               PropertyPath.set(model, entry.getValue(), patch.get(entry.getKey()));
+         }
+
+         dialogService.setViewsheetInfo(runtimeId, model, user, dispatcher, linkUri, null);
+      });
+   }
+
+   private static final String VIEWSHEET = "viewsheet";
+
+   private final ViewsheetSessionService sessions;
+   private final ViewsheetPropertyDialogService dialogService;
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -58,6 +58,7 @@ public class ViewsheetAssemblyAgentController {
                                    ViewsheetFormatService formatService,
                                    ScriptImageService imageService,
                                    AssemblyPropertyService propertyService,
+                                   SheetPropertyService sheetPropertyService,
                                    AssemblyHyperlinkService hyperlinkService,
                                    ChartElementService chartElementService,
                                    ChartRegionPropertyService chartRegionService,
@@ -76,6 +77,7 @@ public class ViewsheetAssemblyAgentController {
       this.formatService = formatService;
       this.imageService = imageService;
       this.propertyService = propertyService;
+      this.sheetPropertyService = sheetPropertyService;
       this.hyperlinkService = hyperlinkService;
       this.chartElementService = chartElementService;
       this.chartRegionService = chartRegionService;
@@ -187,6 +189,45 @@ public class ViewsheetAssemblyAgentController {
    {
       requireEnabled();
       propertyService.set(sessionToken, user, request.assembly(), request.properties(), linkUri);
+   }
+
+   /**
+    * The viewsheet's <b>own</b> properties — the Composer's Viewsheet Property dialog — as
+    * opposed to the assembly trio above. There is no assembly name here: the target is the sheet
+    * itself, so {@link SheetPropertyService} is a sibling of {@link AssemblyPropertyService}
+    * rather than a fourth assembly type.
+    */
+   public record ViewsheetPropertyPatchRequest(Map<String, Object> properties) {}
+
+   @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/vs-properties/list")
+   public Map<String, Object> listViewsheetProperties(@PathVariable String sessionToken,
+                                                       Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return sheetPropertyService.list(sessionToken, user);
+   }
+
+   @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/vs-properties")
+   public Object getViewsheetProperties(@PathVariable String sessionToken,
+                                        @RequestParam(required = false) boolean raw,
+                                        Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return sheetPropertyService.get(sessionToken, user, raw);
+   }
+
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/vs-properties")
+   public void setViewsheetProperties(@PathVariable String sessionToken,
+                                      @RequestBody ViewsheetPropertyPatchRequest request,
+                                      @RequestParam(required = false, defaultValue = "")
+                                      String linkUri,
+                                      Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      sheetPropertyService.set(sessionToken, user, request.properties(), linkUri);
    }
 
    public record HyperlinkRequest(String assembly, Integer row, Integer col, String colName,
@@ -635,6 +676,7 @@ public class ViewsheetAssemblyAgentController {
    private final ViewsheetFormatService formatService;
    private final ScriptImageService imageService;
    private final AssemblyPropertyService propertyService;
+   private final SheetPropertyService sheetPropertyService;
    private final AssemblyHyperlinkService hyperlinkService;
    private final ChartElementService chartElementService;
    private final ChartRegionPropertyService chartRegionService;

--- a/core/src/test/java/inetsoft/uql/viewsheet/vslayout/PrintInfoSizeUnitsTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/vslayout/PrintInfoSizeUnitsTest.java
@@ -1,0 +1,109 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.viewsheet.vslayout;
+
+import inetsoft.graph.internal.DimensionD;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The custom page size survives a read/modify/write round trip in every unit.
+ *
+ * <p>Written to settle a review finding that read the other way: that
+ * {@code ViewsheetPropertyDialogService}'s getter takes the custom size in inches while its setter
+ * multiplies by {@code getUnitRatio(units)}, so one unrelated property write would divide a custom
+ * page size by 25.4 and repeat writes would compound.
+ *
+ * <p>The asymmetry is not there, and the reason is easy to miss: {@link PrintInfo#getSize()} does
+ * the inches-to-current-unit conversion <em>itself</em>, which is why the dialog getter passes a
+ * ratio of 1 for the size while passing a real ratio for the margins two lines above. That
+ * difference looks exactly like the bug described. These tests pin the round trip so the next
+ * reader does not have to re-derive it — and so that "fixing" the getter to match the margins,
+ * which would genuinely introduce the reported bug, fails loudly.
+ */
+@Tag("core")
+class PrintInfoSizeUnitsTest {
+   /** What the dialog setter does: a value entered in {@code unit} becomes stored inches. */
+   private static DimensionD asStored(double width, double height, String unit) {
+      double ratio = PrintInfo.getUnitRatio(unit);
+      return new DimensionD(width * ratio, height * ratio);
+   }
+
+   private static PrintInfo infoWith(DimensionD stored, String unit) {
+      PrintInfo info = new PrintInfo();
+      info.setUnit(unit);
+      info.setSize(stored);
+      return info;
+   }
+
+   @Test
+   void customSizeRoundTripsInMillimetres() {
+      PrintInfo info = infoWith(asStored(210, 297, "mm"), "mm");
+
+      // getSize() converts back to the current unit, which is why the dialog displays it as-is.
+      assertEquals(210, info.getSize().getWidth(), 1e-9);
+      assertEquals(297, info.getSize().getHeight(), 1e-9);
+   }
+
+   @Test
+   void customSizeRoundTripsInPoints() {
+      PrintInfo info = infoWith(asStored(612, 792, "points"), "points");
+
+      assertEquals(612, info.getSize().getWidth(), 1e-9);
+      assertEquals(792, info.getSize().getHeight(), 1e-9);
+   }
+
+   @Test
+   void customSizeRoundTripsInInches() {
+      PrintInfo info = infoWith(asStored(8.5, 11, "inches"), "inches");
+
+      assertEquals(8.5, info.getSize().getWidth(), 1e-9);
+      assertEquals(11, info.getSize().getHeight(), 1e-9);
+   }
+
+   /**
+    * The claim underlying the review finding: that repeated writes shrink the page.
+    *
+    * <p>Ten read/modify/write cycles that touch nothing about the size must leave it identical. If
+    * the conversion were one-sided this would be off by 25.4^10.
+    */
+   @Test
+   void repeatedWritesThatDoNotTouchTheSizeLeaveItUnchanged() {
+      String unit = "mm";
+      PrintInfo info = infoWith(asStored(210, 297, unit), unit);
+
+      for(int i = 0; i < 10; i++) {
+         DimensionD displayed = info.getSize();
+         info.setSize(asStored(displayed.getWidth(), displayed.getHeight(), unit));
+      }
+
+      assertEquals(210, info.getSize().getWidth(), 1e-9);
+      assertEquals(297, info.getSize().getHeight(), 1e-9);
+   }
+
+   /** Margins convert through the same ratio, in the opposite direction, on the dialog's side. */
+   @Test
+   void theUnitRatioIsTheSameConstantBothWays() {
+      assertEquals(1 / 25.4, PrintInfo.getUnitRatio("mm"), 1e-12);
+      assertEquals(1 / 72.0, PrintInfo.getUnitRatio("points"), 1e-12);
+      assertEquals(1, PrintInfo.getUnitRatio("inches"), 1e-12);
+      assertEquals(1, PrintInfo.getUnitRatio(null), 1e-12, "an unknown unit must not scale");
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
@@ -87,15 +87,38 @@ class AssemblyPropertyServiceTest {
       assertEquals(3, service.bindingFor("gauge").getterArity());
    }
 
+   /**
+    * Every <b>assembly</b> type in the registry must resolve to a wired dialog service here, so
+    * a covered-but-unwired type never fails at runtime instead of at the build.
+    *
+    * <p>{@code viewsheet} is deliberately excluded: it is the one covered type that names no
+    * assembly at all. {@code ViewsheetPropertyDialogService.getViewsheetInfo}/
+    * {@code setViewsheetInfo} take no assembly name and order their arguments differently from
+    * every assembly dialog service's shared {@code (runtimeId, objectId, ...)} shape, so it is
+    * not — and should never become — one more entry in this reflective dispatch table. It is
+    * wired directly into {@link SheetPropertyService} instead.
+    */
    @Test
-   void everyCoveredTypeHasAWiredService() {
+   void everyCoveredAssemblyTypeHasAWiredService() {
       AssemblyPropertyService service = serviceWith(mock(GaugeVSAssembly.class), null);
 
       for(String type : PropertyAliases.coveredTypes()) {
+         if(type.equals("viewsheet")) {
+            continue;
+         }
+
          assertDoesNotThrow(() -> service.bindingFor(type),
                             "'" + type + "' has aliases but no property service wired, so " +
                             "every call for it would fail at runtime");
       }
+   }
+
+   /** The flip side of the exclusion above: viewsheet must NOT be reachable this way. */
+   @Test
+   void viewsheetIsNotWiredIntoTheAssemblyDispatchTable() {
+      AssemblyPropertyService service = serviceWith(mock(GaugeVSAssembly.class), null);
+
+      assertThrows(Exception.class, () -> service.bindingFor("viewsheet"));
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
@@ -91,7 +91,7 @@ class AssemblyPropertyServiceTest {
     * Every <b>assembly</b> type in the registry must resolve to a wired dialog service here, so
     * a covered-but-unwired type never fails at runtime instead of at the build.
     *
-    * <p>{@code viewsheet} is deliberately excluded: it is the one covered type that names no
+    * <p>{@code sheet} is deliberately excluded: it is the one covered type that names no
     * assembly at all. {@code ViewsheetPropertyDialogService.getViewsheetInfo}/
     * {@code setViewsheetInfo} take no assembly name and order their arguments differently from
     * every assembly dialog service's shared {@code (runtimeId, objectId, ...)} shape, so it is
@@ -103,7 +103,7 @@ class AssemblyPropertyServiceTest {
       AssemblyPropertyService service = serviceWith(mock(GaugeVSAssembly.class), null);
 
       for(String type : PropertyAliases.coveredTypes()) {
-         if(type.equals("viewsheet")) {
+         if(type.equals(PropertyAliases.SHEET)) {
             continue;
          }
 
@@ -113,7 +113,7 @@ class AssemblyPropertyServiceTest {
       }
    }
 
-   /** The flip side of the exclusion above: viewsheet must NOT be reachable this way. */
+   /** The flip side of the exclusion above: the sheet must NOT be reachable this way. */
    @Test
    void viewsheetIsNotWiredIntoTheAssemblyDispatchTable() {
       AssemblyPropertyService service = serviceWith(mock(GaugeVSAssembly.class), null);

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyAliasesTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyAliasesTest.java
@@ -61,9 +61,9 @@ class PropertyAliasesTest {
             assertFalse(alias.getValue().isBlank(), alias.getKey() + " maps to nothing");
 
             // The viewsheet's own dialog model has genuine top-level scalar fields --
-            // width, height, preview, filtersPane, localizationPane -- unlike every assembly
-            // dialog model, which always nests behind at least one general pane. A bare path
-            // is the honest alias there, not a self-referential shortcut around real nesting.
+            // width, height, preview -- unlike every assembly dialog model, which always nests
+            // behind at least one general pane. A bare path is the honest alias there, not a
+            // self-referential shortcut around real nesting.
             if(type.equals("viewsheet")) {
                continue;
             }
@@ -79,9 +79,8 @@ class PropertyAliasesTest {
 
    @Test
    void exposesTheViewsheetVocabulary() {
-      for(String alias : java.util.List.of("alias", "desc", "maxRows", "snapGrid",
-                                           "filtersPane", "localizationPane", "width", "height",
-                                           "preview"))
+      for(String alias : java.util.List.of("alias", "desc", "maxRows", "snapGrid", "width",
+                                           "height", "preview"))
       {
          assertTrue(PropertyAliases.forType("viewsheet").aliases().containsKey(alias),
                     "viewsheet should expose '" + alias + "'");
@@ -133,10 +132,17 @@ class PropertyAliasesTest {
    }
 
    /**
-    * {@code filtersPane} and {@code localizationPane} are readable (they are in the vocabulary
-    * above) but not writable in v1: their entries are relational to other assemblies in the
-    * sheet (filter ids keyed to selection assemblies, localization keyed to the component
-    * tree), not a simple scalar {@code info.setX}.
+    * {@code filtersPane} and {@code localizationPane} are deliberately absent from the vocabulary
+    * and still refused on write.
+    *
+    * <p>They are read-only -- their entries are relational to other assemblies (filter ids keyed to
+    * selection assemblies, localization keyed to the component tree), not a simple scalar
+    * {@code info.setX}. They were briefly aliased so they could be read by name, which made every
+    * list/get carry the whole localization component tree: ~350 lines on a small sheet, growing
+    * with assembly count. Reading them is what {@code raw: true} is for.
+    *
+    * <p>These two tests matter more now, not less: the refusal has to keep working for a key that
+    * is no longer in the map, which it does because {@code resolveForWrite} matches on the path.
     */
    @Test
    void refusesToWriteFiltersPane() {

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyAliasesTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyAliasesTest.java
@@ -27,6 +27,13 @@ import static org.junit.jupiter.api.Assertions.*;
 @Tag("core")
 class PropertyAliasesTest {
    /**
+    * The viewsheet aliases that legitimately map to a bare, dot-free path because the field really
+    * does sit at the top of {@code ViewsheetPropertyDialogModel}. Kept as an explicit list so the
+    * nesting invariant stays live for every other alias of that type.
+    */
+   private static final java.util.Set<String> SHEET_TOP_LEVEL = java.util.Set.of();
+
+   /**
     * <b>The highest-value test in this band.</b> It reflects over every declared alias and
     * asserts the path exists on its dialog model. When the composer renames a pane field, this
     * breaks the build instead of letting the plugin ship an alias that silently resolves to
@@ -60,11 +67,10 @@ class PropertyAliasesTest {
          for(Map.Entry<String, String> alias : entry.aliases().entrySet()) {
             assertFalse(alias.getValue().isBlank(), alias.getKey() + " maps to nothing");
 
-            // The viewsheet's own dialog model has genuine top-level scalar fields --
-            // width, height, preview -- unlike every assembly dialog model, which always nests
-            // behind at least one general pane. A bare path is the honest alias there, not a
-            // self-referential shortcut around real nesting.
-            if(type.equals("viewsheet")) {
+            // Skip only the aliases that are genuinely top-level accessors on the viewsheet's own
+            // dialog model, not every alias of that type. Blanket-skipping the type would let a
+            // future "desc -> desc" typo through, which is exactly what this test exists to catch.
+            if(type.equals(PropertyAliases.SHEET) && SHEET_TOP_LEVEL.contains(alias.getKey())) {
                continue;
             }
 
@@ -79,10 +85,10 @@ class PropertyAliasesTest {
 
    @Test
    void exposesTheViewsheetVocabulary() {
-      for(String alias : java.util.List.of("alias", "desc", "maxRows", "snapGrid", "width",
-                                           "height", "preview"))
+      for(String alias : java.util.List.of("alias", "desc", "maxRows", "snapGrid",
+                                           "useMetaData", "promptForParams"))
       {
-         assertTrue(PropertyAliases.forType("viewsheet").aliases().containsKey(alias),
+         assertTrue(PropertyAliases.forType(PropertyAliases.SHEET).aliases().containsKey(alias),
                     "viewsheet should expose '" + alias + "'");
       }
    }
@@ -94,7 +100,7 @@ class PropertyAliasesTest {
     */
    @Test
    void theViewsheetVocabularyNamesNoScriptKey() {
-      for(String alias : PropertyAliases.forType("viewsheet").aliases().keySet()) {
+      for(String alias : PropertyAliases.forType(PropertyAliases.SHEET).aliases().keySet()) {
          assertFalse(alias.toLowerCase().contains("script"),
                      "'" + alias + "' should not be part of the enumerated vocabulary");
       }
@@ -102,7 +108,7 @@ class PropertyAliasesTest {
 
    @Test
    void aliasIsWritableOnAViewsheet() {
-      assertEquals("vsOptionsPane.alias", PropertyAliases.resolveForWrite("viewsheet", "alias"));
+      assertEquals("vsOptionsPane.alias", PropertyAliases.resolveForWrite(PropertyAliases.SHEET, "alias"));
    }
 
    /**
@@ -115,7 +121,7 @@ class PropertyAliasesTest {
    void refusesToWriteTheScriptPaneAndPointsAtUpdateScript() {
       Exception thrown = assertThrows(
          IllegalArgumentException.class,
-         () -> PropertyAliases.resolveForWrite("viewsheet", "vsScriptPane"));
+         () -> PropertyAliases.resolveForWrite(PropertyAliases.SHEET, "vsScriptPane"));
 
       assertTrue(thrown.getMessage().contains("vsScriptPane"));
       assertTrue(thrown.getMessage().contains("update_script"));
@@ -126,7 +132,7 @@ class PropertyAliasesTest {
    void refusesTheScriptPaneEvenAsARawDottedPath() {
       Exception thrown = assertThrows(
          IllegalArgumentException.class,
-         () -> PropertyAliases.resolveForWrite("viewsheet", "vsScriptPane.onInit"));
+         () -> PropertyAliases.resolveForWrite(PropertyAliases.SHEET, "vsScriptPane.onInit"));
 
       assertTrue(thrown.getMessage().contains("update_script"));
    }
@@ -147,27 +153,28 @@ class PropertyAliasesTest {
    @Test
    void refusesToWriteFiltersPane() {
       assertThrows(IllegalArgumentException.class,
-                   () -> PropertyAliases.resolveForWrite("viewsheet", "filtersPane"));
+                   () -> PropertyAliases.resolveForWrite(PropertyAliases.SHEET, "filtersPane"));
    }
 
    @Test
    void refusesToWriteLocalizationPane() {
       assertThrows(IllegalArgumentException.class,
-                   () -> PropertyAliases.resolveForWrite("viewsheet", "localizationPane"));
+                   () -> PropertyAliases.resolveForWrite(PropertyAliases.SHEET, "localizationPane"));
    }
 
    /** Excluded with the layout/{@code refLayoutName} path -- its own capability, not v1's. */
    @Test
    void refusesToWriteScreensPaneEvenAsARawPath() {
       assertThrows(IllegalArgumentException.class,
-                   () -> PropertyAliases.resolveForWrite("viewsheet", "screensPane.targetScreen"));
+                   () -> PropertyAliases.resolveForWrite(PropertyAliases.SHEET, "screensPane.targetScreen"));
    }
 
    @Test
    void resolvesAnOrdinaryScalarForWrite() {
       assertEquals("vsOptionsPane.maxRows",
-                   PropertyAliases.resolveForWrite("viewsheet", "maxRows"));
-      assertEquals("width", PropertyAliases.resolveForWrite("viewsheet", "width"));
+                   PropertyAliases.resolveForWrite(PropertyAliases.SHEET, "maxRows"));
+      assertEquals("vsOptionsPane.snapGrid",
+                   PropertyAliases.resolveForWrite(PropertyAliases.SHEET, "snapGrid"));
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyAliasesTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyAliasesTest.java
@@ -59,11 +59,109 @@ class PropertyAliasesTest {
 
          for(Map.Entry<String, String> alias : entry.aliases().entrySet()) {
             assertFalse(alias.getValue().isBlank(), alias.getKey() + " maps to nothing");
+
+            // The viewsheet's own dialog model has genuine top-level scalar fields --
+            // width, height, preview, filtersPane, localizationPane -- unlike every assembly
+            // dialog model, which always nests behind at least one general pane. A bare path
+            // is the honest alias there, not a self-referential shortcut around real nesting.
+            if(type.equals("viewsheet")) {
+               continue;
+            }
+
             assertTrue(alias.getValue().contains("."),
                        alias.getKey() + " maps to '" + alias.getValue() + "', which is not a " +
                        "model path — an alias must name a real nested field");
          }
       }
+   }
+
+   // ── viewsheet vocabulary (vs-level properties) ────────────────────────────
+
+   @Test
+   void exposesTheViewsheetVocabulary() {
+      for(String alias : java.util.List.of("alias", "desc", "maxRows", "snapGrid",
+                                           "filtersPane", "localizationPane", "width", "height",
+                                           "preview"))
+      {
+         assertTrue(PropertyAliases.forType("viewsheet").aliases().containsKey(alias),
+                    "viewsheet should expose '" + alias + "'");
+      }
+   }
+
+   /**
+    * {@code vsScriptPane} is deliberately not part of the enumerated vocabulary at all --
+    * reading it is still possible through a raw model dump, but it is never offered as a named
+    * "property" a caller might reasonably try to set.
+    */
+   @Test
+   void theViewsheetVocabularyNamesNoScriptKey() {
+      for(String alias : PropertyAliases.forType("viewsheet").aliases().keySet()) {
+         assertFalse(alias.toLowerCase().contains("script"),
+                     "'" + alias + "' should not be part of the enumerated vocabulary");
+      }
+   }
+
+   @Test
+   void aliasIsWritableOnAViewsheet() {
+      assertEquals("vsOptionsPane.alias", PropertyAliases.resolveForWrite("viewsheet", "alias"));
+   }
+
+   /**
+    * {@code vsScriptPane} carries onInit/onLoad script. Writing it through a properties patch
+    * would be a second, ungoverned path to authoring viewsheet script that routes around the
+    * (unbuilt) script-kind taxonomy. The refusal names the field and points at the tool that
+    * does own writing script.
+    */
+   @Test
+   void refusesToWriteTheScriptPaneAndPointsAtUpdateScript() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> PropertyAliases.resolveForWrite("viewsheet", "vsScriptPane"));
+
+      assertTrue(thrown.getMessage().contains("vsScriptPane"));
+      assertTrue(thrown.getMessage().contains("update_script"));
+   }
+
+   /** The raw-path escape hatch must not reach the script pane under a different spelling. */
+   @Test
+   void refusesTheScriptPaneEvenAsARawDottedPath() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> PropertyAliases.resolveForWrite("viewsheet", "vsScriptPane.onInit"));
+
+      assertTrue(thrown.getMessage().contains("update_script"));
+   }
+
+   /**
+    * {@code filtersPane} and {@code localizationPane} are readable (they are in the vocabulary
+    * above) but not writable in v1: their entries are relational to other assemblies in the
+    * sheet (filter ids keyed to selection assemblies, localization keyed to the component
+    * tree), not a simple scalar {@code info.setX}.
+    */
+   @Test
+   void refusesToWriteFiltersPane() {
+      assertThrows(IllegalArgumentException.class,
+                   () -> PropertyAliases.resolveForWrite("viewsheet", "filtersPane"));
+   }
+
+   @Test
+   void refusesToWriteLocalizationPane() {
+      assertThrows(IllegalArgumentException.class,
+                   () -> PropertyAliases.resolveForWrite("viewsheet", "localizationPane"));
+   }
+
+   /** Excluded with the layout/{@code refLayoutName} path -- its own capability, not v1's. */
+   @Test
+   void refusesToWriteScreensPaneEvenAsARawPath() {
+      assertThrows(IllegalArgumentException.class,
+                   () -> PropertyAliases.resolveForWrite("viewsheet", "screensPane.targetScreen"));
+   }
+
+   @Test
+   void resolvesAnOrdinaryScalarForWrite() {
+      assertEquals("vsOptionsPane.maxRows",
+                   PropertyAliases.resolveForWrite("viewsheet", "maxRows"));
+      assertEquals("width", PropertyAliases.resolveForWrite("viewsheet", "width"));
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyPathTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyPathTest.java
@@ -215,6 +215,54 @@ class PropertyPathTest {
                    "a wither takes the same coercion as a setter");
    }
 
+   /**
+    * A root that is itself immutable, with no mutable holder anywhere above it -- the exact
+    * shape {@code ViewsheetPropertyDialogModel} takes for {@code width}/{@code height}/
+    * {@code preview}: a direct top-level scalar with only a wither, no nested pane to absorb the
+    * rebuild. Every other Immutables case in this suite nests the immutable at least one level
+    * under a mutable holder, so the wither's new instance always has somewhere mutable to be
+    * written back into. Here there is nothing above the root, so the only way the caller can see
+    * the new value is if {@code set} hands the (possibly rebuilt) root back.
+    */
+   public static final class ImmutableScalarRoot {
+      ImmutableScalarRoot(int width) { this.width = width; }
+
+      public int width() { return width; }
+      public ImmutableScalarRoot withWidth(int value) { return new ImmutableScalarRoot(value); }
+
+      private final int width;
+   }
+
+   @Test
+   void rebuildingAnImmutableRootReturnsTheNewInstance() {
+      ImmutableScalarRoot root = new ImmutableScalarRoot(0);
+
+      Object result = PropertyPath.set(root, "width", 100);
+
+      assertNotSame(root, result, "the root itself had only a wither, so it had to be rebuilt");
+      assertEquals(100, ((ImmutableScalarRoot) result).width());
+   }
+
+   @Test
+   void theOriginalImmutableRootIsLeftUnchanged() {
+      ImmutableScalarRoot root = new ImmutableScalarRoot(0);
+
+      PropertyPath.set(root, "width", 100);
+
+      assertEquals(0, root.width(),
+                   "immutable -- a caller that ignores the returned instance and keeps using " +
+                   "the original would silently lose the write");
+   }
+
+   @Test
+   void writingAMutableRootReturnsThatSameRoot() {
+      Root root = new Root();
+
+      Object result = PropertyPath.set(root, "middle.leaf.title", "Revenue");
+
+      assertSame(root, result, "a mutable root is updated in place, not replaced");
+   }
+
    @Test
    void refusesAnUnknownLeafOnAnImmutableOwnerNamingWhatExists() {
       MutableRoot root = new MutableRoot();

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/SheetPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/SheetPropertyServiceTest.java
@@ -56,6 +56,14 @@ class SheetPropertyServiceTest {
       assertTrue(names.contains("maxRows"));
       assertTrue(names.contains("snapGrid"));
 
+      // Not sheet state: the getter never populates them, so they read back as the Immutables
+      // defaults, and the setter uses them only to size a one-off refresh. preview:true also
+      // reached VSEventUtil.clearScale, discarding assembly scaling. onDemandMvEnabled is a
+      // capability flag the setter never reads.
+      for(String phantom : java.util.List.of("width", "height", "preview", "onDemandMvEnabled")) {
+         assertFalse(names.contains(phantom), phantom + " is not a settable viewsheet property");
+      }
+
       // filtersPane and localizationPane are deliberately absent: whole object graphs, read-only,
       // and aliasing them made every list/get carry the entire localization component tree.
       // Reading them is what raw:true is for.
@@ -109,29 +117,21 @@ class SheetPropertyServiceTest {
       verify(sessions, times(1)).mutate(anyString(), any(Principal.class), any());
    }
 
-   /**
-    * {@code width} lives directly on the immutable {@code ViewsheetPropertyDialogModel} root,
-    * with only a wither and no nested pane to absorb the rebuild. If the service kept using the
-    * model object it originally read instead of the (possibly rebuilt) one {@code PropertyPath}
-    * hands back, this write would silently vanish -- the exact defect this whole layer exists
-    * to avoid.
+   /*
+    * There was a test here proving that set() rebuilds the root when the written field is a
+    * top-level Immutables scalar, driven through the "width" alias.
+    *
+    * It is gone because width/height/preview are no longer in the vocabulary: they are not sheet
+    * state, so writing one always was a silent no-op. No alias now targets a bare top-level field,
+    * which makes that path unreachable from here.
+    *
+    * The behaviour it covered is NOT untested. PropertyPath.set still returns the (possibly
+    * rebuilt) root, and PropertyPathTest exercises that directly against an Immutables scalar
+    * root -- which is the honest place for it, since it is PropertyPath's contract rather than
+    * this service's. Keeping the hardening without a vocabulary entry that needs it is
+    * deliberate: the next alias that does target a top-level field would otherwise vanish
+    * silently, with no compile error.
     */
-   @Test
-   void setRebuildsTheRootWhenTheWrittenFieldIsATopLevelImmutableScalar() throws Exception {
-      ViewsheetPropertyDialogService dialog = mock(ViewsheetPropertyDialogService.class);
-      ViewsheetPropertyDialogModel model = modelWith(20, "old");
-      when(dialog.getViewsheetInfo(anyString(), any(Principal.class))).thenReturn(model);
-
-      SheetPropertyService service = new SheetPropertyService(sessionsMock(), dialog);
-
-      service.set("tok", principal(), Map.of("width", 800), "");
-
-      ArgumentCaptor<ViewsheetPropertyDialogModel> captor =
-         ArgumentCaptor.forClass(ViewsheetPropertyDialogModel.class);
-      verify(dialog).setViewsheetInfo(eq("rt1"), captor.capture(), any(Principal.class), any(),
-                                      anyString(), any());
-      assertEquals(800, captor.getValue().width());
-   }
 
    @Test
    void aliasIsWritable() throws Exception {

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/SheetPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/SheetPropertyServiceTest.java
@@ -54,7 +54,13 @@ class SheetPropertyServiceTest {
 
       assertTrue(names.contains("desc"));
       assertTrue(names.contains("maxRows"));
-      assertTrue(names.contains("filtersPane"));
+      assertTrue(names.contains("snapGrid"));
+
+      // filtersPane and localizationPane are deliberately absent: whole object graphs, read-only,
+      // and aliasing them made every list/get carry the entire localization component tree.
+      // Reading them is what raw:true is for.
+      assertFalse(names.contains("filtersPane"));
+      assertFalse(names.contains("localizationPane"));
 
       for(Object name : names) {
          assertFalse(String.valueOf(name).toLowerCase().contains("script"),

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/SheetPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/SheetPropertyServiceTest.java
@@ -1,0 +1,209 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.web.composer.model.vs.ViewsheetPropertyDialogModel;
+import inetsoft.web.composer.model.vs.VSOptionsPaneModel;
+import inetsoft.web.composer.vs.dialog.ViewsheetPropertyDialogService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class SheetPropertyServiceTest {
+   @Test
+   void listsTheViewsheetVocabularyWithNoScriptKey() throws Exception {
+      SheetPropertyService service = serviceWith(modelWith(20, "old desc"));
+
+      Map<String, Object> listed = service.list("tok", principal());
+
+      @SuppressWarnings("unchecked")
+      List<Map<String, Object>> properties = (List<Map<String, Object>>) listed.get("properties");
+      assertNotNull(properties);
+
+      Set<Object> names = new java.util.HashSet<>();
+
+      for(Map<String, Object> property : properties) {
+         names.add(property.get("name"));
+      }
+
+      assertTrue(names.contains("desc"));
+      assertTrue(names.contains("maxRows"));
+      assertTrue(names.contains("filtersPane"));
+
+      for(Object name : names) {
+         assertFalse(String.valueOf(name).toLowerCase().contains("script"),
+                     "no script-named key should appear in the vocabulary: " + name);
+      }
+   }
+
+   @Test
+   void getReturnsCurrentValuesByAlias() throws Exception {
+      SheetPropertyService service = serviceWith(modelWith(30, "hello"));
+
+      @SuppressWarnings("unchecked")
+      Map<String, Object> values = (Map<String, Object>) service.get("tok", principal(), false);
+
+      assertEquals("hello", values.get("desc"));
+      assertEquals(30, values.get("maxRows"));
+   }
+
+   @Test
+   void getRawReturnsTheWholeModel() throws Exception {
+      ViewsheetPropertyDialogModel model = modelWith(30, "hello");
+      SheetPropertyService service = serviceWith(model);
+
+      assertSame(model, service.get("tok", principal(), true));
+   }
+
+   @Test
+   void setWritesAScalarPropertyThroughOneCheckpoint() throws Exception {
+      ViewsheetPropertyDialogService dialog = mock(ViewsheetPropertyDialogService.class);
+      ViewsheetPropertyDialogModel model = modelWith(20, "old");
+      when(dialog.getViewsheetInfo(anyString(), any(Principal.class))).thenReturn(model);
+      ViewsheetSessionService sessions = sessionsMock();
+
+      SheetPropertyService service = new SheetPropertyService(sessions, dialog);
+
+      service.set("tok", principal(), Map.of("desc", "new description"), "");
+
+      ArgumentCaptor<ViewsheetPropertyDialogModel> captor =
+         ArgumentCaptor.forClass(ViewsheetPropertyDialogModel.class);
+      verify(dialog).setViewsheetInfo(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                      anyString(), any());
+      assertEquals("new description", captor.getValue().vsOptionsPane().getDesc());
+
+      // One mutate call -- the whole patch is one undo checkpoint, exactly as the assembly
+      // path is.
+      verify(sessions, times(1)).mutate(anyString(), any(Principal.class), any());
+   }
+
+   /**
+    * {@code width} lives directly on the immutable {@code ViewsheetPropertyDialogModel} root,
+    * with only a wither and no nested pane to absorb the rebuild. If the service kept using the
+    * model object it originally read instead of the (possibly rebuilt) one {@code PropertyPath}
+    * hands back, this write would silently vanish -- the exact defect this whole layer exists
+    * to avoid.
+    */
+   @Test
+   void setRebuildsTheRootWhenTheWrittenFieldIsATopLevelImmutableScalar() throws Exception {
+      ViewsheetPropertyDialogService dialog = mock(ViewsheetPropertyDialogService.class);
+      ViewsheetPropertyDialogModel model = modelWith(20, "old");
+      when(dialog.getViewsheetInfo(anyString(), any(Principal.class))).thenReturn(model);
+
+      SheetPropertyService service = new SheetPropertyService(sessionsMock(), dialog);
+
+      service.set("tok", principal(), Map.of("width", 800), "");
+
+      ArgumentCaptor<ViewsheetPropertyDialogModel> captor =
+         ArgumentCaptor.forClass(ViewsheetPropertyDialogModel.class);
+      verify(dialog).setViewsheetInfo(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                      anyString(), any());
+      assertEquals(800, captor.getValue().width());
+   }
+
+   @Test
+   void aliasIsWritable() throws Exception {
+      ViewsheetPropertyDialogService dialog = mock(ViewsheetPropertyDialogService.class);
+      ViewsheetPropertyDialogModel model = modelWith(20, "old");
+      when(dialog.getViewsheetInfo(anyString(), any(Principal.class))).thenReturn(model);
+
+      SheetPropertyService service = new SheetPropertyService(sessionsMock(), dialog);
+
+      service.set("tok", principal(), Map.of("alias", "Q1 Sales"), "");
+
+      ArgumentCaptor<ViewsheetPropertyDialogModel> captor =
+         ArgumentCaptor.forClass(ViewsheetPropertyDialogModel.class);
+      verify(dialog).setViewsheetInfo(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                      anyString(), any());
+      assertEquals("Q1 Sales", captor.getValue().vsOptionsPane().getAlias());
+   }
+
+   @Test
+   void refusesToSetTheScriptPaneNamingUpdateScript() throws Exception {
+      ViewsheetPropertyDialogService dialog = mock(ViewsheetPropertyDialogService.class);
+      SheetPropertyService service = new SheetPropertyService(sessionsMock(), dialog);
+
+      Exception thrown = assertThrows(Exception.class,
+         () -> service.set("tok", principal(), Map.of("vsScriptPane", Map.of()), ""));
+
+      assertTrue(thrown.getMessage().contains("update_script"));
+      verify(dialog, never()).setViewsheetInfo(anyString(), any(), any(), any(), anyString(),
+                                               any());
+   }
+
+   @Test
+   void refusesAnEmptyPatchRatherThanOpeningACheckpointForNothing() {
+      ViewsheetPropertyDialogService dialog = mock(ViewsheetPropertyDialogService.class);
+      SheetPropertyService service = new SheetPropertyService(sessionsMock(), dialog);
+
+      assertThrows(Exception.class, () -> service.set("tok", principal(), Map.of(), ""));
+   }
+
+   // ── harness ───────────────────────────────────────────────────────────────
+
+   private static SheetPropertyService serviceWith(ViewsheetPropertyDialogModel model)
+      throws Exception
+   {
+      ViewsheetPropertyDialogService dialog = mock(ViewsheetPropertyDialogService.class);
+      when(dialog.getViewsheetInfo(anyString(), any(Principal.class))).thenReturn(model);
+      return new SheetPropertyService(sessionsMock(), dialog);
+   }
+
+   private static ViewsheetSessionService sessionsMock() {
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getID()).thenReturn("rt1");
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+
+      try {
+         when(sessions.resolve(anyString(), any(Principal.class))).thenReturn(rvs);
+         doAnswer(invocation -> {
+            ViewsheetSessionService.Mutation mutation = invocation.getArgument(2);
+            mutation.run(rvs, "rt1", null);
+            return null;
+         }).when(sessions).mutate(anyString(), any(Principal.class), any());
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(e);
+      }
+
+      return sessions;
+   }
+
+   private static ViewsheetPropertyDialogModel modelWith(int maxRows, String desc) {
+      VSOptionsPaneModel options = new VSOptionsPaneModel();
+      options.setMaxRows(maxRows);
+      options.setDesc(desc);
+      return ViewsheetPropertyDialogModel.builder().vsOptionsPane(options).build();
+   }
+
+   private static Principal principal() {
+      return () -> "admin";
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -26,9 +26,10 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.security.Principal;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @Tag("core")
@@ -100,6 +101,69 @@ class ViewsheetAssemblyAgentControllerTest {
       verify(sessionService).close("my-token");
    }
 
+   /**
+    * {@code list_viewsheet_properties} / {@code get_viewsheet_properties} /
+    * {@code set_viewsheet_properties} delegate straight through to {@link SheetPropertyService},
+    * exactly as the assembly property trio delegates to {@link AssemblyPropertyService} — no
+    * assembly name in the request, since the target is the sheet itself.
+    */
+   @Test
+   void listViewsheetPropertiesDelegatesToTheService() throws Exception {
+      SheetPropertyService propertyService = mock(SheetPropertyService.class);
+      Map<String, Object> expected = Map.of("properties", List.of());
+      when(propertyService.list(eq("tok"), any(Principal.class))).thenReturn(expected);
+
+      ViewsheetAssemblyAgentController controller = controllerWith(propertyService);
+
+      assertSame(expected, controller.listViewsheetProperties("tok", principal()));
+   }
+
+   @Test
+   void getViewsheetPropertiesDelegatesToTheService() throws Exception {
+      SheetPropertyService propertyService = mock(SheetPropertyService.class);
+      Map<String, Object> expected = Map.of("desc", "hello");
+      when(propertyService.get(eq("tok"), any(Principal.class), eq(false))).thenReturn(expected);
+
+      ViewsheetAssemblyAgentController controller = controllerWith(propertyService);
+
+      assertSame(expected, controller.getViewsheetProperties("tok", false, principal()));
+   }
+
+   @Test
+   void setViewsheetPropertiesDelegatesToTheService() throws Exception {
+      SheetPropertyService propertyService = mock(SheetPropertyService.class);
+      ViewsheetAssemblyAgentController controller = controllerWith(propertyService);
+      Map<String, Object> patch = Map.of("desc", "new");
+
+      controller.setViewsheetProperties(
+         "tok", new ViewsheetAssemblyAgentController.ViewsheetPropertyPatchRequest(patch),
+         "link", principal());
+
+      verify(propertyService).set(eq("tok"), any(Principal.class), eq(patch), eq("link"));
+   }
+
+   /**
+    * A refused patch (a bad key, or the {@code vsScriptPane} refusal) must surface as the same
+    * named-field {@code IllegalArgumentException} the global {@code WizControllerErrorHandler}
+    * turns into a 400 — never a bare 500 that reads as a server bug.
+    */
+   @Test
+   void aRefusedPatchPropagatesTheNamedFieldError() throws Exception {
+      SheetPropertyService propertyService = mock(SheetPropertyService.class);
+      doThrow(new IllegalArgumentException("'vsScriptPane' is not settable ... use update_script."))
+         .when(propertyService).set(anyString(), any(Principal.class), anyMap(), anyString());
+
+      ViewsheetAssemblyAgentController controller = controllerWith(propertyService);
+      Map<String, Object> patch = Map.of("vsScriptPane", Map.of());
+
+      Exception thrown = assertThrows(IllegalArgumentException.class, () ->
+         controller.setViewsheetProperties(
+            "tok", new ViewsheetAssemblyAgentController.ViewsheetPropertyPatchRequest(patch),
+            "", principal()));
+
+      assertTrue(thrown.getMessage().contains("update_script"));
+   }
+
    private static ViewsheetAssemblyAgentController controllerWith(SheetAgentFeature feature,
                                                           ViewsheetSessionService sessions,
                                                           ViewsheetReadService reader)
@@ -118,6 +182,33 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(ViewsheetFormatService.class),
                                           mock(inetsoft.web.wiz.script.ScriptImageService.class),
                                           mock(AssemblyPropertyService.class),
+                                          mock(SheetPropertyService.class),
+                                          mock(AssemblyHyperlinkService.class),
+                                          mock(ChartElementService.class),
+                                          mock(ChartRegionPropertyService.class),
+                                          mock(AssemblyConditionService.class),
+                                          mock(AssemblyHighlightService.class),
+                                          mock(DateComparisonService.class),
+                                          mock(inetsoft.analytic.composition.ViewsheetService.class),
+                                          mock(SheetAgentBroadcastService.class));
+   }
+
+   /** Feature enabled, only {@code propertyService} wired -- for the property-trio tests. */
+   private static ViewsheetAssemblyAgentController controllerWith(
+      SheetPropertyService propertyService)
+   {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      when(feature.isEnabled()).thenReturn(true);
+
+      return new ViewsheetAssemblyAgentController(feature, mock(SheetJoinService.class),
+                                          mock(SheetSessionService.class),
+                                          mock(ViewsheetSessionService.class),
+                                          mock(ViewsheetReadService.class),
+                                          mock(ViewsheetEditService.class),
+                                          mock(ViewsheetFormatService.class),
+                                          mock(inetsoft.web.wiz.script.ScriptImageService.class),
+                                          mock(AssemblyPropertyService.class),
+                                          propertyService,
                                           mock(AssemblyHyperlinkService.class),
                                           mock(ChartElementService.class),
                                           mock(ChartRegionPropertyService.class),


### PR DESCRIPTION
Adds read/write access to the viewsheet's **own** properties — the settings behind the Composer's Viewsheet Property dialog. Until now every property endpoint was assembly-keyed, so none of this was reachable: description, display alias, max rows, snap grid, metadata mode, MV, selection association.

Paired with plugin-side tools in stylebi-wiz (`list`/`get`/`set_viewsheet_properties`).

### Why a sibling service rather than a parameter

`AssemblyPropertyService` reflects one signature onto every dialog service — `(runtimeId, assemblyName, model, linkUri, user, dispatcher)`. The viewsheet's own service does not have it: `getViewsheetInfo(runtimeId, principal)` and `setViewsheetInfo(runtimeId, value, principal, dispatcher, linkUri, refLayoutName)` take no assembly name, order their arguments differently, and add `refLayoutName`.

Threading a nullable `assemblyName` through the existing service would make every existing call site read as though it might be sheet-level. `SheetPropertyService` is a sibling instead, sharing the same whole-patch validation, nearest-match refusal on unknown keys, and forgiving-but-not-guessing scalar coercion.

### A latent bug this surfaced

`PropertyPath.set` returned `void`. That is correct for every case that existed — each target sat under a mutable holder that absorbed an Immutables wither's rebuild. But `width`/`height`/`preview` sit **directly on the immutable root**, so the rebuilt instance had nowhere to go and the write vanished with a clean return.

It now returns the (possibly rebuilt) root. `AssemblyPropertyService` was hardened the same way — no behaviour change today, since none of its aliases target a top-level field of an Immutables model, but the next one that does would silently no-op.

### One deliberate refusal

`vsScriptPane` is readable and refuses writes, pointing the caller at the script tools. It carries the sheet's `onInit`/`onLoad` script, and writing it through a *properties* patch would be a second, ungoverned path to authoring script — while the taxonomy meant to govern that is still unbuilt. The refusal checks the **resolved path**, not the input key, so a raw dotted path cannot reach it under another spelling.

`screensPane` is excluded entirely: renaming or rearranging a layout is not a property edit.

`alias` **is** writable. An earlier draft refused it; that was wrong — `set_worksheet_properties` already ships exactly that capability for the sibling sheet type, and `alias` is an explicitly named key, so there is no side effect to guard against.

### Two existing tests changed

`everyCoveredTypeHasAWiredService` assumed every covered type is assembly-wired, and `noAliasIsAnEmptyOrSelfReferentialPath` assumed every alias nests. The new `viewsheet` type breaks both by design. Each got an explicit, documented carve-out rather than being loosened generally.

### Tests

`./mvnw -pl core -Dtest="inetsoft.web.wiz.viewsheet.*Test" test` — the whole package, not just the new files, to catch collateral damage: **277 tests, 0 failures/errors**. Written test-first; each new test was confirmed failing before the code that satisfies it.

The full module suite was not run — impractical here. Stated rather than implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)