### PR TITLE
Describe six more REST connectors, and add Twilio's missing calls and messages

### DIFF
--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/asana/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/asana/endpoints.json
@@ -3,47 +3,56 @@
     {
       "name": "Attachment",
       "paged": true,
-      "suffix": "/1.0/attachments/{Attachment}?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/attachments/{Attachment}?opt_fields={Returned Fields?}",
+      "description": "One file attached to a task, project brief or other object, by gid, with its name, size, host and download url."
     },
     {
       "name": "Task Attachments",
       "paged": true,
-      "suffix": "/1.0/tasks/{Task}/attachments?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/attachments?parent={Task}&opt_fields={Returned Fields?}",
+      "description": "The attachments on one task. Requires the task gid as the parent parameter. NOTE THE SHAPE: Asana replaced the nested per-task path with a single attachments endpoint filtered by parent, and parent accepts a project brief or project as well as a task -- so this endpoint is general, and the task case is one use of it."
     },
     {
       "name": "Custom Field",
       "paged": false,
-      "suffix": "/1.0/custom_fields/{Custom Field}?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/custom_fields/{Custom Field}?opt_fields={Returned Fields?}",
+      "description": "One custom field definition by gid, with its name, type (text, number, enum, multi-enum, date, people) and, for enum fields, the option list. Requires a custom field gid."
     },
     {
       "name": "Workspace Custom Fields",
       "paged": true,
-      "suffix": "/1.0/workspaces/{Workspace}/custom_fields?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/workspaces/{Workspace}/custom_fields?opt_fields={Returned Fields?}",
+      "description": "Every custom field defined in one workspace. Requires a workspace id. The account's vocabulary for describing work beyond Asana's built-in fields."
     },
     {
       "name": "Project Custom Fields",
       "paged": true,
-      "suffix": "/1.0/projects/{Project}/custom_field_settings?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/projects/{Project}/custom_field_settings?opt_fields={Returned Fields?}",
+      "description": "The custom fields ENABLED ON one project, as settings records carrying the field, whether it is important, and its parent. Requires a project id. A workspace can define many fields while a project uses a few, so this is what says which columns a project's tasks actually carry -- and therefore which are meaningfully empty rather than simply not applicable."
     },
     {
       "name": "Portfolio Custom Fields",
       "paged": true,
-      "suffix": "/1.0/portfolios/{Portfolio}/custom_field_settings?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/portfolios/{Portfolio}/custom_field_settings?opt_fields={Returned Fields?}",
+      "description": "The custom fields enabled on one portfolio. Requires a portfolio id. The same distinction at the programme level."
     },
     {
       "name": "Events",
       "paged": true,
-      "suffix": "/1.0/events?resource={Resource}&sync={Sync?}&opt_fields={Returned Fields?}"
+      "suffix": "/1.0/events?resource={Resource}&sync={Sync?}&opt_fields={Returned Fields?}",
+      "description": "The change stream for one resource -- a project, task or workspace -- returning what has happened since the last call. Requires a resource gid and a SYNC TOKEN, and the first call has no token: it returns an error carrying a fresh token, which is the intended way to start rather than a failure. Events are retained for about 24 HOURS, so a gap longer than that invalidates the token and the stream must be restarted from a full read. Built for incremental sync, not for history."
     },
     {
       "name": "Job",
       "paged": false,
-      "suffix": "/1.0/jobs/{Job}?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/jobs/{Job}?opt_fields={Returned Fields?}",
+      "description": "The status of one asynchronous job by gid -- duplicating a project or task, or instantiating a template -- with its state and the resource it produced. Operational: it reports whether a long-running action finished, since the action itself only reports being queued."
     },
     {
       "name": "Organization Export Request",
       "paged": true,
-      "suffix": "/1.0/organization_exports/{Organization Export}?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/organization_exports/{Organization Export}?opt_fields={Returned Fields?}",
+      "description": "The status of one full organization export by gid, with its state and, when complete, the download url. Requires organization admin rights. The route to a complete account snapshot, which no listing endpoint can assemble -- and the practical answer when the task listing constraints make a full extract impractical."
     },
     {
       "name": "Portfolios",
@@ -56,32 +65,38 @@
           "key": "gid",
           "parameterName": "Portfolio"
         }
-      ]
+      ],
+      "description": "The portfolios the caller owns, within a workspace. Requires a workspace and an owner. A portfolio is a collection of projects used for programme-level roll-up -- so it is the only container above the project, and where a question about an initiative spanning projects is answered. A Premium feature: on a free workspace this returns an error rather than an empty list, which is a licensing fact and not an absence of programmes."
     },
     {
       "name": "Portfolio",
       "paged": false,
-      "suffix": "/1.0/portfolios/{Portfolio}?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/portfolios/{Portfolio}?opt_fields={Returned Fields?}",
+      "description": "One portfolio by gid, with its name, owner, colour and custom field settings."
     },
     {
       "name": "Portfolio Items",
       "paged": true,
-      "suffix": "/1.0/portfolios/{Portfolio}/items?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/portfolios/{Portfolio}/items?opt_fields={Returned Fields?}",
+      "description": "The projects inside one portfolio. Requires a portfolio id. The link from a programme to the work making it up; progress must be rolled up from those projects, since the portfolio carries no aggregate of its own."
     },
     {
       "name": "Portfolio Memberships",
       "paged": true,
-      "suffix": "/1.0/portfolio_memberships?portfolio={Portfolio?}&workspace={Workspace?}&user={User?}&opt_fields={Returned Fields?}"
+      "suffix": "/1.0/portfolio_memberships?portfolio={Portfolio?}&workspace={Workspace?}&user={User?}&opt_fields={Returned Fields?}",
+      "description": "Portfolio membership records, filtered by portfolio, workspace or user. Who can see and edit a portfolio."
     },
     {
       "name": "Portfolio Membership",
       "paged": false,
-      "suffix": "/1.0/portfolio_memberships/{Portfolio Membership}?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/portfolio_memberships/{Portfolio Membership}?opt_fields={Returned Fields?}",
+      "description": "One portfolio membership by gid."
     },
     {
       "name": "Memberships from a Portfolio",
       "paged": true,
-      "suffix": "/1.0/portfolios/{Portfolio}/portfolio_memberships?user={User?}&opt_fields={Returned Fields?}"
+      "suffix": "/1.0/portfolios/{Portfolio}/portfolio_memberships?user={User?}&opt_fields={Returned Fields?}",
+      "description": "The membership records of one portfolio. Requires a portfolio id."
     },
     {
       "name": "Projects",
@@ -120,57 +135,68 @@
           "parameterName": "Project",
           "inheritParameters": false
         }
-      ]
+      ],
+      "description": "The projects visible to the caller. With opt_fields each carries name, notes, the owning team, created_at and modified_at, due_on and start_on, archived, public, color, and the current status. Projects are the container tasks are reached through, so this is usually the first request in any Asana question. ARCHIVED PROJECTS ARE INCLUDED unless filtered out, and they are the normal resting state of finished work -- so a count of active projects needs the archived flag."
     },
     {
       "name": "Project",
       "paged": false,
-      "suffix": "/1.0/projects/{Project}?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/projects/{Project}?opt_fields={Returned Fields?}",
+      "description": "One project by gid, with its full field set when requested."
     },
     {
       "name": "Task Projects",
       "paged": true,
-      "suffix": "/1.0/tasks/{Task}/projects?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/tasks/{Task}/projects?opt_fields={Returned Fields?}",
+      "description": "The projects one task belongs to. Requires a task gid. A task can be in several, which is why project-level totals overlap."
     },
     {
       "name": "Team Projects",
       "paged": true,
-      "suffix": "/1.0/teams/{Team}/projects?archived={Archived?:false|true}&opt_fields={Returned Fields?}"
+      "suffix": "/1.0/teams/{Team}/projects?archived={Archived?:false|true}&opt_fields={Returned Fields?}",
+      "description": "The projects owned by one team. Requires a team id. The per-team slice."
     },
     {
       "name": "Workspace Projects",
       "paged": true,
-      "suffix": "/1.0/workspaces/{Workspace}/projects?archived={Archived?:false|true}&opt_fields={Returned Fields?}"
+      "suffix": "/1.0/workspaces/{Workspace}/projects?archived={Archived?:false|true}&opt_fields={Returned Fields?}",
+      "description": "The projects in one workspace. Requires a workspace id. The account-wide project list, and the practical starting point for walking to tasks."
     },
     {
       "name": "Project Task Count",
       "paged": false,
-      "suffix": "/1.0/projects/{Project}/task_counts?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/projects/{Project}/task_counts?opt_fields={Returned Fields?}",
+      "description": "The task counts of one project: total, completed, incomplete, milestones and their completed counts. Requires a project id, and each count must be requested by name in opt_fields. A ready-made aggregate -- far cheaper than paging every task -- but note it counts the project's own tasks, so subtasks are excluded here too."
     },
     {
       "name": "Project Membership",
       "paged": false,
-      "suffix": "/1.0/project_memberships/{Project Membership}?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/project_memberships/{Project Membership}?opt_fields={Returned Fields?}",
+      "description": "One project membership by gid."
     },
     {
       "name": "Project Memberships",
       "paged": true,
-      "suffix": "/1.0/projects/{Project}/project_memberships?user={User?}&opt_fields={Returned Fields?}"
+      "suffix": "/1.0/projects/{Project}/project_memberships?user={User?}&opt_fields={Returned Fields?}",
+      "description": "The membership records of one project -- who has access and at what write level. Requires a project id. Project access in Asana is a mix of explicit members and team-wide access, so this lists the explicit ones; a person reaching the project through its team may not appear."
     },
     {
       "name": "Project Status",
       "paged": false,
-      "suffix": "/1.0/project_statuses/{Project Status}?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/project_statuses/{Project Status}?opt_fields={Returned Fields?}",
+      "description": "One project status update by gid."
     },
     {
       "name": "Project Statuses",
       "paged": true,
-      "suffix": "/1.0/projects/{Project}/project_statuses?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/projects/{Project}/project_statuses?opt_fields={Returned Fields?}",
+      "description": "The status updates posted on one project, each with its text, the colour signalling green, yellow or red, the author and when it was posted. Requires a project id. The narrative record of how a project was reported over time, which no task data reconstructs -- and the colour is the only explicit health signal Asana holds."
     },
     {
       "name": "Section",
       "paged": false,
-      "suffix": "/1.0/sections/{Section}?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/sections/{Section}?opt_fields={Returned Fields?}",
+      "description": "One section by gid, with its name and project."
     },
     {
       "name": "Project Sections",
@@ -184,37 +210,44 @@
           "parameterName": "Section",
           "inheritParameters": false
         }
-      ]
+      ],
+      "description": "The sections of one project, in order. Requires a project id. Sections are the board columns or list headings -- so they are where a team's workflow stages are actually named, and the dimension a 'what stage is work in' question groups by."
     },
     {
       "name": "Story",
       "paged": false,
-      "suffix": "/1.0/stories/{Story}?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/stories/{Story}?opt_fields={Returned Fields?}",
+      "description": "One story by gid, with its text, type and author."
     },
     {
       "name": "Task Stories",
       "paged": true,
-      "suffix": "/1.0/tasks/{Task}/stories?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/tasks/{Task}/stories?opt_fields={Returned Fields?}",
+      "description": "The activity feed of one task: every comment AND every system event -- assigned, completed, due date changed, added to a project, moved between sections -- each with its author and created_at. Requires a task gid. THE TASK CARRIES ONLY ITS CURRENT STATE, so this is the sole source for when it moved, how long it sat in a section, and who changed what. Comments and system events are mixed together and told apart by the type field, so filter before counting either: system stories usually outnumber human comments several times over."
     },
     {
       "name": "Tags",
       "paged": true,
-      "suffix": "/1.0/tags?workspace={Workspace?}&opt_fields={Returned Fields?}"
+      "suffix": "/1.0/tags?workspace={Workspace?}&opt_fields={Returned Fields?}",
+      "description": "The tags defined across the caller's workspaces, with name and colour. Tags are Asana's cross-project labelling, so they are how work is grouped when projects are the wrong axis."
     },
     {
       "name": "Tag",
       "paged": false,
-      "suffix": "/1.0/tags/{Tag}?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/tags/{Tag}?opt_fields={Returned Fields?}",
+      "description": "One tag by gid."
     },
     {
       "name": "Task Tags",
       "paged": true,
-      "suffix": "/1.0/tasks/{Task}/tags?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/tasks/{Task}/tags?opt_fields={Returned Fields?}",
+      "description": "The tags on one task. Requires a task gid."
     },
     {
       "name": "Workspace Tags",
       "paged": false,
-      "suffix": "/1.0/workspaces/{Workspace}/tags?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/workspaces/{Workspace}/tags?opt_fields={Returned Fields?}",
+      "description": "The tags in one workspace. Requires a workspace id. The account-level tag vocabulary, worth reading before filtering tasks by tag since near-duplicates are unconstrained."
     },
     {
       "name": "Tasks",
@@ -222,67 +255,81 @@
       "suffix": "/1.0/tasks?assignee={Assignee?}&project={Project?}&section={Section?}&workspace={Workspace?}&completed_since={Completed Since?:yyyy-MM-ddTHH:mm:ssZ}&modified_since={Modified Since?:yyyy-MM-ddTHH:mm:ssZ}",
       "lookups": [
         {
-          "endpoints": ["Task", "Task Stories"],
+          "endpoints": [
+            "Task",
+            "Task Stories"
+          ],
           "jsonPath": "$.data.[*]",
           "key": "gid",
           "parameterName": "Task"
         }
-      ]
+      ],
+      "description": "Tasks, the unit of work in Asana -- but READ THE CONSTRAINT FIRST: this endpoint REQUIRES a filter and refuses an unfiltered request. There is no 'all tasks in the account' listing anywhere in Asana; a task set must be reached through a project, a section, a tag, a user task list, or an assignee together with a workspace. Any question phrased as 'all our tasks' is really a loop over projects. THE SECOND CONSTRAINT applies to every endpoint in this connector: Asana returns a COMPACT record by default, carrying only gid, name and resource_type. Completed, due_on, assignee, created_at, custom_fields and the rest are ABSENT unless named in opt_fields -- and their absence looks like empty data rather than an unmade request."
     },
     {
       "name": "Task",
       "paged": false,
-      "suffix": "/1.0/tasks/{Task}?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/tasks/{Task}?opt_fields={Returned Fields?}",
+      "description": "One task by gid. Requires the task gid. With opt_fields it carries name, notes, completed and completed_at, due_on and due_at, start_on, the assignee and assignee_status, created_at and modified_at, its projects and tags, its parent task, custom_fields, and memberships. NOTE THAT COMPLETION IS TWO COLUMNS: completed is the flag, completed_at the timestamp, and cycle-time questions need the second, which the compact record does not include."
     },
     {
       "name": "Project Tasks",
       "paged": true,
-      "suffix": "/1.0/projects/{Project}/tasks?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/projects/{Project}/tasks?opt_fields={Returned Fields?}",
+      "description": "The tasks in one project. Requires a project id. The usual entry point to a task set, since the unfiltered task list is refused. Note a task can belong to several projects, so summing across projects double-counts shared work."
     },
     {
       "name": "Section Tasks",
       "paged": true,
-      "suffix": "/1.0/sections/{Section}/tasks?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/sections/{Section}/tasks?opt_fields={Returned Fields?}",
+      "description": "The tasks in one section. Requires a section id. Sections are the columns of a board or the headings of a list, so this is the per-stage slice."
     },
     {
       "name": "Tag Tasks",
       "paged": true,
-      "suffix": "/1.0/tags/{Tag}/tasks?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/tags/{Tag}/tasks?opt_fields={Returned Fields?}",
+      "description": "The tasks carrying one tag. Requires a tag id."
     },
     {
       "name": "User Task List Tasks",
       "paged": true,
-      "suffix": "/1.0/user_task_lists/{User Task List}/tasks?completed_since={Completed Since?:yyyy-MM-ddTHH:mm:ssZ}&opt_fields={Returned Fields?}"
+      "suffix": "/1.0/user_task_lists/{User Task List}/tasks?completed_since={Completed Since?:yyyy-MM-ddTHH:mm:ssZ}&opt_fields={Returned Fields?}",
+      "description": "The tasks in one user's My Tasks list. Requires a user task list id. A personal queue rather than a project view, and the only place a task assigned but filed in no project reliably appears."
     },
     {
       "name": "Task Subtasks",
       "paged": true,
-      "suffix": "/1.0/tasks/{Task}/subtasks?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/tasks/{Task}/subtasks?opt_fields={Returned Fields?}",
+      "description": "The subtasks of one task. Requires a task gid. SUBTASKS ARE TASKS: they have their own assignees, due dates and completion, and they are NOT returned by the project task list, so a project's task count excludes them. Counting work per project without walking subtasks understates it, sometimes heavily."
     },
     {
       "name": "Task Dependencies",
       "paged": true,
-      "suffix": "/1.0/tasks/{Task}/dependencies?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/tasks/{Task}/dependencies?opt_fields={Returned Fields?}",
+      "description": "The tasks one task is waiting on. Requires a task gid. The blocking relationships, which no task field expresses."
     },
     {
       "name": "Task Dependents",
       "paged": true,
-      "suffix": "/1.0/tasks/{Task}/dependents?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/tasks/{Task}/dependents?opt_fields={Returned Fields?}",
+      "description": "The tasks waiting on this one. Requires a task gid. The reverse direction -- use it to find what a delay will hold up."
     },
     {
       "name": "Workspace Task Search",
       "paged": false,
-      "suffix": "/1.0/workspaces/{Workspace}/tasks/search?limit=100&text={Text?}&resource_subtype={Resource Subtype?}&assignee.any={Assignee?}&projects.any={Projects?}&tags.any={Tags?}&teams.any={Teams?}"
+      "suffix": "/1.0/workspaces/{Workspace}/tasks/search?limit=100&text={Text?}&resource_subtype={Resource Subtype?}&assignee.any={Assignee?}&projects.any={Projects?}&tags.any={Tags?}&teams.any={Teams?}",
+      "description": "Advanced task search within one workspace, filtering on assignee, project, section, tag, completion, due date, creation date, custom field values and more. Requires a workspace id. The only way to reach a task set by CRITERIA rather than by container, and therefore the closest thing to a general query -- a Premium feature, so it returns an error rather than results on a free workspace."
     },
     {
       "name": "Team",
       "paged": false,
-      "suffix": "/1.0/teams/{Team}?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/teams/{Team}?opt_fields={Returned Fields?}",
+      "description": "One team by gid, with its name, description and organization."
     },
     {
       "name": "Organization Teams",
       "paged": true,
-      "suffix": "/1.0/organizations/{Workspace}/teams?opt_fields={Returned Fields?}",
+      "suffix": "/1.0/workspaces/{Workspace}/teams?opt_fields={Returned Fields?}",
       "lookups": [
         {
           "endpoint": "Team Memberships",
@@ -290,37 +337,44 @@
           "key": "gid",
           "parameterName": "Team"
         }
-      ]
+      ],
+      "description": "The teams in one workspace or organization. Requires the workspace gid. Teams own projects, so this is the organisational dimension above projects and the axis most cross-project reporting groups by. NOTE THE PATH: Asana renamed this from an organizations path to a workspaces one, since an organization is a workspace; the connector now uses the current form."
     },
     {
       "name": "User Teams",
       "paged": true,
-      "suffix": "/1.0/users/{User}/teams?organization={Organization}&opt_fields={Returned Fields?}"
+      "suffix": "/1.0/users/{User}/teams?organization={Organization}&opt_fields={Returned Fields?}",
+      "description": "The teams one user belongs to. Requires a user id and a workspace. The per-person view of team membership."
     },
     {
       "name": "Team Membership",
       "paged": false,
-      "suffix": "/1.0/team_memberships/{Team Membership}?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/team_memberships/{Team Membership}?opt_fields={Returned Fields?}",
+      "description": "One team membership by gid."
     },
     {
       "name": "Team Memberships",
       "paged": true,
-      "suffix": "/1.0/team_memberships?team={Team?}&user={User?}&workspace={Workspace?}"
+      "suffix": "/1.0/team_memberships?team={Team?}&user={User?}&workspace={Workspace?}",
+      "description": "Team membership records, filtered by team, user or workspace. Each carries the user, the team, and whether they are a guest or a limited-access member. The guest flag matters for access questions: a guest sees only what they are explicitly added to."
     },
     {
       "name": "Memberships from a Team",
       "paged": true,
-      "suffix": "/1.0/teams/{Team}/team_memberships?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/teams/{Team}/team_memberships?opt_fields={Returned Fields?}",
+      "description": "The membership records of one team. Requires a team id. Richer than Team Users, which returns the users without the membership attributes."
     },
     {
       "name": "Memberships from a User",
       "paged": true,
-      "suffix": "/1.0/users/{User}/team_memberships?workspace={Workspace}&opt_fields={Returned Fields?}"
+      "suffix": "/1.0/users/{User}/team_memberships?workspace={Workspace}&opt_fields={Returned Fields?}",
+      "description": "One user's team memberships. Requires a user id and a workspace."
     },
     {
       "name": "Typeahead Search",
       "paged": true,
-      "suffix": "/1.0/workspaces/{Workspace}/typeahead?resource_type={Resource Type:custom_field|project|portfolio|tag|task|user}&type={Type?}&query={Query?}&count={Count?}"
+      "suffix": "/1.0/workspaces/{Workspace}/typeahead?resource_type={Resource Type:custom_field|project|portfolio|tag|task|user}&type={Type?}&query={Query?}&count={Count?}",
+      "description": "Objects matching a partial string within one workspace -- tasks, projects, users, tags and more. Requires a workspace id and a resource type. BUILT FOR AN AUTOCOMPLETE CONTROL: results are truncated, ranked for display, and biased toward the caller's recent activity, so it is unsuitable as a data source. Workspace Task Search is the one to use for anything counted."
     },
     {
       "name": "Users",
@@ -358,7 +412,8 @@
           "key": "gid",
           "parameterName": "User"
         }
