### PR TITLE
Bug #76022, keep bottom-tab children flush with the tab strip in layouts

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/vslayout/AbstractLayout.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/vslayout/AbstractLayout.java
@@ -426,8 +426,12 @@ public abstract class AbstractLayout implements AssetObject {
             childSize =
                new Dimension((int) (childSize.width * scaleRadio.x),
                              (int) (childSize.height * scaleRadio.y));
+            // for bottom tabs the tab bar is placed at the end of the content
+            // area, so bottom-align each child within it. Only the tallest
+            // child fills contentHeight; shorter ones would otherwise float
+            // detached above the tab bar.
             Point childPos = bottomTabs ?
-               new Point(npos.x, npos.y) :
+               new Point(npos.x, npos.y + Math.max(0, contentHeight - childSize.height)) :
                new Point(npos.x, npos.y + tabSize.height);
             applyAssembly(child, childPos, childSize);
          }

--- a/core/src/main/java/inetsoft/web/composer/vs/controller/VSLayoutService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/VSLayoutService.java
@@ -434,15 +434,22 @@ public class VSLayoutService {
             getChildAssemblies((ContainerVSAssembly) assembly, rvs,
                                childModels, objectModelService);
 
-            // for bottom tabs, position children at the visual top of the
-            // layout area (the stored position is the visual top)
+            // for bottom tabs, children sit above the tab bar. The stored
+            // position is the visual top of the tab area, and the tab bar is
+            // drawn below the tallest child (see the bottomTabsChildHeight
+            // padding in layout-object.component), so bottom-align each child
+            // within that band to keep every child flush with the tab bar.
             if(isBottomTabs) {
                Point layoutPos = assemblyLayout.getPosition();
+               double maxChildHeight = childModels.stream()
+                  .mapToDouble(child -> child.getObjectFormat().getHeight())
+                  .max()
+                  .orElse(0);
 
                for(VSObjectModel childModel : childModels) {
                   VSFormatModel fmt = childModel.getObjectFormat();
                   fmt.setPositions(
-                     layoutPos.x, layoutPos.y,
+                     layoutPos.x, layoutPos.y + (maxChildHeight - fmt.getHeight()),
                      fmt.getWidth(), fmt.getHeight());
                }
             }

--- a/core/src/test/java/inetsoft/uql/viewsheet/vslayout/AbstractLayoutTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/vslayout/AbstractLayoutTest.java
@@ -1,0 +1,118 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.viewsheet.vslayout;
+
+import inetsoft.test.*;
+import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.internal.TabVSAssemblyInfo;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.awt.*;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for tab positioning in {@link AbstractLayout#apply(Viewsheet)}.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class },
+                      initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class AbstractLayoutTest {
+   /**
+    * Bug #76022: children of a bottom-tabs container must end flush with the
+    * top of the tab bar. Only the tallest child fills the content band, so a
+    * shorter child (a radio button next to a gauge) used to float above it.
+    */
+   @Test
+   void applyBottomTabsChildrenFlushWithTabBar() {
+      Viewsheet applied = createTabLayout().apply(createTabViewsheet(true));
+
+      // tab bar goes at the end of the content band
+      int tabBarY = LAYOUT_Y + TALL_HEIGHT;
+      assertEquals(tabBarY, layoutTop(applied, "Tab1"), "tab bar position");
+
+      assertEquals(LAYOUT_Y, layoutTop(applied, "Tall"),
+                   "tallest child fills the content band");
+      assertEquals(tabBarY - SHORT_HEIGHT, layoutTop(applied, "Short"),
+                   "shorter child should be pushed down against the tab bar");
+   }
+
+   @Test
+   void applyTopTabsChildrenBelowTabBar() {
+      Viewsheet applied = createTabLayout().apply(createTabViewsheet(false));
+
+      assertEquals(LAYOUT_Y, layoutTop(applied, "Tab1"), "tab bar position");
+      assertEquals(LAYOUT_Y + TAB_HEIGHT, layoutTop(applied, "Tall"),
+                   "children sit below the tab bar");
+      assertEquals(LAYOUT_Y + TAB_HEIGHT, layoutTop(applied, "Short"),
+                   "children sit below the tab bar");
+   }
+
+   private ViewsheetLayout createTabLayout() {
+      ViewsheetLayout layout = new ViewsheetLayout();
+      layout.setVSAssemblyLayouts(List.of(
+         new VSAssemblyLayout("Tab1", new Point(LAYOUT_X, LAYOUT_Y),
+                              new Dimension(200, TAB_HEIGHT + TALL_HEIGHT))));
+
+      return layout;
+   }
+
+   private Viewsheet createTabViewsheet(boolean bottomTabs) {
+      Viewsheet vs = new Viewsheet();
+
+      TextVSAssembly tall = new TextVSAssembly(vs, "Tall");
+      tall.setPixelOffset(new Point(160, 204));
+      tall.setPixelSize(new Dimension(140, TALL_HEIGHT));
+
+      TextVSAssembly shrt = new TextVSAssembly(vs, "Short");
+      shrt.setPixelOffset(new Point(160, 304));
+      shrt.setPixelSize(new Dimension(200, SHORT_HEIGHT));
+
+      TabVSAssembly tab = new TabVSAssembly(vs, "Tab1");
+      tab.setPixelOffset(new Point(160, 344));
+      tab.setPixelSize(new Dimension(200, TAB_HEIGHT));
+      ((TabVSAssemblyInfo) tab.getInfo()).setBottomTabsValue(bottomTabs);
+
+      vs.addAssembly(tall);
+      vs.addAssembly(shrt);
+      vs.addAssembly(tab);
+      tab.setAssemblies(new String[]{ "Tall", "Short" });
+
+      return vs;
+   }
+
+   private int layoutTop(Viewsheet vs, String name) {
+      return ((VSAssembly) vs.getAssembly(name)).getVSAssemblyInfo()
+         .getLayoutPosition().y;
+   }
+
+   private static final int LAYOUT_X = 80;
+   private static final int LAYOUT_Y = 80;
+   private static final int TAB_HEIGHT = 24;
+   private static final int TALL_HEIGHT = 140;
+   private static final int SHORT_HEIGHT = 40;
+}

--- a/core/src/test/java/inetsoft/web/composer/vs/controller/VSLayoutServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/controller/VSLayoutServiceTest.java
@@ -18,7 +18,7 @@
 package inetsoft.web.composer.vs.controller;
 
 import inetsoft.report.composition.RuntimeViewsheet;
-import inetsoft.test.SreeHome;
+import inetsoft.test.*;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.TabVSAssemblyInfo;
 import inetsoft.uql.viewsheet.vslayout.VSAssemblyLayout;
@@ -27,17 +27,26 @@ import inetsoft.web.viewsheet.model.VSFormatModel;
 import inetsoft.web.viewsheet.model.VSObjectModel;
 import inetsoft.web.viewsheet.model.VSObjectModelFactoryService;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.awt.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
-@SreeHome()
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class },
+                      initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
 @ExtendWith(MockitoExtension.class)
 class VSLayoutServiceTest {
 
@@ -47,7 +56,7 @@ class VSLayoutServiceTest {
    }
 
    @Test
-   void bottomTabsChildrenPositionedAtVisualTop() {
+   void bottomTabsSingleChildFillsContentBand() {
       Viewsheet vs = new Viewsheet();
 
       // tab assembly with bottomTabs enabled
@@ -97,7 +106,7 @@ class VSLayoutServiceTest {
    }
 
    @Test
-   void bottomTabsMultipleChildrenAllAtVisualTop() {
+   void bottomTabsMultipleChildrenFlushWithTabBar() {
       Viewsheet vs = new Viewsheet();
 
       TabVSAssembly tab = new TabVSAssembly(vs, "Tab1");
@@ -136,13 +145,69 @@ class VSLayoutServiceTest {
       assertEquals(layoutY, result.top(),
          "model top should be the visual top (layout position)");
 
-      // both children positioned at the visual top of the layout area
-      assertEquals(layoutY,
+      // the tab bar is drawn below the tallest child, so both children are
+      // bottom-aligned to it rather than stacked at the visual top
+      assertEquals(layoutY + (child2Height - child1Height),
          (int) childModel1.getObjectFormat().getTop(),
-         "child1 top should be at the visual top of the layout area");
+         "shorter child should be pushed down so its bottom meets the tab bar");
       assertEquals(layoutY,
          (int) childModel2.getObjectFormat().getTop(),
-         "child2 top should be at the visual top of the layout area");
+         "tallest child should start at the visual top of the layout area");
+      assertEquals(layoutY + child2Height,
+         (int) (childModel1.getObjectFormat().getTop() + child1Height),
+         "child1 bottom should be flush with the tab bar");
+      assertEquals(layoutY + child2Height,
+         (int) (childModel2.getObjectFormat().getTop() + child2Height),
+         "child2 bottom should be flush with the tab bar");
+   }
+
+   /**
+    * Bug #76022 repro: a radio button (40px) sharing a bottom-tab container
+    * with a gauge (140px) floated 100px above the tab strip.
+    */
+   @Test
+   void bottomTabsShortChildFlushWithTabBar() {
+      Viewsheet vs = new Viewsheet();
+
+      TabVSAssembly tab = new TabVSAssembly(vs, "Tab1");
+      TabVSAssemblyInfo tabInfo = (TabVSAssemblyInfo) tab.getInfo();
+      tabInfo.setBottomTabsValue(true);
+
+      TextVSAssembly radio = new TextVSAssembly(vs, "Text1");
+      TextVSAssembly gauge = new TextVSAssembly(vs, "Text2");
+      vs.addAssembly(radio);
+      vs.addAssembly(gauge);
+      vs.addAssembly(tab);
+      tab.setAssemblies(new String[]{"Text1", "Text2"});
+
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      int radioHeight = 40;
+      int gaugeHeight = 140;
+
+      VSObjectModel tabModel = mockObjectModel();
+      VSObjectModel radioModel = mockObjectModel();
+      VSObjectModel gaugeModel = mockObjectModel();
+      radioModel.getObjectFormat().setPositions(0, 0, 200, radioHeight);
+      gaugeModel.getObjectFormat().setPositions(0, 0, 140, gaugeHeight);
+
+      when(objectModelService.createModel(any(TabVSAssembly.class), eq(rvs))).thenReturn(tabModel);
+      when(objectModelService.createModel(any(TextVSAssembly.class), eq(rvs)))
+         .thenReturn(radioModel, gaugeModel);
+
+      int layoutY = 80;
+      // height is the tab bar (24) plus the tallest child
+      VSAssemblyLayout layout = new VSAssemblyLayout(
+         "Tab1", new Point(80, layoutY), new Dimension(200, 164));
+
+      service.createObjectModel(rvs, layout, objectModelService);
+
+      assertEquals(layoutY + gaugeHeight - radioHeight,
+         (int) radioModel.getObjectFormat().getTop(),
+         "radio button should sit directly above the tab strip");
+      assertEquals(layoutY,
+         (int) gaugeModel.getObjectFormat().getTop(),
+         "gauge fills the content band");
    }
 
    @Test


### PR DESCRIPTION
## Issue

`<tab>` when bottom tabs is true, the radio button position is wrong in device layout.

Repro: open viewsheet `tab` in the composer, select layout `a`. The radio button is not attached to the tab strip — its bottom should be aligned with the tab. Preview shows the same defect.

## Root cause

The tab strip and its children were positioned by two different rules, so they only lined up for the *tallest* child.

In the reported asset, `Tab1` (`bottomTabs=true`, 24px) contains `Gauge1` (140px) and `RadioButton1` (40px). Layout `a` stores one entry for `Tab1`: `(80,80)` size `200x164` (24 strip + 140 tallest child); the children have no stored positions and are derived.

- The **tab strip** is drawn at the bottom of the content band — the `padding-top` from `bottomTabsChildHeight` in `layout-object.component.ts`, and `npos.y + contentHeight` on the server.
- The **children** were all placed at the *top* of that band (`VSLayoutService` set every child model to the layout position; `AbstractLayout.applyTab` set every child to `npos.y`).

For the tallest child the two coincide, so the bug was invisible. `RadioButton1` ends at `120` while the strip sits at `220` — the ~100px gap in the report.

This regressed in Bug #74523, which changed the stored position to mean "visual top of the tab area" and dropped the per-child offset, relying on `VSEventUtil.applyTabScale` to re-flush children. That only runs when scale-to-screen applies at runtime, and never in the composer layout pane.

## Fix

Bottom-align each child within the content band so every child's bottom edge meets the top of the strip — the design-time rule the rest of the code already follows (`TabVSAssemblyInfo.repositionForBottomTabs`: bar fixed, children flush to it). The visual-top position convention from #74523 is preserved.

- `AbstractLayout.applyTab` — layout apply, preview, export: child y = `npos.y + max(0, contentHeight - childHeight)`
- `VSLayoutService.createObjectModel` — composer layout pane: child top = `layoutPos.y + (maxChildHeight - childHeight)`

The band height in `VSLayoutService` is deliberately the max *child model* height rather than `layoutHeight - tabHeight`, because that is the same number the template uses for its `padding-top`; if the two disagreed the gap would move instead of closing.

Export paths that shift a shrunk table flush to the bar (`applyShrunkBottomTabsShift`, `VsToReportConverter`) key off the assembly's own declared-vs-rendered height, not tab geometry, so they do not double-shift.

## Tests

Both fixes are covered by tests confirmed to fail without them:

- New `AbstractLayoutTest` reproduces the asset (140/40 children, 24px bar) — without the fix: `expected: <180> but was: <80>`, exactly the reported gap. Also asserts top-tabs positioning is unchanged.
- `VSLayoutServiceTest` gains a #76022 case and an updated multi-child expectation — without the fix: `<360>` vs `<300>` and `<180>` vs `<80>`.

Both classes were missing the Spring test wiring that `@SreeHome` needs (`SpringExtension` + `BaseTestConfiguration`), so they errored out before reaching any assertion; that wiring plus `@Tag("core")` is added so they actually run under the pom's tag filter.

`./mvnw test -pl core -Dtest=VSLayoutServiceTest,AbstractLayoutTest` → 8/8 pass.

Not yet verified in a running server — composer view, preview, and a PDF/Excel export of a bottom-tabs layout are worth a visual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)