### PR TITLE
fix(write-coordination): version-stamped commit check across the Composer's write paths

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/RuntimeViewsheet.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeViewsheet.java
@@ -2119,6 +2119,21 @@ public class RuntimeViewsheet extends RuntimeSheet {
    }
 
    /**
+    * For the binding editor's cloned runtime only: the base runtime's write revision at the
+    * moment editing started. {@code finishEdit} compares this against the base runtime's
+    * CURRENT revision before replacing its whole viewsheet, so a concurrent write elsewhere in
+    * the base viewsheet during the binding session is not silently discarded. {@code null} on
+    * every runtime that isn't a binding-editor clone.
+    */
+   public Integer getBaseWriteRevisionAtOpen() {
+      return baseWriteRevisionAtOpen;
+   }
+
+   public void setBaseWriteRevisionAtOpen(Integer baseWriteRevisionAtOpen) {
+      this.baseWriteRevisionAtOpen = baseWriteRevisionAtOpen;
+   }
+
+   /**
     * Get the base worksheet.
     */
    public RuntimeWorksheet getRuntimeWorksheet() {
@@ -2909,6 +2924,7 @@ public class RuntimeViewsheet extends RuntimeSheet {
    private boolean needRefresh = false; // force refresh
    private int mode; // viewsheet mode
    private transient int writeRevision; // bumped on every dialog-owning commit; see getWriteRevision
+   private transient Integer baseWriteRevisionAtOpen; // binding-editor clones only; see accessor
    private ViewsheetSandbox box; // query sandbox
    private AssetRepository rep; // asset repository
    private String execSessionID; // Execution Session ID used for Auditing

--- a/core/src/main/java/inetsoft/report/composition/RuntimeViewsheet.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeViewsheet.java
@@ -2099,6 +2099,26 @@ public class RuntimeViewsheet extends RuntimeSheet {
    }
 
    /**
+    * Get the current write revision. A Composer dialog captures this when it reads its model and
+    * sends it back on commit; a commit whose revision no longer matches is stale and must be
+    * refused rather than silently applied over whatever changed in between. See
+    * {@code 2026-08-17-write-coordination-design.md} for why this exists and
+    * {@code 2026-08-17-write-coordination-implementation.md} for why it is a dedicated counter
+    * rather than the undo-checkpoint index.
+    */
+   public int getWriteRevision() {
+      return writeRevision;
+   }
+
+   /**
+    * Bump the write revision after a dialog-owning commit lands. Returns the new value so a caller
+    * can report it in the same step.
+    */
+   public int bumpWriteRevision() {
+      return ++writeRevision;
+   }
+
+   /**
     * Get the base worksheet.
     */
    public RuntimeWorksheet getRuntimeWorksheet() {
@@ -2888,6 +2908,7 @@ public class RuntimeViewsheet extends RuntimeSheet {
    private boolean preview; // preview flag
    private boolean needRefresh = false; // force refresh
    private int mode; // viewsheet mode
+   private transient int writeRevision; // bumped on every dialog-owning commit; see getWriteRevision
    private ViewsheetSandbox box; // query sandbox
    private AssetRepository rep; // asset repository
    private String execSessionID; // Execution Session ID used for Auditing

--- a/core/src/main/java/inetsoft/web/binding/service/VSBindingService.java
+++ b/core/src/main/java/inetsoft/web/binding/service/VSBindingService.java
@@ -1824,6 +1824,7 @@ public class VSBindingService {
          }
 
          nrvs.setOriginalID(vsId);
+         nrvs.setBaseWriteRevisionAtOpen(rvs.getWriteRevision());
          nrvs.setViewsheet(vs);
          nrvs.setVSTemporaryInfo(wizardTemporaryInfoService.getVSTemporaryInfo(rvs));
          engine.flushRuntimeSheet(id);
@@ -1894,6 +1895,19 @@ public class VSBindingService {
             obox.get().getVariableTable().addAll(nbox.get().getVariableTable());
          }
 
+         // Write coordination: the binding editor edits a CLONE (createRuntimeSheet) and
+         // replaces the base runtime's ENTIRE viewsheet on finish, not just the assembly
+         // being bound -- the largest blast radius of any write path in the Composer. Refuse
+         // rather than silently discard whatever changed in the base viewsheet (any assembly,
+         // via any other write tool) while this binding session was open. See
+         // 2026-08-17-write-coordination-design.md / -implementation.md.
+         Integer expectedRevision = nrvs.getBaseWriteRevisionAtOpen();
+
+         if(expectedRevision != null && expectedRevision != orvs.getWriteRevision()) {
+            throw new MessageException(Catalog.getCatalog().getString(
+               "common.writeConflict", "the viewsheet"));
+         }
+
          updateVSAssemblyBoundAssemblies(nrvs, orvs, assemblyName);
          Viewsheet nvs = nrvs.getViewsheet().clone();
          VSAssembly assembly = nvs.getAssembly(assemblyName);
@@ -1919,6 +1933,7 @@ public class VSBindingService {
          }
 
       orvs.setViewsheet(nvs);
+      orvs.bumpWriteRevision();
       // setViewsheet() triggers resetRuntime() which clears parametersApplied.
       // Mark parameters as already applied so that applyParameterToInput() does
       // not overwrite input-assembly selections with stale variable-table entries

--- a/core/src/main/java/inetsoft/web/binding/service/VSBindingService.java
+++ b/core/src/main/java/inetsoft/web/binding/service/VSBindingService.java
@@ -1901,55 +1901,67 @@ public class VSBindingService {
          // rather than silently discard whatever changed in the base viewsheet (any assembly,
          // via any other write tool) while this binding session was open. See
          // 2026-08-17-write-coordination-design.md / -implementation.md.
+         //
+         // The refusal must still tear the clone runtime down (clear orvs's bindingID, flush,
+         // close nid) -- those calls used to sit after this check, so a conflict left the base
+         // believing a binding session was still open and the clone runtime never closed. Every
+         // retry re-threw at the same point with no way to recover. So the apply-to-orvs step is
+         // skipped on conflict, but the teardown below always runs, and the throw moves to the
+         // end.
          Integer expectedRevision = nrvs.getBaseWriteRevisionAtOpen();
+         boolean conflict = expectedRevision != null && expectedRevision != orvs.getWriteRevision();
+         Viewsheet nvs = null;
 
-         if(expectedRevision != null && expectedRevision != orvs.getWriteRevision()) {
-            throw new MessageException(Catalog.getCatalog().getString(
-               "common.writeConflict", "the viewsheet"));
+         if(!conflict) {
+            updateVSAssemblyBoundAssemblies(nrvs, orvs, assemblyName);
+            nvs = nrvs.getViewsheet().clone();
+            VSAssembly assembly = nvs.getAssembly(assemblyName);
+            AssemblyInfo info = assembly.getInfo();
+            // In any case to clear wizard object editing flag.
+            assembly.setWizardEditing(false);
+
+            if(info instanceof ChartVSAssemblyInfo) {
+               ChartVSAssemblyInfo chartInfo = (ChartVSAssemblyInfo) info;
+               chartInfo.setMaxSize(null);
+               chartInfo.setSummarySortCol(-1);
+               chartInfo.setSummarySortVal(0);
+            }
+
+            if(nbox.isPresent() && VSUtil.isVSAssemblyBinding(assembly) && assembly instanceof CalcTableVSAssembly) {
+               String source = VSUtil.getVSAssemblyBinding(assembly.getTableName());
+               nbox.get().resetDataMap(source);
+            }
+
+            if(info instanceof DataVSAssemblyInfo && !VSWizardEditModes.VIEWSHEET_PANE.equals(editMode)) {
+               //once in binding, click finish, the editedByWizard is false
+               ((DataVSAssemblyInfo) info).setEditedByWizard(false);
+            }
+
+            orvs.setViewsheet(nvs);
+            orvs.bumpWriteRevision();
+            // setViewsheet() triggers resetRuntime() which clears parametersApplied.
+            // Mark parameters as already applied so that applyParameterToInput() does
+            // not overwrite input-assembly selections with stale variable-table entries
+            // on the next reset(initing=true) cycle (e.g. combobox selection change).
+            // Same pattern as the undo/redo fix in RuntimeViewsheet.restoreCheckpoint0().
+            orvs.getViewsheetSandbox().ifPresent(ViewsheetSandbox::markParametersApplied);
+
+            orvs.getViewsheet().setMaxMode(false);
          }
 
-         updateVSAssemblyBoundAssemblies(nrvs, orvs, assemblyName);
-         Viewsheet nvs = nrvs.getViewsheet().clone();
-         VSAssembly assembly = nvs.getAssembly(assemblyName);
-         AssemblyInfo info = assembly.getInfo();
-         // In any case to clear wizard object editing flag.
-         assembly.setWizardEditing(false);
+         orvs.setBindingID(null);
 
-         if(info instanceof ChartVSAssemblyInfo) {
-            ChartVSAssemblyInfo chartInfo = (ChartVSAssemblyInfo) info;
-            chartInfo.setMaxSize(null);
-            chartInfo.setSummarySortCol(-1);
-            chartInfo.setSummarySortVal(0);
-         }
-
-         if(nbox.isPresent() && VSUtil.isVSAssemblyBinding(assembly) && assembly instanceof CalcTableVSAssembly) {
-            String source = VSUtil.getVSAssemblyBinding(assembly.getTableName());
-            nbox.get().resetDataMap(source);
-         }
-
-         if(info instanceof DataVSAssemblyInfo && !VSWizardEditModes.VIEWSHEET_PANE.equals(editMode)) {
-            //once in binding, click finish, the editedByWizard is false
-            ((DataVSAssemblyInfo) info).setEditedByWizard(false);
-         }
-
-      orvs.setViewsheet(nvs);
-      orvs.bumpWriteRevision();
-      // setViewsheet() triggers resetRuntime() which clears parametersApplied.
-      // Mark parameters as already applied so that applyParameterToInput() does
-      // not overwrite input-assembly selections with stale variable-table entries
-      // on the next reset(initing=true) cycle (e.g. combobox selection change).
-      // Same pattern as the undo/redo fix in RuntimeViewsheet.restoreCheckpoint0().
-      orvs.getViewsheetSandbox().ifPresent(ViewsheetSandbox::markParametersApplied);
-
-      orvs.setBindingID(null);
-      orvs.getViewsheet().setMaxMode(false);
-
-         if(!VSWizardEditModes.WIZARD_DASHBOARD.equals(originalMode)) {
+         if(!conflict && !VSWizardEditModes.WIZARD_DASHBOARD.equals(originalMode)) {
             orvs.addCheckpoint(nvs.prepareCheckpoint());
          }
 
          engine.flushRuntimeSheet(oid == null ? nid : oid);
          engine.closeViewsheet(nid, principal);
+
+         if(conflict) {
+            throw new MessageException(Catalog.getCatalog().getString(
+               "common.writeConflict", "the viewsheet"));
+         }
 
          return oid;
       }

--- a/core/src/main/java/inetsoft/web/composer/model/vs/CalcTablePropertyDialogModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/CalcTablePropertyDialogModel.java
@@ -62,7 +62,21 @@ public class CalcTablePropertyDialogModel implements Serializable {
       this.calcTableAdvancedPaneModel = calcTableAdvancedPaneModel;
    }
 
+   /**
+    * The write revision this model was read at. See
+    * {@link inetsoft.report.composition.RuntimeViewsheet#getWriteRevision()} and
+    * 2026-08-17-write-coordination-implementation.md.
+    */
+   public Integer getRevision() {
+      return revision;
+   }
+
+   public void setRevision(Integer revision) {
+      this.revision = revision;
+   }
+
    TableViewGeneralPaneModel tableViewGeneralPaneModel;
    CalcTableAdvancedPaneModel calcTableAdvancedPaneModel;
    VSAssemblyScriptPaneModel vsAssemblyScriptPaneModel;
+   private Integer revision;
 }

--- a/core/src/main/java/inetsoft/web/composer/model/vs/CalendarPropertyDialogModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/CalendarPropertyDialogModel.java
@@ -73,8 +73,21 @@ public class CalendarPropertyDialogModel implements Serializable {
       this.vsAssemblyScriptPaneModel = vsAssemblyScriptPaneModel;
    }
 
+   /**
+    * The write revision this model was read at. See {@link inetsoft.report.composition.
+    * RuntimeViewsheet#getWriteRevision()} and 2026-08-17-write-coordination-implementation.md.
+    */
+   public Integer getRevision() {
+      return revision;
+   }
+
+   public void setRevision(Integer revision) {
+      this.revision = revision;
+   }
+
    private CalendarGeneralPaneModel calendarGeneralPaneModel;
    private CalendarDataPaneModel calendarDataPaneModel;
    private CalendarAdvancedPaneModel calendarAdvancedPaneModel;
    private VSAssemblyScriptPaneModel vsAssemblyScriptPaneModel;
+   private Integer revision;
 }

--- a/core/src/main/java/inetsoft/web/composer/model/vs/ChartPropertyDialogModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/ChartPropertyDialogModel.java
@@ -75,9 +75,23 @@ public class ChartPropertyDialogModel implements Serializable {
       this.vsAssemblyScriptPaneModel = vsAssemblyScriptPaneModel;
    }
 
+   /**
+    * The write revision this model was read at. See
+    * {@link inetsoft.report.composition.RuntimeViewsheet#getWriteRevision()} and
+    * 2026-08-17-write-coordination-implementation.md.
+    */
+   public Integer getRevision() {
+      return revision;
+   }
+
+   public void setRevision(Integer revision) {
+      this.revision = revision;
+   }
+
    private ChartGeneralPaneModel chartGeneralPaneModel;
    private ChartAdvancedPaneModel chartAdvancedPaneModel;
    private ChartLinePaneModel chartLinePaneModel;
    private HierarchyPropertyPaneModel hierarchyPropertyPaneModel;
    private VSAssemblyScriptPaneModel vsAssemblyScriptPaneModel;
+   private Integer revision;
 }

--- a/core/src/main/java/inetsoft/web/composer/model/vs/CrosstabPropertyDialogModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/CrosstabPropertyDialogModel.java
@@ -75,8 +75,21 @@ public class CrosstabPropertyDialogModel implements Serializable {
       this.vsAssemblyScriptPaneModel = vsAssemblyScriptPaneModel;
    }
 
+   /**
+    * The write revision this model was read at. See {@link inetsoft.report.composition.
+    * RuntimeViewsheet#getWriteRevision()} and 2026-08-17-write-coordination-implementation.md.
+    */
+   public Integer getRevision() {
+      return revision;
+   }
+
+   public void setRevision(Integer revision) {
+      this.revision = revision;
+   }
+
    private TableViewGeneralPaneModel tableViewGeneralPaneModel;
    private CrosstabAdvancedPaneModel crosstabAdvancedPaneModel;
    private HierarchyPropertyPaneModel hierarchyPropertyPaneModel;
    private VSAssemblyScriptPaneModel vsAssemblyScriptPaneModel;
+   private Integer revision;
 }

--- a/core/src/main/java/inetsoft/web/composer/model/vs/GaugePropertyDialogModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/GaugePropertyDialogModel.java
@@ -71,6 +71,20 @@ public class GaugePropertyDialogModel implements Serializable {
       this.vsAssemblyScriptPaneModel = vsAssemblyScriptPaneModel;
    }
 
+   /**
+    * The write revision this model was read at (see {@link inetsoft.report.composition.
+    * RuntimeViewsheet#getWriteRevision()}). Sent back unchanged on commit so the server can refuse
+    * a stale write instead of silently applying it. {@code null} until the client is updated to
+    * round-trip it -- see 2026-08-17-write-coordination-implementation.md.
+    */
+   public Integer getRevision() {
+      return revision;
+   }
+
+   public void setRevision(Integer revision) {
+      this.revision = revision;
+   }
+
    @Override
    public String toString() {
       return "GaugePropertyDialogModel{" +
@@ -85,4 +99,5 @@ public class GaugePropertyDialogModel implements Serializable {
    private DataOutputPaneModel dataOutputPaneModel;
    private GaugeAdvancedPaneModel gaugeAdvancedPaneModel;
    private VSAssemblyScriptPaneModel vsAssemblyScriptPaneModel;
+   private Integer revision;
 }

--- a/core/src/main/java/inetsoft/web/composer/model/vs/GroupContainerPropertyDialogModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/GroupContainerPropertyDialogModel.java
@@ -57,7 +57,21 @@ public class GroupContainerPropertyDialogModel implements Serializable {
       this.vsAssemblyScriptPane = vsAssemblyScriptPane;
    }
 
+   /**
+    * The write revision this model was read at. See
+    * {@link inetsoft.report.composition.RuntimeViewsheet#getWriteRevision()} and
+    * 2026-08-17-write-coordination-implementation.md.
+    */
+   public Integer getRevision() {
+      return revision;
+   }
+
+   public void setRevision(Integer revision) {
+      this.revision = revision;
+   }
+
    private GroupContainerGeneralPaneModel groupContainerGeneralPane;
    private ImageScalePaneModel imageScalePane;
    private VSAssemblyScriptPaneModel vsAssemblyScriptPane;
+   private Integer revision;
 }

--- a/core/src/main/java/inetsoft/web/composer/model/vs/HighlightDialogModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/HighlightDialogModel.java
@@ -153,6 +153,19 @@ public class HighlightDialogModel implements Serializable {
       this.text = text;
    }
 
+   /**
+    * The write revision this model was read at. See
+    * {@link inetsoft.report.composition.RuntimeViewsheet#getWriteRevision()} and
+    * 2026-08-17-write-coordination-implementation.md.
+    */
+   public Integer getRevision() {
+      return revision;
+   }
+
+   public void setRevision(Integer revision) {
+      this.revision = revision;
+   }
+
     private int row;
     private int col;
     private String measure;
@@ -169,4 +182,5 @@ public class HighlightDialogModel implements Serializable {
     private List<String> nonsupportBrowseFields;
     private boolean axis;
     private boolean text;
+    private Integer revision;
 }

--- a/core/src/main/java/inetsoft/web/composer/model/vs/HyperlinkDialogModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/HyperlinkDialogModel.java
@@ -226,6 +226,19 @@ public class HyperlinkDialogModel implements Serializable {
       this.emptyPlotLink = emptyPlotLink;
    }
 
+   /**
+    * The write revision this model was read at. See
+    * {@link inetsoft.report.composition.RuntimeViewsheet#getWriteRevision()} and
+    * 2026-08-17-write-coordination-implementation.md.
+    */
+   public Integer getRevision() {
+      return revision;
+   }
+
+   public void setRevision(Integer revision) {
+      this.revision = revision;
+   }
+
    @Override
    public String toString() {
       return "HyperlinkDialogModel{" +
@@ -272,4 +285,5 @@ public class HyperlinkDialogModel implements Serializable {
    private DataRefModel[] grayedOutFields;
    private boolean titleLink;
    private boolean emptyPlotLink;
+   private Integer revision;
 }

--- a/core/src/main/java/inetsoft/web/composer/model/vs/ImagePropertyDialogModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/ImagePropertyDialogModel.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.serial.Serial;
 import org.immutables.value.Value;
 
+import javax.annotation.Nullable;
+
 /**
  * Data transfer object that represents the {@link ImagePropertyDialogModel} for the
  * image property dialog
@@ -54,6 +56,14 @@ public abstract class ImagePropertyDialogModel {
          .scriptEnabled(false)
          .build();
    }
+
+   /**
+    * The write revision this model was read at. See
+    * {@link inetsoft.report.composition.RuntimeViewsheet#getWriteRevision()} and
+    * 2026-08-17-write-coordination-implementation.md.
+    */
+   @Nullable
+   public abstract Integer revision();
 
    public static Builder builder() {
       return new Builder();

--- a/core/src/main/java/inetsoft/web/composer/model/vs/LinePropertyDialogModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/LinePropertyDialogModel.java
@@ -63,6 +63,18 @@ public class LinePropertyDialogModel implements Serializable {
       this.vsAssemblyScriptPaneModel = vsAssemblyScriptPaneModel;
    }
 
+   /**
+    * The write revision this model was read at. See {@link inetsoft.report.composition.
+    * RuntimeViewsheet#getWriteRevision()} and 2026-08-17-write-coordination-implementation.md.
+    */
+   public Integer getRevision() {
+      return revision;
+   }
+
+   public void setRevision(Integer revision) {
+      this.revision = revision;
+   }
+
    @Override
    public String toString() {
       return "LinePropertyDialogModel{" +
@@ -75,4 +87,5 @@ public class LinePropertyDialogModel implements Serializable {
    private ShapeGeneralPaneModel shapeGeneralPaneModel;
    private LinePropertyPaneModel linePropertyPaneModel;
    private VSAssemblyScriptPaneModel vsAssemblyScriptPaneModel;
+   private Integer revision;
 }

--- a/core/src/main/java/inetsoft/web/composer/model/vs/OvalPropertyDialogModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/OvalPropertyDialogModel.java
@@ -63,6 +63,18 @@ public class OvalPropertyDialogModel implements Serializable {
       this.vsAssemblyScriptPaneModel = vsAssemblyScriptPaneModel;
    }
 
+   /**
+    * The write revision this model was read at. See {@link inetsoft.report.composition.
+    * RuntimeViewsheet#getWriteRevision()} and 2026-08-17-write-coordination-implementation.md.
+    */
+   public Integer getRevision() {
+      return revision;
+   }
+
+   public void setRevision(Integer revision) {
+      this.revision = revision;
+   }
+
    @Override
    public String toString() {
       return "OvalPropertyDialogModel{" +
@@ -75,4 +87,5 @@ public class OvalPropertyDialogModel implements Serializable {
    private ShapeGeneralPaneModel shapeGeneralPaneModel;
    private OvalPropertyPaneModel ovalPropertyPaneModel;
    private VSAssemblyScriptPaneModel vsAssemblyScriptPaneModel;
+   private Integer revision;
 }

--- a/core/src/main/java/inetsoft/web/composer/model/vs/RangeSliderPropertyDialogModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/RangeSliderPropertyDialogModel.java
@@ -66,8 +66,22 @@ public class RangeSliderPropertyDialogModel implements Serializable {
       this.vsAssemblyScriptPaneModel = vsAssemblyScriptPaneModel;
    }
 
+   /**
+    * The write revision this model was read at. See
+    * {@link inetsoft.report.composition.RuntimeViewsheet#getWriteRevision()} and
+    * 2026-08-17-write-coordination-implementation.md.
+    */
+   public Integer getRevision() {
+      return revision;
+   }
+
+   public void setRevision(Integer revision) {
+      this.revision = revision;
+   }
+
    private RangeSliderGeneralPaneModel rangeSliderGeneralPaneModel;
    private RangeSliderDataPaneModel rangeSliderDataPaneModel;
    private RangeSliderAdvancedPaneModel rangeSliderAdvancedPaneModel;
    private VSAssemblyScriptPaneModel vsAssemblyScriptPaneModel;
+   private Integer revision;
 }

--- a/core/src/main/java/inetsoft/web/composer/model/vs/RectanglePropertyDialogModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/RectanglePropertyDialogModel.java
@@ -63,6 +63,18 @@ public class RectanglePropertyDialogModel implements Serializable {
       this.vsAssemblyScriptPaneModel = vsAssemblyScriptPaneModel;
    }
 
+   /**
+    * The write revision this model was read at. See {@link inetsoft.report.composition.
+    * RuntimeViewsheet#getWriteRevision()} and 2026-08-17-write-coordination-implementation.md.
+    */
+   public Integer getRevision() {
+      return revision;
+   }
+
+   public void setRevision(Integer revision) {
+      this.revision = revision;
+   }
+
    @Override
    public String toString() {
       return "RectanglePropertyDialogModel{" +
@@ -75,4 +87,5 @@ public class RectanglePropertyDialogModel implements Serializable {
    private ShapeGeneralPaneModel shapeGeneralPaneModel;
    private RectanglePropertyPaneModel rectanglePropertyPaneModel;
    private VSAssemblyScriptPaneModel vsAssemblyScriptPaneModel;
+   private Integer revision;
 }

--- a/core/src/main/java/inetsoft/web/composer/model/vs/SelectionContainerPropertyDialogModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/SelectionContainerPropertyDialogModel.java
@@ -44,6 +44,20 @@ public class SelectionContainerPropertyDialogModel implements Serializable {
       this.vsAssemblyScriptPaneModel = vsAssemblyScriptPaneModel;
    }
 
+   /**
+    * The write revision this model was read at. See
+    * {@link inetsoft.report.composition.RuntimeViewsheet#getWriteRevision()} and
+    * 2026-08-17-write-coordination-implementation.md.
+    */
+   public Integer getRevision() {
+      return revision;
+   }
+
+   public void setRevision(Integer revision) {
+      this.revision = revision;
+   }
+
    private SelectionContainerGeneralPaneModel selectionContainerGeneralPaneModel;
    private VSAssemblyScriptPaneModel vsAssemblyScriptPaneModel;
+   private Integer revision;
 }

--- a/core/src/main/java/inetsoft/web/composer/model/vs/SelectionListPropertyDialogModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/SelectionListPropertyDialogModel.java
@@ -58,7 +58,21 @@ public class SelectionListPropertyDialogModel implements Serializable {
       this.vsAssemblyScriptPaneModel = vsAssemblyScriptPaneModel;
    }
 
+   /**
+    * The write revision this model was read at. See
+    * {@link inetsoft.report.composition.RuntimeViewsheet#getWriteRevision()} and
+    * 2026-08-17-write-coordination-implementation.md.
+    */
+   public Integer getRevision() {
+      return revision;
+   }
+
+   public void setRevision(Integer revision) {
+      this.revision = revision;
+   }
+
    private SelectionGeneralPaneModel selectionGeneralPaneModel;
    private SelectionListPaneModel selectionListPaneModel;
    private VSAssemblyScriptPaneModel vsAssemblyScriptPaneModel;
+   private Integer revision;
 }

--- a/core/src/main/java/inetsoft/web/composer/model/vs/SelectionTreePropertyDialogModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/SelectionTreePropertyDialogModel.java
@@ -55,7 +55,20 @@ public class SelectionTreePropertyDialogModel implements Serializable {
       this.vsAssemblyScriptPaneModel = vsAssemblyScriptPaneModel;
    }
 
+   /**
+    * The write revision this model was read at. See {@link inetsoft.report.composition.
+    * RuntimeViewsheet#getWriteRevision()} and 2026-08-17-write-coordination-implementation.md.
+    */
+   public Integer getRevision() {
+      return revision;
+   }
+
+   public void setRevision(Integer revision) {
+      this.revision = revision;
+   }
+
    private SelectionGeneralPaneModel selectionGeneralPaneModel;
    private SelectionTreePaneModel selectionTreePaneModel;
    private VSAssemblyScriptPaneModel vsAssemblyScriptPaneModel;
+   private Integer revision;
 }

--- a/core/src/main/java/inetsoft/web/composer/model/vs/SubmitPropertyDialogModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/SubmitPropertyDialogModel.java
@@ -55,6 +55,19 @@ public class SubmitPropertyDialogModel implements Serializable {
       this.clickableScriptPaneModel = clickableScriptPaneModel;
    }
 
+   /**
+    * The write revision this model was read at. See {@link
+    * inetsoft.report.composition.RuntimeViewsheet#getWriteRevision()} and
+    * 2026-08-17-write-coordination-implementation.md.
+    */
+   public Integer getRevision() {
+      return revision;
+   }
+
+   public void setRevision(Integer revision) {
+      this.revision = revision;
+   }
+
    @Override
    public String toString() {
       return "SubmitPropertyDialogModel{" +
@@ -65,4 +78,5 @@ public class SubmitPropertyDialogModel implements Serializable {
 
    private SubmitGeneralPaneModel submitGeneralPaneModel;
    private ClickableScriptPaneModel clickableScriptPaneModel;
+   private Integer revision;
 }

--- a/core/src/main/java/inetsoft/web/composer/model/vs/TabPropertyDialogModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/TabPropertyDialogModel.java
@@ -49,6 +49,19 @@ public class TabPropertyDialogModel implements Serializable {
       this.vsAssemblyScriptPaneModel = vsAssemblyScriptPaneModel;
    }
 
+   /**
+    * The write revision this model was read at. See
+    * {@link inetsoft.report.composition.RuntimeViewsheet#getWriteRevision()} and
+    * 2026-08-17-write-coordination-implementation.md.
+    */
+   public Integer getRevision() {
+      return revision;
+   }
+
+   public void setRevision(Integer revision) {
+      this.revision = revision;
+   }
+
    @Override
    public String toString() {
       return "TabPropertyDialogModel{" +
@@ -59,4 +72,5 @@ public class TabPropertyDialogModel implements Serializable {
 
    private TabGeneralPaneModel tabGeneralPaneModel;
    private VSAssemblyScriptPaneModel vsAssemblyScriptPaneModel;
+   private Integer revision;
 }

--- a/core/src/main/java/inetsoft/web/composer/model/vs/TableViewPropertyDialogModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/TableViewPropertyDialogModel.java
@@ -68,8 +68,22 @@ public class TableViewPropertyDialogModel implements Serializable {
       this.id = id;
    }
 
+   /**
+    * The write revision this model was read at. See
+    * {@link inetsoft.report.composition.RuntimeViewsheet#getWriteRevision()} and
+    * 2026-08-17-write-coordination-implementation.md.
+    */
+   public Integer getRevision() {
+      return revision;
+   }
+
+   public void setRevision(Integer revision) {
+      this.revision = revision;
+   }
+
    private String id;
    private TableViewGeneralPaneModel tableViewGeneralPaneModel;
    private TableAdvancedPaneModel tableAdvancedPaneModel;
    private VSAssemblyScriptPaneModel vsAssemblyScriptPaneModel;
+   private Integer revision;
 }

--- a/core/src/main/java/inetsoft/web/composer/model/vs/TextPropertyDialogModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/TextPropertyDialogModel.java
@@ -81,6 +81,19 @@ public class TextPropertyDialogModel implements Serializable {
       this.clickableScriptPaneModel = clickableScriptPaneModel;
    }
 
+   /**
+    * The write revision this model was read at. See {@link
+    * inetsoft.report.composition.RuntimeViewsheet#getWriteRevision()} and
+    * 2026-08-17-write-coordination-implementation.md.
+    */
+   public Integer getRevision() {
+      return revision;
+   }
+
+   public void setRevision(Integer revision) {
+      this.revision = revision;
+   }
+
    @Override
    public String toString() {
       return "TextPropertyDialogModel{" +
@@ -95,4 +108,5 @@ public class TextPropertyDialogModel implements Serializable {
    private TextGeneralPaneModel textGeneralPaneModel;
    private DataOutputPaneModel dataOutputPaneModel;
    private ClickableScriptPaneModel clickableScriptPaneModel;
+   private Integer revision;
 }

--- a/core/src/main/java/inetsoft/web/composer/model/vs/VSConditionDialogModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/VSConditionDialogModel.java
@@ -50,10 +50,24 @@ public class VSConditionDialogModel implements Serializable {
       this.fields = fields;
    }
 
+   /**
+    * The write revision this model was read at. See
+    * {@link inetsoft.report.composition.RuntimeViewsheet#getWriteRevision()} and
+    * 2026-08-17-write-coordination-implementation.md.
+    */
+   public Integer getRevision() {
+      return revision;
+   }
+
+   public void setRevision(Integer revision) {
+      this.revision = revision;
+   }
+
    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "jsonType")
    @JsonSubTypes({ @JsonSubTypes.Type(value = ConditionModel.class, name = "condition"),
                    @JsonSubTypes.Type(value = JunctionOperatorModel.class, name = "junction") })
    private Object[] conditionList;
    private String tableName;
    private DataRefModel[] fields;
+   private Integer revision;
 }

--- a/core/src/main/java/inetsoft/web/composer/model/vs/ViewsheetObjectPropertyDialogModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/ViewsheetObjectPropertyDialogModel.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.serial.Serial;
 import org.immutables.value.Value;
 
+import javax.annotation.Nullable;
+
 /**
  * Data transfer object that represents the {@link ViewsheetObjectPropertyDialogModel}
  * for the embedded viewsheet property dialog
@@ -45,6 +47,13 @@ public abstract class ViewsheetObjectPropertyDialogModel {
    public SizePositionPaneModel sizePositionPaneModel() {
       return new SizePositionPaneModel();
    }
+
+   /**
+    * The write revision this model was read at. See {@link inetsoft.report.composition.
+    * RuntimeViewsheet#getWriteRevision()} and 2026-08-17-write-coordination-implementation.md.
+    */
+   @Nullable
+   public abstract Integer revision();
 
    public static Builder builder() {
       return new Builder();

--- a/core/src/main/java/inetsoft/web/composer/model/vs/ViewsheetPropertyDialogModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/ViewsheetPropertyDialogModel.java
@@ -33,6 +33,13 @@ import javax.annotation.Nullable;
 public interface ViewsheetPropertyDialogModel {
    @Nullable String id();
 
+   /**
+    * The write revision this model was read at. See
+    * {@link inetsoft.report.composition.RuntimeViewsheet#getWriteRevision()} and
+    * 2026-08-17-write-coordination-implementation.md.
+    */
+   @Nullable Integer revision();
+
    @Value.Default
    default VSOptionsPaneModel vsOptionsPane() {
       return new VSOptionsPaneModel();

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/CalcTablePropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/CalcTablePropertyDialogService.java
@@ -186,6 +186,7 @@ public class CalcTablePropertyDialogService {
       vsAssemblyScriptPaneModel.expression(calcTableAssemblyInfo.getScript() == null ?
                                               "" : calcTableAssemblyInfo.getScript());
       result.setVsAssemblyScriptPaneModel(vsAssemblyScriptPaneModel.build());
+      result.setRevision(rvs.getWriteRevision());
 
       return result;
    }
@@ -460,7 +461,7 @@ public class CalcTablePropertyDialogService {
 
       this.vsObjectPropertyService.editObjectProperty(
          viewsheet, calcTableAssemblyInfo, objectId, basicGeneralPaneModel.getName(), linkUri,
-         principal, commandDispatcher);
+         principal, commandDispatcher, true, value.getRevision());
       return null;
    }
 

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/CalendarPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/CalendarPropertyDialogService.java
@@ -147,6 +147,7 @@ public class CalendarPropertyDialogService {
          calendarAssemblyInfo.getScript() == null ?
             "" : calendarAssemblyInfo.getScript());
       result.setVsAssemblyScriptPaneModel(vsAssemblyScriptPaneModel.build());
+      result.setRevision(rvs.getWriteRevision());
 
       return result;
    }
@@ -326,7 +327,7 @@ public class CalendarPropertyDialogService {
 
       this.vsObjectPropertyService.editObjectProperty(
          viewsheet, info, objectId, basicGeneralPaneModel.getName(), linkUri,
-         principal, commandDispatcher);
+         principal, commandDispatcher, true, value.getRevision());
 
       return null;
    }

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/ChartPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/ChartPropertyDialogService.java
@@ -295,6 +295,7 @@ public class ChartPropertyDialogService {
       vsAssemblyScriptPaneModel.expression(chartAssemblyInfo.getScript() == null ?
                                               "" : chartAssemblyInfo.getScript());
       result.setVsAssemblyScriptPaneModel(vsAssemblyScriptPaneModel.build());
+      result.setRevision(rvs.getWriteRevision());
 
       return result;
    }
@@ -468,7 +469,7 @@ public class ChartPropertyDialogService {
 
       this.vsObjectPropertyService.editObjectProperty(
          viewsheet, assemblyInfo, objectId, basicGeneralPaneModel.getName(), linkUri,
-         principal, commandDispatcher);
+         principal, commandDispatcher, true, value.getRevision());
 
       if(viewsheet.getOriginalID() != null) {
          VSChartInfo cinfo = assemblyInfo.getVSChartInfo();

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/ChartPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/ChartPropertyDialogService.java
@@ -467,11 +467,14 @@ public class ChartPropertyDialogService {
          }
       }
 
-      this.vsObjectPropertyService.editObjectProperty(
+      boolean applied = this.vsObjectPropertyService.editObjectProperty(
          viewsheet, assemblyInfo, objectId, basicGeneralPaneModel.getName(), linkUri,
          principal, commandDispatcher, true, value.getRevision());
 
-      if(viewsheet.getOriginalID() != null) {
+      // A refusal (write conflict, dependency cycle, ...) means assemblyInfo was never
+      // committed to the runtime -- pushing a binding model built from it here would tell
+      // the client the edit succeeded when it did not.
+      if(applied && viewsheet.getOriginalID() != null) {
          VSChartInfo cinfo = assemblyInfo.getVSChartInfo();
          cinfo.setChartDescriptor(((ChartDescriptor) chartDescriptor.clone()));
          GraphUtil.fixVisualFrames(cinfo);

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/CrosstabPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/CrosstabPropertyDialogService.java
@@ -207,6 +207,7 @@ public class CrosstabPropertyDialogService {
       vsAssemblyScriptPaneModel.expression(crosstabAssemblyInfo.getScript() == null ?
                                               "" : crosstabAssemblyInfo.getScript());
       result.setVsAssemblyScriptPaneModel(vsAssemblyScriptPaneModel.build());
+      result.setRevision(rvs.getWriteRevision());
 
       return result;
    }
@@ -338,7 +339,7 @@ public class CrosstabPropertyDialogService {
 
       this.vsObjectPropertyService.editObjectProperty(
          viewsheet, assemblyInfo, objectId, basicGeneralPaneModel.getName(), linkUri,
-         principal, commandDispatcher);
+         principal, commandDispatcher, true, value.getRevision());
 
       return null;
    }

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/GaugePropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/GaugePropertyDialogService.java
@@ -199,6 +199,7 @@ public class GaugePropertyDialogService {
       vsAssemblyScriptPaneModel.expression(gaugeAssemblyInfo.getScript() == null ?
                                               "" : gaugeAssemblyInfo.getScript());
       result.setVsAssemblyScriptPaneModel(vsAssemblyScriptPaneModel.build());
+      result.setRevision(rvs.getWriteRevision());
 
       return result;
    }
@@ -322,7 +323,7 @@ public class GaugePropertyDialogService {
 
       this.vsObjectPropertyService.editObjectProperty(
          rvs, gaugeAssemblyInfo, objectId, basicGeneralPaneModel.getName(), linkUri, principal,
-         commandDispatcher);
+         commandDispatcher, true, value.getRevision());
 
       return null;
    }

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/GroupContainerPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/GroupContainerPropertyDialogService.java
@@ -137,6 +137,8 @@ public class GroupContainerPropertyDialogService {
       vsAssemblyScriptPane.expression(info.getScript() == null ? "" : info.getScript());
       groupContainerPropertyDialog.setVsAssemblyScriptPane(vsAssemblyScriptPane.build());
 
+      groupContainerPropertyDialog.setRevision(rvs.getWriteRevision());
+
       return groupContainerPropertyDialog;
    }
 
@@ -207,7 +209,8 @@ public class GroupContainerPropertyDialogService {
       info.setScript(vsAssemblyScriptPane.expression());
 
       this.vsObjectPropertyService.editObjectProperty(
-         rvs, info, objectId, basicGeneralPane.getName(), linkUri, principal, commandDispatcher);
+         rvs, info, objectId, basicGeneralPane.getName(), linkUri, principal, commandDispatcher,
+         true, value.getRevision());
 
       return null;
    }

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/HighlightDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/HighlightDialogService.java
@@ -369,6 +369,7 @@ public class HighlightDialogService {
       }
 
       model.setHighlights(highlightModelList.toArray(new HighlightModel[0]));
+      model.setRevision(rvs.getWriteRevision());
       return model;
    }
 
@@ -420,7 +421,8 @@ public class HighlightDialogService {
       VSAssemblyInfo assemblyInfo = updateHighlights(model, oldAssemblyInfo, box.get(), principal);
 
       this.vsObjectPropertyService.editObjectProperty(
-         rvs, assemblyInfo, objectId, objectId, linkUri, principal, dispatcher);
+         rvs, assemblyInfo, objectId, objectId, linkUri, principal, dispatcher,
+         true, model.getRevision());
 
       return null;
    }

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/HyperlinkDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/HyperlinkDialogService.java
@@ -181,6 +181,7 @@ public class HyperlinkDialogService {
          model.setLinkType(NONE);
          model.setSelf(true);
          model.setSendViewsheetParameters(true);
+         model.setRevision(rvs.getWriteRevision());
 
          return model;
       }
@@ -231,6 +232,7 @@ public class HyperlinkDialogService {
       }
 
       model.setParamList(parameters);
+      model.setRevision(rvs.getWriteRevision());
 
       return model;
    }
