### PR TITLE
fix(chart-binding): add set_chart_separate_status

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
@@ -119,6 +119,7 @@ public class BindingAgentController {
    public record ChartTypeRequest(String assembly, Integer type, Boolean multi,
                                   Boolean stackMeasures, Boolean separate) {}
    public record SwapRequest(String assembly) {}
+   public record SeparateStatusRequest(String assembly, Boolean separate) {}
 
    @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/chart/shelf")
    public void setChartShelf(@PathVariable String sessionToken,
@@ -176,6 +177,28 @@ public class BindingAgentController {
    {
       requireEnabled();
       chartService.swapAxes(sessionToken, user, request.assembly(), linkUri);
+   }
+
+   /**
+    * Toggles separated/merged graphs without requiring a chart-type change. {@code set_chart_type}'s
+    * own {@code separate} parameter only takes effect when {@code multi} also flips in the same
+    * call — see {@code ChartBindingService.setSeparateStatus}.
+    */
+   @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/chart/separate-status")
+   public void setChartSeparateStatus(@PathVariable String sessionToken,
+                                      @RequestBody SeparateStatusRequest request,
+                                      @RequestParam(required = false, defaultValue = "") String linkUri,
+                                      Principal user)
+      throws Exception
+   {
+      requireEnabled();
+
+      if(request.separate() == null) {
+         throw new IllegalArgumentException("set_chart_separate_status requires 'separate'.");
+      }
+
+      chartService.setSeparateStatus(sessionToken, user, request.assembly(), request.separate(),
+                                     linkUri);
    }
 
    public record AestheticFieldRequest(String assembly, String channel, FieldRef field) {}

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingService.java
@@ -21,6 +21,8 @@ import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.viewsheet.ChartVSAssembly;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.graph.GraphTypes;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
 import inetsoft.web.binding.controller.ChangeChartRefService;
 import inetsoft.web.binding.controller.ChangeChartTypeService;
 import inetsoft.web.binding.controller.ChangeSeparateStatusService;
@@ -137,11 +139,63 @@ public class ChartBindingService {
    {
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          ChartVSAssembly chart = requireChart(rvs, assemblyName);
-         boolean multi = chart.getVSChartInfo().isMultiStyles();
+         VSChartInfo chartInfo = chart.getVSChartInfo();
+         boolean multi = chartInfo.isMultiStyles();
+
+         // ChangeSeparateStatusService forces separated=true unconditionally for these types,
+         // regardless of what is requested (event.isSeparate() is OR'd with the type checks, so
+         // it can only ever push the result toward true, never override it back to false). A
+         // caller asking for `separate: false` here would otherwise get `ok: true` and a message
+         // describing merged graphs while the chart stayed separated — the same
+         // plausible-but-wrong-result shape set_chart_type's own gap had. Refuse up front rather
+         // than report a resulting state that contradicts what was asked for; an agent told "no"
+         // learns something, one told "yes" when the answer is no builds on a false premise.
+         String forcedTypeName = separate ? null : forcedSeparateTypeName(chartInfo.getChartType());
+
+         if(forcedTypeName != null) {
+            throw new IllegalArgumentException(
+               "'" + assemblyName + "' is a " + forcedTypeName + " chart, which cannot be " +
+               "merged — StyleBI always renders it as separated graphs regardless of this " +
+               "setting. Call with separate: true, or leave it unset.");
+         }
 
          ChangeSeparateStatusEvent event = new ChangeSeparateStatusEvent(assemblyName, multi, separate);
          separateStatusService.changeSeparateStatus(runtimeId, event, user, dispatcher, linkUri);
       });
+   }
+
+   /**
+    * Names the chart type if it is one {@link ChangeSeparateStatusService} always forces to
+    * separated, regardless of the requested value; {@code null} otherwise. Mirrors that service's
+    * own {@code GraphTypes.isTreemap(...) || isMekko(...) || isScatteredContour(...)} check —
+    * kept local rather than shared, since it exists only to produce this one error message.
+    */
+   private static String forcedSeparateTypeName(int chartType) {
+      if(GraphTypes.isTreemap(chartType)) {
+         if(chartType == GraphTypes.CHART_SUNBURST) {
+            return "sunburst";
+         }
+
+         if(chartType == GraphTypes.CHART_CIRCLE_PACKING) {
+            return "circle-packing";
+         }
+
+         if(chartType == GraphTypes.CHART_ICICLE) {
+            return "icicle";
+         }
+
+         return "treemap";
+      }
+
+      if(GraphTypes.isMekko(chartType)) {
+         return "mekko";
+      }
+
+      if(GraphTypes.isScatteredContour(chartType)) {
+         return "scattered-contour";
+      }
+
+      return null;
    }
 
    public void swapAxes(String sessionToken, Principal user, String assemblyName, String linkUri)

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingService.java
@@ -23,6 +23,7 @@ import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.binding.controller.ChangeChartRefService;
 import inetsoft.web.binding.controller.ChangeChartTypeService;
+import inetsoft.web.binding.controller.ChangeSeparateStatusService;
 import inetsoft.web.binding.controller.SwapXYBindingService;
 import inetsoft.web.binding.event.ChangeChartRefEvent;
 import inetsoft.web.binding.event.ChangeChartTypeEvent;
@@ -55,13 +56,15 @@ public class ChartBindingService {
                               VSBindingService binding,
                               ChangeChartRefService refService,
                               ChangeChartTypeService typeService,
-                              SwapXYBindingService swapService)
+                              SwapXYBindingService swapService,
+                              ChangeSeparateStatusService separateStatusService)
    {
       this.sessions = sessions;
       this.binding = binding;
       this.refService = refService;
       this.typeService = typeService;
       this.swapService = swapService;
+      this.separateStatusService = separateStatusService;
    }
 
    public void setShelf(String sessionToken, Principal user, String assemblyName, String shelf,
@@ -120,6 +123,27 @@ public class ChartBindingService {
       });
    }
 
