### PR TITLE
Bug #76125, report the org default theme as the default in single-tenant mode

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/presentation/model/CustomThemeModel.java
+++ b/core/src/main/java/inetsoft/web/admin/presentation/model/CustomThemeModel.java
@@ -60,10 +60,7 @@ public interface CustomThemeModel {
 //         groups(theme.getGroups());
 //         roles(theme.getRoles());
 
-         String orgSelected = customThemesManager.getOrgSelectedTheme();
-         String globalSelected = customThemesManager.getGlobalSelectedTheme();
-         defaultThemeGlobal(Objects.equals(globalSelected, theme.getId()));
-         defaultThemeOrg(Objects.equals(theme.getId(), orgSelected));
+         applyDefaultFlags(theme, customThemesManager);
 
          return this;
       }
@@ -76,13 +73,24 @@ public interface CustomThemeModel {
          global(theme.getOrgID() == null);
          portalCss(portalCss);
          emCss(emCss);
-
-         String orgSelected = customThemesManager.getOrgSelectedTheme();
-         String globalSelected = customThemesManager.getGlobalSelectedTheme();
-         defaultThemeGlobal(Objects.equals(globalSelected, theme.getId()));
-         defaultThemeOrg(Objects.equals(theme.getId(), orgSelected));
+         applyDefaultFlags(theme, customThemesManager);
 
          return this;
+      }
+
+      private void applyDefaultFlags(CustomTheme theme, CustomThemesManager customThemesManager) {
+         String orgSelected = customThemesManager.getOrgSelectedTheme();
+         String globalSelected = customThemesManager.getGlobalSelectedTheme();
+         boolean isOrgDefault = Objects.equals(theme.getId(), orgSelected);
+         boolean isGlobalDefault = Objects.equals(globalSelected, theme.getId());
+
+         // In single-tenant mode the only default control in the UI is the "Default" checkbox,
+         // which is bound to defaultThemeGlobal. The org selected theme still takes priority in
+         // CustomThemesImpl.getSelectedTheme(), so a theme that only holds the org pointer (e.g.
+         // set as "Default for This Organization" before multi-tenancy was disabled) is the
+         // effective default and must be reported as such.
+         defaultThemeGlobal(isGlobalDefault || !SUtil.isMultiTenant() && isOrgDefault);
+         defaultThemeOrg(isOrgDefault);
       }
    }
 }


### PR DESCRIPTION
### Issue

Presentation → Themes: create two themes on the host org with multi-tenancy enabled, uncheck "Visible to All Organizations" on both, check "Default for This Organization" on Theme2, then disable multi-tenancy and security. Theme2 is still the default (the list shows its checkmark and Portal applies it) but the properties pane shows **Default** unchecked.

### Cause

The org default and global default are two separate `SreeEnv` pointers — `portal.org.selectedThemeId.<orgID>` and `portal.org.selectedThemeId`. In single-tenant mode the properties pane renders only one checkbox, bound to `defaultThemeGlobal`, while `CustomThemeModel.Builder.from()` derived that flag purely from the *global* pointer.

The org pointer survives the multi-tenancy toggle — the host org and the single-tenant default org share the ID `host-org` — and `CustomThemesImpl.getSelectedTheme()` prefers it over the global pointer. So the theme really is the effective default, but the checkbox said otherwise. The theme list's checkmark reads `defaultThemeOrg` first, which is why the two views disagreed.

### Fix

Extracted the flag derivation into `applyDefaultFlags()` (shared by both `from()` overloads) and, when `!SUtil.isMultiTenant()`, report `defaultThemeGlobal` as global-pointer **or** org-pointer match, so the single "Default" checkbox reflects the theme that is actually applied.

The write side (ignoring the stale hidden `defaultThemeOrg` value and clearing the leftover org pointer when "Default" is unchecked) is in the paired enterprise PR, along with the `ThemeServiceTest` coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)