@@ -324,7 +326,7 @@ public class HyperlinkDialogService {
          }
 
          this.vsObjectPropertyService.editObjectProperty(
-            rvs, info, objectId, objectId, linkUri, principal, dispatcher);
+            rvs, info, objectId, objectId, linkUri, principal, dispatcher, true, model.getRevision());
       }
       else {
          VSAssemblyInfo info = (VSAssemblyInfo) assembly.getInfo();

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/ImagePropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/ImagePropertyDialogService.java
@@ -165,6 +165,7 @@ public class ImagePropertyDialogService {
          .dataOutputPaneModel(dataOutputPaneModel)
          .imageAdvancedPaneModel(imageAdvancedPaneModel)
          .clickableScriptPaneModel(clickableScriptPaneModel.build())
+         .revision(rvs.getWriteRevision())
          .build();
 
       GeneralPropPaneModel generalPropPaneModel = outputGeneralPaneModel.getGeneralPropPaneModel();
@@ -369,7 +370,7 @@ public class ImagePropertyDialogService {
 
       this.vsObjectPropertyService.editObjectProperty(
          rvs, imageAssemblyInfo, objectId, basicGeneralPaneModel.getName(), linkUri, principal,
-         commandDispatcher);
+         commandDispatcher, true, value.revision());
 
       return null;
    }

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/LinePropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/LinePropertyDialogService.java
@@ -104,6 +104,7 @@ public class LinePropertyDialogService {
       vsAssemblyScriptPaneModel.expression(lineAssemblyInfo.getScript() == null ?
                                               "" : lineAssemblyInfo.getScript());
       result.setVsAssemblyScriptPaneModel(vsAssemblyScriptPaneModel.build());
+      result.setRevision(rvs.getWriteRevision());
 
       return result;
    }
@@ -200,7 +201,7 @@ public class LinePropertyDialogService {
 
       this.vsObjectPropertyService.editObjectProperty(
          rvs, lineAssemblyInfo, objectId, basicGeneralPaneModel.getName(), linkUri, principal,
-         commandDispatcher);
+         commandDispatcher, true, value.getRevision());
 
       return null;
    }

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/OvalPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/OvalPropertyDialogService.java
@@ -135,6 +135,7 @@ public class OvalPropertyDialogService {
       vsAssemblyScriptPaneModel.expression(ovalAssemblyInfo.getScript() == null ?
                                               "" : ovalAssemblyInfo.getScript());
       result.setVsAssemblyScriptPaneModel(vsAssemblyScriptPaneModel.build());
+      result.setRevision(rvs.getWriteRevision());
 
       return result;
    }
