### PR TITLE
Describe thirty more connectors, mostly ones with no published spec

### DIFF
--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/adobeanalytics/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/adobeanalytics/endpoints.json
@@ -1,84 +1,100 @@
 {
-    "endpoints": [
-        {
-            "name": "Caluculated Metrics",
-            "paged": false,
-            "suffix": "/calculatedmetrics?expansion={Additional Fields?}&rsids={RSIDs?}&ownerId={Owner ID?}&filterByIds={IDs?}&locale={Locale?:en_US}&name={Name?}&tagNames={Tage Names?}&includeType={Include Type?:all|shared|templates}"
-        },
-        {
-            "name": "Calculated Metric",
-            "paged": false,
-            "suffix": "/calculatedmetrics/{ID}?expansion={Additional Fields?}&locale={Locale?:en_US}"
-        },
-        {
-            "name": "Calculated Metric Functions",
-            "paged": false,
-            "suffix": "/calculatedmetrics/functions?locale={Locale?:en_US}"
-        },
-        {
-            "name": "Calculated Metric Function",
-            "paged": false,
-            "suffix": "/calculatedmetrics/functions/{ID}?locale={Locale?:en_US}"
-        },
-        {
-            "name": "Report Suites",
-            "paged": false,
-            "suffix": "/collections/suites?expansion={Additional Fields?}&rsids={RSIDs?}&rsidContains{RSID Contains?}"
-        },
-        {
-            "name": "Report Suite",
-            "paged": false,
-            "suffix": "/collections/suites/{RSID}?expansion={Additional Fields?}"
-        },
-        {
-            "name": "Dateranges",
-            "paged": false,
-            "suffix": "/dateranges?expansion={Additional Fields?}&locale={Locale?:en_US}&filterByIds={Daterange IDs}&includeType={Include Type?:all|shared|templates}"
-        },
-        {
-            "name": "Daterange",
-            "paged": false,
-            "suffix": "/dateranges/{Daterange ID}?expansion={Additional Fields?}&locale={Locale?:en_US}"
-        },
-        {
-            "name": "Dimensions",
-            "paged": false,
-            "suffix": "/dimensions?rsid={RSID}&expansion={Additional Fields?}&locale={Locale?:en_US}&segmentable={Segmentable?}&reportable={Reportable?}&classifiable={Classifiable?}"
-        },
-        {
-            "name": "Dimension",
-            "paged": false,
-            "suffix": "/dimensions/{Dimension ID}?rsid={RSID}&expansion={Additional Fields?}&locale={Locale?:en_US}"
-        },
-        {
-            "name": "Metrics",
-            "paged": false,
-            "suffix": "/metrics?rsid={RSID}&expansion={Additional Fields?}&locale={Locale?:en_US}&segmentable={Segmentable?}"
-        },
-        {
-            "name": "Metric",
-            "paged": false,
-            "suffix": "/metrics/{ID}?rsid={RSID}&expansion={Additional Fields?}&locale={Locale?:en_US}"
-        },
-        {
-            "name": "Segments",
-            "paged": false,
-            "suffix": "/segments?expansion={Additional Fields?}&rsids={RSIDs?}&segmentFilter={IDs?}&locale={Locale?:en_US}&name={Name?}&tagNames={Tag Names?}&filterByPublishedSegments={Filter by Published Segments}&includeType={Include Type?:all|shared|templates}"
-        },
-        {
-            "name": "Segment",
-            "paged": false,
-            "suffix": "/segments/{ID}?expansion={Additional Fields?}&locale={Locale?:en_US}"
-        },
-        {
-            "name": "Users",
-            "paged": false,
-            "suffix": "/users"
-        },
-        {
-            "name": "Current User",
-            "paged": false,
-            "suffix": "/users/me"
-        }
-    ]
+  "endpoints": [
+    {
+      "name": "Caluculated Metrics",
+      "paged": false,
+      "suffix": "/calculatedmetrics?expansion={Additional Fields?}&rsids={RSIDs?}&ownerId={Owner ID?}&filterByIds={IDs?}&locale={Locale?:en_US}&name={Name?}&tagNames={Tage Names?}&includeType={Include Type?:all|shared|templates}",
+      "description": "The calculated metrics defined on the account -- derived measures built from other metrics, such as revenue per visit or a custom conversion rate. Each carries its name, the report suites it applies to, its owner and its formula. THE FORMULA IS THE POINT: a calculated metric is where the business's own definition of a KPI is written down, and the name alone rarely conveys it."
+    },
+    {
+      "name": "Calculated Metric",
+      "paged": false,
+      "suffix": "/calculatedmetrics/{ID}?expansion={Additional Fields?}&locale={Locale?:en_US}",
+      "description": "One calculated metric by id, with its full definition."
+    },
+    {
+      "name": "Calculated Metric Functions",
+      "paged": false,
+      "suffix": "/calculatedmetrics/functions?locale={Locale?:en_US}",
+      "description": "The functions available for building calculated metrics, with their parameters. Reference data for reading or constructing a formula."
+    },
+    {
+      "name": "Calculated Metric Function",
+      "paged": false,
+      "suffix": "/calculatedmetrics/functions/{ID}?locale={Locale?:en_US}",
+      "description": "One calculated metric function by id."
+    },
+    {
+      "name": "Report Suites",
+      "paged": false,
+      "suffix": "/collections/suites?expansion={Additional Fields?}&rsids={RSIDs?}&rsidContains{RSID Contains?}",
+      "description": "The report suites the account can reach, each with its id, name, timezone, currency and calendar type. A report suite is the container all Adobe Analytics data belongs to, and every metadata endpoint here needs an RSID -- so this is the first request. The TIMEZONE and CALENDAR TYPE matter for any period comparison, since suites can be configured on a retail rather than a Gregorian calendar."
+    },
+    {
+      "name": "Report Suite",
+      "paged": false,
+      "suffix": "/collections/suites/{RSID}?expansion={Additional Fields?}",
+      "description": "One report suite by RSID, with its settings."
+    },
+    {
+      "name": "Dateranges",
+      "paged": false,
+      "suffix": "/dateranges?expansion={Additional Fields?}&locale={Locale?:en_US}&filterByIds={Daterange IDs}&includeType={Include Type?:all|shared|templates}",
+      "description": "The saved date ranges, with name and definition -- rolling windows such as last 30 days as well as fixed periods. Requires nothing but the account. Useful because a report referencing one of these is only interpretable through it."
+    },
+    {
+      "name": "Daterange",
+      "paged": false,
+      "suffix": "/dateranges/{Daterange ID}?expansion={Additional Fields?}&locale={Locale?:en_US}",
+      "description": "One saved date range by id."
+    },
+    {
+      "name": "Dimensions",
+      "paged": false,
+      "suffix": "/dimensions?rsid={RSID}&expansion={Additional Fields?}&locale={Locale?:en_US}&segmentable={Segmentable?}&reportable={Reportable?}&classifiable={Classifiable?}",
+      "description": "The dimensions available in one report suite -- page, referrer, eVars, props, marketing channel and the rest -- each with its id, display name, type, category and whether it supports segmentation or pathing. Requires an RSID. THE DECODER FOR ADOBE'S FIELD IDS: a dimension is referenced in queries as something like variables/evar12, and this is the only place that resolves it to the name the business gave it. eVar and prop names are entirely account-specific, so this table is not optional."
+    },
+    {
+      "name": "Dimension",
+      "paged": false,
+      "suffix": "/dimensions/{Dimension ID}?rsid={RSID}&expansion={Additional Fields?}&locale={Locale?:en_US}",
+      "description": "One dimension by id. Requires the RSID."
+    },
+    {
+      "name": "Metrics",
+      "paged": false,
+      "suffix": "/metrics?rsid={RSID}&expansion={Additional Fields?}&locale={Locale?:en_US}&segmentable={Segmentable?}",
+      "description": "The metrics available in one report suite -- occurrences, visits, visitors, revenue, custom events -- each with id, name, type, and the polarity that says whether higher is better. Requires an RSID. Custom events are named per account in the same way eVars are, so metrics/event7 means nothing without this."
+    },
+    {
+      "name": "Metric",
+      "paged": false,
+      "suffix": "/metrics/{ID}?rsid={RSID}&expansion={Additional Fields?}&locale={Locale?:en_US}",
+      "description": "One metric by id. Requires the RSID."
+    },
+    {
+      "name": "Segments",
+      "paged": false,
+      "suffix": "/segments?expansion={Additional Fields?}&rsids={RSIDs?}&segmentFilter={IDs?}&locale={Locale?:en_US}&name={Name?}&tagNames={Tag Names?}&filterByPublishedSegments={Filter by Published Segments}&includeType={Include Type?:all|shared|templates}",
+      "description": "The saved segments defined on the account, with name, description, the report suite each belongs to, its definition and owner. Segments are the audience filters the business has already agreed on, so their definitions carry the organisation's own meaning of terms like 'engaged visitor' -- worth reading before inventing an equivalent."
+    },
+    {
+      "name": "Segment",
+      "paged": false,
+      "suffix": "/segments/{ID}?expansion={Additional Fields?}&locale={Locale?:en_US}",
+      "description": "One segment by id, with its full definition."
+    },
+    {
+      "name": "Users",
+      "paged": false,
+      "suffix": "/users",
+      "description": "The users of the Analytics account, with name, email and login. Administrative."
+    },
+    {
+      "name": "Current User",
+      "paged": false,
+      "suffix": "/users/me",
+      "description": "The account the credentials belong to, with the report suites it can reach. One record, and the explanation for why a suite is missing from the list."
+    }
+  ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/airtable/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/airtable/endpoints.json
@@ -1,14 +1,16 @@
 {
-    "endpoints": [
-        {
-            "name": "Records",
-            "paged": true,
-            "suffix": "/v0/{Base ID}/{Table Name}?fields={Fields?,:Name,Description,...}&filterByFormula={Filter by Formula?}&view={View Name?}&cellFormat={Cell Format?:string|json}&timeZone={Time Zone:America/Los_Angeles|America/New_York|...}&userLocale={User Locale:en|en-gb|es|...}"
-        },
-        {
-            "name": "Record",
-            "paged": false,
-            "suffix": "/v0/{Base ID}/{Table Name}/{Record ID}"
-        }
-    ]
+  "endpoints": [
+    {
+      "name": "Records",
+      "paged": true,
+      "suffix": "/v0/{Base ID}/{Table Name}?fields={Fields?,:Name,Description,...}&filterByFormula={Filter by Formula?}&view={View Name?}&cellFormat={Cell Format?:string|json}&timeZone={Time Zone:America/Los_Angeles|America/New_York|...}&userLocale={User Locale:en|en-gb|es|...}",
+      "description": "The rows of one Airtable table. Requires the base id and the table name -- both of which are per-account, so nothing here is portable between bases. Each row returns an id, a createdTime, and a fields object. THE FIELDS OBJECT IS KEYED BY THE COLUMN'S DISPLAY NAME as the user typed it, spaces and capitals included, which means renaming a column in the Airtable interface silently breaks every query written against it. EMPTY FIELDS ARE OMITTED ENTIRELY rather than returned as null, so rows have different shapes and a missing key means 'blank', not 'no such column'. filterByFormula takes Airtable's own formula language and is evaluated server-side; view restricts to what a saved view shows, which is usually the quickest way to inherit filtering and ordering the team already agreed on."
+    },
+    {
+      "name": "Record",
+      "paged": false,
+      "suffix": "/v0/{Base ID}/{Table Name}/{Record ID}",
+      "description": "One row by record id. Requires the base id and table name. Same field-name keying and the same omission of empty fields."
+    }
+  ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/appfigures/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/appfigures/endpoints.json
@@ -1,199 +1,238 @@
 {
-    "endpoints": [
-        {
-            "name": "Root",
-            "paged": false,
-            "suffix": "/v2/"
-        },
-        {
-            "name": "Product",
-            "paged": false,
-            "suffix": "/v2/products/{Product ID}"
-        },
-        {
-            "name": "Product Search",
-            "paged": false,
-            "suffix": "/v2/products/search/{Term}?filter={Filter?}"
-        },
-        {
-            "name": "Product by Store ID",
-            "paged": false,
-            "suffix": "/v2/products/{Store}/{Store ID}"
-        },
-        {
-            "name": "My Products",
-            "paged": false,
-            "suffix": "/v2/products/mine?store={Store Name?}"
-        },
-        {
-            "name": "Report Regions",
-            "paged": false,
-            "suffix": "/v2/reports/sales/regions?start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&granularity={Granularity?:daily|weekly|monthly|yearly}&products={ProductIDs?}&countries={Countries?}&dataset={Dataset?:none|financial}&include_inapps={Include In Apps?:true|false}"
-        },
-        {
-            "name": "Report Revenue",
-            "paged": false,
-            "suffix": "/v2/reports/revenue?group_by={Group By?:product|country|date|store}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&products={Products?}&countries={Countries?}"
-        },
-        {
-            "name": "Reports Subscriptions",
-            "paged": false,
-            "suffix": "/v2/reports/subscriptions?start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&products={Products?}&countries={Countries?}"
-        },
-        {
-            "name": "Reports Subscription",
-            "paged": false,
-            "suffix": "/v2/reports/subscriptions?group_by={Group By?:product|country|date|store}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&products={Products?}&countries={Countries?}"
-        },
-        {
-            "name": "Reports Ads",
-            "paged": false,
-            "suffix": "/v2/reports/ads?group_by={Group By?:product|country|date|store|network}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&products={Products?}&countries={Countries?}&networks={Networks?}"
-        },
-        {
-            "name": "Reports Ads Details",
-            "paged": false,
-            "suffix": "/v2/reports/ads?group_by={Group By?:product|country|date|store|network}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&products={Products?}&countries={Countries?}"
-        },
-        {
-            "name": "Advertiser Analytics",
-            "paged": false,
-            "suffix": "/v2/reports/adspend?group_by={Group By?:product|country|date|store|network}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&products={Products?}&countries={Countries?}&networks={Networks?}"
-        },
-        {
-            "name": "Ratings",
-            "paged": false,
-            "suffix": "/v2/reports/ratings?start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&granularity={Granularity?}&products={Product IDs?}&countries={Countries?}"
-        },
-        {
-            "name": "Ratings Details",
-            "paged": false,
-            "suffix": "/v2/reports/ratings?group_by={Group By?:product|country|date}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&granularity={Granularity?}&products={Product IDs?}&countries={Countries?}"
-        },
-        {
-            "name": "Usages",
-            "paged": false,
-            "suffix": "/v2/reports/usage?group_by={Group By?:product|country|date|network}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&products={Product IDs?}&countries={Countries?}&networks={Networks?}"
-        },
-        {
-            "name": "All Usages",
-            "paged": false,
-            "suffix": "/v2/usage"
-        },
-        {
-            "name": "Report Sales",
-            "paged": false,
-            "suffix": "/v2/reports/sales?group_by={Group By?:products|countries|dates|stores}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&products={Product IDs?}&countries={Countries?}"
-        },
-        {
-            "name": "Ranks",
-            "paged": false,
-            "suffix": "/v2/ranks/{Product IDS}/{Granularity:hourly|daily}/{Start Date:YYYY-MM-DD}/{End Date:YYYY-MM-DD}?countries={Countries?}&filter={Filter?}&tz={Timezone?:user|utc|est}"
-        },
-        {
-            "name": "Ranks Snapshot",
-            "paged": false,
-           "suffix": "/v2/ranks/snapshots/{Time:HH-MM-SS}/{Country}/{Category}/{Subcategory:free|paid|topgrossing}?top={Top?}"
-        },
-        {
-            "name": "Featured",
-            "paged": false,
-            "suffix": "/v2/featured/summary/{Start Date:YYYY-MM-DD}/{End Date:YYYY-MM-DD}?products={Products?}"
-        },
-        {
-            "name": "Featured Full",
-            "paged": false,
-            "suffix": "/v2/featured/full/{Product ID}/{Start Date:YYYY-MM-DD}/{End Date:YYYY-MM-DD}?countries={Countries?}"
-        },
-        {
-            "name": "Featured Count",
-            "paged": false,
-            "suffix": "/v2/featured/counts?end={End Date?:YYYY-MM-DD}&products={Products?}&granularity={Granularity?:daily|weekly}&show_empty={Show Empty?:true|false}"
-        },
-        {
-            "name": "Featured History",
-            "paged": false,
-            "suffix": "/v2/featured/history/{Product ID}/{Featured Category ID}"
-        },
-        {
-            "name": "Review",
-            "paged": false,
-            "suffix": "/v2/reviews?stars={Stars?}"
-        },
-        {
-            "name": "Review Filters Counts",
-            "paged": false,
-            "suffix": "/v2/reviews/count?stars={Stars?}"
-        },
-        {
-            "name": "Events",
-            "paged": false,
-            "suffix": "/v2/events/"
-        },
-        {
-            "name": "Archive",
-            "paged": false,
-            "suffix": "/v2/archive?type={Type?:daily|weekly|monthly|yearly|finance|payment|all}&date={Date?:YYYY-MM-DD}"
-        },
-        {
-            "name": "Latest Report Listings",
-            "paged": false,
-            "suffix": "/v2/archive/latest?type={Type?:daily|weekly|monthly|yearly|finance|payment|all}"
-        },
-        {
-            "name": "Raw Report Data",
-            "paged": false,
-            "suffix": "/v2/archive/raw/{ID}/"
-        },
-        {
-            "name": "Users",
-            "paged": false,
-            "suffix": "/v2/users/{Email}"
-        },
-        {
-            "name": "Accounts",
-            "paged": false,
-            "suffix": "/v2/external_accounts"
-        },
-        {
-            "name": "Account",
-            "paged": false,
-            "suffix": "/v2/external_accounts/{External Account ID}"
-        },
-        {
-            "name": "Categories",
-            "paged": false,
-            "suffix": "/v2/data/categories"
-        },
-        {
-            "name": "Countries",
-            "paged": false,
-            "suffix": "/v2/data/countries"
-        },
-        {
-            "name": "Apple Country",
-            "paged": false,
-            "suffix": "/v2/data/countries/apple"
-        },
-        {
-            "name": "Languages",
-            "paged": false,
-            "suffix": "/v2/data/languages"
-        },
-        {
-            "name": "Currencies",
-            "paged": false,
-            "suffix": "/v2/data/currencies"
-        },
-        {
-            "name": "Stores",
-            "paged": false,
-            "suffix": "/v2/data/stores"
-        },
-        {
-            "name": "Sdks",
-            "paged": false,
-            "suffix": "/v2/data/sdks"
-        }
-    ]
+  "endpoints": [
+    {
+      "name": "Root",
+      "paged": false,
+      "suffix": "/v2/",
+      "description": "The API root, listing the available resources and the authenticated account. A discovery and connectivity check."
+    },
+    {
+      "name": "Product",
+      "paged": false,
+      "suffix": "/v2/products/{Product ID}",
+      "description": "One app by its Appfigures product id, with its store metadata."
+    },
+    {
+      "name": "Product Search",
+      "paged": false,
+      "suffix": "/v2/products/search/{Term}?filter={Filter?}",
+      "description": "Apps matching a search term across the connected stores, including apps the account does not own. Competitor discovery."
+    },
+    {
+      "name": "Product by Store ID",
+      "paged": false,
+      "suffix": "/v2/products/{Store}/{Store ID}",
+      "description": "One app looked up by store and the store's own id. The bridge from an App Store or Play Store identifier to the Appfigures product id everything else needs."
+    },
+    {
+      "name": "My Products",
+      "paged": false,
+      "suffix": "/v2/products/mine?store={Store Name?}",
+      "description": "The apps connected to the account, optionally filtered by store. THE STARTING POINT: every report here takes product ids, and these are the ones the account actually owns, as opposed to the whole store catalogue the product endpoints can reach."
+    },
+    {
+      "name": "Report Regions",
+      "paged": false,
+      "suffix": "/v2/reports/sales/regions?start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&granularity={Granularity?:daily|weekly|monthly|yearly}&products={ProductIDs?}&countries={Countries?}&dataset={Dataset?:none|financial}&include_inapps={Include In Apps?:true|false}",
+      "description": "Sales broken down by region over a date range. The geographic cut of the sales report."
+    },
+    {
+      "name": "Report Revenue",
+      "paged": false,
+      "suffix": "/v2/reports/revenue?group_by={Group By?:product|country|date|store}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&products={Products?}&countries={Countries?}",
+      "description": "Revenue over a date range, grouped the same ways. Distinct from Report Sales, which counts units: revenue is net of the store's commission and of refunds, so revenue and downloads do not move together."
+    },
+    {
+      "name": "Reports Subscriptions",
+      "paged": false,
+      "suffix": "/v2/reports/subscriptions?start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&products={Products?}&countries={Countries?}",
+      "description": "Subscription figures over a date range -- active subscriptions, new, renewals, cancellations and revenue. The recurring-revenue view, which the one-off sales report cannot express."
+    },
+    {
+      "name": "Reports Subscription",
+      "paged": false,
+      "suffix": "/v2/reports/subscriptions?group_by={Group By?:product|country|date|store}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&products={Products?}&countries={Countries?}",
+      "description": "The same subscription figures with an explicit grouping. Identical endpoint to Reports Subscriptions, differing only in which parameters the connector fills in."
+    },
+    {
+      "name": "Reports Ads",
+      "paged": false,
+      "suffix": "/v2/reports/ads?group_by={Group By?:product|country|date|store|network}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&products={Products?}&countries={Countries?}&networks={Networks?}",
+      "description": "Advertising revenue earned from the ad networks connected -- impressions, clicks, fill rate and revenue -- grouped by product, country, date, store or network. The monetisation side that has nothing to do with app sales, and where an ad-funded app's actual income is."
+    },
+    {
+      "name": "Reports Ads Details",
+      "paged": false,
+      "suffix": "/v2/reports/ads?group_by={Group By?:product|country|date|store|network}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&products={Products?}&countries={Countries?}",
+      "description": "The same ad revenue report at a finer grouping. The same endpoint as Reports Ads with a different default grouping."
+    },
+    {
+      "name": "Advertiser Analytics",
+      "paged": false,
+      "suffix": "/v2/reports/adspend?group_by={Group By?:product|country|date|store|network}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&products={Products?}&countries={Countries?}&networks={Networks?}",
+      "description": "Advertising SPEND -- what was paid to acquire users, by product, country, date, store or network. The opposite side of Reports Ads: that is money earned from showing ads, this is money spent buying installs, and user acquisition profitability is the gap between them."
+    },
+    {
+      "name": "Ratings",
+      "paged": false,
+      "suffix": "/v2/reports/ratings?start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&granularity={Granularity?}&products={Product IDs?}&countries={Countries?}",
+      "description": "Star ratings over a date range, with the counts at each star level. The rating snapshot rather than the reviews behind it."
+    },
+    {
+      "name": "Ratings Details",
+      "paged": false,
+      "suffix": "/v2/reports/ratings?group_by={Group By?:product|country|date}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&granularity={Granularity?}&products={Product IDs?}&countries={Countries?}",
+      "description": "The same ratings with an explicit grouping by product, country or date. Same endpoint as Ratings."
+    },
+    {
+      "name": "Usages",
+      "paged": false,
+      "suffix": "/v2/reports/usage?group_by={Group By?:product|country|date|network}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&products={Product IDs?}&countries={Countries?}&networks={Networks?}",
+      "description": "App usage figures -- sessions and active users -- grouped by product, country, date or network, over a range. Only populated where a usage SDK is connected, so an empty result here is an integration fact rather than an absence of use."
+    },
+    {
+      "name": "All Usages",
+      "paged": false,
+      "suffix": "/v2/usage",
+      "description": "The account-wide usage summary."
+    },
+    {
+      "name": "Report Sales",
+      "paged": false,
+      "suffix": "/v2/reports/sales?group_by={Group By?:products|countries|dates|stores}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&products={Product IDs?}&countries={Countries?}",
+      "description": "Sales and download figures across the connected app stores, grouped by product, country, date or store, over a date range. THE CENTRAL REPORT: it unifies Apple, Google and the other stores into one shape, which is the whole point of Appfigures -- each store reports differently and this is the normalised view. Note the figures are as the STORES report them, so they arrive with the stores' own delay and are restated when a store restates."
+    },
+    {
+      "name": "Ranks",
+      "paged": false,
+      "suffix": "/v2/ranks/{Product IDS}/{Granularity:hourly|daily}/{Start Date:YYYY-MM-DD}/{End Date:YYYY-MM-DD}?countries={Countries?}&filter={Filter?}&tz={Timezone?:user|utc|est}",
+      "description": "The store rank history of given products at hourly or daily granularity over a date range. Requires product ids and dates. The historical series; every other rank endpoint here is a snapshot."
+    },
+    {
+      "name": "Ranks Snapshot",
+      "paged": false,
+      "suffix": "/v2/ranks/snapshots/{Time:HH-MM-SS}/{Country}/{Category}/{Subcategory:free|paid|topgrossing}?top={Top?}",
+      "description": "The chart standings at one moment, for a country, category and subcategory. Requires the time and the chart coordinates. Who was where at a point in time, including competitors the account does not own."
+    },
+    {
+      "name": "Featured",
+      "paged": false,
+      "suffix": "/v2/featured/summary/{Start Date:YYYY-MM-DD}/{End Date:YYYY-MM-DD}?products={Products?}",
+      "description": "A summary of the store featuring one or more products received over a date range. Being featured by a store is the single largest driver of a download spike, and this is the only record of it."
+    },
+    {
+      "name": "Featured Full",
+      "paged": false,
+      "suffix": "/v2/featured/full/{Product ID}/{Start Date:YYYY-MM-DD}/{End Date:YYYY-MM-DD}?countries={Countries?}",
+      "description": "The full featuring detail for one product over a range -- every placement, where and when. Requires a product id and dates."
+    },
+    {
+      "name": "Featured Count",
+      "paged": false,
+      "suffix": "/v2/featured/counts?end={End Date?:YYYY-MM-DD}&products={Products?}&granularity={Granularity?:daily|weekly}&show_empty={Show Empty?:true|false}",
+      "description": "How many featuring placements products received, without the detail. The cheap size check."
+    },
+    {
+      "name": "Featured History",
+      "paged": false,
+      "suffix": "/v2/featured/history/{Product ID}/{Featured Category ID}",
+      "description": "The featuring history of one product in one featured category. Requires the product id and category id."
+    },
+    {
+      "name": "Review",
+      "paged": false,
+      "suffix": "/v2/reviews?stars={Stars?}",
+      "description": "User reviews, filterable by star rating. The qualitative record behind a rating movement."
+    },
+    {
+      "name": "Review Filters Counts",
+      "paged": false,
+      "suffix": "/v2/reviews/count?stars={Stars?}",
+      "description": "How many reviews match given filters, without returning them. The cheap way to size a review set before fetching it."
+    },
+    {
+      "name": "Events",
+      "paged": false,
+      "suffix": "/v2/events/",
+      "description": "The dated events recorded on the account -- releases, campaigns, price changes. The business context behind a movement in the numbers, which no report explains on its own."
+    },
+    {
+      "name": "Archive",
+      "paged": false,
+      "suffix": "/v2/archive?type={Type?:daily|weekly|monthly|yearly|finance|payment|all}&date={Date?:YYYY-MM-DD}",
+      "description": "The raw report files the stores delivered, by type and period. The unprocessed source behind the normalised reports, and the way to reconcile a figure against what a store actually sent."
+    },
+    {
+      "name": "Latest Report Listings",
+      "paged": false,
+      "suffix": "/v2/archive/latest?type={Type?:daily|weekly|monthly|yearly|finance|payment|all}",
+      "description": "The most recent report file of each type. The quick check on whether a store's data has arrived."
+    },
+    {
+      "name": "Raw Report Data",
+      "paged": false,
+      "suffix": "/v2/archive/raw/{ID}/",
+      "description": "The contents of one archived report file by id. The store's own format, unnormalised."
+    },
+    {
+      "name": "Users",
+      "paged": false,
+      "suffix": "/v2/users/{Email}",
+      "description": "One Appfigures user by email address. Administrative."
+    },
+    {
+      "name": "Accounts",
+      "paged": false,
+      "suffix": "/v2/external_accounts",
+      "description": "The store and network accounts connected to Appfigures -- iTunes Connect, Google Play, ad networks. Their status is what determines whether a report has data at all: a broken connection produces gaps that look like zero sales."
+    },
+    {
+      "name": "Account",
+      "paged": false,
+      "suffix": "/v2/external_accounts/{External Account ID}",
+      "description": "One connected external account by id, with its sync status."
+    },
+    {
+      "name": "Categories",
+      "paged": false,
+      "suffix": "/v2/data/categories",
+      "description": "The store category taxonomy across the supported stores. Reference data; category ids differ per store, which is why a cross-store category comparison needs this."
+    },
+    {
+      "name": "Countries",
+      "paged": false,
+      "suffix": "/v2/data/countries",
+      "description": "The country codes used across reports. Reference data."
+    },
+    {
+      "name": "Apple Country",
+      "paged": false,
+      "suffix": "/v2/data/countries/apple",
+      "description": "Apple's own country and storefront codes, which differ from the general list. The decoder for App Store regional figures."
+    },
+    {
+      "name": "Languages",
+      "paged": false,
+      "suffix": "/v2/data/languages",
+      "description": "The language codes used in store listings and reviews. Reference data."
+    },
+    {
+      "name": "Currencies",
+      "paged": false,
+      "suffix": "/v2/data/currencies",
+      "description": "The currencies revenue is reported in. Relevant because store payouts arrive in several, and totals across them need conversion Appfigures does not perform in these endpoints."
+    },
+    {
+      "name": "Stores",
+      "paged": false,
+      "suffix": "/v2/data/stores",
+      "description": "The app stores Appfigures supports, with their ids. The decoder for the store column that appears throughout the reports."
+    },
+    {
+      "name": "Sdks",
+      "paged": false,
+      "suffix": "/v2/data/sdks",
+      "description": "The SDK catalogue Appfigures recognises. Reference data for SDK-based product searches."
+    }
+  ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/azureblob/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/azureblob/endpoints.json
@@ -15,52 +15,62 @@
           "key": "Name",
           "parameterName": "Container"
         }
-      ]
+      ],
+      "description": "The containers in the storage account, each with its name, last-modified time, lease state and public access level. The top level of blob storage and the starting point, since everything else needs a container name. Note this returns XML rather than JSON, as does every endpoint in this connector -- Azure's Blob REST API is XML-only."
     },
     {
       "name": "Blob Service Properties",
       "paged": false,
-      "suffix": "/?restype=service&comp=properties&timeout={Timeout?}"
+      "suffix": "/?restype=service&comp=properties&timeout={Timeout?}",
+      "description": "The account's blob service settings: logging, metrics, CORS rules, the default service version and the soft-delete retention policy. The soft-delete policy is worth reading alongside any storage figure, since deleted blobs continue to be billed for its duration."
     },
     {
       "name": "Account",
       "paged": false,
-      "suffix": "/?restype=account&comp=properties"
+      "suffix": "/?restype=account&comp=properties",
+      "description": "The storage account's kind and SKU. One record, and the context for everything else -- the SKU determines which tiers and features are available at all."
     },
     {
       "name": "Container Properties",
       "paged": false,
-      "suffix": "/{Container}?restype=container&timeout={Timeout?}"
+      "suffix": "/{Container}?restype=container&timeout={Timeout?}",
+      "description": "One container's properties: last-modified, ETag, lease status and public access. Requires a container name."
     },
     {
       "name": "Container Metadata",
       "paged": false,
-      "suffix": "/{Container}?restype=container&comp=metadata&timeout={Timeout?}"
+      "suffix": "/{Container}?restype=container&comp=metadata&timeout={Timeout?}",
+      "description": "The user-defined name-value metadata on one container. Requires a container name. Azure defines no meaning for these, so organisations use them to record things the service has no field for -- worth checking before concluding some attribute is unavailable."
     },
     {
       "name": "Container ACL",
       "paged": false,
-      "suffix": "/{Container}?restype=container&comp=acl&timeout={Timeout?}"
+      "suffix": "/{Container}?restype=container&comp=acl&timeout={Timeout?}",
+      "description": "The public access level of one container and its stored access policies, with their permissions and expiry. Requires a container name. THE SECURITY-REVIEW ENDPOINT: a container set to blob or container access is readable without credentials, which is the single most consequential setting in a storage account."
     },
     {
       "name": "Blobs",
       "paged": true,
-      "suffix": "/{Container}?restype=container&comp=list&prefix={Prefix?}&delimiter={Delimiter?}&include={Include?:snapshots|metadata|uncommittedblobs|copy|deleted}&timeout={Timeout?}"
+      "suffix": "/{Container}?restype=container&comp=list&prefix={Prefix?}&delimiter={Delimiter?}&include={Include?:snapshots|metadata|uncommittedblobs|copy|deleted}&timeout={Timeout?}",
+      "description": "The blobs inside one container, with name, size, content type, last-modified, ETag, blob type, access tier and lease state. Requires a container name. Storage and lifecycle questions are answered here: size and access tier together are what determine cost. THE DELIMITER PARAMETER IS WHAT MAKES IT LOOK LIKE FOLDERS -- blob storage is flat, and a delimiter of / groups by prefix to simulate a directory tree; without it every blob in the container comes back regardless of depth. Snapshots and versions are excluded unless asked for by the include parameter, so a size total omits them by default even though they are billed."
     },
     {
       "name": "Blob Metadata",
       "paged": false,
-      "suffix": "/{Container}/{Blob}?comp=metadata&snapshot={Snapshot?:yyyy-MM-dd\u2019T\u2019HH:mm:ssZ}&timeout={Timeout?}"
+      "suffix": "/{Container}/{Blob}?comp=metadata&snapshot={Snapshot?:yyyy-MM-dd’T’HH:mm:ssZ}&timeout={Timeout?}",
+      "description": "The user-defined metadata on one blob. Requires the container and blob names."
     },
     {
       "name": "Block List",
       "paged": false,
-      "suffix": "/{Container}/{Blob}?comp=blocklist&snapshot={Snapshot?:yyyy-MM-dd\u2019T\u2019HH:mm:ssZ}&blocklisttype={Blocklist Type:committed|uncommitted|all}&timeout={Timeout?}"
+      "suffix": "/{Container}/{Blob}?comp=blocklist&snapshot={Snapshot?:yyyy-MM-dd’T’HH:mm:ssZ}&blocklisttype={Blocklist Type:committed|uncommitted|all}&timeout={Timeout?}",
+      "description": "The blocks making up one block blob, committed and uncommitted, with their sizes. Requires the container and blob names. UNCOMMITTED BLOCKS ARE BILLED BUT INVISIBLE in the blob listing -- an abandoned upload leaves them behind, and this is the only endpoint that shows them, which makes it the explanation for a storage bill that exceeds the sum of the blobs."
     },
     {
       "name": "Page Ranges",
       "paged": false,
-      "suffix": "/{Container}/{Blob}?comp=pagelist&snapshot={Snapshot?:yyyy-MM-dd\u2019T\u2019HH:mm:ssZ}&prevsnapshot={Previous Snapshot?:yyyy-MM-dd\u2019T\u2019HH:mm:ssZ}&timeout={Timeout?}"
+      "suffix": "/{Container}/{Blob}?comp=pagelist&snapshot={Snapshot?:yyyy-MM-dd’T’HH:mm:ssZ}&prevsnapshot={Previous Snapshot?:yyyy-MM-dd’T’HH:mm:ssZ}&timeout={Timeout?}",
+      "description": "The ranges of one page blob that actually hold data, optionally as the difference against an earlier snapshot. Requires the container and blob names. A page blob is sparse -- virtual machine disks are the usual case -- so its declared size and its billed size differ, and only this endpoint gives the second."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/azuresearch/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/azuresearch/endpoints.json
@@ -3,7 +3,8 @@
     {
       "paged": "false",
       "name": "Index",
-      "suffix": "/indexes/{Index Name}?api-version=2019-05-06"
+      "suffix": "/indexes/{Index Name}?api-version=2019-05-06",
+      "description": "One index by name, with its full field definitions, analyzers, scoring profiles and suggesters."
     },
     {
       "paged": "false",
@@ -21,32 +22,38 @@
           "key": "name",
           "parameterName": "Index Name"
         }
-      ]
+      ],
+      "description": "The search indexes defined on the service, each with its fields, their types, and which are searchable, filterable, sortable, facetable and retrievable. The schema of a search service; every document query needs an index name, so this is the first request. THE PER-FIELD FLAGS ARE WHAT DECIDE WHAT IS POSSIBLE: a field that is not filterable cannot be filtered on, and the query fails rather than returning nothing."
     },
     {
       "paged": "false",
       "name": "Index Statistics",
-      "suffix": "/indexes/{Index Name}/stats?api-version=2019-05-06"
+      "suffix": "/indexes/{Index Name}/stats?api-version=2019-05-06",
+      "description": "The document count and storage size of one index. Requires an index name. The cheap way to size an index without counting documents."
     },
     {
       "paged": "true",
       "name": "Document Search",
-      "suffix": "/indexes/{Index Name}/docs?api-version=2019-05-06&search={Search Text?}"
+      "suffix": "/indexes/{Index Name}/docs?api-version=2019-05-06&search={Search Text?}",
+      "description": "Searches one index. Requires an index name; takes the search text plus optional filter, select, orderby, facet, top and skip. The main data endpoint. NOTE THE PAGING LIMIT: skip is capped at 100,000, so an index cannot be exhaustively paged this way -- large extracts need a filter that partitions the data. Facets are the cheap way to get counts by field without retrieving documents at all."
     },
     {
       "paged": "false",
       "name": "Document",
-      "suffix": "/indexes/{Index Name}/docs/{Document Key}?api-version=2019-05-06"
+      "suffix": "/indexes/{Index Name}/docs/{Document Key}?api-version=2019-05-06",
+      "description": "One document by its key. Requires the index name and document key."
     },
     {
       "paged": "false",
       "name": "Document Count",
-      "suffix": "/indexes/{Index Name}/docs/$count?api-version=2019-05-06"
+      "suffix": "/indexes/{Index Name}/docs/$count?api-version=2019-05-06",
+      "description": "The number of documents in one index. Requires an index name. A single number."
     },
     {
       "paged": "false",
       "name": "Data Source",
-      "suffix": "/datasources/{Data Source Name}?api-version=2019-05-06"
+      "suffix": "/datasources/{Data Source Name}?api-version=2019-05-06",
+      "description": "One data source by name, with its connection details and change-detection policy."
     },
     {
       "paged": "false",
@@ -59,17 +66,20 @@
           "key": "name",
           "parameterName": "Data Source Name"
         }
