### PR TITLE
Make open_base_worksheet actually work end to end: four live-found defects

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/ws/OpenWorksheetController.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/OpenWorksheetController.java
@@ -130,8 +130,11 @@ public class OpenWorksheetController extends WorksheetController {
 
       entry.setProperty("openAutoSaved", event.openAutoSavedFile() + "");
       entry.setProperty("gettingStarted", event.gettingStartedWs() + "");
+      // event.runtimeId() is set when the server already opened this worksheet and told the
+      // browser to attach to it; opening a second runtime of the same asset would leave the
+      // agent and the user editing different copies. See WorksheetEventService.openWorksheet.
       String runtimeId = eventService.openWorksheet(
-         principal, entry, event.openAutoSavedFile(), event.createQuery(),
+         principal, entry, event.openAutoSavedFile(), event.createQuery(), event.runtimeId(),
          commandDispatcher);
 
       getRuntimeViewsheetRef().setRuntimeId(runtimeId);

--- a/core/src/main/java/inetsoft/web/composer/ws/assembly/WorksheetEventService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/assembly/WorksheetEventService.java
@@ -50,7 +50,32 @@ public class WorksheetEventService {
                                boolean gettingStartedCreateQuery,
                                CommandDispatcher commandDispatcher) throws Exception
    {
-      String runtimeId = engine.openWorksheet(entry, user);
+      return openWorksheet(user, entry, openAutoSaved, gettingStartedCreateQuery, null,
+                           commandDispatcher);
+   }
+
+   /**
+    * Open the worksheet, or attach to a runtime that is already open.
+    *
+    * <p>{@code existingRuntimeId} is set when the server opened the runtime itself and told the
+    * browser to attach to it — the {@code open_base_worksheet} agent flow. Opening a second
+    * runtime of the same asset there is the defect this parameter exists to prevent: the agent
+    * edits one runtime while the user watches the other, both ends report success, and nothing
+    * surfaces until one save clobbers the other.
+    *
+    * <p>Everything after the runtime exists is identical either way — socket identifiers, the
+    * {@code OpenWorksheetCommand}, the refresh — so only the creation step is skipped. An id
+    * naming a runtime that does not exist, or one owned by another user, fails inside
+    * {@code engine.getWorksheet} on the proxy call rather than quietly opening a fresh one.
+    *
+    * @param existingRuntimeId a runtime to attach to, or {@code null} to open a new one
+    */
+   public String openWorksheet(Principal user, AssetEntry entry, boolean openAutoSaved,
+                               boolean gettingStartedCreateQuery, String existingRuntimeId,
+                               CommandDispatcher commandDispatcher) throws Exception
+   {
+      String runtimeId = existingRuntimeId != null
+         ? existingRuntimeId : engine.openWorksheet(entry, user);
       WorksheetEventServiceProxy p = proxy.getIfAvailable();
 
       if(p != null) {

--- a/core/src/main/java/inetsoft/web/composer/ws/event/OpenWorksheetEvent.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/event/OpenWorksheetEvent.java
@@ -20,6 +20,8 @@ package inetsoft.web.composer.ws.event;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.immutables.value.Value;
 
+import javax.annotation.Nullable;
+
 @Value.Immutable
 @JsonDeserialize(builder = OpenWorksheetEvent.Builder.class)
 public abstract class OpenWorksheetEvent {
@@ -30,6 +32,17 @@ public abstract class OpenWorksheetEvent {
    public abstract boolean gettingStartedWs();
 
    public abstract boolean createQuery();
+
+   /**
+    * A runtime the server already opened, which this browser must attach to instead of opening
+    * its own — the {@code open_base_worksheet} agent flow. {@code null} for the normal case where
+    * the browser is the one opening the worksheet.
+    *
+    * <p>Mirrors {@code OpenViewsheetEvent.runtimeViewsheetId}, which the viewsheet pane has long
+    * used for the same purpose.
+    */
+   @Nullable
+   public abstract String runtimeId();
 
    public static Builder builder() {
       return new Builder();

--- a/core/src/main/java/inetsoft/web/wiz/pairing/SheetAgentBroadcastService.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/SheetAgentBroadcastService.java
@@ -37,10 +37,12 @@ import inetsoft.web.viewsheet.model.VSObjectModel;
 import inetsoft.web.viewsheet.model.VSObjectModelFactoryService;
 import inetsoft.web.viewsheet.service.CommandDispatcher;
 import inetsoft.web.viewsheet.service.CommandDispatcherService;
+import inetsoft.web.viewsheet.service.ComposerClientService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.SimpMessageType;
 import org.springframework.stereotype.Service;
 
 import java.security.Principal;
@@ -203,6 +205,38 @@ public class SheetAgentBroadcastService {
 
    private void sendCommand(String user, String sessionId, String runtimeId, Object command) {
       sendToBrowser(user, sessionId, runtimeId, command);
+   }
+
+   /**
+    * Push a <b>composer-level</b> command — one addressed at the Composer application itself
+    * rather than at any open sheet — to the browser holding a paired session.
+    *
+    * <p>Deliberately not {@link #sendToBrowser}. That publishes to
+    * {@link CommandDispatcher#COMMANDS_TOPIC} ({@code "/commands"}), the per-sheet-runtime channel
+    * a {@code ViewsheetClientService} listens on and filters by
+    * {@link CommandDispatcher#RUNTIME_ID_ATTR}. An {@code OpenComposerAssetCommand} has no open
+    * sheet to be filtered by — the runtime it names is precisely the one the browser has not
+    * opened yet — and its only client handler subscribes to {@code /user/composer-client}. Sent to
+    * the sheet channel it is delivered to a destination with no handler and dropped silently,
+    * while every call up the stack still reports success.
+    *
+    * <p>The two destination constants are both named {@code COMMANDS_TOPIC}, on
+    * {@link CommandDispatcher} and {@link ComposerClientService}. Reaching for the wrong one is a
+    * one-word mistake that produces no error anywhere. This mirrors {@code ComposerController}'s
+    * native "Edit Data" send: address the socket session, set no runtime header.
+    *
+    * @param socketSessionId the paired browser's STOMP session id — both the destination user and
+    *                        the session header, as the native path does
+    */
+   public void sendToComposer(String socketSessionId, Object command) {
+      SimpMessageHeaderAccessor headers =
+         SimpMessageHeaderAccessor.create(SimpMessageType.MESSAGE);
+      headers.setSessionId(socketSessionId);
+      headers.setLeaveMutable(true);
+
+      commandDispatcherService.convertAndSendToUser(
+         socketSessionId, ComposerClientService.COMMANDS_TOPIC, command,
+         headers.getMessageHeaders());
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/SheetOpenService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/SheetOpenService.java
@@ -111,7 +111,13 @@ public class SheetOpenService {
             "open_base_worksheet.");
       }
 
-      String runtimeId = worksheetService.openWorksheet(baseEntry, user);
+      // Owned by the BROWSER's principal, not the agent's. WorksheetEngine.getSheet refuses a
+      // principal that does not match the runtime's owner unless it carries pairedAgent or
+      // supportLogin: the agent has pairedAgent, the browser has neither. Opening as the agent
+      // makes the user's own browser the outsider and its attach dies on "Invalid user found",
+      // two principals for the same user differing only by session. A paired viewsheet is already
+      // browser-owned with the agent reaching in through the flag; this matches it.
+      String runtimeId = worksheetService.openWorksheet(baseEntry, rvs.getUser());
 
       JoinSession wsSession = sheetSessions.open(runtimeId, vsSession.ownerIdentity(),
                                                   SheetType.WORKSHEET,

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/SheetOpenService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/SheetOpenService.java
@@ -124,8 +124,9 @@ public class SheetOpenService {
          .runtimeId(runtimeId)
          .build();
 
-      broadcast.sendToBrowser(vsSession.socketUserName(), vsSession.socketSessionId(), runtimeId,
-                              command);
+      // The Composer's own channel, not the paired sheet's: this command is handled by
+      // composer-main, which subscribes to /user/composer-client. See sendToComposer.
+      broadcast.sendToComposer(vsSession.socketSessionId(), command);
 
       return wsSession;
    }

--- a/core/src/test/java/inetsoft/web/composer/ws/assembly/WorksheetEventServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/ws/assembly/WorksheetEventServiceTest.java
@@ -1,0 +1,89 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.composer.ws.assembly;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.web.viewsheet.service.CommandDispatcher;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+
+import java.security.Principal;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Whether opening a worksheet creates a runtime or attaches to one that already exists.
+ *
+ * <p>An agent tool ({@code open_base_worksheet}) opens a worksheet runtime server-side and tells
+ * the browser to attach to it. If the browser opens its own runtime instead, both ends report
+ * success and diverge silently: the agent edits one worksheet, the user watches another, and
+ * nothing surfaces until a save overwrites one with the other.
+ */
+@Tag("core")
+class WorksheetEventServiceTest {
+   /**
+    * The attach. Creating a second runtime here is the whole defect, so this asserts the negative
+    * ({@code engine.openWorksheet} never called) as well as the positive -- delegating with the
+    * right id while ALSO opening a stray runtime would satisfy the positive alone.
+    */
+   @Test
+   void attachesToTheSuppliedRuntimeInsteadOfOpeningASecondOne() throws Exception {
+      Fixture f = new Fixture();
+
+      f.service.openWorksheet(f.user, f.entry, false, false, "ws-server-1", f.dispatcher);
+
+      verify(f.engine, never()).openWorksheet(any(AssetEntry.class), any(Principal.class));
+      verify(f.proxy).openWorksheet(eq("ws-server-1"), eq(f.user), eq(f.entry), eq(false),
+                                    eq(false), eq(f.dispatcher));
+   }
+
+   /**
+    * The normal path, which every Composer user takes. The attach branch must not capture it:
+    * with no runtime supplied the server still opens one of its own.
+    */
+   @Test
+   void opensANewRuntimeWhenNoneIsSupplied() throws Exception {
+      Fixture f = new Fixture();
+      when(f.engine.openWorksheet(f.entry, f.user)).thenReturn("ws-fresh-1");
+
+      f.service.openWorksheet(f.user, f.entry, false, false, null, f.dispatcher);
+
+      verify(f.engine).openWorksheet(f.entry, f.user);
+      verify(f.proxy).openWorksheet(eq("ws-fresh-1"), eq(f.user), eq(f.entry), eq(false),
+                                    eq(false), eq(f.dispatcher));
+   }
+
+   @SuppressWarnings("unchecked")
+   private static final class Fixture {
+      final ViewsheetService engine = mock(ViewsheetService.class);
+      final WorksheetEventServiceProxy proxy = mock(WorksheetEventServiceProxy.class);
+      final ObjectProvider<WorksheetEventServiceProxy> provider = mock(ObjectProvider.class);
+      final AssetEntry entry = mock(AssetEntry.class);
+      final CommandDispatcher dispatcher = mock(CommandDispatcher.class);
+      final Principal user = () -> "alice~;~host-org";
+      final WorksheetEventService service;
+
+      Fixture() {
+         when(provider.getIfAvailable()).thenReturn(proxy);
+         service = new WorksheetEventService(engine, provider);
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/SheetOpenServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/SheetOpenServiceTest.java
@@ -63,6 +63,16 @@ class SheetOpenServiceTest {
     */
    private SheetAgentBroadcastService broadcast;
 
+   /** Populated by {@code serviceWithBase} so tests can assert which principal opened the runtime. */
+   private WorksheetService worksheetService;
+
+   /**
+    * The principal that owns the paired viewsheet runtime — i.e. the user's browser session.
+    * Deliberately a different object from {@link #principal()}, the agent: the two are the same
+    * logical user but different sessions, and the ownership check compares sessions.
+    */
+   private static final Principal BROWSER_PRINCIPAL = () -> OWNER;
+
    /**
     * Necessarily equal to {@link #OWNER}: {@code SheetSessionService.resolve} refuses a session
     * whose {@code ownerIdentity} differs from the agent's identity, so a session where these two
@@ -205,6 +215,27 @@ class SheetOpenServiceTest {
                    "must be delivered to the paired browser's socket session");
    }
 
+   /**
+    * Who owns the new runtime. The browser must, not the agent.
+    *
+    * <p>{@code WorksheetEngine.getSheet} rejects a principal that does not match the runtime's
+    * owner unless it carries {@code pairedAgent} or {@code supportLogin}. The agent carries
+    * {@code pairedAgent}; the user's browser carries neither. Opening the runtime as the agent
+    * therefore makes the <em>browser</em> the outsider, and its attach dies on "Invalid user
+    * found" — two principals for the same admin differing only by session id.
+    *
+    * <p>A paired viewsheet already has this the right way round: the browser opened it and the
+    * agent reaches it through the flag. Mirroring that keeps one rule for both sheet types.
+    */
+   @Test
+   void opensTheRuntimeAsTheViewsheetsOwnerSoTheBrowserCanAttach() throws Exception {
+      SheetOpenService service = serviceWithBase(worksheetEntry(), true, null);
+
+      service.openBaseWorksheet("tok-vs", principal());
+
+      verify(worksheetService).openWorksheet(any(AssetEntry.class), same(BROWSER_PRINCIPAL));
+   }
+
    // ── harness ───────────────────────────────────────────────────────────────
 
    /** The four-guard helper. Defaults the viewsheet session's socketSessionId to {@code "sock-1"}. */
@@ -236,6 +267,7 @@ class SheetOpenServiceTest {
 
          RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
          when(rvs.getViewsheet()).thenReturn(vs);
+         when(rvs.getUser()).thenReturn(BROWSER_PRINCIPAL);
 
          JoinSession vsSession = new JoinSession(
             "tok-vs", "vs-runtime-1", OWNER, SheetType.VIEWSHEET, 0L,
@@ -256,7 +288,7 @@ class SheetOpenServiceTest {
          // the point of keeping the two values distinct.
          when(sheetSessions.findOpen(OWNER, SheetType.WORKSHEET)).thenReturn(held);
 
-         WorksheetService worksheetService = mock(WorksheetService.class);
+         worksheetService = mock(WorksheetService.class);
          when(worksheetService.openWorksheet(any(AssetEntry.class), any(Principal.class)))
             .thenReturn("ws-runtime-1");
 

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/SheetOpenServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/SheetOpenServiceTest.java
@@ -29,9 +29,14 @@ import inetsoft.web.wiz.pairing.JoinSession;
 import inetsoft.web.wiz.pairing.SheetAgentBroadcastService;
 import inetsoft.web.wiz.pairing.SheetSessionService;
 import inetsoft.web.wiz.pairing.SheetType;
+import inetsoft.web.viewsheet.model.VSObjectModelFactoryService;
+import inetsoft.web.viewsheet.service.ComposerClientService;
+import inetsoft.web.viewsheet.service.CommandDispatcherService;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 
 import java.security.Principal;
 
@@ -159,12 +164,45 @@ class SheetOpenServiceTest {
       service.openBaseWorksheet("tok-vs", principal());
 
       ArgumentCaptor<Object> command = ArgumentCaptor.forClass(Object.class);
-      verify(broadcast).sendToBrowser(eq(SOCKET_USER), eq("sock-1"), anyString(),
-                                       command.capture());
+      verify(broadcast).sendToComposer(eq("sock-1"), command.capture());
 
       OpenComposerAssetCommand sent = (OpenComposerAssetCommand) command.getValue();
       assertEquals("ws-runtime-1", sent.runtimeId(), "the browser must attach, not open its own");
       assertFalse(sent.viewsheet());
+   }
+
+   /**
+    * Which STOMP destination the command lands on -- the assertion whose absence let this ship
+    * broken.
+    *
+    * <p>{@code OpenComposerAssetCommand} has exactly one handler in the client: composer-main,
+    * fed by a subscription to {@code /user/composer-client}. Published instead to
+    * {@link inetsoft.web.viewsheet.service.CommandDispatcher#COMMANDS_TOPIC} ({@code "/commands"})
+    * it reaches the per-sheet client, which has no handler for it, and is dropped with no error --
+    * the user's Composer opens no tab while every call up the stack still reports success.
+    *
+    * <p>Both constants are named {@code COMMANDS_TOPIC}, on different classes, which is how the
+    * wrong one survived review. This test drives the <b>real</b> broadcast service over a mocked
+    * dispatcher: mocking the broadcast service is what made the sibling test above blind, since
+    * the destination is chosen inside the very method that was stubbed.
+    */
+   @Test
+   void theOpenCommandGoesToTheComposerClientTopicNotTheSheetRuntimeTopic() throws Exception {
+      CommandDispatcherService dispatcher = mock(CommandDispatcherService.class);
+      SheetAgentBroadcastService realBroadcast = new SheetAgentBroadcastService(
+         dispatcher, mock(VSObjectModelFactoryService.class));
+      SheetOpenService service =
+         serviceWithBase(worksheetEntry(), true, null, "sock-1", realBroadcast);
+
+      service.openBaseWorksheet("tok-vs", principal());
+
+      ArgumentCaptor<MessageHeaders> headers = ArgumentCaptor.forClass(MessageHeaders.class);
+      verify(dispatcher).convertAndSendToUser(
+         eq("sock-1"), eq(ComposerClientService.COMMANDS_TOPIC),
+         any(OpenComposerAssetCommand.class), headers.capture());
+
+      assertEquals("sock-1", SimpMessageHeaderAccessor.getSessionId(headers.getValue()),
+                   "must be delivered to the paired browser's socket session");
    }
 
    // ── harness ───────────────────────────────────────────────────────────────
@@ -179,6 +217,18 @@ class SheetOpenServiceTest {
    private SheetOpenService serviceWithBase(AssetEntry base, boolean hasPermission,
                                              String heldWorksheetRuntimeId,
                                              String socketSessionId)
+   {
+      return serviceWithBase(base, hasPermission, heldWorksheetRuntimeId, socketSessionId, null);
+   }
+
+   /**
+    * @param broadcastService the collaborator to inject, or {@code null} for a mock. Pass a real
+    *                         one to assert on what actually reaches the dispatcher.
+    */
+   private SheetOpenService serviceWithBase(AssetEntry base, boolean hasPermission,
+                                             String heldWorksheetRuntimeId,
+                                             String socketSessionId,
+                                             SheetAgentBroadcastService broadcastService)
    {
       try {
          Viewsheet vs = mock(Viewsheet.class);
@@ -226,7 +276,8 @@ class SheetOpenServiceTest {
                                  eq(socketSessionId), eq(SOCKET_USER)))
             .thenReturn(newWsSession);
 
-         broadcast = mock(SheetAgentBroadcastService.class);
+         broadcast = broadcastService == null
+            ? mock(SheetAgentBroadcastService.class) : broadcastService;
 
          return new SheetOpenService(viewsheetSessions, sheetSessions, worksheetService,
                                       securityProvider, broadcast);

--- a/web/projects/portal/src/app/composer/data/sheet.ts
+++ b/web/projects/portal/src/app/composer/data/sheet.ts
@@ -114,6 +114,15 @@ export abstract class Sheet {
          this.savePoint = sheet.savePoint;
          this.loading = sheet.loading;
          this.annotationChanged = sheet.annotationChanged;
+         // Must travel with runtimeId, which is copied above. closeOnServer is false only for a
+         // sheet whose runtime the SERVER opened; a copy that keeps the runtime but drops the
+         // flag claims the right to close a runtime it does not own. These copies are made
+         // constantly -- processUpdateUndoStateCommand builds one on every UpdateUndoStateCommand,
+         // which an agent broadcasts after every edit it makes -- so the flag would be right when
+         // the tab opens and wrong from the first edit on, and closing the tab would then destroy
+         // the runtime the agent is paired to.
+         this.closeOnServer = sheet.closeOnServer;
+         this.closedOnServer = sheet.closedOnServer;
       }
    }
 

--- a/web/projects/portal/src/app/composer/data/ws/worksheet.spec.ts
+++ b/web/projects/portal/src/app/composer/data/ws/worksheet.spec.ts
@@ -1,0 +1,53 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { Worksheet } from "./worksheet";
+
+describe("Sheet copy constructor", () => {
+   // closeOnServer defaults to true and is set to false only for a sheet whose runtime the
+   // SERVER opened (open_base_worksheet). The copy constructor carries runtimeId, so a copy that
+   // drops closeOnServer still points at the server's runtime while claiming the right to close
+   // it -- and the copies are made constantly: processUpdateUndoStateCommand builds one on every
+   // UpdateUndoStateCommand, which the agent broadcasts after every edit it makes. The flag is
+   // correct when the tab opens and wrong from the first edit onward, so closing the tab then
+   // destroys the runtime the agent is paired to.
+   it("preserves closeOnServer, which decides whether closing a tab kills the runtime", () => {
+      const original = new Worksheet();
+      original.runtimeId = "ws-server-1";
+      original.closeOnServer = false;
+
+      const copy = new Worksheet(original);
+
+      expect(copy.runtimeId).toBe("ws-server-1");
+      expect(copy.closeOnServer).toBe(false);
+   });
+
+   it("preserves closedOnServer, the guard against closing a runtime twice", () => {
+      const original = new Worksheet();
+      original.closedOnServer = true;
+
+      const copy = new Worksheet(original);
+
+      expect(copy.closedOnServer).toBe(true);
+   });
+
+   it("still defaults closeOnServer to true for a browser-opened sheet", () => {
+      expect(new Worksheet().closeOnServer).toBe(true);
+      expect(new Worksheet(new Worksheet()).closeOnServer).toBe(true);
+   });
+});

--- a/web/projects/portal/src/app/composer/gui/ws/editor/ws-pane.component.ts
+++ b/web/projects/portal/src/app/composer/gui/ws/editor/ws-pane.component.ts
@@ -785,6 +785,15 @@ export class WSPaneComponent extends CommandProcessor implements OnDestroy, OnIn
       const event = new OpenWorksheetEvent();
       event.setId(this.worksheet.id);
 
+      // The server already opened this runtime and told us to attach to it (open_base_worksheet).
+      // Without both of these the browser opens a SECOND runtime of the same asset: the agent
+      // edits one, the user watches the other, and every call on both sides still succeeds.
+      // Mirrors openExistingViewsheet, which sets runtimeViewsheetId and binds its client.
+      if(this.worksheet.runtimeId) {
+         event.setRuntimeId(this.worksheet.runtimeId);
+         this.worksheetClient.runtimeId = this.worksheet.runtimeId;
+      }
+
       if(this.worksheet.gettingStarted) {
          event.setGettingStartedWs(true);
          event.setCreateQuery(this.gettingStartedService.isCreateQuery());

--- a/web/projects/portal/src/app/composer/gui/ws/socket/open-ws/open-ws-event.ts
+++ b/web/projects/portal/src/app/composer/gui/ws/socket/open-ws/open-ws-event.ts
@@ -20,9 +20,18 @@ export class OpenWorksheetEvent {
    private openAutoSavedFile: boolean = false;
    private gettingStartedWs: boolean = false;
    private createQuery: boolean = false;
+   /**
+    * A runtime the server already opened, which this browser attaches to instead of opening one
+    * of its own. Left null in the normal flow. Mirrors OpenViewsheetEvent.runtimeViewsheetId.
+    */
+   private runtimeId: string = null;
 
    public setId(id: string) {
       this.id = id;
+   }
+
+   public setRuntimeId(runtimeId: string) {
+      this.runtimeId = runtimeId;
    }
 
    public setOpenAutoSavedFile(openAutoSavedFile: boolean) {


### PR DESCRIPTION
`open_base_worksheet` shipped as "built, merged, and deployed", with only live verification
outstanding. Verification found it had never worked end to end: four defects, in series, each
one hidden behind a fully green suite. Every one was found live and is now fixed and re-verified
live.

The feature's own note predicted this: *"Not proven by anything yet: that the browser attaches to
a real server-created runtime end to end."* That sentence was the only accurate status in the
handoff.

## The four defects

**1. The open command went to the wrong STOMP topic** (`664b0a8fd`)

`OpenComposerAssetCommand` has exactly one client handler — composer-main, fed by a subscription
to `/user/composer-client`. It was published to `CommandDispatcher.COMMANDS_TOPIC`
(`"/commands"`), the per-sheet-runtime channel, tagged `RUNTIME_ID_ATTR` = the brand-new
worksheet runtime, which no open client is bound to. Two independent reasons it could not
arrive, neither of which errors. No tab opened; every call returned success.

Both destination constants are named `COMMANDS_TOPIC`, on `CommandDispatcher` and on
`ComposerClientService`. Reusing `sendToBrowser` looked like correct reuse — it is the method for
reaching the paired browser. It reaches the wrong channel on it: a refresh is sheet-scoped, this
command is composer-scoped. New `sendToComposer` mirrors `ComposerController`'s native
"Edit Data" send.

**2. The browser opened its own runtime instead of attaching** (`7ee0203c6`)

The tab opened, and the user still watched a different worksheet than the agent edited — the
agent renamed a column on `a1-1` while the browser showed the original.

Task 4 assigned `ws.runtimeId`/`ws.closeOnServer` on the model, which is what its component tests
assert, but nothing downstream read `runtimeId` at open time: `openExistingWorksheet` sent only
the asset id, and `/ws/open` unconditionally opened a new runtime. The viewsheet path it was said
to mirror does the attach in `openExistingViewsheet` — setting `runtimeViewsheetId` *and* binding
the client — not in `openSheet`, so the mirror was drawn one level too high and the assignment
landed on an object nobody consults.

`OpenWorksheetEvent` gains a nullable `runtimeId`; `WorksheetEventService` skips
`engine.openWorksheet` when one is supplied. Everything after the runtime exists — socket
identifiers, `OpenWorksheetCommand`, the refresh — was already shared, so only the creation step
is conditional.

**3. The runtime was owned by the agent, so the browser was refused** (`f0be937b0`)

With the attach wired up, the browser reached `/ws/open` and StyleBI rejected it:

```
Invalid user found: Principal[Client[admin@...@536be9db...]]
instead of Principal[Client[admin@...@825f5dfe...]]
```

Same admin, same host, different session. `WorksheetEngine.getSheet` refuses a principal that
does not match the runtime's owner unless it carries `pairedAgent` or `supportLogin`. The agent
carries `pairedAgent`; a browser carries neither. Opening the runtime as the agent made the
user's own browser the outsider.

A paired viewsheet already has this the right way round — the browser opens it, the agent reaches
in through the flag, exactly as `mayActForOwner`'s javadoc describes. The worksheet now matches:
opened as `rvs.getUser()`.

**4. `closeOnServer` was lost on every Sheet copy** (`b1581febc`)

Closing the tab destroyed the runtime and killed the paired session. `closeOnServer = !runtimeId`
should have prevented it, and every close path is guarded by that flag.

Reading could not resolve the contradiction, so it was measured: a temporary stack trace at
`WorksheetEngine.closeSheet` named `CloseWorksheetController`, proving the browser really did
send `/ws/close` and the flag really was `true`.

`Sheet`'s copy constructor carries `runtimeId` but not `closeOnServer`, so a copy still points at
the server's runtime while reverting to the class default `true`.
`processUpdateUndoStateCommand` builds such a copy on every `UpdateUndoStateCommand` — which
`SheetAgentBroadcastService.sendUndoState` broadcasts after every agent edit. The flag was right
at open and wrong from the first edit onward. The diagnostic was removed before this PR.

## Live verification, on `local-1211`

| Check | Result |
|---|---|
| 1. Base worksheet opens as one new tab; `status` reports two sessions | PASS |
| 2. An agent edit appears in the browser with no manual refresh | PASS |
| 3. Closing the tab leaves the agent's session alive | PASS |
| 4. A logical-model base is refused, naming the type | not run — needs a second viewsheet |
| 5. A second call is refused, naming the held runtime | PASS |

Check 3 was run *after* an edit, deliberately: the edit is what used to poison `closeOnServer`,
so closing a tab without one would pass for the wrong reason.

## On the tests

Every defect here sat behind a green suite, and three of the four were invisible for the same
reason — the assertion could not observe the thing that was broken:

- the destination was chosen inside the method the test mocked;
- the test asserted a field assignment that nothing downstream read;
- nothing asserted which principal opens the runtime;
- nothing tested the copy constructor at all.

Each new test was checked by neutralizing the source and confirming that exactly that test fails:

- destination test: fails with wanted `/composer-client` / actual `/commands`, other 7 pass
- attach test: fails on its `verify(engine, never())` assertion, normal-path test stays green
- ownership test: browser owner is a distinct object from the agent, same logical user and
  different session — the distinction the check actually makes
- copy-constructor tests: two fail without the fix; a third pins the default at `true` for a
  browser-opened sheet and passed before and after, proving the fix does not over-correct and
  break every normal tab close

`WorksheetEventServiceTest` also covers the normal open path that every Composer user takes, since
the attach branch must not capture it.

**One gap, stated rather than papered over:** there is no unit test on the `ws-pane`
`openExistingWorksheet` branch. No spec exists for that component, and standing one up for two
lines would be a worse test than the live check it duplicates — the same decorative-test trap that
produced defect 2. Check 2 is its proof.

## Test results

- `core`: 1497 tests across `inetsoft.web.wiz` and `inetsoft.web.composer.ws`, 0 failures
- `portal`: 3/3 new `worksheet.spec.ts`, 77/77 across the composer-main tl specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