@@ -209,7 +210,7 @@ public class OvalPropertyDialogService {
 
       this.vsObjectPropertyService.editObjectProperty(
          rvs, ovalAssemblyInfo, objectId, basicGeneralPaneModel.getName(), linkUri, principal,
-         commandDispatcher);
+         commandDispatcher, true, value.getRevision());
 
       return null;
    }

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/RangeSliderPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/RangeSliderPropertyDialogService.java
@@ -211,6 +211,7 @@ public class RangeSliderPropertyDialogService {
       vsAssemblyScriptPaneModel.expression(timeSliderAssemblyInfo.getScript() == null ?
                                               "" : timeSliderAssemblyInfo.getScript());
       result.setVsAssemblyScriptPaneModel(vsAssemblyScriptPaneModel.build());
+      result.setRevision(rvs.getWriteRevision());
 
       return result;
    }
@@ -289,7 +290,7 @@ public class RangeSliderPropertyDialogService {
 
       this.vsObjectPropertyService.editObjectProperty(
          viewsheet, info, objectId, basicGeneralPaneModel.getName(), linkUri,
-         principal, commandDispatcher);
+         principal, commandDispatcher, true, value.getRevision());
 
       return null;
    }

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/RectanglePropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/RectanglePropertyDialogService.java
@@ -134,6 +134,7 @@ public class RectanglePropertyDialogService {
       vsAssemblyScriptPaneModel.expression(rectangleAssemblyInfo.getScript() == null ?
                                               "" : rectangleAssemblyInfo.getScript());
       result.setVsAssemblyScriptPaneModel(vsAssemblyScriptPaneModel.build());
+      result.setRevision(rvs.getWriteRevision());
 
       return result;
    }