-      ]
+      ],
+      "description": "The external stores indexers pull from -- Azure SQL, Cosmos DB, Blob Storage -- with their type and container. Configuration, and the answer to where an index's contents originate."
     },
     {
       "paged": "false",
       "name": "Indexer",
-      "suffix": "/indexers/{Indexer Name}?api-version=2019-05-06"
+      "suffix": "/indexers/{Indexer Name}?api-version=2019-05-06",
+      "description": "One indexer by name, with its full configuration."
     },
     {
       "paged": "false",
       "name": "Indexer Status",
-      "suffix": "/indexers/{Indexer Name}/status?api-version=2019-05-06"
+      "suffix": "/indexers/{Indexer Name}/status?api-version=2019-05-06",
+      "description": "The execution history of one indexer: the last run and several before it, each with start and end times, the counts of items processed and FAILED, and any error messages. Requires an indexer name. THE ONLY PLACE A PARTIALLY FAILED INDEX IS VISIBLE -- an index missing documents looks identical to a source that never had them, and the failure counts here are what distinguish the two."
     },
     {
       "paged": "false",
@@ -85,17 +95,20 @@
           "key": "name",
           "parameterName": "Indexer Name"
         }
-      ]
+      ],
+      "description": "The jobs that pull from a data source into an index, with their schedule, field mappings and the skillset applied. Configuration; their outcomes are in Indexer Status."
     },
     {
       "paged": "false",
       "name": "Service Statistics",
-      "suffix": "/servicestats?api-version=2019-05-06"
+      "suffix": "/servicestats?api-version=2019-05-06",
+      "description": "The service's usage against its limits -- how many indexes, indexers, data sources, storage and synonym maps are used out of the quota. One record. The place to look when creating something fails."
     },
     {
       "paged": "false",
       "name": "Skillset",
-      "suffix": "/skillsets/{Skillset Name}?api-version=2019-05-06"
+      "suffix": "/skillsets/{Skillset Name}?api-version=2019-05-06",
+      "description": "One skillset by name, with its skills and their input and output mappings."
     },
     {
       "paged": "false",
@@ -108,12 +121,14 @@
           "key": "name",
           "parameterName": "Skillset Name"
         }
-      ]
+      ],
+      "description": "The AI enrichment pipelines applied during indexing -- OCR, entity recognition, key phrase extraction and custom skills. Configuration, and the explanation for fields in an index that exist in no source system."
     },
     {
       "paged": "false",
       "name": "Synonym Map",
-      "suffix": "/synonymmaps/{Synonym Map Name}?api-version=2019-05-06"
+      "suffix": "/synonymmaps/{Synonym Map Name}?api-version=2019-05-06",
+      "description": "One synonym map by name, with its rules."
     },
     {
       "paged": "false",
@@ -126,7 +141,8 @@
           "key": "name",
           "parameterName": "Synonym Map Name"
         }
-      ]
+      ],
+      "description": "The synonym rules applied at query time. Configuration, but it materially changes results: a search for one term can match documents containing another, which is otherwise inexplicable from the index contents."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/chartmogul/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/chartmogul/endpoints.json
@@ -3,17 +3,20 @@
     {
       "paged": "false",
       "name": "Data Source",
-      "suffix": "/v1/data_sources/{Data Source UUID}"
+      "suffix": "/v1/data_sources/{Data Source UUID}",
+      "description": "One data source by UUID, with its sync status."
     },
     {
       "paged": "true",
       "name": "Data Sources",
-      "suffix": "/v1/data_sources?name={Name?}&system={System?:Stripe|Recurly|Chargify|Import API}"
+      "suffix": "/v1/data_sources?name={Name?}&system={System?:Stripe|Recurly|Chargify|Import API}",
+      "description": "The billing systems feeding ChartMogul -- Stripe, Recurly, Chargify, an import and so on -- with their name, system and status. Every customer, plan and invoice belongs to one, which is what makes the source dimension necessary when a business bills through more than one."
     },
     {
       "paged": "false",
       "name": "Customer",
-      "suffix": "/v1/customers/{Customer UUID}"
+      "suffix": "/v1/customers/{Customer UUID}",
+      "description": "One customer by UUID, with their full attributes and current MRR."
     },
     {
       "paged": "true",
@@ -22,113 +25,133 @@
       "lookups": [
         {
           "endpoints": [
-             "Customer",
-             "Customer's Subscriptions",
-             "Customer's Invoices",
-             "Customer's Attributes",
-             "Customer Subscriptions",
-             "Customer Activities"
+            "Customer",
+            "Customer's Subscriptions",
+            "Customer's Invoices",
+            "Customer's Attributes",
+            "Customer Subscriptions",
+            "Customer Activities"
           ],
           "jsonPath": "$.entries[*]",
           "key": "uuid",
           "parameterName": "Customer UUID"
         }
-      ]
+      ],
+      "description": "The customers in the account, with name, company, email, country, the data source they came from, their status, and their current MRR. Filterable by data source, external id and status. The subject table: metrics aggregate these."
     },
     {
       "paged": "false",
       "name": "Plan",
-      "suffix": "/v1/plans/{Plan UUID}"
+      "suffix": "/v1/plans/{Plan UUID}",
+      "description": "One plan by UUID."
     },
     {
       "paged": "true",
       "name": "Plans",
-      "suffix": "/v1/plans?data_source_uuid={Data Source UUID?}&external_id={External ID?}&system={System?:Stripe|Recurly|Chargify|Import API}"
+      "suffix": "/v1/plans?data_source_uuid={Data Source UUID?}&external_id={External ID?}&system={System?:Stripe|Recurly|Chargify|Import API}",
+      "description": "The subscription plans imported, with name, interval, interval count and the data source each came from. Plans are per data source, so THE SAME COMMERCIAL PLAN IMPORTED FROM TWO BILLING SYSTEMS APPEARS TWICE -- a breakdown by plan double-counts unless they have been merged in ChartMogul."
     },
     {
       "paged": "true",
       "name": "Customer's Subscriptions",
-      "suffix": "/v1/import/customers/{Customer UUID}/subscriptions"
+      "suffix": "/v1/import/customers/{Customer UUID}/subscriptions",
+      "description": "The subscriptions of one customer as recorded through the import API, with the source system's own identifiers. Requires the UUID. The import view rather than the computed one -- useful for reconciling against the billing system that fed it."
     },
     {
       "paged": "false",
       "name": "Invoice",
-      "suffix": "/v1/invoices/{Invoice UUID}"
+      "suffix": "/v1/invoices/{Invoice UUID}",
+      "description": "One invoice by UUID, with its line items and transactions."
     },
     {
       "paged": "true",
       "name": "Customer's Invoices",
-      "suffix": "/v1/import/customers/{Customer UUID}/invoices"
+      "suffix": "/v1/import/customers/{Customer UUID}/invoices",
+      "description": "The invoices of one customer. Requires the UUID."
     },
     {
       "paged": "true",
       "name": "Invoices",
-      "suffix": "/v1/invoices?data_source_uuid={Data Source UUID?}&customer_uuid={Customer UUID?}&external_id={External ID?}"
+      "suffix": "/v1/invoices?data_source_uuid={Data Source UUID?}&customer_uuid={Customer UUID?}&external_id={External ID?}",
+      "description": "The invoices imported into ChartMogul, with the customer, date, currency, line items and payment status. Filterable by data source and customer. The billing evidence beneath the metrics."
     },
     {
       "paged": "true",
       "name": "Search for Customers",
-      "suffix": "/v1/customers/search?email={Email}"
+      "suffix": "/v1/customers/search?email={Email}",
+      "description": "Customers matching an email address. The lookup when the UUID is not known -- note it searches email specifically rather than free text."
     },
     {
       "paged": "false",
       "name": "Customer's Attributes",
-      "suffix": "/v1/customers/{Customer UUID}/attributes"
+      "suffix": "/v1/customers/{Customer UUID}/attributes",
+      "description": "The tags and custom attributes on one customer. Requires the UUID. Where a business records segment, plan tier or account owner -- ChartMogul defines no meaning for these, so this is often the only place a customer dimension beyond country exists."
     },
     {
       "paged": "false",
       "name": "Metrics",
-      "suffix": "/v1/metrics/all?start-date={Start Date:YYYY-MM-DD}&end-date={End Date:YYYY-MM-DD}&interval={Interval?:day|week|month}&geo={Geo?:US,GB,DE}&plans={Plans?}"
+      "suffix": "/v1/metrics/all?start-date={Start Date:YYYY-MM-DD}&end-date={End Date:YYYY-MM-DD}&interval={Interval?:day|week|month}&geo={Geo?:US,GB,DE}&plans={Plans?}",
+      "description": "ChartMogul's full subscription metric set over a date range, in one call: MRR, ARR, ARPA, ASP, customer count, customer churn rate, MRR churn rate and LTV, per interval. Requires start and end dates and an interval. THE ENDPOINT MOST QUESTIONS SHOULD USE -- it returns every headline metric together rather than one per request, and ChartMogul has already applied the subscription accounting (proration, currency normalisation, upgrade and downgrade attribution) that reconstructing from invoices would mean reimplementing."
     },
     {
       "paged": "false",
       "name": "Monthly Recurring Revenue",
-      "suffix": "/v1/metrics/mrr?start-date={Start Date:YYYY-MM-DD}&end-date={End Date:YYYY-MM-DD}&interval={Interval?:day|week|month}&geo={Geo?:US,GB,DE}&plans={Plans?}"
+      "suffix": "/v1/metrics/mrr?start-date={Start Date:YYYY-MM-DD}&end-date={End Date:YYYY-MM-DD}&interval={Interval?:day|week|month}&geo={Geo?:US,GB,DE}&plans={Plans?}",
+      "description": "MRR over a date range, broken into its MOVEMENTS -- new business, expansion, contraction, churn and reactivation -- per interval. This decomposition is the point: a flat MRR line can hide large new business exactly offset by large churn, and only the movement breakdown shows it."
     },
     {
       "paged": "false",
       "name": "Annualized Run Rate",
-      "suffix": "/v1/metrics/arr?start-date={Start Date:YYYY-MM-DD}&end-date={End Date:YYYY-MM-DD}&interval={Interval?:day|week|month}&geo={Geo?:US,GB,DE}&plans={Plans?}"
+      "suffix": "/v1/metrics/arr?start-date={Start Date:YYYY-MM-DD}&end-date={End Date:YYYY-MM-DD}&interval={Interval?:day|week|month}&geo={Geo?:US,GB,DE}&plans={Plans?}",
+      "description": "ARR over a date range. Derived directly from MRR, so it carries no information MRR does not; useful where the business reports in annual terms."
     },
     {
       "paged": "false",
       "name": "Average Revenue Per Account",
-      "suffix": "/v1/metrics/arpa?start-date={Start Date:YYYY-MM-DD}&end-date={End Date:YYYY-MM-DD}&interval={Interval?:day|week|month}&geo={Geo?:US,GB,DE}&plans={Plans?}"
+      "suffix": "/v1/metrics/arpa?start-date={Start Date:YYYY-MM-DD}&end-date={End Date:YYYY-MM-DD}&interval={Interval?:day|week|month}&geo={Geo?:US,GB,DE}&plans={Plans?}",
+      "description": "ARPA over a date range. Moves when the customer mix changes as well as when prices do, so a rise here is not by itself evidence of a pricing gain."
     },
     {
       "paged": "false",
       "name": "Average Sale Price",
-      "suffix": "/v1/metrics/asp?start-date={Start Date:YYYY-MM-DD}&end-date={End Date:YYYY-MM-DD}&interval={Interval?:day|week|month}&geo={Geo?:US,GB,DE}&plans={Plans?}"
+      "suffix": "/v1/metrics/asp?start-date={Start Date:YYYY-MM-DD}&end-date={End Date:YYYY-MM-DD}&interval={Interval?:day|week|month}&geo={Geo?:US,GB,DE}&plans={Plans?}",
+      "description": "The average value of new subscriptions closed in each interval. Unlike ARPA this covers only NEW business, which makes it the measure of what is being sold now rather than of the whole base."
     },
     {
       "paged": "false",
       "name": "Customer Count",
-      "suffix": "/v1/metrics/customer-count?start-date={Start Date:YYYY-MM-DD}&end-date={End Date:YYYY-MM-DD}&interval={Interval?:day|week|month}&geo={Geo?:US,GB,DE}&plans={Plans?}"
+      "suffix": "/v1/metrics/customer-count?start-date={Start Date:YYYY-MM-DD}&end-date={End Date:YYYY-MM-DD}&interval={Interval?:day|week|month}&geo={Geo?:US,GB,DE}&plans={Plans?}",
+      "description": "The number of paying customers at each interval. The denominator for most per-customer figures, and it counts customers rather than subscriptions -- one customer with three subscriptions is one row."
     },
     {
       "paged": "false",
       "name": "Customer Churn Rate",
-      "suffix": "/v1/metrics/customer-churn-rate?start-date={Start Date:YYYY-MM-DD}&end-date={End Date:YYYY-MM-DD}&interval={Interval?:day|week|month}&geo={Geo?:US,GB,DE}&plans={Plans?}"
+      "suffix": "/v1/metrics/customer-churn-rate?start-date={Start Date:YYYY-MM-DD}&end-date={End Date:YYYY-MM-DD}&interval={Interval?:day|week|month}&geo={Geo?:US,GB,DE}&plans={Plans?}",
+      "description": "The percentage of customers lost per interval. Distinct from MRR churn: losing many small customers and losing one large one look very different in these two, which is why both exist."
     },
     {
       "paged": "false",
       "name": "MRR Churn Rate",
-      "suffix": "/v1/metrics/mrr-churn-rate?start-date={Start Date:YYYY-MM-DD}&end-date={End Date:YYYY-MM-DD}&geo={Geo?:US,GB,DE}&plans={Plans?}"
+      "suffix": "/v1/metrics/mrr-churn-rate?start-date={Start Date:YYYY-MM-DD}&end-date={End Date:YYYY-MM-DD}&geo={Geo?:US,GB,DE}&plans={Plans?}",
+      "description": "The percentage of recurring revenue lost per interval, net of expansion. CAN BE NEGATIVE where expansion within the retained base exceeds losses, which is a healthy result and not an error."
     },
     {
       "paged": "false",
       "name": "Customer Lifetime Value",
-      "suffix": "/v1/metrics/ltv?start-date={Start Date:YYYY-MM-DD}&end-date={End Date:YYYY-MM-DD}&geo={Geo?:US,GB,DE}&plans={Plans?}"
+      "suffix": "/v1/metrics/ltv?start-date={Start Date:YYYY-MM-DD}&end-date={End Date:YYYY-MM-DD}&geo={Geo?:US,GB,DE}&plans={Plans?}",
+      "description": "Computed LTV per interval. A modelled figure derived from churn and ARPA rather than an observed one, so it is a projection whose accuracy depends on churn staying as it was."
     },
     {
       "paged": "true",
       "name": "Customer Subscriptions",
-      "suffix": "/v1/customers/{Customer UUID}/subscriptions"
+      "suffix": "/v1/customers/{Customer UUID}/subscriptions",
+      "description": "The subscriptions of one customer, with plan, quantity, MRR and the period each covers. Requires the UUID. What makes up a customer's MRR, which the customer record only totals."
     },
     {
       "paged": "true",
       "name": "Customer Activities",
-      "suffix": "/v1/customers/{Customer UUID}/activities"
+      "suffix": "/v1/customers/{Customer UUID}/activities",
+      "description": "The subscription events of one customer over time -- new business, expansion, contraction, churn, reactivation -- each with its date and MRR change. Requires the UUID. THE PER-CUSTOMER MOVEMENT HISTORY: the aggregate movements in the MRR endpoint are sums of these, so this is where a particular month's churn is traced to the accounts responsible."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/clockify/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/clockify/endpoints.json
@@ -3,47 +3,56 @@
     {
       "name": "Clients",
       "paged": true,
-      "suffix": "/v1/workspaces/{Workspace Id}/clients?archived={Archived?:true|false}&name={Name?}&sort-column={Sort Column?}&sort-order={Sort Order?:ASCENDING|DESCENDING}"
+      "suffix": "/v1/workspaces/{Workspace Id}/clients?archived={Archived?:true|false}&name={Name?}&sort-column={Sort Column?}&sort-order={Sort Order?:ASCENDING|DESCENDING}",
+      "description": "The clients in one workspace, with name and archived state. Requires a workspace id. The top of the billing hierarchy: projects belong to clients, so this is the axis client-profitability questions group by."
     },
     {
       "name": "Projects",
       "paged": true,
-      "suffix": "/v1/workspaces/{Workspace Id}/projects?archived={Archived?:true|false}&name={Name?}&billable={Billable?:true|false}&clients={Clients?}&contains-client={Contains Client?:true|false}&client-status={Client Status?:ACTIVE|ARCHIVED}&users={Users?}&contains-users={Contains Users?:true|false}&is-template={Is Template?:true|false}&sort-column={Sort Column?}&sort-order={Sort Order?:ASCENDING|DESCENDING}"
+      "suffix": "/v1/workspaces/{Workspace Id}/projects?archived={Archived?:true|false}&name={Name?}&billable={Billable?:true|false}&clients={Clients?}&contains-client={Contains Client?:true|false}&client-status={Client Status?:ACTIVE|ARCHIVED}&users={Users?}&contains-users={Contains Users?:true|false}&is-template={Is Template?:true|false}&sort-column={Sort Column?}&sort-order={Sort Order?:ASCENDING|DESCENDING}",
+      "description": "The projects in one workspace, with name, the client, colour, billable flag, hourly rate, estimate, and archived state. Requires a workspace id. The HOURLY RATE here is what turns recorded time into money -- a time entry carries duration and nothing else, so revenue is always a join. Archived projects are excluded by default, which quietly drops finished work from any historical total."
     },
     {
       "name": "Project",
       "paged": false,
-      "suffix": "/v1/workspaces/{Workspace Id}/{Project Id}"
+      "suffix": "/v1/workspaces/{Workspace Id}/{Project Id}",
+      "description": "One project by id. Requires the workspace id."
     },
     {
       "name": "Tags",
       "paged": true,
-      "suffix": "/v1/workspaces/{Workspace Id}/tags?archived={Archived?:true|false}&name={Name?}&sort-column={Sort Column?}&sort-order={Sort Order?:ASCENDING|DESCENDING}"
+      "suffix": "/v1/workspaces/{Workspace Id}/tags?archived={Archived?:true|false}&name={Name?}&sort-column={Sort Column?}&sort-order={Sort Order?:ASCENDING|DESCENDING}",
+      "description": "The tags in one workspace. Requires a workspace id. Tags are the free-form cross-cutting label on time entries -- billable category, activity type, whatever the team chose -- and often the only dimension beyond project and task."
     },
     {
       "name": "Tasks",
       "paged": true,
-      "suffix": "/v1/workspaces/{Workspace Id}/projects/{Project Id}/tasks?is-active={Is Active?:true|false}&name={Name?}"
+      "suffix": "/v1/workspaces/{Workspace Id}/projects/{Project Id}/tasks?is-active={Is Active?:true|false}&name={Name?}",
+      "description": "The tasks within one project, with name, status, estimate and assignees. Requires the workspace and project ids. The level below project that time is booked against."
     },
     {
       "name": "Task",
       "paged": false,
-      "suffix": "/v1/workspaces/{Workspace Id}/projects/{Project Id}/tasks/{Task Id}"
+      "suffix": "/v1/workspaces/{Workspace Id}/projects/{Project Id}/tasks/{Task Id}",
+      "description": "One task by id. Requires the workspace and project ids."
     },
     {
       "name": "Time Entries",
       "paged": true,
-      "suffix": "/v1/workspaces/{Workspace Id}/user/{User Id}/time-entries?description={Description?}&start={Start?:yyyy-MM-ddTHH:mm:ss}&end={End?:yyyy-MM-ddTHH:mm:ss}&project={Project?}&task={Task?}&tags={Tags?}&project-required={Project Required?:true|false}&task-required={Task Required?:true|false}&consider-duration-format={Consider Duration Format?:true|false}&hydrated={Hydrated?:true|false}&in-project={In Progress?:true|false}"
+      "suffix": "/v1/workspaces/{Workspace Id}/user/{User Id}/time-entries?description={Description?}&start={Start?:yyyy-MM-ddTHH:mm:ss}&end={End?:yyyy-MM-ddTHH:mm:ss}&project={Project?}&task={Task?}&tags={Tags?}&project-required={Project Required?:true|false}&task-required={Task Required?:true|false}&consider-duration-format={Consider Duration Format?:true|false}&hydrated={Hydrated?:true|false}&in-project={In Progress?:true|false}",
+      "description": "The time entries of ONE USER. Requires the workspace and user ids. Carries the description, the project and task, tags, the billable flag, and a timeInterval holding start, end and duration. TWO THINGS. It is per user, so a workspace-wide extract is a loop over the member list. And DURATION IS AN ISO 8601 PERIOD STRING like PT1H30M, not a number -- it must be parsed before it can be summed, and a running entry has no end and no duration at all."
     },
     {
       "name": "Time Entry",
       "paged": false,
-      "suffix": "/v1/workspaces/{Workspace Id}/time-entries/{Time Entry Id}"
+      "suffix": "/v1/workspaces/{Workspace Id}/time-entries/{Time Entry Id}",
+      "description": "One time entry by id. Requires the workspace id. Same ISO duration format."
     },
     {
       "name": "User",
       "paged": false,
-      "suffix": "/v1/user"
+      "suffix": "/v1/user",
+      "description": "The account the credentials belong to. One record, always the caller -- and the id needed by the time entry endpoints, which are addressed per user."
     },
     {
       "name": "Users",
@@ -56,12 +65,14 @@
           "key": "id",
           "parameterName": "User Id"
         }
-      ]
+      ],
+      "description": "The members of one workspace, with name, email, status and their memberships. Requires a workspace id. Status separates active members from those deactivated, who still own their historical entries."
     },
     {
       "name": "Groups",
       "paged": true,
-      "suffix": "/v1/workspaces/{Workspace Id}/user-groups?name={Name?}&projectId={Project Id?}&sort-column={Sort Column?}&sort-order={Sort Order?:ASCENDING|DESCENDING}"
+      "suffix": "/v1/workspaces/{Workspace Id}/user-groups?name={Name?}&projectId={Project Id?}&sort-column={Sort Column?}&sort-order={Sort Order?:ASCENDING|DESCENDING}",
+      "description": "The user groups in one workspace. Requires a workspace id. Groups are how permissions and project access are granted in bulk."
     },
     {
       "name": "Workspaces",
@@ -81,7 +92,8 @@
           "key": "id",
           "parameterName": "Workspace Id"
         }
-      ]
+      ],
+      "description": "The workspaces the authenticated user belongs to, with name, and the settings that govern time tracking -- rounding, whether time can be entered for other users, and the default billable state. Every other endpoint needs a workspace id, so this is the first request. The ROUNDING SETTING is worth reading: where it is on, recorded durations are adjusted before they reach reports, so raw time entries and report totals legitimately disagree."
     },
     {
       "name": "Summary Report",
@@ -89,8 +101,8 @@
       "post": true,
       "suffix": "/v1/workspaces/{Workspace Id}/reports/summary",
       "url": "https://reports.api.clockify.me",
-      "bodyTemplate": "{\n \"dateRangeStart\": \"2020-05-10T00:00:00.000Z\",\n \"dateRangeEnd\": \"2020-05-16T23:59:59.000Z\",\n \"summaryFilter\": {\n \"groups\": [\n \"USER\",\n \"PROJECT\",\n \"TIMEENTRY\"\n ]\n }\n }\n"
-
+      "bodyTemplate": "{\n \"dateRangeStart\": \"2020-05-10T00:00:00.000Z\",\n \"dateRangeEnd\": \"2020-05-16T23:59:59.000Z\",\n \"summaryFilter\": {\n \"groups\": [\n \"USER\",\n \"PROJECT\",\n \"TIMEENTRY\"\n ]\n }\n }\n",
+      "description": "Totals grouped by up to three levels -- project, client, user, tag, date -- for a date range. Sent as a POST with the grouping and filters in the body, against Clockify's separate reports host. THE RIGHT ENDPOINT FOR ANY AGGREGATE: it applies the workspace's rounding and rates, which summing raw time entries does not, so its totals are the ones that match what the business bills."
     },
     {
       "name": "Detailed Report",
@@ -98,7 +110,8 @@
       "post": true,
       "suffix": "/v1/workspaces/{Workspace Id}/reports/detailed",
       "url": "https://reports.api.clockify.me",
-      "bodyTemplate": "{\n \"dateRangeStart\": \"2020-05-10T00:00:00.000Z\",\n \"dateRangeEnd\": \"2020-05-16T23:59:59.000Z\"\n}\n"
+      "bodyTemplate": "{\n \"dateRangeStart\": \"2020-05-10T00:00:00.000Z\",\n \"dateRangeEnd\": \"2020-05-16T23:59:59.000Z\"\n}\n",
+      "description": "Every individual time entry matching the filters, with its project, task, user, tags and amount, for a date range. POST, same reports host. The row-level companion to the summary, and the practical way to extract a workspace's entries in one request rather than looping per user."
     },
     {
       "name": "Weekly Report",
@@ -106,7 +119,8 @@
       "post": true,
       "suffix": "/v1/workspaces/{Workspace Id}/reports/weekly",
       "url": "https://reports.api.clockify.me",
-      "bodyTemplate": "{\n \"dateRangeStart\": \"2020-05-10T00:00:00.000Z\",\n \"dateRangeEnd\": \"2020-05-16T23:59:59.000Z\",\n \"weeklyFilter\": {\n \"group\": \"USER\",\n \"subgroup\": \"TIME\"\n }\n }\n"
+      "bodyTemplate": "{\n \"dateRangeStart\": \"2020-05-10T00:00:00.000Z\",\n \"dateRangeEnd\": \"2020-05-16T23:59:59.000Z\",\n \"weeklyFilter\": {\n \"group\": \"USER\",\n \"subgroup\": \"TIME\"\n }\n }\n",
+      "description": "Time totals laid out by day of week for a range, per user or per project. POST, same reports host. Built for timesheet review rather than analysis."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/constantcontact/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/constantcontact/endpoints.json
@@ -3,77 +3,92 @@
     {
       "name": "Account Email Addresses",
       "paged": false,
-      "suffix": "/v3/account/emails?confirm_status={Confirm Status?:CONFIRMED|UNCONFIRMED}&role_code={Role Code?:CONTACT|BILLING|JOURNALING|REPLY_TO|OTHER}&email_address={Email Address?}"
+      "suffix": "/v3/account/emails?confirm_status={Confirm Status?:CONFIRMED|UNCONFIRMED}&role_code={Role Code?:CONTACT|BILLING|JOURNALING|REPLY_TO|OTHER}&email_address={Email Address?}",
+      "description": "The from addresses registered for the account, with their confirmation status. AN UNCONFIRMED ADDRESS CANNOT SEND, so this is the usual explanation for a campaign that will not go out."
     },
     {
       "name": "Account Details",
       "paged": false,
-      "suffix": "/v3/account/summary?extra_fields={Extra Fields?:value1,value2,...}"
+      "suffix": "/v3/account/summary?extra_fields={Extra Fields?:value1,value2,...}",
+      "description": "The account's name, contact details and settings. One record."
     },
     {
       "name": "Account Physical Address",
       "paged": false,
-      "suffix": "/v3/account/summary/physical_address"
+      "suffix": "/v3/account/summary/physical_address",
+      "description": "The postal address included in every campaign footer, as required by anti-spam law. Configuration."
     },
     {
       "name": "User Privileges",
       "paged": false,
-      "suffix": "/v3/account/user/privileges"
+      "suffix": "/v3/account/user/privileges",
+      "description": "The permissions the calling account holds. The direct explanation for a permission error elsewhere."
     },
     {
       "name": "Activity Statuses",
       "paged": true,
-      "suffix": "/v3/activities?state={State?:processing|completed|cancelled|failed|timed_out}"
+      "suffix": "/v3/activities?state={State?:processing|completed|cancelled|failed|timed_out}",
+      "description": "The asynchronous bulk jobs on the account -- imports, exports, deletions -- with their state. Bulk operations report only that they were queued, so this is where their outcome is found."
     },
     {
       "name": "Activity Status",
       "paged": false,
-      "suffix": "/v3/activities/{Activity ID}"
+      "suffix": "/v3/activities/{Activity ID}",
+      "description": "One bulk job by id, with its progress and any errors. The error detail is where silently dropped import rows show up."
     },
     {
       "name": "Contacts",
       "paged": true,
-      "suffix": "/v3/contacts?status={Status?:value1,value2,...}&email={Search Email Address?}&lists={Contacts List?}&updated_after={Updated After?:yyyy-MM-dd}&include={Include?:custom_fields|list_memberships|phone_numbers|street_addresses}&include_count={Include Count?:true|false}"
+      "suffix": "/v3/contacts?status={Status?:value1,value2,...}&email={Search Email Address?}&lists={Contacts List?}&updated_after={Updated After?:yyyy-MM-dd}&include={Include?:custom_fields|list_memberships|phone_numbers|street_addresses}&include_count={Include Count?:true|false}",
+      "description": "The contacts in the account, with email, name, the lists they belong to, custom fields, the source they were created from, and their timestamps. Filterable by status and email. STATUS IS THE FILTER THAT MATTERS: unsubscribed and removed contacts remain in the table, so a subscriber count taken without it overstates the reachable audience."
     },
     {
       "name": "Contact",
       "paged": false,
-      "suffix": "/v3/contacts/{Contact ID}?include={Include?:value1,value2,...}"
+      "suffix": "/v3/contacts/{Contact ID}?include={Include?:value1,value2,...}",
+      "description": "One contact by id. The include parameter inlines list memberships, custom fields, notes and street addresses, which are otherwise absent."
     },
     {
       "name": "Contact Lists",
       "paged": true,
-      "suffix": "/v3/contact_lists?include_count={Include Count?:true|false}"
+      "suffix": "/v3/contact_lists?include_count={Include Count?:true|false}",
+      "description": "The mailing lists, each with name, description and, when include_count is passed, its membership count. The count is not returned by default, which is easy to miss when the list appears to have no size."
     },
     {
       "name": "Contact List",
       "paged": false,
-      "suffix": "/v3/contact_lists/{List ID}"
+      "suffix": "/v3/contact_lists/{List ID}",
+      "description": "One list by id."
     },
     {
       "name": "Contact Activity Details",
       "paged": true,
-      "suffix": "/v3/reports/contact_reports/{Contact ID}/activity_details?tracking_activities_list={Tracking Activities List:em_sends|em_opens|em_clicks|em_bounces|em_optouts|em_forwards}"
+      "suffix": "/v3/reports/contact_reports/{Contact ID}/activity_details?tracking_activities_list={Tracking Activities List:em_sends|em_opens|em_clicks|em_bounces|em_optouts|em_forwards}",
+      "description": "One contact's individual email events over a period, filterable by activity type. Requires a contact id. The row-level history behind the summary."
     },
     {
       "name": "Contact Action Summary",
       "paged": true,
-      "suffix": "/v3/reports/contact_reports/{Contact ID}/activity_summary?start={Start:yyyy-MM-dd|yyyy-MM-ddTHH:mm:ssZ}&end={End:yyyy-MM-dd|yyyy-MM-ddTHH:mm:ssZ}"
+      "suffix": "/v3/reports/contact_reports/{Contact ID}/activity_summary?start={Start:yyyy-MM-dd|yyyy-MM-ddTHH:mm:ssZ}&end={End:yyyy-MM-dd|yyyy-MM-ddTHH:mm:ssZ}",
+      "description": "One contact's aggregate email behaviour over a period -- how many sends, opens, clicks, bounces and opt-outs. Requires a contact id and dates. The per-person engagement summary, already computed."
     },
     {
       "name": "Average Open and Click Rates",
       "paged": true,
-      "suffix": "/v3/reports/contact_reports/{Contact ID}/open_and_click_rates?start={Start:yyyy-MM-dd|yyyy-MM-ddTHH:mm:ssZ}&end={End:yyyy-MM-dd|yyyy-MM-ddTHH:mm:ssZ}"
+      "suffix": "/v3/reports/contact_reports/{Contact ID}/open_and_click_rates?start={Start:yyyy-MM-dd|yyyy-MM-ddTHH:mm:ssZ}&end={End:yyyy-MM-dd|yyyy-MM-ddTHH:mm:ssZ}",
+      "description": "One contact's average open and click rates over a period. Requires a contact id and dates. A ready-made engagement score per person -- the usual basis for identifying a lapsing subscriber."
     },
     {
       "name": "Custom Fields",
       "paged": true,
-      "suffix": "/v3/contact_custom_fields"
+      "suffix": "/v3/contact_custom_fields",
+      "description": "The custom contact fields defined, with name and type. The decoder for custom values on a contact."
     },
     {
       "name": "Custom Field",
       "paged": false,
-      "suffix": "/v3/contact_custom_fields/{Custom Field ID}"
+      "suffix": "/v3/contact_custom_fields/{Custom Field ID}",
+      "description": "One custom field by id."
     },
     {
       "name": "Email Campaigns",
@@ -86,12 +101,14 @@
           "key": "campaign_id",
           "parameterName": "Campaign ID"
         }
-      ]
+      ],
+      "description": "The email campaigns in the account, with name, current status and timestamps. NOTE THE TWO-LEVEL MODEL, which is the single most confusing thing about this API: a CAMPAIGN is the container, and a CAMPAIGN ACTIVITY is an actual send. Statistics attach to the ACTIVITY, not the campaign, so every reporting endpoint here takes a campaign activity id -- and a campaign resent or A/B tested has several."
     },
     {
       "name": "Email Campaign Activity",
       "paged": false,
-      "suffix": "/v3/emails/activities/{Campaign Activity ID}?include={Include?:physical_address_in_footer|permalink_url|html_content|document_properties}"
+      "suffix": "/v3/emails/activities/{Campaign Activity ID}?include={Include?:physical_address_in_footer|permalink_url|html_content|document_properties}",
+      "description": "One send of one campaign, with its subject, from address, preheader, the lists targeted and the physical address block. Requires an activity id. This is the level everything measurable hangs off."
     },
     {
       "name": "Email Campaign",
@@ -117,62 +134,74 @@
           "key": "campaign_activity_id",
           "parameterName": "Campaign Activity ID"
         }
