### PR TITLE
open_base_worksheet: follow a connected viewsheet to its base worksheet

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/command/OpenComposerAssetCommand.java
+++ b/core/src/main/java/inetsoft/web/composer/command/OpenComposerAssetCommand.java
@@ -49,6 +49,15 @@ public abstract class OpenComposerAssetCommand {
       return -1;
    }
 
+   /**
+    * The server-opened runtime id to attach to, or {@code null} for the normal flow where the
+    * browser opens its own runtime. Set when an agent tool (e.g. {@code open_base_worksheet})
+    * already opened the runtime server-side -- the browser must attach to that runtime instead
+    * of opening a second one of the same asset.
+    */
+   @Nullable
+   public abstract String runtimeId();
+
    public static Builder builder() {
       return new Builder();
    }

--- a/core/src/main/java/inetsoft/web/wiz/pairing/SheetAgentBroadcastService.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/SheetAgentBroadcastService.java
@@ -202,15 +202,28 @@ public class SheetAgentBroadcastService {
    }
 
    private void sendCommand(String user, String sessionId, String runtimeId, Object command) {
+      sendToBrowser(user, sessionId, runtimeId, command);
+   }
+
+   /**
+    * Push one command to the browser holding a paired session.
+    *
+    * <p>Public because opening the base worksheet has to reach the same browser as a refresh
+    * does, with the same headers, but is not a refresh. The private {@code sendCommand} delegates
+    * here.
+    */
+   public void sendToBrowser(String socketUserName, String socketSessionId, String runtimeId,
+                             Object command)
+   {
       SimpMessageHeaderAccessor headers = SimpMessageHeaderAccessor.create();
-      headers.setSessionId(sessionId);
+      headers.setSessionId(socketSessionId);
       headers.setLeaveMutable(true);
       headers.setNativeHeader(CommandDispatcher.RUNTIME_ID_ATTR, runtimeId);
       headers.setNativeHeader(CommandDispatcher.COMMAND_TYPE_HEADER,
                               resolveCommandType(command));
 
       commandDispatcherService.convertAndSendToUser(
-         user, CommandDispatcher.COMMANDS_TOPIC, command, headers.getMessageHeaders());
+         socketUserName, CommandDispatcher.COMMANDS_TOPIC, command, headers.getMessageHeaders());
    }
 
    private Object buildCommand(SheetType sheetType, RuntimeSheet rs, Principal owner) {

--- a/core/src/main/java/inetsoft/web/wiz/pairing/SheetSessionService.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/SheetSessionService.java
@@ -72,6 +72,32 @@ public class SheetSessionService {
 
    public void close(String token) { if (token != null) sessions.remove(token); }
 
+   /**
+    * Returns an unexpired session of {@code sheetType} owned by {@code ownerIdentity}, or null if
+    * none is held.
+    *
+    * <p>Used to refuse silently replacing a session the user may be editing -- e.g.
+    * {@code open_base_worksheet} refusing to open a second worksheet runtime out from under one
+    * already paired, naming its runtime id instead of ending it with a success response.
+    */
+   public JoinSession findOpen(String ownerIdentity, SheetType sheetType) {
+      if(ownerIdentity == null) {
+         return null;
+      }
+
+      long now = clock.getAsLong();
+
+      for(JoinSession s : sessions.values()) {
+         if(!s.isExpired(now) && s.sheetType() == sheetType &&
+            ownerIdentity.equals(s.ownerIdentity()))
+         {
+            return s;
+         }
+      }
+
+      return null;
+   }
+
    @Scheduled(fixedDelay = 10 * 60_000)
    void evictExpired() {
       long now = clock.getAsLong();

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/SheetOpenService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/SheetOpenService.java
@@ -1,0 +1,119 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.composition.WorksheetService;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityProvider;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.wiz.pairing.JoinSession;
+import inetsoft.web.wiz.pairing.SheetSessionService;
+import inetsoft.web.wiz.pairing.SheetType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+
+/**
+ * Opens the base worksheet of the viewsheet already paired to a session, for the
+ * {@code open_base_worksheet} agent tool.
+ *
+ * <p>This is the first tool that reaches a <b>second</b> sheet from a paired session — every
+ * other property/binding tool operates on the sheet a human paired directly. Because of that, the
+ * refusal guards carry most of this feature's value: each one must name the specific thing that
+ * is wrong (the actual base type, the held runtime id, the tool to call next) so that an agent
+ * that hits one can act on it rather than retry the same call.
+ *
+ * <p>The happy path — actually opening the worksheet runtime, minting a paired session for it, and
+ * telling the browser to attach — is not implemented here yet; see the class-level TODO on
+ * {@link #openBaseWorksheet}.
+ */
+@Service
+public class SheetOpenService {
+   @Autowired
+   public SheetOpenService(ViewsheetSessionService viewsheetSessions,
+                            SheetSessionService sheetSessions,
+                            WorksheetService worksheetService,
+                            SecurityProvider securityProvider)
+   {
+      this.viewsheetSessions = viewsheetSessions;
+      this.sheetSessions = sheetSessions;
+      this.worksheetService = worksheetService;
+      this.securityProvider = securityProvider;
+   }
+
+   /**
+    * Open the base worksheet of the viewsheet paired to {@code sessionToken}, for {@code user}.
+    *
+    * @throws IllegalArgumentException on every refusal, with a message naming the specific
+    *                                  problem and, where there is one, the next tool to call.
+    */
+   public JoinSession openBaseWorksheet(String sessionToken, Principal user) throws Exception {
+      JoinSession vsSession = viewsheetSessions.requireSession(sessionToken, user);
+      RuntimeViewsheet rvs = viewsheetSessions.resolve(sessionToken, user);
+      Viewsheet vs = rvs == null ? null : rvs.getViewsheet();
+      AssetEntry baseEntry = vs == null ? null : vs.getBaseEntry();
+
+      if(baseEntry == null) {
+         throw new IllegalArgumentException(
+            "This viewsheet has no base worksheet to open.");
+      }
+
+      if(!baseEntry.isWorksheet()) {
+         throw new IllegalArgumentException(
+            "The connected viewsheet's base is a " + baseEntry.getType() + ", not a worksheet, " +
+            "and cannot be opened with open_base_worksheet.");
+      }
+
+      boolean canWorksheet = securityProvider.checkPermission(
+         user, ResourceType.WORKSHEET, "*", ResourceAction.ACCESS);
+
+      if(!canWorksheet) {
+         throw new IllegalArgumentException(
+            "You do not have permission to open this Data Worksheet in Visual Composer.");
+      }
+
+      JoinSession held = sheetSessions.findOpen(vsSession.ownerIdentity(), SheetType.WORKSHEET);
+
+      if(held != null) {
+         throw new IllegalArgumentException(
+            "A worksheet session is already open (runtimeId=" + held.runtimeId() + "). Call " +
+            "detach_sheet to close it before opening another base worksheet.");
+      }
+
+      if(vsSession.socketSessionId() == null) {
+         throw new IllegalArgumentException(
+            "The connected viewsheet session has no active browser connection to open the " +
+            "worksheet in; ask the user to re-pair (run connect_viewsheet again) before calling " +
+            "open_base_worksheet.");
+      }
+
+      // TODO(Task 2): open the worksheet runtime (worksheetService.openWorksheet), mint+join a
+      // session carrying vsSession's socketSessionId/socketUserName, broadcast an
+      // OpenComposerAssetCommand carrying the new runtime id, and return the new session.
+      throw new UnsupportedOperationException("not yet implemented");
+   }
+
+   private final ViewsheetSessionService viewsheetSessions;
+   private final SheetSessionService sheetSessions;
+   private final WorksheetService worksheetService;
+   private final SecurityProvider securityProvider;
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/SheetOpenService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/SheetOpenService.java
@@ -24,7 +24,9 @@ import inetsoft.sree.security.ResourceType;
 import inetsoft.sree.security.SecurityProvider;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.composer.command.OpenComposerAssetCommand;
 import inetsoft.web.wiz.pairing.JoinSession;
+import inetsoft.web.wiz.pairing.SheetAgentBroadcastService;
 import inetsoft.web.wiz.pairing.SheetSessionService;
 import inetsoft.web.wiz.pairing.SheetType;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,9 +44,10 @@ import java.security.Principal;
  * is wrong (the actual base type, the held runtime id, the tool to call next) so that an agent
  * that hits one can act on it rather than retry the same call.
  *
- * <p>The happy path — actually opening the worksheet runtime, minting a paired session for it, and
- * telling the browser to attach — is not implemented here yet; see the class-level TODO on
- * {@link #openBaseWorksheet}.
+ * <p>The happy path opens the worksheet runtime server-side, mints a paired session for it that
+ * carries the <b>viewsheet</b> session's socket identifiers (not the agent's), and pushes an
+ * {@link OpenComposerAssetCommand} carrying the new runtime id so the browser attaches to the
+ * runtime the server just created instead of opening a second one of its own.
  */
 @Service
 public class SheetOpenService {
@@ -52,12 +55,14 @@ public class SheetOpenService {
    public SheetOpenService(ViewsheetSessionService viewsheetSessions,
                             SheetSessionService sheetSessions,
                             WorksheetService worksheetService,
-                            SecurityProvider securityProvider)
+                            SecurityProvider securityProvider,
+                            SheetAgentBroadcastService broadcast)
    {
       this.viewsheetSessions = viewsheetSessions;
       this.sheetSessions = sheetSessions;
       this.worksheetService = worksheetService;
       this.securityProvider = securityProvider;
+      this.broadcast = broadcast;
    }
 
    /**
@@ -106,14 +111,28 @@ public class SheetOpenService {
             "open_base_worksheet.");
       }
 
-      // TODO(Task 2): open the worksheet runtime (worksheetService.openWorksheet), mint+join a
-      // session carrying vsSession's socketSessionId/socketUserName, broadcast an
-      // OpenComposerAssetCommand carrying the new runtime id, and return the new session.
-      throw new UnsupportedOperationException("not yet implemented");
+      String runtimeId = worksheetService.openWorksheet(baseEntry, user);
+
+      JoinSession wsSession = sheetSessions.open(runtimeId, vsSession.ownerIdentity(),
+                                                  SheetType.WORKSHEET,
+                                                  vsSession.socketSessionId(),
+                                                  vsSession.socketUserName());
+
+      OpenComposerAssetCommand command = OpenComposerAssetCommand.builder()
+         .assetId(baseEntry.toIdentifier())
+         .viewsheet(false)
+         .runtimeId(runtimeId)
+         .build();
+
+      broadcast.sendToBrowser(vsSession.socketUserName(), vsSession.socketSessionId(), runtimeId,
+                              command);
+
+      return wsSession;
    }
 
    private final ViewsheetSessionService viewsheetSessions;
    private final SheetSessionService sheetSessions;
    private final WorksheetService worksheetService;
    private final SecurityProvider securityProvider;
+   private final SheetAgentBroadcastService broadcast;
 }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -66,7 +66,8 @@ public class ViewsheetAssemblyAgentController {
                                    AssemblyHighlightService highlightService,
                                    DateComparisonService comparisonService,
                                    ViewsheetService viewsheetService,
-                                   SheetAgentBroadcastService broadcast)
+                                   SheetAgentBroadcastService broadcast,
+                                   SheetOpenService openService)
    {
       this.feature = feature;
       this.joinService = joinService;
@@ -86,6 +87,7 @@ public class ViewsheetAssemblyAgentController {
       this.comparisonService = comparisonService;
       this.viewsheetService = viewsheetService;
       this.broadcast = broadcast;
+      this.openService = openService;
    }
 
    public record JoinRequest(String code) {}
@@ -102,6 +104,22 @@ public class ViewsheetAssemblyAgentController {
    public JoinResponse join(@RequestBody JoinRequest body, Principal user) throws PairingException {
       requireEnabled();
       JoinSession session = joinService.join(body.code(), user);
+      return new JoinResponse(session.sessionToken(), session.runtimeId(), session.ownerIdentity(),
+                              session.sheetType().name().toLowerCase());
+   }
+
+   /**
+    * Opens the base worksheet of the viewsheet paired to {@code sessionToken} and pairs a new
+    * session for it. {@link SheetOpenService} performs every guard and the browser broadcast;
+    * this endpoint only translates its {@link JoinSession} into the same join shape {@link #join}
+    * returns, with {@code sheetType} read off the session rather than assumed by the caller.
+    */
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/open-base-worksheet")
+   public JoinResponse openBaseWorksheet(@PathVariable String sessionToken, Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      JoinSession session = openService.openBaseWorksheet(sessionToken, user);
       return new JoinResponse(session.sessionToken(), session.runtimeId(), session.ownerIdentity(),
                               session.sheetType().name().toLowerCase());
    }
@@ -685,4 +703,5 @@ public class ViewsheetAssemblyAgentController {
    private final DateComparisonService comparisonService;
    private final ViewsheetService viewsheetService;
    private final SheetAgentBroadcastService broadcast;
+   private final SheetOpenService openService;
 }

--- a/core/src/test/java/inetsoft/web/wiz/pairing/SheetSessionServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/pairing/SheetSessionServiceTest.java
@@ -115,4 +115,33 @@ class SheetSessionServiceTest {
       svc.close(token);
       assertNull(svc.resolve(token, "carol~;~org"));
    }
+
+   @Test
+   void findOpenReturnsTheMatchingSessionForOwnerAndType() {
+      SheetSessionService svc = serviceAt(FIXED_NOW);
+      JoinSession session = svc.open("rt-6", "dave~;~org", SheetType.WORKSHEET, null, null);
+
+      JoinSession found = svc.findOpen("dave~;~org", SheetType.WORKSHEET);
+
+      assertNotNull(found);
+      assertEquals(session.sessionToken(), found.sessionToken());
+   }
+
+   @Test
+   void findOpenIgnoresWrongTypeWrongOwnerAndExpiredSessions() {
+      SheetSessionService svc = serviceAt(FIXED_NOW);
+      svc.open("rt-7", "erin~;~org", SheetType.VIEWSHEET, null, null);
+      svc.open("rt-8", "frank~;~org", SheetType.WORKSHEET, null, null);
+
+      assertNull(svc.findOpen("erin~;~org", SheetType.WORKSHEET),
+                 "same owner but a viewsheet session should not satisfy a worksheet lookup");
+      assertNull(svc.findOpen("frank~;~org", SheetType.VIEWSHEET),
+                 "same owner but a worksheet session should not satisfy a viewsheet lookup");
+      assertNull(svc.findOpen("nobody~;~org", SheetType.WORKSHEET));
+
+      SheetSessionService svcLater = new SheetSessionService(
+         () -> FIXED_NOW + SheetSessionService.TTL_MILLIS + 1, svc);
+      assertNull(svcLater.findOpen("frank~;~org", SheetType.WORKSHEET),
+                 "an expired session must not be reported as held");
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/SheetOpenServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/SheetOpenServiceTest.java
@@ -1,0 +1,168 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.composition.WorksheetService;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityProvider;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.wiz.pairing.JoinSession;
+import inetsoft.web.wiz.pairing.SheetSessionService;
+import inetsoft.web.wiz.pairing.SheetType;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class SheetOpenServiceTest {
+   @Test
+   void refusesWhenTheViewsheetHasNoBaseWorksheet() {
+      SheetOpenService service = serviceWithBase(null, true, null);
+
+      IllegalArgumentException thrown = assertThrows(
+         IllegalArgumentException.class, () -> service.openBaseWorksheet("tok-vs", principal()));
+
+      assertTrue(thrown.getMessage().contains("no base worksheet"), thrown.getMessage());
+   }
+
+   /**
+    * A logical model or data source is a legitimate base and is NOT a worksheet. The message must
+    * name what it actually is, or the caller retries the same call expecting a different answer.
+    */
+   @Test
+   void refusesWhenTheBaseIsNotAWorksheetAndNamesTheActualType() {
+      AssetEntry logicModel = mock(AssetEntry.class);
+      when(logicModel.isWorksheet()).thenReturn(false);
+      when(logicModel.getType()).thenReturn(AssetEntry.Type.LOGIC_MODEL);
+      SheetOpenService service = serviceWithBase(logicModel, true, null);
+
+      IllegalArgumentException thrown = assertThrows(
+         IllegalArgumentException.class, () -> service.openBaseWorksheet("tok-vs", principal()));
+
+      assertTrue(thrown.getMessage().contains("LOGIC_MODEL"), thrown.getMessage());
+   }
+
+   @Test
+   void refusesWhenTheAgentLacksWorksheetPermission() {
+      SheetOpenService service = serviceWithBase(worksheetEntry(), false, null);
+
+      IllegalArgumentException thrown = assertThrows(
+         IllegalArgumentException.class, () -> service.openBaseWorksheet("tok-vs", principal()));
+
+      assertTrue(thrown.getMessage().toLowerCase().contains("permission"), thrown.getMessage());
+   }
+
+   /**
+    * Silently replacing a held session is the defect that shipped once already: it ends a session
+    * the user may be editing, with a success response.
+    */
+   @Test
+   void refusesWhenAWorksheetSessionIsAlreadyHeldAndNamesItsRuntimeId() {
+      SheetOpenService service = serviceWithBase(worksheetEntry(), true, "ws-existing");
+
+      IllegalArgumentException thrown = assertThrows(
+         IllegalArgumentException.class, () -> service.openBaseWorksheet("tok-vs", principal()));
+
+      assertTrue(thrown.getMessage().contains("ws-existing"), thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("detach_sheet"), thrown.getMessage());
+   }
+
+   /**
+    * A session with no recorded socket cannot reach a browser, so the worksheet would open
+    * nowhere. Refusing beats opening a runtime the user never sees and cannot close.
+    */
+   @Test
+   void refusesWhenTheViewsheetSessionHasNoSocketSession() {
+      SheetOpenService service = serviceWithBase(worksheetEntry(), true, null, null);
+
+      IllegalArgumentException thrown = assertThrows(
+         IllegalArgumentException.class, () -> service.openBaseWorksheet("tok-vs", principal()));
+
+      assertTrue(thrown.getMessage().toLowerCase().contains("re-pair"), thrown.getMessage());
+   }
+
+   // ── harness ───────────────────────────────────────────────────────────────
+
+   /** The four-guard helper. Defaults the viewsheet session's socketSessionId to {@code "sock-1"}. */
+   private static SheetOpenService serviceWithBase(AssetEntry base, boolean hasPermission,
+                                                     String heldWorksheetRuntimeId)
+   {
+      return serviceWithBase(base, hasPermission, heldWorksheetRuntimeId, "sock-1");
+   }
+
+   private static SheetOpenService serviceWithBase(AssetEntry base, boolean hasPermission,
+                                                     String heldWorksheetRuntimeId,
+                                                     String socketSessionId)
+   {
+      try {
+         Viewsheet vs = mock(Viewsheet.class);
+         when(vs.getBaseEntry()).thenReturn(base);
+
+         RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+         when(rvs.getViewsheet()).thenReturn(vs);
+
+         JoinSession vsSession = new JoinSession(
+            "tok-vs", "vs-runtime-1", "alice", SheetType.VIEWSHEET, 0L,
+            SheetSessionService.TTL_MILLIS, JoinSession.ConnectionMode.PAIRED,
+            socketSessionId, "alice");
+
+         ViewsheetSessionService viewsheetSessions = mock(ViewsheetSessionService.class);
+         when(viewsheetSessions.requireSession(anyString(), any(Principal.class)))
+            .thenReturn(vsSession);
+         when(viewsheetSessions.resolve(anyString(), any(Principal.class))).thenReturn(rvs);
+
+         SheetSessionService sheetSessions = mock(SheetSessionService.class);
+         JoinSession held = heldWorksheetRuntimeId == null ? null : new JoinSession(
+            "tok-ws-held", heldWorksheetRuntimeId, "alice", SheetType.WORKSHEET, 0L,
+            SheetSessionService.TTL_MILLIS, JoinSession.ConnectionMode.PAIRED, "sock-1", "alice");
+         when(sheetSessions.findOpen("alice", SheetType.WORKSHEET)).thenReturn(held);
+
+         WorksheetService worksheetService = mock(WorksheetService.class);
+
+         SecurityProvider securityProvider = mock(SecurityProvider.class);
+         when(securityProvider.checkPermission(any(Principal.class), eq(ResourceType.WORKSHEET),
+                                                eq("*"), eq(ResourceAction.ACCESS)))
+            .thenReturn(hasPermission);
+
+         return new SheetOpenService(viewsheetSessions, sheetSessions, worksheetService,
+                                      securityProvider);
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(e);
+      }
+   }
+
+   private static AssetEntry worksheetEntry() {
+      AssetEntry entry = mock(AssetEntry.class);
+      when(entry.isWorksheet()).thenReturn(true);
+      when(entry.getType()).thenReturn(AssetEntry.Type.WORKSHEET);
+      return entry;
+   }
+
+   private static Principal principal() {
+      return () -> "alice";
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/SheetOpenServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/SheetOpenServiceTest.java
@@ -24,11 +24,14 @@ import inetsoft.sree.security.ResourceType;
 import inetsoft.sree.security.SecurityProvider;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.composer.command.OpenComposerAssetCommand;
 import inetsoft.web.wiz.pairing.JoinSession;
+import inetsoft.web.wiz.pairing.SheetAgentBroadcastService;
 import inetsoft.web.wiz.pairing.SheetSessionService;
 import inetsoft.web.wiz.pairing.SheetType;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.security.Principal;
 
@@ -48,6 +51,12 @@ class SheetOpenServiceTest {
     */
    private static final String OWNER = "alice~;~host-org";
    private static final String SOCKET_USER = "alice-browser";
+
+   /**
+    * Populated by {@code serviceWithBase} so tests can verify the broadcast the happy path sends
+    * to the browser, without threading a mock through every call site.
+    */
+   private SheetAgentBroadcastService broadcast;
 
    /**
     * Necessarily equal to {@link #OWNER}: {@code SheetSessionService.resolve} refuses a session
@@ -127,18 +136,49 @@ class SheetOpenServiceTest {
       assertTrue(thrown.getMessage().toLowerCase().contains("re-pair"), thrown.getMessage());
    }
 
+   /**
+    * The single most important assertion in this feature. Without the viewsheet session's socket
+    * identifiers on the new grant, the agent's worksheet edits never broadcast and the user
+    * watches a stale sheet -- the divergence failure the consolidation existed to remove.
+    */
+   @Test
+   void theNewSessionCarriesTheViewsheetSessionsSocketIdentifiers() throws Exception {
+      SheetOpenService service = serviceWithBase(worksheetEntry(), true, null);
+
+      JoinSession opened = service.openBaseWorksheet("tok-vs", principal());
+
+      assertEquals("sock-1", opened.socketSessionId());
+      assertEquals(SOCKET_USER, opened.socketUserName());
+      assertEquals(SheetType.WORKSHEET, opened.sheetType());
+   }
+
+   @Test
+   void pushesAnOpenCommandCarryingTheServerCreatedRuntimeId() throws Exception {
+      SheetOpenService service = serviceWithBase(worksheetEntry(), true, null);
+
+      service.openBaseWorksheet("tok-vs", principal());
+
+      ArgumentCaptor<Object> command = ArgumentCaptor.forClass(Object.class);
+      verify(broadcast).sendToBrowser(eq(SOCKET_USER), eq("sock-1"), anyString(),
+                                       command.capture());
+
+      OpenComposerAssetCommand sent = (OpenComposerAssetCommand) command.getValue();
+      assertEquals("ws-runtime-1", sent.runtimeId(), "the browser must attach, not open its own");
+      assertFalse(sent.viewsheet());
+   }
+
    // ── harness ───────────────────────────────────────────────────────────────
 
    /** The four-guard helper. Defaults the viewsheet session's socketSessionId to {@code "sock-1"}. */
-   private static SheetOpenService serviceWithBase(AssetEntry base, boolean hasPermission,
-                                                     String heldWorksheetRuntimeId)
+   private SheetOpenService serviceWithBase(AssetEntry base, boolean hasPermission,
+                                             String heldWorksheetRuntimeId)
    {
       return serviceWithBase(base, hasPermission, heldWorksheetRuntimeId, "sock-1");
    }
 
-   private static SheetOpenService serviceWithBase(AssetEntry base, boolean hasPermission,
-                                                     String heldWorksheetRuntimeId,
-                                                     String socketSessionId)
+   private SheetOpenService serviceWithBase(AssetEntry base, boolean hasPermission,
+                                             String heldWorksheetRuntimeId,
+                                             String socketSessionId)
    {
       try {
          Viewsheet vs = mock(Viewsheet.class);
@@ -167,14 +207,29 @@ class SheetOpenServiceTest {
          when(sheetSessions.findOpen(OWNER, SheetType.WORKSHEET)).thenReturn(held);
 
          WorksheetService worksheetService = mock(WorksheetService.class);
+         when(worksheetService.openWorksheet(any(AssetEntry.class), any(Principal.class)))
+            .thenReturn("ws-runtime-1");
 
          SecurityProvider securityProvider = mock(SecurityProvider.class);
          when(securityProvider.checkPermission(any(Principal.class), eq(ResourceType.WORKSHEET),
                                                 eq("*"), eq(ResourceAction.ACCESS)))
             .thenReturn(hasPermission);
 
+         // The new worksheet session must carry the viewsheet session's socket identifiers, not
+         // the agent's principal -- stubbed argument-specific so a call with the wrong identity
+         // returns null and the happy-path tests fail loudly.
+         JoinSession newWsSession = new JoinSession(
+            "tok-ws-new", "ws-runtime-1", OWNER, SheetType.WORKSHEET, 0L,
+            SheetSessionService.TTL_MILLIS, JoinSession.ConnectionMode.PAIRED,
+            socketSessionId, SOCKET_USER);
+         when(sheetSessions.open(eq("ws-runtime-1"), eq(OWNER), eq(SheetType.WORKSHEET),
+                                 eq(socketSessionId), eq(SOCKET_USER)))
+            .thenReturn(newWsSession);
+
+         broadcast = mock(SheetAgentBroadcastService.class);
+
          return new SheetOpenService(viewsheetSessions, sheetSessions, worksheetService,
-                                      securityProvider);
+                                      securityProvider, broadcast);
       }
       catch(Exception e) {
          throw new IllegalStateException(e);

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/SheetOpenServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/SheetOpenServiceTest.java
@@ -38,6 +38,26 @@ import static org.mockito.Mockito.*;
 
 @Tag("core")
 class SheetOpenServiceTest {
+   /**
+    * Three identities, deliberately different.
+    *
+    * <p>The session's {@code ownerIdentity}, the browser's socket user name, and the agent's own
+    * principal name are separate concepts that happen to coincide in practice. Holding them apart
+    * here is what lets these tests prove <em>which</em> one each guard keys on: with all three set
+    * to the same string, a lookup on the wrong one still passes.
+    */
+   private static final String OWNER = "alice~;~host-org";
+   private static final String SOCKET_USER = "alice-browser";
+
+   /**
+    * Necessarily equal to {@link #OWNER}: {@code SheetSessionService.resolve} refuses a session
+    * whose {@code ownerIdentity} differs from the agent's identity, so a session where these two
+    * differ cannot exist. A review asked for distinct values here to prove which one the
+    * already-held guard keys on; that is not constructible, so the argument-specific stub in
+    * {@code serviceWithBase} carries that proof instead.
+    */
+   private static final String PRINCIPAL_NAME = OWNER;
+
    @Test
    void refusesWhenTheViewsheetHasNoBaseWorksheet() {
       SheetOpenService service = serviceWithBase(null, true, null);
@@ -88,6 +108,9 @@ class SheetOpenServiceTest {
 
       assertTrue(thrown.getMessage().contains("ws-existing"), thrown.getMessage());
       assertTrue(thrown.getMessage().contains("detach_sheet"), thrown.getMessage());
+      // WHICH identity the lookup keys on is pinned by the helper's stub, which is argument-
+      // specific: findOpen is stubbed for OWNER alone, so a call with any other value returns
+      // null, the guard does not fire, and this test fails with no exception thrown.
    }
 
    /**
@@ -125,9 +148,9 @@ class SheetOpenServiceTest {
          when(rvs.getViewsheet()).thenReturn(vs);
 
          JoinSession vsSession = new JoinSession(
-            "tok-vs", "vs-runtime-1", "alice", SheetType.VIEWSHEET, 0L,
+            "tok-vs", "vs-runtime-1", OWNER, SheetType.VIEWSHEET, 0L,
             SheetSessionService.TTL_MILLIS, JoinSession.ConnectionMode.PAIRED,
-            socketSessionId, "alice");
+            socketSessionId, SOCKET_USER);
 
          ViewsheetSessionService viewsheetSessions = mock(ViewsheetSessionService.class);
          when(viewsheetSessions.requireSession(anyString(), any(Principal.class)))
@@ -136,9 +159,12 @@ class SheetOpenServiceTest {
 
          SheetSessionService sheetSessions = mock(SheetSessionService.class);
          JoinSession held = heldWorksheetRuntimeId == null ? null : new JoinSession(
-            "tok-ws-held", heldWorksheetRuntimeId, "alice", SheetType.WORKSHEET, 0L,
-            SheetSessionService.TTL_MILLIS, JoinSession.ConnectionMode.PAIRED, "sock-1", "alice");
-         when(sheetSessions.findOpen("alice", SheetType.WORKSHEET)).thenReturn(held);
+            "tok-ws-held", heldWorksheetRuntimeId, OWNER, SheetType.WORKSHEET, 0L,
+            SheetSessionService.TTL_MILLIS, JoinSession.ConnectionMode.PAIRED, "sock-1", SOCKET_USER);
+         // Stubbed for OWNER only. If the guard ever keys the lookup on the agent's principal name
+         // instead of the session's ownerIdentity, this returns null and the test fails -- which is
+         // the point of keeping the two values distinct.
+         when(sheetSessions.findOpen(OWNER, SheetType.WORKSHEET)).thenReturn(held);
 
          WorksheetService worksheetService = mock(WorksheetService.class);
 
@@ -163,6 +189,6 @@ class SheetOpenServiceTest {
    }
 
    private static Principal principal() {
-      return () -> "alice";
+      return () -> PRINCIPAL_NAME;
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -164,6 +164,55 @@ class ViewsheetAssemblyAgentControllerTest {
       assertTrue(thrown.getMessage().contains("update_script"));
    }
 
+   /**
+    * {@code sheetType} is reported by {@link SheetOpenService} through the {@link JoinSession} it
+    * returns, never inferred by the controller — a plugin that guesses the runtime type files the
+    * session under the wrong key and overwrites a live one while reporting success.
+    */
+   @Test
+   void openBaseWorksheetReturnsTheJoinShapeWithSheetTypeReported() throws Exception {
+      SheetOpenService openService = mock(SheetOpenService.class);
+      when(openService.openBaseWorksheet(eq("tok-vs"), any()))
+         .thenReturn(new JoinSession("tok-ws", "ws-runtime-1", "alice", SheetType.WORKSHEET,
+                                     0L, 1000L, JoinSession.ConnectionMode.PAIRED, "sock-1",
+                                     "alice"));
+
+      ViewsheetAssemblyAgentController controller = controllerWith(openService);
+
+      var response = controller.openBaseWorksheet("tok-vs", principal());
+
+      assertEquals("tok-ws", response.sessionToken());
+      assertEquals("ws-runtime-1", response.runtimeId());
+      // Reported by the server, never inferred: a plugin that guesses the runtime type files the
+      // session under the wrong key and overwrites a live one while reporting success.
+      assertEquals("worksheet", response.sheetType());
+   }
+
+   /** Feature enabled, only {@code openService} wired -- for the open_base_worksheet test. */
+   private static ViewsheetAssemblyAgentController controllerWith(SheetOpenService openService) {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      when(feature.isEnabled()).thenReturn(true);
+
+      return new ViewsheetAssemblyAgentController(feature, mock(SheetJoinService.class),
+                                          mock(SheetSessionService.class),
+                                          mock(ViewsheetSessionService.class),
+                                          mock(ViewsheetReadService.class),
+                                          mock(ViewsheetEditService.class),
+                                          mock(ViewsheetFormatService.class),
+                                          mock(inetsoft.web.wiz.script.ScriptImageService.class),
+                                          mock(AssemblyPropertyService.class),
+                                          mock(SheetPropertyService.class),
+                                          mock(AssemblyHyperlinkService.class),
+                                          mock(ChartElementService.class),
+                                          mock(ChartRegionPropertyService.class),
+                                          mock(AssemblyConditionService.class),
+                                          mock(AssemblyHighlightService.class),
+                                          mock(DateComparisonService.class),
+                                          mock(inetsoft.analytic.composition.ViewsheetService.class),
+                                          mock(SheetAgentBroadcastService.class),
+                                          openService);
+   }
+
    private static ViewsheetAssemblyAgentController controllerWith(SheetAgentFeature feature,
                                                           ViewsheetSessionService sessions,
                                                           ViewsheetReadService reader)
@@ -190,7 +239,8 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(AssemblyHighlightService.class),
                                           mock(DateComparisonService.class),
                                           mock(inetsoft.analytic.composition.ViewsheetService.class),
-                                          mock(SheetAgentBroadcastService.class));
+                                          mock(SheetAgentBroadcastService.class),
+                                          mock(SheetOpenService.class));
    }
 
    /** Feature enabled, only {@code propertyService} wired -- for the property-trio tests. */
@@ -216,7 +266,8 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(AssemblyHighlightService.class),
                                           mock(DateComparisonService.class),
                                           mock(inetsoft.analytic.composition.ViewsheetService.class),
-                                          mock(SheetAgentBroadcastService.class));
+                                          mock(SheetAgentBroadcastService.class),
+                                          mock(SheetOpenService.class));
    }
 
    private static Principal principal() {

--- a/web/projects/portal/src/app/composer/command/open-composer-asset-command.ts
+++ b/web/projects/portal/src/app/composer/command/open-composer-asset-command.ts
@@ -26,4 +26,5 @@ export interface OpenComposerAssetCommand {
    baseDataSource?: string;
    baseDataSourceType?: number;
    parentId?: string;
+   runtimeId?: string;
 }

--- a/web/projects/portal/src/app/composer/gui/composer-main.component.interaction.tl.spec.ts
+++ b/web/projects/portal/src/app/composer/gui/composer-main.component.interaction.tl.spec.ts
@@ -46,6 +46,9 @@
  *   Group 14 [baseline] — copySheet/cutSheet delegate to clipboardService.addToClipboard
  *   Group 15 [baseline] — onTabClick: sets selectedTab; setGrayedOutFields / toggleImportDialog
  *   Group 16 [Risk 2]  — closePreview: focus returns to parent VS after preview closed (Bug #19612)
+ *   Group 17 [Risk 3]  — openWorksheet: runtimeId → attaches to a server-provided runtime
+ *                         (closeOnServer=false); no runtimeId → new runtime (closeOnServer=true)
+ *                         (open_base_worksheet Task 4)
  *
  * Confirmed bugs (it.fails): none in this pass
  *
@@ -735,5 +738,39 @@ describe("ComposerMainComponent — closePreview: parent focus (Bug #19612)", ()
 
       expect(comp.sheets).toHaveLength(1);
       expect(comp.openedTabs).toHaveLength(1);
+   });
+});
+
+// ---------------------------------------------------------------------------
+// Group 17: openWorksheet — runtimeId attach (open_base_worksheet Task 4) (Risk 3)
+// ---------------------------------------------------------------------------
+
+describe("ComposerMainComponent — openWorksheet: runtimeId (open_base_worksheet Task 4)", () => {
+   // 🔁 Regression-sensitive: when the server has already created and paired a runtime (e.g. an
+   // agent editing session), the browser must attach to it rather than opening a second runtime,
+   // and must NOT close that runtime when its tab closes — closeOnServer=true here would kill the
+   // agent's paired session out from under it the moment the user closes the tab.
+   it("should attach to a server-provided runtime and set closeOnServer=false", async () => {
+      const { comp } = await renderComponent();
+
+      comp.openWorksheet("wsId", false, "server-rt-001");
+
+      const ws = comp.sheets.find(s => s.id === "wsId") as Worksheet;
+      expect(ws).toBeTruthy();
+      expect(ws.runtimeId).toBe("server-rt-001");
+      expect(ws.closeOnServer).toBe(false);
+   });
+
+   // 🔁 Regression-sensitive: the ordinary "new worksheet, no server runtime" path must keep
+   // closeOnServer=true, or the browser-owned runtime would leak on the server after tab close.
+   it("should create its own runtime and set closeOnServer=true when no runtimeId is given", async () => {
+      const { comp } = await renderComponent();
+
+      comp.openWorksheet("wsId2");
+
+      const ws = comp.sheets.find(s => s.id === "wsId2") as Worksheet;
+      expect(ws).toBeTruthy();
+      expect(ws.runtimeId).toBeNull();
+      expect(ws.closeOnServer).toBe(true);
    });
 });

--- a/web/projects/portal/src/app/composer/gui/composer-main.component.interaction.tl.spec.ts
+++ b/web/projects/portal/src/app/composer/gui/composer-main.component.interaction.tl.spec.ts
@@ -763,6 +763,12 @@ describe("ComposerMainComponent — openWorksheet: runtimeId (open_base_workshee
 
    // 🔁 Regression-sensitive: the ordinary "new worksheet, no server runtime" path must keep
    // closeOnServer=true, or the browser-owned runtime would leak on the server after tab close.
+   //
+   // ⚠️ The closeOnServer assertion alone is NOT a guard on this path: Sheet defaults it to true
+   // (sheet.ts:42), so deleting the branch's assignment entirely leaves this green — a reviewer
+   // proved that. The runtimeId assertion is what makes the test load-bearing here, because the
+   // base class leaves runtimeId undefined and only the branch's assignment makes it null.
+   // Keep both, and keep them in this order.
    it("should create its own runtime and set closeOnServer=true when no runtimeId is given", async () => {
       const { comp } = await renderComponent();
 
@@ -770,6 +776,7 @@ describe("ComposerMainComponent — openWorksheet: runtimeId (open_base_workshee
 
       const ws = comp.sheets.find(s => s.id === "wsId2") as Worksheet;
       expect(ws).toBeTruthy();
+      // Assigned by the branch, not inherited: Sheet leaves this undefined.
       expect(ws.runtimeId).toBeNull();
       expect(ws.closeOnServer).toBe(true);
    });

--- a/web/projects/portal/src/app/composer/gui/composer-main.component.ts
+++ b/web/projects/portal/src/app/composer/gui/composer-main.component.ts
@@ -1765,9 +1765,9 @@ export class ComposerMainComponent implements OnInit, OnDestroy, AfterViewInit {
       this.navigateToExisting(index);
    }
 
-   public openWorksheet(assetId: string, gettingStarted?: boolean) {
+   public openWorksheet(assetId: string, gettingStarted?: boolean, runtimeId: string = null) {
       this.openSheet({ type: "worksheet", assetId}, false,
-         null, false, gettingStarted);
+         runtimeId, false, gettingStarted);
    }
 
    public openViewsheet(assetId: string, embedded: boolean = false,
@@ -1795,6 +1795,8 @@ export class ComposerMainComponent implements OnInit, OnDestroy, AfterViewInit {
                ws.localId = sheetCounter++;
                ws.newSheet = newSheet;
                ws.gettingStarted = gettingStarted;
+               ws.runtimeId = runtimeId;
+               ws.closeOnServer = !runtimeId;
 
                index = this.sheets.push(ws) - 1;
                this.openedTabs.push(new ComposerTabModel(ws.type, ws));
@@ -2971,7 +2973,7 @@ export class ComposerMainComponent implements OnInit, OnDestroy, AfterViewInit {
             }
             else {
                this.composerRecentService.addRecentlyViewed(createAssetEntry(command.assetId));
-               this.openWorksheet(command.assetId);
+               this.openWorksheet(command.assetId, false, command.runtimeId);
             }
          });
       });


### PR DESCRIPTION
Lets an agent open **the connected viewsheet's own base worksheet** in the user's Composer, paired and ready, with no second pairing code. Paired with the plugin half in stylebi-wiz.

This is the cross-domain flow the four-plugin consolidation existed to enable. Until now the domains shared a session but could not follow a sheet down to the data feeding it — "the chart is wrong, fix the join behind it" needed the user to pair a second sheet by hand.

### Why the obvious implementation does not work

The design sketch was "resolve `getBaseEntry()`, check `WORKSHEET` access, send `OpenComposerAssetCommand`". That is most of it, but it cannot auto-pair.

Pairing is minted **from an already-open runtime** — the browser sends `{runtimeId, sheetType}` from the sheet it has open. And `OpenComposerAssetCommand` carries an **asset id**, so the browser creates its *own* runtime, asynchronously, after the command arrives. At the moment the server says "open this", there is nothing to pair.

Three ways out were considered; this takes the third:

1. Correlation token + client auto-mint — needs a correlation store, a wait, and a new implicit-pairing path.
2. Server opens its own runtime, browser opens another — **two runtimes of one worksheet**, agent editing one and user watching the other, diverging until save. That is the failure the consolidation removed.
3. **Server opens the runtime; the browser attaches to it.** One runtime, no correlation, no wait.

It is also the smallest change, because the pattern already exists: the *viewsheet* branch of `openSheet` already accepts a server-supplied runtime, and `runtimeId`/`closeOnServer` are declared on the `Sheet` base class that `Worksheet` extends. The worksheet branch simply never set them.

### The two details most likely to be got wrong

**The new session carries the viewsheet session's `socketSessionId`/`socketUserName`.** Without them the agent's worksheet edits never broadcast and the user watches a stale sheet while every call returns success. Verified by neutralization: passing `null` or the principal's name instead fails exactly that test.

**`closeOnServer = !runtimeId`.** With a server-created runtime the browser must not close it on tab close, or the agent's paired session dies underneath it — a bug that only surfaces when a user closes a tab.

### Guards

Five refusals, each naming what to do: no base entry; base is a `LOGIC_MODEL`/data source (a legitimate configuration, not an error — the message names the actual type); no `WORKSHEET` permission **checked against the agent's own principal**, so pairing a viewsheet is not an authorization bypass; a worksheet session already held (refused, naming its runtime, rather than silently replaced); and no socket session recorded.

### Tests

`inetsoft.web.wiz.**.*Test` — **1,487 tests, 0 failures** (1,477 baseline + 10). Angular: `composer-main.component.interaction.tl.spec.ts` 41/41.

Every guard and both happy-path assertions were verified load-bearing by neutralizing the source and confirming exactly the intended test fails. One test comment records that its `closeOnServer` assertion is satisfied by a base-class default and the `runtimeId` assertion is what actually guards that path — so nobody trims the wrong "redundant" line.

### Not proven here

That the browser attaches to a real server-created runtime end to end. The component test asserts field assignment; the attach itself needs a live check — open the base worksheet, make an agent edit, and confirm it appears without a manual refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)