### PR TITLE
D1+D2: highlight fall-forward fix + node channels for relation charts

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/binding/AestheticChannels.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/AestheticChannels.java
@@ -28,18 +28,27 @@ import java.util.List;
  * {@code texture} have frames but no field binding, so a caller asking to bind a field to
  * {@code line} gets told why instead of a shrug.
  *
- * <p>Node channels belong to relation charts and arrive with spec 2c Phase 3.
+ * <p>Node channels belong to relation charts (spec 2c Phase 3): {@code node-color} and
+ * {@code node-size} each take both a field binding and a frame, exactly like {@code color}/
+ * {@code size} — the model reuses the same {@code ColorFrameModel}/{@code SizeFrameModel} types,
+ * just on a second pair of properties ({@code nodeColorField}/{@code nodeSizeField}). They are
+ * kept out of {@link #FIELD_CHANNELS}/{@link #FRAME_CHANNELS} rather than merged in: the fields
+ * exist on {@code ChartBindingModel} for every chart type, but only render on a relation chart,
+ * so a caller working a bar or line chart must never be told they apply.
  */
 public final class AestheticChannels {
-   /** Channels that accept a field binding. */
+   /** Channels that accept a field binding, on every chart type. */
    public static final List<String> FIELD_CHANNELS = List.of("color", "shape", "size", "text");
 
-   /** Channels that accept a visual frame. */
+   /** Channels that accept a visual frame, on every chart type. */
    public static final List<String> FRAME_CHANNELS =
       List.of("color", "shape", "size", "line", "texture");
 
    /** Frame channels that can be written. Every frame channel is supported since 2c Phase 2. */
    public static final List<String> SUPPORTED_FRAME_CHANNELS = FRAME_CHANNELS;
+
+   /** Field+frame channels valid only when the target chart is a relation type. */
+   public static final List<String> NODE_CHANNELS = List.of("node-color", "node-size");
 
    private AestheticChannels() {
    }
@@ -49,7 +58,26 @@ public final class AestheticChannels {
    }
 
    public static String requireFieldChannel(String channel) {
+      return requireFieldChannel(channel, false);
+   }
+
+   /**
+    * @param relationChart whether the target chart is a relation type (network, tree, chord).
+    *                      Gates {@link #NODE_CHANNELS} — accepting one elsewhere would store a
+    *                      binding that this chart type never renders.
+    */
+   public static String requireFieldChannel(String channel, boolean relationChart) {
       String name = normalize(channel);
+
+      if(NODE_CHANNELS.contains(name)) {
+         if(relationChart) {
+            return name;
+         }
+
+         throw new IllegalArgumentException(
+            "Channel '" + channel + "' only applies to relation charts (network, tree, chord) " +
+            "— this chart is not one. Field channels: " + String.join(", ", FIELD_CHANNELS) + ".");
+      }
 
       if(FIELD_CHANNELS.contains(name)) {
          return name;
@@ -67,7 +95,22 @@ public final class AestheticChannels {
    }
 
    public static String requireFrameChannel(String channel) {
+      return requireFrameChannel(channel, false);
+   }
+
+   /** @param relationChart see {@link #requireFieldChannel(String, boolean)}. */
+   public static String requireFrameChannel(String channel, boolean relationChart) {
       String name = normalize(channel);
+
+      if(NODE_CHANNELS.contains(name)) {
+         if(relationChart) {
+            return name;
+         }
+
+         throw new IllegalArgumentException(
+            "Channel '" + channel + "' only applies to relation charts (network, tree, chord) " +
+            "— this chart is not one. Frame channels: " + String.join(", ", FRAME_CHANNELS) + ".");
+      }
 
       if(SUPPORTED_FRAME_CHANNELS.contains(name)) {
          return name;

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticAgentService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticAgentService.java
@@ -21,6 +21,8 @@ import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.viewsheet.ChartVSAssembly;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.graph.GraphTypes;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
 import inetsoft.web.binding.controller.ChangeChartAestheticService;
 import inetsoft.web.binding.event.ChangeChartRefEvent;
 import inetsoft.web.binding.model.ChartBindingModel;
@@ -62,29 +64,33 @@ public class ChartAestheticAgentService {
                         FieldRef field, String linkUri) throws Exception
    {
       // Validated before the runtime is touched, so a bad channel costs nothing and does not
-      // open a checkpoint the caller then has to undo.
-      String name = AestheticChannels.requireFieldChannel(channel);
+      // open a checkpoint the caller then has to undo. This still needs the chart itself — node
+      // channels are only valid on a relation chart — so it costs a resolve, not a mutate.
+      boolean relationChart = isRelationChart(sessionToken, user, assemblyName);
+      String name = AestheticChannels.requireFieldChannel(channel, relationChart);
 
       apply(sessionToken, user, assemblyName, name, linkUri,
-            model -> ChartAestheticMutator.setField(model, name, field));
+            model -> ChartAestheticMutator.setField(model, name, field, relationChart));
    }
 
    public void clearField(String sessionToken, Principal user, String assemblyName,
                           String channel, String linkUri) throws Exception
    {
-      String name = AestheticChannels.requireFieldChannel(channel);
+      boolean relationChart = isRelationChart(sessionToken, user, assemblyName);
+      String name = AestheticChannels.requireFieldChannel(channel, relationChart);
 
       apply(sessionToken, user, assemblyName, name, linkUri,
-            model -> ChartAestheticMutator.clearField(model, name));
+            model -> ChartAestheticMutator.clearField(model, name, relationChart));
    }
 
    public void setFrame(String sessionToken, Principal user, String assemblyName, String channel,
                         Map<String, Object> frame, String linkUri) throws Exception
    {
-      String name = AestheticChannels.requireFrameChannel(channel);
+      boolean relationChart = isRelationChart(sessionToken, user, assemblyName);
+      String name = AestheticChannels.requireFrameChannel(channel, relationChart);
 
       apply(sessionToken, user, assemblyName, name, linkUri,
-            model -> ChartAestheticMutator.setFrame(model, name, frame));
+            model -> ChartAestheticMutator.setFrame(model, name, frame, relationChart));
    }
 
    /** Reads the channels without opening a checkpoint. */
@@ -93,16 +99,44 @@ public class ChartAestheticAgentService {
    {
       RuntimeViewsheet rvs = sessions.resolve(sessionToken, user);
       ChartVSAssembly chart = requireChart(rvs, assemblyName);
-      return ChartAestheticMutator.describe((ChartBindingModel) binding.createModel(chart));
+      return ChartAestheticMutator.describe((ChartBindingModel) binding.createModel(chart),
+                                            isRelationChart(chart));
    }
 
-   /** The channels and frame types available, so an agent can discover rather than guess. */
+   /**
+    * The channels and frame types available, so an agent can discover rather than guess.
+    *
+    * <p>{@link AestheticChannels#NODE_CHANNELS} are deliberately not in {@code fieldChannels}/
+    * {@code frameChannels} here: this endpoint has no assembly, so no chart to check the type
+    * of, and listing them unconditionally would advertise a channel most charts cannot render.
+    * {@code get_chart_aesthetics} reports them per-chart, once there is one to check.
+    */
    public Map<String, Object> options() {
       return Map.of(
          "fieldChannels", AestheticChannels.FIELD_CHANNELS,
          "frameChannels", AestheticChannels.SUPPORTED_FRAME_CHANNELS,
          "frameTypes", List.of("static", "categorical", "gradient", "palette"),
-         "palettes", List.copyOf(VisualFrameAliases.PALETTES.keySet()));
+         "palettes", List.copyOf(VisualFrameAliases.PALETTES.keySet()),
+         "nodeChannels", AestheticChannels.NODE_CHANNELS,
+         "nodeChannelsNote", "node-color and node-size apply only to relation charts " +
+            "(network, tree, chord) — call get_chart_aesthetics on the chart to see whether " +
+            "they apply here.");
+   }
+
+   private boolean isRelationChart(String sessionToken, Principal user, String assemblyName)
+      throws Exception
+   {
+      RuntimeViewsheet rvs = sessions.resolve(sessionToken, user);
+      return isRelationChart(requireChart(rvs, assemblyName));
+   }
+
+   /**
+    * A bare mock in a test that never stubs {@code getVSChartInfo()} returns null for it, same
+    * as a chart assembly with no binding yet — neither is a relation chart.
+    */
+   private static boolean isRelationChart(ChartVSAssembly chart) {
+      VSChartInfo info = chart.getVSChartInfo();
+      return info != null && GraphTypes.isRelation(info.getChartType());
    }
 
    private void apply(String sessionToken, Principal user, String assemblyName, String channel,

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticMutator.java
@@ -42,7 +42,14 @@ public final class ChartAestheticMutator {
 
    /** Binds a field to a channel. Replaces whatever that channel held; leaves the rest alone. */
    public static void setField(ChartBindingModel model, String channel, FieldRef field) {
-      String name = AestheticChannels.requireFieldChannel(channel);
+      setField(model, channel, field, false);
+   }
+
+   /** @param relationChart see {@link AestheticChannels#requireFieldChannel(String, boolean)}. */
+   public static void setField(ChartBindingModel model, String channel, FieldRef field,
+                               boolean relationChart)
+   {
+      String name = AestheticChannels.requireFieldChannel(channel, relationChart);
 
       if(field == null) {
          throw new IllegalArgumentException(
@@ -59,15 +66,27 @@ public final class ChartAestheticMutator {
 
    /** Unbinds a channel. */
    public static void clearField(ChartBindingModel model, String channel) {
-      assign(model, AestheticChannels.requireFieldChannel(channel), null);
+      clearField(model, channel, false);
+   }
+
+   /** @param relationChart see {@link AestheticChannels#requireFieldChannel(String, boolean)}. */
+   public static void clearField(ChartBindingModel model, String channel, boolean relationChart) {
+      assign(model, AestheticChannels.requireFieldChannel(channel, relationChart), null);
    }
 
    /** Sets a channel's visual frame from the agent vocabulary. */
    public static void setFrame(ChartBindingModel model, String channel,
                                Map<String, Object> spec)
    {
-      String name = AestheticChannels.requireFrameChannel(channel);
-      VisualFrameModel frame = VisualFrameAliases.create(name, spec);
+      setFrame(model, channel, spec, false);
+   }
+
+   /** @param relationChart see {@link AestheticChannels#requireFieldChannel(String, boolean)}. */
+   public static void setFrame(ChartBindingModel model, String channel,
+                               Map<String, Object> spec, boolean relationChart)
+   {
+      String name = AestheticChannels.requireFrameChannel(channel, relationChart);
+      VisualFrameModel frame = VisualFrameAliases.create(name, spec, relationChart);
 
       switch(name) {
          case "color" -> model.setColorFrame((ColorFrameModel) frame);
@@ -75,6 +94,8 @@ public final class ChartAestheticMutator {
          case "size" -> model.setSizeFrame((SizeFrameModel) frame);
          case "line" -> model.setLineFrame((LineFrameModel) frame);
          case "texture" -> model.setTextureFrame((TextureFrameModel) frame);
+         case "node-color" -> model.setNodeColorFrame((ColorFrameModel) frame);
+         case "node-size" -> model.setNodeSizeFrame((SizeFrameModel) frame);
          default -> throw new IllegalArgumentException("Unhandled frame channel '" + name + "'.");
       }
    }
@@ -85,6 +106,15 @@ public final class ChartAestheticMutator {
     * only what someone already set.
     */
    public static Map<String, Object> describe(ChartBindingModel model) {
+      return describe(model, false);
+   }
+
+   /**
+    * @param relationChart whether to also report {@link AestheticChannels#NODE_CHANNELS}. Left
+    *                      out for every other chart type, so the response never advertises a
+    *                      channel this chart cannot render.
+    */
+   public static Map<String, Object> describe(ChartBindingModel model, boolean relationChart) {
       Map<String, Object> out = new LinkedHashMap<>();
 
       for(String channel : AestheticChannels.FIELD_CHANNELS) {
@@ -95,18 +125,33 @@ public final class ChartAestheticMutator {
          out.computeIfAbsent(channel, name -> channelView(model, name));
       }
 
+      if(relationChart) {
+         for(String channel : AestheticChannels.NODE_CHANNELS) {
+            out.put(channel, channelView(model, channel));
+         }
+      }
+
       return out;
+   }
+
+   private static boolean acceptsField(String channel) {
+      return AestheticChannels.FIELD_CHANNELS.contains(channel) ||
+         AestheticChannels.NODE_CHANNELS.contains(channel);
+   }
+
+   private static boolean acceptsFrame(String channel) {
+      return AestheticChannels.FRAME_CHANNELS.contains(channel) ||
+         AestheticChannels.NODE_CHANNELS.contains(channel);
    }
 
    private static Map<String, Object> channelView(ChartBindingModel model, String channel) {
       Map<String, Object> view = new LinkedHashMap<>();
-      AestheticInfo info = AestheticChannels.FIELD_CHANNELS.contains(channel)
-         ? read(model, channel) : null;
+      AestheticInfo info = acceptsField(channel) ? read(model, channel) : null;
 
       view.put("field", fieldNameOf(info));
       view.put("frame", VisualFrameAliases.describe(frameOf(model, channel)));
-      view.put("acceptsField", AestheticChannels.FIELD_CHANNELS.contains(channel));
-      view.put("acceptsFrame", AestheticChannels.FRAME_CHANNELS.contains(channel));
+      view.put("acceptsField", acceptsField(channel));
+      view.put("acceptsFrame", acceptsFrame(channel));
       return view;
    }
 
@@ -143,6 +188,8 @@ public final class ChartAestheticMutator {
          case "size" -> model.getSizeFrame();
          case "line" -> model.getLineFrame();
          case "texture" -> model.getTextureFrame();
+         case "node-color" -> model.getNodeColorFrame();
+         case "node-size" -> model.getNodeSizeFrame();
          default -> null;
       };
    }
@@ -153,6 +200,8 @@ public final class ChartAestheticMutator {
          case "shape" -> model.getShapeField();
          case "size" -> model.getSizeField();
          case "text" -> model.getTextField();
+         case "node-color" -> model.getNodeColorField();
+         case "node-size" -> model.getNodeSizeField();
          default -> null;
       };
    }
@@ -163,6 +212,8 @@ public final class ChartAestheticMutator {
          case "shape" -> model.setShapeField(info);
          case "size" -> model.setSizeField(info);
          case "text" -> model.setTextField(info);
+         case "node-color" -> model.setNodeColorField(info);
+         case "node-size" -> model.setNodeSizeField(info);
          default -> throw new IllegalArgumentException("Unhandled field channel '" + channel + "'.");
       }
    }

--- a/core/src/main/java/inetsoft/web/wiz/binding/VisualFrameAliases.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/VisualFrameAliases.java
@@ -114,11 +114,18 @@ public final class VisualFrameAliases {
     * @param spec    {@code {type, ...}} in the alias vocabulary
     */
    public static VisualFrameModel create(String channel, Map<String, Object> spec) {
+      return create(channel, spec, false);
+   }
+
+   /** @param relationChart see {@link AestheticChannels#requireFieldChannel(String, boolean)}. */
+   public static VisualFrameModel create(String channel, Map<String, Object> spec,
+                                         boolean relationChart)
+   {
       // The type is read before the channel is validated so a mismatch can name both. Being
       // told "the size channel is not supported" when you asked for a categorical colour
       // frame leaves you guessing which half of the call was wrong.
       String type = str(spec, "type");
-      String name = requireFrameChannelFor(channel, type);
+      String name = requireFrameChannelFor(channel, type, relationChart);
 
       if(type == null) {
          throw new IllegalArgumentException(
@@ -133,7 +140,9 @@ public final class VisualFrameAliases {
       // refused, naming both.
       requireNoUnusedKeys(name, type, spec);
 
-      return switch(name) {
+      // node-color/node-size reuse color/size's frame-type taxonomy verbatim: the model holds
+      // the identical ColorFrameModel/SizeFrameModel types, just on a second property pair.
+      return switch(frameFamily(name)) {
          case "color" -> colorFrame(spec, type);
          case "shape" -> shapeFrame(spec, type);
          case "size" -> sizeFrame(spec, type);
@@ -142,11 +151,23 @@ public final class VisualFrameAliases {
       };
    }
 
+   /**
+    * {@code node-color}/{@code node-size} map to {@code color}/{@code size} — same frame-type
+    * taxonomy, same model classes, just a second target property on {@code ChartBindingModel}.
+    */
+   private static String frameFamily(String channel) {
+      return switch(channel) {
+         case "node-color" -> "color";
+         case "node-size" -> "size";
+         default -> channel;
+      };
+   }
+
    /** The value keys a given channel and frame type actually read. */
    private static Set<String> consumedKeys(String channel, String type) {
       Set<String> keys = new LinkedHashSet<>(List.of("type"));
 
-      switch(channel) {
+      switch(frameFamily(channel)) {
          case "color" -> {
             switch(type) {
                case "static", "brightness", "saturation" -> keys.add("color");
@@ -692,9 +713,11 @@ public final class VisualFrameAliases {
 
    // ── helpers ───────────────────────────────────────────────────────────────
 
-   private static String requireFrameChannelFor(String channel, String type) {
+   private static String requireFrameChannelFor(String channel, String type,
+                                                boolean relationChart)
+   {
       try {
-         return AestheticChannels.requireFrameChannel(channel);
+         return AestheticChannels.requireFrameChannel(channel, relationChart);
       }
       catch(IllegalArgumentException e) {
          if(type == null) {
@@ -765,7 +788,7 @@ public final class VisualFrameAliases {
 
    /** The frame types valid for a channel, for discovery and for error messages. */
    public static List<String> typeNames(String channel) {
-      List<String> names = new ArrayList<>(switch(AestheticChannels.normalize(channel)) {
+      List<String> names = new ArrayList<>(switch(frameFamily(AestheticChannels.normalize(channel))) {
          case "color" -> List.of("static", "categorical", "gradient", "palette", "brightness",
                                  "saturation", "bipolar", "circular", "rainbow", "heat");
          case "shape" -> List.of("static", "categorical", "fill", "orientation", "oval",

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -476,7 +476,7 @@ public class ViewsheetAssemblyAgentController {
                                   List<ConditionClause> conditions, Boolean applyRow,
                                   Boolean replace) {
       AssemblyHighlightService.Region region() {
-         return new AssemblyHighlightService.Region(row, col, colName, false, false);
+         return highlightRegion(row, col, colName);
       }
 
       AssemblyHighlightService.Highlight highlight() {
@@ -504,8 +504,24 @@ public class ViewsheetAssemblyAgentController {
    {
       requireEnabled();
       return highlightService.list(sessionToken, user, assembly,
-                                   new AssemblyHighlightService.Region(row, col, colName, false,
-                                                                       false));
+                                   highlightRegion(row, col, colName));
+   }
+
+   /**
+    * A {@code null} Region means "the caller named no location", which
+    * {@link AssemblyHighlightService#list}/{@code set}/{@code delete} read as "fall forward to
+    * the first data cell if the default region has nothing to highlight". Building a
+    * {@code Region} unconditionally — as this used to — collapses that signal before it arrives:
+    * the record's own compact constructor normalizes a null row/col to 0, so every call produced
+    * a non-null {@code Region(0, 0, ...)} and the fall-forward became dead code. Omitting
+    * {@code row}/{@code col} then always addressed cell (0,0) — a table's header — and was
+    * refused for exposing no highlightable fields.
+    */
+   private static AssemblyHighlightService.Region highlightRegion(Integer row, Integer col,
+                                                                   String colName)
+   {
+      return row == null && col == null ? null
+         : new AssemblyHighlightService.Region(row, col, colName, false, false);
    }
 
    @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/highlights")

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticAgentServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticAgentServiceTest.java
@@ -19,6 +19,8 @@ package inetsoft.web.wiz.binding;
 
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.graph.GraphTypes;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
 import inetsoft.web.binding.controller.ChangeChartAestheticService;
 import inetsoft.web.binding.event.ChangeChartRefEvent;
 import inetsoft.web.binding.model.ChartBindingModel;
@@ -189,6 +191,68 @@ class ChartAestheticAgentServiceTest {
                    () -> service.setField("tok", principal(), "Chart1", "colour",
                                           new FieldRef("Region", "dimension", null, null, null),
                                           ""));
+   }
+
+   // ── node channels (spec 2c Phase 3) ───────────────────────────────────────
+
+   @Test
+   void refusesNodeColorOnAChartThatIsNotARelationChart() {
+      ChartAestheticAgentService service = serviceWith(
+         sessionsFor(mock(ChartVSAssembly.class)), new ChartBindingModel(),
+         mock(ChangeChartAestheticService.class));
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> service.setField("tok", principal(), "Chart1", "node-color",
+                                new FieldRef("Region", "dimension", null, null, null), ""));
+      assertTrue(thrown.getMessage().contains("relation"));
+   }
+
+   @Test
+   void acceptsNodeColorOnARelationChart() throws Exception {
+      ChartVSAssembly relationChart = relationChartAssembly();
+      ChangeChartAestheticService aesthetics = mock(ChangeChartAestheticService.class);
+
+      serviceWith(sessionsFor(relationChart), new ChartBindingModel(), aesthetics)
+         .setField("tok", principal(), "Chart1", "node-color",
+                  new FieldRef("Region", "dimension", null, null, null), "");
+
+      assertEquals("Region", captureEvent(aesthetics).getModel().getNodeColorField().getFullName());
+   }
+
+   @Test
+   void readReportsNodeChannelsOnlyForARelationChart() throws Exception {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setField(model, "node-color",
+                                     new FieldRef("Region", "dimension", null, null, null), true);
+      ChartAestheticAgentService onRelation = serviceWith(sessionsFor(relationChartAssembly()),
+                                                     model, mock(ChangeChartAestheticService.class));
+      ChartAestheticAgentService onBar = serviceWith(sessionsFor(mock(ChartVSAssembly.class)),
+                                               model, mock(ChangeChartAestheticService.class));
+
+      assertTrue(onRelation.read("tok", principal(), "Chart1").containsKey("node-color"));
+      assertFalse(onBar.read("tok", principal(), "Chart1").containsKey("node-color"),
+                 "a bar chart's read must not advertise a channel it cannot render");
+   }
+
+   @Test
+   void optionsNamesTheNodeChannelsWithTheRelationChartCaveat() {
+      ChartAestheticAgentService service = serviceWith(
+         sessionsFor(mock(ChartVSAssembly.class)), new ChartBindingModel(),
+         mock(ChangeChartAestheticService.class));
+
+      Map<String, Object> options = service.options();
+
+      assertEquals(List.of("node-color", "node-size"), options.get("nodeChannels"));
+      assertTrue(((String) options.get("nodeChannelsNote")).contains("relation charts"));
+   }
+
+   private static ChartVSAssembly relationChartAssembly() {
+      VSChartInfo info = mock(VSChartInfo.class);
+      when(info.getChartType()).thenReturn(GraphTypes.CHART_NETWORK);
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      when(chart.getVSChartInfo()).thenReturn(info);
+      return chart;
    }
 
    // ── harness ───────────────────────────────────────────────────────────────

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticMutatorTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticMutatorTest.java
@@ -311,4 +311,90 @@ class ChartAestheticMutatorTest {
          assertTrue(described.containsKey(channel), "missing channel " + channel);
       }
    }
+
+   // ── node channels (spec 2c Phase 3) ───────────────────────────────────────
+
+   @Test
+   void bindsAFieldToTheNodeColorChannelOnARelationChart() {
+      ChartBindingModel model = new ChartBindingModel();
+
+      ChartAestheticMutator.setField(model, "node-color", dimension("Region"), true);
+
+      AestheticInfo info = model.getNodeColorField();
+      assertNotNull(info);
+      assertEquals("Region", info.getFullName());
+      // The regular color channel is a separate property -- binding the node channel must not
+      // also populate it, or the two would be indistinguishable to a later read.
+      assertNull(model.getColorField());
+   }
+
+   @Test
+   void bindsAFieldToTheNodeSizeChannelOnARelationChart() {
+      ChartBindingModel model = new ChartBindingModel();
+
+      ChartAestheticMutator.setField(model, "node-size", measure("Weight", "Sum"), true);
+
+      assertNotNull(model.getNodeSizeField());
+      assertNull(model.getSizeField());
+   }
+
+   @Test
+   void refusesTheNodeColorChannelWhenTheChartIsNotARelationChart() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartAestheticMutator.setField(new ChartBindingModel(), "node-color",
+                                              dimension("Region"), false));
+
+      assertTrue(thrown.getMessage().contains("relation"));
+   }
+
+   /** The 3-arg overload every existing caller uses defaults to non-relation. */
+   @Test
+   void theThreeArgOverloadRefusesNodeChannelsByDefault() {
+      assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartAestheticMutator.setField(new ChartBindingModel(), "node-color",
+                                              dimension("Region")));
+   }
+
+   @Test
+   void clearingTheNodeColorChannelUnbindsItWithoutTouchingColor() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setField(model, "color", dimension("Region"));
+      ChartAestheticMutator.setField(model, "node-color", dimension("Category"), true);
+
+      ChartAestheticMutator.clearField(model, "node-color", true);
+
+      assertNull(model.getNodeColorField());
+      assertNotNull(model.getColorField(), "clearing node-color must not clear color");
+   }
+
+   @Test
+   void setsANodeColorFrameOnARelationChart() {
+      ChartBindingModel model = new ChartBindingModel();
+
+      ChartAestheticMutator.setFrame(model, "node-color",
+                                     spec("type", "static", "color", "#4e79a7"), true);
+
+      assertNotNull(model.getNodeColorFrame());
+      assertNull(model.getColorFrame());
+   }
+
+   @Test
+   void describesNodeChannelsOnlyWhenAskedToOnARelationChart() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setField(model, "node-color", dimension("Region"), true);
+
+      Map<String, Object> notRelation = ChartAestheticMutator.describe(model);
+      Map<String, Object> relation = ChartAestheticMutator.describe(model, true);
+
+      assertFalse(notRelation.containsKey("node-color"),
+                  "a non-relation read must not advertise a channel this chart cannot render");
+      assertTrue(relation.containsKey("node-color"));
+      @SuppressWarnings("unchecked")
+      Map<String, Object> nodeColor = (Map<String, Object>) relation.get("node-color");
+      assertEquals("Region", nodeColor.get("field"));
+      assertEquals(true, nodeColor.get("acceptsField"));
+      assertEquals(true, nodeColor.get("acceptsFrame"));
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/binding/VisualFrameAliasesTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/VisualFrameAliasesTest.java
@@ -426,4 +426,47 @@ class VisualFrameAliasesTest {
       assertEquals(false, described.get("useGlobal"));
       assertEquals(Map.of("East", "#4E79A7"), described.get("mapping"));
    }
+
+   // ── node channels (spec 2c Phase 3) ───────────────────────────────────────
+
+   /**
+    * {@code node-color}/{@code node-size} reuse {@code color}/{@code size}'s frame-type
+    * taxonomy verbatim — the model holds the identical {@code ColorFrameModel}/
+    * {@code SizeFrameModel} types, just on a second property pair.
+    */
+   @Test
+   void buildsANodeColorFrameUsingTheColorTaxonomy() {
+      VisualFrameModel frame = VisualFrameAliases.create(
+         "node-color", spec("type", "static", "color", "#4e79a7"), true);
+
+      assertInstanceOf(StaticColorModel.class, frame);
+      assertEquals("#4E79A7", ((StaticColorModel) frame).getColor());
+   }
+
+   @Test
+   void buildsANodeSizeFrameUsingTheSizeTaxonomy() {
+      VisualFrameModel frame = VisualFrameAliases.create(
+         "node-size", spec("type", "static", "size", 5.0), true);
+
+      assertInstanceOf(StaticSizeModel.class, frame);
+   }
+
+   @Test
+   void refusesANodeChannelWhenTheChartIsNotARelationChart() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> VisualFrameAliases.create("node-color", spec("type", "static", "color", "#000"),
+                                         false));
+
+      assertTrue(thrown.getMessage().contains("relation"));
+   }
+
+   @Test
+   void refusesANodeSizeKeyMeantForColor() {
+      assertThrows(
+         IllegalArgumentException.class,
+         () -> VisualFrameAliases.create("node-size", spec("type", "static", "color", "#000"),
+                                         true),
+         "'color' is not a key node-size's static frame reads -- it reads 'size'");
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -270,6 +270,94 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(SheetOpenService.class));
    }
 
+   /**
+    * Regression for the highlight header-cell defect: omitting {@code row}/{@code col} must
+    * reach {@link AssemblyHighlightService} as a {@code null} Region, not
+    * {@code Region(0, 0, ...)}. A non-null Region there skips the service's fall-forward to the
+    * first data cell, so every call that named no location landed on a table's header — which
+    * has no highlightable fields — and was refused. An explicit {@code row}/{@code col} of 0 must
+    * still arrive as a real Region: the caller asked for that cell, and second-guessing it would
+    * highlight somewhere they did not request.
+    */
+   @Test
+   void listHighlightsPassesANullRegionWhenNoLocationWasNamed() throws Exception {
+      AssemblyHighlightService highlightService = mock(AssemblyHighlightService.class);
+      ViewsheetAssemblyAgentController controller = controllerWith(highlightService);
+
+      controller.listHighlights("tok", "Table1", null, null, null, principal());
+
+      verify(highlightService).list(eq("tok"), any(Principal.class), eq("Table1"),
+                                    isNull());
+   }
+
+   @Test
+   void listHighlightsPassesARealRegionWhenALocationWasNamed() throws Exception {
+      AssemblyHighlightService highlightService = mock(AssemblyHighlightService.class);
+      ViewsheetAssemblyAgentController controller = controllerWith(highlightService);
+
+      controller.listHighlights("tok", "Table1", 1, 1, null, principal());
+
+      verify(highlightService).list(eq("tok"), any(Principal.class), eq("Table1"),
+                                    eq(new AssemblyHighlightService.Region(1, 1, null, false,
+                                                                          false)));
+   }
+
+   /** Same signal, reached through {@code HighlightRequest.region()} for set/delete. */
+   @Test
+   void setHighlightPassesANullRegionWhenNoLocationWasNamed() throws Exception {
+      AssemblyHighlightService highlightService = mock(AssemblyHighlightService.class);
+      ViewsheetAssemblyAgentController controller = controllerWith(highlightService);
+      var request = new ViewsheetAssemblyAgentController.HighlightRequest(
+         "Table1", null, null, null, "HighRevenue", null, "#FFDDDD", List.of(), false, false);
+
+      controller.setHighlight("tok", request, "", principal());
+
+      verify(highlightService).set(eq("tok"), any(Principal.class), eq("Table1"), isNull(),
+                                   any(), eq(false), eq(""));
+   }
+
+   @Test
+   void setHighlightPassesARealRegionWhenALocationWasNamed() throws Exception {
+      AssemblyHighlightService highlightService = mock(AssemblyHighlightService.class);
+      ViewsheetAssemblyAgentController controller = controllerWith(highlightService);
+      var request = new ViewsheetAssemblyAgentController.HighlightRequest(
+         "Table1", 0, 0, null, "HighRevenue", null, "#FFDDDD", List.of(), false, false);
+
+      controller.setHighlight("tok", request, "", principal());
+
+      verify(highlightService).set(eq("tok"), any(Principal.class), eq("Table1"),
+                                   eq(new AssemblyHighlightService.Region(0, 0, null, false,
+                                                                          false)),
+                                   any(), eq(false), eq(""));
+   }
+
+   /** Feature enabled, only {@code highlightService} wired -- for the highlight-region tests. */
+   private static ViewsheetAssemblyAgentController controllerWith(
+      AssemblyHighlightService highlightService)
+   {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      when(feature.isEnabled()).thenReturn(true);
+
+      return new ViewsheetAssemblyAgentController(feature, mock(SheetJoinService.class),
+                                          mock(SheetSessionService.class),
+                                          mock(ViewsheetSessionService.class),
+                                          mock(ViewsheetReadService.class),
+                                          mock(ViewsheetEditService.class),
+                                          mock(ViewsheetFormatService.class),
+                                          mock(inetsoft.web.wiz.script.ScriptImageService.class),
+                                          mock(AssemblyPropertyService.class),
+                                          mock(SheetPropertyService.class),
+                                          mock(AssemblyHyperlinkService.class),
+                                          mock(ChartElementService.class),
+                                          mock(ChartRegionPropertyService.class),
+                                          mock(AssemblyConditionService.class),
+                                          highlightService,
+                                          mock(DateComparisonService.class),
+                                          mock(inetsoft.analytic.composition.ViewsheetService.class),
+                                          mock(SheetAgentBroadcastService.class),
+                                          mock(SheetOpenService.class));
+   }
+
    private static Principal principal() {
       return () -> "admin";
    }


### PR DESCRIPTION
## Summary
Two independently-diagnosed items from the composer automation roadmap's Lane D (`docs/superpowers/specs/2026-08-13-composer-automation-roadmap.md`), landed together since both touch `inetsoft/web/wiz`:

- **D1** — `set_highlight`/`list_highlights`/`delete_highlight` landed on a table's header cell and refused whenever the caller omitted `row`/`col`. `AssemblyHighlightService.read()`'s fall-forward-to-first-data-cell logic is gated on `region == null`, but the controller never actually produced `null` — both `HighlightRequest.region()` and the `listHighlights` GET handler unconditionally built `new Region(row, col, ...)`, and `Region`'s own compact constructor normalizes a null row/col to 0. So the fall-forward was dead code on every real request, caught only by a unit test that called the service directly with a literal `null` — bypassing the controller that never produces one. Fixed by only constructing a `Region` when the caller actually named `row` or `col`.
- **D2** — wires `node-color`/`node-size` (the last uncovered piece of spec 2c's aesthetic-frame taxonomy) through the existing channel vocabulary, gated to relation charts (network, tree, chord) only — `ChartBindingModel` already carries the four node fields, this was purely vocabulary wiring.

## Test plan
- [x] `ViewsheetAssemblyAgentControllerTest` — 4 new tests pin the null-region / explicit-region(0,0) distinction (13/13 pass)
- [x] `AssemblyHighlightServiceTest` — unaffected, still 22/22
- [x] `AestheticChannelsTest`/`ChartAestheticMutatorTest` (26/26), `ChartAestheticAgentServiceTest` (14/14), `VisualFrameAliasesTest` (42/42) — new node-channel coverage plus full existing suites green
- [x] Full `inetsoft.web.wiz.**` sweep (156 test classes) — 0 failures, 0 errors
- [x] Companion plugin PR in `stylebi-wiz` wires the same channels through `set_aesthetic_field`/`clear_aesthetic_field`/`set_visual_frame`

🤖 Generated with [Claude Code](https://claude.com/claude-code)