-      ]
+      ],
+      "description": "One campaign by id, with its activities listed. The route from a campaign name to the activity ids the report endpoints need."
     },
     {
       "name": "Email Links",
       "paged": false,
-      "suffix": "/v3/reports/email_reports/{Campaign Activity ID}/links"
+      "suffix": "/v3/reports/email_reports/{Campaign Activity ID}/links",
+      "description": "The links in one activity with their click counts. Requires an activity id. Which content drew the response, as opposed to whether anything did."
     },
     {
       "name": "Email Bounces",
       "paged": true,
-      "suffix": "/v3/reports/email_reports/{Campaign Activity ID}/tracking/bounces?bounce_code={Bounce Code?}"
+      "suffix": "/v3/reports/email_reports/{Campaign Activity ID}/tracking/bounces?bounce_code={Bounce Code?}",
+      "description": "Bounce events for one activity, with the bounce code. Requires an activity id. The code separates a permanent failure from a temporary one, and treating them alike overstates list decay."
     },
     {
       "name": "Email Clicks",
       "paged": true,
-      "suffix": "/v3/reports/email_reports/{Campaign Activity ID}/tracking/clicks?url_id={URL ID?}"
+      "suffix": "/v3/reports/email_reports/{Campaign Activity ID}/tracking/clicks?url_id={URL ID?}",
+      "description": "Click events for one activity, optionally filtered to one link. Requires an activity id. Clicks are the sounder engagement signal, since open tracking depends on images loading."
     },
     {
       "name": "Email Did Not Opens",
       "paged": true,
-      "suffix": "/v3/reports/email_reports/{Campaign Activity ID}/tracking/didnotopens"
+      "suffix": "/v3/reports/email_reports/{Campaign Activity ID}/tracking/didnotopens",
+      "description": "The contacts who were sent one activity and did not open it. Requires an activity id. Available directly rather than as a subtraction, which is what makes re-engagement targeting straightforward."
     },
     {
       "name": "Email Forwards",
       "paged": true,
-      "suffix": "/v3/reports/email_reports/{Campaign Activity ID}/tracking/forwards"
+      "suffix": "/v3/reports/email_reports/{Campaign Activity ID}/tracking/forwards",
+      "description": "Forward events for one activity. Requires an activity id. Only forwards made through the email's own forward link are counted, so this understates real sharing."
     },
     {
       "name": "Email Opens",
       "paged": true,
-      "suffix": "/v3/reports/email_reports/{Campaign Activity ID}/tracking/opens"
+      "suffix": "/v3/reports/email_reports/{Campaign Activity ID}/tracking/opens",
+      "description": "Every open event for one activity, with the contact and timestamp. Requires an activity id. Note this is TOTAL opens including repeats -- Email Unique Opens is the per-person count, and the two answer different questions."
     },
     {
       "name": "Email Opt-outs",
       "paged": true,
-      "suffix": "/v3/reports/email_reports/{Campaign Activity ID}/tracking/optouts"
+      "suffix": "/v3/reports/email_reports/{Campaign Activity ID}/tracking/optouts",
+      "description": "Unsubscribe events attributable to one activity, with timestamps. Requires an activity id. The per-send cost of a campaign, as opposed to the account-wide unsubscribe list."
     },
     {
       "name": "Email Sends",
       "paged": true,
-      "suffix": "/v3/reports/email_reports/{Campaign Activity ID}/tracking/sends"
+      "suffix": "/v3/reports/email_reports/{Campaign Activity ID}/tracking/sends",
+      "description": "The contacts one activity was sent to, with timestamps. Requires an activity id. The denominator for every rate below it."
     },
     {
       "name": "Email Unique Opens",
       "paged": true,
-      "suffix": "/v3/reports/email_reports/{Campaign Activity ID}/tracking/unique_opens"
+      "suffix": "/v3/reports/email_reports/{Campaign Activity ID}/tracking/unique_opens",
+      "description": "The distinct contacts who opened one activity. Requires an activity id. The right numerator for an open rate."
     },
     {
       "name": "Email Campaign Activity Schedule",
       "paged": false,
-      "suffix": "/v3/emails/activities/{Campaign Activity ID}/schedules"
+      "suffix": "/v3/emails/activities/{Campaign Activity ID}/schedules",
+      "description": "When one activity is or was scheduled to send. Requires an activity id."
     },
     {
       "name": "Email Campaign Activity Send History",
       "paged": false,
-      "suffix": "/v3/emails/activities/{Campaign Activity ID}/send_history"
+      "suffix": "/v3/emails/activities/{Campaign Activity ID}/send_history",
+      "description": "The send attempts for one activity, with their outcomes. Requires an activity id. Where a resend or a failed send is recorded, which the activity itself does not show."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/copper/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/copper/endpoints.json
@@ -1,207 +1,236 @@
 {
   "endpoints": [
     {
-      "post": "false", 
-      "paged": "false", 
-      "name": "Account Details", 
-      "bodyTemplate": null, 
-      "suffix": "/v1/account"
-    }, 
+      "post": "false",
+      "paged": "false",
+      "name": "Account Details",
+      "bodyTemplate": null,
+      "suffix": "/v1/account",
+      "description": "The Copper account's name and id. One record."
+    },
     {
-      "post": "false", 
-      "paged": "false", 
-      "name": "User", 
-      "bodyTemplate": null, 
-      "suffix": "/v1/users/{User ID}"
-    }, 
+      "post": "false",
+      "paged": "false",
+      "name": "User",
+      "bodyTemplate": null,
+      "suffix": "/v1/users/{User ID}",
+      "description": "One user by id."
+    },
     {
       "post": "true",
-      "paged": "true", 
-      "name": "Users", 
+      "paged": "true",
+      "name": "Users",
       "bodyTemplate": "{}",
-      "suffix": "/v1/users/search"
-    }, 
+      "suffix": "/v1/users/search",
+      "description": "The users in the account, through search. Every record carries an owner id, so this is the dimension per-person performance joins to."
+    },
     {
-      "post": "false", 
-      "paged": "false", 
-      "name": "Lead", 
-      "bodyTemplate": null, 
-      "suffix": "/v1/leads/{Lead ID}"
-    }, 
+      "post": "false",
+      "paged": "false",
+      "name": "Lead",
+      "bodyTemplate": null,
+      "suffix": "/v1/leads/{Lead ID}",
+      "description": "One lead by id."
+    },
     {
       "post": "true",
-      "paged": "true", 
-      "name": "Leads", 
+      "paged": "true",
+      "name": "Leads",
       "bodyTemplate": "{\n  \"name\": \"John Doe\",\n  \"phone_number\": \"555-555-5555\",\n  \"emails\": \"user@example.com\",\n  \"assignee_ids\": [ 1 ],\n  \"status_ids\": [ 1 ],\n  \"customer_source_ids\": [ 1 ],\n  \"city\": \"Manhattan\",\n  \"state\": \"NY\",\n  \"postal_code\": \"10001\",\n  \"country\": \"US\",\n  \"tags\": [ \"tag\" ],\n  \"followed\": 1,\n  \"age\": 1,\n  \"minimum_monetary_value\": 1,\n  \"maximum_monetary_value\": 1,\n  \"minimum_interaction_count\": 1,\n  \"maximum_interaction_count\": 1,\n  \"minimum_interaction_date\": 1,\n  \"maximum_interaction_date\": 1,\n  \"minimum_created_date\": 1,\n  \"maximum_created_date\": 1,\n  \"minimum_modified_date\": 1,\n  \"maximum_modified_date\": 1\n}",
-      "suffix": "/v1/leads/search"
-    }, 
-    {
-      "post": "true", 
-      "paged": "false", 
-      "name": "Lead Activites", 
-      "bodyTemplate": "{\n  \"activity_types\": [\n    {\n      \"id\": 1,\n      \"category\": \"user\"\n    }\n  ]\n}", 
-      "suffix": "/v1/leads/{Lead ID}/activities"
-    }, 
-    {
-      "post": "false", 
-      "paged": "false", 
-      "name": "Customer Sources", 
-      "bodyTemplate": null, 
-      "suffix": "/v1/customer_sources"
-    }, 
-    {
-      "post": "false", 
-      "paged": "false", 
-      "name": "Lead Statuses", 
-      "bodyTemplate": null, 
-      "suffix": "/v1/lead_statuses"
-    }, 
-    {
-      "post": "false", 
-      "paged": "false", 
-      "name": "Person", 
-      "bodyTemplate": null, 
-      "suffix": "/v1/people/{Person ID}"
-    }, 
+      "suffix": "/v1/leads/search",
+      "description": "Leads, through search. In Copper a lead is a person not yet qualified into the contact-and-opportunity model, so leads and people are separate tables holding different stages -- and a lead CONVERTED into a person exists in both, which double-counts if summed."
+    },
     {
       "post": "true",
-      "paged": "false", 
+      "paged": "false",
+      "name": "Lead Activites",
+      "bodyTemplate": "{\n  \"activity_types\": [\n    {\n      \"id\": 1,\n      \"category\": \"user\"\n    }\n  ]\n}",
+      "suffix": "/v1/leads/{Lead ID}/activities",
+      "description": "The activity timeline of one lead. Requires a lead id."
+    },
+    {
+      "post": "false",
+      "paged": "false",
+      "name": "Customer Sources",
+      "bodyTemplate": null,
+      "suffix": "/v1/customer_sources",
+      "description": "The lead source values configured. The attribution dimension: where a lead or opportunity came from, and account-specific."
+    },
+    {
+      "post": "false",
+      "paged": "false",
+      "name": "Lead Statuses",
+      "bodyTemplate": null,
+      "suffix": "/v1/lead_statuses",
+      "description": "The lead statuses configured, with their names and order. Account-specific, and the decoder for the status id on a lead."
+    },
+    {
+      "post": "false",
+      "paged": "false",
+      "name": "Person",
+      "bodyTemplate": null,
+      "suffix": "/v1/people/{Person ID}",
+      "description": "One contact by id, with the full record."
+    },
+    {
+      "post": "true",
+      "paged": "false",
       "name": "Person by Email",
       "bodyTemplate": "{\n  \"email\": \"user@example.com\"\n}",
-      "suffix": "/v1/people/fetch_by_email"
-    }, 
+      "suffix": "/v1/people/fetch_by_email",
+      "description": "One contact looked up by email address. The efficient way in when the email is known and the id is not."
+    },
     {
-      "post": "true", 
-      "paged": "true", 
-      "name": "People", 
-      "bodyTemplate": "{\n  \"name\": \"John Doe\",\n  \"phone_number\": \"555-555-5555\",\n  \"emails\": [ \"user@example.com\" ],\n  \"contact_type_ids\": [ 1 ],\n  \"assignee_ids\": [ 1 ],\n  \"company_ids\": [ 1 ],\n  \"opportunity_ids\": [ 1 ],\n  \"city\": \"Manhattan\",\n  \"state\": \"NY\",\n  \"postal_code\": \"10001\",\n  \"country\": \"US\",\n  \"tags\": [ \"tag\" ],\n  \"followed\": 1,\n  \"age\": 1,\n  \"minimum_interaction_count\": 1,\n  \"minimum_interaction_date\": 1,\n  \"minimum_created_date\": 1,\n  \"maximum_created_date\": 1\n}", 
-      "suffix": "/v1/people/search"
-    }, 
+      "post": "true",
+      "paged": "true",
+      "name": "People",
+      "bodyTemplate": "{\n  \"name\": \"John Doe\",\n  \"phone_number\": \"555-555-5555\",\n  \"emails\": [ \"user@example.com\" ],\n  \"contact_type_ids\": [ 1 ],\n  \"assignee_ids\": [ 1 ],\n  \"company_ids\": [ 1 ],\n  \"opportunity_ids\": [ 1 ],\n  \"city\": \"Manhattan\",\n  \"state\": \"NY\",\n  \"postal_code\": \"10001\",\n  \"country\": \"US\",\n  \"tags\": [ \"tag\" ],\n  \"followed\": 1,\n  \"age\": 1,\n  \"minimum_interaction_count\": 1,\n  \"minimum_interaction_date\": 1,\n  \"minimum_created_date\": 1,\n  \"maximum_created_date\": 1\n}",
+      "suffix": "/v1/people/search",
+      "description": "Contacts, retrieved through a SEARCH endpoint rather than a plain list -- which is how everything in Copper works: leads, companies, opportunities, projects, tasks and activities are all reached by posting search criteria, and there is no unfiltered listing anywhere. Carries name, emails, phone numbers, the company, the owner, tags and custom fields. Note EMAILS AND PHONE NUMBERS ARE ARRAYS of labelled entries rather than single values."
+    },
     {
-      "post": "true", 
-      "paged": "false", 
-      "name": "Person Activity", 
-      "bodyTemplate": "{\n  \"activity_types\": [\n    {\n      \"id\": 1,\n      \"category\": \"user\"\n    }\n  ]\n}", 
-      "suffix": "/v1/people/{Person ID}/activities"
-    }, 
+      "post": "true",
+      "paged": "false",
+      "name": "Person Activity",
+      "bodyTemplate": "{\n  \"activity_types\": [\n    {\n      \"id\": 1,\n      \"category\": \"user\"\n    }\n  ]\n}",
+      "suffix": "/v1/people/{Person ID}/activities",
+      "description": "The activity timeline of one contact -- calls, meetings, notes and system events. Requires a person id. The contact carries current state only; this is when it changed."
+    },
     {
-      "post": "false", 
-      "paged": "false", 
-      "name": "Contact Types", 
-      "bodyTemplate": null, 
-      "suffix": "/v1/contact_types"
-    }, 
+      "post": "false",
+      "paged": "false",
+      "name": "Contact Types",
+      "bodyTemplate": null,
+      "suffix": "/v1/contact_types",
+      "description": "The contact types configured -- potential customer, current customer, partner and so on. The decoder for the contact type id on a person."
+    },
     {
-      "post": "false", 
-      "paged": "false", 
-      "name": "Company", 
-      "bodyTemplate": null, 
-      "suffix": "/v1/companies/{Company ID}"
-    }, 
+      "post": "false",
+      "paged": "false",
+      "name": "Company",
+      "bodyTemplate": null,
+      "suffix": "/v1/companies/{Company ID}",
+      "description": "One company by id."
+    },
     {
-      "post": "true", 
-      "paged": "true", 
-      "name": "Companies", 
-      "bodyTemplate": "{\n  \"name\": \"Example Inc.\",\n  \"phone_number\": \"555-555-5555\",\n  \"email_domains\": \"example.com\",\n  \"contact_type_ids\": [ 1 ],\n  \"assignee_ids\": [ 1 ],\n  \"city\": \"Manhattan\",\n  \"state\": \"NY\",\n  \"postal_code\": \"10001\",\n  \"country\": \"US\",\n  \"tags\": [ \"tag\" ],\n  \"followed\": 1,\n  \"age\": 1,\n  \"minimum_interaction_count\": 1,\n  \"maximum_interaction_count\": 1,\n  \"minimum_interaction_date\": 1,\n  \"maximum_interaction_date\": 1,\n  \"minimum_created_date\": 1,\n  \"maximum_created_date\": 1\n}", 
-      "suffix": "/v1/companies/search"
-    }, 
+      "post": "true",
+      "paged": "true",
+      "name": "Companies",
+      "bodyTemplate": "{\n  \"name\": \"Example Inc.\",\n  \"phone_number\": \"555-555-5555\",\n  \"email_domains\": \"example.com\",\n  \"contact_type_ids\": [ 1 ],\n  \"assignee_ids\": [ 1 ],\n  \"city\": \"Manhattan\",\n  \"state\": \"NY\",\n  \"postal_code\": \"10001\",\n  \"country\": \"US\",\n  \"tags\": [ \"tag\" ],\n  \"followed\": 1,\n  \"age\": 1,\n  \"minimum_interaction_count\": 1,\n  \"maximum_interaction_count\": 1,\n  \"minimum_interaction_date\": 1,\n  \"maximum_interaction_date\": 1,\n  \"minimum_created_date\": 1,\n  \"maximum_created_date\": 1\n}",
+      "suffix": "/v1/companies/search",
+      "description": "Companies, through search. Carries name, address, phone, website, the owner, tags and custom fields. The account-level dimension people and opportunities group under."
+    },
     {
-      "post": "true", 
-      "paged": "false", 
-      "name": "Company Activities", 
-      "bodyTemplate": "{\n  \"activity_types\": [\n    {\n      \"id\": 1,\n      \"category\": \"user\"\n    }\n  ]\n}", 
-      "suffix": "/v1/companies/{Company ID}/activities"
-    }, 
+      "post": "true",
+      "paged": "false",
+      "name": "Company Activities",
+      "bodyTemplate": "{\n  \"activity_types\": [\n    {\n      \"id\": 1,\n      \"category\": \"user\"\n    }\n  ]\n}",
+      "suffix": "/v1/companies/{Company ID}/activities",
+      "description": "The activity timeline of one company. Requires a company id."
+    },
     {
-      "post": "false", 
-      "paged": "false", 
-      "name": "Opportunity", 
-      "bodyTemplate": null, 
-      "suffix": "/v1/opportunities/{Opportunity ID}"
-    }, 
+      "post": "false",
+      "paged": "false",
+      "name": "Opportunity",
+      "bodyTemplate": null,
+      "suffix": "/v1/opportunities/{Opportunity ID}",
+      "description": "One opportunity by id."
+    },
     {
-      "post": "true", 
-      "paged": "true", 
-      "name": "Opportunities", 
-      "bodyTemplate": "{\n  \"name\": \"Op 1\",\n  \"assignee_ids\": [ 1 ],\n  \"status_ids\": [ 1 ],\n  \"pipeline_ids\": [ 1 ],\n  \"priority_ids\": [ 1 ],\n  \"customer_source_ids\": [ 1 ],\n  \"loss_reason_ids\": [ 1 ],\n  \"company_ids\": [ 1 ],\n  \"tags\": [ \"tag\" ],\n  \"followed\": 1,\n  \"minimum_monetary_value\": 1,\n  \"maximum_monetary_value\": 1,\n  \"minimum_interaction_count\": 1,\n  \"maximum_interaction_count\": 1,\n  \"minimum_close_date\": 1,\n  \"maximum_close_date\": 1,\n  \"minimum_interaction_date\": 1,\n  \"maximum_interaction_date\": 1,\n  \"minimum_stage_change_date\": 1,\n  \"maximum_stage_change_date\": 1,\n  \"minimum_created_date\": 1,\n  \"maximum_created_date\": 1,\n  \"minimum_modified_date\": 1,\n  \"maximum_modified_date\": 1\n}", 
-      "suffix": "/v1/opportunities/search"
-    }, 
+      "post": "true",
+      "paged": "true",
+      "name": "Opportunities",
+      "bodyTemplate": "{\n  \"name\": \"Op 1\",\n  \"assignee_ids\": [ 1 ],\n  \"status_ids\": [ 1 ],\n  \"pipeline_ids\": [ 1 ],\n  \"priority_ids\": [ 1 ],\n  \"customer_source_ids\": [ 1 ],\n  \"loss_reason_ids\": [ 1 ],\n  \"company_ids\": [ 1 ],\n  \"tags\": [ \"tag\" ],\n  \"followed\": 1,\n  \"minimum_monetary_value\": 1,\n  \"maximum_monetary_value\": 1,\n  \"minimum_interaction_count\": 1,\n  \"maximum_interaction_count\": 1,\n  \"minimum_close_date\": 1,\n  \"maximum_close_date\": 1,\n  \"minimum_interaction_date\": 1,\n  \"maximum_interaction_date\": 1,\n  \"minimum_stage_change_date\": 1,\n  \"maximum_stage_change_date\": 1,\n  \"minimum_created_date\": 1,\n  \"maximum_created_date\": 1,\n  \"minimum_modified_date\": 1,\n  \"maximum_modified_date\": 1\n}",
+      "suffix": "/v1/opportunities/search",
+      "description": "Opportunities, through search -- the revenue pipeline. Carries name, the company and primary contact, monetary value, win probability, the pipeline and stage, close date, status and the owner. STATUS separates Open from Won, Lost and Abandoned, so a win rate has a specific denominator and an unfiltered value total is not a forecast."
+    },
     {
-      "post": "false", 
-      "paged": "false", 
-      "name": "Loss Reasons", 
-      "bodyTemplate": null, 
-      "suffix": "/v1/loss_reasons"
-    }, 
+      "post": "false",
+      "paged": "false",
+      "name": "Loss Reasons",
+      "bodyTemplate": null,
+      "suffix": "/v1/loss_reasons",
+      "description": "The reasons configured for losing an opportunity. The decoder for the loss reason id -- and usually the only structured explanation of why revenue was not won."
+    },
     {
-      "post": "false", 
-      "paged": "false", 
-      "name": "Pipelines", 
-      "bodyTemplate": null, 
-      "suffix": "/v1/pipelines"
-    }, 
+      "post": "false",
+      "paged": "false",
+      "name": "Pipelines",
+      "bodyTemplate": null,
+      "suffix": "/v1/pipelines",
+      "description": "The sales pipelines defined, each with its stages. Most accounts run more than one, and stages are not comparable between them -- so a funnel question has to name the pipeline."
+    },
     {
-      "post": "false", 
-      "paged": "false", 
-      "name": "Pipeline Stages", 
-      "bodyTemplate": null, 
-      "suffix": "/v1/pipeline_stages"
-    }, 
+      "post": "false",
+      "paged": "false",
+      "name": "Pipeline Stages",
+      "bodyTemplate": null,
+      "suffix": "/v1/pipeline_stages",
+      "description": "Every stage across all pipelines, with its name, order and win probability. The dimension a funnel breakdown joins to."
+    },
     {
-      "post": "false", 
-      "paged": "false", 
-      "name": "Stages in Pipeline", 
-      "bodyTemplate": null, 
-      "suffix": "/v1/pipeline_stages/pipeline/{Pipeline ID}"
-    }, 
+      "post": "false",
+      "paged": "false",
+      "name": "Stages in Pipeline",
+      "bodyTemplate": null,
+      "suffix": "/v1/pipeline_stages/pipeline/{Pipeline ID}",
+      "description": "The stages of one pipeline, in order. Requires a pipeline id. The correct per-pipeline funnel definition."
+    },
     {
-      "post": "false", 
-      "paged": "false", 
-      "name": "Project", 
-      "bodyTemplate": null, 
-      "suffix": "/v1/projects/{Project ID}"
-    }, 
+      "post": "false",
+      "paged": "false",
+      "name": "Project",
+      "bodyTemplate": null,
+      "suffix": "/v1/projects/{Project ID}",
+      "description": "One project by id."
+    },
     {
-      "post": "true", 
-      "paged": "true", 
-      "name": "Projects", 
-      "bodyTemplate": "{\n  \"name\": \"Big Project\",\n  \"assignee_ids\": [ 1 ],\n  \"status_ids\": [ 1 ],\n  \"tags\": [ \"tag\" ],\n  \"followed\": 1,\n  \"minimum_created_date\": 1,\n  \"maximum_created_date\": 1,\n  \"minimum_modified_date\": 1,\n  \"maximum_modified_date\": 1\n}", 
-      "suffix": "/v1/projects/search"
-    }, 
+      "post": "true",
+      "paged": "true",
+      "name": "Projects",
+      "bodyTemplate": "{\n  \"name\": \"Big Project\",\n  \"assignee_ids\": [ 1 ],\n  \"status_ids\": [ 1 ],\n  \"tags\": [ \"tag\" ],\n  \"followed\": 1,\n  \"minimum_created_date\": 1,\n  \"maximum_created_date\": 1,\n  \"minimum_modified_date\": 1,\n  \"maximum_modified_date\": 1\n}",
+      "suffix": "/v1/projects/search",
+      "description": "Projects, through search. Copper's post-sale delivery tracking, separate from opportunities."
+    },
     {
-      "post": "false", 
-      "paged": "false", 
-      "name": "Task", 
-      "bodyTemplate": null, 
-      "suffix": "/v1/tasks/{Task ID}"
-    }, 
+      "post": "false",
+      "paged": "false",
+      "name": "Task",
+      "bodyTemplate": null,
+      "suffix": "/v1/tasks/{Task ID}",
+      "description": "One task by id."
+    },
     {
-      "post": "true", 
-      "paged": "true", 
-      "name": "Tasks", 
-      "bodyTemplate": "{\n  \"name\": \"Task 1\",\n  \"assignee_ids\": [ 1 ],\n  \"opportunity_ids\": [ 1 ],\n  \"project_ids\": [ 1 ],\n  \"statuses\": [ \"Open\" ],\n  \"tags\": [ \"tag\" ],\n  \"followed\": 1,\n  \"minimum_due_date\": 1,\n  \"maximum_due_date\": 1,\n  \"minimum_created_date\": 1,\n  \"maximum_created_date\": 1,\n  \"minimum_modified_date\": 1,\n  \"maximum_modified_date\": 1\n}", 
-      "suffix": "/v1/tasks/search"
-    }, 
+      "post": "true",
+      "paged": "true",
+      "name": "Tasks",
+      "bodyTemplate": "{\n  \"name\": \"Task 1\",\n  \"assignee_ids\": [ 1 ],\n  \"opportunity_ids\": [ 1 ],\n  \"project_ids\": [ 1 ],\n  \"statuses\": [ \"Open\" ],\n  \"tags\": [ \"tag\" ],\n  \"followed\": 1,\n  \"minimum_due_date\": 1,\n  \"maximum_due_date\": 1,\n  \"minimum_created_date\": 1,\n  \"maximum_created_date\": 1,\n  \"minimum_modified_date\": 1,\n  \"maximum_modified_date\": 1\n}",
+      "suffix": "/v1/tasks/search",
+      "description": "Tasks, through search. Carries name, due date, priority, status, the assignee and the record it relates to."
+    },
     {
-      "post": "false", 
-      "paged": "false", 
-      "name": "Activity", 
-      "bodyTemplate": null, 
-      "suffix": "/v1/activities/{Activity ID}"
-    }, 
+      "post": "false",
+      "paged": "false",
+      "name": "Activity",
+      "bodyTemplate": null,
+      "suffix": "/v1/activities/{Activity ID}",
+      "description": "One activity by id."
+    },
     {
-      "post": "true", 
-      "paged": "true", 
-      "name": "Activities", 
-      "bodyTemplate": "{\n  \"parent\": {\n    \"id\": \"parent_id\",\n    \"type\": \"company\"\n  },\n  \"activity_types\": [\n    {\n      \"id\": 1,\n      \"category\": \"user\"\n    }\n  ],\n  \"minimum_activity_date\": 1,\n  \"maximum_activity_date\": 1,\n  \"full_result\": false\n}", 
-      "suffix": "/v1/activities/search"
-    }, 
+      "post": "true",
+      "paged": "true",
+      "name": "Activities",
+      "bodyTemplate": "{\n  \"parent\": {\n    \"id\": \"parent_id\",\n    \"type\": \"company\"\n  },\n  \"activity_types\": [\n    {\n      \"id\": 1,\n      \"category\": \"user\"\n    }\n  ],\n  \"minimum_activity_date\": 1,\n  \"maximum_activity_date\": 1,\n  \"full_result\": false\n}",
+      "suffix": "/v1/activities/search",
+      "description": "Activity records, through search -- logged calls, meetings, notes and system events across all record types. The account-wide activity feed, as opposed to the per-record timelines."
+    },
     {
-      "post": "false", 
-      "paged": "false", 
-      "name": "Activity Types", 
-      "bodyTemplate": null, 
-      "suffix": "/v1/activity_types"
+      "post": "false",
+      "paged": "false",
+      "name": "Activity Types",
+      "bodyTemplate": null,
+      "suffix": "/v1/activity_types",
+      "description": "The activity types configured, split into user types (logged by people) and system types (generated by Copper). THE DISTINCTION MATTERS FOR MEASURING EFFORT: system activities record that a field changed, and counting them alongside logged calls inflates apparent sales activity."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/datadotworld/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/datadotworld/endpoints.json
@@ -1,164 +1,196 @@
 {
-    "endpoints": [
-        {
-            "name": "Projects",
-            "paged": false,
-            "suffix": "/v0/projects/{Project Owner}"
-        },
-        {
-            "name": "Project Information",
-            "paged": false,
-            "suffix": "/v0/projects/{Project Owner}/{Project ID}"
-        },
-        {
-            "name": "Project Information of a Version",
-            "paged": false,
-            "suffix": "/v0/projects/{Project Owner}/{Project ID}/v/{Version ID}"
-        },
-        {
-            "name": "Project Insights",
-            "paged": false,
-            "suffix": "/v0/insights/{Project Owner}/{Project ID}"
-        },
-        {
-            "name": "Project Insight",
-            "paged": false,
-            "suffix": "/v0/insights/{Project Owner}/{Project ID}/{ID}"
-        },
-        {
-            "name": "Project Insight of a Version",
-            "paged": false,
-            "suffix": "/v0/insights/{Project Owner}/{Project ID}/{ID}/v/{Version ID}"
-        },
-        {
-            "name": "Dataset Queries",
-            "paged": false,
-            "suffix": "/v0/datasets/{Dataset Owner}/{Dataset ID}/queries"
-        },
-        {
-            "name": "Project Queries",
-            "paged": false,
-            "suffix": "/v0/projects/{Project Owner}/{Project ID}/queries"
-        },
-        {
-            "name": "Query Information",
-            "paged": false,
-            "suffix": "/v0/queries/{Query ID}"
-        },
-        {
-            "name": "Execute Query",
-            "paged": false,
-            "suffix": "/v0/queries/{Query ID}/results?includeTableSchema={Include Table Schema?:true|false}"
-        },
-        {
-            "name": "Query Information Of a Version",
-            "paged": false,
-            "suffix": "/v0/queries/{Query ID}/v/{Version ID}"
-        },
-        {
-            "name": "Execute SPARQL query",
-            "paged": false,
-            "suffix": "/v0/sparql/{Dataset Owner}/{ID}?query={SQL/SPARQL Query}"
-        },
-        {
-            "name": "Execute SQL query",
-            "paged": false,
-            "suffix": "/v0/sql/{Dataset or Project Owner}/{Dataset ID}?includeTableSchema={Include Table Schema?:true|false}&query={SQL/SPARQL Query}"
-        },
-        {
-            "name": "Datasets",
-            "paged": false,
-            "suffix": "/v0/datasets/{Dataset Owner}"
-        },
-        {
-            "name": "Dataset Info",
-            "paged": false,
-            "suffix": "/v0/datasets/{Dataset Owner}/{Dataset ID}"
-        },
-        {
-            "name": "Dataset Information of a Version",
-            "paged": false,
-            "suffix": "/v0/datasets/{Dataset Owner}/{Dataset ID}/v/{Version ID}"
-        },
-        {
-            "name": "Download Dataset",
-            "paged": false,
-            "suffix": "/v0/download/{Dataset Owner}/{Dataset ID}"
-        },
-        {
-            "name": "Sync Files",
-            "paged": false,
-            "suffix": "/v0/datasets/{Dataset Owner}/{Dataset ID}/sync"
-        },
-        {
-            "name": "Download File",
-            "paged": false,
-            "suffix": "/v0/file_download/{Dataset Owner}/{Dataset ID}/{File Name}"
-        },
-        {
-            "name": "Stream Schema",
-            "paged": false,
-            "suffix": "/v0/streams/{Dataset or Project Owner}/{Dataset ID}/{Stream ID}/schema"
-        },
-        {
-            "name": "User Profile",
-            "paged": false,
-            "suffix": "/v0/user"
-        },
-        {
-            "name": "User Contributing Datasets",
-            "paged": false,
-            "suffix": "/v0/user/datasets/contributing"
-        },
-        {
-            "name": "User Liked Datasets",
-            "paged": false,
-            "suffix": "/v0/user/datasets/liked"
-        },
-        {
-            "name": "User Own Datasets",
-            "paged": false,
-            "suffix": "/v0/user/datasets/own"
-        },
-        {
-            "name": "User Contributing Projects",
-            "paged": false,
-            "suffix": "/v0/user/projects/contributing"
-        },
-        {
-            "name": "User Liked Projects",
-            "paged": false,
-            "suffix": "/v0/user/projects/liked"
-        },
-        {
-            "name": "User Own Projects",
-            "paged": false,
-            "suffix": "/v0/user/projects/own"
-        },
-        {
-            "name": "Account User Profile",
-            "paged": false,
-            "suffix": "/v0/users/{Account}"
-        },
-        {
-            "name": "Webhook Subscriptions",
-            "paged": false,
-            "suffix": "/v0/user/webhooks"
-        },
-        {
-            "name": "Dataset Webhook Subscription",
-            "paged": false,
-            "suffix": "/v0/user/webhooks/datasets/{Dataset or Project Owner}/{Dataset ID}"
-        },
-        {
-            "name": "Project Webhook Subscription",
-            "paged": false,
-            "suffix": "/v0/user/webhooks/projects/{Project Owner}/{Project ID}"
-        },
-        {
-            "name": "Account Webhook Subscription",
-            "paged": false,
-            "suffix": "/v0/user/webhooks/users/{Account}"
-        }
-    ]
+  "endpoints": [
+    {
+      "name": "Projects",
+      "paged": false,
+      "suffix": "/v0/projects/{Project Owner}",
+      "description": "The projects owned by one account. Requires an owner. A project links several datasets together with analysis; the datasets remain separate resources."
+    },
+    {
+      "name": "Project Information",
+      "paged": false,
+      "suffix": "/v0/projects/{Project Owner}/{Project ID}",
+      "description": "One project by owner and id, with the datasets it links and its files."
+    },
+    {
+      "name": "Project Information of a Version",
+      "paged": false,
+      "suffix": "/v0/projects/{Project Owner}/{Project ID}/v/{Version ID}",
+      "description": "One project at a named version. Same pinning purpose as the dataset version endpoint."
+    },
+    {
+      "name": "Project Insights",
+      "paged": false,
+      "suffix": "/v0/insights/{Project Owner}/{Project ID}",
+      "description": "The insights published in one project -- saved charts, notes and findings. Requires the owner and project id. The analytical output, as opposed to the data it was drawn from."
+    },
+    {
+      "name": "Project Insight",
+      "paged": false,
+      "suffix": "/v0/insights/{Project Owner}/{Project ID}/{ID}",
+      "description": "One insight by id, with its content and the query behind it."
+    },
+    {
+      "name": "Project Insight of a Version",
+      "paged": false,
+      "suffix": "/v0/insights/{Project Owner}/{Project ID}/{ID}/v/{Version ID}",
+      "description": "One insight at a named version."
+    },
+    {
+      "name": "Dataset Queries",
+      "paged": false,
+      "suffix": "/v0/datasets/{Dataset Owner}/{Dataset ID}/queries",
+      "description": "The saved queries defined on one dataset. Requires the owner and dataset id. Saved queries carry the questions the community has already found worth asking, and their SQL is the fastest statement of how the data is meant to be joined."
+    },
+    {
+      "name": "Project Queries",
+      "paged": false,
+      "suffix": "/v0/projects/{Project Owner}/{Project ID}/queries",
+      "description": "The saved queries defined on one project."
+    },
+    {
+      "name": "Query Information",
+      "paged": false,
+      "suffix": "/v0/queries/{Query ID}",
+      "description": "One saved query by id, with its SQL or SPARQL text and its parameters."
+    },
+    {
+      "name": "Execute Query",
+      "paged": false,
+      "suffix": "/v0/queries/{Query ID}/results?includeTableSchema={Include Table Schema?:true|false}",
+      "description": "RUNS one saved query and returns its results. Requires the query id. Pass includeTableSchema to get column types alongside the rows, which is otherwise absent and has to be guessed."
+    },
+    {
+      "name": "Query Information Of a Version",
+      "paged": false,
+      "suffix": "/v0/queries/{Query ID}/v/{Version ID}",
+      "description": "One saved query at a named version."
+    },
+    {
+      "name": "Execute SPARQL query",
+      "paged": false,
+      "suffix": "/v0/sparql/{Dataset Owner}/{ID}?query={SQL/SPARQL Query}",
+      "description": "Runs a SPARQL query against a dataset's linked-data representation. Requires the owner and id. The graph counterpart to the SQL endpoint, for datasets modelled as RDF."
+    },
+    {
+      "name": "Execute SQL query",
+      "paged": false,
+      "suffix": "/v0/sql/{Dataset or Project Owner}/{Dataset ID}?includeTableSchema={Include Table Schema?:true|false}&query={SQL/SPARQL Query}",
+      "description": "Runs an arbitrary SQL statement against a dataset or project. Requires the owner and dataset id and the query text. THE MOST DIRECT DATA PATH IN THIS CONNECTOR: data.world exposes uploaded files as queryable tables, so this reaches the contents rather than the metadata everything else returns."
+    },
+    {
+      "name": "Datasets",
+      "paged": false,
+      "suffix": "/v0/datasets/{Dataset Owner}",
+      "description": "The datasets owned by one account. Requires an owner. Carries title, description, visibility, licence, tags, and the files and summary of each. NOTE THE PATH MODEL: everything in data.world is addressed by OWNER AND SLUG rather than by an opaque id, so both are needed for every request and the owner is not optional anywhere."
+    },
+    {
+      "name": "Dataset Info",
+      "paged": false,
+      "suffix": "/v0/datasets/{Dataset Owner}/{Dataset ID}",
+      "description": "One dataset by owner and id, with its files, tags, licence and description."
+    },
+    {
+      "name": "Dataset Information of a Version",
+      "paged": false,
+      "suffix": "/v0/datasets/{Dataset Owner}/{Dataset ID}/v/{Version ID}",
+      "description": "One dataset as it stood at a named version. Requires the version id. Datasets are versioned, so this is how an analysis is pinned to the data it actually ran against -- which the current view cannot give once the data has moved on."
+    },
+    {
+      "name": "Download Dataset",
+      "paged": false,
+      "suffix": "/v0/download/{Dataset Owner}/{Dataset ID}",
+      "description": "The whole dataset as a downloadable archive. Requires the owner and id. Returns a file rather than rows, which makes it the route to a bulk extract that the query endpoints cannot provide."
+    },
+    {
+      "name": "Sync Files",
+      "paged": false,
+      "suffix": "/v0/datasets/{Dataset Owner}/{Dataset ID}/sync",
+      "description": "The synchronisation state of a dataset's linked files -- those pulled from an external URL rather than uploaded. Requires the owner and dataset id. Explains stale data: a linked file that has stopped syncing keeps serving its last successful fetch with nothing in the dataset to say so."
+    },
+    {
+      "name": "Download File",
+      "paged": false,
+      "suffix": "/v0/file_download/{Dataset Owner}/{Dataset ID}/{File Name}",
+      "description": "One named file from a dataset. Requires the owner, dataset id and file name."
+    },
+    {
+      "name": "Stream Schema",
+      "paged": false,
+      "suffix": "/v0/streams/{Dataset or Project Owner}/{Dataset ID}/{Stream ID}/schema",
+      "description": "The inferred schema of one data stream within a dataset. Requires the owner, dataset id and stream id. Streams are appended to rather than replaced, so their schema is inferred from what has arrived."
+    },
+    {
+      "name": "User Profile",
+      "paged": false,
+      "suffix": "/v0/user",
+      "description": "The account the credentials belong to, with its display name and avatar. One record, always the caller."
+    },
+    {
+      "name": "User Contributing Datasets",
+      "paged": false,
+      "suffix": "/v0/user/datasets/contributing",
+      "description": "The datasets the calling user contributes to but does not own."
+    },
+    {
+      "name": "User Liked Datasets",
+      "paged": false,
+      "suffix": "/v0/user/datasets/liked",
+      "description": "The datasets the calling user has bookmarked."
+    },
+    {
+      "name": "User Own Datasets",
+      "paged": false,
+      "suffix": "/v0/user/datasets/own",
+      "description": "The datasets the calling user owns."
+    },
+    {
+      "name": "User Contributing Projects",
+      "paged": false,
+      "suffix": "/v0/user/projects/contributing",
+      "description": "The projects the calling user contributes to."
+    },
+    {
+      "name": "User Liked Projects",
+      "paged": false,
+      "suffix": "/v0/user/projects/liked",
+      "description": "The projects the calling user has bookmarked."
+    },
+    {
+      "name": "User Own Projects",
+      "paged": false,
+      "suffix": "/v0/user/projects/own",
+      "description": "The projects the calling user owns."
+    },
+    {
+      "name": "Account User Profile",
+      "paged": false,
+      "suffix": "/v0/users/{Account}",
+      "description": "One account's public profile by name. The lookup for an owner named in a dataset or project path."
+    },
+    {
+      "name": "Webhook Subscriptions",
+      "paged": false,
+      "suffix": "/v0/user/webhooks",
+      "description": "Every event subscription the calling user holds, across datasets, projects and accounts. Integration inventory."
+    },
+    {
+      "name": "Dataset Webhook Subscription",
+      "paged": false,
+      "suffix": "/v0/user/webhooks/datasets/{Dataset or Project Owner}/{Dataset ID}",
+      "description": "The caller's subscription to one dataset's events. Requires the owner and dataset id."
+    },
+    {
+      "name": "Project Webhook Subscription",
+      "paged": false,
+      "suffix": "/v0/user/webhooks/projects/{Project Owner}/{Project ID}",
+      "description": "The caller's subscription to one project's events."
+    },
+    {
+      "name": "Account Webhook Subscription",
+      "paged": false,
+      "suffix": "/v0/user/webhooks/users/{Account}",
+      "description": "The caller's subscription to one account's events."
+    }
+  ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/firebase/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/firebase/endpoints.json
@@ -1,54 +1,64 @@
 {
-    "endpoints": [
-        {
-            "name": "Field",
-            "paged": false,
-            "suffix": "/v1/projects/#projectId#/databases/{Database ID}/collectionGroups/{Collection ID}/fields/{Field ID}"
-        },
-        {
-            "name": "Fields",
-            "paged": true,
-            "suffix": "/v1/projects/#projectId#/databases/{Database ID}/collectionGroups/{Collection ID}/fields?filter={Filter}"
-        },
-        {
-            "name": "Index",
-            "paged": false,
-            "suffix": "/v1/projects/#projectId#/databases/{Database ID}/collectionGroups/{Collection ID}/indexes/{Index ID}"
-        },
-        {
-            "name": "Indexes",
-            "paged": true,
-            "suffix": "/v1/projects/#projectId#/databases/{Database ID}/collectionGroups/{Collection ID}/indexes?filter={Filter?}"
-        },
-        {
-            "name": "Document",
-            "paged": false,
-            "suffix": "/v1/projects/#projectId#/databases/{Database ID}/documents/{Document Path}?mask={Document Mask?}&transaction={Transaction?}&readTime={Read Time?:YYYY-MM-DDThh:mm:ssZ}"
-        },
-        {
-            "name": "Documents",
-            "paged": true,
-            "suffix": "/v1/projects/#projectId#/databases/{Database ID}/documents/{Document Path?}/{Collection ID}?orderBy={Order By?}&mask={Document Mask?}&showMissing={Show Missing?:true|false}&transaction={Transaction?}&readTime={Read Time?:YYYY-MM-DDThh:mm:ssZ}"
-        },
-        {
-            "name": "Operation",
-            "paged": false,
-            "suffix": "/v1/projects/#projectId#/databases/{Database ID}/operations/{Operation}"
-        },
-        {
-            "name": "Operations",
-            "paged": true,
-            "suffix": "/v1/projects/#projectId#/databases/{Database ID}/operations?filter={Filter?}"
-        },
-        {
-            "name": "Location",
-            "paged": false,
-            "suffix": "/v1/projects/#projectId#/locations/{Location}"
-        },
-        {
-            "name": "Locations",
-            "paged": true,
-            "suffix": "/v1/projects/#projectId#/locations?filter={Filter?}"
-        }
-    ]
+  "endpoints": [
+    {
+      "name": "Field",
+      "paged": false,
+      "suffix": "/v1/projects/#projectId#/databases/{Database ID}/collectionGroups/{Collection ID}/fields/{Field ID}",
+      "description": "One field configuration by name."
+    },
+    {
+      "name": "Fields",
+      "paged": true,
+      "suffix": "/v1/projects/#projectId#/databases/{Database ID}/collectionGroups/{Collection ID}/fields?filter={Filter}",
+      "description": "The field configurations of one collection group -- which fields have single-field indexing overridden, and any TTL policy. Requires the database and collection group. Configuration rather than data, but it explains why a query on a particular field is refused."
+    },
+    {
+      "name": "Index",
+      "paged": false,
+      "suffix": "/v1/projects/#projectId#/databases/{Database ID}/collectionGroups/{Collection ID}/indexes/{Index ID}",
+      "description": "One composite index by id, with its state. The state matters: an index still building does not yet serve queries."
+    },
+    {
+      "name": "Indexes",
+      "paged": true,
+      "suffix": "/v1/projects/#projectId#/databases/{Database ID}/collectionGroups/{Collection ID}/indexes?filter={Filter?}",
+      "description": "The composite indexes defined on one collection group, with the fields and orderings each covers. Requires the database and collection group. FIRESTORE REFUSES ANY QUERY IT HAS NO INDEX FOR, so this is the definitive statement of which queries are possible against a collection -- and the first place to look when a query fails rather than returns nothing."
+    },
+    {
+      "name": "Document",
+      "paged": false,
+      "suffix": "/v1/projects/#projectId#/databases/{Database ID}/documents/{Document Path}?mask={Document Mask?}&transaction={Transaction?}&readTime={Read Time?:YYYY-MM-DDThh:mm:ssZ}",
+      "description": "One document by its full path. Requires the database id and document path. The mask parameter limits which fields come back, which is worth using on documents holding large maps or arrays."
+    },
+    {
+      "name": "Documents",
+      "paged": true,
+      "suffix": "/v1/projects/#projectId#/databases/{Database ID}/documents/{Document Path?}/{Collection ID}?orderBy={Order By?}&mask={Document Mask?}&showMissing={Show Missing?:true|false}&transaction={Transaction?}&readTime={Read Time?:YYYY-MM-DDThh:mm:ssZ}",
+      "description": "The documents in one Firestore collection. Requires the database id and the collection path. Firestore is schemaless, so DOCUMENTS IN THE SAME COLLECTION NEED NOT SHARE FIELDS, and each value comes back wrapped in a type tag -- stringValue, integerValue, timestampValue, mapValue, arrayValue -- rather than as a bare value, so every field needs unwrapping before use. Note also that subcollections are NOT returned with their parent: a document's nested collections are separate paths and must be walked deliberately."
+    },
+    {
+      "name": "Operation",
+      "paged": false,
+      "suffix": "/v1/projects/#projectId#/databases/{Database ID}/operations/{Operation}",
+      "description": "One long-running operation by name, with its state and result."
+    },
+    {
+      "name": "Operations",
+      "paged": true,
+      "suffix": "/v1/projects/#projectId#/databases/{Database ID}/operations?filter={Filter?}",
+      "description": "The long-running administrative operations on one database -- imports, exports, index builds -- with their progress and outcome. Requires the database id. Operational; an export is how a full Firestore extract is actually obtained, since the document endpoints page rather than dump."
+    },
+    {
+      "name": "Location",
+      "paged": false,
+      "suffix": "/v1/projects/#projectId#/locations/{Location}",
+      "description": "One location by name."
+    },
+    {
+      "name": "Locations",
+      "paged": true,
+      "suffix": "/v1/projects/#projectId#/locations?filter={Filter?}",
+      "description": "The regions a Firestore database can be created in for this project. Reference data; relevant to data-residency questions."
+    }
+  ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/fortytwomatters/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/fortytwomatters/endpoints.json
@@ -8,7 +8,8 @@
       "pageLimit": 0,
       "freePageLimit": 0,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "Everything 42matters knows about ONE Android app, by package name: title, developer, category, description, price, install-count band, rating and rating count, current version, release and update dates, permissions, and the SDKs it embeds. The core enrichment endpoint. NOTE THIS IS MARKET INTELLIGENCE, NOT ANALYTICS -- it describes any app in the Play Store as the store presents it, so figures such as installs are the coarse bands Google publishes rather than exact counts, and none of it is your own app's data."
     },
     {
       "name": "Android Reviews",
@@ -18,7 +19,8 @@
       "pageLimit": 100,
       "freePageLimit": 5,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "User reviews of one Android app, filterable by rating, date and language. Requires a package name. The qualitative side: ratings give a number, these give the reasons, and they are the only text explaining a score movement."
     },
     {
       "name": "Android Review Analysis",
@@ -28,7 +30,8 @@
       "pageLimit": 0,
       "freePageLimit": 0,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "The topics 42matters extracted from one app's reviews, with sentiment. Requires a package name. Derived rather than reported: it saves reading thousands of reviews to learn what people complain about, at the cost of being a model's interpretation."
     },
     {
       "name": "Android Country Availability",
@@ -38,7 +41,8 @@
       "pageLimit": 0,
       "freePageLimit": 0,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "Which countries one Android app is published in, and its price in each. Requires a package name. Market coverage, and the explanation for an app that appears missing in one region."
     },
     {
       "name": "Android IAB Category for Apps",
@@ -48,7 +52,8 @@
       "pageLimit": 0,
       "freePageLimit": 0,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "The IAB advertising category of one Android app. Requires a package name. The advertising industry's taxonomy rather than the store's own, which is what ad platforms actually target on."
     },
     {
       "name": "Android App-Ads txt for Apps",
@@ -58,7 +63,8 @@
       "pageLimit": 0,
       "freePageLimit": 0,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "The app-ads.txt entries declared for one Android app -- the authorised sellers of its advertising inventory. Requires a package name. Ad-fraud verification: inventory sold by anyone not listed here is unauthorised."
     },
     {
       "name": "Android Changelog History",
@@ -68,7 +74,8 @@
       "pageLimit": 100,
       "freePageLimit": 5,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "The release notes of one Android app over time, with version numbers and dates. Requires a package name. THE RELEASE CADENCE OF A COMPETITOR, which no other table gives -- how often they ship and what they say they changed."
     },
     {
       "name": "Android App Matching",
@@ -78,7 +85,8 @@
       "pageLimit": 0,
       "freePageLimit": 0,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "Resolves partial or fuzzy identifiers to a specific Play Store app. Requires a package name or search terms. The disambiguation step before enrichment, when the identifier in hand is not exact."
     },
     {
       "name": "Android Search",
@@ -88,7 +96,8 @@
       "pageLimit": 50,
       "freePageLimit": 5,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "Apps matching a search phrase in the Play Store, optionally including descriptions. Discovery when the package name is unknown."
     },
     {
       "name": "Android Advanced Query",
@@ -98,7 +107,8 @@
       "pageLimit": 50,
       "freePageLimit": 50,
       "post": true,
-      "bodyTemplate": "{\n  \"query\": {\n    \"query_params\": {\n      \"see\": \"https://42matters.com/docs/app-market-data/android/apps/advanced-query-api\"\n    }\n  }\n}\n"
+      "bodyTemplate": "{\n  \"query\": {\n    \"query_params\": {\n      \"see\": \"https://42matters.com/docs/app-market-data/android/apps/advanced-query-api\"\n    }\n  }\n}\n",
+      "description": "Play Store apps matching a structured query across many attributes at once -- category, rating, install band, price, SDKs, release date. The systematic way to build a market segment, where the plain search only matches text."
     },
     {
       "name": "Android Integrated SDKs",
@@ -108,7 +118,8 @@
       "pageLimit": 0,
       "freePageLimit": 0,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "The third-party SDKs detected inside one Android app -- analytics, advertising, crash reporting, payments. Requires a package name. TECHNOLOGY INTELLIGENCE: it says what a competitor built with, and is the basis of any question about which vendors an app ecosystem uses."
     },
     {
       "name": "Android Search by SDKs",
@@ -118,7 +129,8 @@
       "pageLimit": 0,
       "freePageLimit": 0,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "Apps that embed given SDKs. The reverse of the SDK lookup -- use it to size a vendor's install base or to build a prospect list of apps using a competing tool."
     },
     {
       "name": "Android Search by Web Domain",
@@ -128,7 +140,8 @@
       "pageLimit": 50,
       "freePageLimit": 5,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "Apps associated with a web domain. The link from a company's website to the apps it publishes, which the store listings do not make searchable."
     },
     {
       "name": "Android Search by Permissions",
@@ -138,7 +151,8 @@
       "pageLimit": 50,
       "freePageLimit": 5,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "Apps requesting given Android permissions. Privacy and capability analysis -- and Android-only, since iOS exposes no equivalent."
     },
     {
       "name": "Android Google Play Top Charts",
@@ -148,7 +162,8 @@
       "pageLimit": 100,
       "freePageLimit": 25,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "The current Play Store rankings for a named chart, category and country. A snapshot of who is winning a category right now."
     },
     {
       "name": "Android Google Play App Rank History",
@@ -158,7 +173,8 @@
       "pageLimit": 100,
       "freePageLimit": 100,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "How one app's Play Store rank moved over time, by chart and country. Requires a package name and dates. Rankings are a snapshot everywhere else here; this is the only historical series."
     },
     {
       "name": "iOS Lookup",
@@ -168,7 +184,8 @@
       "pageLimit": 0,
       "freePageLimit": 0,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "The same for one iOS app, by App Store id or bundle id. Same distinction: this is what the App Store publishes about an app, not private analytics. Note Apple publishes no install counts at all, so the fields available differ from Android's."
     },
     {
       "name": "iOS Reviews",
@@ -178,7 +195,8 @@
       "pageLimit": 100,
       "freePageLimit": 5,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "User reviews of one iOS app, filterable by rating and date. Requires an app id. NOTE APPLE'S REVIEWS ARE PER STOREFRONT -- a review left in one country is not returned for another -- so a complete picture needs the country dimension considered."
     },
     {
       "name": "iOS Review Analysis",
@@ -188,7 +206,8 @@
       "pageLimit": 0,
       "freePageLimit": 0,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "The same topic and sentiment extraction for an iOS app."
     },
     {
       "name": "iOS Country Availability",
@@ -198,7 +217,8 @@
       "pageLimit": 0,
       "freePageLimit": 0,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "The same storefront availability for an iOS app."
     },
     {
       "name": "iOS IAB Category for Apps",
@@ -208,7 +228,8 @@
       "pageLimit": 0,
       "freePageLimit": 0,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "The IAB advertising category of one iOS app."
     },
     {
       "name": "iOS App-Ads.txt for Apps",
@@ -218,7 +239,8 @@
       "pageLimit": 0,
       "freePageLimit": 0,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "The same authorised-seller declarations for an iOS app."
     },
     {
       "name": "iOS Changelog History",
@@ -228,7 +250,8 @@
       "pageLimit": 100,
       "freePageLimit": 5,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "The same version history for an iOS app."
     },
     {
       "name": "iOS App Matching",
@@ -238,7 +261,8 @@
       "pageLimit": 0,
       "freePageLimit": 0,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "The same resolution for the App Store, by id or bundle id."
     },
     {
       "name": "iOS Search",
@@ -248,7 +272,8 @@
       "pageLimit": 50,
       "freePageLimit": 5,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "Apps matching a search phrase in the App Store."
     },
     {
       "name": "iOS Advanced Query",
@@ -258,7 +283,8 @@
       "pageLimit": 50,
       "freePageLimit": 50,
       "post": true,
-      "bodyTemplate": "{\n  \"query\": {\n    \"query_params\": {\n      \"see\": \"https://42matters.com/docs/app-market-data/ios/apps/advanced-query-api\"\n    }\n  }\n}\n"
+      "bodyTemplate": "{\n  \"query\": {\n    \"query_params\": {\n      \"see\": \"https://42matters.com/docs/app-market-data/ios/apps/advanced-query-api\"\n    }\n  }\n}\n",
+      "description": "The same structured query against the App Store."
     },
     {
       "name": "iOS Integrated SDKs",
@@ -268,7 +294,8 @@
       "pageLimit": 0,
       "freePageLimit": 0,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "The same SDK detection for an iOS app."
     },
     {
       "name": "iOS Search by SDKs",
@@ -278,7 +305,8 @@
       "pageLimit": 50,
       "freePageLimit": 5,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "The same reverse SDK search for iOS."
     },
     {
       "name": "iOS Search by Web Domain",
@@ -288,7 +316,8 @@
       "pageLimit": 50,
       "freePageLimit": 5,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "The same domain search for iOS."
     },
     {
       "name": "iOS App Store Top Charts",
@@ -298,7 +327,8 @@
       "pageLimit": 100,
       "freePageLimit": 25,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "The current App Store rankings for a named chart, category and country."
     },
     {
       "name": "iOS App Store Rank History",
@@ -308,7 +338,8 @@
       "pageLimit": 0,
       "freePageLimit": 0,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "The same rank history for an iOS app."
     },
     {
       "name": "Tencent Lookup",
@@ -318,7 +349,8 @@
       "pageLimit": 0,
       "freePageLimit": 0,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "The same lookup against the Tencent MyApp store, by package name. China's Android market is served by local stores rather than Google Play, so an app's Chinese presence is only visible through this and the Huawei endpoint."
     },
     {
       "name": "Tencent MyApp Top Charts",
@@ -328,7 +360,8 @@
       "pageLimit": 100,
       "freePageLimit": 25,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "The current Tencent MyApp rankings by category."
     },
     {
       "name": "Amazon Appstore Lookup",
@@ -338,7 +371,8 @@
       "pageLimit": 0,
       "freePageLimit": 0,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "The same lookup against the Amazon Appstore, by ASIN."
     },
     {
       "name": "Huawei AppGallery Lookup",
@@ -348,7 +382,8 @@
       "pageLimit": 0,
       "freePageLimit": 0,
       "post": false,
-      "bodyTemplate": null
+      "bodyTemplate": null,
+      "description": "The same lookup against Huawei AppGallery, by app id."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/freshsales/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/freshsales/endpoints.json
@@ -1,139 +1,166 @@
 {
   "endpoints": [
     {
-      "paged": "false", 
-      "name": "Lead", 
-      "suffix": "/leads/{Lead ID}?include={Include?:owner|creater|updater|...}"
-    }, 
+      "paged": "false",
+      "name": "Lead",
+      "suffix": "/leads/{Lead ID}?include={Include?:owner|creater|updater|...}",
+      "description": "One lead by id. The include parameter inlines related records -- owner, creator, updater -- which are otherwise returned as bare ids."
+    },
     {
-      "paged": "true", 
-      "name": "Leads", 
-      "suffix": "/leads/view/{View ID}"
-    }, 
+      "paged": "true",
+      "name": "Leads",
+      "suffix": "/leads/view/{View ID}",
+      "description": "Leads returned through a saved VIEW. Requires a view id -- and note the shape of this API: Freshsales has no plain 'all leads' listing, so every record set comes through a view, and Lead Filters is what lists the available view ids. The views are whatever the account's users created, so their names carry the organisation's own segmentation."
+    },
     {
-      "paged": "true", 
-      "name": "Lead Filters", 
-      "suffix": "/leads/filters"
-    }, 
+      "paged": "true",
+      "name": "Lead Filters",
+      "suffix": "/leads/filters",
+      "description": "The saved views available for leads, with their ids and names. THE PREREQUISITE for the leads listing, since that endpoint takes a view id and there is no default."
+    },
     {
-      "paged": "true", 
-      "name": "Lead Fields", 
-      "suffix": "/settings/leads/fields?include={Include?:field_group}"
-    }, 
+      "paged": "true",
+      "name": "Lead Fields",
+      "suffix": "/settings/leads/fields?include={Include?:field_group}",
+      "description": "Every field a lead can carry, standard and custom, with type and field group. The decoder for custom field keys, and the statement of what the account actually records about a lead."
+    },
     {
-      "paged": "true", 
-      "name": "Lead Activites", 
-      "suffix": "/leads/{Lead ID}/activities?include={Include?:owner|creater|updater|...}"
-    }, 
+      "paged": "true",
+      "name": "Lead Activites",
+      "suffix": "/leads/{Lead ID}/activities?include={Include?:owner|creater|updater|...}",
+      "description": "The activity timeline of one lead -- calls, emails, notes, status changes. Requires a lead id. The lead record carries its current state only, so this is the source for when it moved and who touched it."
+    },
     {
-      "paged": "false", 
-      "name": "Contact", 
-      "suffix": "/contacts/{Contact ID}?include={Include?:owner|creater|updater|...}"
-    }, 
+      "paged": "false",
+      "name": "Contact",
+      "suffix": "/contacts/{Contact ID}?include={Include?:owner|creater|updater|...}",
+      "description": "One contact by id."
+    },
     {
-      "paged": "true", 
-      "name": "Contacts", 
-      "suffix": "/contacts/view/{View ID}"
-    }, 
+      "paged": "true",
+      "name": "Contacts",
+      "suffix": "/contacts/view/{View ID}",
+      "description": "Contacts through a saved view. Requires a view id, from Contact Filters. Same view-based access as leads. Note that in Freshsales a LEAD IS CONVERTED INTO A CONTACT, so the two tables hold different stages of the same people and counting both double-counts anyone converted."
+    },
     {
-      "paged": "true", 
-      "name": "Contact Filters", 
-      "suffix": "/contacts/filters"
-    }, 
+      "paged": "true",
+      "name": "Contact Filters",
+      "suffix": "/contacts/filters",
+      "description": "The saved views available for contacts."
+    },
     {
-      "paged": "true", 
-      "name": "Contact Fields", 
-      "suffix": "/settings/contacts/fields?include={Include?:field_group}"
-    }, 
+      "paged": "true",
+      "name": "Contact Fields",
+      "suffix": "/settings/contacts/fields?include={Include?:field_group}",
+      "description": "Every field a contact can carry, standard and custom."
+    },
     {
-      "paged": "true", 
-      "name": "Contact Actvities", 
-      "suffix": "/contacts/{Contact ID}/activities?include={Include?:owner|creater|updater|...}"
-    }, 
+      "paged": "true",
+      "name": "Contact Actvities",
+      "suffix": "/contacts/{Contact ID}/activities?include={Include?:owner|creater|updater|...}",
+      "description": "The activity timeline of one contact. Requires a contact id."
+    },
     {
-      "paged": "false", 
-      "name": "Account", 
-      "suffix": "/sales_accounts/{Account ID}?include={Include?:owner|creater|updater|...}"
-    }, 
+      "paged": "false",
+      "name": "Account",
+      "suffix": "/sales_accounts/{Account ID}?include={Include?:owner|creater|updater|...}",
+      "description": "One sales account by id."
+    },
     {
-      "paged": "true", 
-      "name": "Accounts", 
-      "suffix": "/sales_accounts/view/{View ID}"
-    }, 
+      "paged": "true",
+      "name": "Accounts",
+      "suffix": "/sales_accounts/view/{View ID}",
+      "description": "Sales accounts -- the companies contacts belong to -- through a saved view. Requires a view id from Account Filters."
+    },
     {
-      "paged": "true", 
-      "name": "Account Filters", 
-      "suffix": "/sales_accounts/filters"
-    }, 
+      "paged": "true",
+      "name": "Account Filters",
+      "suffix": "/sales_accounts/filters",
+      "description": "The saved views available for sales accounts."
+    },
     {
-      "paged": "true", 
-      "name": "Account Fields", 
-      "suffix": "/settings/sales_accounts/fields?include={Include?:field_group}"
-    }, 
+      "paged": "true",
+      "name": "Account Fields",
+      "suffix": "/settings/sales_accounts/fields?include={Include?:field_group}",
+      "description": "Every field a sales account can carry."
+    },
     {
-      "paged": "false", 
-      "name": "Deal", 
-      "suffix": "/deals/{Deal ID}?include={Include?:owner|creater|updater|...}"
-    }, 
+      "paged": "false",
+      "name": "Deal",
+      "suffix": "/deals/{Deal ID}?include={Include?:owner|creater|updater|...}",
+      "description": "One deal by id, with its stage and amount."
+    },
     {
-      "paged": "true", 
-      "name": "Deals", 
-      "suffix": "/deals/view/{View ID}"
-    }, 
+      "paged": "true",
+      "name": "Deals",
+      "suffix": "/deals/view/{View ID}",
+      "description": "Deals through a saved view. Requires a view id from Deal Filters. The revenue pipeline: deals carry amount, expected close date, stage and probability, and the view determines which subset comes back."
+    },
     {
-      "paged": "true", 
-      "name": "Deal Filters", 
-      "suffix": "/deals/filters"
-    }, 
+      "paged": "true",
+      "name": "Deal Filters",
+      "suffix": "/deals/filters",
+      "description": "The saved views available for deals. Views here usually encode the pipeline stages the sales team actually works, so reading them is often faster than inferring the process."
+    },
     {
-      "paged": "true", 
-      "name": "Deal Fields", 
-      "suffix": "/settings/deals/fields?include={Include?:field_group}"
-    }, 
+      "paged": "true",
+      "name": "Deal Fields",
+      "suffix": "/settings/deals/fields?include={Include?:field_group}",
+      "description": "Every field a deal can carry, standard and custom."
+    },
     {
-      "paged": "false", 
-      "name": "Task", 
-      "suffix": "/tasks/{Task ID}?include={Include?:users|targetable}"
-    }, 
+      "paged": "false",
+      "name": "Task",
+      "suffix": "/tasks/{Task ID}?include={Include?:users|targetable}",
+      "description": "One task by id."
+    },
     {
-      "paged": "true", 
-      "name": "Tasks", 
-      "suffix": "/tasks?filter={Filter:open|due today|overdue|completed}&include={Include?:users|targetable|owner}"
-    }, 
+      "paged": "true",
+      "name": "Tasks",
+      "suffix": "/tasks?filter={Filter:open|due today|overdue|completed}&include={Include?:users|targetable|owner}",
+      "description": "Tasks, filtered by open, due today, overdue or completed. THE FILTER IS REQUIRED and there is no 'all' value, so a complete task set means several requests -- and an overdue count taken from the open filter alone will be wrong."
+    },
     {
-      "paged": "false", 
-      "name": "Appointment", 
-      "suffix": "/appointments/{Appointment ID}"
-    }, 
+      "paged": "false",
+      "name": "Appointment",
+      "suffix": "/appointments/{Appointment ID}",
+      "description": "One appointment by id."
+    },
     {
-      "paged": "true", 
-      "name": "Appointments", 
-      "suffix": "/appointments?filter={Filter:past|upcoming}&include={Include?:creater|targetable|appointment_attendees}"
-    }, 
+      "paged": "true",
+      "name": "Appointments",
+      "suffix": "/appointments?filter={Filter:past|upcoming}&include={Include?:creater|targetable|appointment_attendees}",
+      "description": "Appointments, filtered by past or upcoming. Required filter again, and the two are disjoint, so both are needed for a full picture."
+    },
     {
-      "paged": "false", 
-      "name": "Sales Activity", 
-      "suffix": "/sales_activities/{Sales Activity ID}"
-    }, 
+      "paged": "false",
+      "name": "Sales Activity",
+      "suffix": "/sales_activities/{Sales Activity ID}",
+      "description": "One sales activity by id."
+    },
     {
-      "paged": "true", 
-      "name": "Sales Activities", 
-      "suffix": "/sales_activities"
-    }, 
+      "paged": "true",
+      "name": "Sales Activities",
+      "suffix": "/sales_activities",
+      "description": "The logged sales activities -- calls, meetings and custom activity types -- across the account. The measure of selling effort, as opposed to the deals that resulted."
+    },
     {
-      "paged": "true", 
-      "name": "Search", 
-      "suffix": "/search?q={Search Query}&include={Entity:user|lead|contact|sales_account|deal}"
-    }, 
+      "paged": "true",
+      "name": "Search",
+      "suffix": "/search?q={Search Query}&include={Entity:user|lead|contact|sales_account|deal}",
+      "description": "Free-text search across users, leads, contacts, sales accounts and deals at once. Returns mixed record types told apart by their type field, so it is not a single-shape table."
+    },
     {
-      "paged": "true", 
-      "name": "Lookup Search", 
-      "suffix": "/lookup?q={Search Query}&f={Field:email|name|...}&entities={Entities?:lead|contact|sales_account|deal}"
-    }, 
+      "paged": "true",
+      "name": "Lookup Search",
+      "suffix": "/lookup?q={Search Query}&f={Field:email|name|...}&entities={Entities?:lead|contact|sales_account|deal}",
+      "description": "Searches ONE named field across chosen entities -- email or name. Narrower and more precise than the general search, and the right choice when matching a known identifier such as an email address."
+    },
     {
-      "paged": "false", 
-      "name": "Files and Links", 
-      "suffix": "/leads/{Lead ID}/document_associations"
+      "paged": "false",
+      "name": "Files and Links",
+      "suffix": "/leads/{Lead ID}/document_associations",
+      "description": "The documents and links attached to one lead. Requires a lead id."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/freshservice/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/freshservice/endpoints.json
@@ -3,7 +3,8 @@
     {
       "name": "Ticket",
       "paged": false,
-      "suffix": "/api/v2/tickets/{Ticket ID}"
+      "suffix": "/api/v2/tickets/{Ticket ID}",
+      "description": "One ticket by id, with its full field set including custom fields."
     },
     {
       "name": "Tickets",
@@ -21,217 +22,260 @@
             "Module Name": "tickets"
           }
         }