-      ]
+      ],
+      "description": "Users visible to the caller, filtered by workspace or team. Same thin record. There is no account-wide user listing without naming a workspace."
     },
     {
       "name": "User",
@@ -369,27 +424,30 @@
           "endpoint": "User Teams",
           "jsonPath": "$.data.workspaces.[*]",
           "key": "$(User)",
-           "parameterName": "User",
-           "parameters": {
-              "Organization": "$.gid"
-           }
+          "parameterName": "User",
+          "parameters": {
+            "Organization": "$.gid"
+          }
         }
-      ]
+      ],
+      "description": "One user by gid, or the literal 'me' for the caller. Carries name, email and photo, and the workspaces they belong to."
     },
     {
       "name": "User Favorites",
       "paged": true,
-      "suffix": "/1.0/users/{User}/favorites?resource_type={Resource Type:project|team|portfolio|user|tag}&workspace={Workspace}&opt_fields={Returned Fields?}"
+      "suffix": "/1.0/users/{User}/favorites?resource_type={Resource Type:project|team|portfolio|user|tag}&workspace={Workspace}&opt_fields={Returned Fields?}",
+      "description": "The projects, portfolios, tags or users one person has starred. Requires a user id and a resource type. A personal interest signal, scoped to that user."
     },
     {
       "name": "Team Users",
       "paged": true,
-      "suffix": "/1.0/teams/{Team}/users?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/teams/{Team}/users?opt_fields={Returned Fields?}",
+      "description": "The users in one team. Requires a team id."
     },
     {
       "name": "Workspace Users",
       "paged": true,
-       "suffix": "/1.0/workspaces/{Workspace}/users?opt_fields={Returned Fields?}",
+      "suffix": "/1.0/workspaces/{Workspace}/users?opt_fields={Returned Fields?}",
       "lookups": [
         {
           "endpoint": "Portfolios",
@@ -397,27 +455,32 @@
           "key": "gid",
           "parameterName": "Owner"
         }
-      ]
+      ],
+      "description": "The users in one workspace or organization. Requires a workspace id. The roster any per-person analysis joins to. Note Asana user records are thin -- name, email and photo -- with no role, activity or last-login information anywhere in the API, so questions about who is active have to be answered from the work itself."
     },
     {
       "name": "User Task List",
       "paged": true,
-      "suffix": "/1.0/user_task_lists/{User Task List}?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/user_task_lists/{User Task List}?opt_fields={Returned Fields?}",
+      "description": "One user task list by gid, with its owner and workspace."
     },
     {
       "name": "User's Task List",
       "paged": true,
-      "suffix": "/1.0/users/{User}/user_task_list?workspace={Workspace}&opt_fields={Returned Fields?}"
+      "suffix": "/1.0/users/{User}/user_task_list?workspace={Workspace}&opt_fields={Returned Fields?}",
+      "description": "The My Tasks list belonging to one user, as a container record. Requires a user id and a workspace. The tasks themselves come from User Task List Tasks."
     },
     {
       "name": "Webhooks",
       "paged": true,
-      "suffix": "/1.0/webhooks?workspace={Workspace}&resource={Resource?}&opt_fields={Returned Fields?}"
+      "suffix": "/1.0/webhooks?workspace={Workspace}&resource={Resource?}&opt_fields={Returned Fields?}",
+      "description": "The webhooks registered by the calling application, filtered by workspace. Each carries the resource it watches, the target url, its filters and whether it is active. Note it lists only THIS application's webhooks, not every webhook on the workspace."
     },
     {
       "name": "Webhook",
       "paged": false,
-      "suffix": "/1.0/webhooks/{Webhook}?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/webhooks/{Webhook}?opt_fields={Returned Fields?}",
+      "description": "One webhook by gid, with its resource, target and last delivery result. The delivery result is the useful part: it identifies integrations that are configured and quietly failing."
     },
     {
       "name": "Workspaces",
@@ -461,27 +524,32 @@
           "key": "gid",
           "parameterName": "Workspace"
         }
