### PR TITLE
Bug #76119, stop presentation reset from deleting custom shapes

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/presentation/PresentationSettingsController.java
+++ b/core/src/main/java/inetsoft/web/admin/presentation/PresentationSettingsController.java
@@ -21,10 +21,8 @@ import inetsoft.graph.geo.service.MapboxStyle;
 import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.internal.cluster.Cluster;
 import inetsoft.sree.security.*;
-import inetsoft.uql.viewsheet.graph.aesthetic.ImageShapes;
 import inetsoft.util.Catalog;
 import inetsoft.util.InvalidOrgException;
-import inetsoft.web.admin.content.dataspace.DataSpaceContentSettingsService;
 import inetsoft.web.admin.general.WebMapSettingsService;
 import inetsoft.web.admin.presentation.model.PresentationSettingsModel;
 import inetsoft.web.security.RequiredPermission;
@@ -56,7 +54,6 @@ public class PresentationSettingsController {
       PresentationTimeSettingsService timeSettingsService,
       PresentationDataSourceVisibilitySettingsService dataSourceVisibilitySettingsService,
       WebMapSettingsService webMapSettingsService,
-      DataSpaceContentSettingsService dataSpaceContentSettingsService,
       AISettingsService aiSettingsService,
       Cluster cluster)
    {
@@ -76,7 +73,6 @@ public class PresentationSettingsController {
       this.timeSettingsService = timeSettingsService;
       this.dataSourceVisibilitySettingsService = dataSourceVisibilitySettingsService;
       this.webMapSettingsService = webMapSettingsService;
-      this.dataSpaceContentSettingsService = dataSpaceContentSettingsService;
       this.aiSettingsService = aiSettingsService;
       this.cluster = cluster;
    }
@@ -304,9 +300,8 @@ public class PresentationSettingsController {
          timeSettingsService.resetSettings(globalSettings);
          dataSourceVisibilitySettingsService.resetSettings(globalSettings);
          webMapSettingsService.resetSettings(principal, globalSettings);
-         String shapesDirectory = globalSettings ?
-            ImageShapes.getGlobalShapesDirectory() : ImageShapes.getShapesDirectory();
-         dataSpaceContentSettingsService.deleteDataSpaceNode(shapesDirectory, false);
+         // custom shapes are uploaded content stored in the data space, not a presentation
+         // property, so they are intentionally left alone by the reset
          welcomePageService.resetSettings(globalSettings);
          loginBannerSettingsService.resetSettings(globalSettings);
 
@@ -338,7 +333,6 @@ public class PresentationSettingsController {
    private final PresentationTimeSettingsService timeSettingsService;
    private final PresentationDataSourceVisibilitySettingsService dataSourceVisibilitySettingsService;
    private final WebMapSettingsService webMapSettingsService;
-   private final DataSpaceContentSettingsService dataSpaceContentSettingsService;
    private final AISettingsService aiSettingsService;
    private final Cluster cluster;
    private static final String SETTINGS_LOCK = PresentationSettingsController.class.getName() + ".settingsLock";

--- a/core/src/test/java/inetsoft/web/admin/presentation/PresentationSettingsControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/presentation/PresentationSettingsControllerTest.java
@@ -41,13 +41,15 @@ package inetsoft.web.admin.presentation;
  *   Same globalSettings gate for fontMapping and AI:
  *     [global]     fontMappingSettingsService.resetSettings and aiSettingsService.resetSettings called
  *     [non-global] those two services skipped
+ *   resetSettings does not touch the data space: custom shapes uploaded to
+ *   portal/shapes (or portal/<orgID>/shapes) are content, not a presentation property, and
+ *   must survive a reset at either scope.
  */
 
 import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.internal.cluster.Cluster;
 import inetsoft.sree.security.*;
 import inetsoft.util.InvalidOrgException;
-import inetsoft.web.admin.content.dataspace.DataSpaceContentSettingsService;
 import inetsoft.web.admin.general.WebMapSettingsService;
 import inetsoft.web.admin.general.model.WebMapSettingsModel;
 import inetsoft.web.admin.presentation.model.*;
@@ -83,7 +85,6 @@ class PresentationSettingsControllerTest {
    @Mock private PresentationTimeSettingsService timeSettingsService;
    @Mock private PresentationDataSourceVisibilitySettingsService dataSourceVisibilitySettingsService;
    @Mock private WebMapSettingsService webMapSettingsService;
-   @Mock private DataSpaceContentSettingsService dataSpaceContentSettingsService;
    @Mock private AISettingsService aiSettingsService;
    @Mock private Cluster cluster;
    @Mock private Lock settingsLock;
@@ -106,7 +107,7 @@ class PresentationSettingsControllerTest {
          fontMappingSettingsService, shareSettingsService, securityEngine,
          composerMessageSettingsService, timeSettingsService,
          dataSourceVisibilitySettingsService, webMapSettingsService,
-         dataSpaceContentSettingsService, aiSettingsService, cluster);
+         aiSettingsService, cluster);
 
       sUtilStatic = mockStatic(SUtil.class, withSettings().lenient());
       orgManagerStatic = mockStatic(OrganizationManager.class, withSettings().lenient());
@@ -234,7 +235,8 @@ class PresentationSettingsControllerTest {
    // resetSettings — globalSettings gate for fontMapping and AI
    // -------------------------------------------------------------------------
 
-   // [global] fontMapping and AI reset methods called
+   // [global] fontMapping and AI reset methods called; custom shapes in portal/shapes are
+   // left alone (the controller no longer holds a DataSpaceContentSettingsService)
    @Test
    void resetSettings_globalSettings_resetsFontMappingAndAi() throws Exception {
       when(orgManager.isSiteAdmin(principal)).thenReturn(true);
@@ -247,7 +249,8 @@ class PresentationSettingsControllerTest {
       verify(aiSettingsService).resetSettings();
    }
 
-   // [non-global] fontMapping and AI reset skipped
+   // [non-global] fontMapping and AI reset skipped; org-scoped custom shapes in
+   // portal/<orgID>/shapes are likewise left alone
    @Test
    void resetSettings_nonGlobalSettings_skipsFontMappingAndAiReset() throws Exception {
       when(orgManager.isSiteAdmin(principal)).thenReturn(false);


### PR DESCRIPTION
## Problem

In EM → Settings → Presentation → Look and Feel: open **Custom Shapes**, upload a shape, close the dialog, then click **Reset to Default** — every custom shape disappears, including shapes that were in the environment beforehand.

`PresentationSettingsController.resetSettings()` recursively deleted the whole shapes directory:

```java
String shapesDirectory = globalSettings ?
   ImageShapes.getGlobalShapesDirectory() : ImageShapes.getShapesDirectory();
dataSpaceContentSettingsService.deleteDataSpaceNode(shapesDirectory, false);
```

Both `deleteChildren` and `DataSpace.delete` recurse, so the folder and every file under it were removed.

This is unrecoverable data loss:

- The 16 built-in shapes are classpath resources (`ImageShapes.loadBuiltins`, `/inetsoft/uql/viewsheet/graph/shapes/`). Nothing in the product ever seeds `portal/shapes`, so **every file in that folder is uploaded content with no default to fall back on**.
- `ImageShapes.loadShapes()` reads the global `portal/shapes` folder for *every* org, so a global reset destroyed shapes shared across tenants.
- In a single-tenant deployment `ImageShapes.getShapesDirectory()` also resolves to `portal/shapes`, so even the org-scoped branch hit the global folder.
- Reset was the only shapes-deletion path that bypassed `DataSpaceTreeController.checkDeletePermission`.

Everything else the look-and-feel reset touches is a *named file* backed by a classpath or manager default (logo, favicon, `format.css`, fonts, `userformat.xml`). Shapes were the only blunt recursive folder wipe.

## Fix

Custom shapes are data space content, not a presentation property, so the reset no longer touches them at either scope. The `DataSpaceContentSettingsService` dependency and the `ImageShapes` import are removed along with the delete call, so the controller can no longer reach the data space at all — that removal is the regression guard.

Nothing else in `resetSettings` changed: the `globalSettings` derivation and the `SETTINGS_LOCK` usage are untouched.

### Note on Bug #76034

This reverses the behavior that #76034 asked for. Commit cf16991b67 retargeted this delete from `portal/<currentOrg>/shapes` to `portal/shapes` for a global reset; before that a global reset hit the site admin's normally-empty org folder, which is why reset appeared not to affect custom shapes. The two reports want opposite things from the same line, and the decision here is that reset never deletes uploaded shapes. cf16991b67 is left in history.

## Testing

- `PresentationSettingsControllerTest` — 8 tests, 0 failures. Updated for the positional constructor change; the strategy comment now records that `resetSettings` does not touch the data space.
- `core` compiles cleanly.

Manual steps to confirm: upload two shapes via **Custom Shapes**, click **Reset to Default**, re-open the dialog — both files should still be listed, and still selectable in a chart's shape dropdown. Logo/favicon/tree-sort/CSS/fonts should still reset as before.

## Related pre-existing defects (not addressed here)

Found while tracing; each deserves its own issue:

- `DataSpaceContentSettingsService.deleteDataSpaceNode` only calls `ImageShapes.clearShapes()` when the path starts with `".../shapes/"` (trailing slash), so deleting the shapes *folder* from the EM Data Space page leaves a stale in-memory cache. `clearShapes()` also only clears the current org's entry.
- `custom-shape-dialog.component.ts:186` hardcodes `portal/host-org/shapes` as the only protected root, so a non-default org's root and the global root stay deletable from the dialog.
- `LookAndFeelService.setLogo`/`setFavicon` build the org delete path as `portal/portal/<orgID>/logo.png`, so org logo/favicon files survive a reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