@@ -214,7 +215,7 @@ public class RectanglePropertyDialogService {
 
       this.vsObjectPropertyService.editObjectProperty(
          rvs, rectangleAssemblyInfo, objectId, basicGeneralPaneModel.getName(), linkUri, principal,
-         commandDispatcher);
+         commandDispatcher, true, value.getRevision());
 
       return null;
    }

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/SelectionContainerPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/SelectionContainerPropertyDialogService.java
@@ -103,6 +103,7 @@ public class SelectionContainerPropertyDialogService {
          selectionContainerAssemblyInfo.getScript() == null ?
             "" : selectionContainerAssemblyInfo.getScript());
       result.setVsAssemblyScriptPaneModel(vsAssemblyScriptPaneModel.build());
+      result.setRevision(rvs.getWriteRevision());
 
       return result;
    }
@@ -161,7 +162,7 @@ public class SelectionContainerPropertyDialogService {
 
       this.vsObjectPropertyService.editObjectProperty(
          viewsheet, selectionContainerAssemblyInfo, objectId, basicGeneralPaneModel.getName(),
-         linkUri, principal, commandDispatcher);
+         linkUri, principal, commandDispatcher, true, value.getRevision());
 
       return null;
    }

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/SelectionListPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/SelectionListPropertyDialogService.java
@@ -173,6 +173,7 @@ public class SelectionListPropertyDialogService {
       vsAssemblyScriptPaneModel.expression(selectionListAssemblyInfo.getScript() == null ?
                                               "" : selectionListAssemblyInfo.getScript());
       result.setVsAssemblyScriptPaneModel(vsAssemblyScriptPaneModel.build());
+      result.setRevision(rvs.getWriteRevision());
 
       return result;
    }
@@ -271,7 +272,7 @@ public class SelectionListPropertyDialogService {
 
       this.vsObjectPropertyService.editObjectProperty(
          rvs, selectionListAssemblyInfo, objectId, basicGeneralPaneModel.getName(), linkUri,
-         principal, commandDispatcher);
+         principal, commandDispatcher, true, value.getRevision());
 
       return null;
    }

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/SelectionTreePropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/SelectionTreePropertyDialogService.java
@@ -200,6 +200,7 @@ public class SelectionTreePropertyDialogService {
       vsAssemblyScriptPaneModel.expression(selectionTreeAssemblyInfo.getScript() == null ?
                                               "" : selectionTreeAssemblyInfo.getScript());
       result.setVsAssemblyScriptPaneModel(vsAssemblyScriptPaneModel.build());
+      result.setRevision(rvs.getWriteRevision());
 
       return result;
    }
@@ -306,7 +307,7 @@ public class SelectionTreePropertyDialogService {
 
       this.vsObjectPropertyService.editObjectProperty(
          viewsheet, streeInfo, objectId, basicGeneralPaneModel.getName(), linkUri,
-         principal, commandDispatcher);
+         principal, commandDispatcher, true, value.getRevision());
 
       Viewsheet vs = viewsheet.getViewsheet();
       selectionTreeAssembly =

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/SelectionTreePropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/SelectionTreePropertyDialogService.java
@@ -305,9 +305,15 @@ public class SelectionTreePropertyDialogService {
       streeInfo.setScriptEnabled(vsAssemblyScriptPaneModel.scriptEnabled());
       streeInfo.setScript(vsAssemblyScriptPaneModel.expression());
 
-      this.vsObjectPropertyService.editObjectProperty(
+      boolean applied = this.vsObjectPropertyService.editObjectProperty(
          viewsheet, streeInfo, objectId, basicGeneralPaneModel.getName(), linkUri,
          principal, commandDispatcher, true, value.getRevision());
+
+      // A refusal (write conflict, dependency cycle, ...) means the rename never happened --
+      // looking the assembly up by its never-applied new name here would NPE.
+      if(!applied) {
+         return null;
+      }
 
       Viewsheet vs = viewsheet.getViewsheet();
       selectionTreeAssembly =

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/SubmitPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/SubmitPropertyDialogService.java
@@ -101,6 +101,7 @@ public class SubmitPropertyDialogService {
       clickableScriptPaneModel.scriptExpression(script);
       clickableScriptPaneModel.onClickExpression(onClick);
       result.setClickableScriptPaneModel(clickableScriptPaneModel.build());
+      result.setRevision(rvs.getWriteRevision());
 
       return result;
    }
@@ -149,7 +150,7 @@ public class SubmitPropertyDialogService {
 
       this.vsObjectPropertyService.editObjectProperty(
          viewsheet, submitAssemblyInfo, objectId, basicGeneralPaneModel.getName(), linkUri,
-         principal, commandDispatcher);
+         principal, commandDispatcher, true, value.getRevision());
 
       return null;
    }

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/TabPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/TabPropertyDialogService.java
@@ -212,13 +212,17 @@ public class TabPropertyDialogService {
       tabAssemblyInfo.setScriptEnabled(vsAssemblyScriptPaneModel.scriptEnabled());
       tabAssemblyInfo.setScript(vsAssemblyScriptPaneModel.expression());
 
-      this.vsObjectPropertyService.editObjectProperty(
+      boolean applied = this.vsObjectPropertyService.editObjectProperty(
          viewsheet, tabAssemblyInfo, objectId, basicGeneralPaneModel.getName(), linkUri, principal,
          commandDispatcher, true, value.getRevision());
 
-      VSObjectTreeNode tree = vsObjectTreeService.getObjectTree(viewsheet);
-      PopulateVSObjectTreeCommand treeCommand = new PopulateVSObjectTreeCommand(tree);
-      commandDispatcher.sendCommand(treeCommand);
+      // A refusal means the tab's tree position/labels never changed -- pushing a fresh tree
+      // to the client here would misreport a no-op as applied.
+      if(applied) {
+         VSObjectTreeNode tree = vsObjectTreeService.getObjectTree(viewsheet);
+         PopulateVSObjectTreeCommand treeCommand = new PopulateVSObjectTreeCommand(tree);
+         commandDispatcher.sendCommand(treeCommand);
+      }
 
       return null;
    }

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/TabPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/TabPropertyDialogService.java
@@ -110,6 +110,7 @@ public class TabPropertyDialogService {
       vsAssemblyScriptPaneModel.expression(tabAssemblyInfo.getScript() == null ?
                                               "" : tabAssemblyInfo.getScript());
       result.setVsAssemblyScriptPaneModel(vsAssemblyScriptPaneModel.build());
+      result.setRevision(rvs.getWriteRevision());
 
       return result;
    }
@@ -213,7 +214,7 @@ public class TabPropertyDialogService {
 
       this.vsObjectPropertyService.editObjectProperty(
          viewsheet, tabAssemblyInfo, objectId, basicGeneralPaneModel.getName(), linkUri, principal,
-         commandDispatcher);
+         commandDispatcher, true, value.getRevision());
 
       VSObjectTreeNode tree = vsObjectTreeService.getObjectTree(viewsheet);
       PopulateVSObjectTreeCommand treeCommand = new PopulateVSObjectTreeCommand(tree);

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/TableViewPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/TableViewPropertyDialogService.java
@@ -150,6 +150,7 @@ public class TableViewPropertyDialogService {
       vsAssemblyScriptPaneModel.expression(tableAssemblyInfo.getScript() == null ?
                                               "" : tableAssemblyInfo.getScript());
       result.setVsAssemblyScriptPaneModel(vsAssemblyScriptPaneModel.build());
+      result.setRevision(rvs.getWriteRevision());
 
       return result;
    }
@@ -272,7 +273,7 @@ public class TableViewPropertyDialogService {
 
       this.vsObjectPropertyService.editObjectProperty(
          viewsheet, tableAssemblyInfo, objectId, basicGeneralPaneModel.getName(), linkUri,
-         principal, commandDispatcher);
+         principal, commandDispatcher, true, value.getRevision());
 
       return null;
    }

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/TextPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/TextPropertyDialogService.java
@@ -179,6 +179,7 @@ public class TextPropertyDialogService {
       clickableScriptPaneModel.scriptExpression(script);
       clickableScriptPaneModel.onClickExpression(onClick);
       result.setClickableScriptPaneModel(clickableScriptPaneModel.build());
+      result.setRevision(rvs.getWriteRevision());
 
       return result;
    }
@@ -293,7 +294,7 @@ public class TextPropertyDialogService {
 
       this.vsObjectPropertyService.editObjectProperty(
          rvs, textAssemblyInfo, objectId, basicGeneralPaneModel.getName(), linkUri, principal,
-         commandDispatcher);
+         commandDispatcher, true, value.getRevision());
 
       return null;
    }

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/VSConditionDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/VSConditionDialogService.java
@@ -39,6 +39,7 @@ import inetsoft.uql.util.*;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.graph.VSChartInfo;
 import inetsoft.uql.viewsheet.internal.*;
+import inetsoft.util.Catalog;
 import inetsoft.web.binding.drm.ColumnRefModel;
 import inetsoft.web.binding.drm.DataRefModel;
 import inetsoft.web.binding.handler.VSAssemblyInfoHandler;
@@ -50,6 +51,7 @@ import inetsoft.web.composer.model.condition.ConditionUtil;
 import inetsoft.web.composer.model.vs.VSConditionDialogModel;
 import inetsoft.web.composer.ws.assembly.ConditionTrapModel;
 import inetsoft.web.composer.ws.assembly.ConditionTrapValidator;
+import inetsoft.web.viewsheet.command.MessageCommand;
 import inetsoft.web.viewsheet.service.CommandDispatcher;
 import org.springframework.stereotype.Service;
 
@@ -93,6 +95,7 @@ public class VSConditionDialogService {
       }
 
       VSConditionDialogModel model = new VSConditionDialogModel();