-      ]
+      ],
+      "description": "The workspaces and organizations the caller belongs to. AN ORGANIZATION IS A WORKSPACE with email-domain membership -- the is_organization flag distinguishes them, and the same gid works wherever either is asked for. Nearly every other endpoint here needs a workspace gid, so this is the natural first request."
     },
     {
       "name": "Workspace",
       "paged": false,
-      "suffix": "/1.0/workspaces/{Workspace}?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/workspaces/{Workspace}?opt_fields={Returned Fields?}",
+      "description": "One workspace by gid, with its name, is_organization flag and email domains."
     },
     {
       "name": "Workspace Membership",
       "paged": false,
-      "suffix": "/1.0/workspace_memberships/{Workspace Membership}?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/workspace_memberships/{Workspace Membership}?opt_fields={Returned Fields?}",
+      "description": "One workspace membership by gid."
     },
     {
       "name": "User Workspace Memberships",
       "paged": true,
-      "suffix": "/1.0/users/{User}/workspace_memberships?opt_fields={Returned Fields?}"
+      "suffix": "/1.0/users/{User}/workspace_memberships?opt_fields={Returned Fields?}",
+      "description": "The workspaces one user belongs to, as membership records. Requires a user id."
     },
     {
       "name": "Workspace Memberships",
       "paged": true,
-      "suffix": "/1.0/workspaces/{Workspace}/workspace_memberships?user={User?}&opt_fields={Returned Fields?}"
+      "suffix": "/1.0/workspaces/{Workspace}/workspace_memberships?user={User?}&opt_fields={Returned Fields?}",
+      "description": "The membership records of one workspace, one per user. Requires a workspace id. Carries whether each person is an ACTIVE member, whether they are a guest, and their user task list. The active flag is the closest thing Asana offers to a deactivated-user marker, and guests are the external collaborators -- both are worth separating before counting an organisation's size."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/box/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/box/endpoints.json
@@ -1,478 +1,560 @@
 {
-    "endpoints": [
-        {
-            "name": "Collaboration Whitelist",
-            "paged": true,
-            "suffix": "/2.0/collaboration_whitelist_entries?marker={Marker?}"
-        },
-        {
-            "name": "Collaboration Whitelist Entry",
-            "paged": false,
-            "suffix": "/2.0/collaboration_whitelist_entries/{Collaboration ID}"
-        },
-        {
-            "name": "Collaboration Whitelist Exempt Targets",
-            "paged": true,
-            "suffix": "/2.0/collaboration_whitelist_exempt_targets?marker={Marker?}"
-        },
-        {
-            "name": "Collaboration Whitelist Exempt Target",
-            "paged": false,
-            "suffix": "/2.0/collaboration_whitelist_exempt_targets/{Collaboration Exempt ID}"
-        },
-        {
-            "name": "Collaboration",
-            "paged": false,
-            "suffix": "/2.0/collaborations/{Collaboration ID}?fields={Fields?}"
-        },
-        {
-            "name": "File Collaborations",
-            "paged": true,
-            "suffix": "/2.0/files/{File ID}/collaborations?fields={Fields?}&marker={Marker?}"
-        },
-        {
-            "name": "Folder Collaborations",
-            "paged": true,
-            "suffix": "/2.0/folders/{Folder ID}/collaborations?fields={Fields?}"
-        },
-        {
-            "name": "Pending Collaborations",
-            "paged": true,
-            "suffix": "/2.0/collaborations?status=pending&fields={Fields?}"
-        },
-        {
-            "name": "Group Collaborations",
-            "paged": true,
-            "suffix": "/2.0/groups/{Group ID}/collaborations"
-        },
-        {
-            "name": "Collections",
-            "paged": true,
-            "suffix": "/2.0/collections?fields={Fields?}",
-            "lookups": [
-              {
-                "endpoint": "Collection Items",
-                "jsonPath": "$.entries[*]",
-                "key": "id",
-                "parameterName": "Collection ID"
-              }
-            ]
-        },
-        {
-            "name": "Collection Items",
-            "paged": true,
-            "suffix": "/2.0/collections/{Collection ID}/items?fields={Fields?}"
-        },
-        {
-            "name": "File Comments",
-            "paged": true,
-            "suffix": "/2.0/files/{File ID}/comments?fields={Fields?}"
-        },
-        {
-            "name": "Comment",
-            "paged": false,
-            "suffix": "/2.0/comments/{Comment ID}?fields={Fields?}"
-        },
-        {
-            "name": "Device Pin",
-            "paged": false,
-            "suffix": "/2.0/device_pinners/{Device Pinner ID}"
-        },
-        {
-            "name": "Enterprise Device Pins",
-            "paged": true,
-            "suffix": "/2.0/enterprises/{Enterprise ID}/device_pinners?marker={Marker?}"
-        },
-        {
-            "name": "Download File",
-            "paged": false,
-            "suffix": "/2.0/files/{File ID}/content?version={Version?}"
-        },
-        {
-            "name": "User's Email Aliases",
-            "paged": true,
-            "suffix": "/2.0/users/{User ID}/email_aliases"
-        },
-        {
-            "name": "User and Enterprise Events",
-            "paged": true,
-            "suffix": "/2.0/events?created_after={Created After?:yyyy-MM-dd\u2019T\u2019HH:mm:ssZ}&created_before={Created Before?:yyyy-MM-dd\u2019T\u2019HH:mm:ssZ}&event_type={Event Type?:ACCESS_GRANTED|ACCESS_REVOKED|ADD_DEVICE_ASSOCIATION}&stream_position={Stream Position?}&stream_type={Stream Type?:all|changes|sync|admin_logs}"
-        },
-        {
-            "name": "File Version Legal Hold",
-            "paged": false,
-            "suffix": "/2.0/file_version_legal_holds/{File Version Legal ID}"
-        },
-        {
-            "name": "File Version Legal Holds",
-            "paged": true,
-            "suffix": "/2.0/file_version_legal_holds?marker={Marker?}&policy_id={Policy ID?}"
-        },
-        {
-            "name": "Retention on File",
-            "paged": false,
-            "suffix": "/2.0/file_version_retentions/{File Version Retention ID}"
-        },
-        {
-            "name": "File Version Retentions",
-            "paged": true,
-            "suffix": "/2.0/file_version_retentions?disposition_action={Disposition Action?:permanently_delete|remove_retention}&disposition_after={Disposition After?:yyyy-MM-dd\u2019T\u2019HH:mm:ssZ}&disposition_before={Disposition Before?:yyyy-MM-dd\u2019T\u2019HH:mm:ssZ}&file_id={File ID?}&file_version_id={File Version ID?}&marker={Marker?}&policy_id={Policy ID?}"
-        },
-        {
-            "name": "File Versions",
-            "paged": true,
-            "suffix": "/2.0/files/{File ID}/versions?fields={Fields?}"
-        },
-        {
-            "name": "File Version",
-            "paged": false,
-            "suffix": "/2.0/files/{File ID}/versions/{File Version ID}?fields={Fields?}"
-        },
-        {
-            "name": "File Information",
-            "paged": true,
-            "suffix": "/2.0/files/{File ID}?fields={Fields?}"
-        },
-        {
-            "name": "Folder Information",
-            "paged": true,
-            "suffix": "/2.0/folders/{Folder ID}?fields={Fields?}"
-        },
-        {
-            "name": "Folder Items",
-            "paged": true,
-            "suffix": "/2.0/folders/{Folder ID}/items?fields={Fields?}"
-        },
-        {
-            "name": "User's Groups",
-            "paged": true,
-            "suffix": "/2.0/users/{User ID}/memberships",
-            "lookups": [
-              {
-                "endpoint": "Group Members",
-                "jsonPath": "$.entries[*]",
-                "key": "id",
-                "parameterName": "Group ID"
-              },
-              {
-                "endpoint": "Group Collaborations",
-                "jsonPath": "$.entries[*]",
-                "key": "id",
-                "parameterName": "Group ID"
-              }
-            ]
-        },
-        {
-            "name": "Group Members",
-            "paged": true,
-            "suffix": "/2.0/groups/{Group ID}/memberships"
-        },
-        {
-            "name": "Group Membership",
-            "paged": false,
-            "suffix": "/2.0/group_memberships/{Group Membership ID}?fields={Fields?}"
-        },
-        {
-            "name": "Enterprise Groups",
-            "paged": true,
-            "suffix": "/2.0/groups?fields={Fields?}",
-            "lookups": [
-              {
-                "endpoint": "Group",
-                "jsonPath": "$.entries[*]",
-                "key": "id",
-                "parameterName": "Group ID"
-              },
-              {
-                "endpoint": "Group Members",
-                "jsonPath": "$.entries[*]",
-                "key": "id",
-                "parameterName": "Group ID"
-              },
-              {
-                "endpoint": "Group Collaborations",
-                "jsonPath": "$.entries[*]",
-                "key": "id",
-                "parameterName": "Group ID"
-              }
-            ]
-        },
-        {
-            "name": "Group",
-            "paged": false,
-            "suffix": "/2.0/groups/{Group ID}?fields={Fields?}"
-        },
-        {
-            "name": "User Invite Status",
-            "paged": false,
-            "suffix": "/2.0/invites/{Invite ID}?fields={Fields?}"
-        },
-        {
-            "name": "Legal Hold Policies",
-            "paged": true,
-            "suffix": "/2.0/legal_hold_policies?fields={Fields?}&marker={Marker?}&policy_name={Policy Name?}"
-        },
-        {
-            "name": "Legal Hold Policy",
-            "paged": false,
-            "suffix": "/2.0/legal_hold_policies/{Legal Hold Policy ID}"
-        },
-        {
-            "name": "Legal Hold Policy Assignments",
-            "paged": true,
-            "suffix": "/2.0/legal_hold_policy_assignments?policy_id={Policy ID}&assign_to_id={Assign To ID?}&assign_to_type={Assign To Type?:file|file_version|folder|user}&marker={Marker?}",
-            "lookups": [
-              {
-                "endpoint": "Legal Hold Policy Assignment",
-                "jsonPath": "$.entries[*]",
-                "key": "id",
-                "parameterName": "Legal Hold Policy Assignment ID"
-              }
-            ]
-        },
-        {
-            "name": "Legal Hold Policy Assignment",
-            "paged": false,
-            "suffix": "/2.0/legal_hold_policy_assignments/{Legal Hold Policy Assignment ID}"
-        },
-        {
-            "name": "Current File Versions",
-            "paged": true,
-            "suffix": "/2.0/legal_hold_policy_assignments/{Legal Hold Policy Assignment ID}/files_on_hold?fields={Fields?}&marker={Marker?}"
-        },
-        {
-            "name": "Previous File Versions",
-            "paged": true,
-            "suffix": "/2.0/legal_hold_policy_assignments/{Legal Hold Policy Assignment ID}/file_versions_on_hold?fields={Fields?}&marker={Marker?}"
-        },
-        {
-            "name": "Metadata Cascade Policies",
-            "paged": true,
-            "suffix": "/2.0/metadata_cascade_policies?folder_id={Folder_id}&marker={Marker?}&owner_enterprise_id={Owner Enterprise ID}"
-        },
-        {
-            "name": "Metadata Cascade Policy",
-            "paged": false,
-            "suffix": "/2.0/metadata_cascade_policies/{Metadata Cascade Policy ID}"
-        },
-        {
-            "name": "File Metadata Instances",
-            "paged": true,
-            "suffix": "/2.0/files/{File ID}/metadata"
-        },
-        {
-            "name": "File Metadata Instance",
-            "paged": false,
-            "suffix": "/2.0/files/{File ID}/metadata/{Scope:global|enterprise}/{Template Key}"
-        },
-        {
-            "name": "Folder Metadata Instances",
-            "paged": true,
-            "suffix": "/2.0/folders/{Folder ID}/metadata"
-        },
-        {
-            "name": "Folder Metadata Instance",
-            "paged": false,
-            "suffix": "/2.0/folders/{Folder ID}/metadata/{Scope:global|enterprise}/{Template Key}"
-        },
-        {
-            "name": "Metadata Template by Instance ID",
-            "paged": false,
-            "suffix": "/2.0/metadata_templates?metadata_instance_id={Metadata Instance ID}"
-        },
-        {
-            "name": "Metadata Template by Name",
-            "paged": false,
-            "suffix": "/2.0/metadata_templates/{Scope}/{Template Key}/schema"
-        },
-        {
-            "name": "Metadata Template by ID",
-            "paged": false,
-            "suffix": "/2.0/metadata_templates/{Template ID}"
-        },
-        {
-            "name": "Global Templates",
-            "paged": true,
-            "suffix": "/2.0/metadata_templates/global"
-        },
-        {
-            "name": "Enterprise Templates",
-            "paged": true,
-            "suffix": "/2.0/metadata_templates/enterprise?marker={Marker?}"
-        },
-        {
-            "name": "Recently Accessed Items",
-            "paged": true,
-            "suffix": "/2.0/recent_items?fields={Fields?}&marker={Marker?}"
-        },
-        {
-            "name": "Retention Policies",
-            "paged": true,
-            "suffix": "/2.0/retention_policies?created_by_user_id={Created By User ID?}&policy_name={Policy Name?}&policy_type={Policy Type?:finite|indefinite}"
-        },
-        {
-            "name": "Retention Policy",
-            "paged": false,
-            "suffix": "/2.0/retention_policies/{Retention Policy ID}"
-        },
-        {
-            "name": "Retention Policy Assignments",
-            "paged": true,
-            "suffix": "/2.0/retention_policies/{Retention Policy ID}/assignments?marker={Marker?}&type={Type?:folder|enterprise}"
-        },
-        {
-            "name": "Retention Policy Assignment",
-            "paged": false,
-            "suffix": "/2.0/retention_policy_assignments/{Retention Policy Assignment ID}"
-        },
-        {
-            "name": "Search for Content",
-            "paged": true,
-            "suffix": "/2.0/search?query={Query}&ancestor_folder_ids={Ancestor Folder IDs?}&content_types={Content Types?name|description|file_content|comments|tag}&created_at_range={Created At Range?}&fields={Fields?}&file_extensions={File Extensions?}"
-        },
-        {
-            "name": "Find Item for Shared Link",
-            "paged": true,
-            "suffix": "/2.0/shared_items?fields={Fields?}"
-        },
-        {
-            "name": "Storage Policies",
-            "paged": true,
-            "suffix": "/2.0/storage_policies?fields={Fields?}&marker={Marker?}"
-        },
-        {
-            "name": "Storage Policy",
-            "paged": false,
-            "suffix": "/2.0/storage_policies/{Storage Policy ID}"
-        },
-        {
-            "name": "Storage Policy Assignments",
-            "paged": true,
-            "suffix": "/2.0/storage_policy_assignments?resolved_for_id={Resolved For ID}&resolved_for_type={Resolved For Type:user|enterprise}&marker={Marker?}"
-        },
-        {
-            "name": "Storage Policy Assignment",
-            "paged": false,
-            "suffix": "/2.0/storage_policy_assignments/{Storage Policy Assignment ID}"
-        },
-        {
-            "name": "Task Assignments",
-            "paged": true,
-            "suffix": "/2.0/tasks/{Task ID}/assignments"
-        },
-        {
-            "name": "Task Assignment",
-            "paged": false,
-            "suffix": "/2.0/task_assignments/{Task Assignment ID}"
-        },
-        {
-            "name": "Tasks on File",
-            "paged": true,
-            "suffix": "/2.0/files/{File ID}/tasks"
-        },
-        {
-            "name": "Task",
-            "paged": false,
-            "suffix": "/2.0/tasks/{Task ID}"
-        },
-        {
-            "name": "Terms of Services",
-            "paged": true,
-            "suffix": "/2.0/terms_of_services?tos_type={Terms of Service Type?:external|managed}"
-        },
-        {
-            "name": "Terms of Service",
-            "paged": false,
-            "suffix": "/2.0/terms_of_services/{Terms Of Service ID}"
-        },
-        {
-            "name": "Terms of Service User Statuses",
-            "paged": true,
-            "suffix": "/2.0/terms_of_service_user_statuses?tos_id={Terms of Service ID}&user_id={User ID?}"
-        },
-        {
-            "name": "Trashed File",
-            "paged": false,
-            "suffix": "/2.0/folders/{Folder ID}/trash?fields={Fields?}"
-        },
-        {
-            "name": "Trashed Folder",
-            "paged": false,
-            "suffix": "/2.0/folders/{Folder ID}/trash?fields={Fields?}"
-        },
-        {
-            "name": "Trashed Items",
-            "paged": true,
-            "suffix": "/2.0/folders/trash/items?fields={Fields?}&marker={Marker?}&usemarker={Use Marker?false|true}"
-        },
-        {
-            "name": "Trashed Web Link",
-            "paged": false,
-            "suffix": "/2.0/web_links/{Web Link ID}/trash?fields={Fields?}"
-        },
-        {
-            "name": "Upload Session",
-            "paged": false,
-            "suffix": "/2.0/files/upload_sessions/{Upload Session ID}"
-        },
-        {
-            "name": "Upload Session Parts",
-            "paged": true,
-            "suffix": "/2.0/files/upload_sessions/{Upload Session ID}/parts"
-        },
-        {
-            "name": "Enterprise Users",
-            "paged": true,
-            "suffix": "/2.0/users?fields={Fields?}&filter_term={Filter Term?}&marker={Marker?}&usemarker={Usemarker?:false|true}&user_type={User Type?:all|managed|external}",
-            "lookups": [
-              {
-                "endpoint": "User's Email Aliases",
-                "jsonPath": "$.entries[*]",
-                "key": "id",
-                "parameterName": "User ID"
-              },
-              {
-                "endpoint": "User's Groups",
-                "jsonPath": "$.entries[*]",
-                "key": "id",
-                "parameterName": "User ID"
-              }
-            ]
-        },
-        {
-            "name": "Current User",
-            "paged": true,
-            "suffix": "/2.0/users/me?fields={Fields?}"
-        },
-        {
-            "name": "User",
-            "paged": false,
-            "suffix": "/2.0/users/{User ID}?fields={Fields?}"
-        },
-        {
-            "name": "File Watermark",
-            "paged": false,
-            "suffix": "/2.0/files/{File ID}/watermark"
-        },
-        {
-            "name": "Folder Watermark",
-            "paged": false,
-            "suffix": "/2.0/folders/{Folder ID}/watermark"
-        },
-        {
-            "name": "Web Link",
-            "paged": true,
-            "suffix": "/2.0/web_links/{Web Link ID}"
-        },
-        {
-            "name": "Webhooks",
-            "paged": true,
-            "suffix": "/2.0/webhooks?marker={Marker?}"
-        },
-        {
-            "name": "Webhook",
-            "paged": false,
-            "suffix": "/2.0/webhooks/{Webhook ID}"
+  "endpoints": [
+    {
+      "name": "Collaboration Whitelist",
+      "paged": true,
+      "suffix": "/2.0/collaboration_whitelist_entries?marker={Marker?}",
+      "description": "The external domains this enterprise permits collaboration with, and the direction each is allowed in. When entries exist, collaboration with any other domain is blocked -- so this is the explanation for invitations that silently fail, and the boundary of who can be shared with at all."
+    },
+    {
+      "name": "Collaboration Whitelist Entry",
+      "paged": false,
+      "suffix": "/2.0/collaboration_whitelist_entries/{Collaboration ID}",
+      "description": "One allowed domain entry by id."
+    },
+    {
+      "name": "Collaboration Whitelist Exempt Targets",
+      "paged": true,
+      "suffix": "/2.0/collaboration_whitelist_exempt_targets?marker={Marker?}",
+      "description": "The users exempted from the domain restrictions. Every row here is someone who can share outside the permitted domains, which makes this a short and important list for an access review."
+    },
+    {
+      "name": "Collaboration Whitelist Exempt Target",
+      "paged": false,
+      "suffix": "/2.0/collaboration_whitelist_exempt_targets/{Collaboration Exempt ID}",
+      "description": "One exempt user by id."
+    },
+    {
+      "name": "Collaboration",
+      "paged": false,
+      "suffix": "/2.0/collaborations/{Collaboration ID}?fields={Fields?}",
+      "description": "One collaboration by id: who was granted access to which file or folder, the ROLE they hold, the status, who invited them and when, and any expiry. Roles run editor, viewer, previewer, uploader, previewer uploader, viewer uploader, co-owner and owner -- the distinction that matters most is that anything from editor upward can change or remove content."
+    },
+    {
+      "name": "File Collaborations",
+      "paged": true,
+      "suffix": "/2.0/files/{File ID}/collaborations?fields={Fields?}&marker={Marker?}",
+      "description": "Everyone with explicit access to one file, with their role and status. Requires a file id. Note it lists collaborations granted ON THIS FILE; access inherited from a parent folder does not appear here, so an empty result does not mean the file is private."
+    },
+    {
+      "name": "Folder Collaborations",
+      "paged": true,
+      "suffix": "/2.0/folders/{Folder ID}/collaborations?fields={Fields?}",
+      "description": "Everyone with explicit access to one folder, with role and status. Requires a folder id. Because access is normally granted at folder level and inherited downward, this is where sharing actually lives -- and where an external collaborator on a whole tree shows up."
+    },
+    {
+      "name": "Pending Collaborations",
+      "paged": true,
+      "suffix": "/2.0/collaborations?status=pending&fields={Fields?}",
+      "description": "READ THE NAME LITERALLY: this returns ONLY collaborations awaiting the caller's acceptance, not the account's collaborations. Box has no endpoint that lists every collaboration -- they are reachable per file or per folder, so an access review has to walk the content tree. Treating this as the sharing table understates access to almost nothing."
+    },
+    {
+      "name": "Group Collaborations",
+      "paged": true,
+      "suffix": "/2.0/groups/{Group ID}/collaborations",
+      "description": "The folders and files one group has been granted access to, with the role on each. Requires a group id. The reverse view: what a team can reach, rather than who can reach one item."
+    },
+    {
+      "name": "Collections",
+      "paged": true,
+      "suffix": "/2.0/collections?fields={Fields?}",
+      "lookups": [
+        {
+          "endpoint": "Collection Items",
+          "jsonPath": "$.entries[*]",
+          "key": "id",
+          "parameterName": "Collection ID"
         }
-    ]
+      ],
+      "description": "The calling user's collections -- in practice the Favorites collection, which is the only type Box currently supports. Scoped to the caller."
+    },
+    {
+      "name": "Collection Items",
+      "paged": true,
+      "suffix": "/2.0/collections/{Collection ID}/items?fields={Fields?}",
+      "description": "The items in one collection. Requires a collection id. Same fields rule as folder items."
+    },
+    {
+      "name": "File Comments",
+      "paged": true,
+      "suffix": "/2.0/files/{File ID}/comments?fields={Fields?}",
+      "description": "The comments left on one file, with the message, the author and when it was posted. Requires a file id. Where discussion about a document lives; the file record carries no indication that any exists."
+    },
+    {
+      "name": "Comment",
+      "paged": false,
+      "suffix": "/2.0/comments/{Comment ID}?fields={Fields?}",
+      "description": "One comment by id, with its message and author."
+    },
+    {
+      "name": "Device Pin",
+      "paged": false,
+      "suffix": "/2.0/device_pinners/{Device Pinner ID}",
+      "description": "One device pin by id."
+    },
+    {
+      "name": "Enterprise Device Pins",
+      "paged": true,
+      "suffix": "/2.0/enterprises/{Enterprise ID}/device_pinners?marker={Marker?}",
+      "description": "The mobile devices authorised for the enterprise, with the user, device name and platform. Requires an enterprise id. A device inventory: it shows which endpoints hold synced content, which no user or file table reveals."
+    },
+    {
+      "name": "Download File",
+      "paged": false,
+      "suffix": "/2.0/files/{File ID}/content?version={Version?}",
+      "description": "The binary contents of one file. Requires a file id. NOT tabular data -- it returns the file itself, or a redirect to it, so it is useful for retrieving a document and useless for reporting on one."
+    },
+    {
+      "name": "User's Email Aliases",
+      "paged": true,
+      "suffix": "/2.0/users/{User ID}/email_aliases",
+      "description": "The additional email addresses registered to one user. Requires a user id. Relevant because collaborations and events can reference any of them, so matching activity to a person by primary email alone misses some of it."
+    },
+    {
+      "name": "User and Enterprise Events",
+      "paged": true,
+      "suffix": "/2.0/events?created_after={Created After?:yyyy-MM-dd’T’HH:mm:ssZ}&created_before={Created Before?:yyyy-MM-dd’T’HH:mm:ssZ}&event_type={Event Type?:ACCESS_GRANTED|ACCESS_REVOKED|ADD_DEVICE_ASSOCIATION}&stream_position={Stream Position?}&stream_type={Stream Type?:all|changes|sync|admin_logs}",
+      "description": "The event stream of the account -- who did what to which item and when. TWO DIFFERENT STREAMS come from this one endpoint and the stream_type parameter chooses between them. The user stream returns the calling user's own recent activity. The ADMIN LOGS stream returns enterprise-wide events -- logins, downloads, shares, deletions, permission changes -- and is the audit trail an access or compliance question needs; it requires admin credentials. Two limits worth stating: the enterprise stream is not real time and lags by a period Box does not guarantee, and history is bounded by the retention Box keeps for the account, so questions about long-past activity may find nothing rather than an empty answer."
+    },
+    {
+      "name": "File Version Legal Hold",
+      "paged": false,
+      "suffix": "/2.0/file_version_legal_holds/{File Version Legal ID}",
+      "description": "One file version legal hold record by id."
+    },
+    {
+      "name": "File Version Legal Holds",
+      "paged": true,
+      "suffix": "/2.0/file_version_legal_holds?marker={Marker?}&policy_id={Policy ID?}",
+      "description": "The individual file versions frozen by legal holds, one row each, with the hold that froze them. Filter by a legal hold policy assignment. This is the version-level record of what is actually under hold -- the assignment says what a hold reaches, this says which specific versions it caught, which matters because a hold placed on a user or folder pulls in versions nobody named."
+    },
+    {
+      "name": "Retention on File",
+      "paged": false,
+      "suffix": "/2.0/file_version_retentions/{File Version Retention ID}",
+      "description": "One file version retention record by id."
+    },
+    {
+      "name": "File Version Retentions",
+      "paged": true,
+      "suffix": "/2.0/file_version_retentions?disposition_action={Disposition Action?:permanently_delete|remove_retention}&disposition_after={Disposition After?:yyyy-MM-dd’T’HH:mm:ssZ}&disposition_before={Disposition Before?:yyyy-MM-dd’T’HH:mm:ssZ}&file_id={File ID?}&file_version_id={File Version ID?}&marker={Marker?}&policy_id={Policy ID?}",
+      "description": "The individual file versions currently held under retention, with the applicable policy and the disposition date. The record of what is actually retained, as opposed to what the policies say should be -- and the way to find what is due for disposition."
+    },
+    {
+      "name": "File Versions",
+      "paged": true,
+      "suffix": "/2.0/files/{File ID}/versions?fields={Fields?}",
+      "description": "The version history of one file, one row per prior version, with the version id, size, who created it, and when it was uploaded or restored. Requires a file id. NOTE that the CURRENT version is not among them -- this lists previous versions only, so a file never revised returns an empty list rather than one row. Storage questions want this: a heavily revised file consumes the sum of its versions, not the size shown on the file."
+    },
+    {
+      "name": "File Version",
+      "paged": false,
+      "suffix": "/2.0/files/{File ID}/versions/{File Version ID}?fields={Fields?}",
+      "description": "One prior version of a file by version id. Requires the file id as well."
+    },
+    {
+      "name": "File Information",
+      "paged": true,
+      "suffix": "/2.0/files/{File ID}?fields={Fields?}",
+      "description": "One file's metadata. Requires a file id. Can carry name, size in bytes, created_at and modified_at, created_by, modified_by and owned_by, the parent folder, path_collection giving its full ancestry, sha1, item_status, and any shared link. Subject to the same fields rule as everything else here -- ask for what is needed by name or most of that list does not arrive. path_collection is the only place a file's full path exists; the record otherwise names just its immediate parent."
+    },
+    {
+      "name": "Folder Information",
+      "paged": true,
+      "suffix": "/2.0/folders/{Folder ID}?fields={Fields?}",
+      "description": "One folder's metadata, with the same shape as a file plus item counts and, when requested, size roll-ups. Requires a folder id, where 0 is the root. Same fields rule."
+    },
+    {
+      "name": "Folder Items",
+      "paged": true,
+      "suffix": "/2.0/folders/{Folder ID}/items?fields={Fields?}",
+      "description": "The direct contents of one folder -- files, subfolders and web links -- one row each, told apart by the type column. Requires a folder id, and FOLDER ID 0 IS THE ROOT of the account. This is the workhorse of the whole connector, because BOX HAS NO ENDPOINT THAT LISTS ALL FILES: content is reached by walking this folder by folder from the root, or by Search for Content. Two things decide whether the rows are usable. THE fields PARAMETER IS ALMOST ALWAYS REQUIRED -- Box returns a minimal record by default, carrying little more than type, id, name and etag, so size, timestamps, owner and parent are ABSENT unless asked for by name, and their absence looks like empty data rather than an unmade request. And large folders must be paged with marker rather than offset: pass usemarker=true, since offset paging is capped and silently stops."
+    },
+    {
+      "name": "User's Groups",
+      "paged": true,
+      "suffix": "/2.0/users/{User ID}/memberships",
+      "lookups": [
+        {
+          "endpoint": "Group Members",
+          "jsonPath": "$.entries[*]",
+          "key": "id",
+          "parameterName": "Group ID"
+        },
+        {
+          "endpoint": "Group Collaborations",
+          "jsonPath": "$.entries[*]",
+          "key": "id",
+          "parameterName": "Group ID"
+        }
+      ],
+      "description": "The groups one user belongs to. Requires a user id. The per-person view of group-derived access, which no collaboration table gives."
+    },
+    {
+      "name": "Group Members",
+      "paged": true,
+      "suffix": "/2.0/groups/{Group ID}/memberships",
+      "description": "The members of one group, as membership records carrying the user and their role in the group. Requires a group id."
+    },
+    {
+      "name": "Group Membership",
+      "paged": false,
+      "suffix": "/2.0/group_memberships/{Group Membership ID}?fields={Fields?}",
+      "description": "One group membership by id, with the user, the group and the role."
+    },
+    {
+      "name": "Enterprise Groups",
+      "paged": true,
+      "suffix": "/2.0/groups?fields={Fields?}",
+      "lookups": [
+        {
+          "endpoint": "Group",
+          "jsonPath": "$.entries[*]",
+          "key": "id",
+          "parameterName": "Group ID"
+        },
+        {
+          "endpoint": "Group Members",
+          "jsonPath": "$.entries[*]",
+          "key": "id",
+          "parameterName": "Group ID"
+        },
+        {
+          "endpoint": "Group Collaborations",
+          "jsonPath": "$.entries[*]",
+          "key": "id",
+          "parameterName": "Group ID"
+        }
+      ],
+      "description": "The groups defined in the enterprise, with name, and the settings governing who may view members and invite them. Groups are how access is granted at scale, so this is the dimension that explains permissions no individual collaboration records."
+    },
+    {
+      "name": "Group",
+      "paged": false,
+      "suffix": "/2.0/groups/{Group ID}?fields={Fields?}",
+      "description": "One group by id, with its settings."
+    },
+    {
+      "name": "User Invite Status",
+      "paged": false,
+      "suffix": "/2.0/invites/{Invite ID}?fields={Fields?}",
+      "description": "The state of one invitation to join the enterprise. Requires an invite id. Pending onboarding, which the user list does not show."
+    },
+    {
+      "name": "Legal Hold Policies",
+      "paged": true,
+      "suffix": "/2.0/legal_hold_policies?fields={Fields?}&marker={Marker?}&policy_name={Policy Name?}",
+      "description": "The legal holds in force, each with its name, description, and the period it covers. A legal hold freezes content against deletion regardless of retention policy, so anything under hold is exempt from the normal lifecycle -- which is why deletion counts and storage figures can behave unexpectedly during litigation."
+    },
+    {
+      "name": "Legal Hold Policy",
+      "paged": false,
+      "suffix": "/2.0/legal_hold_policies/{Legal Hold Policy ID}",
+      "description": "One legal hold policy by id, with counts of its assignments."
+    },
+    {
+      "name": "Legal Hold Policy Assignments",
+      "paged": true,
+      "suffix": "/2.0/legal_hold_policy_assignments?policy_id={Policy ID}&assign_to_id={Assign To ID?}&assign_to_type={Assign To Type?:file|file_version|folder|user}&marker={Marker?}",
+      "lookups": [
+        {
+          "endpoint": "Legal Hold Policy Assignment",
+          "jsonPath": "$.entries[*]",
+          "key": "id",
+          "parameterName": "Legal Hold Policy Assignment ID"
+        }
+      ],
+      "description": "What one hold applies to -- users, folders or files. Requires a policy id. The scope of the freeze."
+    },
+    {
+      "name": "Legal Hold Policy Assignment",
+      "paged": false,
+      "suffix": "/2.0/legal_hold_policy_assignments/{Legal Hold Policy Assignment ID}",
+      "description": "One legal hold assignment by id."
+    },
+    {
+      "name": "Current File Versions",
+      "paged": true,
+      "suffix": "/2.0/legal_hold_policy_assignments/{Legal Hold Policy Assignment ID}/files_on_hold?fields={Fields?}&marker={Marker?}",
+      "description": "The files whose CURRENT version is held under one legal hold assignment. Requires an assignment id. What is frozen as it stands today."
+    },
+    {
+      "name": "Previous File Versions",
+      "paged": true,
+      "suffix": "/2.0/legal_hold_policy_assignments/{Legal Hold Policy Assignment ID}/file_versions_on_hold?fields={Fields?}&marker={Marker?}",
+      "description": "The PRIOR versions held under one legal hold assignment. Requires an assignment id. Held separately from current versions because a hold preserves the history as well as the present state, and the two lists rarely match."
+    },
+    {
+      "name": "Metadata Cascade Policies",
+      "paged": true,
+      "suffix": "/2.0/metadata_cascade_policies?folder_id={Folder_id}&marker={Marker?}&owner_enterprise_id={Owner Enterprise ID}",
+      "description": "The policies that push a folder's metadata down onto everything inside it. Requires a folder id. Explains metadata appearing on files nobody set it on -- without this, inherited values look like they were applied individually."
+    },
+    {
+      "name": "Metadata Cascade Policy",
+      "paged": false,
+      "suffix": "/2.0/metadata_cascade_policies/{Metadata Cascade Policy ID}",
+      "description": "One cascade policy by id."
+    },
+    {
+      "name": "File Metadata Instances",
+      "paged": true,
+      "suffix": "/2.0/files/{File ID}/metadata",
+      "description": "All metadata attached to one file, one entry per template applied. Requires a file id. Box metadata is how organisations record business attributes files do not natively have -- contract value, department, retention class. The VALUES ARE KEYED BY TEMPLATE FIELD KEY, so they cannot be read without the template: Metadata Template by Name or by ID is the decoder."
+    },
+    {
+      "name": "File Metadata Instance",
+      "paged": false,
+      "suffix": "/2.0/files/{File ID}/metadata/{Scope:global|enterprise}/{Template Key}",
+      "description": "One metadata instance on a file, identified by its scope and template key. Requires the file id, scope (enterprise or global) and template key."
+    },
+    {
+      "name": "Folder Metadata Instances",
+      "paged": true,
+      "suffix": "/2.0/folders/{Folder ID}/metadata",
+      "description": "All metadata attached to one folder. Requires a folder id. Same keying, same need for the template."
+    },
+    {
+      "name": "Folder Metadata Instance",
+      "paged": false,
+      "suffix": "/2.0/folders/{Folder ID}/metadata/{Scope:global|enterprise}/{Template Key}",
+      "description": "One metadata instance on a folder, by scope and template key."
+    },
+    {
+      "name": "Metadata Template by Instance ID",
+      "paged": false,
+      "suffix": "/2.0/metadata_templates?metadata_instance_id={Metadata Instance ID}",
+      "description": "The template behind a given metadata instance id. The reverse lookup, for when an instance is in hand and its shape is not."
+    },
+    {
+      "name": "Metadata Template by Name",
+      "paged": false,
+      "suffix": "/2.0/metadata_templates/{Scope}/{Template Key}/schema",
+      "description": "One metadata template by its scope and template key, with every field it defines: the field key, its display name, its type, and for enum fields the allowed options. THE DECODER for metadata instances -- an instance returns values under field keys and nothing else identifies them."
+    },
+    {
+      "name": "Metadata Template by ID",
+      "paged": false,
+      "suffix": "/2.0/metadata_templates/{Template ID}",
+      "description": "The same template found by its id rather than by name."
+    },
+    {
+      "name": "Global Templates",
+      "paged": true,
+      "suffix": "/2.0/metadata_templates/global",
+      "description": "The metadata templates Box provides to every account, chiefly the properties template used for arbitrary key-value pairs. Reference data, identical everywhere."
+    },
+    {
+      "name": "Enterprise Templates",
+      "paged": true,
+      "suffix": "/2.0/metadata_templates/enterprise?marker={Marker?}",
+      "description": "Every metadata template defined by this enterprise, with their fields. The account's own vocabulary for describing content, and the natural starting point before reading any metadata."
+    },
+    {
+      "name": "Recently Accessed Items",
+      "paged": true,
+      "suffix": "/2.0/recent_items?fields={Fields?}&marker={Marker?}",
+      "description": "The items the calling user has recently opened, with the interaction type and time. Scoped to the caller, so it describes one person's activity rather than the account's."
+    },
+    {
+      "name": "Retention Policies",
+      "paged": true,
+      "suffix": "/2.0/retention_policies?created_by_user_id={Created By User ID?}&policy_name={Policy Name?}&policy_type={Policy Type?:finite|indefinite}",
+      "description": "The retention policies defined in the enterprise, with the name, the retention length, the disposition action, and whether the policy is finite or indefinite. Retention decides how long content survives deletion, so this is what explains why some files cannot be removed and others vanish on schedule."
+    },
+    {
+      "name": "Retention Policy",
+      "paged": false,
+      "suffix": "/2.0/retention_policies/{Retention Policy ID}",
+      "description": "One retention policy by id."
+    },
+    {
+      "name": "Retention Policy Assignments",
+      "paged": true,
+      "suffix": "/2.0/retention_policies/{Retention Policy ID}/assignments?marker={Marker?}&type={Type?:folder|enterprise}",
+      "description": "What one policy applies to -- an enterprise, a folder, or a metadata template. Requires a policy id. The policy says the rule; this says its reach, and a policy assigned to nothing has no effect at all."
+    },
+    {
+      "name": "Retention Policy Assignment",
+      "paged": false,
+      "suffix": "/2.0/retention_policy_assignments/{Retention Policy Assignment ID}",
+      "description": "One retention policy assignment by id."
+    },
+    {
+      "name": "Search for Content",
+      "paged": true,
+      "suffix": "/2.0/search?query={Query}&ancestor_folder_ids={Ancestor Folder IDs?}&content_types={Content Types?name|description|file_content|comments|tag}&created_at_range={Created At Range?}&fields={Fields?}&file_extensions={File Extensions?}",
+      "description": "Searches the account's content by keyword, with filters for file extension, size range, date range, owner, ancestor folder and content type. The alternative to walking the folder tree, and usually the faster route to a set of files. Note that search indexes content and metadata, is eventually consistent so very recent uploads may be missing, and returns trashed items only when explicitly asked for."
+    },
+    {
+      "name": "Find Item for Shared Link",
+      "paged": true,
+      "suffix": "/2.0/shared_items?fields={Fields?}",
+      "description": "Resolves a shared link URL back to the item it points at. Requires the link in a header rather than the path. Use it to identify what a circulating link actually exposes."
+    },
+    {
+      "name": "Storage Policies",
+      "paged": true,
+      "suffix": "/2.0/storage_policies?fields={Fields?}&marker={Marker?}",
+      "description": "The storage policies available to the enterprise, which determine the geographic region content is stored in. Data-residency configuration -- relevant to compliance questions about where content physically lives."
+    },
+    {
+      "name": "Storage Policy",
+      "paged": false,
+      "suffix": "/2.0/storage_policies/{Storage Policy ID}",
+      "description": "One storage policy by id."
+    },
+    {
+      "name": "Storage Policy Assignments",
+      "paged": true,
+      "suffix": "/2.0/storage_policy_assignments?resolved_for_id={Resolved For ID}&resolved_for_type={Resolved For Type:user|enterprise}&marker={Marker?}",
+      "description": "Which users or enterprises each storage policy is assigned to. The reach of a residency rule."
+    },
+    {
+      "name": "Storage Policy Assignment",
+      "paged": false,
+      "suffix": "/2.0/storage_policy_assignments/{Storage Policy Assignment ID}",
+      "description": "One storage policy assignment by id."
+    },
+    {
+      "name": "Task Assignments",
+      "paged": true,
+      "suffix": "/2.0/tasks/{Task ID}/assignments",
+      "description": "Who a task was assigned to, with each assignee's resolution state and when they responded. Requires a task id. The task says what was asked; this says who answered and how."
+    },
+    {
+      "name": "Task Assignment",
+      "paged": false,
+      "suffix": "/2.0/task_assignments/{Task Assignment ID}",
+      "description": "One task assignment by id."
+    },
+    {
+      "name": "Tasks on File",
+      "paged": true,
+      "suffix": "/2.0/files/{File ID}/tasks",
+      "description": "The review or approval tasks attached to one file, with the action required, the message, the due date, and the completion rule. Requires a file id. Box tasks are how a document is routed for approval, so this plus its assignments is the audit of who was asked to sign off."
+    },
+    {
+      "name": "Task",
+      "paged": false,
+      "suffix": "/2.0/tasks/{Task ID}",
+      "description": "One task by id, with its assignments and completion state."
+    },
+    {
+      "name": "Terms of Services",
+      "paged": true,
+      "suffix": "/2.0/terms_of_services?tos_type={Terms of Service Type?:external|managed}",
+      "description": "The terms of service configured for the enterprise, with their text, whether each is enabled, and whether it applies to managed users or to external collaborators. Configuration."
+    },
+    {
+      "name": "Terms of Service",
+      "paged": false,
+      "suffix": "/2.0/terms_of_services/{Terms Of Service ID}",
+      "description": "One terms of service by id."
+    },
+    {
+      "name": "Terms of Service User Statuses",
+      "paged": true,
+      "suffix": "/2.0/terms_of_service_user_statuses?tos_id={Terms of Service ID}&user_id={User ID?}",
+      "description": "Who has accepted a given terms of service and when. Requires a terms of service id. The acceptance record, and therefore the compliance evidence -- the policy alone proves nothing about uptake."
+    },
+    {
+      "name": "Trashed File",
+      "paged": false,
+      "suffix": "/2.0/files/{File ID}/trash?fields={Fields?}",
+      "description": "One trashed file's metadata by file id. Confirms an item is in the trash and reports when it was deleted; a file not in the trash is not found here."
+    },
+    {
+      "name": "Trashed Folder",
+      "paged": false,
+      "suffix": "/2.0/folders/{Folder ID}/trash?fields={Fields?}",
+      "description": "One trashed folder's metadata by folder id."
+    },
+    {
+      "name": "Trashed Items",
+      "paged": true,
+      "suffix": "/2.0/folders/trash/items?fields={Fields?}&marker={Marker?}&usemarker={Use Marker?false|true}",
+      "description": "Everything currently in the account's trash -- files, folders and web links -- with when each was moved there. Deleted content is EXCLUDED from Folder Items and from search, so a count taken there does not include it; this is where it went. Items leave trash permanently after the retention period, so this is a window, not a history."
+    },
+    {
+      "name": "Trashed Web Link",
+      "paged": false,
+      "suffix": "/2.0/web_links/{Web Link ID}/trash?fields={Fields?}",
+      "description": "One trashed web link by id."
+    },
+    {
+      "name": "Upload Session",
+      "paged": false,
+      "suffix": "/2.0/files/upload_sessions/{Upload Session ID}",
+      "description": "The state of one chunked upload in progress, with the total parts expected and how many have arrived. Requires a session id. Operational, and short-lived -- it describes an upload happening now, not any file that exists."
+    },
+    {
+      "name": "Upload Session Parts",
+      "paged": true,
+      "suffix": "/2.0/files/upload_sessions/{Upload Session ID}/parts",
+      "description": "The parts already uploaded in one chunked session, with their offsets and sizes. Requires a session id. Same short-lived scope."
+    },
+    {
+      "name": "Enterprise Users",
+      "paged": true,
+      "suffix": "/2.0/users?fields={Fields?}&filter_term={Filter Term?}&marker={Marker?}&usemarker={Usemarker?:false|true}&user_type={User Type?:all|managed|external}",
+      "lookups": [
+        {
+          "endpoint": "User's Email Aliases",
+          "jsonPath": "$.entries[*]",
+          "key": "id",
+          "parameterName": "User ID"
+        },
+        {
+          "endpoint": "User's Groups",
+          "jsonPath": "$.entries[*]",
+          "key": "id",
+          "parameterName": "User ID"
+        }
+      ],
+      "description": "The user accounts in the enterprise, one row each. Carries name, login, status (active, inactive, cannot delete or edit, and so on), role, created_at, and -- when requested by name -- SPACE_AMOUNT and SPACE_USED in bytes. Those two are the storage-per-user answer and are among the fields Box omits unless the fields parameter asks for them. Note that inactive users still own their content, so excluding them from a storage total loses that content rather than tidying the figure."
+    },
+    {
+      "name": "Current User",
+      "paged": true,
+      "suffix": "/2.0/users/me?fields={Fields?}",
+      "description": "The account the credentials belong to. One record, always the caller -- and worth reading first, because most listings here are scoped to what this user can see, and an admin token and a user token return very different pictures of the same account."
+    },
+    {
+      "name": "User",
+      "paged": false,
+      "suffix": "/2.0/users/{User ID}?fields={Fields?}",
+      "description": "One user by id. Same fields and the same fields-parameter rule."
+    },
+    {
+      "name": "File Watermark",
+      "paged": false,
+      "suffix": "/2.0/files/{File ID}/watermark",
+      "description": "Whether a watermark is applied to one file, and when it was set. Requires a file id. A protection setting; its presence usually indicates content the business treats as sensitive."
+    },
+    {
+      "name": "Folder Watermark",
+      "paged": false,
+      "suffix": "/2.0/folders/{Folder ID}/watermark",
+      "description": "Whether a watermark is applied to one folder, cascading to its contents. Requires a folder id."
+    },
+    {
+      "name": "Web Link",
+      "paged": true,
+      "suffix": "/2.0/web_links/{Web Link ID}",
+      "description": "One web link by id -- a bookmark stored in the folder tree alongside files, with its url, name and parent folder. Web links appear as rows in Folder Items and are neither files nor folders, so a naive file count that does not filter on type includes them."
+    },
+    {
+      "name": "Webhooks",
+      "paged": true,
+      "suffix": "/2.0/webhooks?marker={Marker?}",
+      "description": "The webhooks configured on the account: the item each watches, the events it fires on, and its target URL. Integration configuration; deliveries are not recorded here. Worth checking to see whether an external system already receives this content in real time."
+    },
+    {
+      "name": "Webhook",
+      "paged": false,
+      "suffix": "/2.0/webhooks/{Webhook ID}",
+      "description": "One webhook by id."
+    }
+  ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/square/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/square/endpoints.json
@@ -11,12 +11,14 @@
           "key": "location_id",
           "parameterName": "Location ID"
         }
-      ]
+      ],
+      "description": "Card, cash and external payments taken, one row each -- the central table of a Square account. Carries the amount, tip, total and app fee, the processing fee, the status, source_type, location_id, order_id, customer_id, created_at and updated_at, the receipt number and url, and card details including brand and last four digits. THREE THINGS DECIDE WHETHER A TOTAL IS RIGHT. MONEY IS IN THE SMALLEST CURRENCY UNIT: an amount of 1000 with currency USD is ten dollars, not a thousand, and every money field in this connector works that way. STATUS matters: APPROVED is authorised but not captured, only COMPLETED is settled money, and CANCELED and FAILED are rows that never became revenue. And processing_fee is frequently ABSENT until Square settles, so net revenue computed the same day is not the net revenue computed a week later. Filter by location_id and a time range; both are required in practice on a multi-location account."
     },
     {
       "name": "Payment",
       "paged": false,
-      "suffix": "/v2/payments/{Payment ID}"
+      "suffix": "/v2/payments/{Payment ID}",
+      "description": "One payment by id, with the full detail including the itemised processing fees."
     },
     {
       "name": "Refunds",
@@ -35,17 +37,20 @@
           "key": "payment_id",
           "parameterName": "Payment ID"
         }