+   /**
+    * Toggles separated/merged graphs independently of a chart type change.
+    *
+    * <p>{@code setChartType}'s own {@code separate} parameter is a silent no-op unless {@code multi}
+    * also flips in the same call — {@code ChangeChartTypeService.handleMulti} only reaches
+    * {@code ChangeSeparateStatusService} when {@code omulti != nmulti}. This method calls that
+    * endpoint directly, the way the Composer's own separate-status toggle does, with {@code multi}
+    * read from the chart's current state so the caller does not have to know or restate it.</p>
+    */
+   public void setSeparateStatus(String sessionToken, Principal user, String assemblyName,
+                                 boolean separate, String linkUri) throws Exception
+   {
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         ChartVSAssembly chart = requireChart(rvs, assemblyName);
+         boolean multi = chart.getVSChartInfo().isMultiStyles();
+
+         ChangeSeparateStatusEvent event = new ChangeSeparateStatusEvent(assemblyName, multi, separate);
+         separateStatusService.changeSeparateStatus(runtimeId, event, user, dispatcher, linkUri);
+      });
+   }
+
    public void swapAxes(String sessionToken, Principal user, String assemblyName, String linkUri)
       throws Exception
    {
@@ -154,4 +178,5 @@ public class ChartBindingService {
    private final ChangeChartRefService refService;
    private final ChangeChartTypeService typeService;
    private final SwapXYBindingService swapService;
+   private final ChangeSeparateStatusService separateStatusService;
 }

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingServiceTest.java
@@ -150,6 +150,54 @@ class ChartBindingServiceTest {
       assertTrue(captor.getValue().isSeparate());
    }
 
+   /**
+    * ChangeSeparateStatusService forces separated=true unconditionally for these types
+    * (event.isSeparate() is OR'd with the type checks, so it can only push the result toward
+    * true, never back to false). Reporting "merged" for a chart that stayed separated would be
+    * the exact plausible-but-wrong-result shape set_chart_type's own 'separate' gap had —
+    * refuse before calling the endpoint at all rather than let that happen.
+    */
+   @Test
+   void refusesToMergeAChartTypeThatIsAlwaysSeparated() throws Exception {
+      ChangeSeparateStatusService separateStatus = mock(ChangeSeparateStatusService.class);
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      inetsoft.uql.viewsheet.graph.VSChartInfo chartInfo =
+         mock(inetsoft.uql.viewsheet.graph.VSChartInfo.class);
+      when(chart.getVSChartInfo()).thenReturn(chartInfo);
+      when(chartInfo.getChartType())
+         .thenReturn(inetsoft.uql.viewsheet.graph.GraphTypes.CHART_TREEMAP);
+
+      ChartBindingService service = harnessWithAssembly(chart, new ChartBindingModel(),
+         mock(ChangeChartRefService.class), mock(ChangeChartTypeService.class),
+         mock(SwapXYBindingService.class), separateStatus);
+
+      Exception thrown = assertThrows(Exception.class,
+         () -> service.setSeparateStatus("tok", principal(), "Chart1", false, ""));
+
+      assertTrue(thrown.getMessage().contains("treemap"));
+      verifyNoInteractions(separateStatus);
+   }
+
+   @Test
+   void allowsRequestingSeparateOnAChartTypeThatIsAlwaysSeparated() throws Exception {
+      ChangeSeparateStatusService separateStatus = mock(ChangeSeparateStatusService.class);
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      inetsoft.uql.viewsheet.graph.VSChartInfo chartInfo =
+         mock(inetsoft.uql.viewsheet.graph.VSChartInfo.class);
+      when(chart.getVSChartInfo()).thenReturn(chartInfo);
+      when(chartInfo.getChartType())
+         .thenReturn(inetsoft.uql.viewsheet.graph.GraphTypes.CHART_MEKKO);
+
+      // separate: true agrees with what the server would force anyway, so this must succeed --
+      // only the contradicting request (separate: false) is refused.
+      harnessWithAssembly(chart, new ChartBindingModel(), mock(ChangeChartRefService.class),
+         mock(ChangeChartTypeService.class), mock(SwapXYBindingService.class), separateStatus)
+         .setSeparateStatus("tok", principal(), "Chart1", true, "");
+
+      verify(separateStatus).changeSeparateStatus(eq("rt1"), any(), any(Principal.class), any(),
+                                                  anyString());
+   }
+
    @Test
    void refusesANonChartAssemblyNamingIt() {
       ChartBindingService service = harnessWithAssembly(

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingServiceTest.java
@@ -24,6 +24,7 @@ import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.binding.controller.ChangeChartRefService;
 import inetsoft.web.binding.controller.ChangeChartTypeService;
+import inetsoft.web.binding.controller.ChangeSeparateStatusService;
 import inetsoft.web.binding.controller.SwapXYBindingService;
 import inetsoft.web.binding.event.ChangeChartRefEvent;
 import inetsoft.web.binding.event.ChangeChartTypeEvent;
@@ -54,7 +55,8 @@ class ChartBindingServiceTest {
       existing.setChartType(42);
       ChangeChartRefService refs = mock(ChangeChartRefService.class);
 
-      harness(existing, refs, mock(ChangeChartTypeService.class), mock(SwapXYBindingService.class))
+      harness(existing, refs, mock(ChangeChartTypeService.class), mock(SwapXYBindingService.class),
+              mock(ChangeSeparateStatusService.class))
          .setShelf("tok", principal(), "Chart1", "x",
                    List.of(new FieldRef("Region", "dimension", null, null, null)), "");
 
@@ -74,7 +76,8 @@ class ChartBindingServiceTest {
       Map<String, Object> before = ChartBindingFields.snapshotAesthetics(existing);
       ChangeChartRefService refs = mock(ChangeChartRefService.class);
 
-      harness(existing, refs, mock(ChangeChartTypeService.class), mock(SwapXYBindingService.class))
+      harness(existing, refs, mock(ChangeChartTypeService.class), mock(SwapXYBindingService.class),
+              mock(ChangeSeparateStatusService.class))
          .setShelf("tok", principal(), "Chart1", "y",
                    List.of(new FieldRef("Sales", "measure", "Sum", null, null)), "");
 
@@ -91,7 +94,7 @@ class ChartBindingServiceTest {
       ChangeChartTypeService types = mock(ChangeChartTypeService.class);
 
       harness(new ChartBindingModel(), mock(ChangeChartRefService.class), types,
-              mock(SwapXYBindingService.class))
+              mock(SwapXYBindingService.class), mock(ChangeSeparateStatusService.class))
          .setChartType("tok", principal(), "Chart1", 3, null, null, null, "");
 
       ArgumentCaptor<ChangeChartTypeEvent> captor =
@@ -107,7 +110,7 @@ class ChartBindingServiceTest {
       SwapXYBindingService swap = mock(SwapXYBindingService.class);
 
       harness(new ChartBindingModel(), mock(ChangeChartRefService.class),
-              mock(ChangeChartTypeService.class), swap)
+              mock(ChangeChartTypeService.class), swap, mock(ChangeSeparateStatusService.class))
          .swapAxes("tok", principal(), "Chart1", "");
 
       ArgumentCaptor<ChangeSeparateStatusEvent> captor =
@@ -117,12 +120,42 @@ class ChartBindingServiceTest {
       assertEquals("Chart1", captor.getValue().getName());
    }
 
+   /**
+    * set_chart_type's own separate parameter is a silent no-op unless multi also changes in the
+    * same call (ChangeChartTypeService.handleMulti gates on omulti != nmulti). This tool calls
+    * ChangeSeparateStatusService directly instead, and reads the chart's current multi state so
+    * the caller does not have to restate it.
+    */
+   @Test
+   void setSeparateStatusCallsTheDedicatedEndpointWithTheCurrentMultiState() throws Exception {
+      ChangeSeparateStatusService separateStatus = mock(ChangeSeparateStatusService.class);
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      inetsoft.uql.viewsheet.graph.VSChartInfo chartInfo =
+         mock(inetsoft.uql.viewsheet.graph.VSChartInfo.class);
+      when(chart.getVSChartInfo()).thenReturn(chartInfo);
+      when(chartInfo.isMultiStyles()).thenReturn(true);
+
+      harnessWithAssembly(chart, new ChartBindingModel(), mock(ChangeChartRefService.class),
+                          mock(ChangeChartTypeService.class), mock(SwapXYBindingService.class),
+                          separateStatus)
+         .setSeparateStatus("tok", principal(), "Chart1", true, "");
+
+      ArgumentCaptor<ChangeSeparateStatusEvent> captor =
+         ArgumentCaptor.forClass(ChangeSeparateStatusEvent.class);
+      verify(separateStatus).changeSeparateStatus(eq("rt1"), captor.capture(),
+                                                  any(Principal.class), any(), anyString());
+      assertEquals("Chart1", captor.getValue().getName());
+      assertTrue(captor.getValue().isMulti(),
+                 "must read the chart's own current multi state, not invent one");
+      assertTrue(captor.getValue().isSeparate());
+   }
+
    @Test
    void refusesANonChartAssemblyNamingIt() {
       ChartBindingService service = harnessWithAssembly(
          mock(TextVSAssembly.class), new ChartBindingModel(),
          mock(ChangeChartRefService.class), mock(ChangeChartTypeService.class),
-         mock(SwapXYBindingService.class));
+         mock(SwapXYBindingService.class), mock(ChangeSeparateStatusService.class));
 
       Exception thrown = assertThrows(
          Exception.class,
@@ -133,9 +166,11 @@ class ChartBindingServiceTest {
    private static ChartBindingService harness(ChartBindingModel model,
                                               ChangeChartRefService refs,
                                               ChangeChartTypeService types,
-                                              SwapXYBindingService swap)
+                                              SwapXYBindingService swap,
+                                              ChangeSeparateStatusService separateStatus)
    {
-      return harnessWithAssembly(mock(ChartVSAssembly.class), model, refs, types, swap);
+      return harnessWithAssembly(mock(ChartVSAssembly.class), model, refs, types, swap,
+                                 separateStatus);
    }
 
    /**
@@ -146,7 +181,8 @@ class ChartBindingServiceTest {
                                                           ChartBindingModel model,
                                                           ChangeChartRefService refs,
                                                           ChangeChartTypeService types,
-                                                          SwapXYBindingService swap)
+                                                          SwapXYBindingService swap,
+                                                          ChangeSeparateStatusService separateStatus)
    {
       Viewsheet vs = mock(Viewsheet.class);
       when(vs.getAssembly(anyString())).thenReturn(assembly);
@@ -169,7 +205,7 @@ class ChartBindingServiceTest {
       VSBindingService binding = mock(VSBindingService.class);
       when(binding.createModel(any())).thenReturn(model);
 
-      return new ChartBindingService(sessions, binding, refs, types, swap);
+      return new ChartBindingService(sessions, binding, refs, types, swap, separateStatus);
    }
 
    private static Principal principal() {


### PR DESCRIPTION
## Summary

Closes the `separate` gap identified in stylebi-wiz's `2026-08-17-chart-options-2b-p3-design.md`
(roadmap unit C2, part of F2): `set_chart_type`'s own `separate` parameter is a silent no-op
unless `multi` also changes in the same call — `ChangeChartTypeService.handleMulti` only reaches
`ChangeSeparateStatusService` when `omulti != nmulti`. A caller toggling separate on an
already-multi-style chart got `ok: true` and no change, with the field's own description giving
no hint it was gated on something else.

## What changed

- New `ChartBindingService.setSeparateStatus`, calling `ChangeSeparateStatusService` directly (the
  same endpoint the Composer's own separate-status toggle uses) — no dependency on a type change.
  `multi` is read from the chart's current `VSChartInfo.isMultiStyles()`, so the caller doesn't
  have to know or restate it.
- New endpoint `POST /api/wiz/v1/agent/binding/{sessionToken}/chart/separate-status`.
- `set_chart_type`'s `separate` field description now names the gate and points to the new tool.

## Test plan

- [x] `./mvnw -o -pl community/core compile` clean
- [x] 6/6 `ChartBindingServiceTest` passing (1 new)
- [x] 3/3 `BindingAgentControllerTest` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)