### PR TITLE
Bug #75998, scope-guard permission transfer on folder rename/delete

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/AbstractAssetEngine.java
+++ b/core/src/main/java/inetsoft/uql/asset/AbstractAssetEngine.java
@@ -2100,6 +2100,14 @@ public abstract class AbstractAssetEngine implements AssetRepository, AutoClosea
          return;
       }
 
+      // Permissions are only keyed by path for global-scope assets. A user's private assets
+      // live in the same path namespace (the owner is carried by the entry, not the path), so
+      // transferring the permission of a private folder would move/clear the permission of the
+      // same-named folder in the global repository.
+      if(oentry.getScope() != GLOBAL_SCOPE) {
+         return;
+      }
+
       SecurityEngine securityEngine = SecurityEngine.getSecurity();
       ResourceType type = getAssetResourceType(oentry);
       Permission oldPermission = securityEngine.getPermission(type, oentry.getPath());
@@ -2109,7 +2117,12 @@ public abstract class AbstractAssetEngine implements AssetRepository, AutoClosea
       }
 
       securityEngine.removePermission(type, oentry.getPath());
-      securityEngine.setPermission(type, nentry.getPath(), oldPermission);
+
+      // moving out of the global repository (e.g. into a user's private assets); the old
+      // permission no longer applies to any path and must not be copied to the private path
+      if(nentry.getScope() == GLOBAL_SCOPE) {
+         securityEngine.setPermission(type, nentry.getPath(), oldPermission);
+      }
    }
 
    /**


### PR DESCRIPTION
## Issue

Reported: after a user renames or deletes a private folder that happens to share a name with a global repository folder, the *global* folder's permission is reset to "Derive Permissions from Parent".

Repro:
1. Create user `user0`, give it EM access and READ on the global `Examples` folder.
2. As `user0`, create an `Examples` folder under `User Private Assets/user0`.
3. Rename or delete that private `Examples` folder.
4. As admin, open Content and expand the repository — global `Examples` now shows "Derive Permissions from Parent".

## Root cause

Permission grants are keyed by `(ResourceType, path, orgID)` — no owner. A private folder's owner lives on the `AssetEntry` (`scope = USER_SCOPE`, `user = user0`), not in its path, so `user0`'s private `Examples` and the global `Examples` collapse onto the same permission key. Private assets never consult that table (`checkAssetPermission0` short-circuits on `USER_SCOPE`), so any path-keyed permission write made on behalf of a private folder necessarily hits the global folder's ACL.

`RepletEngine` guards for this everywhere it maintains permissions (`changeFolder0`, `changeSheet0`, `removeFolder0`, `removeSheet0` all test `GLOBAL_SCOPE`; the registry event handlers test `!SUtil.isMyReport(name)`). `AbstractAssetEngine.updatePermission()` — added for Bug #70982 so a moved global folder keeps its permissions — did not, and `changeFolder0` calls it for every scope:

```java
Permission oldPermission = securityEngine.getPermission(type, oentry.getPath());  // global "Examples" grant
securityEngine.removePermission(type, oentry.getPath());                          // global ACL cleared
securityEngine.setPermission(type, nentry.getPath(), oldPermission);              // grant parked elsewhere
```

Both reported steps reach it through the same registry rename (delete is a rename into `Recycle Bin/<uuid>`):

```
EM rename                                EM delete
RepletRegistryService                    RecycleUtils
  .updateRepositoryFolder                  .moveRepositoryFolderToRecycleBin
        └──> RepletRegistry.changeFolder("My Dashboards/Examples", <target>)
                     └──> RENAME_FOLDER_EVENT
                             └──> RepletEngine strips the "My Dashboards/" prefix and re-issues
                                  super.changeFolder(USER_SCOPE, "Examples" -> <target>)
                                     └──> changeFolder0 -> updatePermission
```

Private worksheet folders hit the same path under `ResourceType.ASSET`.

## Fix

`AbstractAssetEngine.updatePermission()` now follows the same scope rule as the rest of the code:

- Return early when the source entry is not `GLOBAL_SCOPE` — private and report-scope folders own no path-keyed permission, so nothing is read, moved, or cleared. This is the bug fix.
- When a global folder moves *out* of the global repository, remove the old grant but do not copy it onto the private path, where it would silently become a different folder's ACL.

`GLOBAL_SCOPE -> GLOBAL_SCOPE` renames and moves — the Bug #70982 case — are unchanged.

## Side effects traced

- The removal-only branch overlaps `RepletEngine.changeFolder0`, which already removes the old grant for non-repository global folders; a second `removePermission` on a cleared key is a no-op. For repository folders `RepletEngine` skips that block, which is where the grant used to leak into the private namespace.
- `REPORT_SCOPE` (report-embedded) entries no longer touch the permission table; they never had an entry in it.

## Testing

`core` compiles clean. No unit test added: `updatePermission` is private and only reachable through `changeFolder0`, which needs a live `IndexedStorage` plus the static `SecurityEngine`. Verified by reasoning through the call chain; the reporter's four steps are the practical check.

## Related, not changed here

`RecycleUtils.moveRepositoryFolderToRecycleBin` calls `getEntryPermission(REPORT, "My Dashboards/<folder>")`, which walks up to the global root when no explicit grant exists and then writes that inherited permission to the recycle-bin path. It creates stray grants on private deletes rather than resetting anything, so it is cosmetic — but it is the same scope-blindness and could be cleaned up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
