### PR TITLE
Typed script kinds: wire vocabulary, deterministic ids, and the grammar contract

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptContextService.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptContextService.java
@@ -19,11 +19,13 @@ package inetsoft.web.wiz.script;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.script.viewsheet.ViewsheetScope;
 import inetsoft.uql.asset.Assembly;
 import inetsoft.uql.viewsheet.ChartVSAssembly;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.binding.VSScriptableService;
+import inetsoft.web.wiz.pairing.PairingException;
 import inetsoft.web.wiz.script.model.AssemblyContext;
 import inetsoft.web.wiz.script.model.ScriptContext;
 import org.slf4j.Logger;
@@ -82,7 +84,72 @@ public class ScriptContextService {
       this.scriptableService = scriptableService;
    }
 
-   public ScriptContext context(RuntimeViewsheet rvs) {
+   /**
+    * The scriptable surface for one target.
+    *
+    * <p>Scoped because an unscoped dump is both enormous and the reason this tool got reached for
+    * during non-script work: the full apiTree for every assembly is a viewsheet-wide inventory,
+    * which is the pull the GUI-first rule exists to resist. Without a target the assembly LIST
+    * still comes back — that is what makes a target choosable — but without the trees.
+    *
+    * @param target null for the unscoped listing; a viewsheet-level kind keeps every tree, because
+    *               an onInit/onLoad script coordinates across assemblies by definition.
+    */
+   public ScriptContext context(RuntimeViewsheet rvs, ScriptTarget target) throws PairingException {
+      List<AssemblyContext> all = describeAssemblies(rvs);
+
+      if(target == null) {
+         // No kind stated, so no basis for narrowing the vars: report the union rather than
+         // guessing a context the caller has not chosen.
+         return new ScriptContext(all.stream().map(ScriptContextService::withoutApiTree).toList(),
+                                  CONTEXT_VARS);
+      }
+
+      List<String> vars = contextVars(target.kind());
+
+      if(target.assemblyName() == null) {
+         return new ScriptContext(all, vars);
+      }
+
+      List<AssemblyContext> one = all.stream()
+         .filter(a -> target.assemblyName().equals(a.name()))
+         .toList();
+
+      if(one.isEmpty()) {
+         throw new PairingException("Assembly not found: " + target.assemblyName());
+      }
+
+      return new ScriptContext(one, vars);
+   }
+
+   /**
+    * The variables actually in scope for this kind.
+    *
+    * <p>The API differs by context, so reporting one flat list makes the tool wrong for every kind
+    * but one. {@code event} resolves from {@link ViewsheetScope}'s vmap
+    * ({@code ViewsheetScope.java:368}) and is populated only while an onClick is executing —
+    * offering it to an onInit script promises a variable that is always null there.
+    *
+    * <p>This is the seam Tier 2 kinds extend: a {@code calcField} runs per row with
+    * {@code field['x']} and no assembly API at all, so it will add a case here rather than a
+    * special path elsewhere.
+    */
+   private static List<String> contextVars(ScriptTarget.Kind kind) {
+      return switch(kind) {
+         case ASSEMBLY_ON_CLICK -> CONTEXT_VARS;
+         default -> CONTEXT_VARS.stream().filter(v -> !"event".equals(v)).toList();
+      };
+   }
+
+   private static AssemblyContext withoutApiTree(AssemblyContext a) {
+      return new AssemblyContext(a.name(), a.type(), a.scriptable(), a.scriptableMembers(), null);
+   }
+
+   /**
+    * Builds the per-assembly scriptable surface via the live {@code VSScriptableService} lookup,
+    * falling back to the curated member list for charts when the live lookup fails.
+    */
+   List<AssemblyContext> describeAssemblies(RuntimeViewsheet rvs) {
       List<AssemblyContext> assemblies = new ArrayList<>();
       Viewsheet vs = rvs.getViewsheet();
 
@@ -110,7 +177,7 @@ public class ScriptContextService {
          }
       }
 
-      return new ScriptContext(assemblies, CONTEXT_VARS);
+      return assemblies;
    }
 
    private final VSScriptableService scriptableService;