-      ]
+      ],
+      "description": "The service desk tickets, with subject, description, status, priority, urgency, impact, the requester, the agent and group assigned, the category and subcategory, the source, and created, updated and due timestamps. Filterable by a named filter or requester email. NOTE THE CODED COLUMNS: status, priority, source, urgency and impact are all returned as NUMBERS, not labels, and Freshservice fixes their meaning rather than exposing a decoder endpoint -- status 2 is Open, 3 Pending, 4 Resolved, 5 Closed, and priority runs 1 Low to 4 Urgent. A breakdown left as raw integers is unreadable."
     },
     {
       "name": "Tickets Requested By ID",
       "paged": true,
-      "suffix": "/api/v2/tickets?requester_id={Requester ID}"
+      "suffix": "/api/v2/tickets?requester_id={Requester ID}",
+      "description": "The tickets raised by one requester. Requires a requester id. Equivalent to filtering the ticket list, and the per-person view."
     },
     {
       "name": "Custom Ticket Query",
       "paged": true,
-      "suffix": "/api/v2/tickets/filter?query={Query}"
+      "suffix": "/api/v2/tickets/filter?query={Query}",
+      "description": "Tickets matching a query in Freshservice's own filter syntax. Requires a query. The only route to arbitrary criteria -- the plain listing supports a few named filters and nothing else -- so most non-trivial ticket questions come through here."
     },
     {
       "name": "Ticket Fields",
       "paged": false,
-      "suffix": "/api/v2/ticket_form_fields"
+      "suffix": "/api/v2/ticket_form_fields",
+      "description": "Every field a ticket can carry, standard and custom, with type, whether required, and for dropdowns the allowed choices. The decoder for custom fields, and the statement of what the account actually records."
     },
     {
       "name": "Problem",
       "paged": false,
-      "suffix": "/api/v2/problems/{Problem Display ID}"
+      "suffix": "/api/v2/problems/{Problem Display ID}",
+      "description": "One problem by its display id."
     },
     {
       "name": "Problems",
       "paged": true,
-      "suffix": "/api/v2/problems"
+      "suffix": "/api/v2/problems",
+      "description": "Problem records -- the underlying causes behind recurring incidents, in ITIL terms. Carries the same coded status and priority columns as tickets. The link from many tickets to one root cause is what makes this table worth having."
     },
     {
       "name": "Problem Fields",
       "paged": false,
-      "suffix": "/api/v2/problem_form_fields"
+      "suffix": "/api/v2/problem_form_fields",
+      "description": "Every field a problem can carry."
     },
     {
       "name": "Change",
       "paged": false,
-      "suffix": "/api/v2/changes/{Change ID}"
+      "suffix": "/api/v2/changes/{Change ID}",
+      "description": "One change by id."
     },
     {
       "name": "Changes",
       "paged": true,
-      "suffix": "/api/v2/changes"
+      "suffix": "/api/v2/changes",
+      "description": "Change records -- planned modifications to infrastructure, with their risk, impact, planned start and end, and approval state. The ITIL change log; change failure rate is measured from here rather than from tickets."
     },
     {
       "name": "Custom Changes Query",
       "paged": true,
-      "suffix": "/api/v2/changes?query={Query}"
+      "suffix": "/api/v2/changes?query={Query}",
+      "description": "Changes matching a query. Requires a query; the arbitrary-criteria route for changes."
     },
     {
       "name": "Change Fields",
       "paged": false,
-      "suffix": "/api/v2/change_fields"
+      "suffix": "/api/v2/change_fields",
+      "description": "Every field a change can carry."
     },
     {
       "name": "Release",
       "paged": false,
-      "suffix": "/api/v2/releases/{Release Display ID}"
+      "suffix": "/api/v2/releases/{Release Display ID}",
+      "description": "One release by its display id."
     },
     {
       "name": "Releases",
       "paged": true,
-      "suffix": "/api/v2/releases"
+      "suffix": "/api/v2/releases",
+      "description": "Release records -- the deployments changes are grouped into. The delivery record above changes."
     },
     {
       "name": "Filtered Releases",
       "paged": true,
-      "suffix": "/api/v2/releases/filter_name={Filter Name:all|my_open|deleted|unassigned|completed|incompleted}"
+      "suffix": "/api/v2/releases?filter_name={Filter Name:all|my_open|deleted|unassigned|completed|incompleted}",
+      "description": "Releases restricted to a named filter -- all, my open, deleted, unassigned, completed or incompleted. Requires the filter name."
     },
     {
       "name": "Release Fields",
       "paged": false,
-      "suffix": "/api/v2/release_form_fields"
+      "suffix": "/api/v2/release_form_fields",
+      "description": "Every field a release can carry."
     },
     {
       "name": "Time Entries",
       "paged": false,
-      "suffix": "/api/v2/{Module Name:tickets|problems|changes|releases}/{Module Item ID}/time_entries"
+      "suffix": "/api/v2/{Module Name:tickets|problems|changes|releases}/{Module Item ID}/time_entries",
+      "description": "The time logged against one ticket, problem, change or release. Requires the module name and the item id. Effort per item, which the item record itself does not carry -- so cost of support is only answerable through this."
     },
     {
       "name": "Task",
       "paged": false,
-      "suffix": "/api/v2/{Module Name:tickets|problems|changes|releases}/{Module Item ID}/tasks/{Task ID}"
+      "suffix": "/api/v2/{Module Name:tickets|problems|changes|releases}/{Module Item ID}/tasks/{Task ID}",
+      "description": "The tasks attached to one ticket, problem, change or release. Requires the module name and item id. Sub-work within an item, each with its own status and agent."
     },
     {
       "name": "Release Tasks by ID",
       "paged": false,
-      "suffix": "/api/v2/releases/{Release ID}/tasks"
+      "suffix": "/api/v2/releases/{Release ID}/tasks",
+      "description": "The tasks of one release. Requires a release id."
     },
     {
       "name": "Agent",
       "paged": false,
-      "suffix": "/api/v2/agents/{Agent ID}"
+      "suffix": "/api/v2/agents/{Agent ID}",
+      "description": "One agent by id, with their name, email, groups and roles."
     },
     {
       "name": "Active Agents",
       "paged": false,
-      "suffix": "/api/v2/agents?active=true"
+      "suffix": "/api/v2/agents?active=true",
+      "description": "The agents currently active. The working roster; agents who have left remain owners of their historical tickets."
     },
     {
       "name": "Agents by Status",
       "paged": false,
-      "suffix": "/api/v2/agents?state={Status:fulltime|occasional}"
+      "suffix": "/api/v2/agents?state={Status:fulltime|occasional}",
+      "description": "Agents filtered to full-time or occasional. Requires the status. Occasional agents share a licence pool, which is why a headcount and a licence count differ."
     },
     {
       "name": "User by ID",
       "paged": false,
-      "suffix": "/api/v2/requesters/{User ID}"
+      "suffix": "/api/v2/requesters/{User ID}",
+      "description": "One requester by id."
     },
     {
       "name": "Users",
       "paged": false,
-      "suffix": "/api/v2/requesters?query={Query?}"
+      "suffix": "/api/v2/requesters?query={Query?}",
+      "description": "The requesters -- the people who raise tickets, as opposed to the agents who work them. Optionally filtered by a query. In Freshservice these are two different tables, so a count of people in the system is the sum of both."
     },
     {
       "name": "Department",
       "paged": false,
-      "suffix": "/api/v2/departments/{Department ID}"
+      "suffix": "/api/v2/departments/{Department ID}",
+      "description": "One department by id."
     },
     {
       "name": "Departments",
       "paged": false,
-      "suffix": "/api/v2/departments"
+      "suffix": "/api/v2/departments",
+      "description": "The departments requesters belong to, with their heads and domains. The organisational dimension ticket volume is broken down by."
     },
     {
       "name": "Asset CI Types",
       "paged": false,
-      "suffix": "/api/v2/asset_types"
+      "suffix": "/api/v2/asset_types",
+      "description": "The asset type hierarchy -- the classes assets belong to, each with its parent. Types are account-specific and nested, so an asset's own fields depend on its type."
     },
     {
       "name": "Asset CI Type Fields",
       "paged": false,
-      "suffix": "/api/v2/assets_types/{asset_type_id}/fields"
+      "suffix": "/api/v2/asset_types/{asset_type_id}/fields",
+      "description": "The fields defined for one asset type. Requires the asset type id. THE DECODER for type-specific asset fields, which differ entirely between a laptop and a database service."
     },
     {
       "name": "Asset",
       "paged": false,
-      "suffix": "/api/v2/assets/{Asset Display ID}"
+      "suffix": "/api/v2/assets/{Asset Display ID}",
+      "description": "One asset by its display id, with its type-specific fields."
     },
     {
       "name": "Assets",
       "paged": true,
-      "suffix": "/api/v2/assets"
+      "suffix": "/api/v2/assets",
+      "description": "The configuration items in the CMDB -- hardware, software, services -- with their asset type, display id, impact, usage and assignment. THE ITSM SIDE THAT TICKETS ATTACH TO: a ticket about a failing laptop is only connectable to that laptop through here."
     },
     {
       "name": "Asset Search",
       "paged": true,
-      "suffix": "/api/v2/assets?search={Query}"
+      "suffix": "/api/v2/assets?search={Query}",
+      "description": "Assets matching a search query. Requires the query."
     },
     {
       "name": "Relationship Types",
       "paged": false,
-      "suffix": "/api/v2/relationship_types"
+      "suffix": "/api/v2/relationship_types",
+      "description": "The relationship types defined, each with its forward and reverse names. The decoder for the direction of a relationship, which the relationship record only references."
     },
     {
       "name": "Relationships",
       "paged": false,
-      "suffix": "/api/v2/relationships/{Asset Display ID}"
+      "suffix": "/api/v2/relationships/{Asset Display ID}",
+      "description": "The relationships one asset has to others -- depends on, connected to, hosted on. Requires the asset display id. The CMDB's graph, and what makes impact analysis possible: which services a failing server takes down is only answerable here."
     },
     {
       "name": "Solution Category",
       "paged": false,
-      "suffix": "/api/v2/solutions/categories/{Category ID}"
+      "suffix": "/api/v2/solutions/categories/{Category ID}",
+      "description": "One knowledge base category by id."
     },
     {
       "name": "Solution Folders",
       "paged": false,
-      "suffix": "/api/v2/solutions/folders/{Folder ID}"
+      "suffix": "/api/v2/solutions/folders/{Folder ID}",
+      "description": "The folders within one category. Requires the folder id."
     },
     {
       "name": "Solution Categories",
       "paged": false,
-      "suffix": "/api/v2/solutions/categories"
+      "suffix": "/api/v2/solutions/categories",
+      "description": "The top level of the knowledge base."
     },
     {
       "name": "Solution Article",
       "paged": false,
-      "suffix": "/api/v2/solutions/articles/{Article ID}"
+      "suffix": "/api/v2/solutions/articles/{Article ID}",
+      "description": "One article by id, with its body."
     },
     {
       "name": "Solution Articles",
       "paged": false,
-      "suffix": "/api/v2/solutions/articles?folder_id={Folder ID}"
+      "suffix": "/api/v2/solutions/articles?folder_id={Folder ID}",
+      "description": "The knowledge base articles in one folder, with title, status and view counts. Requires a folder id. The self-service content whose use is what deflects tickets."
     },
     {
       "name": "Service Items",
       "paged": true,
-      "suffix": "/api/v2/service_catalog/items"
+      "suffix": "/api/v2/service_catalog/items",
+      "description": "Every item in the service catalogue, with name, description, cost and delivery time. What can be requested, and the cost figure is one of the few monetary values Freshservice holds."
     },
     {
       "name": "Service Categories",
       "paged": false,
-      "suffix": "/api/v2/service_catalog/categories"
+      "suffix": "/api/v2/service_catalog/categories",
+      "description": "The categories of the service catalogue -- the requestable services, as opposed to the incidents in the ticket table."
     },
     {
       "name": "Service Category Items",
       "paged": true,
-      "suffix": "/api/v2/service_catalog/items"
+      "suffix": "/api/v2/service_catalog/items?category_id={Category ID}",
+      "description": "The catalogue items within one category. Requires a category id."
     },
     {
       "name": "Service Item",
       "paged": false,
-      "suffix": "/api/v2/service_catalog/items/{Item Display ID}.json"
+      "suffix": "/api/v2/service_catalog/items/{Item Display ID}.json",
+      "description": "One catalogue item by its display id, with its request fields."
     },
     {
       "name": "Contract",
       "paged": false,
-      "suffix": "/api/v2/contracts/{Contract Display ID}.json"
+      "suffix": "/api/v2/contracts/{Contract Display ID}.json",
+      "description": "One contract by its display id."
     },
     {
       "name": "Contracts",
       "paged": true,
-      "suffix": "/api/v2/contracts"
+      "suffix": "/api/v2/contracts",
+      "description": "The support and licence contracts recorded, with vendor, cost, start and expiry dates, and the assets covered. Contract expiry is the usual reason this table is consulted, and it is not derivable from the assets themselves."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/googlecal/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/googlecal/endpoints.json
@@ -7,28 +7,33 @@
       "lookups": [
         {
           "endpoints": [
-            "Calendar", "Events"
+            "Calendar",
+            "Events"
           ],
           "jsonPath": "$.items[*]",
           "key": "items.id",
           "parameterName": "Calendar ID"
         }
-      ]
+      ],
+      "description": "The calendars in the authenticated user's list, each with its id, summary, time zone, colour, the ACCESS ROLE the user holds on it, and whether it is selected or primary. The starting point: every event query needs a calendar id, and the access role is what decides whether event details or only free-busy blocks come back."
     },
     {
       "name": "Calendar List",
       "paged": false,
-      "suffix": "/v3/users/me/calendarList/{Calendar ID}"
+      "suffix": "/v3/users/me/calendarList/{Calendar ID}",
+      "description": "One calendar list entry by id, with the user's own settings for it -- colour, notifications, default reminders."
     },
     {
       "name": "Calendar",
       "paged": false,
-      "suffix": "/v3/calendars/{Calendar ID}"
+      "suffix": "/v3/calendars/{Calendar ID}",
+      "description": "One calendar's own properties: summary, description, location and time zone. Distinct from the list entry, which holds the USER's settings for that calendar; this holds the calendar's, and the time zone here is what recurrence rules are evaluated against."
     },
     {
       "name": "Colors",
       "paged": false,
-      "suffix": "/v3/colors"
+      "suffix": "/v3/colors",
+      "description": "The colour palette calendars and events can use, as id-to-hex pairs. A small decoder: events carry a colorId and nothing else, so the actual colour is only readable through this."
     },
     {
       "name": "Events",
@@ -37,33 +42,38 @@
       "lookups": [
         {
           "endpoints": [
-             "Recurring Event Instances"
+            "Recurring Event Instances"
           ],
           "jsonPath": "$.items[*]",
           "key": "items.id",
           "parameterName": "Event ID"
         }
-      ]
+      ],
+      "description": "The events of one calendar. Requires a calendar id. Carries summary, description, location, start and end, attendees with their response status, organizer, creator, status, recurrence rules, and created and updated times. THE START AND END ARE POLYMORPHIC: a timed event carries dateTime with a time zone, an all-day event carries date instead, and code that reads only one of them silently drops the other kind. RECURRING EVENTS RETURN AS A SINGLE ROW carrying a recurrence rule, not as one row per occurrence -- pass singleEvents=true to expand them, or a weekly meeting counts once. Note also that cancelled occurrences appear as rows with status cancelled rather than disappearing."
     },
     {
       "name": "Event",
       "paged": false,
-      "suffix": "/v3/calendars/{Calendar ID}/events/{Event ID}?maxAttendees={Max Attendees?}&timeZone={Time Zone?}"
+      "suffix": "/v3/calendars/{Calendar ID}/events/{Event ID}?maxAttendees={Max Attendees?}&timeZone={Time Zone?}",
+      "description": "One event by id. Requires the calendar id. Same polymorphic start and end."
     },
     {
       "name": "Recurring Event Instances",
       "paged": true,
-      "suffix": "/v3/calendars/{Calendar ID}/events/{Event ID}/instances?maxAttendees={Max Attendees?}&originalStart={Original Start Time?}&showDeleted={Show Deleted?:True|False}&timeMax={Before Time?:yyyy-MM-ddTHH:mm:ssZ}&timeMin={After Time?:yyyy-MM-ddTHH:mm:ssZ}&timeZone={Time Zone?}"
+      "suffix": "/v3/calendars/{Calendar ID}/events/{Event ID}/instances?maxAttendees={Max Attendees?}&originalStart={Original Start Time?}&showDeleted={Show Deleted?:True|False}&timeMax={Before Time?:yyyy-MM-ddTHH:mm:ssZ}&timeMin={After Time?:yyyy-MM-ddTHH:mm:ssZ}&timeZone={Time Zone?}",
+      "description": "The individual occurrences of one recurring event, expanded. Requires the calendar id and the recurring event id. The explicit way to turn a rule into dated rows, including any occurrence that was moved or cancelled -- which the rule alone cannot express."
     },
     {
       "name": "Settings",
       "paged": true,
-      "suffix": "/v3/users/me/settings"
+      "suffix": "/v3/users/me/settings",
+      "description": "The authenticated user's calendar settings -- default time zone, week start, working-hours and locale preferences. Relevant because the user's time zone is what the interface renders events in, which need not match the calendar's own."
     },
     {
       "name": "Setting",
       "paged": false,
-      "suffix": "/v3/users/me/settings/{Setting ID}"
+      "suffix": "/v3/users/me/settings/{Setting ID}",
+      "description": "One setting by id."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/gsearchconsole/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/gsearchconsole/endpoints.json
@@ -4,19 +4,22 @@
       "post": "true",
       "name": "Query",
       "bodyTemplate": "{\n  \"startDate\":\"YYYY-MM-DD\",\n  \"endDate\":\"YYYY-MM-DD\"\n}",
-      "suffix": "/v3/sites/{Site URL}/searchAnalytics/query"
+      "suffix": "/v3/sites/{Site URL}/searchAnalytics/query",
+      "description": "Search performance for one verified site: clicks, impressions, CTR and average position, broken down by whatever dimensions the request asks for -- query, page, country, device, searchAppearance, date. Sent as a POST with a body, so the date range and dimensions travel in the body rather than the URL. FOUR THINGS SHAPE THE ANSWER. Data is delayed by two to three days, so the most recent dates are missing rather than zero. ROWS ARE CAPPED at 25,000 per request and the API drops the long tail rather than paging it fully, so totals built from a query breakdown fall short of the site totals. Google WITHHOLDS rare queries for privacy, which is the main reason those two figures disagree. And average position is an average of averages, so it cannot be re-aggregated across rows."
     },
     {
       "post": "false",
       "name": "Sitemaps",
-      "bodyTemplate": null, 
-      "suffix": "/v3/sites/{Site URL}/sitemaps"
+      "bodyTemplate": null,
+      "suffix": "/v3/sites/{Site URL}/sitemaps",
+      "description": "The sitemaps submitted for one site, each with the submission and last-download dates, whether it is an index, warning and error counts, and per-content-type counts of URLs submitted and indexed. Requires a site URL. The submitted-versus-indexed gap is the useful part -- it is the direct measure of how much of a site Google actually took."
     },
     {
       "post": "false",
       "name": "Sitemap",
       "bodyTemplate": null,
-      "suffix": "/v3/sites/{Site URL}/sitemaps/{Feedpath}"
+      "suffix": "/v3/sites/{Site URL}/sitemaps/{Feedpath}",
+      "description": "One sitemap by its full URL. Requires the site URL and the sitemap path."
     },
     {
       "post": "false",
@@ -33,19 +36,22 @@
           "key": "siteUrl",
           "parameterName": "Site URL"
         }