-      ]
+      ],
+      "description": "Refunds issued, with the amount, the payment refunded, the status, the location, the reason and created_at. Refunds are NOT negative payments and do not appear in the payments table, so net revenue is payments minus this table -- taking payments alone overstates it. Status matters here too: only COMPLETED refunds have actually moved money."
     },
     {
       "name": "Refund",
       "paged": false,
-      "suffix": "/v2/refunds/{Refund ID}"
+      "suffix": "/v2/refunds/{Refund ID}",
+      "description": "One refund by id."
     },
     {
       "name": "Catalog Info",
       "paged": false,
-      "suffix": "/v2/catalog/info"
+      "suffix": "/v2/catalog/info",
+      "description": "The limits of the catalogue API -- batch sizes and supported types. Reference data about the API itself, not about the catalogue."
     },
     {
       "name": "List Catalog",
@@ -64,22 +69,26 @@
           "key": "id",
           "parameterName": "Catalog Object ID"
         }
-      ]
+      ],
+      "description": "The catalogue -- but note its shape before using it. Square stores everything sellable as a CATALOG OBJECT with a type discriminator, so this ONE endpoint returns items, item variations, categories, taxes, discounts, modifiers, modifier lists and images, all in one list, and the types parameter is what narrows it. THE PRICE IS NOT ON THE ITEM: an ITEM holds the name and description while its ITEM_VARIATION children hold the price, sku and stock behaviour, so a catalogue with prices requires both types and a join between them."
     },
     {
       "name": "Catalog Object",
       "paged": false,
-      "suffix": "/v2/catalog/object/{Object ID}?include_related_objects={Include Related Objects?:true|false}"
+      "suffix": "/v2/catalog/object/{Object ID}?include_related_objects={Include Related Objects?:true|false}",
+      "description": "One catalogue object by id, optionally with the related objects it depends on. Requires the object id. Use the related-objects option to pull an item's variations and category in a single call rather than resolving them separately."
     },
     {
       "name": "Inventory Adjustment",
       "paged": false,
-      "suffix": "/v2/inventory/adjustment/{Adjustment ID}"
+      "suffix": "/v2/inventory/adjustment/{Adjustment ID}",
+      "description": "One inventory adjustment by id, with the from and to states, quantity, and the employee and reference behind it. The from-and-to states are what give an adjustment its meaning: IN_STOCK to SOLD is a sale, IN_STOCK to WASTE is a loss."
     },
     {
       "name": "Inventory Physical Count",
       "paged": false,
-      "suffix": "/v2/inventory/physical-count/{Physical Count ID}"
+      "suffix": "/v2/inventory/physical-count/{Physical Count ID}",
+      "description": "One physical stock count by id, with the counted quantity, location, employee and time. A recount overrides the running total rather than adjusting it, which is why a count can make stock jump with no corresponding sale."
     },
     {
       "name": "Inventory Count",
@@ -92,22 +101,26 @@
           "key": "location_id",
           "parameterName": "Location ID"
         }
-      ]
+      ],
+      "description": "The current stock of one catalogue object, per location, with the state and the calculated_at timestamp. Requires a catalogue object id. STOCK IS TRACKED PER VARIATION AND PER LOCATION, so a single item across several locations is several rows, and a total needs them summed. The state separates IN_STOCK from SOLD, WASTE, RETURNED_BY_CUSTOMER and the rest -- only IN_STOCK is sellable inventory."
     },
     {
       "name": "Inventory Changes",
       "paged": true,
-      "suffix": "/v2/inventory/{Catalog Object ID}/changes?location_ids={Location IDs?}"
+      "suffix": "/v2/inventory/{Catalog Object ID}/changes?location_ids={Location IDs?}",
+      "description": "Every movement of one catalogue object's stock: adjustments, physical counts and transfers, each with its type, quantity, location and timestamp. Requires a catalogue object id. The current count is a running total; this is how it got there, and the only way to distinguish sales from shrinkage, transfers or recounts."
     },
     {
       "name": "Customers",
       "paged": true,
-      "suffix": "/v2/customers"
+      "suffix": "/v2/customers",
+      "description": "The customer records held by the merchant, with name, email, phone, address, company, birthday, the reference id linking to an external system, creation and update times, and the creation source. Carries no purchase history: the link to spending is customer_id on Payments, and a customer created at the point of sale may have no name at all, so a customer count is not a count of identified people."
     },
     {
       "name": "Customer",
       "paged": false,
-      "suffix": "/v2/customers/{Customer ID}"
+      "suffix": "/v2/customers/{Customer ID}",
+      "description": "One customer by id."
     },
     {
       "name": "Merchants",
@@ -120,12 +133,14 @@
           "key": "main_location_id",
           "parameterName": "Location ID"
         }
-      ]
+      ],
+      "description": "The merchant accounts the credentials can reach, with the business name, country, language and currency. A merchant owns locations, so this sits one level above them; most accounts have exactly one."
     },
     {
       "name": "Merchant",
       "paged": false,
-      "suffix": "/v2/merchants/{Merchant ID}"
+      "suffix": "/v2/merchants/{Merchant ID}",
+      "description": "One merchant by id."
     },
     {
       "name": "Locations",
@@ -138,67 +153,80 @@
           "key": "merchant_id",
           "parameterName": "Merchant ID"
         }
-      ]
+      ],
+      "description": "The merchant's locations, with name, address, timezone, currency, business hours, status and capabilities. NEARLY EVERYTHING ELSE IN THIS CONNECTOR IS SCOPED BY LOCATION -- payments, inventory, cash drawers and labour all take a location_id, and several require it -- so this is the first request on any multi-location account and the dimension all comparisons group by. The currency is per location, which matters for any total spanning countries."
     },
     {
       "name": "Location",
       "paged": false,
-      "suffix": "/v2/locations/{Location ID}"
+      "suffix": "/v2/locations/{Location ID}",
+      "description": "One location by id, with its full settings."
     },
     {
       "name": "Team Member",
       "paged": false,
-      "suffix": "/v2/team-members/{Team Member ID}"
+      "suffix": "/v2/team-members/{Team Member ID}",
+      "description": "One team member by id, with name, email, phone, status and the locations they are assigned to. NOTE THE GAP: Square exposes no way to LIST team members through a plain read -- its search is a POST endpoint this connector cannot reach -- so members can only be fetched one at a time by an id obtained elsewhere, such as from a shift or a payment."
     },
     {
       "name": "Team Member Wage Setting",
       "paged": false,
-      "suffix": "/v2/team-members/{Team Member ID}/wage-setting"
+      "suffix": "/v2/team-members/{Team Member ID}/wage-setting",
+      "description": "One team member's wage configuration, with the job assignments and the hourly rate for each. Requires a team member id. The rate is what turns recorded hours into labour cost; the shift records carry hours only."
     },
     {
       "name": "Break Types",
       "paged": true,
-      "suffix": "/v2/labor/break-types?location_id={Location ID?}"
+      "suffix": "/v2/labor/break-types?location_id={Location ID?}",
+      "description": "The break types configured per location, each with a name, expected duration and whether it is paid. Requires a location id. The paid flag is what decides whether a break is deducted from paid hours, so labour cost cannot be computed correctly without it."
     },
     {
       "name": "Break Type",
       "paged": false,
-      "suffix": "/v2/labor/break-types/{Break Type ID}"
+      "suffix": "/v2/labor/break-types/{Break Type ID}",
+      "description": "One break type by id."
     },
     {
       "name": "Team Member Wages",
       "paged": true,
-      "suffix": "/v2/labor/team-member-wages?team_member_id={Team Member ID?}"
+      "suffix": "/v2/labor/team-member-wages?team_member_id={Team Member ID?}",
+      "description": "The wage records across team members, each pairing a member with a job title and hourly rate. The account-wide view of pay rates, and the practical lookup table for costing labour."
     },
     {
       "name": "Team Member Wage",
       "paged": false,
-      "suffix": "/v2/labor/team-member-wages/{Team Member Wage ID}"
+      "suffix": "/v2/labor/team-member-wages/{Team Member Wage ID}",
+      "description": "One team member wage record by id."
     },
     {
       "name": "Shift",
       "paged": false,
-      "suffix": "/v2/labor/shifts/{Shift ID}"
+      "suffix": "/v2/labor/shifts/{Shift ID}",
+      "description": "One recorded work shift by id, with the team member, location, start and end times, the declared cash tips, the wage applied, and any breaks taken. THE SAME GAP AS TEAM MEMBERS: shift search is a POST endpoint, so shifts cannot be listed here and must be fetched individually by id. That makes labour-cost analysis impractical through this connector unless the ids are already known."
     },
     {
       "name": "Workweek Configurations",
       "paged": true,
-      "suffix": "/v2/labor/workweek-configs"
+      "suffix": "/v2/labor/workweek-configs",
+      "description": "How the workweek is defined -- which day it starts and the cut-off time. One record per merchant. Overtime and weekly hour totals are computed against this boundary, so a week measured from any other start date will not agree with Square's own figures."
     },
     {
       "name": "Cash Drawer Shifts",
       "paged": true,
-      "suffix": "/v2/cash-drawers/shifts?location_id={Location ID}&begin_time={Begin Time:yyyy-MM-ddTHH:mm:ssZ}&end_time={End Time:yyyy-MM-ddTHH:mm:ssZ}"
+      "suffix": "/v2/cash-drawers/shifts?location_id={Location ID}&begin_time={Begin Time:yyyy-MM-ddTHH:mm:ssZ}&end_time={End Time:yyyy-MM-ddTHH:mm:ssZ}",
+      "description": "Cash drawer sessions at one location over a time range, each with the opening and closing amounts, expected versus actual cash, and the DIFFERENCE. Requires a location id and a date range. That difference is the till discrepancy -- over or short at close -- which no payment table records and which is the point of this group."
     },
     {
       "name": "Cash Drawer Shift",
       "paged": false,
-      "suffix": "/v2/cash-drawers/shifts/{Shift ID}?location_id={Location ID}"
+      "suffix": "/v2/cash-drawers/shifts/{Shift ID}?location_id={Location ID}",
+      "description": "One cash drawer session by id, with its opening, closing and expected amounts."
     },
     {
       "name": "Cash Drawer Shift Events",
       "paged": true,
-      "suffix": "/v2/cash-drawers/shifts/{Shift ID}?/events?location_id={Location ID}"
+      "suffix": "/v2/cash-drawers/shifts/{Shift ID}/events?location_id={Location ID}",
+      "description": "The individual cash movements within one session -- each payment, refund, paid-in and paid-out -- with amount, type and time. Requires the shift id and location id. Where a discrepancy is traced to a specific event rather than merely observed at close."
     },
     {
       "name": "Bank Accounts",
@@ -211,12 +239,14 @@
           "key": "location_id",
           "parameterName": "Location ID"
         }