+      model.setRevision(rvs.getWriteRevision());
 
       if(!(vsAssembly instanceof DynamicBindableVSAssembly)) {
          return model;
@@ -173,6 +176,20 @@ public class VSConditionDialogService {
                         Principal principal, CommandDispatcher commandDispatcher) throws Exception
    {
       RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, principal);
+
+      // Write coordination: refuse a stale commit rather than silently applying it over
+      // whatever changed since this dialog's model was read. See
+      // 2026-08-17-write-coordination-design.md / -implementation.md.
+      Integer expectedRevision = model.getRevision();
+
+      if(expectedRevision != null && expectedRevision != rvs.getWriteRevision()) {
+         MessageCommand command = new MessageCommand();
+         command.setMessage(Catalog.getCatalog().getString("common.writeConflict", assemblyName));
+         command.setType(MessageCommand.Type.ERROR);
+         commandDispatcher.sendCommand(command);
+         return null;
+      }
+
       Optional<ViewsheetSandbox> box = rvs.getViewsheetSandbox();
 
       if(box.isEmpty()) {
@@ -205,6 +222,7 @@ public class VSConditionDialogService {
 
          this.vsAssemblyInfoHandler.apply(rvs, info, viewsheetService, false, false,
                                           true, false, commandDispatcher, null, null, linkUri, null);
+         rvs.bumpWriteRevision();
       }
       finally {
          box.get().unlockWrite();

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/ViewsheetObjectPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/ViewsheetObjectPropertyDialogService.java
@@ -87,6 +87,7 @@ public class ViewsheetObjectPropertyDialogService {
       sizePositionPaneModel.setPositions(pos, size);
       sizePositionPaneModel.setContainer(embeddedVs.getContainer() != null);
       model.sizePositionPaneModel(sizePositionPaneModel);
+      model.revision(rvs.getWriteRevision());
 
       return model.build();
    }
@@ -118,7 +119,7 @@ public class ViewsheetObjectPropertyDialogService {
 
       this.vsObjectPropertyService.editObjectProperty(
          rvs, info, objectId, basicGeneralPaneModel.getName(), linkUri, principal,
-         commandDispatcher);
+         commandDispatcher, true, model.revision());
 
       return null;
    }

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/ViewsheetPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/ViewsheetPropertyDialogService.java
@@ -253,6 +253,7 @@ public class ViewsheetPropertyDialogService {
       vsScriptPane.enableAutocomplete(true);
       vsScriptPane.enableScript(info.isScriptEnabled());
       vsModel.vsScriptPane(vsScriptPane.build());
+      vsModel.revision(rvs.getWriteRevision());
 
       return vsModel.build();
    }
@@ -265,6 +266,22 @@ public class ViewsheetPropertyDialogService {
    {
       String updatedName = null;
       RuntimeViewsheet rvs = this.viewsheetService.getViewsheet(runtimeId, principal);
+
+      // Write coordination: refuse a stale commit rather than silently applying it over
+      // whatever changed since this dialog's model was read. This dialog has no defensive
+      // clone at all -- it mutates ViewsheetInfo live -- so the check matters even more here
+      // than in the dialogs that at least clone before patching. See
+      // 2026-08-17-write-coordination-design.md / -implementation.md.
+      Integer expectedRevision = value.revision();
+
+      if(expectedRevision != null && expectedRevision != rvs.getWriteRevision()) {
+         MessageCommand command = new MessageCommand();
+         command.setMessage(Catalog.getCatalog().getString("common.writeConflict", "Viewsheet"));
+         command.setType(MessageCommand.Type.ERROR);
+         commandDispatcher.sendCommand(command);
+         return null;
+      }
+
       Viewsheet viewsheet = rvs.getViewsheet();
       ViewsheetInfo info = viewsheet.getViewsheetInfo();
       VSOptionsPaneModel vsOptionsPaneModel = value.vsOptionsPane();
@@ -501,6 +518,8 @@ public class ViewsheetPropertyDialogService {
             throw e;
          }
       }
+
+      rvs.bumpWriteRevision();
 
       return updatedName;
    }

--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/VSObjectPropertyService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/VSObjectPropertyService.java
@@ -127,21 +127,21 @@ public class VSObjectPropertyService {
     *                         applied over whatever changed. See
     *                         {@code 2026-08-17-write-coordination-design.md}.
     */
-   public void editObjectProperty(RuntimeViewsheet rvs, VSAssemblyInfo info, String oldName,
-                                  String newName, String linkUri, Principal user,
-                                  CommandDispatcher commandDispatcher, boolean propertyChanged,
-                                  Integer expectedRevision)
+   public boolean editObjectProperty(RuntimeViewsheet rvs, VSAssemblyInfo info, String oldName,
+                                     String newName, String linkUri, Principal user,
+                                     CommandDispatcher commandDispatcher, boolean propertyChanged,
+                                     Integer expectedRevision)
       throws Exception
    {
       if(rvs == null || rvs.isDisposed()) {
-         return;
+         return false;
       }
 
       if(expectedRevision != null && expectedRevision != rvs.getWriteRevision()) {
          this.coreLifecycleService.sendMessage(
             Catalog.getCatalog().getString("common.writeConflict", oldName),
             MessageCommand.Type.ERROR, commandDispatcher);
-         return;
+         return false;
       }
 
       Viewsheet vs = rvs.getViewsheet();
@@ -169,7 +169,7 @@ public class VSObjectPropertyService {
             }
          }
 
-         return;
+         return false;
       }
 
       if(checkTipDependency(vs, info, new HashMap<>()) ||
@@ -178,13 +178,13 @@ public class VSObjectPropertyService {
          this.coreLifecycleService.sendMessage(
             Catalog.getCatalog().getString("common.dependencyCycle"),
             MessageCommand.Type.ERROR, commandDispatcher);
-         return;
+         return false;
       }
 
       if(info instanceof ListInputVSAssemblyInfo &&
          !checkInputList((ListInputVSAssemblyInfo) info, commandDispatcher))
       {
-         return;
+         return false;
       }
 
       String name = newName == null ? oldName : newName;
@@ -194,7 +194,7 @@ public class VSObjectPropertyService {
          this.coreLifecycleService.sendMessage(
             Catalog.getCatalog().getString("viewer.viewsheet.editPropertyFailed"),
             MessageCommand.Type.ERROR, commandDispatcher);
-         return;
+         return false;
       }
 
       VSAssemblyInfo oldInfo = vsAssembly.getVSAssemblyInfo();
@@ -225,7 +225,7 @@ public class VSObjectPropertyService {
             this.coreLifecycleService.sendMessage(
                Catalog.getCatalog().getString("viewer.viewsheet.scriptFailed",
                ex.getMessage()), MessageCommand.Type.CONFIRM, commandDispatcher);
-            return;
+            return false;
          }
       }
 
@@ -240,7 +240,7 @@ public class VSObjectPropertyService {
             this.coreLifecycleService.sendMessage(
                Catalog.getCatalog().getString("common.renameViewsheetFailed"),
                MessageCommand.Type.OK, commandDispatcher);
-            return;
+            return false;
          }
 
          if(vsAssembly.getContainer() instanceof TabVSAssembly) {
@@ -266,7 +266,7 @@ public class VSObjectPropertyService {
          rvs.bumpWriteRevision();
          this.coreLifecycleService.refreshVSAssembly(rvs, vsAssembly.getAbsoluteName(),
                                                      commandDispatcher, true);
-         return;
+         return true;
       }
 
       AbstractVSAssembly assembly = (AbstractVSAssembly) vsAssembly;
@@ -280,7 +280,7 @@ public class VSObjectPropertyService {
       if(!confirmed && checkTrap) {
          if(tinfo != null && tinfo.showWarning()) {
             //TODO show trap warning message
-            return;
+            return false;
          }
       }
 
@@ -416,7 +416,7 @@ public class VSObjectPropertyService {
       Optional<ViewsheetSandbox> box = rvs.getViewsheetSandbox();
 
       if(box.isEmpty()) {
-         return;
+         return true;
       }
 
       //first process selection by script
@@ -703,6 +703,7 @@ public class VSObjectPropertyService {
       //processRefresh(rvs, assembly, commandDispatcher);
 
       annotationEdited(rvs, assembly);
+      return true;
    }
 
    private void refreshTipAndPopAssembly(RuntimeViewsheet rvs, VSAssembly target, CommandDispatcher dispatcher)

--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/VSObjectPropertyService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/VSObjectPropertyService.java
@@ -114,7 +114,33 @@ public class VSObjectPropertyService {
                                   CommandDispatcher commandDispatcher, boolean propertyChanged)
       throws Exception
    {
+      editObjectProperty(rvs, info, oldName, newName, linkUri, user, commandDispatcher,
+                         propertyChanged, null);
+   }
+
+   /**
+    * @param expectedRevision the write revision the caller's dialog model was read at, or
+    *                         {@code null} if the caller does not participate in write
+    *                         coordination (every caller but a dialog commit today). When
+    *                         non-null and stale -- something else committed to this viewsheet
+    *                         since the dialog opened -- the edit is refused rather than silently
+    *                         applied over whatever changed. See
+    *                         {@code 2026-08-17-write-coordination-design.md}.
+    */
+   public void editObjectProperty(RuntimeViewsheet rvs, VSAssemblyInfo info, String oldName,
+                                  String newName, String linkUri, Principal user,
+                                  CommandDispatcher commandDispatcher, boolean propertyChanged,
+                                  Integer expectedRevision)
+      throws Exception
+   {
       if(rvs == null || rvs.isDisposed()) {
+         return;
+      }
+
+      if(expectedRevision != null && expectedRevision != rvs.getWriteRevision()) {
+         this.coreLifecycleService.sendMessage(
+            Catalog.getCatalog().getString("common.writeConflict", oldName),
+            MessageCommand.Type.ERROR, commandDispatcher);
          return;
       }
 
@@ -237,6 +263,7 @@ public class VSObjectPropertyService {
       //embedded viewsheet
       if(!(vsAssembly instanceof AbstractVSAssembly)) {
          vsAssembly.setVSAssemblyInfo(info);
+         rvs.bumpWriteRevision();
          this.coreLifecycleService.refreshVSAssembly(rvs, vsAssembly.getAbsoluteName(),
                                                      commandDispatcher, true);
          return;
@@ -331,6 +358,7 @@ public class VSObjectPropertyService {
       int hint = 0;
 
       hint = assembly.setVSAssemblyInfo(info);
+      rvs.bumpWriteRevision();
       // if script contains binding change, re-process data
       hint = assembly instanceof SelectionVSAssembly ? (hint | hintScript) : hint;
 

--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptEditService.java
@@ -134,6 +134,14 @@ public class ScriptEditService {
 
       mutation.accept(rvs);
 
+      // Write coordination: this is a direct live write, not routed through any
+      // XxxPropertyDialogService, so it must bump the shared counter itself -- otherwise a
+      // property dialog with an embedded script pane (Gauge, Chart, ... -- 15 of the 18
+      // registered types) would read this write's revision as unchanged and silently clobber
+      // it on its own later commit. See 2026-08-17-write-coordination-design.md /
+      // -implementation.md.
+      rvs.bumpWriteRevision();
+
       broadcast.broadcastRefresh(rvs, SheetType.VIEWSHEET, session.runtimeId(), agent);
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetSessionService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetSessionService.java
@@ -126,6 +126,19 @@ public class ViewsheetSessionService {
             rvs.addCheckpoint(vs.prepareCheckpoint());
          }
 
+         // Every mutation through this method is a write to the live viewsheet, whether or not
+         // it fully succeeded (see the partial-apply reasoning above the checkpoint call, which
+         // applies identically here) -- and every one of the 20+ Composer dialogs that embed a
+         // script pane, or otherwise commit through VSObjectPropertyService/
+         // VSConditionDialogService/ViewsheetPropertyDialogService, checks this counter before
+         // committing its own stale snapshot. Without this bump, an agent write that lands
+         // through this seam (chart binding, aesthetics, table binding, calc layout -- anything
+         // that does not go through one of those three services directly) is invisible to that
+         // check: a human's dialog, opened before the agent's write and read at a now-stale
+         // revision, would still match on commit and silently overwrite it. See
+         // 2026-08-17-write-coordination-design.md / -implementation.md.
+         rvs.bumpWriteRevision();
+
          broadcast.broadcastRefresh(rvs, SheetType.VIEWSHEET, session.runtimeId(), agent);
       }
    }

--- a/core/src/main/resources/inetsoft/util/srinter.properties
+++ b/core/src/main/resources/inetsoft/util/srinter.properties
@@ -3532,6 +3532,7 @@ common.worksheetLocked.warning=Asset is locked\: {0} by {1} and {2}.\nChanges wi
 common.worksheetNoPrimary=This Data Worksheet has no primary assembly. Save anyway?
 common.worksheetNotExist=Data Worksheet not found\: {0}
 common.writeAuthority=Write access denied\: {0}
+common.writeConflict={0} changed while this dialog was open. Reopen it to see the current state before committing.
 common.xasset.assembly=Assembly ''{0}'' in Dashboard
 common.xasset.assembly1=Assembly ''{0}'' in Data Worksheet
 common.xasset.cycle=Data cycle ''{0}''

--- a/core/src/test/java/inetsoft/web/binding/service/VSBindingServiceFinishEditTest.java
+++ b/core/src/test/java/inetsoft/web/binding/service/VSBindingServiceFinishEditTest.java
@@ -91,6 +91,13 @@ class VSBindingServiceFinishEditTest {
          service.finishEdit(viewsheetService, "nid1", "Chart1", null, null, null));
 
       verify(orvs, never()).setViewsheet(any());
+
+      // The refusal must still tear the clone runtime down -- otherwise the base keeps
+      // believing a binding session is open and the clone runtime never closes, wedging the
+      // session on every retry.
+      verify(orvs).setBindingID(null);
+      verify(viewsheetService).flushRuntimeSheet("oid1");
+      verify(viewsheetService).closeViewsheet("nid1", null);
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/binding/service/VSBindingServiceFinishEditTest.java
+++ b/core/src/test/java/inetsoft/web/binding/service/VSBindingServiceFinishEditTest.java
@@ -1,0 +1,135 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.binding.service;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.test.*;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.analytic.AnalyticAssistant;
+import inetsoft.util.MessageException;
+import inetsoft.web.binding.handler.VSAssemblyInfoHandler;
+import inetsoft.web.composer.vs.VSObjectTreeService;
+import inetsoft.web.composer.vs.objects.controller.GroupingService;
+import inetsoft.web.composer.vs.objects.controller.VSTableService;
+import inetsoft.web.composer.vs.objects.controller.VSTrapService;
+import inetsoft.web.viewsheet.model.VSObjectModelFactoryService;
+import inetsoft.web.viewsheet.service.CoreLifecycleService;
+import inetsoft.web.viewsheet.service.VSSelectionContainerService;
+import inetsoft.web.vswizard.service.VSWizardTemporaryInfoService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.security.Principal;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Write coordination (2026-08-17-write-coordination-design.md / -implementation.md): the
+ * binding editor's {@code finishEdit} replaces the ENTIRE live viewsheet on the base runtime,
+ * not just the assembly being bound -- the largest blast radius of any write path in the
+ * Composer. This is the highest-value regression test in the whole write-coordination effort:
+ * it is the one case no document had identified as whole-viewsheet before the design spec.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome()
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@Tag("core")
+class VSBindingServiceFinishEditTest {
+   @BeforeEach
+   void setup() {
+      service = new VSBindingService(trapService, vsTableService, groupingService,
+         viewsheetService, Collections.emptyList(), dataRefService, objectModelService,
+         wizardTemporaryInfoService, vsSelectionContainerService, analyticAssistant,
+         assemblyHandler, vsObjectTreeService, coreLifecycleService);
+   }
+
+   @Test
+   void refusesToReplaceTheBaseViewsheetWhenItChangedDuringEditing() throws Exception {
+      when(viewsheetService.getViewsheet("nid1", null)).thenReturn(nrvs);
+      when(nrvs.getOriginalID()).thenReturn("oid1");
+      when(viewsheetService.getViewsheet("oid1", null)).thenReturn(orvs);
+      when(orvs.getEntry()).thenReturn(entry);
+
+      // The base viewsheet accepted a concurrent write (any write tool, any assembly) after
+      // the binding editor opened -- its revision moved from what nrvs captured at open time.
+      when(nrvs.getBaseWriteRevisionAtOpen()).thenReturn(4);
+      when(orvs.getWriteRevision()).thenReturn(5);
+
+      Assertions.assertThrows(MessageException.class, () ->
+         service.finishEdit(viewsheetService, "nid1", "Chart1", null, null, null));
+
+      verify(orvs, never()).setViewsheet(any());
+   }
+
+   @Test
+   void proceedsWhenTheBaseRevisionIsUnchanged() throws Exception {
+      when(viewsheetService.getViewsheet("nid1", null)).thenReturn(nrvs);
+      when(nrvs.getOriginalID()).thenReturn("oid1");
+      when(viewsheetService.getViewsheet("oid1", null)).thenReturn(orvs);
+      when(orvs.getEntry()).thenReturn(entry);
+      when(nrvs.getBaseWriteRevisionAtOpen()).thenReturn(5);
+      when(orvs.getWriteRevision()).thenReturn(5);
+
+      // Bail out cleanly right after the revision check, the same way an empty sandbox does
+      // elsewhere in this codebase -- proves reachability without mocking the rest of a
+      // whole-viewsheet commit.
+      when(orvs.getViewsheetSandbox()).thenThrow(new RuntimeException("reached past the check"));
+      when(nrvs.getViewsheetSandbox()).thenReturn(java.util.Optional.empty());
+
+      RuntimeException thrown = Assertions.assertThrows(RuntimeException.class, () ->
+         service.finishEdit(viewsheetService, "nid1", "Chart1", null, null, null));
+
+      Assertions.assertEquals("reached past the check", thrown.getMessage());
+   }
+
+   @Mock VSTrapService trapService;
+   @Mock VSTableService vsTableService;
+   @Mock GroupingService groupingService;
+   @Mock ViewsheetService viewsheetService;
+   @Mock DataRefModelFactoryService dataRefService;
+   @Mock VSObjectModelFactoryService objectModelService;
+   @Mock VSWizardTemporaryInfoService wizardTemporaryInfoService;
+   @Mock VSSelectionContainerService vsSelectionContainerService;
+   @Mock AnalyticAssistant analyticAssistant;
+   @Mock VSAssemblyInfoHandler assemblyHandler;
+   @Mock VSObjectTreeService vsObjectTreeService;
+   @Mock CoreLifecycleService coreLifecycleService;
+   @Mock RuntimeViewsheet nrvs;
+   @Mock RuntimeViewsheet orvs;
+   @Mock AssetEntry entry;
+   @Mock Viewsheet viewsheet;
+
+   private VSBindingService service;
+}

--- a/core/src/test/java/inetsoft/web/composer/vs/dialog/CalendarPropertyDialogServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/dialog/CalendarPropertyDialogServiceTest.java
@@ -103,7 +103,9 @@ class CalendarPropertyDialogServiceTest {
                                                          any(String.class),
                                                          any(String.class),
                                                          nullable(Principal.class),
-                                                         any(CommandDispatcher.class));
+                                                         any(CommandDispatcher.class),
+                                                         eq(true),
+                                                         nullable(Integer.class));
 
       CalendarVSAssemblyInfo result = argument.getValue();
       // dropdown stays dropdown, title height changed to 30

--- a/core/src/test/java/inetsoft/web/composer/vs/dialog/GaugePropertyDialogServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/dialog/GaugePropertyDialogServiceTest.java
@@ -1,0 +1,145 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.composer.vs.dialog;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.test.*;
+import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.internal.GaugeVSAssemblyInfo;
+import inetsoft.web.binding.handler.VSAssemblyInfoHandler;
+import inetsoft.web.composer.model.vs.GaugePropertyDialogModel;
+import inetsoft.web.composer.model.vs.VSAssemblyScriptPaneModel;
+import inetsoft.web.composer.vs.objects.controller.VSObjectPropertyService;
+import inetsoft.web.composer.vs.objects.controller.VSTrapService;
+import inetsoft.web.viewsheet.service.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.security.Principal;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Write-coordination wiring (2026-08-17-write-coordination-implementation.md, Phase 1): confirms
+ * the dialog's own revision -- read at open time, held by the browser, sent back on commit --
+ * reaches {@link VSObjectPropertyService#editObjectProperty} unchanged. The refusal logic itself
+ * is {@link inetsoft.web.composer.vs.objects.controller.VSObjectPropertyServiceTest}'s job; this
+ * only proves Gauge threads the value through rather than dropping it.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome()
+@ExtendWith(MockitoExtension.class)
+@Tag("core")
+class GaugePropertyDialogServiceTest {
+   @BeforeEach
+   void setup() {
+      service = new GaugePropertyDialogService(
+         vsObjectPropertyService,
+         vsOutputService,
+         dialogService,
+         engine,
+         trapService,
+         assemblyInfoHandler);
+   }
+
+   @Test
+   void forwardsTheModelsRevisionToEditObjectProperty() throws Exception {
+      when(engine.getViewsheet(anyString(), nullable(Principal.class))).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(viewsheet.getAssembly(anyString())).thenReturn(gaugeAssembly);
+      when(gaugeAssembly.getVSAssemblyInfo()).thenReturn(new GaugeVSAssemblyInfo());
+
+      GaugePropertyDialogModel model = new GaugePropertyDialogModel();
+      model.setRevision(42);
+      model.setVsAssemblyScriptPaneModel(
+         VSAssemblyScriptPaneModel.builder().scriptEnabled(false).expression("").build());
+
+      service.setGaugePropertyDialogModel("Viewsheet1", "Gauge1", model, "", null,
+                                          commandDispatcher);
+
+      verify(vsObjectPropertyService).editObjectProperty(
+         any(RuntimeViewsheet.class), any(GaugeVSAssemblyInfo.class), eq("Gauge1"),
+         nullable(String.class), any(String.class), nullable(Principal.class),
+         any(CommandDispatcher.class), eq(true), eq(42));
+   }
+
+   @Test
+   void forwardsANullRevisionUnchanged() throws Exception {
+      when(engine.getViewsheet(anyString(), nullable(Principal.class))).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(viewsheet.getAssembly(anyString())).thenReturn(gaugeAssembly);
+      when(gaugeAssembly.getVSAssemblyInfo()).thenReturn(new GaugeVSAssemblyInfo());
+
+      // A model built by a client that doesn't yet round-trip a revision leaves it null --
+      // editObjectProperty must see null, not some invented default, so it does not participate
+      // in the conflict check at all (today's unconditional-commit behavior).
+      GaugePropertyDialogModel model = new GaugePropertyDialogModel();
+      model.setVsAssemblyScriptPaneModel(
+         VSAssemblyScriptPaneModel.builder().scriptEnabled(false).expression("").build());
+
+      service.setGaugePropertyDialogModel("Viewsheet1", "Gauge1", model, "", null,
+                                          commandDispatcher);
+
+      verify(vsObjectPropertyService).editObjectProperty(
+         any(RuntimeViewsheet.class), any(GaugeVSAssemblyInfo.class), eq("Gauge1"),
+         nullable(String.class), any(String.class), nullable(Principal.class),
+         any(CommandDispatcher.class), eq(true), isNull());
+   }
+
+   @Test
+   void readSideAttachesTheCurrentWriteRevision() throws Exception {
+      when(engine.getViewsheet(anyString(), nullable(Principal.class))).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(viewsheet.getAssembly(anyString())).thenReturn(gaugeAssembly);
+      when(gaugeAssembly.getVSAssemblyInfo()).thenReturn(new GaugeVSAssemblyInfo());
+      when(rvs.getWriteRevision()).thenReturn(7);
+      when(dialogService.getAssemblyPosition(any(), any())).thenReturn(new java.awt.Point(0, 0));
+      when(dialogService.getAssemblySize(any(), any()))
+         .thenReturn(new java.awt.Dimension(100, 100));
+
+      GaugePropertyDialogModel result =
+         service.getGaugePropertyDialogModel("Viewsheet1", "Gauge1", null);
+
+      org.junit.jupiter.api.Assertions.assertEquals(7, result.getRevision());
+   }
+
+   @Mock VSObjectPropertyService vsObjectPropertyService;
+   @Mock VSOutputService vsOutputService;
+   @Mock VSDialogService dialogService;
+   @Mock ViewsheetService engine;
+   @Mock VSTrapService trapService;
+   @Mock VSAssemblyInfoHandler assemblyInfoHandler;
+   @Mock CommandDispatcher commandDispatcher;
+   @Mock RuntimeViewsheet rvs;
+   @Mock Viewsheet viewsheet;
+   @Mock GaugeVSAssembly gaugeAssembly;
+
+   private GaugePropertyDialogService service;
+}

--- a/core/src/test/java/inetsoft/web/composer/vs/dialog/RangeSliderPropertyDialogServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/dialog/RangeSliderPropertyDialogServiceTest.java
@@ -93,7 +93,9 @@ class RangeSliderPropertyDialogServiceTest {
                                                          any(String.class),
                                                          any(String.class),
                                                          nullable(Principal.class),
-                                                         any(CommandDispatcher.class));
+                                                         any(CommandDispatcher.class),
+                                                         eq(true),
+                                                         nullable(Integer.class));
 
       assertTrue(argument.getValue().getLogScaleValue());
    }

--- a/core/src/test/java/inetsoft/web/composer/vs/dialog/SelectionListPropertyDialogServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/dialog/SelectionListPropertyDialogServiceTest.java
@@ -105,7 +105,9 @@ class SelectionListPropertyDialogServiceTest {
                                                          any(String.class),
                                                          any(String.class),
                                                          nullable(Principal.class),
-                                                         any(CommandDispatcher.class));
+                                                         any(CommandDispatcher.class),
+                                                         eq(true),
+                                                         nullable(Integer.class));
 
       SelectionListVSAssemblyInfo result = argument.getValue();
       // switching from dropdown to list: titleHeight(20) + listHeight(6) * cellHeight(20) = 140
@@ -160,7 +162,9 @@ class SelectionListPropertyDialogServiceTest {
                                                          any(String.class),
                                                          any(String.class),
                                                          nullable(Principal.class),
-                                                         any(CommandDispatcher.class));
+                                                         any(CommandDispatcher.class),
+                                                         eq(true),
+                                                         nullable(Integer.class));
 
       SelectionListVSAssemblyInfo result = argument.getValue();
       // switching from list to dropdown: size.height = titleHeight = 20
@@ -218,7 +222,9 @@ class SelectionListPropertyDialogServiceTest {
                                                          any(String.class),
                                                          any(String.class),
                                                          nullable(Principal.class),
-                                                         any(CommandDispatcher.class));
+                                                         any(CommandDispatcher.class),
+                                                         eq(true),
+                                                         nullable(Integer.class));
 
       SelectionListVSAssemblyInfo result = argument.getValue();
       // dropdown stays dropdown, title height changed to 30

--- a/core/src/test/java/inetsoft/web/composer/vs/dialog/SelectionTreePropertyDialogServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/dialog/SelectionTreePropertyDialogServiceTest.java
@@ -98,7 +98,9 @@ class SelectionTreePropertyDialogServiceTest {
                                                          any(String.class),
                                                          any(String.class),
                                                          nullable(Principal.class),
-                                                         any(CommandDispatcher.class));
+                                                         any(CommandDispatcher.class),
+                                                         eq(true),
+                                                         nullable(Integer.class));
 
       assertNotNull(argument.getValue().getLabelValue());
 
@@ -155,7 +157,9 @@ class SelectionTreePropertyDialogServiceTest {
                                                          any(String.class),
                                                          any(String.class),
                                                          nullable(Principal.class),
-                                                         any(CommandDispatcher.class));
+                                                         any(CommandDispatcher.class),
+                                                         eq(true),
+                                                         nullable(Integer.class));
 
       SelectionTreeVSAssemblyInfo result = argument.getValue();
       // switching from dropdown to list: listHeight(6) * cellHeight(20) = 120
@@ -212,7 +216,9 @@ class SelectionTreePropertyDialogServiceTest {
                                                          any(String.class),
                                                          any(String.class),
                                                          nullable(Principal.class),
-                                                         any(CommandDispatcher.class));
+                                                         any(CommandDispatcher.class),
+                                                         eq(true),
+                                                         nullable(Integer.class));
 
       SelectionTreeVSAssemblyInfo result = argument.getValue();
       // switching from list to dropdown: size.height = titleHeight = 20
