### PR TITLE
Describe the last 21 connectors — all 65 now complete

### DIFF
--- a/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/datasource/pipedrive/PipedriveQuery.java
+++ b/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/datasource/pipedrive/PipedriveQuery.java
@@ -105,7 +105,26 @@ public class PipedriveQuery extends EndpointJsonQuery<PipedriveEndpoint> {
 
    @Override
    protected void updatePagination(PipedriveEndpoint endpoint) {
-      if(endpoint.isPaged()) {
+      if(!endpoint.isPaged()) {
+         paginationSpec = PaginationSpec.builder()
+            .type(PaginationType.NONE)
+            .build();
+      }
+      else if(isVersion2(endpoint)) {
+         // v2 pages by an opaque cursor and reports the end with a null next_cursor. It carries
+         // no offset and no total, so the v1 spec below cannot drive it: there is no next_start
+         // to advance and nothing to count towards.
+         paginationSpec = PaginationSpec.builder()
+            .type(PaginationType.ITERATION)
+            .hasNextParam(PaginationParamType.JSON_PATH, "$.additional_data.next_cursor")
+            .pageOffsetParamToRead(PaginationParamType.JSON_PATH, "$.additional_data.next_cursor")
+            .pageOffsetParamToWrite(PaginationParamType.QUERY, "cursor")
+            .maxResultsPerPageParam(PaginationParamType.QUERY, "limit")
+            .maxResultsPerPage(500)
+            .build();
+      }
+      else {
+         // How v1 pages, and how every endpoint still on v1 continues to page.
          paginationSpec = PaginationSpec.builder()
             .type(PaginationType.ITERATION)
             .hasNextParam(PaginationParamType.JSON_PATH, "$.additional_data.pagination.more_items_in_collection")
@@ -115,11 +134,18 @@ public class PipedriveQuery extends EndpointJsonQuery<PipedriveEndpoint> {
             .maxResultsPerPage(500)
             .build();
       }
-      else {
-         paginationSpec = PaginationSpec.builder()
-            .type(PaginationType.NONE)
-            .build();
-      }
+   }
+
+   /**
+    * Whether an endpoint targets Pipedrive's v2 API.
+    *
+    * <p>Read from the suffix rather than from a declared property, because the suffix is what
+    * actually decides which API is called — a flag could disagree with it, and the two failure
+    * modes that produces (v1 paging against v2, or the reverse) are both silent.</p>
+    */
+   private static boolean isVersion2(PipedriveEndpoint endpoint) {
+      final String suffix = endpoint.getSuffix();
+      return suffix != null && suffix.startsWith(VERSION_2_PREFIX);
    }
 
    @Override
@@ -136,4 +162,6 @@ public class PipedriveQuery extends EndpointJsonQuery<PipedriveEndpoint> {
       private final Map<String, PipedriveEndpoint> endpoints =
          Endpoints.load(PipedriveEndpoints.class);
     }
+
+   static final String VERSION_2_PREFIX = "/api/v2/";
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/activecampaign/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/activecampaign/endpoints.json
@@ -3,102 +3,122 @@
     {
       "name": "Accounts",
       "suffix": "/3/accounts?search={Search?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The customer organisations contacts belong to, with name, account URL and their created dates. The company-level dimension in ActiveCampaign's CRM."
     },
     {
       "name": "Account",
       "suffix": "/3/accounts/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One account by id."
     },
     {
       "name": "Account Associations",
       "suffix": "/3/accountContacts?filters[contact]={Contract?}&filters[account]={Account?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The links between contacts and accounts, each with the contact's job title. How people are attached to companies, which neither record states alone."
     },
     {
       "name": "Account Association",
       "suffix": "/3/accountContacts/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One account association by id."
     },
     {
       "name": "Custom account fields",
       "suffix": "/3/accountCustomFieldMeta",
-      "paged": "true"
+      "paged": "true",
+      "description": "The custom field definitions for accounts."
     },
     {
       "name": "Custom account field",
       "suffix": "/3/accountCustomFieldMeta/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One account field definition by id."
     },
     {
       "name": "Custom account field values",
       "suffix": "/3/accountCustomFieldData?filters[customerAccountId]={Customer Account ID?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The custom field values on accounts, keyed by field id."
     },
     {
       "name": "Custom account field value",
       "suffix": "/3/accountCustomFieldData/{Field ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One account field value by id."
     },
     {
       "name": "Addresses",
       "suffix": "/3/addresses",
-      "paged": "true"
+      "paged": "true",
+      "description": "The physical sender addresses used in campaign footers, as anti-spam law requires. Configuration."
     },
     {
       "name": "Address",
       "suffix": "/3/addresses/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One address by id."
     },
     {
       "name": "Automations",
       "suffix": "/3/automations",
-      "paged": "true"
+      "paged": "true",
+      "description": "The automation workflows defined, with name, status and entry conditions. WHERE MOST EMAIL ACTUALLY GETS SENT in an ActiveCampaign account -- campaign volume alone understates sending, because automations run continuously in response to behaviour."
     },
     {
       "name": "Brandings",
       "suffix": "/3/brandings",
-      "paged": "true"
+      "paged": "true",
+      "description": "The branding configurations available for emails and pages. Presentation."
     },
     {
       "name": "Branding",
       "suffix": "/3/brandings/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One branding by id."
     },
     {
       "name": "Calendar feeds",
       "suffix": "/3/calendars",
-      "paged": "true"
+      "paged": "true",
+      "description": "The calendar feeds published from the account."
     },
     {
       "name": "Calendar",
       "suffix": "/3/calendars/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One calendar feed by id."
     },
     {
       "name": "Campaigns",
       "suffix": "/3/campaigns",
-      "paged": "true"
+      "paged": "true",
+      "description": "The email campaigns, with name, type, status, send date, and the counts of sends, opens, clicks, bounces and unsubscribes. The performance table. Status separates drafts and scheduled sends from those actually delivered, so counting all rows counts campaigns that never went out."
     },
     {
       "name": "Campaign links",
       "suffix": "/3/campaigns/{ID}/links",
-      "paged": "true"
+      "paged": "true",
+      "description": "The links in one campaign with their click counts. Requires a campaign id. Which content drew the response, as opposed to whether anything did."
     },
     {
       "name": "Campaign",
       "suffix": "/3/campaigns/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One campaign by id, with its full statistics."
     },
     {
       "name": "Messages",
       "suffix": "/3/messages",
-      "paged": "true"
+      "paged": "true",
+      "description": "The message templates campaigns send -- the subject, sender and content. A campaign references a message, so this is what turns a campaign into readable content."
     },
     {
       "name": "Message",
       "suffix": "/3/messages/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One message by id."
     },
     {
       "name": "Contacts",
@@ -117,332 +137,398 @@
           "key": "id",
           "parameterName": "ID"
         }
-      ]
+      ],
+      "description": "The contacts in the account, with email, name, phone, the customer account, and their created and updated dates. The central table. NOTE THE CUSTOM FIELD SPLIT, which is the shape of this whole API: a contact's custom values do NOT come back on the contact -- they live in Custom contact field values, keyed by field id, and Custom contact fields is what names those ids. Nothing is readable from one table alone."
     },
     {
       "name": "Contact",
       "suffix": "/3/contacts/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One contact by id."
     },
     {
       "name": "Contact's automations",
       "suffix": "/3/contacts/{ID}/contactAutomations",
-      "paged": "true"
+      "paged": "true",
+      "description": "The automations one contact is currently in, with their status and the step reached. Requires a contact id. WHERE A CONTACT SITS IN THE MARKETING PROCESS -- the contact record itself says nothing about it."
     },
     {
       "name": "Contact's score values",
       "suffix": "/3/contacts/{ID}/scoreValues",
-      "paged": "true"
+      "paged": "true",
+      "description": "The lead scores of one contact. Requires a contact id. Scores are computed from behaviour, so this is the engagement measure the contact record lacks."
     },
     {
       "name": "Contact automations",
       "suffix": "/3/contactAutomations",
-      "paged": "true"
+      "paged": "true",
+      "description": "Every contact-to-automation membership on the account. The account-wide view of who is in what, and the basis for automation funnel analysis."
     },
     {
       "name": "Contact automation",
       "suffix": "/3/contactAutomations/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One contact automation record by id."
     },
     {
       "name": "Custom contact fields",
       "suffix": "/3/fields",
-      "paged": "true"
+      "paged": "true",
+      "description": "The custom field DEFINITIONS for contacts, with their titles, types and options. The decoder half of the split."
     },
     {
       "name": "Custom contact field",
       "suffix": "/3/fields/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One contact field definition by id."
     },
     {
       "name": "Custom contact field values",
       "suffix": "/3/fieldValues?filters[fieldid]={Field ID?}&filters[val]={Value?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The custom field VALUES, each pairing a contact, a field id and a value. The data half. Join to the definitions to make it readable."
     },
     {
       "name": "Custom contact field value",
       "suffix": "/3/fieldValues/{Field ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One contact field value by id."
     },
     {
       "name": "Deals",
       "suffix": "/3/deals?filters[search]={Search?}&filters[search_field]={Search Field?}&filters[title]={Title?}&filters[stage]={Stage?}&filters[group]={Group?}&filters[status]={Status?}&filters[owner]={Owner?}&filters[nextdate_range]={Nextdate Range?}&filters[tag]={Tag?}&filters[tasktype]={Tasktype?}&filters[created_before]={Created Before?}&filters[created_after]={Created After?}&filters[updated_before]={Updated Before?}&filters[updated_after]={Updated After?}&filters[organization]={Organization?}&filters[minimum_value]={Minimum Value?}&filters[maximum_value]={Maximum Value?}&filters[score_greater_than]={Score Greater Than?}&filters[score_less_than]={Score Less Than?}&filters[score]={Score?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The sales opportunities, with title, value, currency, the contact and account, the pipeline and stage, owner, status and expected close date. The CRM side of ActiveCampaign. Custom values follow the same split as contacts -- Custom deal field values holds them, Custom deal fields names them."
     },
     {
       "name": "Deal",
       "suffix": "/3/deals/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One deal by id."
     },
     {
       "name": "Pipelines",
       "suffix": "/3/dealGroups?filters[title]={Title?}&filters[have_stages]={Have Stages?:0|1}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The deal pipelines defined. Most accounts run more than one and stages are not comparable between them, so a funnel question has to name the pipeline."
     },
     {
       "name": "Pipeline",
       "suffix": "/3/dealGroups/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One pipeline by id."
     },
     {
       "name": "Stages",
       "suffix": "/3/dealStages?filters[title]={Title?}&filters[d_groupid]={Deal Group ID?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The stages within pipelines, with their order and the pipeline each belongs to. The dimension a funnel breakdown joins to."
     },
     {
       "name": "Stage",
       "suffix": "/3/dealStages/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One stage by id."
     },
     {
       "name": "Custom deal fields",
       "suffix": "/3/dealCustomFieldMeta",
-      "paged": "true"
+      "paged": "true",
+      "description": "The custom field definitions for deals."
     },
     {
       "name": "Custom deal field",
       "suffix": "/3/dealCustomFieldMeta/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One deal field definition by id."
     },
     {
       "name": "Custom deal field values",
       "suffix": "/3/dealCustomFieldData?filters[dealId]={Deal ID?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The custom field values on deals, keyed by field id."
     },
     {
       "name": "Custom deal field value",
       "suffix": "/3/dealCustomFieldData/{Field ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One deal field value by id."
     },
     {
       "name": "Secondary contacts",
       "suffix": "/3/contactDeals",
-      "paged": "true"
+      "paged": "true",
+      "description": "The additional contacts linked to deals beyond the primary one. A deal names one contact; this is everyone involved."
     },
     {
       "name": "Secondary contact",
       "suffix": "/3/contactDeals/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One deal-to-contact link by id."
     },
     {
       "name": "Connections",
       "suffix": "/3/connections?filters[service]={Service?}&filters[externalid]={External ID?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The e-commerce store connections configured, with their service and status. WHETHER THE STORE IS CONNECTED DECIDES whether the e-commerce tables have anything in them, so an empty result there is usually an integration fact rather than an absence of sales."
     },
     {
       "name": "Connection",
       "suffix": "/3/connections/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One connection by id."
     },
     {
       "name": "E-Commerce customers",
       "suffix": "/3/ecomCustomers?filters[email]={Email?}&filters[externalid]={External ID?}&filters[connectionid]={Connection ID?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The customers synced from a connected store, each linked to an ActiveCampaign contact and carrying their store-side identifiers. The bridge between marketing contacts and purchase behaviour."
     },
     {
       "name": "E-Commerce customer",
       "suffix": "/3/ecomCustomers/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One e-commerce customer by id."
     },
     {
       "name": "E-Commerce orders",
       "suffix": "/3/ecomOrders?filters[connectionid]={Connection ID?}&filters[externalid]={External ID?}&filters[externalcheckoutid]={External Checkout ID?}&filters[email]={Email?}&filters[state]={State?:0|1|2|3|4}&filters[customerid]={Customer ID?}&filters[external_created_date]={External Created Date?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The orders synced from connected stores, with the customer, total, currency, date and source. REVENUE ATTRIBUTION LIVES HERE: campaigns and automations can be tied to orders, which is the only way to connect email to money in ActiveCampaign."
     },
     {
       "name": "E-Commerce order",
       "suffix": "/3/ecomOrders/{E-Commerce Order ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One order by id."
     },
     {
       "name": "E-Commerce order products",
       "suffix": "/3/ecomOrderProducts",
-      "paged": "true"
+      "paged": "true",
+      "description": "The line items across orders. What was actually bought, as opposed to the order total."
     },
     {
       "name": "E-Commerce order products for a specific E-Commerce Order",
       "suffix": "/3/ecomOrders/{E-Commerce Order ID}/orderProducts",
-      "paged": "true"
+      "paged": "true",
+      "description": "The line items of one order. Requires an order id."
     },
     {
       "name": "E-Commerce order product",
       "suffix": "/3/ecomOrderProducts/{E-Commerce Order Product ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One order line item by id."
     },
     {
       "name": "Forms",
       "suffix": "/3/forms",
-      "paged": "true"
+      "paged": "true",
+      "description": "The signup forms, with their fields and the lists they feed. The acquisition side, and the explanation for where contacts came from."
     },
     {
       "name": "Form",
       "suffix": "/3/forms/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One form by id."
     },
     {
       "name": "Lists",
       "suffix": "/3/lists?filters[name]={Name?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The mailing lists, with name, subscriber counts and the sender details. The audience container."
     },
     {
       "name": "List",
       "suffix": "/3/lists/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One list by id."
     },
     {
       "name": "Contact Notes",
       "suffix": "/3/contacts/{Contact ID}/notes",
-      "paged": "false"
+      "paged": "false",
+      "description": "The notes on one contact. Requires a contact id."
     },
     {
       "name": "Note",
       "suffix": "/3/notes/{Note ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One note by id."
     },
     {
       "name": "Organizations",
       "suffix": "/3/organizations?filters[name]={Name?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The organisations defined for user grouping. Distinct from Accounts, which are customer companies; these group the account's own staff."
     },
     {
       "name": "Organization",
       "suffix": "/3/organizations/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One organization by id."
     },
     {
       "name": "Saved responses",
       "suffix": "/3/savedResponses",
-      "paged": "true"
+      "paged": "true",
+      "description": "The canned replies available. Which exist says a good deal about the standard cases handled."
     },
     {
       "name": "Saved response",
       "suffix": "/3/savedResponses/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One saved response by id."
     },
     {
       "name": "Scores",
       "suffix": "/3/scores",
-      "paged": "true"
+      "paged": "true",
+      "description": "The scoring rules defined, each with the conditions that add or subtract points. The definitions behind a score value, and where the business's own idea of a qualified lead is written down."
     },
     {
       "name": "Score",
       "suffix": "/3/scores/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One score rule by id."
     },
     {
       "name": "Segments",
       "suffix": "/3/segments",
-      "paged": "true"
+      "paged": "true",
+      "description": "The segments defined, each with the conditions describing an audience. Their conditions state the organisation's own definitions of terms like engaged or lapsed."
     },
     {
       "name": "Segment",
       "suffix": "/3/segments/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One segment by id."
     },
     {
       "name": "Event tracking status",
       "suffix": "/3/eventTracking",
-      "paged": "false"
+      "paged": "false",
+      "description": "Whether custom event tracking is enabled. Event data is only collected when it is, so this explains an empty event vocabulary."
     },
     {
       "name": "Names of tracked events",
       "suffix": "/3/eventTrackingEvents",
-      "paged": "true"
+      "paged": "true",
+      "description": "The custom event names being recorded. Events are whatever the site's own code sends, so this is the only way to learn what exists before segmenting on it."
     },
     {
       "name": "Site tracking status",
       "suffix": "/3/siteTracking",
-      "paged": "false"
+      "paged": "false",
+      "description": "Whether site visit tracking is enabled."
     },
     {
       "name": "Whitelisted site tracking domains",
       "suffix": "/3/siteTrackingDomains",
-      "paged": "true"
+      "paged": "true",
+      "description": "The domains site tracking accepts. Visits from anywhere else are not recorded, which is a common cause of gaps."
     },
     {
       "name": "Tags",
       "suffix": "/3/tags?search={Search?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The tags defined. In ActiveCampaign tags drive automation entry and segmentation, so this list is effectively the catalogue of states the business tracks."
     },
     {
       "name": "Tag",
       "suffix": "/3/tags/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One tag by id."
     },
     {
       "name": "Tasks",
       "suffix": "/3/dealTasks?filters[title]={Title?}&filters[reltype]={Relating Object?}&filters[relid]={Relational Object ID?}&filters[status]={Status?}&filters[note]={Note?}&filters[duedate]={Due Date?}&filters[d_tasktypeid]={Task Type?}&filters[userid]={User ID?}&filters[due_after]={Due After?}&filters[due_before]={Due Before?}&filters[duedate_range]={Due Date Range?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The tasks attached to deals, with due date, type, owner and completion. The forward-looking sales work."
     },
     {
       "name": "Task",
       "suffix": "/3/dealTasks/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One deal task by id."
     },
     {
       "name": "Task types",
       "suffix": "/3/dealTasktypes",
-      "paged": "true"
+      "paged": "true",
+      "description": "The task types configured -- call, email, meeting. The decoder for a task's type and the dimension that turns task volume into activity mix."
     },
     {
       "name": "Task type",
       "suffix": "/3/dealTasktypes/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One task type by id."
     },
     {
       "name": "Template",
       "suffix": "/3/templates/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One email template by id. The design layer beneath messages."
     },
     {
       "name": "Users",
       "suffix": "/3/users",
-      "paged": "true"
+      "paged": "true",
+      "description": "The staff users of the account, with name, email and group. Every deal carries an owner, so this is the dimension per-person performance joins to."
     },
     {
       "name": "User by id",
       "suffix": "/3/users/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One user by id."
     },
     {
       "name": "User by email",
       "suffix": "/3/users/email/{Email}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One user by email address. The lookup when the id is unknown."
     },
     {
       "name": "User by username",
       "suffix": "/3/users/username/{Username}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One user by username."
     },
     {
       "name": "Logged-in user",
       "suffix": "/3/users/me",
-      "paged": "false"
+      "paged": "false",
+      "description": "The account the credentials belong to. One record, always the caller."
     },
     {
       "name": "Groups",
       "suffix": "/3/groups",
-      "paged": "true"
+      "paged": "true",
+      "description": "The permission groups users belong to, each with what its members may see. The reason two users get different row counts."
     },
     {
       "name": "Group",
       "suffix": "/3/groups/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One group by id."
     },
     {
       "name": "Webhooks",
       "suffix": "/3/webhooks?filters[name]={Name?}&filters[url]={URL Filter?}&filters[listid]={List ID?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The webhooks configured, with the events each subscribes to. Integration configuration."
     },
     {
       "name": "Webhook events",
       "suffix": "/3/webhook/events",
-      "paged": "true"
+      "paged": "true",
+      "description": "The event types a webhook can subscribe to. Reference data."
     },
     {
       "name": "Webhook",
       "suffix": "/3/webhooks/{ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One webhook by id."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/campaignmonitor/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/campaignmonitor/endpoints.json
@@ -95,52 +95,62 @@
           "key": "ClientID",
           "parameterName": "Client ID"
         }
-      ]
+      ],
+      "description": "The client accounts under this Campaign Monitor login. AGENCIES ARE THE POINT OF THIS STRUCTURE: nearly every other endpoint takes a client id, and an account with several clients holds several entirely separate sets of lists, campaigns and subscribers. The first request in any question here."
     },
     {
       "name": "Billing details",
       "suffix": "/v3.2/billingdetails.json",
-      "paged": "false"
+      "paged": "false",
+      "description": "The account's billing state -- credits held and the plan in force. One record."
     },
     {
       "name": "Countries",
       "suffix": "/v3.2/countries.json",
-      "paged": "false"
+      "paged": "false",
+      "description": "The country list Campaign Monitor accepts. Reference data."
     },
     {
       "name": "Timezones",
       "suffix": "/v3.2/timezones.json",
-      "paged": "false"
+      "paged": "false",
+      "description": "The timezone list Campaign Monitor accepts. Reference data, and relevant because a client's timezone determines how their timestamps read."
     },
     {
       "name": "Current date",
       "suffix": "/v3.2/systemdate.json",
-      "paged": "false"
+      "paged": "false",
+      "description": "Campaign Monitor's own system date and time. Useful for anchoring a relative date range to the service's clock rather than the caller's."
     },
     {
       "name": "Administrators",
       "suffix": "/v3.2/admins.json",
-      "paged": "false"
+      "paged": "false",
+      "description": "The administrators on the account, with name, email and status."
     },
     {
       "name": "Administrator details",
       "suffix": "/v3.2/admins.json?email={Email?}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One administrator by email address."
     },
     {
       "name": "Primary contact",
       "suffix": "/v3.2/primarycontact.json",
-      "paged": "false"
+      "paged": "false",
+      "description": "The main contact for the whole account."
     },
     {
       "name": "Campaign summary",
       "suffix": "/v3.2/campaigns/{Campaign ID}/summary.json",
-      "paged": "false"
+      "paged": "false",
+      "description": "The headline statistics of one campaign -- recipients, total and unique opens, clicks, unsubscribes, bounces, spam complaints and the web version views. Requires a campaign id. THE RIGHT ENDPOINT FOR A RATE: the detail endpoints below return one row per event and paging them to count is far more expensive than reading these totals."
     },
     {
       "name": "Campaign email client usage",
       "suffix": "/v3.2/campaigns/{Campaign ID}/emailclientusage.json",
-      "paged": "false"
+      "paged": "false",
+      "description": "The email clients recipients opened one campaign in, with counts and percentages. Requires a campaign id. What a template has to render in -- and inferred from opens, so it describes the opening audience rather than the whole."
     },
     {
       "name": "Campaign lists and segments",
@@ -219,42 +229,50 @@
           "key": "SegmentID",
           "parameterName": "Segment ID"
         }
-      ]
+      ],
+      "description": "Which lists and segments one campaign was sent to. Requires a campaign id. The targeting record, which the campaign itself does not state."
     },
     {
       "name": "Campaign recipients",
       "suffix": "/v3.2/campaigns/{Campaign ID}/recipients.json",
-      "paged": "true"
+      "paged": "true",
+      "description": "Everyone one campaign was sent to, with their email and list. Requires a campaign id. The denominator, and the way to see which lists a campaign actually reached."
     },
     {
       "name": "Campaign bounces",
       "suffix": "/v3.2/campaigns/{Campaign ID}/bounces.json?date={Date?:YYYY-MM-DD HH:MM}",
-      "paged": "true"
+      "paged": "true",
+      "description": "Bounce events, with the subscriber and the bounce type. Requires a campaign id. Hard and soft bounces mean different things and are distinguished here; treating them alike overstates list decay."
     },
     {
       "name": "Campaign opens",
       "suffix": "/v3.2/campaigns/{Campaign ID}/opens.json?date={Date?:YYYY-MM-DD HH:MM}",
-      "paged": "true"
+      "paged": "true",
+      "description": "Every open event for one campaign, with the subscriber, timestamp, IP and geolocation. Requires a campaign id. TOTAL opens including repeats -- the summary carries the unique figure. Carries the usual caveat that opens depend on images loading."
     },
     {
       "name": "Campaign clicks",
       "suffix": "/v3.2/campaigns/{Campaign ID}/clicks.json?date={Date?:YYYY-MM-DD HH:MM}",
-      "paged": "true"
+      "paged": "true",
+      "description": "Every click event, with the subscriber, the URL clicked, timestamp and geolocation. Requires a campaign id. The sounder engagement signal, and the URL column is what says which content drew the response."
     },
     {
       "name": "Campaign unsubscribes",
       "suffix": "/v3.2/campaigns/{Campaign ID}/unsubscribes.json?date={Date?:YYYY-MM-DD HH:MM}",
-      "paged": "true"
+      "paged": "true",
+      "description": "Unsubscribe events attributable to one campaign, with timestamps. Requires a campaign id. The per-send cost of a campaign."
     },
     {
       "name": "Campaign spam complaints",
       "suffix": "/v3.2/campaigns/{Campaign ID}/spam.json?date={Date?:YYYY-MM-DD HH:MM}",
-      "paged": "true"
+      "paged": "true",
+      "description": "Spam complaints from one campaign. Requires a campaign id. Small numbers matter -- a handful is enough to affect deliverability for everything sent afterwards."
     },
     {
       "name": "Client's details",
       "suffix": "/v3.2/clients/{Client ID}.json",
-      "paged": "false"
+      "paged": "false",
+      "description": "One client's settings -- company, timezone, country, and their billing and permission configuration. Requires a client id. THE TIMEZONE MATTERS: campaign and subscriber timestamps are returned in the client's own timezone, so figures from two clients are not on the same clock."
     },
     {
       "name": "Sent campaigns",
@@ -315,7 +333,8 @@
           "key": "CampaignID",
           "parameterName": "Campaign ID"
         }
-      ]
+      ],
+      "description": "The campaigns one client has actually sent, with name, subject, sent date, the number of recipients, and the web version url. Requires a client id. The starting point for reporting: only sent campaigns have statistics, and the campaign id here is what every report endpoint below takes."
     },
     {
       "name": "Scheduled campaigns",
@@ -376,7 +395,8 @@
           "key": "CampaignID",
           "parameterName": "Campaign ID"
         }
-      ]
+      ],
+      "description": "Campaigns queued to send, with their scheduled date. Requires a client id. Forward-looking; no statistics exist yet."
     },
     {
       "name": "Draft campaigns",
@@ -437,11 +457,12 @@
           "key": "CampaignID",
           "parameterName": "Campaign ID"
         }
-      ]
+      ],
+      "description": "Campaigns not yet scheduled. Requires a client id. Counting all three campaign endpoints together counts work that was never sent."
     },
     {
       "name": "Subscriber lists",
-      "suffix": "/v3.2/clients/{Client ID}/campaigns.json",
+      "suffix": "/v3.2/clients/{Client ID}/lists.json",
       "paged": "false",
       "lookups": [
         {
@@ -504,7 +525,8 @@
           "key": "ListID",
           "parameterName": "List ID"
         }
-      ]
+      ],
+      "description": "The subscriber lists belonging to one client. Requires a client id. The audience container; subscribers belong to a list rather than to the client, so the same person on two lists is two subscriber records."
     },
     {
       "name": "Lists for an email address",
@@ -571,7 +593,8 @@
           "key": "ListID",
           "parameterName": "List ID"
         }
-      ]
+      ],
+      "description": "Which of a client's lists one email address appears on, and in what state. Requires the client id and email. The answer to why someone did or did not receive a send."
     },
     {
       "name": "Segments",
@@ -590,32 +613,38 @@
           "key": "SegmentID",
           "parameterName": "Segment ID"
         }
-      ]
+      ],
+      "description": "All segments across one client's lists. Requires a client id."
     },
     {
       "name": "Suppression list",
       "suffix": "/v3.2/clients/{Client ID}/suppressionlist.json",
-      "paged": "true"
+      "paged": "true",
+      "description": "Addresses suppressed across one client -- never mailed regardless of list. Requires a client id. The explanation for a send reaching fewer people than the list size."
     },
     {
       "name": "Templates",
       "suffix": "/v3.2/clients/{Client ID}/templates.json",
-      "paged": "false"
+      "paged": "false",
+      "description": "The email templates belonging to one client. Requires a client id."
     },
     {
       "name": "People",
       "suffix": "/v3.2/clients/{Client ID}/people.json",
-      "paged": "false"
+      "paged": "false",
+      "description": "The users belonging to one client, with their access level. Requires a client id. Client-level access, as opposed to account-level administrators."
     },
     {
       "name": "Person details",
       "suffix": "/v3.2/clients/{Client ID}/people.json?email={Email?}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One client user by email address. Requires the client id."
     },
     {
       "name": "Client's primary contact",
       "suffix": "/v3.2/clients/{Client ID}/primarycontact.json",
-      "paged": "false"
+      "paged": "false",
+      "description": "The main contact for one client."
     },
     {
       "name": "Journeys",
@@ -628,7 +657,8 @@
           "key": "JourneyID",
           "parameterName": "Journey ID"
         }
-      ]
+      ],
+      "description": "The automated journeys defined for one client. Requires a client id. Journeys send over time in response to behaviour, so their sends are separate from campaigns entirely -- an email volume figure taken from campaigns alone omits everything automation sent."
     },
     {
       "name": "Journey summary",
@@ -665,112 +695,134 @@
           "key": "EmailID",
           "parameterName": "Email ID"
         }
-      ]
+      ],
+      "description": "One journey's structure and its aggregate performance. Requires a journey id. The email ids here are what the journey report endpoints take."
     },
     {
       "name": "Journey email recipients",
       "suffix": "/v3.2/journeys/email/{Email ID}/recipients.json?date={Date?:YYYY-MM-DD HH:MM}",
-      "paged": "true"
+      "paged": "true",
+      "description": "Who one journey email was sent to. Requires the email id."
     },
     {
       "name": "Journey email opens",
       "suffix": "/v3.2/journeys/email/{Email ID}/opens.json?date={Date?:YYYY-MM-DD HH:MM}",
-      "paged": "true"
+      "paged": "true",
+      "description": "Open events for one journey email. Requires the email id."
     },
     {
       "name": "Journey email clicks",
       "suffix": "/v3.2/journeys/email/{Email ID}/clicks.json?date={Date?:YYYY-MM-DD HH:MM}",
-      "paged": "true"
+      "paged": "true",
+      "description": "Click events for one journey email. Requires the email id."
     },
     {
       "name": "Journey email bounces",
       "suffix": "/v3.2/journeys/email/{Email ID}/bounces.json?date={Date?:YYYY-MM-DD HH:MM}",
-      "paged": "true"
+      "paged": "true",
+      "description": "Bounce events for one journey email. Requires the email id."
     },
     {
       "name": "Journey email unsubscribes",
       "suffix": "/v3.2/journeys/email/{Email ID}/unsubscribes.json?date={Date?:YYYY-MM-DD HH:MM}",
-      "paged": "true"
+      "paged": "true",
+      "description": "Unsubscribe events attributable to one journey email. Requires the email id."
     },
     {
       "name": "List details",
       "suffix": "/v3.2/lists/{List ID}.json",
-      "paged": "false"
+      "paged": "false",
+      "description": "One list's settings -- name, confirmation requirements and the unsubscribe behaviour. Requires a list id. THE UNSUBSCRIBE SETTING MATTERS: a list set to unsubscribe from all client lists behaves very differently from one that unsubscribes only from itself, which explains audience losses that no single campaign accounts for."
     },
     {
       "name": "List stats",
       "suffix": "/v3.2/lists/{List ID}/stats.json",
-      "paged": "false"
+      "paged": "false",
+      "description": "The counts of one list -- active, unconfirmed, bounced, unsubscribed and deleted subscribers, with the new-subscriber and unsubscribe totals for the period. Requires a list id. A ready-made summary; the five state endpoints below are the row-level detail."
     },
     {
       "name": "List custom fields",
       "suffix": "/v3.2/lists/{List ID}/customfields.json",
-      "paged": "false"
+      "paged": "false",
+      "description": "The custom fields defined on one list, with their names and types. Requires a list id. The decoder for custom values on subscribers, and note fields are PER LIST -- the same attribute on two lists is two definitions."
     },
     {
       "name": "List segments",
       "suffix": "/v3.2/lists/{List ID}/segments.json",
-      "paged": "false"
+      "paged": "false",
+      "description": "The segments defined on one list, with their rules. Requires a list id."
     },
     {
       "name": "Active subscribers",
       "suffix": "/v3.2/lists/{List ID}/active.json?date={Date?:YYYY-MM-DD}&includetrackingpreference={Include Tracking Preference?:true|false}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The subscribers on one list who can be mailed, optionally added since a date. Requires a list id. THE ONLY MAILABLE STATE -- the four endpoints below hold the rest, and a subscriber count taken from the list without regard to state overstates reach."
     },
     {
       "name": "Unconfirmed subscribers",
       "suffix": "/v3.2/lists/{List ID}/unconfirmed.json?date={Date?:YYYY-MM-DD}&includetrackingpreference={Include Tracking Preference?:true|false}",
-      "paged": "true"
+      "paged": "true",
+      "description": "Subscribers who signed up but never confirmed, on a confirmed-opt-in list. They are not mailable and are not opt-outs either -- they are a signup funnel leak, and counting them as lost subscribers misattributes the cause."
     },
     {
       "name": "Unsubscribed subscribers",
       "suffix": "/v3.2/lists/{List ID}/unsubscribed.json?date={Date?:YYYY-MM-DD}&includetrackingpreference={Include Tracking Preference?:true|false}",
-      "paged": "true"
+      "paged": "true",
+      "description": "Subscribers who opted out, with the date. The deliberate departures."
     },
     {
       "name": "Bounced subscribers",
       "suffix": "/v3.2/lists/{List ID}/bounced.json?date={Date?:YYYY-MM-DD}&includetrackingpreference={Include Tracking Preference?:true|false}",
-      "paged": "true"
+      "paged": "true",
+      "description": "Subscribers removed for bouncing. Address decay rather than a decision, which is why it should be separated from unsubscribes when explaining audience shrinkage."
     },
     {
       "name": "Deleted subscribers",
       "suffix": "/v3.2/lists/{List ID}/deleted.json?date={Date?:YYYY-MM-DD}&includetrackingpreference={Include Tracking Preference?:true|false}",
-      "paged": "true"
+      "paged": "true",
+      "description": "Subscribers removed from the list by an administrator."
     },
     {
       "name": "List webhooks",
       "suffix": "/v3.2/lists/{List ID}/webhooks.json",
-      "paged": "false"
+      "paged": "false",
+      "description": "The webhooks configured on one list. Requires a list id. Integration configuration."
     },
     {
       "name": "Testing a webhook",
       "suffix": "/v3.2/lists/{List ID}/webhooks/{Webhook ID}/test.json",
-      "paged": "false"
+      "paged": "false",
+      "description": "Fires a test payload at one webhook and reports the result. Requires the list and webhook ids. A diagnostic action rather than data."
     },
     {
       "name": "Segment's details",
       "suffix": "/v3.2/segments/{Segment ID}.json",
-      "paged": "false"
+      "paged": "false",
+      "description": "One segment's rules and its current subscriber count. Requires a segment id. The rules state the client's own definition of the audience, which the name rarely conveys."
     },
     {
       "name": "Segment's active subsribers",
       "suffix": "/v3.2/segments/{Segment ID}/active.json?date={Date?:YYYY-MM-DD}&includetrackingpreference={Include Tracking Preference?:true|false}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The mailable subscribers currently matching one segment. Requires a segment id. Evaluated at request time, so it can differ from the count the segment reports."
     },
     {
       "name": "Subscriber's details",
       "suffix": "/v3.2/subscribers/{List ID}.json?email={Email}&includetrackingpreference={Include Tracking Preference?:true|false}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One subscriber on one list, by email, optionally with their tracking history. Requires the list id and email."
     },
     {
       "name": "Subscriber's history",
       "suffix": "/v3.2/subscribers/{List ID}/history.json?email={Email}",
-      "paged": "false"
+      "paged": "false",
+      "description": "Every action one subscriber took across campaigns -- opens, clicks, unsubscribes -- with timestamps. Requires the list id and email. THE PER-PERSON ENGAGEMENT RECORD, which no campaign report gives, and the basis for identifying a lapsing subscriber."
     },
     {
       "name": "Template",
       "suffix": "/v3.2/templates/{Template ID}.json",
-      "paged": "false"
+      "paged": "false",
+      "description": "One template by id, with its content and screenshot."
     },
     {
       "name": "Smart email listing",
@@ -783,22 +835,26 @@
           "key": "ID",
           "parameterName": "Smart Email ID"
         }
-      ]
+      ],
+      "description": "The transactional smart emails defined, by status. Transactional sends are a separate product from campaigns and journeys, with their own statistics -- a complete picture of email volume needs all three."
     },
     {
       "name": "Smart email details",
       "suffix": "/v3.2/transactional/smartEmail/{Smart Email ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One smart email by id, with its content and settings."
     },
     {
       "name": "Classic email group listing",
       "suffix": "/v3.2/transactional/classicEmail/groups?clientID={Client ID?}",
-      "paged": "false"
+      "paged": "false",
+      "description": "The classic transactional email groups for one client."
     },
     {
       "name": "Statistics",
       "suffix": "/v3.2/transactional/statistics?clientID={Client ID?}&smartEmailID={Smart Email ID?}&group={Group?}&from={From?:YYYY-MM-DD}&to={To?:YYYY-MM-DD}&timezone={Timezone?:utc|client}",
-      "paged": "false"
+      "paged": "false",
+      "description": "Transactional email statistics -- sent, delivered, bounced, opened and clicked -- over a period, optionally for one smart email. The aggregate view of transactional sending."
     },
     {
       "name": "Message timeline",
@@ -811,12 +867,14 @@
           "key": "MessageID",
           "parameterName": "Message ID"
         }
-      ]
+      ],
+      "description": "Individual transactional messages with their status, filterable by status and count. The per-message record, as opposed to the aggregate."
     },
     {
       "name": "Message details",
       "suffix": "/v3.2/transactional/messages/{Message ID}?statistics={Statistics?:false|true}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One transactional message by id, optionally with its statistics. Where a specific message's delivery is traced."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/chargebee/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/chargebee/endpoints.json
@@ -1,8 +1,8 @@
 {
   "endpoints": [
     {
-      "paged": "true", 
-      "name": "Subscriptions", 
+      "paged": "true",
+      "name": "Subscriptions",
       "suffix": "/v2/subscriptions?include_deleted={Include Deleted?:true|false}",
       "lookups": [
         {
@@ -20,25 +20,33 @@
             "Entity Type": "subscription"
           }
         }
-      ]
-    }, 
+      ],
+      "description": "The subscriptions on the site, one row each -- the central table of a recurring-revenue business. Carries the customer, plan, quantity, unit price, billing period and period unit, the STATUS, current_term_start and current_term_end, next_billing_at, trial dates, activated_at, cancelled_at and the cancellation reason, and the MRR. STATUS IS THE FILTER EVERYTHING DEPENDS ON: future, in_trial, active, non_renewing, paused and cancelled all live here, and only active and non_renewing are billing revenue -- while non_renewing means active but already cancelled at period end, which is the leading indicator of churn and is invisible if status is read as a simple active-or-not. NOTE ALSO THAT MONEY IS IN THE SMALLEST CURRENCY UNIT throughout Chargebee: an amount of 1000 with currency USD is ten dollars. Deleted records are excluded unless include_deleted is passed."
+    },
     {
-      "paged": "false", 
-      "name": "Subscription", 
-      "suffix": "/v2/subscriptions/{Subscription ID}"
-    }, 
+      "paged": "false",
+      "name": "Subscription",
+      "suffix": "/v2/subscriptions/{Subscription ID}",
+      "description": "One subscription by id, with its full term and addon detail."
+    },
     {
-      "paged": "false", 
-      "name": "Subscription with Scheduled Changes", 
-      "suffix": "/v2/subscriptions/{Subscription ID}/retrieve_with_scheduled_changes"
-    }, 
+      "paged": "false",
+      "name": "Subscription with Scheduled Changes",
+      "suffix": "/v2/subscriptions/{Subscription ID}/retrieve_with_scheduled_changes",
+      "description": "One subscription together with any CHANGES ALREADY SCHEDULED for its next term -- plan switches, quantity changes, price updates. Requires the subscription id. The subscription itself shows today's terms only, so a forward revenue view that ignores this misses committed changes."
+    },
     {
-      "paged": "true", 
-      "name": "Customers", 
+      "paged": "true",
+      "name": "Customers",
       "suffix": "/v2/customers?include_deleted={Include Deleted?:true|false}",
       "lookups": [
         {
-          "endpoints": ["Contacts for a Customer", "Hierarchy", "Customer's card", "Upcoming Invoices Estimates"],
+          "endpoints": [
+            "Contacts for a Customer",
+            "Hierarchy",
+            "Customer's card",
+            "Upcoming Invoices Estimates"
+          ],
           "jsonPath": "$.list[*].customer",
           "key": "id",
           "parameterName": "Customer ID"
@@ -52,61 +60,72 @@
             "Entity Type": "customer"
           }
         }
-      ]
-    }, 
+      ],
+      "description": "The customers, with company, email, billing address, the payment method on file, auto_collection setting, net term days, the taxability and any excess payments or refundable credits. The account-level entity subscriptions hang off; one customer can hold several. AUTO_COLLECTION matters for cash questions: a customer set to off is invoiced rather than charged, so their invoices sit open by design rather than through failure."
+    },
     {
-      "paged": "false", 
-      "name": "Customer", 
-      "suffix": "/v2/customers/{Customer ID}"
-    }, 
+      "paged": "false",
+      "name": "Customer",
+      "suffix": "/v2/customers/{Customer ID}",
+      "description": "One customer by id."
+    },
     {
-      "paged": "true", 
-      "name": "Contacts for a Customer", 
-      "suffix": "/v2/customers/{Customer ID}/contacts"
-    }, 
+      "paged": "true",
+      "name": "Contacts for a Customer",
+      "suffix": "/v2/customers/{Customer ID}/contacts",
+      "description": "The additional contacts on one customer, with their roles and whether each receives billing email. Requires a customer id."
+    },
     {
-      "paged": "false", 
-      "name": "Hierarchy", 
-      "suffix": "/v2/customers/{Customer ID}/hierarchy?hierarchy_operation_type={Hierarchy Operation Type?:complete_hierarchy|subordinates|path_to_root}"
-    }, 
+      "paged": "false",
+      "name": "Hierarchy",
+      "suffix": "/v2/customers/{Customer ID}/hierarchy?hierarchy_operation_type={Hierarchy Operation Type?:complete_hierarchy|subordinates|path_to_root}",
+      "description": "The parent and child relationships of one customer, for accounts that bill a group under one payer. Requires a customer id and an operation type. Where consolidated invoicing is in use, a child's revenue appears on the parent's invoice -- so per-customer revenue read without this attributes money to the wrong account."
+    },
     {
-      "paged": "true", 
-      "name": "Payment Sources", 
-      "suffix": "/v2/payment_sources"
-    }, 
+      "paged": "true",
+      "name": "Payment Sources",
+      "suffix": "/v2/payment_sources",
+      "description": "The stored payment methods, with type, status, the gateway, the card's expiry and last four digits. AN EXPIRING CARD IS THE COMMONEST CAUSE OF INVOLUNTARY CHURN, and the expiry month and year here are the only place it can be seen coming."
+    },
     {
-      "paged": "false", 
-      "name": "Payment Source", 
-      "suffix": "/v2/payment_sources/{Customer Payment Source ID}"
-    }, 
+      "paged": "false",
+      "name": "Payment Source",
+      "suffix": "/v2/payment_sources/{Customer Payment Source ID}",
+      "description": "One payment source by id."
+    },
     {
-      "paged": "true", 
-      "name": "Virtual Bank Accounts", 
-      "suffix": "/v2/virtual_bank_accounts"
-    }, 
+      "paged": "true",
+      "name": "Virtual Bank Accounts",
+      "suffix": "/v2/virtual_bank_accounts",
+      "description": "The virtual account numbers issued to customers for bank transfer payments. Relevant where collection is by transfer rather than card."
+    },
     {
-      "paged": "false", 
-      "name": "Virtual Bank Account", 
-      "suffix": "/v2/virtual_bank_accounts/{Virtual Bank Account ID}"
-    }, 
+      "paged": "false",
+      "name": "Virtual Bank Account",
+      "suffix": "/v2/virtual_bank_accounts/{Virtual Bank Account ID}",
+      "description": "One virtual bank account by id."
+    },
     {
-      "paged": "false", 
-      "name": "Customer's card", 
-      "suffix": "/v2/cards/{Customer ID}"
-    }, 
+      "paged": "false",
+      "name": "Customer's card",
+      "suffix": "/v2/cards/{Customer ID}",
+      "description": "The card on file for one customer, in Chargebee's older card representation. Requires a customer id. Superseded by payment sources, which covers every method rather than cards alone."
+    },
     {
-      "paged": "true", 
-      "name": "Promotional Credits", 
-      "suffix": "/v2/promotional_credits"
-    }, 
+      "paged": "true",
+      "name": "Promotional Credits",
+      "suffix": "/v2/promotional_credits",
+      "description": "Non-refundable credits granted to customers -- goodwill, incentives, referral rewards -- with the amount, type and description. These reduce what a customer pays without appearing as a discount on the plan, so revenue analysis that ignores them overstates realised price."
+    },
     {
-      "paged": "false", 
-      "name": "Promotional Credit", 
-      "suffix": "/v2/promotional_credits/{Account Credit ID}"
-    }, 
+      "paged": "false",
+      "name": "Promotional Credit",
+      "suffix": "/v2/promotional_credits/{Account Credit ID}",
+      "description": "One promotional credit entry by id."
+    },
     {
-      "paged": "true", 
-      "name": "Invoices", 
+      "paged": "true",
+      "name": "Invoices",
       "suffix": "/v2/invoices?include_deleted={Include Deleted?:true|false}",
       "lookups": [
         {
@@ -118,16 +137,18 @@
             "Entity Type": "invoice"
           }
         }
-      ]
-    }, 
+      ],
+      "description": "The invoices raised, with the customer and subscription, the date, the STATUS, the total, amount_paid, amount_due and amount_adjusted, the line items, taxes and discounts, and the due date. Status separates paid, posted, payment_due, not_paid, voided and pending -- and only paid represents collected money while voided never counted at all. This is the billing record; recurring-revenue metrics come from subscriptions, and the two legitimately disagree because invoices include one-off charges."
+    },
     {
-      "paged": "false", 
-      "name": "Invoice", 
-      "suffix": "/v2/invoices/{Invoice ID}"
-    }, 
+      "paged": "false",
+      "name": "Invoice",
+      "suffix": "/v2/invoices/{Invoice ID}",
+      "description": "One invoice by id, with its full line items and linked transactions."
+    },
     {
-      "paged": "true", 
-      "name": "Credit Notes", 
+      "paged": "true",
+      "name": "Credit Notes",
       "suffix": "/v2/credit_notes?include_deleted={Include Deleted?:true|false}",
       "lookups": [
         {
@@ -139,41 +160,48 @@
             "Entity Type": "credit_note"
           }
         }
-      ]
-    }, 
+      ],
+      "description": "Credits issued against invoices, with the reason code, the amount, what has been refunded and what remains allocatable. Revenue net of credits requires this: the invoice totals alone overstate it."
+    },
     {
-      "paged": "false", 
-      "name": "Credit Note", 
-      "suffix": "/v2/credit_notes/{credit_note_id}"
-    }, 
+      "paged": "false",
+      "name": "Credit Note",
+      "suffix": "/v2/credit_notes/{credit_note_id}",
+      "description": "One credit note by id."
+    },
     {
-      "paged": "true", 
-      "name": "Unbilled Charges", 
-      "suffix": "/v2/unbilled_charges?include_deleted={Include Deleted?:true|false}"
-    }, 
+      "paged": "true",
+      "name": "Unbilled Charges",
+      "suffix": "/v2/unbilled_charges?include_deleted={Include Deleted?:true|false}",
+      "description": "Charges accrued but NOT YET INVOICED -- usage recorded mid-term, one-off additions, proration from a mid-cycle change. Revenue that exists and is invisible in the invoice table until the next billing run, which is why an accrual view and a billed view differ."
+    },
     {
-      "paged": "true", 
-      "name": "Orders", 
-      "suffix": "/v2/orders?include_deleted={Include Deleted?:true|false}"
-    }, 
+      "paged": "true",
+      "name": "Orders",
+      "suffix": "/v2/orders?include_deleted={Include Deleted?:true|false}",
+      "description": "Orders raised from invoices, where the site fulfils physical goods. Carries status, shipping details and the invoice it derives from."
+    },
     {
-      "paged": "false", 
-      "name": "Order", 
-      "suffix": "/v2/orders/{Order ID}"
-    }, 
+      "paged": "false",
+      "name": "Order",
+      "suffix": "/v2/orders/{Order ID}",
+      "description": "One order by id."
+    },
     {
-      "paged": "true", 
-      "name": "Gifts", 
-      "suffix": "/v2/gifts"
-    }, 
+      "paged": "true",
+      "name": "Gifts",
+      "suffix": "/v2/gifts",
+      "description": "Gift subscriptions, with the giver, receiver and claim status. Only meaningful on sites that sell gifting."
+    },
     {
-      "paged": "false", 
-      "name": "Gift", 
-      "suffix": "/v2/gifts/{Gift ID}"
-    }, 
+      "paged": "false",
+      "name": "Gift",
+      "suffix": "/v2/gifts/{Gift ID}",
+      "description": "One gift by id."
+    },
     {
-      "paged": "true", 
-      "name": "Transactions", 
+      "paged": "true",
+      "name": "Transactions",
       "suffix": "/v2/transactions?include_deleted={Include Deleted?:true|false}",
       "lookups": [
         {
@@ -185,36 +213,42 @@
             "Entity Type": "transaction"
           }
         }
-      ]
-    }, 
+      ],
+      "description": "The payment attempts and their outcomes, with the type (payment, refund, authorization), the STATUS (success, failure, timeout, needs_attention), the gateway, the amount, the error code and text where it failed, and the invoices settled. FAILED PAYMENTS ARE ROWS HERE AND NOWHERE ELSE -- an invoice shows only that it is unpaid, and involuntary churn is diagnosed from the error codes in this table."
+    },
     {
-      "paged": "false", 
-      "name": "Transaction", 
-      "suffix": "/v2/transactions/{Transaction ID}"
-    }, 
+      "paged": "false",
+      "name": "Transaction",
+      "suffix": "/v2/transactions/{Transaction ID}",
+      "description": "One transaction by id, with its gateway response."
+    },
     {
-      "paged": "true", 
-      "name": "Hosted Pages", 
-      "suffix": "/v2/hosted_pages"
-    }, 
+      "paged": "true",
+      "name": "Hosted Pages",
+      "suffix": "/v2/hosted_pages",
+      "description": "The checkout and portal pages generated, with their state and the object each created. Operational records of checkout sessions rather than customer data."
+    },
     {
-      "paged": "false", 
-      "name": "Hosted Page", 
-      "suffix": "/v2/hosted_pages/{Hosted Page ID}"
-    }, 
+      "paged": "false",
+      "name": "Hosted Page",
+      "suffix": "/v2/hosted_pages/{Hosted Page ID}",
+      "description": "One hosted page by id."
+    },
     {
-      "paged": "false", 
-      "name": "Subscription Renewal Estimate", 
-      "suffix": "/v2/subscriptions/{Subscription ID}/renewal_estimate?include_delayed_charges={Include Delayed Charges?}&use_existing_balances={Use Existing Balances?}&ignore_scheduled_cancellation={Ignore Scheduled Cancellation?}&ignore_scheduled_changes={Ignore Scheduled Changes?}"
-    }, 
+      "paged": "false",
+      "name": "Subscription Renewal Estimate",
+      "suffix": "/v2/subscriptions/{Subscription ID}/renewal_estimate?include_delayed_charges={Include Delayed Charges?}&use_existing_balances={Use Existing Balances?}&ignore_scheduled_cancellation={Ignore Scheduled Cancellation?}&ignore_scheduled_changes={Ignore Scheduled Changes?}",
+      "description": "What one subscription WILL be charged at its next renewal, computed by Chargebee. Requires the subscription id. Forward-looking rather than historical -- and it applies the coupons, taxes and scheduled changes that make a naive price-times-quantity estimate wrong."
+    },
     {
-      "paged": "false", 
-      "name": "Upcoming Invoices Estimates", 
-      "suffix": "/v2/customers/{Customer ID}/upcoming_invoices_estimate"
-    }, 
+      "paged": "false",
+      "name": "Upcoming Invoices Estimates",
+      "suffix": "/v2/customers/{Customer ID}/upcoming_invoices_estimate",
+      "description": "The invoices one customer is due to receive next, estimated across all their subscriptions. Requires a customer id. The customer-level forward view."
+    },
     {
-      "paged": "true", 
-      "name": "Quotes", 
+      "paged": "true",
+      "name": "Quotes",
       "suffix": "/v2/quotes?include_deleted={Include Deleted?:true|false}",
       "lookups": [
         {
@@ -226,16 +260,18 @@
             "Entity Type": "quote"
           }
         }
-      ]
-    }, 
+      ],
+      "description": "Quotes issued to prospects, with the line items, total and status. The pipeline before a subscription exists; an accepted quote becomes a subscription."
+    },
     {
-      "paged": "false", 
-      "name": "Quote", 
-      "suffix": "/v2/quotes/{Quote ID}"
-    }, 
+      "paged": "false",
+      "name": "Quote",
+      "suffix": "/v2/quotes/{Quote ID}",
+      "description": "One quote by id."
+    },
     {
-      "paged": "true", 
-      "name": "Plans", 
+      "paged": "true",
+      "name": "Plans",
       "suffix": "/v2/plans",
       "lookups": [
         {
@@ -247,16 +283,18 @@
             "Entity Type": "plan"
           }
         }
-      ]
-    }, 
+      ],
+      "description": "The recurring plans offered, with price, billing period and period unit, currency, trial period, setup cost, and status. The catalogue subscriptions reference. Note a plan is per currency, so the same commercial offer in three currencies is three plans."
+    },
     {
-      "paged": "false", 
-      "name": "Plan", 
-      "suffix": "/v2/plans/{Plan ID}"
-    }, 
+      "paged": "false",
+      "name": "Plan",
+      "suffix": "/v2/plans/{Plan ID}",
+      "description": "One plan by id."
+    },
     {
-      "paged": "true", 
-      "name": "Addons", 
+      "paged": "true",
+      "name": "Addons",
       "suffix": "/v2/addons",
       "lookups": [
         {
@@ -268,16 +306,18 @@
             "Entity Type": "addon"
           }
         }
-      ]
-    }, 
+      ],
+      "description": "The optional extras subscriptions can carry, with price, type (recurring, non-recurring or quantity-based), and period. Addon revenue sits alongside plan revenue and is easy to omit from an ARPU figure."
+    },
     {
-      "paged": "false", 
-      "name": "Addon", 
-      "suffix": "/v2/addons/{Addon ID}"
-    }, 
+      "paged": "false",
+      "name": "Addon",
+      "suffix": "/v2/addons/{Addon ID}",
+      "description": "One addon by id."
+    },
     {
-      "paged": "true", 
-      "name": "Coupons", 
+      "paged": "true",
+      "name": "Coupons",
       "suffix": "/v2/coupons",
       "lookups": [
         {
@@ -289,82 +329,98 @@
             "Entity Type": "coupon"
           }
         }
-      ]
-    }, 
+      ],
+      "description": "The discounts defined, with the discount type and amount, duration, and the plans they apply to. The gap between list price and realised price is explained here."
+    },
     {
-      "paged": "false", 
-      "name": "Coupon", 
-      "suffix": "/v2/coupons/{coupon_id}"
-    }, 
+      "paged": "false",
+      "name": "Coupon",
+      "suffix": "/v2/coupons/{coupon_id}",
+      "description": "One coupon by id."
+    },
     {
-      "paged": "true", 
-      "name": "Coupon Sets", 
-      "suffix": "/v2/coupon_sets"
-    }, 
+      "paged": "true",
+      "name": "Coupon Sets",
+      "suffix": "/v2/coupon_sets",
+      "description": "Groups of single-use coupon codes issued under one campaign. The container; the individual codes are separate."
+    },
     {
-      "paged": "false", 
-      "name": "Coupon Set", 
-      "suffix": "/v2/coupon_sets/{Coupon Set ID}"
-    }, 
+      "paged": "false",
+      "name": "Coupon Set",
+      "suffix": "/v2/coupon_sets/{Coupon Set ID}",
+      "description": "One coupon set by id, with how many of its codes are used and how many remain."
+    },
     {
-      "paged": "true", 
-      "name": "Coupon Codes", 
-      "suffix": "/v2/coupon_codes"
-    }, 
+      "paged": "true",
+      "name": "Coupon Codes",
+      "suffix": "/v2/coupon_codes",
+      "description": "The individual redeemable codes within coupon sets, with their redemption status. Take-up of a campaign is counted here."
+    },
     {
-      "paged": "false", 
-      "name": "Coupon Code", 
-      "suffix": "/v2/coupon_codes/{Coupon Code Code}"
-    }, 
+      "paged": "false",
+      "name": "Coupon Code",
+      "suffix": "/v2/coupon_codes/{Coupon Code Code}",
+      "description": "One coupon code by its code string."
+    },
     {
-      "paged": "true", 
-      "name": "Addresses", 
-      "suffix": "/v2/addresses?subscription_id={Subscription ID}&label={Label}"
-    }, 
+      "paged": "true",
+      "name": "Addresses",
+      "suffix": "/v2/addresses?subscription_id={Subscription ID}&label={Label}",
+      "description": "The shipping and billing addresses on one subscription, by label. Requires the subscription id."
+    },
     {
-      "paged": "true", 
-      "name": "Events", 
-      "suffix": "/v2/events"
-    }, 
+      "paged": "true",
+      "name": "Events",
+      "suffix": "/v2/events",
+      "description": "Everything that has happened on the site as a stream -- subscription created, changed, cancelled, payment succeeded or failed, invoice generated -- each with its type, timestamp and the affected object. THE AUDIT TRAIL AND THE INCREMENTAL-SYNC MECHANISM: entity tables carry current state only, so when a subscription changed and what it changed from is answerable only here. Events are retained for a limited period, so older history is genuinely gone."
+    },
     {
-      "paged": "false", 
-      "name": "Event", 
-      "suffix": "/v2/events/{Event ID}"
-    }, 
+      "paged": "false",
+      "name": "Event",
+      "suffix": "/v2/events/{Event ID}",
+      "description": "One event by id, with its full payload."
+    },
     {
-      "paged": "true", 
-      "name": "Comments", 
-      "suffix": "/v2/comments?entity_type={Entity Type?}&entity_id={Entity ID?}"
-    }, 
+      "paged": "true",
+      "name": "Comments",
+      "suffix": "/v2/comments?entity_type={Entity Type?}&entity_id={Entity ID?}",
+      "description": "Internal notes on customers, subscriptions and invoices, filterable by entity type and id. Where a human explanation of an unusual account is recorded."
+    },
     {
-      "paged": "false", 
-      "name": "Comment", 
-      "suffix": "/v2/comments/{Comment ID}"
-    }, 
+      "paged": "false",
+      "name": "Comment",
+      "suffix": "/v2/comments/{Comment ID}",
+      "description": "One comment by id."
+    },
     {
-      "paged": "false", 
-      "name": "Portal Session", 
-      "suffix": "/v2/portal_sessions/{Portal Session ID}"
-    }, 
+      "paged": "false",
+      "name": "Portal Session",
+      "suffix": "/v2/portal_sessions/{Portal Session ID}",
+      "description": "One customer self-service portal session by id. Short-lived operational record."
+    },
     {
-      "paged": "true", 
-      "name": "Site Migration Details", 
-      "suffix": "/v2/site_migration_details"
-    }, 
+      "paged": "true",
+      "name": "Site Migration Details",
+      "suffix": "/v2/site_migration_details",
+      "description": "Records of subscriptions migrated in or out of this site. Explains subscriptions whose history appears to begin mid-life."
+    },
     {
-      "paged": "false", 
-      "name": "Time Machine", 
-      "suffix": "/v2/time_machines/{Time Machine Name}"
-    }, 
+      "paged": "false",
+      "name": "Time Machine",
+      "suffix": "/v2/time_machines/{Time Machine Name}",
+      "description": "The state of a test site's simulated clock. Requires the time machine name. TEST SITES ONLY -- it exists so future billing can be simulated, and returns nothing meaningful on a live site."
+    },
     {
-      "paged": "false", 
-      "name": "Export", 
-      "suffix": "/v2/exports/{Export ID}"
-    }, 
+      "paged": "false",
+      "name": "Export",
+      "suffix": "/v2/exports/{Export ID}",
+      "description": "The status of one bulk export job, with its download link once complete. Requires an export id. THE ROUTE TO A FULL EXTRACT: the list endpoints page, and an export is how a whole site's data is obtained in one piece."
+    },
     {
-      "paged": "false", 
-      "name": "Payment Intent", 
-      "suffix": "/v2/payment_intents/{Payment Intent ID}"
+      "paged": "false",
+      "name": "Payment Intent",
+      "suffix": "/v2/payment_intents/{Payment Intent ID}",
+      "description": "One payment intent by id, used in checkout flows requiring additional authentication. Operational rather than analytical."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/chargify/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/chargify/endpoints.json
@@ -3,32 +3,38 @@
     {
       "name": "Management Link",
       "suffix": "/portal/customers/{Customer ID}/management_link.json",
-      "paged": false
+      "paged": false,
+      "description": "A self-service portal link for one customer. Requires a customer id. Operational, and short-lived."
     },
     {
       "name": "Component by Handle",
       "suffix": "/components/lookup.json?handle={Component Handle}",
-      "paged": false
+      "paged": false,
+      "description": "One component by handle."
     },
     {
       "name": "Product Family Components",
       "suffix": "/product_families/{Product Family ID}/components.json?include_archived={Include Archived?:true/false}",
-      "paged": false
+      "paged": false,
+      "description": "The components available within one family. Requires a family id."
     },
     {
       "name": "Product Family Component",
       "suffix": "/product_families/{Product Family ID}/components/{Component ID}.json",
-      "paged": false
+      "paged": false,
+      "description": "One component within a family."
     },
     {
       "name": "Product Family Component by Handle",
       "suffix": "/product_families/{Product Family ID}/components/handle:{Component Handle}.json",
-      "paged": false
+      "paged": false,
+      "description": "One component within a family, by handle."
     },
     {
       "name": "Subscription Components",
       "suffix": "/subscriptions/{Subscription ID}/components.json",
-      "paged": false
+      "paged": false,
+      "description": "The components attached to one subscription, with their allocated quantities and prices. Requires a subscription id. What a subscription actually consists of beyond its product."
     },
     {
       "name": "Components",
@@ -43,182 +49,218 @@
           "key": "component.id",
           "parameterName": "Component ID"
         }
-      ]
+      ],
+      "description": "The metered, quantity and on-off components that can be attached to subscriptions -- the usage-based part of a bill, as opposed to the flat product price."
     },
     {
       "name": "Subscription Component",
       "suffix": "/subscriptions/{Subscription ID}/components/{Component ID}.json",
-      "paged": false
+      "paged": false,
+      "description": "One component on one subscription."
     },
     {
       "name": "Subscription Component Usage",
       "suffix": "/subscriptions/{Subscription ID}/components/{Component ID}/usages.json?since_id={IDs Greater Than or Equal To?}&max_id={IDs Less Than or Equal To?}&since_date={Since Date?:yyyy-MM-dd}&until_date={Until Date?:yyyy-MM-dd}",
-      "paged": true
+      "paged": true,
+      "description": "The metered usage recorded against one component on one subscription. Requires both ids. THE RAW CONSUMPTION that a usage-based charge is computed from -- the invoice shows the charge, this shows what drove it."
     },
     {
       "name": "Subscription Component Allocations",
       "suffix": "/subscriptions/{Subscription ID}/components/{Component ID}/allocations.json",
-      "paged": false
+      "paged": false,
+      "description": "The history of quantity changes for one component on one subscription. Requires both ids. Upgrades and downgrades within a term are recorded here rather than on the subscription, so seat-count changes are only traceable through this."
     },
     {
       "name": "Component Price Points",
       "suffix": "/components/{Component ID}/price_points.json",
-      "paged": false
+      "paged": false,
+      "description": "The alternative price points of one component. Requires a component id."
     },
     {
       "name": "Product Family Coupons",
       "suffix": "/product_families/{Product Family ID}/coupons.json",
-      "paged": true
+      "paged": true,
+      "description": "The coupons within one family. Requires a family id. The gap between list price and realised price is explained here."
     },
     {
       "name": "Product Family Coupon",
       "suffix": "/product_families/{Product Family ID}/coupons/{Coupon ID}.json",
-      "paged": false
+      "paged": false,
+      "description": "One coupon within a family."
     },
     {
       "name": "Coupon Usage",
       "suffix": "/coupons/{Coupon ID}/usage.json",
-      "paged": false
+      "paged": false,
+      "description": "How often one coupon has been redeemed, and against which products. Requires a coupon id. Campaign take-up, which the coupon definition does not carry."
     },
     {
       "name": "Coupon Search",
       "suffix": "/coupons/find.json?product_family_id={Product Family ID?}&code={Coupon Code?}",
-      "paged": false
+      "paged": false,
+      "description": "Coupons matching criteria across families. The lookup when the family is not known."
     },
     {
       "name": "Default Product Family Coupons",
       "suffix": "/coupons.json",
-      "paged": true
+      "paged": true,
+      "description": "The coupons of the default product family."
     },
     {
       "name": "Coupon Subcodes",
       "suffix": "/coupons/{Coupon ID}/codes.json",
-      "paged": false
+      "paged": false,
+      "description": "The individual codes issued under one coupon. Requires a coupon id. Where a campaign issues unique codes per recipient, redemption is tracked at this level."
     },
     {
       "name": "Customers",
       "suffix": "/customers.json",
-      "paged": true
+      "paged": true,
+      "description": "The customers, with name, email, organisation, address, the reference from the source system, and their created and updated dates."
     },
     {
       "name": "Customer",
       "suffix": "/customers/{Customer ID}.json",
-      "paged": false
+      "paged": false,
+      "description": "One customer by id."
     },
     {
       "name": "Customer by Reference",
       "suffix": "/customers/lookup.json?reference={Reference ID}",
-      "paged": false
+      "paged": false,
+      "description": "One customer by the external reference. The lookup from a source-system id."
     },
     {
       "name": "Customer Subscriptions",
       "suffix": "/customers/{Customer ID}/subscriptions.json",
-      "paged": false
+      "paged": false,
+      "description": "The subscriptions of one customer. Requires a customer id. One customer can hold several."
     },
     {
       "name": "Customer Search",
       "suffix": "/customers.json?q={Search Term?:email,ID,reference,organization}",
-      "paged": false
+      "paged": false,
+      "description": "Customers matching a term across email, id, reference and organisation. The general lookup."
     },
     {
       "name": "Subscription Events",
       "suffix": "/subscriptions/{Subscription ID}/events.json?since_id={IDs Greater Than or Equal To?}&max_id={IDs Less Than or Equal To?}&filter={Filter?}",
-      "paged": true
+      "paged": true,
+      "description": "The event history of one subscription since a given id. Requires a subscription id. The per-account lifecycle, and the source for churn timing."
     },
     {
       "name": "Events",
       "suffix": "/events.json?since_id={IDs Greater Than or Equal To?}&max_id={IDs Less Than or Equal To?}&filter={Filter?}",
-      "paged": true
+      "paged": true,
+      "description": "Everything that has happened on the site since a given id -- subscription state changes, payments, renewals, component allocations. THE AUDIT TRAIL AND THE INCREMENTAL-SYNC MECHANISM: entity tables carry current state only, so when a subscription changed and what it changed from is answerable here alone."
     },
     {
       "name": "Event Count",
       "suffix": "/events/count.json?since_id={IDs Greater Than or Equal To?}&max_id={IDs Less Than or Equal To?}&filter={Filter?}",
-      "paged": false
+      "paged": false,
+      "description": "The number of events matching the filters. The size check before a sync."
     },
     {
       "name": "Invoices",
       "suffix": "/invoices.json?subscription_id={Subscription ID?}&start_date={Start Date?:yyyy-MM-dd}&end_date={End Date?:yyyy-MM-dd}&status={Status?:draft|open|paid|pending|voided}&line_items={Include Line Items?:true|false}&discounts={Include Discounts?:true|false}&taxes={Include Taxes Data?:true|false}&credits={Include Credits Data?:true|false}&payments={Include Payments Data?:true|false}&custom_fields={Include Custom Fields?:true|false}",
-      "paged": true
+      "paged": true,
+      "description": "The invoices raised, filterable by subscription and date. Carries the customer, subscription, number, status, totals and line items."
     },
     {
       "name": "Invoice",
       "suffix": "/invoices/{Invoice ID}.json?start_date={Start Date?:yyyy-MM-dd}&end_date={End Date?:yyyy-MM-dd}",
-      "paged": false
+      "paged": false,
+      "description": "One invoice by id, with its line items and payments."
     },
     {
       "name": "Invoice Payments",
       "suffix": "/invoices/{Invoice ID}/payments.json?start_date={Start Date?:yyyy-MM-dd}&end_date={End Date?:yyyy-MM-dd}",
-      "paged": false
+      "paged": false,
+      "description": "The payments applied to one invoice. Requires an invoice id. The invoice carries a balance; this says when money arrived."
     },
     {
       "name": "Invoice Events",
       "suffix": "/invoices/events.json?since_id={IDs Greater Than or Equal To?}&since_date={Since Date?:yyyy-MM-dd}&invoice_uid={Invoice ID?}",
-      "paged": true
+      "paged": true,
+      "description": "The events on invoices since a given id -- issued, applied, voided, refunded. The change log for billing documents, and the incremental-sync route for them."
     },
     {
       "name": "Credit Notes",
       "suffix": "/credit_notes.json?subscription_id={Subscription ID?}&line_items={Include Line Items?:true|false}&discounts={Include Discounts?:true|false}&taxes={Include Taxes Data?:true|false}&refunds={Include Credits Data?:true|false}&applications={Include Payments Data?:true|false}",
-      "paged": false
+      "paged": false,
+      "description": "Credits issued against invoices, filterable by subscription. Revenue net of credits requires this; invoice totals alone overstate it."
     },
     {
       "name": "Credit Note",
       "suffix": "/credit_notes/{Credit Note ID}",
-      "paged": false
+      "paged": false,
+      "description": "One credit note by id."
     },
     {
       "name": "Notes",
       "suffix": "/subscriptions/{Subscription ID}/notes.json",
-      "paged": true
+      "paged": true,
+      "description": "Internal notes on one subscription. Requires a subscription id. Where a human explanation of an unusual account is recorded."
     },
     {
       "name": "Note",
       "suffix": "/subscriptions/{Subscription ID}/notes/{Note ID}.json",
-      "paged": false
+      "paged": false,
+      "description": "One note by id."
     },
     {
       "name": "Offers",
       "suffix": "/offers.json",
-      "paged": false
+      "paged": false,
+      "description": "The bundled offers defined -- a product plus components and coupons sold as one package. What is actually presented for sale, as opposed to its constituent parts."
     },
     {
       "name": "Offer",
       "suffix": "/offers/{Offer ID}.json",
-      "paged": false
+      "paged": false,
+      "description": "One offer by id, with its components."
     },
     {
       "name": "Payment Profiles",
       "suffix": "/payment_profiles.json?customer_id={Customer ID?}",
-      "paged": true
+      "paged": true,
+      "description": "The stored payment methods, optionally for one customer. Carries the type, the card's expiry and last four digits, and the gateway. AN EXPIRING CARD IS THE COMMONEST CAUSE OF INVOLUNTARY CHURN and the expiry here is the only place it can be anticipated."
     },
     {
       "name": "Payment Profile",
       "suffix": "/payment_profiles/{Payment Profile ID}.json",
-      "paged": false
+      "paged": false,
+      "description": "One payment profile by id."
     },
     {
       "name": "Products",
       "suffix": "/product_families/{Product Family ID}/products.json?include_archived={Include Archived?:true|false}",
-      "paged": false
+      "paged": false,
+      "description": "The products within one family, with their price, billing period, trial and setup charges. Requires a family id. What subscriptions are sold on."
     },
     {
       "name": "Product",
       "suffix": "/products/{Product ID}.json",
-      "paged": false
+      "paged": false,
+      "description": "One product by id."
     },
     {
       "name": "Product by Handle",
       "suffix": "/products/handle/{Product Handle}.json",
-      "paged": false
+      "paged": false,
+      "description": "One product by its handle -- the human-readable identifier, more stable than the numeric id across environments."
     },
     {
       "name": "Product Price Points",
       "suffix": "/products/{Product ID}/price_points.json",
-      "paged": false
+      "paged": false,
+      "description": "The alternative price points of one product. Requires a product id. A product can be sold at several prices, so the product's headline price is not necessarily what a given subscription pays."
     },
     {
       "name": "Product Price Point",
       "suffix": "/products/{Product ID}/price_points/{Price Point ID}.json",
-      "paged": false
+      "paged": false,
+      "description": "One product price point by id."
     },
     {
       "name": "Product Families",
@@ -236,62 +278,74 @@
           "key": "product_family.id",
           "parameterName": "Product Family ID"
         }
-      ]
+      ],
+      "description": "The product families -- the top-level grouping products, components and coupons belong to. NEARLY EVERYTHING IN CHARGIFY IS SCOPED TO A FAMILY, so this is the first request and a figure taken without regard to family may span unrelated product lines."
     },
     {
       "name": "Product Family",
       "suffix": "/product_families/{Product Family ID}.json",
-      "paged": false
+      "paged": false,
+      "description": "One product family by id."
     },
     {
       "name": "Reason Codes",
       "suffix": "/reason_codes.json",
-      "paged": true
+      "paged": true,
+      "description": "The cancellation reason codes configured. THE STRUCTURED ANSWER TO WHY CUSTOMERS LEAVE, which the cancellation message alone does not give in analysable form."
     },
     {
       "name": "Reason Code",
       "suffix": "/reason_codes/{Reason Code ID}.json",
-      "paged": false
+      "paged": false,
+      "description": "One reason code by id."
     },
     {
       "name": "Validate Referral Code",
       "suffix": "/referral_codes/validate.json?code={Referral Code}",
-      "paged": false
+      "paged": false,
+      "description": "Checks whether a referral code is valid. A validation call rather than data."
     },
     {
       "name": "Subscription Statement IDs",
       "suffix": "/subscriptions/{Subscription ID}/statements/ids.json?settled_since={Settled Since?:UNIX timestamp}",
-      "paged": false
+      "paged": false,
+      "description": "The statement ids of one subscription, filterable by settlement date."
     },
     {
       "name": "Statement IDs",
       "suffix": "/statements/ids.json?settled_since={Settled Since?:UNIX timestamp}",
-      "paged": false
+      "paged": false,
+      "description": "The ids of statements settled since a date. The cheap way to find what to fetch rather than paging statements themselves."
     },
     {
       "name": "Subscription Statements",
       "suffix": "/subscriptions/{Subscription ID}/statements.json",
-      "paged": true
+      "paged": true,
+      "description": "The statements of one subscription. Requires a subscription id."
     },
     {
       "name": "Statements",
       "suffix": "/statements.json",
-      "paged": false
+      "paged": false,
+      "description": "The billing statements produced. A statement is the period summary sent to a customer, as distinct from an invoice."
     },
     {
       "name": "Statement",
       "suffix": "/statements/{Statement ID}.json",
-      "paged": false
+      "paged": false,
+      "description": "One statement by id."
     },
     {
       "name": "Stats",
       "suffix": "/stats.json",
-      "paged": false
+      "paged": false,
+      "description": "The site's headline figures -- subscription counts by state, revenue this month, and similar. One record of totals, and the cheapest sanity check on any figure derived the long way."
     },
     {
       "name": "Subscription",
       "suffix": "/subscriptions/{Subscription ID}.json",
-      "paged": false
+      "paged": false,
+      "description": "One subscription by id, with its full state and product detail."
     },
     {
       "name": "Subscriptions",
@@ -309,37 +363,44 @@
           "key": "subscription.id",
           "parameterName": "Subscription ID"
         }
-      ]
+      ],
+      "description": "The subscriptions on the site, one row each -- the central table. Carries the customer, product, the STATE, current period start and end, activated_at, cancelled_at and the cancellation message, the balance, and any coupon applied. Filterable by state. STATE IS THE FILTER EVERYTHING DEPENDS ON, and Chargify's set is unusually fine: trialing, assessing, active, soft_failure, past_due, canceled, expired, unpaid, on_hold and pending_cancellation. PAST_DUE AND SOFT_FAILURE ARE STILL ACTIVE SUBSCRIPTIONS whose payment failed -- they are the involuntary-churn pipeline, and reading state as a simple active-or-cancelled misses them entirely."
     },
     {
       "name": "Subscription by Reference",
       "suffix": "/subscriptions/lookup.json?reference={Reference}",
-      "paged": false
+      "paged": false,
+      "description": "One subscription looked up by the reference the source system assigned. The bridge from an external identifier to Chargify's own."
     },
     {
       "name": "Transactions",
       "suffix": "/transactions.json?kinds[]={Transactions Types?,:charge,payment,credit,...}&since_id={IDs Greater Than or Equal To?}&max_id={IDs Less Than or Equal To?}&since_date={Since Date?:yyyy-MM-dd}&until_date={Until Date?:yyyy-MM-dd}",
-      "paged": true
+      "paged": true,
+      "description": "Payment attempts and their outcomes, filterable by kind. Carries the type, amount, success flag, the gateway response and the subscription. FAILED PAYMENTS EXIST HERE AND NOWHERE ELSE, which is where involuntary churn is diagnosed."
     },
     {
       "name": "Transaction",
       "suffix": "/transactions/{Transaction ID}.json",
-      "paged": false
+      "paged": false,
+      "description": "One transaction by id."
     },
     {
       "name": "Subscription Transactions",
       "suffix": "/subscriptions/{Subscription ID}/transactions.json?kinds[]={Transactions Types?,:charge,payment,credit,...}&since_id={IDs Greater Than or Equal To?}&max_id={IDs Less Than or Equal To?}&since_date={Since Date?:yyyy-MM-dd}&until_date={Until Date?:yyyy-MM-dd}",
-      "paged": true
+      "paged": true,
+      "description": "The transactions of one subscription, filterable by kind. Requires a subscription id. The per-account payment history."
     },
     {
       "name": "Transaction Count",
       "suffix": "/transactions/count.json",
-      "paged": false
+      "paged": false,
+      "description": "The number of transactions matching the filters, without returning them. The cheap size check before an extract."
     },
     {
       "name": "Webhooks",
       "suffix": "/webhooks.json?since_date={Since Date?:yyyy-MM-dd}&until_date={Until Date?:yyyy-MM-dd}",
-      "paged": true
+      "paged": true,
+      "description": "The webhook deliveries attempted, filterable by date and status. NOT configuration: this is the delivery log, so a silently broken integration is visible here."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/freshdesk/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/freshdesk/endpoints.json
@@ -1,289 +1,346 @@
 {
   "endpoints": [
     {
-      "paged": "false", 
-      "name": "Ticket", 
-      "suffix": "/v2/tickets/{Ticket ID}"
-    }, 
+      "paged": "false",
+      "name": "Ticket",
+      "suffix": "/v2/tickets/{Ticket ID}",
+      "description": "One ticket by id, with its full field set. Related records -- conversations, requester, company -- are inlined only when explicitly included."
+    },
     {
-      "paged": "true", 
-      "name": "Tickets", 
-      "suffix": "/v2/tickets?query={Query?:(status:1 OR tag:'tag')}"
-    }, 
+      "paged": "true",
+      "name": "Tickets",
+      "suffix": "/v2/tickets?query={Query?:(status:1 OR tag:'tag')}",
+      "description": "The support tickets, with subject, description, the requester, the agent and group assigned, the product, source, tags, custom fields, and created, updated and due timestamps. The query parameter takes Freshdesk's own filter syntax. NOTE THE CODED COLUMNS, which Freshdesk fixes rather than exposing a decoder for: STATUS is 2 Open, 3 Pending, 4 Resolved, 5 Closed; PRIORITY is 1 Low, 2 Medium, 3 High, 4 Urgent; SOURCE is 1 Email, 2 Portal, 3 Phone, 7 Chat, 9 Feedback Widget, 10 Outbound Email. A breakdown left as raw integers is unreadable. NOTE ALSO THAT THE DEFAULT LISTING RETURNS ONLY THE LAST 30 DAYS unless a date filter says otherwise, which silently truncates any historical question."
+    },
     {
-      "paged": "true", 
-      "name": "Ticket Fields", 
-      "suffix": "/v2/ticket_fields?type={Type?}"
-    }, 
+      "paged": "true",
+      "name": "Ticket Fields",
+      "suffix": "/v2/ticket_fields?type={Type?}",
+      "description": "Every field a ticket can carry, standard and custom, with type, whether required at which stage, and for dropdowns the allowed choices. The decoder for custom fields, and the statement of what the account actually records."
+    },
     {
-      "paged": "true", 
-      "name": "Ticket Conversations", 
-      "suffix": "/v2/tickets/{Ticket ID}/conversations"
-    }, 
+      "paged": "true",
+      "name": "Ticket Conversations",
+      "suffix": "/v2/tickets/{Ticket ID}/conversations",
+      "description": "The replies and private notes on one ticket, with author, body, whether each is private, and timestamps. Requires a ticket id. THE PRIVATE FLAG MATTERS: internal notes and customer-facing replies share this table, and counting both as responses overstates how much the customer heard."
+    },
     {
-      "paged": "true", 
-      "name": "Ticket Time Entries", 
-      "suffix": "/v2/tickets/{Ticket ID}/time_entries"
-    }, 
+      "paged": "true",
+      "name": "Ticket Time Entries",
+      "suffix": "/v2/tickets/{Ticket ID}/time_entries",
+      "description": "The time logged against one ticket, with the agent, duration, whether it is billable, and any note. Requires a ticket id. Cost of support is only answerable through this; the ticket itself carries no effort figure."
+    },
     {
-      "paged": "true", 
-      "name": "Ticket Satisfaction Ratings", 
-      "suffix": "/v2/tickets/{Ticket ID}/satisfaction_ratings"
-    }, 
+      "paged": "true",
+      "name": "Ticket Satisfaction Ratings",
+      "suffix": "/v2/tickets/{Ticket ID}/satisfaction_ratings",
+      "description": "The satisfaction responses for one ticket. Requires a ticket id."
+    },
     {
-      "paged": "false", 
-      "name": "Contact", 
-      "suffix": "/v2/contacts/{Contact ID}"
-    }, 
+      "paged": "false",
+      "name": "Contact",
+      "suffix": "/v2/contacts/{Contact ID}",
+      "description": "One contact by id."
+    },
     {
-      "paged": "true", 
-      "name": "Contacts", 
-      "suffix": "/v2/contacts?query={Query?:(active:true AND tag:'tag')}"
-    }, 
+      "paged": "true",
+      "name": "Contacts",
+      "suffix": "/v2/contacts?query={Query?:(active:true AND tag:'tag')}",
+      "description": "The end users who raise tickets, with name, email, phone, the company, tags, custom fields, and their active state. The query parameter takes the filter syntax. Note contacts and AGENTS are separate tables in Freshdesk, so a count of people in the system is the sum of both."
+    },
     {
-      "paged": "true", 
-      "name": "Contact Fields", 
-      "suffix": "/v2/contact_fields"
-    }, 
+      "paged": "true",
+      "name": "Contact Fields",
+      "suffix": "/v2/contact_fields",
+      "description": "Every field a contact can carry, standard and custom."
+    },
     {
-      "paged": "false", 
-      "name": "Contact Imports", 
-      "suffix": "/v2/contacts/imports?status={Status?:in_progress|completed|cancelled|failed}"
-    }, 
+      "paged": "false",
+      "name": "Contact Imports",
+      "suffix": "/v2/contacts/imports?status={Status?:in_progress|completed|cancelled|failed}",
+      "description": "Bulk contact import jobs and their status. Where a data load's outcome, including failed rows, is recorded -- the import itself reports only that it was queued."
+    },
     {
-      "paged": "false", 
+      "paged": "false",
       "name": "Contact Import",
-      "suffix": "/v2/contacts/imports/{Import ID}"
-    }, 
+      "suffix": "/v2/contacts/imports/{Import ID}",
+      "description": "One contact import by id, with its per-row errors."
+    },
     {
-      "paged": "false", 
-      "name": "Agent", 
-      "suffix": "/v2/agents/{Agent ID}"
-    }, 
+      "paged": "false",
+      "name": "Agent",
+      "suffix": "/v2/agents/{Agent ID}",
+      "description": "One agent by id."
+    },
     {
-      "paged": "true", 
-      "name": "Agents", 
-      "suffix": "/v2/agents?email={Email Address?}&mobile={Mobile Phone?}&phone={Phone?}&state={State?:fulltime|occasional}"
-    }, 
+      "paged": "true",
+      "name": "Agents",
+      "suffix": "/v2/agents?email={Email Address?}&mobile={Mobile Phone?}&phone={Phone?}&state={State?:fulltime|occasional}",
+      "description": "The support staff, with name, email, ticket scope, groups, roles, whether available, and their signature. Filterable by email, phone or state. TICKET SCOPE decides which tickets an agent can see, and is therefore why two agents running the same query get different counts."
+    },
     {
-      "paged": "false", 
-      "name": "Current Agent", 
-      "suffix": "/v2/agents/me"
-    }, 
+      "paged": "false",
+      "name": "Current Agent",
+      "suffix": "/v2/agents/me",
+      "description": "The agent the credentials belong to, with their scope and roles. Worth reading first, since that scope filters nearly everything else here."
+    },
     {
-      "paged": "false", 
-      "name": "Skill", 
-      "suffix": "/v2/skills/{Skill ID}"
-    }, 
+      "paged": "false",
+      "name": "Skill",
+      "suffix": "/v2/skills/{Skill ID}",
+      "description": "One skill by id."
+    },
     {
-      "paged": "true", 
-      "name": "Skills", 
-      "suffix": "/v2/skills"
-    }, 
+      "paged": "true",
+      "name": "Skills",
+      "suffix": "/v2/skills",
+      "description": "The skills defined for skills-based routing, with the agents holding each. Where routing depends on capability rather than group, this is what determines who could take a ticket."
+    },
     {
-      "paged": "false", 
-      "name": "Role", 
-      "suffix": "/v2/roles/{Role ID}"
-    }, 
+      "paged": "false",
+      "name": "Role",
+      "suffix": "/v2/roles/{Role ID}",
+      "description": "One role by id."
+    },
     {
-      "paged": "true", 
-      "name": "Roles", 
-      "suffix": "/v2/roles"
-    }, 
+      "paged": "true",
+      "name": "Roles",
+      "suffix": "/v2/roles",
+      "description": "The permission roles agents hold, with the abilities each grants."
+    },
     {
-      "paged": "false", 
-      "name": "Group", 
-      "suffix": "/v2/groups/{Group ID}"
-    }, 
+      "paged": "false",
+      "name": "Group",
+      "suffix": "/v2/groups/{Group ID}",
+      "description": "One group by id."
+    },
     {
-      "paged": "true", 
-      "name": "Groups", 
-      "suffix": "/v2/groups"
-    }, 
+      "paged": "true",
+      "name": "Groups",
+      "suffix": "/v2/groups",
+      "description": "The agent groups tickets are assigned to, with their business hours, escalation settings and members. The team dimension, and the business-hours link is what makes SLA timings interpretable."
+    },
     {
-      "paged": "false", 
-      "name": "Company", 
-      "suffix": "/v2/companies/{Company ID}"
-    }, 
+      "paged": "false",
+      "name": "Company",
+      "suffix": "/v2/companies/{Company ID}",
+      "description": "One company by id."
+    },
     {
-      "paged": "true", 
-      "name": "Companies", 
-      "suffix": "/v2/companies?query={Query?:(domain:inetsoft.com AND created_at:2020-01-15)}"
-    }, 
+      "paged": "true",
+      "name": "Companies",
+      "suffix": "/v2/companies?query={Query?:(domain:inetsoft.com AND created_at:2020-01-15)}",
+      "description": "The customer organisations contacts belong to, with name, domains, description, custom fields and account tier. The account-level dimension ticket volume is grouped by."
+    },
     {
-      "paged": "true", 
-      "name": "Company Search", 
-      "suffix": "/v2/companies/autocomplete?name={Name}"
-    }, 
+      "paged": "true",
+      "name": "Company Search",
+      "suffix": "/v2/companies/autocomplete?name={Name}",
+      "description": "Companies whose name matches a term. The autocomplete lookup, for when the id is not known."
+    },
     {
-      "paged": "true", 
-      "name": "Company Fields", 
-      "suffix": "/v2/company_fields"
-    }, 
+      "paged": "true",
+      "name": "Company Fields",
+      "suffix": "/v2/company_fields",
+      "description": "Every field a company can carry, standard and custom."
+    },
     {
-      "paged": "false", 
-      "name": "Company Imports", 
-      "suffix": "/v2/companies/imports?status={Status?:in_progress|completed|cancelled|failed}"
-    }, 
+      "paged": "false",
+      "name": "Company Imports",
+      "suffix": "/v2/companies/imports?status={Status?:in_progress|completed|cancelled|failed}",
+      "description": "Bulk company import jobs and their status."
+    },
     {
-      "paged": "false", 
+      "paged": "false",
       "name": "Company Import",
-      "suffix": "/v2/companies/imports/{Import ID}"
-    }, 
+      "suffix": "/v2/companies/imports/{Import ID}",
+      "description": "One company import by id."
+    },
     {
-      "paged": "true", 
-      "name": "Canned Response Folders", 
-      "suffix": "/v2/canned_response_folders"
-    }, 
+      "paged": "true",
+      "name": "Canned Response Folders",
+      "suffix": "/v2/canned_response_folders",
+      "description": "The folders canned responses are filed under."
+    },
     {
-      "paged": "true", 
-      "name": "Canned Responses", 
-      "suffix": "/v2/canned_response_folders/{Folder ID}"
-    }, 
+      "paged": "true",
+      "name": "Canned Responses",
+      "suffix": "/v2/canned_response_folders/{Folder ID}",
+      "description": "The canned responses in one folder, by title. Requires a folder id."
+    },
     {
-      "paged": "true", 
-      "name": "Detailed Canned Responses", 
-      "suffix": "/v2/canned_response_folders/{Folder ID}/responses"
-    }, 
+      "paged": "true",
+      "name": "Detailed Canned Responses",
+      "suffix": "/v2/canned_response_folders/{Folder ID}/responses",
+      "description": "The canned responses in one folder WITH their full content. Requires a folder id. Which responses exist says a good deal about the standard cases a team handles."
+    },
     {
-      "paged": "false", 
-      "name": "Forum Category", 
-      "suffix": "/v2/discussions/categories/{Category ID}"
-    }, 
+      "paged": "false",
+      "name": "Forum Category",
+      "suffix": "/v2/discussions/categories/{Category ID}",
+      "description": "One forum category by id."
+    },
     {
-      "paged": "true", 
-      "name": "Forum Categories", 
-      "suffix": "/v2/discussions/categories"
-    }, 
+      "paged": "true",
+      "name": "Forum Categories",
+      "suffix": "/v2/discussions/categories",
+      "description": "The top level of the community forums."
+    },
     {
-      "paged": "true", 
-      "name": "Forums in Category", 
-      "suffix": "/v2/discussions/categories/{Category ID}/forums"
-    }, 
+      "paged": "true",
+      "name": "Forums in Category",
+      "suffix": "/v2/discussions/categories/{Category ID}/forums",
+      "description": "The forums within one category. Requires a category id."
+    },
     {
-      "paged": "false", 
-      "name": "Forum", 
-      "suffix": "/v2/discussions/forums/{Forum ID}"
-    }, 
+      "paged": "false",
+      "name": "Forum",
+      "suffix": "/v2/discussions/forums/{Forum ID}",
+      "description": "One forum by id, with its type -- questions, ideas, problems or announcements. The type decides what the topics within mean."
+    },
     {
-      "paged": "true", 
-      "name": "Forum Topics", 
-      "suffix": "/v2/discussions/forums/{Forum ID}/topics"
-    }, 
+      "paged": "true",
+      "name": "Forum Topics",
+      "suffix": "/v2/discussions/forums/{Forum ID}/topics",
+      "description": "The topics in one forum, with author, replies and votes. Requires a forum id. Community demand: an idea topic's vote count is the closest thing to a feature request tally."
+    },
     {
-      "paged": "false", 
-      "name": "Forum Topic", 
-      "suffix": "/v2/discussions/topics/{Topic ID}"
-    }, 
+      "paged": "false",
+      "name": "Forum Topic",
+      "suffix": "/v2/discussions/topics/{Topic ID}",
+      "description": "One topic by id."
+    },
     {
-      "paged": "true", 
-      "name": "Forum Topic Comments", 
-      "suffix": "/v2/discussions/topics/{Topic ID}/comments"
-    }, 
+      "paged": "true",
+      "name": "Forum Topic Comments",
+      "suffix": "/v2/discussions/topics/{Topic ID}/comments",
+      "description": "The replies on one topic. Requires a topic id."
+    },
     {
-      "paged": "true", 
-      "name": "Monitored Topics", 
-      "suffix": "/v2/discussions/topics/followed_by?user_id={User ID}"
-    }, 
+      "paged": "true",
+      "name": "Monitored Topics",
+      "suffix": "/v2/discussions/topics/followed_by?user_id={User ID}",
+      "description": "The topics one user follows. Requires a user id."
+    },
     {
-      "paged": "true", 
-      "name": "Participated Topics", 
-      "suffix": "/v2/discussions/topics/participated_by?user_id={User ID}"
-    }, 
+      "paged": "true",
+      "name": "Participated Topics",
+      "suffix": "/v2/discussions/topics/participated_by?user_id={User ID}",
+      "description": "The topics one user has replied to. Requires a user id."
+    },
     {
-      "paged": "false", 
-      "name": "Solution Category", 
-      "suffix": "/v2/solutions/categories/{Category ID}/{Language Code?}"
-    }, 
+      "paged": "false",
+      "name": "Solution Category",
+      "suffix": "/v2/solutions/categories/{Category ID}/{Language Code?}",
+      "description": "One knowledge base category by id and language."
+    },
     {
-      "paged": "true", 
-      "name": "Solutions Categories", 
-      "suffix": "/v2/solutions/categories/{Language Code?}"
-    }, 
+      "paged": "true",
+      "name": "Solutions Categories",
+      "suffix": "/v2/solutions/categories/{Language Code?}",
+      "description": "The top level of the knowledge base, optionally in a given language."
+    },
     {
-      "paged": "false", 
-      "name": "Solution Folder", 
-      "suffix": "/v2/solutions/folders/{Folder ID}/{Language Code?}"
-    }, 
+      "paged": "false",
+      "name": "Solution Folder",
+      "suffix": "/v2/solutions/folders/{Folder ID}/{Language Code?}",
+      "description": "One folder by id and language."
+    },
     {
-      "paged": "true", 
-      "name": "Solution Folders in Category", 
-      "suffix": "/v2/solutions/categories/{Category ID}/folders/{Language Code?}"
-    }, 
+      "paged": "true",
+      "name": "Solution Folders in Category",
+      "suffix": "/v2/solutions/categories/{Category ID}/folders/{Language Code?}",
+      "description": "The folders within one category. Requires a category id."
+    },
     {
-      "paged": "false", 
-      "name": "Solution Article", 
-      "suffix": "/v2/solutions/articles/{Article ID}/{Language Code?}"
-    }, 
+      "paged": "false",
+      "name": "Solution Article",
+      "suffix": "/v2/solutions/articles/{Article ID}/{Language Code?}",
+      "description": "One article by id and language, with its body and vote counts."
+    },
     {
-      "paged": "true", 
-      "name": "Solution Articles in Folder", 
-      "suffix": "/v2/solutions/folders/{Folder ID}/articles/{Language Code?}"
-    }, 
+      "paged": "true",
+      "name": "Solution Articles in Folder",
+      "suffix": "/v2/solutions/folders/{Folder ID}/articles/{Language Code?}",
+      "description": "The articles in one folder, with title, status, and the thumbs-up and thumbs-down counts. Requires a folder id. THE VOTE COUNTS ARE THE USEFUL PART: they identify documentation that is present but not helping, which no ticket table reveals."
+    },
     {
-      "paged": "true", 
-      "name": "Solution Article Search", 
-      "suffix": "/v2/search/solutions?term={Keyword}"
-    }, 
+      "paged": "true",
+      "name": "Solution Article Search",
+      "suffix": "/v2/search/solutions?term={Keyword}",
+      "description": "Articles matching a keyword. The search customers themselves use."
+    },
     {
-      "paged": "true", 
-      "name": "Surveys", 
-      "suffix": "/v2/surveys"
-    }, 
+      "paged": "true",
+      "name": "Surveys",
+      "suffix": "/v2/surveys",
+      "description": "The satisfaction surveys configured, with their questions and rating scales. The decoder for what a rating value means, since the scale is configurable."
+    },
     {
-      "paged": "true", 
-      "name": "Satisfaction Ratings", 
-      "suffix": "/v2/surveys/satisfaction_ratings?created_since={Created Since?:yyyy-MM-ddTHH:mm:ssZ}&userId={User ID?}"
-    }, 
+      "paged": "true",
+      "name": "Satisfaction Ratings",
+      "suffix": "/v2/surveys/satisfaction_ratings?created_since={Created Since?:yyyy-MM-ddTHH:mm:ssZ}&userId={User ID?}",
+      "description": "Satisfaction survey responses across the account, filterable by date. The CSAT table. Ratings attach to a ticket and an agent, so this is where support quality is measured -- and the response rate matters, since only a fraction of tickets are rated and the rated ones skew towards strong feelings."
+    },
     {
-      "paged": "false", 
-      "name": "Email Mailbox", 
-      "suffix": "/v2/email/mailboxes/{Mailbox ID}"
-    }, 
+      "paged": "false",
+      "name": "Email Mailbox",
+      "suffix": "/v2/email/mailboxes/{Mailbox ID}",
+      "description": "One mailbox by id."
+    },
     {
-      "paged": "true", 
-      "name": "Email Mailboxes", 
-      "suffix": "/v2/email/mailboxes?support_email={Support Email?}&forward_email={Forward Email?}&product_id={Product ID?}&group_id={Group ID?}&active={Active?:true|false}"
-    }, 
+      "paged": "true",
+      "name": "Email Mailboxes",
+      "suffix": "/v2/email/mailboxes?support_email={Support Email?}&forward_email={Forward Email?}&product_id={Product ID?}&group_id={Group ID?}&active={Active?:true|false}",
+      "description": "The support mailboxes configured, with their addresses and forwarding state. Inbound mail arrives through these, so this maps an incoming ticket to a product or group -- and the verification state is why mail to an address may not be arriving."
+    },
     {
-      "paged": "false", 
-      "name": "Mailbox Settings", 
-      "suffix": "/v2/email/settings"
-    }, 
+      "paged": "false",
+      "name": "Mailbox Settings",
+      "suffix": "/v2/email/settings",
+      "description": "The account's email settings. Configuration."
+    },
     {
-      "paged": "false", 
-      "name": "Automatic Bcc Emails", 
-      "suffix": "/v2/notifications/email/bcc"
-    }, 
+      "paged": "false",
+      "name": "Automatic Bcc Emails",
+      "suffix": "/v2/notifications/email/bcc",
+      "description": "The addresses blind-copied on outgoing notifications. Configuration."
+    },
     {
-      "paged": "false", 
-      "name": "Product", 
-      "suffix": "/v2/products/{Product ID}"
-    }, 
+      "paged": "false",
+      "name": "Product",
+      "suffix": "/v2/products/{Product ID}",
+      "description": "One product by id."
+    },
     {
-      "paged": "true", 
-      "name": "Products", 
-      "suffix": "/v2/products"
-    }, 
+      "paged": "true",
+      "name": "Products",
+      "suffix": "/v2/products",
+      "description": "The products tickets can be raised against, each with its own portal and support email. Multi-product accounts route by product, so this is a routing dimension as well as a reporting one."
+    },
     {
-      "paged": "false", 
-      "name": "Business Hour", 
-      "suffix": "/v2/business_hours/{Business Hour ID}"
-    }, 
+      "paged": "false",
+      "name": "Business Hour",
+      "suffix": "/v2/business_hours/{Business Hour ID}",
+      "description": "One business hours calendar by id, with its holidays."
+    },
     {
-      "paged": "true", 
-      "name": "Business Hours", 
-      "suffix": "/v2/business_hours"
-    }, 
+      "paged": "true",
+      "name": "Business Hours",
+      "suffix": "/v2/business_hours",
+      "description": "The working-hour calendars, with the daily hours and holidays of each. SLA CLOCKS COUNT BUSINESS HOURS rather than wall-clock time where a calendar applies, so a duration read as elapsed time is simply wrong for those tickets."
+    },
     {
-      "paged": "true", 
-      "name": "SLA Policies", 
-      "suffix": "/v2/sla_policies"
-    }, 
+      "paged": "true",
+      "name": "SLA Policies",
+      "suffix": "/v2/sla_policies",
+      "description": "The service level policies, with the response and resolution targets per priority and the conditions each applies under. THE TARGETS THAT MAKE A DURATION FAST OR SLOW -- a resolution time is meaningless without them, and the policies are applied conditionally, so different tickets are held to different targets."
+    },
     {
-      "paged": "false", 
-      "name": "Helpdesk Settings", 
-      "suffix": "/v2/settings/helpdesk"
+      "paged": "false",
+      "name": "Helpdesk Settings",
+      "suffix": "/v2/settings/helpdesk",
+      "description": "The account's helpdesk settings, including the primary language and the languages supported. WORTH READING BEFORE THE KNOWLEDGE BASE ENDPOINTS, which all take a language code: an article requested in an unsupported language returns nothing rather than falling back."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/fusebill/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/fusebill/endpoints.json
@@ -95,42 +95,50 @@
           "key": "id",
           "parameterName": "Customer ID"
         }
-      ]
+      ],
+      "description": "The customers on the account, filterable with Fusebill's query syntax. Carries the company or personal name, reference, status, currency, the primary contact and addresses. THE QUERY PARAMETER IS THE FILTERING MODEL throughout this connector -- a field:value expression rather than named parameters -- so most questions are shaped by what that syntax supports."
     },
     {
       "paged": "false",
       "name": "Customer Overview",
-      "suffix": "/v1/customers/{Customer ID}/overview"
+      "suffix": "/v1/customers/{Customer ID}/overview",
+      "description": "One customer's headline figures in a single call -- balances, subscription counts and recent activity. Requires a customer id. The efficient summary, as opposed to assembling it from the subscription, invoice and payment tables separately."
     },
     {
       "paged": "false",
       "name": "Customer",
-      "suffix": "/v1/customers/{Customer ID}"
+      "suffix": "/v1/customers/{Customer ID}",
+      "description": "One customer by id."
     },
     {
       "paged": "false",
       "name": "Customer Email Preferences",
-      "suffix": "/v1/customers/{Customer ID}/CustomerEmailPreferences"
+      "suffix": "/v1/customers/{Customer ID}/CustomerEmailPreferences",
+      "description": "Which billing emails one customer receives. Requires a customer id."
     },
     {
       "paged": "false",
       "name": "Customer Billing Settings",
-      "suffix": "/v1/customerbillingsetting/{Customer ID}"
+      "suffix": "/v1/customerbillingsetting/{Customer ID}",
+      "description": "One customer's billing configuration -- payment terms, currency, tax settings and collection behaviour. Requires a customer id. Collection behaviour is what explains an invoice sitting unpaid by design rather than through failure."
     },
     {
       "paged": "false",
       "name": "Customer Address Preferences",
-      "suffix": "/v1/customerAddressPreferences/{Customer ID}"
+      "suffix": "/v1/customerAddressPreferences/{Customer ID}",
+      "description": "The address configuration of one customer -- which address is used for billing, shipping and tax. Requires a customer id. Tax is computed against one of these, so it matters for reconciling a tax figure."
     },
     {
       "paged": "false",
       "name": "Customer Ship/Bill Address",
-      "suffix": "/v1/Addresses/{Address ID}"
+      "suffix": "/v1/Addresses/{Address ID}",
+      "description": "One address by id, with its full detail."
     },
     {
       "paged": "false",
       "name": "Countries",
-      "suffix": "/v1/Countries"
+      "suffix": "/v1/Countries",
+      "description": "The countries and their subdivisions Fusebill recognises. Reference data, and relevant because tax rules are keyed on them."
     },
     {
       "paged": "true",
@@ -155,222 +163,266 @@
           "key": "id",
           "parameterName": "Subscription ID"
         }
-      ]
+      ],
+      "description": "Every subscription on the account, filterable by query. Carries the customer, status, activation and cancellation dates, the billing period, and the products attached. The recurring-revenue backbone."
     },
     {
       "paged": "true",
       "name": "Subscription Summaries",
-      "suffix": "/v1/subscriptionSummary?query={Query?:field:queryString}"
+      "suffix": "/v1/subscriptionSummary?query={Query?:field:queryString}",
+      "description": "A condensed view of subscriptions, filterable by query. Cheaper than the full records when only status and value are wanted."
     },
     {
       "paged": "true",
       "name": "Customer Subscriptions",
-      "suffix": "/v1/customers/{Customer ID}/subscriptions?query={Query?:parameterName:value}"
+      "suffix": "/v1/customers/{Customer ID}/subscriptions?query={Query?:parameterName:value}",
+      "description": "The subscriptions of one customer. Requires a customer id."
     },
     {
       "paged": "false",
       "name": "Subscription",
-      "suffix": "/v1/subscriptions/{Subscription ID}"
+      "suffix": "/v1/subscriptions/{Subscription ID}",
+      "description": "One subscription by id, with its products and schedule."
     },
     {
       "paged": "false",
       "name": "Subscription Count by Status",
-      "suffix": "/v1/customers/customerId/subscriptions/GetCountByStatus?status={Status:Active|Draft|Cancelled|Provisioning|Expired|Suspended}"
+      "suffix": "/v1/customers/customerId/subscriptions/GetCountByStatus?status={Status:Active|Draft|Cancelled|Provisioning|Expired|Suspended}",
+      "description": "How many subscriptions sit in each status. A ready-made aggregate, and the cheapest health check on a recurring-revenue base."
     },
     {
       "paged": "false",
       "name": "Subscription Product",
-      "suffix": "/v1/SubscriptionProducts/{Subscription Product ID}"
+      "suffix": "/v1/SubscriptionProducts/{Subscription Product ID}",
+      "description": "One product on one subscription, with its price, quantity and schedule. What a subscription actually consists of, as opposed to its header."
     },
     {
       "paged": "true",
       "name": "Customer Billing Period Definitions",
-      "suffix": "/v1/customers/{Customer ID}/billingperioddefinitions"
+      "suffix": "/v1/customers/{Customer ID}/billingperioddefinitions",
+      "description": "The billing periods configured for one customer. Requires a customer id. When a customer is billed, which decides which period a charge falls in."
     },
     {
       "paged": "false",
       "name": "Subscription Billing Period Definition",
-      "suffix": "/v1/BillingPeriodDefinitions/GetBySubscription/{Subscription ID}"
+      "suffix": "/v1/BillingPeriodDefinitions/GetBySubscription/{Subscription ID}",
+      "description": "The billing period of one subscription. Requires a subscription id."
     },
     {
       "paged": "false",
       "name": "Billing Period Definition Details",
-      "suffix": "/v1/BillingPeriodDefinitions/{Billing Period Definition ID}"
+      "suffix": "/v1/BillingPeriodDefinitions/{Billing Period Definition ID}",
+      "description": "One billing period definition by id, with its start, end and cycle."
     },
     {
       "paged": "true",
       "name": "Coupons",
-      "suffix": "/v1/Coupons?query={Query?:parameterName:value}"
+      "suffix": "/v1/Coupons?query={Query?:parameterName:value}",
+      "description": "The coupons defined, filterable by query. Campaign-level discounting, as opposed to per-purchase discounts."
     },
     {
       "paged": "false",
       "name": "Coupon",
-      "suffix": "/v1/Coupons/{Coupon ID}"
+      "suffix": "/v1/Coupons/{Coupon ID}",
+      "description": "One coupon by id, with its redemption terms."
     },
     {
       "paged": "false",
       "name": "Subscription Scheduled Migrations",
-      "suffix": "/v1/subscriptions/{Subscription ID}/migrate"
+      "suffix": "/v1/subscriptions/{Subscription ID}/migrate",
+      "description": "The plan changes already scheduled for one subscription. Requires a subscription id. FORWARD-LOOKING: the subscription shows today's plan, so a revenue projection that ignores this misses committed upgrades and downgrades."
     },
     {
       "paged": "true",
       "name": "Purchases by Product",
-      "suffix": "/v1/Purchases/GetByProductId?id={Product ID}&query={Query?:parameterName:value}"
+      "suffix": "/v1/Purchases/GetByProductId?id={Product ID}&query={Query?:parameterName:value}",
+      "description": "The purchases of one product across customers. Requires a product id. Which customers bought a given item."
     },
     {
       "paged": "true",
       "name": "Purchases by Customer",
-      "suffix": "/v1/Customers/{Customer ID}/Purchases?query={Query?:field:queryString}"
+      "suffix": "/v1/Customers/{Customer ID}/Purchases?query={Query?:field:queryString}",
+      "description": "The one-off purchases of one customer, filterable by query. Requires a customer id. Non-recurring revenue, which the subscription tables do not represent -- a total that counts only subscriptions understates what a customer paid."
     },
     {
       "paged": "false",
       "name": "Purchase",
-      "suffix": "/v1/Purchases/{Purchase ID}"
+      "suffix": "/v1/Purchases/{Purchase ID}",
+      "description": "One purchase by id, with its items."
     },
     {
       "paged": "false",
       "name": "Purchase Discount",
-      "suffix": "/v1/PurchaseDiscounts/{Purchase Discount ID}"
+      "suffix": "/v1/PurchaseDiscounts/{Purchase Discount ID}",
+      "description": "One discount applied to a purchase, by id."
     },
     {
       "paged": "true",
       "name": "Tracked Items",
-      "suffix": "/v1/ProductItems?query={Query?:parameterName:Value}"
+      "suffix": "/v1/ProductItems?query={Query?:parameterName:Value}",
+      "description": "The item types tracked for quantity-based billing -- seats, users, devices. The unit definitions behind usage counts."
     },
     {
       "paged": "true",
       "name": "Subscription Product Items",
-      "suffix": "/v1/subscriptionProducts/{Subscription Product ID}/items?query={Query?:parameterName:value}"
+      "suffix": "/v1/subscriptionProducts/{Subscription Product ID}/items?query={Query?:parameterName:value}",
+      "description": "The tracked items within one subscription product. Requires a subscription product id. The unit level -- seats, licences, devices -- that quantity-based billing counts."
     },
     {
       "paged": "false",
       "name": "Subscription Product Item",
-      "suffix": "/v1/subscriptionproductitems/{Subscription Product Item ID}"
+      "suffix": "/v1/subscriptionproductitems/{Subscription Product Item ID}",
+      "description": "One subscription product item by id."
     },
     {
       "paged": "false",
       "name": "Purchase Product Item",
-      "suffix": "/v1/purchaseProductItems/{Purchase Product Item ID}"
+      "suffix": "/v1/purchaseProductItems/{Purchase Product Item ID}",
+      "description": "One purchased item by id."
     },
     {
       "paged": "false",
       "name": "Related Statuses",
-      "suffix": "/v1/SubscriptionProductItemStatuses?reference={Reference}&parentId={Product ID}"
+      "suffix": "/v1/SubscriptionProductItemStatuses?reference={Reference}&parentId={Product ID}",
+      "description": "The statuses a subscription product item can hold, by reference. The decoder for an item's status."
     },
     {
       "paged": "false",
       "name": "Sales Tracking Code by Type",
-      "suffix": "/v1/salesTrackingCodes/{Type:Sales Tracking Code 1|Sales Tracking Code 2|...}"
+      "suffix": "/v1/salesTrackingCodes/{Type:Sales Tracking Code 1|Sales Tracking Code 2|...}",
+      "description": "The sales tracking codes of one type. Fusebill offers several free-form tracking code slots, which is where an account records campaign, region or rep attribution -- and their meaning is entirely account-specific."
     },
     {
       "paged": "false",
       "name": "Sales Tracking Code by Type and Code",
-      "suffix": "/v1/SalesTrackingCodes?type={Type:Sales Tracking Code 1|Sales Tracking Code 2|...}&code={Code?}"
+      "suffix": "/v1/SalesTrackingCodes?type={Type:Sales Tracking Code 1|Sales Tracking Code 2|...}&code={Code?}",
+      "description": "One tracking code by its type and value."
     },
     {
       "paged": "false",
       "name": "Payment Details",
-      "suffix": "/v1/payments/{Payment ID}"
+      "suffix": "/v1/payments/{Payment ID}",
+      "description": "One payment by id, with its method, amount and outcome."
     },
     {
       "paged": "true",
       "name": "Customer Payment Activities",
-      "suffix": "/v1/customers/{Customer ID}/paymentactivities?query={Query?:parameterName:value}"
+      "suffix": "/v1/customers/{Customer ID}/paymentactivities?query={Query?:parameterName:value}",
+      "description": "The payment activity of one customer. Requires a customer id."
     },
     {
       "paged": "true",
       "name": "Payment Activities",
-      "suffix": "/v1/PaymentActivities/GetByAccountID?query={Query?:parameterName:value}"
+      "suffix": "/v1/PaymentActivities/GetByAccountID?query={Query?:parameterName:value}",
+      "description": "Payment activity across the account, filterable by query. The transaction log: attempts, successes and failures. FAILED PAYMENTS ARE HERE AND NOT ON THE INVOICE, which is where involuntary churn is diagnosed."
     },
     {
       "paged": "true",
       "name": "Child Payment Activities",
-      "suffix": "/v1/customers/{Customer ID}/childPaymentActivities?query={Query?:field:querystring}"
+      "suffix": "/v1/customers/{Customer ID}/childPaymentActivities?query={Query?:field:querystring}",
+      "description": "The payment activity of a customer's child accounts. Requires the parent customer id. Where a parent pays for children, revenue read at the parent alone misattributes it."
     },
     {
       "paged": "false",
       "name": "Payment Activity",
-      "suffix": "/v1/PaymentActivities/{Payment Activity ID}"
+      "suffix": "/v1/PaymentActivities/{Payment Activity ID}",
+      "description": "One payment activity by id, with its gateway response."
     },
     {
       "paged": "false",
       "name": "Refund",
-      "suffix": "/v1/Refunds/{Transaction ID}"
+      "suffix": "/v1/Refunds/{Transaction ID}",
+      "description": "One refund by transaction id."
     },
     {
       "paged": "true",
       "name": "Payment Methods",
-      "suffix": "/v1/customers/{Customer ID}/paymentMethods/all?query={Query?:parameterName:value}"
+      "suffix": "/v1/customers/{Customer ID}/paymentMethods/all?query={Query?:parameterName:value}",
+      "description": "All payment methods on file for one customer. Requires a customer id."
     },
     {
       "paged": "true",
       "name": "Credit Card Payment Methods",
-      "suffix": "/v1/customers/{Customer ID}/paymentMethods/creditCard?query={Query?:field:queryString}"
+      "suffix": "/v1/customers/{Customer ID}/paymentMethods/creditCard?query={Query?:field:queryString}",
+      "description": "The cards on file for one customer, with expiry and last four digits. Requires a customer id. AN EXPIRING CARD IS THE COMMONEST CAUSE OF INVOLUNTARY CHURN, and the expiry here is the only place it can be anticipated."
     },
     {
       "paged": "false",
       "name": "Credit Card Payment Method",
-      "suffix": "/v1/paymentMethods/{Payment Method ID}/creditCard"
+      "suffix": "/v1/paymentMethods/{Payment Method ID}/creditCard",
+      "description": "One card payment method by id."
     },
     {
       "paged": "true",
       "name": "ACH Payment Methods",
-      "suffix": "/v1/customers/{Customer ID}/paymentMethods/achCard?query={Query?:parameterName:Value}"
+      "suffix": "/v1/customers/{Customer ID}/paymentMethods/achCard?query={Query?:parameterName:Value}",
+      "description": "The bank-draft payment methods on file for one customer. Requires a customer id. ACH fails differently from cards -- later and for different reasons -- so the two are worth separating in any failure analysis."
     },
     {
       "paged": "false",
       "name": "ACH Payment Method",
-      "suffix": "/v1/paymentMethods/{Payment Method ID}/achCard"
+      "suffix": "/v1/paymentMethods/{Payment Method ID}/achCard",
+      "description": "One ACH payment method by id."
     },
     {
       "paged": "true",
       "name": "AR Activities",
-      "suffix": "/v1/aractivities?query={Query?:startDate:yyyy-MM-dd;endDate:yyyy-MM-dd}"
+      "suffix": "/v1/aractivities?query={Query?:startDate:yyyy-MM-dd;endDate:yyyy-MM-dd}",
+      "description": "Accounts receivable activity over a date range -- invoices raised, payments received, credits applied. The ledger view of what customers owe and have paid."
     },
     {
       "paged": "true",
       "name": "Customer AR Activities",
-      "suffix": "/v1/customers/{Customer ID}/customerArActivities?query={Query?:startDate:yyyy-MM-dd;endDate:yyyy-MM-dd}"
+      "suffix": "/v1/customers/{Customer ID}/customerArActivities?query={Query?:startDate:yyyy-MM-dd;endDate:yyyy-MM-dd}",
+      "description": "The receivable activity of one customer. Requires a customer id. The per-account statement."
     },
     {
       "paged": "false",
       "name": "Credit",
-      "suffix": "/v1/Credits/{Transaction ID}"
+      "suffix": "/v1/Credits/{Transaction ID}",
+      "description": "One credit transaction by id."
     },
     {
       "paged": "false",
       "name": "Debit",
-      "suffix": "/v1/Debits/{Transaction ID}"
+      "suffix": "/v1/Debits/{Transaction ID}",
+      "description": "One debit transaction by id."
     },
     {
       "paged": "true",
       "name": "Credit Note Summaries",
-      "suffix": "/v1/CreditNotes?query={Query?:parameterName:value}"
+      "suffix": "/v1/CreditNotes?query={Query?:parameterName:value}",
+      "description": "The credit notes issued, filterable by query. Revenue net of credits requires this; invoice totals alone overstate it."
     },
     {
       "paged": "false",
       "name": "Credit Note",
-      "suffix": "/v1/CreditNotes/{Credit Note ID}"
+      "suffix": "/v1/CreditNotes/{Credit Note ID}",
+      "description": "One credit note by id."
     },
     {
       "paged": "true",
       "name": "Draft Invoice Summaries",
-      "suffix": "/v1/DraftInvoices?query={Query?:parameterName:value}"
+      "suffix": "/v1/DraftInvoices?query={Query?:parameterName:value}",
+      "description": "The draft invoices, filterable by query. NOT YET ISSUED -- they represent charges accrued and about to be billed, so they are the forward view that the issued-invoice table cannot give."
     },
     {
       "paged": "true",
       "name": "Customer Draft Invoices",
-      "suffix": "/v1/Customers/{Customer ID}/DraftInvoices?query={Query?:parameterName:value}"
+      "suffix": "/v1/Customers/{Customer ID}/DraftInvoices?query={Query?:parameterName:value}",
+      "description": "The draft invoices of one customer. Requires a customer id."
     },
     {
       "paged": "false",
       "name": "Draft Invoice",
-      "suffix": "/v1/DraftInvoices/{Draft Invoice ID}"
+      "suffix": "/v1/DraftInvoices/{Draft Invoice ID}",
+      "description": "One draft invoice by id, with its lines."
     },
     {
       "paged": "true",
       "name": "Invoice Summaries",
-      "suffix": "/v1/invoiceSummaries?query={Query?:parameterName:value}"
+      "suffix": "/v1/invoiceSummaries?query={Query?:parameterName:value}",
+      "description": "A condensed invoice listing, filterable by query. Cheaper for totals and status than the full records."
     },
     {
       "paged": "true",
@@ -389,17 +441,20 @@
           "key": "id",
           "parameterName": "Invoice ID"
         }
-      ]
+      ],
+      "description": "The invoices issued, filterable by query. Carries the customer, number, dates, status, totals and line items. Only issued invoices are revenue; drafts are a separate table entirely."
     },
     {
       "paged": "true",
       "name": "Customer Invoices",
-      "suffix": "/v1/Customers/{Customer ID}/Invoices/?showZeroDollarCharges={Show Zero Dollar Changes?:true|false}&query={Query?:filter:queryString}"
+      "suffix": "/v1/Customers/{Customer ID}/Invoices/?showZeroDollarCharges={Show Zero Dollar Changes?:true|false}&query={Query?:filter:queryString}",
+      "description": "The invoices of one customer, optionally including zero-dollar ones. Requires a customer id. ZERO-DOLLAR INVOICES ARE EXCLUDED BY DEFAULT, which quietly changes an invoice count -- they are real documents produced by fully discounted or credited subscriptions."
     },
     {
       "paged": "false",
       "name": "Invoice",
-      "suffix": "/v1/Invoices/{Invoice ID}"
+      "suffix": "/v1/Invoices/{Invoice ID}",
+      "description": "One invoice by id, with its lines."
     },
     {
       "paged": "false",
@@ -412,7 +467,8 @@
           "key": "creditId",
           "parameterName": "Transaction ID"
         }
-      ]
+      ],
+      "description": "How credits were applied to one invoice. Requires an invoice id. An invoice's balance falls through payment or credit, and only this distinguishes the two."
     },
     {
       "paged": "false",
@@ -425,12 +481,14 @@
           "key": "paymentId",
           "parameterName": "Payment ID"
         }
-      ]
+      ],
+      "description": "How payments were applied to one invoice. Requires an invoice id. The other half of how a balance was settled."
     },
     {
       "paged": "true",
       "name": "Charge Summary",
-      "suffix": "/v1/customers/{Customer ID}/chargeSummary?query={Query?:parameterName:value}"
+      "suffix": "/v1/customers/{Customer ID}/chargeSummary?query={Query?:parameterName:value}",
+      "description": "The charges accrued for one customer, filterable by query. Requires a customer id. Accrued rather than billed, which is why it and the invoice total legitimately differ mid-period."
     },
     {
       "paged": "true",
@@ -449,17 +507,20 @@
           "key": "id",
           "parameterName": "Plan ID"
         }
-      ]
+      ],
+      "description": "The subscription plans offered, filterable by query. What is sold on a recurring basis."
     },
     {
       "paged": "false",
       "name": "Plan",
-      "suffix": "/v1/Plans/{Plan ID}"
+      "suffix": "/v1/Plans/{Plan ID}",
+      "description": "One plan by id."
     },
     {
       "paged": "true",
       "name": "Product Summaries",
-      "suffix": "/v1/ProductSummary/?query={Query?:parameterName:value}"
+      "suffix": "/v1/ProductSummary/?query={Query?:parameterName:value}",
+      "description": "A condensed product listing, filterable by query."
     },
     {
       "paged": "true",
@@ -472,72 +533,86 @@
           "key": "id",
           "parameterName": "Product ID"
         }
-      ]
+      ],
+      "description": "The product catalogue, optionally with pricing. The individual sellable items plans are built from."
     },
     {
       "paged": "false",
       "name": "Product",
-      "suffix": "/v1/Products/{Product ID}"
+      "suffix": "/v1/Products/{Product ID}",
+      "description": "One product by id."
     },
     {
       "paged": "true",
       "name": "Plan Products by Plan",
-      "suffix": "/v1/plans/{Plan ID}/planProducts?query={Query?:parameterName:value}"
+      "suffix": "/v1/plans/{Plan ID}/planProducts?query={Query?:parameterName:value}",
+      "description": "The products within one plan, with their prices. Requires a plan id. What a plan actually includes."
     },
     {
       "paged": "true",
       "name": "Plan Products by Catalog Product",
-      "suffix": "/v1/products/{Product ID}/planProducts?query={Query?:parameterName:value}"
+      "suffix": "/v1/products/{Product ID}/planProducts?query={Query?:parameterName:value}",
+      "description": "The plans one product appears in. Requires a product id. The reverse view -- where a product is sold."
     },
     {
       "paged": "false",
       "name": "Plan Product",
-      "suffix": "/v1/PlanProducts/{Plan Product ID}"
+      "suffix": "/v1/PlanProducts/{Plan Product ID}",
+      "description": "One plan product by id."
     },
     {
       "paged": "true",
       "name": "Discounts",
-      "suffix": "/v1/Discounts?query={Query?:field:querystring}"
+      "suffix": "/v1/Discounts?query={Query?:field:querystring}",
+      "description": "The discounts defined, filterable by query. The gap between list price and realised price."
     },
     {
       "paged": "false",
       "name": "Discount",
-      "suffix": "/v1/Discounts/{Discount ID}"
+      "suffix": "/v1/Discounts/{Discount ID}",
+      "description": "One discount by id."
     },
     {
       "paged": "false",
       "name": "Plan Families",
-      "suffix": "/v1/PlanFamilies"
+      "suffix": "/v1/PlanFamilies",
+      "description": "The families plans are grouped into. The catalogue's top level, and the axis that separates product lines."
     },
     {
       "paged": "false",
       "name": "Plan Family",
-      "suffix": "/v1/PlanFamilies/{Plan Family ID}"
+      "suffix": "/v1/PlanFamilies/{Plan Family ID}",
+      "description": "One plan family by id."
     },
     {
       "paged": "false",
       "name": "Plan Families by Plan",
-      "suffix": "/v1/PlanFamilies/ByPlan/{Plan ID}"
+      "suffix": "/v1/PlanFamilies/ByPlan/{Plan ID}",
+      "description": "The families one plan belongs to. Requires a plan id."
     },
     {
       "paged": "false",
       "name": "Plan Families by Subscription",
-      "suffix": "/v1/planFamilies/bySubscription/{Subscription ID}"
+      "suffix": "/v1/planFamilies/bySubscription/{Subscription ID}",
+      "description": "The families reached through one subscription. Requires a subscription id."
     },
     {
       "paged": "false",
       "name": "QuickBooks Online Exchange Rates",
-      "suffix": "/v1/QuickBooksOnlineExchangeRates"
+      "suffix": "/v1/QuickBooksOnlineExchangeRates",
+      "description": "The exchange rates synced from QuickBooks Online. Relevant because Fusebill holds amounts in their own currencies and this is where conversion comes from."
     },
     {
       "paged": "false",
       "name": "Net Collections Summary",
-      "suffix": "/v1/NetCollections?currency={Currency:USD|EUR|GBP|...}"
+      "suffix": "/v1/NetCollections?currency={Currency:USD|EUR|GBP|...}",
+      "description": "Net cash collected in one currency, as a summary. A ready-made figure, and it separates cash from billings, which accrual-based invoice totals conflate."
     },
     {
       "paged": "false",
       "name": "Net Earned Revenue Summary",
-      "suffix": "/v1/NetEarned?currency={Currency:USD|EUR|GBP|...}"
+      "suffix": "/v1/NetEarned?currency={Currency:USD|EUR|GBP|...}",
+      "description": "Net earned revenue in one currency. The accrual counterpart to net collections -- the two answer different questions and diverge exactly by deferred revenue."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/gosquared/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/gosquared/endpoints.json
@@ -1,55 +1,67 @@
 {
   "endpoints": [
     {
-      "name": "Blocked Items", 
-      "suffix": "/account/v1/blocked?presenter={Presenter?:plain|tags|indexedTags}"
-    }, 
+      "name": "Blocked Items",
+      "suffix": "/account/v1/blocked?presenter={Presenter?:plain|tags|indexedTags}",
+      "description": "Everything excluded from tracking -- bots, IP addresses and visitors. WORTH READING BEFORE TRUSTING TRAFFIC FIGURES: an exclusion rule changes every number in the trends tables and appears nowhere in them."
+    },
     {
-      "name": "Blocked Bots", 
-      "suffix": "/account/v1/blocked/bots"
-    }, 
+      "name": "Blocked Bots",
+      "suffix": "/account/v1/blocked/bots",
+      "description": "The bot exclusions in force."
+    },
     {
-      "name": "Blocked IPs", 
-      "suffix": "/account/v1/blocked/ips"
-    }, 
+      "name": "Blocked IPs",
+      "suffix": "/account/v1/blocked/ips",
+      "description": "The IP addresses excluded, which is typically how a company filters its own staff out of its analytics."
+    },
     {
-      "name": "Blocked Visitors", 
-      "suffix": "/account/v1/blocked/visitors"
-    }, 
+      "name": "Blocked Visitors",
+      "suffix": "/account/v1/blocked/visitors",
+      "description": "The individual visitors excluded."
+    },
     {
-      "name": "Feeds", 
-      "suffix": "/account/v1/feeds"
-    }, 
+      "name": "Feeds",
+      "suffix": "/account/v1/feeds",
+      "description": "The activity feeds available on the account."
+    },
     {
-      "name": "Report Preferences", 
-      "suffix": "/account/v1/reportPreferences"
-    }, 
+      "name": "Report Preferences",
+      "suffix": "/account/v1/reportPreferences",
+      "description": "The report and notification preferences configured. Configuration."
+    },
     {
-      "name": "Team Members", 
-      "suffix": "/account/v1/sharedUsers"
-    }, 
+      "name": "Team Members",
+      "suffix": "/account/v1/sharedUsers",
+      "description": "The users with access to the account."
+    },
     {
-      "name": "Sites", 
-      "suffix": "/account/v1/sites?presenter={Presenter?:grouped|flat}"
-    }, 
+      "name": "Sites",
+      "suffix": "/account/v1/sites?presenter={Presenter?:grouped|flat}",
+      "description": "The sites tracked on the account, with their tokens. EVERY OTHER ENDPOINT NEEDS A SITE TOKEN, so this is the first request. The presenter parameter changes the response shape -- grouped or flat -- which is a pattern throughout this connector and worth noticing, since the same endpoint returns structurally different JSON depending on it."
+    },
     {
-      "name": "Site Domains", 
-      "suffix": "/account/v1/sites/{Site Token}/domains"
-    }, 
+      "name": "Site Domains",
+      "suffix": "/account/v1/sites/{Site Token}/domains",
+      "description": "The domains registered for one site. Requires a site token. Traffic is only tracked from these, so an unexpected gap in data often traces back to a domain that was never registered."
+    },
     {
-      "name": "Site Domain", 
-      "suffix": "/account/v1/sites/{Site Token}/domains/{Domain}"
-    }, 
+      "name": "Site Domain",
+      "suffix": "/account/v1/sites/{Site Token}/domains/{Domain}",
+      "description": "One domain by name. Requires the site token."
+    },
     {
-      "name": "Tagged Visitors", 
-      "suffix": "/account/v1/taggedVisitors?presenter={Presenter?:plain|indexed}"
-    }, 
+      "name": "Tagged Visitors",
+      "suffix": "/account/v1/taggedVisitors?presenter={Presenter?:plain|indexed}",
+      "description": "The visitors carrying tags. Tags are the manual segmentation of individuals, as opposed to the rule-based smart groups."
+    },
     {
-      "name": "Trigger Types", 
-      "suffix": "/account/v1/triggerTypes"
-    }, 
+      "name": "Trigger Types",
+      "suffix": "/account/v1/triggerTypes",
+      "description": "The trigger types webhooks can subscribe to. Reference data."
+    },
     {
-      "name": "Webhooks", 
+      "name": "Webhooks",
       "suffix": "/account/v1/webhooks",
       "lookups": [
         {
@@ -58,195 +70,243 @@
           "key": "id",
           "parameterName": "Webhook ID"
         }
-      ]
-    }, 
+      ],
+      "description": "The webhooks configured. Integration configuration."
+    },
     {
-      "name": "Webhook", 
-      "suffix": "/account/v1/webhooks/{Webhook ID}"
-    }, 
+      "name": "Webhook",
+      "suffix": "/account/v1/webhooks/{Webhook ID}",
+      "description": "One webhook by id."
+    },
     {
-      "name": "Webhook Triggers", 
-      "suffix": "/account/v1/webhooks/{Webhook ID}/triggers"
-    }, 
+      "name": "Webhook Triggers",
+      "suffix": "/account/v1/webhooks/{Webhook ID}/triggers",
+      "description": "The triggers attached to one webhook. Requires a webhook id."
+    },
     {
-      "name": "Online Browsers", 
-      "suffix": "/now/v3/browsers/presenter={Presenter?:truncatedList|list|truncatedObject|object}"
-    }, 
+      "name": "Online Browsers",
+      "suffix": "/now/v3/browsers/presenter={Presenter?:truncatedList|list|truncatedObject|object}",
+      "description": "The browsers current visitors are using."
+    },
     {
-      "name": "Online Campaigns", 
-      "suffix": "/now/v3/campaigns"
-    }, 
+      "name": "Online Campaigns",
+      "suffix": "/now/v3/campaigns",
+      "description": "The marketing campaigns current visitors arrived through."
+    },
     {
-      "name": "Online Concurrent Visitors", 
-      "suffix": "/now/v3/concurrents"
-    }, 
+      "name": "Online Concurrent Visitors",
+      "suffix": "/now/v3/concurrents",
+      "description": "How many people are on the site right now."
+    },
     {
-      "name": "Online Countries", 
-      "suffix": "/now/v3/countries"
-    }, 
+      "name": "Online Countries",
+      "suffix": "/now/v3/countries",
+      "description": "Where current visitors are, by country."
+    },
     {
-      "name": "Realtime Engagement", 
-      "suffix": "/now/v3/engagement"
-    }, 
+      "name": "Realtime Engagement",
+      "suffix": "/now/v3/engagement",
+      "description": "The live engagement measure -- how actively current visitors are interacting rather than merely present."
+    },
     {
-      "name": "Online Geographic User Info", 
-      "suffix": "/now/v3/geo?visitorsMode={Visitors Mode?:all|tagged|returning}&dateFormat={Date Format?}"
-    }, 
+      "name": "Online Geographic User Info",
+      "suffix": "/now/v3/geo?visitorsMode={Visitors Mode?:all|tagged|returning}&dateFormat={Date Format?}",
+      "description": "Current visitors by geography in more detail, filterable by visitor mode."
+    },
     {
-      "name": "Online Languages", 
-      "suffix": "/now/v3/languages?presenter={Presenter?:truncatedList|list|truncatedObject|object}"
-    }, 
+      "name": "Online Languages",
+      "suffix": "/now/v3/languages?presenter={Presenter?:truncatedList|list|truncatedObject|object}",
+      "description": "The browser languages of current visitors."
+    },
     {
-      "name": "Online Notifications", 
-      "suffix": "/now/v3/notifications?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}"
-    }, 
+      "name": "Online Notifications",
+      "suffix": "/now/v3/notifications?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}",
+      "description": "The notifications raised for the site over a period -- traffic spikes, goals met, alerts fired. The events GoSquared thought worth flagging."
+    },
     {
-      "name": "Online Organizations", 
-      "suffix": "/now/v3/organisations?presenter={Presenter?:truncatedList|list|truncatedObject|object}"
-    }, 
+      "name": "Online Organizations",
+      "suffix": "/now/v3/organisations?presenter={Presenter?:truncatedList|list|truncatedObject|object}",
+      "description": "The organisations current visitors resolve to, from their IP addresses. B2B attribution -- which companies are on the site now, which no consumer analytics tool offers."
+    },
     {
-      "name": "Realtime Overview", 
-      "suffix": "/now/v3/overview?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}"
-    }, 
+      "name": "Realtime Overview",
+      "suffix": "/now/v3/overview?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}",
+      "description": "The live headline figures for a site -- concurrent visitors, pages viewed, and the current engagement summary. THE NOW API IS A SNAPSHOT: everything under it describes this instant and keeps no history, so a trend can only be built by sampling repeatedly. The trends endpoints below are the historical ones."
+    },
     {
-      "name": "Online Pages", 
-      "suffix": "/now/v3/pages?href={Page URL?}"
-    }, 
+      "name": "Online Pages",
+      "suffix": "/now/v3/pages?href={Page URL?}",
+      "description": "The pages being viewed right now, with their visitor counts."
+    },
     {
-      "name": "Online Platforms", 
-      "suffix": "/now/v3/platforms?presenter={Presenter?:truncatedList|list|truncatedObject|object}"
-    }, 
+      "name": "Online Platforms",
+      "suffix": "/now/v3/platforms?presenter={Presenter?:truncatedList|list|truncatedObject|object}",
+      "description": "The operating systems and devices of current visitors."
+    },
     {
-      "name": "Online Sources", 
-      "suffix": "/now/v3/sources?sections={Sources?:direct,site,social,organic,internal}&minimal={Compact?:true|false}"
-    }, 
+      "name": "Online Sources",
+      "suffix": "/now/v3/sources?sections={Sources?:direct,site,social,organic,internal}&minimal={Compact?:true|false}",
+      "description": "Where current visitors came from, by section -- direct, search, social, referral."
+    },
     {
-      "name": "Current Time", 
-      "suffix": "/now/v3/time"
-    }, 
+      "name": "Current Time",
+      "suffix": "/now/v3/time",
+      "description": "GoSquared's own clock. Useful for anchoring a relative range to the service's time rather than the caller's."
+    },
     {
-      "name": "Time Series", 
-      "suffix": "/now/v3/timeSeries?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}&interval={Interval?:5min}"
-    }, 
+      "name": "Time Series",
+      "suffix": "/now/v3/timeSeries?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}&interval={Interval?:5min}",
+      "description": "A live time series over a short recent window. The bridge between the instantaneous now API and the historical trends API."
+    },
     {
-      "name": "Visitors", 
-      "suffix": "/now/v3/visitors?visitorsMode={Visitors Mode?:all|tagged|returning}&from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}"
-    }, 
+      "name": "Visitors",
+      "suffix": "/now/v3/visitors?visitorsMode={Visitors Mode?:all|tagged|returning}&from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}",
+      "description": "The individual visitors currently on the site, filterable to all, tagged or returning. The person-level live view, as opposed to the counts."
+    },
     {
-      "name": "Historical Aggregate Data", 
-      "suffix": "/trends/v2/aggregate?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}&interval={Interval?:hour|day|month}"
-    }, 
+      "name": "Historical Aggregate Data",
+      "suffix": "/trends/v2/aggregate?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}&interval={Interval?:hour|day|month}",
+      "description": "Site totals over a date range -- visits, page views, unique visitors and engagement. THE TRENDS API IS THE HISTORICAL ONE, in contrast to the now API above, and this is its headline table."
+    },
     {
-      "name": "Historical Browser Data", 
-      "suffix": "/trends/v2/browser?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}"
-    }, 
+      "name": "Historical Browser Data",
+      "suffix": "/trends/v2/browser?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}",
+      "description": "Traffic by browser over a date range."
+    },
     {
-      "name": "Historical Campaign Content", 
-      "suffix": "/trends/v2/campaign_content?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}"
-    }, 
+      "name": "Historical Campaign Content",
+      "suffix": "/trends/v2/campaign_content?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}",
+      "description": "Traffic by campaign content -- utm_content, which distinguishes creative variants."
+    },
     {
-      "name": "Historical Campaign Medium", 
-      "suffix": "/trends/v2/campaign_medium?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}"
-    }, 
+      "name": "Historical Campaign Medium",
+      "suffix": "/trends/v2/campaign_medium?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}",
+      "description": "Traffic by campaign medium -- utm_medium."
+    },
     {
-      "name": "Historical Campaign Name", 
-      "suffix": "/trends/v2/campaign_name?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}"
-    }, 
+      "name": "Historical Campaign Name",
+      "suffix": "/trends/v2/campaign_name?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}",
+      "description": "Traffic by campaign name over a range -- the utm_campaign dimension."
+    },
     {
-      "name": "Historical Campaign Source", 
-      "suffix": "/trends/v2/campaign_source?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}"
-    }, 
+      "name": "Historical Campaign Source",
+      "suffix": "/trends/v2/campaign_source?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}",
+      "description": "Traffic by campaign source -- utm_source."
+    },
     {
-      "name": "Historical Campaign Term", 
-      "suffix": "/trends/v2/campaign_term?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}"
-    }, 
+      "name": "Historical Campaign Term",
+      "suffix": "/trends/v2/campaign_term?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}",
+      "description": "Traffic by campaign term -- utm_term, the paid keyword."
+    },
     {
-      "name": "Historical Country Data", 
-      "suffix": "/trends/v2/country?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}"
-    }, 
+      "name": "Historical Country Data",
+      "suffix": "/trends/v2/country?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}",
+      "description": "Traffic by country over a date range."
+    },
     {
-      "name": "Historical Event Data", 
-      "suffix": "/trends/v2/event?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}"
-    }, 
+      "name": "Historical Event Data",
+      "suffix": "/trends/v2/event?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}",
+      "description": "Custom events recorded over a date range. Events are whatever the site's own code sends, so their names and meanings are entirely account-specific."
+    },
     {
-      "name": "Historical Language Data", 
-      "suffix": "/trends/v2/language?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}"
-    }, 
+      "name": "Historical Language Data",
+      "suffix": "/trends/v2/language?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}",
+      "description": "Traffic by browser language over a date range."
+    },
     {
-      "name": "Historical Organization Data", 
-      "suffix": "/trends/v2/organisation?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}"
-    }, 
+      "name": "Historical Organization Data",
+      "suffix": "/trends/v2/organisation?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}",
+      "description": "Traffic by resolved organisation over a date range. The historical B2B view, and the basis for account-based marketing questions."
+    },
     {
-      "name": "Historical OS Data", 
-      "suffix": "/trends/v2/os?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}"
-    }, 
+      "name": "Historical OS Data",
+      "suffix": "/trends/v2/os?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}",
+      "description": "Traffic by operating system over a date range."
+    },
     {
-      "name": "Historical Page Data", 
-      "suffix": "/trends/v2/page?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}"
-    }, 
+      "name": "Historical Page Data",
+      "suffix": "/trends/v2/page?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}",
+      "description": "Page views over a date range, by page. Which content earned the traffic."
+    },
     {
-      "name": "Historical Base Path Data", 
-      "suffix": "/trends/v2/path1?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}"
-    }, 
+      "name": "Historical Base Path Data",
+      "suffix": "/trends/v2/path1?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}",
+      "description": "Traffic grouped by the FIRST path segment over a range. The section-level view -- blog, product, docs -- which the per-page table cannot give without manual grouping."
+    },
     {
-      "name": "Historical Screen Dimensions Data", 
-      "suffix": "/trends/v2/screenDimensions?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}"
-    }, 
+      "name": "Historical Screen Dimensions Data",
+      "suffix": "/trends/v2/screenDimensions?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}",
+      "description": "Traffic by screen size over a date range. What a responsive design actually has to serve."
+    },
     {
-      "name": "Historical Sources Data", 
-      "suffix": "/trends/v2/sources?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}&group={Group by Common Source?:true|false}"
-    }, 
+      "name": "Historical Sources Data",
+      "suffix": "/trends/v2/sources?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}&dateFormat={Date Format?}&group={Group by Common Source?:true|false}",
+      "description": "Traffic by referral source over a date range. The acquisition table."
+    },
     {
-      "name": "People CRM Devices", 
-      "suffix": "/people/v1/devices"
-    }, 
+      "name": "People CRM Devices",
+      "suffix": "/people/v1/devices",
+      "description": "The devices seen, each linked to the person using it. One person can have several, which is why device counts and people counts differ."
+    },
     {
-      "name": "People CRM Device", 
-      "suffix": "/people/v1/devices/{Device ID}"
-    }, 
+      "name": "People CRM Device",
+      "suffix": "/people/v1/devices/{Device ID}",
+      "description": "One device by id."
+    },
     {
-      "name": "People CRM Event Types", 
-      "suffix": "/people/v1/eventTypes"
-    }, 
+      "name": "People CRM Event Types",
+      "suffix": "/people/v1/eventTypes",
+      "description": "The event types recorded against people. The vocabulary of behaviours being tracked."
+    },
     {
-      "name": "People CRM Search", 
-      "suffix": "/people/v1/people?query={Search Term}&fields={Fields?:id,email,...}&dateFormat={Date Format?}"
-    }, 
+      "name": "People CRM Search",
+      "suffix": "/people/v1/people?query={Search Term}&fields={Fields?:id,email,...}&dateFormat={Date Format?}",
+      "description": "People in the GoSquared CRM matching a query. THIS IS THE IDENTITY LAYER: analytics elsewhere counts anonymous sessions, and People links those sessions to named individuals with properties and event history -- so it is what turns traffic into accounts."
+    },
     {
-      "name": "People CRM Person", 
-      "suffix": "/people/v1/people/{Person ID}"
-    }, 
+      "name": "People CRM Person",
+      "suffix": "/people/v1/people/{Person ID}",
+      "description": "One person by id, with their properties and activity."
+    },
     {
-      "name": "People CRM Property Types", 
-      "suffix": "/people/v1/propertyTypes"
-    }, 
+      "name": "People CRM Property Types",
+      "suffix": "/people/v1/propertyTypes",
+      "description": "The properties people can carry, standard and custom. The decoder for the property keys on a person."
+    },
     {
-      "name": "People CRM Custom Property Types", 
-      "suffix": "/people/v1/propertyTypes/custom"
-    }, 
+      "name": "People CRM Custom Property Types",
+      "suffix": "/people/v1/propertyTypes/custom",
+      "description": "Only the custom properties defined. What the business chose to record about people, which is entirely account-specific."
+    },
     {
-      "name": "People CRM Property Type", 
-      "suffix": "/people/v1/propertyTypes/{Property ID}"
-    }, 
+      "name": "People CRM Property Type",
+      "suffix": "/people/v1/propertyTypes/{Property ID}",
+      "description": "One property type by id."
+    },
     {
-      "name": "People CRM Smart Groups", 
-      "suffix": "/people/v1/smartgroups"
-    }, 
+      "name": "People CRM Smart Groups",
+      "suffix": "/people/v1/smartgroups",
+      "description": "The smart groups defined -- audiences described by rules over properties and behaviour rather than by explicit membership. Their rules state the business's own segment definitions."
+    },
     {
-      "name": "People CRM Smart Group", 
-      "suffix": "/people/v1/smartgroups/{Group ID}"
-    }, 
+      "name": "People CRM Smart Group",
+      "suffix": "/people/v1/smartgroups/{Group ID}",
+      "description": "One smart group by id, with its rules and current membership count."
+    },
     {
-      "name": "Archived Chats", 
-      "suffix": "/chat/v1/archivedChats?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}"
-    }, 
+      "name": "Archived Chats",
+      "suffix": "/chat/v1/archivedChats?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}",
+      "description": "Closed chat conversations over a period. The historical record; active chats move here when they end."
+    },
     {
-      "name": "Active Chats", 
-      "suffix": "/chat/v1/chats?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}"
-    }, 
+      "name": "Active Chats",
+      "suffix": "/chat/v1/chats?from={From Date?:yyyy-MM-ddTHH:mm:ss}&to={End Date?:yyyy-MM-ddTHH:mm:ss}",
+      "description": "Live chat conversations over a period. The support channel alongside the analytics."
+    },
     {
-      "name": "Active Chat", 
-      "suffix": "/chat/v1/chats/{Chat ID}"
+      "name": "Active Chat",
+      "suffix": "/chat/v1/chats/{Chat ID}",
+      "description": "One chat by id, with its messages."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/hubspot/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/hubspot/endpoints.json
@@ -3,57 +3,68 @@
     {
       "name": "Account Details",
       "pageType": 0,
-      "suffix": "/integrations/v1/me"
+      "suffix": "/integrations/v1/me",
+      "description": "The portal's own details -- portal id, time zone, currency and the account type. One record, and the time zone matters because analytics periods are computed in it."
     },
     {
       "name": "Category Analytics Data",
       "pageType": 1,
-      "suffix": "/analytics/v2/reports/{Breakdown By:totals|sessions|sources|geolocation|utm-[campaigns|contents|mediums|sources]}/{Time Period:total|daily|weekly|monthly|summarize/daily|summarize/weekly|summarize/monthly }?start={Start  Date:YYYYMMDD}&end={End Date:YYYYMMDD}&d1={First Drilldown?}&d2={Second Drilldown?}&f={Filter?}&e={Exclude?}&filterId={Analytics View ID?}"
+      "suffix": "/analytics/v2/reports/{Breakdown By:totals|sessions|sources|geolocation|utm-[campaigns|contents|mediums|sources]}/{Time Period:total|daily|weekly|monthly|summarize/daily|summarize/weekly|summarize/monthly }?start={Start  Date:YYYYMMDD}&end={End Date:YYYYMMDD}&d1={First Drilldown?}&d2={Second Drilldown?}&f={Filter?}&e={Exclude?}&filterId={Analytics View ID?}",
+      "description": "Traffic and conversion analytics broken down by a chosen category -- totals, sessions, sources, geolocation, devices and more. Requires the breakdown and a date range. HUBSPOT'S ANALYTICS IS BREAKDOWN-DRIVEN: the same endpoint returns a different report depending on the breakdown asked for, so the question defines the request."
     },
     {
       "name": "Object Type Analytics Data",
       "pageType": 1,
-      "suffix": "/analytics/v2/reports/{Object Type:event-completions|forms|pages|social-assists}/{Time Period:total|daily|weekly|monthly|summarize/daily|summarize/weekly|summarize/monthly }?start={Start Date:YYYYMMDD}&end={End Date:YYYYMMDD}&f={Filter?}&e={Exclude?}&filterId={Analytics View ID?}"
+      "suffix": "/analytics/v2/reports/{Object Type:event-completions|forms|pages|social-assists}/{Time Period:total|daily|weekly|monthly|summarize/daily|summarize/weekly|summarize/monthly }?start={Start Date:YYYYMMDD}&end={End Date:YYYYMMDD}&f={Filter?}&e={Exclude?}&filterId={Analytics View ID?}",
+      "description": "Analytics broken down by object type -- event completions, forms, pages, CTAs. Requires the object type and dates."
     },
     {
       "name": "Hosted Content Analytics Data",
       "pageType": 1,
-      "suffix": "/analytics/v2/reports/{Content Type:landing-pages|standard-pages|blog-posts|listing-pages|knowledge-articles}/{Time Period:total|daily|weekly|monthly|summarize/daily|summarize/weekly|summarize/monthly }?start={Start Date:YYYYMMDD}&end={End Date:YYYYMMDD}&f={Filter?}&e={Exclude?}&filterId={Analytics View ID?}"
+      "suffix": "/analytics/v2/reports/{Content Type:landing-pages|standard-pages|blog-posts|listing-pages|knowledge-articles}/{Time Period:total|daily|weekly|monthly|summarize/daily|summarize/weekly|summarize/monthly }?start={Start Date:YYYYMMDD}&end={End Date:YYYYMMDD}&f={Filter?}&e={Exclude?}&filterId={Analytics View ID?}",
+      "description": "Analytics for hosted content -- landing pages, site pages, blog posts. Requires the content type and dates."
     },
     {
       "name": "Page Analytics Details",
       "pageType": 1,
-      "suffix": "/analytics/v2/reports/{Content Type:landing-pages|standard-pages|blog-posts|listing-pages|knowledge-articles}/{Page ID}/sources/{Time Period:total|daily|weekly|monthly|summarize/daily|summarize/weekly|summarize/monthly }?start={Start Date:YYYYMMDD}&end={End Date:YYYYMMDD}&f={Filter?}&e={Exclude?}&filterId={Analytics View ID?}"
+      "suffix": "/analytics/v2/reports/{Content Type:landing-pages|standard-pages|blog-posts|listing-pages|knowledge-articles}/{Page ID}/sources/{Time Period:total|daily|weekly|monthly|summarize/daily|summarize/weekly|summarize/monthly }?start={Start Date:YYYYMMDD}&end={End Date:YYYYMMDD}&f={Filter?}&e={Exclude?}&filterId={Analytics View ID?}",
+      "description": "Per-page analytics detail. Requires the content type and dates."
     },
     {
       "name": "Blog Analytics details",
       "pageType": 1,
-      "suffix": "/analytics/v2/reports/{Content Type:landing-pages|standard-pages|blog-posts|listing-pages|knowledge-articles}/content-group/{Blog ID}/sources/{Time Period:total|daily|weekly|monthly|summarize/daily|summarize/weekly|summarize/monthly }?start={Start Date:YYYYMMDD}&end={End Date:YYYYMMDD}&f={Filter?}&e={Exclude?}&filterId={Analytics View ID?}"
+      "suffix": "/analytics/v2/reports/{Content Type:landing-pages|standard-pages|blog-posts|listing-pages|knowledge-articles}/content-group/{Blog ID}/sources/{Time Period:total|daily|weekly|monthly|summarize/daily|summarize/weekly|summarize/monthly }?start={Start Date:YYYYMMDD}&end={End Date:YYYYMMDD}&f={Filter?}&e={Exclude?}&filterId={Analytics View ID?}",
+      "description": "Per-blog-post analytics detail. Requires the content type and dates."
     },
     {
       "name": "Object Type Analytics Data Exists",
       "pageType": 0,
-      "suffix": "/analytics/v2/reports/{Object Type:event-completions|forms|pages|social-assists|landing-pages|standard-pages|blog-posts|listing-pages|knowledge-articles}/exists"
+      "suffix": "/analytics/v2/reports/{Object Type:event-completions|forms|pages|social-assists|landing-pages|standard-pages|blog-posts|listing-pages|knowledge-articles}/exists",
+      "description": "Whether analytics data exists for one object type. A cheap existence check before a full report."
     },
     {
       "name": "Events Data",
       "pageType": 0,
-      "suffix": "/reports/v2/events?includeDeletes={Include Deleted?:true|false}"
+      "suffix": "/reports/v2/events?includeDeletes={Include Deleted?:true|false}",
+      "description": "The behavioural events recorded in the portal. The same endpoint as Events, under a second name."
     },
     {
       "name": "Calendar Events",
       "pageType": 0,
-      "suffix": "/calendar/v1/events/content?start={Start Date:yyyy-MM-dd'T'HH:mm:ss.SSS'Z'|milliseconds}&end={End Date:yyyy-MM-dd'T'HH:mm:ss.SSS'Z'|milliseconds}&contentCategory={Content Category?:blog-post,email,recurring-email,landing-page}&campaignGuid={Campaign Guid?}&includeNoCampaigns={Include No Campaigns?:true|false}"
+      "suffix": "/calendar/v1/events/content?start={Start Date:yyyy-MM-dd'T'HH:mm:ss.SSS'Z'|milliseconds}&end={End Date:yyyy-MM-dd'T'HH:mm:ss.SSS'Z'|milliseconds}&contentCategory={Content Category?:blog-post,email,recurring-email,landing-page}&campaignGuid={Campaign Guid?}&includeNoCampaigns={Include No Campaigns?:true|false}",
+      "description": "The content calendar entries -- planned pages, posts and emails, with their dates and states. The publishing plan, as opposed to what was published."
     },
     {
       "name": "Calendar Social  Events",
       "pageType": 0,
-      "suffix": "/calendar/v1/events/social?start={Start Date:yyyy-MM-dd'T'HH:mm:ss.SSS'Z'|milliseconds}&end={End Date:yyyy-MM-dd'T'HH:mm:ss.SSS'Z'|milliseconds}&contentCategory={Content Category?:blog-post,email,recurring-email,landing-page}&campaignGuid={Campaign GUID?}&includeNoCampaigns={Include No Campaigns?:true|false}"
+      "suffix": "/calendar/v1/events/social?start={Start Date:yyyy-MM-dd'T'HH:mm:ss.SSS'Z'|milliseconds}&end={End Date:yyyy-MM-dd'T'HH:mm:ss.SSS'Z'|milliseconds}&contentCategory={Content Category?:blog-post,email,recurring-email,landing-page}&campaignGuid={Campaign GUID?}&includeNoCampaigns={Include No Campaigns?:true|false}",
+      "description": "The planned social posts on the content calendar."
     },
     {
       "name": "Calendar Task Events",
       "pageType": 0,
-      "suffix": "/calendar/v1/events?start={Start Date:yyyy-MM-dd'T'HH:mm:ss.SSS'Z'|milliseconds}&end={End Date:yyyy-MM-dd'T'HH:mm:ss.SSS'Z'|milliseconds}&type={Type?:CONTENT,SOCIAL,PUBLISHING_TASK,PUBLISHING_TASK}&contentCategory={Content Category?:blog-post,email,recurring-email,landing-page}&campaignGuid={Campaign Guid?}&includeNoCampaigns={Include No Campaigns?:true|false}"
+      "suffix": "/calendar/v1/events?start={Start Date:yyyy-MM-dd'T'HH:mm:ss.SSS'Z'|milliseconds}&end={End Date:yyyy-MM-dd'T'HH:mm:ss.SSS'Z'|milliseconds}&type={Type?:CONTENT,SOCIAL,PUBLISHING_TASK,PUBLISHING_TASK}&contentCategory={Content Category?:blog-post,email,recurring-email,landing-page}&campaignGuid={Campaign Guid?}&includeNoCampaigns={Include No Campaigns?:true|false}",
+      "description": "The tasks on the content calendar."
     },
     {
       "name": "Companies",
@@ -72,7 +83,8 @@
           "key": "companyId",
           "parameterName": "Company ID"
         }
-      ]
+      ],
+      "description": "The companies in the CRM, paged. Same properties model as contacts -- values live in a properties object keyed by internal name, and Company Properties is the decoder. Identified by companyId."
     },
     {
       "name": "Recently Modified Companies",
@@ -91,7 +103,8 @@
           "key": "companyId",
           "parameterName": "Company ID"
         }
-      ]
+      ],
+      "description": "Companies changed most recently. The incremental-sync route."
     },
     {
       "name": "Recently Created Companies",
@@ -110,37 +123,44 @@
           "key": "companyID",
           "parameterName": "Company ID"
         }
-      ]
+      ],
+      "description": "Companies created most recently."
     },
     {
       "name": "Company",
       "pageType": 0,
-      "suffix": "/companies/v2/companies/{Company ID}?includeMergeAudits={Include Merge Audits?:true|false}"
+      "suffix": "/companies/v2/companies/{Company ID}?includeMergeAudits={Include Merge Audits?:true|false}",
+      "description": "One company by id, with its full properties."
     },
     {
       "name": "Company Contacts",
       "pageType": 3,
-      "suffix": "/companies/v2/companies/{Company ID}/contacts"
+      "suffix": "/companies/v2/companies/{Company ID}/contacts",
+      "description": "The contacts associated with one company. Requires a company id."
     },
     {
       "name": "Contacts IDs",
       "pageType": 3,
-      "suffix": "/companies/v2/companies/{Company ID}/vids"
+      "suffix": "/companies/v2/companies/{Company ID}/vids",
+      "description": "Just the vids of one company's contacts. Requires a company id. Cheaper than the full contact records when only the association matters."
     },
     {
       "name": "Company Properties",
       "pageType": 0,
-      "suffix": "/properties/v1/companies/properties"
+      "suffix": "/properties/v1/companies/properties",
+      "description": "Every property a company can carry, standard and custom. The decoder for company data."
     },
     {
       "name": "Company Property",
       "pageType": 0,
-      "suffix": "/properties/v1/companies/properties/named/{Property Name}"
+      "suffix": "/properties/v1/companies/properties/named/{Property Name}",
+      "description": "One company property by internal name."
     },
     {
       "name": "Company Groups",
       "pageType": 0,
-      "suffix": "/properties/v1/companies/groups?includeProperties={Include Properties?:true|false}"
+      "suffix": "/properties/v1/companies/groups?includeProperties={Include Properties?:true|false}",
+      "description": "The groups company properties are organised into."
     },
     {
       "name": "All Contacts",
@@ -153,62 +173,74 @@
           "key": "vid",
           "parameterName": "Contact ID"
         }
-      ]
+      ],
+      "description": "Every contact in the portal, paged. THE SINGLE MOST IMPORTANT THING ABOUT HUBSPOT'S CRM DATA: a contact's fields are not columns on the record, they live in a PROPERTIES object keyed by internal property name, each holding a value and a version history. Custom property internal names are generated rather than chosen, so Contact Properties is the only decoder. AND THE LISTING RETURNS ONLY A SMALL DEFAULT SET OF PROPERTIES -- everything else, including most custom fields, must be named in the property parameter or it is simply absent. Contacts are identified by vid, not by email."
     },
     {
       "name": "Recently Modified Contacts",
       "pageType": 3,
-      "suffix": "/contacts/v1/lists/recently_updated/contacts/recent?timeOffset={Time Offset?}&property={Property?}&propertyMode={Property Mode?:value_only|value_and_history}&formSubmissionMode={Form Submission Mode?:all|none|newest|oldest}&showListMemberships={List Memberships?:true|false}"
+      "suffix": "/contacts/v1/lists/recently_updated/contacts/recent?timeOffset={Time Offset?}&property={Property?}&propertyMode={Property Mode?:value_only|value_and_history}&formSubmissionMode={Form Submission Mode?:all|none|newest|oldest}&showListMemberships={List Memberships?:true|false}",
+      "description": "Contacts changed most recently, newest first. The incremental-sync route; the full listing has no date filter."
     },
     {
       "name": "Recently Created Contacts",
       "pageType": 3,
-      "suffix": "/contacts/v1/lists/all/contacts/recent?timeOffset={Time Offset?}&property={Property?}&propertyMode={Property Mode?:value_only|value_and_history}&formSubmissionMode={Form Submission Mode?:all|none|newest|oldest}&showListMemberships={List Memberships?:true|false}"
+      "suffix": "/contacts/v1/lists/all/contacts/recent?timeOffset={Time Offset?}&property={Property?}&propertyMode={Property Mode?:value_only|value_and_history}&formSubmissionMode={Form Submission Mode?:all|none|newest|oldest}&showListMemberships={List Memberships?:true|false}",
+      "description": "Contacts created most recently, newest first."
     },
     {
       "name": "Contact Profile By ID",
       "pageType": 0,
-      "suffix": "/contacts/v1/contact/vid/{Contact ID}/profile?property={Property?}&propertyMode={Property Mode?:value_only|value_and_history}&formSubmissionMode={Form Submission Mode?:all|none|newest|oldest}&showListMemberships={List Memberships?:true|false}"
+      "suffix": "/contacts/v1/contact/vid/{Contact ID}/profile?property={Property?}&propertyMode={Property Mode?:value_only|value_and_history}&formSubmissionMode={Form Submission Mode?:all|none|newest|oldest}&showListMemberships={List Memberships?:true|false}",
+      "description": "One contact by vid, with the full property set and their form submissions and list memberships."
     },
     {
-      "name": "Contacts\u00a0Informations",
+      "name": "Contacts Informations",
       "pageType": 0,
-      "suffix": "/contacts/v1/contact/vids/batch?&&vid={Contact ID}&property={Property?}&propertyMode={Property Mode?:value_only|value_and_history}&formSubmissionMode={Form Submission Mode?:all|none|newest|oldest}&showListMemberships={List Memberships?:true|false}&includeDeletes={Include Deletes?:true|false}"
+      "suffix": "/contacts/v1/contact/vids/batch?&&vid={Contact ID}&property={Property?}&propertyMode={Property Mode?:value_only|value_and_history}&formSubmissionMode={Form Submission Mode?:all|none|newest|oldest}&showListMemberships={List Memberships?:true|false}&includeDeletes={Include Deletes?:true|false}",
+      "description": "Several contacts by vid, in one request. The efficient way to hydrate a known set rather than fetching one at a time."
     },
     {
       "name": "Contact (By Email)",
       "pageType": 0,
-      "suffix": "/contacts/v1/contact/email/{Contact Email Address}/profile?property={Property?}&propertyMode={Property Mode?:value_only|value_and_history}&formSubmissionMode={Form Submission Mode?:all|none|newest|oldest}&showListMemberships={List Memberships?:true|false}"
+      "suffix": "/contacts/v1/contact/email/{Contact Email Address}/profile?property={Property?}&propertyMode={Property Mode?:value_only|value_and_history}&formSubmissionMode={Form Submission Mode?:all|none|newest|oldest}&showListMemberships={List Memberships?:true|false}",
+      "description": "One contact by email address. The lookup when the vid is unknown -- and note an email can be reassigned between contacts, so the vid is the stable identifier."
     },
     {
       "name": "Contact Profile",
       "pageType": 0,
-      "suffix": "/contacts/v1/contact/utk/{Contact User Token}/profile?property={Property?}&propertyMode={Property Mode?:value_only|value_and_history}&formSubmissionMode={Form Submission Mode?:all|none|newest|oldest}&showListMemberships={List Memberships?:true|false}"
+      "suffix": "/contacts/v1/contact/utk/{Contact User Token}/profile?property={Property?}&propertyMode={Property Mode?:value_only|value_and_history}&formSubmissionMode={Form Submission Mode?:all|none|newest|oldest}&showListMemberships={List Memberships?:true|false}",
+      "description": "One contact by their tracking cookie token. The route from an anonymous website visitor to a known contact."
     },
     {
       "name": "Contact By User Token",
       "pageType": 0,
-      "suffix": "/contacts/v1/contact/utk/{Contact User Token}/profile?property={Property?}&propertyMode={Property Mode?:value_only|value_and_history}&formSubmissionMode={Form Submission Mode?:all|none|newest|oldest}&showListMemberships={List Memberships?:true|false}"
+      "suffix": "/contacts/v1/contact/utk/{Contact User Token}/profile?property={Property?}&propertyMode={Property Mode?:value_only|value_and_history}&formSubmissionMode={Form Submission Mode?:all|none|newest|oldest}&showListMemberships={List Memberships?:true|false}",
+      "description": "One contact by tracking token. The same endpoint as Contact Profile under a second name; either will do."
     },
     {
       "name": "Contacts By User Token",
       "pageType": 0,
-      "suffix": "/contacts/v1/contact/utks/batch?utk={Contact user token}&property={Property?}&propertyMode={Property Mode?:value_only|value_and_history}&formSubmissionMode={Form Submission Mode?:all|none|newest|oldest}&showListMemberships={List Memberships?:true|false}"
+      "suffix": "/contacts/v1/contact/utks/batch?utk={Contact user token}&property={Property?}&propertyMode={Property Mode?:value_only|value_and_history}&formSubmissionMode={Form Submission Mode?:all|none|newest|oldest}&showListMemberships={List Memberships?:true|false}",
+      "description": "Several contacts by tracking token, in one request."
     },
     {
       "name": "Search Contacts",
       "pageType": 2,
-      "suffix": "/contacts/v1/search/query?q={Search Query}&property={Property?}"
+      "suffix": "/contacts/v1/search/query?q={Search Query}&property={Property?}",
+      "description": "Contacts matching a free-text query across name, email and company. Locates contacts rather than reporting on them."
     },
     {
       "name": "Contacts Lifecycle Stage Metrics",
       "pageType": 0,
-      "suffix": "/contacts/v1/search/external/lifecyclestages?fromTimestamp={From Timestamp}&toTimestamp={To Timestamp}&aggregationProperty={Aggregation Property?}"
+      "suffix": "/contacts/v1/search/external/lifecyclestages?fromTimestamp={From Timestamp}&toTimestamp={To Timestamp}&aggregationProperty={Aggregation Property?}",
+      "description": "Contact counts by lifecycle stage. THE FUNNEL: HubSpot's lifecycle stage runs subscriber, lead, marketing qualified, sales qualified, opportunity, customer, and this is the pre-computed count at each."
     },
     {
       "name": "Contact Statistics",
       "pageType": 0,
-      "suffix": "/contacts/v1/contacts/statistics?includeTotalContacts={Include Total Contacts?:true|false}&includeLastNewContactAt={Include Last Contact At?:true|false}"
+      "suffix": "/contacts/v1/contacts/statistics?includeTotalContacts={Include Total Contacts?:true|false}&includeLastNewContactAt={Include Last Contact At?:true|false}",
+      "description": "Portal-wide contact counts -- total, new, and by lifecycle stage. A ready-made summary rather than a scan."
     },
     {
       "name": "Contact lists",
@@ -227,12 +259,14 @@
           "key": "listId",
           "parameterName": "List ID"
         }
-      ]
+      ],
+      "description": "The contact lists in the portal, with name, size and whether each is static or dynamic."
     },
     {
       "name": "Contact Lists By Its Unique ID",
       "pageType": 0,
-      "suffix": "/contacts/v1/lists/{List ID}"
+      "suffix": "/contacts/v1/lists/{List ID}",
+      "description": "One list by id."
     },
     {
       "name": "A Group Of Contact Lists",
@@ -251,47 +285,56 @@
           "key": "listId",
           "parameterName": "List ID"
         }
-      ]
+      ],
+      "description": "Several lists by id, in one request."
     },
     {
       "name": "Static Contact Lists",
       "pageType": 2,
-      "suffix": "/contacts/v1/lists/static"
+      "suffix": "/contacts/v1/lists/static",
+      "description": "Only the static lists -- fixed membership, added explicitly."
     },
     {
       "name": "Dynamic Contact Lists (Active Lists)",
       "pageType": 2,
-      "suffix": "/contacts/v1/lists/dynamic"
+      "suffix": "/contacts/v1/lists/dynamic",
+      "description": "Only the dynamic lists -- membership defined by filters and re-evaluated continuously. THE DISTINCTION MATTERS: a dynamic list's size changes on its own, so a membership count is a moment in time rather than a stable figure, and its filters state the business's own definition of the segment."
     },
     {
       "name": "Contacts In A List",
       "pageType": 3,
-      "suffix": "/contacts/v1/lists/{List ID}/contacts/all?property={Property?}&propertyMode={Property Mode?:value_only|value_and_history}&formSubmissionMode={Form Submission Mode?:all|none|newest|oldest}&showListMemberships={List Memberships?:true|false}"
+      "suffix": "/contacts/v1/lists/{List ID}/contacts/all?property={Property?}&propertyMode={Property Mode?:value_only|value_and_history}&formSubmissionMode={Form Submission Mode?:all|none|newest|oldest}&showListMemberships={List Memberships?:true|false}",
+      "description": "The contacts in one list. Requires a list id."
     },
     {
       "name": "Recently Added Contacts From A List",
       "pageType": 3,
-      "suffix": "/contacts/v1/lists/{List ID}/contacts/recent?timeOffset={Time Offset?}&property={Property?}&propertyMode={Property Mode?:value_only|value_and_history}&formSubmissionMode={Form Submission Mode?:all|none|newest|oldest}&showListMemberships={List Memberships?:true|false}"
+      "suffix": "/contacts/v1/lists/{List ID}/contacts/recent?timeOffset={Time Offset?}&property={Property?}&propertyMode={Property Mode?:value_only|value_and_history}&formSubmissionMode={Form Submission Mode?:all|none|newest|oldest}&showListMemberships={List Memberships?:true|false}",
+      "description": "The contacts most recently added to one list. Requires a list id. The incremental view of a growing segment."
     },
     {
       "name": "Contact Properties",
       "pageType": 0,
-      "suffix": "/properties/v1/contacts/properties"
+      "suffix": "/properties/v1/contacts/properties",
+      "description": "Every property a contact can carry, standard and custom, with internal name, label, type, field type and options. THE DECODER without which contact data is values against opaque names."
     },
     {
       "name": "Contact Property",
       "pageType": 0,
-      "suffix": "/properties/v1/contacts/properties/named/{Property Name}"
+      "suffix": "/properties/v1/contacts/properties/named/{Property Name}",
+      "description": "One contact property by internal name."
     },
     {
       "name": "Contact Property Groups",
       "pageType": 0,
-      "suffix": "/properties/v1/contacts/groups?includeProperties={Include Properties?:true|false}"
+      "suffix": "/properties/v1/contacts/groups?includeProperties={Include Properties?:true|false}",
+      "description": "The groups contact properties are organised into."
     },
     {
       "name": "Contact Property Group Details",
       "pageType": 0,
-      "suffix": "/properties/v1/contacts/groups/named/{Group Name}?includeProperties={Include Properties?:true|false}"
+      "suffix": "/properties/v1/contacts/groups/named/{Group Name}?includeProperties={Include Properties?:true|false}",
+      "description": "One contact property group by name, with its properties."
     },
     {
       "name": "List Blogs",
@@ -304,47 +347,56 @@
           "key": "id",
           "parameterName": "Blog ID"
         }
-      ]
+      ],
+      "description": "The blogs configured in the portal -- a portal can run several."
     },
     {
       "name": "Blog By ID",
       "pageType": 0,
-      "suffix": "/content/api/v2/blogs/{Blog ID}"
+      "suffix": "/content/api/v2/blogs/{Blog ID}",
+      "description": "One blog by id, with its settings."
     },
     {
       "name": "Blog Previous Versions",
       "pageType": 0,
-      "suffix": "/content/api/v2/blogs/{Blog ID}/versions"
+      "suffix": "/content/api/v2/blogs/{Blog ID}/versions",
+      "description": "The version history of one blog's settings."
     },
     {
       "name": "Blog Previous Version",
       "pageType": 0,
-      "suffix": "/content/api/v2/blogs/{Blog ID}/versions/{Blog Version ID}"
+      "suffix": "/content/api/v2/blogs/{Blog ID}/versions/{Blog Version ID}",
+      "description": "One earlier version of a blog's settings."
     },
     {
       "name": "Blog Authors (v3)",
       "pageType": 1,
-      "suffix": "/blogs/v3/blog-authors?id={ID?}&fullName={Full Name?}&slug={Slug?}&created={Created?:milliseconds }&updated={Updated?:milliseconds}&email={Email?}&casing={Casing?}"
+      "suffix": "/blogs/v3/blog-authors?id={ID?}&fullName={Full Name?}&slug={Slug?}&created={Created?:milliseconds }&updated={Updated?:milliseconds}&email={Email?}&casing={Casing?}",
+      "description": "The blog authors, with name, bio and social links. The per-writer dimension."
     },
     {
       "name": "Search Blog Authors (v3)",
       "pageType": 1,
-      "suffix": "/blogs/v3/blog-authors/search?casing={Casing?:snake_case|camelCase}&q={Query String?}&active={Active?:true|false}&blog={Blog ID?}"
+      "suffix": "/blogs/v3/blog-authors/search?casing={Casing?:snake_case|camelCase}&q={Query String?}&active={Active?:true|false}&blog={Blog ID?}",
+      "description": "Blog authors matching a query."
     },
     {
       "name": "Blog Author By ID (v3)",
       "pageType": 0,
-      "suffix": "/blogs/v3/blog-authors/{Blog Author ID}?casing={Casing?:snake_case|camelCase}"
+      "suffix": "/blogs/v3/blog-authors/{Blog Author ID}?casing={Casing?:snake_case|camelCase}",
+      "description": "One blog author by id."
     },
     {
       "name": "List Comments",
       "pageType": 1,
-      "suffix": "/comments/v3/comments?portalId={Portal Number?}&state={Comment State?:APPROVED|SPAM|REJECTED|PENDING_MODERATION}&contentId={Post ID?}&reverse={Reverse?:true|false}&query={Query String?}"
+      "suffix": "/comments/v3/comments?portalId={Portal Number?}&state={Comment State?:APPROVED|SPAM|REJECTED|PENDING_MODERATION}&contentId={Post ID?}&reverse={Reverse?:true|false}&query={Query String?}",
+      "description": "The comments on blog posts, with author, content and moderation state. Note unapproved and spam comments share this table, so an engagement count that does not filter includes them."
     },
     {
       "name": "Blog Comment By ID",
       "pageType": 0,
-      "suffix": "/comments/v3/comments/{Comment ID}?"
+      "suffix": "/comments/v3/comments/{Comment ID}?",
+      "description": "One comment by id."
     },
     {
       "name": "Blog Posts",
@@ -357,62 +409,74 @@
           "key": "id",
           "parameterName": "Blog Post ID"
         }
-      ]
+      ],
+      "description": "The blog posts, with title, slug, author, publish date, state and content. The content table."
     },
     {
       "name": "Blog Post By ID",
       "pageType": 0,
-      "suffix": "/content/api/v2/blog-posts/{Blog Post ID}"
+      "suffix": "/content/api/v2/blog-posts/{Blog Post ID}",
+      "description": "One blog post by id."
     },
     {
       "name": "Blog Posts Buffer Contents",
       "pageType": 0,
-      "suffix": "/content/api/v2/blog-posts/{Blog Post ID}/buffer"
+      "suffix": "/content/api/v2/blog-posts/{Blog Post ID}/buffer",
+      "description": "The unpublished draft edits of one post. What has been written but not yet published."
     },
     {
       "name": "Blog Post Previous Version",
       "pageType": 0,
-      "suffix": "/content/api/v2/blog-posts/{Blog Post ID}/versions/{Version ID}"
+      "suffix": "/content/api/v2/blog-posts/{Blog Post ID}/versions/{Version ID}",
+      "description": "One earlier version of a blog post. The edit history, which the post itself does not carry."
     },
     {
       "name": "Blog Topics",
       "pageType": 1,
-      "suffix": "/blogs/v3/topics?id={ID?}&slug={Slug?}&created={Created?:milliseconds}&casing={Casing?}"
+      "suffix": "/blogs/v3/topics?id={ID?}&slug={Slug?}&created={Created?:milliseconds}&casing={Casing?}",
+      "description": "The topics posts are tagged with. The content taxonomy, and the dimension subject-level performance groups by."
     },
     {
       "name": "Search Blog Topics",
       "pageType": 1,
-      "suffix": "/blogs/v3/topics/search?id={ID?}&slug={Slug?}&created={Created?:milliseconds}&casing={Casing?}&q={Query String?}&active={Active?:true|false}&blog={Blog Version ID?}"
+      "suffix": "/blogs/v3/topics/search?id={ID?}&slug={Slug?}&created={Created?:milliseconds}&casing={Casing?}&q={Query String?}&active={Active?:true|false}&blog={Blog Version ID?}",
+      "description": "Topics matching a query."
     },
     {
       "name": "Blog Topic By ID",
       "pageType": 0,
-      "suffix": "/blogs/v3/topics/{Topic ID}?casing={Casing?}"
+      "suffix": "/blogs/v3/topics/{Topic ID}?casing={Casing?}",
+      "description": "One topic by id."
     },
     {
       "name": "Domains",
       "pageType": 1,
-      "suffix": "/cos-domains/v1/domains?created={Created?}&domain={Domain?}&id={ID?}&is_resolving={Is Resolving?:true|false}&primary_site_page={Primary Site Page?}"
+      "suffix": "/cos-domains/v1/domains?created={Created?}&domain={Domain?}&id={ID?}&is_resolving={Is Resolving?:true|false}&primary_site_page={Primary Site Page?}",
+      "description": "The domains connected to the portal, with their type and whether each is primary. Which domain content is served from, and the explanation for a page's public URL."
     },
     {
       "name": "Domain By ID",
       "pageType": 0,
-      "suffix": "/cos-domains/v1/domains/{Domain ID}"
+      "suffix": "/cos-domains/v1/domains/{Domain ID}",
+      "description": "One domain by id."
     },
     {
       "name": "Files Metadata",
       "pageType": 1,
-      "suffix": "/filemanager/api/v2/files?alt_key={Alt Key?}&created={Created?}&deleted_at={Deleted At?:milliseconds}&extension={Extension?}&folder_id={Folder ID?}&id={ID?}&name={Name?}&type={Type?}"
+      "suffix": "/filemanager/api/v2/files?alt_key={Alt Key?}&created={Created?}&deleted_at={Deleted At?:milliseconds}&extension={Extension?}&folder_id={Folder ID?}&id={ID?}&name={Name?}&type={Type?}",
+      "description": "The files in the file manager, with name, type, size, folder and URL. Metadata; contents are served from their URLs."
     },
     {
       "name": "File Metadata",
       "pageType": 0,
-      "suffix": "/filemanager/api/v2/files/{File ID}?"
+      "suffix": "/filemanager/api/v2/files/{File ID}?",
+      "description": "One file by id."
     },
     {
       "name": "Folder by ID",
       "pageType": 0,
-      "suffix": "/filemanager/api/v2/folders/{Folder ID}?"
+      "suffix": "/filemanager/api/v2/folders/{Folder ID}?",
+      "description": "One file manager folder by id."
     },
     {
       "name": "Tables",
@@ -431,22 +495,26 @@
           "key": "id",
           "parameterName": "Table ID"
         }
-      ]
+      ],
+      "description": "The HubDB tables -- HubSpot's own structured data store for driving dynamic pages. USER-DEFINED SCHEMA: each table's columns are whatever its creator chose, so Table Details must be read before its rows mean anything."
     },
     {
       "name": "Table Details",
       "pageType": 0,
-      "suffix": "/hubdb/api/v2/tables/{Table ID}"
+      "suffix": "/hubdb/api/v2/tables/{Table ID}",
+      "description": "One HubDB table's schema and settings. Requires a table id. The decoder for its rows."
     },
     {
       "name": "Table Draft Details",
       "pageType": 0,
-      "suffix": "/hubdb/api/v2/tables/{Table ID}/draft"
+      "suffix": "/hubdb/api/v2/tables/{Table ID}/draft",
+      "description": "The unpublished draft schema of one table. Where a schema change is pending."
     },
     {
       "name": "Table Rows",
       "pageType": 1,
-      "suffix": "/hubdb/api/v2/tables/{Table ID}/rows"
+      "suffix": "/hubdb/api/v2/tables/{Table ID}/rows",
+      "description": "The rows of one HubDB table. Requires a table id. The data behind dynamic pages, and often where a business keeps reference data HubSpot has no native object for."
     },
     {
       "name": "Layouts",
@@ -471,27 +539,32 @@
           "key": "id",
           "parameterName": "Layout ID"
         }
-      ]
+      ],
+      "description": "The page layouts defined."
     },
     {
       "name": "Layout Buffer Contents",
       "pageType": 0,
-      "suffix": "/content/api/v2/layouts/{Layout ID}/buffer?"
+      "suffix": "/content/api/v2/layouts/{Layout ID}/buffer?",
+      "description": "The unpublished edits of one layout."
     },
     {
       "name": "Layout Previous Versions",
       "pageType": 0,
-      "suffix": "/content/api/v2/layouts/{Layout ID}/versions"
+      "suffix": "/content/api/v2/layouts/{Layout ID}/versions",
+      "description": "The version history of one layout."
     },
     {
       "name": "Layout Previous Version",
       "pageType": 0,
-      "suffix": "/content/api/v2/layouts/{Layout ID}/versions/{Version ID}"
+      "suffix": "/content/api/v2/layouts/{Layout ID}/versions/{Version ID}",
+      "description": "One earlier version of a layout."
     },
     {
       "name": "If Live Layout Has Buffered changes",
       "pageType": 0,
-      "suffix": "/content/api/v2/layouts/{Layout ID}/has-buffered-changes"
+      "suffix": "/content/api/v2/layouts/{Layout ID}/has-buffered-changes",
+      "description": "Whether one layout has unpublished edits."
     },
     {
       "name": "Pages",
@@ -510,42 +583,50 @@
           "key": "id",
           "parameterName": "Page ID"
         }
-      ]
+      ],
+      "description": "The website and landing pages, with name, slug, state, publish date and their content. Landing pages are the conversion side of HubSpot's marketing, so their performance links to the forms they carry."
     },
     {
       "name": "Page",
       "pageType": 0,
-      "suffix": "/content/api/v2/pages/{Page ID}"
+      "suffix": "/content/api/v2/pages/{Page ID}",
+      "description": "One page by id."
     },
     {
       "name": "Page Buffer Contents",
       "pageType": 0,
-      "suffix": "/content/api/v2/pages/{Page ID}/buffer"
+      "suffix": "/content/api/v2/pages/{Page ID}/buffer",
+      "description": "The unpublished draft edits of one page."
     },
     {
       "name": "Page Previous Versions",
       "pageType": 0,
-      "suffix": "/content/api/v2/pages/{Page ID}/versions"
+      "suffix": "/content/api/v2/pages/{Page ID}/versions",
+      "description": "The version history of one page."
     },
     {
       "name": "Site Maps",
       "pageType": 1,
-      "suffix": "/content/api/v2/site-maps?deleted_at={Deleted At?:milliseconds}&id={ID?}&name={Name?}"
+      "suffix": "/content/api/v2/site-maps?deleted_at={Deleted At?:milliseconds}&id={ID?}&name={Name?}",
+      "description": "The sitemaps generated for the portal."
     },
     {
       "name": "Site Map",
       "pageType": 0,
-      "suffix": "/content/api/v2/site-maps/{Site Map ID}"
+      "suffix": "/content/api/v2/site-maps/{Site Map ID}",
+      "description": "One sitemap by id."
     },
     {
       "name": "Search Your Site",
       "pageType": 1,
-      "suffix": "/contentsearch/v2/search?portalId={Portal ID}&term={Search Term}&type={Type?:SITE_PAGE,LANDING_PAGE,BLOG_POST,LISTING_PAGE,KNOWLEDGE_ARTICLE}&domain={Domain?}&language={Language?}&property={Property?:title|description|html|author_full_name|author_handle}&groupId={Group ID?}&tableId={Table ID?}&hubdbQuery={HubDB Query?}&pathPrefix={Path Prefix?}&matchPrefix={Match Prefix?:true|false}"
+      "suffix": "/contentsearch/v2/search?portalId={Portal ID}&term={Search Term}&type={Type?:SITE_PAGE,LANDING_PAGE,BLOG_POST,LISTING_PAGE,KNOWLEDGE_ARTICLE}&domain={Domain?}&language={Language?}&property={Property?:title|description|html|author_full_name|author_handle}&groupId={Group ID?}&tableId={Table ID?}&hubdbQuery={HubDB Query?}&pathPrefix={Path Prefix?}&matchPrefix={Match Prefix?:true|false}",
+      "description": "Searches the portal's published content. The site search readers themselves use."
     },
     {
       "name": "Indexed Properties",
       "pageType": 0,
-      "suffix": "/contentsearch/v2/search/{Document ID}?portalId={Portal ID}&type={Type:SITE_PAGE|BLOG_POST|KNOWLEDGE_ARTICLE}"
+      "suffix": "/contentsearch/v2/search/{Document ID}?portalId={Portal ID}&type={Type:SITE_PAGE|BLOG_POST|KNOWLEDGE_ARTICLE}",
+      "description": "The indexed fields of one search document. Requires the document id. What the site search actually matches on."
     },
     {
       "name": "Templates",
@@ -564,167 +645,200 @@
           "key": "id",
           "parameterName": "Template ID"
         }
-      ]
+      ],
+      "description": "The page and email templates in the design manager."
     },
     {
       "name": "Template",
       "pageType": 0,
-      "suffix": "/content/api/v2/templates/{Template ID}"
+      "suffix": "/content/api/v2/templates/{Template ID}",
+      "description": "One template by id, with its source."
     },
     {
       "name": "Template Buffer Contents",
       "pageType": 0,
-      "suffix": "/content/api/v2/templates/{Template ID}/buffer"
+      "suffix": "/content/api/v2/templates/{Template ID}/buffer",
+      "description": "The unpublished edits of one template."
     },
     {
       "name": "Template Previous Versions",
       "pageType": 0,
-      "suffix": "/content/api/v2/templates/{Template ID}/versions"
+      "suffix": "/content/api/v2/templates/{Template ID}/versions",
+      "description": "The version history of one template."
     },
     {
       "name": "Template Previous Version",
       "pageType": 0,
-      "suffix": "/content/api/v2/templates/{Template ID}/versions/{Version ID}"
+      "suffix": "/content/api/v2/templates/{Template ID}/versions/{Version ID}",
+      "description": "One earlier version of a template."
     },
     {
       "name": "URL Mappings",
       "pageType": 1,
-      "suffix": "/url-mappings/v3/url-mappings?id={ID?}&routePrefix={Route Prefix?}&destination={Destination?}&contentGroupId={Content Group ID?}&name={name?}&isOnlyAfterNotFound={Is Only After Not Found?:true|false}&isRegex={Is Regex?:true|false}&isMatchFullUrl={Is Match Full Url?:true|false}&isPattern={Is Pattern?:true|false}&created={Created?:milliseconds }&deleted_at={Deleted at?:milliseconds}&updated={Updated?:milliseconds}&causing={Causing?}"
+      "suffix": "/url-mappings/v3/url-mappings?id={ID?}&routePrefix={Route Prefix?}&destination={Destination?}&contentGroupId={Content Group ID?}&name={name?}&isOnlyAfterNotFound={Is Only After Not Found?:true|false}&isRegex={Is Regex?:true|false}&isMatchFullUrl={Is Match Full Url?:true|false}&isPattern={Is Pattern?:true|false}&created={Created?:milliseconds }&deleted_at={Deleted at?:milliseconds}&updated={Updated?:milliseconds}&causing={Causing?}",
+      "description": "The URL redirects configured. Where content moved, and the record of what used to live at an address."
     },
     {
       "name": "URL Mapping",
       "pageType": 0,
-      "suffix": "/url-mappings/v3/url-mappings/{Url Mapping ID}?casing={Casing?}"
+      "suffix": "/url-mappings/v3/url-mappings/{Url Mapping ID}?casing={Casing?}",
+      "description": "One URL mapping by id."
     },
     {
       "name": "CRM Object Associations",
       "pageType": 1,
-      "suffix": "/crm-associations/v1/associations/{Object ID}/HUBSPOT_DEFINED/{Association Type}"
+      "suffix": "/crm-associations/v1/associations/{Object ID}/HUBSPOT_DEFINED/{Association Type}",
+      "description": "The objects associated with one record, by association type. Requires the object id and association type id. HUBSPOT MODELS RELATIONSHIPS AS TYPED ASSOCIATIONS with numeric type ids, so the graph is only traversable through this and the type id decides what the relationship means."
     },
     {
       "name": "View Object Type",
       "pageType": 0,
-      "suffix": "/extensions/sales-objects/v1/object-types/{Object Type ID}"
+      "suffix": "/extensions/sales-objects/v1/object-types/{Object Type ID}",
+      "description": "The definition of one sales object type. Requires the object type id."
     },
     {
       "name": "Object Properties",
       "pageType": 0,
-      "suffix": "/properties/v2/{Object Type:tickets|products|line_items}/properties"
+      "suffix": "/properties/v2/{Object Type:tickets|products|line_items}/properties",
+      "description": "Every property of one crm-objects type -- tickets, products, line items. Requires the object type. The decoder for the newer object model, as the per-object property endpoints are for the legacy one."
     },
     {
       "name": "Object Property Groups",
       "pageType": 0,
-      "suffix": "/properties/v2/{Object Type:tickets|products|line_items}/groups"
+      "suffix": "/properties/v2/{Object Type:tickets|products|line_items}/groups",
+      "description": "The property groups of one crm-objects type."
     },
     {
       "name": "Object Type Pipelines",
       "pageType": 0,
-      "suffix": "/crm-pipelines/v1/pipelines/{Object Type:tickets|deals}?includeInactive={Include Inactive?:EXCLUDE_DELETED|INCLUDE_DELETED}"
+      "suffix": "/crm-pipelines/v1/pipelines/{Object Type:tickets|deals}?includeInactive={Include Inactive?:EXCLUDE_DELETED|INCLUDE_DELETED}",
+      "description": "The pipelines of one object type -- tickets and deals both have them. Requires the object type. Ticket pipelines are the support workflow, so this is what turns a ticket's stage id into a status."
     },
     {
       "name": "Deals",
       "pageType": 7,
-      "suffix": "/deals/v1/deal/paged?properties={Properties?}&propertiesWithHistory={Properties With History?}&includeAssociations={Associations?:true|false}"
+      "suffix": "/deals/v1/deal/paged?properties={Properties?}&propertiesWithHistory={Properties With History?}&includeAssociations={Associations?:true|false}",
+      "description": "The deals in the CRM, paged. Carries the properties object holding amount, closedate, dealstage, pipeline and any custom fields. DEALSTAGE IS AN INTERNAL ID, not a label, and stages are defined per pipeline -- so Deal Pipelines is required to make a funnel readable, and stages from different pipelines are not comparable."
     },
     {
       "name": "Recently Modified Deals",
       "pageType": 2,
-      "suffix": "/deals/v1/deal/recent/modified?since={Since?:milliseconds}&includePropertyVersions={Include Property Versions?:true|false}"
+      "suffix": "/deals/v1/deal/recent/modified?since={Since?:milliseconds}&includePropertyVersions={Include Property Versions?:true|false}",
+      "description": "Deals changed most recently. The incremental-sync route."
     },
     {
       "name": "Recently Created Deals",
       "pageType": 2,
-      "suffix": "/deals/v1/deal/recent/created?since={Since?:milliseconds}&includePropertyVersions={Include Property Versions?:true|false}"
+      "suffix": "/deals/v1/deal/recent/created?since={Since?:milliseconds}&includePropertyVersions={Include Property Versions?:true|false}",
+      "description": "Deals created most recently."
     },
     {
       "name": "Deal",
       "pageType": 0,
-      "suffix": "/deals/v1/deal/{Deal ID}?includePropertyVersions={Include Property Versions?:true|false}"
+      "suffix": "/deals/v1/deal/{Deal ID}?includePropertyVersions={Include Property Versions?:true|false}",
+      "description": "One deal by id, with its properties and associations."
     },
     {
       "name": "Associated Deals",
       "pageType": 6,
-      "suffix": "/deals/v1/deal/associated/{Object Type:CONTACT|COMPANY}/{Object ID}/paged?properties={Properties?}&propertiesWithHistory={Properties With History?}&includeAssociations={Associations?:true|false}"
+      "suffix": "/deals/v1/deal/associated/{Object Type:CONTACT|COMPANY}/{Object ID}/paged?properties={Properties?}&propertiesWithHistory={Properties With History?}&includeAssociations={Associations?:true|false}",
+      "description": "The deals associated with one contact, company or other object. Requires the object type and id."
     },
     {
       "name": "Deal Pipeline",
       "pageType": 0,
-      "suffix": "/deals/v1/pipelines/{Pipeline ID}"
+      "suffix": "/deals/v1/pipelines/{Pipeline ID}",
+      "description": "One deal pipeline by id, with its stages."
     },
     {
       "name": "Deal Pipelines",
       "pageType": 0,
-      "suffix": "/deals/v1/pipelines"
+      "suffix": "/deals/v1/pipelines",
+      "description": "The deal pipelines, each with its stages, their order and their probability. THE DECODER for dealstage, and most portals run more than one pipeline."
     },
     {
       "name": "Deal Properties",
       "pageType": 0,
-      "suffix": "/properties/v1/deals/properties/"
+      "suffix": "/properties/v1/deals/properties/",
+      "description": "Every property a deal can carry, standard and custom."
     },
     {
       "name": "Deal Property",
       "pageType": 0,
-      "suffix": "/properties/v1/deals/properties/named/{Property Name}"
+      "suffix": "/properties/v1/deals/properties/named/{Property Name}",
+      "description": "One deal property by internal name."
     },
     {
       "name": "Deal Property Groups",
       "pageType": 0,
-      "suffix": "/properties/v1/deals/groups?includeProperties={Include Properties?:true|false}"
+      "suffix": "/properties/v1/deals/groups?includeProperties={Include Properties?:true|false}",
+      "description": "The groups deal properties are organised into."
     },
     {
       "name": "Deal Property Group",
       "pageType": 0,
-      "suffix": "/properties/v1/deals/groups/named/{Property Group}?includeProperties={Include Properties?:true|false}"
+      "suffix": "/properties/v1/deals/groups/named/{Property Group}?includeProperties={Include Properties?:true|false}",
+      "description": "One deal property group by name."
     },
     {
       "name": "Ecommerce Settings",
       "pageType": 0,
-      "suffix": "/extensions/ecomm/v2/settings?showProvidedMappings={Show Provided Mappings?:true|false}"
+      "suffix": "/extensions/ecomm/v2/settings?showProvidedMappings={Show Provided Mappings?:true|false}",
+      "description": "The e-commerce integration settings of the portal."
     },
     {
       "name": "Stores",
       "pageType": 0,
-      "suffix": "/extensions/ecomm/v2/stores"
+      "suffix": "/extensions/ecomm/v2/stores",
+      "description": "The e-commerce stores connected to the portal. The bridge to purchase data."
     },
     {
       "name": "Store Details",
       "pageType": 0,
-      "suffix": "/extensions/ecomm/v2/stores/{Store ID}"
+      "suffix": "/extensions/ecomm/v2/stores/{Store ID}",
+      "description": "One store by id, with its sync settings."
     },
     {
       "name": "App Sync Errors",
       "pageType": 4,
-      "suffix": "/extensions/ecomm/v2/sync/errors/app/{App ID}?includeResolved={Include Resolved Errors?:true|false}&errorType={Error Type?:INACTIVE_PORTAL|NO_SYNC_SETTINGS|SETTINGS_NOT_ENABLED|NO_MAPPINGS_DEFINED|...}&objectType={Object Type?:CONTACT|DEAL|PRODUCT|LINE_ITEM}&page={Page?}"
+      "suffix": "/extensions/ecomm/v2/sync/errors/app/{App ID}?includeResolved={Include Resolved Errors?:true|false}&errorType={Error Type?:INACTIVE_PORTAL|NO_SYNC_SETTINGS|SETTINGS_NOT_ENABLED|NO_MAPPINGS_DEFINED|...}&objectType={Object Type?:CONTACT|DEAL|PRODUCT|LINE_ITEM}&page={Page?}",
+      "description": "The sync errors for one connected app. Requires the app id. Where a silently broken e-commerce sync shows up."
     },
     {
       "name": "Account Sync Errors",
       "pageType": 4,
-      "suffix": "/extensions/ecomm/v2/sync/errors/portal?includeResolved={Include Resolved Errors?:true|false}&errorType={Error Type?:INACTIVE_PORTAL|NO_SYNC_SETTINGS|SETTINGS_NOT_ENABLED|NO_MAPPINGS_DEFINED|...}&objectType={Object Type?:CONTACT|DEAL|PRODUCT|LINE_ITEM}&page={Page?}"
+      "suffix": "/extensions/ecomm/v2/sync/errors/portal?includeResolved={Include Resolved Errors?:true|false}&errorType={Error Type?:INACTIVE_PORTAL|NO_SYNC_SETTINGS|SETTINGS_NOT_ENABLED|NO_MAPPINGS_DEFINED|...}&objectType={Object Type?:CONTACT|DEAL|PRODUCT|LINE_ITEM}&page={Page?}",
+      "description": "The sync errors across the portal."
     },
     {
       "name": "App Account Sync Errors",
       "pageType": 4,
-      "suffix": "/extensions/ecomm/v2/sync/errors?includeResolved={Include Resolved Errors?:true|false}&errorType={Error Type?:INACTIVE_PORTAL|NO_SYNC_SETTINGS|SETTINGS_NOT_ENABLED|NO_MAPPINGS_DEFINED|...}&objectType={Object Type?:CONTACT|DEAL|PRODUCT|LINE_ITEM}&page={Page?}"
+      "suffix": "/extensions/ecomm/v2/sync/errors?includeResolved={Include Resolved Errors?:true|false}&errorType={Error Type?:INACTIVE_PORTAL|NO_SYNC_SETTINGS|SETTINGS_NOT_ENABLED|NO_MAPPINGS_DEFINED|...}&objectType={Object Type?:CONTACT|DEAL|PRODUCT|LINE_ITEM}&page={Page?}",
+      "description": "The sync errors for apps on this account."
     },
     {
       "name": "Object Sync Status",
       "pageType": 0,
-      "suffix": "/extensions/ecomm/v2/sync/status/{Store ID}/{Object Type:CONTACT|DEAL|PRODUCT|LINE_ITEM}/{External Object ID}"
+      "suffix": "/extensions/ecomm/v2/sync/status/{Store ID}/{Object Type:CONTACT|DEAL|PRODUCT|LINE_ITEM}/{External Object ID}",
+      "description": "The sync state of one object type in one store. Requires the store id and object type. Whether purchase data is actually flowing, which an empty result cannot distinguish from no sales."
     },
     {
       "name": "Email Subscription Types",
       "pageType": 0,
-      "suffix": "/email/public/v1/subscriptions?portalId={Portal ID}"
+      "suffix": "/email/public/v1/subscriptions?portalId={Portal ID}",
+      "description": "The subscription types recipients can opt into or out of -- newsletters, product updates. Opting out of one is not opting out of all, so this is what distinguishes a lost topic from a lost subscriber."
     },
     {
       "name": "View Portal Subscriptions Timeline",
       "pageType": 1,
-      "suffix": "/email/public/v1/subscriptions/timeline?changeType={Change Type?:SUBSCRIPTION_STATUS|PORTAL_STATUS|SUBSCRIPTION_SPAM_REPORT|PORTAL_SPAM_REPORT|PORTAL_BOUNCE}&startTimestamp={Start Timestamp?:milliseconds}&endTimestamp={End Timestamp?:milliseconds}&includeSnapshots={Include Snapshots?}"
+      "suffix": "/email/public/v1/subscriptions/timeline?changeType={Change Type?:SUBSCRIPTION_STATUS|PORTAL_STATUS|SUBSCRIPTION_SPAM_REPORT|PORTAL_SPAM_REPORT|PORTAL_BOUNCE}&startTimestamp={Start Timestamp?:milliseconds}&endTimestamp={End Timestamp?:milliseconds}&includeSnapshots={Include Snapshots?}",
+      "description": "The subscription changes across the portal over time. When people opted in and out, which the current status cannot say."
     },
     {
       "name": "Email Subscription Status",
       "pageType": 0,
-      "suffix": "/email/public/v1/subscriptions/{Email Address}?portalId={Portal ID}"
+      "suffix": "/email/public/v1/subscriptions/{Email Address}?portalId={Portal ID}",
+      "description": "One address's subscription status across every type. Requires the email address. Whether a specific person can still be mailed, and about what."
     },
     {
       "name": "Portal Campaign IDs",
@@ -737,7 +851,8 @@
           "key": "id",
           "parameterName": "Campaign ID"
         }
-      ]
+      ],
+      "description": "The ids of every email campaign in the portal. The index that makes the campaign detail endpoint usable."
     },
     {
       "name": "Portal Campaign IDs With Recent Activity",
@@ -750,107 +865,128 @@
           "key": "id",
           "parameterName": "Campaign ID"
         }
-      ]
+      ],
+      "description": "Only campaigns with recent activity. The narrower, more useful list on a portal with a long history."
     },
     {
       "name": "Campaign Data",
       "pageType": 0,
-      "suffix": "/email/public/v1/campaigns/{Campaign ID}"
+      "suffix": "/email/public/v1/campaigns/{Campaign ID}",
+      "description": "One email campaign's aggregate figures by id -- sent, opened, clicked, bounced and the counts behind them. The campaign-level rollup of the event stream."
     },
     {
       "name": "Email Events",
       "pageType": 7,
-      "suffix": "/email/public/v1/events?appId={HubSpot App ID?}&campaignId={HubSpot Campaign ID?}&recipient={Recipient Email Address?}&eventType={Event type?}&startTimestamp={Start Timestamp?:milliseconds}&endTimestamp={End Timestamp?:milliseconds}&excludeFilteredEvents={Exclude Filtered Events?:true|false}"
+      "suffix": "/email/public/v1/events?appId={HubSpot App ID?}&campaignId={HubSpot Campaign ID?}&recipient={Recipient Email Address?}&eventType={Event type?}&startTimestamp={Start Timestamp?:milliseconds}&endTimestamp={End Timestamp?:milliseconds}&excludeFilteredEvents={Exclude Filtered Events?:true|false}",
+      "description": "The individual email event stream -- every SENT, DELIVERED, OPEN, CLICK, BOUNCE, DROPPED, SPAMREPORT and UNSUBSCRIBE, with the recipient, campaign and timestamp. THE ROW-LEVEL COMPANION to the aggregate statistics, and where a specific recipient's experience is traced. Very large on an active portal, so bound it by campaign or time."
     },
     {
       "name": "Email Event",
       "pageType": 0,
-      "suffix": "/email/public/v1/events/{Event Creation Timestamp}/{Event ID}"
+      "suffix": "/email/public/v1/events/{Event Creation Timestamp}/{Event ID}",
+      "description": "One email event by its creation timestamp and id."
     },
     {
       "name": "Engagement",
       "pageType": 0,
-      "suffix": "/engagements/v1/engagements/{Engagement ID}"
+      "suffix": "/engagements/v1/engagements/{Engagement ID}",
+      "description": "One engagement by id, with its associations."
     },
     {
       "name": "Engagements",
       "pageType": 6,
-      "suffix": "/engagements/v1/engagements/paged"
+      "suffix": "/engagements/v1/engagements/paged",
+      "description": "THE ACTIVITY TABLE -- notes, calls, emails, meetings and tasks are all engagements, distinguished by a type field, each with its own metadata shape and the contacts, companies and deals it is associated with. Paged. Sales activity, meeting counts and call logging all come from here, and the per-type metadata means one parsing rule does not fit all of them."
     },
     {
       "name": "Recent Engagements",
       "pageType": 2,
-      "suffix": "/engagements/v1/engagements/recent/modified"
+      "suffix": "/engagements/v1/engagements/recent/modified",
+      "description": "Engagements changed most recently. The incremental-sync route."
     },
     {
       "name": "Associated Engagements",
       "pageType": 0,
-      "suffix": "/email/public/v1/events/{Event Creation Timestamp}/{Event ID}"
+      "suffix": "/email/public/v1/events/{Event Creation Timestamp}/{Event ID}",
+      "description": "The same path as Email Event; the connector carries it under a second name."
     },
     {
       "name": "Call Engagement Dispositions",
       "pageType": 0,
-      "suffix": "/calling/v1/dispositions"
+      "suffix": "/calling/v1/dispositions",
+      "description": "The call outcome values configured -- connected, left voicemail, no answer. The decoder for a call engagement's disposition, and what turns call volume into call effectiveness."
     },
     {
       "name": "Events",
       "pageType": 0,
-      "suffix": "/reports/v2/events?includeDeletes={Include Deleted?:true|false}"
+      "suffix": "/reports/v2/events?includeDeletes={Include Deleted?:true|false}",
+      "description": "The custom behavioural events defined and recorded. Events are whatever the portal's own tracking sends, so their names and meanings are entirely account-specific."
     },
     {
       "name": "Event",
       "pageType": 0,
-      "suffix": "/reports/v2/events/{Event ID}?includeDeletes={Include Deleted?:true|false}"
+      "suffix": "/reports/v2/events/{Event ID}?includeDeletes={Include Deleted?:true|false}",
+      "description": "One event definition by id."
     },
     {
       "name": "A Group Of Events",
       "pageType": 0,
-      "suffix": "/reports/v2/events/batch?id={ID}&includeDeleted={Include Deleted?:true|false}"
+      "suffix": "/reports/v2/events/batch?id={ID}&includeDeleted={Include Deleted?:true|false}",
+      "description": "Several events by id, in one request."
     },
     {
       "name": "Forms",
       "pageType": 1,
-      "suffix": "/forms/v2/forms?formTypes={Form Types?}"
+      "suffix": "/forms/v2/forms?formTypes={Form Types?}",
+      "description": "The forms in the portal, with name, fields, submission counts and the lists they feed. The acquisition mechanism, and the explanation for where contacts came from."
     },
     {
       "name": "Form",
       "pageType": 0,
-      "suffix": "/forms/v2/forms/{Form GUID}?"
+      "suffix": "/forms/v2/forms/{Form GUID}?",
+      "description": "One form by GUID, with its full field definitions."
     },
     {
       "name": "Form Submissions",
       "pageType": 5,
-      "suffix": "/form-integrations/v1/submissions/forms/{Form ID}"
+      "suffix": "/form-integrations/v1/submissions/forms/{Form ID}",
+      "description": "The submissions of one form, with the values entered and the timestamp. Requires the form id. THE RAW LEAD CAPTURE -- a contact record shows the current value of a field, this shows what was actually typed and when."
     },
     {
       "name": "File Uploaded Via Form",
       "pageType": 0,
-      "suffix": "/form-integrations/v1/uploaded-files/signed-url-redirect/{File ID}"
+      "suffix": "/form-integrations/v1/uploaded-files/signed-url-redirect/{File ID}",
+      "description": "A signed redirect to a file uploaded through a form. Returns a link rather than data."
     },
     {
       "name": "Form Fields",
       "pageType": 0,
-      "suffix": "/forms/v2/fields/{Form GUID}"
+      "suffix": "/forms/v2/fields/{Form GUID}",
+      "description": "The fields of one form. Requires the form GUID. The decoder for a submission's values, which reference field names."
     },
     {
       "name": "Form Single Field",
       "pageType": 0,
-      "suffix": "/forms/v2/fields/{Form GUID}/{Field Name}"
+      "suffix": "/forms/v2/fields/{Form GUID}/{Field Name}",
+      "description": "One field of one form."
     },
     {
       "name": "Line Items",
       "pageType": 6,
-      "suffix": "/crm-objects/v1/objects/line_items/paged?properties={Properties?}&propertiesWithHistory={Properties With History?}"
+      "suffix": "/crm-objects/v1/objects/line_items/paged?properties={Properties?}&propertiesWithHistory={Properties With History?}",
+      "description": "The line items on deals -- the products actually sold and at what price. Paged. A deal carries a single amount; what makes it up is only here, so product-level revenue analysis depends on this table."
     },
     {
       "name": "Line Item",
       "pageType": 0,
-      "suffix": "/crm-objects/v1/objects/line_items/{Line Item ID}?properties={Properties?}&propertiesWithHistory={Properties With History?}&includeDeletes={Include Deletes?:true|false}"
+      "suffix": "/crm-objects/v1/objects/line_items/{Line Item ID}?properties={Properties?}&propertiesWithHistory={Properties With History?}&includeDeletes={Include Deletes?:true|false}",
+      "description": "One line item by id."
     },
     {
       "name": "Line items Change Log",
       "pageType": 0,
-      "suffix": "/crm-objects/v1/change-log/line_items}?timestamp={Timestamp?}&changeType={Change Type?:SUBSCRIPTION_STATUS|PORTAL_STATUS|SUBSCRIPTION_SPAM_REPORT|PORTAL_SPAM_REPORT|PORTAL_BOUNCE}&objectId={Object ID}"
+      "suffix": "/crm-objects/v1/change-log/line_items?timestamp={Timestamp?}&changeType={Change Type?:SUBSCRIPTION_STATUS|PORTAL_STATUS|SUBSCRIPTION_SPAM_REPORT|PORTAL_SPAM_REPORT|PORTAL_BOUNCE}&objectId={Object ID}",
+      "description": "The change history of line items since a point."
     },
     {
       "name": "Marketing Emails",
@@ -875,107 +1011,128 @@
           "key": "id",
           "parameterName": "Email ID"
         }
-      ]
+      ],
+      "description": "The marketing emails in the portal, with name, subject, state, publish date and the lists targeted. The campaign catalogue."
     },
     {
       "name": "Marketing Email Revisions",
       "pageType": 0,
-      "suffix": "/marketing-emails/v1/emails/{Email ID}/versions"
+      "suffix": "/marketing-emails/v1/emails/{Email ID}/versions",
+      "description": "The version history of one marketing email. Requires the email id."
     },
     {
       "name": "Marketing Email Statistics",
       "pageType": 0,
-      "suffix": "/marketing-emails/v1/emails/with-statistics/{Email ID}"
+      "suffix": "/marketing-emails/v1/emails/with-statistics/{Email ID}",
+      "description": "The statistics of one email by id. Requires the email id."
     },
     {
       "name": "If Email Has Buffered Changes",
       "pageType": 0,
-      "suffix": "/marketing-emails/v1/emails/{Email ID}/has-buffered-changes"
+      "suffix": "/marketing-emails/v1/emails/{Email ID}/has-buffered-changes",
+      "description": "Whether one email has unpublished edits. Requires the email id."
     },
     {
       "name": "Marketing Emails Statistics",
       "pageType": 1,
-      "suffix": "/marketing-emails/v1/emails/with-statistics"
+      "suffix": "/marketing-emails/v1/emails/with-statistics",
+      "description": "The same emails WITH their performance -- sent, delivered, opened, clicked, bounced, unsubscribed and the derived rates. THE ONE TO USE for email performance; the plain listing carries no statistics at all."
     },
     {
       "name": "Owners",
       "pageType": 0,
-      "suffix": "/owners/v2/owners?includeInactive={Include Inactive?:true|false}&email={Email address}"
+      "suffix": "/owners/v2/owners?includeInactive={Include Inactive?:true|false}&email={Email address}",
+      "description": "The HubSpot users records can be assigned to, with name, email and their remote ids. Every CRM record carries an owner id, so this is the dimension per-person performance joins to."
     },
     {
       "name": "Owner",
       "pageType": 0,
-      "suffix": "/owners/v2/owners/{Owner ID}"
+      "suffix": "/owners/v2/owners/{Owner ID}",
+      "description": "One owner by id."
     },
     {
       "name": "Products",
       "pageType": 6,
-      "suffix": "/crm-objects/v1/objects/products/paged?properties={Properties?}&propertiesWithHistory={Properties With History?:true|false}"
+      "suffix": "/crm-objects/v1/objects/products/paged?properties={Properties?}&propertiesWithHistory={Properties With History?:true|false}",
+      "description": "The product catalogue, paged. Part of the crm-objects model."
     },
     {
       "name": "Product",
       "pageType": 0,
-      "suffix": "/crm-objects/v1/objects/products/{Product ID}?properties={Properties?}&propertiesWithHistory={Properties With History?:true|false}&includeDeletes={Include Deleted?:true|false}"
+      "suffix": "/crm-objects/v1/objects/products/{Product ID}?properties={Properties?}&propertiesWithHistory={Properties With History?:true|false}&includeDeletes={Include Deleted?:true|false}",
+      "description": "One product by id."
     },
     {
       "name": "ProductsChange Log",
       "pageType": 0,
-      "suffix": "/crm-objects/v1/change-log/products?timestamp={Timestamp?}&changeType={Change Type?:SUBSCRIPTION_STATUS|PORTAL_STATUS|SUBSCRIPTION_SPAM_REPORT|PORTAL_SPAM_REPORT|PORTAL_BOUNCE}&objectId={Object ID}"
+      "suffix": "/crm-objects/v1/change-log/products?timestamp={Timestamp?}&changeType={Change Type?:SUBSCRIPTION_STATUS|PORTAL_STATUS|SUBSCRIPTION_SPAM_REPORT|PORTAL_SPAM_REPORT|PORTAL_BOUNCE}&objectId={Object ID}",
+      "description": "The change history of products since a point."
     },
     {
       "name": "Publishing Channels",
       "pageType": 0,
-      "suffix": "/broadcast/v1/channels/setting/publish/current"
+      "suffix": "/broadcast/v1/channels/setting/publish/current",
+      "description": "The social accounts connected for publishing. Whether a channel is connected decides whether broadcast data exists for it."
     },
     {
       "name": "Broadcast Messages",
       "pageType": 2,
-      "suffix": "/broadcast/v1/broadcasts?status={Filter By Status?:success|waiting|canceled|error_fatal}&since={Filter By Created At?:milliseconds }&channelGuid={Filter By Channel?}"
+      "suffix": "/broadcast/v1/broadcasts?status={Filter By Status?:success|waiting|canceled|error_fatal}&since={Filter By Created At?:milliseconds }&channelGuid={Filter By Channel?}",
+      "description": "The social media posts published through HubSpot, with the channel, content, timing and their interaction counts. Social reach, which the content analytics does not cover."
     },
     {
       "name": "Broadcast Message",
       "pageType": 0,
-      "suffix": "/broadcast/v1/broadcasts/{Broadcast GUID}"
+      "suffix": "/broadcast/v1/broadcasts/{Broadcast GUID}",
+      "description": "One social message by GUID."
     },
     {
       "name": "Tickets",
       "pageType": 7,
-      "suffix": "/crm-objects/v1/objects/tickets/paged?properties={Properties?}&propertiesWithHistory={Properties With History?:true|false}"
+      "suffix": "/crm-objects/v1/objects/tickets/paged?properties={Properties?}&propertiesWithHistory={Properties With History?:true|false}",
+      "description": "The support tickets, paged. Part of HubSpot's newer crm-objects model rather than the legacy per-object APIs, so the shape differs slightly from contacts and deals -- properties still carry the data."
     },
     {
       "name": "Ticket",
       "pageType": 0,
-      "suffix": "/crm-objects/v1/objects/tickets/{Ticket ID}?properties={Properties?}&propertiesWithHistory={Ticket Properties With History?:true|false}&includeDeletes={Include Deleted?:true|false}"
+      "suffix": "/crm-objects/v1/objects/tickets/{Ticket ID}?properties={Properties?}&propertiesWithHistory={Ticket Properties With History?:true|false}&includeDeletes={Include Deleted?:true|false}",
+      "description": "One ticket by id."
     },
     {
       "name": "Tickets Change Log",
       "pageType": 0,
-      "suffix": "/crm-objects/v1/change-log/tickets?timestamp={Timestamp?}&changeType={Change Type?:SUBSCRIPTION_STATUS|PORTAL_STATUS|SUBSCRIPTION_SPAM_REPORT|PORTAL_SPAM_REPORT|PORTAL_BOUNCE}&objectId={Object ID}"
+      "suffix": "/crm-objects/v1/change-log/tickets?timestamp={Timestamp?}&changeType={Change Type?:SUBSCRIPTION_STATUS|PORTAL_STATUS|SUBSCRIPTION_SPAM_REPORT|PORTAL_SPAM_REPORT|PORTAL_BOUNCE}&objectId={Object ID}",
+      "description": "The change history of tickets since a point. The incremental-sync feed, and the only record of what a ticket's earlier values were."
     },
     {
       "name": "Timeline Event",
       "pageType": 0,
-      "suffix": "/integrations/v1/{Application ID}/timeline/event/{Event type ID}/{Event ID}?access_token={Access Token}"
+      "suffix": "/integrations/v1/{Application ID}/timeline/event/{Event type ID}/{Event ID}?access_token={Access Token}",
+      "description": "One timeline event by id. Requires the application id."
     },
     {
       "name": "Timeline Event Types",
       "pageType": 0,
-      "suffix": "/integrations/v1/{Application ID}/timeline/event-types"
+      "suffix": "/integrations/v1/{Application ID}/timeline/event-types",
+      "description": "The custom timeline event types an application has defined. Requires the application id. Integrations write their own events onto contact timelines, so this is the vocabulary of what a given app records."
     },
     {
       "name": "Timeline Event By ID",
       "pageType": 0,
-      "suffix": "/integrations/v1/{Application ID}/timeline/event-types/{Event type ID}"
+      "suffix": "/integrations/v1/{Application ID}/timeline/event-types/{Event type ID}",
+      "description": "One timeline event type by id."
     },
     {
       "name": "Timeline Event Type Properties",
       "pageType": 0,
-      "suffix": "/integrations/v1/{Application ID}/timeline/event-types/{Event type ID}/properties"
+      "suffix": "/integrations/v1/{Application ID}/timeline/event-types/{Event type ID}/properties",
+      "description": "The properties of one timeline event type. The decoder for its event data."
     },
     {
       "name": "SMTP API Tokens",
       "pageType": 0,
-      "suffix": "/email/public/v1/smtpapi/tokens"
+      "suffix": "/email/public/v1/smtpapi/tokens",
+      "description": "The SMTP tokens issued for sending transactional mail through HubSpot. Security inventory."
     },
     {
       "name": "Workflows",
@@ -988,17 +1145,20 @@
           "key": "id",
           "parameterName": "Workflow ID"
         }
-      ]
+      ],
+      "description": "The automation workflows, with name, type, enrolment criteria and whether each is enabled. WHERE MOST MARKETING ACTION HAPPENS in a HubSpot portal -- contacts move through these based on behaviour, so a campaign-only view of activity understates it."
     },
     {
       "name": "Workflow",
       "pageType": 0,
-      "suffix": "/automation/v3/workflows/{Workflow ID}?errors={Error?:true|false}&stats={Stats?:true|false}"
+      "suffix": "/automation/v3/workflows/{Workflow ID}?errors={Error?:true|false}&stats={Stats?:true|false}",
+      "description": "One workflow by id, with its actions and enrolment settings."
     },
     {
       "name": "Workflow Performance Statistics",
       "pageType": 0,
-      "suffix": "/automation/v3/performance/workflow/{Workflow ID}?start={Start Date?:milliseconds}&end={End Date?:milliseconds}&bucket={Time Period?:DAY|WEEK|MONTH}"
+      "suffix": "/automation/v3/performance/workflow/{Workflow ID}?start={Start Date?:milliseconds}&end={End Date?:milliseconds}&bucket={Time Period?:DAY|WEEK|MONTH}",
+      "description": "The performance of one workflow -- enrolments, completions and conversion. Requires a workflow id. Whether the automation is achieving anything, which the definition cannot say."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/hubspot/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/hubspot/endpoints.json
@@ -210,7 +210,7 @@
       "name": "Contact Profile",
       "pageType": 0,
       "suffix": "/contacts/v1/contact/utk/{Contact User Token}/profile?property={Property?}&propertyMode={Property Mode?:value_only|value_and_history}&formSubmissionMode={Form Submission Mode?:all|none|newest|oldest}&showListMemberships={List Memberships?:true|false}",
-      "description": "One contact by their tracking cookie token. The route from an anonymous website visitor to a known contact."
+      "description": "One contact by their tracking cookie token. The route from an anonymous website visitor to a known contact. NOTE this is the same endpoint as Contact By User Token, which the connector carries under a second name."
     },
     {
       "name": "Contact By User Token",
@@ -884,7 +884,7 @@
       "name": "Email Event",
       "pageType": 0,
       "suffix": "/email/public/v1/events/{Event Creation Timestamp}/{Event ID}",
-      "description": "One email event by its creation timestamp and id."
+      "description": "One email event by its creation timestamp and id. NOTE the connector also carries this same path under the name Associated Engagements."
     },
     {
       "name": "Engagement",
@@ -920,7 +920,7 @@
       "name": "Events",
       "pageType": 0,
       "suffix": "/reports/v2/events?includeDeletes={Include Deleted?:true|false}",
-      "description": "The custom behavioural events defined and recorded. Events are whatever the portal's own tracking sends, so their names and meanings are entirely account-specific."
+      "description": "The custom behavioural events defined and recorded. Events are whatever the portal's own tracking sends, so their names and meanings are entirely account-specific. NOTE this is the same endpoint as Events Data, which the connector carries under a second name; either will do."
     },
     {
       "name": "Event",

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/influxdb/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/influxdb/endpoints.json
@@ -366,7 +366,7 @@
       "paged": false,
       "suffix": "/query/analyze",
       "post": true,
-      "description": "Checks a Flux query for errors without running it. Requires the query. Validation rather than data -- useful for confirming a generated query before spending a long-running request on it."
+      "description": "Checks a Flux query for errors without running it. Sent as a POST with the query in the request body, like the query endpoint itself. Validation rather than data -- useful for confirming a generated query before spending a long-running request on it."
     },
     {
       "name": "Generate Abstract Syntax Tree from a Query",

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/influxdb/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/influxdb/endpoints.json
@@ -1,612 +1,704 @@
 {
-    "endpoints": [
-        {
-            "name": "V1 Requests",
-            "paged": false,
-            "suffix": "/debug/requests/?seconds={Seconds?}",
-            "post": false
-        },
-        {
-            "name": "V1 Statistics",
-            "paged": false,
-            "suffix": "/debug/vars",
-            "post": false
-        },
-        {
-            "name": "V1 Query",
-            "paged": false,
-            "suffix": "/query?db={Database Name}&q={Query Statement}&chunked={Chunked?:true|false}&epoch={Epoch?:ns|U|ms|s|m|h}",
-            "post": false
-        },
-        {
-            "name": "Authorizations",
-            "paged": false,
-            "suffix": "/api/v2/authorizations?org={Organization Name?}&orgID={Organization ID?}&user={User Name?}&userID={User ID?}",
-            "post": false
-        },
-        {
-            "name": "Authorization",
-            "paged": false,
-            "suffix": "/api/v2/authorizations/{Authorization ID}",
-            "post": false
-        },
-        {
-            "name": "Metadata Snapshot",
-            "paged": false,
-            "suffix": "/api/v2/backup/metadata",
-            "post": false
-        },
-        {
-            "name": "TSM Data Snapshot",
-            "paged": false,
-            "suffix": "/api/v2/backup/shards/{Shard ID}?since={Since?}",
-            "post": false
-        },
-        {
-            "name": "Buckets",
-            "paged": true,
-            "suffix": "/api/v2/buckets?id={Bucket ID?}&name={Bucket Name?}&org={Organization Name?}&orgID={Organization ID?}&after={After ID?}",
-            "post": false,
-			"lookups": [
-			{
-				"endpoints": [
-					"Bucket Labels",
-					"Bucket Members",
-					"Bucket Owners"
-				],
-				"jsonPath": "$.buckets[*]",
-				"key": "id",
-				"parameterName": "Bucket ID"
-			}]
-        },
-        {
-            "name": "Bucket",
-            "paged": false,
-            "suffix": "/api/v2/buckets/{Bucket ID?}",
-            "post": false
-        },
-        {
-            "name": "Bucket Labels",
-            "paged": false,
-            "suffix": "/api/v2/buckets/{Bucket ID?}/labels",
-            "post": false
-        },
-        {
-            "name": "Bucket Members",
-            "paged": false,
-            "suffix": "/api/v2/buckets/{Bucket ID?}/members",
-            "post": false
-        },
-        {
-            "name": "Bucket Owners",
-            "paged": false,
-            "suffix": "/api/v2/buckets/{Bucket ID?}/owners",
-            "post": false
-        },
-        {
-            "name": "Source Buckets",
-            "paged": false,
-            "suffix": "/api/v2/sources/{Source ID}/buckets?org={Organization Name?}",
-            "post": false
-        },
-        {
-            "name": "Cell View",
-            "paged": false,
-            "suffix": "/api/v2/dashboards/{Dashboard ID}/cells/{Cell ID}/view",
-            "post": false
-        },
-        {
-            "name": "Checks",
-            "paged": true,
-            "suffix": "/api/v2/checks?orgID={Organization ID}",
-            "post": false,
-			"lookups": [
-			{
-				"endpoints": [
-					"Check Labels",
-					"Check Query"
-				],
-				"jsonPath": "$.checks[*]",
-				"key": "id",
-				"parameterName": "Check ID"
-			}]
-        },
-        {
-            "name": "Check",
-            "paged": false,
-            "suffix": "/api/v2/checks/{Check ID}",
-            "post": false
-        },
-        {
-            "name": "Check Labels",
-            "paged": false,
-            "suffix": "/api/v2/checks/{Check ID}/labels",
-            "post": false
-        },
-        {
-            "name": "Check Query",
-            "paged": false,
-            "suffix": "/api/v2/checks/{Check ID}/query",
-            "post": false
-        },
-        {
-            "name": "Dashboards",
-            "paged": true,
-            "suffix": "/api/v2/dashboards?descending={Descending?:true|false}&id={Dashboard ID?}&org={Organization Name?}&orgID={Organization ID?}&owner={Owner?}",
-            "post": false
-        },
-        {
-            "name": "Dashboard",
-            "paged": true,
-            "suffix": "/api/v2/dashboards/{Dashboard ID?}",
-            "post": false,
-			"lookups": [
-			{
-				"endpoints": [
-					"Dashboard Labels",
-					"Dashboard Members",
-					"Dashboard Owners"
-				],
-				"jsonPath": "$.dashboards[*]",
-				"key": "id",
-				"parameterName": "Dashboard ID"
-			}]
-        },
-        {
-            "name": "Dashboard Labels",
-            "paged": true,
-            "suffix": "/api/v2/dashboards/{Dashboard ID?}/labels",
-            "post": false
-        },
-        {
-            "name": "Dashboard Members",
-            "paged": true,
-            "suffix": "/api/v2/dashboards/{Dashboard ID?}/members",
-            "post": false
-        },
-        {
-            "name": "Dashboard Owners",
-            "paged": true,
-            "suffix": "/api/v2/dashboards/{Dashboard ID?}/owners",
-            "post": false
-        },
-        {
-            "name": "Database Retention Policy Mappings",
-            "paged": false,
-            "suffix": "/api/v2/dbrps?bucketID={Bucket ID?}&db={Database?}&default={Default Filter?:true|false}&id={Mapping ID?}&org={Organization Name?}&orgID={Organization ID?}&rp={Retention Policy?}",
-            "post": false
-        },
-        {
-            "name": "Database Retention Policy Mapping",
-            "paged": false,
-            "suffix": "/api/v2/dbrps/{dbrpsID}",
-            "post": false
-        },
-        {
-            "name": "Health",
-            "paged": false,
-            "suffix": "/health",
-            "post": false
-        },
-        {
-            "name": "Labels",
-            "paged": false,
-            "suffix": "/api/v2/labels?orgID={Organization ID?}",
-            "post": false
-        },
-        {
-            "name": "Label",
-            "paged": false,
-            "suffix": "/api/v2/labels/{Label ID}",
-            "post": false
-        },
-        {
-            "name": "Legacy Authorizations",
-            "paged": false,
-            "suffix": "/legacy/authorizations?authID={Authorization ID?}&org={Organization Name?}&orgID={Organization ID?}&token={Token (Authorization Name)?}&user={User Name?}&userID={User ID?}",
-            "post": false
-        },
-        {
-            "name": "Legacy Authorization",
-            "paged": false,
-            "suffix": "/legacy/authorizations/{Authorization ID?}",
-            "post": false
-        },
-        {
-            "name": "Metrics",
-            "paged": false,
-            "suffix": "/metrics",
-            "post": false
-        },
-        {
-            "name": "Notification Endpoints",
-            "paged": true,
-            "suffix": "/api/v2/notificationEndpoints?orgID={Organization ID}",
-            "post": false
-        },
-        {
-            "name": "Notification Endpoint",
-            "paged": false,
-            "suffix": "/api/v2/notificationEndpoints/{Endpoint ID}",
-            "post": false
-        },
-        {
-            "name": "Notification Endpoint Labels",
-            "paged": false,
-            "suffix": "/api/v2/notificationEndpoints/{Endpoint ID}/labels",
-            "post": false
-        },
-        {
-            "name": "Notification Rules",
-            "paged": true,
-            "suffix": "/api/v2/notificationRules?checkID={Check ID?}&orgID={Organization ID}&tag={Tag}",
-            "post": false
-        },
-        {
-            "name": "Notification Rule",
-            "paged": true,
-            "suffix": "/api/v2/notificationRules/{Rule ID}",
-            "post": false
-        },
-        {
-            "name": "Notification Rule Labels",
-            "paged": true,
-            "suffix": "/api/v2/notificationRules/{Rule ID}/labels",
-            "post": false
-        },
-        {
-            "name": "Organizations",
-            "paged": true,
-            "suffix": "/api/v2/orgs?descending={Descending?:true|false}&org={Organization Name?}&orgID={Organization ID?}&userID={User ID?}",
-            "post": false,
-			"lookups": [
-			{
-				"endpoints": [
-					"Organization Members",
-					"Organization Owners",
-					"Authorizations",
-					"Buckets",
-					"Checks",
-					"Dashboards",
-					"Database Retention Policy Mappings",
-					"Labels",
-					"Legacy Authorizations",
-					"Notification Endpoints",
-					"Notification Rules",
-					"Scraper Targets",
-					"Tasks",
-					"Telegraf Configurations",
-					"Installed Templates",
-					"Variables"
-				],
-				"jsonPath": "$.orgs[*]",
-				"key": "id",
-				"parameterName": "Organization ID"
-			}]
-        },
-        {
-            "name": "Organization",
-            "paged": false,
-            "suffix": "/api/v2/orgs/{Organization ID}",
-            "post": false
-        },
-        {
-            "name": "Organization Members",
-            "paged": false,
-            "suffix": "/api/v2/orgs/{Organization ID}/members",
-            "post": false
-        },
-        {
-            "name": "Organization Owners",
-            "paged": false,
-            "suffix": "/api/v2/orgs/{Organization ID}/owners",
-            "post": false
-        },
-		{
-            "name": "Ping",
-            "paged": false,
-            "suffix": "/ping",
-            "post": false
-        },
-        {
-            "name": "Query",
-            "paged": false,
-            "suffix": "/query?org={Organization?}&orgID={Organization ID?}",
-            "post": true
-        },
-        {
-            "name": "Analyze Flux Query",
-            "paged": false,
-            "suffix": "/query/analyze",
-            "post": true
-        },
-        {
-            "name": "Generate Abstract Syntax Tree from a Query",
-            "paged": false,
-            "suffix": "/api/v2/query/ast",
-            "post": true
-        },
-        {
-            "name": "Instance Readiness",
-            "paged": false,
-            "suffix": "/ready",
-            "post": false
-        },
-        {
-            "name": "Resources",
-            "paged": false,
-            "suffix": "/api/v2/resources",
-            "post": false
-        },
-        {
-            "name": "Routes",
-            "paged": false,
-            "suffix": "/api/v2/",
-            "post": false
-        },
-        {
-            "name": "Notification Rule Array",
-            "paged": false,
-            "suffix": "/api/v2/notificationRules/{Rule ID}/query",
-            "post": false
-        },
-        {
-            "name": "Scraper Targets",
-            "paged": false,
-            "suffix": "/api/v2/scrapers?id={Scraper Target ID?}&name={Scraper Name ID?}&org={Organization Name?}&orgID={Organization ID?}",
-            "post": false,
-			"lookups": [
-			{
-				"endpoints": [
-					"Scraper Target Labels",
-					"Scraper Target Members",
-					"Scraper Target Owners"
-				],
-				"jsonPath": "$.configurations[*]",
-				"key": "id",
-				"parameterName": "Scraper Target ID"
-			}]
-        },
-        {
-            "name": "Scraper Target",
-            "paged": false,
-            "suffix": "/api/v2/scrapers/{Scraper Target ID}",
-            "post": false
-        },
-        {
-            "name": "Scraper Target Labels",
-            "paged": false,
-            "suffix": "/api/v2/scrapers/{Scraper Target ID}/labels",
-            "post": false
-        },
-        {
-            "name": "Scraper Target Members",
-            "paged": false,
-            "suffix": "/api/v2/scrapers/{Scraper Target ID}/members",
-            "post": false
-        },
-        {
-            "name": "Scraper Target Owners",
-            "paged": false,
-            "suffix": "/api/v2/scrapers/{Scraper Target ID}/owners",
-            "post": false
-        },
-        {
-            "name": "Secret Keys",
-            "paged": false,
-            "suffix": "/api/v2/orgs/{Organization ID}/secrets",
-            "post": false
-        },
-        {
-            "name": "Check Default User, Org, Bucket",
-            "paged": false,
-            "suffix": "/api/v2/setup",
-            "post": false
-        },
-        {
-            "name": "Sources",
-            "paged": false,
-            "suffix": "/api/v2/sources?&org={Organization Name?}",
-            "post": false,
-			"lookups": [
-			{
-				"endpoints": [
-					"Source Health",
-					"Source Buckets"
-				],
-				"jsonPath": "$.sources[*]",
-				"key": "id",
-				"parameterName": "Source ID"
-			}]
-        },
-        {
-            "name": "Source",
-            "paged": false,
-            "suffix": "/api/v2/sources/{Source ID}",
-            "post": false
-        },
-        {
-            "name": "Source Health",
-            "paged": false,
-            "suffix": "/api/v2/sources/{Source ID}/health",
-            "post": false
-        },
-        {
-            "name": "Tasks",
-            "paged": false,
-            "suffix": "/api/v2/tasks?limit=500&after={After ID?}&name={Task Name?}&org={Organization Name?}&orgID={Organization ID?}&status={Status?:active|inactive}&type={Type?:basic|system}&user={User ID}",
-            "post": false,
-			"lookups": [
-			{
-				"endpoints": [
-					"Task Labels",
-					"Task Logs",
-					"Task Members",
-					"Task Owners",
-					"Task Runs"
-				],
-				"jsonPath": "$.tasks[*]",
-				"key": "id",
-				"parameterName": "Task ID"
-			}]
-        },
-        {
-            "name": "Task",
-            "paged": false,
-            "suffix": "/api/v2/tasks/{Task ID}",
-            "post": false
-        },
-        {
-            "name": "Task Labels",
-            "paged": false,
-            "suffix": "/api/v2/tasks/{Task ID}/labels",
-            "post": false
-        },
-        {
-            "name": "Task Logs",
-            "paged": false,
-            "suffix": "/api/v2/tasks/{Task ID}/logs",
-            "post": false
-        },
-        {
-            "name": "Task Members",
-            "paged": false,
-            "suffix": "/api/v2/tasks/{Task ID}/members",
-            "post": false
-        },
-        {
-            "name": "Task Owners",
-            "paged": false,
-            "suffix": "/api/v2/tasks/{Task ID}/owners",
-            "post": false
-        },
-        {
-            "name": "Task Runs",
-            "paged": false,
-            "suffix": "/api/v2/tasks/{Task ID}/runs?limit=500&after={After ID?}&afterTime={After Time?}&beforeTime={Before Time?}",
-            "post": false
-        },
-        {
-            "name": "Task Run",
-            "paged": false,
-            "suffix": "/api/v2/tasks/{Task ID}/runs/{Run ID}",
-            "post": false
-        },
-        {
-            "name": "Task Run Logs",
-            "paged": false,
-            "suffix": "/api/v2/tasks/{Task ID}/runs/{Run ID}/logs",
-            "post": false
-        },
-        {
-            "name": "Telegraf Plugins",
-            "paged": false,
-            "suffix": "/api/v2/telegraf/plugins?type={Type?}",
-            "post": false
-        },
-        {
-            "name": "Telegraf Configurations",
-            "paged": false,
-            "suffix": "/api/v2/telegrafs?orgID={Organization ID?}",
-            "post": false,
-			"lookups": [
-			{
-				"endpoints": [
-					"Telegraf Configuration Labels",
-					"Telegraf Configuration Members",
-					"Telegraf Configuration Owners"
-				],
-				"jsonPath": "$.configurations[*]",
-				"key": "id",
-				"parameterName": "Telegraf Configuration ID"
-			}]
-        },
-        {
-            "name": "Telegraf Configuration",
-            "paged": false,
-            "suffix": "/api/v2/telegrafs/{Telegraf Configuration ID}",
-            "post": false
-        },
-        {
-            "name": "Telegraf Configuration Labels",
-            "paged": false,
-            "suffix": "/api/v2/telegrafs/{Telegraf Configuration ID}/labels",
-            "post": false
-        },
-        {
-            "name": "Telegraf Configuration Members",
-            "paged": false,
-            "suffix": "/api/v2/telegrafs/{Telegraf Configuration ID}/members",
-            "post": false
-        },
-        {
-            "name": "Telegraf Configuration Owners",
-            "paged": false,
-            "suffix": "/api/v2/telegrafs/{Telegraf Configuration ID}/owners",
-            "post": false
-        },
-        {
-            "name": "Installed Templates",
-            "paged": false,
-            "suffix": "/api/v2/stacks?&orgID={Organization ID}&name={Name?}&stackID={Stack ID?}",
-            "post": false
-        },
-        {
-            "name": "Stack",
-            "paged": false,
-            "suffix": "/api/v2/stacks/{Stack ID}",
-            "post": false
-        },
-        {
-            "name": "Current User Feature Flags",
-            "paged": false,
-            "suffix": "/api/v2/flags",
-            "post": false
-        },
-        {
-            "name": "Current User",
-            "paged": false,
-            "suffix": "/api/v2/me",
-            "post": false
-        },
-        {
-            "name": "Users",
-            "paged": true,
-            "suffix": "/api/v2/users?after={After ID?}&id={User ID?}&name={User Name?}",
-            "post": false
-        },
-        {
-            "name": "User",
-            "paged": false,
-            "suffix": "/api/v2/users/{User ID}",
-            "post": false
-        },
-        {
-            "name": "Variables",
-            "paged": false,
-            "suffix": "/api/v2/variables?org={Organization Name?}&orgID={Organization ID?}",
-            "post": false,
-			"lookups": [
-			{
-				"endpoints": [
-					"Variable Labels"
-				],
-				"jsonPath": "$.variables[*]",
-				"key": "id",
-				"parameterName": "Variable ID"
-			}]
-        },
-        {
-            "name": "Variable",
-            "paged": false,
-            "suffix": "/api/v2/variables/{Variable ID}",
-            "post": false
-        },
-        {
-            "name": "Variable Labels",
-            "paged": false,
-            "suffix": "/api/v2/variables/{Variable ID}/labels",
-            "post": false
+  "endpoints": [
+    {
+      "name": "V1 Requests",
+      "paged": false,
+      "suffix": "/debug/requests/?seconds={Seconds?}",
+      "post": false,
+      "description": "The requests the instance received over a recent window, by user and database. Operational, and useful for finding which client is generating load."
+    },
+    {
+      "name": "V1 Statistics",
+      "paged": false,
+      "suffix": "/debug/vars",
+      "post": false,
+      "description": "The instance's internal statistics in the v1 debug format. Operational."
+    },
+    {
+      "name": "V1 Query",
+      "paged": false,
+      "suffix": "/query?db={Database Name}&q={Query Statement}&chunked={Chunked?:true|false}&epoch={Epoch?:ns|U|ms|s|m|h}",
+      "post": false,
+      "description": "Runs an INFLUXQL query against a v1-style database. Requires the database name and the statement. The compatibility endpoint for installations and tools written against InfluxDB 1.x; it returns JSON rather than the CSV the Flux endpoint returns, which is why both exist."
+    },
+    {
+      "name": "Authorizations",
+      "paged": false,
+      "suffix": "/api/v2/authorizations?org={Organization Name?}&orgID={Organization ID?}&user={User Name?}&userID={User ID?}",
+      "post": false,
+      "description": "The API tokens issued, with their permissions, the organisation and user, and their status. Security inventory -- a token's permission set is what decides which of these endpoints it can reach."
+    },
+    {
+      "name": "Authorization",
+      "paged": false,
+      "suffix": "/api/v2/authorizations/{Authorization ID}",
+      "post": false,
+      "description": "One authorization by id, with its permissions."
+    },
+    {
+      "name": "Metadata Snapshot",
+      "paged": false,
+      "suffix": "/api/v2/backup/metadata",
+      "post": false,
+      "description": "A backup of the instance's metadata. Operational, and returns a binary payload rather than rows."
+    },
+    {
+      "name": "TSM Data Snapshot",
+      "paged": false,
+      "suffix": "/api/v2/backup/shards/{Shard ID}?since={Since?}",
+      "post": false,
+      "description": "A backup of one shard's time series data. Requires a shard id. Binary backup content, not queryable data."
+    },
+    {
+      "name": "Buckets",
+      "paged": true,
+      "suffix": "/api/v2/buckets?id={Bucket ID?}&name={Bucket Name?}&org={Organization Name?}&orgID={Organization ID?}&after={After ID?}",
+      "post": false,
+      "lookups": [
+        {
+          "endpoints": [
+            "Bucket Labels",
+            "Bucket Members",
+            "Bucket Owners"
+          ],
+          "jsonPath": "$.buckets[*]",
+          "key": "id",
+          "parameterName": "Bucket ID"
         }
-    ]
+      ],
+      "description": "The buckets on the instance -- the containers time series are written into, each with its organisation and its RETENTION PERIOD. Filterable by name, id and organisation. THE RETENTION PERIOD BOUNDS EVERY QUERY AGAINST A BUCKET: data older than it has been deleted, so an empty result for last year is expected behaviour rather than missing data, and this is the only place that boundary is visible."
+    },
+    {
+      "name": "Bucket",
+      "paged": false,
+      "suffix": "/api/v2/buckets/{Bucket ID?}",
+      "post": false,
+      "description": "One bucket by id, with its retention rules."
+    },
+    {
+      "name": "Bucket Labels",
+      "paged": false,
+      "suffix": "/api/v2/buckets/{Bucket ID?}/labels",
+      "post": false,
+      "description": "The labels on one bucket. Requires a bucket id."
+    },
+    {
+      "name": "Bucket Members",
+      "paged": false,
+      "suffix": "/api/v2/buckets/{Bucket ID?}/members",
+      "post": false,
+      "description": "The users with member access to one bucket."
+    },
+    {
+      "name": "Bucket Owners",
+      "paged": false,
+      "suffix": "/api/v2/buckets/{Bucket ID?}/owners",
+      "post": false,
+      "description": "The users owning one bucket."
+    },
+    {
+      "name": "Source Buckets",
+      "paged": false,
+      "suffix": "/api/v2/sources/{Source ID}/buckets?org={Organization Name?}",
+      "post": false,
+      "description": "The buckets available through one source. Requires a source id."
+    },
+    {
+      "name": "Cell View",
+      "paged": false,
+      "suffix": "/api/v2/dashboards/{Dashboard ID}/cells/{Cell ID}/view",
+      "post": false,
+      "description": "The visualisation configuration of one dashboard cell, INCLUDING THE FLUX QUERY BEHIND IT. Requires the dashboard and cell ids. The map from a chart back to the query producing it, which is the fastest route to a known-good query for a metric."
+    },
+    {
+      "name": "Checks",
+      "paged": true,
+      "suffix": "/api/v2/checks?orgID={Organization ID}",
+      "post": false,
+      "lookups": [
+        {
+          "endpoints": [
+            "Check Labels",
+            "Check Query"
+          ],
+          "jsonPath": "$.checks[*]",
+          "key": "id",
+          "parameterName": "Check ID"
+        }
+      ],
+      "description": "The monitoring checks defined -- the queries evaluated on a schedule to decide a status. Requires an organisation id. Checks produce statuses, notification rules act on them, and notification endpoints deliver them: the three together are InfluxDB's alerting, and none makes sense alone."
+    },
+    {
+      "name": "Check",
+      "paged": false,
+      "suffix": "/api/v2/checks/{Check ID}",
+      "post": false,
+      "description": "One check by id, with its thresholds and schedule."
+    },
+    {
+      "name": "Check Labels",
+      "paged": false,
+      "suffix": "/api/v2/checks/{Check ID}/labels",
+      "post": false,
+      "description": "The labels on one check."
+    },
+    {
+      "name": "Check Query",
+      "paged": false,
+      "suffix": "/api/v2/checks/{Check ID}/query",
+      "post": false,
+      "description": "The Flux query one check actually runs. Requires a check id. What a check MEANS, as opposed to its name."
+    },
+    {
+      "name": "Dashboards",
+      "paged": true,
+      "suffix": "/api/v2/dashboards?descending={Descending?:true|false}&id={Dashboard ID?}&org={Organization Name?}&orgID={Organization ID?}&owner={Owner?}",
+      "post": false,
+      "description": "The dashboards defined, with their cells and the organisation. What the operators actually watch, which is a fair guide to the metrics that matter on this instance."
+    },
+    {
+      "name": "Dashboard",
+      "paged": true,
+      "suffix": "/api/v2/dashboards/{Dashboard ID?}",
+      "post": false,
+      "lookups": [
+        {
+          "endpoints": [
+            "Dashboard Labels",
+            "Dashboard Members",
+            "Dashboard Owners"
+          ],
+          "jsonPath": "$.dashboards[*]",
+          "key": "id",
+          "parameterName": "Dashboard ID"
+        }
+      ],
+      "description": "One dashboard by id, with its cells."
+    },
+    {
+      "name": "Dashboard Labels",
+      "paged": true,
+      "suffix": "/api/v2/dashboards/{Dashboard ID?}/labels",
+      "post": false,
+      "description": "The labels on one dashboard."
+    },
+    {
+      "name": "Dashboard Members",
+      "paged": true,
+      "suffix": "/api/v2/dashboards/{Dashboard ID?}/members",
+      "post": false,
+      "description": "The users with member access to one dashboard."
+    },
+    {
+      "name": "Dashboard Owners",
+      "paged": true,
+      "suffix": "/api/v2/dashboards/{Dashboard ID?}/owners",
+      "post": false,
+      "description": "The users owning one dashboard."
+    },
+    {
+      "name": "Database Retention Policy Mappings",
+      "paged": false,
+      "suffix": "/api/v2/dbrps?bucketID={Bucket ID?}&db={Database?}&default={Default Filter?:true|false}&id={Mapping ID?}&org={Organization Name?}&orgID={Organization ID?}&rp={Retention Policy?}",
+      "post": false,
+      "description": "The mappings from v1-style database and retention-policy names onto v2 buckets. THE TRANSLATION LAYER: a v1 query names a database and retention policy, and this is what resolves those to the bucket actually holding the data."
+    },
+    {
+      "name": "Database Retention Policy Mapping",
+      "paged": false,
+      "suffix": "/api/v2/dbrps/{dbrpsID}",
+      "post": false,
+      "description": "One mapping by id."
+    },
+    {
+      "name": "Health",
+      "paged": false,
+      "suffix": "/health",
+      "post": false,
+      "description": "Whether the instance is healthy. A liveness check."
+    },
+    {
+      "name": "Labels",
+      "paged": false,
+      "suffix": "/api/v2/labels?orgID={Organization ID?}",
+      "post": false,
+      "description": "The labels defined, optionally by organisation. The cross-cutting tagging of buckets, dashboards, tasks and checks -- the only organisational dimension InfluxDB offers besides the organisation itself."
+    },
+    {
+      "name": "Label",
+      "paged": false,
+      "suffix": "/api/v2/labels/{Label ID}",
+      "post": false,
+      "description": "One label by id."
+    },
+    {
+      "name": "Legacy Authorizations",
+      "paged": false,
+      "suffix": "/legacy/authorizations?authID={Authorization ID?}&org={Organization Name?}&orgID={Organization ID?}&token={Token (Authorization Name)?}&user={User Name?}&userID={User ID?}",
+      "post": false,
+      "description": "The v1-compatible tokens issued. Present where 1.x tools still write to this instance."
+    },
+    {
+      "name": "Legacy Authorization",
+      "paged": false,
+      "suffix": "/legacy/authorizations/{Authorization ID?}",
+      "post": false,
+      "description": "One legacy authorization by id."
+    },
+    {
+      "name": "Metrics",
+      "paged": false,
+      "suffix": "/metrics",
+      "post": false,
+      "description": "The instance's own operational metrics in Prometheus format. NOT the time series data stored in buckets -- this is InfluxDB reporting on itself, and it is the endpoint for questions about the database's own load rather than its contents."
+    },
+    {
+      "name": "Notification Endpoints",
+      "paged": true,
+      "suffix": "/api/v2/notificationEndpoints?orgID={Organization ID}",
+      "post": false,
+      "description": "Where notifications are delivered -- Slack, PagerDuty, HTTP. Requires an organisation id. The final layer; a rule firing into a dead endpoint is silent."
+    },
+    {
+      "name": "Notification Endpoint",
+      "paged": false,
+      "suffix": "/api/v2/notificationEndpoints/{Endpoint ID}",
+      "post": false,
+      "description": "One notification endpoint by id."
+    },
+    {
+      "name": "Notification Endpoint Labels",
+      "paged": false,
+      "suffix": "/api/v2/notificationEndpoints/{Endpoint ID}/labels",
+      "post": false,
+      "description": "The labels on one notification endpoint."
+    },
+    {
+      "name": "Notification Rules",
+      "paged": true,
+      "suffix": "/api/v2/notificationRules?checkID={Check ID?}&orgID={Organization ID}&tag={Tag}",
+      "post": false,
+      "description": "The rules deciding which check statuses become notifications, filterable by check. The middle layer of alerting."
+    },
+    {
+      "name": "Notification Rule",
+      "paged": true,
+      "suffix": "/api/v2/notificationRules/{Rule ID}",
+      "post": false,
+      "description": "One notification rule by id."
+    },
+    {
+      "name": "Notification Rule Labels",
+      "paged": true,
+      "suffix": "/api/v2/notificationRules/{Rule ID}/labels",
+      "post": false,
+      "description": "The labels on one notification rule."
+    },
+    {
+      "name": "Organizations",
+      "paged": true,
+      "suffix": "/api/v2/orgs?descending={Descending?:true|false}&org={Organization Name?}&orgID={Organization ID?}&userID={User ID?}",
+      "post": false,
+      "lookups": [
+        {
+          "endpoints": [
+            "Organization Members",
+            "Organization Owners",
+            "Authorizations",
+            "Buckets",
+            "Checks",
+            "Dashboards",
+            "Database Retention Policy Mappings",
+            "Labels",
+            "Legacy Authorizations",
+            "Notification Endpoints",
+            "Notification Rules",
+            "Scraper Targets",
+            "Tasks",
+            "Telegraf Configurations",
+            "Installed Templates",
+            "Variables"
+          ],
+          "jsonPath": "$.orgs[*]",
+          "key": "id",
+          "parameterName": "Organization ID"
+        }
+      ],
+      "description": "The organisations on the instance. Everything in InfluxDB 2 belongs to an organisation -- buckets, dashboards, tasks, tokens -- so this is the first request and the scope every other one needs."
+    },
+    {
+      "name": "Organization",
+      "paged": false,
+      "suffix": "/api/v2/orgs/{Organization ID}",
+      "post": false,
+      "description": "One organisation by id."
+    },
+    {
+      "name": "Organization Members",
+      "paged": false,
+      "suffix": "/api/v2/orgs/{Organization ID}/members",
+      "post": false,
+      "description": "The users with member access to one organisation."
+    },
+    {
+      "name": "Organization Owners",
+      "paged": false,
+      "suffix": "/api/v2/orgs/{Organization ID}/owners",
+      "post": false,
+      "description": "The users owning one organisation."
+    },
+    {
+      "name": "Ping",
+      "paged": false,
+      "suffix": "/ping",
+      "post": false,
+      "description": "Whether the instance is reachable, and its version. The lightest connectivity check, and the version matters because available endpoints differ between releases."
+    },
+    {
+      "name": "Query",
+      "paged": false,
+      "suffix": "/query?org={Organization?}&orgID={Organization ID?}",
+      "post": true,
+      "description": "Runs a FLUX query and returns its results. THE DATA ENDPOINT: InfluxDB holds time series, and there is no table to list -- a query defines what comes back, so the question is the request. Requires an organisation. Results come back as annotated CSV rather than JSON, which is the single most surprising thing about this API and means the response needs parsing differently from every other endpoint here."
+    },
+    {
+      "name": "Analyze Flux Query",
+      "paged": false,
+      "suffix": "/query/analyze",
+      "post": true,
+      "description": "Checks a Flux query for errors without running it. Requires the query. Validation rather than data -- useful for confirming a generated query before spending a long-running request on it."
+    },
+    {
+      "name": "Generate Abstract Syntax Tree from a Query",
+      "paged": false,
+      "suffix": "/api/v2/query/ast",
+      "post": true,
+      "description": "Parses a Flux query into its syntax tree. For tooling that manipulates queries programmatically; of no analytical use."
+    },
+    {
+      "name": "Instance Readiness",
+      "paged": false,
+      "suffix": "/ready",
+      "post": false,
+      "description": "Whether the instance has finished starting and is ready to serve. Distinct from health, which reports on a running instance."
+    },
+    {
+      "name": "Resources",
+      "paged": false,
+      "suffix": "/api/v2/resources",
+      "post": false,
+      "description": "The resource types the API exposes. Reference data for building permission sets."
+    },
+    {
+      "name": "Routes",
+      "paged": false,
+      "suffix": "/api/v2/",
+      "post": false,
+      "description": "The API's own route listing. A discovery endpoint."
+    },
+    {
+      "name": "Notification Rule Array",
+      "paged": false,
+      "suffix": "/api/v2/notificationRules/{Rule ID}/query",
+      "post": false,
+      "description": "The Flux query one notification rule runs. Requires a rule id."
+    },
+    {
+      "name": "Scraper Targets",
+      "paged": false,
+      "suffix": "/api/v2/scrapers?id={Scraper Target ID?}&name={Scraper Name ID?}&org={Organization Name?}&orgID={Organization ID?}",
+      "post": false,
+      "lookups": [
+        {
+          "endpoints": [
+            "Scraper Target Labels",
+            "Scraper Target Members",
+            "Scraper Target Owners"
+          ],
+          "jsonPath": "$.configurations[*]",
+          "key": "id",
+          "parameterName": "Scraper Target ID"
+        }
+      ],
+      "description": "The Prometheus-format endpoints InfluxDB scrapes on a schedule, with their URL and target bucket. Where data arrives without anything writing to InfluxDB explicitly."
+    },
+    {
+      "name": "Scraper Target",
+      "paged": false,
+      "suffix": "/api/v2/scrapers/{Scraper Target ID}",
+      "post": false,
+      "description": "One scraper target by id."
+    },
+    {
+      "name": "Scraper Target Labels",
+      "paged": false,
+      "suffix": "/api/v2/scrapers/{Scraper Target ID}/labels",
+      "post": false,
+      "description": "The labels on one scraper target."
+    },
+    {
+      "name": "Scraper Target Members",
+      "paged": false,
+      "suffix": "/api/v2/scrapers/{Scraper Target ID}/members",
+      "post": false,
+      "description": "The users with member access to one scraper target."
+    },
+    {
+      "name": "Scraper Target Owners",
+      "paged": false,
+      "suffix": "/api/v2/scrapers/{Scraper Target ID}/owners",
+      "post": false,
+      "description": "The users owning one scraper target."
+    },
+    {
+      "name": "Secret Keys",
+      "paged": false,
+      "suffix": "/api/v2/orgs/{Organization ID}/secrets",
+      "post": false,
+      "description": "The names of the secrets stored for one organisation. Requires an organisation id. Names only -- values are never returned -- and useful for knowing what a task can reference."
+    },
+    {
+      "name": "Check Default User, Org, Bucket",
+      "paged": false,
+      "suffix": "/api/v2/setup",
+      "post": false,
+      "description": "Whether the instance has completed initial setup, and its default user, organisation and bucket. A first-run check."
+    },
+    {
+      "name": "Sources",
+      "paged": false,
+      "suffix": "/api/v2/sources?&org={Organization Name?}",
+      "post": false,
+      "lookups": [
+        {
+          "endpoints": [
+            "Source Health",
+            "Source Buckets"
+          ],
+          "jsonPath": "$.sources[*]",
+          "key": "id",
+          "parameterName": "Source ID"
+        }
+      ],
+      "description": "The data sources configured, optionally by organisation. Connections to other InfluxDB instances."
+    },
+    {
+      "name": "Source",
+      "paged": false,
+      "suffix": "/api/v2/sources/{Source ID}",
+      "post": false,
+      "description": "One source by id."
+    },
+    {
+      "name": "Source Health",
+      "paged": false,
+      "suffix": "/api/v2/sources/{Source ID}/health",
+      "post": false,
+      "description": "Whether one source is reachable. Requires a source id."
+    },
+    {
+      "name": "Tasks",
+      "paged": false,
+      "suffix": "/api/v2/tasks?limit=500&after={After ID?}&name={Task Name?}&org={Organization Name?}&orgID={Organization ID?}&status={Status?:active|inactive}&type={Type?:basic|system}&user={User ID}",
+      "post": false,
+      "lookups": [
+        {
+          "endpoints": [
+            "Task Labels",
+            "Task Logs",
+            "Task Members",
+            "Task Owners",
+            "Task Runs"
+          ],
+          "jsonPath": "$.tasks[*]",
+          "key": "id",
+          "parameterName": "Task ID"
+        }
+      ],
+      "description": "The scheduled Flux tasks, with their name, cron or interval, status, and the organisation. TASKS ARE HOW DERIVED DATA IS PRODUCED -- downsampling, alerting, materialised aggregates -- so a bucket that appears to hold suspiciously tidy data usually has a task behind it, and this is where that is visible."
+    },
+    {
+      "name": "Task",
+      "paged": false,
+      "suffix": "/api/v2/tasks/{Task ID}",
+      "post": false,
+      "description": "One task by id, with its Flux script."
+    },
+    {
+      "name": "Task Labels",
+      "paged": false,
+      "suffix": "/api/v2/tasks/{Task ID}/labels",
+      "post": false,
+      "description": "The labels on one task."
+    },
+    {
+      "name": "Task Logs",
+      "paged": false,
+      "suffix": "/api/v2/tasks/{Task ID}/logs",
+      "post": false,
+      "description": "The recent log entries across one task's runs. Requires a task id."
+    },
+    {
+      "name": "Task Members",
+      "paged": false,
+      "suffix": "/api/v2/tasks/{Task ID}/members",
+      "post": false,
+      "description": "The users with member access to one task."
+    },
+    {
+      "name": "Task Owners",
+      "paged": false,
+      "suffix": "/api/v2/tasks/{Task ID}/owners",
+      "post": false,
+      "description": "The users owning one task."
+    },
+    {
+      "name": "Task Runs",
+      "paged": false,
+      "suffix": "/api/v2/tasks/{Task ID}/runs?limit=500&after={After ID?}&afterTime={After Time?}&beforeTime={Before Time?}",
+      "post": false,
+      "description": "The execution history of one task, with each run's scheduled time, start and finish, and status. Requires a task id. WHETHER A TASK ACTUALLY RAN is what determines whether the data it produces is complete, and a silently failing task leaves gaps that look like an absence of activity."
+    },
+    {
+      "name": "Task Run",
+      "paged": false,
+      "suffix": "/api/v2/tasks/{Task ID}/runs/{Run ID}",
+      "post": false,
+      "description": "One task run by id, with its outcome."
+    },
+    {
+      "name": "Task Run Logs",
+      "paged": false,
+      "suffix": "/api/v2/tasks/{Task ID}/runs/{Run ID}/logs",
+      "post": false,
+      "description": "The log output of one task run. Requires the task and run ids. Where a failure's cause is found."
+    },
+    {
+      "name": "Telegraf Plugins",
+      "paged": false,
+      "suffix": "/api/v2/telegraf/plugins?type={Type?}",
+      "post": false,
+      "description": "The Telegraf plugins available, by type. Reference data."
+    },
+    {
+      "name": "Telegraf Configurations",
+      "paged": false,
+      "suffix": "/api/v2/telegrafs?orgID={Organization ID?}",
+      "post": false,
+      "lookups": [
+        {
+          "endpoints": [
+            "Telegraf Configuration Labels",
+            "Telegraf Configuration Members",
+            "Telegraf Configuration Owners"
+          ],
+          "jsonPath": "$.configurations[*]",
+          "key": "id",
+          "parameterName": "Telegraf Configuration ID"
+        }
+      ],
+      "description": "The Telegraf agent configurations stored, filterable by organisation. Telegraf is the collection agent, so these describe what is being collected and from where -- which explains the shape of the data in a bucket."
+    },
+    {
+      "name": "Telegraf Configuration",
+      "paged": false,
+      "suffix": "/api/v2/telegrafs/{Telegraf Configuration ID}",
+      "post": false,
+      "description": "One Telegraf configuration by id, with its full TOML."
+    },
+    {
+      "name": "Telegraf Configuration Labels",
+      "paged": false,
+      "suffix": "/api/v2/telegrafs/{Telegraf Configuration ID}/labels",
+      "post": false,
+      "description": "The labels on one Telegraf configuration."
+    },
+    {
+      "name": "Telegraf Configuration Members",
+      "paged": false,
+      "suffix": "/api/v2/telegrafs/{Telegraf Configuration ID}/members",
+      "post": false,
+      "description": "The users with member access to one Telegraf configuration."
+    },
+    {
+      "name": "Telegraf Configuration Owners",
+      "paged": false,
+      "suffix": "/api/v2/telegrafs/{Telegraf Configuration ID}/owners",
+      "post": false,
+      "description": "The users owning one Telegraf configuration."
+    },
+    {
+      "name": "Installed Templates",
+      "paged": false,
+      "suffix": "/api/v2/stacks?&orgID={Organization ID}&name={Name?}&stackID={Stack ID?}",
+      "post": false,
+      "description": "The template stacks installed on the instance, filterable by organisation. Stacks are bundles of dashboards, tasks and buckets installed together, so this explains resources nobody created individually."
+    },
+    {
+      "name": "Stack",
+      "paged": false,
+      "suffix": "/api/v2/stacks/{Stack ID}",
+      "post": false,
+      "description": "One template stack by id, with the resources it created."
+    },
+    {
+      "name": "Current User Feature Flags",
+      "paged": false,
+      "suffix": "/api/v2/flags",
+      "post": false,
+      "description": "The feature flags in force for the caller. Explains why a documented capability is or is not present."
+    },
+    {
+      "name": "Current User",
+      "paged": false,
+      "suffix": "/api/v2/me",
+      "post": false,
+      "description": "The account the token belongs to. One record, always the caller -- and the explanation for what the rest of this connector can see, since InfluxDB scopes everything by token permissions."
+    },
+    {
+      "name": "Users",
+      "paged": true,
+      "suffix": "/api/v2/users?after={After ID?}&id={User ID?}&name={User Name?}",
+      "post": false,
+      "description": "The users on the instance, filterable by id and name. Administrative."
+    },
+    {
+      "name": "User",
+      "paged": false,
+      "suffix": "/api/v2/users/{User ID}",
+      "post": false,
+      "description": "One user by id."
+    },
+    {
+      "name": "Variables",
+      "paged": false,
+      "suffix": "/api/v2/variables?org={Organization Name?}&orgID={Organization ID?}",
+      "post": false,
+      "lookups": [
+        {
+          "endpoints": [
+            "Variable Labels"
+          ],
+          "jsonPath": "$.variables[*]",
+          "key": "id",
+          "parameterName": "Variable ID"
+        }
+      ],
+      "description": "The dashboard variables defined, each with its query or value list. Variables parameterise dashboard queries, so a cell's query is incomplete without them."
+    },
+    {
+      "name": "Variable",
+      "paged": false,
+      "suffix": "/api/v2/variables/{Variable ID}",
+      "post": false,
+      "description": "One variable by id."
+    },
+    {
+      "name": "Variable Labels",
+      "paged": false,
+      "suffix": "/api/v2/variables/{Variable ID}/labels",
+      "post": false,
+      "description": "The labels on one variable."
+    }
+  ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/insightly/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/insightly/endpoints.json
@@ -1,23 +1,26 @@
 {
   "endpoints": [
     {
-      "paged": "true", 
-      "name": "Activity Sets", 
-      "suffix": "/v3.0/ActivitySets?brief={Brief?:true|false}&count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Activity Sets",
+      "suffix": "/v3.0/ActivitySets?brief={Brief?:true|false}&count_total=true",
+      "description": "The templates that create a standard batch of tasks and events at once -- Insightly's repeatable process definitions. What a team considers its standard procedure."
+    },
     {
-      "paged": "false", 
-      "name": "Activity Set", 
-      "suffix": "/v3.0/ActivitySets/{Activity Set ID}"
-    }, 
+      "paged": "false",
+      "name": "Activity Set",
+      "suffix": "/v3.0/ActivitySets/{Activity Set ID}",
+      "description": "One activity set by id, with its tasks and events."
+    },
     {
-      "paged": "true", 
-      "name": "Comment File Attachments", 
-      "suffix": "/v3.0/Comment/{Comment ID}/FileAttachments?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Comment File Attachments",
+      "suffix": "/v3.0/Comment/{Comment ID}/FileAttachments?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&count_total=true",
+      "description": "The files attached to one comment. Requires a comment id."
+    },
     {
-      "paged": "true", 
-      "name": "Contacts", 
+      "paged": "true",
+      "name": "Contacts",
       "suffix": "/v3.0/Contacts?brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -33,15 +36,17 @@
           "key": "CONTACT_ID",
           "parameterName": "Contact ID"
         }
-      ]
-    }, 
+      ],
+      "description": "The people in the CRM, with name, contact details, the organisation, owner, tags, dates and custom fields. THE PATTERN OF THIS CONNECTOR, which repeats for every major object: a plain listing, a Search variant taking field criteria, a SearchByTag variant, and a family of child endpoints for that record's emails, events, notes, tasks, links, files and follow state. Once one object is understood the rest follow the same shape."
+    },
     {
-      "paged": "false", 
-      "name": "Contact", 
-      "suffix": "/v3.0/Contacts/{Contact ID}"
-    }, 
+      "paged": "false",
+      "name": "Contact",
+      "suffix": "/v3.0/Contacts/{Contact ID}",
+      "description": "One contact by id."
+    },
     {
-      "paged": "true", 
+      "paged": "true",
       "name": "Contact Emails",
       "suffix": "/v3.0/Contacts/{Contact ID}/Emails?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
@@ -56,11 +61,12 @@
           "key": "EMAIL_ID",
           "parameterName": "Email ID"
         }
-      ]
-    }, 
+      ],
+      "description": "The emails linked to one contact. Requires a contact id."
+    },
     {
-      "paged": "true", 
-      "name": "Contact Events", 
+      "paged": "true",
+      "name": "Contact Events",
       "suffix": "/v3.0/Contacts/{Contact ID}/Events?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -69,26 +75,30 @@
           "key": "EVENT_ID",
           "parameterName": "Event ID"
         }
-      ]
-    }, 
+      ],
+      "description": "The calendar events involving one contact. Requires a contact id."
+    },
     {
-      "paged": "true", 
-      "name": "Contact File Attachments", 
-      "suffix": "/v3.0//Contacts/{Contact ID}/FileAttachments?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Contact File Attachments",
+      "suffix": "/v3.0/Contacts/{Contact ID}/FileAttachments?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&count_total=true",
+      "description": "The files attached to one contact. Requires a contact id."
+    },
     {
-      "paged": "false", 
-      "name": "Contact Follow State", 
-      "suffix": "/v3.0/Contacts/{Contact ID}/Follow"
-    }, 
+      "paged": "false",
+      "name": "Contact Follow State",
+      "suffix": "/v3.0/Contacts/{Contact ID}/Follow",
+      "description": "Whether the calling user follows one contact. Scoped to the caller."
+    },
     {
-      "paged": "false", 
-      "name": "Contact Links", 
-      "suffix": "/v3.0/Contacts/{Contact ID}/Links"
-    }, 
+      "paged": "false",
+      "name": "Contact Links",
+      "suffix": "/v3.0/Contacts/{Contact ID}/Links",
+      "description": "The other records one contact is linked to -- organisations, opportunities, projects. Requires a contact id. LINKS ARE HOW INSIGHTLY MODELS RELATIONSHIPS: a contact carries one organisation id, but everything else it relates to is expressed here, so the object graph is only traversable through the link endpoints."
+    },
     {
-      "paged": "true", 
-      "name": "Contact Notes", 
+      "paged": "true",
+      "name": "Contact Notes",
       "suffix": "/v3.0/Contacts/{Contact ID}/Notes?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -102,11 +112,12 @@
           "key": "NOTE_ID",
           "parameterName": "Note ID"
         }
-      ]
-    }, 
+      ],
+      "description": "The notes on one contact. Requires a contact id."
+    },
     {
-      "paged": "true", 
-      "name": "Contact Tasks", 
+      "paged": "true",
+      "name": "Contact Tasks",
       "suffix": "/v3.0/Contacts/{Contact ID}/Tasks?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -120,11 +131,12 @@
           "key": "TASK_ID",
           "parameterName": "Task ID"
         }
-      ]
-    }, 
+      ],
+      "description": "The tasks relating to one contact. Requires a contact id."
+    },
     {
-      "paged": "true", 
-      "name": "Filtered Contacts", 
+      "paged": "true",
+      "name": "Filtered Contacts",
       "suffix": "/v3.0/Contacts/Search?field_name={Field Name?}&field_value={Field Value?}&updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -140,11 +152,12 @@
           "key": "CONTACT_ID",
           "parameterName": "Contact ID"
         }
-      ]
-    }, 
+      ],
+      "description": "Contacts matching field criteria. The filtered route where the plain listing only pages."
+    },
     {
-      "paged": "true", 
-      "name": "Filtered Contacts by Tag", 
+      "paged": "true",
+      "name": "Filtered Contacts by Tag",
       "suffix": "/v3.0/Contacts/SearchByTag?tagName={TagName}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -160,31 +173,36 @@
           "key": "CONTACT_ID",
           "parameterName": "Contact ID"
         }
-      ]
-    }, 
+      ],
+      "description": "Contacts carrying a given tag. Tags are Insightly's cross-cutting segmentation, so this is often the fastest way to a business-meaningful subset."
+    },
     {
-      "paged": "false", 
-      "name": "Countries", 
-      "suffix": "/v3.0/Countries"
-    }, 
+      "paged": "false",
+      "name": "Countries",
+      "suffix": "/v3.0/Countries",
+      "description": "The country list Insightly recognises. Reference data."
+    },
     {
-      "paged": "false", 
-      "name": "Currencies", 
-      "suffix": "/v3.0/Currencies"
-    }, 
+      "paged": "false",
+      "name": "Currencies",
+      "suffix": "/v3.0/Currencies",
+      "description": "The currencies configured, with their codes. Opportunity values are held in their own currency, so a total spanning them needs conversion Insightly does not perform here."
+    },
     {
-      "paged": "false", 
-      "name": "Custom Fields", 
-      "suffix": "/v3.0/CustomFields/{Object Name}"
-    }, 
+      "paged": "false",
+      "name": "Custom Fields",
+      "suffix": "/v3.0/CustomFields/{Object Name}",
+      "description": "The custom fields defined on one object. Requires the object name. THE DECODER for custom values, which arrive keyed by field id on every standard object as well as custom ones."
+    },
     {
-      "paged": "false", 
-      "name": "Custom Field", 
-      "suffix": "/v3.0/CustomFields/{Object Name}/Search?fieldName={Field Name}"
-    }, 
+      "paged": "false",
+      "name": "Custom Field",
+      "suffix": "/v3.0/CustomFields/{Object Name}/Search?fieldName={Field Name}",
+      "description": "One custom field definition, searched within an object."
+    },
     {
-      "paged": "false", 
-      "name": "Custom Objects", 
+      "paged": "false",
+      "name": "Custom Objects",
       "suffix": "/v3.0/CustomObjects",
       "lookups": [
         {
@@ -196,31 +214,36 @@
           "key": "OBJECT_NAME",
           "parameterName": "Object Name"
         }
-      ]
-    }, 
+      ],
+      "description": "The custom objects defined on the account. INSIGHTLY LETS AN ACCOUNT DEFINE ITS OWN RECORD TYPES, so this is the first request whenever a question involves anything beyond the standard objects -- what exists is entirely account-specific."
+    },
     {
-      "paged": "false", 
-      "name": "Custom Object", 
-      "suffix": "/v3.0/CustomObjects/{Custom Object Name}"
-    }, 
+      "paged": "false",
+      "name": "Custom Object",
+      "suffix": "/v3.0/CustomObjects/{Custom Object Name}",
+      "description": "One custom object's definition by name, with its fields."
+    },
     {
-      "paged": "true", 
-      "name": "Custom Object Records", 
-      "suffix": "/v3.0/{Object Name}?brief={Brief?:true|false}&count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Custom Object Records",
+      "suffix": "/v3.0/{Object Name}?brief={Brief?:true|false}&count_total=true",
+      "description": "The records of one custom object. Requires the object name. The data behind a user-defined record type."
+    },
     {
-      "paged": "false", 
-      "name": "Custom Object Record", 
-      "suffix": "/v3.0/{Object Name}/{Record ID}"
-    }, 
+      "paged": "false",
+      "name": "Custom Object Record",
+      "suffix": "/v3.0/{Object Name}/{Record ID}",
+      "description": "One custom object record by id."
+    },
     {
-      "paged": "true", 
-      "name": "Filtered Custom Object Records", 
-      "suffix": "/v3.0/{Object Name}/Search?field_name={Field Name?}&field_value={Field Value?}&updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Filtered Custom Object Records",
+      "suffix": "/v3.0/{Object Name}/Search?field_name={Field Name?}&field_value={Field Value?}&updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
+      "description": "Custom object records matching field criteria."
+    },
     {
-      "paged": "true", 
-      "name": "Emails", 
+      "paged": "true",
+      "name": "Emails",
       "suffix": "/v3.0/Emails?brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -234,36 +257,42 @@
           "key": "EMAIL_ID",
           "parameterName": "Email ID"
         }
-      ]
-    }, 
+      ],
+      "description": "The emails captured into the CRM, with subject, body, sender, recipients and date. Where correspondence is filed against records."
+    },
     {
-      "paged": "false", 
-      "name": "Email", 
-      "suffix": "/v3.0/Emails/{Email ID}"
-    }, 
+      "paged": "false",
+      "name": "Email",
+      "suffix": "/v3.0/Emails/{Email ID}",
+      "description": "One email by id."
+    },
     {
-      "paged": "true", 
-      "name": "Email Comments", 
-      "suffix": "/v3.0/Emails/{Email ID}/Comments?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Email Comments",
+      "suffix": "/v3.0/Emails/{Email ID}/Comments?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&count_total=true",
+      "description": "The comments on one email."
+    },
     {
-      "paged": "true", 
-      "name": "Email File Attachments", 
-      "suffix": "/v3.0/Emails/{Email ID}/FileAttachments?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Email File Attachments",
+      "suffix": "/v3.0/Emails/{Email ID}/FileAttachments?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&count_total=true",
+      "description": "The files attached to one email."
+    },
     {
-      "paged": "false", 
-      "name": "Email Follow State", 
-      "suffix": "/v3.0/Emails/{Email ID}/Follow"
-    }, 
+      "paged": "false",
+      "name": "Email Follow State",
+      "suffix": "/v3.0/Emails/{Email ID}/Follow",
+      "description": "Whether the caller follows one email."
+    },
     {
-      "paged": "false", 
-      "name": "Email Links", 
-      "suffix": "/v3.0/Emails/{Email ID}/Links"
-    }, 
+      "paged": "false",
+      "name": "Email Links",
+      "suffix": "/v3.0/Emails/{Email ID}/Links",
+      "description": "The records one email is linked to."
+    },
     {
-      "paged": "true", 
-      "name": "Filtered Emails", 
+      "paged": "true",
+      "name": "Filtered Emails",
       "suffix": "/v3.0/Emails/Search?field_name={Field Name?}&field_value={Field Value?}&updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -277,11 +306,12 @@
           "key": "EMAIL_ID",
           "parameterName": "Email ID"
         }
-      ]
-    }, 
+      ],
+      "description": "Emails matching field criteria."
+    },
     {
-      "paged": "true", 
-      "name": "Filtered Emails by Tag", 
+      "paged": "true",
+      "name": "Filtered Emails by Tag",
       "suffix": "/v3.0/Emails/SearchByTag?tagName={TagName}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -295,11 +325,12 @@
           "key": "EMAIL_ID",
           "parameterName": "Email ID"
         }
-      ]
-    }, 
+      ],
+      "description": "Emails carrying a given tag."
+    },
     {
-      "paged": "true", 
-      "name": "Events", 
+      "paged": "true",
+      "name": "Events",
       "suffix": "/v3.0/Events?brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -308,21 +339,24 @@
           "key": "EVENT_ID",
           "parameterName": "Event ID"
         }
-      ]
-    }, 
+      ],
+      "description": "The calendar events -- meetings and appointments -- with title, times, location and attendees. The activity record beside tasks."
+    },
     {
-      "paged": "false", 
+      "paged": "false",
       "name": "Event",
-      "suffix": "/v3.0/Events/{Event ID}"
-    }, 
+      "suffix": "/v3.0/Events/{Event ID}",
+      "description": "One event by id."
+    },
     {
-      "paged": "false", 
-      "name": "Event Links", 
-      "suffix": "/v3.0/Events/{Event ID}/Links"
-    }, 
+      "paged": "false",
+      "name": "Event Links",
+      "suffix": "/v3.0/Events/{Event ID}/Links",
+      "description": "The records one event is linked to."
+    },
     {
-      "paged": "true", 
-      "name": "Filtered Events", 
+      "paged": "true",
+      "name": "Filtered Events",
       "suffix": "/v3.0/Events/Search?field_name={Field Name?}&field_value={Field Value?}&updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -331,26 +365,30 @@
           "key": "EVENT_ID",
           "parameterName": "Event ID"
         }
-      ]
-    }, 
+      ],
+      "description": "Events matching field criteria."
+    },
     {
-      "paged": "true", 
-      "name": "File Categories", 
-      "suffix": "/v3.0/FileCategories?count_total=true"
-    }, 
+      "paged": "true",
+      "name": "File Categories",
+      "suffix": "/v3.0/FileCategories?count_total=true",
+      "description": "The categories file attachments are classified under."
+    },
     {
-      "paged": "false", 
-      "name": "File Category", 
-      "suffix": "/v3.0/FileCategories/{File Category ID}"
-    }, 
+      "paged": "false",
+      "name": "File Category",
+      "suffix": "/v3.0/FileCategories/{File Category ID}",
+      "description": "One file category by id."
+    },
     {
-      "paged": "true", 
-      "name": "Followed Records", 
-      "suffix": "/v3.0/Follows?record_type={Record Type?}&count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Followed Records",
+      "suffix": "/v3.0/Follows?record_type={Record Type?}&count_total=true",
+      "description": "The records the calling user follows, across types. Scoped to the caller."
+    },
     {
-      "paged": "true", 
-      "name": "Leads", 
+      "paged": "true",
+      "name": "Leads",
       "suffix": "/v3.0/Leads?brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -368,16 +406,18 @@
           "key": "LEAD_ID",
           "parameterName": "Lead ID"
         }
-      ]
-    }, 
+      ],
+      "description": "The unqualified prospects, with name, company, contact details, status, source, owner and custom fields. IN INSIGHTLY A LEAD IS CONVERTED into a contact, organisation and opportunity, and the lead record survives -- so leads and contacts hold different stages of the same people and counting both double-counts anyone converted."
+    },
     {
-      "paged": "false", 
-      "name": "Lead", 
-      "suffix": "/v3.0/Leads/{Lead ID}"
-    }, 
+      "paged": "false",
+      "name": "Lead",
+      "suffix": "/v3.0/Leads/{Lead ID}",
+      "description": "One lead by id."
+    },
     {
-      "paged": "true", 
-      "name": "Lead Emails", 
+      "paged": "true",
+      "name": "Lead Emails",
       "suffix": "/v3.0/Leads/{Lead ID}/Emails?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -391,11 +431,12 @@
           "key": "EMAIL_ID",
           "parameterName": "Email ID"
         }
-      ]
-    }, 
+      ],
+      "description": "The emails linked to one lead."
+    },
     {
-      "paged": "true", 
-      "name": "Lead Events", 
+      "paged": "true",
+      "name": "Lead Events",
       "suffix": "/v3.0/Leads/{Lead ID}/Events?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -404,31 +445,36 @@
           "key": "EVENT_ID",
           "parameterName": "Event ID"
         }
-      ]
-    }, 
+      ],
+      "description": "The calendar events involving one lead."
+    },
     {
-      "paged": "true", 
-      "name": "Lead File Attachments", 
-      "suffix": "/v3.0/Leads/{Lead ID}/FileAttachments?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Lead File Attachments",
+      "suffix": "/v3.0/Leads/{Lead ID}/FileAttachments?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&count_total=true",
+      "description": "The files attached to one lead."
+    },
     {
-      "paged": "false", 
-      "name": "Lead Follow State", 
-      "suffix": "/v3.0/Leads/{Lead ID}/Follow"
-    }, 
+      "paged": "false",
+      "name": "Lead Follow State",
+      "suffix": "/v3.0/Leads/{Lead ID}/Follow",
+      "description": "Whether the caller follows one lead."
+    },
     {
-      "paged": "false", 
-      "name": "Lead Email Address", 
-      "suffix": "/v3.0/Leads/{Lead ID}/LinkEmailAddress"
-    }, 
+      "paged": "false",
+      "name": "Lead Email Address",
+      "suffix": "/v3.0/Leads/{Lead ID}/LinkEmailAddress",
+      "description": "The dedicated email address that files mail against one lead. Requires a lead id. How correspondence is captured without forwarding by hand."
+    },
     {
-      "paged": "false", 
-      "name": "Lead Links", 
-      "suffix": "/v3.0/Leads/{Lead ID}/Links"
-    }, 
+      "paged": "false",
+      "name": "Lead Links",
+      "suffix": "/v3.0/Leads/{Lead ID}/Links",
+      "description": "The records one lead is linked to."
+    },
     {
-      "paged": "true", 
-      "name": "Lead Notes", 
+      "paged": "true",
+      "name": "Lead Notes",
       "suffix": "/v3.0/Leads/{Lead ID}/Notes?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -442,11 +488,12 @@
           "key": "NOTE_ID",
           "parameterName": "Note ID"
         }
-      ]
-    }, 
+      ],
+      "description": "The notes on one lead."
+    },
     {
-      "paged": "true", 
-      "name": "Lead Tasks", 
+      "paged": "true",
+      "name": "Lead Tasks",
       "suffix": "/v3.0/Leads/{Lead ID}/Tasks?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -460,11 +507,12 @@
           "key": "TASK_ID",
           "parameterName": "Task ID"
         }
-      ]
-    }, 
+      ],
+      "description": "The tasks relating to one lead."
+    },
     {
-      "paged": "true", 
-      "name": "Filtered Leads", 
+      "paged": "true",
+      "name": "Filtered Leads",
       "suffix": "/v3.0/Leads/Search?field_name={Field Name?}&field_value={Field Value?}&updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -482,11 +530,12 @@
           "key": "LEAD_ID",
           "parameterName": "Lead ID"
         }
-      ]
-    }, 
+      ],
+      "description": "Leads matching field criteria."
+    },
     {
-      "paged": "true", 
-      "name": "Filtered Leads by Tag", 
+      "paged": "true",
+      "name": "Filtered Leads by Tag",
       "suffix": "/v3.0/Leads/SearchByTag?tagName={TagName}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -504,36 +553,42 @@
           "key": "LEAD_ID",
           "parameterName": "Lead ID"
         }
-      ]
-    }, 
+      ],
+      "description": "Leads carrying a given tag."
+    },
     {
-      "paged": "true", 
-      "name": "Lead Sources", 
-      "suffix": "/v3.0/LeadSources?count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Lead Sources",
+      "suffix": "/v3.0/LeadSources?count_total=true",
+      "description": "The lead source values configured. The attribution dimension, and account-specific."
+    },
     {
-      "paged": "true", 
-      "name": "Lead Statuses", 
-      "suffix": "/v3.0/LeadStatuses?include_converted={Include Converted?:true|false}&count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Lead Statuses",
+      "suffix": "/v3.0/LeadStatuses?include_converted={Include Converted?:true|false}&count_total=true",
+      "description": "The lead status values configured. The stages before conversion, and the decoder for a lead's status id."
+    },
     {
-      "paged": "true", 
-      "name": "Milestones", 
-      "suffix": "/v3.0/Milestone?brief={Brief?:true|false}&count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Milestones",
+      "suffix": "/v3.0/Milestone?brief={Brief?:true|false}&count_total=true",
+      "description": "The milestones across all projects. The account-wide delivery schedule."
+    },
     {
-      "paged": "false", 
-      "name": "Milestone", 
-      "suffix": "/v3.0/Milestone/{Milestone ID}"
-    }, 
+      "paged": "false",
+      "name": "Milestone",
+      "suffix": "/v3.0/Milestone/{Milestone ID}",
+      "description": "One milestone by id."
+    },
     {
-      "paged": "true", 
-      "name": "Filtered Milestones", 
-      "suffix": "/v3.0/Milestone/Search?field_name={Field Name?}&field_value={Field Value?}&updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Filtered Milestones",
+      "suffix": "/v3.0/Milestone/Search?field_name={Field Name?}&field_value={Field Value?}&updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
+      "description": "Milestones matching field criteria."
+    },
     {
-      "paged": "true", 
-      "name": "Notes", 
+      "paged": "true",
+      "name": "Notes",
       "suffix": "/v3.0/Notes?brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -547,36 +602,42 @@
           "key": "NOTE_ID",
           "parameterName": "Note ID"
         }
-      ]
-    }, 
+      ],
+      "description": "The free-text notes across records. The qualitative record, and where the reasoning behind an outcome is usually written."
+    },
     {
-      "paged": "false", 
-      "name": "Note", 
-      "suffix": "/v3.0/Notes/{Note ID}"
-    }, 
+      "paged": "false",
+      "name": "Note",
+      "suffix": "/v3.0/Notes/{Note ID}",
+      "description": "One note by id."
+    },
     {
-      "paged": "true", 
-      "name": "Note Comments", 
-      "suffix": "/v3.0/Notes/{Note ID}/Comments?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Note Comments",
+      "suffix": "/v3.0/Notes/{Note ID}/Comments?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&count_total=true",
+      "description": "The comments on one note."
+    },
     {
-      "paged": "true", 
-      "name": "Note File Attachments", 
-      "suffix": "/v3.0/Notes/{Note ID}/FileAttachments?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Note File Attachments",
+      "suffix": "/v3.0/Notes/{Note ID}/FileAttachments?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&count_total=true",
+      "description": "The files attached to one note."
+    },
     {
-      "paged": "false", 
-      "name": "Note Follow State", 
-      "suffix": "/v3.0/Notes/{Note ID}/Follow"
-    }, 
+      "paged": "false",
+      "name": "Note Follow State",
+      "suffix": "/v3.0/Notes/{Note ID}/Follow",
+      "description": "Whether the caller follows one note."
+    },
     {
-      "paged": "false", 
-      "name": "Note Links", 
-      "suffix": "/v3.0/Notes/{Note ID}/Links"
-    }, 
+      "paged": "false",
+      "name": "Note Links",
+      "suffix": "/v3.0/Notes/{Note ID}/Links",
+      "description": "The records one note is linked to."
+    },
     {
-      "paged": "true", 
-      "name": "Filtered Notes", 
+      "paged": "true",
+      "name": "Filtered Notes",
       "suffix": "/v3.0/Notes/Search?field_name={Field Name?}&field_value={Field Value?}&updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -590,16 +651,18 @@
           "key": "NOTE_ID",
           "parameterName": "Note ID"
         }
-      ]
-    }, 
+      ],
+      "description": "Notes matching field criteria."
+    },
     {
-      "paged": "true", 
-      "name": "Opportunities", 
-      "suffix": "/v3.0/Opportunities?brief={Brief?:true|false}&count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Opportunities",
+      "suffix": "/v3.0/Opportunities?brief={Brief?:true|false}&count_total=true",
+      "description": "The revenue opportunities, with name, value and currency, the pipeline and stage, probability, forecast and actual close dates, state, and the organisation and contacts involved. The pipeline table. STATE separates Open from Won, Lost, Suspended and Abandoned, so a win rate has a specific denominator and an unfiltered value total is not a forecast."
+    },
     {
-      "paged": "false", 
-      "name": "Opportunity", 
+      "paged": "false",
+      "name": "Opportunity",
       "suffix": "/v3.0/Opportunities/{Opportunity ID}",
       "lookups": [
         {
@@ -618,11 +681,12 @@
           "key": "OPPORTUNITY_ID",
           "parameterName": "Opportunity ID"
         }
-      ]
-    }, 
+      ],
+      "description": "One opportunity by id."
+    },
     {
-      "paged": "true", 
-      "name": "Opportunity Emails", 
+      "paged": "true",
+      "name": "Opportunity Emails",
       "suffix": "/v3.0/Opportunities/{Opportunity ID}/Emails?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -636,11 +700,12 @@
           "key": "EMAIL_ID",
           "parameterName": "Email ID"
         }
-      ]
+      ],
+      "description": "The emails linked to one opportunity."
     },
     {
-      "paged": "true", 
-      "name": "Opportunity Events", 
+      "paged": "true",
+      "name": "Opportunity Events",
       "suffix": "/v3.0/Opportunities/{Opportunity ID}/Events?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -649,31 +714,36 @@
           "key": "EVENT_ID",
           "parameterName": "Event ID"
         }
-      ]
-    }, 
+      ],
+      "description": "The calendar events involving one opportunity."
+    },
     {
-      "paged": "true", 
-      "name": "Opportunity File Attachments", 
-      "suffix": "/v3.0/Opportunities/{Opportunity ID}/FileAttachments?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Opportunity File Attachments",
+      "suffix": "/v3.0/Opportunities/{Opportunity ID}/FileAttachments?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
+      "description": "The files attached to one opportunity."
+    },
     {
-      "paged": "false", 
-      "name": "Opportunity Follow State", 
-      "suffix": "/v3.0/Opportunities/{Opportunity ID}/Follow"
-    }, 
+      "paged": "false",
+      "name": "Opportunity Follow State",
+      "suffix": "/v3.0/Opportunities/{Opportunity ID}/Follow",
+      "description": "Whether the caller follows one opportunity."
+    },
     {
-      "paged": "false", 
-      "name": "Opportunity Email Address", 
-      "suffix": "/v3.0/Opportunities/{Opportunity ID}/LinkEmailAddress"
-    }, 
+      "paged": "false",
+      "name": "Opportunity Email Address",
+      "suffix": "/v3.0/Opportunities/{Opportunity ID}/LinkEmailAddress",
+      "description": "The dedicated email address that files mail against one opportunity."
+    },
     {
-      "paged": "false", 
-      "name": "Opportunity Links", 
-      "suffix": "/v3.0/Opportunities/{Opportunity ID}/Links"
-    }, 
+      "paged": "false",
+      "name": "Opportunity Links",
+      "suffix": "/v3.0/Opportunities/{Opportunity ID}/Links",
+      "description": "The records one opportunity is linked to."
+    },
     {
-      "paged": "true", 
-      "name": "Opportunity Notes", 
+      "paged": "true",
+      "name": "Opportunity Notes",
       "suffix": "/v3.0/Opportunities/{Opportunity ID}/Notes?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -687,16 +757,18 @@
           "key": "NOTE_ID",
           "parameterName": "Note ID"
         }
-      ]
-    }, 
+      ],
+      "description": "The notes on one opportunity."
+    },
     {
-      "paged": "false", 
-      "name": "Opportunity State History", 
-      "suffix": "/v3.0/Opportunities/{Opportunity ID}/StateHistory"
-    }, 
+      "paged": "false",
+      "name": "Opportunity State History",
+      "suffix": "/v3.0/Opportunities/{Opportunity ID}/StateHistory",
+      "description": "THE STAGE AND STATE HISTORY of one opportunity, with the dates of each change. Requires an opportunity id. The opportunity carries its current stage only, so time-in-stage, stage skipping and the date a deal actually closed are answerable here and nowhere else."
+    },
     {
-      "paged": "true", 
-      "name": "Opportunity Tasks", 
+      "paged": "true",
+      "name": "Opportunity Tasks",
       "suffix": "/v3.0/Opportunities/{Opportunity ID}/Tasks?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -710,11 +782,12 @@
           "key": "TASK_ID",
           "parameterName": "Task ID"
         }
-      ]
-    }, 
+      ],
+      "description": "The tasks relating to one opportunity."
+    },
     {
-      "paged": "true", 
-      "name": "Filtered Opportunities", 
+      "paged": "true",
+      "name": "Filtered Opportunities",
       "suffix": "/v3.0/Opportunities/Search?field_name={Field Name?}&field_value={Field Value?}&updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -733,11 +806,12 @@
           "key": "OPPORTUNITY_ID",
           "parameterName": "Opportunity ID"
         }
-      ]
-    }, 
+      ],
+      "description": "Opportunities matching field criteria."
+    },
     {
-      "paged": "true", 
-      "name": "Filtered Opportunities by Tag", 
+      "paged": "true",
+      "name": "Filtered Opportunities by Tag",
       "suffix": "/v3.0/Opportunities/SearchByTag?tagName={TagName}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -756,26 +830,30 @@
           "key": "OPPORTUNITY_ID",
           "parameterName": "Opportunity ID"
         }
-      ]
-    }, 
+      ],
+      "description": "Opportunities carrying a given tag."
+    },
     {
-      "paged": "true", 
-      "name": "Opportunity Categories", 
-      "suffix": "/v3.0/OpportunityCategories?count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Opportunity Categories",
+      "suffix": "/v3.0/OpportunityCategories?count_total=true",
+      "description": "The categories opportunities are classified under. An extra dimension beyond pipeline and stage."
+    },
     {
-      "paged": "false", 
-      "name": "Opportunity Category", 
-      "suffix": "/v3.0/OpportunityCategories/{Opportunity Category ID}"
-    }, 
+      "paged": "false",
+      "name": "Opportunity Category",
+      "suffix": "/v3.0/OpportunityCategories/{Opportunity Category ID}",
+      "description": "One opportunity category by id."
+    },
     {
-      "paged": "true", 
-      "name": "Opportunity State Reasons", 
-      "suffix": "/v3.0/OpportunityStateReasons?count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Opportunity State Reasons",
+      "suffix": "/v3.0/OpportunityStateReasons?count_total=true",
+      "description": "The reasons configured for an opportunity reaching each state -- why it was won, lost or abandoned. The structured explanation behind a state, which the state alone does not give."
+    },
     {
-      "paged": "true", 
-      "name": "Organizations", 
+      "paged": "true",
+      "name": "Organizations",
       "suffix": "/v3.0/Organisations?brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -792,16 +870,18 @@
           "key": "ORGANISATION_ID",
           "parameterName": "Organization ID"
         }
-      ]
-    }, 
+      ],
+      "description": "The companies in the CRM, with name, address, phone, website, owner, tags and custom fields. NOTE THE SPELLING: the API path is Organisations with an s, while the connector names the endpoints Organizations -- the same records either way."
+    },
     {
-      "paged": "false", 
-      "name": "Organization", 
-      "suffix": "/v3.0/Organisations/{Organization ID}"
-    }, 
+      "paged": "false",
+      "name": "Organization",
+      "suffix": "/v3.0/Organisations/{Organization ID}",
+      "description": "One organisation by id."
+    },
     {
-      "paged": "true", 
-      "name": "Organization Emails", 
+      "paged": "true",
+      "name": "Organization Emails",
       "suffix": "/v3.0/Organisations/{Organization ID}/Emails?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -815,11 +895,12 @@
           "key": "EMAIL_ID",
           "parameterName": "Email ID"
         }
-      ]
-    }, 
+      ],
+      "description": "The emails linked to one organisation. Requires an organisation id."
+    },
     {
-      "paged": "true", 
-      "name": "Organization Events", 
+      "paged": "true",
+      "name": "Organization Events",
       "suffix": "/v3.0/Organisations/{Organization ID}/Events?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -828,31 +909,36 @@
           "key": "EVENT_ID",
           "parameterName": "Event ID"
         }
-      ]
-    }, 
+      ],
+      "description": "The calendar events involving one organisation."
+    },
     {
-      "paged": "true", 
-      "name": "Organization File Attachments", 
-      "suffix": "/v3.0/Organisations/{Organization ID}/FileAttachments?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Organization File Attachments",
+      "suffix": "/v3.0/Organisations/{Organization ID}/FileAttachments?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&count_total=true",
+      "description": "The files attached to one organisation."
+    },
     {
-      "paged": "false", 
-      "name": "Organization Follow State", 
-      "suffix": "/v3.0/Organisations/{Organization ID}/Follow"
-    }, 
+      "paged": "false",
+      "name": "Organization Follow State",
+      "suffix": "/v3.0/Organisations/{Organization ID}/Follow",
+      "description": "Whether the caller follows one organisation."
+    },
     {
-      "paged": "false", 
-      "name": "Organization Links", 
-      "suffix": "/v3.0/Organisations/{Organization ID}/Links"
-    }, 
+      "paged": "false",
+      "name": "Organization Links",
+      "suffix": "/v3.0/Organisations/{Organization ID}/Links",
+      "description": "The records one organisation is linked to."
+    },
     {
-      "paged": "true", 
-      "name": "Organization Notes", 
-      "suffix": "/v3.0/Organisations/{Organization ID}/Notes?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Organization Notes",
+      "suffix": "/v3.0/Organisations/{Organization ID}/Notes?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
+      "description": "The notes on one organisation."
+    },
     {
-      "paged": "true", 
-      "name": "Organization Tasks", 
+      "paged": "true",
+      "name": "Organization Tasks",
       "suffix": "/v3.0/Organisations/{Organization ID}/Tasks?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -866,11 +952,12 @@
           "key": "TASK_ID",
           "parameterName": "Task ID"
         }
-      ]
-    }, 
+      ],
+      "description": "The tasks relating to one organisation."
+    },
     {
-      "paged": "true", 
-      "name": "Filtered Organizations", 
+      "paged": "true",
+      "name": "Filtered Organizations",
       "suffix": "/v3.0/Organisations/Search?field_name={Field Name?}&field_value={Field Value?}&updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -887,11 +974,12 @@
           "key": "ORGANISATION_ID",
           "parameterName": "Organization ID"
         }
-      ]
-    }, 
+      ],
+      "description": "Organisations matching field criteria."
+    },
     {
-      "paged": "true", 
-      "name": "Filtered Organizations by Tag", 
+      "paged": "true",
+      "name": "Filtered Organizations by Tag",
       "suffix": "/v3.0/Organisations/SearchByTag?tagName={TagName}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -908,46 +996,54 @@
           "key": "ORGANISATION_ID",
           "parameterName": "Organization ID"
         }
-      ]
-    }, 
+      ],
+      "description": "Organisations carrying a given tag."
+    },
     {
-      "paged": "false", 
-      "name": "User Permissions", 
-      "suffix": "/v3.0/Permissions"
-    }, 
+      "paged": "false",
+      "name": "User Permissions",
+      "suffix": "/v3.0/Permissions",
+      "description": "The permissions the calling user holds. The direct explanation for a record that cannot be seen."
+    },
     {
-      "paged": "true", 
-      "name": "Pipelines", 
-      "suffix": "/v3.0/Pipelines?count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Pipelines",
+      "suffix": "/v3.0/Pipelines?count_total=true",
+      "description": "The pipelines defined, with the record type each applies to -- opportunities or projects. Insightly pipelines cover both, so a pipeline question has to say which."
+    },
     {
-      "paged": "false", 
-      "name": "Pipeline", 
-      "suffix": "/v3.0/Pipelines/{Pipeline ID}"
-    }, 
+      "paged": "false",
+      "name": "Pipeline",
+      "suffix": "/v3.0/Pipelines/{Pipeline ID}",
+      "description": "One pipeline by id."
+    },
     {
-      "paged": "true", 
-      "name": "Pipeline Stages", 
-      "suffix": "/v3.0/PipelineStages?count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Pipeline Stages",
+      "suffix": "/v3.0/PipelineStages?count_total=true",
+      "description": "The stages within pipelines, with their order and the pipeline each belongs to. The dimension a funnel breakdown joins to."
+    },
     {
-      "paged": "false", 
-      "name": "Pipeline Stage", 
-      "suffix": "/v3.0/PipelineStages/{Pipeline Stage ID}"
-    }, 
+      "paged": "false",
+      "name": "Pipeline Stage",
+      "suffix": "/v3.0/PipelineStages/{Pipeline Stage ID}",
+      "description": "One pipeline stage by id."
+    },
     {
-      "paged": "true", 
-      "name": "Project Categories", 
-      "suffix": "/v3.0/ProjectCategories?count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Project Categories",
+      "suffix": "/v3.0/ProjectCategories?count_total=true",
+      "description": "The categories projects are classified under."
+    },
     {
-      "paged": "false", 
-      "name": "Project Category", 
-      "suffix": "/v3.0/ProjectCategories/{Project Category ID}"
-    }, 
+      "paged": "false",
+      "name": "Project Category",
+      "suffix": "/v3.0/ProjectCategories/{Project Category ID}",
+      "description": "One project category by id."
+    },
     {
-      "paged": "true", 
-      "name": "Projects", 
+      "paged": "true",
+      "name": "Projects",
       "suffix": "/v3.0/Projects?brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -966,16 +1062,18 @@
           "key": "PROJECT_ID",
           "parameterName": "Project ID"
         }
-      ]
-    }, 
+      ],
+      "description": "The delivery projects, with name, status, the pipeline and stage, dates, the responsible user and the organisation. THE POST-SALE SIDE: an opportunity becomes a project, so delivery tracking lives here while the sale lives in opportunities, and the two are separate records."
+    },
     {
-      "paged": "false", 
-      "name": "Project", 
-      "suffix": "/v3.0/Projects/{Project ID}"
-    }, 
+      "paged": "false",
+      "name": "Project",
+      "suffix": "/v3.0/Projects/{Project ID}",
+      "description": "One project by id."
+    },
     {
-      "paged": "true", 
-      "name": "Project Emails", 
+      "paged": "true",
+      "name": "Project Emails",
       "suffix": "/v3.0/Projects/{Project ID}/Emails?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -989,11 +1087,12 @@
           "key": "EMAIL_ID",
           "parameterName": "Email ID"
         }
-      ]
-    }, 
+      ],
+      "description": "The emails linked to one project."
+    },
     {
-      "paged": "true", 
-      "name": "Project Events", 
+      "paged": "true",
+      "name": "Project Events",
       "suffix": "/v3.0/Projects/{Project ID}/Events?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -1002,41 +1101,48 @@
           "key": "EVENT_ID",
           "parameterName": "Event ID"
         }
-      ]
-    }, 
+      ],
+      "description": "The calendar events involving one project."
+    },
     {
-      "paged": "true", 
-      "name": "Project File Attachments", 
-      "suffix": "/v3.0/Projects/{Project ID}/FileAttachments?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Project File Attachments",
+      "suffix": "/v3.0/Projects/{Project ID}/FileAttachments?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&count_total=true",
+      "description": "The files attached to one project."
+    },
     {
-      "paged": "false", 
-      "name": "Project Follow State", 
-      "suffix": "/v3.0/Projects/{Project ID}/Follow"
-    }, 
+      "paged": "false",
+      "name": "Project Follow State",
+      "suffix": "/v3.0/Projects/{Project ID}/Follow",
+      "description": "Whether the caller follows one project."
+    },
     {
-      "paged": "false", 
-      "name": "Project Email Address", 
-      "suffix": "/v3.0/Projects/{Project ID}/LinkEmailAddress"
-    }, 
+      "paged": "false",
+      "name": "Project Email Address",
+      "suffix": "/v3.0/Projects/{Project ID}/LinkEmailAddress",
+      "description": "The dedicated email address that files mail against one project."
+    },
     {
-      "paged": "false", 
-      "name": "Project Links", 
-      "suffix": "/v3.0/Projects/{Project ID}/Links"
-    }, 
+      "paged": "false",
+      "name": "Project Links",
+      "suffix": "/v3.0/Projects/{Project ID}/Links",
+      "description": "The records one project is linked to."
+    },
     {
-      "paged": "false", 
-      "name": "Project Milestones", 
-      "suffix": "/v3.0/Projects/{Project ID}/Milestones"
-    }, 
+      "paged": "false",
+      "name": "Project Milestones",
+      "suffix": "/v3.0/Projects/{Project ID}/Milestones",
+      "description": "The milestones of one project. Requires a project id. The delivery schedule within a project."
+    },
     {
-      "paged": "true", 
-      "name": "Project Notes", 
-      "suffix": "/v3.0/Projects/{Project ID}/Notes?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Project Notes",
+      "suffix": "/v3.0/Projects/{Project ID}/Notes?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
+      "description": "The notes on one project."
+    },
     {
-      "paged": "true", 
-      "name": "Project Tasks", 
+      "paged": "true",
+      "name": "Project Tasks",
       "suffix": "/v3.0/Projects/{Project ID}/Tasks?updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -1050,11 +1156,12 @@
           "key": "TASK_ID",
           "parameterName": "Task ID"
         }
-      ]
-    }, 
+      ],
+      "description": "The tasks relating to one project."
+    },
     {
-      "paged": "true", 
-      "name": "Filtered Projects", 
+      "paged": "true",
+      "name": "Filtered Projects",
       "suffix": "/v3.0/Projects/Search?field_name={Field Name?}&field_value={Field Value?}&updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -1073,11 +1180,12 @@
           "key": "PROJECT_ID",
           "parameterName": "Project ID"
         }
-      ]
-    }, 
+      ],
+      "description": "Projects matching field criteria."
+    },
     {
-      "paged": "true", 
-      "name": "Filtered Projects by Tag", 
+      "paged": "true",
+      "name": "Filtered Projects by Tag",
       "suffix": "/v3.0/Projects/SearchByTag?tagName={TagName}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -1096,31 +1204,36 @@
           "key": "PROJECT_ID",
           "parameterName": "Project ID"
         }
-      ]
-    }, 
+      ],
+      "description": "Projects carrying a given tag."
+    },
     {
-      "paged": "true", 
-      "name": "Relationships", 
-      "suffix": "/v3.0/Relationships?count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Relationships",
+      "suffix": "/v3.0/Relationships?count_total=true",
+      "description": "The relationship types defined between records -- reports to, works with, supplier of. The vocabulary the Links endpoints use, and the decoder for what a link actually means."
+    },
     {
-      "paged": "true", 
-      "name": "Record Type Tags", 
-      "suffix": "/v3.0/Tags?record_type={Record Type?}&count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Record Type Tags",
+      "suffix": "/v3.0/Tags?record_type={Record Type?}&count_total=true",
+      "description": "The tags in use, by record type. The segmentation vocabulary, and the input to every SearchByTag endpoint."
+    },
     {
-      "paged": "true", 
-      "name": "Task Categories", 
-      "suffix": "/v3.0/TaskCategories?count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Task Categories",
+      "suffix": "/v3.0/TaskCategories?count_total=true",
+      "description": "The categories tasks are classified under. The dimension that turns task volume into activity mix."
+    },
     {
-      "paged": "false", 
-      "name": "Task Category", 
-      "suffix": "/v3.0/TaskCategories/{Task Category ID}"
-    }, 
+      "paged": "false",
+      "name": "Task Category",
+      "suffix": "/v3.0/TaskCategories/{Task Category ID}",
+      "description": "One task category by id."
+    },
     {
-      "paged": "true", 
-      "name": "Tasks", 
+      "paged": "true",
+      "name": "Tasks",
       "suffix": "/v3.0/Tasks?brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -1133,31 +1246,36 @@
           "key": "TASK_ID",
           "parameterName": "Task ID"
         }
-      ]
-    }, 
+      ],
+      "description": "The to-dos, with title, due date, completion, priority, the responsible user and the record each relates to. The forward-looking work."
+    },
     {
-      "paged": "false", 
-      "name": "Task", 
-      "suffix": "/v3.0/Tasks/{Task ID}"
-    }, 
+      "paged": "false",
+      "name": "Task",
+      "suffix": "/v3.0/Tasks/{Task ID}",
+      "description": "One task by id."
+    },
     {
-      "paged": "true", 
-      "name": "Task Comments", 
-      "suffix": "/v3.0/Tasks/{Task ID}/Comments?count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Task Comments",
+      "suffix": "/v3.0/Tasks/{Task ID}/Comments?count_total=true",
+      "description": "The comments on one task. Requires a task id."
+    },
     {
-      "paged": "false", 
-      "name": "Task Follow State", 
-      "suffix": "/v3.0/Tasks/{Task ID}/Follow"
-    }, 
+      "paged": "false",
+      "name": "Task Follow State",
+      "suffix": "/v3.0/Tasks/{Task ID}/Follow",
+      "description": "Whether the caller follows one task."
+    },
     {
-      "paged": "false", 
-      "name": "Task Links", 
-      "suffix": "/v3.0/Tasks/{Task ID}/Links"
-    }, 
+      "paged": "false",
+      "name": "Task Links",
+      "suffix": "/v3.0/Tasks/{Task ID}/Links",
+      "description": "The records one task is linked to."
+    },
     {
-      "paged": "true", 
-      "name": "Filtered Tasks", 
+      "paged": "true",
+      "name": "Filtered Tasks",
       "suffix": "/v3.0/Tasks/Search?field_name={Field Name?}&field_value={Field Value?}&updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&brief={Brief?:true|false}&count_total=true",
       "lookups": [
         {
@@ -1170,47 +1288,56 @@
           "key": "TASK_ID",
           "parameterName": "Task ID"
         }
-      ]
-    }, 
+      ],
+      "description": "Tasks matching field criteria."
+    },
     {
-      "paged": "true", 
-      "name": "Team Members", 
-      "suffix": "/v3.0/TeamMembers?count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Team Members",
+      "suffix": "/v3.0/TeamMembers?count_total=true",
+      "description": "The user-to-team memberships across the account."
+    },
     {
-      "paged": "false", 
-      "name": "Team Member", 
-      "suffix": "/v3.0/TeamMembers/{Team Member ID}"
-    }, 
+      "paged": "false",
+      "name": "Team Member",
+      "suffix": "/v3.0/TeamMembers/{Team Member ID}",
+      "description": "One team membership by id."
+    },
     {
-      "paged": "true", 
-      "name": "Teams", 
-      "suffix": "/v3.0/Teams?brief={Brief?:true|false}&count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Teams",
+      "suffix": "/v3.0/Teams?brief={Brief?:true|false}&count_total=true",
+      "description": "The teams users belong to. The grouping above individuals for reporting."
+    },
     {
-      "paged": "false", 
-      "name": "Team", 
-      "suffix": "/v3.0/Teams/{Team ID}"
-    }, 
+      "paged": "false",
+      "name": "Team",
+      "suffix": "/v3.0/Teams/{Team ID}",
+      "description": "One team by id."
+    },
     {
-      "paged": "true", 
-      "name": "Users", 
-      "suffix": "/v3.0/Users?count_total=true"
-    }, 
+      "paged": "true",
+      "name": "Users",
+      "suffix": "/v3.0/Users?count_total=true",
+      "description": "The users of the account, with name, email, whether active and administrative, and their timezone. Every record carries an owner and a responsible user, so this is the dimension per-person performance joins to."
+    },
     {
-      "paged": "false", 
-      "name": "User", 
-      "suffix": "/v3.0/Users/{User ID}"
-    }, 
+      "paged": "false",
+      "name": "User",
+      "suffix": "/v3.0/Users/{User ID}",
+      "description": "One user by id."
+    },
     {
-      "paged": "false", 
-      "name": "Current User", 
-      "suffix": "/v3.0/Users/Me"
-    }, 
+      "paged": "false",
+      "name": "Current User",
+      "suffix": "/v3.0/Users/Me",
+      "description": "The account the credentials belong to. One record, always the caller."
+    },
     {
-      "paged": "true", 
-      "name": "Filtered Users", 
-      "suffix": "/v3.0/Users/Search?field_name={Field Name?}&field_value={Field Value?}&updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&count_total=true"
+      "paged": "true",
+      "name": "Filtered Users",
+      "suffix": "/v3.0/Users/Search?field_name={Field Name?}&field_value={Field Value?}&updated_after_utc={Updated After?:YYYY-MM-DDTHH:MM:SSZ}&count_total=true",
+      "description": "Users matching field criteria."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/intervals/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/intervals/endpoints.json
@@ -1,289 +1,346 @@
 {
   "endpoints": [
     {
-      "paged": "true", 
-      "name": "Clients", 
-      "suffix": "/client?localid={Local ID?}&active={Active?:t|f}&search={Search Text?}&projectsonly={With Active Projects Only?:t|f}"
-    }, 
+      "paged": "true",
+      "name": "Clients",
+      "suffix": "/client?localid={Local ID?}&active={Active?:t|f}&search={Search Text?}&projectsonly={With Active Projects Only?:t|f}",
+      "description": "The client organisations, filterable by active state and search term. The billing entity projects belong to."
+    },
     {
-      "paged": "false", 
+      "paged": "false",
       "name": "Client",
-      "suffix": "/client/{Client ID}"
-    }, 
+      "suffix": "/client/{Client ID}",
+      "description": "One client by id."
+    },
     {
-      "paged": "false", 
-      "name": "Contact Descriptors", 
-      "suffix": "/contactdescriptor?contacttypeid={Contact Type ID?}"
-    }, 
+      "paged": "false",
+      "name": "Contact Descriptors",
+      "suffix": "/contactdescriptor?contacttypeid={Contact Type ID?}",
+      "description": "The descriptors within one contact type -- work, home, mobile. Requires the contact type id."
+    },
     {
-      "paged": "false", 
-      "name": "Contact Types", 
-      "suffix": "/contacttype"
-    }, 
+      "paged": "false",
+      "name": "Contact Types",
+      "suffix": "/contacttype",
+      "description": "The contact types available -- phone, email, address and so on. The decoder for a person contact's type."
+    },
     {
-      "paged": "false", 
-      "name": "Customers", 
-      "suffix": "/customer"
-    }, 
+      "paged": "false",
+      "name": "Customers",
+      "suffix": "/customer",
+      "description": "The customer contacts associated with clients. The people at a client, as opposed to the client itself."
+    },
     {
-      "paged": "true", 
-      "name": "Documents", 
-      "suffix": "/document?public={Visible to Executive-level Only?:t|f}&taskid={Task ID?}&milestoneid={Milestone ID?}&queueid={Queue ID?}&clientid={Client ID?}&projectid={Project ID?}&moduleid={Module ID?}&personId={Person ID?}&search={Search Text?}&projectactive={Active Projects?:t|f}&taskassignedorownedby={Tasks Assigned or Owned By?:Person ID}&tag={Tag?}&datebegin={Uploaded On or After?:yyyy-MM-dd}&dateend={Uploaded On or Before?:yyyy-MM-dd}"
-    }, 
+      "paged": "true",
+      "name": "Documents",
+      "suffix": "/document?public={Visible to Executive-level Only?:t|f}&taskid={Task ID?}&milestoneid={Milestone ID?}&queueid={Queue ID?}&clientid={Client ID?}&projectid={Project ID?}&moduleid={Module ID?}&personId={Person ID?}&search={Search Text?}&projectactive={Active Projects?:t|f}&taskassignedorownedby={Tasks Assigned or Owned By?:Person ID}&tag={Tag?}&datebegin={Uploaded On or After?:yyyy-MM-dd}&dateend={Uploaded On or Before?:yyyy-MM-dd}",
+      "description": "The documents stored, filterable by visibility and tags. Metadata rather than content."
+    },
     {
-      "paged": "false", 
-      "name": "Document", 
-      "suffix": "/document/{Document ID}"
-    }, 
+      "paged": "false",
+      "name": "Document",
+      "suffix": "/document/{Document ID}",
+      "description": "One document by id."
+    },
     {
-      "paged": "true", 
-      "name": "Expenses", 
-      "suffix": "/expense?projectid={Project ID?}&personid={Person ID?}&clientid={Client ID?}&managerid={Manager ID?}&datebegin={Passed On or After?:yyyy-MM-dd}&dateend={Passed On or Before?:yyyy-MM-dd}&date={Date Passed?:yyyy-MM-dd}"
-    }, 
+      "paged": "true",
+      "name": "Expenses",
+      "suffix": "/expense?projectid={Project ID?}&personid={Person ID?}&clientid={Client ID?}&managerid={Manager ID?}&datebegin={Passed On or After?:yyyy-MM-dd}&dateend={Passed On or Before?:yyyy-MM-dd}&date={Date Passed?:yyyy-MM-dd}",
+      "description": "The expenses recorded, filterable by project, person, client and date. Carries the amount, the expense type, whether billable, and the project. Project profitability is time cost plus these, so an expense-blind margin overstates it."
+    },
     {
-      "paged": "false", 
-      "name": "Expense", 
-      "suffix": "/expense/{Expense ID}"
-    }, 
+      "paged": "false",
+      "name": "Expense",
+      "suffix": "/expense/{Expense ID}",
+      "description": "One expense by id."
+    },
     {
-      "paged": "false", 
-      "name": "Groups", 
-      "suffix": "/group"
-    }, 
+      "paged": "false",
+      "name": "Groups",
+      "suffix": "/group",
+      "description": "The groups people belong to. The team dimension."
+    },
     {
-      "paged": "true", 
-      "name": "Invoices", 
-      "suffix": "/invoice?localid={Local ID?}&clientid={Client ID?}&projectid={Project ID?}&datebegin={Passed On or After?:yyyy-MM-dd}&dateend={Passed On or Before?:yyyy-MM-dd}&status={Status?:outstanding|paid}&search={Search Text?}"
-    }, 
+      "paged": "true",
+      "name": "Invoices",
+      "suffix": "/invoice?localid={Local ID?}&clientid={Client ID?}&projectid={Project ID?}&datebegin={Passed On or After?:yyyy-MM-dd}&dateend={Passed On or Before?:yyyy-MM-dd}&status={Status?:outstanding|paid}&search={Search Text?}",
+      "description": "The invoices issued, filterable by client, project and status. Carries the client, dates, status and totals. Only issued invoices are revenue; drafts are not."
+    },
     {
-      "paged": "false", 
-      "name": "Invoice", 
-      "suffix": "/invoice/{Invoice ID}"
-    }, 
+      "paged": "false",
+      "name": "Invoice",
+      "suffix": "/invoice/{Invoice ID}",
+      "description": "One invoice by id."
+    },
     {
-      "paged": "true", 
-      "name": "Invoice Items", 
-      "suffix": "/invoiceitem?invoiceid={Invoice ID?}"
-    }, 
+      "paged": "true",
+      "name": "Invoice Items",
+      "suffix": "/invoiceitem?invoiceid={Invoice ID?}",
+      "description": "The line items on one invoice, optionally filtered by invoice. Requires an invoice id in practice. What was billed, as opposed to the invoice total."
+    },
     {
-      "paged": "false", 
-      "name": "Invoice Item", 
-      "suffix": "/invoiceitem/{Invoice Item ID}"
-    }, 
+      "paged": "false",
+      "name": "Invoice Item",
+      "suffix": "/invoiceitem/{Invoice Item ID}",
+      "description": "One invoice item by id."
+    },
     {
-      "paged": "true", 
-      "name": "Invoice Notes", 
-      "suffix": "/invoicenote?invoiceid={Invoice ID?}&authorid={Author ID?}"
-    }, 
+      "paged": "true",
+      "name": "Invoice Notes",
+      "suffix": "/invoicenote?invoiceid={Invoice ID?}&authorid={Author ID?}",
+      "description": "Notes attached to invoices, filterable by invoice and author."
+    },
     {
-      "paged": "false", 
-      "name": "Invoice Note", 
-      "suffix": "/invoicenote/{Invoice Note ID}"
-    }, 
+      "paged": "false",
+      "name": "Invoice Note",
+      "suffix": "/invoicenote/{Invoice Note ID}",
+      "description": "One invoice note by id."
+    },
     {
-      "paged": "false", 
-      "name": "Invoice Terms", 
-      "suffix": "/invoiceterm"
-    }, 
+      "paged": "false",
+      "name": "Invoice Terms",
+      "suffix": "/invoiceterm",
+      "description": "The payment terms available. The decoder for an invoice's term, and what determines its due date."
+    },
     {
-      "paged": "false", 
-      "name": "Current User", 
-      "suffix": "/me"
-    }, 
+      "paged": "false",
+      "name": "Current User",
+      "suffix": "/me",
+      "description": "The account the credentials belong to, with its permissions. Worth reading first, since Intervals restricts visibility by role and two users legitimately see different rows."
+    },
     {
-      "paged": "true", 
-      "name": "Milestones", 
-      "suffix": "/milestone?localid={Local ID?}&search={Search Text?}&clientid={Client ID?}&projectid={Project ID?}&ownerid={Owner ID?}&hasmilestonerelation={Related To?:Person ID}&complete={Complete?:t|f}&dateduebegin={Due Date On or After?:yyyy-MM-dd}&datedueend={Due Date On or Before?:yyyy-MM-dd}&title={Title Contains?}"
-    }, 
+      "paged": "true",
+      "name": "Milestones",
+      "suffix": "/milestone?localid={Local ID?}&search={Search Text?}&clientid={Client ID?}&projectid={Project ID?}&ownerid={Owner ID?}&hasmilestonerelation={Related To?:Person ID}&complete={Complete?:t|f}&dateduebegin={Due Date On or After?:yyyy-MM-dd}&datedueend={Due Date On or Before?:yyyy-MM-dd}&title={Title Contains?}",
+      "description": "The project milestones, filterable by client, project and search term. Carries the title, date and the project it belongs to. The planning layer above tasks."
+    },
     {
-      "paged": "false", 
-      "name": "Milestone", 
-      "suffix": "/milestone/{Milestone ID}"
-    }, 
+      "paged": "false",
+      "name": "Milestone",
+      "suffix": "/milestone/{Milestone ID}",
+      "description": "One milestone by id."
+    },
     {
-      "paged": "true", 
-      "name": "Milestone Notes", 
-      "suffix": "/milestonenote?milestoneid={Milestone ID?}"
-    }, 
+      "paged": "true",
+      "name": "Milestone Notes",
+      "suffix": "/milestonenote?milestoneid={Milestone ID?}",
+      "description": "Notes on one milestone. Requires the milestone id."
+    },
     {
-      "paged": "false", 
-      "name": "Milestone Note", 
-      "suffix": "/milestonenote/{Milestone Note ID}"
-    }, 
+      "paged": "false",
+      "name": "Milestone Note",
+      "suffix": "/milestonenote/{Milestone Note ID}",
+      "description": "One milestone note by id."
+    },
     {
-      "paged": "true", 
-      "name": "Modules", 
-      "suffix": "/module?active={Active?:t|f}"
-    }, 
+      "paged": "true",
+      "name": "Modules",
+      "suffix": "/module?active={Active?:t|f}",
+      "description": "The module definitions available across the account, filterable by active state. The catalogue; which are enabled per project is in Project Modules."
+    },
     {
-      "paged": "false", 
-      "name": "Module", 
-      "suffix": "/module/{Module ID}"
-    }, 
+      "paged": "false",
+      "name": "Module",
+      "suffix": "/module/{Module ID}",
+      "description": "One module by id."
+    },
     {
-      "paged": "true", 
-      "name": "Payments", 
-      "suffix": "/payment?clientid={Client ID?}&projectid={Project ID?}&personid={Person ID?}&date={Date Passed?:yyyy-MM-dd}&typeid={Type ID?}&invoiceid={Invoice ID?}"
-    }, 
+      "paged": "true",
+      "name": "Payments",
+      "suffix": "/payment?clientid={Client ID?}&projectid={Project ID?}&personid={Person ID?}&date={Date Passed?:yyyy-MM-dd}&typeid={Type ID?}&invoiceid={Invoice ID?}",
+      "description": "The payments received, filterable by client, project and person. The invoice carries a balance; this says when money actually arrived, which is what a collection-time question needs."
+    },
     {
-      "paged": "false", 
-      "name": "Payment", 
-      "suffix": "/payment/{Payment ID}"
-    }, 
+      "paged": "false",
+      "name": "Payment",
+      "suffix": "/payment/{Payment ID}",
+      "description": "One payment by id."
+    },
     {
-      "paged": "false", 
-      "name": "Payment Types", 
-      "suffix": "/paymenttype"
-    }, 
+      "paged": "false",
+      "name": "Payment Types",
+      "suffix": "/paymenttype",
+      "description": "The payment methods configured. The decoder for a payment's type."
+    },
     {
-      "paged": "true", 
-      "name": "People", 
-      "suffix": "/person?localid={Local ID?}&username={Username?}&email={Email?}&firstname={First Name?}&lastname={Last Name?}&excludegroupids={Exclude Group IDs?:1,2,...}&projectid={Project IDs?:1,2,...}&clientid={Client IDs?:1,2,...}&projectclientid={Projects Belonging to Clients?:clientId1,clientId2,...}&search={Search Text?}&active={Active?:t|f}&groupId={Group ID?}&allprojects={Should be Added to All Future Projects?:t|f}&restricttasks={Restricted to Owned or Assigned Tasks?:t|f}"
-    }, 
+      "paged": "true",
+      "name": "People",
+      "suffix": "/person?localid={Local ID?}&username={Username?}&email={Email?}&firstname={First Name?}&lastname={Last Name?}&excludegroupids={Exclude Group IDs?:1,2,...}&projectid={Project IDs?:1,2,...}&clientid={Client IDs?:1,2,...}&projectclientid={Projects Belonging to Clients?:clientId1,clientId2,...}&search={Search Text?}&active={Active?:t|f}&groupId={Group ID?}&allprojects={Should be Added to All Future Projects?:t|f}&restricttasks={Restricted to Owned or Assigned Tasks?:t|f}",
+      "description": "The people in the account, filterable by username, email and active state. Carries name, email, role and active state."
+    },
     {
-      "paged": "false", 
-      "name": "Person", 
-      "suffix": "/person/{Person ID}"
-    }, 
+      "paged": "false",
+      "name": "Person",
+      "suffix": "/person/{Person ID}",
+      "description": "One person by id."
+    },
     {
-      "paged": "false", 
-      "name": "Person Contacts", 
-      "suffix": "/personcontact?personid={Person ID?}&contacttypeid={Contact Type ID?}&contactdescriptorid={Contact Descriptor ID?}"
-    }, 
+      "paged": "false",
+      "name": "Person Contacts",
+      "suffix": "/personcontact?personid={Person ID?}&contacttypeid={Contact Type ID?}&contactdescriptorid={Contact Descriptor ID?}",
+      "description": "The contact details recorded for one person, by contact type. Requires the person id."
+    },
     {
-      "paged": "false", 
-      "name": "Person Contact", 
-      "suffix": "/personcontact/{Person Contact ID}"
-    }, 
+      "paged": "false",
+      "name": "Person Contact",
+      "suffix": "/personcontact/{Person Contact ID}",
+      "description": "One person contact entry by id."
+    },
     {
-      "paged": "true", 
-      "name": "Projects", 
-      "suffix": "/project?localid={Local ID?}&clientid={Client ID?}&managerid={Manager ID?}&name={Name?}&datestart={Beginning On?:yyyy-MM-dd}&dateend={Ending On?:yyyy-MM-dd}&search={Search Text?}&active={Active?:t|f}&billable={Billable?:t|f}&personid={Accessable By?:Person ID}"
-    }, 
+      "paged": "true",
+      "name": "Projects",
+      "suffix": "/project?localid={Local ID?}&clientid={Client ID?}&managerid={Manager ID?}&name={Name?}&datestart={Beginning On?:yyyy-MM-dd}&dateend={Ending On?:yyyy-MM-dd}&search={Search Text?}&active={Active?:t|f}&billable={Billable?:t|f}&personid={Accessable By?:Person ID}",
+      "description": "The projects, filterable by client, manager and active state. Carries the name, client, manager, dates, and the budget. The container time and expenses are booked against."
+    },
     {
-      "paged": "false", 
-      "name": "Project", 
-      "suffix": "/project/{Project ID}"
-    }, 
+      "paged": "false",
+      "name": "Project",
+      "suffix": "/project/{Project ID}",
+      "description": "One project by id."
+    },
     {
-      "paged": "true", 
-      "name": "Project Modules", 
-      "suffix": "/projectmodule?projectid={Project ID}&active={Active?:t|f}&personid={Accessable By?:Person ID}"
-    }, 
+      "paged": "true",
+      "name": "Project Modules",
+      "suffix": "/projectmodule?projectid={Project ID}&active={Active?:t|f}&personid={Accessable By?:Person ID}",
+      "description": "The modules enabled on one project, with their budgets. Requires a project id. A MODULE IS INTERVALS'S SUB-PROJECT DIVISION -- phases or workstreams -- and budgets can be set per module, so project-level budget tracking misses where the overrun actually is."
+    },
     {
-      "paged": "false", 
-      "name": "Project Module", 
-      "suffix": "/projectmodule/{Project Module ID}"
-    }, 
+      "paged": "false",
+      "name": "Project Module",
+      "suffix": "/projectmodule/{Project Module ID}",
+      "description": "One project module by id."
+    },
     {
-      "paged": "true", 
-      "name": "Project Notes", 
-      "suffix": "/projectnote?localid={Local ID?}&clientid={Client ID?}&projectid={Project ID?}&authorid={Author ID?}&title={Title?}&search={Search Text?}&noteid={Note ID?}"
-    }, 
+      "paged": "true",
+      "name": "Project Notes",
+      "suffix": "/projectnote?localid={Local ID?}&clientid={Client ID?}&projectid={Project ID?}&authorid={Author ID?}&title={Title?}&search={Search Text?}&noteid={Note ID?}",
+      "description": "Notes recorded against projects, filterable by client, project and date. The narrative record of a project -- scope changes, client decisions, the reasons behind an overrun -- which no time or budget figure explains on its own."
+    },
     {
-      "paged": "false", 
-      "name": "Project Note", 
-      "suffix": "/projectnote/{Project Note ID}"
-    }, 
+      "paged": "false",
+      "name": "Project Note",
+      "suffix": "/projectnote/{Project Note ID}",
+      "description": "One project note by id."
+    },
     {
-      "paged": "true", 
-      "name": "Project Work Types", 
-      "suffix": "/projectworktype?projectid={Project ID?}&active={Active?:t|f}&personid={Person ID}"
-    }, 
+      "paged": "true",
+      "name": "Project Work Types",
+      "suffix": "/projectworktype?projectid={Project ID?}&active={Active?:t|f}&personid={Person ID}",
+      "description": "The work types enabled on one project, each with its own billable rate. Requires a project id. THE RATE THAT ACTUALLY APPLIES: a time entry carries hours and a work type, and this is what prices it -- so revenue is a join, and the same work type can be priced differently on two projects."
+    },
     {
-      "paged": "false", 
-      "name": "Project Work Type", 
-      "suffix": "/projectworktype/{Project Work Type ID}"
-    }, 
+      "paged": "false",
+      "name": "Project Work Type",
+      "suffix": "/projectworktype/{Project Work Type ID}",
+      "description": "One project work type by id."
+    },
     {
-      "paged": "true", 
-      "name": "Work Requests", 
-      "suffix": "/request?priorityid={Priority ID?}&personid={Person ID?}&projectid={Project ID?}"
-    }, 
+      "paged": "true",
+      "name": "Work Requests",
+      "suffix": "/request?priorityid={Priority ID?}&personid={Person ID?}&projectid={Project ID?}",
+      "description": "Incoming requests for work, filterable by priority, person and project. The intake queue before something becomes a task -- so demand that was never scheduled is only visible here."
+    },
     {
-      "paged": "false", 
-      "name": "Work Request", 
-      "suffix": "/request/{Work Request ID}"
-    }, 
+      "paged": "false",
+      "name": "Work Request",
+      "suffix": "/request/{Work Request ID}",
+      "description": "One work request by id."
+    },
     {
-      "paged": "true", 
-      "name": "Tasks", 
-      "suffix": "/task?localid={Local ID?}&personid={Person ID?}&assigneeid={Assignee ID?}&followerid={Follower ID?}&statusid={Status ID?}&clientid={Client ID?}&projectid={Project ID?}&moduleid={Module ID?}&milestoneid={Milestone ID?}&title={Title?}&dateopen={Opening On or After?:yyyy-MM-dd}&dateopenbegin={Starting After?:yyyy-MM-dd}&datedue={Date Due?:yyyy-MM-dd}&dateduebegin={Date Due After?:yyyy-MM-dd}&datedueend={Date Due Before?:yyyy-MM-dd}&dateclosed={Date Closed?:yyyy-MM-dd}&dateclosedbegin={Date Closed After?:yyyy-MM-dd}&dateclosedend={Date Closed Before?:yyyy-MM-dd}&hasduedate={Has Due Date?:t|f}&ownerid={Owner ID?}&priorityid={Priority ID?}&tasklistfilterid={Task List Filter ID?}&overdue={Overdue?:t|f}&excludeclosed={Exclude Closed?:t|f}&hastaskrelation={Related To?:Person ID}&search={Search Text?}"
-    }, 
+      "paged": "true",
+      "name": "Tasks",
+      "suffix": "/task?localid={Local ID?}&personid={Person ID?}&assigneeid={Assignee ID?}&followerid={Follower ID?}&statusid={Status ID?}&clientid={Client ID?}&projectid={Project ID?}&moduleid={Module ID?}&milestoneid={Milestone ID?}&title={Title?}&dateopen={Opening On or After?:yyyy-MM-dd}&dateopenbegin={Starting After?:yyyy-MM-dd}&datedue={Date Due?:yyyy-MM-dd}&dateduebegin={Date Due After?:yyyy-MM-dd}&datedueend={Date Due Before?:yyyy-MM-dd}&dateclosed={Date Closed?:yyyy-MM-dd}&dateclosedbegin={Date Closed After?:yyyy-MM-dd}&dateclosedend={Date Closed Before?:yyyy-MM-dd}&hasduedate={Has Due Date?:t|f}&ownerid={Owner ID?}&priorityid={Priority ID?}&tasklistfilterid={Task List Filter ID?}&overdue={Overdue?:t|f}&excludeclosed={Exclude Closed?:t|f}&hastaskrelation={Related To?:Person ID}&search={Search Text?}",
+      "description": "The tasks work is booked against, filterable by person, assignee, project, status and priority. Carries the title, project, module, assignees, estimated hours, status and priority."
+    },
     {
-      "paged": "false", 
-      "name": "Task", 
-      "suffix": "/task/{Task ID}"
-    }, 
+      "paged": "false",
+      "name": "Task",
+      "suffix": "/task/{Task ID}",
+      "description": "One task by id."
+    },
     {
-      "paged": "true", 
-      "name": "Task List Filters", 
-      "suffix": "/tasklistfilter"
-    }, 
+      "paged": "true",
+      "name": "Task List Filters",
+      "suffix": "/tasklistfilter",
+      "description": "The saved task filters defined. These encode the queues the team actually works from."
+    },
     {
-      "paged": "false", 
-      "name": "Task List Filter", 
-      "suffix": "/tasklistfilter/{Task List Filter ID}"
-    }, 
+      "paged": "false",
+      "name": "Task List Filter",
+      "suffix": "/tasklistfilter/{Task List Filter ID}",
+      "description": "One saved task filter by id."
+    },
     {
-      "paged": "true", 
-      "name": "Task Notes", 
-      "suffix": "/tasknote?taskid={Task ID?}&title={Title?}&date={Date Created?:yyyy-MM-dd}&datebegin={Created On or After?:yyyy-MM-dd}&dateend={Created On or Before?:yyyy-MM-dd}&datemodifiedbegin={Modified On or After?:yyyy-MM-dd}&datemodifiedend={Modified On or Before?:yyyy-MM-dd}&authorid={Author ID?}&public={Public?:t|f}"
-    }, 
+      "paged": "true",
+      "name": "Task Notes",
+      "suffix": "/tasknote?taskid={Task ID?}&title={Title?}&date={Date Created?:yyyy-MM-dd}&datebegin={Created On or After?:yyyy-MM-dd}&dateend={Created On or Before?:yyyy-MM-dd}&datemodifiedbegin={Modified On or After?:yyyy-MM-dd}&datemodifiedend={Modified On or Before?:yyyy-MM-dd}&authorid={Author ID?}&public={Public?:t|f}",
+      "description": "Notes on tasks, filterable by task, title and date. The discussion beside the task record."
+    },
     {
-      "paged": "false", 
-      "name": "Task Note", 
-      "suffix": "/tasknote/{Task Note ID}"
-    }, 
+      "paged": "false",
+      "name": "Task Note",
+      "suffix": "/tasknote/{Task Note ID}",
+      "description": "One task note by id."
+    },
     {
-      "paged": "true", 
-      "name": "Task Priorities", 
-      "suffix": "/taskpriority?active={Active?:t|f}"
-    }, 
+      "paged": "true",
+      "name": "Task Priorities",
+      "suffix": "/taskpriority?active={Active?:t|f}",
+      "description": "The task priorities configured. The decoder for a task's priority id."
+    },
     {
-      "paged": "false", 
-      "name": "Task Priority", 
-      "suffix": "/taskpriority/{Task Priority ID}"
-    }, 
+      "paged": "false",
+      "name": "Task Priority",
+      "suffix": "/taskpriority/{Task Priority ID}",
+      "description": "One task priority by id."
+    },
     {
-      "paged": "true", 
-      "name": "Task Statuses", 
-      "suffix": "/taskstatus?active={Active?:t|f}"
-    }, 
+      "paged": "true",
+      "name": "Task Statuses",
+      "suffix": "/taskstatus?active={Active?:t|f}",
+      "description": "The task statuses configured, filterable by active state. Account-specific, and the decoder for a task's status id."
+    },
     {
-      "paged": "false", 
-      "name": "Task Status", 
-      "suffix": "/taskstatus/{Task Status ID}"
-    }, 
+      "paged": "false",
+      "name": "Task Status",
+      "suffix": "/taskstatus/{Task Status ID}",
+      "description": "One task status by id."
+    },
     {
-      "paged": "true", 
-      "name": "Times", 
-      "suffix": "/time?activeonly={Active Only?:t|f}&moduleid={Module ID?}&taskid={Task ID?}&worktypeid={Work Type ID?}&personid={Person ID?}&clientid={Client ID?}&projectid={Project ID?}&milestoneid={Milestone ID?}&date={Date Passed?:yyyy-MM-dd}&datebegin={Pased On or After?:yyyy-MM-dd}&dateend={Passed On or Before?:yyyy-MM-dd}&billable={Billable?:t|f}&approved={Approved?:t|f}"
-    }, 
+      "paged": "true",
+      "name": "Times",
+      "suffix": "/time?activeonly={Active Only?:t|f}&moduleid={Module ID?}&taskid={Task ID?}&worktypeid={Work Type ID?}&personid={Person ID?}&clientid={Client ID?}&projectid={Project ID?}&milestoneid={Milestone ID?}&date={Date Passed?:yyyy-MM-dd}&datebegin={Pased On or After?:yyyy-MM-dd}&dateend={Passed On or Before?:yyyy-MM-dd}&billable={Billable?:t|f}&approved={Approved?:t|f}",
+      "description": "The time entries recorded -- the central table. Carries the person, project, module, work type, task, the date, HOURS AS A DECIMAL, the billable flag, and whether it has been invoiced. Filterable by module, person, project and date. NOTE THE INVOICED FLAG: once time is billed it is locked to an invoice, so unbilled work in progress and already-invoiced revenue are distinguished here and nowhere else."
+    },
     {
-      "paged": "false", 
-      "name": "Time", 
-      "suffix": "/time/{Time ID}"
-    }, 
+      "paged": "false",
+      "name": "Time",
+      "suffix": "/time/{Time ID}",
+      "description": "One time entry by id."
+    },
     {
-      "paged": "true", 
-      "name": "Timers", 
-      "suffix": "/timer?generaltimers={General Timers?:t|f}&gettimerinfo={Include Timer Info?:t|f}&taskid={Task ID?}&personid={Person ID?}&projectid={Project ID?}&clientid={Client ID?}"
-    }, 
+      "paged": "true",
+      "name": "Timers",
+      "suffix": "/timer?generaltimers={General Timers?:t|f}&gettimerinfo={Include Timer Info?:t|f}&taskid={Task ID?}&personid={Person ID?}&projectid={Project ID?}&clientid={Client ID?}",
+      "description": "The timers currently running, optionally with their detail. A live view of who is working on what right now, not history -- a running timer has produced no time entry yet, so work in progress is invisible in the Times table until it is stopped."
+    },
     {
-      "paged": "false", 
-      "name": "Timer", 
-      "suffix": "/timer/{Timer ID}"
-    }, 
+      "paged": "false",
+      "name": "Timer",
+      "suffix": "/timer/{Timer ID}",
+      "description": "One timer by id."
+    },
     {
-      "paged": "true", 
-      "name": "Work Types", 
-      "suffix": "/worktype?active={Active?:t|f}"
-    }, 
+      "paged": "true",
+      "name": "Work Types",
+      "suffix": "/worktype?active={Active?:t|f}",
+      "description": "The work type definitions across the account -- design, development, project management -- with their default rates. The catalogue behind the per-project overrides."
+    },
     {
-      "paged": "false", 
-      "name": "Work Type", 
-      "suffix": "/worktype/{Work Type ID}"
+      "paged": "false",
+      "name": "Work Type",
+      "suffix": "/worktype/{Work Type ID}",
+      "description": "One work type by id."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/jive/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/jive/endpoints.json
@@ -1298,7 +1298,7 @@
       "name": "Place Topics",
       "paged": true,
       "suffix": "/api/core/v3/placeTopics",
-      "description": "The topics of one place. Requires the place id."
+      "description": "The place topics defined across the community. Topics are the subject labels places are tagged with, so this is the community-wide vocabulary; one topic by id comes from Place Topic."
     },
     {
       "name": "Publication",
@@ -1442,7 +1442,7 @@
       "name": "Slides",
       "paged": true,
       "suffix": "/api/core/v3/slides",
-      "description": "The slides of one presentation object. Requires the content id."
+      "description": "The slides held across the community's presentation content. The per-slide detail comes from Slide."
     },
     {
       "name": "Banner",
@@ -1682,7 +1682,7 @@
       "name": "Vitals",
       "paged": true,
       "suffix": "/api/core/v3/vitals",
-      "description": "The vital statistics of one object -- view, like, comment and follower counts in one call. Requires the object id. THE CHEAP ENGAGEMENT SUMMARY: it avoids fetching the likes, comments and followers separately when only the totals are wanted."
+      "description": "Vital statistics -- view, like, comment and follower counts -- for content across the community. THE CHEAP ENGAGEMENT SUMMARY: it avoids fetching likes, comments and followers separately when only the totals are wanted."
     },
     {
       "name": "Votes",

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/jive/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/jive/endpoints.json
@@ -3,17 +3,20 @@
     {
       "name": "Abuse Report",
       "paged": false,
-      "suffix": "/api/core/v3/abuseReports/{Report ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/abuseReports/{Report ID}?fields={Fields?}",
+      "description": "One abuse report by id, with the reporter and the object reported. Community moderation, and the record behind removed content."
     },
     {
       "name": "Acclaims",
       "paged": true,
-      "suffix": "/api/core/v3/acclaim?before={Before?:yyyy-MM-dd'T'HH:mm:ssZ}"
+      "suffix": "/api/core/v3/acclaim?before={Before?:yyyy-MM-dd'T'HH:mm:ssZ}",
+      "description": "The acclaim awarded within the community. Recognition at the community level."
     },
     {
       "name": "Action",
       "paged": false,
-      "suffix": "/api/core/v3/actions/{Action ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/actions/{Action ID}?fields={Fields?}",
+      "description": "One action by id."
     },
     {
       "name": "Actions",
@@ -28,47 +31,56 @@
           "key": "id",
           "parameterName": "Action ID"
         }
-      ]
+      ],
+      "description": "The actionable items assigned to the calling user -- approvals, mentions, tasks awaiting response. The personal work queue."
     },
     {
       "name": "Actions Counts",
       "paged": false,
-      "suffix": "/api/core/v3/actions/counts"
+      "suffix": "/api/core/v3/actions/counts",
+      "description": "How many actions are outstanding, by type. The badge counts, without fetching the items."
     },
     {
       "name": "Activities",
       "paged": true,
-      "suffix": "/api/core/v3/activities?filter={Filter?:author|notifications|object|type|unread|verb}&before={Before?:yyyy-MM-dd'T'HH:mm:ssZ}&after={After?:yyyy-MM-dd'T'HH:mm:ssZ}&fields={Fields?}&collapse={Collapse?:false|true}&oldestUnread={Oldest Unread?:false|true}"
+      "suffix": "/api/core/v3/activities?filter={Filter?:author|notifications|object|type|unread|verb}&before={Before?:yyyy-MM-dd'T'HH:mm:ssZ}&after={After?:yyyy-MM-dd'T'HH:mm:ssZ}&fields={Fields?}&collapse={Collapse?:false|true}&oldestUnread={Oldest Unread?:false|true}",
+      "description": "The community activity stream -- every action taken, with the actor, the verb, the object acted on and the timestamp. THE BEHAVIOURAL RECORD, as opposed to the content tables which hold what exists: who read, liked, commented, followed and created, and when. Filterable by time and by activity type. Note streams have a retention window, so this is not a permanent history."
     },
     {
       "name": "Activities Count",
       "paged": false,
-      "suffix": "/api/core/v3/activities/count?after={After?:yyyy-MM-dd'T'HH:mm:ssZ}&max={Max Number?}&exclude={Exclude?:false|true}"
+      "suffix": "/api/core/v3/activities/count?after={After?:yyyy-MM-dd'T'HH:mm:ssZ}&max={Max Number?}&exclude={Exclude?:false|true}",
+      "description": "How many activities match given filters, without returning them. The cheap size check."
     },
     {
       "name": "Frequent Content",
       "paged": true,
-      "suffix": "/api/core/v3/activities/frequent/content?fields={Fields?}&filter={Filter?}&abridged={Abridged?:false|true}"
+      "suffix": "/api/core/v3/activities/frequent/content?fields={Fields?}&filter={Filter?}&abridged={Abridged?:false|true}",
+      "description": "The content the calling user interacts with most. Personalised."
     },
     {
       "name": "Frequent People",
       "paged": true,
-      "suffix": "/api/core/v3/activities/frequent/people?fields={Fields?}"
+      "suffix": "/api/core/v3/activities/frequent/people?fields={Fields?}",
+      "description": "The people the calling user interacts with most. Personalised -- and one of the few endpoints that measures working relationships rather than declared ones."
     },
     {
       "name": "Frequent Places",
       "paged": true,
-      "suffix": "/api/core/v3/activities/frequent/places?fields={Fields?}"
+      "suffix": "/api/core/v3/activities/frequent/places?fields={Fields?}",
+      "description": "The places the calling user visits most. Personalised."
     },
     {
       "name": "Add On",
       "paged": true,
-      "suffix": "/api/core/v3/addOns/{AddOn UUID}?fields={Fields?}"
+      "suffix": "/api/core/v3/addOns/{AddOn UUID}?fields={Fields?}",
+      "description": "One add-on by id, with its status. Add-ons provide tiles, external streams and app content, so this explains community features and data that Jive itself did not produce."
     },
     {
       "name": "Plugin",
       "paged": false,
-      "suffix": "/api/core/v3/admin/plugins/{Plugin Name}?fields={Fields?}"
+      "suffix": "/api/core/v3/admin/plugins/{Plugin Name}?fields={Fields?}",
+      "description": "One plugin by id."
     },
     {
       "name": "Plugins",
@@ -83,17 +95,20 @@
           "key": "pluginID",
           "parameterName": "Plugin Name"
         }
-      ]
+      ],
+      "description": "The plugins installed on the instance. Administrative inventory."
     },
     {
       "name": "Profile Field",
       "paged": false,
-      "suffix": "/api/core/v3/admin/profileFields/{Profile Field ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/admin/profileFields/{Profile Field ID}?fields={Fields?}",
+      "description": "One profile field by id."
     },
     {
       "name": "Profile Field Name",
       "paged": false,
-      "suffix": "/api/core/v3/admin/profileFields/@name?fields={Fields?}"
+      "suffix": "/api/core/v3/admin/profileFields/@name?fields={Fields?}",
+      "description": "One profile field by name."
     },
     {
       "name": "Profile Fields",
@@ -108,7 +123,8 @@
           "key": "profileFieldID",
           "parameterName": "Profile Field ID"
         }
-      ]
+      ],
+      "description": "The profile fields configured community-wide, with their types and whether each is searchable. THE DECODER for the profile field values on a person, and the statement of what the organisation records about people."
     },
     {
       "name": "Properties",
@@ -123,17 +139,20 @@
           "key": "id",
           "parameterName": "Property Name"
         }
-      ]
+      ],
+      "description": "The system properties of the instance. Administrative configuration, and worth checking when a feature-dependent endpoint returns nothing."
     },
     {
       "name": "Property",
       "paged": false,
-      "suffix": "/api/core/v3/admin/properties/{Property Name}?fields={Fields?}"
+      "suffix": "/api/core/v3/admin/properties/{Property Name}?fields={Fields?}",
+      "description": "One system property by name."
     },
     {
       "name": "Announcement",
       "paged": false,
-      "suffix": "/api/core/v3/announcements/{Announcement ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/announcements/{Announcement ID}?fields={Fields?}",
+      "description": "One announcement by id, with its body and the place it applies to."
     },
     {
       "name": "System Announcements",
@@ -148,517 +167,620 @@
           "key": "id",
           "parameterName": "Announcement ID"
         }
-      ]
+      ],
+      "description": "The community-wide announcements currently active. Administrative communication rather than user content."
     },
     {
       "name": "Attachment",
       "paged": false,
-      "suffix": "/api/core/v3/attachments/{Attachment ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/attachments/{Attachment ID}?fields={Fields?}",
+      "description": "One attachment by id."
     },
     {
       "name": "Attachments",
       "paged": true,
-      "suffix": "/api/core/v3/attachments/contents/{Content ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/attachments/contents/{Content ID}?fields={Fields?}",
+      "description": "The attachments on one object. Requires the object id. Metadata; binaries are separate."
     },
     {
       "name": "Event Calendar",
       "paged": false,
-      "suffix": "/api/core/v3/calendar/{Place ID}"
+      "suffix": "/api/core/v3/calendar/{Place ID}",
+      "description": "The calendar of events in the community, with their dates and places. Events are content with a schedule, so they appear in the content tables too -- this is the time-ordered view."
     },
     {
       "name": "Check Points",
       "paged": true,
-      "suffix": "/api/core/v3/checkpoints/{Project ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/checkpoints/{Project ID}?fields={Fields?}",
+      "description": "The checkpoints of one video, marking positions viewers reached. Requires the video id. Video engagement depth, as opposed to view counts."
     },
     {
       "name": "Collaboration",
       "paged": false,
-      "suffix": "/api/core/v3/collaborations/{Collaboration ID}"
+      "suffix": "/api/core/v3/collaborations/{Collaboration ID}",
+      "description": "One collaboration session by id -- Jive's real-time co-editing record."
     },
     {
       "name": "Collaboration by External ID",
       "paged": false,
-      "suffix": "/api/core/v3/collaborations/ext/{External ID}"
+      "suffix": "/api/core/v3/collaborations/ext/{External ID}",
+      "description": "One collaboration by the external system's identifier."
     },
     {
       "name": "Interaction",
       "paged": false,
-      "suffix": "/api/core/v3/collaborations/interactions/{Interaction ID}"
+      "suffix": "/api/core/v3/collaborations/interactions/{Interaction ID}",
+      "description": "One interaction by id."
     },
     {
       "name": "Interaction Optionally With Context",
       "paged": false,
-      "suffix": "/api/core/v3/collaborations/{Collaboration ID}/interactions/{Interaction ID}"
+      "suffix": "/api/core/v3/collaborations/{Collaboration ID}/interactions/{Interaction ID}",
+      "description": "One interaction with its surrounding context, where available."
     },
     {
       "name": "Interactions",
       "paged": true,
-      "suffix": "/api/core/v3/collaborations/{Collaboration ID}/interactions"
+      "suffix": "/api/core/v3/collaborations/{Collaboration ID}/interactions",
+      "description": "The interactions within collaborations -- the individual actions taken in a session. Fine-grained collaboration telemetry."
     },
     {
       "name": "Participants",
       "paged": true,
-      "suffix": "/api/core/v3/collaborations/{Collaboration ID}/participants"
+      "suffix": "/api/core/v3/collaborations/{Collaboration ID}/participants",
+      "description": "Who took part in one collaboration. Requires the collaboration id."
     },
     {
       "name": "Abuse Reports for Comment",
       "paged": true,
-      "suffix": "/api/core/v3/comments/{Comment ID}/abuseReports?fields={Fields?}"
+      "suffix": "/api/core/v3/comments/{Comment ID}/abuseReports?fields={Fields?}",
+      "description": "The abuse reports raised against one comment. Requires the comment id."
     },
     {
       "name": "Comment",
       "paged": false,
-      "suffix": "/api/core/v3/comments/{Comment ID}?fields={Fields?}&abridged={Abridged?:false|true}"
+      "suffix": "/api/core/v3/comments/{Comment ID}?fields={Fields?}&abridged={Abridged?:false|true}",
+      "description": "One comment by id, with its body and author."
     },
     {
       "name": "Comment Likes",
       "paged": true,
-      "suffix": "/api/core/v3/comments/{Comment ID}/likes?fields={Fields?}"
+      "suffix": "/api/core/v3/comments/{Comment ID}/likes?fields={Fields?}",
+      "description": "Who liked one comment. Requires the comment id."
     },
     {
       "name": "Comment Comments",
       "paged": true,
-      "suffix": "/api/core/v3/comments/{Comment ID}/comments?fields={Fields?}&anchor={Anchor?}&excludeReplies={Exclude Replies?:false|true}"
+      "suffix": "/api/core/v3/comments/{Comment ID}/comments?fields={Fields?}&anchor={Anchor?}&excludeReplies={Exclude Replies?:false|true}",
+      "description": "The replies to one comment. Requires the comment id. Comments nest, so a full thread means walking this."
     },
     {
       "name": "Editable Comment",
       "paged": false,
-      "suffix": "/api/core/v3/comments/{Comment ID}/editable?fields={Fields?}"
+      "suffix": "/api/core/v3/comments/{Comment ID}/editable?fields={Fields?}",
+      "description": "Whether the calling user may edit one comment. A permission check."
     },
     {
       "name": "Comment Marked Helpful",
       "paged": true,
-      "suffix": "/api/core/v3/comments/{Comment ID}/helpful?fields={Fields?}"
+      "suffix": "/api/core/v3/comments/{Comment ID}/helpful?fields={Fields?}",
+      "description": "Whether one comment is marked helpful, and by whom. Requires the comment id. IN A SUPPORT COMMUNITY THIS IS THE QUALITY SIGNAL -- a helpful mark says an answer worked, which no like count conveys."
     },
     {
       "name": "Comment Marked Unhelpful",
       "paged": true,
-      "suffix": "/api/core/v3/comments/{Comment ID}/unhelpful?fields={Fields?}"
+      "suffix": "/api/core/v3/comments/{Comment ID}/unhelpful?fields={Fields?}",
+      "description": "Whether one comment is marked unhelpful. The negative signal, and worth reading alongside the positive rather than instead of it."
     },
     {
       "name": "Comment Outcome Types",
       "paged": true,
-      "suffix": "/api/core/v3/comments/{Comment ID}/outcomeTypes?fields={Fields?}"
+      "suffix": "/api/core/v3/comments/{Comment ID}/outcomeTypes?fields={Fields?}",
+      "description": "The outcome types applicable to one comment. Requires the comment id."
     },
     {
       "name": "Abuse Reports for Content",
       "paged": true,
-      "suffix": "/api/core/v3/contents/{Content ID}/abuseReports?fields={Fields?}"
+      "suffix": "/api/core/v3/contents/{Content ID}/abuseReports?fields={Fields?}",
+      "description": "The abuse reports raised against one content object. Requires the content id. Moderation, and the explanation for content that disappeared."
     },
     {
       "name": "Child Outcome Types",
       "paged": true,
-      "suffix": "/api/core/v3/contents/{Content ID}/childOutcomeTypes?fields={Fields?}&isCreate={Is Create?:false|true}"
+      "suffix": "/api/core/v3/contents/{Content ID}/childOutcomeTypes?fields={Fields?}&isCreate={Is Create?:false|true}",
+      "description": "The outcome types applicable to the children of one content object. Requires the content id."
     },
     {
       "name": "Content Comments",
       "paged": true,
-      "suffix": "/api/core/v3/contents/{Content ID}/comments?filter={Filter?:outcomeType}&fields={Fields?}&anchor={Anchor?}&excludeReplies={Exclude Replies?:false|true}&hierarchical={Hierarchical?:true|false}&author={Author?:false|true}&inline={Inline?:false|true}"
+      "suffix": "/api/core/v3/contents/{Content ID}/comments?filter={Filter?:outcomeType}&fields={Fields?}&anchor={Anchor?}&excludeReplies={Exclude Replies?:false|true}&hierarchical={Hierarchical?:true|false}&author={Author?:false|true}&inline={Inline?:false|true}",
+      "description": "The comments on one content object. Requires the content id. Where discussion beneath a document or blog post lives."
     },
     {
       "name": "Content Data",
       "paged": false,
-      "suffix": "/api/core/v3/contents/{Content ID}/data"
+      "suffix": "/api/core/v3/contents/{Content ID}/data",
+      "description": "One content object by id, with its full body and metadata. Requires the content id."
     },
     {
       "name": "Content Followers",
       "paged": false,
-      "suffix": "/api/core/v3/contents/{Content ID}/followers?fields={Fields?}"
+      "suffix": "/api/core/v3/contents/{Content ID}/followers?fields={Fields?}",
+      "description": "Who follows one content object. Requires the content id. Following is Jive's subscription mechanism, so this is the audience that gets notified about a document."
     },
     {
       "name": "Content Following In",
       "paged": true,
-      "suffix": "/api/core/v3/contents/{Content ID}/followingIn?fields={Fields?}"
+      "suffix": "/api/core/v3/contents/{Content ID}/followingIn?fields={Fields?}",
+      "description": "The streams one content object is being followed in. Requires the content id."
     },
     {
       "name": "Content Likes",
       "paged": true,
-      "suffix": "/api/core/v3/contents/{Content ID}/likes?fields={Fields?}"
+      "suffix": "/api/core/v3/contents/{Content ID}/likes?fields={Fields?}",
+      "description": "Who liked one content object. Requires the content id. The content record carries a like count; this is who they were."
     },
     {
       "name": "Contents",
       "paged": true,
-      "suffix": "/api/core/v3/contents?filter={Filter?}&fields={Fields?}&abridged={Abridged?:false|true}&includeBlogs={Include Blogs?:false|true}"
+      "suffix": "/api/core/v3/contents?filter={Filter?}&fields={Fields?}&abridged={Abridged?:false|true}&includeBlogs={Include Blogs?:false|true}",
+      "description": "ALL CONTENT IN THE COMMUNITY IN ONE TABLE -- documents, discussions, blog posts, polls, ideas, files, videos and status updates are every one of them 'content', told apart by a TYPE field. This polymorphism is the defining fact of the Jive API and it repeats for places and activities: one endpoint, many shapes, and a type discriminator deciding which fields are even present. So any question about a particular kind of content is a filter on type, and a count taken without one counts everything the community has ever produced. TWO OTHER THINGS APPLY THROUGHOUT. The FILTER parameter takes Jive's own syntax -- type(document), place(...), search(...), tag(...) -- and is the only real query mechanism. And the FIELDS parameter decides which fields come back: Jive returns a default subset, so most of a content object is absent unless named."
     },
     {
       "name": "Editable Content",
       "paged": false,
-      "suffix": "/api/core/v3/contents/{Content ID}/editable?fields={Fields?}"
+      "suffix": "/api/core/v3/contents/{Content ID}/editable?fields={Fields?}",
+      "description": "The content the calling user may edit. A permission view, scoped to the caller."
     },
     {
       "name": "Featured Content",
       "paged": true,
-      "suffix": "/api/core/v3/contents/featured?filter={Filter?:place|type}&fields={Fields?}&abridged={Abridged?:false|true}"
+      "suffix": "/api/core/v3/contents/featured?filter={Filter?:place|type}&fields={Fields?}&abridged={Abridged?:false|true}",
+      "description": "The content editorially marked as featured. A human choice rather than a computed one."
     },
     {
       "name": "My Entitlements",
       "paged": true,
-      "suffix": "/api/core/v3/contents/{Content ID}/entitlements?fields={Fields?}"
+      "suffix": "/api/core/v3/contents/{Content ID}/entitlements?fields={Fields?}",
+      "description": "The permissions the calling user holds on one content object. Requires the content id. Why the caller can or cannot act on it."
     },
     {
       "name": "Content Outcomes",
       "paged": true,
-      "suffix": "/api/core/v3/contents/{Content ID}/outcomes?fields={Fields?}&includeChildrenOutcomes={Include?:false|true}"
+      "suffix": "/api/core/v3/contents/{Content ID}/outcomes?fields={Fields?}&includeChildrenOutcomes={Include?:false|true}",
+      "description": "The outcomes marked on one content object -- resolved, decision, action item, success and the rest. Requires the content id. OUTCOMES ARE HOW JIVE RECORDS THAT SOMETHING WAS SETTLED: a discussion with an answer is distinguished from one without only by an outcome, so question-resolution rates depend entirely on this table."
     },
     {
       "name": "Content Outcome Types",
       "paged": true,
-      "suffix": "/api/core/v3/contents/{Content ID}/outcomeTypes?fields={Fields?}"
+      "suffix": "/api/core/v3/contents/{Content ID}/outcomeTypes?fields={Fields?}",
+      "description": "The outcome types that may be applied to one content object. Requires the content id. Which outcomes are permitted depends on the content type, so this is the per-object vocabulary."
     },
     {
       "name": "Popular Content",
       "paged": true,
-      "suffix": "/api/core/v3/contents/popular"
+      "suffix": "/api/core/v3/contents/popular",
+      "description": "The content ranked by engagement over a period. Jive's own popularity calculation rather than a raw count."
     },
     {
       "name": "Preview Image",
       "paged": false,
-      "suffix": "/api/core/v3/contents/{Content ID}/previewImage?size={Size?}&returnDefaultImageWhenNoPreviewAvailable={Preview Available?}"
+      "suffix": "/api/core/v3/contents/{Content ID}/previewImage?size={Size?}&returnDefaultImageWhenNoPreviewAvailable={Preview Available?}",
+      "description": "The preview image of one content object. Requires the content id. Presentation."
     },
     {
       "name": "Recent Content",
       "paged": true,
-      "suffix": "/api/core/v3/contents/recent?filter={Filter?:place|type}&fields={Fields?}&abridged={Abridged?:false|true}"
+      "suffix": "/api/core/v3/contents/recent?filter={Filter?:place|type}&fields={Fields?}&abridged={Abridged?:false|true}",
+      "description": "The content most recently created or modified across the community. The incremental view, and the practical entry point when the question is about what changed."
     },
     {
       "name": "Recommended Content",
       "paged": true,
-      "suffix": "/api/core/v3/contents/recommended?fields={Fields?}&abridged={Abridged?:false|true}"
+      "suffix": "/api/core/v3/contents/recommended?fields={Fields?}&abridged={Abridged?:false|true}",
+      "description": "Content Jive recommends to the calling user. Personalised, so it describes the caller rather than the community."
     },
     {
       "name": "Trending Content",
       "paged": true,
-      "suffix": "/api/core/v3/contents/trending?filter={Filter?:place|type}&fields={Fields?}&abridged={Abridged?:false|true}"
+      "suffix": "/api/core/v3/contents/trending?filter={Filter?:place|type}&fields={Fields?}&abridged={Abridged?:false|true}",
+      "description": "The content gaining engagement fastest right now. Distinct from popular: trending is about acceleration, popular about volume, and a piece of content can be one without the other."
     },
     {
       "name": "User Entitlements",
       "paged": true,
-      "suffix": "/api/core/v3/contents/{Content ID}/entitlements/{Person ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/contents/{Content ID}/entitlements/{Person ID}?fields={Fields?}",
+      "description": "The permissions a named user holds on one content object. Requires the content id."
     },
     {
       "name": "Deleted Contents",
       "paged": true,
-      "suffix": "/api/core/v3/deletedObjects/contents?filter={Filter?:since|type}&fields={Fields?}"
+      "suffix": "/api/core/v3/deletedObjects/contents?filter={Filter?:since|type}&fields={Fields?}",
+      "description": "The content deleted since a given time. THE ONLY WAY A SYNCHRONISED COPY LEARNS THAT CONTENT HAS GONE -- deletions leave no trace in the content tables, so a downstream store diverges silently without this."
     },
     {
       "name": "Deleted Object",
       "paged": false,
-      "suffix": "/api/core/v3/deletedObjects/{Deleted Object ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/deletedObjects/{Deleted Object ID}?fields={Fields?}",
+      "description": "One deleted object's record, by id."
     },
     {
       "name": "Deleted People",
       "paged": true,
-      "suffix": "/api/core/v3/deletedObjects/people?filter={Filter?:since}&fields={Fields?}"
+      "suffix": "/api/core/v3/deletedObjects/people?filter={Filter?:since}&fields={Fields?}",
+      "description": "The people deleted since a given time."
     },
     {
       "name": "Deleted Places",
       "paged": true,
-      "suffix": "/api/core/v3/deletedObjects/places?filter={Filter?:since|type}&fields={Fields?}"
+      "suffix": "/api/core/v3/deletedObjects/places?filter={Filter?:since|type}&fields={Fields?}",
+      "description": "The places deleted since a given time."
     },
     {
       "name": "Direct Message Comments",
       "paged": true,
-      "suffix": "/api/core/v3 /dms/{Direct Message ID}/comments?filter={Filter?}&fields={Fields?}&anchor={Anchor?}&excludeReplies={Exclude Replies?:false|true}&hierarchical={Hierarchical?:true|false}"
+      "suffix": "/api/core/v3/dms/{Direct Message ID}/comments?filter={Filter?}&fields={Fields?}&anchor={Anchor?}&excludeReplies={Exclude Replies?:false|true}&hierarchical={Hierarchical?:true|false}",
+      "description": "The replies within one direct message thread. Requires the message id."
     },
     {
       "name": "Direct Message Images",
       "paged": true,
-      "suffix": "/api/core/v3/dms/{Direct Message ID}/images?fields={Fields?}"
+      "suffix": "/api/core/v3/dms/{Direct Message ID}/images?fields={Fields?}",
+      "description": "The images within one direct message. Requires the message id."
     },
     {
       "name": "Direct Message",
       "paged": false,
-      "suffix": "/api/core/v3/dms/{Direct Message ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/dms/{Direct Message ID}?fields={Fields?}",
+      "description": "One direct message by id. Private messages between users, invisible in the content and activity tables, which is why community-wide engagement figures understate real communication."
     },
     {
       "name": "Event Type",
       "paged": false,
-      "suffix": "/api/core/v3/eventTypes/{Event Type ID}"
+      "suffix": "/api/core/v3/eventTypes/{Event Type ID}",
+      "description": "One event type by id."
     },
     {
       "name": "Event Types",
       "paged": true,
-      "suffix": "/api/core/v3/eventTypes"
+      "suffix": "/api/core/v3/eventTypes",
+      "description": "The event types configured. The decoder for an event's type."
     },
     {
       "name": "External Stream Definition",
       "paged": false,
-      "suffix": "/api/core/v3/extstreamDefs/{Definition ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/extstreamDefs/{Definition ID}?fields={Fields?}",
+      "description": "One external stream definition by id."
     },
     {
       "name": "External Stream Definition I18n Resource",
       "paged": false,
-      "suffix": "/api/core/v3/extstreamDefs/{Definition ID}/i18n/{Language?}/{Country?}"
+      "suffix": "/api/core/v3/extstreamDefs/{Definition ID}/i18n/{Language?}/{Country?}",
+      "description": "The translated strings of one external stream definition."
     },
     {
       "name": "External Stream Definitions",
       "paged": true,
-      "suffix": "/api/core/v3/extstreamDefs?filter={Filter?:name|addonUUID|state}&fields={Fields?}"
+      "suffix": "/api/core/v3/extstreamDefs?filter={Filter?:name|addonUUID|state}&fields={Fields?}",
+      "description": "The external stream types add-ons provide."
     },
     {
       "name": "Prototype",
       "paged": false,
-      "suffix": "/api/core/v3/extstreamDefs/{Definition ID}/prototype?fields={Fields?}"
+      "suffix": "/api/core/v3/extstreamDefs/{Definition ID}/prototype?fields={Fields?}",
+      "description": "A prototype external stream object. Scaffolding."
     },
     {
       "name": "External Stream Tile Category",
       "paged": false,
-      "suffix": "/api/core/v3/extstreamDefs/category/{Tile Category ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/extstreamDefs/category/{Tile Category ID}?fields={Fields?}",
+      "description": "The tile category associated with an external stream definition."
     },
     {
       "name": "Specified External Stream Instance",
       "paged": false,
-      "suffix": "/api/core/v3/extstreams/{Definition ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/extstreams/{Definition ID}?fields={Fields?}",
+      "description": "One external stream instance by id."
     },
     {
       "name": "Instance by External ID",
       "paged": false,
-      "suffix": "/api/core/v3/extstreams/external/{Extension UUID}/{External ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/extstreams/external/{Extension UUID}/{External ID}?fields={Fields?}",
+      "description": "One external stream instance by the external system's identifier."
     },
     {
       "name": "External Stream Instances",
       "paged": true,
-      "suffix": "/api/core/v3/extstreams?filter={Filter:tilePage}&fields={Fields?}"
+      "suffix": "/api/core/v3/extstreams?filter={Filter:tilePage}&fields={Fields?}",
+      "description": "The external stream instances configured -- integrations pushing activity from other systems into Jive streams. WHERE ACTIVITY FROM OUTSIDE JIVE ENTERS: the activity tables include these, so an activity count spans systems, and this is what says which."
     },
     {
       "name": "External Stream Private Properties",
       "paged": true,
-      "suffix": "/api/core/v3/extstreams/{Instance ID}/privateprops"
+      "suffix": "/api/core/v3/extstreams/{Instance ID}/privateprops",
+      "description": "The private configuration of one external stream instance."
     },
     {
       "name": "Content Votes",
       "paged": true,
-      "suffix": "/api/core/v3/ideaVotes/{Content ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/ideaVotes/{Content ID}?fields={Fields?}",
+      "description": "The votes cast on one poll or idea. Requires the content id. THE OUTCOME OF A POLL OR IDEA lives here rather than on the content itself, so a result is only readable through this."
     },
     {
       "name": "Content Images",
       "paged": true,
-      "suffix": "/api/core/v3/images/contents/{Content ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/images/contents/{Content ID}?fields={Fields?}",
+      "description": "The images embedded in one content object. Requires the content id."
     },
     {
       "name": "Image",
       "paged": false,
-      "suffix": "/api/core/v3/images/{Image ID}?width={Width?}&height={Height?}&preserveAspectRatio={Preserve?:false|true}&thumbnail={Thumbnail?}false|true"
+      "suffix": "/api/core/v3/images/{Image ID}?width={Width?}&height={Height?}&preserveAspectRatio={Preserve?:false|true}&thumbnail={Thumbnail?}false|true",
+      "description": "One image by id."
     },
     {
       "name": "Activity Inbox",
       "paged": true,
-      "suffix": "/api/core/v3/inbox?filter={Filter?:author|notifications|type|unread|verb}&before={Before?:yyyy-MM-ddT'HH:mm:ssZ}&after={After?:yyyy-MM-dd'T'HH:mm:ssZ}&fields={Fields?}&collapse={Collapse?:false|true}&oldestUnread={Oldest Unread?:false|true}&directive={Directive?:include_rtc|collapse|collapseSkip}"
+      "suffix": "/api/core/v3/inbox?filter={Filter?:author|notifications|type|unread|verb}&before={Before?:yyyy-MM-ddT'HH:mm:ssZ}&after={After?:yyyy-MM-dd'T'HH:mm:ssZ}&fields={Fields?}&collapse={Collapse?:false|true}&oldestUnread={Oldest Unread?:false|true}&directive={Directive?:include_rtc|collapse|collapseSkip}",
+      "description": "The calling user's inbox stream -- everything they are meant to see. Scoped to the caller, so it describes one person's attention rather than the community."
     },
     {
       "name": "Counts",
       "paged": false,
-      "suffix": "/api/core/v3/inbox/counts?filter={Filter?}"
+      "suffix": "/api/core/v3/inbox/counts?filter={Filter?}",
+      "description": "The unread counts of the calling user's inbox."
     },
     {
       "name": "Invite",
       "paged": false,
-      "suffix": "/api/core/v3/invites/{Invite ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/invites/{Invite ID}?fields={Fields?}",
+      "description": "One invitation by id. Pending membership, which no member list shows."
     },
     {
       "name": "Place Invites",
       "paged": true,
-      "suffix": "/api/core/v3/invites/places/{Place ID}?fields={Fields?}&inviter={Inviter?}&invitee={Invitee?}"
+      "suffix": "/api/core/v3/invites/places/{Place ID}?fields={Fields?}&inviter={Inviter?}&invitee={Invitee?}",
+      "description": "The invitations to join one place. Requires the place id. Pending membership, which the member list does not show."
     },
     {
       "name": "All Invites",
       "paged": true,
-      "suffix": "/api/core/v3/invites/event/all/{Event ID}"
+      "suffix": "/api/core/v3/invites/event/all/{Event ID}",
+      "description": "Every outstanding invitation. The onboarding backlog."
     },
     {
       "name": "Member",
       "paged": false,
-      "suffix": "/api/core/v3/members/{Member ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/members/{Member ID}?fields={Fields?}",
+      "description": "One membership record by id, with the person and group and the role held."
     },
     {
       "name": "Members by Group",
       "paged": true,
-      "suffix": "/api/core/v3/members/places/{Place ID}?filter={Filter?:person}&fields={Fields?}&state={State?:banned|invited|member|owner|pending}"
+      "suffix": "/api/core/v3/members/places/{Place ID}?filter={Filter?:person}&fields={Fields?}&state={State?:banned|invited|member|owner|pending}",
+      "description": "The members of one security group. Requires the group id."
     },
     {
       "name": "Members by Person",
       "paged": true,
-      "suffix": "/api/core/v3/members/people/{Person ID}?filter={Filter?:place}&fields={Fields?}&state={State?:banned|invited|member|owner|pending}"
+      "suffix": "/api/core/v3/members/people/{Person ID}?filter={Filter?:place}&fields={Fields?}&state={State?:banned|invited|member|owner|pending}",
+      "description": "The groups one person belongs to. Requires the person id."
     },
     {
       "name": "Mention",
       "paged": false,
-      "suffix": "/api/core/v3/mentions/{Mention ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/mentions/{Mention ID}?fields={Fields?}",
+      "description": "One mention by id -- a reference to a person inside content. Mentions are how attention is directed in Jive, so they are a better signal of who is being pulled into work than follower counts."
     },
     {
       "name": "Content Replies",
       "paged": true,
-      "suffix": "/api/core/v3/messages/contents/{Content ID}?filter={Filter?}&fields={Fields?}&anchor={Anchor?}&excludeReplies={Exclude Replies?:false|true}&hierarchical={Hierarchical?:true|false}"
+      "suffix": "/api/core/v3/messages/contents/{Content ID}?filter={Filter?}&fields={Fields?}&anchor={Anchor?}&excludeReplies={Exclude Replies?:false|true}&hierarchical={Hierarchical?:true|false}",
+      "description": "The replies to one message. Requires the message id. Discussions are threaded through messages rather than comments, which is why both exist."
     },
     {
       "name": "Editable Message",
       "paged": false,
-      "suffix": "/api/core/v3/messages/{Message ID}/editable?fields={Fields?}"
+      "suffix": "/api/core/v3/messages/{Message ID}/editable?fields={Fields?}",
+      "description": "Whether the calling user may edit one message. A permission check."
     },
     {
       "name": "Message Marked Helpful",
       "paged": true,
-      "suffix": "/api/core/v3/messages/{Message ID}/helpful?fields={Fields?}"
+      "suffix": "/api/core/v3/messages/{Message ID}/helpful?fields={Fields?}",
+      "description": "Whether one message is marked helpful, and by whom. Requires the message id."
     },
     {
       "name": "Message Marked Unhelpful",
       "paged": true,
-      "suffix": "/api/core/v3/messages/{Message ID}/unhelpful?fields={Fields?}"
+      "suffix": "/api/core/v3/messages/{Message ID}/unhelpful?fields={Fields?}",
+      "description": "Whether one message is marked unhelpful. Requires the message id."
     },
     {
       "name": "Message",
       "paged": false,
-      "suffix": "/api/core/v3/messages/{Message ID}?fields={Fields?}&abridged={Abridged?:false|true}"
+      "suffix": "/api/core/v3/messages/{Message ID}?fields={Fields?}&abridged={Abridged?:false|true}",
+      "description": "One message by id -- a reply within a discussion thread. Discussions are built from messages, not comments, which is the distinction to keep straight when counting participation."
     },
     {
       "name": "Message Likes",
       "paged": true,
-      "suffix": "/api/core/v3/messages/{Message ID}/likes?fields={Fields?}"
+      "suffix": "/api/core/v3/messages/{Message ID}/likes?fields={Fields?}",
+      "description": "Who liked one message. Requires the message id."
     },
     {
       "name": "Message Outcomes",
       "paged": true,
-      "suffix": "/api/core/v3/messages/{Message ID}/outcomes?fields={Fields?}"
+      "suffix": "/api/core/v3/messages/{Message ID}/outcomes?fields={Fields?}",
+      "description": "The outcomes marked on one message. Requires the message id. A message marked as the correct answer is how a question is resolved, so this is the resolution record for discussions."
     },
     {
       "name": "Message Replies",
       "paged": true,
-      "suffix": "/api/core/v3/messages/{Message ID}/messages?filter={Filter?}&fields={Fields?}&anchor={Anchor?}&excludeReplies={Exclude Replies?:false|true}&hierarchical={Hierarchical?:true|false}&messageTarget={Message Target?}"
+      "suffix": "/api/core/v3/messages/{Message ID}/messages?filter={Filter?}&fields={Fields?}&anchor={Anchor?}&excludeReplies={Exclude Replies?:false|true}&hierarchical={Hierarchical?:true|false}&messageTarget={Message Target?}",
+      "description": "The replies to one message. Requires the message id. How a discussion thread branches."
     },
     {
       "name": "Available Locale Metadata",
       "paged": true,
-      "suffix": "/api/core/v3/metadata/locales/available"
+      "suffix": "/api/core/v3/metadata/locales/available",
+      "description": "The locales the instance could offer."
     },
     {
       "name": "Supported Locale Metadata",
       "paged": true,
-      "suffix": "/api/core/v3/metadata/locales/supported"
+      "suffix": "/api/core/v3/metadata/locales/supported",
+      "description": "The locales the instance actually supports. Content and profile fields are localised, so this bounds what a multilingual query can ask for."
     },
     {
       "name": "All Object Metadata",
       "paged": true,
-      "suffix": "/api/core/v3/metadata/objects/@all?fields={Fields?:@all}"
+      "suffix": "/api/core/v3/metadata/objects/@all?fields={Fields?:@all}",
+      "description": "The metadata of every object type. The whole schema in one call."
     },
     {
       "name": "Field Metadata",
       "paged": false,
-      "suffix": "/api/core/v3/metadata/objects/{Object Name}/{Field}"
+      "suffix": "/api/core/v3/metadata/objects/{Object Name}/{Field}",
+      "description": "The metadata of one field -- its type, constraints and whether it is filterable."
     },
     {
       "name": "Field Metadata Values",
       "paged": true,
-      "suffix": "/api/core/v3/metadata/objects/{Object Name}/{Field}/values?filter={Filter?:search|fieldValues}&count={Count?}&includeCount={Include Count?:false|true}&objectValues={Object Values?:false|true}"
+      "suffix": "/api/core/v3/metadata/objects/{Object Name}/{Field}/values?filter={Filter?:search|fieldValues}&count={Count?}&includeCount={Include Count?:false|true}&objectValues={Object Values?:false|true}",
+      "description": "The permitted values of one field. The decoder for that field's codes."
     },
     {
       "name": "Object Metadata",
       "paged": false,
-      "suffix": "/api/core/v3/metadata/objects/{Object Name}"
+      "suffix": "/api/core/v3/metadata/objects/{Object Name}",
+      "description": "The metadata of one object type -- its fields, their types and their constraints. Requires the type name."
     },
     {
       "name": "Object Metadata Values",
       "paged": true,
-      "suffix": "/api/core/v3/metadata/objects/{Object Name}/values?filter={Filter?:search|fieldValues}&count={Count?}&includeCount={Include Count?:false|true}&fields={Fields?}"
+      "suffix": "/api/core/v3/metadata/objects/{Object Name}/values?filter={Filter?:search|fieldValues}&count={Count?}&includeCount={Include Count?:false|true}&fields={Fields?}",
+      "description": "The permitted values of one object type's enumerated fields. The decoder for coded values."
     },
     {
       "name": "Object Types",
       "paged": true,
-      "suffix": "/api/core/v3/metadata/objects"
+      "suffix": "/api/core/v3/metadata/objects",
+      "description": "The object types the API exposes. THE ROOT OF JIVE'S METADATA MODEL, which is unusually complete: the platform describes its own schema, so what a field means and which values it accepts are answerable from the API rather than from documentation."
     },
     {
       "name": "All Property Metadata",
       "paged": true,
-      "suffix": "/api/core/v3/metadata/properties"
+      "suffix": "/api/core/v3/metadata/properties",
+      "description": "The metadata of every system property."
     },
     {
       "name": "Property Metadata",
       "paged": false,
-      "suffix": "/api/core/v3/metadata/properties/{Property Name}"
+      "suffix": "/api/core/v3/metadata/properties/{Property Name}",
+      "description": "The metadata of one system property."
     },
     {
       "name": "All Public Property Metadata",
       "paged": true,
-      "suffix": "/api/core/v3/metadata/properties/public"
+      "suffix": "/api/core/v3/metadata/properties/public",
+      "description": "The metadata of the publicly readable properties. The subset available without administrative rights."
     },
     {
       "name": "Public Property Metadata",
       "paged": false,
-      "suffix": "/api/core/v3/metadata/properties/public/{Property Name}"
+      "suffix": "/api/core/v3/metadata/properties/public/{Property Name}",
+      "description": "The metadata of one public property."
     },
     {
       "name": "Field Resource Metadata",
       "paged": false,
-      "suffix": "/api/core/v3/metadata/resources/{Object Name}/{Field}"
+      "suffix": "/api/core/v3/metadata/resources/{Object Name}/{Field}",
+      "description": "The API resources associated with one field."
     },
     {
       "name": "Object Resource Metadata",
       "paged": false,
-      "suffix": "/api/core/v3/metadata/resources/{Object Name}"
+      "suffix": "/api/core/v3/metadata/resources/{Object Name}",
+      "description": "The API resources available on one object type. What can be done with it."
     },
     {
       "name": "Object Type Mappings",
       "paged": true,
-      "suffix": "/api/core/v3/metadata/resources"
+      "suffix": "/api/core/v3/metadata/resources",
+      "description": "How object type names map to their identifiers. The translation between the names used in filters and those in responses."
     },
     {
       "name": "All Time Zone Metadata",
       "paged": false,
-      "suffix": "/api/core/v3/metadata/timezones"
+      "suffix": "/api/core/v3/metadata/timezones",
+      "description": "Every time zone the instance recognises. Relevant because activity timestamps are rendered per user."
     },
     {
       "name": "Time Zone Metadata",
       "paged": false,
-      "suffix": "/api/core/v3/metadata/timezones/{First}/{Second}/{Third?}"
+      "suffix": "/api/core/v3/metadata/timezones/{First}/{Second}/{Third?}",
+      "description": "One time zone's metadata."
     },
     {
       "name": "Moderation Counts",
       "paged": false,
-      "suffix": "/api/core/v3/moderation/pending/counts?filter={Filter?}"
+      "suffix": "/api/core/v3/moderation/pending/counts?filter={Filter?}",
+      "description": "How many items await moderation, by type. The backlog size."
     },
     {
       "name": "Moderation",
       "paged": false,
-      "suffix": "/api/core/v3/moderation/{Moderation ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/moderation/{Moderation ID}?fields={Fields?}",
+      "description": "The moderation queue -- content awaiting approval. Content in moderation is NOT visible in the ordinary content listings, so a publishing-volume figure omits it until it is approved."
     },
     {
       "name": "Pending Moderation",
       "paged": false,
-      "suffix": "/api/core/v3/moderation/pending?filter={Filter?:objectType|place|author|moderationType}&fields={Fields?}"
+      "suffix": "/api/core/v3/moderation/pending?filter={Filter?:objectType|place|author|moderationType}&fields={Fields?}",
+      "description": "The items awaiting moderation for the calling user, as a moderator."
     },
     {
       "name": "Embed",
       "paged": false,
-      "suffix": "/api/core/v3/oembed"
+      "suffix": "/api/core/v3/oembed",
+      "description": "The oEmbed representation of a URL. A rendering helper rather than data."
     },
     {
       "name": "History",
       "paged": false,
-      "suffix": "/api/core/v3/outcomes/{Outcome ID}/history"
+      "suffix": "/api/core/v3/outcomes/{Outcome ID}/history",
+      "description": "The history of outcomes on one object. Requires the object id. An outcome can be changed or removed, so this is the record of how a resolution state evolved."
     },
     {
       "name": "Outcome",
       "paged": false,
-      "suffix": "/api/core/v3/outcomes/{Outcome ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/outcomes/{Outcome ID}?fields={Fields?}",
+      "description": "One outcome by id, with the object it was applied to and by whom."
     },
     {
       "name": "Outcomes",
       "paged": false,
-      "suffix": "/api/core/v3/outcomes?fields={Fields?}&hidden={Hidden?:false|true}"
+      "suffix": "/api/core/v3/outcomes?fields={Fields?}&hidden={Hidden?:false|true}",
+      "description": "The outcomes recorded across the community -- resolved, decision, action item, success, helpful. OUTCOMES ARE HOW JIVE RECORDS THAT SOMETHING WAS SETTLED, so resolution rates, decision counts and unanswered-question analysis all reduce to this table."
     },
     {
       "name": "Page",
       "paged": false,
-      "suffix": "/api/core/v3/pages/{Page ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/pages/{Page ID}?fields={Fields?}",
+      "description": "One page by id, with its tiles."
     },
     {
       "name": "Prototype Page",
       "paged": false,
-      "suffix": "/api/core/v3/pages/prototype?placeTemplateID={PlaceTemplate ID}&placeURI={Place URI}&fields={Fields?}"
+      "suffix": "/api/core/v3/pages/prototype?placeTemplateID={PlaceTemplate ID}&placeURI={Place URI}&fields={Fields?}",
+      "description": "A blank page object, for building a new one. Scaffolding rather than data."
     },
     {
       "name": "Activity Person",
       "paged": true,
-      "suffix": "/api/core/v3/people/{Person ID}/activities?filter={Filter?}&before={Before?:yyyy-MM-ddT'HH:mm:ssZ}&after={After?:yyyy-MM-dd'T'HH:mm:ssZ}&fields={Fields?}&collapse={Collapse?:false|true}&oldestUnread={Oldest Unread?:false|true}"
+      "suffix": "/api/core/v3/people/{Person ID}/activities?filter={Filter?}&before={Before?:yyyy-MM-ddT'HH:mm:ssZ}&after={After?:yyyy-MM-dd'T'HH:mm:ssZ}&fields={Fields?}&collapse={Collapse?:false|true}&oldestUnread={Oldest Unread?:false|true}",
+      "description": "The activity stream of one person. Requires the person id. What someone actually did, as opposed to what they are."
     },
     {
       "name": "All People",
@@ -701,172 +823,206 @@
           "key": "id",
           "parameterName": "Person ID"
         }
-      ]
+      ],
+      "description": "Every person in the community, paged. The complete roster, as opposed to the filtered listing."
     },
     {
       "name": "Blog",
       "paged": false,
-      "suffix": "/api/core/v3/people/{Person ID}/blog?fields={Fields?}"
+      "suffix": "/api/core/v3/people/{Person ID}/blog?fields={Fields?}",
+      "description": "One person's blog. Requires the person id."
     },
     {
       "name": "Colleagues",
       "paged": true,
-      "suffix": "/api/core/v3/people/{Person ID}/@colleagues?fields={Fields?}"
+      "suffix": "/api/core/v3/people/{Person ID}/@colleagues?fields={Fields?}",
+      "description": "The colleagues of one person. Requires the person id."
     },
     {
       "name": "Common Bidirectional Related People",
       "paged": true,
-      "suffix": "/api/core/v3/people/{Person ID}/@common?fields={Fields?}"
+      "suffix": "/api/core/v3/people/{Person ID}/@common?fields={Fields?}",
+      "description": "The people two users have in common, following each other. THE SOCIAL GRAPH INTERSECTION -- who connects two people, which no directory can answer."
     },
     {
       "name": "Featured Content for Person",
       "paged": true,
-      "suffix": "/api/core/v3/people/{Person ID}/@featuredContent?filter={Filter?:type}&fields={Fields?}&abridged={Abridged?:false|true}"
+      "suffix": "/api/core/v3/people/{Person ID}/@featuredContent?filter={Filter?:type}&fields={Fields?}&abridged={Abridged?:false|true}",
+      "description": "The content featured for one person. Personalised."
     },
     {
       "name": "Filterable Fields",
       "paged": true,
-      "suffix": "/api/core/v3/people/@filterableFields"
+      "suffix": "/api/core/v3/people/@filterableFields",
+      "description": "The person fields that may be filtered on. Narrower than the supported set, and the limit on what a people query can ask."
     },
     {
       "name": "Followers",
       "paged": true,
-      "suffix": "/api/core/v3/people/{Person ID}/@followers?fields={Fields?}"
+      "suffix": "/api/core/v3/people/{Person ID}/@followers?fields={Fields?}",
+      "description": "Who follows one person. Requires the person id."
     },
     {
       "name": "Following",
       "paged": true,
-      "suffix": "/api/core/v3/people/{Person ID}/@following?fields={Fields?}"
+      "suffix": "/api/core/v3/people/{Person ID}/@following?fields={Fields?}",
+      "description": "Who one person follows. Requires the person id."
     },
     {
       "name": "Following In",
       "paged": true,
-      "suffix": "/api/core/v3/people/{Person ID}/followingIn?fields={Fields?}"
+      "suffix": "/api/core/v3/people/{Person ID}/followingIn?fields={Fields?}",
+      "description": "The streams one person is followed in. Requires the person id."
     },
     {
       "name": "Following Person",
       "paged": false,
-      "suffix": "/api/core/v3/people/{Person ID}/@following/{Followed Person ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/people/{Person ID}/@following/{Followed Person ID}?fields={Fields?}",
+      "description": "Whether one person follows another. A relationship check."
     },
     {
       "name": "Manager",
       "paged": false,
-      "suffix": "/api/core/v3/people/{Person ID}/@manager"
+      "suffix": "/api/core/v3/people/{Person ID}/@manager",
+      "description": "One person's manager. Requires the person id. The organisational hierarchy, where Jive is fed from a directory."
     },
     {
       "name": "Metadata",
       "paged": false,
-      "suffix": "/api/core/v3/people/@metadata"
+      "suffix": "/api/core/v3/people/@metadata",
+      "description": "The metadata describing the person object. The schema behind a person record."
     },
     {
       "name": "News",
       "paged": true,
-      "suffix": "/api/core/v3/people/{Person ID}/@news?fields={Fields?}&maxPerStream={Max Number?}"
+      "suffix": "/api/core/v3/people/{Person ID}/@news?fields={Fields?}&maxPerStream={Max Number?}",
+      "description": "The news stream of one person. Requires the person id. What Jive presents to them, not what they produced."
     },
     {
       "name": "Pages",
       "paged": true,
-      "suffix": "/api/core/v3/people/{Person ID}/pages"
+      "suffix": "/api/core/v3/people/{Person ID}/pages",
+      "description": "The custom pages built in the community. Layout containers assembled from tiles."
     },
     {
       "name": "Pages Prototype",
       "paged": false,
-      "suffix": "/api/core/v3/people/{Person ID}/pages/prototype?fields={Fields?}"
+      "suffix": "/api/core/v3/people/{Person ID}/pages/prototype?fields={Fields?}",
+      "description": "A prototype page object for one person, for building a new page."
     },
     {
       "name": "Pending Expertise Tags",
       "paged": true,
-      "suffix": "/api/core/v3/people/{Person ID}/expertise/pending"
+      "suffix": "/api/core/v3/people/{Person ID}/expertise/pending",
+      "description": "The expertise endorsements awaiting one person's acceptance. Requires the person id."
     },
     {
       "name": "People",
       "paged": false,
-      "suffix": "/api/core/v3/people?ids={Person IDs?}&query={Query?}&fields={Fields?}&filter={Filter?}"
+      "suffix": "/api/core/v3/people?ids={Person IDs?}&query={Query?}&fields={Fields?}&filter={Filter?}",
+      "description": "The users of the community, with name, email, title, location, the profile fields, and their follower and content counts. Filterable and field-selectable like everything else here."
     },
     {
       "name": "Person by ID",
       "paged": false,
-      "suffix": "/api/core/v3/people/{Person ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/people/{Person ID}?fields={Fields?}",
+      "description": "One person by id."
     },
     {
       "name": "Person by Email",
       "paged": false,
-      "suffix": "/api/core/v3/people/email/{Email}?fields={Fields?}"
+      "suffix": "/api/core/v3/people/email/{Email}?fields={Fields?}",
+      "description": "One person by email address. The lookup when the id is unknown."
     },
     {
       "name": "Person by External Identity",
       "paged": false,
-      "suffix": "/api/core/v3/people/external/{Identity Type}/{Identity?}?fields={Fields?}"
+      "suffix": "/api/core/v3/people/external/{Identity Type}/{Identity?}?fields={Fields?}",
+      "description": "One person by an identity from an external system. THE BRIDGE from a corporate directory or single-sign-on identifier to a Jive user, which no other endpoint provides."
     },
     {
       "name": "Person by Username",
       "paged": false,
-      "suffix": "/api/core/v3/people/username/{User Name}?fields={Fields?}"
+      "suffix": "/api/core/v3/people/username/{User Name}?fields={Fields?}",
+      "description": "One person by username."
     },
     {
       "name": "Private Properties for Person",
       "paged": true,
-      "suffix": "/api/core/v3/people/{Person ID}/privateprops"
+      "suffix": "/api/core/v3/people/{Person ID}/privateprops",
+      "description": "The private properties stored against one person. Requires the person id. Application storage rather than profile data."
     },
     {
       "name": "Profile Field Privacy",
       "paged": false,
-      "suffix": "/api/core/v3/people/{Person ID}/profilePrivacy/{Field ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/people/{Person ID}/profilePrivacy/{Field ID}?fields={Fields?}",
+      "description": "The privacy setting of one profile field for a person. WHY A FIELD IS BLANK: a hidden field returns nothing, which looks identical to an unfilled one."
     },
     {
       "name": "Profile Fields Privacy",
       "paged": true,
-      "suffix": "/api/core/v3/people/{Person ID}/profilePrivacy?fields={Fields?}"
+      "suffix": "/api/core/v3/people/{Person ID}/profilePrivacy?fields={Fields?}",
+      "description": "The privacy settings of all profile fields for a person."
     },
     {
       "name": "Profile Image",
       "paged": false,
-      "suffix": "/api/core/v3/people/{Person ID}/images/{Image Index}"
+      "suffix": "/api/core/v3/people/{Person ID}/images/{Image Index}",
+      "description": "One person's profile image."
     },
     {
       "name": "Profile Images",
       "paged": true,
-      "suffix": "/api/core/v3/people/{Person ID}/images?fields={Fields?}"
+      "suffix": "/api/core/v3/people/{Person ID}/images?fields={Fields?}",
+      "description": "All profile images of one person."
     },
     {
       "name": "Recognition",
       "paged": false,
-      "suffix": "/api/core/v3/people/{Person ID}/@recognition?maxOutcomes={Outcomes Number?}&fields={Fields?}"
+      "suffix": "/api/core/v3/people/{Person ID}/@recognition?maxOutcomes={Outcomes Number?}&fields={Fields?}",
+      "description": "The recognition badges awarded to one person. Requires the person id. Jive's peer-recognition record."
     },
     {
       "name": "Recommended People",
       "paged": false,
-      "suffix": "/api/core/v3/people/recommended?fields={Fields?}"
+      "suffix": "/api/core/v3/people/recommended?fields={Fields?}",
+      "description": "People recommended to the calling user. Personalised."
     },
     {
       "name": "Report",
       "paged": false,
-      "suffix": "/api/core/v3/people/{Person ID}/@reports/{Report Person ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/people/{Person ID}/@reports/{Report Person ID}?fields={Fields?}",
+      "description": "One direct report of a person."
     },
     {
       "name": "Reports",
       "paged": true,
-      "suffix": "/api/core/v3/people/{Person ID}/@reports?fields={Fields?}"
+      "suffix": "/api/core/v3/people/{Person ID}/@reports?fields={Fields?}",
+      "description": "The direct reports of one person. Requires the person id. Together with Manager this reconstructs the org chart."
     },
     {
       "name": "Person Resources",
       "paged": true,
-      "suffix": "/api/core/v3/people/@resources"
+      "suffix": "/api/core/v3/people/@resources",
+      "description": "The API resources available for one person. A discovery aid rather than data."
     },
     {
       "name": "Person Roles",
       "paged": true,
-      "suffix": "/api/core/v3/people/{Person ID}/roles"
+      "suffix": "/api/core/v3/people/{Person ID}/roles",
+      "description": "The roles one person holds. Requires the person id. Roles decide capability, so this is why two users can do different things."
     },
     {
       "name": "Security Groups for Person",
       "paged": true,
-      "suffix": "/api/core/v3/people/{Person ID}/securityGroups?fields={Fields?}"
+      "suffix": "/api/core/v3/people/{Person ID}/securityGroups?fields={Fields?}",
+      "description": "The security groups one person belongs to. Requires the person id. Group membership is how most access is granted, so this is the practical answer to what someone can reach."
     },
     {
       "name": "Social Users",
       "paged": true,
-      "suffix": "/api/core/v3/people/{Person ID}/@social?fields={Fields?}"
+      "suffix": "/api/core/v3/people/{Person ID}/@social?fields={Fields?}",
+      "description": "The external social accounts linked to one person. Requires the person id."
     },
     {
       "name": "Streams",
@@ -884,122 +1040,146 @@
           "key": "id",
           "parameterName": "Stream ID"
         }
-      ]
+      ],
+      "description": "The custom streams defined -- the curated feeds users assemble from places, people and content they follow. A stream's ASSOCIATIONS state what its owner considered worth watching, which is a more honest signal of interest than following counts."
     },
     {
       "name": "Supported Fields",
       "paged": true,
-      "suffix": "/api/core/v3/people/@supportedFields"
+      "suffix": "/api/core/v3/people/@supportedFields",
+      "description": "The person fields the API supports returning. The vocabulary for the fields parameter."
     },
     {
       "name": "Tags on User",
       "paged": false,
-      "suffix": "/api/core/v3/people/{Person ID}/expertise/endorse"
+      "suffix": "/api/core/v3/people/{Person ID}/expertise/endorse",
+      "description": "The tags applied to one person. Requires the person id."
     },
     {
       "name": "Tasks",
       "paged": true,
-      "suffix": "/api/core/v3/people/{Person ID}/tasks?filter={Filter?:completed}&fields={Fields?}"
+      "suffix": "/api/core/v3/people/{Person ID}/tasks?filter={Filter?:completed}&fields={Fields?}",
+      "description": "The tasks assigned to one person. Requires the person id."
     },
     {
       "name": "Terms And Conditions",
       "paged": false,
-      "suffix": "/api/core/v3/people/{Person ID}/termsAndConditions"
+      "suffix": "/api/core/v3/people/{Person ID}/termsAndConditions",
+      "description": "The terms and conditions record for one person -- whether they accepted and when. Compliance evidence."
     },
     {
       "name": "Top Expertise",
       "paged": true,
-      "suffix": "/api/core/v3/people/{Person ID}/expertise/top"
+      "suffix": "/api/core/v3/people/{Person ID}/expertise/top",
+      "description": "The expertise tags one person is most endorsed for. Requires the person id."
     },
     {
       "name": "Trending Content for Person",
       "paged": true,
-      "suffix": "/api/core/v3/people/{Person ID}/@trendingContent?fields={Fields?}&abridged={Abridged?:false|true}&fallback={Fallback?:false|true}"
+      "suffix": "/api/core/v3/people/{Person ID}/@trendingContent?fields={Fields?}&abridged={Abridged?:false|true}&fallback={Fallback?:false|true}",
+      "description": "The content trending for one person. Personalised."
     },
     {
       "name": "Trending People",
       "paged": false,
-      "suffix": "/api/core/v3/people/trending?filter={Filter?:place}&fields={Fields?}"
+      "suffix": "/api/core/v3/people/trending?filter={Filter?:place}&fields={Fields?}",
+      "description": "The people gaining followers or engagement fastest."
     },
     {
       "name": "Trending Places for Person",
       "paged": true,
-      "suffix": "/api/core/v3/people/{Person ID}/@trendingPlaces?fields={Fields?}&fallback={Fallback?:false|true}"
+      "suffix": "/api/core/v3/people/{Person ID}/@trendingPlaces?fields={Fields?}&fallback={Fallback?:false|true}",
+      "description": "The places trending for one person. Personalised."
     },
     {
       "name": "Users by Expertise",
       "paged": true,
-      "suffix": "/api/core/v3/people/expertise/{Tag Name}?fields={Fields?}"
+      "suffix": "/api/core/v3/people/expertise/{Tag Name}?fields={Fields?}",
+      "description": "People holding a given expertise tag. EXPERTISE IS JIVE'S SKILLS MODEL, endorsed by colleagues rather than self-declared, so this is a socially validated answer to who knows about something."
     },
     {
       "name": "Who Endorsed",
       "paged": true,
-      "suffix": "/api/core/v3/people/{Person ID}/expertise/endorsers/{Tag Name}?fields={Fields?}"
+      "suffix": "/api/core/v3/people/{Person ID}/expertise/endorsers/{Tag Name}?fields={Fields?}",
+      "description": "Who endorsed one person for a given expertise. Requires the person id and tag. The evidence behind an expertise claim."
     },
     {
       "name": "Place Activity",
       "paged": true,
-      "suffix": "/api/core/v3/places/{Place ID}/activities?filter={Filter?}&before={Before?:yyyy-MM-ddT'HH:mm:ssZ}&after={After?:yyyy-MM-dd'T'HH:mm:ssZ}&fields={Fields?}&collapse={Collapse?:false|true}&oldestUnread={Oldest Unread?:false|true}"
+      "suffix": "/api/core/v3/places/{Place ID}/activities?filter={Filter?}&before={Before?:yyyy-MM-ddT'HH:mm:ssZ}&after={After?:yyyy-MM-dd'T'HH:mm:ssZ}&fields={Fields?}&collapse={Collapse?:false|true}&oldestUnread={Oldest Unread?:false|true}",
+      "description": "The activity stream of one place. Requires the place id."
     },
     {
       "name": "Place Applied Entitlements",
       "paged": true,
-      "suffix": "/api/core/v3/places/{Place ID}/appliedEntitlements?fields={Fields?}"
+      "suffix": "/api/core/v3/places/{Place ID}/appliedEntitlements?fields={Fields?}",
+      "description": "The entitlements actually in force on one place, after inheritance. Requires the place id. The resolved answer, as opposed to the configuration."
     },
     {
       "name": "Place Content",
       "paged": true,
-      "suffix": "/api/core/v3/places/{Place ID}/contents?filter={Filter?:type}&fields={Fields?}&abridged={Abridged?:false|true}"
+      "suffix": "/api/core/v3/places/{Place ID}/contents?filter={Filter?:type}&fields={Fields?}&abridged={Abridged?:false|true}",
+      "description": "The content inside one place. Requires the place id. The per-container view, and the usual route from an organisational unit to what it produced."
     },
     {
       "name": "Place Featured Content",
       "paged": true,
-      "suffix": "/api/core/v3/places/{Place ID}/contents/featured?filter={Filter?:type}&fields={Fields?}&abridged={Abridged?:false|true}"
+      "suffix": "/api/core/v3/places/{Place ID}/contents/featured?filter={Filter?:type}&fields={Fields?}&abridged={Abridged?:false|true}",
+      "description": "The content editorially featured in one place. Requires the place id."
     },
     {
       "name": "Place",
       "paged": false,
-      "suffix": "/api/core/v3/places/{Place ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/places/{Place ID}?fields={Fields?}",
+      "description": "One place by id, with its settings and counts."
     },
     {
       "name": "Place Announcements",
       "paged": true,
-      "suffix": "/api/core/v3/places/{Place ID}/announcements?fields={Fields?}&activeOnly={Active Only?:false|true}"
+      "suffix": "/api/core/v3/places/{Place ID}/announcements?fields={Fields?}&activeOnly={Active Only?:false|true}",
+      "description": "The announcements posted in one place. Requires the place id."
     },
     {
       "name": "Place Avatar",
       "paged": false,
-      "suffix": "/api/core/v3/places/{Place ID}/avatar?size={Size?:large|medium|small}"
+      "suffix": "/api/core/v3/places/{Place ID}/avatar?size={Size?:large|medium|small}",
+      "description": "The avatar image of one place. Presentation."
     },
     {
       "name": "Place Categories",
       "paged": true,
-      "suffix": "/api/core/v3/places/{Place ID}/categories?fields={Fields?}"
+      "suffix": "/api/core/v3/places/{Place ID}/categories?fields={Fields?}",
+      "description": "The categories defined within one place. Requires the place id. A place's own content taxonomy, which is local rather than community-wide."
     },
     {
       "name": "Place Category",
       "paged": false,
-      "suffix": "/api/core/v3/places/{Place ID}/categories/{Category ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/places/{Place ID}/categories/{Category ID}?fields={Fields?}",
+      "description": "One place category by id."
     },
     {
       "name": "Place Followers",
       "paged": true,
-      "suffix": "/api/core/v3/places/{Place ID}/followers?fields={Fields?}"
+      "suffix": "/api/core/v3/places/{Place ID}/followers?fields={Fields?}",
+      "description": "Who follows one place. Requires the place id. The audience a place's content reaches."
     },
     {
       "name": "Place Following In",
       "paged": true,
-      "suffix": "/api/core/v3/places/{Place ID}/followingIn?fields={Fields?}"
+      "suffix": "/api/core/v3/places/{Place ID}/followingIn?fields={Fields?}",
+      "description": "The streams one place is being followed in. Requires the place id."
     },
     {
       "name": "Place Permissions",
       "paged": true,
-      "suffix": "/api/core/v3/places/{Place ID}/permissions"
+      "suffix": "/api/core/v3/places/{Place ID}/permissions",
+      "description": "The permissions configured on one place. Requires the place id. Who may see and post, which is why two users see different content lists."
     },
     {
       "name": "Place Places",
       "paged": true,
-      "suffix": "/api/core/v3/places/{Place ID}/places?filter={Filter?:type|search|tag}&fields={Fields?}"
+      "suffix": "/api/core/v3/places/{Place ID}/places?filter={Filter?:type|search|tag}&fields={Fields?}",
+      "description": "The child places of one place. Requires the place id. Places nest, so a full tree means walking this repeatedly."
     },
     {
       "name": "Places",
@@ -1033,332 +1213,398 @@
           "key": "placeId",
           "parameterName": "Place ID"
         }
-      ]
+      ],
+      "description": "THE CONTAINERS CONTENT LIVES IN -- spaces, groups and projects, again polymorphic and told apart by a type field. A space is the permanent organisational structure, a group is a self-forming community, a project is time-bounded work, and they behave differently enough that mixing them in one count is rarely meaningful. Same filter and fields rules as content."
     },
     {
       "name": "Place Settings",
       "paged": false,
-      "suffix": "/api/core/v3/places/{Place ID}/settings"
+      "suffix": "/api/core/v3/places/{Place ID}/settings",
+      "description": "The settings of one place. Requires the place id."
     },
     {
       "name": "Place Statics",
       "paged": true,
-      "suffix": "/api/core/v3/places/{Place ID}/statics?fields={Fields?}"
+      "suffix": "/api/core/v3/places/{Place ID}/statics?fields={Fields?}",
+      "description": "The static resources attached to one place. Requires the place id."
     },
     {
       "name": "Place Suggested Places",
       "paged": true,
-      "suffix": "/api/core/v3/places/{Place ID}/suggested/{Content Type}?filter={Filter?:type}&fields={Fields?}"
+      "suffix": "/api/core/v3/places/{Place ID}/suggested/{Content Type}?filter={Filter?:type}&fields={Fields?}",
+      "description": "Places Jive suggests as related to one place. Requires the place id. Derived rather than curated."
     },
     {
       "name": "Place Tasks",
       "paged": true,
-      "suffix": "/api/core/v3/places/{Place ID}/tasks?fields={Fields?}"
+      "suffix": "/api/core/v3/places/{Place ID}/tasks?fields={Fields?}",
+      "description": "The tasks within one place. Requires the place id."
     },
     {
       "name": "Recommended Places",
       "paged": true,
-      "suffix": "/api/core/v3/places/recommended?fields={Fields?}"
+      "suffix": "/api/core/v3/places/recommended?fields={Fields?}",
+      "description": "Places recommended to the calling user. Personalised."
     },
     {
       "name": "Root Space",
       "paged": false,
-      "suffix": "/api/core/v3/places/root?fields={Fields?}"
+      "suffix": "/api/core/v3/places/root?fields={Fields?}",
+      "description": "The top-level space of the community. The root of the place hierarchy, and the starting point for walking it."
     },
     {
       "name": "Suggested Places",
       "paged": true,
-      "suffix": "/api/core/v3/places/suggested/{Content Type}?filter={Filter?:type}&fields={Fields?}"
+      "suffix": "/api/core/v3/places/suggested/{Content Type}?filter={Filter?:type}&fields={Fields?}",
+      "description": "Places suggested to the calling user. Personalised."
     },
     {
       "name": "Trending Places",
       "paged": true,
-      "suffix": "/api/core/v3/places/trending?fields={Fields?}"
+      "suffix": "/api/core/v3/places/trending?fields={Fields?}",
+      "description": "The places gaining activity fastest. The community-wide view of where attention is moving."
     },
     {
       "name": "Place Template Categories",
       "paged": true,
-      "suffix": "/api/core/v3/placeTemplateCategories?filter={Filter?:templateState}&fields={Fields?}"
+      "suffix": "/api/core/v3/placeTemplateCategories?filter={Filter?:templateState}&fields={Fields?}",
+      "description": "The categories place templates are grouped into."
     },
     {
       "name": "Place Template Category",
       "paged": false,
-      "suffix": "/api/core/v3/placeTemplateCategories/{Category ID}"
+      "suffix": "/api/core/v3/placeTemplateCategories/{Category ID}",
+      "description": "One place template category by id."
     },
     {
       "name": "Place Template",
       "paged": false,
-      "suffix": "/api/core/v3/placeTemplates/{Place Template ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/placeTemplates/{Place Template ID}?fields={Fields?}",
+      "description": "One place template by id."
     },
     {
       "name": "Place Templates",
       "paged": true,
-      "suffix": "/api/core/v3/placeTemplates?filter={Filter?:author|name|displayName|global|state}&fields={Fields?}"
+      "suffix": "/api/core/v3/placeTemplates?filter={Filter?:author|name|displayName|global|state}&fields={Fields?}",
+      "description": "The templates new places are created from. What the organisation considers a standard kind of space or group."
     },
     {
       "name": "Place Topic",
       "paged": false,
-      "suffix": "/api/core/v3/placeTopics/{Topic ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/placeTopics/{Topic ID}?fields={Fields?}",
+      "description": "One place topic by id."
     },
     {
       "name": "Place Topics",
       "paged": true,
-      "suffix": "/api/core/v3/placeTopics"
+      "suffix": "/api/core/v3/placeTopics",
+      "description": "The topics of one place. Requires the place id."
     },
     {
       "name": "Publication",
       "paged": false,
-      "suffix": "/api/core/v3/publications/{Publication ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/publications/{Publication ID}?fields={Fields?}",
+      "description": "One publication by id, with its sections."
     },
     {
       "name": "Publications",
       "paged": true,
-      "suffix": "/api/core/v3/publications?fields={Fields?}"
+      "suffix": "/api/core/v3/publications?fields={Fields?}",
+      "description": "The publications defined -- Jive's curated content collections, distributed on a schedule. Editorial rather than organic content."
     },
     {
       "name": "Subscriber Users",
       "paged": true,
-      "suffix": "/api/core/v3/publications/{Publication ID}/subscriptions/{Subscription ID}/subscribers?fields={Fields?}"
+      "suffix": "/api/core/v3/publications/{Publication ID}/subscriptions/{Subscription ID}/subscribers?fields={Fields?}",
+      "description": "Who subscribes to one publication. Requires the publication id. The reach of a curated channel."
     },
     {
       "name": "Have Same Questions",
       "paged": true,
-      "suffix": "/api/core/v3/questions/{Content ID}/sameQuestion?fields={Fields?}"
+      "suffix": "/api/core/v3/questions/{Content ID}/sameQuestion?fields={Fields?}",
+      "description": "The people who indicated they have the same question. Requires the content id. Demand for an answer, which the view count cannot express."
     },
     {
       "name": "RSVP Invitees",
       "paged": true,
-      "suffix": "/api/core/v3/rsvp/{Event ID}/invitees"
+      "suffix": "/api/core/v3/rsvp/{Event ID}/invitees",
+      "description": "Who was invited to one event, regardless of response. The denominator for any attendance figure."
     },
     {
       "name": "RSVP Maybe Attendees",
       "paged": true,
-      "suffix": "/api/core/v3/rsvp/{Event ID}/attendees/maybe"
+      "suffix": "/api/core/v3/rsvp/{Event ID}/attendees/maybe",
+      "description": "Who responded tentatively to one event."
     },
     {
       "name": "RSVP No Attendees",
       "paged": true,
-      "suffix": "/api/core/v3/rsvp/{Event ID}/attendees/no"
+      "suffix": "/api/core/v3/rsvp/{Event ID}/attendees/no",
+      "description": "Who declined one event."
     },
     {
       "name": "RSVP Events",
       "paged": true,
-      "suffix": "/api/core/v3/rsvp/{Event ID}"
+      "suffix": "/api/core/v3/rsvp/{Event ID}",
+      "description": "The events the calling user has been invited to."
     },
     {
       "name": "RSVP Yes Attendees",
       "paged": true,
-      "suffix": "/api/core/v3/rsvp/{Event ID}/attendees/yes"
+      "suffix": "/api/core/v3/rsvp/{Event ID}/attendees/yes",
+      "description": "Who accepted one event. Requires the event id. ATTENDANCE INTENT IS SPLIT ACROSS FOUR ENDPOINTS -- yes, no, maybe and invited -- so a response rate needs all of them, and the invited list is the denominator."
     },
     {
       "name": "Search Contents",
       "paged": true,
-      "suffix": "/api/core/v3/search/contents?filter={Filter?}&fields={Fields?}&directive={Directive?:include_rtc}&collapse={Collapse?:false|true}&highlight={Highlight?:false|true}&socialSearch={Social Search?:false|true}&returnScore={Score?:false|true}&origin={Origin?}&includeCategoryFacets={Include Facets?:false|true}"
+      "suffix": "/api/core/v3/search/contents?filter={Filter?}&fields={Fields?}&directive={Directive?:include_rtc}&collapse={Collapse?:false|true}&highlight={Highlight?:false|true}&socialSearch={Social Search?:false|true}&returnScore={Score?:false|true}&origin={Origin?}&includeCategoryFacets={Include Facets?:false|true}",
+      "description": "Content matching a search query. Jive's search takes its own filter syntax, and searching is usually faster than filtering the content listing when the question is about words rather than structure."
     },
     {
       "name": "Search People",
       "paged": true,
-      "suffix": "/api/core/v3/search/people?filter={Filter?}&fields={Fields?}&origin={Origin?}&viewContentURI={URI?}"
+      "suffix": "/api/core/v3/search/people?filter={Filter?}&fields={Fields?}&origin={Origin?}&viewContentURI={URI?}",
+      "description": "People matching a search term across name, title and profile fields."
     },
     {
       "name": "Search Places",
       "paged": true,
-      "suffix": "/api/core/v3/search/places?filter={Filter?:nameonly|search}&fields={Fields?}&collapse={Collapse?:false|true}&highlight={Highlight?:false|true}&socialSearch={Social Search?:false|true}&returnScore={Score?:false|true}&origin={Origin?}"
+      "suffix": "/api/core/v3/search/places?filter={Filter?:nameonly|search}&fields={Fields?}&collapse={Collapse?:false|true}&highlight={Highlight?:false|true}&socialSearch={Social Search?:false|true}&returnScore={Score?:false|true}&origin={Origin?}",
+      "description": "Places matching a search query."
     },
     {
       "name": "Search Tags",
       "paged": true,
-      "suffix": "/api/core/v3/search/tags?filter={Filter?:search}&origin={Origin?}"
+      "suffix": "/api/core/v3/search/tags?filter={Filter?:search}&origin={Origin?}",
+      "description": "Tags matching a search query. Useful for discovering the community's own vocabulary before filtering by tag."
     },
     {
       "name": "Section Avatar",
       "paged": false,
-      "suffix": "/api/core/v3/sections/{Section ID}/avatar?size={Size?:large|medium|small}"
+      "suffix": "/api/core/v3/sections/{Section ID}/avatar?size={Size?:large|medium|small}",
+      "description": "The avatar image of one section."
     },
     {
       "name": "Section",
       "paged": false,
-      "suffix": "/api/core/v3/sections/{Section ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/sections/{Section ID}?fields={Fields?}",
+      "description": "One section by id."
     },
     {
       "name": "Sections",
       "paged": true,
-      "suffix": "/api/core/v3/sections?fields={Fields?}"
+      "suffix": "/api/core/v3/sections?fields={Fields?}",
+      "description": "The sections of a publication or support centre. The structural level below a publication."
     },
     {
       "name": "Group Administrators",
       "paged": true,
-      "suffix": "/api/core/v3/securityGroups/{Group ID}/administrators?fields={Fields?}"
+      "suffix": "/api/core/v3/securityGroups/{Group ID}/administrators?fields={Fields?}",
+      "description": "The administrators of one security group. Requires the group id."
     },
     {
       "name": "Group Member",
       "paged": false,
-      "suffix": "/api/core/v3/securityGroups/{Group ID}/members/{Person ID}"
+      "suffix": "/api/core/v3/securityGroups/{Group ID}/members/{Person ID}",
+      "description": "One member of a security group."
     },
     {
       "name": "Group Members",
       "paged": true,
-      "suffix": "/api/core/v3/securityGroups/{Group ID}/members?fields={Fields?}"
+      "suffix": "/api/core/v3/securityGroups/{Group ID}/members?fields={Fields?}",
+      "description": "The members of one security group. Requires the group id."
     },
     {
       "name": "Security Group by Name",
       "paged": false,
-      "suffix": "/api/core/v3/securityGroups/name/{Group Name}?fields={Fields?}"
+      "suffix": "/api/core/v3/securityGroups/name/{Group Name}?fields={Fields?}",
+      "description": "One security group by name."
     },
     {
       "name": "Security Groups",
       "paged": true,
-      "suffix": "/api/core/v3/securityGroups?filter={Filter?:updated}&fields={Fields?}"
+      "suffix": "/api/core/v3/securityGroups?filter={Filter?:updated}&fields={Fields?}",
+      "description": "The security groups defined -- the units access is granted to. Together with place permissions this is how visibility is actually determined, and why two users see different content."
     },
     {
       "name": "Share",
       "paged": false,
-      "suffix": "/api/core/v3/shares/{Share ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/shares/{Share ID}?fields={Fields?}",
+      "description": "One share by id -- content passed to a person or place with a note. The internal amplification record."
     },
     {
       "name": "Slide",
       "paged": false,
-      "suffix": "/api/core/v3/slides/{Slide ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/slides/{Slide ID}?fields={Fields?}",
+      "description": "One slide by id."
     },
     {
       "name": "Slides",
       "paged": true,
-      "suffix": "/api/core/v3/slides"
+      "suffix": "/api/core/v3/slides",
+      "description": "The slides of one presentation object. Requires the content id."
     },
     {
       "name": "Banner",
       "paged": true,
-      "suffix": "/api/core/v3/solutions/supportCenter/banner?fields={Fields?}"
+      "suffix": "/api/core/v3/solutions/supportCenter/banner?fields={Fields?}",
+      "description": "The support centre banner configuration. Presentation."
     },
     {
       "name": "Channels",
       "paged": true,
-      "suffix": "/api/core/v3/solutions/supportCenter/channels?fields={Fields?}"
+      "suffix": "/api/core/v3/solutions/supportCenter/channels?fields={Fields?}",
+      "description": "The support channels configured. How customers may reach support, which no ticket table states."
     },
     {
       "name": "Support Center Section",
       "paged": false,
-      "suffix": "/api/core/v3/solutions/supportCenter/sections/{Section ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/solutions/supportCenter/sections/{Section ID}?fields={Fields?}",
+      "description": "One support centre section by id."
     },
     {
       "name": "Support Center Sections",
       "paged": true,
-      "suffix": "/api/core/v3/solutions/supportCenter/sections?fields={Fields?}"
+      "suffix": "/api/core/v3/solutions/supportCenter/sections?fields={Fields?}",
+      "description": "The sections within the support centre."
     },
     {
       "name": "Support Center Categories",
       "paged": true,
-      "suffix": "/api/core/v3/solutions/supportCenter/categories"
+      "suffix": "/api/core/v3/solutions/supportCenter/categories",
+      "description": "The categories of the support centre -- Jive's customer-facing help structure."
     },
     {
       "name": "Stage",
       "paged": false,
-      "suffix": "/api/core/v3/stages/{Stage ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/stages/{Stage ID}?fields={Fields?}",
+      "description": "One stage by id."
     },
     {
       "name": "Stages",
       "paged": true,
-      "suffix": "/api/core/v3/stages?fields={Fields?}"
+      "suffix": "/api/core/v3/stages?fields={Fields?}",
+      "description": "The stages an idea moves through -- Jive's idea lifecycle. WHERE IDEAS SIT IN THE PROCESS, which the idea content object records only as a current value."
     },
     {
       "name": "Static",
       "paged": false,
-      "suffix": "/api/core/v3/statics/{Static ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/statics/{Static ID}?fields={Fields?}",
+      "description": "One static resource by id."
     },
     {
       "name": "Statics",
       "paged": true,
-      "suffix": "/api/core/v3/statics?filter={Filter?}&fields={Fields?}"
+      "suffix": "/api/core/v3/statics?filter={Filter?}&fields={Fields?}",
+      "description": "The static resources uploaded to the community."
     },
     {
       "name": "Stream Comments",
       "paged": true,
-      "suffix": "/api/core/v3/streamEntries/{Entry ID}/comments?filter={Filter?}&fields={Fields?}&anchor={Anchor?}&excludeReplies={Exclude Replies?:false|true}&hierarchical={Hierarchical?:true|false}"
+      "suffix": "/api/core/v3/streamEntries/{Entry ID}/comments?filter={Filter?}&fields={Fields?}&anchor={Anchor?}&excludeReplies={Exclude Replies?:false|true}&hierarchical={Hierarchical?:true|false}",
+      "description": "The comments on one stream entry. Requires the entry id."
     },
     {
       "name": "Stream Likes",
       "paged": true,
-      "suffix": "/api/core/v3/streamEntries/{Entry ID}/likes?fields={Fields?}"
+      "suffix": "/api/core/v3/streamEntries/{Entry ID}/likes?fields={Fields?}",
+      "description": "The likes on one stream entry. Requires the entry id."
     },
     {
       "name": "Stream Activity",
       "paged": true,
-      "suffix": "/api/core/v3/streams/{Stream ID}/activities?filter={Filter?:author|notifications|object|type|unread|verb}&before={Before?:yyyy-MM-ddT'HH:mm:ssZ}&after={After?:yyyy-MM-dd'T'HH:mm:ssZ}&fields={Fields?}&collapse={Collapse?:false|true}&oldestUnread={Oldest Unread?:false|true}&updateLastRead={Update Last Read?:false|true}"
+      "suffix": "/api/core/v3/streams/{Stream ID}/activities?filter={Filter?:author|notifications|object|type|unread|verb}&before={Before?:yyyy-MM-ddT'HH:mm:ssZ}&after={After?:yyyy-MM-dd'T'HH:mm:ssZ}&fields={Fields?}&collapse={Collapse?:false|true}&oldestUnread={Oldest Unread?:false|true}&updateLastRead={Update Last Read?:false|true}",
+      "description": "The activity within one stream. Requires the stream id."
     },
     {
       "name": "Stream Activity Count",
       "paged": false,
-      "suffix": "/api/core/v3/streams/{Stream ID}/activities/count?after={After?:yyyy-MM-ddTHH:mm:ssZ}&max={Max Number?}&exclude={Exclude?:false|true}"
+      "suffix": "/api/core/v3/streams/{Stream ID}/activities/count?after={After?:yyyy-MM-ddTHH:mm:ssZ}&max={Max Number?}&exclude={Exclude?:false|true}",
+      "description": "How much activity one stream carries. The size check."
     },
     {
       "name": "Stream Association",
       "paged": false,
-      "suffix": "/api/core/v3/streams/{Stream ID}/associations/{Object Type}/{Object ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/streams/{Stream ID}/associations/{Object Type}/{Object ID}?fields={Fields?}",
+      "description": "One stream association by id."
     },
     {
       "name": "Stream Associations",
       "paged": true,
-      "suffix": "/api/core/v3/streams/{Stream ID}/associations?filter={Filter?:type}&fields={Fields?}"
+      "suffix": "/api/core/v3/streams/{Stream ID}/associations?filter={Filter?:type}&fields={Fields?}",
+      "description": "What one stream is subscribed to. Requires the stream id. The stream's actual definition."
     },
     {
       "name": "Connections Activity",
       "paged": true,
-      "suffix": "/api/core/v3/streams/connections/activities?filter={Filter?:author|notifications|object|type|unread|verb}&before={Before?:yyyy-MM-ddT'HH:mm:ssZ}&after={After?:yyyy-MM-dd'T'HH:mm:ssZ}&fields={Fields?}&collapse={Collapse?:false|true}&oldestUnread={Oldest Unread?:false|true}"
+      "suffix": "/api/core/v3/streams/connections/activities?filter={Filter?:author|notifications|object|type|unread|verb}&before={Before?:yyyy-MM-ddT'HH:mm:ssZ}&after={After?:yyyy-MM-dd'T'HH:mm:ssZ}&fields={Fields?}&collapse={Collapse?:false|true}&oldestUnread={Oldest Unread?:false|true}",
+      "description": "The activity of the people the calling user is connected to. The social feed."
     },
     {
       "name": "Stream",
       "paged": false,
-      "suffix": "/api/core/v3/streams/{Stream ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/streams/{Stream ID}?fields={Fields?}",
+      "description": "One stream by id."
     },
     {
       "name": "Tag",
       "paged": true,
-      "suffix": "/api/core/v3/tags/{Tag ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/tags/{Tag ID}?fields={Fields?}",
+      "description": "One tag by name, with its usage. Tags are the community's free-form taxonomy, unconstrained and often near-duplicated."
     },
     {
       "name": "Tile Definition",
       "paged": false,
-      "suffix": "/api/core/v3/tileDefs/{Tile ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/tileDefs/{Tile ID}?fields={Fields?}",
+      "description": "One tile definition -- the type of tile an add-on provides, as opposed to an instance of it."
     },
     {
       "name": "Tile Definition I18n Resource",
       "paged": false,
-      "suffix": "/api/core/v3/tileDefs/{Tile ID}/i18n/{Language?}/{Country?}"
+      "suffix": "/api/core/v3/tileDefs/{Tile ID}/i18n/{Language?}/{Country?}",
+      "description": "The translated strings of one tile definition."
     },
     {
       "name": "Tile Definition Instances",
       "paged": true,
-      "suffix": "/api/core/v3/tileDefs?filter={Filter?:name|addonUUID|state}&fields={Fields?}"
+      "suffix": "/api/core/v3/tileDefs?filter={Filter?:name|addonUUID|state}&fields={Fields?}",
+      "description": "The instances created from one tile definition. Requires the definition id. How widely an add-on's tile is actually used."
     },
     {
       "name": "Tile Definition Prototype",
       "paged": false,
-      "suffix": "/api/core/v3/tileDefs/{Tile ID}/prototype?fields={Fields?}"
+      "suffix": "/api/core/v3/tileDefs/{Tile ID}/prototype?fields={Fields?}",
+      "description": "A prototype tile object for a definition. Scaffolding."
     },
     {
       "name": "Tile Definition Categories",
       "paged": true,
-      "suffix": "/api/core/v3/tileDefs/categories?filter={Filter?:tileState}&fields={Fields?}"
+      "suffix": "/api/core/v3/tileDefs/categories?filter={Filter?:tileState}&fields={Fields?}",
+      "description": "The categories tile definitions are grouped into."
     },
     {
       "name": "Tile Definition Category",
       "paged": false,
-      "suffix": "/api/core/v3/tileDefs/category/{Tile Category ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/tileDefs/category/{Tile Category ID}?fields={Fields?}",
+      "description": "One tile definition category by id."
     },
     {
       "name": "Tile Instance",
       "paged": false,
-      "suffix": "/api/core/v3/tiles/{Instance ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/tiles/{Instance ID}?fields={Fields?}",
+      "description": "One tile instance by id."
     },
     {
       "name": "Tile Instance by External ID",
       "paged": false,
-      "suffix": "/api/core/v3/tiles/external/{Extension UUID}/{External ID}"
+      "suffix": "/api/core/v3/tiles/external/{Extension UUID}/{External ID}",
+      "description": "One tile instance by the external system's identifier. The bridge from an integration's own id to Jive's."
     },
     {
       "name": "Tile Instance Data",
       "paged": false,
-      "suffix": "/api/core/v3/tiles/{Instance ID}/data"
+      "suffix": "/api/core/v3/tiles/{Instance ID}/data",
+      "description": "THE DATA A TILE IS DISPLAYING. Requires the tile id. Where an integration has pushed content into Jive, this is the only place that content is readable -- it lives in the tile rather than in any content table."
     },
     {
       "name": "Tile Instances",
@@ -1375,62 +1621,74 @@
           "key": "id",
           "parameterName": "Instance ID"
         }
-      ]
+      ],
+      "description": "The tile instances across the community."
     },
     {
       "name": "Tile Private Properties",
       "paged": true,
-      "suffix": "/api/core/v3/tiles/{Instance ID}/privateprops"
+      "suffix": "/api/core/v3/tiles/{Instance ID}/privateprops",
+      "description": "The private configuration of one tile instance. Application storage."
     },
     {
       "name": "Tile Categories",
       "paged": true,
-      "suffix": "/api/core/v3/tiles/categories?filter={Filter?:tilePage}&fields={Fields?}"
+      "suffix": "/api/core/v3/tiles/categories?filter={Filter?:tilePage}&fields={Fields?}",
+      "description": "The categories tiles are grouped into."
     },
     {
       "name": "Tile Category",
       "paged": false,
-      "suffix": "/api/core/v3/tiles/categories/{Tile Category ID}"
+      "suffix": "/api/core/v3/tiles/categories/{Tile Category ID}",
+      "description": "One tile category by id."
     },
     {
       "name": "URL Comments",
       "paged": true,
-      "suffix": "/api/core/v3/urls/{URL ID}/comments?filter={Filter?:type}&fields={Fields?}&anchor={Anchor?}&excludeReplies={Exclude Replies?:false|true}&hierarchical={Hierarchical?:true|false}"
+      "suffix": "/api/core/v3/urls/{URL ID}/comments?filter={Filter?:type}&fields={Fields?}&anchor={Anchor?}&excludeReplies={Exclude Replies?:false|true}&hierarchical={Hierarchical?:true|false}",
+      "description": "The comments on one external URL object. Requires the URL id."
     },
     {
       "name": "Content External URLs",
       "paged": true,
-      "suffix": "/api/core/v3/urls/contents/{Content ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/urls/contents/{Content ID}?fields={Fields?}",
+      "description": "The external links referenced by one content object. Requires the content id."
     },
     {
       "name": "External URL",
       "paged": false,
-      "suffix": "/api/core/v3/urls/{URL ID}"
+      "suffix": "/api/core/v3/urls/{URL ID}",
+      "description": "One external URL object by id. Jive tracks links shared into the community as objects, so this is how external references become countable."
     },
     {
       "name": "Version",
       "paged": false,
-      "suffix": "/api/core/v3/versions/{Content ID}/{Version Number}"
+      "suffix": "/api/core/v3/versions/{Content ID}/{Version Number}",
+      "description": "One version of one content object."
     },
     {
       "name": "Versions",
       "paged": true,
-      "suffix": "/api/core/v3/versions/{Content ID}?fields={Fields?}"
+      "suffix": "/api/core/v3/versions/{Content ID}?fields={Fields?}",
+      "description": "The version history of one content object. Requires the content id. Jive versions documents, so this is the only record of what a document said before it was edited -- and who changed it."
     },
     {
       "name": "Download Options",
       "paged": false,
-      "suffix": "/api/core/v3/videos/downloadOptions/{Video ID}"
+      "suffix": "/api/core/v3/videos/downloadOptions/{Video ID}",
+      "description": "The download formats available for one video. Requires the video id."
     },
     {
       "name": "Vitals",
       "paged": true,
-      "suffix": "/api/core/v3/vitals"
+      "suffix": "/api/core/v3/vitals",
+      "description": "The vital statistics of one object -- view, like, comment and follower counts in one call. Requires the object id. THE CHEAP ENGAGEMENT SUMMARY: it avoids fetching the likes, comments and followers separately when only the totals are wanted."
     },
     {
       "name": "Votes",
       "paged": true,
-      "suffix": "/api/core/v3/votes/{Content ID}"
+      "suffix": "/api/core/v3/votes/{Content ID}",
+      "description": "The votes cast on one poll. Requires the poll id. The result of a poll, which the poll object does not carry."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/keap/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/keap/endpoints.json
@@ -3,52 +3,62 @@
     {
       "name": "Account Profile",
       "paged": false,
-      "suffix": "/v1/account/profile"
+      "suffix": "/v1/account/profile",
+      "description": "The Keap account's own details -- company name, address, currency and time zone. One record."
     },
     {
       "name": "Commissions",
       "paged": true,
-      "suffix": "/v1/affiliates/commissions?since={Since?: yyyy-MM-ddTHH:mm:ssZ}&until={Until?:yyyy-MM-ddTHH:mm:ssZ}&affiliateId={Affiliate ID?}"
+      "suffix": "/v1/affiliates/commissions?since={Since?: yyyy-MM-ddTHH:mm:ssZ}&until={Until?:yyyy-MM-ddTHH:mm:ssZ}&affiliateId={Affiliate ID?}",
+      "description": "Affiliate commissions earned, filterable by date. Requires the affiliate programme to be in use. What partners are owed, which appears nowhere in the order table."
     },
     {
       "name": "Affiliate Model",
       "paged": false,
-      "suffix": "/v1/affiliates/model"
+      "suffix": "/v1/affiliates/model",
+      "description": "The schema of the affiliate object."
     },
     {
       "name": "Appointments",
       "paged": true,
-      "suffix": "/v1/appointments?since={Since?: yyyy-MM-ddTHH:mm:ssZ}&until={Until?:yyyy-MM-ddTHH:mm:ssZ}&contact_id={Contact ID?}"
+      "suffix": "/v1/appointments?since={Since?: yyyy-MM-ddTHH:mm:ssZ}&until={Until?:yyyy-MM-ddTHH:mm:ssZ}&contact_id={Contact ID?}",
+      "description": "Calendar appointments, filterable by date range. Carries the contact, times, location and remind time."
     },
     {
       "name": "Appointment",
       "paged": false,
-      "suffix": "/v1/appointments/{Appointment ID}"
+      "suffix": "/v1/appointments/{Appointment ID}",
+      "description": "One appointment by id."
     },
     {
       "name": "Appointment Model",
       "paged": false,
-      "suffix": "/v1/appointments/model"
+      "suffix": "/v1/appointments/model",
+      "description": "The schema of the appointment object."
     },
     {
       "name": "Campaigns",
       "paged": true,
-      "suffix": "/v1/campaigns?search_text={Search Text?}"
+      "suffix": "/v1/campaigns?search_text={Search Text?}",
+      "description": "The marketing campaigns -- Keap's automation sequences -- filterable by search text. Carries the name, the goals and sequences within, and the counts of contacts active in each. WHERE AUTOMATION LIVES: contacts move through these based on tags and behaviour, and the active counts are the closest thing to a funnel state for the business."
     },
     {
       "name": "Campaign",
       "paged": false,
-      "suffix": "/v1/campaigns/{Campaign ID}?optional_properties={Optional Properties?: value1,value2,...}"
+      "suffix": "/v1/campaigns/{Campaign ID}?optional_properties={Optional Properties?: value1,value2,...}",
+      "description": "One campaign by id, with its sequences and goals."
     },
     {
       "name": "Companies",
       "paged": true,
-      "suffix": "/v1/companies?company_name={Company Name?}&optional_properties={Optional Properties?: value1,value2,...}"
+      "suffix": "/v1/companies?company_name={Company Name?}&optional_properties={Optional Properties?: value1,value2,...}",
+      "description": "The companies contacts belong to, filterable by name. The organisation dimension."
     },
     {
       "name": "Company Model",
       "paged": false,
-      "suffix": "/v1/companies/model"
+      "suffix": "/v1/companies/model",
+      "description": "The schema of the company object, including custom fields."
     },
     {
       "name": "Contacts",
@@ -65,32 +75,38 @@
           "key": "id",
           "parameterName": "Contact ID"
         }
-      ]
+      ],
+      "description": "The contacts in the account, filterable by email, given name and family name. Carries names, email addresses and phone numbers as ARRAYS of labelled entries rather than single values, addresses, the owner, the source, tags, and custom fields. The central table of a Keap account. Note optional_properties: several useful fields -- custom fields among them -- are omitted unless named there, so their absence is often an unmade request rather than empty data."
     },
     {
       "name": "Credit Cards",
       "paged": false,
-      "suffix": "/v1/contacts/{Contact ID}/creditCards"
+      "suffix": "/v1/contacts/{Contact ID}/creditCards",
+      "description": "The payment cards stored on one contact. Requires a contact id. Metadata only; card numbers are not returned."
     },
     {
       "name": "Contact Emails",
       "paged": true,
-      "suffix": "/v1/contacts/{Contact ID}/emails?email={Email?}"
+      "suffix": "/v1/contacts/{Contact ID}/emails?email={Email?}",
+      "description": "The email addresses on one contact. Requires a contact id."
     },
     {
       "name": "Applied Tags",
       "paged": true,
-      "suffix": "/v1/contacts/{Contact ID}/tags"
+      "suffix": "/v1/contacts/{Contact ID}/tags",
+      "description": "The tags applied to one contact. Requires a contact id. Tags in Keap are the primary segmentation mechanism -- automation is driven by them -- so a contact's tags say more about where they sit in the business than any status field."
     },
     {
       "name": "Contact",
       "paged": false,
-      "suffix": "/v1/contacts/{ID}?optional_properties={Optional Properties?: value1,value2,...}"
+      "suffix": "/v1/contacts/{ID}?optional_properties={Optional Properties?: value1,value2,...}",
+      "description": "One contact by id, with the same optional_properties behaviour."
     },
     {
       "name": "Contact Model",
       "paged": false,
-      "suffix": "/v1/contacts/model"
+      "suffix": "/v1/contacts/model",
+      "description": "The schema of the contact object -- every field including custom ones, with its type and options. THE DECODER, and Keap gives every major object one of these model endpoints, which is the pattern to reach for whenever a custom field appears."
     },
     {
       "name": "Orders",
@@ -103,157 +119,188 @@
           "key": "id",
           "parameterName": "Order ID"
         }
-      ]
+      ],
+      "description": "The orders placed, filterable by date range, contact and product. Carries the contact, order items, total, status and the date. The commerce side of Keap, distinct from opportunities: an opportunity is a forecast, an order is money owed."
     },
     {
       "name": "Order",
       "paged": false,
-      "suffix": "/v1/orders/{Order ID}"
+      "suffix": "/v1/orders/{Order ID}",
+      "description": "One order by id, with its line items."
     },
     {
       "name": "Order Transactions",
       "paged": true,
-      "suffix": "/v1/orders/{Order ID}/transactions?since={Since?: yyyy-MM-ddTHH:mm:ssZ}&until={Until?:yyyy-MM-ddTHH:mm:ssZ}&contact_id={Contact ID}"
+      "suffix": "/v1/orders/{Order ID}/transactions?since={Since?: yyyy-MM-ddTHH:mm:ssZ}&until={Until?:yyyy-MM-ddTHH:mm:ssZ}&contact_id={Contact ID}",
+      "description": "The payments applied against one order. Requires an order id. The order carries a total; this says when and whether money actually arrived."
     },
     {
       "name": "Custom Order Model",
       "paged": false,
-      "suffix": "/v1/orders/model"
+      "suffix": "/v1/orders/model",
+      "description": "The schema of the order object, including custom fields."
     },
     {
       "name": "Subscriptions",
       "paged": true,
-      "suffix": "/v1/subscriptions?contact_id={Contact ID?}"
+      "suffix": "/v1/subscriptions?contact_id={Contact ID?}",
+      "description": "The recurring billing subscriptions, optionally for one contact. Carries the product, billing cycle, amount and status. Recurring revenue, which the order table records only as individual charges."
     },
     {
       "name": "Subscription Model",
       "paged": false,
-      "suffix": "/v1/subscriptions/model"
+      "suffix": "/v1/subscriptions/model",
+      "description": "The schema of the subscription object."
     },
     {
       "name": "Transactions",
       "paged": true,
-      "suffix": "/v1/transactions?since={Since?: yyyy-MM-ddTHH:mm:ssZ}&until={Until?:yyyy-MM-ddTHH:mm:ssZ}&contact_id={Contact ID?}"
+      "suffix": "/v1/transactions?since={Since?: yyyy-MM-ddTHH:mm:ssZ}&until={Until?:yyyy-MM-ddTHH:mm:ssZ}&contact_id={Contact ID?}",
+      "description": "All payment transactions across the account, filterable by date and contact. The account-wide cash view, as opposed to the per-order one."
     },
     {
       "name": "Transaction",
       "paged": false,
-      "suffix": "/v1/transactions/{Transaction ID}"
+      "suffix": "/v1/transactions/{Transaction ID}",
+      "description": "One transaction by id."
     },
     {
       "name": "Emails",
       "paged": true,
-      "suffix": "/v1/emails?contact_id={Contact ID?}&email={Email?}&since_sent_date={Since Sent Date?:yyyy-MM-ddTHH:mm:ssZ}&until_sent_date={Until Sent Date?:yyyy-MM-ddTHH:mm:ssZ}"
+      "suffix": "/v1/emails?contact_id={Contact ID?}&email={Email?}&since_sent_date={Since Sent Date?:yyyy-MM-ddTHH:mm:ssZ}&until_sent_date={Until Sent Date?:yyyy-MM-ddTHH:mm:ssZ}",
+      "description": "The emails sent to contacts, filterable by contact, address and sent date. The record of what was actually delivered, as opposed to the campaign that intended it."
     },
     {
       "name": "Email",
       "paged": false,
-      "suffix": "/v1/emails/{ID}"
+      "suffix": "/v1/emails/{ID}",
+      "description": "One email by id, with its content and headers."
     },
     {
       "name": "Files",
       "paged": true,
-      "suffix": "/v1/files?viewable={Viewable?:PUBLIC | PRIVATE | BOTH}&permission={Permission?:USER | COMPANY | BOTH}&type={Type?:Application | Image | Fax | ... }&name={Name?}&contact_id={Contact ID}"
+      "suffix": "/v1/files?viewable={Viewable?:PUBLIC | PRIVATE | BOTH}&permission={Permission?:USER | COMPANY | BOTH}&type={Type?:Application | Image | Fax | ... }&name={Name?}&contact_id={Contact ID}",
+      "description": "The files stored, filterable by visibility and permission. Metadata; contents are a separate fetch."
     },
     {
       "name": "File",
       "paged": false,
-      "suffix": "/v1/files/{FileId}?optional_properties={Optional Properties?: value1,value2,...}"
+      "suffix": "/v1/files/{FileId}?optional_properties={Optional Properties?: value1,value2,...}",
+      "description": "One file by id."
     },
     {
       "name": "Countries",
       "paged": false,
-      "suffix": "/v1/locales/countries"
+      "suffix": "/v1/locales/countries",
+      "description": "The country list Keap accepts. Reference data."
     },
     {
       "name": "Country's Provinces",
       "paged": false,
-      "suffix": "/v1/locales/countries/{Country Code}/provinces"
+      "suffix": "/v1/locales/countries/{Country Code}/provinces",
+      "description": "The provinces or states of one country. Requires the country code."
     },
     {
       "name": "Merchants",
       "paged": false,
-      "suffix": "/v1/merchants"
+      "suffix": "/v1/merchants",
+      "description": "The payment gateways configured. Which processor a transaction went through, and the explanation for a payment method that is unavailable."
     },
     {
       "name": "Notes",
       "paged": true,
-      "suffix": "/v1/notes?user_id={User ID?}&contact_id={Contact ID?}"
+      "suffix": "/v1/notes?user_id={User ID?}&contact_id={Contact ID?}",
+      "description": "Notes recorded against contacts, filterable by user and contact. The qualitative record."
     },
     {
       "name": "Note",
       "paged": false,
-      "suffix": "/v1/notes/{Note ID}"
+      "suffix": "/v1/notes/{Note ID}",
+      "description": "One note by id."
     },
     {
       "name": "Note Model",
       "paged": false,
-      "suffix": "/v1/notes/model"
+      "suffix": "/v1/notes/model",
+      "description": "The schema of the note object."
     },
     {
       "name": "Opportunities",
       "paged": true,
-      "suffix": "/v1/opportunities?user_id={User ID?}&stage_id={Stage ID?}&search_term={Search Term?}"
+      "suffix": "/v1/opportunities?user_id={User ID?}&stage_id={Stage ID?}&search_term={Search Term?}",
+      "description": "The sales opportunities, filterable by owner, stage and search term. Carries the contact, the stage, estimated close date, value and probability. The pipeline table."
     },
     {
       "name": "Opportunity",
       "paged": false,
-      "suffix": "/v1/opportunities/{Opportunity ID}?optional_properties={Optional Properties?: value1,value2,...}"
+      "suffix": "/v1/opportunities/{Opportunity ID}?optional_properties={Optional Properties?: value1,value2,...}",
+      "description": "One opportunity by id."
     },
     {
       "name": "Opportunity Model",
       "paged": false,
-      "suffix": "/v1/opportunities/model"
+      "suffix": "/v1/opportunities/model",
+      "description": "The schema of the opportunity object."
     },
     {
       "name": "Opportunity Stage Pipelines",
       "paged": false,
-      "suffix": "/v1/opportunity/stage_pipeline"
+      "suffix": "/v1/opportunity/stage_pipeline",
+      "description": "The pipelines and their stages, in order. The dimension a funnel breakdown joins to, and the decoder for the stage id on an opportunity."
     },
     {
       "name": "Products",
       "paged": true,
-      "suffix": "/v1/products?active={Active?:true | false}"
+      "suffix": "/v1/products?active={Active?:true | false}",
+      "description": "The product catalogue, filterable by active state, with price, SKU and description."
     },
     {
       "name": "Product",
       "paged": false,
-      "suffix": "/v1/products/{Product ID}"
+      "suffix": "/v1/products/{Product ID}",
+      "description": "One product by id."
     },
     {
       "name": "Product Subscription",
       "paged": false,
-      "suffix": "/v1/products/{Product ID}/subscriptions/{Subscription ID}"
+      "suffix": "/v1/products/{Product ID}/subscriptions/{Subscription ID}",
+      "description": "One subscription plan on one product. Requires both ids. The recurring offer attached to a product."
     },
     {
       "name": "Synced Products",
       "paged": true,
-      "suffix": "/v1/products/sync?sync_token={Sync Token}"
+      "suffix": "/v1/products/sync?sync_token={Sync Token}",
+      "description": "Products changed since a sync token was issued. Requires the token. The incremental-sync route for the catalogue, which the plain listing cannot provide."
     },
     {
       "name": "Hook Event Types",
       "paged": false,
-      "suffix": "/v1/hooks/event_keys"
+      "suffix": "/v1/hooks/event_keys",
+      "description": "The event types a webhook can subscribe to. Reference data."
     },
     {
       "name": "Hook Subscriptions",
       "paged": false,
-      "suffix": "/v1/hooks"
+      "suffix": "/v1/hooks",
+      "description": "The webhooks registered by the calling application, with the events each subscribes to. Note it lists this application's hooks, not every hook on the account."
     },
     {
       "name": "Hook Subscription",
       "paged": false,
-      "suffix": "/v1/hooks/{Key}"
+      "suffix": "/v1/hooks/{Key}",
+      "description": "One webhook by key."
     },
     {
       "name": "Application Status",
       "paged": false,
-      "suffix": "/v1/setting/application/enabled"
+      "suffix": "/v1/setting/application/enabled",
+      "description": "Whether the Keap application is enabled. A health check."
     },
     {
       "name": "Contact Types",
       "paged": false,
-      "suffix": "/v1/setting/contact/optionTypes"
+      "suffix": "/v1/setting/contact/optionTypes",
+      "description": "The contact option types configured. Reference data for the contact model."
     },
     {
       "name": "Tags",
@@ -261,57 +308,70 @@
       "suffix": "/v1/tags?category={Category?}&name={Name?}",
       "lookups": [
         {
-          "endpoints": ["Tagged Companies", "Tagged Contacts"],
+          "endpoints": [
+            "Tagged Companies",
+            "Tagged Contacts"
+          ],
           "jsonPath": "$.tags[*]",
           "key": "id",
           "parameterName": "Tag ID"
         }
-      ]
+      ],
+      "description": "The tags defined, filterable by category and name. Since automation runs on tags, this list is effectively the catalogue of states and segments the business tracks."
     },
     {
       "name": "Tag",
       "paged": false,
-      "suffix": "/v1/tags/{ID}"
+      "suffix": "/v1/tags/{ID}",
+      "description": "One tag by id."
     },
     {
       "name": "Tagged Companies",
       "paged": true,
-      "suffix": "/v1/tags/{Tag ID}/companies"
+      "suffix": "/v1/tags/{Tag ID}/companies",
+      "description": "The companies carrying one tag. Requires a tag id."
     },
     {
       "name": "Tagged Contacts",
       "paged": true,
-      "suffix": "/v1/tags/{Tag ID}/contacts"
+      "suffix": "/v1/tags/{Tag ID}/contacts",
+      "description": "The contacts carrying one tag. Requires a tag id. The membership behind a segment."
     },
     {
       "name": "Tasks",
       "paged": true,
-      "suffix": "/v1/tasks?contact_id={Contact ID?}&has_due_date={Has Due Date?:true | false}&user_id={User ID?}&since={Since?: yyyy-MM-ddTHH:mm:ssZ}&until={Until?:yyyy-MM-ddTHH:mm:ssZ}&completed={Completed?:true | false}"
+      "suffix": "/v1/tasks?contact_id={Contact ID?}&has_due_date={Has Due Date?:true | false}&user_id={User ID?}&since={Since?: yyyy-MM-ddTHH:mm:ssZ}&until={Until?:yyyy-MM-ddTHH:mm:ssZ}&completed={Completed?:true | false}",
+      "description": "The to-dos, filterable by contact, due date presence and completion. Carries the contact, due date, priority and owner."
     },
     {
       "name": "Task",
       "paged": false,
-      "suffix": "/v1/tasks/{Task ID}"
+      "suffix": "/v1/tasks/{Task ID}",
+      "description": "One task by id."
     },
     {
       "name": "Task Model",
       "paged": false,
-      "suffix": "/v1/tasks/model"
+      "suffix": "/v1/tasks/model",
+      "description": "The schema of the task object."
     },
     {
       "name": "Search Tasks",
       "paged": true,
-      "suffix": "/v1/tasks/search?contact_id={Contact ID?}&has_due_date={Has Due Date?:true | false}&user_id={User ID}&since={Since?: yyyy-MM-ddTHH:mm:ssZ}&until={Until?:yyyy-MM-ddTHH:mm:ssZ}&completed={Completed?:true | false}"
+      "suffix": "/v1/tasks/search?contact_id={Contact ID?}&has_due_date={Has Due Date?:true | false}&user_id={User ID}&since={Since?: yyyy-MM-ddTHH:mm:ssZ}&until={Until?:yyyy-MM-ddTHH:mm:ssZ}&completed={Completed?:true | false}",
+      "description": "Tasks matching search criteria. The filtered route where the plain listing's parameters are insufficient."
     },
     {
       "name": "User Info",
       "paged": false,
-      "suffix": "/v1/oauth/connect/userinfo"
+      "suffix": "/v1/oauth/connect/userinfo",
+      "description": "The account the credentials belong to. One record, always the caller."
     },
     {
       "name": "Users",
       "paged": true,
-      "suffix": "/v1/users?include_inactive={Include Inactive?:true|false}&include_partners={Include Partners?:true | false}"
+      "suffix": "/v1/users?include_inactive={Include Inactive?:true|false}&include_partners={Include Partners?:true | false}",
+      "description": "The users of the account, optionally including inactive ones. Every record carries an owner, so this is the dimension per-person performance joins to."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/linkedin/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/linkedin/endpoints.json
@@ -77,7 +77,7 @@
       "paged": true,
       "pageType": "ITERATION",
       "suffix": "/rest/creatives?q=search",
-      "description": "The creatives -- the actual ads -- within one account, with their status, the campaign each belongs to, and the content they reference. Requires an account id. A campaign holds several creatives, so creative-level performance is where a winning variant is identified."
+      "description": "The creatives -- the actual ads -- with their status, the campaign each belongs to, and the content they reference. Uses LinkedIn's search finder, so the account and campaign are given as SEARCH CRITERIA rather than as named parameters, which is why no account id appears in the path. A campaign holds several creatives, so creative-level performance is where a winning variant is identified."
     },
     {
       "name": "Ad Targeting Facets",

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/linkedin/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/linkedin/endpoints.json
@@ -3,508 +3,597 @@
     {
       "name": "Ad Account",
       "paged": false,
-      "suffix": "/rest/adAccounts/{Ad Account ID}"
+      "suffix": "/rest/adAccounts/{Ad Account ID}",
+      "description": "One advertising account by id, with its budget and status."
     },
     {
       "name": "Ad Accounts",
       "paged": true,
       "pageType": "ITERATION",
-      "suffix": "/rest/adAccounts?q=search"
+      "suffix": "/rest/adAccounts?q=search",
+      "description": "The advertising accounts the credentials can reach, with name, type, status, currency and the reference the advertiser assigned. THE STARTING POINT: nearly every endpoint here takes a sponsored account URN, and LINKEDIN IDENTIFIES EVERYTHING BY URN rather than by bare id -- a string like urn:li:sponsoredAccount:12345 -- so an id lifted from one response usually needs wrapping before another will accept it."
     },
     {
       "name": "Ad Account User",
       "paged": false,
-      "suffix": "/rest/adAccountUsers?account={Sponsored Account URN}&user={User URN}"
+      "suffix": "/rest/adAccountUsers?account={Sponsored Account URN}&user={User URN}",
+      "description": "One user's access to one account. Requires both URNs."
     },
     {
       "name": "Authenticated Ad Account User",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/adAccountUsers?q=authenticatedUser"
+      "suffix": "/rest/adAccountUsers?q=authenticatedUser",
+      "description": "The caller's own access records. Always the caller's, and the explanation for which accounts the rest of this connector can see."
     },
     {
       "name": "Ad Account Users by Accounts",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/adAccountUsers?q=accounts&accounts={Sponsored Account URNs,:urn1,urn2,...}"
+      "suffix": "/rest/adAccountUsers?q=accounts&accounts={Sponsored Account URNs,:urn1,urn2,...}",
+      "description": "Access records across several named accounts at once. The efficient route for an agency managing many."
     },
     {
       "name": "Ad Account Users",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/adAccountUsers?&q=account&totals=true&Account={Sponsored Account URN}"
+      "suffix": "/rest/adAccountUsers?&q=account&totals=true&Account={Sponsored Account URN}",
+      "description": "The users with access to one account and the role each holds. Requires the account URN."
     },
     {
       "name": "Campaign Group",
       "paged": false,
-      "suffix": "/rest/adAccounts/{Ad Account ID}/adCampaignGroups/{Campaign Group ID}"
+      "suffix": "/rest/adAccounts/{Ad Account ID}/adCampaignGroups/{Campaign Group ID}",
+      "description": "One campaign group by id."
     },
     {
       "name": "Campaign Groups",
       "paged": true,
       "pageType": "ITERATION",
-      "suffix": "/rest/adAccounts/{Ad Account ID}/adCampaignGroups?q=search"
+      "suffix": "/rest/adAccounts/{Ad Account ID}/adCampaignGroups?q=search",
+      "description": "The campaign groups within one account -- the budget and scheduling container above campaigns. Requires an account id. Budgets are frequently set here rather than per campaign, so campaign-level spend does not add up to the group's budget."
     },
     {
       "name": "Campaign",
       "paged": false,
-      "suffix": "/rest/adAccounts/{Ad Account ID}/adCampaigns/{Campaign ID}"
+      "suffix": "/rest/adAccounts/{Ad Account ID}/adCampaigns/{Campaign ID}",
+      "description": "One campaign by id, with its full targeting."
     },
     {
       "name": "Campaigns",
       "paged": true,
       "pageType": "ITERATION",
-      "suffix": "/rest/adAccounts/{Ad Account ID}/adCampaigns?q=search"
+      "suffix": "/rest/adAccounts/{Ad Account ID}/adCampaigns?q=search",
+      "description": "The campaigns within one account, with name, type, status, objective, the daily and total budget, bid, schedule and targeting criteria. Requires an account id. The unit most advertising questions are asked about. STATUS separates ACTIVE from PAUSED, DRAFT, ARCHIVED, COMPLETED and CANCELED, so an unfiltered spend or count includes campaigns that never ran."
     },
     {
       "name": "Creative",
       "paged": false,
-      "suffix": "/rest/creatives/{Creative ID}"
+      "suffix": "/rest/creatives/{Creative ID}",
+      "description": "One creative by id."
     },
     {
       "name": "Creatives",
       "paged": true,
       "pageType": "ITERATION",
-      "suffix": "/rest/creatives?q=search"
+      "suffix": "/rest/creatives?q=search",
+      "description": "The creatives -- the actual ads -- within one account, with their status, the campaign each belongs to, and the content they reference. Requires an account id. A campaign holds several creatives, so creative-level performance is where a winning variant is identified."
     },
     {
       "name": "Ad Targeting Facets",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/adTargetingFacets"
+      "suffix": "/rest/adTargetingFacets",
+      "description": "The targeting dimensions available -- industry, job function, seniority, skills, company size and the rest. The vocabulary campaigns are targeted in."
     },
     {
       "name": "Ad Targeting Entities",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/adTargetingEntities?q=adTargetingFacet&facet={Ad Targeting Facet URN}"
+      "suffix": "/rest/adTargetingEntities?q=adTargetingFacet&facet={Ad Targeting Facet URN}",
+      "description": "The specific values within one targeting facet. Requires the facet. THE DECODER for targeting criteria: a campaign's targeting is a set of URNs, and this is what resolves them to names."
     },
     {
       "name": "Ad Targeting Entities by Similar Entities",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/adTargetingEntities?q=similarEntities&facet={Ad Targeting Facet URN}&entities={Entity URN}"
+      "suffix": "/rest/adTargetingEntities?q=similarEntities&facet={Ad Targeting Facet URN}&entities={Entity URN}",
+      "description": "Targeting values similar to given ones. Audience expansion, for finding adjacent segments."
     },
     {
       "name": "Audience Counts",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/audienceCounts?q=targetingCriteria&targetingCriteria={Targeting Criteria}"
+      "suffix": "/rest/audienceCounts?q=targetingCriteria&targetingCriteria={Targeting Criteria}",
+      "description": "The estimated size of an audience matching given targeting criteria. Planning rather than reporting -- it says how many people could be reached, not how many were."
     },
     {
       "name": "Ad Supply Forecasts",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/adSupplyForecasts?q=criteriaV2&targetingCriteria={Targeting Criteria}"
+      "suffix": "/rest/adSupplyForecasts?q=criteriaV2&targetingCriteria={Targeting Criteria}",
+      "description": "The forecast impressions available for given targeting criteria. The inventory side of the same planning question."
     },
     {
       "name": "Video Ad",
       "paged": false,
-      "suffix": "/rest/adDirectSponsoredContents/{UGC Post URN}"
+      "suffix": "/rest/adDirectSponsoredContents/{UGC Post URN}",
+      "description": "One video ad by its post URN."
     },
     {
       "name": "Video Ads By Account",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/adDirectSponsoredContents?q=account&types=List[VIDEO]&includeTotals=false&account={Sponsored Account URN}&owner={Organization URN}"
+      "suffix": "/rest/adDirectSponsoredContents?q=account&types=List[VIDEO]&includeTotals=false&account={Sponsored Account URN}&owner={Organization URN}",
+      "description": "The video creatives available to one account. Requires the account URN. Video is handled separately from other creative types in LinkedIn's model."
     },
     {
       "name": "Video Ads by Owner",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/adDirectSponsoredContents?q=owner&owner={Organization URN}"
+      "suffix": "/rest/adDirectSponsoredContents?q=owner&owner={Organization URN}",
+      "description": "The video creatives owned by one organisation."
     },
     {
       "name": "Sponsored Conversation",
       "paged": false,
-      "suffix": "/rest/sponsoredConversations/{Conversation ID}"
+      "suffix": "/rest/sponsoredConversations/{Conversation ID}",
+      "description": "One sponsored conversation by id, with its flow."
     },
     {
       "name": "Sponsored Conversations",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/sponsoredConversations?ids={Conversation IDs:List(id1,id2,...)}"
+      "suffix": "/rest/sponsoredConversations?ids={Conversation IDs:List(id1,id2,...)}",
+      "description": "The sponsored conversation ads -- LinkedIn's interactive message format -- by id. The message-based ad type, distinct from feed ads."
     },
     {
       "name": "Sponsored Message Contents",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/sponsoredConversations/{Conversation ID}/sponsoredMessageContents"
+      "suffix": "/rest/sponsoredConversations/{Conversation ID}/sponsoredMessageContents",
+      "description": "The message steps within one sponsored conversation. Requires the conversation id. The conversation's actual content and branching."
     },
     {
       "name": "Sponsored Message Content",
       "paged": false,
-      "suffix": "/rest/sponsoredConversations/{Conversation ID}/sponsoredMessageContents/{Content ID}"
+      "suffix": "/rest/sponsoredConversations/{Conversation ID}/sponsoredMessageContents/{Content ID}",
+      "description": "One message step within a conversation."
     },
     {
       "name": "Ad InMail Content",
       "paged": false,
-      "suffix": "/rest/adInMailContents/{Content ID}"
+      "suffix": "/rest/adInMailContents/{Content ID}",
+      "description": "One InMail content by id."
     },
     {
       "name": "Ad InMail Contents",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/adInMailContents?ids={Content IDs,:id1,id2,...}"
+      "suffix": "/rest/adInMailContents?ids={Content IDs,:id1,id2,...}",
+      "description": "The sponsored InMail message contents by id. The older single-message format."
     },
     {
       "name": "Member Sender Permissions by Account",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/adInMailMemberSenderPermissions?q=account&account={Sponsored Account URN}"
+      "suffix": "/rest/adInMailMemberSenderPermissions?q=account&account={Sponsored Account URN}",
+      "description": "Which members may be used as the sender of sponsored messages for one account. Requires the account URN. Sponsored messages come from a person, so this is who the account may send as."
     },
     {
       "name": "Company Senders by Account",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/adInMailCompanySenderPermissions?q=account&account={Sponsored Account URN}"
+      "suffix": "/rest/adInMailCompanySenderPermissions?q=account&account={Sponsored Account URN}",
+      "description": "Which companies may be used as the sender for one account."
     },
     {
       "name": "Sender Permissions by Member",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/adInMailMemberSenderPermissions?q=member&member={Member URN}"
+      "suffix": "/rest/adInMailMemberSenderPermissions?q=member&member={Member URN}",
+      "description": "The accounts one member has granted sending permission to. The reverse view."
     },
     {
       "name": "Ad Analytics",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/adAnalytics?q=analytics&pivot={Pivot}&timeGranularity={Time Granularity}&campaignType={Campaign Types?}&shares={Share URNs?}&campaigns={Campaign URNs?}&creatives={Creative URNs?}&campaignGroups={Campaign Group URNs?}&accounts={Account URNs?}&companies={Organization URNs?}&dateRange.start.year={Start Year?}&dateRange.start.month={Start Month?}&dateRange.start.day={Start Day?}&dateRange.end.year={End Year?}&dateRange.end.month={End Month?}&dateRange.end.day={End Day?}"
+      "suffix": "/rest/adAnalytics?q=analytics&pivot={Pivot}&timeGranularity={Time Granularity}&campaignType={Campaign Types?}&shares={Share URNs?}&campaigns={Campaign URNs?}&creatives={Creative URNs?}&campaignGroups={Campaign Group URNs?}&accounts={Account URNs?}&companies={Organization URNs?}&dateRange.start.year={Start Year?}&dateRange.start.month={Start Month?}&dateRange.start.day={Start Day?}&dateRange.end.year={End Year?}&dateRange.end.month={End Month?}&dateRange.end.day={End Day?}",
+      "description": "THE PERFORMANCE TABLE, and the one most questions here reduce to. Requires a pivot, a time granularity and a date range. Returns impressions, clicks, spend, conversions, video views and dozens of other metrics, PIVOTED by whatever dimension is asked for -- campaign, creative, account, company, job function, seniority, industry and more. THREE THINGS TO KNOW. The pivot IS the grouping: the same query pivoted differently is a different report, and only one pivot is allowed per request. Metrics must be named in the fields parameter or a minimal default set comes back. And demographic pivots are subject to a minimum-audience threshold -- LinkedIn withholds rows below it for privacy, so pivoted totals do not add up to the unpivoted figure."
     },
     {
       "name": "Ad Statistics",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/adAnalytics?q=statistics&pivots={Pivots}&objectiveType={Objective Type}&timeGranularity={Time Granularity}&campaignType={Campaign Types?}&shares={Share URNs}&campaigns={Campaign URNs?}&creatives={Creative URNs?}&campaignGroups={Campaign Group URNs?}&accounts={Sponsored Account URNs?}&companies={Organization URNs?}&dateRange.start.year={Start Year?}&dateRange.start.month={Start Month?}&dateRange.start.day={Start Day?}&dateRange.end.year={End Year?}&dateRange.end.month={End Month?}&dateRange.end.day={End Day?}"
+      "suffix": "/rest/adAnalytics?q=statistics&pivots={Pivots}&objectiveType={Objective Type}&timeGranularity={Time Granularity}&campaignType={Campaign Types?}&shares={Share URNs}&campaigns={Campaign URNs?}&creatives={Creative URNs?}&campaignGroups={Campaign Group URNs?}&accounts={Sponsored Account URNs?}&companies={Organization URNs?}&dateRange.start.year={Start Year?}&dateRange.start.month={Start Month?}&dateRange.start.day={Start Day?}&dateRange.end.year={End Year?}&dateRange.end.month={End Month?}&dateRange.end.day={End Day?}",
+      "description": "The same analytics addressed by the statistics finder, taking multiple pivots and an objective type. Use it where a breakdown needs two dimensions at once, which the single-pivot analytics finder cannot express."
     },
     {
       "name": "Pricing Insights by Criteria",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/adBudgetPricing?q=criteriaV2&campaignType={Campaign Type}&account={Sponsored Account URN}&bidType={Bid Type}&currency={ISO Currency Code?}&countryCode={ISO Country Code}&matchType={Match Type}&targetingCriteria={Targeting Criteria}&dailyBudget={Daily Budget}&objectiveType={Objective Type}&optimizationTargetType={Optimization Target Type}"
+      "suffix": "/rest/adBudgetPricing?q=criteriaV2&campaignType={Campaign Type}&account={Sponsored Account URN}&bidType={Bid Type}&currency={ISO Currency Code?}&countryCode={ISO Country Code}&matchType={Match Type}&targetingCriteria={Targeting Criteria}&dailyBudget={Daily Budget}&objectiveType={Objective Type}&optimizationTargetType={Optimization Target Type}",
+      "description": "The estimated bid range for a given campaign type and targeting. Forward-looking market pricing, used before spending rather than after."
     },
     {
       "name": "Insight Tags by Account",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/insightTags?q=account&account={Sponsored Account URN}"
+      "suffix": "/rest/insightTags?q=account&account={Sponsored Account URN}",
+      "description": "The LinkedIn Insight Tags in one account -- the tracking pixels installed on the advertiser's site. Requires the account URN. NO TAG MEANS NO CONVERSION DATA, so this is the first thing to check when conversions are absent."
     },
     {
       "name": "Insight Tag",
       "paged": false,
-      "suffix": "/rest/insightTags/{Insight Tag ID}"
+      "suffix": "/rest/insightTags/{Insight Tag ID}",
+      "description": "One insight tag by id."
     },
     {
       "name": "Insight Tag Permissions by Account",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/insightTagPermission?q=account&account={Sponsored Account URN}"
+      "suffix": "/rest/insightTagPermission?q=account&account={Sponsored Account URN}",
+      "description": "Who may use one account's insight tags. Relevant on shared or agency-managed tags."
     },
     {
       "name": "Insight Tag Domains by Account",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/insightTagDomains?q=account&account={Sponsored Account URN}"
+      "suffix": "/rest/insightTagDomains?q=account&account={Sponsored Account URN}",
+      "description": "The domains an account's insight tags are firing on. Where tracking is actually installed, as opposed to where it was intended."
     },
     {
       "name": "Conversion",
       "paged": false,
-      "suffix": "/rest/conversions/{Conversion ID}?account={Sponsored Account URN}"
+      "suffix": "/rest/conversions/{Conversion ID}?account={Sponsored Account URN}",
+      "description": "One conversion definition by id."
     },
     {
       "name": "Conversions",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/conversions?account={Sponsored Account URN}&ids={Conversion IDs}"
+      "suffix": "/rest/conversions?account={Sponsored Account URN}&ids={Conversion IDs}",
+      "description": "Several conversion definitions by id."
     },
     {
       "name": "Conversions by Account",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/conversions?q=account&account={Sponsored Account URN}"
+      "suffix": "/rest/conversions?q=account&account={Sponsored Account URN}",
+      "description": "The conversion definitions in one account -- the actions on the advertiser's own site that count as success, with their type and attribution window. Requires the account URN. Conversion COUNTS appear in analytics; what a conversion MEANS is defined here."
     },
     {
       "name": "Campaign Conversion",
       "paged": false,
-      "suffix": "/rest/campaignConversions/{Campaign and Conversion URN}"
+      "suffix": "/rest/campaignConversions/{Campaign and Conversion URN}",
+      "description": "One campaign-to-conversion association."
     },
     {
       "name": "Campaign Conversions",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/campaignConversions?ids={Campaign and Conversion URNs}"
+      "suffix": "/rest/campaignConversions?ids={Campaign and Conversion URNs}",
+      "description": "Several campaign-to-conversion associations by URN."
     },
     {
       "name": "Campaign Conversions by Campaign",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/campaignConversions?q=campaigns&campaigns={Campaign URNs}"
+      "suffix": "/rest/campaignConversions?q=campaigns&campaigns={Campaign URNs}",
+      "description": "Which conversions are attached to which campaigns. The link that decides what a campaign's conversion count is counting."
     },
     {
       "name": "Campaign Recommendations",
       "paged": false,
-      "suffix": "/rest/adCampaignRecommendations?q=campaigns&campaigns={Campaign URNs}"
+      "suffix": "/rest/adCampaignRecommendations?q=campaigns&campaigns={Campaign URNs}",
+      "description": "LinkedIn's suggested changes to named campaigns -- budget, bid and targeting adjustments. Advice, not data."
     },
     {
       "name": "Campaign Insights",
       "paged": false,
-      "suffix": "/rest/adCampaignInsights?q=entities&entities={Campaign URNs}"
+      "suffix": "/rest/adCampaignInsights?q=entities&entities={Campaign URNs}",
+      "description": "LinkedIn's own generated observations about named campaigns. Interpretation rather than measurement."
     },
     {
       "name": "Third-Party Tracking Tag",
       "paged": false,
-      "suffix": "/rest/thirdPartyTrackingTags/{Tag ID}"
+      "suffix": "/rest/thirdPartyTrackingTags/{Tag ID}",
+      "description": "One third-party tracking tag by id."
     },
     {
       "name": "Third-Party Tracking Tags by Creative",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/thirdPartyTrackingTags?q=creative&totals=true&creative={Creative URN}"
+      "suffix": "/rest/thirdPartyTrackingTags?q=creative&totals=true&creative={Creative URN}",
+      "description": "The external tracking tags attached to one creative. Requires the creative URN. Third-party verification, which produces figures that will not match LinkedIn's own."
     },
     {
       "name": "Ad Forms by Account",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/adForms?q=account&totals=true&account={Sponsored Account URN}"
+      "suffix": "/rest/adForms?q=account&totals=true&account={Sponsored Account URN}",
+      "description": "The lead generation forms in one account. Requires the account URN. Lead gen forms collect contact details in-platform, so they are the conversion mechanism for lead campaigns."
     },
     {
       "name": "Ad Form",
       "paged": false,
-      "suffix": "/rest/adForms/{Form ID}"
+      "suffix": "/rest/adForms/{Form ID}",
+      "description": "One lead gen form by id, with its questions."
     },
     {
       "name": "Ad Forms",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/adForms?ids={Form IDs,}"
+      "suffix": "/rest/adForms?ids={Form IDs,}",
+      "description": "Several lead gen forms by id."
     },
     {
       "name": "Ad Form Question",
       "paged": false,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/adFormQuestions?form={Form URN}&questionId={Question ID}"
+      "suffix": "/rest/adFormQuestions?form={Form URN}&questionId={Question ID}",
+      "description": "One question within a form. Requires the form URN and question id. The decoder for a response's answers, which reference question ids."
     },
     {
       "name": "Ad Form Responses by Account",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/adFormResponses?q=account&account={Sponsored Account URN}&campaign={Campaign URN?}&creative={Creative URN?}&form={Form URN?}&leadType={Lead Type?}&timeRange.start={Start Time?:Unix Timestamp}&timeRange.end={End Time?:Unix Timestamp}"
+      "suffix": "/rest/adFormResponses?q=account&account={Sponsored Account URN}&campaign={Campaign URN?}&creative={Creative URN?}&form={Form URN?}&leadType={Lead Type?}&timeRange.start={Start Time?:Unix Timestamp}&timeRange.end={End Time?:Unix Timestamp}",
+      "description": "THE LEADS THEMSELVES -- every form submission in one account, with the answers given and the campaign that produced them. Requires the account URN. The commercial output of a lead gen campaign, and the only place the actual contact details are."
     },
     {
       "name": "Ad Form Response",
       "paged": false,
-      "suffix": "/rest/adFormResponses/{Response ID}?account={Sponsored Account URN}"
+      "suffix": "/rest/adFormResponses/{Response ID}?account={Sponsored Account URN}",
+      "description": "One form response by id. Requires the account URN."
     },
     {
       "name": "Ad Form Responses",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/adFormResponses?account={Sponsored Account URN}&ids={Response IDs,}"
+      "suffix": "/rest/adFormResponses?account={Sponsored Account URN}&ids={Response IDs,}",
+      "description": "Several form responses by id."
     },
     {
       "name": "DMP Segments",
       "paged": false,
-      "suffix": "/rest/dmpSegments?ids={Segment IDs}"
+      "suffix": "/rest/dmpSegments?ids={Segment IDs}",
+      "description": "Several segments by id."
     },
     {
       "name": "DMP Segment",
       "paged": false,
-      "suffix": "/rest/dmpSegments/{Segment ID}"
+      "suffix": "/rest/dmpSegments/{Segment ID}",
+      "description": "One segment by id, with its size and status."
     },
     {
       "name": "DMP Segments by Account",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/dmpSegments?q=account&account={Sponsored Account URN}"
+      "suffix": "/rest/dmpSegments?q=account&account={Sponsored Account URN}",
+      "description": "The matched audience segments in one account -- uploaded contact lists, website retargeting audiences and lookalikes. Requires the account URN. Carries the match rate, which is what determines whether an uploaded list is usable: a low match rate means most of the uploaded people were not found on LinkedIn."
     },
     {
       "name": "DMP Segment Destination",
       "paged": false,
-      "suffix": "/rest/dmpSegments/{Segment ID}/destinations/{Destination}"
+      "suffix": "/rest/dmpSegments/{Segment ID}/destinations/{Destination}",
+      "description": "One segment destination."
     },
     {
       "name": "DMP Segment Destinations",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/dmpSegments/{Segment ID}/destinations"
+      "suffix": "/rest/dmpSegments/{Segment ID}/destinations",
+      "description": "Where one segment is shared to. Requires the segment id."
     },
     {
       "name": "DMP Segment Lookalikes",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/dmpSegments/{Segment ID}/lookalikes"
+      "suffix": "/rest/dmpSegments/{Segment ID}/lookalikes",
+      "description": "The lookalike audiences derived from one segment. Requires the segment id. Audience expansion built on a seed list."
     },
     {
       "name": "Ad Segment Status",
       "paged": false,
-      "suffix": "/rest/adSegments/{Segment ID}"
+      "suffix": "/rest/adSegments/{Segment ID}",
+      "description": "The processing status of one audience segment. Segments take time to build after upload, so this explains a segment that exists but cannot yet be targeted."
     },
     {
       "name": "Organization",
       "paged": false,
-      "suffix": "/rest/organizations/{Organization ID}"
+      "suffix": "/rest/organizations/{Organization ID}",
+      "description": "One organisation by id -- the company page behind an advertiser. Carries the name, vanity name, description, industry, size and locations."
     },
     {
       "name": "Organization by Email Domain",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/organizations?q=emailDomain&emailDomain={Email Domain}"
+      "suffix": "/rest/organizations?q=emailDomain&emailDomain={Email Domain}",
+      "description": "The organisation matching an email domain. The lookup from a company's mail domain to its LinkedIn page."
     },
     {
       "name": "Organization Follower Count",
       "paged": false,
-      "suffix": "/rest/networkSizes/{Organization URN}?edgeType=CompanyFollowedByMember"
+      "suffix": "/rest/networkSizes/{Organization URN}?edgeType=CompanyFollowedByMember",
+      "description": "The follower count of one organisation. Requires the organisation URN. A single number and the cheapest audience-size check."
     },
     {
       "name": "Organization Brand",
       "paged": false,
-      "suffix": "/rest/organizationBrands/{Brand ID}"
+      "suffix": "/rest/organizationBrands/{Brand ID}",
+      "description": "One brand page by id."
     },
     {
       "name": "Organization Brands by Organization",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/organizations?q=parentOrganization&parent={Parent Organization URN}"
+      "suffix": "/rest/organizations?q=parentOrganization&parent={Parent Organization URN}",
+      "description": "The brand pages under one parent organisation. Large companies run several brand pages, so a total for the company means summing them."
     },
     {
       "name": "Organization Brands by Vanity Name",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/organizationBrands?q=vanityName&vanityName={Vanity Name}"
+      "suffix": "/rest/organizationBrands?q=vanityName&vanityName={Vanity Name}",
+      "description": "A brand page by its vanity URL name."
     },
     {
       "name": "Follower Statistics",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/organizationalEntityFollowerStatistics?q=organizationalEntity&organizationalEntity={Organization URN}&timeIntervals.timeGranularityType={Time Granularity?:DAY|MONTH}&timeIntervals.timeRange.start={Start Time?:Unix Timestamp}&timeIntervals.timeRange.end={End Time?:Unix Timestamp}"
+      "suffix": "/rest/organizationalEntityFollowerStatistics?q=organizationalEntity&organizationalEntity={Organization URN}&timeIntervals.timeGranularityType={Time Granularity?:DAY|MONTH}&timeIntervals.timeRange.start={Start Time?:Unix Timestamp}&timeIntervals.timeRange.end={End Time?:Unix Timestamp}",
+      "description": "Follower counts and gains for one organisation, broken down by seniority, function, industry, staff count and country. THE AUDIENCE COMPOSITION TABLE -- who follows the page, as opposed to how many. Subject to the same minimum-threshold suppression as ad demographics."
     },
     {
       "name": "Organization Page Statistics",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/organizationPageStatistics?q=organization&organization={Organization URN}&timeIntervals.timeGranularityType={Time Granularity?:DAY|MONTH}&timeIntervals.timeRange.start={Start Time?:Unix Timestamp}&timeIntervals.timeRange.end={End Time?:Unix Timestamp}"
+      "suffix": "/rest/organizationPageStatistics?q=organization&organization={Organization URN}&timeIntervals.timeGranularityType={Time Granularity?:DAY|MONTH}&timeIntervals.timeRange.start={Start Time?:Unix Timestamp}&timeIntervals.timeRange.end={End Time?:Unix Timestamp}",
+      "description": "Page views and unique visitors for one organisation's page, by section and by viewer demographic, over a time range. The organic counterpart to ad analytics."
     },
     {
       "name": "Brand Page Statistics",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/brandPageStatistics?q=brand&brand={Brand URN}&timeIntervals.timeGranularityType={Time Granularity?:DAY|MONTH}&timeIntervals.timeRange.start={Start Time?:Unix Timestamp}&timeIntervals.timeRange.end={End Time?:Unix Timestamp}"
+      "suffix": "/rest/brandPageStatistics?q=brand&brand={Brand URN}&timeIntervals.timeGranularityType={Time Granularity?:DAY|MONTH}&timeIntervals.timeRange.start={Start Time?:Unix Timestamp}&timeIntervals.timeRange.end={End Time?:Unix Timestamp}",
+      "description": "The same page statistics for one brand page. Requires the brand URN."
     },
     {
       "name": "Share Statistics",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/organizationalEntityShareStatistics?q=organizationalEntity&organizationalEntity={Organization URN}&timeIntervals.timeGranularityType={Time Granularity?:DAY|MONTH}&timeIntervals.timeRange.start={Start Time?:Unix Timestamp}&timeIntervals.timeRange.end={End Time?:Unix Timestamp}"
+      "suffix": "/rest/organizationalEntityShareStatistics?q=organizationalEntity&organizationalEntity={Organization URN}&timeIntervals.timeGranularityType={Time Granularity?:DAY|MONTH}&timeIntervals.timeRange.start={Start Time?:Unix Timestamp}&timeIntervals.timeRange.end={End Time?:Unix Timestamp}",
+      "description": "Engagement statistics for one organisation's posts -- impressions, clicks, likes, comments, shares and engagement rate. ORGANIC PERFORMANCE, which the advertising analytics does not cover: a company's own posting reach lives here."
     },
     {
       "name": "UGC Posts by URN",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/posts/{Post or Share URN}?viewContext={View Context:AUTHOR|READER}"
+      "suffix": "/rest/posts/{Post or Share URN}?viewContext={View Context:AUTHOR|READER}",
+      "description": "One post by its URN, in a given view context."
     },
     {
       "name": "UGC Posts",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/posts?ids={Post URNs}"
+      "suffix": "/rest/posts?ids={Post URNs}",
+      "description": "Several posts by URN."
     },
     {
       "name": "UGC Posts by Authors",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/posts?q=authors&authors={Person or Organization URNs}"
+      "suffix": "/rest/posts?q=authors&authors={Person or Organization URNs}",
+      "description": "The posts authored by named people or organisations. Requires the author URNs. The content table for organic activity."
     },
     {
       "name": "UGC Posts by Group",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/posts?q=containerEntities&containerEntities={Group URNs}"
+      "suffix": "/rest/posts?q=containerEntities&containerEntities={Group URNs}",
+      "description": "The posts within a LinkedIn group. Requires the group URN."
     },
     {
       "name": "UGC Posts by Permalink Suffixes",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/posts?q=permalinkSuffixes&permalinkSuffixes={Permalink Suffixes}"
+      "suffix": "/rest/posts?q=permalinkSuffixes&permalinkSuffixes={Permalink Suffixes}",
+      "description": "Posts looked up by the suffix of their public URL. The route in when only a shared link is known."
     },
     {
       "name": "Share",
       "paged": false,
-      "suffix": "/rest/shares/{Share ID}"
+      "suffix": "/rest/shares/{Share ID}",
+      "description": "One share by id."
     },
     {
       "name": "Shares by Owner",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/shares?q=owners&owners={Owner URN}&sharesPerOwner={Shares Per Owner?}"
+      "suffix": "/rest/shares?q=owners&owners={Owner URN}&sharesPerOwner={Shares Per Owner?}",
+      "description": "The shares posted by one owner. Requires the owner URN. Shares are the older post model that coexists with UGC posts, so a complete content history may need both."
     },
     {
       "name": "Shares",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/shares?ids={Share IDs}"
+      "suffix": "/rest/shares?ids={Share IDs}",
+      "description": "Several shares by id."
     },
     {
       "name": "Activities",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/activities?ids={Activity IDs,}"
+      "suffix": "/rest/activities?ids={Activity IDs,}",
+      "description": "Activity records by id. The wrapper LinkedIn uses around shares and posts in some contexts."
     },
     {
       "name": "Social Actions Summary",
       "paged": false,
-      "suffix": "/rest/socialActions/{Share/Post/Comment URN}"
+      "suffix": "/rest/socialActions/{Share/Post/Comment URN}",
+      "description": "The like, comment and share counts on one post, share or comment. Requires its URN. The engagement totals; the individual actions are separate endpoints."
     },
     {
       "name": "Likes",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/socialActions/{Share/Post/Comment URN}/likes"
+      "suffix": "/rest/socialActions/{Share/Post/Comment URN}/likes",
+      "description": "The individual likes on one post or comment. Requires its URN. Who engaged, as opposed to how many."
     },
     {
       "name": "Comments",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/socialActions/{Share/Post/Comment URN}/comments"
+      "suffix": "/rest/socialActions/{Share/Post/Comment URN}/comments",
+      "description": "The comments on one post, with their authors and text. Requires the post URN. The qualitative response to content, which no engagement count conveys."
     },
     {
       "name": "Social Metadata Summary",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/socialMetadata/{Share/Post/Comment URN}"
+      "suffix": "/rest/socialMetadata/{Share/Post/Comment URN}",
+      "description": "The social metadata of one entity -- comment and reaction settings and totals. Requires its URN."
     },
     {
       "name": "Social Metadata Summaries",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/socialMetadata?ids={Share/Post/Comment URNs}"
+      "suffix": "/rest/socialMetadata?ids={Share/Post/Comment URNs}",
+      "description": "The same for several entities at once."
     },
     {
       "name": "Reactions",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/reactions/{Share/Post/Comment URN}?q=entity"
+      "suffix": "/rest/reactions/{Share/Post/Comment URN}?q=entity",
+      "description": "The reactions on one post, by reaction type -- like, celebrate, support, insightful and the rest. Requires the post URN. Finer than a like count, and the reaction mix says something a total cannot."
     },
     {
       "name": "Video Analytics",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/rest/videoAnalytics?q=entity&entity={Post URN}&type={Type:VIDEO_VIEW|VIEWER|TIME_WATCHED|TIME_WATCHED_FOR_VIDEO_VIEWS}&aggregation={Aggregation?:DAY|WEEK|ALL}"
+      "suffix": "/rest/videoAnalytics?q=entity&entity={Post URN}&type={Type:VIDEO_VIEW|VIEWER|TIME_WATCHED|TIME_WATCHED_FOR_VIDEO_VIEWS}&aggregation={Aggregation?:DAY|WEEK|ALL}",
+      "description": "The view statistics of one video post -- views, view rate and completion. Requires the post URN. Video completion is measured here rather than in the general analytics endpoint."
     },
     {
       "name": "Current User Profile",
       "paged": false,
-      "suffix": "/v2/me"
+      "suffix": "/v2/me",
+      "description": "The member profile the credentials belong to. One record, always the caller. Note LinkedIn restricts profile fields severely: what comes back depends on the permissions granted, and most fields available in the interface are not available through the API at all."
     },
     {
       "name": "User Profile",
       "paged": false,
-      "suffix": "/v2/people/{Person ID}"
+      "suffix": "/v2/people/{Person ID}",
+      "description": "One member profile by id. Subject to the same severe field restrictions -- LinkedIn does not permit general profile lookup, so this works only for members who have authorised the application."
     },
     {
       "name": "User Profiles",
       "paged": true,
       "pageType": "TOTAL_COUNT_AND_OFFSET",
-      "suffix": "/v2/people?ids={Person IDs}"
+      "suffix": "/v2/people?ids={Person IDs}",
+      "description": "Several member profiles by id, with the same restrictions."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/liveagent/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/liveagent/endpoints.json
@@ -4,282 +4,329 @@
       "name": "Agent list",
       "suffix": "/v3/agents",
       "paged": "true",
-      "lookups":[
+      "lookups": [
         {
           "endpoint": "Agent statuses in departments",
           "jsonPath": "$.[*]",
           "key": "id",
           "parameterName": "User ID"
         }
-      ]
+      ],
+      "description": "The agents on the account, with name, email, role and status."
     },
     {
       "name": "Agent",
       "suffix": "/v3/agents/{User ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One agent by user id."
     },
     {
       "name": "Agent statuses in departments",
       "suffix": "/v3/agents/{User ID}/status",
-      "paged": "false"
+      "paged": "false",
+      "description": "One agent's availability per department. Requires a user id. Availability is per department rather than global, so an agent can be online for chat and offline for calls."
     },
     {
       "name": "Agent activity list",
       "suffix": "/v3/agents/activity?_filters={Filters?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "Agent activity records, filtered -- when agents were online, on calls or handling chats. The staffing and utilisation table."
     },
     {
       "name": "Ban list",
       "suffix": "/v3/bans?_filters={Filters?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The banned visitors and addresses, filtered. Moderation; also the explanation for contacts whose messages never became tickets."
     },
     {
       "name": "Ban",
       "suffix": "/v3/bans/{Ban ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One ban by id."
     },
     {
       "name": "Call list",
       "suffix": "/v3/calls?_filters={Filters?}",
       "paged": "true",
-      "lookups":[
+      "lookups": [
         {
           "endpoint": "Call status",
           "jsonPath": "$.[*]",
           "key": "id",
           "parameterName": "Call ID"
         }
-      ]
+      ],
+      "description": "Phone calls, filtered. The voice channel, with direction, duration and the agent who took it."
     },
     {
       "name": "Call status",
       "suffix": "/v3/calls/{Call ID}/status?unreachableAgents={Unreachable Agents?}",
-      "paged": "false"
+      "paged": "false",
+      "description": "The live status of one call, optionally including agents currently unreachable. Requires a call id. A real-time snapshot, not history."
     },
     {
       "name": "Canned message list",
       "suffix": "/v3/canned_messages",
-      "paged": "true"
+      "paged": "true",
+      "description": "The canned responses agents insert. Which exist and which are used says a good deal about the standard cases a team handles."
     },
     {
       "name": "Canned message",
       "suffix": "/v3/canned_messages/{Canned Message ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One canned message by id."
     },
     {
       "name": "Chat list",
       "suffix": "/v3/chats?_filters={Filters?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "Live chat conversations, filtered. Chats become tickets, so these overlap with the ticket table -- this is the chat-specific view with its own timings such as wait time before an agent joined."
     },
     {
       "name": "Company list",
       "suffix": "/v3/companies?_filters={Filters?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The companies contacts belong to, filtered. The account-level dimension ticket volume can be grouped by."
     },
     {
       "name": "Company",
       "suffix": "/v3/companies/{Company ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One company by id."
     },
     {
       "name": "Contact list",
       "suffix": "/v3/contacts?_filters={Filters?}",
       "paged": "true",
-      "lookups":[
+      "lookups": [
         {
           "endpoint": "Page visits",
           "jsonPath": "$.[*]",
           "key": "id",
           "parameterName": "Contact ID"
         }
-      ]
+      ],
+      "description": "The customers who have contacted support, filtered. Carries name, emails, phone numbers and the company each belongs to."
     },
     {
       "name": "Contact",
       "suffix": "/v3/contacts/{Contact ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One contact by id."
     },
     {
       "name": "Custom button list",
       "suffix": "/v3/custom_buttons?_filters={Filters?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The custom buttons configured in the agent interface, filtered. Interface configuration."
     },
     {
       "name": "Custom button",
       "suffix": "/v3/custom_buttons/{Custom Button ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One custom button by id."
     },
     {
       "name": "Department list",
       "suffix": "/v3/departments?_filters={Filters?}",
       "paged": "true",
-      "lookups":[
+      "lookups": [
         {
           "endpoint": "Device departments by department id",
           "jsonPath": "$.[*]",
           "key": "department_id",
           "parameterName": "Department ID"
         }
-      ]
+      ],
+      "description": "The departments tickets are routed to, filtered. The team dimension."
     },
     {
       "name": "Department",
       "suffix": "/v3/departments/{Department ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One department by id."
     },
     {
       "name": "Is agent in department",
       "suffix": "/v3/departments/{Department ID}/{Agent ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "Whether one agent belongs to one department. Requires both ids. A membership check rather than a listing."
     },
     {
       "name": "Device list",
       "suffix": "/v3/devices?_filters={Filters?}",
       "paged": "true",
-      "lookups":[
+      "lookups": [
         {
           "endpoint": "Device departments",
           "jsonPath": "$.[*]",
           "key": "id",
           "parameterName": "Device ID"
         }
-      ]
+      ],
+      "description": "The devices registered on the account, filtered."
     },
     {
       "name": "Device",
       "suffix": "/v3/devices/{Device ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One device by id."
     },
     {
       "name": "Device departments",
       "suffix": "/v3/devices/{Device ID}/departments?_filters={Filters?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The departments one device serves. Requires a device id."
     },
     {
       "name": "Device department by id",
       "suffix": "/v3/devices/{Device ID}/departments/{Department ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One device-to-department assignment."
     },
     {
       "name": "Device department plan",
       "suffix": "/v3/devices/{Device ID}/departments/{Department ID}/plans",
-      "paged": "false"
+      "paged": "false",
+      "description": "The routing plan for one device in one department."
     },
     {
       "name": "Device departments by department id",
       "suffix": "/v3/devices/departments/{Department ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "The devices serving one department. The reverse view."
     },
     {
       "name": "Filter list",
       "suffix": "/v3/filters?_filters={Filters?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The saved ticket filters defined, filtered. These encode the queues agents actually work from, so their definitions state the team's own categories."
     },
     {
       "name": "Filter",
       "suffix": "/v3/filters/{Filter ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One saved filter by id, with its conditions."
     },
     {
       "name": "List of reports for time reports grid",
       "suffix": "/v3/grid/reports/time?_filters={Filters?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "Time-based report rows, filtered. LiveAgent's own reporting output -- pre-aggregated, and the cheaper route to figures that would otherwise be computed from ticket history."
     },
     {
       "name": "Contact group list",
       "suffix": "/v3/groups",
-      "paged": "true"
+      "paged": "true",
+      "description": "The groups contacts are organised into. The customer segmentation dimension."
     },
     {
       "name": "Contact group",
       "suffix": "/v3/groups/{Group ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One contact group by id."
     },
     {
       "name": "Message",
       "suffix": "/v3/messages/{Message ID}?subString_Start={Substring Start?}&subString_Length={Substring Length?}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One message by id, optionally with a substring of its body. The individual message rather than the ticket conversation."
     },
     {
       "name": "Page visits",
       "suffix": "/v3/page_visits/{Contact ID}/contact?_filters={Filters?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The pages one contact visited on the website before contacting support. Requires a contact id. Behavioural context for a ticket, which the ticket itself does not carry."
     },
     {
       "name": "Phone numbers list",
       "suffix": "/v3/phone_numbers?additionalObjects={Additional Objects?}&&_filters={Filters?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The phone numbers configured, with the department each routes to. The inbound voice routing map."
     },
     {
       "name": "Phone number",
       "suffix": "/v3/phone_numbers/{Phone Number ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One phone number by id."
     },
     {
       "name": "Available dial out prefix",
       "suffix": "/v3/phone_numbers/availablePrefix",
-      "paged": "false"
+      "paged": "false",
+      "description": "The dial-out prefixes available. Configuration for outbound calling."
     },
     {
       "name": "Phone device list",
       "suffix": "/v3/phones?_filters={Filters?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The registered phone devices -- softphones and hardware -- agents take calls on."
     },
     {
       "name": "Phone device",
       "suffix": "/v3/phones/{Phone ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One phone device by id."
     },
     {
       "name": "Predefined answer list",
       "suffix": "/v3/predefined_answers?_filters={Filters?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The predefined answers available, filtered. Similar to canned messages, used in different contexts."
     },
     {
       "name": "Predefined answer",
       "suffix": "/v3/predefined_answers/{Predefined Answer ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One predefined answer by id."
     },
     {
       "name": "Batch status and remaining items to process",
       "suffix": "/v3/queue/batch/{Batch ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "The progress of a queued batch operation. Requires a batch id. Operational."
     },
     {
       "name": "Settings list",
       "suffix": "/v3/settings?settingsNames={Settings Names?}",
-      "paged": "false"
+      "paged": "false",
+      "description": "The account settings, optionally by name. Configuration, and worth checking when a feature-dependent table comes back empty."
     },
     {
       "name": "Sla list",
       "suffix": "/v3/slas",
-      "paged": "false"
+      "paged": "false",
+      "description": "The SLA levels defined, with their response and resolution targets. The targets that make a duration fast or slow; a raw resolution time means nothing without them."
     },
     {
       "name": "Sla",
       "suffix": "/v3/slas/{Level ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One SLA level by id."
     },
     {
       "name": "Ticket Sla history",
       "suffix": "/v3/slas/{Ticket ID}/history",
-      "paged": "false"
+      "paged": "false",
+      "description": "The SLA events of one ticket over time. Requires the ticket id. When the clock started, paused and stopped -- and therefore why a breach happened."
     },
     {
       "name": "Tag list",
       "suffix": "/v3/tags",
-      "paged": "true"
+      "paged": "true",
+      "description": "The tags applied to tickets. The free-form categorisation, and usually the only statement of what tickets are about beyond their subject line."
     },
     {
       "name": "Tag",
       "suffix": "/v3/tags/{Tag ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One tag by id."
     },
     {
       "name": "Ticket list",
       "suffix": "/v3/tickets?_filters={Filters?}",
       "paged": "true",
-      "lookups":[
+      "lookups": [
         {
           "endpoint": "Ticket history",
           "jsonPath": "$.[*]",
@@ -304,42 +351,50 @@
           "key": "id",
           "parameterName": "Ticket ID"
         }
-      ]
+      ],
+      "description": "The support tickets, filtered by LiveAgent's own _filters expression. Carries the subject, the customer, the department and assigned agent, status, channel, tags, and the created and changed timestamps. The central table. NOTE THE CHANNEL COLUMN: LiveAgent unifies email, chat, phone calls and social messages into one ticket stream, so a ticket count spans channels that behave nothing alike -- a chat and an email ticket have very different natural durations, and mixing them makes an average response time meaningless."
     },
     {
       "name": "Ticket",
       "suffix": "/v3/tickets/{Ticket ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One ticket by id, with its full detail."
     },
     {
       "name": "Ticket attribute",
       "suffix": "/v3/tickets/{Ticket ID}/attributes/{Attribute Name:endChatOrCall|note}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One named attribute of a ticket, such as whether a chat or call has ended. Requires the ticket id and attribute name."
     },
     {
       "name": "Ticket history",
       "suffix": "/v3/tickets/{Ticket ID}/history",
-      "paged": "false"
+      "paged": "false",
+      "description": "The change history of one ticket: status changes, transfers, assignments, each with the actor and timestamp. Requires a ticket id. The ticket holds current state only, so response and resolution timings are derived from here."
     },
     {
       "name": "Ticket message groups and messages",
       "suffix": "/v3/tickets/{Ticket ID}/messages?includeQuotedMessages={Include Quoted Messages?:true|false}&_filters={Filters?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "The conversation on one ticket, grouped into message groups. Requires a ticket id. Where the actual text lives -- the ticket record carries only its subject."
     },
     {
       "name": "Ticket Sla",
       "suffix": "/v3/tickets/{Ticket ID}/sla",
-      "paged": "false"
+      "paged": "false",
+      "description": "The SLA applying to one ticket and its current state against it. Requires a ticket id. Whether a ticket is breaching is only answerable here; the ticket itself carries no SLA field."
     },
     {
       "name": "Tickets history list",
       "suffix": "/v3/tickets/history?_filters={Filters?}",
-      "paged": "true"
+      "paged": "true",
+      "description": "Ticket history events across all tickets, filtered. The account-wide change log, and the practical basis for time-in-status analysis without a request per ticket."
     },
     {
       "name": "User",
       "suffix": "/v3/users/{User ID}",
-      "paged": "false"
+      "paged": "false",
+      "description": "One user by id."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/pipedrive/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/pipedrive/endpoints.json
@@ -3,7 +3,7 @@
     {
       "name": "Activities",
       "paged": true,
-      "suffix": "/v1/activities?user_id={User ID?}&filter_id={Filter ID?}&type={Type?}&start_date={Start Date?:YYYY-MM-DD}&end_date={End Date?:YYYY-MM-DD}&done={Done?:0|1}",
+      "suffix": "/api/v2/activities?owner_id={Owner ID?}&filter_id={Filter ID?}&deal_id={Deal ID?}&person_id={Person ID?}&org_id={Organization ID?}&done={Done?:true|false}&updated_since={Updated Since?:yyyy-MM-ddTHH:mm:ssZ}&updated_until={Updated Until?:yyyy-MM-ddTHH:mm:ssZ}&sort_by={Sort By?:id|update_time|add_time}&sort_direction={Sort Direction?:asc|desc}",
       "lookups": [
         {
           "endpoint": "User",
@@ -30,13 +30,13 @@
           "parameterName": "Organization ID"
         }
       ],
-      "description": "The scheduled work against deals and contacts -- calls, meetings, tasks, deadlines and emails -- one row each. Carries type, subject, due_date and due_time, duration, the DONE flag, add_time and marked_as_done_time, the owning user, and the deal, person and organization it is attached to. The activity-versus-outcome table: done tells completion, due_date against marked_as_done_time tells punctuality, and an activity with no done marker and a past due date is overdue rather than absent. Same version note: moved to API v2."
+      "description": "The scheduled work against deals and contacts -- calls, meetings, tasks, deadlines and emails -- one row each. Carries type, subject, due_date and due_time, duration, the DONE flag, add_time and marked_as_done_time, the owning user, and the deal, person and organization it is attached to. The activity-versus-outcome table: done tells completion, due_date against marked_as_done_time tells punctuality, and an activity with no done marker and a past due date is overdue rather than absent. Filter by any of its parent ids, by done, and incrementally with updated_since."
     },
     {
       "name": "Activity",
       "paged": false,
-      "suffix": "/v1/activities/{Activity ID}",
-      "description": "One activity by id. Same fields, same version note."
+      "suffix": "/api/v2/activities/{Activity ID}?include_fields={Include Fields?}",
+      "description": "One activity by id."
     },
     {
       "name": "Activity Fields",
@@ -59,7 +59,7 @@
     {
       "name": "Deals",
       "paged": true,
-      "suffix": "/v1/deals?user_id={User ID?}&filter_id={Filter ID?}&stage_id={Stage ID?}&status={Status?:all_not_deleted|open|...}&owned_by_you={Owned By You?:0|1}",
+      "suffix": "/api/v2/deals?owner_id={Owner ID?}&filter_id={Filter ID?}&person_id={Person ID?}&org_id={Organization ID?}&pipeline_id={Pipeline ID?}&stage_id={Stage ID?}&status={Status?:open|won|lost|deleted}&updated_since={Updated Since?:yyyy-MM-ddTHH:mm:ssZ}&updated_until={Updated Until?:yyyy-MM-ddTHH:mm:ssZ}&custom_fields={Custom Field Keys?:key1,key2,... (max 15)}&sort_by={Sort By?:id|update_time|add_time}&sort_direction={Sort Direction?:asc|desc}",
       "lookups": [
         {
           "endpoints": [
@@ -78,13 +78,13 @@
           "parameterName": "Deal ID"
         }
       ],
-      "description": "The sales opportunities on the account, one row each -- the central table of a Pipedrive CRM. Carries title, value and currency, STATUS, the pipeline and stage, the person and organization it belongs to, the owning user, add_time and update_time, expected_close_date, close_time, won_time, lost_time and lost_reason, plus probability and weighted_value. THE STATUS COLUMN HAS FOUR VALUES: open, won, lost and DELETED. Deleted deals are still returned, so any total that does not filter status counts records the business considers gone -- and a win rate is won over won plus lost, never over all rows. CUSTOM FIELDS ARRIVE AS 40-CHARACTER HASH KEYS such as 9dc80c50d78a15643bfc4ca79d76156a99a9ba60, with no name attached anywhere in this response; Deal Fields is the only thing that decodes them. VERSION NOTE: Pipedrive has moved this resource to API v2 and the v1 path this endpoint uses is being retired."
+      "description": "The sales opportunities on the account, one row each -- the central table of a Pipedrive CRM. Carries title, value and currency, STATUS, the pipeline and stage, the person and organization, the owner, add_time and update_time, expected_close_date, close_time, won_time, lost_time and lost_reason. THE STATUS COLUMN HAS FOUR VALUES: open, won, lost and DELETED. Deleted deals are still returned, so any total that does not filter status counts records the business considers gone -- and a win rate is won over won plus lost, never over all rows. CUSTOM FIELDS ARE NOT RETURNED BY DEFAULT: v2 keeps them in a custom_fields object and only includes the keys named in the custom_fields parameter, up to fifteen at a time -- so their absence is an unmade request rather than empty data, and Deal Fields is what supplies the 40-character keys to ask for. Filter incrementally with updated_since and updated_until."
     },
     {
       "name": "Deal Search",
       "paged": true,
-      "suffix": "/v1/deals/search?term={Term}&fields={Fields?:field1,field2,...}&exact_match={Exact Match?:true|false}&person_id={Person ID?}&organization_id={Organization ID?}&status={Status?:open|won|lost}",
-      "description": "Deals matching a search term across title, notes and custom fields. Returns matches with a relevance score rather than the full deal record, so it locates deals rather than reporting on them. Same version note."
+      "suffix": "/api/v2/deals/search?term={Term}&fields={Fields?:custom_fields,notes,title}&exact_match={Exact Match?:true|false}&person_id={Person ID?}&organization_id={Organization ID?}&status={Status?:open|won|lost}&include_fields={Include Fields?}",
+      "description": "Deals matching a search term across title, notes and custom fields. Returns matches with a relevance score rather than the full deal record, so it locates deals rather than reporting on them. Narrow with person_id, organization_id or status."
     },
     {
       "name": "Deal Summary",
@@ -101,13 +101,13 @@
     {
       "name": "Deal",
       "paged": false,
-      "suffix": "/v1/deals/{Deal ID}",
-      "description": "One deal by id. Same fields as Deals, including the hash-keyed custom fields. Same version note."
+      "suffix": "/api/v2/deals/{Deal ID}?include_fields={Include Fields?}&custom_fields={Custom Field Keys?:key1,key2,... (max 15)}",
+      "description": "One deal by id. Same fields as Deals, and the same custom_fields rule -- name the keys wanted or none arrive."
     },
     {
       "name": "Deal Activities",
       "paged": true,
-      "suffix": "/v1/deals/{Deal ID}/activities",
+      "suffix": "/api/v2/activities?deal_id={Deal ID}&done={Done?:true|false}&updated_since={Updated Since?:yyyy-MM-ddTHH:mm:ssZ}&updated_until={Updated Until?:yyyy-MM-ddTHH:mm:ssZ}&sort_by={Sort By?:id|update_time|add_time}&sort_direction={Sort Direction?:asc|desc}",
       "lookups": [
         {
           "endpoint": "User",
@@ -134,7 +134,7 @@
           "parameterName": "Organization ID"
         }
       ],
-      "description": "The activities linked to one deal. Requires a deal id. SUPERSEDED: Pipedrive replaced these per-parent listings with filters on the main collection in API v2, where the same rows come from the activities endpoint with a deal_id filter. This v1 path is absent from Pipedrive's current API description."
+      "description": "The activities linked to one deal. Requires a deal id. NOTE THE SHAPE: v2 replaced the per-deal listing with a deal_id filter on the activities collection, so this is the activities endpoint scoped to one deal rather than a separate resource -- and every activity filter, including done and the update-time range, is available on it."
     },
     {
       "name": "Deal Files",
@@ -183,14 +183,14 @@
     {
       "name": "Deal People",
       "paged": true,
-      "suffix": "/v1/deals/{Deal ID}/persons",
-      "description": "The people linked to one deal. Requires a deal id. SUPERSEDED in the same way -- v2 answers this with a deal_id filter on the persons collection, and this v1 path is absent from the current API description."
+      "suffix": "/api/v2/persons?deal_id={Deal ID}&custom_fields={Custom Field Keys?:key1,key2,... (max 15)}&sort_by={Sort By?:id|update_time|add_time}&sort_direction={Sort Direction?:asc|desc}",
+      "description": "The people linked to one deal. Requires a deal id. The persons collection filtered by deal_id, for the same reason."
     },
     {
       "name": "Deal Products",
       "paged": true,
-      "suffix": "/v1/deals/{Deal ID}/products?include_product_data={Include Product Data?:0|1}",
-      "description": "The products attached to one deal, with quantity, item price, discount and the resulting sum. Requires a deal id. A deal's value is a single number; what makes it up is only here. Same version note."
+      "suffix": "/api/v2/deals/{Deal ID}/products?sort_by={Sort By?:id|update_time|add_time}&sort_direction={Sort Direction?:asc|desc}",
+      "description": "The products attached to one deal, with quantity, item price, discount and the resulting sum. Requires a deal id. A deal's value is a single number; what makes it up is only here."
     },
     {
       "name": "Deal Fields",
@@ -343,7 +343,7 @@
     {
       "name": "Organizations",
       "paged": true,
-      "suffix": "/v1/organizations?user_id={User ID?}&filter_id={Filter ID?}&first_char={First Char?}",
+      "suffix": "/api/v2/organizations?owner_id={Owner ID?}&filter_id={Filter ID?}&updated_since={Updated Since?:yyyy-MM-ddTHH:mm:ssZ}&updated_until={Updated Until?:yyyy-MM-ddTHH:mm:ssZ}&custom_fields={Custom Field Keys?:key1,key2,... (max 15)}&sort_by={Sort By?:id|update_time|add_time}&sort_direction={Sort Direction?:asc|desc}",
       "lookups": [
         {
           "endpoints": [
@@ -362,31 +362,31 @@
           "parameterName": "Organization ID"
         }
       ],
-      "description": "The companies on the account, one row each. Carries name, the address with its parsed components, the owning user, add_time and update_time, the label, cc_email, and running counts of people, open, won, lost and closed deals, and activities. The account-level dimension: deals and contacts both reference an org_id, so this is what per-customer analysis groups by. Custom fields are hash-keyed here too, decoded by Organization Fields. VERSION NOTE: moved to API v2; the v1 path is being retired."
+      "description": "The companies on the account, one row each. Carries name, the owning user, add_time and update_time, and running counts of people, open, won, lost and closed deals, and activities. The account-level dimension: deals and contacts both reference an org_id, so this is what per-customer analysis groups by. Custom fields follow the v2 rule and are decoded by Organization Fields."
     },
     {
       "name": "Organization Search",
       "paged": true,
-      "suffix": "/v1/organizations/search?term={Term}&fields={Fields?:field1,field2,...}&exact_match={Exact Match?:true|false}",
-      "description": "Companies matching a search term across name, address and custom fields. Returns scored matches rather than full records. Same version note."
+      "suffix": "/api/v2/organizations/search?term={Term}&fields={Fields?:address,custom_fields,notes,name}&exact_match={Exact Match?:true|false}",
+      "description": "Companies matching a search term across name, address and custom fields. Returns scored matches."
     },
     {
       "name": "Organization",
       "paged": false,
-      "suffix": "/v1/organizations/{Organization ID}",
-      "description": "One company by id. Same fields, same version note."
+      "suffix": "/api/v2/organizations/{Organization ID}?include_fields={Include Fields?}&custom_fields={Custom Field Keys?:key1,key2,... (max 15)}",
+      "description": "One company by id. Same custom_fields rule."
     },
     {
       "name": "Organization Activities",
       "paged": true,
-      "suffix": "/v1/organizations/{Organization ID}/activities?done={Done?:0|1}&exclude={Exclude?}",
-      "description": "The activities linked to one company. Requires an organization id. SUPERSEDED: v2 answers this with an org_id filter on the activities collection; this v1 path is absent from the current API description."
+      "suffix": "/api/v2/activities?org_id={Organization ID}&done={Done?:true|false}&updated_since={Updated Since?:yyyy-MM-ddTHH:mm:ssZ}&updated_until={Updated Until?:yyyy-MM-ddTHH:mm:ssZ}&sort_by={Sort By?:id|update_time|add_time}&sort_direction={Sort Direction?:asc|desc}",
+      "description": "The activities linked to one company. Requires an organization id. The activities collection filtered by org_id."
     },
     {
       "name": "Organization Deals",
       "paged": true,
-      "suffix": "/v1/organizations/{Organization ID}/deals?status={Status?:all_not_deleted|open|won|...}&only_primary_association={Only Primary Association?:0|1}",
-      "description": "The deals linked to one company. Requires an organization id. SUPERSEDED: v2 uses an org_id filter on the deals collection; this v1 path is absent from the current API description."
+      "suffix": "/api/v2/deals?org_id={Organization ID}&status={Status?:open|won|lost|deleted}&updated_since={Updated Since?:yyyy-MM-ddTHH:mm:ssZ}&updated_until={Updated Until?:yyyy-MM-ddTHH:mm:ssZ}&custom_fields={Custom Field Keys?:key1,key2,... (max 15)}&sort_by={Sort By?:id|update_time|add_time}&sort_direction={Sort Direction?:asc|desc}",
+      "description": "The deals linked to one company. Requires an organization id. The deals collection filtered by org_id."
     },
     {
       "name": "Organization Files",
@@ -421,8 +421,8 @@
     {
       "name": "Organization People",
       "paged": true,
-      "suffix": "/v1/organizations/{Organization ID}/persons",
-      "description": "The contacts belonging to one company. Requires an organization id. SUPERSEDED: v2 uses an org_id filter on the persons collection; this v1 path is absent from the current API description."
+      "suffix": "/api/v2/persons?org_id={Organization ID}&custom_fields={Custom Field Keys?:key1,key2,... (max 15)}&sort_by={Sort By?:id|update_time|add_time}&sort_direction={Sort Direction?:asc|desc}",
+      "description": "The contacts belonging to one company. Requires an organization id. The persons collection filtered by org_id."
     },
     {
       "name": "Organization Relationships",
@@ -476,7 +476,7 @@
     {
       "name": "People",
       "paged": true,
-      "suffix": "/v1/persons?user_id={User ID?}&filter_id={Filter ID?}&first_char={First Char?}",
+      "suffix": "/api/v2/persons?owner_id={Owner ID?}&filter_id={Filter ID?}&org_id={Organization ID?}&updated_since={Updated Since?:yyyy-MM-ddTHH:mm:ssZ}&updated_until={Updated Until?:yyyy-MM-ddTHH:mm:ssZ}&custom_fields={Custom Field Keys?:key1,key2,... (max 15)}&sort_by={Sort By?:id|update_time|add_time}&sort_direction={Sort Direction?:asc|desc}",
       "lookups": [
         {
           "endpoints": [
@@ -494,24 +494,24 @@
           "parameterName": "Person ID"
         }
       ],
-      "description": "The contacts on the account, one row each -- what Pipedrive calls persons. Carries name split into first and last, the organization and owning user, add_time and update_time, last_activity_date and next_activity_date, the label, and running counts of open, won, lost and closed deals plus done and undone activities. TWO SHAPE TRAPS. EMAIL AND PHONE ARE ARRAYS, not single values: each entry is an object with the value, a label such as work or home, and a primary flag, so a person with three addresses is one row with a nested list, and reading 'the email' means picking the primary one. And custom fields arrive under 40-character hash keys that only Person Fields decodes. The deal counts are already computed, so per-contact value questions rarely need the deals table at all. VERSION NOTE: moved to API v2; the v1 path this endpoint uses is being retired."
+      "description": "The contacts on the account, one row each -- what Pipedrive calls persons. Carries name, the organization and owning user, add_time and update_time, and the running counts of open, won, lost and closed deals plus done and undone activities. TWO SHAPE TRAPS. EMAILS AND PHONES ARE ARRAYS, not single values: each entry carries the value, a label such as work or home, and a primary flag, so a person with three addresses is one row with a nested list and reading 'the email' means picking the primary one. And custom fields follow the v2 rule -- returned only under the keys named in the custom_fields parameter, decoded by Person Fields. The deal counts are already computed, so per-contact value questions rarely need the deals table at all."
     },
     {
       "name": "Person Search",
       "paged": true,
-      "suffix": "/v1/persons/search?term={Term}&fields={Fields?:field1,field2,...}&exact_match={Exact Match?:true|false}&organization_id={Organization ID?}",
-      "description": "Contacts matching a search term across name, email, phone and custom fields. Returns matches with a relevance score rather than full records. Same version note."
+      "suffix": "/api/v2/persons/search?term={Term}&fields={Fields?:custom_fields,email,notes,phone,name}&exact_match={Exact Match?:true|false}&organization_id={Organization ID?}&include_fields={Include Fields?}",
+      "description": "Contacts matching a search term across name, email, phone and custom fields. Returns scored matches rather than full records."
     },
     {
       "name": "Person",
       "paged": false,
-      "suffix": "/v1/persons/{Person ID}",
-      "description": "One contact by id. Same fields and the same array-shaped email and phone. Same version note."
+      "suffix": "/api/v2/persons/{Person ID}?include_fields={Include Fields?}&custom_fields={Custom Field Keys?:key1,key2,... (max 15)}",
+      "description": "One contact by id. Same array-shaped emails and phones, same custom_fields rule."
     },
     {
       "name": "Person Activities",
       "paged": true,
-      "suffix": "/v1/persons/{Person ID}/activities?done={Done?}&exclude={Exclude?}",
+      "suffix": "/api/v2/activities?person_id={Person ID}&done={Done?:true|false}&updated_since={Updated Since?:yyyy-MM-ddTHH:mm:ssZ}&updated_until={Updated Until?:yyyy-MM-ddTHH:mm:ssZ}&sort_by={Sort By?:id|update_time|add_time}&sort_direction={Sort Direction?:asc|desc}",
       "lookups": [
         {
           "endpoint": "User",
@@ -520,13 +520,13 @@
           "parameterName": "User ID"
         }
       ],
-      "description": "The activities linked to one contact. Requires a person id. SUPERSEDED: Pipedrive replaced these per-parent listings with filters on the main collection in v2, where the same rows come from the activities endpoint with a person_id filter. This v1 path is absent from the current API description."
+      "description": "The activities linked to one contact. Requires a person id. The activities collection filtered by person_id."
     },
     {
       "name": "Person Deals",
       "paged": true,
-      "suffix": "/v1/persons/{Person ID}/deals?status={Status?:all_not_deleted|open|...}",
-      "description": "The deals linked to one contact. Requires a person id. SUPERSEDED in the same way -- v2 answers it with a person_id filter on the deals collection, and this v1 path is absent from the current API description."
+      "suffix": "/api/v2/deals?person_id={Person ID}&status={Status?:open|won|lost|deleted}&updated_since={Updated Since?:yyyy-MM-ddTHH:mm:ssZ}&updated_until={Updated Until?:yyyy-MM-ddTHH:mm:ssZ}&custom_fields={Custom Field Keys?:key1,key2,... (max 15)}&sort_by={Sort By?:id|update_time|add_time}&sort_direction={Sort Direction?:asc|desc}",
+      "description": "The deals linked to one contact. Requires a person id. The deals collection filtered by person_id, so the deal filters -- status, update-time range, custom fields -- all apply here too."
     },
     {
       "name": "Person Files",
@@ -579,7 +579,7 @@
     {
       "name": "Pipelines",
       "paged": true,
-      "suffix": "/v1/pipelines",
+      "suffix": "/api/v2/pipelines?sort_by={Sort By?:id|update_time|add_time}&sort_direction={Sort Direction?:asc|desc}",
       "lookups": [
         {
           "endpoints": [
@@ -592,13 +592,13 @@
           "parameterName": "Pipeline ID"
         }
       ],
-      "description": "The sales pipelines on the account, each with name, order, whether it is active and whether deal probability is enabled on it. A pipeline is a sequence of stages, and most organisations run more than one -- so any funnel question needs to name the pipeline, or it mixes processes that are not comparable. Same version note as Deals: this resource has moved to API v2."
+      "description": "The sales pipelines on the account, each with name, order and whether deal probability is enabled. A pipeline is a sequence of stages, and most organisations run more than one -- so any funnel question needs to name the pipeline, or it mixes processes that are not comparable."
     },
     {
       "name": "Pipeline",
       "paged": false,
-      "suffix": "/v1/pipelines/{Pipeline ID}?totals_convert_currency={Totals Convert Currency?}",
-      "description": "One pipeline by id. Same fields, same version note."
+      "suffix": "/api/v2/pipelines/{Pipeline ID}",
+      "description": "One pipeline by id."
     },
     {
       "name": "Pipeline Conversion Rates",
@@ -621,7 +621,7 @@
     {
       "name": "Products",
       "paged": true,
-      "suffix": "/v1/products?user_id={User ID?}&filter_id={Filter ID?}&first_char={Starts With Character?}",
+      "suffix": "/api/v2/products?owner_id={Owner ID?}&filter_id={Filter ID?}&updated_since={Updated Since?:yyyy-MM-ddTHH:mm:ssZ}&custom_fields={Custom Field Keys?:key1,key2,... (max 15)}&sort_by={Sort By?:id|update_time|add_time}&sort_direction={Sort Direction?:asc|desc}",
       "lookups": [
         {
           "endpoints": [
@@ -635,19 +635,19 @@
           "parameterName": "Product ID"
         }
       ],
-      "description": "The products or services the account sells, one row each. Carries name, code, unit, tax, the active and selectable flags, visibility, and the owning user. NOTE THE PRICE SHAPE: prices is an ARRAY with one entry per currency, each carrying the price, cost and overhead cost -- there is no single price column, so reading 'the price' means choosing a currency first. What was actually charged on a deal is in Deal Products, not here. VERSION NOTE: moved to API v2; the v1 path is being retired."
+      "description": "The products or services the account sells, one row each. Carries name, code, unit, tax, the active and selectable flags, visibility, and the owning user. NOTE THE PRICE SHAPE: prices is an ARRAY with one entry per currency, each carrying the price, cost and overhead cost -- there is no single price column, so reading 'the price' means choosing a currency first. What was actually charged on a deal is in Deal Products, not here. Custom fields follow the v2 rule."
     },
     {
       "name": "Product Search",
       "paged": true,
-      "suffix": "/v1/products/search?term={Term}&fields={Fields?:field1,field2,...}&exact_match={Exact Match?:true|false}",
-      "description": "Products matching a search term across name, code and custom fields. Returns scored matches. Same version note."
+      "suffix": "/api/v2/products/search?term={Term}&fields={Fields?:code,custom_fields,name}&exact_match={Exact Match?:true|false}&include_fields={Include Fields?}",
+      "description": "Products matching a search term across name, code and custom fields. Returns scored matches."
     },
     {
       "name": "Product",
       "paged": false,
-      "suffix": "/v1/products/{Product ID}",
-      "description": "One product by id, with its full per-currency price array. Same version note."
+      "suffix": "/api/v2/products/{Product ID}",
+      "description": "One product by id, with its full per-currency price array."
     },
     {
       "name": "Product Deals",
@@ -736,19 +736,19 @@
     {
       "name": "Search",
       "paged": true,
-      "suffix": "/v1/itemSearch?term={Term}&item_types={Item Types?:type1,type2,...}&fields={Fields?:field1,field2,...}&search_for_related_items={Search for Related Items?:true|false}&exact_match={Exact Match?:true|false}",
-      "description": "Searches across several item types at once -- deals, persons, organizations, products, files and more -- for a term. Returns matches with a relevance score and an item type on each, so the result set is mixed-shape rather than one table. Reach for a specific resource's own search when the type is already known; this is for when it is not. VERSION NOTE: moved to API v2; the v1 path is being retired."
+      "suffix": "/api/v2/itemSearch?term={Term}&item_types={Item Types?:deal,person,organization,product,...}&fields={Fields?:field1,field2,...}&search_for_related_items={Search for Related Items?:true|false}&exact_match={Exact Match?:true|false}&include_fields={Include Fields?}",
+      "description": "Searches across several item types at once -- deals, persons, organizations, products and more -- for a term. Returns matches with a relevance score and an item type on each, so the result set is mixed-shape rather than one table. Reach for a specific resource's own search when the type is already known; this is for when it is not."
     },
     {
       "name": "Field Search",
       "paged": true,
-      "suffix": "/v1/itemSearch/field?term={Term}&field_type={Field Type:dealField|personField|...}&field_key={Field Key}&exact_match={Exact Match?:true|false}&return_item_ids={Return Item IDs?:true|false}",
-      "description": "Searches one named field of one item type for a term, returning the matching values. Built for autocomplete, so it returns field values rather than whole records. Same version note."
+      "suffix": "/api/v2/itemSearch/field?term={Term}&entity_type={Entity Type:deal|person|organization|product|lead|project}&field={Field Key}&match={Match?:exact|beginning|middle}",
+      "description": "Searches ONE named field of one entity type for a term, returning the matching values. Built for autocomplete, so it returns field values rather than whole records. NOTE V2 RENAMED EVERY PARAMETER HERE: the entity is now entity_type, the field is field, and the old exact_match became a three-valued match of exact, beginning or middle."
     },
     {
       "name": "Stages",
       "paged": true,
-      "suffix": "/v1/stages?pipeline_id={Pipeline ID?}",
+      "suffix": "/api/v2/stages?pipeline_id={Pipeline ID?}&sort_by={Sort By?:id|update_time|add_time}&sort_direction={Sort Direction?:asc|desc}",
       "lookups": [
         {
           "endpoint": "Stage Deals",
@@ -763,13 +763,13 @@
           "parameterName": "Pipeline ID"
         }
       ],
-      "description": "The stages making up the pipelines, each with its name, the pipeline it belongs to, its order_nr, and its deal_probability. Deals reference a stage_id, so this is the dimension any funnel breakdown joins to. NOTE the probability is a configured expectation, not a measured rate -- Pipeline Conversion Rates is where the measured one lives. Same version note: moved to API v2."
+      "description": "The stages making up the pipelines, each with its name, the pipeline it belongs to, its order_nr and its deal_probability. Deals reference a stage_id, so this is the dimension any funnel breakdown joins to. NOTE the probability is a configured expectation, not a measured rate -- Pipeline Conversion Rates is where the measured one lives. Filter by pipeline_id for one pipeline's stages in order."
     },
     {
       "name": "Stage",
       "paged": false,
-      "suffix": "/v1/stages/{Stage ID}",
-      "description": "One stage by id. Same fields, same version note."
+      "suffix": "/api/v2/stages/{Stage ID}",
+      "description": "One stage by id."
     },
     {
       "name": "Stage Deals",

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/pipelinecrm/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/pipelinecrm/endpoints.json
@@ -3,17 +3,19 @@
     {
       "name": "Profile",
       "paged": true,
-      "suffix": "/v3/profile.json"
+      "suffix": "/v3/profile.json",
+      "description": "The account the credentials belong to, with its settings. One record, always the caller."
     },
     {
       "name": "Searches",
       "paged": true,
-      "suffix": "/v3/searches.json"
+      "suffix": "/v3/searches.json",
+      "description": "The SAVED SEARCHES defined on the account, each with its criteria and the record type it applies to. Most listing endpoints here accept a search_id, so these are reusable, organisation-approved definitions -- and reading their criteria is usually the fastest way to learn what a business term means here."
     },
     {
       "name": "Notes",
       "paged": true,
-      "suffix": "/v3/notes.json?deal_id={Deal ID?}&person_id={Person ID?}&company_id={Company ID?}&\nsearch_id={Search ID?}&conditions[activity_modified][from_date={Activity Modified From?:YYYY-MM-DD}&conditions[activity_modified][to_date]={Activity Modified To?:YYYY-MM-DD}",
+      "suffix": "/v3/notes.json?deal_id={Deal ID?}&person_id={Person ID?}&company_id={Company ID?}&search_id={Search ID?}&conditions[activity_modified][from_date={Activity Modified From?:YYYY-MM-DD}&conditions[activity_modified][to_date]={Activity Modified To?:YYYY-MM-DD}",
       "lookups": [
         {
           "endpoint": "Comments",
@@ -21,57 +23,68 @@
           "key": "id",
           "parameterName": "Note ID"
         }
-      ]
+      ],
+      "description": "The notes recorded against deals, people and companies, filterable by any of them. The qualitative record beside the structured one, and where the reasoning behind a deal's outcome is usually written."
     },
     {
       "name": "Note",
       "paged": false,
-      "suffix": "/v3/notes/{Note ID}.json"
+      "suffix": "/v3/notes/{Note ID}.json",
+      "description": "One note by id."
     },
     {
       "name": "Account Notifications",
       "paged": true,
-      "suffix": "/v3/account_notifications.json?conditions[user_id]={User ID?}"
+      "suffix": "/v3/account_notifications.json?conditions[user_id]={User ID?}",
+      "description": "The notifications raised for users, filterable by user. The alert record rather than any CRM data."
     },
     {
       "name": "Account Notification",
       "paged": false,
-      "suffix": "/v3/account_notifications/{Account ID}.json"
+      "suffix": "/v3/account_notifications/{Account ID}.json",
+      "description": "One notification by id."
     },
     {
       "name": "Calendar Events",
       "paged": true,
-      "suffix": "/v3/calendar_entries.json?search_id={Search ID?}&conditions[named]={Calendar Entry Name?}"
+      "suffix": "/v3/calendar_entries.json?search_id={Search ID?}&conditions[named]={Calendar Entry Name?}",
+      "description": "The scheduled meetings, calls and tasks, filterable by conditions or a saved search. Carries the type, times, attendees and the records each relates to. The activity table."
     },
     {
       "name": "Calendar Event",
       "paged": false,
-      "suffix": "/v3/calendar_entries/{Entry ID}.json"
+      "suffix": "/v3/calendar_entries/{Entry ID}.json",
+      "description": "One calendar event by id."
     },
     {
       "name": "Comments",
       "paged": true,
-      "suffix": "/v3/notes/{Note ID}/comments.json"
+      "suffix": "/v3/notes/{Note ID}/comments.json",
+      "description": "The comments on one note. Requires a note id. Notes carry discussion, so this is the thread beneath one."
     },
     {
       "name": "Comment",
       "paged": false,
-      "suffix": "/v3/notes/{Note ID}/comments/{Comment ID}.json"
+      "suffix": "/v3/notes/{Note ID}/comments/{Comment ID}.json",
+      "description": "One comment by id. Requires the note id."
     },
     {
       "name": "Company Comments",
       "paged": true,
-      "suffix": "/v3/companies/{Association ID}/notes/{Note ID}/comments.json"
+      "suffix": "/v3/companies/{Association ID}/notes/{Note ID}/comments.json",
+      "description": "The comments on one note attached to a company. Requires the company and note ids."
     },
     {
       "name": "Deal Comments",
       "paged": true,
-      "suffix": "/v3/deals/{Association ID}/notes/{Note ID}/comments.json"
+      "suffix": "/v3/deals/{Association ID}/notes/{Note ID}/comments.json",
+      "description": "The comments on one note attached to a deal. Requires the deal and note ids."
     },
     {
       "name": "People Comments",
       "paged": true,
-      "suffix": "/v3/people/{Association ID}/notes/{Note ID}/comments.json"
+      "suffix": "/v3/people/{Association ID}/notes/{Note ID}/comments.json",
+      "description": "The comments on one note attached to a contact. Requires the person and note ids."
     },
     {
       "name": "Company Notes",
@@ -84,7 +97,8 @@
           "key": "id",
           "parameterName": "Note ID"
         }
-      ]
+      ],
+      "description": "The notes on one company. Requires a company id."
     },
     {
       "name": "Company People",
@@ -101,7 +115,8 @@
           "key": "id",
           "parameterName": "Person ID"
         }
-      ]
+      ],
+      "description": "The contacts at one company. Requires a company id."
     },
     {
       "name": "Company Deals",
@@ -118,12 +133,14 @@
           "key": "id",
           "parameterName": "Deal ID"
         }
-      ]
+      ],
+      "description": "The deals with one company. Requires a company id."
     },
     {
       "name": "Company Calendar Entries",
       "paged": true,
-      "suffix": "/v3/companies/{Company ID}/calendar_entries.json"
+      "suffix": "/v3/companies/{Company ID}/calendar_entries.json",
+      "description": "The calendar events involving one company. Requires a company id."
     },
     {
       "name": "Companies",
@@ -141,12 +158,14 @@
           "key": "id",
           "parameterName": "Company ID"
         }
-      ]
+      ],
+      "description": "The organisations contacts and deals belong to, with name, address, website, owner, tags and custom fields. The account-level dimension."
     },
     {
       "name": "Company",
       "paged": false,
-      "suffix": "/v3/companies/{Company ID}.json"
+      "suffix": "/v3/companies/{Company ID}.json",
+      "description": "One company by id."
     },
     {
       "name": "Deals",
@@ -163,12 +182,14 @@
           "key": "id",
           "parameterName": "Deal ID"
         }
-      ]
+      ],
+      "description": "The sales opportunities -- the central table. Carries the name, value, the company and primary contact, the stage, probability, expected close date, status, owner, source and custom fields. NOTE THE FILTERING MODEL, which is uniform across this connector: listings take conditions[field] parameters rather than a query language, and a search_id referencing a SAVED SEARCH. Those saved searches encode the segments the business already agreed on, which is usually faster than reconstructing a filter."
     },
     {
       "name": "Deal",
       "paged": false,
-      "suffix": "/v3/deals/{Deal ID}.json"
+      "suffix": "/v3/deals/{Deal ID}.json",
+      "description": "One deal by id."
     },
     {
       "name": "Deal Notes",
@@ -181,7 +202,8 @@
           "key": "id",
           "parameterName": "Note ID"
         }
-      ]
+      ],
+      "description": "The notes on one deal. Requires a deal id."
     },
     {
       "name": "Deal People",
@@ -198,22 +220,26 @@
           "key": "id",
           "parameterName": "Person ID"
         }
-      ]
+      ],
+      "description": "The people associated with one deal. Requires a deal id. A deal names one primary contact; this is everyone involved."
     },
     {
       "name": "Deal Calendar Entries",
       "paged": true,
-      "suffix": "/v3/deals/{Deal ID}/calendar_entries.json"
+      "suffix": "/v3/deals/{Deal ID}/calendar_entries.json",
+      "description": "The calendar events linked to one deal. Requires a deal id. The meeting history behind an opportunity."
     },
     {
       "name": "Documents",
       "paged": true,
-      "suffix": "/v3/documents.json?conditions[document_name]={Document Name?}&conditions[document_type]={Document Type?}&conditions[document_owner]={Document Owner?}"
+      "suffix": "/v3/documents.json?conditions[document_name]={Document Name?}&conditions[document_type]={Document Type?}&conditions[document_owner]={Document Owner?}",
+      "description": "The files stored, filterable by name. Metadata rather than content."
     },
     {
       "name": "Document",
       "paged": false,
-      "suffix": "/v3/documents/{Document ID}.json"
+      "suffix": "/v3/documents/{Document ID}.json",
+      "description": "One document by id."
     },
     {
       "name": "Person Notes",
@@ -226,7 +252,8 @@
           "key": "id",
           "parameterName": "Note ID"
         }
-      ]
+      ],
+      "description": "The notes on one contact. Requires a person id."
     },
     {
       "name": "Person Deals",
@@ -243,12 +270,14 @@
           "key": "id",
           "parameterName": "Deal ID"
         }
-      ]
+      ],
+      "description": "The deals one contact is involved in. Requires a person id."
     },
     {
       "name": "Person Calendar Entries",
       "paged": true,
-      "suffix": "/v3/people/{Person ID}/calendar_entries.json"
+      "suffix": "/v3/people/{Person ID}/calendar_entries.json",
+      "description": "The calendar events involving one contact. Requires a person id."
     },
     {
       "name": "People",
@@ -265,212 +294,254 @@
           "key": "id",
           "parameterName": "Person ID"
         }
-      ]
+      ],
+      "description": "The contacts, with name, contact details, the company, owner, lead source and status, tags and custom fields. Filterable by conditions or a saved search."
     },
     {
       "name": "Person",
       "paged": false,
-      "suffix": "/v3/people/{Person ID}.json"
+      "suffix": "/v3/people/{Person ID}.json",
+      "description": "One contact by id."
     },
     {
       "name": "Company Custom Groups",
       "paged": true,
-      "suffix": "/v3/admin/company_custom_field_groups.json?conditions[company_custom_field_group_created_at][from_date]={Created From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[company_custom_field_group_created_at][to_date]={Created To Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[company_custom_field_group_updated_at][from_date]={Updated From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[company_custom_field_group_updated_at][to_date]={Updated To Date?:YYYY-MM-DDTHH:MM:SSZ}"
+      "suffix": "/v3/admin/company_custom_field_groups.json?conditions[company_custom_field_group_created_at][from_date]={Created From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[company_custom_field_group_created_at][to_date]={Created To Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[company_custom_field_group_updated_at][from_date]={Updated From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[company_custom_field_group_updated_at][to_date]={Updated To Date?:YYYY-MM-DDTHH:MM:SSZ}",
+      "description": "The custom field groups defined for companies."
     },
     {
       "name": "Company Custom Group",
       "paged": false,
-      "suffix": "/v3/admin/company_custom_field_groups/{Group ID}.json"
+      "suffix": "/v3/admin/company_custom_field_groups/{Group ID}.json",
+      "description": "One company custom field group by id."
     },
     {
       "name": "Company Custom Labels",
       "paged": true,
-      "suffix": "/v3/admin/company_custom_field_labels.json?conditions[company_custom_field_label_created_at][from_date]={Created From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[company_custom_field_label_created_at][to_date]={Created To Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[company_custom_field_label_updated_at][from_date]={Updated From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[company_custom_field_label_updated_at][to_date]={Updated To Date?:YYYY-MM-DDTHH:MM:SSZ}"
+      "suffix": "/v3/admin/company_custom_field_labels.json?conditions[company_custom_field_label_created_at][from_date]={Created From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[company_custom_field_label_created_at][to_date]={Created To Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[company_custom_field_label_updated_at][from_date]={Updated From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[company_custom_field_label_updated_at][to_date]={Updated To Date?:YYYY-MM-DDTHH:MM:SSZ}",
+      "description": "The custom field definitions for companies. The decoder for custom values on a company."
     },
     {
       "name": "Company Custom Label",
       "paged": false,
-      "suffix": "/v3/admin/company_custom_field_labels/{Label ID}.json"
+      "suffix": "/v3/admin/company_custom_field_labels/{Label ID}.json",
+      "description": "One company custom field by id."
     },
     {
       "name": "Company Custom Label Entries",
       "paged": true,
-      "suffix": "/v3/admin/custom_field_label_dropdown_entries.json?conditions[custom_field_label_dropdown_entry_created_at][from_date]={Created From Date?:YYYY-MM-DDTHH:MM:SSZ}&\nconditions[custom_field_label_dropdown_entry_created_at][to_date]={Created To Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[custom_field_label_dropdown_entry_updated_at][from_date]={Updated From Date?:YYYY-MM-DDTHH:MM:SSZ}&\nconditions[custom_field_label_dropdown_entry_updated_at][to_date]={Updated To Date?:YYYY-MM-DDTHH:MM:SSZ}"
+      "suffix": "/v3/admin/custom_field_label_dropdown_entries.json?conditions[custom_field_label_dropdown_entry_created_at][from_date]={Created From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[custom_field_label_dropdown_entry_created_at][to_date]={Created To Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[custom_field_label_dropdown_entry_updated_at][from_date]={Updated From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[custom_field_label_dropdown_entry_updated_at][to_date]={Updated To Date?:YYYY-MM-DDTHH:MM:SSZ}",
+      "description": "The dropdown options of custom fields, with their stored values and display text. THE SECOND HALF OF THE DECODER: a dropdown custom field stores an option id, and only this resolves it to something readable."
     },
     {
       "name": "Company Custom Label Entry",
       "paged": false,
-      "suffix": "/v3/admin/custom_field_label_dropdown_entries/{Entry ID}.json"
+      "suffix": "/v3/admin/custom_field_label_dropdown_entries/{Entry ID}.json",
+      "description": "One custom field dropdown option by id."
     },
     {
       "name": "Deal Custom Groups",
       "paged": true,
-      "suffix": "/v3/admin/deal_custom_field_groups.json?conditions[deal_custom_field_group_created_at][from_date]={Created From Date?:YYYY-MM-DDTHH:MM:SSZ}&\nconditions[deal_custom_field_group_created_at][to_date]={Created To Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[deal_custom_field_group_updated_at][from_date]={Updated From Date?:YYYY-MM-DDTHH:MM:SSZ}&\nconditions[deal_custom_field_group_updated_at][to_date]={Updated To Date?:YYYY-MM-DDTHH:MM:SSZ}"
+      "suffix": "/v3/admin/deal_custom_field_groups.json?conditions[deal_custom_field_group_created_at][from_date]={Created From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[deal_custom_field_group_created_at][to_date]={Created To Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[deal_custom_field_group_updated_at][from_date]={Updated From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[deal_custom_field_group_updated_at][to_date]={Updated To Date?:YYYY-MM-DDTHH:MM:SSZ}",
+      "description": "The custom field groups defined for deals. Fields are organised into groups, so this is the outer level of the custom-field schema."
     },
     {
       "name": "Deal Custom Group",
       "paged": false,
-      "suffix": "/v3/admin/deal_custom_field_groups/{Group ID}.json"
+      "suffix": "/v3/admin/deal_custom_field_groups/{Group ID}.json",
+      "description": "One deal custom field group by id."
     },
     {
       "name": "Deal Custom Labels",
       "paged": false,
-      "suffix": "/v3/admin/deal_custom_field_labels.json?conditions[deal_custom_field_label_created_at][from_date]={Created From Date?:YYYY-MM-DDTHH:MM:SSZ}&\nconditions[deal_custom_field_label_created_at][to_date]={Created To Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[deal_custom_field_label_updated_at][from_date]={Updated From Date?:YYYY-MM-DDTHH:MM:SSZ}&\nconditions[deal_custom_field_label_updated_at][to_date]={Updated To Date?:YYYY-MM-DDTHH:MM:SSZ}"
+      "suffix": "/v3/admin/deal_custom_field_labels.json?conditions[deal_custom_field_label_created_at][from_date]={Created From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[deal_custom_field_label_created_at][to_date]={Created To Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[deal_custom_field_label_updated_at][from_date]={Updated From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[deal_custom_field_label_updated_at][to_date]={Updated To Date?:YYYY-MM-DDTHH:MM:SSZ}",
+      "description": "The custom field definitions for deals, with their labels and types. THE DECODER for custom values on a deal, which arrive keyed by label id."
     },
     {
       "name": "Deal Custom Label",
       "paged": false,
-      "suffix": "/v3/admin/deal_custom_field_labels/{Label ID}.json"
+      "suffix": "/v3/admin/deal_custom_field_labels/{Label ID}.json",
+      "description": "One deal custom field by id."
     },
     {
       "name": "Deal Loss Reasons",
       "paged": true,
-      "suffix": "/v3/admin/deal_loss_reasons.json?conditions[deal_loss_reason_created_at][from_date]={Created From Date?:YYYY-MM-DDTHH:MM:SSZ}&\nconditions[deal_loss_reason_created_at][to_date]={Created To Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[deal_loss_reason_updated_at][from_date]={Updated From Date?:YYYY-MM-DDTHH:MM:SSZ}&\nconditions[deal_loss_reason_updated_at][to_date]={Updated To Date?:YYYY-MM-DDTHH:MM:SSZ}"
+      "suffix": "/v3/admin/deal_loss_reasons.json?conditions[deal_loss_reason_created_at][from_date]={Created From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[deal_loss_reason_created_at][to_date]={Created To Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[deal_loss_reason_updated_at][from_date]={Updated From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[deal_loss_reason_updated_at][to_date]={Updated To Date?:YYYY-MM-DDTHH:MM:SSZ}",
+      "description": "The reasons configured for losing a deal. The structured explanation for revenue not won, which the deal's status alone does not give."
     },
     {
       "name": "Deal Loss Reason",
       "paged": true,
-      "suffix": "/v3/admin/deal_loss_reasons/{Reason ID}.json"
+      "suffix": "/v3/admin/deal_loss_reasons/{Reason ID}.json",
+      "description": "One loss reason by id."
     },
     {
       "name": "Deal Stages",
       "paged": true,
-      "suffix": "/v3/admin/deal_stages.json?conditions[deal_stage_created_at][from_date]={Created From Date?:YYYY-MM-DDTHH:MM:SSZ}&\nconditions[deal_stage_created_at][to_date]={Created To Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[deal_stage_updated_at][from_date]={Updated From Date?:YYYY-MM-DDTHH:MM:SSZ}&\nconditions[deal_stage_updated_at][to_date]={Updated To Date?:YYYY-MM-DDTHH:MM:SSZ}"
+      "suffix": "/v3/admin/deal_stages.json?conditions[deal_stage_created_at][from_date]={Created From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[deal_stage_created_at][to_date]={Created To Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[deal_stage_updated_at][from_date]={Updated From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[deal_stage_updated_at][to_date]={Updated To Date?:YYYY-MM-DDTHH:MM:SSZ}",
+      "description": "The pipeline stages, with name, position and probability. The dimension a funnel breakdown joins to, and the decoder for a deal's stage id."
     },
     {
       "name": "Deal Stage",
       "paged": false,
-      "suffix": "/v3/admin/deal_stages/{Stage ID}.json"
+      "suffix": "/v3/admin/deal_stages/{Stage ID}.json",
+      "description": "One deal stage by id."
     },
     {
       "name": "Documents Tags",
       "paged": true,
-      "suffix": "/v3/admin/document_tags.json?conditions[document_tag_created_at][from_date]={Created From Date?:YYYY-MM-DDTHH:MM:SSZ}&\nconditions[document_tag_created_at][to_date]={Created To Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[document_tag_updated_at][from_date]={Updated From Date?:YYYY-MM-DDTHH:MM:SSZ}&\nconditions[document_tag_updated_at][to_date]={Updated To Date?:YYYY-MM-DDTHH:MM:SSZ}"
+      "suffix": "/v3/admin/document_tags.json?conditions[document_tag_created_at][from_date]={Created From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[document_tag_created_at][to_date]={Created To Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[document_tag_updated_at][from_date]={Updated From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[document_tag_updated_at][to_date]={Updated To Date?:YYYY-MM-DDTHH:MM:SSZ}",
+      "description": "The tags applied to documents. The classification of stored files."
     },
     {
       "name": "Document Tag",
       "paged": false,
-      "suffix": "/v3/admin/document_tags/{Tag ID}.json"
+      "suffix": "/v3/admin/document_tags/{Tag ID}.json",
+      "description": "One document tag by id."
     },
     {
       "name": "Event Categories",
       "paged": true,
-      "suffix": "/v3/admin/event_categories.json?conditions[event_category_created_at][from_date]={Created From Date?:YYYY-MM-DDTHH:MM:SSZ}&\nconditions[event_category_created_at][to_date]={Created To Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[event_category_updated_at][from_date]={Updated From Date?:YYYY-MM-DDTHH:MM:SSZ}&\nconditions[event_category_updated_at][to_date]={Updated To Date?:YYYY-MM-DDTHH:MM:SSZ}"
+      "suffix": "/v3/admin/event_categories.json?conditions[event_category_created_at][from_date]={Created From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[event_category_created_at][to_date]={Created To Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[event_category_updated_at][from_date]={Updated From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[event_category_updated_at][to_date]={Updated To Date?:YYYY-MM-DDTHH:MM:SSZ}",
+      "description": "The categories calendar events are classified under. The decoder for an event's category, and the dimension that turns activity volume into activity type."
     },
     {
       "name": "Event Category",
       "paged": false,
-      "suffix": "/v3/admin/event_categories/{Event Category ID}.json"
+      "suffix": "/v3/admin/event_categories/{Event Category ID}.json",
+      "description": "One event category by id."
     },
     {
       "name": "Lead Sources",
       "paged": true,
-      "suffix": "/v3/admin/lead_sources.json?conditions[lead_source_created_at][from_date]={Created From Date?:YYYY-MM-DDTHH:MM:SSZ}&\nconditions[lead_source_created_at][to_date]={Created To Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[lead_source_updated_at][from_date]={Updated From Date?:YYYY-MM-DDTHH:MM:SSZ}&\nconditions[lead_source_updated_at][to_date]={Updated To Date?:YYYY-MM-DDTHH:MM:SSZ}"
+      "suffix": "/v3/admin/lead_sources.json?conditions[lead_source_created_at][from_date]={Created From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[lead_source_created_at][to_date]={Created To Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[lead_source_updated_at][from_date]={Updated From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[lead_source_updated_at][to_date]={Updated To Date?:YYYY-MM-DDTHH:MM:SSZ}",
+      "description": "The lead source values configured. The attribution dimension -- where deals and contacts came from -- and account-specific."
     },
     {
       "name": "Lead Source",
       "paged": false,
-      "suffix": "/v3/admin/lead_sources/{Source ID}.json"
+      "suffix": "/v3/admin/lead_sources/{Source ID}.json",
+      "description": "One lead source by id."
     },
     {
       "name": "Lead Statuses",
       "paged": true,
-      "suffix": "/v3/admin/lead_statuses.json?conditions[lead_status_created_at][from_date]={Created From Date?:YYYY-MM-DDTHH:MM:SSZ}&\nconditions[lead_status_created_at][to_date]={Created To Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[lead_status_updated_at][from_date]={Updated From Date?:YYYY-MM-DDTHH:MM:SSZ}&\nconditions[lead_status_updated_at][to_date]={Updated To Date?:YYYY-MM-DDTHH:MM:SSZ}"
+      "suffix": "/v3/admin/lead_statuses.json?conditions[lead_status_created_at][from_date]={Created From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[lead_status_created_at][to_date]={Created To Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[lead_status_updated_at][from_date]={Updated From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[lead_status_updated_at][to_date]={Updated To Date?:YYYY-MM-DDTHH:MM:SSZ}",
+      "description": "The lead status values configured. The decoder for a contact's status, and the stages before a deal exists."
     },
     {
       "name": "Lead Status",
       "paged": false,
-      "suffix": "/v3/admin/lead_statuses/{Status ID}.json"
+      "suffix": "/v3/admin/lead_statuses/{Status ID}.json",
+      "description": "One lead status by id."
     },
     {
       "name": "Note Categories",
       "paged": true,
-      "suffix": "/v3/admin/note_categories.json?conditions[note_category_created_at][from_date]={Created From Date?:YYYY-MM-DDTHH:MM:SSZ}&\nconditions[note_category_created_at][to_date]={Created To Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[note_category_updated_at][from_date]={Updated From Date?:YYYY-MM-DDTHH:MM:SSZ}&\nconditions[note_category_updated_at][to_date]={Updated To Date?:YYYY-MM-DDTHH:MM:SSZ}"
+      "suffix": "/v3/admin/note_categories.json?conditions[note_category_created_at][from_date]={Created From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[note_category_created_at][to_date]={Created To Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[note_category_updated_at][from_date]={Updated From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[note_category_updated_at][to_date]={Updated To Date?:YYYY-MM-DDTHH:MM:SSZ}",
+      "description": "The categories notes are filed under. The decoder for a note's category, and the closest thing to a structured classification of what activity a note represents."
     },
     {
       "name": "Note Category",
       "paged": false,
-      "suffix": "/v3/admin/note_categories/{Node Category ID}json"
+      "suffix": "/v3/admin/note_categories/{Note Category ID}.json",
+      "description": "One note category by id."
     },
     {
       "name": "Person Custom Groups",
       "paged": true,
-      "suffix": "/v3/admin/person_custom_field_groups.json?conditions[person_custom_field_group_created_at][from_date]={Created From Date?:YYYY-MM-DDTHH:MM:SSZ}&\nconditions[person_custom_field_group_created_at][to_date]={Created To Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[person_custom_field_group_updated_at][from_date]={Updated From Date?:YYYY-MM-DDTHH:MM:SSZ}&\nconditions[person_custom_field_group_updated_at][to_date]={Updated To Date?:YYYY-MM-DDTHH:MM:SSZ}"
+      "suffix": "/v3/admin/person_custom_field_groups.json?conditions[person_custom_field_group_created_at][from_date]={Created From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[person_custom_field_group_created_at][to_date]={Created To Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[person_custom_field_group_updated_at][from_date]={Updated From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[person_custom_field_group_updated_at][to_date]={Updated To Date?:YYYY-MM-DDTHH:MM:SSZ}",
+      "description": "The custom field groups defined for contacts."
     },
     {
       "name": "Person Custom Group",
       "paged": false,
-      "suffix": "/v3/admin/person_custom_field_groups/{Group ID}.json"
+      "suffix": "/v3/admin/person_custom_field_groups/{Group ID}.json",
+      "description": "One person custom field group by id."
     },
     {
       "name": "Person Custom Labels",
       "paged": true,
-      "suffix": "/v3/admin/person_custom_field_labels.json?conditions[person_custom_field_label_created_at][from_date]={Created From Date?:YYYY-MM-DDTHH:MM:SSZ}&\nconditions[person_custom_field_label_created_at][to_date]={Created To Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[person_custom_field_label_updated_at][from_date]={Updated From Date?:YYYY-MM-DDTHH:MM:SSZ}&\nconditions[person_custom_field_label_updated_at][to_date]={Updated To Date?:YYYY-MM-DDTHH:MM:SSZ}"
+      "suffix": "/v3/admin/person_custom_field_labels.json?conditions[person_custom_field_label_created_at][from_date]={Created From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[person_custom_field_label_created_at][to_date]={Created To Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[person_custom_field_label_updated_at][from_date]={Updated From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[person_custom_field_label_updated_at][to_date]={Updated To Date?:YYYY-MM-DDTHH:MM:SSZ}",
+      "description": "The custom field definitions for contacts. The decoder for custom values on a person."
     },
     {
       "name": "Person Custom Label",
       "paged": false,
-      "suffix": "/v3/admin/person_custom_field_labels/{Label ID}.json"
+      "suffix": "/v3/admin/person_custom_field_labels/{Label ID}.json",
+      "description": "One person custom field by id."
     },
     {
       "name": "Predefined Contact Tags",
       "paged": true,
-      "suffix": "/v3/admin/predefined_contacts_tags.json?conditions[predefined_contacts_tag_created_at][from_date]={Created From Date?:YYYY-MM-DDTHH:MM:SSZ}&\nconditions[predefined_contacts_tag_created_at][to_date]={Created To Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[predefined_contacts_tag_updated_at][from_date]={Updated From Date?:YYYY-MM-DDTHH:MM:SSZ}&\nconditions[predefined_contacts_tag_updated_at][to_date]={Updated To Date?:YYYY-MM-DDTHH:MM:SSZ}"
+      "suffix": "/v3/admin/predefined_contacts_tags.json?conditions[predefined_contacts_tag_created_at][from_date]={Created From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[predefined_contacts_tag_created_at][to_date]={Created To Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[predefined_contacts_tag_updated_at][from_date]={Updated From Date?:YYYY-MM-DDTHH:MM:SSZ}&conditions[predefined_contacts_tag_updated_at][to_date]={Updated To Date?:YYYY-MM-DDTHH:MM:SSZ}",
+      "description": "The tag vocabulary available for contacts. Where tags are predefined rather than free text, this is the complete set."
     },
     {
       "name": "Predefined Contact Tag",
       "paged": false,
-      "suffix": "/v3/admin/predefined_contacts_tags/{Tag ID}.json"
+      "suffix": "/v3/admin/predefined_contacts_tags/{Tag ID}.json",
+      "description": "One predefined contact tag by id."
     },
     {
       "name": "Teams",
       "paged": true,
-      "suffix": "/v3/admin/teams.json"
+      "suffix": "/v3/admin/teams.json",
+      "description": "The teams users belong to. The grouping above individuals for reporting."
     },
     {
       "name": "Team",
       "paged": false,
-      "suffix": "/v3/admin/teams/{Team ID}.json"
+      "suffix": "/v3/admin/teams/{Team ID}.json",
+      "description": "One team by id."
     },
     {
       "name": "Todo Templates",
       "paged": true,
-      "suffix": "/v3/admin/todo_templates.json"
+      "suffix": "/v3/admin/todo_templates.json",
+      "description": "The task list templates defined -- the standard sequences of work a deal or contact triggers. What a team considers its repeatable process."
     },
     {
       "name": "Todo Template",
       "paged": false,
-      "suffix": "/v3/admin/todo_templates/{Template ID}.json"
+      "suffix": "/v3/admin/todo_templates/{Template ID}.json",
+      "description": "One todo template by id."
     },
     {
       "name": "Todo Template Items",
       "paged": true,
-      "suffix": "/v3/admin/todo_template_items.json"
+      "suffix": "/v3/admin/todo_template_items.json",
+      "description": "The individual steps within todo templates. The detail of the process."
     },
     {
       "name": "Todo Template Item",
       "paged": true,
-      "suffix": "/v3/admin/todo_template_items/{Template Item ID}.json"
+      "suffix": "/v3/admin/todo_template_items/{Template Item ID}.json",
+      "description": "One todo template item by id."
     },
     {
       "name": "Users",
       "paged": true,
-      "suffix": "/v3/users.json?conditions[email]={Email Address?}&\nconditions[admin]={Admin?:true|false}&conditions[including_inactive]={Including Inactive?:true|false}&conditions[user_level]={User Level?}"
+      "suffix": "/v3/users.json?conditions[email]={Email Address?}&conditions[admin]={Admin?:true|false}&conditions[including_inactive]={Including Inactive?:true|false}&conditions[user_level]={User Level?}",
+      "description": "The users of the account, filterable by email, admin flag and user level. Every record carries an owner, so this is the dimension per-person performance joins to. Inactive users are excluded unless explicitly included, and they still own their historical records."
     },
     {
       "name": "User",
       "paged": false,
-      "suffix": "/v3/users/{User ID}.json"
+      "suffix": "/v3/users/{User ID}.json",
+      "description": "One user by id."
     },
     {
       "name": "Revenue Types",
       "paged": true,
-      "suffix": "/v3/admin/revenue_types.json"
+      "suffix": "/v3/admin/revenue_types.json",
+      "description": "The revenue types deals can be classified as -- one-off, recurring, and whatever else the business defined. The dimension that separates kinds of revenue, which the deal value alone conflates."
     },
     {
       "name": "Revenue Type",
       "paged": false,
-      "suffix": "/v3/admin/revenue_types/{Revenue Type}.json"
+      "suffix": "/v3/admin/revenue_types/{Revenue Type}.json",
+      "description": "One revenue type by id."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/servicenow/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/servicenow/endpoints.json
@@ -1,135 +1,166 @@
 {
   "endpoints": [
     {
-      "paged": "false", 
-      "name": "Agent Presence Status", 
-      "suffix": "/now/awa/agents/{Agent ID}"
-    }, 
+      "paged": "false",
+      "name": "Agent Presence Status",
+      "suffix": "/now/awa/agents/{Agent ID}",
+      "description": "One agent's current availability in Advanced Work Assignment. Requires an agent id. A live snapshot with no history."
+    },
     {
-      "paged": "false", 
-      "name": "Aggregate Statistics", 
-      "suffix": "/now/stats/{Table Name}?sysparm_query={Query}&sysparm_group_by={Group By Fields?:priority,state,...}&sysparm_avg={Average Fields?}&sysparm_sum={Sum Fields?}sysparm_min_fields={Min Fields?}&sysparm_max_fields={Max Fields?}&sysparm_count={Count Records?:true|false}&sysparm_display_value={Display Value?:true|false}"
-    }, 
+      "paged": "false",
+      "name": "Aggregate Statistics",
+      "suffix": "/now/stats/{Table Name}?sysparm_query={Query}&sysparm_group_by={Group By Fields?:priority,state,...}&sysparm_avg={Average Fields?}&sysparm_sum={Sum Fields?}sysparm_min_fields={Min Fields?}&sysparm_max_fields={Max Fields?}&sysparm_count={Count Records?:true|false}&sysparm_display_value={Display Value?:true|false}",
+      "description": "COUNTS, SUMS, AVERAGES, MINIMA AND MAXIMA computed server-side over any table, with grouping. Requires the table name; takes a query, the aggregate functions and sysparm_group_by. Far cheaper than paging a table to count it, and the right answer to 'how many incidents by priority' or 'average resolution time by group' -- ServiceNow does the aggregation rather than shipping the rows."
+    },
     {
-      "paged": "false", 
-      "name": "Application Service CIs", 
-      "suffix": "/now/cmdb/app_service/{Application Service ID}/getContent?Mode={Mode?:Shallow|Full}"
-    }, 
-    {
-      "paged": "true",
-      "pageType": "OFFSET", 
-      "name": "Attachments", 
-      "suffix": "api/now/attachment?sysparm_query={Query}"
-    }, 
-    {
-      "paged": "false", 
-      "name": "Attachment", 
-      "suffix": "api/now/attachment/{Attachment ID}"
-    }, 
+      "paged": "false",
+      "name": "Application Service CIs",
+      "suffix": "/now/cmdb/app_service/{Application Service ID}/getContent?Mode={Mode?:Shallow|Full}",
+      "description": "The configuration items making up one application service, as a dependency map. Requires an application service id. THE SERVICE-TO-INFRASTRUCTURE MAP: which servers, databases and middleware a business service actually runs on, and therefore what a failure in one takes down."
+    },
     {
       "paged": "true",
-      "pageType": "OFFSET", 
-      "name": "Standard Changes", 
+      "pageType": "OFFSET",
+      "name": "Attachments",
+      "suffix": "api/now/attachment?sysparm_query={Query}",
+      "description": "The file attachments on the instance, filtered by an encoded query -- usually on the table and record they belong to. Metadata; the binary is a separate fetch."
+    },
+    {
+      "paged": "false",
+      "name": "Attachment",
+      "suffix": "api/now/attachment/{Attachment ID}",
+      "description": "One attachment's metadata by sys_id."
+    },
+    {
+      "paged": "true",
+      "pageType": "OFFSET",
+      "name": "Standard Changes",
       "suffix": "/sn_chg_rest/change/standard?sysparm_query={Query?}&textSearch={Text Search?}",
       "lookups": [
         {
-          "endpoints": ["Change Tasks", "Change Conflict Status", "Change Cls"],
+          "endpoints": [
+            "Change Tasks",
+            "Change Conflict Status",
+            "Change Cls"
+          ],
           "jsonPath": "$.result[*].value",
           "key": "value",
           "parameterName": "Change ID"
         }
-      ]
-    }, 
+      ],
+      "description": "Changes of the STANDARD type -- pre-approved, low-risk, raised from a template. They bypass approval entirely, so including them in an approval-time measure drags the average down misleadingly."
+    },
     {
-      "paged": "false", 
-      "name": "Standard Change", 
-      "suffix": "/sn_chg_rest/change/standard/{Change ID}"
-    }, 
-    {
-      "paged": "true",
-      "pageType": "OFFSET", 
-      "name": "Change Templates", 
-      "suffix": "/sn_chg_rest/change/standard/template?sysparm_query={Query?}&textSearch={Text Search?}"
-    }, 
-    {
-      "paged": "false", 
-      "name": "Change Template", 
-      "suffix": "/sn_chg_rest/change/standard/template/{Change Template ID}"
-    }, 
+      "paged": "false",
+      "name": "Standard Change",
+      "suffix": "/sn_chg_rest/change/standard/{Change ID}",
+      "description": "One standard change by id."
+    },
     {
       "paged": "true",
-      "pageType": "OFFSET", 
-      "name": "Normal Changes", 
+      "pageType": "OFFSET",
+      "name": "Change Templates",
+      "suffix": "/sn_chg_rest/change/standard/template?sysparm_query={Query?}&textSearch={Text Search?}",
+      "description": "The templates standard changes are raised from, each with its pre-approved content. The catalogue of what has been deemed routine."
+    },
+    {
+      "paged": "false",
+      "name": "Change Template",
+      "suffix": "/sn_chg_rest/change/standard/template/{Change Template ID}",
+      "description": "One change template by id."
+    },
+    {
+      "paged": "true",
+      "pageType": "OFFSET",
+      "name": "Normal Changes",
       "suffix": "/sn_chg_rest/change/normal?sysparm_query={Query?}&textSearch={Text Search?}",
       "lookups": [
         {
-          "endpoints": ["Change Tasks", "Change Conflict Status", "Change Cls"],
+          "endpoints": [
+            "Change Tasks",
+            "Change Conflict Status",
+            "Change Cls"
+          ],
           "jsonPath": "$.result[*].value",
           "key": "value",
           "parameterName": "Change ID"
         }
-      ]
-    }, 
+      ],
+      "description": "Change requests of the NORMAL type -- those requiring assessment and approval. Filterable by encoded query or text search. ServiceNow separates change types because they follow different processes, so a change-management measure has to say which types it counts."
+    },
     {
-      "paged": "false", 
-      "name": "Normal Change", 
-      "suffix": "/sn_chg_rest/change/normal/{Change ID}"
-    }, 
+      "paged": "false",
+      "name": "Normal Change",
+      "suffix": "/sn_chg_rest/change/normal/{Change ID}",
+      "description": "One normal change by id."
+    },
     {
       "paged": "true",
-      "pageType": "OFFSET", 
-      "name": "Emergency Changes", 
+      "pageType": "OFFSET",
+      "name": "Emergency Changes",
       "suffix": "/sn_chg_rest/change/emergency?sysparm_query={Query?}&textSearch={Text Search?}",
       "lookups": [
         {
-          "endpoints": ["Change Tasks", "Change Conflict Status", "Change Cls"],
+          "endpoints": [
+            "Change Tasks",
+            "Change Conflict Status",
+            "Change Cls"
+          ],
           "jsonPath": "$.result[*].value",
           "key": "value",
           "parameterName": "Change ID"
         }
-      ]
-    }, 
+      ],
+      "description": "Changes of the EMERGENCY type -- raised outside the normal process to fix something now. Their rate and their failure rate are the interesting figures: emergency changes are the ones most likely to cause incidents."
+    },
     {
-      "paged": "false", 
-      "name": "Emergency Change", 
-      "suffix": "/sn_chg_rest/change/emergency/{Change ID}"
-    }, 
-    {
-      "paged": "true",
-      "pageType": "OFFSET", 
-      "name": "Change Tasks", 
-      "suffix": "/sn_chg_rest/change/{Change ID}/task?sysparm_query={Query?}"
-    }, 
-    {
-      "paged": "false", 
-      "name": "Change Task", 
-      "suffix": "/sn_chg_rest/change/{Change ID}/task/{Task ID}"
-    }, 
-    {
-      "paged": "false", 
-      "name": "Change Conflict Status", 
-      "suffix": "/sn_chg_rest/change/{Change ID}/conflict"
-    }, 
+      "paged": "false",
+      "name": "Emergency Change",
+      "suffix": "/sn_chg_rest/change/emergency/{Change ID}",
+      "description": "One emergency change by id."
+    },
     {
       "paged": "true",
-      "pageType": "OFFSET", 
-      "name": "Change Cls", 
-      "suffix": "/sn_chg_rest/change/{Change ID}/ci?association_type={Association Type?:affected|impacted|offering}&sysparm_query={Query}"
-    }, 
+      "pageType": "OFFSET",
+      "name": "Change Tasks",
+      "suffix": "/sn_chg_rest/change/{Change ID}/task?sysparm_query={Query?}",
+      "description": "The individual tasks making up one change. Requires a change id. A change is a container; the work and its timings are in these."
+    },
     {
-      "paged": "false", 
+      "paged": "false",
+      "name": "Change Task",
+      "suffix": "/sn_chg_rest/change/{Change ID}/task/{Task ID}",
+      "description": "One change task by id. Requires the change id."
+    },
+    {
+      "paged": "false",
+      "name": "Change Conflict Status",
+      "suffix": "/sn_chg_rest/change/{Change ID}/conflict",
+      "description": "Whether one change conflicts with another change or a blackout window. Requires a change id. The scheduling check, and the explanation for a change that was refused rather than rejected."
+    },
+    {
+      "paged": "true",
+      "pageType": "OFFSET",
+      "name": "Change Cls",
+      "suffix": "/sn_chg_rest/change/{Change ID}/ci?association_type={Association Type?:affected|impacted|offering}&sysparm_query={Query}",
+      "description": "The configuration items one change affects, by association type. Requires a change id. THE LINK BETWEEN A CHANGE AND WHAT IT TOUCHED -- which is how a change is connected to the incidents that followed it."
+    },
+    {
+      "paged": "false",
       "name": "Change Worker Status",
-      "suffix": "/sn_chg_rest/change/worker/{Worker ID}"
-    }, 
+      "suffix": "/sn_chg_rest/change/worker/{Worker ID}",
+      "description": "The progress of an asynchronous change operation. Operational."
+    },
     {
-      "paged": "false", 
-      "name": "Account", 
-      "suffix": "/now/account/{Account ID}"
-    }, 
+      "paged": "false",
+      "name": "Account",
+      "suffix": "/now/account/{Account ID}",
+      "description": "One CSM account by id."
+    },
     {
       "paged": "true",
-      "pageType": "OFFSET", 
-      "name": "Accounts", 
+      "pageType": "OFFSET",
+      "name": "Accounts",
       "suffix": "/now/account?sysparm_query={Query?}",
       "lookups": [
         {
@@ -138,123 +169,145 @@
           "key": "primary_contact",
           "parameterName": "Contact ID"
         }
-      ]
-    }, 
+      ],
+      "description": "The customer accounts in Customer Service Management, filterable by query. The company dimension cases group under."
+    },
     {
-      "paged": "false", 
-      "name": "CSM Case", 
-      "suffix": "api/sn_customerservice/case/{Case ID}"
-    }, 
-    {
-      "paged": "true",
-      "pageType": "OFFSET", 
-      "name": "CSM Cases", 
-      "suffix": "/sn_customerservice/case?sysparm_query={Query?}"
-    }, 
-    {
-      "paged": "false", 
-      "name": "CSM Consumer Record", 
-      "suffix": "/now/consumer/{Consumer Record ID}"
-    }, 
+      "paged": "false",
+      "name": "CSM Case",
+      "suffix": "api/sn_customerservice/case/{Case ID}",
+      "description": "One customer service case by id."
+    },
     {
       "paged": "true",
-      "pageType": "OFFSET", 
-      "name": "CSM Consumer Records", 
-      "suffix": "/now/consumer?sysparm_query={Query?}"
-    }, 
+      "pageType": "OFFSET",
+      "name": "CSM Cases",
+      "suffix": "/sn_customerservice/case?sysparm_query={Query?}",
+      "description": "Customer service cases -- the customer-facing counterpart to internal incidents. Filterable by encoded query. Distinct from the incident table: cases are raised by customers against accounts, incidents by employees against services."
+    },
     {
-      "paged": "false", 
-      "name": "CSM Contact", 
-      "suffix": "/now/contact/{Contact ID}"
-    }, 
-    {
-      "paged": "true",
-      "pageType": "OFFSET", 
-      "name": "CSM Contacts", 
-      "suffix": "/now/contact?sysparm_query={Query?}"
-    }, 
+      "paged": "false",
+      "name": "CSM Consumer Record",
+      "suffix": "/now/consumer/{Consumer Record ID}",
+      "description": "One consumer record by id."
+    },
     {
       "paged": "true",
-      "pageType": "OFFSET", 
-      "name": "DevOps Tools", 
-      "suffix": "/sn_devops/devops/admin?id={Tool ID?}&name={Name?}&type={Type?:Planning|Coding|TaskExecution}"
-    }, 
+      "pageType": "OFFSET",
+      "name": "CSM Consumer Records",
+      "suffix": "/now/consumer?sysparm_query={Query?}",
+      "description": "Individual consumers, for business-to-consumer service models where the customer is a person rather than a company."
+    },
     {
-      "paged": "false", 
-      "name": "Code Resource Schema", 
-      "suffix": "/sn_devops/devops/code/schema?resource={Resource?:commit|repository|branch}"
-    }, 
-    {
-      "paged": "false", 
-      "name": "Orchestration Change Control", 
-      "suffix": "/sn_devops/devops/orchestration/changeControl?orchestrationTaskURL={Orchestration Task Url}&toolId={Tool ID}&changeControlId={Change Control ID?}&orchestrationTaskName={Task Name?}&testConnection={Test Connnection?:true|false}&type={Type?:jenkins|...}"
-    }, 
-    {
-      "paged": "false", 
-      "name": "Orchestration Resource Schema", 
-      "suffix": "/sn_devops/devops/orchestration/schema?resource={Resource?:build_details|callback|orchestration_task|task_execution}"
-    }, 
-    {
-      "paged": "false", 
-      "name": "Orchestration Step Mapping", 
-      "suffix": "/sn_devops/devops/orchestration/stepMapping?orchestrationTaskName={Task Name}&orchestrationTaskURL={Orchestration Task Url}&toolId={Tool Id}&branchName={Branch Name?}&parentStageName={Parent Stage Name?}&parentStageURL={Parent Stage URL?}&testConnection={Test Connection?:true|false}&type={Type?:jenkins|...}"
-    }, 
-    {
-      "paged": "false", 
-      "name": "Plan Schema", 
-      "suffix": "/sn_devops/devops/plan/schema?resource={Resource?:build_details|callback|orchestration_task|task_execution}"
-    }, 
-    {
-      "paged": "false", 
-      "name": "Email", 
-      "suffix": "/now/v1/email/{Email ID}"
-    }, 
-    {
-      "paged": "false", 
-      "name": "Import Set", 
-      "suffix": "/now/v1/import/{Table Name}/{Import Set ID}"
-    }, 
-    {
-      "paged": "false", 
-      "name": "Major Incident Communication Cards", 
-      "suffix": "/sn_major_inc_mgmt/mim/status/{Incident ID}"
-    }, 
+      "paged": "false",
+      "name": "CSM Contact",
+      "suffix": "/now/contact/{Contact ID}",
+      "description": "One CSM contact by id."
+    },
     {
       "paged": "true",
-      "pageType": "OFFSET", 
-      "name": "Metric Time Series", 
-      "suffix": "api/now/clotho/table/{Table Name}/{Time Series ID}/{Metric Field Name}?sysparm_start={Start Time?:YYYY-MM-DDTHH:MM:SS}&sysparm_end={End Time?:YYYY-MM-DDTHH:MM:SS}&sysparm_display_value={Display Value?:true|false}"
-    }, 
+      "pageType": "OFFSET",
+      "name": "CSM Contacts",
+      "suffix": "/now/contact?sysparm_query={Query?}",
+      "description": "The people at customer accounts who raise cases. Distinct from sys_user, which holds employees."
+    },
     {
       "paged": "true",
-      "pageType": "OFFSET", 
-      "name": "Metric Transform", 
-      "suffix": "/now/clotho/transform/{Table Name}/{Metric Field Name}?sysparm_start={Start Time?:YYYY-MM-DDTHH:MM:SS}&sysparm_end={End Time?:YYYY-MM-DDTHH:MM:SS}&sysparm_transforms={Transforms?:avg,sum,add,mul,resample,top,label}&sysparm_subject_limit={Subject Limit?}&sysparm_display_value={Display Value?:true|false}"
-    }, 
+      "pageType": "OFFSET",
+      "name": "DevOps Tools",
+      "suffix": "/sn_devops/devops/admin?id={Tool ID?}&name={Name?}&type={Type?:Planning|Coding|TaskExecution}",
+      "description": "The development tools registered with DevOps Change Velocity -- source control, build and deployment systems. The inventory that DevOps change automation runs against."
+    },
     {
-      "paged": "false", 
-      "name": "Published NLU Models", 
-      "suffix": "/now/v1/open-nlu/models"
-    }, 
+      "paged": "false",
+      "name": "Code Resource Schema",
+      "suffix": "/sn_devops/devops/code/schema?resource={Resource?:commit|repository|branch}",
+      "description": "The schema of DevOps code resources such as commits, repositories and branches. Reference data describing what the DevOps tables hold."
+    },
     {
-      "paged": "false", 
-      "name": "Published NLU Intents", 
-      "suffix": "/now/open-nlu/models/{Model ID}/intents"
-    }, 
+      "paged": "false",
+      "name": "Orchestration Change Control",
+      "suffix": "/sn_devops/devops/orchestration/changeControl?orchestrationTaskURL={Orchestration Task Url}&toolId={Tool ID}&changeControlId={Change Control ID?}&orchestrationTaskName={Task Name?}&testConnection={Test Connnection?:true|false}&type={Type?:jenkins|...}",
+      "description": "Whether change control is enabled for a named orchestration task -- that is, whether a pipeline stage requires a change request to proceed. The link between a deployment pipeline and ServiceNow approval."
+    },
+    {
+      "paged": "false",
+      "name": "Orchestration Resource Schema",
+      "suffix": "/sn_devops/devops/orchestration/schema?resource={Resource?:build_details|callback|orchestration_task|task_execution}",
+      "description": "The schema of DevOps orchestration resources such as builds and pipelines."
+    },
+    {
+      "paged": "false",
+      "name": "Orchestration Step Mapping",
+      "suffix": "/sn_devops/devops/orchestration/stepMapping?orchestrationTaskName={Task Name}&orchestrationTaskURL={Orchestration Task Url}&toolId={Tool Id}&branchName={Branch Name?}&parentStageName={Parent Stage Name?}&parentStageURL={Parent Stage URL?}&testConnection={Test Connection?:true|false}&type={Type?:jenkins|...}",
+      "description": "How pipeline steps map to ServiceNow orchestration tasks. The configuration that makes automated change control work."
+    },
+    {
+      "paged": "false",
+      "name": "Plan Schema",
+      "suffix": "/sn_devops/devops/plan/schema?resource={Resource?:build_details|callback|orchestration_task|task_execution}",
+      "description": "The schema of DevOps planning resources such as build details."
+    },
+    {
+      "paged": "false",
+      "name": "Email",
+      "suffix": "/now/v1/email/{Email ID}",
+      "description": "One email record by id, with its recipients, body and delivery state. The notification audit trail."
+    },
+    {
+      "paged": "false",
+      "name": "Import Set",
+      "suffix": "/now/v1/import/{Table Name}/{Import Set ID}",
+      "description": "The result of one import set row -- what a staged import created or updated, and any errors. Requires the table and import set id. Where a data load's outcome, including silently transformed rows, is recorded."
+    },
+    {
+      "paged": "false",
+      "name": "Major Incident Communication Cards",
+      "suffix": "/sn_major_inc_mgmt/mim/status/{Incident ID}",
+      "description": "The status updates published for one major incident. Requires an incident id. The customer-facing communications record, separate from the incident's own work notes."
+    },
+    {
+      "paged": "true",
+      "pageType": "OFFSET",
+      "name": "Metric Time Series",
+      "suffix": "api/now/clotho/table/{Table Name}/{Time Series ID}/{Metric Field Name}?sysparm_start={Start Time?:YYYY-MM-DDTHH:MM:SS}&sysparm_end={End Time?:YYYY-MM-DDTHH:MM:SS}&sysparm_display_value={Display Value?:true|false}",
+      "description": "The time series of one metric field on one table -- ServiceNow's own performance instrumentation. Requires the table, series and metric field. Numeric history rather than record state."
+    },
+    {
+      "paged": "true",
+      "pageType": "OFFSET",
+      "name": "Metric Transform",
+      "suffix": "/now/clotho/transform/{Table Name}/{Metric Field Name}?sysparm_start={Start Time?:YYYY-MM-DDTHH:MM:SS}&sysparm_end={End Time?:YYYY-MM-DDTHH:MM:SS}&sysparm_transforms={Transforms?:avg,sum,add,mul,resample,top,label}&sysparm_subject_limit={Subject Limit?}&sysparm_display_value={Display Value?:true|false}",
+      "description": "A transformed view of a metric series -- aggregated or resampled server-side. Requires the table and metric field."
+    },
+    {
+      "paged": "false",
+      "name": "Published NLU Models",
+      "suffix": "/now/v1/open-nlu/models",
+      "description": "The natural language understanding models published on the instance, used by virtual agent and predictive intelligence."
+    },
+    {
+      "paged": "false",
+      "name": "Published NLU Intents",
+      "suffix": "/now/open-nlu/models/{Model ID}/intents",
+      "description": "The intents defined in one NLU model. Requires the model id. What the virtual agent is able to recognise, which bounds what it can deflect."
+    },
     {
       "paged": "true",
       "pageType": "PAGE",
-      "name": "Analytics Indicators", 
-      "suffix": "/now/pa/scorecards?sysparm_uuid={Indicator/Breakdown/Aggregate/Domain IDs?}&sysparm_breakdown={Breakdown ID?}&sysparm_display_value={Display Value?:true|false|all}&sysparm_include_scores={Include Scores?:true|false}&sysparm_include_aggregates={Include Aggregates?:true|false}&sysparm_include_available_breakdowns={Include Available Breakdowns?:true|false }&sysparm_include_available_aggregates={Include Available Aggregates?:true|false}&sysparm_exclude_reference_link={Exclude Reference Link?:true|false}"
-    }, 
-    {
-      "paged": "false", 
-      "name": "Prediction", 
-      "suffix": "/now/agent_intelligence/solution/{Solution Name}/prediction"
-    }, 
+      "name": "Analytics Indicators",
+      "suffix": "/now/pa/scorecards?sysparm_uuid={Indicator/Breakdown/Aggregate/Domain IDs?}&sysparm_breakdown={Breakdown ID?}&sysparm_display_value={Display Value?:true|false|all}&sysparm_include_scores={Include Scores?:true|false}&sysparm_include_aggregates={Include Aggregates?:true|false}&sysparm_include_available_breakdowns={Include Available Breakdowns?:true|false }&sysparm_include_available_aggregates={Include Available Aggregates?:true|false}&sysparm_exclude_reference_link={Exclude Reference Link?:true|false}",
+      "description": "Performance Analytics scorecard data by indicator, breakdown or aggregate UUID. THE TREND STORE: ServiceNow tables hold current state, and Performance Analytics is what snapshots them over time, so questions about how a backlog moved historically are answerable here and not from the tables."
+    },
     {
       "paged": "false",
-      "name": "Service Catalogs", 
+      "name": "Prediction",
+      "suffix": "/now/agent_intelligence/solution/{Solution Name}/prediction",
+      "description": "A prediction from one trained Predictive Intelligence solution -- category, assignment group or similar. Requires the solution name. Model output rather than recorded data, so it is a suggestion and not a fact."
+    },
+    {
+      "paged": "false",
+      "name": "Service Catalogs",
       "suffix": "/sn_sc/servicecatalog/catalogs?sysparm_view={View?:desktop|mobile|both}&sysparm_text={Title Keyword?}&sysparm_limit=10000",
       "lookups": [
         {
@@ -263,80 +316,95 @@
           "key": "sys_id",
           "parameterName": "Catalog ID"
         }
-      ]
-    }, 
+      ],
+      "description": "The service catalogues published on the instance -- the storefronts users request things from."
+    },
     {
-      "paged": "false", 
-      "name": "Service Catalog", 
-      "suffix": "/sn_sc/servicecatalog/catalogs/{Catalog ID}?sysparm_view={View?:desktop|mobile|both}"
-    }, 
-    {
-      "paged": "true",
-      "pageType": "OFFSET", 
-      "name": "Service Catalog Categories", 
-      "suffix": "/sn_sc/servicecatalog/catalogs/{Catalog ID}/categories?sysparm_top_level_only={Top Level Only?:true|false}&sysparm_view={View?:desktop|mobile|both}"
-    }, 
-    {
-      "paged": "false", 
-      "name": "Service Catalog Category", 
-      "suffix": "/sn_sc/servicecatalog/categories/{Category ID}?sysparm_view={View?:desktop|mobile|both}"
-    }, 
+      "paged": "false",
+      "name": "Service Catalog",
+      "suffix": "/sn_sc/servicecatalog/catalogs/{Catalog ID}?sysparm_view={View?:desktop|mobile|both}",
+      "description": "One catalogue by id."
+    },
     {
       "paged": "true",
-      "pageType": "OFFSET", 
-      "name": "Service Catalog Items", 
-      "suffix": "/sn_sc/servicecatalog/items?sysparm_catalog={Catalog ID?}&sysparm_category={Category ID}sysparm_text={Search Text?}&sysparm_type={Type?:Record Producer|Order Guide}&sysparm_view={View?:desktop|mobile|both}"
-    }, 
+      "pageType": "OFFSET",
+      "name": "Service Catalog Categories",
+      "suffix": "/sn_sc/servicecatalog/catalogs/{Catalog ID}/categories?sysparm_top_level_only={Top Level Only?:true|false}&sysparm_view={View?:desktop|mobile|both}",
+      "description": "The categories within one catalogue. Requires a catalogue id."
+    },
     {
-      "paged": "false", 
-      "name": "Service Catalog Item", 
-      "suffix": "/sn_sc/servicecatalog/items/{Catalog Item ID}?sysparm_view={View?:desktop|mobile|both}"
-    }, 
-    {
-      "paged": "false", 
-      "name": "Service Catalog Cart", 
-      "suffix": "/sn_sc/servicecatalog/cart"
-    }, 
-    {
-      "paged": "false", 
-      "name": "Shipping Address", 
-      "suffix": "/sn_sc/servicecatalog/cart/delivery_address/{User ID}"
-    }, 
+      "paged": "false",
+      "name": "Service Catalog Category",
+      "suffix": "/sn_sc/servicecatalog/categories/{Category ID}?sysparm_view={View?:desktop|mobile|both}",
+      "description": "One catalogue category by id."
+    },
     {
       "paged": "true",
-      "pageType": "OFFSET", 
-      "name": "Table Records", 
-      "suffix": "/now/table/{Table Name}?sysparm_display_value={Display Value?:true|false|all}&sysparm_fields={Fields?:field1,field2,...}&sysparm_query={Query?}&sysparm_view={View?:desktop|mobile|both}"
-    }, 
+      "pageType": "OFFSET",
+      "name": "Service Catalog Items",
+      "suffix": "/sn_sc/servicecatalog/items?sysparm_catalog={Catalog ID?}&sysparm_category={Category ID}sysparm_text={Search Text?}&sysparm_type={Type?:Record Producer|Order Guide}&sysparm_view={View?:desktop|mobile|both}",
+      "description": "The requestable items across the catalogues, with their descriptions, prices and the variables each asks for. What can be requested, as opposed to the requests themselves -- those are rows in the sc_request and sc_req_item tables via Table Records."
+    },
     {
-      "paged": "false", 
-      "name": "Table Record", 
-      "suffix": "/now/table/{Table Name}/{Table Record ID}?sysparm_display_value={Display Value?:true|false|all}&sysparm_fields={Fields?:field1,field2,...}&sysparm_view={View?:desktop|mobile|both}"
-    }, 
+      "paged": "false",
+      "name": "Service Catalog Item",
+      "suffix": "/sn_sc/servicecatalog/items/{Catalog Item ID}?sysparm_view={View?:desktop|mobile|both}",
+      "description": "One catalogue item by id, with its request variables."
+    },
     {
-      "paged": "false", 
-      "name": "Task Channels", 
-      "suffix": "/sn_comm_management/task_communication_management/channels?sysparm_table={Task Table Name}"
-    }, 
+      "paged": "false",
+      "name": "Service Catalog Cart",
+      "suffix": "/sn_sc/servicecatalog/cart",
+      "description": "The calling user's current cart. Scoped to the caller and transient."
+    },
     {
-      "paged": "false", 
-      "name": "Task Channels Metadata", 
-      "suffix": "/sn_comm_management/task_communication_management/changes_per_task/{Task ID}/{Table Name}"
-    }, 
+      "paged": "false",
+      "name": "Shipping Address",
+      "suffix": "/sn_sc/servicecatalog/cart/delivery_address/{User ID}",
+      "description": "The delivery address on one user's cart. Requires a user id."
+    },
     {
-      "paged": "false", 
-      "name": "Communication Plan Details", 
-      "suffix": "/sn_comm_management/task_communication_management/communication_detail/{Task ID}"
-    }, 
+      "paged": "true",
+      "pageType": "OFFSET",
+      "name": "Table Records",
+      "suffix": "/now/table/{Table Name}?sysparm_display_value={Display Value?:true|false|all}&sysparm_fields={Fields?:field1,field2,...}&sysparm_query={Query?}&sysparm_view={View?:desktop|mobile|both}",
+      "description": "The rows of ANY ServiceNow table, by table name -- incident, problem, change_request, sys_user, cmdb_ci, task, sc_request, or any custom table the instance defines. THIS IS THE WHOLE PLATFORM IN ONE ENDPOINT and almost every ServiceNow question should start here; the scoped APIs elsewhere in this connector are convenience wrappers over the same data. THREE PARAMETERS DECIDE WHETHER THE RESULT IS USABLE. sysparm_query takes ServiceNow's encoded query syntax and is the only filtering available. sysparm_fields limits the columns, which matters because instance tables routinely carry hundreds. And sysparm_display_value IS THE ONE THAT CATCHES PEOPLE: by default reference fields come back as 32-character sys_ids, so assigned_to is an opaque string rather than a name and state is a number rather than a label -- set it to true for labels, or all to get both, otherwise the result is unreadable without a lookup per reference."
+    },
     {
-      "paged": "false", 
-      "name": "Communication Plan Groups", 
-      "suffix": "/sn_comm_management/task_communication_management/groups/{Task ID}"
-    }, 
+      "paged": "false",
+      "name": "Table Record",
+      "suffix": "/now/table/{Table Name}/{Table Record ID}?sysparm_display_value={Display Value?:true|false|all}&sysparm_fields={Fields?:field1,field2,...}&sysparm_view={View?:desktop|mobile|both}",
+      "description": "One row of any table by sys_id. Requires the table name and record id. Same display-value behaviour."
+    },
     {
-      "paged": "false", 
-      "name": "User Roles", 
-      "suffix": "/global/user_role_inheritance?user_sysid={User ID}"
+      "paged": "false",
+      "name": "Task Channels",
+      "suffix": "/sn_comm_management/task_communication_management/channels?sysparm_table={Task Table Name}",
+      "description": "The communication channels configured for task notifications, filtered by query."
+    },
+    {
+      "paged": "false",
+      "name": "Task Channels Metadata",
+      "suffix": "/sn_comm_management/task_communication_management/changes_per_task/{Task ID}/{Table Name}",
+      "description": "The change history of task communication channels."
+    },
+    {
+      "paged": "false",
+      "name": "Communication Plan Details",
+      "suffix": "/sn_comm_management/task_communication_management/communication_detail/{Task ID}",
+      "description": "The communication plan attached to a task -- who is told what, and when."
+    },
+    {
+      "paged": "false",
+      "name": "Communication Plan Groups",
+      "suffix": "/sn_comm_management/task_communication_management/groups/{Task ID}",
+      "description": "The recipient groups in one task's communication plan. Requires the task id."
+    },
+    {
+      "paged": "false",
+      "name": "User Roles",
+      "suffix": "/global/user_role_inheritance?user_sysid={User ID}",
+      "description": "The roles one user holds INCLUDING THOSE INHERITED through group membership and role containment. Requires a user id. ServiceNow roles nest, so a user's directly assigned roles are usually a small subset of what they can actually do -- this is the resolved answer."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/smartsheet/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/smartsheet/endpoints.json
@@ -3,7 +3,8 @@
     {
       "paged": "false",
       "name": "Attachment",
-      "suffix": "/2.0/sheets/{Sheet ID}/attachments/{Attachment ID}"
+      "suffix": "/2.0/sheets/{Sheet ID}/attachments/{Attachment ID}",
+      "description": "One attachment by id."
     },
     {
       "paged": "true",
@@ -16,132 +17,158 @@
           "key": "id",
           "parameterName": "Attachment ID"
         }
-      ]
+      ],
+      "description": "The files attached to one sheet. Requires a sheet id. Metadata; the binary is a separate fetch."
     },
     {
       "paged": "true",
       "name": "Discussion Attachments",
-      "suffix": "/2.0/sheets/{Sheet ID}/discussions/{Discussion ID}/attachments"
+      "suffix": "/2.0/sheets/{Sheet ID}/discussions/{Discussion ID}/attachments",
+      "description": "The files attached to one discussion. Requires the sheet and discussion ids."
     },
     {
       "paged": "true",
       "name": "Row Attachments",
-      "suffix": "/2.0/sheets/{Sheet ID}/rows/{Row ID}/attachments"
+      "suffix": "/2.0/sheets/{Sheet ID}/rows/{Row ID}/attachments",
+      "description": "The files attached to one row. Requires the sheet and row ids."
     },
     {
       "paged": "true",
       "name": "Versions",
-      "suffix": "/2.0/sheets/{Sheet ID}/attachments/{Attachment ID}/versions"
+      "suffix": "/2.0/sheets/{Sheet ID}/attachments/{Attachment ID}/versions",
+      "description": "The version history of one attachment. Requires the sheet and attachment ids."
     },
     {
       "paged": "false",
       "name": "Automation Rule",
-      "suffix": "/2.0/sheets/{Sheet ID}/automationrules/{Automation Rule ID}"
+      "suffix": "/2.0/sheets/{Sheet ID}/automationrules/{Automation Rule ID}",
+      "description": "One automation rule by id."
     },
     {
       "paged": "true",
       "name": "Automation Rules",
-      "suffix": "/2.0/sheets/{Sheet ID}/automationrules"
+      "suffix": "/2.0/sheets/{Sheet ID}/automationrules",
+      "description": "The automation rules on one sheet -- alerts, reminders, approval requests and update requests, with their conditions and recipients. Requires a sheet id. Automation changes cells without a person doing it, so this explains edits with no obvious author."
     },
     {
       "paged": "true",
       "name": "Cell History",
-      "suffix": "/2.0/sheets/{Sheet ID}/rows/{Row ID}/columns/{Column ID}/history?include={Include?:columnType,objectValue}&level={Level?}"
+      "suffix": "/2.0/sheets/{Sheet ID}/rows/{Row ID}/columns/{Column ID}/history?include={Include?:columnType,objectValue}&level={Level?}",
+      "description": "Every past value of ONE CELL, with who changed it and when. Requires the sheet, row and column ids. The only audit trail Smartsheet offers at cell level -- a sheet holds current values only, so when a date slipped or a status changed is answerable here and nowhere else, at the cost of one request per cell."
     },
     {
       "paged": "false",
       "name": "Column",
-      "suffix": "/2.0/sheets/{Sheet ID}/columns/{Column ID}?level={Level?}"
+      "suffix": "/2.0/sheets/{Sheet ID}/columns/{Column ID}?level={Level?}",
+      "description": "One column by id. Requires the sheet id."
     },
     {
       "paged": "true",
       "name": "Columns",
-      "suffix": "/2.0/sheets/{Sheet ID}/columns?level={Level?}"
+      "suffix": "/2.0/sheets/{Sheet ID}/columns?level={Level?}",
+      "description": "The column definitions of one sheet, with title, type, index, whether it is the primary column, and for picklists the allowed options. Requires a sheet id. THE SCHEMA: every cell references a columnId, so this is the decoder without which sheet data is a set of numbers against opaque ids."
     },
     {
       "paged": "false",
       "name": "Comment",
-      "suffix": "/2.0/sheets/{Sheet ID}/comments/{Comment ID}"
+      "suffix": "/2.0/sheets/{Sheet ID}/comments/{Comment ID}",
+      "description": "One comment by id. Requires the sheet id."
     },
     {
       "paged": "false",
       "name": "Contact",
-      "suffix": "/2.0/contacts/{Contact ID}?include={Include?:profileImage}"
+      "suffix": "/2.0/contacts/{Contact ID}?include={Include?:profileImage}",
+      "description": "One contact by id."
     },
     {
       "paged": "true",
       "name": "Contacts",
-      "suffix": "/2.0/contacts"
+      "suffix": "/2.0/contacts",
+      "description": "The contacts available to the caller for assignment and sharing. Smartsheet contact-type cells reference these, so it is the decoder for a contact column."
     },
     {
       "paged": "false",
       "name": "Cross-sheet Reference",
-      "suffix": "/2.0/sheets/{Sheet ID}/crosssheetreferences/{Cross Sheet Reference ID}"
+      "suffix": "/2.0/sheets/{Sheet ID}/crosssheetreferences/{Cross Sheet Reference ID}",
+      "description": "One cross-sheet reference by id."
     },
     {
       "paged": "true",
       "name": "Cross-sheet References",
-      "suffix": "/2.0/sheets/{Sheet ID}/crosssheetreferences"
+      "suffix": "/2.0/sheets/{Sheet ID}/crosssheetreferences",
+      "description": "The references one sheet makes to ranges in other sheets. Requires a sheet id. THE DEPENDENCY GRAPH: a formula pulling from another sheet is invisible in the cell values, so this is what reveals that a number is driven by a sheet somewhere else."
     },
     {
       "paged": "true",
       "name": "Discussions",
-      "suffix": "/2.0/sheets/{Sheet ID}/discussions?include={Include?:attachments,comments}"
+      "suffix": "/2.0/sheets/{Sheet ID}/discussions?include={Include?:attachments,comments}",
+      "description": "The comment threads on one sheet. Requires a sheet id. Where the reasoning behind a change is recorded, which the cells do not carry."
     },
     {
       "paged": "false",
       "name": "Discussion",
-      "suffix": "/2.0/sheets/{Sheet ID}/discussions/{Discussion ID}"
+      "suffix": "/2.0/sheets/{Sheet ID}/discussions/{Discussion ID}",
+      "description": "One discussion by id, with its comments."
     },
     {
       "paged": "true",
       "name": "Row Discussions",
-      "suffix": "/2.0/sheets/{Sheet ID}/rows/{Row ID}/discussions?include={Include?:attachments,comments}"
+      "suffix": "/2.0/sheets/{Sheet ID}/rows/{Row ID}/discussions?include={Include?:attachments,comments}",
+      "description": "The comment threads attached to one row. Requires the sheet and row ids."
     },
     {
       "paged": "true",
       "name": "Favorites",
-      "suffix": "/2.0/favorites"
+      "suffix": "/2.0/favorites",
+      "description": "The items the caller has starred. Scoped to the caller."
     },
     {
       "paged": "false",
       "name": "Folder",
-      "suffix": "/2.0/folders/{Folder ID}?include={Include?:ownerInfo,sheetVersion,source}"
+      "suffix": "/2.0/folders/{Folder ID}?include={Include?:ownerInfo,sheetVersion,source}",
+      "description": "One folder by id, with its sheets, reports, dashboards and subfolders."
     },
     {
       "paged": "true",
       "name": "Sheet Folders",
-      "suffix": "/2.0/home/folders"
+      "suffix": "/2.0/home/folders",
+      "description": "The folders in the caller's home area."
     },
     {
       "paged": "true",
       "name": "Subfolders",
-      "suffix": "/2.0/folders/{Folder ID}/folders"
+      "suffix": "/2.0/folders/{Folder ID}/folders",
+      "description": "The folders inside one folder. Requires a folder id. Folders nest, so a full tree means walking this repeatedly."
     },
     {
       "paged": "true",
       "name": "Workspace Folders",
-      "suffix": "/2.0/workspaces/{Workspace ID}/folders"
+      "suffix": "/2.0/workspaces/{Workspace ID}/folders",
+      "description": "The folders inside one workspace. Requires a workspace id."
     },
     {
       "paged": "false",
       "name": "Group",
-      "suffix": "/2.0/groups/{Group ID}"
+      "suffix": "/2.0/groups/{Group ID}",
+      "description": "One group by id, with its members."
     },
     {
       "paged": "true",
       "name": "Organization Groups",
-      "suffix": "/2.0/groups"
+      "suffix": "/2.0/groups",
+      "description": "The groups in the organisation, used to share items in bulk."
     },
     {
       "paged": "false",
       "name": "Contents",
-      "suffix": "/2.0/home?include={Include?:source}&exclude={Exclude?:permalinks}"
+      "suffix": "/2.0/home?include={Include?:source}&exclude={Exclude?:permalinks}",
+      "description": "Everything in the caller's home -- sheets, folders, reports, dashboards, workspaces and templates in one response. The fastest inventory of what a user can reach, and the alternative to walking folders one at a time."
     },
     {
       "paged": "true",
       "name": "Report",
-      "suffix": "/2.0/reports/{Report ID}?include={Include?:attachments,discussions...}&exclude={Exclude?:linkInFromCellDetails,linksOutToCellsDetails}&level={Level?}"
+      "suffix": "/2.0/reports/{Report ID}?include={Include?:attachments,discussions...}&exclude={Exclude?:linkInFromCellDetails,linksOutToCellsDetails}&level={Level?}",
+      "description": "One report by id, with its rows. Requires a report id. Returns data drawn from several sheets, so rows carry a sheet reference the source sheets do not need."
     },
     {
       "paged": "true",
@@ -157,67 +184,80 @@
           "key": "id",
           "parameterName": "Report ID"
         }
-      ]
+      ],
+      "description": "The reports defined, with name and timestamps. A Smartsheet report is a saved query across sheets, so it is the closest thing to a cross-sheet view -- and its definition states which sheets the organisation considers related."
     },
     {
       "paged": "false",
       "name": "Report Publish Status",
-      "suffix": "/2.0/reports/{Report ID}/publish"
+      "suffix": "/2.0/reports/{Report ID}/publish",
+      "description": "Whether one report is published to the web. Requires a report id."
     },
     {
       "paged": "false",
       "name": "Row",
-      "suffix": "/2.0/sheets/{Sheet ID}/rows/{Row ID}?include={Include?:attachments,columnType...}&exclude={Exclude?:linkInFromCellDetails,linksOutToCellsDetails...}&level={Level?}"
+      "suffix": "/2.0/sheets/{Sheet ID}/rows/{Row ID}?include={Include?:attachments,columnType...}&exclude={Exclude?:linkInFromCellDetails,linksOutToCellsDetails...}&level={Level?}",
+      "description": "One row by id, with its cells. Requires the sheet id. Includes optional attachments, discussions and column formulas."
     },
     {
       "paged": "false",
       "name": "Search Everything",
-      "suffix": "/2.0/search?query={Query}&include={Include?:favorite,parentObjectFavorite}&location={Location?}&modifiedSince={Modified Since?:YYYY-MM-DDTHH:MM:SSZ}&scopes={Scopes?:attachments,cellData...}"
+      "suffix": "/2.0/search?query={Query}&include={Include?:favorite,parentObjectFavorite}&location={Location?}&modifiedSince={Modified Since?:YYYY-MM-DDTHH:MM:SSZ}&scopes={Scopes?:attachments,cellData...}",
+      "description": "Searches across every object the caller can access -- sheet names, cell contents, discussions, attachments. The route to finding a value when the sheet holding it is unknown, which the per-sheet endpoints cannot answer."
     },
     {
       "paged": "false",
       "name": "Search Sheet",
-      "suffix": "/2.0/search/sheets/{Sheet ID}?query={Query}"
+      "suffix": "/2.0/search/sheets/{Sheet ID}?query={Query}",
+      "description": "Searches within one sheet. Requires the sheet id and a query."
     },
     {
       "paged": "false",
       "name": "Server Info",
-      "suffix": "/2.0/serverinfo"
+      "suffix": "/2.0/serverinfo",
+      "description": "The Smartsheet server's supported locales, formats and feature set. Notably it lists the FORMAT TABLES -- the numeric codes cells use for fonts, colours and number formats -- which are otherwise uninterpretable."
     },
     {
       "paged": "false",
       "name": "Report Share",
-      "suffix": "/2.0/reports/{Report ID}/shares/{Share ID}"
+      "suffix": "/2.0/reports/{Report ID}/shares/{Share ID}",
+      "description": "One report share by id."
     },
     {
       "paged": "true",
       "name": "Report Shares",
-      "suffix": "/2.0/reports/{Report ID}/shares?include={Include?:workspaceShares}"
+      "suffix": "/2.0/reports/{Report ID}/shares?include={Include?:workspaceShares}",
+      "description": "Who one report is shared with and at what access level. Requires a report id."
     },
     {
       "paged": "false",
       "name": "Sheet Share",
-      "suffix": "/2.0/sheets/{Sheet ID}/shares/{Share ID}"
+      "suffix": "/2.0/sheets/{Sheet ID}/shares/{Share ID}",
+      "description": "One sheet share by id."
     },
     {
       "paged": "true",
       "name": "Sheet Shares",
-      "suffix": "/2.0/sheets/{Sheet ID}/shares?include={Include?:workspaceShares}"
+      "suffix": "/2.0/sheets/{Sheet ID}/shares?include={Include?:workspaceShares}",
+      "description": "Who one sheet is shared with and at what access level. Requires a sheet id. The access list, and the reason two users see different sheets."
     },
     {
       "paged": "false",
       "name": "Sheet Version",
-      "suffix": "/2.0/sheets/{Sheet ID}/version"
+      "suffix": "/2.0/sheets/{Sheet ID}/version",
+      "description": "The current version number of one sheet. Requires a sheet id. A cheap change check: the version increments on every edit, so polling this is far cheaper than refetching the sheet to see whether anything moved."
     },
     {
       "paged": "true",
       "name": "Sheet",
-      "suffix": "/2.0/sheets/{Sheet ID}?include={Include?:attachments,crossSheetReferences...}&exclude={Exclude?:filteredOutRows,linkInFromCellDetails...}&columnIds={Column IDs?:value1,value2...}&filterId={Filter ID?}&ifVersionAfter={If Version After?:version}&level={Level?}&rowIds={Row IDs?:value1,value2...}&rowNumbers={Row Numbers?:value1,value2...}&rowsModifiedSince={Rows Modified Since?:YYYY-MM-DDTHH:MM:SSZ}"
+      "suffix": "/2.0/sheets/{Sheet ID}?include={Include?:attachments,crossSheetReferences...}&exclude={Exclude?:filteredOutRows,linkInFromCellDetails...}&columnIds={Column IDs?:value1,value2...}&filterId={Filter ID?}&ifVersionAfter={If Version After?:version}&level={Level?}&rowIds={Row IDs?:value1,value2...}&rowNumbers={Row Numbers?:value1,value2...}&rowsModifiedSince={Rows Modified Since?:YYYY-MM-DDTHH:MM:SSZ}",
+      "description": "One sheet by id, WITH its rows and cells. Requires a sheet id. The main data endpoint. Cells reference their column by columnId rather than by name, so a row is unreadable without the column list -- and a cell carries both a raw value and a displayValue, which differ for dates, contacts and formulas."
     },
     {
       "paged": "true",
       "name": "Organization Sheets",
-      "suffix": "/2.0/users/sheets?modifiedSince={Modified Since?:YYYY-MM-DDTHH:MM:SSZ}"
+      "suffix": "/2.0/users/sheets?modifiedSince={Modified Since?:YYYY-MM-DDTHH:MM:SSZ}",
+      "description": "Every sheet in the organisation, not just those the caller can access. Administrator only. The inventory view, and the way to find sheets nobody is watching."
     },
     {
       "paged": "true",
@@ -243,27 +283,32 @@
           "key": "id",
           "parameterName": "Sheet ID"
         }
-      ]
+      ],
+      "description": "The sheets the user can access, with name, permalink, createdAt and modifiedAt. THE STARTING POINT, and the shape of Smartsheet is worth stating once: a sheet is a user-built grid, so its COLUMNS ARE DEFINED PER SHEET and nothing about the data is knowable in advance -- Columns is the schema and must be read before any row makes sense. The listing carries no cell data at all."
     },
     {
       "paged": "false",
       "name": "Sheet Publish Status",
-      "suffix": "/2.0/sheets/{Sheet ID}/publish"
+      "suffix": "/2.0/sheets/{Sheet ID}/publish",
+      "description": "Whether one sheet is published to the web, and in what form. Requires a sheet id. A published sheet is readable without credentials, which makes this a security-review endpoint as much as a configuration one."
     },
     {
       "paged": "false",
       "name": "Sheet Summary",
-      "suffix": "/2.0/sheets/{Sheet ID}/summ?include={Include?:format,writerInfo}&exclude={Exclude?:displayValue,image,imageAltText}"
+      "suffix": "/2.0/sheets/{Sheet ID}/summary?include={Include?:format,writerInfo}&exclude={Exclude?:displayValue,image,imageAltText}",
+      "description": "The summary fields of one sheet -- the named values that sit beside the grid rather than in it. Requires a sheet id. Where a sheet records totals, owners and status that are properties of the whole sheet rather than of any row."
     },
     {
       "paged": "true",
       "name": "Summary Fields",
-      "suffix": "/2.0/sheets/{Sheet ID}/summary/fields?include={Include?:format,writerInfo}&exclude={Exclude?:displayValue,image,imageAltText}"
+      "suffix": "/2.0/sheets/{Sheet ID}/summary/fields?include={Include?:format,writerInfo}&exclude={Exclude?:displayValue,image,imageAltText}",
+      "description": "The individual summary fields with their values and formats. Requires a sheet id. The row-shaped view of the same data."
     },
     {
       "paged": "false",
       "name": "Sight",
-      "suffix": "/2.0/sights/{Sight ID}?include={Include?:source}&level={Level?}&objectValue={Object Value?}"
+      "suffix": "/2.0/sights/{Sight ID}?include={Include?:source}&level={Level?}&objectValue={Object Value?}",
+      "description": "One dashboard by id, with its widgets and their sources. The map from a dashboard tile back to the sheet feeding it."
     },
     {
       "paged": "true",
@@ -276,67 +321,80 @@
           "key": "id",
           "parameterName": "Sight ID"
         }
-      ]
+      ],
+      "description": "The dashboards defined, with name and timestamps. Sights are Smartsheet's dashboards, assembled from widgets over sheets and reports."
     },
     {
       "paged": "false",
       "name": "Sight Publish Status",
-      "suffix": "/2.0/sights/{Sight ID}/publish"
+      "suffix": "/2.0/sights/{Sight ID}/publish",
+      "description": "Whether one dashboard is published to the web. Requires a sight id."
     },
     {
       "paged": "true",
       "name": "Public Templates",
-      "suffix": "/2.0/templates/public"
+      "suffix": "/2.0/templates/public",
+      "description": "The templates Smartsheet publishes. Reference content, identical on every account."
     },
     {
       "paged": "true",
       "name": "User-created Templates",
-      "suffix": "/2.0/templates"
+      "suffix": "/2.0/templates",
+      "description": "The templates the account has created."
     },
     {
       "paged": "false",
       "name": "Update Request",
-      "suffix": "/2.0/sheets/{Sheet ID}/updaterequests/{Update Request ID}"
+      "suffix": "/2.0/sheets/{Sheet ID}/updaterequests/{Update Request ID}",
+      "description": "One update request by id."
     },
     {
       "paged": "true",
       "name": "Update Requests",
-      "suffix": "/2.0/sheets/{Sheet ID}/updaterequests"
+      "suffix": "/2.0/sheets/{Sheet ID}/updaterequests",
+      "description": "The pending requests asking someone to fill in rows. Requires a sheet id. Outstanding data collection, which no cell value reveals."
     },
     {
       "paged": "false",
       "name": "Sent Update Request",
-      "suffix": "/2.0/sheets/{Sheet ID}/sentupdaterequests/{Sent Update Request ID}"
+      "suffix": "/2.0/sheets/{Sheet ID}/sentupdaterequests/{Sent Update Request ID}",
+      "description": "One sent update request by id."
     },
     {
       "paged": "true",
       "name": "Sent Update Requests",
-      "suffix": "/2.0/sheets/{Sheet ID}/sentupdaterequests"
+      "suffix": "/2.0/sheets/{Sheet ID}/sentupdaterequests",
+      "description": "Update requests already sent, with their status. Requires a sheet id. The record of who was asked and whether they responded."
     },
     {
       "paged": "false",
       "name": "Current User",
-      "suffix": "/2.0/users/me?include={Include?:groups}"
+      "suffix": "/2.0/users/me?include={Include?:groups}",
+      "description": "The account the credentials belong to, optionally with its groups. One record, and the explanation for which sheets the rest of this connector can see."
     },
     {
       "paged": "false",
       "name": "User",
-      "suffix": "/2.0/users/{User ID}"
+      "suffix": "/2.0/users/{User ID}",
+      "description": "One user by id."
     },
     {
       "paged": "true",
       "name": "Users",
-      "suffix": "/2.0/users?email={Email?}&include={Include?:lastLogin}"
+      "suffix": "/2.0/users?email={Email?}&include={Include?:lastLogin}",
+      "description": "The users in the account, with email, name, admin and licensed flags, and their status. Filterable by email; lastLogin is available only when explicitly included. THE LICENSED FLAG IS THE ONE THAT MATTERS COMMERCIALLY -- Smartsheet bills on licensed users, and unlicensed collaborators are free, so a headcount and a bill do not correspond."
     },
     {
       "paged": "false",
       "name": "Workspace",
-      "suffix": "/2.0/workspaces/{Workspace ID}?loadAll={Load All?:true|false}&include={Include?:ownerInfo,source,sheetVersion}"
+      "suffix": "/2.0/workspaces/{Workspace ID}?loadAll={Load All?:true|false}&include={Include?:ownerInfo,source,sheetVersion}",
+      "description": "One workspace by id, optionally loading its whole contents. Requires a workspace id."
     },
     {
       "paged": "true",
       "name": "Workspaces",
-      "suffix": "/2.0/workspaces"
+      "suffix": "/2.0/workspaces",
+      "description": "The workspaces, each grouping sheets, reports, dashboards and templates with shared permissions. The organisational container above folders."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/surveymonkey/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/surveymonkey/endpoints.json
@@ -3,17 +3,20 @@
     {
       "name": "Me",
       "paged": false,
-      "suffix": "/users/me"
+      "suffix": "/users/me",
+      "description": "The account the credentials belong to, with its plan and language. One record, and the plan matters because several endpoints here are plan-gated."
     },
     {
       "name": "User Workgroups",
       "paged": true,
-      "suffix": "/users/{User ID}/workgroups"
+      "suffix": "/users/{User ID}/workgroups",
+      "description": "The workgroups one user belongs to. Requires a user id."
     },
     {
       "name": "Shared",
       "paged": true,
-      "suffix": "/users/{User ID}/shared?resource_type={Resource Type?: survey}&resource_id={Resource ID?}&include={Include?}"
+      "suffix": "/users/{User ID}/shared?resource_type={Resource Type?: survey}&resource_id={Resource ID?}&include={Include?}",
+      "description": "The resources shared with one user, by resource type. Requires a user id. The access view, and the reason two users see different survey lists."
     },
     {
       "name": "Groups",
@@ -26,22 +29,26 @@
           "key": "id",
           "parameterName": "Group ID"
         }
-      ]
+      ],
+      "description": "The groups on the account -- SurveyMonkey's team container."
     },
     {
       "name": "Group",
       "paged": false,
-      "suffix": "/groups/{Group ID}"
+      "suffix": "/groups/{Group ID}",
+      "description": "One group by id."
     },
     {
       "name": "Group Members",
       "paged": true,
-      "suffix": "/groups/{Group ID}/members"
+      "suffix": "/groups/{Group ID}/members",
+      "description": "The members of one group. Requires a group id."
     },
     {
       "name": "Group Member",
       "paged": false,
-      "suffix": "/groups/{Group ID}/members/{Member ID}"
+      "suffix": "/groups/{Group ID}/members/{Member ID}",
+      "description": "One group member by id."
     },
     {
       "name": "Surveys",
@@ -49,78 +56,101 @@
       "suffix": "/surveys?include={Include?}&title={Title?}&start_modified_at={Start Modified At?}&end_modified_at={End Modified At?}&folder_id={Folder ID?}",
       "lookups": [
         {
-          "endpoints": ["Survey Details", "Survey Pages", "Survey Languages", "Survey Collectors", "Survey Responses", "Bulk Survey Responses", "Survey Rollups", "Survey Trends"],
+          "endpoints": [
+            "Survey Details",
+            "Survey Pages",
+            "Survey Languages",
+            "Survey Collectors",
+            "Survey Responses",
+            "Bulk Survey Responses",
+            "Survey Rollups",
+            "Survey Trends"
+          ],
           "jsonPath": "$.data.[*]",
           "key": "id",
           "parameterName": "Survey ID"
         }
-      ]
+      ],
+      "description": "The surveys on the account, with title, the counts of questions, pages and responses, and the created and modified dates. THE RESPONSE COUNT HERE IS THE CHEAPEST ANSWER to how many people replied; everything below it costs more. Filterable by title and modified date."
     },
     {
       "name": "Survey",
       "paged": false,
-      "suffix": "/surveys/{Survey ID}"
+      "suffix": "/surveys/{Survey ID}",
+      "description": "One survey by id, with its top-level detail and counts."
     },
     {
       "name": "Survey Details",
       "paged": false,
-      "suffix": "/surveys/{Survey ID}/details"
+      "suffix": "/surveys/{Survey ID}/details",
+      "description": "One survey WITH its full structure inlined -- every page, question, answer choice and row, in one response. Requires a survey id. THE ENDPOINT THAT MAKES RESPONSES READABLE: a response returns answers as question ids and choice ids, so without this the data is a graph of opaque identifiers. It replaces walking pages and questions separately."
     },
     {
       "name": "Survey Categories",
       "paged": false,
-      "suffix": "/survey_categories?language={Language?}"
+      "suffix": "/survey_categories?language={Language?}",
+      "description": "The categories SurveyMonkey publishes for template browsing. Reference data."
     },
     {
       "name": "Survey Template",
       "paged": true,
-      "suffix": "/survey_templates?language={Language?}&category={Category?}"
+      "suffix": "/survey_templates?language={Language?}&category={Category?}",
+      "description": "The survey templates available, by category and language. Reference content rather than account data."
     },
     {
       "name": "All Languages",
       "paged": true,
-      "suffix": "/survey_languages"
+      "suffix": "/survey_languages",
+      "description": "The languages SurveyMonkey supports. Reference data."
     },
     {
       "name": "Survey Pages",
       "paged": true,
       "pageLimit": 100,
-      "suffix": "/surveys/{Survey ID}/pages"
+      "suffix": "/surveys/{Survey ID}/pages",
+      "description": "The pages of one survey. Requires a survey id. The structural level between survey and question."
     },
     {
       "name": "Survey Page",
       "paged": false,
-      "suffix": "/surveys/{Survey ID}/pages/{Page ID}"
+      "suffix": "/surveys/{Survey ID}/pages/{Page ID}",
+      "description": "One page by id."
     },
     {
       "name": "Survey Questions",
       "paged": true,
-      "suffix": "/surveys/{Survey ID}/pages/{Page ID}/questions"
+      "suffix": "/surveys/{Survey ID}/pages/{Page ID}/questions",
+      "description": "The questions on one page, with their family and subtype, headings, and answer choices. Requires the survey and page ids. THE QUESTION FAMILY DECIDES HOW ITS ANSWERS ARE SHAPED -- single choice, multiple choice, matrix, open ended and demographic all store answers differently, so a single parsing rule does not work across a survey."
     },
     {
       "name": "Survey Question",
       "paged": false,
-      "suffix": "/surveys/{Survey ID}/pages/{Page ID}/questions/{Question ID}"
+      "suffix": "/surveys/{Survey ID}/pages/{Page ID}/questions/{Question ID}",
+      "description": "One question by id, with its choices."
     },
     {
       "name": "Questions",
       "paged": true,
-      "suffix": "/question_bank/questions?locale={Locale?}&search={Search}&custom={Custom?:true|false}"
+      "suffix": "/question_bank/questions?locale={Locale?}&search={Search}&custom={Custom?:true|false}",
+      "description": "The question bank -- SurveyMonkey's library of pre-written questions, searchable by locale. Reference content for building surveys, not account data."
     },
     {
       "name": "Survey Folders",
       "paged": true,
-      "suffix": "/survey_folders"
+      "suffix": "/survey_folders",
+      "description": "The folders surveys are organised into."
     },
     {
       "name": "Survey Languages",
       "paged": true,
-      "suffix": "/surveys/{Survey ID}/languages"
+      "suffix": "/surveys/{Survey ID}/languages",
+      "description": "The languages one survey is translated into. Requires a survey id."
     },
     {
       "name": "Survey Language",
       "paged": false,
-      "suffix": "/surveys/{Survey ID}/languages/{Language Code}?enabled={Enabled?:true|false}&translations={Translations}"
+      "suffix": "/surveys/{Survey ID}/languages/{Language Code}?enabled={Enabled?:true|false}&translations={Translations}",
+      "description": "One language version of a survey, and whether it is enabled."
     },
     {
       "name": "Contact Lists",
@@ -128,177 +158,214 @@
       "suffix": "/contact_lists",
       "lookups": [
         {
-          "endpoints": ["Contact List Contact", "Bulk Contact"],
+          "endpoints": [
+            "Contact List Contact",
+            "Bulk Contact"
+          ],
           "jsonPath": "$.data.[*]",
           "key": "id",
           "parameterName": "Contact List ID"
         }
-      ]
+      ],
+      "description": "The contact lists used for email collectors. The audience container."
     },
     {
       "name": "Contact List",
       "paged": false,
-      "suffix": "/contact_lists/{Contact List ID}"
+      "suffix": "/contact_lists/{Contact List ID}",
+      "description": "One contact list by id."
     },
     {
       "name": "Contact List Contact",
       "paged": true,
-      "suffix": "/contact_lists/{Contact List ID}/contacts?status={Status?:active|optout|bounced}&search_by={Search By?}&search={Search?}"
+      "suffix": "/contact_lists/{Contact List ID}/contacts?status={Status?:active|optout|bounced}&search_by={Search By?}&search={Search?}",
+      "description": "The contacts on one list, filterable by status. Requires a list id."
     },
     {
       "name": "Bulk Contact",
       "paged": false,
-      "suffix": "/contact_lists/{Contact List ID}/contacts/bulk"
+      "suffix": "/contact_lists/{Contact List ID}/contacts/bulk",
+      "description": "The contacts on one list in bulk. Requires a list id. The extract route for a large list."
     },
     {
       "name": "Contacts",
       "paged": true,
-      "suffix": "/contacts?status={Status?:active|optout|bounced}&search_by={Search By?}&search={Search?}"
+      "suffix": "/contacts?status={Status?:active|optout|bounced}&search_by={Search By?}&search={Search?}",
+      "description": "All contacts on the account, filterable by status and search term. Status separates active from opted out and bounced -- and opted-out contacts cannot be invited, so a mailable audience count has to exclude them."
     },
     {
       "name": "Bulk Contacts",
       "paged": false,
-      "suffix": "/contacts/bulk"
+      "suffix": "/contacts/bulk",
+      "description": "All contacts in bulk. The account-wide extract route."
     },
     {
       "name": "Contact",
       "paged": false,
-      "suffix": "/contact/{Contact ID}"
+      "suffix": "/contact/{Contact ID}",
+      "description": "One contact by id."
     },
     {
       "name": "Contact Fields",
       "paged": true,
-      "suffix": "/contact_fields"
+      "suffix": "/contact_fields",
+      "description": "The custom fields defined on contacts. The decoder for custom values."
     },
     {
       "name": "Contact Field",
       "paged": false,
-      "suffix": "/contact_fields/{Contact Field ID}"
+      "suffix": "/contact_fields/{Contact Field ID}",
+      "description": "One contact field by id."
     },
     {
       "name": "Survey Collectors",
       "paged": true,
-      "suffix": "/surveys/{Survey ID}/collectors?name={Name?}&start_date={Start Date?}&end_date={End Date?}&include={Include?}"
+      "suffix": "/surveys/{Survey ID}/collectors?name={Name?}&start_date={Start Date?}&end_date={End Date?}&include={Include?}",
+      "description": "The collectors of one survey -- the channels it was distributed through, such as a web link, email invitation or embedded widget. Requires a survey id. THE COLLECTOR IS THE DIMENSION MOST RESPONSE ANALYSIS NEEDS: the same survey sent by email and posted as a link produces very different response profiles, and only the collector distinguishes them."
     },
     {
       "name": "Collector",
       "paged": false,
-      "suffix": "/collectors/{Collector ID}"
+      "suffix": "/collectors/{Collector ID}",
+      "description": "One collector by id, with its type, status and response count."
     },
     {
       "name": "Collector Messages",
       "paged": true,
-      "suffix": "/collectors/{Collector ID}/messages"
+      "suffix": "/collectors/{Collector ID}/messages",
+      "description": "The email invitations and reminders sent through one collector. Requires a collector id. Where the send that produced a batch of responses is recorded."
     },
     {
       "name": "Collector Message",
       "paged": false,
-      "suffix": "/collectors/{Collector ID}/messages/{Message ID}"
+      "suffix": "/collectors/{Collector ID}/messages/{Message ID}",
+      "description": "One message by id."
     },
     {
       "name": "Message Recipients",
       "paged": true,
-      "suffix": "/collectors/{Collector ID}/messages/{Message ID}/recipients?include={Include?}"
+      "suffix": "/collectors/{Collector ID}/messages/{Message ID}/recipients?include={Include?}",
+      "description": "Who one message was sent to. Requires the collector and message ids."
     },
     {
       "name": "Recipients",
       "paged": true,
-      "suffix": "/collectors/{Collector ID}/recipients?include={Include?}"
+      "suffix": "/collectors/{Collector ID}/recipients?include={Include?}",
+      "description": "Everyone invited through one collector, with their status -- sent, opened, responded, bounced, opted out. Requires a collector id. THE DENOMINATOR FOR A RESPONSE RATE, which the responses alone cannot give."
     },
     {
       "name": "Recipient",
       "paged": false,
-      "suffix": "/collectors/{Collector ID}/recipients/{Recipient ID}?include={Include?}"
+      "suffix": "/collectors/{Collector ID}/recipients/{Recipient ID}?include={Include?}",
+      "description": "One recipient by id."
     },
     {
       "name": "Stats",
       "paged": false,
-      "suffix": "/collectors/{Collector ID}/stats"
+      "suffix": "/collectors/{Collector ID}/stats",
+      "description": "The aggregate statistics of one collector -- sent, opened, clicked, responded, bounced, opted out. Requires a collector id. Response rate without paging recipients."
     },
     {
       "name": "Message Stats",
       "paged": false,
-      "suffix": "/collectors/{Collector ID}/messages/{Message ID}/stats"
+      "suffix": "/collectors/{Collector ID}/messages/{Message ID}/stats",
+      "description": "The same statistics for one individual message. Requires the collector and message ids. Which send performed, as opposed to the collector overall."
     },
     {
       "name": "Survey Responses",
       "paged": true,
-      "suffix": "/surveys/{Survey ID}/responses"
+      "suffix": "/surveys/{Survey ID}/responses",
+      "description": "The responses to one survey, with the respondent, collector, status, and the dates started and modified -- but NOT the answers. Requires a survey id. The index; answers come from the details variants below."
     },
     {
       "name": "Collector Responses",
       "paged": true,
-      "suffix": "/collectors/{Collector ID}/responses?start_created_at={Start Created At?}&end_created_at={End Created At?}&start_modified_at={Start Modified At?}&end_modified_at={End Modified At?}&status={Status?}&email={Email?}&first_name={First Name}&last_name={Last Name}&ip={IP?}&custom={Custom?}&total_time_max={Total Time Max?}&total_time_min={Total Time Min?}&total_time_units={Total Time Units?}"
+      "suffix": "/collectors/{Collector ID}/responses?start_created_at={Start Created At?}&end_created_at={End Created At?}&start_modified_at={Start Modified At?}&end_modified_at={End Modified At?}&status={Status?}&email={Email?}&first_name={First Name}&last_name={Last Name}&ip={IP?}&custom={Custom?}&total_time_max={Total Time Max?}&total_time_min={Total Time Min?}&total_time_units={Total Time Units?}",
+      "description": "The responses gathered through one collector. Requires a collector id. The per-channel slice."
     },
     {
       "name": "Bulk Collector Responses",
       "paged": true,
-      "suffix": "/collectors/{Collector ID}/responses/bulk?simple={Simple?}&collector_ids={Collector IDs?}&start_created_at={Start Created At?}&end_created_at={End Created At?}&start_modified_at={Start Modified At?}&end_modified_at={End Modified At?}&status={Status?}&email={Email?}&first_name={First Name?}&last_name={Last Name?}&ip={IP?}&custom={Custom?}&total_time_max={Total Time Max?}&total_time_min={Total Time Min?}&total_time_units={Total Time Units?}&page_ids={Page IDs?}&question_ids={Question IDs?}"
+      "suffix": "/collectors/{Collector ID}/responses/bulk?simple={Simple?}&collector_ids={Collector IDs?}&start_created_at={Start Created At?}&end_created_at={End Created At?}&start_modified_at={Start Modified At?}&end_modified_at={End Modified At?}&status={Status?}&email={Email?}&first_name={First Name?}&last_name={Last Name?}&ip={IP?}&custom={Custom?}&total_time_max={Total Time Max?}&total_time_min={Total Time Min?}&total_time_units={Total Time Units?}&page_ids={Page IDs?}&question_ids={Question IDs?}",
+      "description": "Every response through one collector with answers, paged. The per-channel bulk extract."
     },
     {
       "name": "Bulk Survey Responses",
       "paged": true,
-      "suffix": "/surveys/{Survey ID}/responses/bulk?simple={Simple?}&collector_ids={Collector IDs?}&start_created_at={Start Created At?}&end_created_at={End Created At?}&start_modified_at={Start Modified At?}&end_modified_at={End Modified At?}&status={Status?}&email={Email?}&first_name={First Name?}&last_name={Last Name?}&ip={IP?}&custom={Custom?}&total_time_max={Total Time Max?}&total_time_min={Total Time Min?}&total_time_units={Total Time Units?}&page_ids={Page IDs?}&question_ids={Question IDs?}"
+      "suffix": "/surveys/{Survey ID}/responses/bulk?simple={Simple?}&collector_ids={Collector IDs?}&start_created_at={Start Created At?}&end_created_at={End Created At?}&start_modified_at={Start Modified At?}&end_modified_at={End Modified At?}&status={Status?}&email={Email?}&first_name={First Name?}&last_name={Last Name?}&ip={IP?}&custom={Custom?}&total_time_max={Total Time Max?}&total_time_min={Total Time Min?}&total_time_units={Total Time Units?}&page_ids={Page IDs?}&question_ids={Question IDs?}",
+      "description": "Every response to one survey WITH answers, in one paged request. Requires a survey id. THE PRACTICAL EXTRACT ROUTE -- fetching details one response at a time is prohibitive on any real survey. The simple parameter returns answers as text rather than ids, which trades fidelity for readability."
     },
     {
       "name": "Survey Response",
       "paged": false,
-      "suffix": "/surveys/{Survey ID}/responses/{Response ID}"
+      "suffix": "/surveys/{Survey ID}/responses/{Response ID}",
+      "description": "One response by id, without its answers."
     },
     {
       "name": "Collector Response",
       "paged": false,
-      "suffix": "/collectors/{Collector ID}/responses/{Response ID}?survey_id={Survey ID?}&collector_id={Collector ID?}&recipient_id={Recipient ID?}&total_time={Total Time?}&custom_value={Custom Value?}&edit_url={Edit URL?}&analyze_url={Analyze URL?}&ip_address={IP Address?}&custom_variables={Custom Variables?}&logic_path={Logic Path?}&metadata={Metadata?}&response_status={Response Status?}&page_path={Page Path?}&collection_mode={Collection Mode?}&date_created={Date Created?}&date_modified={Date Modified?}"
+      "suffix": "/collectors/{Collector ID}/responses/{Response ID}?survey_id={Survey ID?}&collector_id={Collector ID?}&recipient_id={Recipient ID?}&total_time={Total Time?}&custom_value={Custom Value?}&edit_url={Edit URL?}&analyze_url={Analyze URL?}&ip_address={IP Address?}&custom_variables={Custom Variables?}&logic_path={Logic Path?}&metadata={Metadata?}&response_status={Response Status?}&page_path={Page Path?}&collection_mode={Collection Mode?}&date_created={Date Created?}&date_modified={Date Modified?}",
+      "description": "One response by id within a collector."
     },
     {
       "name": "Survey Response Details",
       "paged": false,
-      "suffix": "/surveys/{Survey ID}/responses/{Response ID}/details"
+      "suffix": "/surveys/{Survey ID}/responses/{Response ID}/details",
+      "description": "One response WITH its answers, as question ids paired with choice ids or text. Requires the survey and response ids. Only interpretable alongside Survey Details, which supplies what those ids mean."
     },
     {
       "name": "Collector Response Details",
       "paged": false,
-      "suffix": "/collectors/{Collector ID}/responses/{Response ID}/details?page_ids={Page IDs?}&question_ids={Question IDs?}"
+      "suffix": "/collectors/{Collector ID}/responses/{Response ID}/details?page_ids={Page IDs?}&question_ids={Question IDs?}",
+      "description": "One collector response with its answers."
     },
     {
       "name": "Survey Rollups",
       "paged": true,
-      "suffix": "/surveys/{Survey ID}/rollups?collector_ids={Collector IDs?}&start_created_at={Start Created At?}&end_created_at={End Created At?}&start_modified_at={Start Modified At?}&end_modified_at={End Modified At?}&status={Status?}&email={Email?}&first_name={First Name?}&last_name={Last Name?}&ip={IP?}&custom={Custom?}&total_time_max={Total Time Max?}&total_time_min={Total Time Min?}&total_time_units={Total Time Units?}"
+      "suffix": "/surveys/{Survey ID}/rollups?collector_ids={Collector IDs?}&start_created_at={Start Created At?}&end_created_at={End Created At?}&start_modified_at={Start Modified At?}&end_modified_at={End Modified At?}&status={Status?}&email={Email?}&first_name={First Name?}&last_name={Last Name?}&ip={IP?}&custom={Custom?}&total_time_max={Total Time Max?}&total_time_min={Total Time Min?}&total_time_units={Total Time Units?}",
+      "description": "Pre-computed aggregates for one survey -- per question, the counts and percentages for each answer choice. Requires a survey id. SURVEYMONKEY HAS ALREADY DONE THE TABULATION, so the usual cross-tab of a survey does not require reading a single response."
     },
     {
       "name": "Survey Page Rollups",
       "paged": true,
-      "suffix": "/surveys/{Survey ID}/pages/{Page ID}/rollups?collector_ids={Collector IDs?}&start_created_at={Start Created At?}&end_created_at={End Created At?}&start_modified_at={Start Modified At?}&end_modified_at={End Modified At?}&status={Status?}&email={Email?}&first_name={First Name?}&last_name={Last Name?}&ip={IP?}&custom={Custom?}&total_time_max={Total Time Max?}&total_time_min={Total Time Min?}&total_time_units={Total Time Units?}"
+      "suffix": "/surveys/{Survey ID}/pages/{Page ID}/rollups?collector_ids={Collector IDs?}&start_created_at={Start Created At?}&end_created_at={End Created At?}&start_modified_at={Start Modified At?}&end_modified_at={End Modified At?}&status={Status?}&email={Email?}&first_name={First Name?}&last_name={Last Name?}&ip={IP?}&custom={Custom?}&total_time_max={Total Time Max?}&total_time_min={Total Time Min?}&total_time_units={Total Time Units?}",
+      "description": "The same aggregates restricted to one page."
     },
     {
       "name": "Survey Question Rollups",
       "paged": true,
-      "suffix": "/surveys/{Survey ID}/pages/{Page ID}/questions/{Question ID}/rollups?collector_ids={Collector IDs?}&start_created_at={Start Created At?}&end_created_at={End Created At?}&start_modified_at={Start Modified At?}&end_modified_at={End Modified At?}&status={Status?}&email={Email?}&first_name={First Name?}&last_name={Last Name?}&ip={IP?}&custom={Custom?}&total_time_max={Total Time Max?}&total_time_min={Total Time Min?}&total_time_units={Total Time Units?}"
+      "suffix": "/surveys/{Survey ID}/pages/{Page ID}/questions/{Question ID}/rollups?collector_ids={Collector IDs?}&start_created_at={Start Created At?}&end_created_at={End Created At?}&start_modified_at={Start Modified At?}&end_modified_at={End Modified At?}&status={Status?}&email={Email?}&first_name={First Name?}&last_name={Last Name?}&ip={IP?}&custom={Custom?}&total_time_max={Total Time Max?}&total_time_min={Total Time Min?}&total_time_units={Total Time Units?}",
+      "description": "The aggregate for one question. Requires the survey, page and question ids."
     },
     {
       "name": "Survey Trends",
       "paged": true,
-      "suffix": "/surveys/{Survey ID}/trends?first_respondent={First Respondent?}&last_respondent={Last Respondent?}&trendy_by={Trend By?:year|quarter|month|week|day|hour}"
+      "suffix": "/surveys/{Survey ID}/trends?first_respondent={First Respondent?}&last_respondent={Last Respondent?}&trendy_by={Trend By?:year|quarter|month|week|day|hour}",
+      "description": "How one survey's answers moved over time, bucketed by period. Requires a survey id. The rollups give a snapshot; this gives the series, which is what a tracking survey exists to produce."
     },
     {
       "name": "Survey Page Trends",
       "paged": true,
-      "suffix": "/surveys/{Survey ID}/pages/{Page ID}/trends?first_respondent={First Respondent?}&last_respondent={Last Respondent?}&trendy_by={Trend By?:year|quarter|month|week|day|hour}"
+      "suffix": "/surveys/{Survey ID}/pages/{Page ID}/trends?first_respondent={First Respondent?}&last_respondent={Last Respondent?}&trendy_by={Trend By?:year|quarter|month|week|day|hour}",
+      "description": "The same trend restricted to one page."
     },
     {
       "name": "Survey Question Trends",
       "paged": true,
-      "suffix": "/surveys/{Survey ID}/pages/{Page ID}/questions/{Question ID}/trends?first_respondent={First Respondent?}&last_respondent={Last Respondent?}&trendy_by={Trend By?:year|quarter|month|week|day|hour}"
+      "suffix": "/surveys/{Survey ID}/pages/{Page ID}/questions/{Question ID}/trends?first_respondent={First Respondent?}&last_respondent={Last Respondent?}&trendy_by={Trend By?:year|quarter|month|week|day|hour}",
+      "description": "The trend for one question over time."
     },
     {
       "name": "Webhooks",
       "paged": true,
-      "suffix": "/webhooks"
+      "suffix": "/webhooks",
+      "description": "The webhooks registered, with the events and objects each watches. Integration configuration; deliveries are not recorded."
     },
     {
       "name": "Webhook",
       "paged": false,
-      "suffix": "/webhooks/{Webhook ID}"
+      "suffix": "/webhooks/{Webhook ID}",
+      "description": "One webhook by id."
     },
     {
       "name": "Benchmark Bundles",
@@ -311,22 +378,26 @@
           "key": "id",
           "parameterName": "Benchmark Bundle ID"
         }
-      ]
+      ],
+      "description": "The benchmark question sets SurveyMonkey publishes, by country. Benchmarks let a result be compared against other organisations rather than only against itself -- which is the one comparison an account's own data can never supply."
     },
     {
       "name": "Benchmark Bundle Questions",
       "paged": false,
-      "suffix": "/benchmark_bundles/{Benchmark Bundle ID}"
+      "suffix": "/benchmark_bundles/{Benchmark Bundle ID}",
+      "description": "The questions in one benchmark bundle. Requires a bundle id."
     },
     {
       "name": "Benchmark Bundle Benchmarks",
       "paged": false,
-      "suffix": "/benchmark_bundles/{Bundle ID}/analyze?question_ids={Question IDs}&percentile_start={Percentile Start?}&percentile_end={Percentile End?}"
+      "suffix": "/benchmark_bundles/{Bundle ID}/analyze?question_ids={Question IDs}&percentile_start={Percentile Start?}&percentile_end={Percentile End?}",
+      "description": "The benchmark values for chosen questions in a bundle. Requires the bundle id and question ids. The external comparison figures."
     },
     {
       "name": "Survey Question Benchmark",
       "paged": false,
-      "suffix": "/surveys/{Survey ID}/pages/{Page ID}/questions/{Question ID}/benchmark?percentile_start={Percentile Start?}&percentile_end={Percentile End?}"
+      "suffix": "/surveys/{Survey ID}/pages/{Page ID}/questions/{Question ID}/benchmark?percentile_start={Percentile Start?}&percentile_end={Percentile End?}",
+      "description": "The benchmark comparison for one question in one survey. Requires the survey, page and question ids. Where an account's own result is placed against the benchmark."
     },
     {
       "name": "Workgroups",
@@ -334,52 +405,64 @@
       "suffix": "/workgroups",
       "lookups": [
         {
-          "endpoints": ["Workgroup Members", "Workgroup Shares"],
+          "endpoints": [
+            "Workgroup Members",
+            "Workgroup Shares"
+          ],
           "jsonPath": "$.data.[*]",
           "key": "id",
           "parameterName": "Workgroup ID"
         }
-      ]
+      ],
+      "description": "The workgroups on the account, a finer sharing unit than groups."
     },
     {
       "name": "Workgroup",
       "paged": false,
-      "suffix": "/workgroups/{Workgroup ID}"
+      "suffix": "/workgroups/{Workgroup ID}",
+      "description": "One workgroup by id."
     },
     {
       "name": "Workgroup Members",
       "paged": true,
-      "suffix": "/workgroups/{Workgroup ID}/members"
+      "suffix": "/workgroups/{Workgroup ID}/members",
+      "description": "The members of one workgroup. Requires a workgroup id."
     },
     {
       "name": "Workgroup Member",
       "paged": false,
-      "suffix": "/workgroups/{Workgroup ID}/members/{Member ID}"
+      "suffix": "/workgroups/{Workgroup ID}/members/{Member ID}",
+      "description": "One workgroup member by id."
     },
     {
       "name": "Workgroup Shares",
       "paged": true,
-      "suffix": "/workgroups/{Workgroup ID}/shares?include={Include?}"
+      "suffix": "/workgroups/{Workgroup ID}/shares?include={Include?}",
+      "description": "The resources shared with one workgroup. Requires a workgroup id."
     },
     {
       "name": "Workgroup Share",
       "paged": false,
-      "suffix": "/workgroups/{Workgroup ID}/shares"
+      "suffix": "/workgroups/{Workgroup ID}/shares/{Share ID}",
+      "description": "One workgroup share by id. Requires the workgroup id."
     },
     {
       "name": "Roles",
       "paged": true,
-      "suffix": "/roles"
+      "suffix": "/roles",
+      "description": "The roles available on the account, with the permissions each grants."
     },
     {
       "name": "Errors",
       "paged": true,
-      "suffix": "/errors"
+      "suffix": "/errors",
+      "description": "The API errors SurveyMonkey defines, with their codes and meanings. Reference data for interpreting a failure, not a log of failures that occurred."
     },
     {
       "name": "Error",
       "paged": false,
-      "suffix": "/errors/{Error ID}"
+      "suffix": "/errors/{Error ID}",
+      "description": "One error definition by id."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/wordpress/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/wordpress/endpoints.json
@@ -487,7 +487,7 @@
     {
       "name": "Insights Data",
       "paged": false,
-      "suffix": "/v1.1/insights/{Report Slug}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&unit={Unit?:daily|monthly|cumulative|&after={Since?:Unix Timestamp}&before={Before?:Unix Timestamp}",
+      "suffix": "/v1.1/insights/{Report Slug}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&unit={Unit?:daily|monthly|cumulative}&after={Since?:Unix Timestamp}&before={Before?:Unix Timestamp}",
       "description": "One insight report by slug."
     },
     {

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/wordpress/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/wordpress/endpoints.json
@@ -3,107 +3,128 @@
     {
       "name": "Site Users",
       "paged": true,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/users?context={Context?:display|edit}&meta={Include Metadata?:sites,likes,...}&fields={Include Fields?:ID,title,...}&authors_only={Fetch Authors Only?:true|false}&type={Post Type?}&search={Search Text?}&search_columns={Search Columns?,:ID,user_login,user_email,...}&role={User Role?}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/users?context={Context?:display|edit}&meta={Include Metadata?:sites,likes,...}&fields={Include Fields?:ID,title,...}&authors_only={Fetch Authors Only?:true|false}&type={Post Type?}&search={Search Text?}&search_columns={Search Columns?,:ID,user_login,user_email,...}&role={User Role?}",
+      "description": "The users of one site, with their roles and capabilities. Requires a site."
     },
     {
       "name": "Site User",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/users/login:{User Login}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/users/login:{User Login}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "One site user by login. Requires the site."
     },
     {
       "name": "Current User Metadata",
       "paged": false,
-      "suffix": "/v1.1/me?meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/me?meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "The authenticated account's profile -- name, email, avatar and primary blog. One record, always the caller."
     },
     {
       "name": "Current User Billing History",
       "paged": false,
-      "suffix": "/v1.1/me/billing-history?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/me/billing-history?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "The caller's purchase history on WordPress.com -- plans, domains and upgrades bought. The commercial record, which no site endpoint carries."
     },
     {
       "name": "Current User Settings",
       "paged": false,
-      "suffix": "/v1.1/me/settings?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/me/settings?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "The caller's account settings."
     },
     {
       "name": "Current User Preferences",
       "paged": false,
-      "suffix": "/v1.1/me/preferences?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/me/preferences?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "The caller's interface preferences."
     },
     {
       "name": "Current User Profile Links",
       "paged": false,
-      "suffix": "/v1.1/me/settings/profile-links?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/me/settings/profile-links?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "The links on the caller's public profile."
     },
     {
       "name": "Current User Connected Applications",
       "paged": false,
-      "suffix": "/v1.1/me/connected-applications?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/me/connected-applications?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "The third-party applications authorised against the caller's account. Security inventory."
     },
     {
       "name": "Current User Connected Application",
       "paged": false,
-      "suffix": "/v1.1/me/connected-applications/{Application ID}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/me/connected-applications/{Application ID}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "One connected application by id."
     },
     {
       "name": "Current User Likes",
       "paged": true,
-      "suffix": "/v1.1/me/likes?meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&after={Dated On or After?:yyyy-MM-ddTHH:mm:ss}&before={Dated On or Before?:yyyy-MM-ddTHH:mm:ss}"
+      "suffix": "/v1.1/me/likes?meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&after={Dated On or After?:yyyy-MM-ddTHH:mm:ss}&before={Dated On or Before?:yyyy-MM-ddTHH:mm:ss}",
+      "description": "The posts the caller has liked across WordPress.com."
     },
     {
       "name": "Site Shortcodes",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/shortcodes?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/shortcodes?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "The shortcodes available on one site. Content embedded through these is invisible in raw post content, which is worth knowing when post text seems incomplete."
     },
     {
       "name": "Site Embeds",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/embeds?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/embeds?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "The embed providers one site supports."
     },
     {
       "name": "Site",
       "paged": false,
-      "suffix": "/v1.2/sites/{Site ID or Domain}?meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.2/sites/{Site ID or Domain}?meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "One site's details -- name, description, URL, post count, subscriber count, language, and the plan and features it has. THIS IS THE WORDPRESS.COM API, not the REST API of a self-hosted install: it serves WordPress.com sites and self-hosted ones connected through Jetpack, and a plain self-hosted WordPress is not reachable through it at all. Every endpoint here takes a site id or domain."
     },
     {
       "name": "Site Page Templates",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/page-templates?meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/page-templates?meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "The page templates the site's theme offers."
     },
     {
       "name": "Site Post Types",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/post-types?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/post-types?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "The post types registered on one site -- post, page, and any custom ones. Requires a site. What kinds of content exist, which the post listing's default hides."
     },
     {
       "name": "Site Post Counts by Type",
       "paged": false,
-      "suffix": "/v1.2/sites/{Site ID or Domain}/post-counts/{Post Type}?meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.2/sites/{Site ID or Domain}/post-counts/{Post Type}?meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "How many posts of one type exist, by status. Requires the site and post type. The cheap count, broken out by draft, published and trashed."
     },
     {
       "name": "Site Widgets",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/widgets?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/widgets?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "The widgets configured on one site."
     },
     {
       "name": "Site WordAds Settings",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/wordads/settings?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/wordads/settings?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "The advertising configuration of one site."
     },
     {
       "name": "Site WordAds Earnings",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/wordads/earnings?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/wordads/earnings?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "Advertising earnings by period. The revenue side of running ads."
     },
     {
       "name": "Site WordAds TOS",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/wordads/tos?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/wordads/tos?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "Whether the site has accepted the advertising terms. Ads do not run until it has, which explains zero earnings on a configured site."
     },
     {
       "name": "Site WordAds Statistics",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/wordads/stats?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&unit={Unit?:day|week|month}&quantity={Quantity?}&date={Date?:yyyy-MM-dd}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/wordads/stats?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&unit={Unit?:day|week|month}&quantity={Quantity?}&date={Date?:yyyy-MM-dd}",
+      "description": "Advertising impressions and revenue for one site over a period. Only meaningful where WordAds is enabled."
     },
     {
       "name": "Current User Sites",
@@ -157,32 +178,38 @@
           "key": "ID",
           "parameterName": "Site ID or Domain"
         }
-      ]
+      ],
+      "description": "The sites the authenticated user can access. The starting point, since everything else needs a site."
     },
     {
       "name": "Site Widget",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/widgets/widget:{Widget ID}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/widgets/widget:{Widget ID}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "One widget by id."
     },
     {
       "name": "Site Theme Headers",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/headers/{Theme Slug}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/headers/{Theme Slug}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "The header images available for one theme. Requires the site and theme slug."
     },
     {
       "name": "Site Headers",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/headers/mine?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/headers/mine?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "The header images in use on one site."
     },
     {
       "name": "Post by ID",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/posts/{Post ID}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/posts/{Post ID}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "One post by id. Requires the site."
     },
     {
       "name": "Post by Slug",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/posts/slug:{Post Slug}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/posts/slug:{Post Slug}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "One post by its URL slug. Requires the site. The route in when only the public URL is known."
     },
     {
       "name": "Search Posts",
@@ -204,7 +231,8 @@
           "key": "ID",
           "parameterName": "Post ID"
         }
-      ]
+      ],
+      "description": "The posts of one site, filterable by status, type, author, category, tag, search term and date. Requires a site. THE MAIN CONTENT TABLE. Carries title, content, excerpt, status, the author, date and modified date, categories, tags, and the counts of likes and comments. NOTE THE DEFAULT: only PUBLISHED posts of type post are returned, so drafts, pages and custom post types are absent unless asked for -- which quietly excludes most of a site's content on anything but a simple blog."
     },
     {
       "name": "Current User Posts",
@@ -226,37 +254,44 @@
           "key": "ID",
           "parameterName": "Post ID"
         }
-      ]
+      ],
+      "description": "The posts the caller has written across their sites."
     },
     {
       "name": "Post Likes",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/posts/{Post ID}/likes?meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/posts/{Post ID}/likes?meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "Who liked one post. Requires the site and post id. The post carries a like count; this is who they were."
     },
     {
       "name": "Current User Post Like Status",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/posts/{Post ID}/likes/mine?meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/posts/{Post ID}/likes/mine?meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "Whether the caller has liked one post."
     },
     {
       "name": "Post Subscribers",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/posts/{Post ID}/subscribers?meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/posts/{Post ID}/subscribers?meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "Who subscribed to one post's comments. Requires the site and post id."
     },
     {
       "name": "Current User Post Subscription Status",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/posts/{Post ID}/subscribers/mine?meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/posts/{Post ID}/subscribers/mine?meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "Whether the caller subscribes to one post."
     },
     {
       "name": "Current User Post Reblog Status",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/posts/{Post ID}/reblogs/mine?meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/posts/{Post ID}/reblogs/mine?meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "Whether the caller has reblogged one post."
     },
     {
       "name": "Comment",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/comments/{Comment ID}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/comments/{Comment ID}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "One comment by id. Requires the site."
     },
     {
       "name": "Recent Comments",
@@ -273,7 +308,8 @@
           "key": "ID",
           "parameterName": "Comment ID"
         }
-      ]
+      ],
+      "description": "The comments on one site, filterable by status. Requires a site. Carries the author, content, date, the post commented on, and the approval status. STATUS MATTERS: unapproved, spam and trashed comments share this table with approved ones, so an engagement count that does not filter includes spam."
     },
     {
       "name": "Post Recent Comments",
@@ -290,32 +326,38 @@
           "key": "ID",
           "parameterName": "Comment ID"
         }
-      ]
+      ],
+      "description": "The comments on one post. Requires the site and post id."
     },
     {
       "name": "Comment Counts",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/comment-counts?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&post_id={Post ID?}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/comment-counts?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&post_id={Post ID?}",
+      "description": "Comment counts by status for one site. Requires a site. The ready-made summary, and it separates approved from spam without paging anything."
     },
     {
       "name": "Comment Audit History",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/comment-history/{Comment ID}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/comment-history/{Comment ID}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "The moderation history of one comment -- approvals, spam marks and edits. Requires the site and comment id. Why a comment is in its current state, which the comment itself does not say."
     },
     {
       "name": "Comment Likes",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/comments/{Comment ID}/likes?meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/comments/{Comment ID}/likes?meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "Who liked one comment. Requires the site and comment id."
     },
     {
       "name": "Current User Comment Like Status",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/comments/{Comment ID}/likes/mine?meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/comments/{Comment ID}/likes/mine?meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "Whether the caller has liked one comment."
     },
     {
       "name": "Site Categories",
       "paged": true,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/categories?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&search={Search?}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/categories?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&search={Search?}",
+      "description": "The categories of one site, with post counts. Requires a site. The primary content taxonomy."
     },
     {
       "name": "Site Tags",
@@ -331,112 +373,134 @@
           "key": "slug",
           "parameterName": "Tag"
         }
-      ]
+      ],
+      "description": "The tags of one site, with post counts. Requires a site. The secondary, free-form taxonomy."
     },
     {
       "name": "Site Category",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/categories/slug:{Category Slug}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/categories/slug:{Category Slug}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "One category by slug. Requires the site."
     },
     {
       "name": "Site Tag",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/tags/slug:{Tag Slug}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/tags/slug:{Tag Slug}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "One tag by slug. Requires the site."
     },
     {
       "name": "Taxonomy Term",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/taxonomies/{Taxonomy}/terms/slug:{Term Slug}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/taxonomies/{Taxonomy}/terms/slug:{Term Slug}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "One taxonomy term by slug. Requires the site and taxonomy."
     },
     {
       "name": "Post Type Taxonomies",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/post-types/{Post Type}/taxonomies?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/post-types/{Post Type}/taxonomies?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "The taxonomies attached to one post type. Requires the site and post type. CUSTOM POST TYPES BRING THEIR OWN TAXONOMIES, so categories and tags are not the whole classification on a site that uses them."
     },
     {
       "name": "Taxonomy Terms",
       "paged": true,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/taxonomies/{Taxonomy}/terms?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&search={Search?}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/taxonomies/{Taxonomy}/terms?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&search={Search?}",
+      "description": "The terms of one taxonomy. Requires the site and taxonomy. The generalised version of categories and tags."
     },
     {
       "name": "Site Followers",
       "paged": true,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/follows?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/follows?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "The followers of one site. Requires a site. The audience list behind the follower count."
     },
     {
       "name": "Current User Blog Following Status",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/follows/mine?meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/follows/mine?meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "Whether the caller follows one site."
     },
     {
       "name": "Sharing Buttons",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/sharing-buttons?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&enabled_only={Enabled Only?:true|false}&visibility={Visibility?:visible|hidden}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/sharing-buttons?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&enabled_only={Enabled Only?:true|false}&visibility={Visibility?:visible|hidden}",
+      "description": "The sharing buttons configured on one site."
     },
     {
       "name": "External Services",
       "paged": false,
-      "suffix": "/v1.1/meta/external-services?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&type={Type?:publicize|other}"
+      "suffix": "/v1.1/meta/external-services?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&type={Type?:publicize|other}",
+      "description": "The external services WordPress.com can connect to. Reference data."
     },
     {
       "name": "External Service",
       "paged": false,
-      "suffix": "/v1.1/meta/external-services/{Service}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/meta/external-services/{Service}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "One external service by name."
     },
     {
       "name": "Current User Publicize Connections",
       "paged": false,
-      "suffix": "/v1.1/me/publicize-connections?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&service={Service?}&keyring_connection_ID={Keyring Connection ID?}&site={Site?}"
+      "suffix": "/v1.1/me/publicize-connections?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&service={Service?}&keyring_connection_ID={Keyring Connection ID?}&site={Site?}",
+      "description": "The caller's own social publishing connections."
     },
     {
       "name": "Current User Publicize Connection",
       "paged": false,
-      "suffix": "/v1.1/me/publicize-connections/{Connection ID}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/me/publicize-connections/{Connection ID}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "One of the caller's publicize connections by id."
     },
     {
       "name": "Current User Keyring Connections",
       "paged": false,
-      "suffix": "/v1.1/me/keyring-connections?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&site={Site?}&force_external_users_refetch={Force Refetch External Users?:true|false}&force_connection_test={Force Test Connection?:true|false}"
+      "suffix": "/v1.1/me/keyring-connections?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&site={Site?}&force_external_users_refetch={Force Refetch External Users?:true|false}&force_connection_test={Force Test Connection?:true|false}",
+      "description": "The caller's underlying authorisations to external services. The credential layer beneath publicize connections."
     },
     {
       "name": "Current User Keyring Connection",
       "paged": false,
-      "suffix": "/v1.1/me/keyring-connections/{Connection ID}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/me/keyring-connections/{Connection ID}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "One keyring connection by id."
     },
     {
       "name": "Site Publicize Connections",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/publicize-connections?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&service={Service?}&user_id={User ID?}&keyring_connection_ID={Keyring Connection ID?}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/publicize-connections?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&service={Service?}&user_id={User ID?}&keyring_connection_ID={Keyring Connection ID?}",
+      "description": "The social accounts one site auto-publishes to. Requires a site. Where a post reaches beyond the site itself."
     },
     {
       "name": "Site Publicize Connection",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/publicize-connections/{Connection ID}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/publicize-connections/{Connection ID}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "One site publicize connection by id."
     },
     {
       "name": "External Services with Sharing Buttons",
       "paged": false,
-      "suffix": "/v1.1/meta/sharing-buttons?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/meta/sharing-buttons?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "The services available as sharing buttons. Reference data."
     },
     {
       "name": "Insights List",
       "paged": false,
-      "suffix": "/v1.1/insights?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/insights?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "The insight reports available. WordPress.com's own prepared analyses, as opposed to the raw statistics."
     },
     {
       "name": "Insights Data",
       "paged": false,
-      "suffix": "/v1.1/insights/{Report Slug}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&unit={Unit?:daily|monthly|cumulative|&after={Since?:Unix Timestamp}&before={Before?:Unix Timestamp}"
+      "suffix": "/v1.1/insights/{Report Slug}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&unit={Unit?:daily|monthly|cumulative|&after={Since?:Unix Timestamp}&before={Before?:Unix Timestamp}",
+      "description": "One insight report by slug."
     },
     {
       "name": "Default Reader Menu",
       "paged": false,
-      "suffix": "/v1.1/read/menu?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/read/menu?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "The Reader's default menu structure. Interface configuration."
     },
     {
       "name": "Feed",
       "paged": false,
-      "suffix": "/v1.1/read/feed/{Feed URL or ID}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/read/feed/{Feed URL or ID}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "One feed by URL or id, with its recent posts."
     },
     {
       "name": "Followed Blog Posts",
@@ -458,7 +522,8 @@
           "key": "ID",
           "parameterName": "Post ID"
         }
-      ]
+      ],
+      "description": "The posts from sites the caller follows. The Reader feed -- consumption rather than publishing."
     },
     {
       "name": "Liked Blog Posts",
@@ -480,7 +545,8 @@
           "key": "ID",
           "parameterName": "Post ID"
         }
-      ]
+      ],
+      "description": "The posts the caller has liked, as a feed."
     },
     {
       "name": "Tagged Posts",
@@ -502,7 +568,8 @@
           "key": "ID",
           "parameterName": "Post ID"
         }
-      ]
+      ],
+      "description": "Recent posts carrying one tag, across WordPress.com. Requires the tag. Cross-site content discovery, unlike Site Tags which is one site's own taxonomy."
     },
     {
       "name": "Subscribed Tags",
@@ -518,7 +585,8 @@
           "key": "slug",
           "parameterName": "Tag"
         }
-      ]
+      ],
+      "description": "The tags the caller follows in the Reader."
     },
     {
       "name": "Trending Tags",
@@ -534,157 +602,188 @@
           "key": "slug",
           "parameterName": "Tag"
         }
-      ]
+      ],
+      "description": "The tags trending across WordPress.com. A snapshot with no history behind it."
     },
     {
       "name": "Tag",
       "paged": false,
-      "suffix": "/v1.1/read/tags/{Tag}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/read/tags/{Tag}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "One Reader tag by name, with its post count."
     },
     {
       "name": "Tag Subscription Status",
       "paged": false,
-      "suffix": "/v1.1/read/tags/{Tag}/mine?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/read/tags/{Tag}/mine?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "Whether the caller follows one tag."
     },
     {
       "name": "Followed Feeds",
       "paged": false,
-      "suffix": "/v1.1/read/following/mine?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/read/following/mine?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "The feeds the caller follows."
     },
     {
       "name": "Feed Search",
       "paged": true,
-      "suffix": "/v1.1/read/feed?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&url={Site Domain or URL?}&q={Query Text?}&exclude_followed={Exclude Already Followed Sites?:true|false}"
+      "suffix": "/v1.1/read/feed?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&url={Site Domain or URL?}&q={Query Text?}&exclude_followed={Exclude Already Followed Sites?:true|false}",
+      "description": "Feeds matching a query. Discovery within the Reader."
     },
     {
       "name": "Recommended Blogs",
       "paged": false,
-      "suffix": "/v1.1/read/recommendations/mine?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&exclude={Exclude Blog IDs?,:id1,id2,...}&lang={Language Code?}&source={Source?:mobile|reader_sidebar|...}"
+      "suffix": "/v1.1/read/recommendations/mine?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&exclude={Exclude Blog IDs?,:id1,id2,...}&lang={Language Code?}&source={Source?:mobile|reader_sidebar|...}",
+      "description": "Blogs WordPress.com recommends to the caller. Algorithmic suggestion rather than data."
     },
     {
       "name": "Site Statistics",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/stats?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/stats?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "The headline traffic figures for one site over a period -- views, visitors, likes and comments. Requires a site. THE WORDPRESS.COM STATS SYSTEM, which is separate from the content tables and computed independently: a post's view count comes from here rather than from the post record."
     },
     {
       "name": "Site Summary Statistics",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/summary?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&num={Number of Periods?}&period={Period?:day|week|month|year}&date={Most Recent Period Date?:yyyy-MM-dd}&offset={Time Zone Offset?}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/summary?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&num={Number of Periods?}&period={Period?:day|week|month|year}&date={Most Recent Period Date?:yyyy-MM-dd}&offset={Time Zone Offset?}",
+      "description": "The site's aggregate figures for a period -- views, visitors, best-ever day and totals. The overview."
     },
     {
       "name": "Site Top Post Statistics",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/top-posts?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&num={Number of Periods?}&period={Period?:day|week|month|year}&date={Most Recent Day to Include?:yyyy-MM-dd}&max={Maximum Number of Results?}&offset={Time Zone Offset?}&summarize={Summarize Data?:true|false}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/top-posts?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&num={Number of Periods?}&period={Period?:day|week|month|year}&date={Most Recent Day to Include?:yyyy-MM-dd}&max={Maximum Number of Results?}&offset={Time Zone Offset?}&summarize={Summarize Data?:true|false}",
+      "description": "The most-viewed posts over a period, with their view counts. Which content actually earned the traffic."
     },
     {
       "name": "Video Post Statistics",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/video/{Post ID}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/video/{Post ID}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "The play statistics of one video post."
     },
     {
       "name": "Site Referrer Statistics",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/referrers?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&num={Number of Periods?}&period={Period?:day|week|month|year}&date={Most Recent Day to Include?:yyyy-MM-dd}&max={Maximum Number of Results?}&offset={Time Zone Offset?}&summary={Summarize Data?:true|false}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/referrers?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&num={Number of Periods?}&period={Period?:day|week|month|year}&date={Most Recent Day to Include?:yyyy-MM-dd}&max={Maximum Number of Results?}&offset={Time Zone Offset?}&summary={Summarize Data?:true|false}",
+      "description": "Where traffic came from over a period, by referring site. The acquisition table."
     },
     {
       "name": "Site Outbound Click Statistics",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/clicks?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&num={Number of Periods?}&period={Period?:day|week|month|year}&date={Most Recent Day to Include?:yyyy-MM-dd}&max={Maximum Number of Results?}&offset={Time Zone Offset?}&summary={Summarize Data?:true|false}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/clicks?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&num={Number of Periods?}&period={Period?:day|week|month|year}&date={Most Recent Day to Include?:yyyy-MM-dd}&max={Maximum Number of Results?}&offset={Time Zone Offset?}&summary={Summarize Data?:true|false}",
+      "description": "The outbound links visitors clicked, over a period. Where readers went next -- which no view count reveals."
     },
     {
       "name": "Site Views by Tag and Category",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/tags?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&max={Maximum Number of Results?}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/tags?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&max={Maximum Number of Results?}",
+      "description": "Traffic by taxonomy term over a period. Which subjects draw readers, as opposed to which individual posts."
     },
     {
       "name": "Site Top Author Statistics",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/top-authors?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&num={Number of Periods?}&period={Period?:day|week|month|year}&date={Most Recent Day to Include?:yyyy-MM-dd}&max={Maximum Number of Results?}&offset={Time Zone Offset?}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/top-authors?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&num={Number of Periods?}&period={Period?:day|week|month|year}&date={Most Recent Day to Include?:yyyy-MM-dd}&max={Maximum Number of Results?}&offset={Time Zone Offset?}",
+      "description": "Views by author over a period. Per-writer performance on a multi-author site."
     },
     {
       "name": "Site Top Comment Statistics",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/comments?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/comments?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "The most-commented posts and the most active commenters over a period."
     },
     {
       "name": "Site Video Plays Statistics",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/video-plays?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&num={Number of Periods?}&period={Period?:day|week|month|year}&date={Most Recent Day to Include?:yyyy-MM-dd}&max={Maximum Number of Results?}&offset={Time Zone Offset?}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/video-plays?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&num={Number of Periods?}&period={Period?:day|week|month|year}&date={Most Recent Day to Include?:yyyy-MM-dd}&max={Maximum Number of Results?}&offset={Time Zone Offset?}",
+      "description": "Video plays across the site over a period."
     },
     {
       "name": "Site File Download Statistics",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/file-downloads?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&num={Number of Periods?}&period={Period?:day|week|month|year}&date={Most Recent Day to Include?:yyyy-MM-dd}&max={Maximum Number of Results?}&offset={Time Zone Offset?}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/file-downloads?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&num={Number of Periods?}&period={Period?:day|week|month|year}&date={Most Recent Day to Include?:yyyy-MM-dd}&max={Maximum Number of Results?}&offset={Time Zone Offset?}",
+      "description": "Downloads of files hosted on the site, over a period."
     },
     {
       "name": "Post View Statistics",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/post/{Post ID}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/post/{Post ID}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "The view history of ONE post over time. Requires the site and post id. The per-post series, as opposed to a ranking snapshot."
     },
     {
       "name": "Site Views by Country",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/country-views?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&num={Number of Periods?}&period={Period?:day|week|month|year}&date={Most Recent Day to Include?:yyyy-MM-dd}&max={Maximum Number of Results?}&offset={Time Zone Offset?}&summary={Summarize Data?:true|false}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/country-views?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&num={Number of Periods?}&period={Period?:day|week|month|year}&date={Most Recent Day to Include?:yyyy-MM-dd}&max={Maximum Number of Results?}&offset={Time Zone Offset?}&summary={Summarize Data?:true|false}",
+      "description": "Traffic by country over a period."
     },
     {
       "name": "Site Follower Statistics",
       "paged": true,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/followers?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&type={Type?:wpcom|email}&search={Email Address?}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/followers?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&type={Type?:wpcom|email}&search={Email Address?}",
+      "description": "The site's follower count over time, and the recent followers. Audience growth rather than traffic."
     },
     {
       "name": "Site Comment Follower Statistics",
       "paged": true,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/comment-followers?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/comment-followers?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "Followers subscribed to comments rather than to posts."
     },
     {
       "name": "Site Publicize Follower Statistics",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/publicize?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/publicize?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "Follower counts on the connected social accounts. Reach beyond the site itself."
     },
     {
       "name": "Site Search Term Statistics",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/search-terms?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&num={Number of Periods?}&period={Period?:day|week|month|year}&date={Most Recent Day to Include?:yyyy-MM-dd}&max={Maximum Number of Results?}&offset={Time Zone Offset?}&summary={Summarize Data?:true|false}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/search-terms?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&num={Number of Periods?}&period={Period?:day|week|month|year}&date={Most Recent Day to Include?:yyyy-MM-dd}&max={Maximum Number of Results?}&offset={Time Zone Offset?}&summary={Summarize Data?:true|false}",
+      "description": "The search terms that brought visitors, over a period. NOTE most search engines withhold the term, so this table is heavily incomplete by design and its totals do not reconcile with search referral counts."
     },
     {
       "name": "Post Total View Statistics",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/views/posts?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&num={Number of Days?:1-30}&post_ids={Post IDs:id1,id2,...}&date={Most Recent Day to Include?:yyyy-MM-dd}&offset={Time Zone Offset?}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/views/posts?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&num={Number of Days?:1-30}&post_ids={Post IDs:id1,id2,...}&date={Most Recent Day to Include?:yyyy-MM-dd}&offset={Time Zone Offset?}",
+      "description": "Lifetime view totals for the site's posts. The all-time ranking rather than a period one."
     },
     {
       "name": "Calendar Heatmap Statistics",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/streak?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&startDate={Start Date?:yyyy-MM-dd}&endDate={End Date?:yyyy-MM-dd}&max={Maximum Number of Posts to Return?}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/stats/streak?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&startDate={Start Date?:yyyy-MM-dd}&endDate={End Date?:yyyy-MM-dd}&max={Maximum Number of Posts to Return?}",
+      "description": "Posting activity by day, as the data behind a contribution-style heatmap. Publishing cadence rather than readership."
     },
     {
       "name": "Media Item",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/media/{Media ID}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/media/{Media ID}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "One media item by id."
     },
     {
       "name": "Media Items",
       "paged": true,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/media?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&search={Search Query?}&post_ID={Post ID?}&mime_type={MIME Type?}&after={Uploaded After?:yyyy-MM-ddTHH:mm:ss}&before={Uploaded Before?:yyyy-MM-ddTHH:mm:ss}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/media?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&search={Search Query?}&post_ID={Post ID?}&mime_type={MIME Type?}&after={Uploaded After?:yyyy-MM-ddTHH:mm:ss}&before={Uploaded Before?:yyyy-MM-ddTHH:mm:ss}",
+      "description": "The media library of one site, with file name, type, dimensions, size, the post each is attached to and the upload date. Requires a site. Storage questions and unused-asset questions are answered here."
     },
     {
       "name": "Navigation Menu",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/menus/{Menu ID}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/menus/{Menu ID}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "One menu by id."
     },
     {
       "name": "Navigation Menus",
       "paged": false,
-      "suffix": "/v1.1/sites/{Site ID or Domain}/menus?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/sites/{Site ID or Domain}/menus?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "The navigation menus of one site, with their items. The site's own structure as presented to readers."
     },
     {
       "name": "Video Metadata",
       "paged": false,
-      "suffix": "/v1.1/videos/{Video ID}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&birth_month={Birth Month?}&birth_day={Birth Day?}&birth_year={Birth Year?}"
+      "suffix": "/v1.1/videos/{Video ID}?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}&birth_month={Birth Month?}&birth_day={Birth Day?}&birth_year={Birth Year?}",
+      "description": "The metadata of one VideoPress video -- duration, dimensions and processing state. Requires a video id."
     },
     {
       "name": "Video Poster",
       "paged": false,
-      "suffix": "/v1.1/videos/{Video ID}/poster?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}"
+      "suffix": "/v1.1/videos/{Video ID}/poster?context={Context?:display|edit}&meta={Include Metadata?:site,likes,...}&fields={Include Fields?:ID,title,...}",
+      "description": "The poster image of one video."
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/zendesksell/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/zendesksell/endpoints.json
@@ -1,229 +1,274 @@
 {
-    "endpoints": [
-        {
-            "name": "Account",
-            "paged": false,
-            "suffix": "/v2/accounts/self"
-        },
-        {
-            "name": "Associated Contact",
-            "paged": true,
-            "suffix": "/v2/deals/{Deal ID}/associated_contacts"
-        },
-        {
-            "name": "Call Outcomes",
-            "paged": true,
-            "suffix": "/v2/call_outcomes"
-        },
-        {
-            "name": "Calls",
-            "paged": true,
-            "suffix": "/v2/calls?ids={Call IDs?:1,2,3,...}&resource_type={Resource Type?:lead|contact}&resource_id={Resource ID?}&associated_deal_id={Associated Deal ID?}"
-        },
-        {
-            "name": "Call",
-            "paged": false,
-            "suffix": "/v2/calls/{Call ID}"
-        },
-        {
-            "name": "Collaborations",
-            "paged": true,
-            "suffix": "/v2/collaborations?ids={Collaboration IDs?:1,2,3...}&creator_id={Creator ID?}&resource_type={Resource Type?:lead|contact|sales_account|deal}&resource_id={Resource ID?}"
-        },
-        {
-            "name": "Collaboration",
-            "paged": false,
-            "suffix": "/v2/collaborations/{Collaboration ID}"
-        },
-        {
-            "name": "Contacts",
-            "paged": true,
-            "suffix": "/v2/contacts?ids={Contact IDs?:1,2,3,...}&creator_id={Creator ID?}&owner_id={Owner ID?}&is_organization={Is Organization?:true|false}&first_name={Contact First Name?}&last_name={Contact Last Name?}&customer_status={Customer Status?:none|current|past}&prospect_status={Prospect Status?:none|current|lost}"
-        },
-        {
-            "name": "Contact",
-            "paged": false,
-            "suffix": "/v2/contacts/{Contact ID}"
-        },
-        {
-            "name": "Custom Fields",
-            "paged": false,
-            "suffix": "/v2/{Resource Type:lead|contact|deal|prospect_and_customer}/custom_fields"
-        },
-        {
-            "name": "Deal Sources",
-            "paged": true,
-            "suffix": "/v2/deal_sources?ids={Deal Source IDs?:1,2,3...}&name={Name?}"
-        },
-        {
-            "name": "Deal Source",
-            "paged": false,
-            "suffix": "/v2/deal_sources/{Deal Source ID}"
-        },
-        {
-            "name": "Deal Unqualified Reasons",
-            "paged": true,
-            "suffix": "/v2/deal_unqualified_reasons?ids={Reason ID?}&name={Name?}"
-        },
-        {
-            "name": "Deal Unqualified Reason",
-            "paged": false,
-            "suffix": "/v2/deal_unqualified_reasons/{Reason ID}"
-        },
-        {
-            "name": "Deals",
-            "paged": true,
-            "suffix": "/v2/deals?ids={Deal IDs?:1,2,3,...}&creator_id={Creator ID?}&owner_id={Owner ID?}&contact_id={Contact ID?}&organization_id={Organization ID?}&name={Name?}"
-        },
-        {
-            "name": "Deal",
-            "paged": false,
-            "suffix": "/v2/deals/{Deal ID}"
-        },
-        {
-            "name": "Documents",
-            "paged": true,
-            "suffix": "/v2/documents?resource_type={Resource Type:lead|contact|sales_account|deal}&resource_id={Resource ID}&ids={Document IDs?:1,2,3,...}&name={Document Name?}"
-        },
-        {
-            "name": "Document",
-            "paged": false,
-            "suffix": "/v2/documents/{Document ID}"
-        },
-        {
-            "name": "Lead Sources",
-            "paged": true,
-            "suffix": "/v2/lead_sources?ids={Lead Source IDs?:1,2,3,...}&name={Name?}"
-        },
-        {
-            "name": "Lead Source",
-            "paged": false,
-            "suffix": "/v2/lead_sources/{Lead Source ID}"
-        },
-        {
-            "name": "Lead Unqualified Reasons",
-            "paged": true,
-            "suffix": "/v2/lead_unqualified_reasons"
-        },
-        {
-            "name": "Leads",
-            "paged": true,
-            "suffix": "/v2/leads?ids={Lead IDs?:1,2,3,...}&creator_id={Creator ID?}&owner_id={Owner ID?}&source_id={Lead Source ID?}&first_name={First Name?}&last_name={Last Name?}&organization_name={Organization Name?}&status={Status?}&email={Email?}"
-        },
-        {
-            "name": "Lead",
-            "paged": false,
-            "suffix": "/v2/leads/{Lead ID}"
-        },
-        {
-            "name": "Line Items",
-            "paged": true,
-            "suffix": "/v2/orders/{Order ID}/line_items?ids={Line Item IDs?:1,2,3,...}&quantity={Line Item Quantity?}&value={Line Item Value?}"
-        },
-        {
-            "name": "Line Item",
-            "paged": false,
-            "suffix": "/v2/orders/{Order ID}/line_items/{Line Item ID}"
-        },
-        {
-            "name": "Loss Reasons",
-            "paged": true,
-            "suffix": "/v2/loss_reasons?ids={Reason IDs?:1,2,3,...}&name={Name?}"
-        },
-        {
-            "name": "Loss Reason",
-            "paged": false,
-            "suffix": "/v2/loss_reasons/{Reason ID}"
-        },
-        {
-            "name": "Notes",
-            "paged": true,
-            "suffix": "/v2/notes?ids={Note IDs?:1,2,3,...}&creator_id={Creator ID?}&q={Search Text?}&resource_type={Resource Type?:lead|contact|deal}&resource_id={Resource ID?}"
-        },
-        {
-            "name": "Note",
-            "paged": false,
-            "suffix": "/v2/notes/{Note ID}"
-        },
-        {
-            "name": "Orders",
-            "paged": true,
-            "suffix": "/v2/orders?ids={Order IDs?:1,2,3,...}&deal_id={Deal ID?}"
-        },
-        {
-            "name": "Order",
-            "paged": false,
-            "suffix": "/v2/orders/{Order ID}"
-        },
-        {
-            "name": "Pipelines",
-            "paged": true,
-            "suffix": "/v2/pipelines?ids={Pipeline IDs?:1,2,3,...}&name={Name?}&disabled={Return Disabled Pipelines?:true|false}"
-        },
-        {
-            "name": "Products",
-            "paged": true,
-            "suffix": "/v2/products?ids={Product IDs?:1,2,3,...}&name={Name?}&sku={SKU?}&active={Active?:true|false}"
-        },
-        {
-            "name": "Product",
-            "paged": false,
-            "suffix": "/v2/products/{Product ID}"
-        },
-        {
-            "name": "Stages",
-            "paged": true,
-            "suffix": "/v2/stages?ids={Stage IDs?:1,2,3,...}&name={Name?}&active={Active?:true|false}"
-        },
-        {
-            "name": "Tags",
-            "paged": true,
-            "suffix": "/v2/tags?ids={Tag IDs?:1,2,3,...}&creator_id={Creator ID?}&name={Name?}&resource_type={Resource Type?:lead|contact|deal}"
-        },
-        {
-            "name": "Tag",
-            "paged": false,
-            "suffix": "/v2/tags/{Tag ID}"
-        },
-        {
-            "name": "Tasks",
-            "paged": true,
-            "suffix": "/v2/tasks?ids={Task IDs?:1,2,3,...}&creator_id={Creator ID?}&owner_id={Owner ID?}&q={Search Text?}&type={Type?:floating|related}&resource_type={Resource Type?:lead|contact|deal}&completed={Completed?:true|false}&overdue={Overdue?:true|false}"
-        },
-        {
-            "name": "Task",
-            "paged": false,
-            "suffix": "/v2/tasks/{Task ID}"
-        },
-        {
-            "name": "Text Messages",
-            "paged": true,
-            "suffix": "/v2/text_messages?ids={Text Message IDs?:1,2,3,...}&resource_type={Resource Type?:lead|contact}&resource_id={Resource ID?}"
-        },
-        {
-            "name": "Text Message",
-            "paged": false,
-            "suffix": "/v2/text_messages/{Message ID}"
-        },
-        {
-            "name": "Users",
-            "paged": true,
-            "suffix": "/v2/users?ids={User IDs?:1,2,3,...}&name={Name?}&email={Email?}&role={Role?:user|admin}&role_id={Role ID?}&status={Status?:active|inactive}&confirmed={Confirmed?:true|false}"
-        },
-        {
-            "name": "User",
-            "paged": false,
-            "suffix": "/v2/users/{User ID}"
-        },
-        {
-            "name": "Visit Outcomes",
-            "paged": true,
-            "suffix": "/v2/visit_outcomes"
-        },
-        {
-            "name": "Visits",
-            "paged": true,
-            "suffix": "/v2/visits?outcome_id={Outcome ID?}&resource_type={Resource Type?:lead|contact}&resource_id={Resource ID?}&rep_location_verification_status={Location Verification Status?:verified|resource_location_too_far|location_unknown|location_services_disabled}"
-        }
-    ]
+  "endpoints": [
+    {
+      "name": "Account",
+      "paged": false,
+      "suffix": "/v2/accounts/self",
+      "description": "The Sell account itself -- name, subdomain, currency and time zone. One record, and the base currency is what any converted total would be expressed in."
+    },
+    {
+      "name": "Associated Contact",
+      "paged": true,
+      "suffix": "/v2/deals/{Deal ID}/associated_contacts",
+      "description": "The people associated with one deal beyond its primary contact, each with their role. Requires a deal id. A deal names one contact; this is everyone actually involved."
+    },
+    {
+      "name": "Call Outcomes",
+      "paged": true,
+      "suffix": "/v2/call_outcomes",
+      "description": "The outcomes a call can be recorded with -- connected, left voicemail, no answer. The decoder for the outcome id, and the dimension that turns call volume into call effectiveness."
+    },
+    {
+      "name": "Calls",
+      "paged": true,
+      "suffix": "/v2/calls?ids={Call IDs?:1,2,3,...}&resource_type={Resource Type?:lead|contact}&resource_id={Resource ID?}&associated_deal_id={Associated Deal ID?}",
+      "description": "Logged phone calls, with the record they relate to, duration, direction, outcome and summary. Filterable by resource type. The measure of outbound effort."
+    },
+    {
+      "name": "Call",
+      "paged": false,
+      "suffix": "/v2/calls/{Call ID}",
+      "description": "One call by id."
+    },
+    {
+      "name": "Collaborations",
+      "paged": true,
+      "suffix": "/v2/collaborations?ids={Collaboration IDs?:1,2,3...}&creator_id={Creator ID?}&resource_type={Resource Type?:lead|contact|sales_account|deal}&resource_id={Resource ID?}",
+      "description": "Records shared with users other than the owner, with the permission granted. Every record has one owner, so this is where additional access is recorded -- and the reason two users see different row counts."
+    },
+    {
+      "name": "Collaboration",
+      "paged": false,
+      "suffix": "/v2/collaborations/{Collaboration ID}",
+      "description": "One collaboration by id."
+    },
+    {
+      "name": "Contacts",
+      "paged": true,
+      "suffix": "/v2/contacts?ids={Contact IDs?:1,2,3,...}&creator_id={Creator ID?}&owner_id={Owner ID?}&is_organization={Is Organization?:true|false}&first_name={Contact First Name?}&last_name={Contact Last Name?}&customer_status={Customer Status?:none|current|past}&prospect_status={Prospect Status?:none|current|lost}",
+      "description": "People and companies -- BOTH LIVE IN THIS ONE TABLE, told apart by the is_organization flag, with a person carrying a contact_id pointing at their employer. Carries name, contact details, address, owner, tags and custom fields. Any per-company analysis has to filter on that flag first, or it mixes individuals with the firms they work for."
+    },
+    {
+      "name": "Contact",
+      "paged": false,
+      "suffix": "/v2/contacts/{Contact ID}",
+      "description": "One contact by id."
+    },
+    {
+      "name": "Custom Fields",
+      "paged": false,
+      "suffix": "/v2/{Resource Type:lead|contact|deal|prospect_and_customer}/custom_fields",
+      "description": "The custom fields defined for one resource type -- lead, contact, deal, or prospect and customer. Requires the resource type. THE DECODER for the custom_fields object on every record, which is keyed by field name and otherwise uninterpretable. Note fields are defined PER RESOURCE TYPE, so the same business attribute on leads and deals is two separate definitions."
+    },
+    {
+      "name": "Deal Sources",
+      "paged": true,
+      "suffix": "/v2/deal_sources?ids={Deal Source IDs?:1,2,3...}&name={Name?}",
+      "description": "The deal source values configured. The attribution dimension for won revenue, distinct from lead sources."
+    },
+    {
+      "name": "Deal Source",
+      "paged": false,
+      "suffix": "/v2/deal_sources/{Deal Source ID}",
+      "description": "One deal source by id."
+    },
+    {
+      "name": "Deal Unqualified Reasons",
+      "paged": true,
+      "suffix": "/v2/deal_unqualified_reasons?ids={Reason ID?}&name={Name?}",
+      "description": "The reasons a deal can be marked unqualified, as distinct from lost. Unqualified means it should never have been a deal; lost means it was winnable and was not won -- conflating them distorts a win rate."
+    },
+    {
+      "name": "Deal Unqualified Reason",
+      "paged": false,
+      "suffix": "/v2/deal_unqualified_reasons/{Reason ID}",
+      "description": "One deal unqualified reason by id."
+    },
+    {
+      "name": "Deals",
+      "paged": true,
+      "suffix": "/v2/deals?ids={Deal IDs?:1,2,3,...}&creator_id={Creator ID?}&owner_id={Owner ID?}&contact_id={Contact ID?}&organization_id={Organization ID?}&name={Name?}",
+      "description": "The revenue opportunities, with name, value and currency, the stage, the contact and organisation, the owner, source, loss reason where lost, tags, custom fields, and the estimated close date. The pipeline table. VALUE IS IN THE DEAL'S OWN CURRENCY, so totals across currencies need conversion Sell does not perform here."
+    },
+    {
+      "name": "Deal",
+      "paged": false,
+      "suffix": "/v2/deals/{Deal ID}",
+      "description": "One deal by id."
+    },
+    {
+      "name": "Documents",
+      "paged": true,
+      "suffix": "/v2/documents?resource_type={Resource Type:lead|contact|sales_account|deal}&resource_id={Resource ID}&ids={Document IDs?:1,2,3,...}&name={Document Name?}",
+      "description": "Files attached to leads, contacts, deals or accounts. Requires a resource type. Metadata rather than content."
+    },
+    {
+      "name": "Document",
+      "paged": false,
+      "suffix": "/v2/documents/{Document ID}",
+      "description": "One document by id."
+    },
+    {
+      "name": "Lead Sources",
+      "paged": true,
+      "suffix": "/v2/lead_sources?ids={Lead Source IDs?:1,2,3,...}&name={Name?}",
+      "description": "The lead source values configured -- the attribution dimension for where prospects came from. Account-specific, and the decoder for the source id on a lead."
+    },
+    {
+      "name": "Lead Source",
+      "paged": false,
+      "suffix": "/v2/lead_sources/{Lead Source ID}",
+      "description": "One lead source by id."
+    },
+    {
+      "name": "Lead Unqualified Reasons",
+      "paged": true,
+      "suffix": "/v2/lead_unqualified_reasons",
+      "description": "The reasons a lead can be marked unqualified. The structured explanation for prospects that went nowhere, which the lead's status alone does not give."
+    },
+    {
+      "name": "Leads",
+      "paged": true,
+      "suffix": "/v2/leads?ids={Lead IDs?:1,2,3,...}&creator_id={Creator ID?}&owner_id={Owner ID?}&source_id={Lead Source ID?}&first_name={First Name?}&last_name={Last Name?}&organization_name={Organization Name?}&status={Status?}&email={Email?}",
+      "description": "Unqualified prospects, with name, company, title, contact details, status, source, owner, tags and custom fields. Filterable by owner, creator and many other attributes. NOTE THE LIFECYCLE: a lead in Sell is CONVERTED into a contact and usually a deal, and the lead record remains afterwards -- so leads and contacts hold different stages of the same people, and counting both double-counts anyone converted."
+    },
+    {
+      "name": "Lead",
+      "paged": false,
+      "suffix": "/v2/leads/{Lead ID}",
+      "description": "One lead by id."
+    },
+    {
+      "name": "Line Items",
+      "paged": true,
+      "suffix": "/v2/orders/{Order ID}/line_items?ids={Line Item IDs?:1,2,3,...}&quantity={Line Item Quantity?}&value={Line Item Value?}",
+      "description": "The products on one order, with quantity, price, discount and the resulting value. Requires an order id. What was actually sold; the deal carries only a total."
+    },
+    {
+      "name": "Line Item",
+      "paged": false,
+      "suffix": "/v2/orders/{Order ID}/line_items/{Line Item ID}",
+      "description": "One line item by id. Requires the order id."
+    },
+    {
+      "name": "Loss Reasons",
+      "paged": true,
+      "suffix": "/v2/loss_reasons?ids={Reason IDs?:1,2,3,...}&name={Name?}",
+      "description": "The reasons configured for losing a deal. Usually the only structured explanation of why revenue was not won."
+    },
+    {
+      "name": "Loss Reason",
+      "paged": false,
+      "suffix": "/v2/loss_reasons/{Reason ID}",
+      "description": "One loss reason by id."
+    },
+    {
+      "name": "Notes",
+      "paged": true,
+      "suffix": "/v2/notes?ids={Note IDs?:1,2,3,...}&creator_id={Creator ID?}&q={Search Text?}&resource_type={Resource Type?:lead|contact|deal}&resource_id={Resource ID?}",
+      "description": "Free-text notes attached to leads, contacts and deals. The qualitative record; why a deal was lost is usually written here rather than captured in the loss reason."
+    },
+    {
+      "name": "Note",
+      "paged": false,
+      "suffix": "/v2/notes/{Note ID}",
+      "description": "One note by id."
+    },
+    {
+      "name": "Orders",
+      "paged": true,
+      "suffix": "/v2/orders?ids={Order IDs?:1,2,3,...}&deal_id={Deal ID?}",
+      "description": "The orders placed against deals, linking a deal to the products sold. The bridge between a deal's headline value and what it actually consists of."
+    },
+    {
+      "name": "Order",
+      "paged": false,
+      "suffix": "/v2/orders/{Order ID}",
+      "description": "One order by id."
+    },
+    {
+      "name": "Pipelines",
+      "paged": true,
+      "suffix": "/v2/pipelines?ids={Pipeline IDs?:1,2,3,...}&name={Name?}&disabled={Return Disabled Pipelines?:true|false}",
+      "description": "The sales pipelines defined. Most accounts run more than one and stages are not comparable between them, so a funnel question has to name the pipeline."
+    },
+    {
+      "name": "Products",
+      "paged": true,
+      "suffix": "/v2/products?ids={Product IDs?:1,2,3,...}&name={Name?}&sku={SKU?}&active={Active?:true|false}",
+      "description": "The product catalogue, with name, SKU, description, active flag and prices per currency. Prices are an array by currency rather than a single value."
+    },
+    {
+      "name": "Product",
+      "paged": false,
+      "suffix": "/v2/products/{Product ID}",
+      "description": "One product by id."
+    },
+    {
+      "name": "Stages",
+      "paged": true,
+      "suffix": "/v2/stages?ids={Stage IDs?:1,2,3,...}&name={Name?}&active={Active?:true|false}",
+      "description": "The pipeline stages, each with its name, position, category and the pipeline it belongs to. The dimension a funnel breakdown groups by, and stage categories are what make stages comparable across pipelines."
+    },
+    {
+      "name": "Tags",
+      "paged": true,
+      "suffix": "/v2/tags?ids={Tag IDs?:1,2,3,...}&creator_id={Creator ID?}&name={Name?}&resource_type={Resource Type?:lead|contact|deal}",
+      "description": "The tags in use across records, with the resource type each applies to. The free-form dimension beyond source and stage."
+    },
+    {
+      "name": "Tag",
+      "paged": false,
+      "suffix": "/v2/tags/{Tag ID}",
+      "description": "One tag by id."
+    },
+    {
+      "name": "Tasks",
+      "paged": true,
+      "suffix": "/v2/tasks?ids={Task IDs?:1,2,3,...}&creator_id={Creator ID?}&owner_id={Owner ID?}&q={Search Text?}&type={Type?:floating|related}&resource_type={Resource Type?:lead|contact|deal}&completed={Completed?:true|false}&overdue={Overdue?:true|false}",
+      "description": "The to-dos recorded against leads, contacts and deals, with due date, completion state, owner and the record each relates to. The forward-looking work, as opposed to activities already logged."
+    },
+    {
+      "name": "Task",
+      "paged": false,
+      "suffix": "/v2/tasks/{Task ID}",
+      "description": "One task by id."
+    },
+    {
+      "name": "Text Messages",
+      "paged": true,
+      "suffix": "/v2/text_messages?ids={Text Message IDs?:1,2,3,...}&resource_type={Resource Type?:lead|contact}&resource_id={Resource ID?}",
+      "description": "SMS exchanged with contacts, with direction, content and the record it relates to. Another channel alongside calls and emails."
+    },
+    {
+      "name": "Text Message",
+      "paged": false,
+      "suffix": "/v2/text_messages/{Message ID}",
+      "description": "One text message by id."
+    },
+    {
+      "name": "Users",
+      "paged": true,
+      "suffix": "/v2/users?ids={User IDs?:1,2,3,...}&name={Name?}&email={Email?}&role={Role?:user|admin}&role_id={Role ID?}&status={Status?:active|inactive}&confirmed={Confirmed?:true|false}",
+      "description": "The users in the account, with name, email, role, status and confirmation state. Every record carries an owner, so this is the dimension per-person performance joins to."
+    },
+    {
+      "name": "User",
+      "paged": false,
+      "suffix": "/v2/users/{User ID}",
+      "description": "One user by id."
+    },
+    {
+      "name": "Visit Outcomes",
+      "paged": true,
+      "suffix": "/v2/visit_outcomes",
+      "description": "The outcomes a visit can be recorded with. The decoder for the visit outcome id."
+    },
+    {
+      "name": "Visits",
+      "paged": true,
+      "suffix": "/v2/visits?outcome_id={Outcome ID?}&resource_type={Resource Type?:lead|contact}&resource_id={Resource ID?}&rep_location_verification_status={Location Verification Status?:verified|resource_location_too_far|location_unknown|location_services_disabled}",
+      "description": "Logged in-person visits, with the outcome, the record visited and location. Field-sales activity, which no call or email table captures."
+    }
+  ]
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/zohocrm/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/zohocrm/endpoints.json
@@ -157,7 +157,7 @@
     {
       "name": "Variable Group",
       "paged": false,
-      "suffix": "/crm/v2/settings/Variable Groups/{Variable Group ID}",
+      "suffix": "/crm/v2/settings/variable_groups/{Variable Group ID}",
       "description": "One variable group by id."
     },
     {

--- a/connectors/inetsoft-rest/src/test/java/inetsoft/uql/rest/datasource/pipedrive/PipedrivePaginationTest.java
+++ b/connectors/inetsoft-rest/src/test/java/inetsoft/uql/rest/datasource/pipedrive/PipedrivePaginationTest.java
@@ -1,0 +1,145 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.rest.datasource.pipedrive;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.uql.rest.json.EndpointJsonQuery.Endpoints;
+import inetsoft.uql.rest.pagination.PaginationParamType;
+import inetsoft.uql.rest.pagination.PaginationSpec;
+import inetsoft.uql.rest.pagination.PaginationType;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * This connector spans two Pipedrive APIs, and they page incompatibly.
+ *
+ * <p>v1 pages by a {@code start} offset it reads back from
+ * {@code additional_data.pagination.next_start}. v2 pages by an opaque {@code cursor} read from
+ * {@code additional_data.next_cursor} and carries no offset and no total at all. Driving either
+ * with the other's spec fails SILENTLY -- the first page returns and iteration stops, or the
+ * cursor is never sent -- so the branch is worth pinning rather than trusting.</p>
+ */
+class PipedrivePaginationTest {
+   @Test
+   void versionTwoEndpointsPageByCursor() {
+      PaginationSpec spec = paginationFor("Deals");
+
+      assertEquals(PaginationType.ITERATION, spec.getType());
+      assertEquals("$.additional_data.next_cursor", spec.getHasNextParam().getValue());
+      assertEquals(PaginationParamType.JSON_PATH, spec.getHasNextParam().getType());
+      assertEquals("$.additional_data.next_cursor", spec.getPageOffsetParamToRead().getValue());
+      assertEquals("cursor", spec.getPageOffsetParamToWrite().getValue());
+      assertEquals(PaginationParamType.QUERY, spec.getPageOffsetParamToWrite().getType());
+   }
+
+   @Test
+   void versionOneEndpointsStillPageByOffset() {
+      // The regression this guards: migrating some endpoints to v2 must not change how the
+      // eighty that stayed on v1 page.
+      PaginationSpec spec = paginationFor("Notes");
+
+      assertEquals(PaginationType.ITERATION, spec.getType());
+      assertEquals("$.additional_data.pagination.more_items_in_collection",
+                   spec.getHasNextParam().getValue());
+      assertEquals("$.additional_data.pagination.next_start",
+                   spec.getPageOffsetParamToRead().getValue());
+      assertEquals("start", spec.getPageOffsetParamToWrite().getValue());
+   }
+
+   @Test
+   void unpagedEndpointsPageNotAtAll() {
+      assertEquals(PaginationType.NONE, paginationFor("Deal").getType());
+   }
+
+   /**
+    * The branch keys on the suffix, so an endpoint reachable at a v2 path and paged the v1 way --
+    * or the reverse -- is the failure mode. Both directions are checked across every endpoint
+    * rather than on a sample.
+    */
+   @Test
+   void everyEndpointPagesTheWayItsPathDemands() {
+      Map<String, PipedriveEndpoint> endpoints = load();
+      assertFalse(endpoints.isEmpty(), "no Pipedrive endpoints loaded");
+      List<String> wrong = new ArrayList<>();
+
+      endpoints.forEach((name, endpoint) -> {
+         if(!endpoint.isPaged()) {
+            return;
+         }
+
+         PipedriveQuery query = new PipedriveQuery();
+         query.updatePagination(endpoint);
+         String cursor = query.getPaginationSpec().getPageOffsetParamToWrite().getValue();
+         boolean v2Path = endpoint.getSuffix().startsWith(PipedriveQuery.VERSION_2_PREFIX);
+         String expected = v2Path ? "cursor" : "start";
+
+         if(!expected.equals(cursor)) {
+            wrong.add(name + " (" + endpoint.getSuffix().split("\\?")[0] + ") pages by " + cursor);
+         }
+      });
+
+      assertTrue(wrong.isEmpty(),
+                 wrong.size() + " endpoint(s) page the wrong way for their path:\n  "
+                    + String.join("\n  ", wrong));
+   }
+
+   /** Nothing should be left half-migrated: every suffix belongs to one API or the other. */
+   @Test
+   void everyEndpointTargetsOneOfTheTwoApis() {
+      List<String> stray = load().values().stream()
+         .map(PipedriveEndpoint::getSuffix)
+         .filter(s -> !s.startsWith(PipedriveQuery.VERSION_2_PREFIX) && !s.startsWith("/v1/"))
+         .toList();
+
+      assertTrue(stray.isEmpty(), "suffixes on neither v1 nor v2: " + stray);
+   }
+
+   private static PaginationSpec paginationFor(String name) {
+      PipedriveEndpoint endpoint = load().get(name);
+      assertNotNull(endpoint, "endpoint not found: " + name);
+      PipedriveQuery query = new PipedriveQuery();
+      query.updatePagination(endpoint);
+      return query.getPaginationSpec();
+   }
+
+   /**
+    * Parses the resource with the loader's own mapper rather than calling {@code Endpoints.load},
+    * which reads SreeEnv and so needs a Spring context this test has no reason to stand up.
+    */
+   private static Map<String, PipedriveEndpoint> load() {
+      try(InputStream input = PipedriveQuery.class.getResourceAsStream("endpoints.json")) {
+         assertNotNull(input, "pipedrive/endpoints.json not on the classpath");
+         ObjectMapper mapper = Endpoints.createObjectMapper();
+         PipedriveEndpoints parsed = mapper.readValue(input, PipedriveEndpoints.class);
+         Map<String, PipedriveEndpoint> byName = new LinkedHashMap<>();
+
+         for(PipedriveEndpoint endpoint : parsed.getEndpoints()) {
+            byName.put(endpoint.getName(), endpoint);
+         }
+
+         return byName;
+      }
+      catch(Exception e) {
+         throw new AssertionError("could not read pipedrive/endpoints.json", e);
+      }
+   }
+}


### PR DESCRIPTION
The final batch: 21 connectors, **1,731 endpoints**. Stacked on #4628.

**All 65 REST connectors are now fully described: 4,035 of 4,035 endpoints.**

zendesksell, chargebee, liveagent, servicenow, campaignmonitor, freshdesk, keap,
intervals, smartsheet, surveymonkey, chargify, gosquared, pipelinecrm, influxdb,
fusebill, activecampaign, wordpress, linkedin, insightly, hubspot, jive.

## Nine more broken paths

Three came from scans that had not been run before, each of which turned out to
have exactly one or two hits across all 65 connectors:

**Literal newlines** — 15 PipelineCRM suffixes had line wrapping saved into the
query string. A newline is illegal in a URI and `URLCreator` hands the assembled
string to `URIBuilder`, whose constructor calls `new URI()`, so every one threw
`URISyntaxException` before a request was made. Only connector affected.

**Non-breaking space in an endpoint NAME** — HubSpot's `Contacts Informations`
carried U+00A0 where a space belongs. Invisible, the only non-ASCII character in
any endpoint name across all 65, and it means the endpoint cannot be matched by
anything that types its name normally — which is what this whole body of work
exists to enable. I hit it myself: my description keyed on the name I could see
failed to apply.

**Stray whitespace in a path** — Jive's `/api/core/v3 /dms/...` (percent-encoded
to `%20`, guaranteed 404) and Zoho's `Variable Groups` as a literal segment.

The rest were single-character or duplicate-path defects: Freshservice's
`assets_types`, a `/` where `?` belongs and a missing `category_id` filter;
Campaign Monitor's `Subscriber lists` pointing at `campaigns.json`; Smartsheet's
`/summ` truncation; SurveyMonkey's `Workgroup Share` with no share id; Insightly's
`/v3.0//Contacts`; HubSpot's `change-log/line_items}`.

### On the whitespace scan

Its first version reported 44 hits and was **wrong**. It cut the query string off
before stripping `{placeholders}`, so every optional path parameter like
`{Bucket ID?}` was split mid-token and its space counted. Stripping placeholders
first leaves exactly two. Worth recording because the false-positive rate looked
like a finding.

## Shapes worth stating once

Several of these APIs are not endpoint catalogues at all, and saying so at the
top of the relevant endpoint is worth more than describing each in isolation:

- **ServiceNow's `Table Records` is the whole platform** — incident,
  change_request, cmdb_ci, any custom table. Everything else here is a
  convenience wrapper. And `sysparm_display_value` decides whether the result is
  readable at all: by default reference fields come back as 32-character sys_ids,
  so `assigned_to` is an opaque string and `state` a bare number.
- **Jive is polymorphic twice over** — documents, discussions, blogs, polls,
  ideas, files and videos are all "content" in one table behind a `type` field;
  spaces, groups and projects are all "places" the same way.
- **InfluxDB has no table to list** — a Flux query defines what comes back, and
  results arrive as *annotated CSV*, not JSON.
- **HubSpot keeps CRM fields in a `properties` object** keyed by internal name,
  with generated names for custom fields, and returns only a small default set —
  so most custom fields are absent unless named, and their absence looks like
  empty data.
- **ActiveCampaign splits custom fields into two tables everywhere** —
  definitions and values, joined by field id. Neither is readable alone.
- **The WordPress connector is the WordPress.com API**, not a self-hosted
  install's REST API. A plain self-hosted WordPress is not reachable through it.

## Values that need a second table, or none exists

Freshdesk and Freshservice both fix their ticket columns as numeric codes and
publish **no decoder endpoint**, so the mappings are written into the
descriptions (status 2 Open, 3 Pending, 4 Resolved, 5 Closed; priority 1–4).
Chargify and Chargebee both hide the involuntary-churn pipeline in a status value
that reads as active — `past_due`, `soft_failure`, `non_renewing` — and put
failed payments only in the transactions table.

## Endpoints that explain why other data looks wrong

GoSquared's blocked-items list changes every number in its trends tables and
appears in none of them. InfluxDB's task runs are where a silently failing task
shows up, since the gaps it leaves look like an absence of activity. Jive's
`deletedObjects` endpoints are the only way a synchronised copy learns content has
gone. Freshdesk's ticket listing defaults to the last 30 days.

## Tests

`EndpointsJsonLoadableTest` passes after every commit — it now stands behind all
65 files. The pre-existing `EndpointJsonQueryTest` Spring failure and the `-am`
build requirement are unchanged from #4623.

## Still outstanding

The **Pipedrive v2 migration** flagged in #4623: 21 of its 108 endpoints are the
core of the CRM and Pipedrive has moved them to `/api/v2`. That changes the base
path, the pagination model and several response shapes, and could not be
validated here without a live account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