-      ]
+      ],
+      "description": "The properties the authenticated account has access to in Search Console, each with its URL and the permission level held. The starting point: every other endpoint here needs a site URL, and it must be given in exactly the form listed here, including the protocol and trailing slash, or the request fails."
     },
     {
       "post": "false",
       "name": "Site",
       "bodyTemplate": null,
-      "suffix": "/v3/sites/{Site URL}"
+      "suffix": "/v3/sites/{Site URL}",
+      "description": "One property by its URL, with the permission level. Requires the site URL exactly as Sites reports it."
     },
     {
       "post": "true",
       "name": "URL Inspection",
       "bodyTemplate": "{\n  \"inspectionUrl\":\"https://www.example.com/mypage\",\n  \"siteUrl\":\"https://www.example.com/\"\n}",
-      "suffix": "/v1/urlInspection/index:inspect"
+      "suffix": "/v1/urlInspection/index:inspect",
+      "description": "What Google knows about ONE URL: whether it is indexed, the canonical it chose, when it was last crawled, the crawling user agent, and the results of the mobile-usability and rich-results checks. Sent as a POST with the URL in the body. Diagnostic rather than analytical -- one URL per request, and heavily rate limited, so it answers why a page is missing rather than surveying a site."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/harvest/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/harvest/endpoints.json
@@ -3,37 +3,44 @@
     {
       "name": "Client Contacts",
       "paged": true,
-      "suffix": "/v2/contacts?updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}"
+      "suffix": "/v2/contacts?updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}",
+      "description": "The people at each client, with name, email, phone and the client they belong to. Who invoices are addressed to."
     },
     {
       "name": "Client Contact",
       "paged": false,
-      "suffix": "/v2/contacts/{Contact ID}"
+      "suffix": "/v2/contacts/{Contact ID}",
+      "description": "One client contact by id."
     },
     {
       "name": "Clients",
       "paged": true,
-      "suffix": "/v2/clients?is_active={Active Only?:true|false}&updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}"
+      "suffix": "/v2/clients?is_active={Active Only?:true|false}&updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}",
+      "description": "The clients, with name, currency and active state. The billing entity projects belong to. NOTE THE CURRENCY IS PER CLIENT, so totals spanning clients mix currencies and Harvest converts nothing."
     },
     {
       "name": "Client",
       "paged": false,
-      "suffix": "/v2/clients/{Client ID}"
+      "suffix": "/v2/clients/{Client ID}",
+      "description": "One client by id."
     },
     {
       "name": "Company",
       "paged": false,
-      "suffix": "/v2/company"
+      "suffix": "/v2/company",
+      "description": "The Harvest account's own settings: name, base currency, week start day, whether time is tracked by duration or by start and end times, and the decimal format. THE TIME-TRACKING MODE MATTERS: a duration-tracking account has no start and end times on its entries at all, so questions about when in the day work happened are unanswerable there."
     },
     {
       "name": "Invoice Messages",
       "paged": true,
-      "suffix": "/v2/invoices/{Invoice ID}/messages?updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}"
+      "suffix": "/v2/invoices/{Invoice ID}/messages?updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}",
+      "description": "The emails sent about one invoice, with recipients and dates. Requires an invoice id. The record of whether an invoice was actually sent or chased."
     },
     {
       "name": "Invoice Payments",
       "paged": true,
-      "suffix": "/v2/invoices/{Invoice ID}/payments?updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}"
+      "suffix": "/v2/invoices/{Invoice ID}/payments?updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}",
+      "description": "The payments received against one invoice, with amount and date. Requires an invoice id. The invoice carries the balance; this says when the money actually arrived, which is what a collection-time question needs."
     },
     {
       "name": "Invoices",
@@ -49,27 +56,32 @@
           "key": "id",
           "parameterName": "Invoice ID"
         }
-      ]
+      ],
+      "description": "The invoices issued, with the client, number, subject, issue and due dates, the state (draft, open, paid or closed), currency, the amount and the amount due, and the period they cover. Filter by client, project or updated_since. Only issued invoices represent real obligations, so state has to be read before any revenue total."
     },
     {
       "name": "Invoice",
       "paged": false,
-      "suffix": "/v2/invoices/{Invoice ID}"
+      "suffix": "/v2/invoices/{Invoice ID}",
+      "description": "One invoice by id, with its line items."
     },
     {
       "name": "Invoice Item Categories",
       "paged": true,
-      "suffix": "/v2/invoice_item_categories?updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}"
+      "suffix": "/v2/invoice_item_categories?updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}",
+      "description": "The categories invoice line items are classified under. The revenue-type dimension."
     },
     {
       "name": "Invoice Item Category",
       "paged": false,
-      "suffix": "/v2/invoice_item_categories/{Invoice Item Category ID}"
+      "suffix": "/v2/invoice_item_categories/{Invoice Item Category ID}",
+      "description": "One invoice item category by id."
     },
     {
       "name": "Estimate Messages",
       "paged": true,
-      "suffix": "/v2/estimates/{Estimate ID}/messages?updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}"
+      "suffix": "/v2/estimates/{Estimate ID}/messages?updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}",
+      "description": "The emails sent about one estimate. Requires an estimate id."
     },
     {
       "name": "Estimates",
@@ -82,92 +94,110 @@
           "key": "id",
           "parameterName": "Estimate ID"
         }
-      ]
+      ],
+      "description": "The quotes issued to clients, with the client, number, subject, dates, state and amount. The pipeline before an invoice: an estimate's state (draft, sent, accepted, declined) is the closest thing Harvest has to a sales funnel."
     },
     {
       "name": "Estimate",
       "paged": false,
-      "suffix": "/v2/estimates/{Estimate ID}"
+      "suffix": "/v2/estimates/{Estimate ID}",
+      "description": "One estimate by id, with its line items."
     },
     {
       "name": "Estimate Item Categories",
       "paged": true,
-      "suffix": "/v2/estimate_item_categories?updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}"
+      "suffix": "/v2/estimate_item_categories?updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}",
+      "description": "The categories estimate line items are classified under."
     },
     {
       "name": "Estimate Item Category",
       "paged": false,
-      "suffix": "/v2/estimate_item_categories/{Estimate Item Category ID}"
+      "suffix": "/v2/estimate_item_categories/{Estimate Item Category ID}",
+      "description": "One estimate item category by id."
     },
     {
       "name": "Expenses",
       "paged": true,
-      "suffix": "/v2/expenses?user_id={User ID?}&client_id={Client ID?}&project_id={Project ID?}&is_billed={Billed Only?:true|false}&updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}&from={Spent On or After?:yyyy-MM-dd'T'HH:mm:ss}&to={Spent On or Before?:yyyy-MM-dd'T'HH:mm:ss}"
+      "suffix": "/v2/expenses?user_id={User ID?}&client_id={Client ID?}&project_id={Project ID?}&is_billed={Billed Only?:true|false}&updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}&from={Spent On or After?:yyyy-MM-dd'T'HH:mm:ss}&to={Spent On or Before?:yyyy-MM-dd'T'HH:mm:ss}",
+      "description": "The expenses recorded, with the user, project, client, expense category, date, total cost, units where the category is unit-based, the billable flag, and the invoice it was billed on. Project profitability is time cost plus these, so an expense-blind margin overstates it."
     },
     {
       "name": "Expense",
       "paged": false,
-      "suffix": "/v2/expenses/{Expense ID}"
+      "suffix": "/v2/expenses/{Expense ID}",
+      "description": "One expense by id."
     },
     {
       "name": "Expense Categories",
       "paged": true,
-      "suffix": "/v2/expense_categories?is_active={Active Only?:true|false}&updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}"
+      "suffix": "/v2/expense_categories?is_active={Active Only?:true|false}&updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}",
+      "description": "The expense categories, each with a unit name and unit price where it is charged per unit rather than at cost -- mileage being the usual case. The unit price is what turns a distance into money."
     },
     {
       "name": "Expense Category",
       "paged": false,
-      "suffix": "/v2/expense_categories/{Expense Category ID}"
+      "suffix": "/v2/expense_categories/{Expense Category ID}",
+      "description": "One expense category by id."
     },
     {
       "name": "Tasks",
       "paged": true,
-      "suffix": "/v2/tasks?is_active={Active Only?:true|false}&updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}"
+      "suffix": "/v2/tasks?is_active={Active Only?:true|false}&updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}",
+      "description": "The task types time can be booked against -- design, development, meetings -- with a default hourly rate and whether each is billable by default. Account-wide definitions; which apply to a project is in Task Assignments."
     },
     {
       "name": "Task",
       "paged": false,
-      "suffix": "/v2/tasks/{Task ID}"
+      "suffix": "/v2/tasks/{Task ID}",
+      "description": "One task by id."
     },
     {
       "name": "Time Entries",
       "paged": true,
-      "suffix": "/v2/time_entries?user_id={User ID?}&client_id={Client ID?}&project_id={Project ID?}&task_id={Task ID?}&is_billed={Billed Only?:true|false}&is_running={Running Only?:true|false}&updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}&from={Spent On or After?:yyyy-MM-dd'T'HH:mm:ss}&to={Spent On or Before?:yyyy-MM-dd'T'HH:mm:ss}"
+      "suffix": "/v2/time_entries?user_id={User ID?}&client_id={Client ID?}&project_id={Project ID?}&task_id={Task ID?}&is_billed={Billed Only?:true|false}&is_running={Running Only?:true|false}&updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}&from={Spent On or After?:yyyy-MM-dd'T'HH:mm:ss}&to={Spent On or Before?:yyyy-MM-dd'T'HH:mm:ss}",
+      "description": "The time entries recorded, one row each -- the central table. Carries the user, client, project, task, the spent_date, HOURS AS A DECIMAL, notes, the billable and billed flags, the billable_rate and cost_rate applied, and the invoice it was billed on. THIS IS RARE AND WORTH KNOWING: unlike most time trackers, Harvest stamps the rates ONTO THE ENTRY at the moment it is recorded, so revenue and cost are readable directly without joining to a project or person, and a historical entry keeps the rate that applied then rather than today's. Filter by user, client, project or updated_since."
     },
     {
       "name": "Time Entry",
       "paged": false,
-      "suffix": "/v2/time_entries/{Time Entry ID}"
+      "suffix": "/v2/time_entries/{Time Entry ID}",
+      "description": "One time entry by id, with its rates and invoice link."
     },
     {
       "name": "User Assignments",
       "paged": true,
-      "suffix": "/v2/user_assignments?user_id={User ID?}&is_active={Active Only?:true|false}&updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}"
+      "suffix": "/v2/user_assignments?user_id={User ID?}&is_active={Active Only?:true|false}&updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}",
+      "description": "Which people are assigned to which projects, each with their billable flag, hourly rate and role on that project. THE PER-PROJECT PERSON RATE, which overrides both the project rate and the person's default -- so this is the table any accurate revenue figure passes through."
     },
     {
       "name": "Project User Assignments",
       "paged": true,
-      "suffix": "/v2/projects/{Project ID}/user_assignments?user_id={User ID?}&is_active={Active Only?:true|false}&updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}"
+      "suffix": "/v2/projects/{Project ID}/user_assignments?user_id={User ID?}&is_active={Active Only?:true|false}&updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}",
+      "description": "The people assigned to one project. Requires a project id."
     },
     {
       "name": "User Assignment",
       "paged": false,
-      "suffix": "/v2/projects/{Project ID}/user_assignments/{User Assignment ID}"
+      "suffix": "/v2/projects/{Project ID}/user_assignments/{User Assignment ID}",
+      "description": "One user assignment by id. Requires the project id."
     },
     {
       "name": "Task Assignments",
       "paged": true,
-      "suffix": "/v2/task_assignments?is_active={Active Only?:true|false}&updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}"
+      "suffix": "/v2/task_assignments?is_active={Active Only?:true|false}&updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}",
+      "description": "Which tasks are available on which projects, each with its own billable flag, hourly rate and budget. The per-project override of the account-wide task defaults, and therefore the rate that actually applies."
     },
     {
       "name": "Project Task Assignments",
       "paged": true,
-      "suffix": "/v2/projects/{Project ID}/task_assignments?is_active={Active Only?:true|false}&updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}"
+      "suffix": "/v2/projects/{Project ID}/task_assignments?is_active={Active Only?:true|false}&updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}",
+      "description": "The task assignments of one project. Requires a project id."
     },
     {
       "name": "Task Assignment",
       "paged": false,
-      "suffix": "/v2/projects/{Project ID}/task_assignments/{Task Assignment ID}"
+      "suffix": "/v2/projects/{Project ID}/task_assignments/{Task Assignment ID}",
+      "description": "One task assignment by id. Requires the project id."
     },
     {
       "name": "Projects",
@@ -183,47 +213,56 @@
           "key": "id",
           "parameterName": "Project ID"
         }
-      ]
+      ],
+      "description": "The projects, with name, code, the client, whether active, the billing method (by project, by task, by person or fixed fee), the budget and how it is measured, and the hourly rate. Requires nothing; filter by client or active state. THE BILLING METHOD DECIDES WHICH RATE APPLIES -- a project billed by person uses the person's rate rather than the project's, so a revenue calculation that assumes one method is wrong for the others. Inactive projects are excluded when filtered, which drops completed work from historical totals."
     },
     {
       "name": "Project",
       "paged": false,
-      "suffix": "/v2/projects/{Project ID}"
+      "suffix": "/v2/projects/{Project ID}",
+      "description": "One project by id, with its budget and billing configuration."
     },
     {
       "name": "Roles",
       "paged": true,
-      "suffix": "/v2/roles"
+      "suffix": "/v2/roles",
+      "description": "The roles defined, each with the users assigned. Organisational grouping of people."
     },
     {
       "name": "Role",
       "paged": false,
-      "suffix": "/v2/roles/{Role ID}"
+      "suffix": "/v2/roles/{Role ID}",
+      "description": "One role by id."
     },
     {
       "name": "User Billable Rates",
       "paged": true,
-      "suffix": "/v2/users/{User ID}/billable_rates"
+      "suffix": "/v2/users/{User ID}/billable_rates",
+      "description": "The history of one person's billable rate, each entry with the date it took effect. Requires a user id. Rates change over time, and this is the record of when -- which matters for restating past periods correctly."
     },
     {
       "name": "User Billable Rate",
       "paged": false,
-      "suffix": "/v2/users/{User ID}/billable_rates/{Billable Rate ID}"
+      "suffix": "/v2/users/{User ID}/billable_rates/{Billable Rate ID}",
+      "description": "One billable rate entry by id."
     },
     {
       "name": "User Cost Rates",
       "paged": true,
-      "suffix": "/v2/users/{User ID}/cost_rates"
+      "suffix": "/v2/users/{User ID}/cost_rates",
+      "description": "The history of one person's COST rate -- what they cost the business, as opposed to what they are billed at. Requires a user id. The margin on a project is the gap between these two tables, and cost rates exist nowhere else."
     },
     {
       "name": "User Cost Rate",
       "paged": false,
-      "suffix": "/v2/users/{User ID}/cost_rates/{Cost Rate ID}"
+      "suffix": "/v2/users/{User ID}/cost_rates/{Cost Rate ID}",
+      "description": "One cost rate entry by id."
     },
     {
       "name": "User Project Assignments",
       "paged": true,
-      "suffix": "/v2/users/{User ID}/project_assignments?updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}"
+      "suffix": "/v2/users/{User ID}/project_assignments?updated_since={Updated Since?:yyyy-MM-dd'T'HH:mm:ss}",
+      "description": "The projects one person is assigned to. Requires a user id. The reverse view, and the answer to what someone is able to book time against."
     },
     {
       "name": "Users",
@@ -240,12 +279,14 @@
           "key": "id",
           "parameterName": "User ID"
         }
-      ]
+      ],
+      "description": "The people in the account, with name, email, whether active, their role, weekly capacity, and default rates. Capacity is what makes a utilisation figure possible: hours recorded mean nothing without the hours available."
     },
     {
       "name": "User",
       "paged": false,
-      "suffix": "/v2/users/{User ID}"
+      "suffix": "/v2/users/{User ID}",
+      "description": "One user by id, with their capacity and default rates."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/helpscoutdocs/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/helpscoutdocs/endpoints.json
@@ -20,7 +20,8 @@
           "key": "id",
           "parameterName": "Article ID"
         }
-      ]
+      ],
+      "description": "The articles in one collection. Requires a collection id. Carries the name, status, the public url, view and popularity counts, and the created and updated times. Filter by status, which defaults to all -- so drafts are included alongside published articles unless excluded."
     },
     {
       "name": "Category Articles",
@@ -42,12 +43,14 @@
           "key": "id",
           "parameterName": "Article ID"
         }
-      ]
+      ],
+      "description": "The articles in one category. Requires a category id. The narrower slice."
     },
     {
       "name": "Article Search",
       "paged": true,
-      "suffix": "/v1/search/articles?query={Query}&collectionId={Collection ID?}&siteId={Site ID?}&status={Status?:all|published|notpublished}&visibility={Visibility?:all|public|private}"
+      "suffix": "/v1/search/articles?query={Query}&collectionId={Collection ID?}&siteId={Site ID?}&status={Status?:all|published|notpublished}&visibility={Visibility?:all|public|private}",
+      "description": "Articles matching a search term, optionally within one collection or site. Full-text across titles and bodies."
     },
     {
       "name": "Related Articles",
@@ -69,22 +72,26 @@
           "key": "id",
           "parameterName": "Article ID"
         }
-      ]
+      ],
+      "description": "The articles Help Scout considers related to one article. Requires an article id. Derived rather than authored, so it reflects text similarity rather than any editorial decision."
     },
     {
       "name": "Revisions",
       "paged": true,
-      "suffix": "/v1/articles/{Article ID}/revisions"
+      "suffix": "/v1/articles/{Article ID}/revisions",
+      "description": "The edit history of one article, each revision with its author and timestamp. Requires an article id. The article carries only its current text, so this is the only record of when documentation changed and who changed it."
     },
     {
       "name": "Article",
       "paged": false,
-      "suffix": "/v1/articles/{Article ID or Number}?draft={Draft: false|true}"
+      "suffix": "/v1/articles/{Article ID or Number}?draft={Draft: false|true}",
+      "description": "One article by id or number, with its full text. The draft parameter returns the unpublished version where one exists, which is how a pending rewrite is seen."
     },
     {
       "name": "Revision",
       "paged": false,
-      "suffix": "/v1/revisions/{Revision ID}"
+      "suffix": "/v1/revisions/{Revision ID}",
+      "description": "One revision by id, with the article text as it stood then."
     },
     {
       "name": "Categories",
@@ -97,12 +104,14 @@
           "key": "id",
           "parameterName": "Category ID"
         }
-      ]
+      ],
+      "description": "The categories within one collection, the level between collection and article. Requires a collection id."
     },
     {
       "name": "Category",
       "paged": false,
-      "suffix": "/v1/categories/{Category ID or Number}"
+      "suffix": "/v1/categories/{Category ID or Number}",
+      "description": "One category by id or number."
     },
     {
       "name": "Collections",
@@ -118,37 +127,44 @@
           "key": "id",
           "parameterName": "Collection ID"
         }