--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptGrammar.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptGrammar.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.script;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * The script target grammar this server speaks.
+ *
+ * <p>One place, because the controller advertises it and {@link ScriptReadService} emits targets
+ * shaped by it: if those two disagreed, a client would negotiate a grammar the responses do not
+ * follow, which is worse than no negotiation.
+ */
+public final class ScriptGrammar {
+   /** v1 = the delimited target string; v2 = kinds, ids and structured params. */
+   public static final int VERSION = 2;
+
+   /**
+    * The kinds this server can serve — those with an internal location behind them. Reserved
+    * kinds are deliberately absent: advertising one and then refusing it is the silent capability
+    * lie this contract exists to prevent.
+    */
+   public static List<String> supportedKinds() {
+      return Arrays.stream(ScriptTarget.Kind.values())
+         .filter(k -> k.location() != null)
+         .map(ScriptTarget.Kind::wireName)
+         .toList();
+   }
+
+   private ScriptGrammar() {
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptReadService.java
@@ -51,8 +51,10 @@ public class ScriptReadService {
 
       ViewsheetInfo vsInfo = vs.getViewsheetInfo();
       boolean vsScriptEnabled = vsInfo.isScriptEnabled();
-      targets.add(new ScriptTargetInfo("vs-init", !isBlank(vsInfo.getOnInit()), vsScriptEnabled));
-      targets.add(new ScriptTargetInfo("vs-load", !isBlank(vsInfo.getOnLoad()), vsScriptEnabled));
+      targets.add(describe(ScriptTarget.Kind.VIEWSHEET_ON_INIT, null,
+                           !isBlank(vsInfo.getOnInit()), vsScriptEnabled));
+      targets.add(describe(ScriptTarget.Kind.VIEWSHEET_ON_LOAD, null,
+                           !isBlank(vsInfo.getOnLoad()), vsScriptEnabled));
 
       for(Assembly a : vs.getAssemblies()) {
          if(!(a instanceof VSAssembly vsAssembly)) {
@@ -60,17 +62,69 @@ public class ScriptReadService {
          }
 
          VSAssemblyInfo info = vsAssembly.getVSAssemblyInfo();
-         targets.add(new ScriptTargetInfo(
-            "assembly:" + a.getName(), !isBlank(info.getScript()), info.isScriptEnabled()));
+         targets.add(describe(ScriptTarget.Kind.ASSEMBLY_MAIN, a.getName(),
+                              !isBlank(info.getScript()), info.isScriptEnabled()));
 
          if(supportsOnClick(info)) {
-            targets.add(new ScriptTargetInfo(
-               "assembly:" + a.getName() + ":onClick", !isBlank(getOnClick(info)),
-               info.isScriptEnabled()));
+            targets.add(describe(ScriptTarget.Kind.ASSEMBLY_ON_CLICK, a.getName(),
+                                 !isBlank(getOnClick(info)), info.isScriptEnabled()));
          }
       }
 
       return targets;
+   }
+
+   /**
+    * Projects one target. Enumeration decides WHICH targets exist; this decides how each is
+    * described, and the two are kept apart so the taxonomy can grow without touching traversal.
+    */
+   private static ScriptTargetInfo describe(ScriptTarget.Kind kind, String assembly,
+                                            boolean hasScript, boolean enabled)
+   {
+      ScriptTarget target;
+
+      try {
+         target = ScriptTarget.of(kind, assembly);
+      }
+      catch(PairingException ex) {
+         // Unreachable: every kind passed here is Tier 1 with the assembly name its kind requires.
+         throw new IllegalStateException("cannot describe " + kind + " for " + assembly, ex);
+      }
+
+      return new ScriptTargetInfo(
+         target.id(), kind.wireName(), assembly, label(kind, assembly), runsWhen(kind),
+         hasScript, enabled, enableScope(kind, assembly), "viewsheet", target.toString());
+   }
+
+   private static String label(ScriptTarget.Kind kind, String assembly) {
+      return switch(kind) {
+         case VIEWSHEET_ON_INIT -> "Viewsheet onInit";
+         case VIEWSHEET_ON_LOAD -> "Viewsheet onLoad";
+         case ASSEMBLY_MAIN -> assembly + " script";
+         case ASSEMBLY_ON_CLICK -> assembly + " onClick";
+         default -> kind.wireName();
+      };
+   }
+
+   private static String runsWhen(ScriptTarget.Kind kind) {
+      return switch(kind) {
+         case VIEWSHEET_ON_INIT -> "once, at viewsheet initialization";
+         case VIEWSHEET_ON_LOAD -> "on every refresh";
+         case ASSEMBLY_MAIN -> "each time the assembly renders";
+         case ASSEMBLY_ON_CLICK -> "on user click";
+         default -> "unknown";
+      };
+   }
+
+   /**
+    * Which enable flag {@code enabled} reflects — the footgun made legible. onInit and onLoad
+    * share the viewsheet flag; an assembly's main and onClick scripts share that assembly's flag.
+    */
+   private static String enableScope(ScriptTarget.Kind kind, String assembly) {
+      return switch(kind) {
+         case VIEWSHEET_ON_INIT, VIEWSHEET_ON_LOAD -> "viewsheet";
+         default -> "assembly:" + assembly;
+      };
    }
 
    /** Reads the current text + enabled-state for {@code target}. */

--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptTarget.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptTarget.java
@@ -242,6 +242,38 @@ public final class ScriptTarget {
       return parse(target);
    }
 
+   /**
+    * Resolves whichever dialect the caller sent into one canonical target.
+    *
+    * <p>Three dialects, one precedence rule, in one place: six endpoints accept all three, and six
+    * copies of this would be six chances for them to disagree about which wins.
+    *
+    * @param vs            the joined viewsheet, for the exact-name precedence fix; may be null
+    * @param id            preferred for an existing target — the caller copies it back verbatim
+    * @param kind          the wire kind name, with {@code assembly} when the kind needs one
+    * @param legacyTarget  the v1 delimited string, still accepted
+    */
+   public static ScriptTarget resolve(Viewsheet vs, String id, String kind, String assembly,
+                                      String legacyTarget)
+      throws PairingException
+   {
+      if(id != null && !id.isBlank()) {
+         return fromId(id);
+      }
+
+      if(kind != null && !kind.isBlank()) {
+         return of(Kind.fromWire(kind), assembly);
+      }
+
+      if(legacyTarget != null && !legacyTarget.isBlank()) {
+         return parse(vs, legacyTarget);
+      }
+
+      throw new PairingException(
+         "A script target is required: pass 'id' (from list_script_targets), or 'kind' with " +
+         "'assembly' where the kind needs one, or the legacy 'target' string.");
+   }
+
    @Override
    public String toString() {
       return switch(location) {

--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptTarget.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptTarget.java
@@ -17,7 +17,13 @@
  */
 package inetsoft.web.wiz.script;
 
+import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.wiz.pairing.PairingException;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
 
 /**
  * Parses/formats the {@code target} string the wiz-services proxy (and the MCP script tools)
@@ -29,8 +35,69 @@ import inetsoft.web.wiz.pairing.PairingException;
 public final class ScriptTarget {
    public enum Location { VS_INIT, VS_LOAD, ASSEMBLY, ASSEMBLY_ONCLICK }
 
-   private ScriptTarget(Location location, String assemblyName) {
-      this.location = location;
+   /**
+    * The wire vocabulary. Distinct from {@link Location}, which is the internal dispatch key every
+    * read/write/execute service already switches on: a wire rename must not ripple into five
+    * services, and two of these kinds have no Location at all until pane-scoped pairing lands.
+    */
+   public enum Kind {
+      VIEWSHEET_ON_INIT("viewsheetOnInit", Location.VS_INIT),
+      VIEWSHEET_ON_LOAD("viewsheetOnLoad", Location.VS_LOAD),
+      ASSEMBLY_MAIN("assemblyMain", Location.ASSEMBLY),
+      ASSEMBLY_ON_CLICK("assemblyOnClick", Location.ASSEMBLY_ONCLICK),
+      // Reserved so the schema does not churn when pane-scoped pairing lands. A session cannot be
+      // scoped to one yet, so ScriptTarget.of refuses them with a scope error.
+      WORKSHEET_EXPRESSION("worksheetExpression", null),
+      WORKSHEET_CONDITION("worksheetCondition", null);
+
+      Kind(String wireName, Location location) {
+         this.wireName = wireName;
+         this.location = location;
+      }
+
+      public String wireName() {
+         return wireName;
+      }
+
+      /** The internal dispatch key, or {@code null} for a kind no service can serve yet. */
+      public Location location() {
+         return location;
+      }
+
+      public static Kind fromWire(String wire) throws PairingException {
+         if(wire == null || wire.isBlank()) {
+            throw new PairingException("kind is required");
+         }
+
+         // Named explicitly rather than aliased: there is no onRefresh in viewsheet scripting, and
+         // silently mapping it to onLoad would teach the caller a location that does not exist.
+         if("onRefresh".equals(wire)) {
+            throw new PairingException(
+               "There is no 'onRefresh' script in StyleBI. 'viewsheetOnLoad' is the script that " +
+               "runs on every refresh; 'viewsheetOnInit' runs once at initialization.");
+         }
+
+         for(Kind k : values()) {
+            if(k.wireName.equals(wire)) {
+               return k;
+            }
+         }
+
+         throw new PairingException("Unknown kind: \"" + wire + "\". Expected one of " +
+                                    String.join(", ", wireNames()) + ".");
+      }
+
+      public static List<String> wireNames() {
+         return Arrays.stream(values()).map(Kind::wireName).toList();
+      }
+
+      private final String wireName;
+      private final Location location;
+   }
+
+   private ScriptTarget(Kind kind, String assemblyName) {
+      this.kind = kind;
+      this.location = kind.location();
       this.assemblyName = assemblyName;
    }
 
@@ -43,17 +110,93 @@ public final class ScriptTarget {
       return assemblyName;
    }
 
+   public Kind kind() {
+      return kind;
+   }
+
+   /**
+    * Builds a target from the canonical tuple.
+    *
+    * @throws PairingException if the kind has no servable location, or an assembly kind carries no
+    *                          assembly name.
+    */
+   public static ScriptTarget of(Kind kind, String assemblyName) throws PairingException {
+      if(kind == null) {
+         throw new PairingException("kind is required");
+      }
+
+      if(kind.location() == null) {
+         throw new PairingException(
+            "kind '" + kind.wireName() + "' requires a session paired from that expression's " +
+            "editor; this session is bound to a whole viewsheet.");
+      }
+
+      boolean needsAssembly = kind == Kind.ASSEMBLY_MAIN || kind == Kind.ASSEMBLY_ON_CLICK;
+
+      if(needsAssembly && (assemblyName == null || assemblyName.isBlank())) {
+         throw new PairingException("kind '" + kind.wireName() + "' requires an assembly name.");
+      }
+
+      if(!needsAssembly && assemblyName != null && !assemblyName.isBlank()) {
+         throw new PairingException(
+            "kind '" + kind.wireName() + "' is viewsheet-level and takes no assembly name.");
+      }
+
+      return new ScriptTarget(kind, needsAssembly ? assemblyName : null);
+   }
+
+   /**
+    * A stable, opaque, URL-safe id for this target.
+    *
+    * <p>A deterministic encoding of the canonical tuple, NOT a server-issued handle: the pairing
+    * store is in-memory, so an id that only resolved inside one session would strand every
+    * workflow that lists targets in one turn and edits in the next. Decodable, which keeps it
+    * readable in logs and errors.
+    */
+   public String id() {
+      String canonical = kind.wireName() + "|" + (assemblyName == null ? "" : assemblyName);
+      return Base64.getUrlEncoder().withoutPadding()
+         .encodeToString(canonical.getBytes(StandardCharsets.UTF_8));
+   }
+
+   public static ScriptTarget fromId(String id) throws PairingException {
+      if(id == null || id.isBlank()) {
+         throw new PairingException("id is required");
+      }
+
+      String canonical;
+
+      try {
+         canonical = new String(Base64.getUrlDecoder().decode(id), StandardCharsets.UTF_8);
+      }
+      catch(IllegalArgumentException ex) {
+         throw new PairingException("Invalid target id: \"" + id + "\".");
+      }
+
+      // Split once: the kind is a fixed vocabulary with no '|', everything after the first
+      // separator is the assembly name verbatim -- which is what makes a name containing ':'
+      // (or '|') addressable at all.
+      int sep = canonical.indexOf('|');
+
+      if(sep < 0) {
+         throw new PairingException("Invalid target id: \"" + id + "\".");
+      }
+
+      String assembly = canonical.substring(sep + 1);
+      return of(Kind.fromWire(canonical.substring(0, sep)), assembly.isEmpty() ? null : assembly);
+   }
+
    public static ScriptTarget parse(String target) throws PairingException {
       if(target == null || target.isBlank()) {
          throw new PairingException("target is required");
       }
 
       if("vs-init".equals(target)) {
-         return new ScriptTarget(Location.VS_INIT, null);
+         return new ScriptTarget(Kind.VIEWSHEET_ON_INIT, null);
       }
 
       if("vs-load".equals(target)) {
-         return new ScriptTarget(Location.VS_LOAD, null);
+         return new ScriptTarget(Kind.VIEWSHEET_ON_LOAD, null);
       }
 
       if(target.startsWith("assembly:")) {
@@ -66,18 +209,37 @@ public final class ScriptTarget {
                throw new PairingException("Invalid target: " + target);
             }
 
-            return new ScriptTarget(Location.ASSEMBLY_ONCLICK, name);
+            return new ScriptTarget(Kind.ASSEMBLY_ON_CLICK, name);
          }
 
          if(rest.isBlank()) {
             throw new PairingException("Invalid target: " + target);
          }
 
-         return new ScriptTarget(Location.ASSEMBLY, rest);
+         return new ScriptTarget(Kind.ASSEMBLY_MAIN, rest);
       }
 
       throw new PairingException("Invalid target: \"" + target +
          "\". Expected \"vs-init\", \"vs-load\", \"assembly:<name>\", or \"assembly:<name>:onClick\".");
+   }
+
+   /**
+    * The v1 string parse, but able to tell an assembly literally named {@code Foo:onClick} from
+    * the onClick script of an assembly named {@code Foo}. An exact assembly match always wins.
+    *
+    * <p>{@link #parse(String)} cannot do this — it is static with no viewsheet in hand — which is
+    * exactly why the delimited grammar is being retired.
+    */
+   public static ScriptTarget parse(Viewsheet vs, String target) throws PairingException {
+      if(vs != null && target != null && target.startsWith("assembly:")) {
+         String rest = target.substring("assembly:".length());
+
+         if(!rest.isBlank() && vs.getAssembly(rest) != null) {
+            return of(Kind.ASSEMBLY_MAIN, rest);
+         }
+      }
+
+      return parse(target);
    }
 
    @Override
@@ -90,6 +252,7 @@ public final class ScriptTarget {
       };
    }
 
+   private final Kind kind;
    private final Location location;
    private final String assemblyName;
 }

--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptTarget.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptTarget.java
@@ -251,6 +251,7 @@ public final class ScriptTarget {
     * @param vs            the joined viewsheet, for the exact-name precedence fix; may be null
     * @param id            preferred for an existing target — the caller copies it back verbatim
     * @param kind          the wire kind name, with {@code assembly} when the kind needs one
+    * @param assembly      the assembly name, required for kinds that need one
     * @param legacyTarget  the v1 delimited string, still accepted
     */
    public static ScriptTarget resolve(Viewsheet vs, String id, String kind, String assembly,

--- a/core/src/main/java/inetsoft/web/wiz/script/ViewsheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ViewsheetAgentController.java
@@ -198,14 +198,25 @@ public class ViewsheetAgentController {
             rvs, target(rvs, req.id(), req.kind(), req.assembly(), req.target()), req.confirmed()));
    }
 
-   /** Live introspection of the joined viewsheet's scriptable surface. */
+   /** Live introspection of the joined viewsheet's scriptable surface, scoped to a target. */
    @GetMapping("/api/wiz/v1/agent/script/{sessionToken}/context")
-   public ScriptContext context(@PathVariable String sessionToken, Principal user)
+   public ScriptContext context(@PathVariable String sessionToken,
+                                @RequestParam(required = false) String target,
+                                @RequestParam(required = false) String id,
+                                @RequestParam(required = false) String kind,
+                                @RequestParam(required = false) String assembly,
+                                Principal user)
       throws PairingException
    {
       requireEnabled();
       RuntimeViewsheet rvs = editService.resolve(sessionToken, user);
-      return contextService.context(rvs);
+      // CONTROLLER RULING 5 — note the `&& isBlank(assembly)`, which this brief originally omitted.
+      // Without it, `?assembly=Chart1` with no `kind` is treated as "no target at all" and silently
+      // returns the whole-viewsheet context instead of erroring on an incomplete dialect. Including
+      // it routes that case to resolve(), which throws the error naming all three dialects.
+      boolean noTarget = isBlank(target) && isBlank(id) && isBlank(kind) && isBlank(assembly);
+      return contextService.context(
+         rvs, noTarget ? null : target(rvs, id, kind, assembly, target));
    }
 
    /**
@@ -238,7 +249,7 @@ public class ViewsheetAgentController {
    {
       requireEnabled();
       RuntimeViewsheet rvs = editService.resolve(sessionToken, user);
-      boolean noTarget = isBlank(target) && isBlank(id) && isBlank(kind);
+      boolean noTarget = isBlank(target) && isBlank(id) && isBlank(kind) && isBlank(assembly);
       ScriptImageService.ChartImage img;
 
       if(noTarget) {

--- a/core/src/main/java/inetsoft/web/wiz/script/ViewsheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ViewsheetAgentController.java
@@ -121,15 +121,20 @@ public class ViewsheetAgentController {
    /** Reads the current text + enabled-state of {@code target}. */
    @GetMapping("/api/wiz/v1/agent/script/{sessionToken}/script")
    public ScriptInfo readScript(@PathVariable String sessionToken,
-                                @RequestParam String target, Principal user)
+                                @RequestParam(required = false) String target,
+                                @RequestParam(required = false) String id,
+                                @RequestParam(required = false) String kind,
+                                @RequestParam(required = false) String assembly,
+                                Principal user)
       throws PairingException
    {
       requireEnabled();
       RuntimeViewsheet rvs = editService.resolve(sessionToken, user);
-      return readService.read(rvs, ScriptTarget.parse(target));
+      return readService.read(rvs, target(rvs, id, kind, assembly, target));
    }
 
-   public record WriteScriptRequest(String target, String text) {}
+   public record WriteScriptRequest(String target, String id, String kind, String assembly,
+                                    String text) {}
 
    /** Overwrites the script text at {@code target} and broadcasts a refresh. */
    @PostMapping("/api/wiz/v1/agent/script/{sessionToken}/script")
@@ -138,11 +143,12 @@ public class ViewsheetAgentController {
       throws Exception
    {
       requireEnabled();
-      ScriptTarget target = ScriptTarget.parse(req.target());
-      editService.apply(sessionToken, user, rvs -> editService.write(rvs, target, req.text()));
+      editService.apply(sessionToken, user, rvs -> editService.write(
+         rvs, target(rvs, req.id(), req.kind(), req.assembly(), req.target()), req.text()));
    }
 
-   public record SetEnabledRequest(String target, boolean enabled) {}
+   public record SetEnabledRequest(String target, String id, String kind, String assembly,
+                                   boolean enabled) {}
 
    /** Toggles whether the script at {@code target} is enabled and broadcasts a refresh. */
    @PostMapping("/api/wiz/v1/agent/script/{sessionToken}/enable")
@@ -151,11 +157,11 @@ public class ViewsheetAgentController {
       throws Exception
    {
       requireEnabled();
-      ScriptTarget target = ScriptTarget.parse(req.target());
-      editService.apply(sessionToken, user, rvs -> editService.setEnabled(rvs, target, req.enabled()));
+      editService.apply(sessionToken, user, rvs -> editService.setEnabled(
+         rvs, target(rvs, req.id(), req.kind(), req.assembly(), req.target()), req.enabled()));
    }
 
-   public record ExecuteRequest(String target) {}
+   public record ExecuteRequest(String target, String id, String kind, String assembly) {}
 
    /**
     * Dry-runs the script currently saved at {@code target} (see {@link ScriptExecuteService}).
@@ -171,13 +177,14 @@ public class ViewsheetAgentController {
       throws Exception
    {
       requireEnabled();
-      ScriptTarget target = ScriptTarget.parse(req.target());
       return editService.applyOnRuntimeIfChanged(sessionToken, user,
-         rvs -> executeService.dryRun(rvs, target),
+         rvs -> executeService.dryRun(
+            rvs, target(rvs, req.id(), req.kind(), req.assembly(), req.target())),
          result -> result.changed() != null && !result.changed().isEmpty());
    }
 
-   public record ExecuteLiveRequest(String target, boolean confirmed) {}
+   public record ExecuteLiveRequest(String target, String id, String kind, String assembly,
+                                    boolean confirmed) {}
 
    /** Runs the script currently saved at {@code target} live and broadcasts a refresh. */
    @PostMapping("/api/wiz/v1/agent/script/{sessionToken}/execute-live")
@@ -186,9 +193,9 @@ public class ViewsheetAgentController {
       throws Exception
    {
       requireEnabled();
-      ScriptTarget target = ScriptTarget.parse(req.target());
       return editService.applyOnRuntime(sessionToken, user,
-         rvs -> executeService.runLive(rvs, target, req.confirmed()));
+         rvs -> executeService.runLive(
+            rvs, target(rvs, req.id(), req.kind(), req.assembly(), req.target()), req.confirmed()));
    }
 
    /** Live introspection of the joined viewsheet's scriptable surface. */
@@ -221,6 +228,9 @@ public class ViewsheetAgentController {
    @GetMapping("/api/wiz/v1/agent/script/{sessionToken}/image")
    public ChartImageResponse image(@PathVariable String sessionToken,
                                    @RequestParam(required = false) String target,
+                                   @RequestParam(required = false) String id,
+                                   @RequestParam(required = false) String kind,
+                                   @RequestParam(required = false) String assembly,
                                    @RequestParam(required = false) Integer width,
                                    @RequestParam(required = false) Integer height,
                                    Principal user)
@@ -228,17 +238,19 @@ public class ViewsheetAgentController {
    {
       requireEnabled();
       RuntimeViewsheet rvs = editService.resolve(sessionToken, user);
+      boolean noTarget = isBlank(target) && isBlank(id) && isBlank(kind);
       ScriptImageService.ChartImage img;
 
-      if(target == null || target.isBlank()) {
+      if(noTarget) {
          img = imageService.getViewsheetImage(rvs, width, height, user);
       }
       else {
-         ScriptTarget t = ScriptTarget.parse(target);
+         ScriptTarget t = target(rvs, id, kind, assembly, target);
 
          if(t.location() != ScriptTarget.Location.ASSEMBLY) {
-            throw new PairingException("image only supports assembly targets (or no target, " +
-                                       "for the whole viewsheet), not \"" + target + "\"");
+            throw new PairingException(
+               "image renders an assembly (kind 'assemblyMain'), or the whole viewsheet when no " +
+               "target is given. '" + t.kind().wireName() + "' is not visual.");
          }
 
          img = imageService.getAssemblyImage(rvs, t.assemblyName(), width, height, user);
@@ -247,6 +259,10 @@ public class ViewsheetAgentController {
       String base64 = Base64.getEncoder().encodeToString(img.pngBytes());
       return new ChartImageResponse(base64, img.isPng() ? "png" : "svg", img.width(), img.height(),
                                     img.note());
+   }
+
+   private static boolean isBlank(String s) {
+      return s == null || s.isBlank();
    }
 
    /**
@@ -314,6 +330,15 @@ public class ViewsheetAgentController {
          throw new ResponseStatusException(HttpStatus.FORBIDDEN,
                                            "Sheet agent pairing is disabled");
       }
+   }
+
+   /** Resolves a target against the joined viewsheet, so the exact-name fix applies everywhere. */
+   private ScriptTarget target(RuntimeViewsheet rvs, String id, String kind, String assembly,
+                               String legacyTarget)
+      throws PairingException
+   {
+      return ScriptTarget.resolve(rvs == null ? null : rvs.getViewsheet(), id, kind, assembly,
+                                  legacyTarget);
    }
 
    private static String agentKey(Principal agent) {

--- a/core/src/main/java/inetsoft/web/wiz/script/ViewsheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ViewsheetAgentController.java
@@ -28,7 +28,7 @@ import inetsoft.web.wiz.script.model.FunctionSignature;
 import inetsoft.web.wiz.script.model.ScriptContext;
 import inetsoft.web.wiz.script.model.ScriptExecResult;
 import inetsoft.web.wiz.script.model.ScriptInfo;
-import inetsoft.web.wiz.script.model.ScriptTargetInfo;
+import inetsoft.web.wiz.script.model.ScriptTargetsResponse;
 import inetsoft.web.wiz.service.RenderNotReadyException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
@@ -40,7 +40,6 @@ import org.springframework.web.server.ResponseStatusException;
 import java.security.Principal;
 import java.util.Base64;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -108,14 +107,15 @@ public class ViewsheetAgentController {
    public record JoinResponse(String sessionToken, String runtimeId, String ownerIdentity,
                               String sheetType) {}
 
-   /** Enumerates every scriptable target on the joined viewsheet. */
+   /** Enumerates every scriptable target on the joined viewsheet, with the grammar it speaks. */
    @GetMapping("/api/wiz/v1/agent/script/{sessionToken}/targets")
-   public List<ScriptTargetInfo> targets(@PathVariable String sessionToken, Principal user)
+   public ScriptTargetsResponse targets(@PathVariable String sessionToken, Principal user)
       throws PairingException
    {
       requireEnabled();
       RuntimeViewsheet rvs = editService.resolve(sessionToken, user);
-      return readService.list(rvs);
+      return new ScriptTargetsResponse(ScriptGrammar.VERSION, ScriptGrammar.supportedKinds(),
+                                       readService.list(rvs));
    }
 
    /** Reads the current text + enabled-state of {@code target}. */

--- a/core/src/main/java/inetsoft/web/wiz/script/model/ScriptTargetInfo.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/model/ScriptTargetInfo.java
@@ -17,5 +17,20 @@
  */
 package inetsoft.web.wiz.script.model;
 
-/** One entry in {@code list_script_targets}. */
-public record ScriptTargetInfo(String target, boolean hasScript, boolean enabled) {}
+/**
+ * One scriptable location, as {@code list_script_targets} reports it.
+ *
+ * @param id         opaque and stable; copy it back verbatim rather than composing an identifier
+ * @param kind       the wire vocabulary, e.g. {@code assemblyOnClick}
+ * @param assembly   the owning assembly, or {@code null} for viewsheet-level kinds
+ * @param label      human-readable; for display and logs only, never an identifier
+ * @param runsWhen   when StyleBI executes this script, in plain words
+ * @param enableScope the flag {@code enabled} reflects. onInit and onLoad share ONE viewsheet
+ *                    flag, and an assembly's main and onClick scripts share ONE assembly flag --
+ *                    so disabling "the onClick" also disables that assembly's main script
+ * @param hostSheet  {@code viewsheet} or {@code worksheet}
+ * @param target     the v1 delimited string, retained so an older plugin still reads this array
+ */
+public record ScriptTargetInfo(String id, String kind, String assembly, String label,
+                               String runsWhen, boolean hasScript, boolean enabled,
+                               String enableScope, String hostSheet, String target) {}

--- a/core/src/main/java/inetsoft/web/wiz/script/model/ScriptTargetsResponse.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/model/ScriptTargetsResponse.java
@@ -1,0 +1,31 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.script.model;
+
+import java.util.List;
+
+/**
+ * The {@code /targets} body.
+ *
+ * <p>An envelope rather than a bare array so the grammar can be advertised rather than probed —
+ * "Invalid target" is indistinguishable from "no such assembly", so a probe cannot tell an old
+ * server from a typo. {@code targets} stays a plain array at a stable key, which is what keeps an
+ * older plugin's read path working: it forwards the body without parsing it structurally.
+ */
+public record ScriptTargetsResponse(int grammarVersion, List<String> supportedKinds,
+                                    List<ScriptTargetInfo> targets) {}

--- a/core/src/test/java/inetsoft/web/wiz/script/ScriptContextServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ScriptContextServiceTest.java
@@ -1,0 +1,138 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.script;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.web.binding.VSScriptableService;
+import inetsoft.web.wiz.script.model.AssemblyContext;
+import inetsoft.web.wiz.script.model.ScriptContext;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+// CONTROLLER NOTE: keep @Tag("core") if it works — this test mocks RuntimeViewsheet and overrides
+// describeAssemblies, so it may never touch Spring. But Task 2 hit exactly this and had to switch:
+// if these tests error with "ShutdownException: Spring application context is not available",
+// replace @Tag("core") with @WizAgentTestSupport (import inetsoft.web.wiz.pairing.WizAgentTestSupport),
+// which is what ScriptEditServiceTest, ScriptExecuteServiceTest, ScriptImageServiceTest and
+// ScriptReadServiceTest all already use. Report which one you ended up needing.
+class ScriptContextServiceTest {
+   /**
+    * Stubs the expensive live lookup so these tests exercise the projection, not VSScriptable.
+    *
+    * <p>The mocked {@code VSScriptableService} is required, not decorative: this class has only
+    * the {@code @Autowired} constructor, no no-arg one, so an anonymous subclass must pass it up.
+    * It is never touched, because {@code describeAssemblies} is exactly what the override replaces.
+    */
+   private static ScriptContextService serviceReturning(List<AssemblyContext> full) {
+      return new ScriptContextService(mock(VSScriptableService.class)) {
+         @Override
+         List<AssemblyContext> describeAssemblies(RuntimeViewsheet rvs) {
+            return full;
+         }
+      };
+   }
+
+   private static final List<AssemblyContext> FULL = List.of(
+      new AssemblyContext("Chart1", "chart", true, List.of("graph"), "CHART_TREE"),
+      new AssemblyContext("Table1", "table", true, List.of("table"), "TABLE_TREE"));
+
+   @Test
+   void withATargetReturnsOnlyThatAssembly() throws Exception {
+      ScriptContext ctx = serviceReturning(FULL).context(
+         mock(RuntimeViewsheet.class), ScriptTarget.of(ScriptTarget.Kind.ASSEMBLY_MAIN, "Table1"));
+
+      assertEquals(1, ctx.assemblies().size());
+      assertEquals("Table1", ctx.assemblies().get(0).name());
+      assertEquals("TABLE_TREE", ctx.assemblies().get(0).apiTree());
+   }
+
+   @Test
+   void withNoTargetListsEveryAssemblyWithoutTheApiTree() throws Exception {
+      ScriptContext ctx = serviceReturning(FULL).context(mock(RuntimeViewsheet.class), null);
+
+      assertEquals(2, ctx.assemblies().size(), "the list is what makes a target choosable");
+      assertTrue(ctx.assemblies().stream().allMatch(a -> a.apiTree() == null),
+                 "the whole-viewsheet dump is what makes this attractive for non-script work");
+      assertEquals(List.of("graph"), ctx.assemblies().get(0).scriptableMembers(),
+                   "the short curated list stays -- it is cheap and aids the choice");
+   }
+
+   @Test
+   void aViewsheetLevelTargetGetsEveryAssemblyBecauseItsScriptReachesThemAll() throws Exception {
+      ScriptContext ctx = serviceReturning(FULL).context(
+         mock(RuntimeViewsheet.class), ScriptTarget.of(ScriptTarget.Kind.VIEWSHEET_ON_INIT, null));
+
+      assertEquals(2, ctx.assemblies().size());
+      assertTrue(ctx.assemblies().stream().allMatch(a -> a.apiTree() != null),
+                 "onInit coordinates across assemblies, so it needs all their trees");
+   }
+
+   /**
+    * The context VARS differ by kind, not just the assembly list — which is the substance of
+    * "scope the returned surface to a target's kind".
+    *
+    * <p>{@code event} resolves from {@code ViewsheetScope}'s vmap
+    * ({@code ViewsheetScope.java:368}) and is only ever populated while an onClick is executing.
+    * Listing it for onInit tells the caller a variable is available that is always null there —
+    * the same always-null-field defect #4618 fixed by removing {@code BindableField.role}.
+    */
+   @Test
+   void reportsEventOnlyForTheKindThatActuallyReceivesOne() throws Exception {
+      ScriptContextService service = serviceReturning(FULL);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+
+      ScriptContext onClick = service.context(
+         rvs, ScriptTarget.of(ScriptTarget.Kind.ASSEMBLY_ON_CLICK, "Table1"));
+      assertTrue(onClick.contextVars().contains("event"));
+
+      for(ScriptTarget.Kind kind : List.of(ScriptTarget.Kind.VIEWSHEET_ON_INIT,
+                                           ScriptTarget.Kind.VIEWSHEET_ON_LOAD))
+      {
+         ScriptContext ctx = service.context(rvs, ScriptTarget.of(kind, null));
+         assertFalse(ctx.contextVars().contains("event"),
+                     kind + " never receives an event; listing it promises a null");
+         assertTrue(ctx.contextVars().contains("thisViewsheet"), kind.toString());
+      }
+
+      ScriptContext main = service.context(
+         rvs, ScriptTarget.of(ScriptTarget.Kind.ASSEMBLY_MAIN, "Table1"));
+      assertFalse(main.contextVars().contains("event"));
+   }
+
+   /** With no target the caller has not said which context, so report the union, not a guess. */
+   @Test
+   void withNoTargetReportsEveryContextVarAnyKindCanSee() throws Exception {
+      assertTrue(serviceReturning(FULL).context(mock(RuntimeViewsheet.class), null)
+                    .contextVars().contains("event"));
+   }
+
+   @Test
+   void anUnknownAssemblyFailsLoudRatherThanReturningAnEmptySurface() throws Exception {
+      ScriptContextService service = serviceReturning(FULL);
+      ScriptTarget target = ScriptTarget.of(ScriptTarget.Kind.ASSEMBLY_MAIN, "Nope");
+
+      assertThrows(inetsoft.web.wiz.pairing.PairingException.class,
+                   () -> service.context(mock(RuntimeViewsheet.class), target));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/script/ScriptReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ScriptReadServiceTest.java
@@ -143,4 +143,13 @@ class ScriptReadServiceTest {
    void everyTargetIsHostedOnTheViewsheet() {
       assertTrue(service.list(runtime()).stream().allMatch(t -> "viewsheet".equals(t.hostSheet())));
    }
+
+   @Test
+   void advertisesOnlyTheKindsThisServerCanActuallyServe() {
+      assertEquals(2, ScriptGrammar.VERSION);
+      assertEquals(List.of("viewsheetOnInit", "viewsheetOnLoad", "assemblyMain", "assemblyOnClick"),
+                   ScriptGrammar.supportedKinds());
+      assertFalse(ScriptGrammar.supportedKinds().contains("worksheetExpression"),
+                  "a reserved kind must not be advertised as servable");
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/script/ScriptReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ScriptReadServiceTest.java
@@ -1,0 +1,146 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.script;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.internal.TextVSAssemblyInfo;
+import inetsoft.uql.viewsheet.internal.ChartVSAssemblyInfo;
+import inetsoft.web.wiz.pairing.WizAgentTestSupport;
+import inetsoft.web.wiz.script.model.ScriptTargetInfo;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@WizAgentTestSupport
+class ScriptReadServiceTest {
+   private final ScriptReadService service = new ScriptReadService();
+
+   private static ScriptTargetInfo find(List<ScriptTargetInfo> all, String kind, String assembly) {
+      return all.stream()
+         .filter(t -> t.kind().equals(kind))
+         .filter(t -> assembly == null ? t.assembly() == null : assembly.equals(t.assembly()))
+         .findFirst()
+         .orElseThrow(() -> new AssertionError(
+            "no target for kind=" + kind + " assembly=" + assembly + " in " + all));
+   }
+
+   /** A viewsheet with init/load text, a chart (main script only) and a text (main + onClick). */
+   private static RuntimeViewsheet runtime() {
+      ViewsheetInfo vsInfo = new ViewsheetInfo();
+      vsInfo.setOnInit("a = 1");
+      vsInfo.setOnLoad("");
+      vsInfo.setScriptEnabled(true);
+
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      ChartVSAssemblyInfo chartInfo = new ChartVSAssemblyInfo();
+      chartInfo.setScript("chart()");
+      chartInfo.setScriptEnabled(true);
+      when(chart.getName()).thenReturn("Chart1");
+      when(chart.getVSAssemblyInfo()).thenReturn(chartInfo);
+
+      TextVSAssembly text = mock(TextVSAssembly.class);
+      TextVSAssemblyInfo textInfo = new TextVSAssemblyInfo();
+      textInfo.setScript("");
+      textInfo.setOnClick("go()");
+      textInfo.setScriptEnabled(false);
+      when(text.getName()).thenReturn("Text1");
+      when(text.getVSAssemblyInfo()).thenReturn(textInfo);
+
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getViewsheetInfo()).thenReturn(vsInfo);
+      when(vs.getAssemblies()).thenReturn(new Assembly[]{ chart, text });
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      return rvs;
+   }
+
+   @Test
+   void everyTargetCarriesAnIdThatDecodesBackToItself() throws Exception {
+      for(ScriptTargetInfo info : service.list(runtime())) {
+         ScriptTarget back = ScriptTarget.fromId(info.id());
+         assertEquals(info.kind(), back.kind().wireName(), info.toString());
+         assertEquals(info.assembly(), back.assemblyName(), info.toString());
+      }
+   }
+
+   @Test
+   void namesTheKindsRatherThanTheDelimitedString() {
+      List<ScriptTargetInfo> all = service.list(runtime());
+
+      assertEquals("viewsheetOnInit", find(all, "viewsheetOnInit", null).kind());
+      assertEquals("assembly:Chart1", find(all, "assemblyMain", "Chart1").target(),
+                   "the v1 string stays, so an old plugin still reads what it expects");
+   }
+
+   @Test
+   void reportsRunsWhenSoTheCallerNeedNotGuess() {
+      List<ScriptTargetInfo> all = service.list(runtime());
+
+      assertEquals("once, at viewsheet initialization",
+                   find(all, "viewsheetOnInit", null).runsWhen());
+      assertEquals("on every refresh", find(all, "viewsheetOnLoad", null).runsWhen());
+      assertEquals("each time the assembly renders",
+                   find(all, "assemblyMain", "Chart1").runsWhen());
+      assertEquals("on user click", find(all, "assemblyOnClick", "Text1").runsWhen());
+   }
+
+   /**
+    * The shared-enable-flag footgun, made explicit. onInit and onLoad share one viewsheet flag;
+    * an assembly's main and onClick scripts share one assembly flag. Disabling "the onClick"
+    * silently disables the assembly's main script too.
+    */
+   @Test
+   void reportsWhichEnableFlagEachTargetShares() {
+      List<ScriptTargetInfo> all = service.list(runtime());
+
+      assertEquals("viewsheet", find(all, "viewsheetOnInit", null).enableScope());
+      assertEquals("viewsheet", find(all, "viewsheetOnLoad", null).enableScope());
+      assertEquals("assembly:Text1", find(all, "assemblyOnClick", "Text1").enableScope());
+      assertEquals("assembly:Text1", find(all, "assemblyMain", "Text1").enableScope());
+   }
+
+   @Test
+   void distinguishesHasScriptFromEnabled() {
+      List<ScriptTargetInfo> all = service.list(runtime());
+
+      assertTrue(find(all, "viewsheetOnInit", null).hasScript());
+      assertFalse(find(all, "viewsheetOnLoad", null).hasScript(), "onLoad text is empty");
+      assertTrue(find(all, "assemblyOnClick", "Text1").hasScript());
+      assertFalse(find(all, "assemblyOnClick", "Text1").enabled(), "Text1's flag is off");
+   }
+
+   @Test
+   void omitsOnClickForAssembliesThatCannotHaveOne() {
+      List<ScriptTargetInfo> all = service.list(runtime());
+
+      assertTrue(all.stream().noneMatch(
+                    t -> "assemblyOnClick".equals(t.kind()) && "Chart1".equals(t.assembly())),
+                 "charts have no onClick: " + all);
+   }
+
+   @Test
+   void everyTargetIsHostedOnTheViewsheet() {
+      assertTrue(service.list(runtime()).stream().allMatch(t -> "viewsheet".equals(t.hostSheet())));
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/script/ScriptTargetTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ScriptTargetTest.java
@@ -17,11 +17,17 @@
  */
 package inetsoft.web.wiz.script;
 
+import inetsoft.uql.viewsheet.TextVSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.wiz.pairing.PairingException;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @Tag("core")
 class ScriptTargetTest {
@@ -74,5 +80,97 @@ class ScriptTargetTest {
    void rejectsUnknownFormat() {
       assertThrows(PairingException.class, () -> ScriptTarget.parse("onInit"));
       assertThrows(PairingException.class, () -> ScriptTarget.parse("Chart1"));
+   }
+
+   @Test
+   void mapsEveryTierOneKindToItsLocation() throws PairingException {
+      assertEquals(ScriptTarget.Location.VS_INIT,
+                   ScriptTarget.Kind.VIEWSHEET_ON_INIT.location());
+      assertEquals(ScriptTarget.Location.VS_LOAD,
+                   ScriptTarget.Kind.VIEWSHEET_ON_LOAD.location());
+      assertEquals(ScriptTarget.Location.ASSEMBLY,
+                   ScriptTarget.Kind.ASSEMBLY_MAIN.location());
+      assertEquals(ScriptTarget.Location.ASSEMBLY_ONCLICK,
+                   ScriptTarget.Kind.ASSEMBLY_ON_CLICK.location());
+   }
+
+   @Test
+   void worksheetKindsAreReservedButNotServable() {
+      assertNull(ScriptTarget.Kind.WORKSHEET_EXPRESSION.location());
+      assertNull(ScriptTarget.Kind.WORKSHEET_CONDITION.location());
+
+      PairingException ex = assertThrows(
+         PairingException.class,
+         () -> ScriptTarget.of(ScriptTarget.Kind.WORKSHEET_EXPRESSION, null));
+      assertTrue(ex.getMessage().contains("paired from that expression's editor"),
+                 "a reserved kind must explain the scope, not read as an unknown kind: " +
+                 ex.getMessage());
+   }
+
+   @Test
+   void wireNamesAreTheCamelCaseTaxonomy() throws PairingException {
+      assertEquals("viewsheetOnInit", ScriptTarget.Kind.VIEWSHEET_ON_INIT.wireName());
+      assertEquals("assemblyOnClick", ScriptTarget.Kind.ASSEMBLY_ON_CLICK.wireName());
+      assertEquals(ScriptTarget.Kind.ASSEMBLY_MAIN, ScriptTarget.Kind.fromWire("assemblyMain"));
+   }
+
+   @Test
+   void rejectsOnRefreshByName() {
+      PairingException ex = assertThrows(
+         PairingException.class, () -> ScriptTarget.Kind.fromWire("onRefresh"));
+      assertTrue(ex.getMessage().contains("viewsheetOnLoad"),
+                 "onRefresh must point at onLoad rather than just being unknown: " +
+                 ex.getMessage());
+   }
+
+   @Test
+   void idRoundTripsWithoutServerState() throws PairingException {
+      ScriptTarget t = ScriptTarget.of(ScriptTarget.Kind.ASSEMBLY_ON_CLICK, "Text1");
+      ScriptTarget back = ScriptTarget.fromId(t.id());
+
+      assertEquals(ScriptTarget.Location.ASSEMBLY_ONCLICK, back.location());
+      assertEquals("Text1", back.assemblyName());
+      assertEquals(t.id(), back.id(), "the encoding must be deterministic, not a handle");
+   }
+
+   @Test
+   void idSurvivesAnAssemblyNameContainingTheDelimiter() throws PairingException {
+      ScriptTarget t = ScriptTarget.of(ScriptTarget.Kind.ASSEMBLY_MAIN, "Foo:onClick");
+      ScriptTarget back = ScriptTarget.fromId(t.id());
+
+      assertEquals(ScriptTarget.Location.ASSEMBLY, back.location());
+      assertEquals("Foo:onClick", back.assemblyName());
+   }
+
+   @Test
+   void idIsUrlSafeAndUnpadded() throws PairingException {
+      String id = ScriptTarget.of(ScriptTarget.Kind.ASSEMBLY_MAIN, "a/b+c?d").id();
+
+      assertFalse(id.contains("/"), id);
+      assertFalse(id.contains("+"), id);
+      assertFalse(id.contains("="), id);
+   }
+
+   @Test
+   void anExactAssemblyNameBeatsTheOnClickSuffix() throws PairingException {
+      Viewsheet vs = mock(Viewsheet.class);
+      TextVSAssembly literal = mock(TextVSAssembly.class);
+      when(vs.getAssembly("Foo:onClick")).thenReturn(literal);
+
+      ScriptTarget t = ScriptTarget.parse(vs, "assembly:Foo:onClick");
+
+      assertEquals(ScriptTarget.Location.ASSEMBLY, t.location());
+      assertEquals("Foo:onClick", t.assemblyName());
+   }
+
+   @Test
+   void withoutAnExactMatchTheSuffixStillMeansOnClick() throws PairingException {
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssembly("Foo:onClick")).thenReturn(null);
+
+      ScriptTarget t = ScriptTarget.parse(vs, "assembly:Foo:onClick");
+
+      assertEquals(ScriptTarget.Location.ASSEMBLY_ONCLICK, t.location());
+      assertEquals("Foo", t.assemblyName());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/script/ScriptTargetTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ScriptTargetTest.java
@@ -173,4 +173,41 @@ class ScriptTargetTest {
       assertEquals(ScriptTarget.Location.ASSEMBLY_ONCLICK, t.location());
       assertEquals("Foo", t.assemblyName());
    }
+
+   @Test
+   void resolvePrefersIdThenKindThenLegacyString() throws PairingException {
+      Viewsheet vs = mock(Viewsheet.class);
+      String id = ScriptTarget.of(ScriptTarget.Kind.ASSEMBLY_MAIN, "Chart1").id();
+
+      ScriptTarget byId = ScriptTarget.resolve(vs, id, "viewsheetOnInit", null, "vs-load");
+      assertEquals("Chart1", byId.assemblyName(), "id must win over every other dialect");
+
+      ScriptTarget byKind = ScriptTarget.resolve(vs, null, "assemblyOnClick", "Text1", "vs-load");
+      assertEquals(ScriptTarget.Location.ASSEMBLY_ONCLICK, byKind.location());
+      assertEquals("Text1", byKind.assemblyName());
+
+      ScriptTarget byLegacy = ScriptTarget.resolve(vs, null, null, null, "vs-load");
+      assertEquals(ScriptTarget.Location.VS_LOAD, byLegacy.location());
+   }
+
+   @Test
+   void resolveNamesEveryAcceptedDialectWhenNoneIsGiven() {
+      PairingException ex = assertThrows(
+         PairingException.class, () -> ScriptTarget.resolve(null, null, null, null, null));
+
+      assertTrue(ex.getMessage().contains("id"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("kind"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("target"), ex.getMessage());
+   }
+
+   @Test
+   void resolveAppliesThePrecedenceFixToTheLegacyDialect() throws PairingException {
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssembly("Foo:onClick")).thenReturn(mock(TextVSAssembly.class));
+
+      ScriptTarget t = ScriptTarget.resolve(vs, null, null, null, "assembly:Foo:onClick");
+
+      assertEquals(ScriptTarget.Location.ASSEMBLY, t.location());
+      assertEquals("Foo:onClick", t.assemblyName());
+   }
 }


### PR DESCRIPTION
Phase 0 + Phase 2 (Tier 1) of the script-kinds spec, plus the unshipped Phase 1 step 3.

Replaces the `:`-delimited script target string with a typed `kind` vocabulary, deterministic opaque ids, and a version-negotiated compatibility contract. No new read/write services — Tier 1 is the taxonomy and the addressing only.

## What changes

**`Kind` is the wire vocabulary; `Location` stays the internal dispatch key.** Five services and the image endpoint already switch on `Location`, so a wire rename must not ripple into them — and two of the new kinds (`worksheetExpression`, `worksheetCondition`) have no `Location` at all. They are reserved so a client's static schema does not churn when pane-scoped pairing lands; asking for one is a scope error, not an unknown kind.

**Every target carries a deterministic id.** Base64url of `kind|assembly`, reproducible without server state — the pairing store is in-memory, so a session-scoped id would strand any workflow that lists targets in one turn and edits in the next. This also fixes a latent bug: an assembly literally named `Foo:onClick` was previously unaddressable, because the static parse splits on a trailing `:onClick` and has no viewsheet to check against.

**`/targets` advertises the grammar rather than making clients probe.** `grammarVersion` and `supportedKinds` travel beside the target array — "Invalid target" is indistinguishable from "no such assembly", so a probe cannot tell an old server from a typo. `supportedKinds` lists only kinds with a service behind them; advertising one the server would then refuse is the capability lie the contract exists to prevent.

**Six endpoints accept three dialects** — id, `kind`+`assembly`, or the legacy string — resolved by one precedence rule in `ScriptTarget.resolve` rather than six copies that could disagree about which wins. Resolution happens where the runtime viewsheet is in hand, so the exact-name fix reaches the legacy dialect too.

**`get_script_context` is scoped to a target, by kind.** The usable API genuinely differs per context: `event` resolves from `ViewsheetScope`'s vmap and is populated only while an onClick executes, so listing it for a `viewsheetOnInit` script promised a variable that is always null there. With no target the union comes back, because the caller has stated no context to narrow to. `contextVars` is a `switch` with a documented default — it is the seam future kinds extend.

## Compatibility

The legacy `target` string still works on every endpoint, and `targets` remains a plain array at a stable key, so an older client that forwards the body without parsing it keeps working. The plugin and the server ship separately, which is why this is a contract rather than a cutover.

## Testing

`inetsoft.web.wiz.**.*Test`: **1487 → 1513**, 0 failures, 0 errors, 1 pre-existing skip. The full package was re-run and the surefire XML parsed after each of the five commits — not read off `BUILD SUCCESS`.

Not yet proven: the wire contract itself. The TypeScript client that consumes `grammarVersion`/`supportedKinds` is a separate change in `stylebi-wiz`, and neither end proves the other. Live verification comes after both land and an image is rebuilt.

## Notes for review

- No `name` field on `ScriptTargetInfo`, though the spec lists one. No Tier 1 kind has a third free-text component, so it would ship permanently null — the defect #4618 fixed by deleting `BindableField.role`. It arrives with the first kind that populates it.
- `calcField` / `highlight` / `cell` / `library` are deliberately absent from the enum. They are wanted — the API surface differs per context, which is what a kind is *for* — but each needs a read/write service behind it first. Order to add one: `Kind` + its `Location`, a `contextVars` case, then the service.
- The six rewired endpoints have no `ViewsheetAgentControllerTest`; wiring correctness currently rests on a per-endpoint manual review rather than an automated regression.

Spec: `docs/superpowers/specs/2026-08-14-script-plugin-scope-and-script-kinds.md`
Plan: `docs/superpowers/plans/2026-08-16-script-kinds-phase0-phase2.md` (both in `stylebi-wiz`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
