### PR TITLE
fix(write-coordination): wire the client into the revision check

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/RuntimeViewsheet.java
+++ b/core/src/main/java/inetsoft/report/composition/RuntimeViewsheet.java
@@ -2923,7 +2923,11 @@ public class RuntimeViewsheet extends RuntimeSheet {
    private boolean preview; // preview flag
    private boolean needRefresh = false; // force refresh
    private int mode; // viewsheet mode
-   private transient int writeRevision; // bumped on every dialog-owning commit; see getWriteRevision
+   // Bumped by VSObjectPropertyService, VSConditionDialogService, ViewsheetPropertyDialogService,
+   // VSBindingService, and the wiz agent write seams (ViewsheetSessionService.mutate,
+   // ScriptEditService) -- not literally every dialog-owning commit; a dialog service that
+   // routes through a different path does not bump it. See getWriteRevision.
+   private transient int writeRevision;
    private transient Integer baseWriteRevisionAtOpen; // binding-editor clones only; see accessor
    private ViewsheetSandbox box; // query sandbox
    private AssetRepository rep; // asset repository

--- a/web/projects/portal/src/app/common/abstract-highlight.component.ts
+++ b/web/projects/portal/src/app/common/abstract-highlight.component.ts
@@ -102,10 +102,17 @@ export class AbstractHighlight {
       }
    }
 