-      ]
+      ],
+      "description": "The top level of a knowledge base -- the groupings articles are filed under -- with name, description, visibility and article count. Requires nothing, or filter by site. VISIBILITY MATTERS: a private collection is invisible to customers, so counting all articles overstates what the public can actually reach."
     },
     {
       "name": "Collection",
       "paged": false,
-      "suffix": "/v1/collections/{Collection ID or Number}"
+      "suffix": "/v1/collections/{Collection ID or Number}",
+      "description": "One collection by id or number."
     },
     {
       "name": "Redirects",
       "paged": true,
-      "suffix": "/v1/redirects/site/{Site ID}"
+      "suffix": "/v1/redirects/site/{Site ID}",
+      "description": "The URL redirects configured for one site. Requires a site id. Where an article was moved or renamed, this is what keeps the old link working -- and the record of what used to live at a given address."
     },
     {
       "name": "Redirect",
       "paged": false,
-      "suffix": "/v1/redirects/{Redirect ID}"
+      "suffix": "/v1/redirects/{Redirect ID}",
+      "description": "One redirect by id."
     },
     {
       "name": "Redirect Search",
       "paged": false,
-      "suffix": "v1/redirects?url={URL}&siteId={Site ID}"
+      "suffix": "v1/redirects?url={URL}&siteId={Site ID}",
+      "description": "Finds the redirect matching a given URL. Requires the URL and site id. Answers where a specific old link now points."
     },
     {
       "name": "Sites",
       "paged": true,
-      "suffix": "/v1/sites"
+      "suffix": "/v1/sites",
+      "description": "The Docs sites on the account, each with its subdomain, title and status. A site is a knowledge base; everything else here belongs to one, so this is the first request on a multi-site account."
     },
     {
       "name": "Site",
       "paged": false,
-      "suffix": "/v1/sites/{Site ID}"
+      "suffix": "/v1/sites/{Site ID}",
+      "description": "One site by id."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/lighthouse/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/lighthouse/endpoints.json
@@ -3,12 +3,14 @@
     {
       "name": "Changesets",
       "paged": false,
-      "suffix": "/projects/{Project ID}/changesets.json"
+      "suffix": "/projects/{Project ID}/changesets.json",
+      "description": "The source-control commits linked to one project, with the revision, author, message and the tickets each references. Requires a project id. The bridge between issues and code, where a repository is connected."
     },
     {
       "name": "Changeset",
       "paged": false,
-      "suffix": "/projects/{Project ID}/changesets/{Revision Name}.json"
+      "suffix": "/projects/{Project ID}/changesets/{Revision Name}.json",
+      "description": "One changeset by revision. Requires the project id."
     },
     {
       "name": "Projects",
@@ -28,82 +30,98 @@
           "key": "id",
           "parameterName": "Project ID"
         }
-      ]
+      ],
+      "description": "The projects in the account, each with name, description, open and closed ticket counts, and its default assignee and milestone. The container everything else belongs to; every other endpoint needs a project id."
     },
     {
       "name": "Project",
       "paged": false,
-      "suffix": "/projects/{Project ID}.json"
+      "suffix": "/projects/{Project ID}.json",
+      "description": "One project by id, with its counts and settings."
     },
     {
       "name": "Initial Project State",
       "paged": false,
-      "suffix": "/projects/new.json"
+      "suffix": "/projects/new.json",
+      "description": "A blank project template returned for building a creation form. Form scaffolding, not data."
     },
     {
       "name": "Tickets",
       "paged": true,
-      "suffix": "/projects/{Project ID}/tickets.json"
+      "suffix": "/projects/{Project ID}/tickets.json",
+      "description": "The issues in one project, with title, state, the assigned user, the milestone, tags, and the created and updated times. Requires a project id. The central table. Note STATE IS FREE TEXT rather than a fixed enum in Lighthouse -- projects define their own state names -- so state values are account-specific and cannot be assumed to be open and closed."
     },
     {
       "name": "Ticket",
       "paged": false,
-      "suffix": "/projects/{Project ID}/tickets/{Ticket Number}.json"
+      "suffix": "/projects/{Project ID}/tickets/{Ticket Number}.json",
+      "description": "One ticket by number, with its full body and comment history. Requires the project id. Note the ticket NUMBER is the per-project one shown in the interface, not a global id."
     },
     {
       "name": "Ticket Bins",
       "paged": false,
-      "suffix": "/projects/{Project ID}/bins.json"
+      "suffix": "/projects/{Project ID}/bins.json",
+      "description": "The saved ticket queries of one project -- Lighthouse's name for saved filters -- each with its query and current ticket count. Requires a project id. The counts are pre-computed, so a bin answers 'how many are in this state' without paging tickets, and the query text records how the team defines that state."
     },
     {
       "name": "Ticket Bin",
       "paged": false,
-      "suffix": "/projects/{Project ID}/bins/{Bin ID}.json"
+      "suffix": "/projects/{Project ID}/bins/{Bin ID}.json",
+      "description": "One ticket bin by id, with its query."
     },
     {
       "name": "Milestones",
       "paged": false,
-      "suffix": "/projects/{Project ID}/milestones.json"
+      "suffix": "/projects/{Project ID}/milestones.json",
+      "description": "The milestones of one project, with title, due date, and the counts of open and closed tickets. Requires a project id. The counts make release-readiness answerable without walking the tickets."
     },
     {
       "name": "Milestone",
       "paged": false,
-      "suffix": "/projects/{Project ID}/milestones/{Milestone ID}.json"
+      "suffix": "/projects/{Project ID}/milestones/{Milestone ID}.json",
+      "description": "One milestone by id."
     },
     {
       "name": "Messages",
       "paged": false,
-      "suffix": "/projects/{Project ID}/messages.json"
+      "suffix": "/projects/{Project ID}/messages.json",
+      "description": "The discussion threads of one project, separate from tickets. Requires a project id. Where design and planning conversation lives when it is not attached to an issue."
     },
     {
       "name": "Message",
       "paged": false,
-      "suffix": "/projects/{Project ID}/messages/{Message ID}.json"
+      "suffix": "/projects/{Project ID}/messages/{Message ID}.json",
+      "description": "One message by id, with its replies."
     },
     {
       "name": "User",
       "paged": false,
-      "suffix": "/users/{User ID}.json"
+      "suffix": "/users/{User ID}.json",
+      "description": "One user by id, with name and job description."
     },
     {
       "name": "Current User",
       "paged": false,
-      "suffix": "/profile.json"
+      "suffix": "/profile.json",
+      "description": "The account the credentials belong to, with its memberships. One record, always the caller."
     },
     {
       "name": "Memberships",
       "paged": false,
-      "suffix": "/users/{User ID}/memberships.json"
+      "suffix": "/users/{User ID}/memberships.json",
+      "description": "The projects one user belongs to, with their role. Requires a user id."
     },
     {
       "name": "Project Memberships",
       "paged": false,
-      "suffix": "/projects/{Project ID}/memberships.json"
+      "suffix": "/projects/{Project ID}/memberships.json",
+      "description": "The users on one project, with their roles. Requires a project id. The access list."
     },
     {
       "name": "Token",
       "paged": false,
-      "suffix": "/tokens/{Token}.json"
+      "suffix": "/tokens/{Token}.json",
+      "description": "The details of one API token, including which user and project it is scoped to. Requires the token. Security metadata rather than project data."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/mixpanel/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/mixpanel/endpoints.json
@@ -1,84 +1,100 @@
 {
-    "endpoints": [
-        {
-            "name": "Annotations",
-            "paged": false,
-            "suffix": "/app/projects/{projectId}/annotations?from_date={From Date?:yyyy-mm-dd}&to_date={To Date?:yyyy-mm-dd}"
-        },
-        {
-            "name": "Top Events for Today",
-            "paged": false,
-            "suffix": "query/events/top?project_id={projectId}&workspace_id={workspaceId?}&type={Type:general|unique|average}&limit={Maximum Number of Events?}"
-        },
-        {
-            "name": "Common Event Names",
-            "paged": false,
-            "suffix": "query/events/names?project_id={projectId}&workspace_id={workspaceId?}&type={Type:general|unique|average}&limit={Maximum Number of Events?}"
-        },
-        {
-            "name": "Event Properties",
-            "paged": false,
-            "suffix": "/query/events/properties?project_id={projectId}&workspace_id={workspaceId?}&event={Event Name}&name={Property Name}&type={Type:general|unique|average}&unit={Unit:minute|hour|day|week|month}&values={Values?:[\"value1\",\"value2\"...]}&interval={Interval?}&from_date={From Date:yyyy-mm-dd}&to_date={To Date:yyyy-mm-dd}&format=json&limit={Maximum Number of Values?}"
-        },
-        {
-            "name": "Top Property Names for Event",
-            "paged": false,
-            "suffix": "query/events/properties/top?project_id={projectId}&workspace_id={workspaceId?}&event={Event Name}&limit={Maximum Number of Properties?}"
-        },
-        {
-            "name": "Top Values for Property",
-            "paged": false,
-            "suffix": "query/events/properties/values?project_id={projectId}&workspace_id={workspaceId?}&event={Event Name}&name={Property Name}&limit={Maximum Number of Values?}"
-        },
-        {
-            "name": "Funnel",
-            "paged": false,
-            "suffix": "/query/funnels?project_id={projectId}&workspace_id={workspaceId?}&funnel_id={Funnel ID}&unit={Unit?:day|week|month}&interval={Interval?}&from_date={From Date:yyyy-mm-dd}&to_date={To Date:yyyy-mm-dd}&length={Length?}&length_unit={Length Unit?:second|minute|hour|day}&on={On?}&where={Where?}&limit={Maximum Number of Values?}"
-        },
-        {
-            "name": "Funnels",
-            "paged": false,
-            "suffix": "/query/funnels/list?project_id={projectId}&workspace_id={workspaceId?}"
-        },
-        {
-            "name": "Segmentation Event Data",
-            "paged": false,
-            "suffix": "/query/segmentation?project_id={projectId}&workspace_id={workspaceId?}&event={Event Name}&from_date={From Date:yyyy-mm-dd}&to_date={To Date:yyyy-mm-dd}&type={Type?:general|unique|average}&unit={Unit?:minute|hour|day|month}&interval={Interval?}&on={On?}&where={Where?}&format=json&limit={Maximum Number of Values?}"
-        },
-        {
-            "name": "Numeric Event Data",
-            "paged": false,
-            "suffix": "/query/segmentation/numeric?project_id={projectId}&workspace_id={workspaceId?}&event={Event Name}&from_date={From Date:yyyy-mm-dd}&to_date={To Date:yyyy-mm-dd}&on={On}&type={Type?:general|unique|average}&unit={Unit?:hour|day}&where={Where?}"
-        },
-        {
-            "name": "Sum",
-            "paged": false,
-            "suffix": "/query/segmentation/sum?project_id={projectId}&workspace_id={workspaceId?}&event={Event Name}&from_date={From Date:yyyy-mm-dd}&to_date={To Date:yyyy-mm-dd}&on={On}&unit={Unit?:hour|day}&where={Where?}"
-        },
-        {
-            "name": "Average",
-            "paged": false,
-            "suffix": "/query/segmentation/average?project_id={projectId}&workspace_id={workspaceId?}&event={Event Name}&from_date={From Date:yyyy-mm-dd}&to_date={To Date:yyyy-mm-dd}&on={On}&unit={Unit?:hour|day}&where={Where?}"
-        },
-        {
-            "name": "Retention",
-            "paged": false,
-            "suffix": "/query/retention?project_id={projectId}&workspace_id={workspaceId?}&from_date={From Date:yyyy-mm-dd}&to_date={To Date:yyyy-mm-dd}&retention_type={Retention Type?:birth|compounded}&born_event={Born Event?}&event={Event Name?}&where={Where?}&interval={Interval?}&interval_count={Interval Count?}&unit={Unit?:day|week|month}&on={On?}&limit={Maximum Number of Values?}"
-        },
-        {
-            "name": "Addiction",
-            "paged": false,
-            "suffix": "/query/retention/addiction?project_id={projectId}&workspace_id={workspaceId?}&from_date={From Date:yyyy-mm-dd}&to_date={To Date:yyyy-mm-dd}&unit={Unit:day|week|month}&addiction_unit={Addiction Unit:hour|day}&event={Event Name?}&on={On?}&where={Where?}&limit={Maximum Number of Values?}"
-        },
-        {
-            "name": "Engage",
-            "paged": true,
-            "suffix": "/query/engage?project_id={projectId}&workspace_id={workspaceId?}&distinct_id={Distinct ID?}&distinct_ids={Distinct Ids?:[\"id1\",\"id2\",...]}&where={Where?}&output_properties={Output Properties?:[\"prop1\",\"prop2\",...]}&session_id={Session ID?}&behaviors={Behaviors?}&as_of_timestamp={As of Timestamp?:Unix timestamp}&filter_by_cohort={Filter By Cohort?}&include_all_users={Include All Users?:True|False}"
-        },
-        {
-            "name": "Scheduled Pipelines",
-            "paged": false,
-            "suffix": "/2.0/nessie/pipeline/jobs?project_id={projectId}"
-        }
-    ]
+  "endpoints": [
+    {
+      "name": "Annotations",
+      "paged": false,
+      "suffix": "/app/projects/{projectId}/annotations?from_date={From Date?:yyyy-mm-dd}&to_date={To Date?:yyyy-mm-dd}",
+      "description": "The dated notes recorded on the project -- releases, campaigns, incidents. Requires the project id and a date range. The only place the business context behind a jump in the numbers is written down."
+    },
+    {
+      "name": "Top Events for Today",
+      "paged": false,
+      "suffix": "query/events/top?project_id={projectId}&workspace_id={workspaceId?}&type={Type:general|unique|average}&limit={Maximum Number of Events?}",
+      "description": "Today's most frequent events with their counts. A quick pulse rather than an analysis; the date range cannot be moved."
+    },
+    {
+      "name": "Common Event Names",
+      "paged": false,
+      "suffix": "query/events/names?project_id={projectId}&workspace_id={workspaceId?}&type={Type:general|unique|average}&limit={Maximum Number of Events?}",
+      "description": "The event names most frequently seen, by volume. The vocabulary of the project -- event names are defined by whatever the application sends, so this is the only way to learn what exists before querying it."
+    },
+    {
+      "name": "Event Properties",
+      "paged": false,
+      "suffix": "/query/events/properties?project_id={projectId}&workspace_id={workspaceId?}&event={Event Name}&name={Property Name}&type={Type:general|unique|average}&unit={Unit:minute|hour|day|week|month}&values={Values?:[\"value1\",\"value2\"...]}&interval={Interval?}&from_date={From Date:yyyy-mm-dd}&to_date={To Date:yyyy-mm-dd}&format=json&limit={Maximum Number of Values?}",
+      "description": "The properties recorded on one event. Requires the event name. The decoder for what can be segmented on -- properties are application-defined, so nothing about them is knowable in advance."
+    },
+    {
+      "name": "Top Property Names for Event",
+      "paged": false,
+      "suffix": "query/events/properties/top?project_id={projectId}&workspace_id={workspaceId?}&event={Event Name}&limit={Maximum Number of Properties?}",
+      "description": "The most common property names on one event, by volume. The shorter, more useful version of the full property list on a busy event."
+    },
+    {
+      "name": "Top Values for Property",
+      "paged": false,
+      "suffix": "query/events/properties/values?project_id={projectId}&workspace_id={workspaceId?}&event={Event Name}&name={Property Name}&limit={Maximum Number of Values?}",
+      "description": "The most common values of one property on one event. Requires the event and property names. Use it to see the actual vocabulary a property takes before filtering on it, since free-text properties often hold far more variation than expected."
+    },
+    {
+      "name": "Funnel",
+      "paged": false,
+      "suffix": "/query/funnels?project_id={projectId}&workspace_id={workspaceId?}&funnel_id={Funnel ID}&unit={Unit?:day|week|month}&interval={Interval?}&from_date={From Date:yyyy-mm-dd}&to_date={To Date:yyyy-mm-dd}&length={Length?}&length_unit={Length Unit?:second|minute|hour|day}&on={On?}&where={Where?}&limit={Maximum Number of Values?}",
+      "description": "The conversion of one saved funnel over a date range, step by step, with the count reaching each step and the overall conversion rate. Requires the project id and a funnel id. FUNNELS MUST BE DEFINED IN MIXPANEL FIRST -- this endpoint evaluates a saved definition and cannot construct one, so the steps and the conversion window are whatever was configured there."
+    },
+    {
+      "name": "Funnels",
+      "paged": false,
+      "suffix": "/query/funnels/list?project_id={projectId}&workspace_id={workspaceId?}",
+      "description": "The saved funnels on the project, with their ids and names. The lookup that makes the funnel endpoint usable, and a fair guide to the conversions the business considers worth measuring."
+    },
+    {
+      "name": "Segmentation Event Data",
+      "paged": false,
+      "suffix": "/query/segmentation?project_id={projectId}&workspace_id={workspaceId?}&event={Event Name}&from_date={From Date:yyyy-mm-dd}&to_date={To Date:yyyy-mm-dd}&type={Type?:general|unique|average}&unit={Unit?:minute|hour|day|month}&interval={Interval?}&on={On?}&where={Where?}&format=json&limit={Maximum Number of Values?}",
+      "description": "Counts of one event over a date range, optionally split by a property and filtered by an expression. Requires the project id, the event name and a date range. THE WORKHORSE: most questions of the form 'how many times did X happen, broken down by Y' are this endpoint. Note the unit parameter chooses hour, day, week or month buckets, and Mixpanel returns a nested object keyed by segment and then by date rather than flat rows, so it needs reshaping."
+    },
+    {
+      "name": "Numeric Event Data",
+      "paged": false,
+      "suffix": "/query/segmentation/numeric?project_id={projectId}&workspace_id={workspaceId?}&event={Event Name}&from_date={From Date:yyyy-mm-dd}&to_date={To Date:yyyy-mm-dd}&on={On}&type={Type?:general|unique|average}&unit={Unit?:hour|day}&where={Where?}",
+      "description": "The same segmentation with a NUMERIC property bucketed into ranges rather than grouped by value. Requires a numeric property. Use it for distributions -- order values, session lengths -- where grouping by exact value would produce thousands of segments."
+    },
+    {
+      "name": "Sum",
+      "paged": false,
+      "suffix": "/query/segmentation/sum?project_id={projectId}&workspace_id={workspaceId?}&event={Event Name}&from_date={From Date:yyyy-mm-dd}&to_date={To Date:yyyy-mm-dd}&on={On}&unit={Unit?:hour|day}&where={Where?}",
+      "description": "The sum of a numeric property across one event over a range. Requires the project, event, property and dates. Revenue and quantity totals come from here; the plain segmentation endpoint counts occurrences and cannot sum a value."
+    },
+    {
+      "name": "Average",
+      "paged": false,
+      "suffix": "/query/segmentation/average?project_id={projectId}&workspace_id={workspaceId?}&event={Event Name}&from_date={From Date:yyyy-mm-dd}&to_date={To Date:yyyy-mm-dd}&on={On}&unit={Unit?:hour|day}&where={Where?}",
+      "description": "The average of a numeric property across one event over a range. Same inputs as Sum."
+    },
+    {
+      "name": "Retention",
+      "paged": false,
+      "suffix": "/query/retention?project_id={projectId}&workspace_id={workspaceId?}&from_date={From Date:yyyy-mm-dd}&to_date={To Date:yyyy-mm-dd}&retention_type={Retention Type?:birth|compounded}&born_event={Born Event?}&event={Event Name?}&where={Where?}&interval={Interval?}&interval_count={Interval Count?}&unit={Unit?:day|week|month}&on={On?}&limit={Maximum Number of Values?}",
+      "description": "Cohort retention: of the users who did a first event in each period, how many returned to do a second event in the periods after. Requires the project, the born event, the return event and a date range. The standard retention grid, computed by Mixpanel rather than reconstructed -- which would otherwise require the full event stream."
+    },
+    {
+      "name": "Addiction",
+      "paged": false,
+      "suffix": "/query/retention/addiction?project_id={projectId}&workspace_id={workspaceId?}&from_date={From Date:yyyy-mm-dd}&to_date={To Date:yyyy-mm-dd}&unit={Unit:day|week|month}&addiction_unit={Addiction Unit:hour|day}&event={Event Name?}&on={On?}&where={Where?}&limit={Maximum Number of Values?}",
+      "description": "Frequency retention: how MANY of the periods in a window each cohort was active in, rather than whether they returned at all. Requires the same inputs. Answers engagement depth where Retention answers survival."
+    },
+    {
+      "name": "Engage",
+      "paged": true,
+      "suffix": "/query/engage?project_id={projectId}&workspace_id={workspaceId?}&distinct_id={Distinct ID?}&distinct_ids={Distinct Ids?:[\"id1\",\"id2\",...]}&where={Where?}&output_properties={Output Properties?:[\"prop1\",\"prop2\",...]}&session_id={Session ID?}&behaviors={Behaviors?}&as_of_timestamp={As of Timestamp?:Unix timestamp}&filter_by_cohort={Filter By Cohort?}&include_all_users={Include All Users?:True|False}",
+      "description": "User profiles, filtered by an expression over profile properties. Requires the project id. THE USER TABLE rather than the event stream: profiles carry whatever properties the application set on them, so their shape is entirely account-specific. This is where a per-user attribute lives; events carry only what was passed at the time."
+    },
+    {
+      "name": "Scheduled Pipelines",
+      "paged": false,
+      "suffix": "/2.0/nessie/pipeline/jobs?project_id={projectId}",
+      "description": "The status of scheduled data export pipelines on the project. Operational: pipelines are how a full event history reaches a warehouse, since the query endpoints aggregate rather than dump."
+    }
+  ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/nicereply/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/nicereply/endpoints.json
@@ -3,142 +3,170 @@
     {
       "name": "Feedback Objects",
       "suffix": "/feedback-objects",
-      "paged": "true"
+      "paged": "true",
+      "description": "The things being rated -- agents, teams or whatever the account configured. Nicereply's abstraction for the subject of a rating, and the dimension per-agent scores are grouped by."
     },
     {
       "name": "Feedback Object",
       "suffix": "/feedback-objects/{Feedback Object ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One feedback object by id."
     },
     {
       "name": "Feedback Object Responses",
       "suffix": "/feedback-objects/{Feedback Object ID}/responses?created_after={Created After?}&created_before={Created Before?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The responses about one feedback object, filterable by date. Requires the object id. The per-agent or per-team score history."
     },
     {
       "name": "Feedback Object Groups",
       "suffix": "/feedback-object-groups",
-      "paged": "true"
+      "paged": "true",
+      "description": "Groupings of feedback objects -- teams of agents, typically. The level above individual subjects."
     },
     {
       "name": "Feedback Object Group",
       "suffix": "/feedback-object-groups/{Feedback Object Group ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One group by id."
     },
     {
       "name": "Feedback Object Group Responses",
       "suffix": "/feedback-object-groups/{Feedback Object Group ID}/responses?created_after={Created After?}&created_before={Created Before?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The responses about one group, filterable by date. Requires the group id. Team-level satisfaction without summing individuals."
     },
     {
       "name": "Customers",
       "suffix": "/customers",
-      "paged": "true"
+      "paged": "true",
+      "description": "The end customers who gave feedback, with their identifying details. The respondent side of a response."
     },
     {
       "name": "Customer",
       "suffix": "/customers/{Customer ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One customer by id."
     },
     {
       "name": "Integrations",
       "suffix": "/integrations",
-      "paged": "true"
+      "paged": "true",
+      "description": "The help desk integrations feeding Nicereply -- Zendesk, Freshdesk and the like -- with their status. The source of the tickets responses are attached to, and the explanation for which conversations get surveyed at all."
     },
     {
       "name": "Integration",
       "suffix": "/integrations/{Integration ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One integration by id."
     },
     {
       "name": "Questions",
       "suffix": "/questions",
-      "paged": "true"
+      "paged": "true",
+      "description": "The questions defined across surveys, with their text and type. The wording matters for interpretation, since satisfaction scores are sensitive to how the question is asked."
     },
     {
       "name": "Question",
       "suffix": "/questions/{Question ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One question by id."
     },
     {
       "name": "Rating Values Settings",
       "suffix": "/rating-values",
-      "paged": "false"
+      "paged": "false",
+      "description": "The rating scales configured -- what the possible values are and what each means. THE DECODER for the rating column: a 5 on a CSAT scale and a 5 on a ten-point NPS are entirely different results, and nothing in the response row distinguishes them."
     },
     {
       "name": "Surveys",
       "suffix": "/surveys",
-      "paged": "true"
+      "paged": "true",
+      "description": "The surveys defined, each with its type (CSAT, CES or NPS), name and status. A survey's TYPE decides how its responses should be aggregated -- NPS is a promoter-minus-detractor calculation, not an average -- so mixing surveys in one average is wrong regardless of scale."
     },
     {
       "name": "Survey",
       "suffix": "/surveys/{Survey ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One survey by id, with its type and questions."
     },
     {
       "name": "Survey Distribution Settings",
       "suffix": "/surveys/{Survey ID}/distribution",
-      "paged": "false"
+      "paged": "false",
+      "description": "How one survey is sent -- the channel, timing and trigger. Requires a survey id. Explains response rates: a survey sent on every ticket and one sent on a sample produce very different volumes for the same underlying satisfaction."
     },
     {
       "name": "Survey Responses",
       "suffix": "/surveys/{Survey ID}/responses?created_after={Created After?}&created_before={Created Before?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The responses to one survey, filterable by date. Requires a survey id. The per-survey slice, and the safe unit to aggregate within."
     },
     {
       "name": "Responses",
       "suffix": "/responses",
-      "paged": "true"
+      "paged": "true",
+      "description": "Every customer satisfaction response collected, one row each -- the central table. Carries the rating, any comment, the customer, the agent it was about, the survey it came from, and when it was submitted. Filterable by date. NOTE THE RATING SCALE IS NOT UNIVERSAL: Nicereply supports CSAT, CES and NPS, and their scales differ, so a rating value only means something once its survey's scale is known -- Rating Values Settings is what states it."
     },
     {
       "name": "Response",
       "suffix": "/responses/{Response ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One response by id, with its rating and comment."
     },
     {
       "name": "Response Ticket Link",
       "suffix": "/responses/{Response ID}/ticket-link",
-      "paged": "false"
+      "paged": "false",
+      "description": "The help desk ticket one response relates to. Requires a response id. THE BRIDGE between satisfaction data and the support system -- without it a low score cannot be traced to the conversation that caused it."
     },
     {
       "name": "Response Issue Status",
       "suffix": "/responses/{Response ID}/issue-status",
-      "paged": "false"
+      "paged": "false",
+      "description": "Whether one response has been flagged for follow-up and its current state. Requires a response id. The record of whether a bad rating was actually acted on, which the response itself does not carry."
     },
     {
       "name": "Tags",
       "suffix": "/tags",
-      "paged": "true"
+      "paged": "true",
+      "description": "The tags applied to responses. The free-form categorisation of feedback -- usually where the reason behind a score is recorded, since the numeric rating carries none."
     },
     {
       "name": "Tag",
       "suffix": "/tags/{Tag ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One tag by id."
     },
     {
       "name": "Unsubscribes",
       "suffix": "/unsubscribes",
-      "paged": "true"
+      "paged": "true",
+      "description": "The customers who opted out of receiving surveys. They are excluded from future sends, so a falling response count may reflect this list growing rather than any change in satisfaction."
     },
     {
       "name": "Unsubscribe",
       "suffix": "/unsubscribes/{Unsubscribe ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One unsubscribe record by id."
     },
     {
       "name": "Users",
       "suffix": "/users",
-      "paged": "true"
+      "paged": "true",
+      "description": "The agents and administrators in the account. Joined to responses through the feedback object, not directly."
     },
     {
       "name": "User",
       "suffix": "/users/{User ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One user by id."
     },
     {
       "name": "Tokens",
       "suffix": "/me/tokens",
-      "paged": "true"
+      "paged": "true",
+      "description": "The API tokens issued for the calling account. Security inventory."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/prometheus/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/prometheus/endpoints.json
@@ -1,74 +1,88 @@
 {
   "endpoints": [
     {
-      "paged": "false", 
-      "name": "Instant Query", 
-      "suffix": "/v1/query?query={Query}&time={Time?:YYYY-MM-DDTHH:MM:SSZ}&timeout={Timeout?}"
-    }, 
+      "paged": "false",
+      "name": "Instant Query",
+      "suffix": "/v1/query?query={Query}&time={Time?:YYYY-MM-DDTHH:MM:SSZ}&timeout={Timeout?}",
+      "description": "Evaluates a PromQL expression at ONE POINT IN TIME and returns the value of each matching series. Requires a query. This is the whole of Prometheus's read interface in miniature: there is no table of metrics to list, only expressions to evaluate, so the question defines the request. Returns a vector -- one entry per label combination -- not a time series, so it answers what a value IS, never how it changed."
+    },
     {
-      "paged": "false", 
-      "name": "Range Query", 
-      "suffix": "/v1/query_range?query={Query String}&start={Start Time:YYYY-MM-DDTHH:MM:SSZ}&end={End Time:YYYY-MM-DDTHH:MM:SSZ}&step={Step}&timeout={Timeout?}"
-    }, 
+      "paged": "false",
+      "name": "Range Query",
+      "suffix": "/v1/query_range?query={Query String}&start={Start Time:YYYY-MM-DDTHH:MM:SSZ}&end={End Time:YYYY-MM-DDTHH:MM:SSZ}&step={Step}&timeout={Timeout?}",
+      "description": "Evaluates a PromQL expression across a time range at a fixed step, returning a series of timestamped values per label combination. Requires the query, start, end and step. The endpoint any trend or chart comes from. NOTE THE STEP: Prometheus caps the number of points it will return (11,000 by default), so a long range with a fine step is refused outright rather than downsampled -- the step has to be chosen to fit the range, and a query that works over a day fails over a year unless it is widened."
+    },
     {
-      "paged": "false", 
-      "name": "Metadata", 
-      "suffix": "/v1/series?match[]={Series Selector,}&start={Start Time:YYYY-MM-DDTHH:MM:SSZ}&end={End Time:YYYY-MM-DDTHH:MM:SSZ}"
-    }, 
+      "paged": "false",
+      "name": "Metadata",
+      "suffix": "/v1/series?match[]={Series Selector,}&start={Start Time:YYYY-MM-DDTHH:MM:SSZ}&end={End Time:YYYY-MM-DDTHH:MM:SSZ}",
+      "description": "The series matching one or more selectors, returned as their full label sets without any values. Requires at least one match[] selector and a time range. Use it to discover what exists -- which label combinations are actually present -- before writing a query against them. On a large installation this is expensive and may be refused for exceeding cardinality limits."
+    },
     {
-      "paged": "false", 
-      "name": "Label Names", 
-      "suffix": "/v1/labels"
-    }, 
+      "paged": "false",
+      "name": "Label Names",
+      "suffix": "/v1/labels",
+      "description": "Every label name present in the data. The vocabulary of dimensions available to group by, and the natural first request when the metric structure is unknown."
+    },
     {
-      "paged": "false", 
-      "name": "Label Values", 
-      "suffix": "/v1/label/{Label Name}/values"
-    }, 
+      "paged": "false",
+      "name": "Label Values",
+      "suffix": "/v1/label/{Label Name}/values",
+      "description": "The values one label takes. Requires the label name. Passing __name__ returns every metric name, which is the closest thing Prometheus has to a table listing."
+    },
     {
-      "paged": "false", 
-      "name": "Targets", 
-      "suffix": "/v1/targets?state={State?:active|dropped|any}"
-    }, 
+      "paged": "false",
+      "name": "Targets",
+      "suffix": "/v1/targets?state={State?:active|dropped|any}",
+      "description": "The endpoints Prometheus scrapes, with their labels, the last scrape time and duration, and their health. Filter by active or dropped. OPERATIONAL AND IMPORTANT FOR TRUSTING DATA: a target that is down produces gaps rather than zeroes, so a metric that appears to have fallen may simply not have been collected, and this is where that is visible."
+    },
     {
-      "paged": "false", 
-      "name": "Rules", 
-      "suffix": "/v1/rules?type={Type:alert|record}"
-    }, 
+      "paged": "false",
+      "name": "Rules",
+      "suffix": "/v1/rules?type={Type:alert|record}",
+      "description": "The recording and alerting rules loaded, with their expressions, evaluation times and current state. Filter by type. Recording rules are pre-computed queries, so this is where to find that an expensive expression already has a cheaper precomputed name."
+    },
     {
-      "paged": "false", 
-      "name": "Alerts", 
-      "suffix": "/v1/alerts"
-    }, 
+      "paged": "false",
+      "name": "Alerts",
+      "suffix": "/v1/alerts",
+      "description": "The alerts currently firing or pending, with their labels, annotations, state and how long they have been active. A live snapshot -- Prometheus keeps no alert history here, so this answers what is wrong now and nothing about the past."
+    },
     {
-      "paged": "false", 
-      "name": "Target Metadata", 
-      "suffix": "/v1/targets/metadata?match_target={Match Target}&metric={Metric}&limit={Limit}"
-    }, 
+      "paged": "false",
+      "name": "Target Metadata",
+      "suffix": "/v1/targets/metadata?match_target={Match Target}&metric={Metric}&limit={Limit}",
+      "description": "The metric metadata a specific target exposes -- the type (counter, gauge, histogram, summary) and help text for each metric. Requires a target matcher and metric. The TYPE matters for correctness: a counter only ever increases and must be read through rate(), while a gauge can be read directly, and treating one as the other gives a meaningless number."
+    },
     {
-      "paged": "false", 
-      "name": "Alert managers", 
-      "suffix": "/v1/alertmanagers"
-    }, 
+      "paged": "false",
+      "name": "Alert managers",
+      "suffix": "/v1/alertmanagers",
+      "description": "The Alertmanager instances Prometheus is sending alerts to, active and dropped. Configuration health; alerts firing here but not reaching anyone is usually visible as a dropped entry."
+    },
     {
-      "paged": "false", 
-      "name": "Status", 
-      "suffix": "/v1/status/config"
-    }, 
+      "paged": "false",
+      "name": "Status",
+      "suffix": "/v1/status/config",
+      "description": "The configuration Prometheus is currently running, as loaded YAML. One record. Useful for confirming which targets and rules should exist before concluding data is missing."
+    },
     {
-      "paged": "false", 
-      "name": "Runtime Information", 
-      "suffix": "/v1/status/runtimeinfo"
-    }, 
+      "paged": "false",
+      "name": "Runtime Information",
+      "suffix": "/v1/status/runtimeinfo",
+      "description": "The running server's uptime, storage retention, reload time and goroutine count. Retention in particular bounds every query here: data older than it does not exist regardless of what is asked for."
+    },
     {
-      "paged": "false", 
-      "name": "Build Information", 
-      "suffix": "/v1/status/buildinfo"
-    }, 
+      "paged": "false",
+      "name": "Build Information",
+      "suffix": "/v1/status/buildinfo",
+      "description": "The Prometheus version and build details. One record; behaviour and available endpoints vary by version."
+    },
     {
-      "paged": "false", 
-      "name": "TSDB Statistics", 
-      "suffix": "/v1/status/tsdb"
+      "paged": "false",
+      "name": "TSDB Statistics",
+      "suffix": "/v1/status/tsdb",
+      "description": "Cardinality statistics for the time series database: the label names and metric names with the most series, and the largest label-value pairs. THE ENDPOINT FOR DIAGNOSING A SLOW OR OVERSIZED PROMETHEUS -- high cardinality is the usual cause, and this names the labels responsible."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/quickbooks/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/quickbooks/endpoints.json
@@ -2,111 +2,138 @@
   "endpoints": [
     {
       "name": "Account List Detail",
-      "suffix": "/reports/AccountList?account_type={Account Type?}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&start_moddate={Start ModDate?:YYYY-MM-DD}&sort_by={Sort By?}&sort_order={Sort Order?:ascend|descend}&moddate_macro={ModDate Macro?}&end_moddate={End ModDate?}&account_status={Account Status?:Deleted|Not_Deleted}&createdate_macro={Create Date Macro?}&columns={Columns?}"
+      "suffix": "/reports/AccountList?account_type={Account Type?}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&start_moddate={Start ModDate?:YYYY-MM-DD}&sort_by={Sort By?}&sort_order={Sort Order?:ascend|descend}&moddate_macro={ModDate Macro?}&end_moddate={End ModDate?}&account_status={Account Status?:Deleted|Not_Deleted}&createdate_macro={Create Date Macro?}&columns={Columns?}",
+      "description": "The chart of accounts with each account's type, detail type and current balance. The dimension every other report is organised by, and the decoder for account names appearing in them."
     },
     {
       "name": "AP Aging Detail",
-      "suffix": "/reports/AgedPayableDetail?shipvia={Ship Via?}&term={Term?}&start_duedate={End Due Date?:YYYY-MM-DD}&end_duedate={End Due Date?:YYYY-MM-DD}&accounting_method={Accounting Method?:Cash|Accrual}&custom1={Custom 1?}&custom2={Custom 2?}&custom3={Custom 3?}&report_date={Report Date?:YYYY-MM-DD}&num_periods={Number of Periods?}&vendor={Vendor?}&past_due={Past Due?}&aging_period={Aging Period?}&columns={Columns?}"
+      "suffix": "/reports/AgedPayableDetail?shipvia={Ship Via?}&term={Term?}&start_duedate={End Due Date?:YYYY-MM-DD}&end_duedate={End Due Date?:YYYY-MM-DD}&accounting_method={Accounting Method?:Cash|Accrual}&custom1={Custom 1?}&custom2={Custom 2?}&custom3={Custom 3?}&report_date={Report Date?:YYYY-MM-DD}&num_periods={Number of Periods?}&vendor={Vendor?}&past_due={Past Due?}&aging_period={Aging Period?}&columns={Columns?}",
+      "description": "The same expanded to individual open bills."
     },
     {
       "name": "AP Aging Summary",
-      "suffix": "/reports/AgedPayables?customer={Customer?}&qzurl={Quick Zoom URL?:true|false}&vendor={Vendor?}&date_macro={Date Macro?}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&department={Department?}&report_date={Report Date?:YYYY-MM-DD}&sort_order={Sort Order?:ascend|descend}&aging_method={Aging Method?:Report_Date|Current}"
+      "suffix": "/reports/AgedPayables?customer={Customer?}&qzurl={Quick Zoom URL?:true|false}&vendor={Vendor?}&date_macro={Date Macro?}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&department={Department?}&report_date={Report Date?:YYYY-MM-DD}&sort_order={Sort Order?:ascend|descend}&aging_method={Aging Method?:Report_Date|Current}",
+      "description": "What the business owes suppliers, bucketed by age. The payables mirror."
     },
     {
       "name": "AR Aging Detail",
-      "suffix": "/reports/AgedReceivableDetail?customer={Customer?}&shipvia={Ship Via?}&term={Term?}&start_duedate={End Due Date?:YYYY-MM-DD}&end_duedate={End Due Date?:YYYY-MM-DD}&custom1={Custom 1?}&custom2={Custom 2?}&custom3={Custom 3?}&report_date={Report Date?:YYYY-MM-DD}&num_periods={Number of Periods?}&past_due={Past Due?}&aging_period={Aging Period?}&columns={Columns?}"
+      "suffix": "/reports/AgedReceivableDetail?customer={Customer?}&shipvia={Ship Via?}&term={Term?}&start_duedate={End Due Date?:YYYY-MM-DD}&end_duedate={End Due Date?:YYYY-MM-DD}&custom1={Custom 1?}&custom2={Custom 2?}&custom3={Custom 3?}&report_date={Report Date?:YYYY-MM-DD}&num_periods={Number of Periods?}&past_due={Past Due?}&aging_period={Aging Period?}&columns={Columns?}",
+      "description": "The same ageing expanded to the individual open invoices behind each bucket."
     },
     {
       "name": "AR Aging Summary",
-      "suffix": "/reports/AgedReceivables?customer={Customer?}&qzurl={Quick Zoom URL?:true|false}&vendor={Vendor?}&date_macro={Date Macro?}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&department={Department?}&report_date={Report Date?:YYYY-MM-DD}&sort_order={Sort Order?:ascend|descend}&aging_method={Aging Method?:Report_Date|Current}"
+      "suffix": "/reports/AgedReceivables?customer={Customer?}&qzurl={Quick Zoom URL?:true|false}&vendor={Vendor?}&date_macro={Date Macro?}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&department={Department?}&report_date={Report Date?:YYYY-MM-DD}&sort_order={Sort Order?:ascend|descend}&aging_method={Aging Method?:Report_Date|Current}",
+      "description": "What customers owe, bucketed by how overdue. The collections table: a single receivables total says nothing about whether it is collectable, and the ageing buckets are what distinguish slow payment from bad debt."
     },
     {
       "name": "Balance Sheet",
-      "suffix": "/reports/BalanceSheet?customer={Customer?}&qzurl={Quick Zoom URL?:true|false}&accounting_method={Accounting Method?:Cash|Accrual}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&adjusted_gain_loss={Adjusted Gain Loss?:true|false}&class={Class?}&item={Item?}&sort_order={Sort Order?:ascend|descend}&summarize_column_by={Summarize Column By?}&department={Department?}&vendor={Vendor?}"
+      "suffix": "/reports/BalanceSheet?customer={Customer?}&qzurl={Quick Zoom URL?:true|false}&accounting_method={Accounting Method?:Cash|Accrual}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&adjusted_gain_loss={Adjusted Gain Loss?:true|false}&class={Class?}&item={Item?}&sort_order={Sort Order?:ascend|descend}&summarize_column_by={Summarize Column By?}&department={Department?}&vendor={Vendor?}",
+      "description": "Assets, liabilities and equity as at a date. A point-in-time statement rather than a range, so it cannot be filtered the way profit and loss is. Same nested Rows shape and accounting-method dependence."
     },
     {
       "name": "Cash Flow",
-      "suffix": "/reports/CashFlow?customer={Customer?}&vendor={Vendor?}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&class={Class?}&item={Item?}&sort_order={Sort Order?:ascend|descend}&summarize_column_by={Summarize Column By?}&department={Department?}"
+      "suffix": "/reports/CashFlow?customer={Customer?}&vendor={Vendor?}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&class={Class?}&item={Item?}&sort_order={Sort Order?:ascend|descend}&summarize_column_by={Summarize Column By?}&department={Department?}",
+      "description": "Cash movement for a date range, split into operating, investing and financing. Distinct from profit and loss on an accrual basis: profit and cash differ by exactly the working-capital movements this report shows, which is why a profitable business can run out of money."
     },
     {
       "name": "Customer Balance",
-      "suffix": "/reports/CustomerBalance?customer={Customer?}&accounting_method={Accounting Method?}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&arpaid={AR Paid?:All|Paid|Unpaid}&report_date={Report Date?:YYYY-MM-DD}&sort_order={Sort Order?:ascend|descend}&summarize_column_by={Summarize Column By?}&department={Department?}"
+      "suffix": "/reports/CustomerBalance?customer={Customer?}&accounting_method={Accounting Method?}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&arpaid={AR Paid?:All|Paid|Unpaid}&report_date={Report Date?:YYYY-MM-DD}&sort_order={Sort Order?:ascend|descend}&summarize_column_by={Summarize Column By?}&department={Department?}",
+      "description": "The outstanding balance per customer. Simpler than the AR ageing where only the amount matters and not its age."
     },
     {
       "name": "Customer Balance Detail",
-      "suffix": "/reports/CustomerBalanceDetail?customer={Customer?}&shipvia={Ship Via?}&term={Term?}&start_duedate={Start Due Date?:YYYY-MM-DD}&end_duedate={End Due Date?:YYYY-MM-DD}&custom1={Custom 1?}&sort_by={Sort By?}&arpaid={AR Paid?:All|Paid|Unpaid}&report_date={Report Date?:YYYY-MM-DD}&sort_order={Sort Order?:ascend|descend}&aging_method={Aging Method?:Report_Date|Current}&department={Department?}&columns={Columns?}"
+      "suffix": "/reports/CustomerBalanceDetail?customer={Customer?}&shipvia={Ship Via?}&term={Term?}&start_duedate={Start Due Date?:YYYY-MM-DD}&end_duedate={End Due Date?:YYYY-MM-DD}&custom1={Custom 1?}&sort_by={Sort By?}&arpaid={AR Paid?:All|Paid|Unpaid}&report_date={Report Date?:YYYY-MM-DD}&sort_order={Sort Order?:ascend|descend}&aging_method={Aging Method?:Report_Date|Current}&department={Department?}&columns={Columns?}",
+      "description": "The open transactions making up each customer's balance."
     },
     {
       "name": "Customer Income",
-      "suffix": "/reports/CustomerIncome?customer={Customer?}&term={Term?}&accounting_method={Accounting Method?:Cash|Accrual}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&class={Class?}&sort_order={Sort Order?:ascend|descend}&summarize_column_by={Summarize Column By?}&department={Department}&vendor={Vendor?}"
+      "suffix": "/reports/CustomerIncome?customer={Customer?}&term={Term?}&accounting_method={Accounting Method?:Cash|Accrual}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&class={Class?}&sort_order={Sort Order?:ascend|descend}&summarize_column_by={Summarize Column By?}&department={Department}&vendor={Vendor?}",
+      "description": "Income and expenses per customer over a range, giving profitability rather than revenue. The difference matters wherever costs are attributed to customers: a large customer is not necessarily a profitable one."
     },
     {
       "name": "General Ledger",
-      "suffix": "/reports/GeneralLedger?customer={Customer?}&account={Account?}&accounting_method={Accounting Method?:Cash|Accrual}&source_account={Source Account?}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&account_type={Account Type?}&sort_by={Sort By?}&sort_order={Sort Order?:ascend|descend?}&summarize_column_by={Summarize Column By?}&department={Department}&vendor={Vendor?}&class={Class?}&columns={Columns?}"
+      "suffix": "/reports/GeneralLedger?customer={Customer?}&account={Account?}&accounting_method={Accounting Method?:Cash|Accrual}&source_account={Source Account?}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&account_type={Account Type?}&sort_by={Sort By?}&sort_order={Sort Order?:ascend|descend?}&summarize_column_by={Summarize Column By?}&department={Department}&vendor={Vendor?}&class={Class?}&columns={Columns?}",
+      "description": "Every posted transaction line by account for a date range, with running balances. The complete underlying record; large, and the source everything else here summarises."
     },
     {
       "name": "Inventory Valuation Summary",
-      "suffix": "/reports/InventoryValuationSummary?qzurl={Quick Zoom URL?:true|false}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&item={Item?}&report_date={Report Date?:YYYY-MM-DD}&sort_order={Sort Order?:ascend|descend}&summarize_column_by={Summarize Column By?}"
+      "suffix": "/reports/InventoryValuationSummary?qzurl={Quick Zoom URL?:true|false}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&item={Item?}&report_date={Report Date?:YYYY-MM-DD}&sort_order={Sort Order?:ascend|descend}&summarize_column_by={Summarize Column By?}",
+      "description": "Quantity on hand, asset value and average cost per inventory item. The link between physical stock and the balance sheet."
     },
     {
       "name": "Journal Report",
-      "suffix": "/reports/JournalReport?start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&sort_by={Sort By?}&sort_order={Sort Order?:ascend|descend?}&columns={Columns?}"
+      "suffix": "/reports/JournalReport?start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&sort_by={Sort By?}&sort_order={Sort Order?:ascend|descend?}&columns={Columns?}",
+      "description": "Every transaction in journal form for a date range, showing both sides of each entry. The double-entry view, useful for auditing rather than reporting."
     },
     {
       "name": "Profit And Loss",
-      "suffix": "/reports/ProfitAndLoss?customer={Customer?}&qzurl={Quick Zoom URL?:true|false}&accounting_method={Accounting Method?:Cash|Accrual}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&adjusted_gain_loss={Adjusted Gain Loss?:true|false}&class={Class?}&item={Item?}&sort_order={Sort Order?:ascend|descend}&summarize_column_by={Summarize Column By?}&department={Department?}&vendor={Vendor?}&"
+      "suffix": "/reports/ProfitAndLoss?customer={Customer?}&qzurl={Quick Zoom URL?:true|false}&accounting_method={Accounting Method?:Cash|Accrual}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&adjusted_gain_loss={Adjusted Gain Loss?:true|false}&class={Class?}&item={Item?}&sort_order={Sort Order?:ascend|descend}&summarize_column_by={Summarize Column By?}&department={Department?}&vendor={Vendor?}&",
+      "description": "The profit and loss statement for a date range, with income, cost of goods, expenses and net income. THE SHAPE APPLIES TO EVERY REPORT IN THIS CONNECTOR: QuickBooks returns a nested Rows structure of sections, header rows, data rows and summary rows -- not a flat row set -- with a separate Columns block naming what each cell means. It must be flattened before use, and the section a row sits in is what gives it meaning. Note also that ACCOUNTING METHOD is a parameter, not a property of the data: the same period returns different numbers on a cash basis than on an accrual basis, so the method has to be stated for a figure to mean anything."
     },
     {
       "name": "Profit And Loss Detail",
-      "suffix": "/reports/ProfitAndLossDetail?customer={Customer?}&account={Account?}&accounting_method={Accounting Method?:Cash|Accrual}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&adjusted_gain_loss={Adjusted Gain Loss?:true|false}&class={Class?}&item={Item?}&sort_by={Sort By?}&payment_method={Payment Method?}&sort_order={Sort Order?:ascend|descend}&employee={Employee?}&department={Department?}&vendor={Vendor?}&account_type={Account Type?}&columns={Columns?}"
+      "suffix": "/reports/ProfitAndLossDetail?customer={Customer?}&account={Account?}&accounting_method={Accounting Method?:Cash|Accrual}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&adjusted_gain_loss={Adjusted Gain Loss?:true|false}&class={Class?}&item={Item?}&sort_by={Sort By?}&payment_method={Payment Method?}&sort_order={Sort Order?:ascend|descend}&employee={Employee?}&department={Department?}&vendor={Vendor?}&account_type={Account Type?}&columns={Columns?}",
+      "description": "The same statement expanded to the individual transactions behind each account. Much larger, and the route from a total to the entries that produced it."
     },
     {
       "name": "Sales By Class Summary",
-      "suffix": "/reports/ClassSales?customer={Customer?}&accounting_method={Accounting Method?:Cash|Accrual}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&class={Class?}&item={Item?}&summarize_column_by={Summarize Column By?}&department={Department?}"
+      "suffix": "/reports/ClassSales?customer={Customer?}&accounting_method={Accounting Method?:Cash|Accrual}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&class={Class?}&item={Item?}&summarize_column_by={Summarize Column By?}&department={Department?}",
+      "description": "Sales by CLASS -- QuickBooks's user-defined dimension for departments, locations, funds or whatever the business chose. Account-specific and often the only analytical axis beyond account and customer, so whether it is in use decides whether that kind of question is answerable at all."
     },
     {
       "name": "Sales By Customer",
-      "suffix": "/reports/CustomerSales?customer={Customer?}&qzurl={Quick Zoom URL?:true|false}&accounting_method={Accounting Method?:Cash|Accrual}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&class={Class?}&item={Item?}&sort_order={Sort Order?:ascend|descend}&summarize_column_by={Summarize Column By?}&department={Department?}"
+      "suffix": "/reports/CustomerSales?customer={Customer?}&qzurl={Quick Zoom URL?:true|false}&accounting_method={Accounting Method?:Cash|Accrual}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&class={Class?}&item={Item?}&sort_order={Sort Order?:ascend|descend}&summarize_column_by={Summarize Column By?}&department={Department?}",
+      "description": "Sales totals per customer over a date range. The revenue-concentration view -- and the answer to how dependent the business is on a few accounts."
     },
     {
       "name": "Sales By Department",
-      "suffix": "/reports/DepartmentSales?customer={Customer?}&accounting_method={Accounting Method?:Cash|Accrual}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&class={Class?}&item={Item?}&sort_order={Sort Order?:ascend|descend}&summarize_column_by={Summarize Column By?}&department={Department?}"
+      "suffix": "/reports/DepartmentSales?customer={Customer?}&accounting_method={Accounting Method?:Cash|Accrual}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&class={Class?}&item={Item?}&sort_order={Sort Order?:ascend|descend}&summarize_column_by={Summarize Column By?}&department={Department?}",
+      "description": "Sales by location or department, where the account uses that dimension."
     },
     {
       "name": "Sales By Product",
-      "suffix": "/reports/ItemSales?customer={Customer?}&start_duedate={Start Due Date?:YYYY-MM-DD}&end_duedate={End Due Date?:YYYY-MM-DD}&accounting_method={Accounting Method?:Cash|Accrual}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&class={Class?}&item={Item?}&sort_order={Sort Order?:ascend|descend}&summarize_column_by={Summarize Column By?}&department={Department?}"
+      "suffix": "/reports/ItemSales?customer={Customer?}&start_duedate={Start Due Date?:YYYY-MM-DD}&end_duedate={End Due Date?:YYYY-MM-DD}&accounting_method={Accounting Method?:Cash|Accrual}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&class={Class?}&item={Item?}&sort_order={Sort Order?:ascend|descend}&summarize_column_by={Summarize Column By?}&department={Department?}",
+      "description": "Sales by product or service item over a range, with quantity and amount. The product-mix view."
     },
     {
       "name": "Tax Summary",
-      "suffix": "/reports/TaxSummary?agency_id={Agency ID:1|2}&accounting_method={Accounting Method?:Cash|Accrual}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&sort_order={Sort Order?:ascend|descend}"
+      "suffix": "/reports/TaxSummary?agency_id={Agency ID:1|2}&accounting_method={Accounting Method?:Cash|Accrual}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&sort_order={Sort Order?:ascend|descend}",
+      "description": "Taxable and non-taxable sales with the tax collected, by agency. Requires an agency id. The basis for a tax return."
     },
     {
       "name": "Transaction List",
-      "suffix": "/reports/TransactionList?start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&payment_method={Payment Method?}&duedate_macro={Due Date Macro?}&arpaid={AR Paid?:All|Paid|Unpaid}&bothamount={Both Amount?}&transaction_type={Transaction Type?}&docnum={DocNum?}&start_moddate={Start ModDate?:YYYY-MM-DD}&end_moddate={End ModDate?:YYYY-MM-DD}&source_account_type={Source Account Type?}&group_by={Group By?}&department={Department?}&start_duedate={Start Due Date?:YYYY-MM-DD}&end_duedate={End Due Date?:YYYY-MM-DD}&columns={Columns?}&vendor={Vendor?}&memo={Memo?}&appaid={AP Paid?:Paid|Unpaid|All}&moddate_macro={ModDate Macro?}&printed={Printed?}&start_createdate={Start Create Date?:YYYY-MM-DD}&end_createdate={End Create Date?:YYYY-MM-DD}&createdate_macro={Create Date Macro?}&cleared={Cleared?}&customer={Customer?}&qzurl={Quick Zoom URL?:true|false}&term={Term?}&name={Name?}&sort_order={Sort Order?:ascend|descend}"
+      "suffix": "/reports/TransactionList?start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&payment_method={Payment Method?}&duedate_macro={Due Date Macro?}&arpaid={AR Paid?:All|Paid|Unpaid}&bothamount={Both Amount?}&transaction_type={Transaction Type?}&docnum={DocNum?}&start_moddate={Start ModDate?:YYYY-MM-DD}&end_moddate={End ModDate?:YYYY-MM-DD}&source_account_type={Source Account Type?}&group_by={Group By?}&department={Department?}&start_duedate={Start Due Date?:YYYY-MM-DD}&end_duedate={End Due Date?:YYYY-MM-DD}&columns={Columns?}&vendor={Vendor?}&memo={Memo?}&appaid={AP Paid?:Paid|Unpaid|All}&moddate_macro={ModDate Macro?}&printed={Printed?}&start_createdate={Start Create Date?:YYYY-MM-DD}&end_createdate={End Create Date?:YYYY-MM-DD}&createdate_macro={Create Date Macro?}&cleared={Cleared?}&customer={Customer?}&qzurl={Quick Zoom URL?:true|false}&term={Term?}&name={Name?}&sort_order={Sort Order?:ascend|descend}",
+      "description": "Every transaction over a date range, with date, type, number, name, account and amount. The flattest table in this connector and the closest thing to a raw transaction feed."
     },
     {
       "name": "Transaction List By Customer",
-      "suffix": "/reports/TransactionListByCustomer?start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&payment_method={Payment Method?}&duedate_macro={Due Date Macro?}&start_duedate={Start Due Date?:YYYY-MM-DD}&end_duedate={End Due Date?:YYYY-MM-DD}&arpaid={AR Paid?:All|Paid|Unpaid}&bothamount={Both Amount?}&transaction_type={Transaction Type?}&docnum={DocNum?}&start_moddate={Start ModDate?:YYYY-MM-DD}&source_account_type={Source Account Type?}&group_by={Group By?}&department={Department?}&columns={Columns?}&memo={Memo?}&appaid={AP Paid?:Paid|Unpaid|All}&moddate_macro={ModDate Macro?}&printed={Printed?}&createdate_macro={Create Date Macro?}&cleared={Cleared?}&qzurl={Quick Zoom URL?:true|false}&term={Term?}&end_createdate={End Create Date?:YYYY-MM-DD}&name={Name?}&sort_by={Sort By?}&sort_order={Sort Order?:ascend|descend}&start_createdate={Start Create Date?:YYYY-MM-DD}&end_moddate={End ModDate?:YYYY-MM-DD}"
+      "suffix": "/reports/TransactionListByCustomer?start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&payment_method={Payment Method?}&duedate_macro={Due Date Macro?}&start_duedate={Start Due Date?:YYYY-MM-DD}&end_duedate={End Due Date?:YYYY-MM-DD}&arpaid={AR Paid?:All|Paid|Unpaid}&bothamount={Both Amount?}&transaction_type={Transaction Type?}&docnum={DocNum?}&start_moddate={Start ModDate?:YYYY-MM-DD}&source_account_type={Source Account Type?}&group_by={Group By?}&department={Department?}&columns={Columns?}&memo={Memo?}&appaid={AP Paid?:Paid|Unpaid|All}&moddate_macro={ModDate Macro?}&printed={Printed?}&createdate_macro={Create Date Macro?}&cleared={Cleared?}&qzurl={Quick Zoom URL?:true|false}&term={Term?}&end_createdate={End Create Date?:YYYY-MM-DD}&name={Name?}&sort_by={Sort By?}&sort_order={Sort Order?:ascend|descend}&start_createdate={Start Create Date?:YYYY-MM-DD}&end_moddate={End ModDate?:YYYY-MM-DD}",
+      "description": "The same list grouped by customer."
     },
     {
       "name": "Transaction List By Vendor",
-      "suffix": "/reports/TransactionListByVendor?date_macro={Date Macro?}&payment_method={Payment Method?}&duedate_macro={Due Date Macro?}&arpaid={AR Paid?:All|Paid|Unpaid}&bothamount={Both Amount?}&transaction_type={Transaction Type?}&docnum={DocNum?}start_moddate={Start ModDate?}&source_account_type={Source Account Type?}&group_by={Group By?}&start_date={Start Date?}&department={Department?}&start_duedate={Start Due Date?:YYYY-MM-DD}&columns={Columns?}&end_duedate={End Due Date?:YYYY-MM-DD}&vendor={Vendor?}&end_date={End Date?:YYYY-MM-DD}&memo={Memo?}&appaid={AP Paid?:Paid|Unpaid|All}&moddate_macro={ModDate Macro?}&printed={Printed?}&createdate_macro={Create Date Macro?}&cleared={Cleared?}&qzurl={Quick Zoom URL?:true|false}&term={Term?}&end_createdate={End Create Date?:YYYY-MM-DD}&name={Name?}&sort_by={Sort By?}&sort_order={Sort Order?:ascend|descend}&start_createdate={Start Create Date?:YYYY-MM-DD}&end_moddate={End ModDate?:YYYY-MM-DD}"
+      "suffix": "/reports/TransactionListByVendor?date_macro={Date Macro?}&payment_method={Payment Method?}&duedate_macro={Due Date Macro?}&arpaid={AR Paid?:All|Paid|Unpaid}&bothamount={Both Amount?}&transaction_type={Transaction Type?}&docnum={DocNum?}start_moddate={Start ModDate?}&source_account_type={Source Account Type?}&group_by={Group By?}&start_date={Start Date?}&department={Department?}&start_duedate={Start Due Date?:YYYY-MM-DD}&columns={Columns?}&end_duedate={End Due Date?:YYYY-MM-DD}&vendor={Vendor?}&end_date={End Date?:YYYY-MM-DD}&memo={Memo?}&appaid={AP Paid?:Paid|Unpaid|All}&moddate_macro={ModDate Macro?}&printed={Printed?}&createdate_macro={Create Date Macro?}&cleared={Cleared?}&qzurl={Quick Zoom URL?:true|false}&term={Term?}&end_createdate={End Create Date?:YYYY-MM-DD}&name={Name?}&sort_by={Sort By?}&sort_order={Sort Order?:ascend|descend}&start_createdate={Start Create Date?:YYYY-MM-DD}&end_moddate={End ModDate?:YYYY-MM-DD}",
+      "description": "The same list grouped by supplier."
     },
     {
       "name": "Trial Balance",
-      "suffix": "/reports/TrialBalance?accounting_method={Accounting Method?:Cash|Accrual}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&sort_order={Sort Order?:ascend|descend}&summarize_column_by={Summarize Column By?}&start_date={Start Date?:YYYY-MM-DD}"
+      "suffix": "/reports/TrialBalance?accounting_method={Accounting Method?:Cash|Accrual}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&sort_order={Sort Order?:ascend|descend}&summarize_column_by={Summarize Column By?}&start_date={Start Date?:YYYY-MM-DD}",
+      "description": "Every account with its debit and credit totals as at a date. The most tabular of these reports -- account level rather than section level -- which makes it the easiest to work with directly and the natural bridge to the ledger."
     },
     {
       "name": "Vendor Balance",
-      "suffix": "/reports/VendorBalance?qzurl={Quick Zoom URL?:true|false}&accounting_method={Accounting Method?:Cash|Accrual}&date_macro={Date Macro?}&appaid={AP Paid?:Paid|Unpaid|All}&report_date={Report Date?:YYYY-MM-DD}&sort_order={Sort Order?:ascend|descend}&summarize_column_by={Summarize Column By?}&department={Department?}&vendor={Vendor?}"
+      "suffix": "/reports/VendorBalance?qzurl={Quick Zoom URL?:true|false}&accounting_method={Accounting Method?:Cash|Accrual}&date_macro={Date Macro?}&appaid={AP Paid?:Paid|Unpaid|All}&report_date={Report Date?:YYYY-MM-DD}&sort_order={Sort Order?:ascend|descend}&summarize_column_by={Summarize Column By?}&department={Department?}&vendor={Vendor?}",
+      "description": "The outstanding balance per supplier."
     },
     {
       "name": "Vendor Balance Detail",
-      "suffix": "/reports/VendorBalanceDetail?term={Term?}&end_duedate={End Due Date?:YYYY-MM-DD}&accounting_method={Accounting Method?:Cash|Accrual}&date_macro={Date Macro?}&start_duedate={Start Due Date?:YYYY-MM-DD}&duedate_macro={Due Date Macro?}&sort_by={Sort By?}&report_date={Report Date?:YYYY-MM-DD}&sort_order={Sort Order?:ascend|descend}&appaid={AP Paid?:Paid|Unpaid|All}&department={Department?}&vendor={Vendor?}&columns={Columns?}"
+      "suffix": "/reports/VendorBalanceDetail?term={Term?}&end_duedate={End Due Date?:YYYY-MM-DD}&accounting_method={Accounting Method?:Cash|Accrual}&date_macro={Date Macro?}&start_duedate={Start Due Date?:YYYY-MM-DD}&duedate_macro={Due Date Macro?}&sort_by={Sort By?}&report_date={Report Date?:YYYY-MM-DD}&sort_order={Sort Order?:ascend|descend}&appaid={AP Paid?:Paid|Unpaid|All}&department={Department?}&vendor={Vendor?}&columns={Columns?}",
+      "description": "The open bills making up each supplier's balance."
     },
     {
       "name": "Vendor Expenses",
-      "suffix": "/reports/VendorExpenses?customer={Customer?}&vendor={Vendor?}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&class={Class?}&sort_order={Sort Order?:ascend|descend}&summarize_column_by={Summarize Column By?}&department={Department?}&accounting_method={Accounting Method?:Cash|Accrual}&start_date={Start Date?:YYYY-MM-DD}"
+      "suffix": "/reports/VendorExpenses?customer={Customer?}&vendor={Vendor?}&end_date={End Date?:YYYY-MM-DD}&date_macro={Date Macro?}&class={Class?}&sort_order={Sort Order?:ascend|descend}&summarize_column_by={Summarize Column By?}&department={Department?}&accounting_method={Accounting Method?:Cash|Accrual}&start_date={Start Date?:YYYY-MM-DD}",
+      "description": "Spend per supplier over a range. The purchasing concentration view."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/remedyforce/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/remedyforce/endpoints.json
@@ -1,64 +1,76 @@
 {
-    "endpoints": [
-        {
-            "name": "Version",
-            "paged": false,
-            "suffix": "/1.0/ServiceUtil/Version"
-        },
-        {
-            "name": "User Detail",
-            "paged": false,
-            "suffix": "/1.0/ServiceUtil/UserDetail"
-        },
-        {
-            "name": "Categories",
-            "paged": false,
-            "suffix": "/1.0/Category"
-        },
-        {
-            "name": "Queues",
-            "paged": false,
-            "suffix": "/1.0/Queue/{Object Name}"
-        },
-        {
-            "name": "Queue",
-            "paged": false,
-            "suffix": "/1.0/Queue/{Record ID}"
-        },
-        {
-            "name": "Knowledge Articles",
-            "paged": false,
-            "suffix": "/1.0/KnowledgeArticle"
-        },
-        {
-            "name": "Knowledge Article",
-            "paged": false,
-            "suffix": "/1.0/KnowledgeArticle/{Article ID}"
-        },
-        {
-            "name": "Service Requests",
-            "paged": false,
-            "suffix": "/1.0/ServiceRequest?query={Query?}&date={Date?:Unix Timestamp}&batchSize={Batch Size?}"
-        },
-        {
-            "name": "Service Request",
-            "paged": false,
-            "suffix": "/1.0/ServiceRequest/{Request ID}"
-        },
-        {
-            "name": "Pending Approval Request",
-            "paged": false,
-            "suffix": "/1.0/Approval"
-        },
-        {
-            "name": "CMDB Parent and Child Class Attributes",
-            "paged": false,
-            "suffix": "/1.0/cmdb/getClassAttributes/{Class Name}/all"
-        },
-        {
-            "name": "CMDB Class Attributes",
-            "paged": false,
-            "suffix": "/1.0/cmdb/getClassAttributes/{Class Name}/specific"
-        }
-    ]
+  "endpoints": [
+    {
+      "name": "Version",
+      "paged": false,
+      "suffix": "/1.0/ServiceUtil/Version",
+      "description": "The Remedyforce API version installed. One record; available fields and behaviour vary by release."
+    },
+    {
+      "name": "User Detail",
+      "paged": false,
+      "suffix": "/1.0/ServiceUtil/UserDetail",
+      "description": "The account the credentials belong to, with its Salesforce user record and permissions. Worth reading first, since Salesforce sharing rules filter nearly everything here and two users legitimately see different rows."
+    },
+    {
+      "name": "Categories",
+      "paged": false,
+      "suffix": "/1.0/Category",
+      "description": "The service request categories configured, which classify incoming requests. The dimension request volume is broken down by, and account-specific rather than standard."
+    },
+    {
+      "name": "Queues",
+      "paged": false,
+      "suffix": "/1.0/Queue/{Object Name}",
+      "description": "The queues defined for a named object, each with its name and id. Requires an object name. Queues are how work is routed to teams in Salesforce, so this is the assignment dimension."
+    },
+    {
+      "name": "Queue",
+      "paged": false,
+      "suffix": "/1.0/Queue/{Record ID}",
+      "description": "One queue by record id."
+    },
+    {
+      "name": "Knowledge Articles",
+      "paged": false,
+      "suffix": "/1.0/KnowledgeArticle",
+      "description": "The knowledge base articles, with title, summary and status. The self-service content alongside the ticket data."
+    },
+    {
+      "name": "Knowledge Article",
+      "paged": false,
+      "suffix": "/1.0/KnowledgeArticle/{Article ID}",
+      "description": "One knowledge article by id, with its body."
+    },
+    {
+      "name": "Service Requests",
+      "paged": false,
+      "suffix": "/1.0/ServiceRequest?query={Query?}&date={Date?:Unix Timestamp}&batchSize={Batch Size?}",
+      "description": "The service requests raised, with their fields as configured on the Salesforce object behind them. Takes an optional query, a date for incremental retrieval, and a batch size. THE MAIN DATA TABLE. Remedyforce runs on Salesforce, so the available fields are whatever the org's administrator configured -- nothing about the schema is fixed, and the query parameter takes Salesforce-style criteria. The date parameter is the incremental hook: it returns what changed after a timestamp, which is how a downstream copy is kept current."
+    },
+    {
+      "name": "Service Request",
+      "paged": false,
+      "suffix": "/1.0/ServiceRequest/{Request ID}",
+      "description": "One service request by id, with its full field set."
+    },
+    {
+      "name": "Pending Approval Request",
+      "paged": false,
+      "suffix": "/1.0/Approval",
+      "description": "The approval requests awaiting action. Approval steps sit outside the request record itself, so a request stalled awaiting sign-off shows here and not in its own status."
+    },
+    {
+      "name": "CMDB Parent and Child Class Attributes",
+      "paged": false,
+      "suffix": "/1.0/cmdb/getClassAttributes/{Class Name}/all",
+      "description": "The attributes of one class INCLUDING those inherited from its parent classes. Requires a class name. CMDB classes form an inheritance hierarchy, so the specific-only list is usually short and misleading; this is the complete set an instance of the class actually carries."
+    },
+    {
+      "name": "CMDB Class Attributes",
+      "paged": false,
+      "suffix": "/1.0/cmdb/getClassAttributes/{Class Name}/specific",
+      "description": "The attributes defined on ONE configuration item class, without inherited ones. Requires a class name. The CMDB is where infrastructure and assets are modelled, and its classes are account-specific -- so this is the schema lookup that makes CMDB data readable."
+    }
+  ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/seomonitor/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/seomonitor/endpoints.json
@@ -3,97 +3,116 @@
     {
       "pageType": 1,
       "name": "Competitor Keywords",
-      "suffix": "/v1/compare/keywords/{Site ID}/{Start Date}/{End Date}/{Competitors}"
+      "suffix": "/v1/compare/keywords/{Site ID}/{Start Date}/{End Date}/{Competitors}",
+      "description": "The keywords named competitors rank for alongside the site, over a range. Requires the site, dates and competitors. Where a competitive gap is actually located, keyword by keyword."
     },
     {
       "pageType": 1,
       "name": "Group Competitor Keywords",
-      "suffix": "/v1/compare/keywords/{Site ID}/{Start Date}/{End_date}/{Competitors}/{Group ID}"
+      "suffix": "/v1/compare/keywords/{Site ID}/{Start Date}/{End_date}/{Competitors}/{Group ID}",
+      "description": "The same competitor keyword comparison within one group."
     },
     {
       "pageType": 0,
       "name": "Competitor Visibility Score",
-      "suffix": "/v1/compare/competitors/visibility_score/{Site ID}/{Start Date}/{End Date}?group_id={Group ID?}&competitors={Competitors?}&device={Device?:1|2}"
+      "suffix": "/v1/compare/competitors/visibility_score/{Site ID}/{Start Date}/{End Date}?group_id={Group ID?}&competitors={Competitors?}&device={Device?:1|2}",
+      "description": "The same visibility measure for named competitors alongside the site, over a range. Requires the site, dates and competitor domains. The comparative view: a site's own score falling while competitors rise means something different from everyone falling together."
     },
     {
       "pageType": 0,
       "name": "Group Competitor Visibility Score",
-      "suffix": "/v1/compare/competitors/visibility_score/{Site ID}/{Start Date}/{End Date}/{Competitors}/{Group ID?}?device={Device?:1|2}"
+      "suffix": "/v1/compare/competitors/visibility_score/{Site ID}/{Start Date}/{End Date}/{Competitors}/{Group ID?}?device={Device?:1|2}",
+      "description": "The competitor comparison restricted to one keyword group. Useful where a competitor is strong in one product area and absent elsewhere, which the site-wide score averages away."
     },
     {
       "pageType": 2,
       "name": "Content Performance",
-      "suffix": "/v1/content/{Site ID}/{Start Date}/{End Date}"
+      "suffix": "/v1/content/{Site ID}/{Start Date}/{End Date}",
+      "description": "Per-page performance over a range: the traffic, rankings and keywords each page attracts. Requires the site id and dates. The page-centric view, as opposed to the keyword-centric one everything else here offers."
     },
     {
       "pageType": 0,
       "name": "Devices",
-      "suffix": "/v1/devices"
+      "suffix": "/v1/devices",
+      "description": "The devices rankings are tracked for -- desktop and mobile. Small reference list, but not incidental: RANKINGS DIFFER BETWEEN DEVICES, often substantially, so any position figure is device-specific and comparing across them without saying which is meaningless."
     },
     {
       "pageType": 0,
       "name": "Forecast",
-      "suffix": "/v1/on_target/{Site ID}"
+      "suffix": "/v1/on_target/{Site ID}",
+      "description": "SeoMonitor's projection of where a site's rankings and traffic are heading against its targets. Requires a site id. Modelled rather than measured -- useful as a target, not as evidence."
     },
     {
       "pageType": 0,
       "name": "Forecast by Date",
-      "suffix": "/v1/on_target/by_dates/{Site ID}"
+      "suffix": "/v1/on_target/by_dates/{Site ID}",
+      "description": "The same projection broken out by date rather than as a summary."
     },
     {
       "pageType": 0,
       "name": "Groups",
-      "suffix": "/v1/groups_list/{Site ID}"
+      "suffix": "/v1/groups_list/{Site ID}",
+      "description": "The keyword groups defined for one site. Requires a site id. Groups are how an account divides its keywords -- by product, by intent, by funnel stage -- and are the only dimension available for slicing rankings beyond individual keywords. What they mean is entirely account-specific."
     },
     {
       "pageType": 0,
       "name": "Group Details",
-      "suffix": "/v1/group_details/{Site ID}/{Group ID}/{Start Date}/{End Date}"
+      "suffix": "/v1/group_details/{Site ID}/{Group ID}/{Start Date}/{End Date}",
+      "description": "The performance of one keyword group over a date range: its keywords, their ranks and the group's aggregate figures. Requires the site id, group id and dates."
     },
     {
       "pageType": 0,
       "name": "All Group Details",
-      "suffix": "/v1/all_group_details/{Site ID}/{Start Date}/{End Date}"
+      "suffix": "/v1/all_group_details/{Site ID}/{Start Date}/{End Date}",
+      "description": "The same figures for every group of a site in one request. Requires the site id and dates. Far cheaper than looping groups, and the natural starting point for a whole-site breakdown."
     },
     {
       "pageType": 2,
       "name": "Keyword Data",
-      "suffix": "/v1/keyword_data/{Site ID}/{Start Date}/{End Date}?keyword_name={Keyword Name?}"
+      "suffix": "/v1/keyword_data/{Site ID}/{Start Date}/{End Date}?keyword_name={Keyword Name?}",
+      "description": "Per-keyword detail for one site over a range: search volume, difficulty, the tracked position and its movement. Requires the site id and dates. VOLUME IS THE MISSING HALF OF ANY RANK ANALYSIS -- a first position on a keyword nobody searches is worth less than a fifth on one they do, and rank alone cannot say which is which."
     },
     {
       "pageType": 2,
       "name": "Group Keyword Data",
-      "suffix": "/v1/keyword_data/{Site ID}/{Group ID}/{Start Date}/{End Date}?keyword_name={Keyword Name?}"
+      "suffix": "/v1/keyword_data/{Site ID}/{Group ID}/{Start Date}/{End Date}?keyword_name={Keyword Name?}",
+      "description": "The same per-keyword detail restricted to one group."
     },
     {
       "pageType": 0,
       "name": "Top Landing Pages",
-      "suffix": "/v1/keyword_serp/{Site ID}?keyword_name={Keyword Name}&mobile={Mobile?:0|1}&full_lp={Full URLs?:0|1}"
+      "suffix": "/v1/keyword_serp/{Site ID}?keyword_name={Keyword Name}&mobile={Mobile?:0|1}&full_lp={Full URLs?:0|1}",
+      "description": "The pages ranking for one keyword in the search results, with their positions. Requires the site id and keyword name. The link from a keyword to the page that actually earns it -- which matters because the page ranking is often not the one intended."
     },
     {
       "pageType": 0,
       "name": "Top Landing Pages by ID",
-      "suffix": "/v1/keyword_serp/{Site ID}/{Keyword ID}?mobile={Mobile?:0|1}&full_lp={Full URLs?:0|1}"
+      "suffix": "/v1/keyword_serp/{Site ID}/{Keyword ID}?mobile={Mobile?:0|1}&full_lp={Full URLs?:0|1}",
+      "description": "The same, addressed by keyword id rather than name. Safer where keyword text contains characters awkward in a URL."
     },
     {
       "pageType": 0,
       "name": "Organic Traffic Statistics",
-      "suffix": "/v1/organic_traffic/{Site ID}/{Start Date}/{End Date}"
+      "suffix": "/v1/organic_traffic/{Site ID}/{Start Date}/{End Date}",
+      "description": "Organic sessions for one site over a date range. Requires the site id and dates. The outcome measure rankings are a proxy for -- worth pairing, since positions can improve while traffic does not."
     },
     {
       "pageType": 0,
       "name": "Organic Traffic Statistics by Brand/Non-brand",
-      "suffix": "/v1/organic_traffic/split/{Site ID}/{Start Date}/{End Date}?type={Type?:brand|non-brand}"
+      "suffix": "/v1/organic_traffic/split/{Site ID}/{Start Date}/{End Date}?type={Type?:brand|non-brand}",
+      "description": "The same traffic SPLIT INTO BRANDED AND NON-BRANDED searches. Requires the site id and dates. The more honest measure of SEO effort: branded traffic follows marketing and word of mouth, non-branded is what optimisation actually won, and a total that mixes them credits SEO with demand it did not create."
     },
     {
       "pageType": 3,
       "name": "Ranks",
-      "suffix": "/v1/ranks/{Site ID}/{Start Date}/{End Date}"
+      "suffix": "/v1/ranks/{Site ID}/{Start Date}/{End Date}",
+      "description": "Keyword positions for one site over a date range -- the core SEO table. Requires the site id and dates. Note a keyword with no ranking in the top results returns a sentinel rather than a position, so averaging raw values without excluding those distorts the figure badly."
     },
     {
       "pageType": 3,
       "name": "Group Ranks",
-      "suffix": "/v1/ranks/{Site ID}/{Start Date}/{End Date}/{Group ID}"
+      "suffix": "/v1/ranks/{Site ID}/{Start Date}/{End Date}/{Group ID}",
+      "description": "The same rankings restricted to one keyword group. Requires the group id as well."
     },
     {
       "pageType": 0,
@@ -101,17 +120,23 @@
       "suffix": "/v1/sites",
       "lookups": [
         {
-          "endpoints": ["Forecast", "Forecast by Date", "Groups"],
+          "endpoints": [
+            "Forecast",
+            "Forecast by Date",
+            "Groups"
+          ],
           "jsonPath": "$.[*]",
           "key": "id",
           "parameterName": "Site ID"
         }
-      ]
+      ],
+      "description": "The sites tracked in the account, each with its id, domain and settings. Every other endpoint here needs a site id, so this is the first request."
     },
     {
       "pageType": 0,
       "name": "Visibility Score",
-      "suffix": "/v1/visibility_score_data/{Site ID}/{Group ID}/{Start Date}/{End Date}?device={Device?:1|2}"
+      "suffix": "/v1/visibility_score_data/{Site ID}/{Group ID}/{Start Date}/{End Date}?device={Device?:1|2}",
+      "description": "SeoMonitor's composite measure of how visible a site is for its tracked keywords, over a date range -- rankings weighted by search volume and expected click-through. Requires the site, group and dates. A single trend line where ranks are hundreds, and the usual answer to whether SEO is improving overall."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/sfreports/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/sfreports/endpoints.json
@@ -1,157 +1,178 @@
 {
-    "endpoints": [
+  "endpoints": [
+    {
+      "name": "Notifications",
+      "paged": false,
+      "suffix": "/@apiVersion@/analytics/notifications?source={Notification Type:lightningDashboardSubscribe|lightningReportSubscribe|waveNotification }&ownerId={Owner ID?}&recordId={Record ID?:reportId|lensId}",
+      "description": "The report and dashboard subscription notifications for the running user, with their source and state. Scoped to the caller."
+    },
+    {
+      "name": "Notification",
+      "paged": false,
+      "suffix": "/@apiVersion@/analytics/notifications/{Notification ID}",
+      "description": "One notification by id."
+    },
+    {
+      "name": "Notification Limits",
+      "paged": false,
+      "suffix": "/@apiVersion@/analytics/notifications/limits?source={Source:lightningDashboardSubscribe|lightningReportSubscribe|waveNotification}&recordId={Record ID?:reportId|lensId}",
+      "description": "How many report or dashboard notifications the user has configured against the allowed maximum. Explains why a new subscription cannot be created."
+    },
+    {
+      "name": "Dashboards",
+      "paged": false,
+      "suffix": "/@apiVersion@/analytics/dashboards",
+      "lookups": [
         {
-            "name": "Notifications",
-            "paged": false,
-            "suffix": "/@apiVersion@/analytics/notifications?source={Notification Type:lightningDashboardSubscribe|lightningReportSubscribe|waveNotification }&ownerId={Owner ID?}&recordId={Record ID?:reportId|lensId}"
-        },
-        {
-            "name": "Notification",
-            "paged": false,
-            "suffix": "/@apiVersion@/analytics/notifications/{Notification ID}"
-        },
-        {
-            "name": "Notification Limits",
-            "paged": false,
-            "suffix": "/@apiVersion@/analytics/notifications/limits?source={Source:lightningDashboardSubscribe|lightningReportSubscribe|waveNotification}&recordId={Record ID?:reportId|lensId}"
-        },
-        {
-            "name": "Dashboards",
-            "paged": false,
-            "suffix": "/@apiVersion@/analytics/dashboards",
-          "lookups": [
-            {
-              "endpoints": [
-                "Dashboard",
-                "Dashboard Metadata",
-                "Dashboard Status"
-              ],
-              "jsonPath": "$.[*]",
-              "key": "id",
-              "parameterName": "Dashboard ID"
-            }
-          ]
-        },
-        {
-            "name": "Dashboard",
-            "paged": false,
-            "suffix": "/@apiVersion@/analytics/dashboards/{Dashboard ID}?runningUser={Running User ID?}&filter1={Filter 1 ID?}&filter2={Filter 2 ID?}&filter3={Filter 3 ID?}"
-        },
-        {
-            "name": "Dashboard Metadata",
-            "paged": false,
-            "suffix": "/@apiVersion@/analytics/dashboards/{Dashboard ID}/describe?loadComponentProperties={Load Component Properties?:true|false}"
-        },
-        {
-            "name": "Dashboard Status",
-            "paged": false,
-            "suffix": "/@apiVersion@/analytics/dashboards/{Dashboard ID}/status?runningUser={Running User ID?}&filter1={Filter 1 ID?}&filter2={Filter 2 ID?}&filter3={Filter 3 ID?}"
-        },
-        {
-            "name": "Filter Operators",
-            "paged": false,
-            "suffix": "/@apiVersion@/analytics/filteroperators?forDashboards={For Dashboards?:true|false}"
-        },
-        {
-            "name": "Folders",
-            "paged": true,
-            "suffix": "/v43.0/folders/",
-          "lookups": [
-            {
-              "endpoints": [
-                "Folder",
-                "Folder Shares",
-                "Folder Children"
-              ],
-              "jsonPath": "$.folders[*]",
-              "key": "id",
-              "parameterName": "Folder ID"
-            }
-          ]
-        },
-        {
-            "name": "Folder",
-            "paged": false,
-            "suffix": "/v43.0/folders/{Folder ID}"
-        },
-        {
-            "name": "Folder Shares",
-            "paged": false,
-            "suffix": "/v41.0/folders/{Folder ID}/shares"
-        },
-        {
-            "name": "Folder Share",
-            "paged": false,
-            "suffix": "/v41.0/folders/{Folder ID}/shares/{Share ID}"
-        },
-        {
-            "name": "Folder Share Recipients",
-            "paged": false,
-            "suffix": "/v41.0/folders/{Folder ID}/share-recipients?shareType={shareType:user|group|role}&searchTerm={Search Term?}"
-        },
-        {
-            "name": "Folder Children",
-            "paged": true,
-            "suffix": "/v43.0/folders/{Folder ID}/children",
-          "lookups": [
-            {
-              "endpoints": [
-                "Folder",
-                "Folder Shares",
-                "Folder Children"
-              ],
-              "jsonPath": "$.folders[*]",
-              "key": "id",
-              "parameterName": "Folder ID"
-            }
-          ]
-        },
-        {
-            "name": "Reports",
-            "paged": false,
-            "suffix": "/@apiVersion@/analytics/reports",
-          "lookups": [
-            {
-              "endpoints": [
-                "Report Metadata",
-                "Execute Report",
-                "Report Instances"
-              ],
-              "jsonPath": "$.[*]",
-              "key": "id",
-              "parameterName": "Report ID"
-            }
-          ]
-        },
-        {
-            "name": "Report Metadata",
-            "paged": false,
-            "suffix": "/@apiVersion@/analytics/reports/{Report ID}/describe"
-        },
-        {
-            "name": "Execute Report",
-            "paged": false,
-            "suffix": "/@apiVersion@/analytics/reports/{Report ID}"
-        },
-        {
-            "name": "Report Instances",
-            "paged": false,
-            "suffix": "/@apiVersion@/analytics/reports/{Report ID}/instances"
-        },
-        {
-            "name": "Report Instance",
-            "paged": false,
-            "suffix": "/@apiVersion@/analytics/reports/{Report ID}/instances/{Instance ID}"
-        },
-        {
-            "name": "Report Types",
-            "paged": false,
-            "suffix": "/@apiVersion@/analytics/report-types"
-        },
-        {
-            "name": "Report Type",
-            "paged": false,
-            "suffix": "/@apiVersion@/analytics/reportTypes/type"
+          "endpoints": [
+            "Dashboard",
+            "Dashboard Metadata",
+            "Dashboard Status"
+          ],
+          "jsonPath": "$.[*]",
+          "key": "id",
+          "parameterName": "Dashboard ID"
         }
-    ]
+      ],
+      "description": "The dashboards the running user can see, with id, name and folder. Dashboards hold components backed by reports, so the list is a fair guide to what the organisation actually watches."
+    },
+    {
+      "name": "Dashboard",
+      "paged": false,
+      "suffix": "/@apiVersion@/analytics/dashboards/{Dashboard ID}?runningUser={Running User ID?}&filter1={Filter 1 ID?}&filter2={Filter 2 ID?}&filter3={Filter 3 ID?}",
+      "description": "One dashboard's current data: each component with its values as of the last refresh. Requires a dashboard id. IMPORTANT -- DASHBOARD DATA IS AS OF ITS LAST REFRESH, not as of now, and the refresh time is in Dashboard Status. A stale dashboard returns stale numbers with no indication in the values themselves."
+    },
+    {
+      "name": "Dashboard Metadata",
+      "paged": false,
+      "suffix": "/@apiVersion@/analytics/dashboards/{Dashboard ID}/describe?loadComponentProperties={Load Component Properties?:true|false}",
+      "description": "The definition of one dashboard: its components, the report behind each, and their groupings and filters. Requires a dashboard id. The map from a dashboard component back to the report that feeds it."
+    },
+    {
+      "name": "Dashboard Status",
+      "paged": false,
+      "suffix": "/@apiVersion@/analytics/dashboards/{Dashboard ID}/status?runningUser={Running User ID?}&filter1={Filter 1 ID?}&filter2={Filter 2 ID?}&filter3={Filter 3 ID?}",
+      "description": "When one dashboard was last refreshed and by whom, and whether a refresh is running. Requires a dashboard id. The companion that makes the dashboard's numbers interpretable."
+    },
+    {
+      "name": "Filter Operators",
+      "paged": false,
+      "suffix": "/@apiVersion@/analytics/filteroperators?forDashboards={For Dashboards?:true|false}",
+      "description": "The filter operators available for report and dashboard filters, by field type. Reference data for reading or building a filter."
+    },
+    {
+      "name": "Folders",
+      "paged": true,
+      "suffix": "/v43.0/folders/",
+      "lookups": [
+        {
+          "endpoints": [
+            "Folder",
+            "Folder Shares",
+            "Folder Children"
+          ],
+          "jsonPath": "$.folders[*]",
+          "key": "id",
+          "parameterName": "Folder ID"
+        }
+      ],
+      "description": "The report and dashboard folders, with their names and types. Folders are how Salesforce scopes visibility, so this is the structure that decides who sees which reports."
+    },
+    {
+      "name": "Folder",
+      "paged": false,
+      "suffix": "/v43.0/folders/{Folder ID}",
+      "description": "One folder by id."
+    },
+    {
+      "name": "Folder Shares",
+      "paged": false,
+      "suffix": "/v41.0/folders/{Folder ID}/shares",
+      "description": "Who a folder is shared with and at what access level. Requires a folder id. The access list behind report visibility -- and the reason two users legitimately see different report catalogues."
+    },
+    {
+      "name": "Folder Share",
+      "paged": false,
+      "suffix": "/v41.0/folders/{Folder ID}/shares/{Share ID}",
+      "description": "One folder share by id."
+    },
+    {
+      "name": "Folder Share Recipients",
+      "paged": false,
+      "suffix": "/v41.0/folders/{Folder ID}/share-recipients?shareType={shareType:user|group|role}&searchTerm={Search Term?}",
+      "description": "The users, groups or roles a folder could be shared with, filtered by share type. A picker source rather than a record of existing access."
+    },
+    {
+      "name": "Folder Children",
+      "paged": true,
+      "suffix": "/v43.0/folders/{Folder ID}/children",
+      "lookups": [
+        {
+          "endpoints": [
+            "Folder",
+            "Folder Shares",
+            "Folder Children"
+          ],
+          "jsonPath": "$.folders[*]",
+          "key": "id",
+          "parameterName": "Folder ID"
+        }
+      ],
+      "description": "The reports and dashboards inside one folder. Requires a folder id."
+    },
+    {
+      "name": "Reports",
+      "paged": false,
+      "suffix": "/@apiVersion@/analytics/reports",
+      "lookups": [
+        {
+          "endpoints": [
+            "Report Metadata",
+            "Execute Report",
+            "Report Instances"
+          ],
+          "jsonPath": "$.[*]",
+          "key": "id",
+          "parameterName": "Report ID"
+        }
+      ],
+      "description": "The reports the running user can see in Salesforce, with id, name, folder, format and the last time each was run. The catalogue: Salesforce reports are built in the interface, so this is the list of analyses the business has already defined, and their names carry the organisation's own vocabulary."
+    },
+    {
+      "name": "Report Metadata",
+      "paged": false,
+      "suffix": "/@apiVersion@/analytics/reports/{Report ID}/describe",
+      "description": "The definition of one report: its columns, groupings, filters, report type and scope. Requires a report id. Needed to interpret a run, since the factMap keys are meaningless without knowing the groupings -- and the filters here are where the business's definition of the report's subject is written."
+    },
+    {
+      "name": "Execute Report",
+      "paged": false,
+      "suffix": "/@apiVersion@/analytics/reports/{Report ID}",
+      "description": "RUNS one report and returns its results. Requires a report id. NOTE THE SHAPE -- this is not a row set. Salesforce returns a factMap keyed by grouping, with the aggregates and detail rows nested inside, plus separate metadata describing the columns; it must be flattened before use and the flattening depends on the report's own grouping. TWO LIMITS THAT SILENTLY TRUNCATE: a synchronous run returns at most 2,000 detail rows, and the response carries an allData flag saying whether it was cut short -- a total taken without checking that flag is simply wrong on any large report."
+    },
+    {
+      "name": "Report Instances",
+      "paged": false,
+      "suffix": "/@apiVersion@/analytics/reports/{Report ID}/instances",
+      "description": "The asynchronous runs of one report, with their status and completion time. Requires a report id. Asynchronous execution is how reports beyond the synchronous row limit are run, so this is the route to a complete large report."
+    },
+    {
+      "name": "Report Instance",
+      "paged": false,
+      "suffix": "/@apiVersion@/analytics/reports/{Report ID}/instances/{Instance ID}",
+      "description": "The results of one asynchronous run. Requires the report id and instance id. Same factMap shape, without the 2,000-row synchronous cap."
+    },
+    {
+      "name": "Report Types",
+      "paged": false,
+      "suffix": "/@apiVersion@/analytics/report-types",
+      "description": "The report types available -- the object combinations a new report can be built on. Reference data describing what could be reported on, rather than anything reported."
+    },
+    {
+      "name": "Report Type",
+      "paged": false,
+      "suffix": "/@apiVersion@/analytics/reportTypes/type",
+      "description": "One report type, with its categories and available fields."
+    }
+  ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/teamdesk/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/teamdesk/endpoints.json
@@ -1,49 +1,58 @@
 {
-    "endpoints": [
-        {
-            "name": "Application",
-            "paged": false,
-            "suffix": "/describe.json"
-        },
-        {
-            "name": "User",
-            "paged": false,
-            "suffix": "/user.json"
-        },
-        {
-            "name": "Table",
-            "paged": false,
-            "suffix": "/{Table Name}/describe.json"
-        },
-        {
-            "name": "Select Table",
-            "paged": true,
-            "suffix": "/{Table Name}/select.json?column={Columns?,:column1,column2,...}&filter={Filter?}"
-        },
-        {
-            "name": "Select View",
-            "paged": true,
-            "suffix": "/{Table Name}/{View Name}/select.json?filter={Filter?}"
-        },
-        {
-            "name": "Retrieve Records",
-            "paged": false,
-            "suffix": "/{Table Name}/retrieve.json?column={Columns?,:column1,column2,...}&key={Key Column Values?,:1,2,3...}&id={Row IDs,:1,2,3...}"
-        },
-        {
-            "name": "Updated Records",
-            "paged": false,
-            "suffix": "/{Table Name}/updated.json?from={From Date?:YYYY-MM-DDTHH:MM:SS+00:00}&to={To Date?:YYYY-MM-DDTHH:MM:SS+00:00}"
-        },
-        {
-            "name": "Deleted Records",
-            "paged": false,
-            "suffix": "/{Table Name}/deleted.json?from={From Date?:YYYY-MM-DDTHH:MM:SS+00:00}&to={To Date?:YYYY-MM-DDTHH:MM:SS+00:00}"
-        },
-        {
-            "name": "Attachments",
-            "paged": false,
-            "suffix": "/{Table Name}/{Column Name}/attachments.json?key={Key Column Value?}&id={Row ID*?}&revisions={Number of Revisions?}"
-        }
-    ]
+  "endpoints": [
+    {
+      "name": "Application",
+      "paged": false,
+      "suffix": "/describe.json",
+      "description": "The database's schema: every table with its columns, types and relationships. THE FIRST REQUEST FOR ANY TEAMDESK QUESTION -- this is a user-built low-code database, so nothing about its structure is knowable in advance, and table and column names are whatever the account's designer chose. Nothing else here can be used without it."
+    },
+    {
+      "name": "User",
+      "paged": false,
+      "suffix": "/user.json",
+      "description": "The account the credentials belong to, with their role and permissions. Worth reading first, since TeamDesk applies row-level and column-level permissions and two users running the same query legitimately get different rows."
+    },
+    {
+      "name": "Table",
+      "paged": false,
+      "suffix": "/{Table Name}/describe.json",
+      "description": "One table's schema: its columns with types, whether each is required, and the views defined on it. Requires the table name. The per-table detail behind the application schema."
+    },
+    {
+      "name": "Select Table",
+      "paged": true,
+      "suffix": "/{Table Name}/select.json?column={Columns?,:column1,column2,...}&filter={Filter?}",
+      "description": "The rows of one table, with an optional column list and filter. Requires the table name. The main data endpoint. Filters use TeamDesk's own expression language and are evaluated server-side; asking for specific columns matters, since a wide user-built table can be very wide indeed."
+    },
+    {
+      "name": "Select View",
+      "paged": true,
+      "suffix": "/{Table Name}/{View Name}/select.json?filter={Filter?}",
+      "description": "The rows a saved VIEW returns. Requires the table and view names. A view already carries the filtering, sorting and column selection the account's users agreed on, so it is usually a better starting point than the raw table -- and its definition is readable from the table schema."
+    },
+    {
+      "name": "Retrieve Records",
+      "paged": false,
+      "suffix": "/{Table Name}/retrieve.json?column={Columns?,:column1,column2,...}&key={Key Column Values?,:1,2,3...}&id={Row IDs,:1,2,3...}",
+      "description": "Specific rows fetched by their key column values. Requires the table name and the key values. The efficient way to hydrate known records rather than filtering for them."
+    },
+    {
+      "name": "Updated Records",
+      "paged": false,
+      "suffix": "/{Table Name}/updated.json?from={From Date?:YYYY-MM-DDTHH:MM:SS+00:00}&to={To Date?:YYYY-MM-DDTHH:MM:SS+00:00}",
+      "description": "The rows changed within a time range. Requires the table name; takes from and to timestamps. The incremental-sync endpoint -- it exists so a downstream copy can be refreshed without re-reading the table."
+    },
+    {
+      "name": "Deleted Records",
+      "paged": false,
+      "suffix": "/{Table Name}/deleted.json?from={From Date?:YYYY-MM-DDTHH:MM:SS+00:00}&to={To Date?:YYYY-MM-DDTHH:MM:SS+00:00}",
+      "description": "The rows deleted within a time range. Requires the table name. The companion to Updated Records: without it a synchronised copy never learns that rows have gone, since deletions leave no trace in the table itself."
+    },
+    {
+      "name": "Attachments",
+      "paged": false,
+      "suffix": "/{Table Name}/{Column Name}/attachments.json?key={Key Column Value?}&id={Row ID*?}&revisions={Number of Revisions?}",
+      "description": "The files held in one attachment column. Requires the table and column names. Metadata and content by row key; revisions are addressable where the column keeps history."
+    }
+  ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/toggl/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/toggl/endpoints.json
@@ -3,12 +3,14 @@
     {
       "name": "Client",
       "paged": false,
-      "suffix": "/api/v9/workspaces/{Workspace ID}/clients/{Client ID}"
+      "suffix": "/api/v9/workspaces/{Workspace ID}/clients/{Client ID}",
+      "description": "One client by id. Requires the workspace id."
     },
     {
-      "name" : "Clients",
-      "paged" : false,
-      "suffix" : "/api/v9/workspaces/{Workspace ID}/clients"
+      "name": "Clients",
+      "paged": false,
+      "suffix": "/api/v9/workspaces/{Workspace ID}/clients",
+      "description": "The clients in one workspace. Requires a workspace id. The billing entity projects belong to. NOTE this is the same endpoint as Workspace Clients under a second name -- the two are identical and either will do."
     },
     {
       "name": "Workspace Projects",
@@ -24,47 +26,56 @@
           "key": "id",
           "parameterName": "Workspace ID"
         }
-      ]
+      ],
+      "description": "The projects in one workspace, with name, client, active state, billable flag, the hourly rate, colour, and estimated hours. Requires a workspace id. The rate is what turns tracked time into money. Filter with active, which defaults to returning only live projects and so omits completed work from historical totals."
     },
     {
       "name": "Workspace Project",
       "paged": false,
-      "suffix": "/api/v9/workspaces/{Workspace ID}/projects/{Project ID}"
+      "suffix": "/api/v9/workspaces/{Workspace ID}/projects/{Project ID}",
+      "description": "One project by id. Requires the workspace id."
     },
     {
       "name": "Workspace Project Users",
       "paged": false,
-      "suffix": "/api/v9/workspaces/{Workspace ID}/project_users"
+      "suffix": "/api/v9/workspaces/{Workspace ID}/project_users",
+      "description": "Who is assigned to which project, with each assignment's own hourly rate. Requires a workspace id. THE PER-PERSON RATE OVERRIDES THE PROJECT RATE, so billing a project at its headline rate overstates or understates it wherever these exist."
     },
     {
       "name": "Workspace Project Tasks",
       "paged": false,
-      "suffix": "/api/v9/workspaces/{Workspace ID}/projects/{Project ID}/tasks/"
+      "suffix": "/api/v9/workspaces/{Workspace ID}/projects/{Project ID}/tasks/",
+      "description": "The tasks within one project, with name, estimated seconds and active state. Requires the workspace and project ids."
     },
     {
       "name": "Workspace Task",
       "paged": false,
-      "suffix": "/api/v9/workspaces/{Workspace ID}/projects/{Project ID}/tasks/{Task ID}"
+      "suffix": "/api/v9/workspaces/{Workspace ID}/projects/{Project ID}/tasks/{Task ID}",
+      "description": "One task by id. Requires the workspace and project ids."
     },
     {
       "name": "Time Entry",
       "paged": false,
-      "suffix": "/api/v9/me/time_entries/{Time Entry ID}"
+      "suffix": "/api/v9/me/time_entries/{Time Entry ID}",
+      "description": "One time entry by id. Same negative-duration convention for a running entry."
     },
     {
       "name": "Current Time Entry",
       "paged": false,
-      "suffix": "/api/v9/me/time_entries/current"
+      "suffix": "/api/v9/me/time_entries/current",
+      "description": "The entry the caller is running right now, or nothing if the clock is stopped. A live check rather than data."
     },
     {
       "name": "Time Entries",
       "paged": false,
-      "suffix": "/api/v9/me/time_entries?start_date={Start Date?:yyyy-MM-ddTHH:mm:ssZ}&end_date={End Date?:yyyy-MM-ddTHH:mm:ssZ}"
+      "suffix": "/api/v9/me/time_entries?start_date={Start Date?:yyyy-MM-ddTHH:mm:ssZ}&end_date={End Date?:yyyy-MM-ddTHH:mm:ssZ}",
+      "description": "The time entries of the AUTHENTICATED USER, filtered by a date range. Carries description, project, task, tags, billable flag, start and stop, and DURATION IN SECONDS. Two things: it is the caller's own entries only, so a workspace-wide extract is not possible through this endpoint; and a RUNNING ENTRY HAS A NEGATIVE DURATION -- Toggl encodes the start time as a negative number until the entry stops, so summing without filtering those out corrupts the total."
     },
     {
       "name": "Current User",
       "paged": false,
-      "suffix": "/api/v9/me?with_related_data={With Related Data?:true|false}"
+      "suffix": "/api/v9/me?with_related_data={With Related Data?:true|false}",
+      "description": "The account the credentials belong to. One record. Pass with_related_data to have workspaces, clients, projects and tags returned alongside, which saves several requests when bootstrapping."
     },
     {
       "name": "Workspaces",
@@ -85,42 +96,50 @@
           "key": "id",
           "parameterName": "Workspace ID"
         }
-      ]
+      ],
+      "description": "The workspaces the authenticated user belongs to, with name, the default hourly rate and currency, and the rounding settings. Every other endpoint needs a workspace id. As with any time tracker, ROUNDING MEANS RAW ENTRY DURATIONS AND REPORTED TOTALS CAN LEGITIMATELY DIFFER."
     },
     {
       "name": "Workspace",
       "paged": false,
-      "suffix": "/api/v9/workspaces/{Workspace ID}"
+      "suffix": "/api/v9/workspaces/{Workspace ID}",
+      "description": "One workspace by id, with its settings."
     },
     {
       "name": "All Users",
       "paged": false,
-      "suffix": "/api/v9/workspaces/{Workspace ID}/users"
+      "suffix": "/api/v9/workspaces/{Workspace ID}/users",
+      "description": "The users in one workspace, as user records with name and email. Requires a workspace id."
     },
     {
-      "name" : "Workspace Clients",
-      "paged" : false,
-      "suffix" : "/api/v9/workspaces/{Workspace ID}/clients"
+      "name": "Workspace Clients",
+      "paged": false,
+      "suffix": "/api/v9/workspaces/{Workspace ID}/clients",
+      "description": "The clients in one workspace. Identical to Clients; the connector carries the same endpoint under both names."
     },
     {
       "name": "Workspace Project Groups",
       "paged": false,
-      "suffix": "/api/v9/workspaces/{Workspace ID}/groups"
+      "suffix": "/api/v9/workspaces/{Workspace ID}/groups",
+      "description": "The group-level project assignments in one workspace. Requires a workspace id."
     },
     {
       "name": "Workspace Tasks",
       "paged": true,
-      "suffix": "/api/v9/workspaces/{Workspace ID}/tasks?active={Active?:true|false|both}"
+      "suffix": "/api/v9/workspaces/{Workspace ID}/tasks?active={Active?:true|false|both}",
+      "description": "Every task across the workspace rather than per project. Requires a workspace id. The efficient way to inventory tasks without walking projects."
     },
     {
       "name": "Workspace Tags",
       "paged": false,
-      "suffix": "/api/v9/workspaces/{Workspace ID}/tags"
+      "suffix": "/api/v9/workspaces/{Workspace ID}/tags",
+      "description": "The tags in one workspace. Requires a workspace id. The free-form dimension on time entries beyond project and task."
     },
     {
       "name": "Workspace Users",
       "paged": false,
-      "suffix": "/api/v9/workspaces/{Workspace ID}/workspace_users"
+      "suffix": "/api/v9/workspaces/{Workspace ID}/workspace_users",
+      "description": "The workspace MEMBERSHIP records rather than the users themselves -- carrying each person's role, whether they are active, and their labour cost. Requires a workspace id. The cost field is here and not on the user, so any cost-of-time calculation joins through this table."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/youtubeanalytics/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/youtubeanalytics/endpoints.json
@@ -1,9 +1,10 @@
 {
-    "endpoints": [
-        {
-            "name": "Reports Query",
-            "pageType": 1,
-            "suffix": "/v2/reports?startDate={Start Date:YYYY-MM-DD}&endDate={End Date:YYYY-MM-DD}&ids={ID :channel==CHANNEL ID Or contentOwner==OWNER NAME}&metrics={Metrics:views,likes,dislikes}&currency={Currency?:estimatedRevenue | estimatedAdRevenue | ...}&dimensions={Dimensions?:video,ageGroup,gender}&filters={Filters?:country==IT}&includeHistoricalChannelData={Include Historical Channel Data?:true | false}"
-        }
-    ]
+  "endpoints": [
+    {
+      "name": "Reports Query",
+      "pageType": 1,
+      "suffix": "/v2/reports?startDate={Start Date:YYYY-MM-DD}&endDate={End Date:YYYY-MM-DD}&ids={ID :channel==CHANNEL ID Or contentOwner==OWNER NAME}&metrics={Metrics:views,likes,dislikes}&currency={Currency?:estimatedRevenue | estimatedAdRevenue | ...}&dimensions={Dimensions?:video,ageGroup,gender}&filters={Filters?:country==IT}&includeHistoricalChannelData={Include Historical Channel Data?:true | false}",
+      "description": "The entire YouTube Analytics API in one endpoint: a report is DEFINED BY ITS PARAMETERS rather than chosen from a list. metrics names what is measured (views, estimatedMinutesWatched, averageViewDuration, subscribersGained, likes, estimatedRevenue and the rest), dimensions names how it is cut (day, video, country, insightTrafficSourceType, ageGroup), and filters narrows it. So this single row in the connector stands for hundreds of possible reports, and the question decides the request. THREE THINGS CONSTRAIN IT. The ids parameter must name the owner -- channel==MINE for a channel, or a content owner id -- and reports differ by which is used. NOT EVERY METRIC WORKS WITH EVERY DIMENSION: YouTube publishes a fixed set of valid combinations, and an invalid pair returns an error rather than an empty result. And revenue and ad-performance metrics require the account to be in the Partner Programme and the caller to hold monetary scopes, so their absence is a permissions fact rather than zero earnings. Data also settles over a few days, so recent figures move after the fact."
+    }
+  ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/zohocrm/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/zohocrm/endpoints.json
@@ -6,182 +6,225 @@
       "suffix": "/crm/v2/settings/modules",
       "lookups": [
         {
-          "endpoints": ["Fields", "Layouts", "Related Lists", "Custom Views", "Records", "Deleted Records", "Tags"],
+          "endpoints": [
+            "Fields",
+            "Layouts",
+            "Related Lists",
+            "Custom Views",
+            "Records",
+            "Deleted Records",
+            "Tags"
+          ],
           "jsonPath": "$.modules.[*]",
           "key": "api_name",
           "parameterName": "Module API Name"
         }
-      ]
+      ],
+      "description": "Every module in the account -- standard and custom -- with its API name, display label, and whether it is visible and creatable. THE FIRST REQUEST: the API name is what every data endpoint here takes, and it is not always the display name, particularly for custom modules."
     },
     {
       "name": "Organization",
       "paged": false,
-      "suffix": "/crm/v2/org"
+      "suffix": "/crm/v2/org",
+      "description": "The CRM organisation's details -- company name, licence edition, time zone, currency and user limits. One record, and the edition matters because several endpoints here are edition-gated."
     },
     {
       "name": "Users",
       "paged": true,
-      "suffix": "/crm/v2/users?type={Type?:AllUsers|ActiveUsers|...}"
+      "suffix": "/crm/v2/users?type={Type?:AllUsers|ActiveUsers|...}",
+      "description": "The users of the CRM, filterable by type -- all, active, deactivated, confirmed, admin. Every record carries an owner, so this is the dimension per-person performance joins to. Deactivated users still own their historical records, so excluding them loses that history."
     },
     {
       "name": "User",
       "paged": false,
-      "suffix": "/crm/v2/users/{User ID}"
+      "suffix": "/crm/v2/users/{User ID}",
+      "description": "One user by id, with their profile and role."
     },
     {
       "name": "Roles",
       "paged": false,
-      "suffix": "/crm/v2/settings/roles"
+      "suffix": "/crm/v2/settings/roles",
+      "description": "The role hierarchy, each role with its reporting parent. ROLES CONTROL WHAT DATA A USER SEES in Zoho -- a manager sees their subordinates' records -- so this hierarchy is the reason two people running the same query get different row counts."
     },
     {
       "name": "Role",
       "paged": false,
-      "suffix": "/crm/v2/settings/roles/{Role ID}"
+      "suffix": "/crm/v2/settings/roles/{Role ID}",
+      "description": "One role by id."
     },
     {
       "name": "Profiles",
       "paged": false,
-      "suffix": "/crm/v2/settings/profiles"
+      "suffix": "/crm/v2/settings/profiles",
+      "description": "The permission profiles, each with the operations it permits. Distinct from roles: a profile says what a user may DO, a role says whose records they may see."
     },
     {
       "name": "Profile",
       "paged": false,
-      "suffix": "/crm/v2/settings/profiles/{Profile ID}"
+      "suffix": "/crm/v2/settings/profiles/{Profile ID}",
+      "description": "One profile by id, with its permission set."
     },
     {
       "name": "Territories",
       "paged": false,
-      "suffix": "/crm/v2/settings/territories"
+      "suffix": "/crm/v2/settings/territories",
+      "description": "The territories defined, if territory management is enabled. A second access dimension beyond the role hierarchy, and another reason record visibility differs between users."
     },
     {
       "name": "Module",
       "paged": false,
-      "suffix": "/crm/v2/settings/modules/{Module API Name}"
+      "suffix": "/crm/v2/settings/modules/{Module API Name}",
+      "description": "One module by API name, with its settings and properties."
     },
     {
       "name": "Fields",
       "paged": false,
-      "suffix": "/crm/v2/settings/fields?module={Module API Name}"
+      "suffix": "/crm/v2/settings/fields?module={Module API Name}",
+      "description": "Every field of one module, with API name, display label, data type, whether it is custom, mandatory or read-only, and for picklists the allowed values. Requires the module API name. THE DECODER: records return values under field API names, and picklist values are stored as their raw values, so neither is readable without this."
     },
     {
       "name": "Layouts",
       "paged": false,
-      "suffix": "/crm/v2/settings/layouts?module={Module API Name}"
+      "suffix": "/crm/v2/settings/layouts?module={Module API Name}",
+      "description": "The page layouts of one module, each with its sections, the fields on it, and which profiles it applies to. Requires the module API name. Different profiles can see different layouts, so this is why two users see different fields on the same record."
     },
     {
       "name": "Layout",
       "paged": false,
-      "suffix": "/crm/v2/settings/layouts/{Layout ID}?module={Module API Name}"
+      "suffix": "/crm/v2/settings/layouts/{Layout ID}?module={Module API Name}",
+      "description": "One layout by id. Requires the module API name."
     },
     {
       "name": "Related Lists",
       "paged": false,
-      "suffix": "/crm/v2/settings/related_lists?module={Module API Name}"
+      "suffix": "/crm/v2/settings/related_lists?module={Module API Name}",
+      "description": "The relationships defined on one module, each with its API name and the module it points at. Requires the module API name. The catalogue of what can be traversed from a record, and the source of the names Related Records needs."
     },
     {
       "name": "Custom Views",
       "paged": true,
-      "suffix": "/crm/v2/settings/custom_views?module={Module API Name}"
+      "suffix": "/crm/v2/settings/custom_views?module={Module API Name}",
+      "description": "The saved views of one module, with name, whether shared, and their criteria. Requires the module API name. Views encode the segments the business already agreed on, and their criteria state the definitions in the organisation's own terms."
     },
     {
       "name": "Custom View",
       "paged": false,
-      "suffix": "/crm/v2/settings/custom_views/{Custom View ID}?module={Module API Name}"
+      "suffix": "/crm/v2/settings/custom_views/{Custom View ID}?module={Module API Name}",
+      "description": "One custom view by id, with its full criteria. Requires the module API name."
     },
     {
       "name": "Records",
       "paged": true,
-      "suffix": "/crm/v2/{Module API Name}?fields={Fields?:value1,value2,...}&converted={Converted?:true|false|both}&approved={Approved?:true|false|both}&cvid={Custom View ID?}&territory_id={Territory ID?}&include_child={Include Children?:true|false}"
+      "suffix": "/crm/v2/{Module API Name}?fields={Fields?:value1,value2,...}&converted={Converted?:true|false|both}&approved={Approved?:true|false|both}&cvid={Custom View ID?}&territory_id={Territory ID?}&include_child={Include Children?:true|false}",
+      "description": "The records of ONE MODULE. Requires the module's API name -- Leads, Contacts, Accounts, Deals, or any custom module the account defined. THIS IS THE DATA ENDPOINT FOR EVERYTHING: Zoho has no per-object endpoints, only this one parameterised by module, so the first request in any Zoho question is Modules, to learn what exists. Fields come back under their API names, which for custom fields are generated rather than chosen, so Fields is needed to read them."
     },
     {
       "name": "Record",
       "paged": false,
-      "suffix": "/crm/v2/{Module API Name}/{Record ID}"
+      "suffix": "/crm/v2/{Module API Name}/{Record ID}",
+      "description": "One record by id within a module. Requires the module API name."
     },
     {
       "name": "Deleted Records",
       "paged": true,
-      "suffix": "/crm/v2/{Module API Name}/deleted?module={Module API Name}&type={Type?:All|Recycle|Permanent}"
+      "suffix": "/crm/v2/{Module API Name}/deleted?module={Module API Name}&type={Type?:All|Recycle|Permanent}",
+      "description": "The records deleted from one module, filterable by whether they were deleted permanently or are in the recycle bin. Requires the module API name. THE ONLY WAY A SYNCHRONISED COPY LEARNS THAT RECORDS HAVE GONE -- deletions leave no trace in the module itself."
     },
     {
       "name": "Record Search",
       "paged": true,
-      "suffix": "/crm/v2/{Module API Name}/search?criteria={Criteria}&email={Email?}&phone={Phone?}&word={Word?}&converted={Converted?:true|false|both}&approved={Approved?:true|false|both}"
+      "suffix": "/crm/v2/{Module API Name}/search?criteria={Criteria}&email={Email?}&phone={Phone?}&word={Word?}&converted={Converted?:true|false|both}&approved={Approved?:true|false|both}",
+      "description": "Records within one module matching criteria, an email, a phone number or a word. Requires the module API name. The criteria syntax is Zoho's own and is evaluated server-side."
     },
     {
       "name": "Related Records",
       "paged": true,
-      "suffix": "/crm/v2/{Module API Name}/{Record ID}/{Related List API Name}"
+      "suffix": "/crm/v2/{Module API Name}/{Record ID}/{Related List API Name}",
+      "description": "The records related to one record through a named relationship -- a deal's contacts, an account's deals. Requires the module, record id and the related list's API name, which comes from Related Lists. How the object graph is actually traversed."
     },
     {
       "name": "Variables",
       "paged": false,
-      "suffix": "/crm/v2/settings/variables"
+      "suffix": "/crm/v2/settings/variables",
+      "description": "The organisation variables -- named values used in workflows and templates. Configuration."
     },
     {
       "name": "Variable",
       "paged": false,
-      "suffix": "/crm/v2/settings/variables/{Variable ID}?group={Variable Group ID}"
+      "suffix": "/crm/v2/settings/variables/{Variable ID}?group={Variable Group ID}",
+      "description": "One variable by id. Requires its group."
     },
     {
       "name": "Variable Group",
       "paged": false,
-      "suffix": "/crm/v2/settings/Variable Groups/{Variable Group ID}"
+      "suffix": "/crm/v2/settings/Variable Groups/{Variable Group ID}",
+      "description": "One variable group by id."
     },
     {
       "name": "Blueprint",
       "paged": false,
-      "suffix": "/crm/v2/{Module API Name}/{Record ID}/actions/blueprint"
+      "suffix": "/crm/v2/{Module API Name}/{Record ID}/actions/blueprint",
+      "description": "The blueprint state of one record -- Zoho's guided process, with the current stage and the transitions available. Requires the module and record id. Where a business process is enforced, the record's own status field is only half the picture; this says where it sits in the process and what may happen next."
     },
     {
       "name": "Tags",
       "paged": false,
-      "suffix": "/crm/v2/settings/tags?module={Module API Name}&my_tags={My Tags?:true|false}"
+      "suffix": "/crm/v2/settings/tags?module={Module API Name}&my_tags={My Tags?:true|false}",
+      "description": "The tags defined for one module, with names and colours. Requires the module API name. Zoho tags are per module rather than global, so the same word on Leads and Deals is two separate tags."
     },
     {
       "name": "Tag Record Count",
       "paged": false,
-      "suffix": "/crm/v2/settings/tags/{Tag ID}/actions/records_count?module={Module API Name}"
+      "suffix": "/crm/v2/settings/tags/{Tag ID}/actions/records_count?module={Module API Name}",
+      "description": "How many records carry one tag within a module. Requires the tag id and module. A ready-made count rather than a filtered scan."
     },
     {
       "name": "Notes",
       "paged": true,
-      "suffix": "/crm/v2/Notes"
+      "suffix": "/crm/v2/Notes",
+      "description": "Every note across the account, with its content, the record it is attached to, and the author. The qualitative record beside the structured one."
     },
     {
       "name": "Record Notes",
       "paged": true,
-      "suffix": "/crm/v2/{Module API Name}/{Record ID}/Notes"
+      "suffix": "/crm/v2/{Module API Name}/{Record ID}/Notes",
+      "description": "The notes on one record. Requires the module and record id."
     },
     {
       "name": "Attachments",
       "paged": false,
-      "suffix": "/crm/v2/{Module API Name}/{Record ID}/Attachments"
+      "suffix": "/crm/v2/{Module API Name}/{Record ID}/Attachments",
+      "description": "The files attached to one record. Requires the module and record id."
     },
     {
       "name": "Mass Update Status",
       "paged": false,
-      "suffix": "/crm/v2/{Module API Name}/actions/mass_update?job_id={Job ID}"
+      "suffix": "/crm/v2/{Module API Name}/actions/mass_update?job_id={Job ID}",
+      "description": "The progress of a bulk update job. Requires the module and job id. Bulk operations report only that they were queued, so this is where their outcome and per-record failures are found."
     },
     {
       "name": "Currencies",
       "paged": false,
-      "suffix": "/crm/v2/org/currencies"
+      "suffix": "/crm/v2/org/currencies",
+      "description": "The currencies enabled, with their exchange rates and which is the base. Records store amounts in their own currency with a rate, so a multi-currency total has to decide which it means."
     },
     {
       "name": "Currency",
       "paged": false,
-      "suffix": "/crm/v2/org/currencies/{Currency ID}"
+      "suffix": "/crm/v2/org/currencies/{Currency ID}",
+      "description": "One currency by id, with its rate."
     },
     {
       "name": "Shared Record",
       "paged": false,
-      "suffix": "/crm/v2/{Module API Name}/{Record ID}/actions/share?sharedTo={Shared To?}&view={View?:summary|manage}"
+      "suffix": "/crm/v2/{Module API Name}/{Record ID}/actions/share?sharedTo={Shared To?}&view={View?:summary|manage}",
+      "description": "Who one record has been shared with and at what permission. Requires the module and record id. Sharing overrides the role hierarchy, so this explains access the hierarchy does not."
     },
     {
       "name": "Notifications",
       "paged": true,
-      "suffix": "/crm/v2/actions/watch?channel_id={Channel ID}&module={Module API Name?}"
+      "suffix": "/crm/v2/actions/watch?channel_id={Channel ID}&module={Module API Name?}",
+      "description": "The change notification channels currently subscribed. Integration state rather than data."
     }
   ]
 }


### PR DESCRIPTION
Thirty connectors complete, **620 endpoints**. Stacked on #4627; retarget as the
stack merges.

Running total: **44 of 65 connectors fully described, 2,304 of 4,035 endpoints.**

youtubeanalytics, airtable, gsearchconsole, googlecal, teamdesk, azureblob,
firebase, prometheus, clockify, toggl, adobeanalytics, azuresearch,
helpscoutdocs, mixpanel, lighthouse, remedyforce, seomonitor, sfreports,
chartmogul, quickbooks, freshsales, nicereply, constantcontact, copper,
datadotworld, harvest, zohocrm, freshservice, fortytwomatters, appfigures.

Unlike the first three PRs, most of these have no published OpenAPI description
to align against, so the work was reading the endpoint set as a whole and saying
what shape of API it is.

## Three broken Freshservice paths

Each provable from the file's own inconsistency rather than an external spec:

| endpoint | was | problem |
|---|---|---|
| `Asset CI Type Fields` | `/api/v2/assets_types/{id}/fields` | sibling endpoint spells it `asset_types` |
| `Filtered Releases` | `/api/v2/releases/filter_name=...` | slash where the query string starts — no other suffix does that |
| `Service Category Items` | identical to `Service Items` | returned the whole catalogue; category is a `category_id` filter, not a path |

## Several of these aren't endpoint catalogues at all

**YouTube Analytics is one endpoint** whose report is defined entirely by its
`metrics` and `dimensions`, so a single row stands for hundreds of reports — and
YouTube publishes a fixed set of legal combinations, where an invalid pair errors
rather than returning nothing. **Prometheus** is the same shape: no table to
list, only PromQL to evaluate.

**Zoho CRM has no per-object endpoints.** `Records` is parameterised by module
API name and serves Leads, Contacts, Deals and every custom module alike, so the
first request in any Zoho question is `Modules`.

**Four have no fixed schema at all**, because the account's users built it —
teamdesk, airtable, firebase, remedyforce. Each description names the endpoint
that must be read first, since nothing else is usable without it.

## Access patterns that decide how a question can be phrased

- **Freshsales** has no plain listing. Leads, contacts, accounts and deals come
  only through a saved *view*, which is why each has a companion Filters
  endpoint whose only job is to supply view ids. Its Tasks and Appointments
  endpoints require a filter with no "all" value, so a complete set is several
  requests.
- **Copper** reaches everything through search.
- **data.world** addresses everything by owner and slug, never an opaque id.
- **Box, Asana and X** (earlier PRs) withhold fields by default; **Airtable**
  goes further and keys fields by the column's *display name*, so renaming a
  column in the interface silently breaks every query.

## Values that can't be read without a second table — or any table

Freshservice's ticket columns are numeric codes with **no decoder endpoint at
all**, so the mapping is written into the description (status 2 Open, 3 Pending,
4 Resolved, 5 Closed; priority 1 Low to 4 Urgent). A Nicereply rating is
meaningless until its survey's scale is known — CSAT, CES and NPS share one
table and NPS is not an average, so aggregating across surveys is wrong
regardless of scale. Constant Contact splits campaigns from campaign
*activities* and attaches every statistic to the activity.

## Where two report connectors need flattening

QuickBooks and Salesforce both return nested structures — sections and summary
rows in one, a `factMap` keyed by grouping in the other — where the section a
value sits in is what gives it meaning. Salesforce additionally truncates a
synchronous run at 2,000 detail rows and reports that in an `allData` flag, so a
total taken without checking it is wrong on any large report. QuickBooks'
accounting method is a *parameter*, so the same period returns different numbers
on a cash basis than an accrual one.

## Units and encodings

Clockify returns durations as ISO 8601 period strings (`PT1H30M`); **Toggl
encodes a running entry as a negative duration**, so totalling without filtering
corrupts the result. Harvest is the opposite and worth noting for it: it stamps
billable and cost rates *onto* each entry, so revenue and cost read directly and
a historical entry keeps the rate that applied then.

## Endpoints that exist to explain why other data looks wrong

Prometheus targets show a metric fell because a scrape failed rather than a value
did. Azure Search indexer status is the only place a partially failed index is
visible. Azure Blob's block list shows uncommitted blocks — billed, but in no
blob listing, and the usual explanation for a storage bill exceeding the sum of
its blobs.

## Tests

`EndpointsJsonLoadableTest` passes after every commit. The pre-existing
`EndpointJsonQueryTest` Spring failure and the `-am` requirement are unchanged
from #4623.

## Remaining

21 connectors, 1,731 endpoints — the large ones: jive (258), hubspot (160),
insightly (127), wordpress (99), linkedin (89), activecampaign (86), influxdb
(83), fusebill (75), pipelinecrm (71), surveymonkey (68), chargify (61),
gosquared (60), smartsheet (58), campaignmonitor (58), freshdesk (57), intervals
(57), keap (57), servicenow (56), liveagent (55), chargebee (51), zendesksell
(45). Plus the Pipedrive v2 migration flagged in #4623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
