### PR TITLE
fix(D1 review): colName-only highlight address was dropped by #4631

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -516,11 +516,21 @@ public class ViewsheetAssemblyAgentController {
     * a non-null {@code Region(0, 0, ...)} and the fall-forward became dead code. Omitting
     * {@code row}/{@code col} then always addressed cell (0,0) — a table's header — and was
     * refused for exposing no highlightable fields.
+    *
+    * <p>{@code colName} is a standalone address, not a qualifier on {@code row}/{@code col} — a
+    * chart has no rows or columns, so picking one of its measures to highlight is addressed by
+    * {@code colName} alone. Collapsing to {@code null} on {@code row == null && col == null}
+    * without also checking {@code colName} silently drops that address: {@code read()} then
+    * substitutes {@code Region.whole()}, whose {@code colName} is also null, so
+    * {@code HighlightDialogService} resolves no measure and the call is refused for exposing no
+    * highlightable fields. Before this method existed the same request worked, because the old
+    * unconditional {@code Region(row, col, colName, ...)} construction preserved {@code colName}
+    * even while normalizing {@code row}/{@code col} to 0.
     */
    private static AssemblyHighlightService.Region highlightRegion(Integer row, Integer col,
                                                                    String colName)
    {
-      return row == null && col == null ? null
+      return row == null && col == null && colName == null ? null
          : new AssemblyHighlightService.Region(row, col, colName, false, false);
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -302,6 +302,26 @@ class ViewsheetAssemblyAgentControllerTest {
                                                                           false)));
    }
 
+   /**
+    * {@code colName} is a standalone address, not a qualifier on {@code row}/{@code col} — a
+    * chart has no rows or columns, so picking one of its measures to highlight is addressed by
+    * {@code colName} alone, with {@code row}/{@code col} both omitted. An earlier version of
+    * {@code highlightRegion} checked only {@code row}/{@code col} for null and dropped a
+    * {@code colName}-only address into the "no location named" branch, silently losing it.
+    */
+   @Test
+   void listHighlightsPassesARealRegionWhenOnlyColNameWasNamed() throws Exception {
+      AssemblyHighlightService highlightService = mock(AssemblyHighlightService.class);
+      ViewsheetAssemblyAgentController controller = controllerWith(highlightService);
+
+      controller.listHighlights("tok", "Chart1", null, null, "Sum(Sales)", principal());
+
+      verify(highlightService).list(eq("tok"), any(Principal.class), eq("Chart1"),
+                                    eq(new AssemblyHighlightService.Region(null, null,
+                                                                          "Sum(Sales)", false,
+                                                                          false)));
+   }
+
    /** Same signal, reached through {@code HighlightRequest.region()} for set/delete. */
    @Test
    void setHighlightPassesANullRegionWhenNoLocationWasNamed() throws Exception {


### PR DESCRIPTION
## Summary
Fixes a regression review found in already-merged #4631, reported by @larryliang-inetsoft.

`highlightRegion`'s null-collapse checked only `row`/`col`, not `colName`. But `colName` is a standalone address, not a qualifier on `row`/`col` — a chart has no rows or columns, so picking one of its measures to highlight is addressed by `colName` alone (`plugin/composer/src/tools/highlightTools.ts` documents and sends it that way). A `colName`-only call now collapsed into the "no location named" branch, silently dropping the address: `AssemblyHighlightService.read()` substituted `Region.whole()` (whose `colName` is also null), so `HighlightDialogService` resolved no measure and the call was refused for exposing no highlightable fields.

Before #4631, the same request worked — the prior unconditional `Region(row, col, colName, ...)` construction preserved `colName` even while its compact constructor normalized `row`/`col` to 0. The fix that closed the "controller never produces a null Region" bug introduced a narrower version of the same class of defect it was fixing.

Fix: collapse to `null` only when `row`, `col` **and** `colName` are all absent.

## Test plan
- [x] `ViewsheetAssemblyAgentControllerTest` — 14/14, including a new `listHighlightsPassesARealRegionWhenOnlyColNameWasNamed` test pinning the `colName`-only case
- [x] `AssemblyHighlightServiceTest` — 22/22, unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)