-      ]
+      ],
+      "description": "The bank accounts linked for settlement, with the last four digits, bank name, holder name, currency, status and the location each belongs to. Where the money ends up; settlement amounts themselves are not in this connector."
     },
     {
       "name": "Bank Account",
       "paged": false,
-      "suffix": "/v2/bank-accounts/{Bank Account ID}"
+      "suffix": "/v2/bank-accounts/{Bank Account ID}",
+      "description": "One linked bank account by id."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/twilio/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/twilio/endpoints.json
@@ -1,9 +1,70 @@
 {
   "endpoints": [
     {
+      "name": "Calls",
+      "paged": true,
+      "suffix": "/2010-04-01/Accounts/{Account ID}/Calls.json?To={To?}&From={From?}&Status={Status?:queued|ringing|in-progress|completed|busy|failed|no-answer}&StartTime={Start Date?:YYYY-MM-DD}&ParentCallSid={Parent Call ID?}",
+      "description": "Voice calls made and received, one row each -- the central table of a Twilio voice account. Carries the To and From numbers, direction (inbound, outbound-api, outbound-dial), status, start_time, end_time and duration in SECONDS, the price and price_unit, the answered_by result where answering-machine detection ran, and the parent call for child legs. TWO THINGS TO READ CAREFULLY. PRICE IS NEGATIVE and populated only once Twilio has rated the call, so it is null on a call still in progress and cost analysis run too soon simply finds nothing. And a single conversation is often SEVERAL ROWS: a call that is forwarded or conferenced creates child legs linked by parent_call_sid, so counting rows counts legs rather than conversations. Filter with To, From, Status or StartTime; Twilio also supports inequality forms of the date filters for ranges, which this endpoint does not expose."
+    },
+    {
+      "name": "Call",
+      "paged": false,
+      "suffix": "/2010-04-01/Accounts/{Account ID}/Calls/{Call ID}.json",
+      "description": "One call by its SID, with the same fields plus the full timing detail. Use it when the call is already identified rather than to scan."
+    },
+    {
+      "name": "Messages",
+      "paged": true,
+      "suffix": "/2010-04-01/Accounts/{Account ID}/Messages.json?To={To?}&From={From?}&DateSent={Date Sent?:YYYY-MM-DD}",
+      "description": "SMS, MMS and messaging-channel messages, one row each. Carries the To and From numbers, body, direction, status, date_sent, date_created and date_updated, num_segments, num_media, price, and error_code and error_message where delivery failed. THE STATUS COLUMN IS THE WHOLE STORY: queued, sending and sent mean Twilio accepted and forwarded the message, while only DELIVERED confirms the carrier accepted it, and failed and undelivered are the ones with an error_code worth grouping by. Counting sent messages as delivered overstates reach, often noticeably. NUM_SEGMENTS is what billing counts, not messages -- a long body is several segments and costs accordingly, so message count and cost do not move together."
+    },
+    {
+      "name": "Message",
+      "paged": false,
+      "suffix": "/2010-04-01/Accounts/{Account ID}/Messages/{Message ID}.json",
+      "description": "One message by its SID, with its body and full delivery detail."
+    },
+    {
+      "name": "Recordings",
+      "paged": true,
+      "suffix": "/2010-04-01/Accounts/{Account ID}/Recordings.json?CallSid={Call ID?}&ConferenceSid={Conference ID?}&DateCreated={Date Created?:YYYY-MM-DD}",
+      "description": "Every recording on the account, from calls and conferences alike, with duration in seconds, channels, source, the call it belongs to, price, and status. Filter by CallSid, ConferenceSid or creation date. Note recordings incur storage cost per month as well as a creation price, so the row count here is an ongoing charge rather than a one-off one -- and the media itself is a separate fetch, not part of this record."
+    },
+    {
+      "name": "Recording",
+      "paged": false,
+      "suffix": "/2010-04-01/Accounts/{Account ID}/Recordings/{Recording ID}.json",
+      "description": "One recording by its SID, with its metadata. The audio is retrieved separately."
+    },
+    {
+      "name": "Call Recordings",
+      "paged": true,
+      "suffix": "/2010-04-01/Accounts/{Account ID}/Calls/{Call ID}/Recordings.json?DateCreated={Date Created?:YYYY-MM-DD}",
+      "description": "The recordings made during one call, with duration, channels, source and price. Requires a call SID. A call can be recorded more than once, so this is a list rather than a single row."
+    },
+    {
+      "name": "Conferences",
+      "paged": true,
+      "suffix": "/2010-04-01/Accounts/{Account ID}/Conferences.json?FriendlyName={Conference Name?}&Status={Status?:init|in-progress|completed}&DateCreated={Date Created?:YYYY-MM-DD}",
+      "description": "Conference calls, with the friendly name, status, region, and the dates created and updated. Requires filtering by name, status or date on a busy account. A conference is the container; who was on it and for how long is in the individual call legs that joined it, which is why conference duration cannot be read here."
+    },
+    {
+      "name": "Conference",
+      "paged": false,
+      "suffix": "/2010-04-01/Accounts/{Account ID}/Conferences/{Conference ID}.json",
+      "description": "One conference by its SID."
+    },
+    {
+      "name": "Conference Recordings",
+      "paged": true,
+      "suffix": "/2010-04-01/Accounts/{Account ID}/Conferences/{Conference ID}/Recordings.json?DateCreated={Date Created?:YYYY-MM-DD}",
+      "description": "The recordings made of one conference. Requires a conference SID."
+    },
+    {
       "name": "Account",
       "paged": false,
-      "suffix": "/2010-04-01/Accounts/{Account ID}.json"
+      "suffix": "/2010-04-01/Accounts/{Account ID}.json",
+      "description": "One account or subaccount by its SID."
     },
     {
       "name": "Accounts",
@@ -11,77 +72,97 @@
       "suffix": "/2010-04-01/Accounts.json?FriendlyName={Account Name?}&Status={Status?:closed|suspended|active}",
       "lookups": [
         {
-          "endpoints": ["Addresses", "Applications", "Keys", "Usage Records", "Usage Triggers"],
+          "endpoints": [
+            "Addresses",
+            "Applications",
+            "Keys",
+            "Usage Records",
+            "Usage Triggers"
+          ],
           "jsonPath": "$.accounts.[*]",
           "key": "sid",
           "parameterName": "Account ID"
         }
-      ]
+      ],
+      "description": "The account and its subaccounts, with the friendly name, status (active, suspended or closed), type, and the auth token. SUBACCOUNTS ARE HOW MOST PLATFORMS SEPARATE THEIR CUSTOMERS, and every other endpoint here takes an Account ID -- so on a multi-tenant account this list is the first request, and a figure taken against the parent account alone excludes all of the subaccount activity."
     },
     {
       "name": "Address",
       "paged": false,
-      "suffix": "/2010-04-01/Accounts/{Account ID}/Addresses/{Address ID}.json"
+      "suffix": "/2010-04-01/Accounts/{Account ID}/Addresses/{Address ID}.json",
+      "description": "One address by its SID."
     },
     {
       "name": "Addresses",
       "paged": true,
-      "suffix": "/2010-04-01/Accounts/{Account ID}/Addresses.json?CustomerName={Customer Name?}&FriendlyName={Address Name?}&IsoCountry={ISO Country Code?}"
+      "suffix": "/2010-04-01/Accounts/{Account ID}/Addresses.json?CustomerName={Customer Name?}&FriendlyName={Address Name?}&IsoCountry={ISO Country Code?}",
+      "description": "The registered street addresses held for regulatory compliance, with the customer name, the address, the ISO country, and whether it has been validated. Many countries require a verified local address before a phone number can be bought or kept, so this is the table that explains why a number cannot be provisioned in a given country."
     },
     {
       "name": "Application",
       "paged": false,
-      "suffix": "/2010-04-01/Accounts/{Account ID}/Applications/{Application ID}.json"
+      "suffix": "/2010-04-01/Accounts/{Account ID}/Applications/{Application ID}.json",
+      "description": "One application by its SID."
     },
     {
       "name": "Applications",
       "paged": true,
-      "suffix": "/2010-04-01/Accounts/{Account ID}/Applications.json?FriendlyName={Application Name?}"
+      "suffix": "/2010-04-01/Accounts/{Account ID}/Applications.json?FriendlyName={Application Name?}",
+      "description": "The TwiML applications configured, each bundling the voice and messaging webhook URLs a phone number can point at. Configuration: it is where a number's behaviour is defined, so it explains what happens on an inbound call without any call record being involved."
     },
     {
       "name": "Key",
       "paged": false,
-      "suffix": "/2010-04-01/Accounts/{Account ID}/Keys/{Key ID}.json"
+      "suffix": "/2010-04-01/Accounts/{Account ID}/Keys/{Key ID}.json",
+      "description": "One API key by its SID."
     },
     {
       "name": "Keys",
       "paged": true,
-      "suffix": "/2010-04-01/Accounts/{Account ID}/Keys.json"
+      "suffix": "/2010-04-01/Accounts/{Account ID}/Keys.json",
+      "description": "The API keys issued for the account, with the friendly name and creation date. The secrets themselves are never returned. Security inventory -- and the way to find keys that were issued and forgotten."
     },
     {
       "name": "Usage Records",
       "paged": true,
-      "suffix": "/2010-04-01/Accounts/{Account ID}/Usage/Records.json?Category={Category?:calls|sms|...}&StartDate={Start Date?:YYYY-MM-DD}&EndDate={End Date?:YYYY-MM-DD}&IncludeSubaccounts={Include Subaccounts?:true|false}"
+      "suffix": "/2010-04-01/Accounts/{Account ID}/Usage/Records.json?Category={Category?:calls|sms|...}&StartDate={Start Date?:YYYY-MM-DD}&EndDate={End Date?:YYYY-MM-DD}&IncludeSubaccounts={Include Subaccounts?:true|false}",
+      "description": "Billed usage by category over a date range -- calls, sms, mms, recordings, phone numbers, and dozens more -- each with the count, the usage quantity, the price and the unit. THE COST TABLE: it answers what was spent and on what, without summing the price column across the calls and messages tables, and it covers categories those tables do not represent at all, such as phone number rental and storage. Set IncludeSubaccounts to reach a whole platform's spend rather than the parent account's own. Note the categories are Twilio's own and are finer than the product names, so a total for a product may span several."
     },
     {
       "name": "Usage Trigger",
       "paged": false,
-      "suffix": "/2010-04-01/Accounts/{Account ID}/Usage/Triggers/{Trigger ID}.json"
+      "suffix": "/2010-04-01/Accounts/{Account ID}/Usage/Triggers/{Trigger ID}.json",
+      "description": "One usage trigger by its SID."
     },
     {
       "name": "Usage Triggers",
       "paged": true,
-      "suffix": "/2010-04-01/Accounts/{Account ID}/Usage/Triggers.json?Recurring={Recurring?:daily|monthly|yearly}&TriggerBy={Trigger By?:count|usage|price}&UsageCategory={Usage Category?:calls|sms|...}"
+      "suffix": "/2010-04-01/Accounts/{Account ID}/Usage/Triggers.json?Recurring={Recurring?:daily|monthly|yearly}&TriggerBy={Trigger By?:count|usage|price}&UsageCategory={Usage Category?:calls|sms|...}",
+      "description": "The alerts configured to fire when usage crosses a threshold, with the category watched, the trigger value, how it recurs, and whether it triggers on count, usage or price. Configuration -- it records what is being watched, not any usage figure."
     },
     {
       "name": "Alert",
       "paged": false,
-      "suffix": "v1/Alerts/{Alert ID}"
+      "suffix": "/v1/Alerts/{Alert ID}",
+      "description": "One alert by its SID, with the full request and response bodies Twilio captured. The detail behind a failure, and the only place the actual payload is visible."
     },
     {
       "name": "Alerts",
       "paged": true,
-      "suffix": "/v1/Alerts?LogLevel={Log Level?:error|warning|notice|debug}&StartDate={Start Date?:YYYY-MM-DD|YYYY-MM-DDThh:mm:ssZ}&End Date={EndDate?:YYYY-MM-DD|YYYY-MM-DDThh:mm:ssZ}"
+      "suffix": "/v1/Alerts?LogLevel={Log Level?:error|warning|notice|debug}&StartDate={Start Date?:YYYY-MM-DD|YYYY-MM-DDThh:mm:ssZ}&EndDate={End Date?:YYYY-MM-DD|YYYY-MM-DDThh:mm:ssZ}",
+      "description": "Errors and warnings raised by the account -- failed webhooks, malformed responses, delivery problems -- with the log level, the error code, the resource involved and when it happened. Served by Twilio's monitor host rather than the main API. THIS IS WHERE FAILURES ARE EXPLAINED: a message with an error_code says something went wrong, and the matching alert here says what. Filter by LogLevel and a date range. Alerts are retained for a limited period, so older failures are simply gone rather than absent."
     },
     {
       "name": "Event",
       "paged": false,
-      "suffix": "/v1/Events/{Event ID}"
+      "suffix": "/v1/Events/{Event ID}",
+      "description": "One audit event by its SID, with the before and after state of what changed."
     },
     {
       "name": "Events",
       "paged": true,
-      "suffix": "/v1/Events?ActorSid={Actor ID?}&EventType={Event Type?}&ResourceSid={Resource ID?}&SourceIpAddress={Source IP Address?}&StartDate={Start Date?:YYYY-MM-DD|YYYY-MM-DDThh:mm:ssZ}&EndDate={End Date?:YYYY-MM-DD|YYYY-MM-DDThh:mm:ssZ}"
+      "suffix": "/v1/Events?ActorSid={Actor ID?}&EventType={Event Type?}&ResourceSid={Resource ID?}&SourceIpAddress={Source IP Address?}&StartDate={Start Date?:YYYY-MM-DD|YYYY-MM-DDThh:mm:ssZ}&EndDate={End Date?:YYYY-MM-DD|YYYY-MM-DDThh:mm:ssZ}",
+      "description": "The account's audit log -- configuration changes, resource creation and deletion, and who made them -- with the actor, event type, resource, source IP and timestamp. Also served by the monitor host. Distinct from Alerts, which records things going wrong; this records things being changed. Filter by actor, event type, resource or date range."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/twitter/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/twitter/endpoints.json
@@ -3,237 +3,284 @@
     {
       "name": "Tweets by IDs",
       "paged": false,
-      "suffix": "/2/tweets?ids={Tweet IDs}&expansions={Expansions?}&media.fields={Media Fields?}&place.fields={Place Fields?}&poll.fields={Poll Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/tweets?ids={Tweet IDs}&expansions={Expansions?}&media.fields={Media Fields?}&place.fields={Place Fields?}&poll.fields={Poll Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}",
+      "description": "Posts fetched by a list of ids, up to 100 per request. The efficient way to hydrate ids already in hand -- from an export, a stream, or a compliance job -- rather than searching for them again. Ids that have been deleted or made private come back in an errors section rather than as rows, so a short result is not a failure."
     },
     {
       "name": "Tweet by ID",
       "paged": false,
-      "suffix": "/2/tweets/{Tweet ID}?expansions={Expansions?}&media.fields={Media Fields?}&place.fields={Place Fields?}&poll.fields={Poll Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/tweets/{Tweet ID}?expansions={Expansions?}&media.fields={Media Fields?}&place.fields={Place Fields?}&poll.fields={Poll Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}",
+      "description": "One post by id. Same field rules: ask for what is needed in tweet.fields, or only id and text arrive."
     },
     {
       "name": "Tweets Liking Users",
       "paged": true,
-      "suffix": "/2/tweets/{Tweet ID}/liking_users?expansions={Expansions?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/tweets/{Tweet ID}/liking_users?expansions={Expansions?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}",
+      "description": "The accounts that liked one post. Requires a post id. Note the post's public_metrics already carries the like COUNT; this is who, and it is paginated and capped well below the totals a viral post reaches."
     },
     {
       "name": "Tweet Retweeted By",
       "paged": true,
-      "suffix": "/2/tweets/{Tweet ID}/retweeted_by?expansions={Expansions?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/tweets/{Tweet ID}/retweeted_by?expansions={Expansions?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}",
+      "description": "The accounts that reposted one post. Requires a post id. Same relationship to the retweet_count metric: the count is on the post, the identities are here, and the list is truncated for large numbers."
     },
     {
       "name": "Tweet Counts All",
       "paged": true,
-      "suffix": "/2/tweets/counts/all?query={Query}&start_time={Start Time?:YYYY-MM-DD}&end_time={End Time?:YYYY-MM-DD}&granularity={Granularity?:minute|hour|day}&since_id={Since ID?}&until_id={Until ID?}"
+      "suffix": "/2/tweets/counts/all?query={Query}&start_time={Start Time?:YYYY-MM-DD}&end_time={End Time?:YYYY-MM-DD}&granularity={Granularity?:minute|hour|day}&since_id={Since ID?}&until_id={Until ID?}",
+      "description": "The same volume counts over the full archive. Requires the higher access tiers, like full-archive search."
     },
     {
       "name": "Tweet Counts Recent",
       "paged": false,
-      "suffix": "/2/tweets/counts/recent?query={Query}&start_time={Start Time?:YYYY-MM-DD}&end_time={End Time?:YYYY-MM-DD}&since_id={Since ID?}&until_id={Until ID?}"
+      "suffix": "/2/tweets/counts/recent?query={Query}&start_time={Start Time?:YYYY-MM-DD}&end_time={End Time?:YYYY-MM-DD}&since_id={Since ID?}&until_id={Until ID?}",
+      "description": "How many posts match a query per day, hour or minute over the last seven days, WITHOUT returning the posts themselves. Far cheaper than searching and paging when only volume matters, and it does not consume the post-retrieval quota the search endpoints draw on -- which, given how tightly that quota is capped, often makes this the only practical way to measure volume at all."
     },
     {
       "name": "Search All Tweets",
       "paged": true,
-      "suffix": "/2/tweets/search/all?query={Query}&max_results=500&start_time={Start Time?:YYYY-MM-DD}&end_time={End Time?:YYYY-MM-DD}&since_id={Since ID?}&until_id={Until ID?}&expansions={Expansions?}&media.fields={Media Fields?}&place.fields={Place Fields?}&poll.fields={Poll Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}&sort_order={Sort Order?:recency|relevancy}"
+      "suffix": "/2/tweets/search/all?query={Query}&max_results=500&start_time={Start Time?:YYYY-MM-DD}&end_time={End Time?:YYYY-MM-DD}&since_id={Since ID?}&until_id={Until ID?}&expansions={Expansions?}&media.fields={Media Fields?}&place.fields={Place Fields?}&poll.fields={Poll Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}&sort_order={Sort Order?:recency|relevancy}",
+      "description": "The same search over the FULL ARCHIVE, back to the first post in 2006. Requires one of X's highest access tiers -- on lower tiers it returns an authorisation error rather than an empty result, which is a subscription fact and not an absence of matching posts. The same tweet.fields and expansions rules apply."
     },
     {
       "name": "Search Recent Tweets",
       "paged": true,
-      "suffix": "/2/tweets/search/recent?query={Query}&max_results=100&start_time={Start Time?:YYYY-MM-DD}&end_time={End Time?:YYYY-MM-DD}&since_id={Since ID?}&until_id={Until ID?}&expansions={Expansions?}&media.fields={Media Fields?}&place.fields={Place Fields?}&poll.fields={Poll Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}&sort_order={Sort Order?:recency|relevancy}"
+      "suffix": "/2/tweets/search/recent?query={Query}&max_results=100&start_time={Start Time?:YYYY-MM-DD}&end_time={End Time?:YYYY-MM-DD}&since_id={Since ID?}&until_id={Until ID?}&expansions={Expansions?}&media.fields={Media Fields?}&place.fields={Place Fields?}&poll.fields={Poll Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}&sort_order={Sort Order?:recency|relevancy}",
+      "description": "Searches posts from the LAST SEVEN DAYS matching a query built in X's search syntax -- keywords, from: and to:, hashtags, language, and operators for excluding retweets or requiring media. The workhorse for any listening or campaign-measurement question, bounded hard at seven days: anything older is not merely absent, it is unreachable through this endpoint at all. TWO THINGS APPLY TO EVERY POST ENDPOINT HERE. A post comes back with ONLY id and text by default -- created_at, author_id, public_metrics, lang and conversation_id are absent unless named in tweet.fields, and their absence looks like empty data rather than an unmade request. And expansions is what inlines the author, the referenced post or the attached media; without it those are ids pointing at nothing in the response."
     },
     {
       "name": "Connect to Stream",
       "paged": false,
-      "suffix": "/2/tweets/search/stream?backfill_minutes={Backfill Minutes?}&start_time={Start Time?:YYYY-MM-DD}&end_time={End Time?:YYYY-MM-DD}&expansions={Expansions?}&media.fields={Media Fields?}&place.fields={Place Fields?}&poll.fields={Poll Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/tweets/search/stream?backfill_minutes={Backfill Minutes?}&start_time={Start Time?:YYYY-MM-DD}&end_time={End Time?:YYYY-MM-DD}&expansions={Expansions?}&media.fields={Media Fields?}&place.fields={Place Fields?}&poll.fields={Poll Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}",
+      "description": "A PERSISTENT CONNECTION delivering posts in real time as they match the active rule set. NOT a request that returns a result set -- it opens and stays open, emitting posts indefinitely, so it does not behave like the other endpoints here and cannot be treated as a table. It is also the only way to capture posts as they happen; the search endpoints are the way to look backwards."
     },
     {
       "name": "Stream Rules",
       "paged": true,
-      "suffix": "/2/tweets/search/stream/rules?ids={Rule IDs?}"
+      "suffix": "/2/tweets/search/stream/rules?ids={Rule IDs?}",
+      "description": "The rules currently filtering the stream, each with its query and tag. The stream returns nothing until rules exist, so an apparently silent stream is usually an empty rule set rather than an absence of matching posts."
     },
     {
       "name": "Users Liked Tweets",
       "paged": true,
-      "suffix": "/2/users/{User ID}/liked_tweets?expansions={Expansions?}&media.fields={Media Fields?}&place.fields={Place Fields?}&poll.fields={Poll Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/users/{User ID}/liked_tweets?expansions={Expansions?}&media.fields={Media Fields?}&place.fields={Place Fields?}&poll.fields={Poll Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}",
+      "description": "The posts one account has liked. Requires a user id, and generally that account's own authorisation."
     },
     {
       "name": "User Mentions",
       "paged": true,
-      "suffix": "/2/users/{User ID}/mentions?max_results=100&start_time={Start Time?:YYYY-MM-DD}&end_time={End Time?:YYYY-MM-DD}&since_id={Since ID?}&until_id={Until ID?}&expansions={Expansions?}&media.fields={Media Fields?}&place.fields={Place Fields?}&poll.fields={Poll Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/users/{User ID}/mentions?max_results=100&start_time={Start Time?:YYYY-MM-DD}&end_time={End Time?:YYYY-MM-DD}&since_id={Since ID?}&until_id={Until ID?}&expansions={Expansions?}&media.fields={Media Fields?}&place.fields={Place Fields?}&poll.fields={Poll Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}",
+      "description": "Posts mentioning one account, most recent first. Requires a user id. The inbound half of an account's activity, and the usual basis for measuring how much a brand is talked to as opposed to talked about. Same 3,200-post ceiling."
     },
     {
       "name": "User Reverse Chronological Timeline",
       "paged": true,
-      "suffix": "/2/users/{User ID}/timelines/reverse_chronological?start_time={Start Time?:YYYY-MM-DD}&end_time={End Time?:YYYY-MM-DD}&since_id={Since ID?}&until_id={Until ID?}&expansions={Expansions?}&media.fields={Media Fields?}&place.fields={Place Fields?}&poll.fields={Poll Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/users/{User ID}/timelines/reverse_chronological?start_time={Start Time?:YYYY-MM-DD}&end_time={End Time?:YYYY-MM-DD}&since_id={Since ID?}&until_id={Until ID?}&expansions={Expansions?}&media.fields={Media Fields?}&place.fields={Place Fields?}&poll.fields={Poll Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}",
+      "description": "The home timeline of one account -- what that user sees from accounts they follow. Requires a user id and that user's own authorisation. It describes a feed, not the user's own posts, and cannot be read for anyone but the authenticated account."
     },
     {
       "name": "Tweets by User ID",
       "paged": true,
-      "suffix": "/2/users/{User ID}/tweets?max_results=100&start_time={Start Time?:YYYY-MM-DD}&end_time={End Time?:YYYY-MM-DD}&exclude={Exclude?:retweets|replies}&since_id={Since ID?}&until_id={Until ID?}&expansions={Expansions?}&media.fields={Media Fields?}&place.fields={Place Fields?}&poll.fields={Poll Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/users/{User ID}/tweets?max_results=100&start_time={Start Time?:YYYY-MM-DD}&end_time={End Time?:YYYY-MM-DD}&exclude={Exclude?:retweets|replies}&since_id={Since ID?}&until_id={Until ID?}&expansions={Expansions?}&media.fields={Media Fields?}&place.fields={Place Fields?}&poll.fields={Poll Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}",
+      "description": "The posts of one account, most recent first. Requires a user id. CAPPED AT ROUGHLY THE LAST 3,200 POSTS however far back the account goes, so a prolific account's earlier history is not reachable here -- full-archive search is. Includes retweets and replies unless excluded, which changes the count substantially for a conversational account."
     },
     {
       "name": "Reposts of Current User",
       "paged": true,
-      "suffix": "/2/users/reposts_of_me?max_results=100&expansions={Expansions?}&media.fields={Media Fields?}&place.fields={Place Fields?}&poll.fields={Poll Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/users/reposts_of_me?max_results=100&expansions={Expansions?}&media.fields={Media Fields?}&place.fields={Place Fields?}&poll.fields={Poll Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}",
+      "description": "Posts that repost the authenticated account's own content. Always the caller's, and only the caller's."
     },
     {
       "name": "User by ID",
       "paged": false,
-      "suffix": "/2/users/{User ID}?expansions={Expansions?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/users/{User ID}?expansions={Expansions?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}",
+      "description": "One account by id, subject to the same user.fields rule."
     },
     {
       "name": "Users by IDs",
       "paged": false,
-      "suffix": "/2/users?{User IDs}&expansions={Expansions?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/users?{User IDs}&expansions={Expansions?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}",
+      "description": "Accounts fetched by a list of ids, up to 100 per request. Like posts, A USER RETURNS ONLY id, name AND username by default -- created_at, description, location, verified, protected and public_metrics (followers_count, following_count, tweet_count, listed_count) all require user.fields. Follower counts, the most commonly wanted column here, are among the absent ones."
     },
     {
       "name": "Blocked Users",
       "paged": true,
-      "suffix": "/2/users/{User ID}/blocking?max_results=1000&expansions={Expansions?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/users/{User ID}/blocking?max_results=1000&expansions={Expansions?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}",
+      "description": "The accounts one user has blocked. Requires that user's own authorisation; it cannot be read for anyone else."
     },
     {
       "name": "Muted Users",
       "paged": true,
-      "suffix": "/2/users/{User ID}/muting?max_results=1000&expansions={Expansions?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/users/{User ID}/muting?max_results=1000&expansions={Expansions?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}",
+      "description": "The accounts one user has muted. Same restriction to the authenticated account."
     },
     {
       "name": "Users by Usernames",
       "paged": false,
-      "suffix": "/2/users/by?usernames={Usernames}&expansions={Expansions?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/users/by?usernames={Usernames}&expansions={Expansions?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}",
+      "description": "Accounts fetched by handle, up to 100 per request. The bridge from a handle someone quoted to the id every other endpoint needs."
     },
     {
       "name": "User by Username",
       "paged": false,
-      "suffix": "/2/users/by/username/{Username}?expansions={Expansions?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/users/by/username/{Username}?expansions={Expansions?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}",
+      "description": "One account by handle."
     },
     {
       "name": "Current User Information",
       "paged": false,
-      "suffix": "/2/users/me?expansions={Expansions?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/users/me?expansions={Expansions?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}",
+      "description": "The account the credentials belong to. One record, always the caller -- and the one endpoint available at every access tier, which makes it the practical way to confirm a token works before anything else is attempted."
     },
     {
       "name": "Users by Query",
       "paged": true,
-      "suffix": "/2/users/search?query={Query}&max_results=1000&expansions={Expansions?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/users/search?query={Query}&max_results=1000&expansions={Expansions?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}",
+      "description": "Accounts matching a search term across handle, name and bio. The discovery route when neither id nor exact handle is known."
     },
     {
       "name": "Spaces by IDs",
       "paged": false,
-      "suffix": "/2/spaces?ids={Space IDs}&expansions={Expansions?}&space.fields={Space Fields}&topic.fields={Topic Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/spaces?ids={Space IDs}&expansions={Expansions?}&space.fields={Space Fields}&topic.fields={Topic Fields?}&user.fields={User Fields?}",
+      "description": "Live audio Spaces by id, up to 100 per request. Carries the state (live, scheduled or ended), title, host, participant and speaker counts, and the scheduled and actual start times. Note that ENDED SPACES BECOME UNAVAILABLE after a period, so historical analysis of Spaces is not possible beyond a short window."
     },
     {
       "name": "Space by ID",
       "paged": false,
-      "suffix": "/2/spaces/{Space ID}?expansions={Expansions?}&space.fields={Space Fields}&topic.fields={Topic Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/spaces/{Space ID}?expansions={Expansions?}&space.fields={Space Fields}&topic.fields={Topic Fields?}&user.fields={User Fields?}",
+      "description": "One Space by id."
     },
     {
       "name": "Space Buyers",
       "paged": true,
-      "suffix": "/2/spaces/{Space ID}/buyers?expansions={Expansions?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/spaces/{Space ID}/buyers?expansions={Expansions?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}",
+      "description": "The accounts that purchased tickets to one ticketed Space. Requires a Space id and the host's authorisation."
     },
     {
       "name": "Space Tweets",
       "paged": false,
-      "suffix": "/2/spaces/{Space ID}/tweets?expansions={Expansions?}&media.fields={Media Fields?}&place.fields={Place Fields?}&poll.fields={Poll Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/spaces/{Space ID}/tweets?expansions={Expansions?}&media.fields={Media Fields?}&place.fields={Place Fields?}&poll.fields={Poll Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}",
+      "description": "The posts shared inside one Space. Requires a Space id."
     },
     {
       "name": "Spaces By Creator IDs",
       "paged": false,
-      "suffix": "/2/spaces/by/creator_ids?user_ids={User IDs}&expansions={Expansions?}&space.fields={Space Fields?}&topic.fields={Topic Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/spaces/by/creator_ids?user_ids={User IDs}&expansions={Expansions?}&space.fields={Space Fields?}&topic.fields={Topic Fields?}&user.fields={User Fields?}",
+      "description": "The Spaces created by given accounts. The per-host view."
     },
     {
       "name": "Spaces By Query",
       "paged": false,
-      "suffix": "/2/spaces/search?query={Query}&state={State?:all|live|scheduled}&expansions={Expansions?}&space.fields={Space Fields?}&topic.fields={Topic Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/spaces/search?query={Query}&state={State?:all|live|scheduled}&expansions={Expansions?}&space.fields={Space Fields?}&topic.fields={Topic Fields?}&user.fields={User Fields?}",
+      "description": "Spaces matching a search term in their title, filtered by state. Live and scheduled Spaces only."
     },
     {
       "name": "Direct Messages By Conversation ID",
       "paged": true,
-      "suffix": "/2/dm_conversations/{Direct Message Conversation ID}/dm_events?event_types={Event Types?:MessageCreate|ParticipantsJoin|ParticipantLeave}&dm_event.fields={DM Event Fields}&expansions={Expansions?}&media.fields={Media Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/dm_conversations/{Direct Message Conversation ID}/dm_events?event_types={Event Types?:MessageCreate|ParticipantsJoin|ParticipantLeave}&dm_event.fields={DM Event Fields}&expansions={Expansions?}&media.fields={Media Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}",
+      "description": "The message events of one conversation. Requires a conversation id and the participant's authorisation."
     },
     {
       "name": "Direct Messages By Participant ID",
       "paged": true,
-      "suffix": "/2/dm_conversations/with/{Participant ID}/dm_events?event_types={Event Types?:MessageCreate|ParticipantsJoin|ParticipantLeave}&dm_event.fields={DM Event Fields}&expansions={Expansions?}&media.fields={Media Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/dm_conversations/with/{Participant ID}/dm_events?event_types={Event Types?:MessageCreate|ParticipantsJoin|ParticipantLeave}&dm_event.fields={DM Event Fields}&expansions={Expansions?}&media.fields={Media Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}",
+      "description": "The one-to-one conversation with a given account. Requires a participant id. The convenient form when the other party is known but the conversation id is not."
     },
     {
       "name": "Direct Messages In Past 30 Days",
       "paged": true,
-      "suffix": "/2/dm_events?event_types={Event Types?:MessageCreate|ParticipantsJoin|ParticipantLeave}&dm_event.fields={DM Event Fields}&expansions={Expansions?}&media.fields={Media Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/dm_events?event_types={Event Types?:MessageCreate|ParticipantsJoin|ParticipantLeave}&dm_event.fields={DM Event Fields}&expansions={Expansions?}&media.fields={Media Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}",
+      "description": "Direct message events across all the authenticated account's conversations, LIMITED TO THE LAST 30 DAYS. Requires that account's authorisation and elevated access. The window is fixed, so a longer history of messages does not exist through this API at all."
     },
     {
       "name": "Direct Messages By Event ID",
       "paged": false,
-      "suffix": "/2/dm_events/{Event ID}"
+      "suffix": "/2/dm_events/{Event ID}",
+      "description": "One direct message event by id."
     },
     {
       "name": "List by List ID",
       "paged": false,
-      "suffix": "/2/lists/{List ID}?expansions={Expansions?}&list.fields={List Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/lists/{List ID}?expansions={Expansions?}&list.fields={List Fields?}&user.fields={User Fields?}",
+      "description": "One list by id, with name, description, member and follower counts, and whether it is private. Lists are curated sets of accounts, and the only user-defined grouping X offers."
     },
     {
       "name": "User Owned Lists",
       "paged": true,
-      "suffix": "/2/users/{User ID}/owned_lists?expansions={Expansions?}&list.fields={List Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/users/{User ID}/owned_lists?expansions={Expansions?}&list.fields={List Fields?}&user.fields={User Fields?}",
+      "description": "The lists one account created. Requires a user id."
     },
     {
       "name": "Tweets by List ID",
       "paged": true,
-      "suffix": "/2/lists/{List ID}/tweets?expansions={Expansions?}&media.fields={Media Fields?}&place.fields={Place Fields?}&poll.fields={Poll Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/lists/{List ID}/tweets?expansions={Expansions?}&media.fields={Media Fields?}&place.fields={Place Fields?}&poll.fields={Poll Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}",
+      "description": "The posts from the accounts in one list, as a timeline. Requires a list id. A pre-curated feed -- useful when a team has already defined the accounts worth watching, since it saves reconstructing that set from a search query."
     },
     {
       "name": "User List Memberships",
       "paged": true,
-      "suffix": "/2/users/{User ID}/list_memberships?expansions={Expansions?}&list.fields={List Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/users/{User ID}/list_memberships?expansions={Expansions?}&list.fields={List Fields?}&user.fields={User Fields?}",
+      "description": "The lists one account has been added to by others. Requires a user id. An external signal of how an account is categorised, which its own profile does not carry."
     },
     {
       "name": "List Members",
       "paged": true,
-      "suffix": "/2/lists/{List ID}/members?expansions={Expansions?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/lists/{List ID}/members?expansions={Expansions?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}",
+      "description": "The accounts in one list. Requires a list id. The membership behind a list, which the list record only counts."
     },
     {
       "name": "User Pinned Lists",
       "paged": false,
-      "suffix": "/2/users/{User ID}/pinned_lists?expansions={Expansions?}&list.fields={List Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/users/{User ID}/pinned_lists?expansions={Expansions?}&list.fields={List Fields?}&user.fields={User Fields?}",
+      "description": "The lists one account has pinned. Requires that account's authorisation."
     },
     {
       "name": "User Bookmarks",
       "paged": true,
-      "suffix": "/2/users/{User ID}/bookmarks?expansions={Expansions?}&media.fields={Media Fields?}&place.fields={Place Fields?}&poll.fields={Poll Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}"
+      "suffix": "/2/users/{User ID}/bookmarks?expansions={Expansions?}&media.fields={Media Fields?}&place.fields={Place Fields?}&poll.fields={Poll Fields?}&tweet.fields={Tweet Fields?}&user.fields={User Fields?}",
+      "description": "The posts the authenticated account has bookmarked. Private to that account and unreachable for anyone else, so this is a personal collection rather than a public signal."
     },
     {
       "name": "Recent Compliance Jobs",
       "paged": false,
-      "suffix": "/2/compliance/jobs?type={Type:users|tweets}&status={Status?:created|in_progress|failed|complete}"
+      "suffix": "/2/compliance/jobs?type={Type:users|tweets}&status={Status?:created|in_progress|failed|complete}",
+      "description": "The batch compliance jobs recently submitted, with their type, status, and the URLs to upload ids to and download results from. Compliance jobs are how a stored copy of X data is kept lawful: a batch of post or user ids goes in, and what comes back says which have since been deleted, suspended or made private. Anyone retaining posts is required to run these, and it is the only bulk way to learn that content has been withdrawn."
     },
     {
       "name": "Compliance Job by Job ID",
       "paged": false,
-      "suffix": "/2/compliance/jobs/{Job ID}"
+      "suffix": "/2/compliance/jobs/{Job ID}",
+      "description": "The status of one compliance job, with its download URL once complete."
     },
     {
       "name": "Project Tweet Usage",
       "paged": false,
-      "suffix": "/2/usage/tweets?days={Days?}&usage.fields={Usage Fields?}"
+      "suffix": "/2/usage/tweets?days={Days?}&usage.fields={Usage Fields?}",
+      "description": "How many posts the project has retrieved against its monthly cap, with a daily breakdown. X's access tiers cap post retrieval tightly and requests are simply refused once the cap is reached, so this is the endpoint that explains a working integration suddenly returning nothing -- and the one to check before planning a large extract."
     },
     {
       "name": "Trends by WOEID",
       "paged": false,
-      "suffix": "/2/trends/by/woeid/{WOEID}"
+      "suffix": "/2/trends/by/woeid/{WOEID}",
+      "description": "The trending topics for one location, identified by a Where On Earth ID. Carries each trend's name and, where available, its post volume. A point-in-time snapshot with NO HISTORY behind it -- trends cannot be asked for retrospectively, so a trend series has to be built by sampling this repeatedly."
     },
     {
       "name": "User Personalized Trends",
       "paged": false,
-      "suffix": "/2/users/personalized_trends"
+      "suffix": "/2/users/personalized_trends",
+      "description": "Trends tailored to the authenticated account. Personal rather than regional, and likewise a snapshot with no history."
     },
     {
       "name": "Community by ID",
       "paged": false,
-      "suffix": "/2/communities/{Community ID}?community.fields={Community Fields?}"
+      "suffix": "/2/communities/{Community ID}?community.fields={Community Fields?}",
+      "description": "One Community by id, with its name, description, access setting and member count."
     },
     {
       "name": "Communities by Query",
       "paged": false,
-      "suffix": "/2/communities/search?query={query}&community.fields={Community Fields?}"
+      "suffix": "/2/communities/search?query={query}&community.fields={Community Fields?}",
+      "description": "Communities matching a search term. Discovery for a feature with no listing endpoint of its own."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/xero/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/xero/endpoints.json
@@ -1,340 +1,394 @@
 {
-    "endpoints": [
+  "endpoints": [
+    {
+      "name": "Attachments",
+      "paged": false,
+      "suffix": "/api.xro/2.0/{Endpoint}/{GUID}/Attachments/{File Name?}",
+      "description": "Files attached to a record. A GENERIC ENDPOINT: the {Endpoint} placeholder takes the resource type -- Invoices, Contacts, BankTransactions and so on -- and the GUID takes that record's id, so one endpoint serves every attachable resource. Returns metadata; the file content is a separate fetch."
+    },
+    {
+      "name": "Accounts",
+      "paged": false,
+      "suffix": "/api.xro/2.0/Accounts/{Account ID?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}",
+      "description": "The chart of accounts -- every account the ledger posts to, with Code, Name, Type (REVENUE, EXPENSE, CURRENT, FIXED, BANK, EQUITY and so on), Class, TaxType, Status, and whether each is a system account. THE DIMENSION THE WHOLE LEDGER HANGS OFF: every journal line, invoice line and bank transaction names an account, and Type is what turns a code into revenue or cost. Bank accounts appear here as Type BANK, carrying the account number and currency."
+    },
+    {
+      "name": "Bank Transactions",
+      "paged": true,
+      "paginationPath": "$.BankTransactions.length()",
+      "suffix": "/api.xro/2.0/BankTransactions/{Bank Transaction ID?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}",
+      "description": "Money in and out of bank accounts recorded directly, without an invoice. Type separates SPEND from RECEIVE (and their overpayment and prepayment variants), so it must be read before summing anything. Carries the contact, bank account, date, status, line items, and totals. This is spending and income that never passed through the invoice tables -- which is why cash movement and invoiced revenue disagree."
+    },
+    {
+      "name": "Bank Transfers",
+      "paged": false,
+      "suffix": "/api.xro/2.0/BankTransfers/{Bank Transfer ID?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}",
+      "description": "Money moved between the business's own bank accounts, with the from and to accounts, amount, date and currency rate. NOT income or expenditure: a transfer appears as money leaving one account and arriving in another, and counting either side as a real flow double-counts the business's activity."
+    },
+    {
+      "name": "Batch Payments",
+      "paged": false,
+      "suffix": "/api.xro/2.0/BatchPayments/{Batch Payment ID?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}",
+      "description": "Payments grouped into a single bank transaction, with the batch total, date, and the individual payments inside. Where a business pays many suppliers at once, the bank statement shows the batch while the ledger shows the parts -- this is what reconciles the two."
+    },
+    {
+      "name": "Branding Themes",
+      "paged": false,
+      "suffix": "/api.xro/2.0/BrandingThemes/{Branding Theme ID?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}",
+      "description": "The invoice templates available, with their names and sort order. Presentation configuration; an invoice references one by id."
+    },
+    {
+      "name": "Contacts",
+      "paged": true,
+      "paginationPath": "$.Contacts.length()",
+      "suffix": "/api.xro/2.0/Contacts/{Contact ID?}?ids={IDs?}&ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}&includeArchived={Include Archived?}",
+      "lookups": [
         {
-            "name": "Attachments",
-            "paged": false,
-            "suffix": "/api.xro/2.0/{Endpoint}/{GUID}/Attachments/{File Name?}"
-        },
-        {
-            "name": "Accounts",
-            "paged": false,
-            "suffix": "/api.xro/2.0/Accounts/{Account ID?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}"
-        },
-        {
-            "name": "Bank Transactions",
-            "paged": true,
-            "paginationPath": "$.BankTransactions.length()",
-            "suffix": "/api.xro/2.0/BankTransactions/{Bank Transaction ID?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}"
-        },
-        {
-            "name": "Bank Transfers",
-            "paged": false,
-            "suffix": "/api.xro/2.0/BankTransfers/{Bank Transfer ID?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}"
-        },
-        {
-            "name": "Batch Payments",
-            "paged": false,
-            "suffix": "/api.xro/2.0/BatchPayments/{Batch Payment ID?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}"
-        },
-        {
-            "name": "Branding Themes",
-            "paged": false,
-            "suffix": "/api.xro/2.0/BrandingThemes/{Branding Theme ID?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}"
-        },
-        {
-            "name": "Contacts",
-            "paged": true,
-            "paginationPath": "$.Contacts.length()",
-            "suffix": "/api.xro/2.0/Contacts/{Contact ID?}?ids={IDs?}&ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}&includeArchived={Include Archived?}",
-          "lookups": [
-            {
-              "endpoints": [
-                "Aged Payables By Contact",
-                "Aged Receivables By Contact"
-              ],
-              "jsonPath": "$.Contacts.*",
-              "key": "ContactID",
-              "parameterName": "Contact ID"
-            }
-          ]
-        },
-        {
-            "name": "Contact Groups",
-            "paged": false,
-            "suffix": "/api.xro/2.0/ContactGroups/{ContactGroup ID?}?&where={Filter?}"
-        },
-        {
-            "name": "Credit Notes",
-            "paged": true,
-            "paginationPath": "$.CreditNotes.length()",
-            "suffix": "/api.xro/2.0/CreditNotes/{Credit Note ID/Number?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}"
-        },
-        {
-            "name": "Currencies",
-            "paged": false,
-            "suffix": "/api.xro/2.0/Currencies?where={Filter?}"
-        },
-        {
-            "name": "Employees",
-            "paged": false,
-            "suffix": "/api.xro/2.0/Employees/{Employee ID?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}"
-        },
-        {
-            "name": "Expense Claims",
-            "paged": false,
-            "suffix": "/api.xro/2.0/ExpenseClaims/{Expense Claim ID?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}"
-        },
-        {
-            "name": "History and Notes",
-            "paged": false,
-            "suffix": "/api.xro/2.0/{Endpoint}/{GUID}/history"
-        },
-        {
-            "name": "Invoices",
-            "paged": true,
-            "paginationPath": "$.Invoices.length()",
-            "suffix": "/api.xro/2.0/Invoices/{Invoice ID/InvoiceNumber?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&IDs={IDs?:value1,value2,...}&InvoiceNumbers={Invoice Numbers?:value1,value2,...}&ContactIDs={Contact IDs?:value1,value2,...}&Statuses={Statuses?:value1,value2,...}&where={Filter?}&createdByMyApp={Created By My App?:true|false}"
-        },
-        {
-            "name": "Invoice Reminders",
-            "paged": false,
-            "suffix": "/api.xro/2.0/InvoiceReminders/Settings/{Identifier?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}"
-        },
-        {
-            "name": "Journals",
-            "paged": false,
-            "suffix": "/api.xro/2.0/Journals/{Identifier?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&offset={Offset?}&paymentsOnly={Payments Only?:true|false}"
-        },
-        {
-            "name": "Linked Transactions (Billable Expenses)",
-            "paged": true,
-            "paginationPath": "$.LinkedTransactions.length()",
-            "suffix": "/api.xro/2.0/LinkedTransactions/{Linked Transaction ID?}?SourceTransactionID={Source Transaction ID?}&ContactID={Contact ID?}&Status={Status?}&TargetTransactionID={Target Transaction ID?}"
-        },
-        {
-            "name": "Manual Journals",
-            "paged": true,
-            "paginationPath": "$.ManualJournals.length()",
-            "suffix": "/api.xro/2.0/ManualJournals/{Manual Journal ID?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}"
-        },
-        {
-            "name": "Organisation",
-            "paged": false,
-            "suffix": "/api.xro/2.0/Organisation"
-        },
-        {
-            "name": "Overpayments",
-            "paged": true,
-            "paginationPath": "$.Overpayments.length()",
-            "suffix": "/api.xro/2.0/Overpayments/{Overpayment ID?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}"
-        },
-        {
-            "name": "Payments",
-            "paged": false,
-            "suffix": "/api.xro/2.0/Payments/{Identifier?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}"
-        },
-        {
-            "name": "Prepayments",
-            "paged": true,
-            "paginationPath": "$.Prepayments.length()",
-            "suffix": "/api.xro/2.0/Prepayments/{Prepayment ID?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}"
-        },
-        {
-            "name": "Purchase Orders",
-            "paged": true,
-            "paginationPath": "$.PurchaseOrders.length()",
-            "suffix": "/api.xro/2.0/PurchaseOrders/{Identifier?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&Status={Status?}&DateFrom={From Date?:yyyy-MM-dd}&DateTo={To Date?:yyyy-MM-dd}"
-        },
-        {
-            "name": "Quotes",
-            "paged": true,
-            "paginationPath": "$.Quotes.length()",
-            "suffix": "/api.xro/2.0/Quotes/{Quote ID?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&Status={Status?}&&DateFrom={From Date?:yyyy-MM-dd}&DateTo={To Date?:yyyy-MM-dd}&&ExpiryDateFrom={From Expiry Date?:yyyy-MM-dd}&ExpiryDateTo={To Expiry Date?:yyyy-MM-dd}&ContactID={Contact ID?}"
-        },
-        {
-            "name": "Receipts",
-            "paged": false,
-            "suffix": "/api.xro/2.0/Receipts/{Receipt ID?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}"
-        },
-        {
-            "name": "Repeating Invoices",
-            "paged": false,
-            "suffix": "/api.xro/2.0/RepeatingInvoices/{Repeating Invoice ID?}?&where={Filter?}"
-        },
-        {
-            "name": "1099 Report",
-            "paged": false,
-            "suffix": "/api.xro/2.0/Reports/TenNinetyNine?reportYear={Report Year?:yyyy}"
-        },
-        {
-            "name": "Aged Payables By Contact",
-            "paged": false,
-            "suffix": "/api.xro/2.0/Reports/AgedPayablesByContact?contactID={Contact ID}&date={Date?:yyyy-MM-dd}&fromDate={From Date?:yyyy-MM-dd}&toDate={To Date?:yyyy-MM-dd}"
-        },
-        {
-            "name": "Aged Receivables By Contact",
-            "paged": false,
-            "suffix": "/2.0/Reports/AgedReceivablesByContact?contactID={Contact ID}&&date={Date?:yyyy-MM-dd}&fromDate={From Date?:yyyy-MM-dd}&toDate={To Date?:yyyy-MM-dd}"
-        },
-        {
-            "name": "Balance Sheet",
-            "paged": false,
-            "suffix": "/api.xro/2.0/Reports/BalanceSheet?date={Date?:yyyy-MM-dd}&periods={Periods?}&timeframe={Timeframe?:MONTH|QUARTER|YEAR}&trackingOptionID1={Tracking Option ID1?}&trackingOptionID2={Tracking Option ID2?}&standardLayout={Standard Layout?:true|false}&paymentsOnly={Payments Only?:true|false}"
-        },
-        {
-            "name": "Bank Summary",
-            "paged": false,
-            "suffix": "/api.xro/2.0/Reports/BankSummary?fromDate={From Date?:yyyy-MM-dd}&toDate={To Date?:yyyy-MM-dd}"
-        },
-        {
-            "name": "BAS Report",
-            "paged": false,
-            "suffix": "/api.xro/2.0/Reports/{Report ID?}"
-        },
-        {
-            "name": "Budget Summary",
-            "paged": false,
-            "suffix": "/api.xro/2.0/Reports/BudgetSummary?date={Date?:yyyy-MM-dd}&periods={Periods?}&timeframe={Timeframe?:1|3|12}"
-        },
-        {
-            "name": "Executive Summary",
-            "paged": false,
-            "suffix": "/api.xro/2.0/Reports/ExecutiveSummary?date={Date?:yyyy-MM-dd}"
-        },
-        {
-            "name": "GST Report",
-            "paged": false,
-            "suffix": "/api.xro/2.0/Reports/{Report ID?}"
-        },
-        {
-            "name": "Profit And Loss",
-            "paged": false,
-            "suffix": "/api.xro/2.0/Reports/ProfitAndLoss?fromDate={From Date?:yyyy-MM-dd}&toDate={To Date?:yyyy-MM-dd}&periods={Periods?}&timeframe={Timeframe?:MONTH|QUARTER|YEAR}&trackingCategoryID={Tracking Category ID?}&trackingOptionID={Tracking Option ID?}&trackingCategoryID2={Tracking Category ID2?}&trackingOptionID2={Tracking Option ID2?}&standardLayout={Standard Layout?:true|false}&paymentsOnly={Payments Only?:true|false}"
-        },
-        {
-            "name": "Trial Balance",
-            "paged": false,
-            "suffix": "/api.xro/2.0/Reports/TrialBalance?date={Date?:yyyy-MM-dd}&paymentsOnly={paymentsOnly?:true|false}"
-        },
-        {
-            "name": "Tax Rates",
-            "paged": false,
-            "suffix": "/api.xro/2.0/TaxRates?TaxType={Tax Type?}&where={Filter?}"
-        },
-        {
-            "name": "Tracking Categories",
-            "paged": false,
-            "suffix": "/api.xro/2.0/TrackingCategories/{Tracking Category ID?}?where={Filter?}&includeArchived={Include Archived?:true|false}"
-        },
-        {
-            "name": "Users",
-            "paged": false,
-            "suffix": "/api.xro/2.0/Users/{User ID?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}"
-        },
-        {
-            "name": "Assets",
-            "paged": true,
-            "paginationPath": "$.items.length()",
-            "suffix": "/assets.xro/1.0/Assets?status={Status:Draft|Registered|Disposed}&sortDirection={Sort Direction?:ASC|DESC}&filterBy={Filter By?}",
-          "lookups": [
-            {
-              "endpoint": "An Asset",
-              "jsonPath": "$.items.*",
-              "key": "assetId",
-              "parameterName": "Asset ID"
-            }
-          ]
-        },
-        {
-            "name": "An Asset",
-            "paged": false,
-            "suffix": "/assets.xro/1.0/Assets/{Asset ID}"
-        },
-        {
-            "name": "Asset Types",
-            "paged": false,
-            "suffix": "/assets.xro/1.0/AssetTypes"
-        },
-        {
-            "name": "Assets Settings",
-            "paged": false,
-            "suffix": "/assets.xro/1.0/Settings"
-        },
-        {
-            "name": "Files",
-            "paged": true,
-            "paginationPath": "$.Items.length()",
-            "suffix": "/files.xro/1.0/Files",
-          "lookups": [
-            {
-              "endpoints": [
-                "A File",
-                "Associations"
-              ],
-              "jsonPath": "$.Items.*",
-              "key": "Id",
-              "parameterName": "File ID"
-            }
-          ]
-        },
-        {
-            "name": "A File",
-            "paged": false,
-            "suffix": "/files.xro/1.0/Files/{File ID}"
-        },
-        {
-            "name": "Folders",
-            "paged": false,
-            "suffix": "/files.xro/1.0/Folders",
-          "lookups": [
-            {
-              "endpoint": "A Folder",
-              "jsonPath": "$.*",
-              "key": "Id",
-              "parameterName": "Folder ID"
-            }
-          ]
-        },
-        {
-            "name": "A Folder",
-            "paged": false,
-            "suffix": "/files.xro/1.0/Folders/{Folder ID}"
-        },
-        {
-            "name": "Associations",
-            "paged": false,
-            "suffix": "/files.xro/1.0/Files/{File ID}/Associations"
-        },
-        {
-            "name": "Projects",
-            "paged": true,
-            "paginationPath": "$.items.length()",
-            "suffix": "/projects.xro/2.0/projects?projectIDs={Project IDs?:value1,value2,...}&contactID={Contact ID?}&states={States?:INPROGRESS|CLOSED}",
-          "lookups": [
-            {
-              "endpoints": [
-                "A Project",
-                "Tasks",
-                "Time"
-              ],
-              "jsonPath": "$.items.*",
-              "key": "projectId",
-              "parameterName": "Project ID"
-            }
-          ]
-        },
-        {
-            "name": "A Project",
-            "paged": false,
-            "suffix": "/projects.xro/2.0/projects/{Project ID}"
-        },
-        {
-            "name": "Projects Users",
-            "paged": true,
-            "paginationPath": "$.items.length()",
-            "suffix": "/projects.xro/2.0/projectsusers"
-        },
-        {
-            "name": "Tasks",
-            "paged": true,
-            "paginationPath": "$.items.length()",
-            "suffix": "/projects.xro/2.0/projects/{Project ID}/tasks/{Task ID?}?taskIDs={Task IDs?:value1,value2,...}&chargeType={Charge Type?:TIME|FIXED|NON_CHARGEABLE}"
-        },
-        {
-            "name": "Time",
-            "paged": true,
-            "paginationPath": "$.items.length()",
-            "suffix": "/projects.xro/2.0/projects/{Project ID}/time/{Time EntryID?}?userID={User ID?}&taskID={Task ID?}&dateAfterUtc={Date After Utc?:yyyy-MM-ddTHH:mm:ss.SSSZ}&dateBeforeUtc={Date Before Utc?:yyyy-MM-ddTHH:mm:ss.SSSZ}&isChargeable={Is Chargeable?}&invoiceID={Invoice ID?}&contactID={Contact ID?}&states={States?}"
+          "endpoints": [
+            "Aged Payables By Contact",
+            "Aged Receivables By Contact"
+          ],
+          "jsonPath": "$.Contacts.*",
+          "key": "ContactID",
+          "parameterName": "Contact ID"
         }
-    ]
+      ],
+      "description": "The people and companies the business trades with -- and CUSTOMERS AND SUPPLIERS ARE THE SAME TABLE, told apart by the IsCustomer and IsSupplier flags, either or both of which can be set. Carries Name, ContactNumber, EmailAddress, addresses and phones, DefaultCurrency, the account numbers used for sales and purchases, payment terms, and Balances holding outstanding and overdue amounts for both directions. Those balances are pre-computed, so 'who owes us most' does not need the invoice table at all. ContactStatus separates ACTIVE from ARCHIVED."
+    },
+    {
+      "name": "Contact Groups",
+      "paged": false,
+      "suffix": "/api.xro/2.0/ContactGroups/{ContactGroup ID?}?&where={Filter?}",
+      "description": "The groups contacts are organised into, with their members. Contact groups are Xero's only native segmentation of customers, so they are the axis available for grouping receivables by anything other than the contact itself."
+    },
+    {
+      "name": "Credit Notes",
+      "paged": true,
+      "paginationPath": "$.CreditNotes.length()",
+      "suffix": "/api.xro/2.0/CreditNotes/{Credit Note ID/Number?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}",
+      "description": "Credit notes, which reduce what is owed -- and like invoices, BOTH DIRECTIONS live here: ACCRECCREDIT reduces a customer's balance, ACCPAYCREDIT reduces a supplier's. Carries the contact, date, status, totals and the remaining credit. Revenue net of credits requires this table; the invoice totals alone overstate it, and AmountCredited on an invoice only shows what was applied to that one."
+    },
+    {
+      "name": "Currencies",
+      "paged": false,
+      "suffix": "/api.xro/2.0/Currencies?where={Filter?}",
+      "description": "The currencies enabled for the organisation, with code and description. Relevant because invoices carry both a CurrencyCode and a CurrencyRate: amounts are stored in the source currency, and only the ledger is in the base currency, so any cross-currency total must decide which of the two it means."
+    },
+    {
+      "name": "Employees",
+      "paged": false,
+      "suffix": "/api.xro/2.0/Employees/{Employee ID?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}",
+      "description": "Employees for expense claim purposes. MOVED: Xero has taken employees out of the Accounting API and into the region-specific Payroll APIs, and this path is absent from the current Accounting description. Expect it to fail; employee data is not reachable through this connector."
+    },
+    {
+      "name": "Expense Claims",
+      "paged": false,
+      "suffix": "/api.xro/2.0/ExpenseClaims/{Expense Claim ID?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}",
+      "description": "Employee expense claims, with the user, status, total, and the receipts making them up. Note the receipts hold the detail; the claim is only their sum."
+    },
+    {
+      "name": "History and Notes",
+      "paged": false,
+      "suffix": "/api.xro/2.0/{Endpoint}/{GUID}/history",
+      "description": "The change history and manual notes on one record. Generic in the same way: {Endpoint} is the resource type and GUID the record. Each entry carries the user, the date, the change type and any note. THE RECORDS THEMSELVES CARRY ONLY THEIR CURRENT STATE, so this is the only source for when an invoice was approved, sent or amended -- and the only audit trail available per document."
+    },
+    {
+      "name": "Invoices",
+      "paged": true,
+      "paginationPath": "$.Invoices.length()",
+      "suffix": "/api.xro/2.0/Invoices/{Invoice ID/InvoiceNumber?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&IDs={IDs?:value1,value2,...}&InvoiceNumbers={Invoice Numbers?:value1,value2,...}&ContactIDs={Contact IDs?:value1,value2,...}&Statuses={Statuses?:value1,value2,...}&where={Filter?}&createdByMyApp={Created By My App?:true|false}",
+      "description": "Invoices, and READ THE TYPE COLUMN BEFORE ANYTHING ELSE: this one table holds BOTH sales invoices (Type = ACCREC, money owed to the business) AND supplier bills (Type = ACCPAY, money the business owes). They are opposite sides of the ledger, so any revenue, receivables or payables figure taken without filtering on Type is meaningless. Each row carries InvoiceNumber, Contact, Date and DueDate, Status, LineAmountTypes, SubTotal, TotalTax and Total, AmountDue, AmountPaid and AmountCredited, CurrencyCode and CurrencyRate. STATUS matters just as much: DRAFT and SUBMITTED are not yet in the books, VOIDED and DELETED are reversed, and only AUTHORISED and PAID represent real obligations -- so a total that does not exclude the first four overstates the business. Note also that line items are omitted from the list view and come only from fetching a single invoice."
+    },
+    {
+      "name": "Invoice Reminders",
+      "paged": false,
+      "suffix": "/api.xro/2.0/InvoiceReminders/Settings/{Identifier?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}",
+      "description": "Whether automatic invoice reminders are switched on. One setting, and the explanation for whether overdue invoices are being chased at all."
+    },
+    {
+      "name": "Journals",
+      "paged": false,
+      "suffix": "/api.xro/2.0/Journals/{Identifier?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&offset={Offset?}&paymentsOnly={Payments Only?:true|false}",
+      "description": "The general ledger itself -- every posted double-entry line, with the JournalDate, the account, the debit or credit amount, the tax, and the source document and its type. THE AUTHORITATIVE RECORD: invoices, bank transactions and credit notes are all documents that produce journal lines, so anything reconciled or audited comes from here, and the sum of this table is the definition of the accounts. Paged in blocks of 100 by an offset parameter, which is the only way through it -- so a full ledger extract is many sequential calls."
+    },
+    {
+      "name": "Linked Transactions (Billable Expenses)",
+      "paged": true,
+      "paginationPath": "$.LinkedTransactions.length()",
+      "suffix": "/api.xro/2.0/LinkedTransactions/{Linked Transaction ID?}?SourceTransactionID={Source Transaction ID?}&ContactID={Contact ID?}&Status={Status?}&TargetTransactionID={Target Transaction ID?}",
+      "description": "Costs recorded against one contact and then re-billed to another -- the link between a supplier bill line and the customer invoice line that recovers it. Requires the source or target transaction. This is the only place cost recovery is traceable; both invoices otherwise look like unrelated documents."
+    },
+    {
+      "name": "Manual Journals",
+      "paged": true,
+      "paginationPath": "$.ManualJournals.length()",
+      "suffix": "/api.xro/2.0/ManualJournals/{Manual Journal ID?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}",
+      "description": "Journal entries posted by hand rather than produced by a document, with narration, date, status and their lines. Adjustments, accruals and corrections live here, and they are exactly the entries that have no invoice or receipt behind them -- worth separating when explaining a movement no transaction accounts for."
+    },
+    {
+      "name": "Organisation",
+      "paged": false,
+      "suffix": "/api.xro/2.0/Organisation",
+      "description": "The organisation itself: name, legal name, country, base currency, financial year end, tax basis, edition and timezone. One record, and the first thing to read -- the FINANCIAL YEAR END determines what any period-based report means, and the base currency determines what its totals are denominated in."
+    },
+    {
+      "name": "Overpayments",
+      "paged": true,
+      "paginationPath": "$.Overpayments.length()",
+      "suffix": "/api.xro/2.0/Overpayments/{Overpayment ID?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}",
+      "description": "Money received or paid beyond what was invoiced, awaiting allocation. Carries the contact, date, total and remaining amount. Cash received here is real money that no invoice accounts for, so reconciling receipts against invoices without it leaves an unexplained difference."
+    },
+    {
+      "name": "Payments",
+      "paged": false,
+      "suffix": "/api.xro/2.0/Payments/{Identifier?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}",
+      "description": "The payments applied against invoices, credit notes and prepayments, one row each, with the date, amount, the invoice it settles, the bank account it moved through, and the currency rate used. The link between an invoice and the cash: an invoice's AmountPaid is the total, while this says WHEN each part arrived, which is what any collection-time or cash-flow-timing question needs."
+    },
+    {
+      "name": "Prepayments",
+      "paged": true,
+      "paginationPath": "$.Prepayments.length()",
+      "suffix": "/api.xro/2.0/Prepayments/{Prepayment ID?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}",
+      "description": "Payments made or received in advance of an invoice, with the amount still unallocated. Same reconciliation role as overpayments, from the other direction in time."
+    },
+    {
+      "name": "Purchase Orders",
+      "paged": true,
+      "paginationPath": "$.PurchaseOrders.length()",
+      "suffix": "/api.xro/2.0/PurchaseOrders/{Identifier?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&Status={Status?}&DateFrom={From Date?:yyyy-MM-dd}&DateTo={To Date?:yyyy-MM-dd}",
+      "description": "Purchase orders raised to suppliers, with the contact, date, delivery date, status, line items and totals. A commitment rather than a liability -- it becomes a bill only when invoiced, so orders are what the business has promised to spend and the ACCPAY invoices are what it actually owes."
+    },
+    {
+      "name": "Quotes",
+      "paged": true,
+      "paginationPath": "$.Quotes.length()",
+      "suffix": "/api.xro/2.0/Quotes/{Quote ID?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&Status={Status?}&&DateFrom={From Date?:yyyy-MM-dd}&DateTo={To Date?:yyyy-MM-dd}&&ExpiryDateFrom={From Expiry Date?:yyyy-MM-dd}&ExpiryDateTo={To Expiry Date?:yyyy-MM-dd}&ContactID={Contact ID?}",
+      "description": "Quotes issued to customers, with the contact, dates, expiry, status and totals. The pipeline before an invoice exists: a quote's status (DRAFT, SENT, ACCEPTED, DECLINED, INVOICED) is the closest thing Xero has to a sales funnel."
+    },
+    {
+      "name": "Receipts",
+      "paged": false,
+      "suffix": "/api.xro/2.0/Receipts/{Receipt ID?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}",
+      "description": "Individual receipts entered against expense claims, with the contact, date, line items, account and total. Draft receipts exist before being claimed, so status separates what has been submitted from what has merely been captured."
+    },
+    {
+      "name": "Repeating Invoices",
+      "paged": false,
+      "suffix": "/api.xro/2.0/RepeatingInvoices/{Repeating Invoice ID?}?&where={Filter?}",
+      "description": "The templates that generate invoices on a schedule, with the contact, the repeat interval, the next scheduled date, the end date and the amounts. Not invoices themselves -- these are what will produce them, so forward revenue commitments are here while the invoices they created are in the invoice table."
+    },
+    {
+      "name": "1099 Report",
+      "paged": false,
+      "suffix": "/api.xro/2.0/Reports/TenNinetyNine?reportYear={Report Year?:yyyy}",
+      "description": "US 1099-MISC contractor payment totals by contact for a tax year. Jurisdiction-specific: it returns nothing meaningful for an organisation outside the United States."
+    },
+    {
+      "name": "Aged Payables By Contact",
+      "paged": false,
+      "suffix": "/api.xro/2.0/Reports/AgedPayablesByContact?contactID={Contact ID}&date={Date?:yyyy-MM-dd}&fromDate={From Date?:yyyy-MM-dd}&toDate={To Date?:yyyy-MM-dd}",
+      "description": "What the business owes each supplier, bucketed by age. The payables mirror of the receivables report."
+    },
+    {
+      "name": "Aged Receivables By Contact",
+      "paged": false,
+      "suffix": "/api.xro/2.0/Reports/AgedReceivablesByContact?contactID={Contact ID}&&date={Date?:yyyy-MM-dd}&fromDate={From Date?:yyyy-MM-dd}&toDate={To Date?:yyyy-MM-dd}",
+      "description": "What each customer owes, bucketed by how overdue it is. Requires a contact id, or runs across contacts for the ageing summary. The collections table -- Contacts carries a single outstanding balance while this says how old it is, which is what distinguishes a slow payer from a bad debt."
+    },
+    {
+      "name": "Balance Sheet",
+      "paged": false,
+      "suffix": "/api.xro/2.0/Reports/BalanceSheet?date={Date?:yyyy-MM-dd}&periods={Periods?}&timeframe={Timeframe?:MONTH|QUARTER|YEAR}&trackingOptionID1={Tracking Option ID1?}&trackingOptionID2={Tracking Option ID2?}&standardLayout={Standard Layout?:true|false}&paymentsOnly={Payments Only?:true|false}",
+      "description": "The balance sheet as at a given date, with assets, liabilities and equity, optionally compared across periods or split by tracking category. Same nested Rows shape. A point-in-time statement, unlike profit and loss which covers a range -- so the two cannot be filtered the same way."
+    },
+    {
+      "name": "Bank Summary",
+      "paged": false,
+      "suffix": "/api.xro/2.0/Reports/BankSummary?fromDate={From Date?:yyyy-MM-dd}&toDate={To Date?:yyyy-MM-dd}",
+      "description": "Opening and closing balances with cash in and out for each bank account over a period. The cash-movement summary, and the quickest reconciliation of what the bank accounts did without reading Bank Transactions."
+    },
+    {
+      "name": "BAS Report",
+      "paged": false,
+      "suffix": "/api.xro/2.0/Reports/{Report ID?}",
+      "description": "An Australian Business Activity Statement, fetched by its report id. Jurisdiction-specific and available only to Australian organisations. NOTE that BAS and GST reports share one endpoint -- both are retrieved as /Reports/{ReportID} -- so the report id is what selects between them, and the two entries here differ in name only."
+    },
+    {
+      "name": "Budget Summary",
+      "paged": false,
+      "suffix": "/api.xro/2.0/Reports/BudgetSummary?date={Date?:yyyy-MM-dd}&periods={Periods?}&timeframe={Timeframe?:1|3|12}",
+      "description": "Budgeted amounts by account for a series of periods. The only place budget figures exist -- actuals come from Profit And Loss, and comparing the two requires both, since no endpoint returns variance."
+    },
+    {
+      "name": "Executive Summary",
+      "paged": false,
+      "suffix": "/api.xro/2.0/Reports/ExecutiveSummary?date={Date?:yyyy-MM-dd}",
+      "description": "A one-page set of headline figures -- cash, profitability, debtor and creditor days, and key ratios -- for a month, with comparison to the previous one. Pre-computed ratios that would otherwise have to be derived, though as a fixed monthly view it cannot be re-cut by period."
+    },
+    {
+      "name": "GST Report",
+      "paged": false,
+      "suffix": "/api.xro/2.0/Reports/{Report ID?}",
+      "description": "A New Zealand GST return, fetched by its report id. Same endpoint as the BAS report, distinguished only by which report id is passed, and available only to New Zealand organisations."
+    },
+    {
+      "name": "Profit And Loss",
+      "paged": false,
+      "suffix": "/api.xro/2.0/Reports/ProfitAndLoss?fromDate={From Date?:yyyy-MM-dd}&toDate={To Date?:yyyy-MM-dd}&periods={Periods?}&timeframe={Timeframe?:MONTH|QUARTER|YEAR}&trackingCategoryID={Tracking Category ID?}&trackingOptionID={Tracking Option ID?}&trackingCategoryID2={Tracking Category ID2?}&trackingOptionID2={Tracking Option ID2?}&standardLayout={Standard Layout?:true|false}&paymentsOnly={Payments Only?:true|false}",
+      "description": "The profit and loss statement for a date range, optionally compared against previous periods and broken down by tracking category. A READY-MADE FINANCIAL STATEMENT: Xero has already applied the accounting rules -- accrual or cash basis per the organisation's setting, the correct sign on each account type, and the subtotals -- which reconstructing from Journals would mean reimplementing. THE SHAPE IS NOT TABULAR: every report here returns a nested Rows structure of sections, header rows and summary rows, not a flat row set, so it needs flattening before it can be charted, and the section a row sits in is what gives it meaning."
+    },
+    {
+      "name": "Trial Balance",
+      "paged": false,
+      "suffix": "/api.xro/2.0/Reports/TrialBalance?date={Date?:yyyy-MM-dd}&paymentsOnly={paymentsOnly?:true|false}",
+      "description": "Every account with its debit and credit movements and closing balance as at a date. The bridge between the ledger and the statements: it is account-level rather than section-level, which makes it the most tabular of the reports and the easiest to work with directly."
+    },
+    {
+      "name": "Tax Rates",
+      "paged": false,
+      "suffix": "/api.xro/2.0/TaxRates?TaxType={Tax Type?}&where={Filter?}",
+      "description": "The tax rates configured, with Name, TaxType, the component rates making each up, and its effective rate. Every invoice and journal line names a TaxType, so this is what turns that code into a rate and a jurisdiction."
+    },
+    {
+      "name": "Tracking Categories",
+      "paged": false,
+      "suffix": "/api.xro/2.0/TrackingCategories/{Tracking Category ID?}?where={Filter?}&includeArchived={Include Archived?:true|false}",
+      "description": "Xero's dimensional tagging -- department, region, cost centre or whatever the business chose -- with each category's options. A ledger line can carry up to TWO tracking options, and this is the ONLY analytical axis Xero offers beyond the account code, so any question about profitability by team or location depends entirely on whether these are in use."
+    },
+    {
+      "name": "Users",
+      "paged": false,
+      "suffix": "/api.xro/2.0/Users/{User ID?}?ModifiedAfter={Modified After?:yyyy-mm-ddThh:mm:ss}&where={Filter?}",
+      "description": "The users with access to the organisation, with name, email, their role, and whether they are subscribers. Xero's role model is coarse, and the role is what explains whether a given token can see payroll or reports at all."
+    },
+    {
+      "name": "Assets",
+      "paged": true,
+      "paginationPath": "$.items.length()",
+      "suffix": "/assets.xro/1.0/Assets?status={Status:Draft|Registered|Disposed}&sortDirection={Sort Direction?:ASC|DESC}&filterBy={Filter By?}",
+      "lookups": [
+        {
+          "endpoint": "An Asset",
+          "jsonPath": "$.items.*",
+          "key": "assetId",
+          "parameterName": "Asset ID"
+        }
+      ],
+      "description": "Fixed assets registered in the fixed asset register, with name, number, purchase date and price, the asset type, current book value, and status. Status separates DRAFT, REGISTERED and DISPOSED -- and depreciation only runs on registered assets, so a draft asset holds a purchase price that has never touched the ledger."
+    },
+    {
+      "name": "An Asset",
+      "paged": false,
+      "suffix": "/assets.xro/1.0/Assets/{Asset ID}",
+      "description": "One fixed asset by id, with its full depreciation settings and book value history."
+    },
+    {
+      "name": "Asset Types",
+      "paged": false,
+      "suffix": "/assets.xro/1.0/AssetTypes",
+      "description": "The asset types configured, each carrying the depreciation method, rate and averaging convention applied to assets of that type. The decoder for how an asset's book value is being reduced; the asset itself names only its type."
+    },
+    {
+      "name": "Assets Settings",
+      "paged": false,
+      "suffix": "/assets.xro/1.0/Settings",
+      "description": "The fixed asset register's settings -- the default accounts depreciation posts to, and the register's start date. The start date matters: assets bought before it are not depreciated by Xero at all."
+    },
+    {
+      "name": "Files",
+      "paged": true,
+      "paginationPath": "$.Items.length()",
+      "suffix": "/files.xro/1.0/Files",
+      "lookups": [
+        {
+          "endpoints": [
+            "A File",
+            "Associations"
+          ],
+          "jsonPath": "$.Items.*",
+          "key": "Id",
+          "parameterName": "File ID"
+        }
+      ],
+      "description": "The files uploaded to the organisation's file store, with name, mime type, size, the folder each is in, and when it was uploaded. Metadata only; contents are a separate fetch."
+    },
+    {
+      "name": "A File",
+      "paged": false,
+      "suffix": "/files.xro/1.0/Files/{File ID}",
+      "description": "One file's metadata by id."
+    },
+    {
+      "name": "Folders",
+      "paged": false,
+      "suffix": "/files.xro/1.0/Folders",
+      "lookups": [
+        {
+          "endpoint": "A Folder",
+          "jsonPath": "$.*",
+          "key": "Id",
+          "parameterName": "Folder ID"
+        }
+      ],
+      "description": "The folders files are organised into, with a file count for each. Includes the Inbox, which is where emailed-in documents arrive before being filed."
+    },
+    {
+      "name": "A Folder",
+      "paged": false,
+      "suffix": "/files.xro/1.0/Folders/{Folder ID}",
+      "description": "One folder by id."
+    },
+    {
+      "name": "Associations",
+      "paged": false,
+      "suffix": "/files.xro/1.0/Files/{File ID}/Associations",
+      "description": "The accounting records one file is attached to -- an invoice, bank transaction or contact. Requires a file id. The link between a stored document and the transaction it evidences, which neither side carries alone."
+    },
+    {
+      "name": "Projects",
+      "paged": true,
+      "paginationPath": "$.items.length()",
+      "suffix": "/projects.xro/2.0/projects?projectIDs={Project IDs?:value1,value2,...}&contactID={Contact ID?}&states={States?:INPROGRESS|CLOSED}",
+      "lookups": [
+        {
+          "endpoints": [
+            "A Project",
+            "Tasks",
+            "Time"
+          ],
+          "jsonPath": "$.items.*",
+          "key": "projectId",
+          "parameterName": "Project ID"
+        }
+      ],
+      "description": "Projects used for time and cost tracking, with name, contact, status, deadline, and the estimated and actual amounts. A separate Xero product from the accounting ledger: project costs appear here whether or not they have been invoiced, so this is where work-in-progress lives before it reaches an invoice."
+    },
+    {
+      "name": "A Project",
+      "paged": false,
+      "suffix": "/projects.xro/2.0/projects/{Project ID}",
+      "description": "One project by id, with its totals: time and expense recorded, amounts invoiced, and what remains to be billed."
+    },
+    {
+      "name": "Projects Users",
+      "paged": true,
+      "paginationPath": "$.items.length()",
+      "suffix": "/projects.xro/2.0/projectsusers",
+      "description": "The users who can record time against projects. The roster for any per-person utilisation question."
+    },
+    {
+      "name": "Tasks",
+      "paged": true,
+      "paginationPath": "$.items.length()",
+      "suffix": "/projects.xro/2.0/projects/{Project ID}/tasks/{Task ID?}?taskIDs={Task IDs?:value1,value2,...}&chargeType={Charge Type?:TIME|FIXED|NON_CHARGEABLE}",
+      "description": "The billable tasks within one project, with the rate, charge type, estimated minutes, and the amounts recorded and invoiced. Requires a project id. The rate and charge type are what turn recorded time into money, so they are needed before any time figure means anything."
+    },
+    {
+      "name": "Time",
+      "paged": true,
+      "paginationPath": "$.items.length()",
+      "suffix": "/projects.xro/2.0/projects/{Project ID}/time/{Time EntryID?}?userID={User ID?}&taskID={Task ID?}&dateAfterUtc={Date After Utc?:yyyy-MM-ddTHH:mm:ss.SSSZ}&dateBeforeUtc={Date Before Utc?:yyyy-MM-ddTHH:mm:ss.SSSZ}&isChargeable={Is Chargeable?}&invoiceID={Invoice ID?}&contactID={Contact ID?}&states={States?}",
+      "description": "Time entries recorded against a project, with the user, task, date, duration in minutes, and description. Requires a project id. DURATION IS IN MINUTES, and the entry carries no monetary value of its own -- the rate lives on the task, so revenue per hour is a join rather than a column."
+    }
+  ]
 }


### PR DESCRIPTION
Continues #4623 with six more connectors — Box, Asana, Xero, X, Square and
Twilio — all now completely described. **Stacked on #4623**; retarget to
`stylebi-wiz-main` once that merges.

| connector | described |
|---|---|
| box | 82 / 82 |
| asana | 65 / 65 |
| xero | 54 / 54 |
| twitter | 47 / 47 |
| square | 30 / 30 |
| twilio | 25 / 25 |

Running total across both PRs: **1,587 endpoints described**, with only zendesk
(193/278) and stripe (101/110) still partial.

## Twilio had no calls and no messages

Fifteen endpoints covering accounts, addresses, applications, API keys, usage and
alerts — and nothing for the subject matter of a Twilio account. Ten added, each
verified against Twilio's published description: calls, messages, recordings and
conferences with their single-item forms, plus per-call and per-conference
recordings. No Java change needed; `TwilioRuntime` routes only the monitor-host
endpoints by name and everything else already gets the right pagination.

Deliberately left out the inequality date filters (`StartTime>`, `DateSent<`)
Twilio documents for ranges. No suffix in this repository uses a comparison
operator in a parameter name and there is no way to test the URL builder against
the live API from here, so exposing them would be a guess. The descriptions say
the ranges exist and that these endpoints do not offer them.

## Five more broken paths

Each of these returned something — which is worse than an error, because nothing
signals the problem:

- **Box** — `Trashed File` and `Trashed Folder` carried the *identical* suffix,
  `/folders/{id}/trash`. Both paths are real, so path alignment matched both;
  only the name gave it away. `/files/{id}/trash` was unreachable through this
  connector.
- **Square** — `Cash Drawer Shift Events` had a question mark where a slash
  belongs: `.../shifts/{Shift ID}?/events?location_id=...`. Everything after it
  is query string, so it returned the **shift** rather than its events.
- **Twilio** — `Alerts` had a parameter name and its label swapped,
  `&End Date={EndDate?...}`. The name goes on the wire, so it sent a parameter
  literally called `End Date`, Twilio ignored it, and the end-date filter
  silently did nothing. `Alert` was also missing its leading slash.
- **Xero** — `Aged Receivables By Contact` was missing the `/api.xro` prefix
  every other accounting endpoint carries.
- **Asana** — two endpoints had moved rather than broken: organization teams is
  now a workspaces path (an organization *is* a workspace), and task attachments
  became a general attachments endpoint taking the task as a `parent` parameter.

Box's surfaced from a scan for two endpoints sharing one suffix. That scan also
found eight more in connectors not covered here — stripe, hubspot, xero, toggl,
freshservice, campaignmonitor — left for when those are done rather than guessed
at now.

## What the descriptions carry

Two connectors withhold almost everything by default, and it looks like empty
data rather than an unmade request:

- **Box** returns a minimal record — size, timestamps, owner and parent are
  absent unless `fields` names them.
- **Asana** returns `gid`, `name`, `resource_type` and nothing else; completed,
  due dates, assignee and custom fields all need `opt_fields`.
- **X** is the same again: a post is `id` and `text` until `tweet.fields` asks
  for more, and a user is `id`, `name`, `username` — so follower counts, the most
  commonly wanted column, are absent by default.

Three have no way to list the thing you actually want:

- **Box** has no endpoint that lists files. Content is reached only by walking
  folder items from folder 0, or by search.
- **Asana** *refuses* an unfiltered task request. A task set is reachable only
  through a project, section, tag, user task list, or assignee plus workspace.
- **Square** puts team-member and labour-shift search behind POST, which a
  read-only connector cannot reach, so both can only be fetched one at a time by
  an id obtained elsewhere.

And several where one table holds two opposite things:

- **Xero** — one Invoices table holds both sales invoices (`ACCREC`) and supplier
  bills (`ACCPAY`). A revenue total that does not filter on Type is not a revenue
  total. Same for Credit Notes, and for Bank Transactions where Type separates
  SPEND from RECEIVE. Contacts likewise holds customers and suppliers together.
- **Square** — refunds are not negative payments and appear in a separate table,
  so net revenue is one minus the other.

Unit and shape traps that quietly multiply a figure:

- **Square money is in the smallest currency unit** — `1000 USD` is ten dollars.
- **Xero reports return a nested `Rows` structure**, not flat rows; the section a
  row sits in is what gives it meaning.
- **Twilio bills by `num_segments`, not message count**, so volume and cost do
  not move together — and a call's `price` is negative and null until rated.
- **Square prices live on item *variations*, not items**, so a priced catalogue
  is a join between two types returned by the same call.

Retention and access boundaries are stated where they make a question
unanswerable rather than merely harder: X recent search covers 7 days, timelines
cap near 3,200 posts, DMs 30 days, trends have no history at all; Box's event
stream is bounded by account retention; Asana's event stream lasts about 24
hours; and full-archive X search returns an authorisation error on lower tiers,
which is a subscription fact rather than an absence of posts.

## Tests

`EndpointsJsonLoadableTest` passes after every commit. `EndpointJsonQueryTest`
still errors with the pre-existing Spring `NoClassDefFoundError` described in
#4623 — confirmed there against `stylebi-wiz-main` with none of these commits
applied. This module also needs `-am` to compile on this branch, likewise
pre-existing.

## Remaining

zendesk (85 undescribed, genuine configuration), stripe (9), and the Pipedrive
v2 migration flagged in #4623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