@@ -270,7 +276,9 @@ class SelectionTreePropertyDialogServiceTest {
                                                          any(String.class),
                                                          any(String.class),
                                                          nullable(Principal.class),
-                                                         any(CommandDispatcher.class));
+                                                         any(CommandDispatcher.class),
+                                                         eq(true),
+                                                         nullable(Integer.class));
 
       SelectionTreeVSAssemblyInfo result = argument.getValue();
       // dropdown stays dropdown, title height changed to 30

--- a/core/src/test/java/inetsoft/web/composer/vs/dialog/SelectionTreePropertyDialogServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/dialog/SelectionTreePropertyDialogServiceTest.java
@@ -55,7 +55,7 @@ import static org.mockito.Mockito.*;
 @Tag("core")
 class SelectionTreePropertyDialogServiceTest {
    @BeforeEach
-   void setup(){
+   void setup() throws Exception {
       service = new SelectionTreePropertyDialogService(
          vsObjectPropertyService,
          vsOutputService,
@@ -67,6 +67,15 @@ class SelectionTreePropertyDialogServiceTest {
          assemblyInfoHandler,
          dataRefService,
          dataSourceRegistry);
+
+      // Every test below commits successfully -- editObjectProperty returning false would skip
+      // the post-rename selection update these tests exercise. See
+      // VSObjectPropertyServiceTest#refusesAStaleCommitAndNeverResolvesTheAssembly for the
+      // refusal case.
+      when(vsObjectPropertyService.editObjectProperty(
+         any(RuntimeViewsheet.class), any(), any(), any(), any(),
+         nullable(Principal.class), any(CommandDispatcher.class), anyBoolean(),
+         nullable(Integer.class))).thenReturn(true);
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/composer/vs/dialog/TableViewPropertyDialogServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/dialog/TableViewPropertyDialogServiceTest.java
@@ -1,0 +1,113 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.composer.vs.dialog;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.test.*;
+import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.internal.TableVSAssemblyInfo;
+import inetsoft.web.composer.model.vs.TableViewPropertyDialogModel;
+import inetsoft.web.composer.model.vs.VSAssemblyScriptPaneModel;
+import inetsoft.web.composer.vs.objects.controller.VSObjectPropertyService;
+import inetsoft.web.viewsheet.service.CommandDispatcher;
+import inetsoft.web.viewsheet.service.VSDialogService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Write-coordination wiring (2026-08-17-write-coordination-implementation.md, Phase 2): the
+ * second full example beyond Gauge, chosen for structural diversity (embedded-table branching,
+ * form/tip/flyover fields). The refusal logic itself is
+ * {@link inetsoft.web.composer.vs.objects.controller.VSObjectPropertyServiceTest}'s job.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome()
+@ExtendWith(MockitoExtension.class)
+@Tag("core")
+class TableViewPropertyDialogServiceTest {
+   @BeforeEach
+   void setup() {
+      service = new TableViewPropertyDialogService(vsObjectPropertyService, dialogService, engine);
+   }
+
+   @Test
+   void forwardsTheModelsRevisionToEditObjectProperty() throws Exception {
+      when(engine.getViewsheet(anyString(), nullable(Principal.class))).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(viewsheet.getAssembly(anyString())).thenReturn(tableAssembly);
+      when(tableAssembly.getVSAssemblyInfo()).thenReturn(new TableVSAssemblyInfo());
+
+      TableViewPropertyDialogModel model = new TableViewPropertyDialogModel();
+      model.setRevision(42);
+      model.setVsAssemblyScriptPaneModel(
+         VSAssemblyScriptPaneModel.builder().scriptEnabled(false).expression("").build());
+
+      service.setTablePropertyModel("Viewsheet1", "Table1", model, "", null, commandDispatcher);
+
+      verify(vsObjectPropertyService).editObjectProperty(
+         any(RuntimeViewsheet.class), any(TableVSAssemblyInfo.class), eq("Table1"),
+         nullable(String.class), any(String.class), nullable(Principal.class),
+         any(CommandDispatcher.class), eq(true), eq(42));
+   }
+
+   @Test
+   void readSideAttachesTheCurrentWriteRevision() throws Exception {
+      when(engine.getViewsheet(anyString(), nullable(Principal.class))).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(rvs.getViewsheetSandbox()).thenReturn(java.util.Optional.of(sandbox));
+      when(viewsheet.getAssembly(anyString())).thenReturn(tableAssembly);
+      when(tableAssembly.getVSAssemblyInfo()).thenReturn(new TableVSAssemblyInfo());
+      when(rvs.getWriteRevision()).thenReturn(7);
+      when(dialogService.getAssemblyPosition(any(), any())).thenReturn(new java.awt.Point(0, 0));
+      when(dialogService.getAssemblySize(any(), any()))
+         .thenReturn(new java.awt.Dimension(100, 100));
+
+      TableViewPropertyDialogModel result =
+         service.getTableViewPropertyDialogModel("Viewsheet1", "Table1", null);
+
+      assertEquals(7, result.getRevision());
+   }
+
+   @Mock VSObjectPropertyService vsObjectPropertyService;
+   @Mock VSDialogService dialogService;
+   @Mock ViewsheetService engine;
+   @Mock CommandDispatcher commandDispatcher;
+   @Mock RuntimeViewsheet rvs;
+   @Mock Viewsheet viewsheet;
+   @Mock TableVSAssembly tableAssembly;
+   @Mock inetsoft.report.composition.execution.ViewsheetSandbox sandbox;
+
+   private TableViewPropertyDialogService service;
+}

--- a/core/src/test/java/inetsoft/web/composer/vs/dialog/TextPropertyDialogServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/dialog/TextPropertyDialogServiceTest.java
@@ -88,7 +88,9 @@ public class TextPropertyDialogServiceTest {
                                                          any(String.class),
                                                          any(String.class),
                                                          nullable(Principal.class),
-                                                         any(CommandDispatcher.class));
+                                                         any(CommandDispatcher.class),
+                                                         eq(true),
+                                                         nullable(Integer.class));
       assertNotNull(infoCaptor.getValue(), "Assembly info must be passed to the property service");
    }
 

--- a/core/src/test/java/inetsoft/web/composer/vs/dialog/ViewsheetPropertyDialogServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/dialog/ViewsheetPropertyDialogServiceTest.java
@@ -112,6 +112,49 @@ public class ViewsheetPropertyDialogServiceTest {
       assertNotNull(viewsheetLayout.getVSAssemblyLayout("Bar001"));
    }
 
+   /**
+    * Write coordination (2026-08-17-write-coordination-design.md / -implementation.md): this
+    * dialog has no defensive clone at all -- it mutates ViewsheetInfo live -- so the revision
+    * check matters even more here than in dialogs that at least clone before patching. A stale
+    * commit must be refused before the live ViewsheetInfo is even read.
+    */
+   @Test
+   public void refusesAStaleCommitBeforeTouchingTheLiveInfo() throws Exception {
+      when(viewsheetService.getViewsheet(anyString(), nullable(Principal.class))).thenReturn(rvs);
+      when(rvs.getWriteRevision()).thenReturn(5);
+
+      ViewsheetPropertyDialogModel model = ViewsheetPropertyDialogModel.builder().revision(4).build();
+
+      String result = service.setViewsheetInfo("Viewsheet1", model, null, commandDispatcher, null, null);
+
+      org.junit.jupiter.api.Assertions.assertNull(result);
+      org.mockito.Mockito.verify(rvs, org.mockito.Mockito.never()).getViewsheet();
+      org.mockito.Mockito.verify(commandDispatcher).sendCommand(
+         org.mockito.ArgumentMatchers.argThat(cmd ->
+            cmd instanceof inetsoft.web.viewsheet.command.MessageCommand mc &&
+            mc.getType() == inetsoft.web.viewsheet.command.MessageCommand.Type.ERROR));
+   }
+
+   @Test
+   public void readSideAttachesTheCurrentWriteRevision() throws Exception {
+      ViewsheetPropertyDialogService readService = new ViewsheetPropertyDialogService(
+         coreLifecycleService, viewsheetService, layoutService, viewsheetSettingsService,
+         vsAssemblyInfoHandler, securityEngine, null, deviceRegistry);
+
+      when(viewsheetService.getViewsheet(anyString(), nullable(Principal.class))).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(rvs.getWriteRevision()).thenReturn(7);
+      when(viewsheet.getViewsheetInfo()).thenReturn(new ViewsheetInfo());
+      when(viewsheet.getAssemblies()).thenReturn(new inetsoft.uql.asset.Assembly[0]);
+      when(viewsheet.getLayoutInfo()).thenReturn(new LayoutInfo());
+      when(viewsheetService.getAssetRepository()).thenReturn(assetRepository);
+      when(deviceRegistry.getDevices()).thenReturn(new DeviceInfo[0]);
+
+      ViewsheetPropertyDialogModel result = readService.getViewsheetInfo("Viewsheet1", null);
+
+      assertEquals(7, result.revision());
+   }
+
    @Mock ViewsheetService viewsheetService;
    @Mock ViewsheetSettingsService viewsheetSettingsService;
    @Mock CoreLifecycleService coreLifecycleService;
@@ -121,5 +164,8 @@ public class ViewsheetPropertyDialogServiceTest {
    @Mock ViewsheetSandbox viewsheetSandbox;
    @Mock CommandDispatcher commandDispatcher;
    @Mock VSAssemblyInfoHandler vsAssemblyInfoHandler;
+   @Mock inetsoft.sree.security.SecurityEngine securityEngine;
+   @Mock DeviceRegistry deviceRegistry;
+   @Mock inetsoft.uql.asset.AssetRepository assetRepository;
    private ViewsheetPropertyDialogService service;
 }

--- a/core/src/test/java/inetsoft/web/composer/vs/objects/controller/VSConditionDialogServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/objects/controller/VSConditionDialogServiceTest.java
@@ -40,7 +40,9 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.security.Principal;
+import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
@@ -95,6 +97,75 @@ class VSConditionDialogServiceTest {
       verify(infoSpy).getPreConditionList();
    }
 
+   @Test
+   void readSideAttachesTheCurrentWriteRevision() throws Exception {
+      when(viewsheetEngine.getViewsheet(anyString(), nullable(Principal.class))).thenReturn(rvs);
+      when(rvs.getViewsheet()).thenReturn(viewsheet);
+      when(rvs.getWriteRevision()).thenReturn(7);
+      when(viewsheet.getAssembly(anyString())).thenReturn(spy(new TextVSAssembly()));
+
+      inetsoft.web.composer.model.vs.VSConditionDialogModel result =
+         service.getModel("Viewsheet1", "TextAssembly", null);
+
+      assertEquals(7, result.getRevision());
+   }
+
+   /**
+    * Write coordination (2026-08-17-write-coordination-design.md / -implementation.md): a stale
+    * commit must be refused before the sandbox is even touched, not silently applied over
+    * whatever changed the viewsheet in between.
+    */
+   @Test
+   void refusesAStaleCommitAndNeverTouchesTheSandbox() throws Exception {
+      when(viewsheetEngine.getViewsheet(anyString(), nullable(Principal.class))).thenReturn(rvs);
+      when(rvs.getWriteRevision()).thenReturn(5);
+
+      inetsoft.web.composer.model.vs.VSConditionDialogModel model =
+         new inetsoft.web.composer.model.vs.VSConditionDialogModel();
+      model.setRevision(4);
+
+      service.setModel("Viewsheet1", "TextAssembly", model, "", null, commandDispatcher);
+
+      verify(rvs, never()).getViewsheetSandbox();
+      verify(vsAssemblyInfoHandler, never()).apply(
+         any(RuntimeViewsheet.class), any(), any(), anyBoolean(), anyBoolean(), anyBoolean(),
+         anyBoolean(), any(), any(), any(), any(), any());
+      verify(commandDispatcher).sendCommand(argThat(cmd ->
+         cmd instanceof inetsoft.web.viewsheet.command.MessageCommand mc &&
+         mc.getType() == inetsoft.web.viewsheet.command.MessageCommand.Type.ERROR &&
+         mc.getMessage().contains("TextAssembly")));
+   }
+
+   @Test
+   void proceedsPastTheCheckWhenTheRevisionMatches() throws Exception {
+      when(viewsheetEngine.getViewsheet(anyString(), nullable(Principal.class))).thenReturn(rvs);
+      when(rvs.getWriteRevision()).thenReturn(5);
+      when(rvs.getViewsheetSandbox()).thenReturn(Optional.empty());
+
+      inetsoft.web.composer.model.vs.VSConditionDialogModel model =
+         new inetsoft.web.composer.model.vs.VSConditionDialogModel();
+      model.setRevision(5);
+
+      service.setModel("Viewsheet1", "TextAssembly", model, "", null, commandDispatcher);
+
+      verify(rvs).getViewsheetSandbox();
+      verify(commandDispatcher, never()).sendCommand(any());
+   }
+
+   @Test
+   void proceedsPastTheCheckWhenNoRevisionIsSupplied() throws Exception {
+      when(viewsheetEngine.getViewsheet(anyString(), nullable(Principal.class))).thenReturn(rvs);
+      when(rvs.getViewsheetSandbox()).thenReturn(Optional.empty());
+
+      inetsoft.web.composer.model.vs.VSConditionDialogModel model =
+         new inetsoft.web.composer.model.vs.VSConditionDialogModel();
+
+      service.setModel("Viewsheet1", "TextAssembly", model, "", null, commandDispatcher);
+
+      verify(rvs).getViewsheetSandbox();
+      verify(commandDispatcher, never()).sendCommand(any());
+   }
+
    @Mock DataRefModelFactoryService dataRefModelFactoryService;
    @Mock VSAssemblyInfoHandler vsAssemblyInfoHandler;
    @Mock RuntimeViewsheetRef runtimeViewsheetRef;
@@ -103,5 +174,6 @@ class VSConditionDialogServiceTest {
    @Mock Viewsheet viewsheet;
    @Mock BindingInfo bindingInfo;
    @Mock DataSourceRegistry dataSourceRegistry;
+   @Mock inetsoft.web.viewsheet.service.CommandDispatcher commandDispatcher;
    private VSConditionDialogService service;
 }

--- a/core/src/test/java/inetsoft/web/composer/vs/objects/controller/VSObjectPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/objects/controller/VSObjectPropertyServiceTest.java
@@ -17,13 +17,16 @@
  */
 package inetsoft.web.composer.vs.objects.controller;
 
+import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.test.*;
 import inetsoft.uql.asset.Assembly;
 import inetsoft.uql.service.DataSourceRegistry;
 import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.internal.GaugeVSAssemblyInfo;
 import inetsoft.web.binding.handler.VSAssemblyInfoHandler;
 import inetsoft.web.binding.handler.VSColumnHandler;
 import inetsoft.web.composer.vs.VSObjectTreeService;
+import inetsoft.web.viewsheet.command.MessageCommand;
 import inetsoft.web.viewsheet.service.*;
 import inetsoft.web.vswizard.service.VSWizardTemporaryInfoService;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,9 +39,8 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
@@ -78,6 +80,53 @@ class VSObjectPropertyServiceTest {
       assertEquals(selectionListAssemblyName, popComponents[0]);
    }
 
+   /**
+    * Write coordination (2026-08-17-write-coordination-design.md / -implementation.md): a stale
+    * commit -- one whose expectedRevision no longer matches the live viewsheet's -- must be
+    * refused before any assembly is even resolved, not silently applied over whatever changed in
+    * between. The marker exception proves reachability past the check without needing to mock the
+    * rest of this method's body (that is other tests' job, unaffected by this change).
+    */
+   @Test
+   void refusesAStaleCommitAndNeverResolvesTheAssembly() throws Exception {
+      when(rvs.isDisposed()).thenReturn(false);
+      when(rvs.getWriteRevision()).thenReturn(5);
+
+      controller.editObjectProperty(rvs, new GaugeVSAssemblyInfo(), "Gauge1", "Gauge1", "",
+                                    null, commandDispatcher, true, 4);
+
+      verify(rvs, never()).getViewsheet();
+      verify(coreLifecycleService).sendMessage(
+         contains("Gauge1"), eq(MessageCommand.Type.ERROR), eq(commandDispatcher));
+   }
+
+   @Test
+   void proceedsWhenTheRevisionMatches() {
+      when(rvs.isDisposed()).thenReturn(false);
+      when(rvs.getWriteRevision()).thenReturn(5);
+      when(rvs.getViewsheet()).thenThrow(new RuntimeException("reached past the check"));
+
+      RuntimeException thrown = assertThrows(RuntimeException.class, () ->
+         controller.editObjectProperty(rvs, new GaugeVSAssemblyInfo(), "Gauge1", "Gauge1", "",
+                                       null, commandDispatcher, true, 5));
+
+      assertEquals("reached past the check", thrown.getMessage());
+   }
+
+   @Test
+   void proceedsWhenNoRevisionIsSupplied() {
+      when(rvs.isDisposed()).thenReturn(false);
+      when(rvs.getViewsheet()).thenThrow(new RuntimeException("reached past the check"));
+
+      // null means "this caller does not participate" -- every caller of editObjectProperty
+      // before this change, and any future one that isn't a dialog commit.
+      RuntimeException thrown = assertThrows(RuntimeException.class, () ->
+         controller.editObjectProperty(rvs, new GaugeVSAssemblyInfo(), "Gauge1", "Gauge1", "",
+                                       null, commandDispatcher, true, null));
+
+      assertEquals("reached past the check", thrown.getMessage());
+   }
+
    @Mock CoreLifecycleService coreLifecycleService;
    @Mock VSColumnHandler vsColumnHandler;
    @Mock VSObjectTreeService vsObjectTreeService;
@@ -87,6 +136,8 @@ class VSObjectPropertyServiceTest {
    @Mock VSCompositionService vsCompositionService;
    @Mock SharedFilterService sharedFilterService;
    @Mock DataSourceRegistry dataSourceRegistry;
+   @Mock RuntimeViewsheet rvs;
+   @Mock CommandDispatcher commandDispatcher;
 
    private VSObjectPropertyService controller;
 }

--- a/core/src/test/java/inetsoft/web/composer/vs/objects/controller/VSObjectPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/objects/controller/VSObjectPropertyServiceTest.java
@@ -92,9 +92,13 @@ class VSObjectPropertyServiceTest {
       when(rvs.isDisposed()).thenReturn(false);
       when(rvs.getWriteRevision()).thenReturn(5);
 
-      controller.editObjectProperty(rvs, new GaugeVSAssemblyInfo(), "Gauge1", "Gauge1", "",
-                                    null, commandDispatcher, true, 4);
+      boolean applied = controller.editObjectProperty(rvs, new GaugeVSAssemblyInfo(), "Gauge1",
+                                                      "Gauge1", "", null, commandDispatcher, true, 4);
 
+      // Callers that do follow-up work keyed on the (possibly renamed) assembly -- e.g.
+      // SelectionTreePropertyDialogService re-resolving by newName -- must see this false and
+      // skip that work, or they NPE looking up a rename that never happened.
+      assertFalse(applied);
       verify(rvs, never()).getViewsheet();
       verify(coreLifecycleService).sendMessage(
          contains("Gauge1"), eq(MessageCommand.Type.ERROR), eq(commandDispatcher));

--- a/core/src/test/java/inetsoft/web/wiz/script/ScriptEditServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ScriptEditServiceTest.java
@@ -76,6 +76,35 @@ class ScriptEditServiceTest {
       verifyNoInteractions(broadcast);
    }
 
+   /**
+    * Write coordination (2026-08-17-write-coordination-design.md / -implementation.md): a script
+    * write is a direct live write, not routed through any XxxPropertyDialogService, so it must
+    * bump the shared write revision itself. Without this, a property dialog with an embedded
+    * script pane (15 of the 18 registered types) would read this write's revision as unchanged
+    * and silently clobber it on its own later commit -- exactly the defect this whole effort
+    * exists to close.
+    */
+   @Test
+   void applyBumpsTheWriteRevisionSoAConcurrentDialogDetectsIt() throws Exception {
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      SheetAgentBroadcastService broadcast = mock(SheetAgentBroadcastService.class);
+
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      JoinSession s = new JoinSession("TOK", "Viewsheet/foo-7", "alice~;~host-org",
+                                      SheetType.VIEWSHEET, 0L, Long.MAX_VALUE,
+                                      JoinSession.ConnectionMode.PAIRED, null, null);
+      when(sessions.resolve(eq("TOK"), any())).thenReturn(s);
+      when(runtimeAccess.getSheetForPairing(eq(SheetType.VIEWSHEET), eq("Viewsheet/foo-7"), eq(agent)))
+         .thenReturn(rvs);
+
+      ScriptEditService svc = new ScriptEditService(sessions, runtimeAccess, broadcast);
+      svc.apply("TOK", agent, r -> {});
+
+      verify(rvs).bumpWriteRevision();
+   }
+
    @Test
    void applyOnRuntimeIfChangedRejectsInvalidSession() {
       SheetSessionService sessions = mock(SheetSessionService.class);

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetSessionServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetSessionServiceTest.java
@@ -1,0 +1,98 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.wiz.pairing.*;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Write coordination (2026-08-17-write-coordination-design.md / -implementation.md): {@code mutate}
+ * is the choke point for every wiz agent write tool that does not go directly through
+ * {@code VSObjectPropertyService}/{@code VSConditionDialogService}/
+ * {@code ViewsheetPropertyDialogService} (chart binding, aesthetics, table binding, calc layout,
+ * ...). Review finding on stylebi#4626: those three services bump the revision themselves, but
+ * nothing bumped it for writes landing through this seam, so a human's dialog -- read at a
+ * revision an agent write here never moved -- would still match on commit and silently overwrite
+ * the agent's change. This is the fix.
+ */
+@WizAgentTestSupport
+class ViewsheetSessionServiceTest {
+
+   @Test
+   void mutateBumpsTheWriteRevisionOnSuccess() throws Exception {
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      SheetAgentBroadcastService broadcast = mock(SheetAgentBroadcastService.class);
+
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      JoinSession s = new JoinSession("TOK", "Viewsheet/foo-7", "alice~;~host-org",
+                                      SheetType.VIEWSHEET, 0L, Long.MAX_VALUE,
+                                      JoinSession.ConnectionMode.PAIRED, null, null);
+      when(sessions.resolve(eq("TOK"), any())).thenReturn(s);
+      when(runtimeAccess.getSheetForPairing(eq(SheetType.VIEWSHEET), eq("Viewsheet/foo-7"), eq(agent)))
+         .thenReturn(rvs);
+
+      ViewsheetSessionService svc = new ViewsheetSessionService(sessions, runtimeAccess, broadcast);
+      svc.mutate("TOK", agent, (r, runtimeId, dispatcher) -> {});
+
+      verify(rvs).bumpWriteRevision();
+   }
+
+   /**
+    * The undo checkpoint and the broadcast happen even when the mutation only partially applied
+    * (see the comment above the checkpoint call in {@code mutate}) -- the write revision must
+    * follow the same rule. A partial edit is a real edit; a dialog holding a pre-edit revision
+    * must not treat it as unchanged.
+    */
+   @Test
+   void mutateBumpsTheWriteRevisionEvenWhenTheMutationThrows() throws Exception {
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      SheetAgentBroadcastService broadcast = mock(SheetAgentBroadcastService.class);
+
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      JoinSession s = new JoinSession("TOK", "Viewsheet/foo-7", "alice~;~host-org",
+                                      SheetType.VIEWSHEET, 0L, Long.MAX_VALUE,
+                                      JoinSession.ConnectionMode.PAIRED, null, null);
+      when(sessions.resolve(eq("TOK"), any())).thenReturn(s);
+      when(runtimeAccess.getSheetForPairing(eq(SheetType.VIEWSHEET), eq("Viewsheet/foo-7"), eq(agent)))
+         .thenReturn(rvs);
+
+      ViewsheetSessionService svc = new ViewsheetSessionService(sessions, runtimeAccess, broadcast);
+
+      assertThrows(RuntimeException.class, () -> svc.mutate("TOK", agent, (r, runtimeId, dispatcher) -> {
+         throw new RuntimeException("partial failure mid-mutation");
+      }));
+
+      verify(rvs).bumpWriteRevision();
+   }
+}


### PR DESCRIPTION
## Summary

Implements the fix designed in stylebi-wiz's `2026-08-17-write-coordination-design.md` (roadmap
unit C1) for the lost-update race: a Composer property dialog reads an assembly's state at open
time, holds a client-side snapshot, and commits it wholesale on OK. Meanwhile a plugin write tool
(or another dialog) can write the same live assembly directly and immediately. If the dialog
commits after that, it silently overwrites the other write — no error, just quiet data loss.

Adds a monotonic `writeRevision` counter on `RuntimeViewsheet`. A dialog's read side attaches the
current revision to its outgoing model; the write side sends it back. The commit path refuses with
a named conflict (`common.writeConflict`) when the revision no longer matches, instead of silently
applying a stale patch.

## What's covered

- **21 property dialogs** (Gauge, Chart, TableView, CalcTable, Calendar, Crosstab, GroupContainer,
  Highlight, Hyperlink, Image, Line, Oval, RangeSlider, Rectangle, SelectionContainer,
  SelectionList, SelectionTree, Submit, Tab, Text, ViewsheetObject) via the shared
  `VSObjectPropertyService.editObjectProperty` choke point — one 9-arg overload covers all of them.
- **The condition dialog** (`VSConditionDialogService`) and **the VS Options pane**
  (`ViewsheetPropertyDialogService`) — independent commit paths, each with its own inline check.
- **The binding editor** (`VSBindingService.finishEdit`) — the highest-value fix: its commit
  replaces the *entire* live viewsheet, not just the assembly being bound. New
  `RuntimeViewsheet.baseWriteRevisionAtOpen` captures the base runtime's revision when the binding
  editor's clone opens; a mismatch at Finish throws instead of silently replacing everything.
- **Scripts** (`ScriptEditService`) — a direct live write with no dialog wrapper, so it never moved
  the counter. Now bumps it, closing the gap where a script-embedding property dialog (15 of the
  18 types) could clobber, or be silently clobbered by, a concurrent script write.
- **The plugin's write tools** (`set_assembly_properties`, condition, `set_viewsheet_properties`,
  highlight tools) inherit the check **transitively, with no code changes**: traced
  `AssemblyPropertyService`/`AssemblyConditionService`/`SheetPropertyService`/
  `AssemblyHighlightService` and found each wraps the exact instrumented get/set pairs above,
  atomically, inside one `sessions.mutate` block.

## Known, deliberate gaps (not silently dropped — see the implementation plan for reasoning)

- `HyperlinkDialogService`'s `TableDataVSAssembly` and generic-assembly branches commit through
  `coreLifecycleService.execute(...)` instead of `editObjectProperty` — not covered, follow-up.
- `VSAssemblyInfoHandler.apply` (which `VSConditionDialogService` calls) is itself called from 13
  other classes across binding/dnd/date-comparison — a possibly larger shared choke point, not
  touched here.
- The script spec's `SetScriptTextCommand` push-into-dialog UX (Option 1) is deliberately not
  built: it has no UI seam until pane-scoped pairing (roadmap Lane G, unit G2) ships, and G2 is
  itself gated on this PR landing. The revision bump alone already closes the silent-loss defect
  for scripts universally.

## Test plan

- [x] `./mvnw -o -pl community/core clean compile` — full module, BUILD SUCCESS
- [x] 34/34 targeted Java tests passing across every touched file (7 new/updated test files, 5
      pre-existing tests fixed for the new trailing arguments)
- [ ] Live verification (C1's five test-plan scenarios) — needs B-lane infrastructure, tracked on
      the stylebi-wiz roadmap board, out of reach from this session's environment

See `docs/superpowers/plans/2026-08-17-write-coordination-implementation.md` in stylebi-wiz for
the full phased plan and reasoning behind each decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)