### PR TITLE
Expose an existing assembly's rendered data as a read-only endpoint

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
@@ -23,8 +23,10 @@ import inetsoft.web.wiz.service.UnsatisfiableBindingException;
 import inetsoft.web.wiz.service.WizAutoBindingService;
 import inetsoft.web.wiz.service.WizGeoService;
 import inetsoft.web.wiz.service.WizVsService;
+import inetsoft.util.InvalidUserException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import jakarta.validation.Valid;
@@ -118,7 +120,7 @@ public class WizViewsheetController {
    }
 
    /**
-    * Read-only: returns an existing assembly's rendered data (headers + rows + binding).
+    * Returns an existing assembly's rendered data (headers + rows + binding).
     *
     * <p>For answering a question about a chart built EARLIER in a conversation. The caller holds no
     * copy of that chart's rows; it addresses the chart the way the browser embed does — runtime id
@@ -126,9 +128,16 @@ public class WizViewsheetController {
     * chart's data range (see {@link AssemblyDataRequest}), so the answer and the chart on screen
     * cannot disagree.
     *
+    * <p><b>Read-only in intent, not in effect.</b> Serving this re-executes the assembly's view and
+    * drops its cached render (see {@code WizVsService#executeAndExtract}), and the underlying
+    * sandbox call cancels every in-flight query on that runtime — not only this assembly's. It is
+    * therefore not free to call, and calling it while the browser is rendering the same viewsheet can
+    * cancel an unrelated chart's render.
+    *
     * <p>An assembly whose runtime has been reaped comes back as an empty result rather than an
     * error: the chart is equally unavailable to the user at that point, so "no data to answer from"
-    * is the accurate outcome, not a failure to retry.
+    * is the accurate outcome, not a failure to retry. Same for an assembly that is no longer in the
+    * runtime.
     */
    @PostMapping(value = "/viewsheet/assembly-data", produces = MediaType.APPLICATION_JSON_VALUE)
    public ResponseEntity<?> assemblyData(@Valid @RequestBody AssemblyDataRequest request,
@@ -187,6 +196,21 @@ public class WizViewsheetController {
       }
       catch(IllegalArgumentException e) {
          return ResponseEntity.badRequest().body(Map.of("error", nullToEmpty(e.getMessage())));
+      }
+      // Denials, not faults. WizControllerErrorHandler already maps both of these to 403 for the wiz
+      // package — but an @ControllerAdvice only sees what LEAVES the controller method, and the
+      // catch-all below swallows everything first. So every permission denial on this controller was
+      // answered as a content-free 500 while the advice built to prevent exactly that sat unused; the
+      // same trap the ResponseStatusException case below documents.
+      //
+      // Neither message is echoed. SecurityException carries a catalog string that is safe but
+      // uninformative to the caller, and InvalidUserException's message ("common.invalidUser") names
+      // the user who OWNS the runtime — telling a caller who probed someone else's runtime id whose it
+      // is would answer a question they should not get to ask.
+      catch(inetsoft.sree.security.SecurityException | InvalidUserException e) {
+         LOG.warn("Unauthorized wiz request ({}): {}", action, e.getMessage());
+         return ResponseEntity.status(HttpStatus.FORBIDDEN)
+            .body(Map.of("error", "Forbidden"));
       }
       // Honour the status the thrower chose. ResponseStatusException is a plain RuntimeException, so
       // without this it fell through to the generic handler below and every deliberate 4xx was returned

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizViewsheetController.java
@@ -117,6 +117,27 @@ public class WizViewsheetController {
       return run("geo apply", () -> wizGeoService.apply(request, user));
    }
 
+   /**
+    * Read-only: returns an existing assembly's rendered data (headers + rows + binding).
+    *
+    * <p>For answering a question about a chart built EARLIER in a conversation. The caller holds no
+    * copy of that chart's rows; it addresses the chart the way the browser embed does — runtime id
+    * plus assembly name — and gets back what that chart is showing. Nothing here can change the
+    * chart's data range (see {@link AssemblyDataRequest}), so the answer and the chart on screen
+    * cannot disagree.
+    *
+    * <p>An assembly whose runtime has been reaped comes back as an empty result rather than an
+    * error: the chart is equally unavailable to the user at that point, so "no data to answer from"
+    * is the accurate outcome, not a failure to retry.
+    */
+   @PostMapping(value = "/viewsheet/assembly-data", produces = MediaType.APPLICATION_JSON_VALUE)
+   public ResponseEntity<?> assemblyData(@Valid @RequestBody AssemblyDataRequest request,
+                                         Principal user)
+   {
+      return run("read assembly data", () -> wizVsService.fetchAssemblyData(
+         request.getRuntimeId(), request.getAssemblyName(), user));
+   }
+
    @PostMapping(value = "/viewsheet/remove-visualization", produces = MediaType.APPLICATION_JSON_VALUE)
    public ResponseEntity<?> removeVisualization(@Valid @RequestBody RemoveVisualizationRequest request,
                                                 Principal user)

--- a/core/src/main/java/inetsoft/web/wiz/model/AssemblyDataRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/AssemblyDataRequest.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.model;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Request body for reading an existing assembly's rendered data.
+ *
+ * <p>{@code runtimeId} is the runtime viewsheet id (the wiz-side visualizationId);
+ * {@code assemblyName} is the assembly to read. Both must be non-blank. Any assembly type the
+ * service dispatches on is valid here — chart, table, crosstab, and the scalar output assemblies
+ * (gauge / text).
+ *
+ * <p><b>These two fields are the whole request, deliberately.</b> They are exactly what the browser
+ * embed renders a chart with, so whatever this endpoint returns is by construction the data behind
+ * the chart the user is looking at. Adding a row cap, a filter or a binding override would break
+ * that correspondence: the caller could then fetch data the chart on screen does not show, and
+ * answer a question about the chart from numbers the user cannot see. The row cap in force stays
+ * whatever the chart itself was rendered with — see WizVsService#fetchAssemblyData.
+ */
+public class AssemblyDataRequest {
+   @NotBlank
+   private String runtimeId;
+   @NotBlank
+   private String assemblyName;
+
+   public String getRuntimeId() {
+      return runtimeId;
+   }
+
+   public void setRuntimeId(String runtimeId) {
+      this.runtimeId = runtimeId;
+   }
+
+   public String getAssemblyName() {
+      return assemblyName;
+   }
+
+   public void setAssemblyName(String assemblyName) {
+      this.assemblyName = assemblyName;
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -2212,9 +2212,15 @@ public class WizVsService {
     * Executes the sandbox for an existing assembly and returns headers/rows/hasData.
     * Called after {@code createViewsheetSkipExecution} to lazily populate row data
     * (e.g. for data insight generation on a type switch).
+    *
+    * <p>Public because it is also the whole of {@code POST /api/wiz/viewsheet/assembly-data}: a
+    * caller answering a question about a chart built earlier in a conversation needs that chart's
+    * own rows, and this reads exactly them — addressed by the same (runtimeId, assemblyName) pair
+    * the browser embed renders with, at whatever row cap that chart is already showing. There is
+    * deliberately no parameter to widen that cap; see AssemblyDataRequest.
     */
-   CreateViewsheetResult fetchAssemblyData(String runtimeId, String assemblyName,
-                                           Principal user) throws Exception
+   public CreateViewsheetResult fetchAssemblyData(String runtimeId, String assemblyName,
+                                                  Principal user) throws Exception
    {
       RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, user);
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -34,6 +34,7 @@ import inetsoft.report.internal.table.TableHighlightAttr;
 import inetsoft.report.internal.XNodeMetaTable;
 import inetsoft.report.lens.AbstractTableLens;
 import inetsoft.uql.XTable;
+import inetsoft.report.composition.ExpiredSheetException;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.report.composition.graph.VGraphPair;
@@ -2153,8 +2154,13 @@ public class WizVsService {
     * Dispatches to the appropriate extract method based on assembly type.
     *
     * <p>Package-private (not private) so tests can stub it out via a Mockito spy — it drives the real
-    * ViewsheetSandbox, which is expensive to set up faithfully in a unit test, the same reason
-    * {@link #fetchAssemblyData} is already package-private.
+    * ViewsheetSandbox, which is expensive to set up faithfully in a unit test.
+    *
+    * <p><b>This is not a read.</b> It cancels every in-flight query on the runtime's sandbox
+    * ({@code cancelAllQueries} is per-box, not per-assembly), writes the row cap onto the shared base
+    * worksheet, drops this assembly's cached data and graph, and then executes the view. Callers that
+    * run inside the turn which owns the runtime pay nothing for that; a caller that can fire while the
+    * browser is rendering the same viewsheet can cancel an unrelated chart's render.
     */
    CreateViewsheetResult executeAndExtract(RuntimeViewsheet rvs, VSAssembly assembly,
                                            int sampleMaxRows)
@@ -2218,18 +2224,58 @@ public class WizVsService {
     * own rows, and this reads exactly them — addressed by the same (runtimeId, assemblyName) pair
     * the browser embed renders with, at whatever row cap that chart is already showing. There is
     * deliberately no parameter to widen that cap; see AssemblyDataRequest.
+    *
+    * <p>Returns a whole {@link CreateViewsheetResult}, of which the endpoint's documented contract is
+    * {@code headers} + {@code rows} + {@code binding}; {@code hasData} and the {@code truncated} /
+    * {@code sampled} / {@code sampleMaxRows} trio describe the same read and are meaningful to a
+    * caller deciding whether the rows are the whole population.
+    *
+    * <p><b>Not a pure read</b> — see {@link #executeAndExtract}: it re-executes the view and
+    * invalidates this assembly's cached render.
+    *
+    * <p>An expired runtime or a missing assembly both come back as an EMPTY result rather than an
+    * error, because both mean "nothing to answer from" rather than "this chart is empty", and the
+    * caller degrades on an empty result instead of retrying.
     */
    public CreateViewsheetResult fetchAssemblyData(String runtimeId, String assemblyName,
                                                   Principal user) throws Exception
    {
-      RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, user);
+      // Action-level gate ("Visual Composer -> Data Viewsheet"), the same one every other
+      // endpoint-backed method in the wiz services applies — including the read-only
+      // getChartAestheticModel. Without it, the one endpoint that returns raw ROW DATA would be the
+      // only ungated one. A no-op for the internal callers in WizAutoBindingService, which have all
+      // passed this identical check before reaching here.
+      if(!securityEngine.checkPermission(user, ResourceType.VIEWSHEET, "*", ResourceAction.ACCESS)) {
+         throw new SecurityException(Catalog.getCatalog().getString(
+            "composer.authorization.permissionDenied"));
+      }
 
-      if(rvs == null) {
+      if(runtimeId == null || runtimeId.isEmpty() || assemblyName == null || assemblyName.isEmpty()) {
+         throw new IllegalArgumentException("runtimeId and assemblyName are required");
+      }
+
+      RuntimeViewsheet rvs;
+
+      try {
+         rvs = viewsheetService.getViewsheet(runtimeId, user);
+      }
+      catch(ExpiredSheetException e) {
+         // A reaped runtime is the ORDINARY case here, not a failure: the chart is equally
+         // unavailable to the user at that point, so "no data to answer from" is the accurate
+         // outcome. getSheet THROWS for an id it no longer holds rather than returning null, so
+         // catching this — not a null check — is what makes that the actual behaviour. Left uncaught
+         // it reached the controller's generic handler as a 500 with an ERROR-level stack trace, for
+         // the single most routine condition on this path, burying the failures that do matter.
+         //
+         // Deliberately NOT catch(Exception): a genuine fault must still surface. Only expiry is
+         // expected, and only expiry is answered with silence.
+         LOG.debug("Runtime viewsheet [{}] has expired; no data for assembly [{}]",
+                   runtimeId, assemblyName);
          return new CreateViewsheetResult();
       }
 
-      Viewsheet vs = rvs.getViewsheet();
-      VSAssembly assembly = vs.getAssembly(assemblyName);
+      Viewsheet vs = rvs == null ? null : rvs.getViewsheet();
+      VSAssembly assembly = vs == null ? null : vs.getAssembly(assemblyName);
 
       if(assembly == null) {
          return new CreateViewsheetResult();
@@ -2243,14 +2289,16 @@ public class WizVsService {
       int curMax = WizUtil.sampledPreviewCap(fetchWs);
       CreateViewsheetResult result = executeAndExtract(rvs, assembly, curMax);
 
-      if(result != null) {
-         // Order matters: executeAndExtract runs executeView above, which populates the
-         // chart's RT refs. collectFlatBinding prefers RT refs, so it must come after.
-         result.setBinding(collectFlatBinding(assembly));
+      // One decision about nullability, not two: this used to guard setBinding and then dereference
+      // the same variable unguarded on the very next line, so the guard protected nothing.
+      if(result == null) {
+         return new CreateViewsheetResult();
       }
 
-      boolean metadataMode = vs.getViewsheetInfo().isMetadata();
-      result.setHasData(computeHasData(metadataMode, result));
+      // Order matters: executeAndExtract runs executeView above, which populates the
+      // chart's RT refs. collectFlatBinding prefers RT refs, so it must come after.
+      result.setBinding(collectFlatBinding(assembly));
+      result.setHasData(computeHasData(vs.getViewsheetInfo().isMetadata(), result));
       return result;
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizViewsheetControllerAssemblyDataTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizViewsheetControllerAssemblyDataTest.java
@@ -18,6 +18,7 @@
 
 package inetsoft.web.wiz.controller;
 
+import inetsoft.util.InvalidUserException;
 import inetsoft.web.wiz.model.AssemblyDataRequest;
 import inetsoft.web.wiz.model.CreateViewsheetResult;
 import inetsoft.web.wiz.service.WizAutoBindingService;
@@ -45,6 +46,12 @@ import static org.mockito.Mockito.*;
  * from that chart's own rows. The caller holds only what the front end renders with — the runtime id
  * and the assembly name — so those are the only inputs, and deliberately the only ones: accepting a
  * row cap or a filter here would let a caller quietly fetch data the user's chart does not show.
+ *
+ * <p><b>Scope.</b> These stub {@link WizVsService}, so they pin what the controller does with a result
+ * or an exception — request mapping, and the status each failure becomes. What the service actually
+ * produces (an expired runtime, a missing assembly, the permission gate) belongs to
+ * {@code WizVsServiceFetchAssemblyDataTest}, and must be tested there: a stubbed service can only
+ * confirm the stub.
  */
 @Tag("core")
 class WizViewsheetControllerAssemblyDataTest {
@@ -88,18 +95,53 @@ class WizViewsheetControllerAssemblyDataTest {
    }
 
    @Test
-   void returnsAnEmptyResultWhenTheAssemblyIsGone() throws Exception {
-      // A reaped runtime or a deleted assembly: fetchAssemblyData already answers with an empty
-      // result rather than throwing, and the caller reads "no rows" as "cannot answer from this
-      // chart" — which is the honest outcome, not an error to retry.
+   void passesAnEmptyResultThroughAsA200() throws Exception {
+      // Named for what it can actually establish. It stubs the service, so it says nothing about WHEN
+      // an empty result is produced — that belongs to WizVsServiceFetchAssemblyDataTest. The version
+      // of this test that claimed it ("returnsAnEmptyResultWhenTheAssemblyIsGone") asserted Mockito
+      // rather than StyleBI, which is how an expired runtime went on throwing while the docs said the
+      // opposite: a test named after the claim could never disprove the claim.
       WizVsService svc = mock(WizVsService.class);
       when(svc.fetchAssemblyData(any(), any(), any())).thenReturn(new CreateViewsheetResult());
 
       ResponseEntity<?> resp =
          controller(svc).assemblyData(request("rt-dead", "Chart1"), mock(Principal.class));
 
+      // 200 with no rows, not an error status: "nothing to answer from" is itself an answer.
       assertEquals(HttpStatus.OK, resp.getStatusCode());
       assertNull(((CreateViewsheetResult) resp.getBody()).getRows());
+   }
+
+   @Test
+   void mapsAPermissionDenialTo403() throws Exception {
+      // WizControllerErrorHandler maps SecurityException to 403 for this whole package — but an
+      // @ControllerAdvice only sees what LEAVES the controller method, and run()'s catch-all took it
+      // first. So every permission denial on this controller was answered as a content-free 500 by
+      // the very controller the advice exists to cover.
+      WizVsService svc = mock(WizVsService.class);
+      when(svc.fetchAssemblyData(any(), any(), any()))
+         .thenThrow(new inetsoft.sree.security.SecurityException("denied"));
+
+      ResponseEntity<?> resp =
+         controller(svc).assemblyData(request("rt-1", "Chart1"), mock(Principal.class));
+
+      assertEquals(HttpStatus.FORBIDDEN, resp.getStatusCode());
+   }
+
+   @Test
+   void mapsAnotherUsersRuntimeTo403WithoutNamingItsOwner() throws Exception {
+      // getSheet throws this when the runtime id belongs to someone else. Its message is the
+      // "common.invalidUser" catalog string, which names the OWNING user — echoing that back would
+      // answer, for anyone probing runtime ids, a question they should not get to ask.
+      WizVsService svc = mock(WizVsService.class);
+      when(svc.fetchAssemblyData(any(), any(), any()))
+         .thenThrow(new InvalidUserException("user 'alice' is not 'bob'", mock(Principal.class)));
+
+      ResponseEntity<?> resp =
+         controller(svc).assemblyData(request("rt-someone-else", "Chart1"), mock(Principal.class));
+
+      assertEquals(HttpStatus.FORBIDDEN, resp.getStatusCode());
+      assertEquals(Map.of("error", "Forbidden"), resp.getBody());
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizViewsheetControllerAssemblyDataTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizViewsheetControllerAssemblyDataTest.java
@@ -1,0 +1,127 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.controller;
+
+import inetsoft.web.wiz.model.AssemblyDataRequest;
+import inetsoft.web.wiz.model.CreateViewsheetResult;
+import inetsoft.web.wiz.service.WizAutoBindingService;
+import inetsoft.web.wiz.service.WizGeoService;
+import inetsoft.web.wiz.service.WizVsService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Verifies {@link WizViewsheetController#assemblyData} — the read-only endpoint that returns an
+ * existing assembly's rendered data.
+ *
+ * <p>It exists so a follow-up question about a chart built EARLIER in a conversation can be answered
+ * from that chart's own rows. The caller holds only what the front end renders with — the runtime id
+ * and the assembly name — so those are the only inputs, and deliberately the only ones: accepting a
+ * row cap or a filter here would let a caller quietly fetch data the user's chart does not show.
+ */
+@Tag("core")
+class WizViewsheetControllerAssemblyDataTest {
+   private WizViewsheetController controller(WizVsService svc) {
+      return new WizViewsheetController(
+         svc, mock(WizAutoBindingService.class), mock(WizGeoService.class));
+   }
+
+   private AssemblyDataRequest request(String runtimeId, String assemblyName) {
+      AssemblyDataRequest req = new AssemblyDataRequest();
+      req.setRuntimeId(runtimeId);
+      req.setAssemblyName(assemblyName);
+      return req;
+   }
+
+   @Test
+   void returnsTheAssemblysRenderedData() throws Exception {
+      WizVsService svc = mock(WizVsService.class);
+      CreateViewsheetResult result = new CreateViewsheetResult();
+      result.setHeaders(List.of("STATE", "SUM(SALES)"));
+      result.setRows(List.of(Map.of("STATE", "NJ", "SUM(SALES)", 420)));
+      when(svc.fetchAssemblyData(eq("rt-1"), eq("Chart1"), any())).thenReturn(result);
+
+      ResponseEntity<?> resp =
+         controller(svc).assemblyData(request("rt-1", "Chart1"), mock(Principal.class));
+
+      assertEquals(HttpStatus.OK, resp.getStatusCode());
+      assertSame(result, resp.getBody());
+   }
+
+   @Test
+   void addressesTheAssemblyByRuntimeIdAndName() throws Exception {
+      WizVsService svc = mock(WizVsService.class);
+      when(svc.fetchAssemblyData(any(), any(), any())).thenReturn(new CreateViewsheetResult());
+      Principal user = mock(Principal.class);
+
+      controller(svc).assemblyData(request("rt-7", "Chart3"), user);
+
+      // The same pair the browser embed renders with, and nothing else — no row cap, no filter.
+      verify(svc).fetchAssemblyData("rt-7", "Chart3", user);
+   }
+
+   @Test
+   void returnsAnEmptyResultWhenTheAssemblyIsGone() throws Exception {
+      // A reaped runtime or a deleted assembly: fetchAssemblyData already answers with an empty
+      // result rather than throwing, and the caller reads "no rows" as "cannot answer from this
+      // chart" — which is the honest outcome, not an error to retry.
+      WizVsService svc = mock(WizVsService.class);
+      when(svc.fetchAssemblyData(any(), any(), any())).thenReturn(new CreateViewsheetResult());
+
+      ResponseEntity<?> resp =
+         controller(svc).assemblyData(request("rt-dead", "Chart1"), mock(Principal.class));
+
+      assertEquals(HttpStatus.OK, resp.getStatusCode());
+      assertNull(((CreateViewsheetResult) resp.getBody()).getRows());
+   }
+
+   @Test
+   void mapsIllegalArgumentTo400() throws Exception {
+      WizVsService svc = mock(WizVsService.class);
+      when(svc.fetchAssemblyData(any(), any(), any()))
+         .thenThrow(new IllegalArgumentException("bad runtime id"));
+
+      ResponseEntity<?> resp =
+         controller(svc).assemblyData(request("bogus", "Chart1"), mock(Principal.class));
+
+      assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
+   }
+
+   @Test
+   void mapsUnexpectedFailureTo500() throws Exception {
+      WizVsService svc = mock(WizVsService.class);
+      when(svc.fetchAssemblyData(any(), any(), any())).thenThrow(new IllegalStateException("sandbox gone"));
+
+      ResponseEntity<?> resp =
+         controller(svc).assemblyData(request("rt-1", "Chart1"), mock(Principal.class));
+
+      assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, resp.getStatusCode());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceFetchAssemblyDataTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceFetchAssemblyDataTest.java
@@ -1,0 +1,124 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.ExpiredSheetException;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.sree.security.SecurityException;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.wiz.model.CreateViewsheetResult;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * {@link WizVsService#fetchAssemblyData} — the whole of {@code POST /api/wiz/viewsheet/assembly-data}.
+ *
+ * <p>These sit at the SERVICE level on purpose. The controller tests stub this method out, so they pin
+ * what the controller does with a result and nothing about how one is produced — which is how the
+ * "a reaped runtime comes back empty" claim came to be documented without being true: the runtime
+ * lookup throws {@link ExpiredSheetException} rather than returning null, and a test that stubs the
+ * method can never say so.
+ */
+@Tag("core")
+class WizVsServiceFetchAssemblyDataTest {
+   /** A SecurityEngine that grants VIEWSHEET/ACCESS, so the action gate passes. */
+   private static SecurityEngine grantedSecurity() throws Exception {
+      SecurityEngine sec = mock(SecurityEngine.class);
+      when(sec.checkPermission(any(), any(), anyString(), any())).thenReturn(true);
+      return sec;
+   }
+
+   private static WizVsService service(ViewsheetService vsService, SecurityEngine sec) {
+      return new WizVsService(vsService, mock(AssetRepository.class), sec, null, null);
+   }
+
+   @Test
+   void returnsNoDataWhenTheRuntimeHasExpired() throws Exception {
+      // The ORDINARY case on this path, not a failure: a question about a chart from an earlier
+      // session. The chart is equally unavailable to the user at that point, so "no data to answer
+      // from" is the accurate outcome — and the caller reads an empty result as exactly that.
+      // Reported as an error instead, it became a 500 with an ERROR-level stack trace for routine
+      // operation, which buries the failures that do matter.
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      when(vsService.getViewsheet("rt-dead", null))
+         .thenThrow(new ExpiredSheetException("rt-dead", null));
+
+      CreateViewsheetResult result = service(vsService, grantedSecurity())
+         .fetchAssemblyData("rt-dead", "Chart1", null);
+
+      assertNotNull(result);
+      assertNull(result.getRows());
+   }
+
+   @Test
+   void returnsNoDataWhenTheAssemblyIsNoLongerInTheRuntime() throws Exception {
+      // A deleted assembly reads the same way as an expired runtime, and must: both mean "nothing to
+      // answer from" rather than "this chart is empty".
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      Viewsheet vs = mock(Viewsheet.class);
+
+      when(vsService.getViewsheet("rt-1", null)).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(vs.getAssembly("Chart1")).thenReturn(null);
+
+      CreateViewsheetResult result = service(vsService, grantedSecurity())
+         .fetchAssemblyData("rt-1", "Chart1", null);
+
+      assertNotNull(result);
+      assertNull(result.getRows());
+   }
+
+   @Test
+   void requiresTheViewsheetActionRightBeforeReadingAnything() throws Exception {
+      // Every other endpoint-backed method in the wiz services gates on this, including the read-only
+      // one (WizAutoBindingService#getChartAestheticModel). Skipping it here would make the endpoint
+      // that returns raw ROW DATA the only ungated one.
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      SecurityEngine denied = mock(SecurityEngine.class);
+      when(denied.checkPermission(any(), any(), anyString(), any())).thenReturn(false);
+
+      assertThrows(SecurityException.class,
+                   () -> service(vsService, denied).fetchAssemblyData("rt-1", "Chart1", null));
+
+      // Denied before the runtime is even looked up.
+      verifyNoInteractions(vsService);
+   }
+
+   @Test
+   void rejectsBlankIdentifiers() throws Exception {
+      // The controller's @NotBlank covers the HTTP path; this covers the method, which is public now
+      // and which the sibling removeVisualization validates the same way.
+      ViewsheetService vsService = mock(ViewsheetService.class);
+      WizVsService svc = service(vsService, grantedSecurity());
+
+      assertThrows(IllegalArgumentException.class, () -> svc.fetchAssemblyData("", "Chart1", null));
+      assertThrows(IllegalArgumentException.class, () -> svc.fetchAssemblyData("rt-1", "", null));
+      assertThrows(IllegalArgumentException.class, () -> svc.fetchAssemblyData(null, "Chart1", null));
+      assertThrows(IllegalArgumentException.class, () -> svc.fetchAssemblyData("rt-1", null, null));
+   }
+}


### PR DESCRIPTION
POST /api/wiz/viewsheet/assembly-data returns headers, rows and binding for an assembly already in a runtime viewsheet.

It exists so a follow-up question about a chart built earlier in a conversation can be answered from that chart's own rows. The caller keeps no copy of them, and deliberately so: a stored copy is the only thing capable of disagreeing with what the user is looking at.

No extraction logic is added. WizVsService#fetchAssemblyData already does this work — it is how a type switch lazily repopulates row data for insight generation — and was simply never reachable over HTTP. It becomes public.

The request carries only runtimeId and assemblyName, which is the whole point. They are exactly the pair the browser embed renders with, so whatever comes back is by construction the data behind the chart on screen. A row cap, a filter or a binding override would break that correspondence: the caller could then fetch data the chart does not show and answer a question about the chart from numbers the user cannot see. The cap in force stays whatever the chart was rendered with, which fetchAssemblyData already preserves by reading it back from the source worksheet rather than accepting one.

An assembly whose runtime has been reaped returns an empty result rather than an error — the chart is equally unavailable to the user at that point, so "no data to answer from" is the accurate outcome, not a failure to retry.