### PR TITLE
D4: list_bindable_fields silently ignores an unknown assembly name

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/binding/BindableFieldsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindableFieldsService.java
@@ -17,8 +17,11 @@
  */
 package inetsoft.web.wiz.binding;
 
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.binding.service.VSBindingTreeService;
 import inetsoft.web.composer.model.TreeNodeModel;
 import inetsoft.web.wiz.binding.model.BindableField;
@@ -40,13 +43,38 @@ import java.util.List;
 @Service
 public class BindableFieldsService {
    @Autowired
-   public BindableFieldsService(VSBindingTreeService tree) {
+   public BindableFieldsService(VSBindingTreeService tree, ViewsheetService viewsheetService) {
       this.tree = tree;
+      this.viewsheetService = viewsheetService;
    }
 
+   /**
+    * Refuses an {@code assembly} that does not exist, rather than silently listing everything.
+    *
+    * <p>{@code VSBindingTreeService.getBinding} resolves the assembly with
+    * {@code viewsheet.getAssembly(name)}, which returns {@code null} for an unknown name exactly
+    * as it does for {@code null} itself — so "list every table" and "list the tables for a name
+    * that doesn't exist" fell into the identical fallback branch and returned the identical
+    * whole-viewsheet tree. An agent scoping to the wrong assembly name got a full, plausible field
+    * list back and had no way to tell its scoping request was silently ignored (CLAUDE.md's
+    * tool-misuse-accepted-silently class). {@code assembly == null} is the caller's deliberate
+    * "list everything," so only a non-null name that fails to resolve is refused.
+    */
    public List<BindableTable> list(String runtimeId, String assembly, Principal user)
       throws Exception
    {
+      if(assembly != null) {
+         RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, user);
+         Viewsheet vs = rvs == null ? null : rvs.getViewsheet();
+
+         if(vs == null || vs.getAssembly(assembly) == null) {
+            throw new IllegalArgumentException(
+               "'" + assembly + "' is not an assembly on this viewsheet. Omit 'assembly' to list " +
+               "every table the viewsheet offers, or call read_viewsheet_model to see what " +
+               "assemblies exist.");
+         }
+      }
+
       TreeNodeModel root = tree.getBinding(runtimeId, assembly, false, user);
       List<BindableTable> tables = new ArrayList<>();
 
@@ -190,4 +218,5 @@ public class BindableFieldsService {
    private static final String MEASURE = "measure";
 
    private final VSBindingTreeService tree;
+   private final ViewsheetService viewsheetService;
 }

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindableFieldsServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindableFieldsServiceTest.java
@@ -17,7 +17,10 @@
  */
 package inetsoft.web.wiz.binding;
 
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.binding.service.VSBindingTreeService;
 import inetsoft.web.composer.model.TreeNodeModel;
 import inetsoft.web.wiz.binding.model.BindableField;
@@ -199,11 +202,73 @@ class BindableFieldsServiceTest {
       assertTrue(serviceReturning(null).list("rt1", null, principal()).isEmpty());
    }
 
+   // ── unknown assembly name (the D4 regression) ────────────────────────────
+
+   /**
+    * {@code VSBindingTreeService.getBinding} resolves {@code viewsheet.getAssembly(name)}, which
+    * returns {@code null} for an unknown name exactly as it does for {@code null} itself — so
+    * scoping to a name that does not exist used to fall into the same "list everything" branch as
+    * not scoping at all, and silently returned the whole-viewsheet field list instead of refusing.
+    */
+   @Test
+   void refusesAnAssemblyNameThatDoesNotExistRatherThanListingEverything() throws Exception {
+      TreeNodeModel root = TreeNodeModel.builder().label("root").build();
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssembly("Nope")).thenReturn(null);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      ViewsheetService engine = mock(ViewsheetService.class);
+      when(engine.getViewsheet(eq("rt1"), any(Principal.class))).thenReturn(rvs);
+      VSBindingTreeService tree = mock(VSBindingTreeService.class);
+      when(tree.getBinding(eq("rt1"), any(), anyBoolean(), any(Principal.class))).thenReturn(root);
+      BindableFieldsService service = new BindableFieldsService(tree, engine);
+
+      Exception thrown = assertThrows(IllegalArgumentException.class,
+                                      () -> service.list("rt1", "Nope", principal()));
+
+      assertTrue(thrown.getMessage().contains("Nope"));
+      verify(tree, never()).getBinding(anyString(), any(), anyBoolean(), any(Principal.class));
+   }
+
+   /** A real assembly name still resolves normally, without touching the existence check's error. */
+   @Test
+   void listsNormallyWhenTheAssemblyNameIsReal() throws Exception {
+      inetsoft.uql.viewsheet.VSAssembly assembly = mock(inetsoft.uql.viewsheet.VSAssembly.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssembly("Table1")).thenReturn(assembly);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      ViewsheetService engine = mock(ViewsheetService.class);
+      when(engine.getViewsheet(eq("rt1"), any(Principal.class))).thenReturn(rvs);
+      VSBindingTreeService tree = mock(VSBindingTreeService.class);
+      when(tree.getBinding(eq("rt1"), eq("Table1"), anyBoolean(), any(Principal.class)))
+         .thenReturn(null);
+      BindableFieldsService service = new BindableFieldsService(tree, engine);
+
+      assertTrue(service.list("rt1", "Table1", principal()).isEmpty());
+   }
+
+   /** Omitting the assembly is the deliberate "list everything" request; it must not resolve one. */
+   @Test
+   void doesNotResolveAnAssemblyWhenNoneWasNamed() throws Exception {
+      ViewsheetService engine = mock(ViewsheetService.class);
+      serviceReturning(null, engine).list("rt1", null, principal());
+
+      verify(engine, never()).getViewsheet(anyString(), any(Principal.class));
+   }
+
    private static BindableFieldsService serviceReturning(TreeNodeModel root) throws Exception {
+      return serviceReturning(root, mock(ViewsheetService.class));
+   }
+
+   private static BindableFieldsService serviceReturning(TreeNodeModel root,
+                                                         ViewsheetService engine)
+      throws Exception
+   {
       VSBindingTreeService tree = mock(VSBindingTreeService.class);
       when(tree.getBinding(eq("rt1"), any(), anyBoolean(), any(Principal.class)))
          .thenReturn(root);
-      return new BindableFieldsService(tree);
+      return new BindableFieldsService(tree, engine);
    }
 
    private static Principal principal() {


### PR DESCRIPTION
## Summary
First concrete instance closed from the D4 silent-acceptance audit (`docs/superpowers/specs/2026-08-13-composer-automation-roadmap.md`, roadmap unit D4).

Root cause: `VSBindingTreeService.getBinding` resolves the requested assembly with `viewsheet.getAssembly(name)`, which returns `null` for a name that does not exist exactly as it does for a `null` name (no assembly requested). So `list_bindable_fields` scoped to a typo'd or wrong assembly name fell into the identical "list everything" fallback branch as an unscoped call, and returned the whole-viewsheet field list instead of refusing — a well-formed, accepted, plausible-but-wrong result, exactly the class of defect CLAUDE.md calls out as a plugin robustness gap to fix rather than route around.

Fix: `BindableFieldsService.list` now resolves the assembly itself before delegating to the tree service, and refuses a non-`null` name that does not exist on the viewsheet, naming it. `assembly == null` (the deliberate "list everything" request) never touches the new check.

Java's own D4 audit (57 grep candidates across `composer/vs/objects/controller`, `composer/vs/dialog`, `web/wiz`) found this to be the one *live, currently agent-reachable* instance in the initial pass — the rest of the candidates are either legitimate absent-value returns already guarded by their callers, or code not reachable from any `wiz/` service today.

## Test plan
- [x] `BindableFieldsServiceTest` — 10/10 pass, including 3 new: refuses an unknown name without ever calling into the tree service; a real name still resolves normally; omitting the name never triggers assembly resolution at all (the common no-scope path is unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)