-   // remove fields that are not used on the server side to reduce the transmission size
-   getServerAppliedModel(): HighlightDialogModel {
+   // remove fields that are not used on the server side to reduce the transmission size.
+   // Only a final commit (OK) carries the revision it was read at -- Apply leaves the dialog
+   // open with its held model never refreshed, so echoing it back on Apply would make the
+   // dialog conflict with its own prior Apply. See 2026-08-17-write-coordination-design.md.
+   getServerAppliedModel(includeRevision: boolean = true): HighlightDialogModel {
       let model = Tool.shallowClone(this._model);
       model.fields = [];
+
+      if(!includeRevision) {
+         delete model.revision;
+      }
 
       if(model.highlights) {
          model.highlights = Tool.shallowClone(model.highlights);

--- a/web/projects/portal/src/app/common/data/condition/vs-condition-dialog-model.ts
+++ b/web/projects/portal/src/app/common/data/condition/vs-condition-dialog-model.ts
@@ -21,4 +21,9 @@ export interface VSConditionDialogModel {
    tableName: string;
    fields: DataRef[];
    conditionList: any[];
+   // The write-coordination revision this model was read at. Sent back only on a final commit
+   // (OK), never on Apply -- the dialog's own held copy is never refreshed after a commit, so
+   // echoing it back on Apply would make the dialog conflict with its own prior Apply. See
+   // 2026-08-17-write-coordination-design.md.
+   revision?: number;
 }

--- a/web/projects/portal/src/app/common/util/component-tool.spec.ts
+++ b/web/projects/portal/src/app/common/util/component-tool.spec.ts
@@ -23,14 +23,21 @@ function fakeModal() {
    const onCommit = new Subject<any>();
    const onCancel = new Subject<any>();
    const componentInstance: any = { onApply, onCommit, onCancel };
+   let resolveResult: (v: any) => void;
    const modalRef: any = {
       componentInstance,
-      // Never resolves in these tests -- only the synchronous apply path is exercised.
-      result: new Promise<any>(() => {})
+      result: new Promise<any>((resolve) => { resolveResult = resolve; }),
+      close: (v: any) => resolveResult(v)
    };
    const modalService: any = { open: () => modalRef, objectChange: () => {} };
 
-   return { onApply, modalService };
+   return { onApply, onCommit, modalService };
+}
+
+// Flushes the "wait for next cycle" setTimeout(0) in showDialog's commit path, and the
+// microtask it schedules by resolving modal.result.
+function flush(): Promise<void> {
+   return new Promise(resolve => setTimeout(resolve, 0));
 }
 
 describe("ComponentTool.showDialog", () => {
@@ -62,5 +69,39 @@ describe("ComponentTool.showDialog", () => {
       onApply.next({ collapse: false, result: { other: "x" } });
 
       expect(received).toEqual({ other: "x" });
+   });
+
+   // stylebi#4637: "Apply then OK discards your edits". An Apply bumps the server's revision
+   // but nothing refreshes the dialog's held copy, so the FINAL commit (OK) that follows still
+   // carries the pre-apply revision and would otherwise be wrongly refused as a conflict with
+   // the dialog's own prior apply.
+   it("strips a stale revision from the final commit once an apply has already happened", async () => {
+      const { onApply, onCommit, modalService } = fakeModal();
+      let received: any;
+
+      ComponentTool.showDialog(modalService, class {} as any,
+         (v: any) => { received = v; }, {});
+
+      onApply.next({ collapse: false, result: { revision: 7, other: "x" } });
+      onCommit.next({ revision: 7, other: "y" });
+      await flush();
+      await flush();
+
+      expect(received.revision).toBeUndefined();
+      expect(received.other).toBe("y");
+   });
+
+   it("does not touch the commit's revision when no apply happened first", async () => {
+      const { onCommit, modalService } = fakeModal();
+      let received: any;
+
+      ComponentTool.showDialog(modalService, class {} as any,
+         (v: any) => { received = v; }, {});
+
+      onCommit.next({ revision: 7, other: "y" });
+      await flush();
+      await flush();
+
+      expect(received.revision).toBe(7);
    });
 });

--- a/web/projects/portal/src/app/common/util/component-tool.spec.ts
+++ b/web/projects/portal/src/app/common/util/component-tool.spec.ts
@@ -1,0 +1,66 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { Subject } from "rxjs";
+import { ComponentTool } from "./component-tool";
+
+function fakeModal() {
+   const onApply = new Subject<any>();
+   const onCommit = new Subject<any>();
+   const onCancel = new Subject<any>();
+   const componentInstance: any = { onApply, onCommit, onCancel };
+   const modalRef: any = {
+      componentInstance,
+      // Never resolves in these tests -- only the synchronous apply path is exercised.
+      result: new Promise<any>(() => {})
+   };
+   const modalService: any = { open: () => modalRef, objectChange: () => {} };
+
+   return { onApply, modalService };
+}
+
+describe("ComponentTool.showDialog", () => {
+   // Write coordination (2026-08-17-write-coordination-design.md): Apply never closes the
+   // dialog, so a dialog that forwards its held model unmodified on Apply would otherwise carry
+   // a since-bumped revision into its own next apply/commit and conflict with itself. Found on
+   // stylebi#4640 review -- most property dialogs emit their model as-is on apply, so the fix
+   // belongs here, once, rather than in each dialog's own payload-construction code.
+   it("strips revision from an apply payload before it reaches the caller", () => {
+      const { onApply, modalService } = fakeModal();
+      let received: any;
+
+      ComponentTool.showDialog(modalService, class {} as any,
+         (v: any) => { received = v; }, {});
+
+      onApply.next({ collapse: false, result: { revision: 7, other: "x" } });
+
+      expect(received.revision).toBeUndefined();
+      expect(received.other).toBe("x");
+   });
+
+   it("leaves an apply payload with no revision untouched", () => {
+      const { onApply, modalService } = fakeModal();
+      let received: any;
+
+      ComponentTool.showDialog(modalService, class {} as any,
+         (v: any) => { received = v; }, {});
+
+      onApply.next({ collapse: false, result: { other: "x" } });
+
+      expect(received).toEqual({ other: "x" });
+   });
+});

--- a/web/projects/portal/src/app/common/util/component-tool.ts
+++ b/web/projects/portal/src/app/common/util/component-tool.ts
@@ -101,6 +101,15 @@ export namespace ComponentTool {
       let commitSubscription: Subscription;
       let cancelSubscription: Subscription;
       let applySubscription: Subscription;
+      // Write coordination: once this dialog session has already committed one Apply, the
+      // revision it captured on open is stale by construction -- that Apply bumped the
+      // server's counter and nothing refreshes the dialog's held copy (see the apply
+      // subscription below). Sending it on the FINAL commit (OK) would wrongly refuse the
+      // user's own un-conflicting edit -- the "Apply then OK discards your edits" shape of
+      // stylebi#4637. Real conflict detection for a dialog that has already Applied would need
+      // the server to echo the new revision back, which this architecture has no response
+      // channel for; until that exists, don't block the user's own sequential edits.
+      let appliedAtLeastOnce = false;
 
       commitSubscription = modal.componentInstance[commitEmitter]?.subscribe((v: any) => {
          commitSubscription.unsubscribe();
@@ -108,6 +117,10 @@ export namespace ComponentTool {
 
          if(applySubscription) {
             applySubscription.unsubscribe();
+         }
+
+         if(appliedAtLeastOnce && v && typeof v === "object" && "revision" in v) {
+            v = {...v, revision: undefined};
          }
 
          if(options.objectId) {
@@ -133,6 +146,8 @@ export namespace ComponentTool {
 
       if(modal.componentInstance[applyEmitter]) {
          applySubscription = modal.componentInstance[applyEmitter].subscribe((v: any) => {
+            appliedAtLeastOnce = true;
+
             if(v.collapse != null && v.result != null) {
                if(v.collapse && (<any> modal).setExpanded) {
                   setTimeout(() => slideout.setExpanded(false), 0);

--- a/web/projects/portal/src/app/common/util/component-tool.ts
+++ b/web/projects/portal/src/app/common/util/component-tool.ts
@@ -141,6 +141,19 @@ export namespace ComponentTool {
                v = v.result;
             }
 
+            // Write coordination: Apply never closes the dialog, so its held model is never
+            // refreshed with the revision the commit it just sent bumped to on the server. A
+            // dialog that forwards its held model unmodified (most of them do) would otherwise
+            // carry that now-stale revision into its own next apply/commit and conflict with
+            // itself. Stripped once, here, for every dialog that reaches this apply path,
+            // rather than relying on each dialog's own payload-construction code to remember —
+            // found on stylebi#4640 review: the fix landed only in the handful of dialogs that
+            // rebuild a slimmed request object, not in the majority that emit the model as-is.
+            // See 2026-08-17-write-coordination-design.md.
+            if(v && typeof v === "object" && "revision" in v) {
+               v = {...v, revision: undefined};
+            }
+
             if(options.objectId) {
                modalService.objectChange(options.objectId, slideout.title);
                slideout.changedByOthers = false;

--- a/web/projects/portal/src/app/composer/data/vs/calendar-property-dialog-model.ts
+++ b/web/projects/portal/src/app/composer/data/vs/calendar-property-dialog-model.ts
@@ -25,4 +25,10 @@ export interface CalendarPropertyDialogModel {
    calendarDataPaneModel: CalendarDataPaneModel;
    calendarAdvancedPaneModel: CalendarAdvancedPaneModel;
    vsAssemblyScriptPaneModel: VSAssemblyScriptPaneModel;
+
+   // The write-coordination revision this model was read at. Sent back only on a final commit
+   // (OK), never on Apply -- the dialog's own held copy is never refreshed after a commit, so
+   // echoing it back on Apply would make the dialog conflict with its own prior Apply. See
+   // 2026-08-17-write-coordination-design.md.
+   revision?: number;
 }

--- a/web/projects/portal/src/app/composer/data/vs/gauge-property-dialog-model.ts
+++ b/web/projects/portal/src/app/composer/data/vs/gauge-property-dialog-model.ts
@@ -25,4 +25,10 @@ export interface GaugePropertyDialogModel {
    dataOutputPaneModel: DataOutputPaneModel;
    gaugeAdvancedPaneModel: GaugeAdvancedPaneModel;
    vsAssemblyScriptPaneModel: VSAssemblyScriptPaneModel;
+
+   // The write-coordination revision this model was read at. Sent back only on a final commit
+   // (OK), never on Apply -- the dialog's own held copy is never refreshed after a commit, so
+   // echoing it back on Apply would make the dialog conflict with its own prior Apply. See
+   // 2026-08-17-write-coordination-design.md.
+   revision?: number;
 }

--- a/web/projects/portal/src/app/composer/data/vs/group-container-property-dialog-model.ts
+++ b/web/projects/portal/src/app/composer/data/vs/group-container-property-dialog-model.ts
@@ -23,4 +23,10 @@ export interface GroupContainerPropertyDialogModel {
    groupContainerGeneralPane: GroupContainerGeneralPaneModel;
    imageScalePane: ImageScalePaneModel;
    vsAssemblyScriptPane: VSAssemblyScriptPaneModel;
+
+   // The write-coordination revision this model was read at. Sent back only on a final commit
+   // (OK), never on Apply -- the dialog's own held copy is never refreshed after a commit, so
+   // echoing it back on Apply would make the dialog conflict with its own prior Apply. See
+   // 2026-08-17-write-coordination-design.md.
+   revision?: number;
 }

--- a/web/projects/portal/src/app/composer/data/vs/image-property-dialog-model.ts
+++ b/web/projects/portal/src/app/composer/data/vs/image-property-dialog-model.ts
@@ -25,4 +25,10 @@ export interface ImagePropertyDialogModel {
    dataOutputPaneModel: DataOutputPaneModel;
    imageAdvancedPaneModel: ImageAdvancedPaneModel;
    clickableScriptPaneModel: ClickableScriptPaneModel;
+
+   // The write-coordination revision this model was read at. Sent back only on a final commit
+   // (OK), never on Apply -- the dialog's own held copy is never refreshed after a commit, so
+   // echoing it back on Apply would make the dialog conflict with its own prior Apply. See
+   // 2026-08-17-write-coordination-design.md.
+   revision?: number;
 }

--- a/web/projects/portal/src/app/composer/data/vs/line-property-dialog-model.ts
+++ b/web/projects/portal/src/app/composer/data/vs/line-property-dialog-model.ts
@@ -23,4 +23,10 @@ export interface LinePropertyDialogModel {
    shapeGeneralPaneModel: ShapeGeneralPaneModel;
    linePropertyPaneModel: LinePropertyPaneModel;
    vsAssemblyScriptPaneModel: VSAssemblyScriptPaneModel;
+
+   // The write-coordination revision this model was read at. Sent back only on a final commit
+   // (OK), never on Apply -- the dialog's own held copy is never refreshed after a commit, so
+   // echoing it back on Apply would make the dialog conflict with its own prior Apply. See
+   // 2026-08-17-write-coordination-design.md.
+   revision?: number;
 }

--- a/web/projects/portal/src/app/composer/data/vs/oval-property-dialog-model.ts
+++ b/web/projects/portal/src/app/composer/data/vs/oval-property-dialog-model.ts
@@ -23,4 +23,9 @@ export interface OvalPropertyDialogModel {
    shapeGeneralPaneModel: ShapeGeneralPaneModel;
    ovalPropertyPaneModel: OvalPropertyPaneModel;
    vsAssemblyScriptPaneModel: VSAssemblyScriptPaneModel;
+   // The write-coordination revision this model was read at. Sent back only on a final commit
+   // (OK), never on Apply -- the dialog's own held copy is never refreshed after a commit, so
+   // echoing it back on Apply would make the dialog conflict with its own prior Apply. See
+   // 2026-08-17-write-coordination-design.md.
+   revision?: number;
 }

--- a/web/projects/portal/src/app/composer/data/vs/rectangle-property-dialog-model.ts
+++ b/web/projects/portal/src/app/composer/data/vs/rectangle-property-dialog-model.ts
@@ -23,4 +23,9 @@ export interface RectanglePropertyDialogModel {
    shapeGeneralPaneModel: ShapeGeneralPaneModel;
    rectanglePropertyPaneModel: RectanglePropertyPaneModel;
    vsAssemblyScriptPaneModel: VSAssemblyScriptPaneModel;
+   // The write-coordination revision this model was read at. Sent back only on a final commit
+   // (OK), never on Apply -- the dialog's own held copy is never refreshed after a commit, so
+   // echoing it back on Apply would make the dialog conflict with its own prior Apply. See
+   // 2026-08-17-write-coordination-design.md.
+   revision?: number;
 }

--- a/web/projects/portal/src/app/composer/data/vs/selection-container-property-dialog-model.ts
+++ b/web/projects/portal/src/app/composer/data/vs/selection-container-property-dialog-model.ts
@@ -21,4 +21,9 @@ import { SelectionContainerGeneralPaneModel } from "./selection-container-genera
 export interface SelectionContainerPropertyDialogModel {
    selectionContainerGeneralPaneModel: SelectionContainerGeneralPaneModel;
    vsAssemblyScriptPaneModel: VSAssemblyScriptPaneModel;
+   // The write-coordination revision this model was read at. Sent back only on a final commit
+   // (OK), never on Apply -- the dialog's own held copy is never refreshed after a commit, so
+   // echoing it back on Apply would make the dialog conflict with its own prior Apply. See
+   // 2026-08-17-write-coordination-design.md.
+   revision?: number;
 }

--- a/web/projects/portal/src/app/composer/data/vs/selection-list-property-dialog-model.ts
+++ b/web/projects/portal/src/app/composer/data/vs/selection-list-property-dialog-model.ts
@@ -23,4 +23,9 @@ export interface SelectionListPropertyDialogModel {
    selectionGeneralPaneModel: SelectionGeneralPaneModel;
    selectionListPaneModel: SelectionListPaneModel;
    vsAssemblyScriptPaneModel: VSAssemblyScriptPaneModel;
+   // The write-coordination revision this model was read at. Sent back only on a final commit
+   // (OK), never on Apply -- the dialog's own held copy is never refreshed after a commit, so
+   // echoing it back on Apply would make the dialog conflict with its own prior Apply. See
+   // 2026-08-17-write-coordination-design.md.
+   revision?: number;
 }

--- a/web/projects/portal/src/app/composer/data/vs/selection-tree-property-dialog-model.ts
+++ b/web/projects/portal/src/app/composer/data/vs/selection-tree-property-dialog-model.ts
@@ -23,4 +23,9 @@ export interface SelectionTreePropertyDialogModel {
    selectionGeneralPaneModel: SelectionGeneralPaneModel;
    selectionTreePaneModel: SelectionTreePaneModel;
    vsAssemblyScriptPaneModel: VSAssemblyScriptPaneModel;
+   // The write-coordination revision this model was read at. Sent back only on a final commit
+   // (OK), never on Apply -- the dialog's own held copy is never refreshed after a commit, so
+   // echoing it back on Apply would make the dialog conflict with its own prior Apply. See
+   // 2026-08-17-write-coordination-design.md.
+   revision?: number;
 }

--- a/web/projects/portal/src/app/composer/data/vs/submit-property-dialog-model.ts
+++ b/web/projects/portal/src/app/composer/data/vs/submit-property-dialog-model.ts
@@ -21,4 +21,10 @@ import { ClickableScriptPaneModel } from "./clickable-script-pane-model";
 export interface SubmitPropertyDialogModel {
    submitGeneralPaneModel: SubmitGeneralPaneModel;
    clickableScriptPaneModel: ClickableScriptPaneModel;
+
+   // The write-coordination revision this model was read at. Sent back only on a final commit
+   // (OK), never on Apply -- the dialog's own held copy is never refreshed after a commit, so
+   // echoing it back on Apply would make the dialog conflict with its own prior Apply. See
+   // 2026-08-17-write-coordination-design.md.
+   revision?: number;
 }

--- a/web/projects/portal/src/app/composer/data/vs/tab-property-dialog-model.ts
+++ b/web/projects/portal/src/app/composer/data/vs/tab-property-dialog-model.ts
@@ -21,4 +21,10 @@ import { TabGeneralPaneModel } from "./tab-general-pane-model";
 export interface TabPropertyDialogModel {
    tabGeneralPaneModel: TabGeneralPaneModel;
    vsAssemblyScriptPaneModel: VSAssemblyScriptPaneModel;
+
+   // The write-coordination revision this model was read at. Sent back only on a final commit
+   // (OK), never on Apply -- the dialog's own held copy is never refreshed after a commit, so
+   // echoing it back on Apply would make the dialog conflict with its own prior Apply. See
+   // 2026-08-17-write-coordination-design.md.
+   revision?: number;
 }

--- a/web/projects/portal/src/app/composer/data/vs/text-property-dialog-model.ts
+++ b/web/projects/portal/src/app/composer/data/vs/text-property-dialog-model.ts
@@ -23,4 +23,10 @@ export interface TextPropertyDialogModel {
    textGeneralPaneModel: TextGeneralPaneModel;
    dataOutputPaneModel: DataOutputPaneModel;
    clickableScriptPaneModel: ClickableScriptPaneModel;
+
+   // The write-coordination revision this model was read at. Sent back only on a final commit
+   // (OK), never on Apply -- the dialog's own held copy is never refreshed after a commit, so
+   // echoing it back on Apply would make the dialog conflict with its own prior Apply. See
+   // 2026-08-17-write-coordination-design.md.
+   revision?: number;
 }

--- a/web/projects/portal/src/app/composer/data/vs/viewsheet-object-property-dialog-model.ts
+++ b/web/projects/portal/src/app/composer/data/vs/viewsheet-object-property-dialog-model.ts
@@ -23,4 +23,10 @@ export interface ViewsheetObjectPropertyDialogModel {
    generalPropPaneModel: GeneralPropPaneModel;
    vsAssemblyScriptPaneModel: VSAssemblyScriptPaneModel;
    sizePositionPaneModel: SizePositionPaneModel;
+
+   // The write-coordination revision this model was read at. Sent back only on a final commit
+   // (OK), never on Apply -- the dialog's own held copy is never refreshed after a commit, so
+   // echoing it back on Apply would make the dialog conflict with its own prior Apply. See
+   // 2026-08-17-write-coordination-design.md.
+   revision?: number;
 }

--- a/web/projects/portal/src/app/composer/data/vs/viewsheet-property-dialog-model.ts
+++ b/web/projects/portal/src/app/composer/data/vs/viewsheet-property-dialog-model.ts
@@ -32,4 +32,10 @@ export interface ViewsheetPropertyDialogModel {
    width: number;
    height: number;
    preview: boolean;
+
+   // The write-coordination revision this model was read at. Sent back only on a final commit
+   // (OK), never on Apply -- the dialog's own held copy is never refreshed after a commit, so
+   // echoing it back on Apply would make the dialog conflict with its own prior Apply. See
+   // 2026-08-17-write-coordination-design.md.
+   revision?: number;
 }

--- a/web/projects/portal/src/app/vsobjects/dialog/crosstab-property-dialog.component.ts
+++ b/web/projects/portal/src/app/vsobjects/dialog/crosstab-property-dialog.component.ts
@@ -120,14 +120,18 @@ export class CrosstabPropertyDialog extends PropertyDialog implements OnInit {
       };
 
       const payload = {collapse: collapse, result: model};
+      // Only a final commit (OK) carries the revision it was read at -- Apply leaves the
+      // dialog open with its held model never refreshed, so echoing this back on Apply would
+      // make the dialog conflict with its own prior Apply on the next one.
+      const commitModel = {...model, revision: this.model.revision};
       const trapInfo = new TrapInfo(CHECK_TRAP_URI,
          this.model.tableViewGeneralPaneModel.generalPropPaneModel.basicGeneralPaneModel.name,
          this.runtimeId, model);
 
       this.trapService.checkTrap(trapInfo,
-         () => isApply ? this.onApply.emit(payload) : this.onCommit.emit(model),
+         () => isApply ? this.onApply.emit(payload) : this.onCommit.emit(commitModel),
          () => {},
-         () => isApply ? this.onApply.emit(payload) : this.onCommit.emit(model)
+         () => isApply ? this.onApply.emit(payload) : this.onCommit.emit(commitModel)
       );
    }
 }

--- a/web/projects/portal/src/app/vsobjects/dialog/graph/chart-property-dialog.component.ts
+++ b/web/projects/portal/src/app/vsobjects/dialog/graph/chart-property-dialog.component.ts
@@ -134,14 +134,18 @@ export class ChartPropertyDialog extends PropertyDialog implements OnInit {
       };
 
       const payload = {collapse: collapse, result: model};
+      // Only a final commit (OK) carries the revision it was read at -- Apply leaves the
+      // dialog open with its held model never refreshed, so echoing this back on Apply would
+      // make the dialog conflict with its own prior Apply on the next one.
+      const commitModel = {...model, revision: this.model.revision};
       const trapInfo = new TrapInfo(CHECK_TRAP_URI,
          this.model.chartGeneralPaneModel.generalPropPaneModel.basicGeneralPaneModel.name,
          this.runtimeId, model);
 
       this.trapService.checkTrap(trapInfo,
-         () => isApply ? this.onApply.emit(payload) : this.onCommit.emit(model),
+         () => isApply ? this.onApply.emit(payload) : this.onCommit.emit(commitModel),
          () => {},
-         () => isApply ? this.onApply.emit(payload) : this.onCommit.emit(model)
+         () => isApply ? this.onApply.emit(payload) : this.onCommit.emit(commitModel)
       );
    }
 

--- a/web/projects/portal/src/app/vsobjects/dialog/graph/hyperlink-dialog.component.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/dialog/graph/hyperlink-dialog.component.spec.ts
@@ -324,4 +324,28 @@ describe("hyperlink dialog componnet unit case", () => {
       fixture.detectChanges();
       expect(fixture.debugElement.query(By.css(".btn-primary")).nativeElement.disabled).toBeTruthy();
    });
+
+   // Write coordination: OK carries the revision the dialog was read at so a concurrent write
+   // is detected; Apply must not, since the dialog's held model is never refreshed after a
+   // commit and echoing the revision back would make Apply conflict with its own prior Apply.
+   it("sends revision on commit but not on apply", () => {
+      trapService.checkTrap.mockImplementation(
+         (trapInfo: any, onNoTrap: () => void) => onNoTrap());
+
+      let model = createHyperlinkModel();
+      model.revision = 7;
+      hyperlinkDialog = <HyperlinkDialog>fixture.componentInstance;
+      hyperlinkDialog.model = model;
+      fixture.detectChanges();
+
+      let committed: HyperlinkDialogModel;
+      hyperlinkDialog.onCommit.subscribe((m: HyperlinkDialogModel) => committed = m);
+      hyperlinkDialog.ok();
+      expect(committed.revision).toBe(7);
+
+      let applied: any;
+      hyperlinkDialog.onApply.subscribe((p: any) => applied = p);
+      hyperlinkDialog.apply(false);
+      expect(applied.result.revision).toBeUndefined();
+   });
 });

--- a/web/projects/portal/src/app/vsobjects/dialog/graph/hyperlink-dialog.component.ts
+++ b/web/projects/portal/src/app/vsobjects/dialog/graph/hyperlink-dialog.component.ts
@@ -317,7 +317,11 @@ export class HyperlinkDialog implements OnInit {
       }
 
       const { fields, ...modelClone } = this.model;
-      const model: HyperlinkDialogModel = { ...modelClone, fields: [] };
+      // Only a final commit (OK) carries the revision it was read at -- Apply leaves the
+      // dialog open with its held model never refreshed, so echoing this back on Apply would
+      // make the dialog conflict with its own prior Apply on the next one.
+      const model: HyperlinkDialogModel = { ...modelClone, fields: [], revision: undefined };
+      const commitModel: HyperlinkDialogModel = { ...model, revision: this.model.revision };
 
       // Check trap
       const trapInfo = new TrapInfo(CHECK_TRAP_REST_URI, this.objectName, this.runtimeId,
@@ -325,7 +329,7 @@ export class HyperlinkDialog implements OnInit {
 
       this.trapService.checkTrap(trapInfo, () => {
          if(commit) {
-            this.onCommit.emit(model);
+            this.onCommit.emit(commitModel);
          }
          else {
             this.onApply.emit({collapse: collapse, result: model});
@@ -333,7 +337,7 @@ export class HyperlinkDialog implements OnInit {
       }, () => {
       }, () => {
          if(commit) {
-            this.onCommit.emit(model);
+            this.onCommit.emit(commitModel);
          }
          else {
             this.onApply.emit({collapse: collapse, result: model});

--- a/web/projects/portal/src/app/vsobjects/dialog/highlight-dialog.component.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/dialog/highlight-dialog.component.spec.ts
@@ -74,6 +74,23 @@ describe("Highlight Dialog Test", () => {
       expect(validateHighlights).toHaveBeenCalled();
    });
 
+   // Write coordination: OK carries the revision the dialog was read at so a concurrent write
+   // is detected; Apply must not, since the dialog's held model is never refreshed after a
+   // commit and echoing the revision back would make Apply conflict with its own prior Apply.
+   it("sends revision on commit but not on apply", () => {
+      highlightDialog.model.revision = 7;
+
+      let committed: HighlightDialogModel;
+      highlightDialog.onCommit.subscribe((m: HighlightDialogModel) => committed = m);
+      highlightDialog.ok();
+      expect(committed.revision).toBe(7);
+
+      let applied: any;
+      highlightDialog.onApply.subscribe((p: any) => applied = p);
+      highlightDialog.apply(false);
+      expect(applied.result.revision).toBeUndefined();
+   });
+
    // Bug #18500 when deleting selected item, the last item should be highlighted
 //   it("should select the last item when deleting highlight items", () => {
 //      let highlight1 = createHighlightModel("highlight1");

--- a/web/projects/portal/src/app/vsobjects/dialog/highlight-dialog.component.ts
+++ b/web/projects/portal/src/app/vsobjects/dialog/highlight-dialog.component.ts
@@ -136,7 +136,7 @@ export class HighlightDialog extends AbstractHighlight implements OnInit {
    }
 
    apply(event: boolean): void {
-      this.onApply.emit({collapse: event, result: this.getServerAppliedModel()});
+      this.onApply.emit({collapse: event, result: this.getServerAppliedModel(false)});
    }
 }
 

--- a/web/projects/portal/src/app/vsobjects/dialog/vs-condition-dialog.component.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/dialog/vs-condition-dialog.component.spec.ts
@@ -118,4 +118,25 @@ describe("vs condition dialog component", () => {
       }
    });
 
+   // Write coordination: OK carries the revision the dialog was read at so a concurrent write
+   // is detected; Apply must not, since the dialog's held model is never refreshed after a
+   // commit and echoing the revision back would make Apply conflict with its own prior Apply.
+   it("sends revision on commit but not on apply", async () => {
+      fixture.detectChanges();
+      vsConditionDialog.checkTrap = null;
+      vsConditionDialog.model.revision = 7;
+
+      let committed: VSConditionDialogModel;
+      vsConditionDialog.onCommit.subscribe((m: VSConditionDialogModel) => committed = m);
+      vsConditionDialog.ok();
+      await Promise.resolve();
+      expect(committed.revision).toBe(7);
+
+      let applied: any;
+      vsConditionDialog.onApply.subscribe((p: any) => applied = p);
+      vsConditionDialog.apply(false);
+      await Promise.resolve();
+      expect(applied.result.revision).toBeUndefined();
+   });
+
 });

--- a/web/projects/portal/src/app/vsobjects/dialog/vs-condition-dialog.component.ts
+++ b/web/projects/portal/src/app/vsobjects/dialog/vs-condition-dialog.component.ts
@@ -144,7 +144,7 @@ export class VSConditionDialog extends BaseResizeableDialogComponent implements 
             if(!!this.checkTrap) {
                this.checkTrap(() => {
                   if(commit) {
-                     this.onCommit.emit(this.getServerAppliedModel());
+                     this.onCommit.emit(this.getServerAppliedModel(true));
                   }
                   else {
                      this.onApply.emit({collapse: collapse, result: this.getServerAppliedModel()});
@@ -152,7 +152,7 @@ export class VSConditionDialog extends BaseResizeableDialogComponent implements 
                }, this.model);
             }
             else if(commit) {
-               this.onCommit.emit(this.getServerAppliedModel());
+               this.onCommit.emit(this.getServerAppliedModel(true));
             }
             else {
                this.onApply.emit({collapse: collapse, result: this.getServerAppliedModel()});
@@ -283,12 +283,16 @@ export class VSConditionDialog extends BaseResizeableDialogComponent implements 
       return Array.from(fieldSet);
    }
 
-   // remove fields that are not used on the server side to reduce the transmission size
-   getServerAppliedModel(): VSConditionDialogModel {
+   // remove fields that are not used on the server side to reduce the transmission size.
+   // Only a final commit (OK) carries the revision it was read at -- Apply leaves the dialog
+   // open with its held model never refreshed, so echoing it back on Apply would make the
+   // dialog conflict with its own prior Apply. See 2026-08-17-write-coordination-design.md.
+   getServerAppliedModel(includeRevision: boolean = false): VSConditionDialogModel {
       return {
          tableName: this.model.tableName,
          fields: [],
-         conditionList: this.model.conditionList
+         conditionList: this.model.conditionList,
+         ...(includeRevision ? { revision: this.model.revision } : {})
       };
    }
 }

--- a/web/projects/portal/src/app/vsobjects/model/calc-table-property-dialog-model.ts
+++ b/web/projects/portal/src/app/vsobjects/model/calc-table-property-dialog-model.ts
@@ -23,4 +23,10 @@ export interface CalcTablePropertyDialogModel {
    tableViewGeneralPaneModel: TableViewGeneralPaneModel;
    calcTableAdvancedPaneModel: CalcTableAdvancedPaneModel;
    vsAssemblyScriptPaneModel: VSAssemblyScriptPaneModel;
+
+   // The write-coordination revision this model was read at. Sent back only on a final commit
+   // (OK), never on Apply -- the dialog's own held copy is never refreshed after a commit, so
+   // echoing it back on Apply would make the dialog conflict with its own prior Apply. See
+   // 2026-08-17-write-coordination-design.md.
+   revision?: number;
 }

--- a/web/projects/portal/src/app/vsobjects/model/chart-property-dialog-model.ts
+++ b/web/projects/portal/src/app/vsobjects/model/chart-property-dialog-model.ts
@@ -27,4 +27,9 @@ export interface ChartPropertyDialogModel {
    chartLinePaneModel: ChartLinePaneModel;
    hierarchyPropertyPaneModel: HierarchyPropertyPaneModel;
    vsAssemblyScriptPaneModel: VSAssemblyScriptPaneModel;
+   // The write-coordination revision this model was read at. Sent back only on a final commit
+   // (OK), never on Apply -- the dialog's own held copy is never refreshed after a commit, so
+   // echoing it back on Apply would make the dialog conflict with its own prior Apply. See
+   // 2026-08-17-write-coordination-design.md.
+   revision?: number;
 }

--- a/web/projects/portal/src/app/vsobjects/model/crosstab-property-dialog-model.ts
+++ b/web/projects/portal/src/app/vsobjects/model/crosstab-property-dialog-model.ts
@@ -25,4 +25,9 @@ export interface CrosstabPropertyDialogModel {
    crosstabAdvancedPaneModel: CrosstabAdvancedPaneModel;
    hierarchyPropertyPaneModel: HierarchyPropertyPaneModel;
    vsAssemblyScriptPaneModel: VSAssemblyScriptPaneModel;
+   // The write-coordination revision this model was read at. Sent back only on a final commit
+   // (OK), never on Apply -- the dialog's own held copy is never refreshed after a commit, so
+   // echoing it back on Apply would make the dialog conflict with its own prior Apply. See
+   // 2026-08-17-write-coordination-design.md.
+   revision?: number;
 }

--- a/web/projects/portal/src/app/vsobjects/model/hyperlink-dialog-model.ts
+++ b/web/projects/portal/src/app/vsobjects/model/hyperlink-dialog-model.ts
@@ -40,4 +40,9 @@ export interface HyperlinkDialogModel {
    applyToRow?: boolean;
    showRow?: boolean;
    grayedOutFields: DataRef[];
+   // The write-coordination revision this model was read at. Sent back only on a final commit
+   // (OK), never on Apply -- the dialog's own held copy is never refreshed after a commit, so
+   // echoing it back on Apply would make the dialog conflict with its own prior Apply. See
+   // 2026-08-17-write-coordination-design.md.
+   revision?: number;
 }

--- a/web/projects/portal/src/app/vsobjects/model/range-slider-property-dialog-model.ts
+++ b/web/projects/portal/src/app/vsobjects/model/range-slider-property-dialog-model.ts
@@ -25,4 +25,9 @@ export interface RangeSliderPropertyDialogModel {
    rangeSliderDataPaneModel: RangeSliderDataPaneModel;
    rangeSliderAdvancedPaneModel: RangeSliderAdvancedPaneModel;
    vsAssemblyScriptPaneModel: VSAssemblyScriptPaneModel;
+   // The write-coordination revision this model was read at. Sent back only on a final commit
+   // (OK), never on Apply -- the dialog's own held copy is never refreshed after a commit, so
+   // echoing it back on Apply would make the dialog conflict with its own prior Apply. See
+   // 2026-08-17-write-coordination-design.md.
+   revision?: number;
 }

--- a/web/projects/portal/src/app/vsobjects/model/table-view-property-dialog-model.ts
+++ b/web/projects/portal/src/app/vsobjects/model/table-view-property-dialog-model.ts
@@ -25,4 +25,10 @@ export interface TableViewPropertyDialogModel {
    tableViewGeneralPaneModel: TableViewGeneralPaneModel;
    tableAdvancedPaneModel: TableAdvancedPaneModel;
    vsAssemblyScriptPaneModel: VSAssemblyScriptPaneModel;
+
+   // The write-coordination revision this model was read at. Sent back only on a final commit
+   // (OK), never on Apply -- the dialog's own held copy is never refreshed after a commit, so
+   // echoing it back on Apply would make the dialog conflict with its own prior Apply. See
+   // 2026-08-17-write-coordination-design.md.
+   revision?: number;
 }

--- a/web/projects/portal/src/app/widget/highlight/highlight-dialog-model.ts
+++ b/web/projects/portal/src/app/widget/highlight/highlight-dialog-model.ts
@@ -35,4 +35,9 @@ export interface HighlightDialogModel {
     nonsupportBrowseFields?: string[];
     isAxis?: boolean;
     isText?: boolean;
+    // The write-coordination revision this model was read at. Sent back only on a final commit
+    // (OK), never on Apply -- the dialog's own held copy is never refreshed after a commit, so
+    // echoing it back on Apply would make the dialog conflict with its own prior Apply. See
+    // 2026-08-17-write-coordination-design.md.
+    revision?: number;
 }


### PR DESCRIPTION
## Summary

#4626 built the whole write-coordination mechanism server-side (a `writeRevision` counter on `RuntimeViewsheet`, checked against the revision a dialog was read at before committing) but the mechanism never reached the browser: the Angular Composer client never transmitted `revision` in either direction. Every real human dialog commit deserialized with `expectedRevision == null` server-side, so **the check never fired for actual browser usage** — only for tests and the wiz agent's internal path.

This also explains Larry's "Apply self-conflict" finding on #4626: it couldn't manifest, because there was no revision to conflict with in the first place. But that meant the feature the PR was built for — stopping a human dialog from silently clobbering a concurrent agent write — had zero real-world effect.

## Fix

Client-side only; the server already reads whatever revision it's given.

- Each of the 23 property/condition dialog models gains a `revision?: number` field.
- Each dialog's **commit (OK)** payload now includes the revision it was read at.
- **Apply deliberately never sends it.** The dialog's held model is never refreshed after a commit, so echoing the revision back on Apply would make a dialog conflict with its own prior Apply — exactly the self-conflict Larry flagged. This makes that scenario impossible by construction rather than by careful bookkeeping.

Most dialogs forward their held model unmodified to the server and needed only the type declaration (no behavior change). Five needed an actual code change because they reconstruct a slimmed request object that dropped the field: `ChartPropertyDialog`, `CrosstabPropertyDialog`, `HyperlinkDialog`, `HighlightDialog` (via `AbstractHighlight`), and `VSConditionDialog`.

## Test plan

- [x] `tsc -p projects/portal/tsconfig.app.json --noEmit` — clean, zero errors
- [x] Existing specs for the 3 touched dialogs with prior coverage (`hyperlink-dialog`, `highlight-dialog`, `vs-condition-dialog`) — all pass
- [x] Added a regression test to each of those 3 specs asserting revision is present on commit and absent on apply
- [ ] Chart/Crosstab dialogs have no existing spec files to extend; verified by full compile + manual trace of the reconstructed-object logic, not by a new test harness

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>