### PR TITLE
Add calcField as the first Tier 2 script kind (read + edit-existing)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/script/CalcFieldService.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/CalcFieldService.java
@@ -1,0 +1,161 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.script;
+
+import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.erm.ExpressionRef;
+import inetsoft.uql.viewsheet.CalculateRef;
+import inetsoft.uql.viewsheet.VSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.internal.DataVSAssemblyInfo;
+import inetsoft.web.wiz.pairing.PairingException;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * The only place that knows how a viewsheet calculated field is stored.
+ *
+ * <p>Its own service rather than another branch of {@link ScriptReadService}, because every other
+ * script kind is reached through a {@code VSAssemblyInfo} accessor and this one is not: calc fields
+ * live in a per-table map on the {@link Viewsheet} itself, keyed by table name, wrapping an
+ * {@link ExpressionRef} inside a {@link CalculateRef}.
+ *
+ * <p><b>This is Tier 2a: read and edit-existing only.</b> Creating or deleting a calc field is
+ * deliberately absent -- re-registering it on the viewsheet, invalidating dependent columns and
+ * re-execution are the hard parts, and they are 2b's scope. A write to a name that does not exist
+ * is refused rather than treated as a create, so a caller cannot get half of 2b by accident.
+ */
+@Service
+public class CalcFieldService {
+   /** One calc field, as enumeration reports it. */
+   public record Found(String table, String name, boolean sql, boolean baseOnDetail) {}
+
+   /**
+    * The tables worth asking about.
+    *
+    * <p>{@code Viewsheet.getCalcFields} answers per table and its backing map is private with no
+    * key accessor, so there is no supported way to ask which tables have calc fields. Every calc
+    * field belongs to a table something is bound to, so the bound assemblies are the honest source
+    * -- and it keeps this change inside the script package rather than reaching into
+    * {@code uql/viewsheet} for an accessor.
+    */
+   public List<String> tablesWithCalcFields(Viewsheet vs) {
+      if(vs == null) {
+         return List.of();
+      }
+
+      List<String> tables = new ArrayList<>();
+
+      for(Assembly a : vs.getAssemblies()) {
+         if(!(a instanceof VSAssembly vsAssembly)) {
+            continue;
+         }
+
+         if(vsAssembly.getVSAssemblyInfo() instanceof DataVSAssemblyInfo info) {
+            String table = info.getTableName();
+
+            if(table != null && !table.isBlank() && !tables.contains(table)) {
+               tables.add(table);
+            }
+         }
+      }
+
+      return tables;
+   }
+
+   /** Every calc field on every bound table. */
+   public List<Found> list(Viewsheet vs) {
+      List<Found> found = new ArrayList<>();
+
+      for(String table : tablesWithCalcFields(vs)) {
+         // getCalcFields returns NULL, not an empty array, for a table with none.
+         CalculateRef[] refs = vs.getCalcFields(table);
+
+         if(refs == null) {
+            continue;
+         }
+
+         for(CalculateRef ref : refs) {
+            found.add(new Found(table, ref.getName(), ref.isSQL(), ref.isBaseOnDetail()));
+         }
+      }
+
+      return found;
+   }
+
+   /** The expression text of one calc field. */
+   public String read(Viewsheet vs, String table, String name) throws PairingException {
+      ExpressionRef ref = expressionOf(vs, table, name);
+      String expression = ref.getExpression();
+      return expression == null ? "" : expression;
+   }
+
+   /**
+    * Replaces the expression text of an EXISTING calc field.
+    *
+    * <p>Refuses a name that is not already there. Creating one is 2b, and silently creating it here
+    * would hand the caller an unregistered field with no dependent-column invalidation -- which
+    * looks like success and is not.
+    */
+   public void write(Viewsheet vs, String table, String name, String expression)
+      throws PairingException
+   {
+      if(expression == null) {
+         throw new PairingException("A calc field's expression text is required.");
+      }
+
+      expressionOf(vs, table, name).setExpression(expression);
+   }
+
+   private ExpressionRef expressionOf(Viewsheet vs, String table, String name)
+      throws PairingException
+   {
+      if(vs == null) {
+         throw new PairingException("Viewsheet not found in runtime");
+      }
+
+      CalculateRef[] refs = vs.getCalcFields(table);
+
+      if(refs == null || refs.length == 0) {
+         throw new PairingException(
+            "Table '" + table + "' has no calculated fields. Tables on this viewsheet: " +
+            String.join(", ", tablesWithCalcFields(vs)) + ".");
+      }
+
+      for(CalculateRef ref : refs) {
+         if(name.equals(ref.getName())) {
+            if(!(ref.getDataRef() instanceof ExpressionRef expression)) {
+               throw new PairingException(
+                  "Calculated field '" + name + "' on '" + table + "' holds no expression.");
+            }
+
+            return expression;
+         }
+      }
+
+      throw new PairingException(
+         "No calculated field '" + name + "' on table '" + table + "'. This tool cannot " +
+         "create a new calculated field -- it edits existing ones only. Present on '" +
+         table + "': " + Arrays.stream(refs).map(CalculateRef::getName)
+            .collect(Collectors.joining(", ")) + ".");
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptContextService.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptContextService.java
@@ -79,6 +79,11 @@ public class ScriptContextService {
       "thisViewsheet", "parameter", "_USER_", "_ROLES_", "_GROUPS_", "event"
    );
 
+   // A calc field evaluates per ROW via field['col']. There is no thisViewsheet, no _USER_/
+   // _ROLES_/_GROUPS_, and no event in scope -- only the row accessor and the standard parameter
+   // map, so this is a DIFFERENT vocabulary, not a filtered CONTEXT_VARS.
+   private static final List<String> CALC_FIELD_VARS = List.of("field", "parameter");
+
    @Autowired
    public ScriptContextService(VSScriptableService scriptableService) {
       this.scriptableService = scriptableService;
@@ -103,6 +108,12 @@ public class ScriptContextService {
          // guessing a context the caller has not chosen.
          return new ScriptContext(all.stream().map(ScriptContextService::withoutApiTree).toList(),
                                   CONTEXT_VARS);
+      }
+
+      if(target.kind() == ScriptTarget.Kind.CALC_FIELD) {
+         // Different in KIND, not a subset: no assembly API is in scope while a calc field
+         // evaluates, so there is no assembly surface to filter down to.
+         return new ScriptContext(List.of(), contextVars(target.kind()));
       }
 
       List<String> vars = contextVars(target.kind());
@@ -137,6 +148,9 @@ public class ScriptContextService {
    private static List<String> contextVars(ScriptTarget.Kind kind) {
       return switch(kind) {
          case ASSEMBLY_ON_CLICK -> CONTEXT_VARS;
+         // A calc field evaluates per ROW. There is no assembly API and no thisViewsheet in scope,
+         // so offering the viewsheet-level vars would advertise an API that is not there.
+         case CALC_FIELD -> CALC_FIELD_VARS;
          default -> CONTEXT_VARS.stream().filter(v -> !"event".equals(v)).toList();
       };
    }

--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptEditService.java
@@ -39,14 +39,23 @@ import java.util.function.Predicate;
 @Service
 public class ScriptEditService {
 
-   @Autowired
    public ScriptEditService(SheetSessionService sessions,
                             SheetRuntimeAccess runtimeAccess,
                             SheetAgentBroadcastService broadcast)
    {
+      this(sessions, runtimeAccess, broadcast, new CalcFieldService());
+   }
+
+   @Autowired
+   public ScriptEditService(SheetSessionService sessions,
+                            SheetRuntimeAccess runtimeAccess,
+                            SheetAgentBroadcastService broadcast,
+                            CalcFieldService calcFields)
+   {
       this.sessions = sessions;
       this.runtimeAccess = runtimeAccess;
       this.broadcast = broadcast;
+      this.calcFields = calcFields;
    }
 
    /**
@@ -149,12 +158,7 @@ public class ScriptEditService {
             VSAssemblyInfo info = ScriptReadService.requireAssemblyInfo(vs, target.assemblyName());
             ScriptReadService.setOnClick(info, text);
          }
-         // Not permanent, unlike setEnabled's refusal below: CalcFieldService (Task 3) replaces
-         // this case with a real write. Until then this is a switch STATEMENT, so leaving it
-         // unhandled would compile clean and silently do nothing -- the exact silent-acceptance
-         // pattern this project treats as a defect, not a corner to route around.
-         case CALC_FIELD -> throw new PairingException(
-            "calcField writes are not wired yet — CalcFieldService lands in Task 3.");
+         case CALC_FIELD -> calcFields.write(vs, target.assemblyName(), target.name(), text);
       }
    }
 
@@ -217,4 +221,5 @@ public class ScriptEditService {
    private final SheetSessionService sessions;
    private final SheetRuntimeAccess runtimeAccess;
    private final SheetAgentBroadcastService broadcast;
+   private final CalcFieldService calcFields;
 }

--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptEditService.java
@@ -149,6 +149,12 @@ public class ScriptEditService {
             VSAssemblyInfo info = ScriptReadService.requireAssemblyInfo(vs, target.assemblyName());
             ScriptReadService.setOnClick(info, text);
          }
+         // Not permanent, unlike setEnabled's refusal below: CalcFieldService (Task 3) replaces
+         // this case with a real write. Until then this is a switch STATEMENT, so leaving it
+         // unhandled would compile clean and silently do nothing -- the exact silent-acceptance
+         // pattern this project treats as a defect, not a corner to route around.
+         case CALC_FIELD -> throw new PairingException(
+            "calcField writes are not wired yet — CalcFieldService lands in Task 3.");
       }
    }
 
@@ -160,6 +166,10 @@ public class ScriptEditService {
          case VS_INIT, VS_LOAD -> vs.getViewsheetInfo().setScriptEnabled(enabled);
          case ASSEMBLY, ASSEMBLY_ONCLICK ->
             ScriptReadService.requireAssemblyInfo(vs, target.assemblyName()).setScriptEnabled(enabled);
+         // Permanent, unlike write's refusal above: a calculated field has no per-field enable
+         // flag at all, so there is nothing for Task 3 (or anyone) to wire in here later.
+         case CALC_FIELD -> throw new PairingException(
+            "A calculated field has no enable flag; only scripts can be enabled or disabled.");
       }
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptExecuteService.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptExecuteService.java
@@ -120,6 +120,12 @@ public class ScriptExecuteService {
       String assemblyName = switch(target.location()) {
          case VS_INIT, VS_LOAD -> null;
          case ASSEMBLY, ASSEMBLY_ONCLICK -> target.assemblyName();
+         // Permanent, not a placeholder: a calculated field is an expression evaluated per row,
+         // not a runnable script, so there is no "wire it up later" for this case the way there
+         // is for write/setEnabled elsewhere.
+         case CALC_FIELD -> throw new PairingException(
+            "A calculated field is an expression evaluated per row, not a runnable script. " +
+            "Use read_script/update_script on it instead.");
       };
 
       try {

--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptGrammar.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptGrammar.java
@@ -35,10 +35,16 @@ public final class ScriptGrammar {
     * The kinds this server can serve — those with an internal location behind them. Reserved
     * kinds are deliberately absent: advertising one and then refusing it is the silent capability
     * lie this contract exists to prevent.
+    *
+    * <p>{@link ScriptTarget.Kind#CALC_FIELD} is excluded for the same reason even though it now
+    * carries a real {@link ScriptTarget.Location}: that location is Tier 2's addressing
+    * foundation only (which kind, which table+field, one opaque id) — {@link ScriptReadService},
+    * {@code ScriptEditService}, and {@code ScriptContextService} cannot yet read or write one.
+    * Remove this exclusion once those services are wired to {@code CALC_FIELD}.
     */
    public static List<String> supportedKinds() {
       return Arrays.stream(ScriptTarget.Kind.values())
-         .filter(k -> k.location() != null)
+         .filter(k -> k.location() != null && k != ScriptTarget.Kind.CALC_FIELD)
          .map(ScriptTarget.Kind::wireName)
          .toList();
    }

--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptGrammar.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptGrammar.java
@@ -36,15 +36,13 @@ public final class ScriptGrammar {
     * kinds are deliberately absent: advertising one and then refusing it is the silent capability
     * lie this contract exists to prevent.
     *
-    * <p>{@link ScriptTarget.Kind#CALC_FIELD} is excluded for the same reason even though it now
-    * carries a real {@link ScriptTarget.Location}: that location is Tier 2's addressing
-    * foundation only (which kind, which table+field, one opaque id) — {@link ScriptReadService},
-    * {@code ScriptEditService}, and {@code ScriptContextService} cannot yet read or write one.
-    * Remove this exclusion once those services are wired to {@code CALC_FIELD}.
+    * <p>{@link ScriptTarget.Kind#CALC_FIELD} is included: {@link ScriptReadService},
+    * {@code ScriptEditService}, and {@code ScriptContextService} are now wired to it, so its
+    * real {@link ScriptTarget.Location} is actually servable rather than merely present.
     */
    public static List<String> supportedKinds() {
       return Arrays.stream(ScriptTarget.Kind.values())
-         .filter(k -> k.location() != null && k != ScriptTarget.Kind.CALC_FIELD)
+         .filter(k -> k.location() != null)
          .map(ScriptTarget.Kind::wireName)
          .toList();
    }

--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptReadService.java
@@ -106,7 +106,11 @@ public class ScriptReadService {
       }
 
       return new ScriptTargetInfo(
-         target.id(), kind.wireName(), assembly, null, label(kind, assembly), runsWhen(kind),
+         target.id(), kind.wireName(), assembly,
+         null,                            // name: only a calc field is keyed by one
+         null,                            // sql: SQL-vs-JavaScript is a calc-field distinction
+         null,                            // baseOnDetail: likewise
+         label(kind, assembly), runsWhen(kind),
          hasScript, enabled, enableScope(kind, assembly), "viewsheet", target.toString());
    }
 
@@ -116,6 +120,11 @@ public class ScriptReadService {
     * alone, has no legacy delimited form, and is always has-script/enabled (an expression, once
     * created, has no disabled state) -- forcing it through {@code describe}'s four-boolean shape
     * would just relitigate those differences inside a signature meant for the other four kinds.
+    *
+    * <p>It is also the only kind that reports {@code sql} and {@code baseOnDetail}. Both say which
+    * expression LANGUAGE and which evaluation SCOPE an edit has to be written for, and a caller
+    * that cannot see them has to guess from the expression text -- {@code PRICE - COST} reads as
+    * either.
     */
    private static ScriptTargetInfo describeCalcField(CalcFieldService.Found f) {
       ScriptTarget target;
@@ -129,6 +138,7 @@ public class ScriptReadService {
 
       return new ScriptTargetInfo(
          target.id(), ScriptTarget.Kind.CALC_FIELD.wireName(), f.table(), f.name(),
+         f.sql(), f.baseOnDetail(),
          "Calculated field '" + f.name() + "' on " + f.table(),
          "per row, when the field is evaluated",
          true,                            // a calc field always has an expression

--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptReadService.java
@@ -28,6 +28,7 @@ import inetsoft.uql.viewsheet.internal.VSAssemblyInfo;
 import inetsoft.web.wiz.pairing.PairingException;
 import inetsoft.web.wiz.script.model.ScriptInfo;
 import inetsoft.web.wiz.script.model.ScriptTargetInfo;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -39,6 +40,15 @@ import java.util.List;
  */
 @Service
 public class ScriptReadService {
+
+   public ScriptReadService() {
+      this(new CalcFieldService());
+   }
+
+   @Autowired
+   public ScriptReadService(CalcFieldService calcFields) {
+      this.calcFields = calcFields;
+   }
 
    /** Enumerates every scriptable target on the viewsheet with its has-script/enabled state. */
    public List<ScriptTargetInfo> list(RuntimeViewsheet rvs) {
@@ -71,6 +81,10 @@ public class ScriptReadService {
          }
       }
 
+      for(CalcFieldService.Found f : calcFields.list(vs)) {
+         targets.add(describeCalcField(f));
+      }
+
       return targets;
    }
 
@@ -92,8 +106,36 @@ public class ScriptReadService {
       }
 
       return new ScriptTargetInfo(
-         target.id(), kind.wireName(), assembly, label(kind, assembly), runsWhen(kind),
+         target.id(), kind.wireName(), assembly, null, label(kind, assembly), runsWhen(kind),
          hasScript, enabled, enableScope(kind, assembly), "viewsheet", target.toString());
+   }
+
+   /**
+    * Projects one calc-field target. Kept apart from {@link #describe}, which every OTHER kind
+    * still uses: a calc field is addressed by (table, field name) rather than (kind, assembly)
+    * alone, has no legacy delimited form, and is always has-script/enabled (an expression, once
+    * created, has no disabled state) -- forcing it through {@code describe}'s four-boolean shape
+    * would just relitigate those differences inside a signature meant for the other four kinds.
+    */
+   private static ScriptTargetInfo describeCalcField(CalcFieldService.Found f) {
+      ScriptTarget target;
+
+      try {
+         target = ScriptTarget.of(ScriptTarget.Kind.CALC_FIELD, f.table(), f.name());
+      }
+      catch(PairingException ex) {
+         throw new IllegalStateException("cannot describe calc field " + f.name(), ex);
+      }
+
+      return new ScriptTargetInfo(
+         target.id(), ScriptTarget.Kind.CALC_FIELD.wireName(), f.table(), f.name(),
+         "Calculated field '" + f.name() + "' on " + f.table(),
+         "per row, when the field is evaluated",
+         true,                            // a calc field always has an expression
+         true,                            // no per-field enable flag exists
+         "calcField:" + f.table() + ":" + f.name(),
+         "viewsheet",
+         null);                           // no legacy string form
    }
 
    private static String label(ScriptTarget.Kind kind, String assembly) {
@@ -158,6 +200,11 @@ public class ScriptReadService {
             text = getOnClick(info);
             enabled = info.isScriptEnabled();
          }
+         case CALC_FIELD -> {
+            Viewsheet vs = requireViewsheet(rvs);
+            text = calcFields.read(vs, target.assemblyName(), target.name());
+            enabled = true;
+         }
          default -> throw new PairingException("Unsupported target: " + target);
       }
 
@@ -172,6 +219,16 @@ public class ScriptReadService {
       }
 
       return vs.getViewsheetInfo();
+   }
+
+   Viewsheet requireViewsheet(RuntimeViewsheet rvs) throws PairingException {
+      Viewsheet vs = rvs.getViewsheet();
+
+      if(vs == null) {
+         throw new PairingException("Viewsheet not found in runtime");
+      }
+
+      return vs;
    }
 
    VSAssemblyInfo requireAssemblyInfo(RuntimeViewsheet rvs, String name) throws PairingException {
@@ -225,4 +282,6 @@ public class ScriptReadService {
    private static boolean isBlank(String s) {
       return s == null || s.isEmpty();
    }
+
+   private final CalcFieldService calcFields;
 }

--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptTarget.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptTarget.java
@@ -33,7 +33,7 @@ import java.util.List;
  * {@code "assembly:<name>:onClick"}.</p>
  */
 public final class ScriptTarget {
-   public enum Location { VS_INIT, VS_LOAD, ASSEMBLY, ASSEMBLY_ONCLICK }
+   public enum Location { VS_INIT, VS_LOAD, ASSEMBLY, ASSEMBLY_ONCLICK, CALC_FIELD }
 
    /**
     * The wire vocabulary. Distinct from {@link Location}, which is the internal dispatch key every
@@ -45,6 +45,18 @@ public final class ScriptTarget {
       VIEWSHEET_ON_LOAD("viewsheetOnLoad", Location.VS_LOAD),
       ASSEMBLY_MAIN("assemblyMain", Location.ASSEMBLY),
       ASSEMBLY_ON_CLICK("assemblyOnClick", Location.ASSEMBLY_ONCLICK),
+
+      /**
+       * A viewsheet calculated field's expression.
+       *
+       * <p>Addressed by (table, field name), not by assembly — {@code Viewsheet.getCalcFields}
+       * is keyed by table. So for THIS kind {@code assemblyName()} carries the TABLE name and
+       * {@code name()} carries the field's own name. That asymmetry is deliberate: a fourth
+       * addressing component, or renaming {@code assembly} to {@code owner} across all five
+       * kinds, would be a larger change than the one thing this kind actually needs.
+       */
+      CALC_FIELD("calcField", Location.CALC_FIELD),
+
       // Reserved so the schema does not churn when pane-scoped pairing lands. A session cannot be
       // scoped to one yet, so ScriptTarget.of refuses them with a scope error.
       WORKSHEET_EXPRESSION("worksheetExpression", null),
@@ -96,18 +108,33 @@ public final class ScriptTarget {
    }
 
    private ScriptTarget(Kind kind, String assemblyName) {
+      this(kind, assemblyName, null);
+   }
+
+   private ScriptTarget(Kind kind, String assemblyName, String name) {
       this.kind = kind;
       this.location = kind.location();
       this.assemblyName = assemblyName;
+      this.name = name;
    }
 
    public Location location() {
       return location;
    }
 
-   /** The assembly name, or {@code null} for {@code VS_INIT}/{@code VS_LOAD}. */
+   /**
+    * The assembly name, or {@code null} for {@code VS_INIT}/{@code VS_LOAD}.
+    *
+    * <p>For {@link Kind#CALC_FIELD}, this carries the TABLE the field belongs to, not an
+    * assembly — see the javadoc on that constant.
+    */
    public String assemblyName() {
       return assemblyName;
+   }
+
+   /** The calc field's own name, or {@code null} for every kind that needs no third component. */
+   public String name() {
+      return name;
    }
 
    public Kind kind() {
@@ -121,6 +148,20 @@ public final class ScriptTarget {
     *                          assembly name.
     */
    public static ScriptTarget of(Kind kind, String assemblyName) throws PairingException {
+      return of(kind, assemblyName, null);
+   }
+
+   /**
+    * Builds a target from the canonical tuple, with the third component {@link Kind#CALC_FIELD}
+    * needs.
+    *
+    * @throws PairingException if the kind has no servable location, an assembly kind carries no
+    *                          assembly name, {@code CALC_FIELD} is missing its table or field
+    *                          name, or a non-{@code CALC_FIELD} kind is given a name.
+    */
+   public static ScriptTarget of(Kind kind, String assemblyName, String name)
+      throws PairingException
+   {
       if(kind == null) {
          throw new PairingException("kind is required");
       }
@@ -129,6 +170,24 @@ public final class ScriptTarget {
          throw new PairingException(
             "kind '" + kind.wireName() + "' requires a session paired from that expression's " +
             "editor; this session is bound to a whole viewsheet.");
+      }
+
+      if(kind == Kind.CALC_FIELD) {
+         if(assemblyName == null || assemblyName.isBlank()) {
+            throw new PairingException(
+               "kind 'calcField' requires the table the field belongs to, in 'assembly'.");
+         }
+
+         if(name == null || name.isBlank()) {
+            throw new PairingException("kind 'calcField' requires the field's 'name'.");
+         }
+
+         return new ScriptTarget(kind, assemblyName, name);
+      }
+
+      if(name != null && !name.isBlank()) {
+         throw new PairingException(
+            "kind '" + kind.wireName() + "' takes no 'name'; only calcField is addressed by one.");
       }
 
       boolean needsAssembly = kind == Kind.ASSEMBLY_MAIN || kind == Kind.ASSEMBLY_ON_CLICK;
@@ -142,7 +201,7 @@ public final class ScriptTarget {
             "kind '" + kind.wireName() + "' is viewsheet-level and takes no assembly name.");
       }
 
-      return new ScriptTarget(kind, needsAssembly ? assemblyName : null);
+      return new ScriptTarget(kind, needsAssembly ? assemblyName : null, null);
    }
 
    /**
@@ -154,7 +213,7 @@ public final class ScriptTarget {
     * readable in logs and errors.
     */
    public String id() {
-      String canonical = kind.wireName() + "|" + (assemblyName == null ? "" : assemblyName);
+      String canonical = kind.wireName() + "|" + escape(assemblyName) + "|" + escape(name);
       return Base64.getUrlEncoder().withoutPadding()
          .encodeToString(canonical.getBytes(StandardCharsets.UTF_8));
    }
@@ -173,17 +232,94 @@ public final class ScriptTarget {
          throw new PairingException("Invalid target id: \"" + id + "\".");
       }
 
-      // Split once: the kind is a fixed vocabulary with no '|', everything after the first
-      // separator is the assembly name verbatim -- which is what makes a name containing ':'
-      // (or '|') addressable at all.
-      int sep = canonical.indexOf('|');
+      // The kind is a fixed vocabulary containing no '|' or '\', so the first UNESCAPED separator
+      // ends it. Assembly and name are arbitrary strings that may themselves contain '|' -- each
+      // is escaped ('\' -> '\\', '|' -> '\|') before encoding, so decoding scans for the next
+      // separator NOT preceded by an escape, rather than splitting blindly on every '|' or trusting
+      // the last '|' in the string to be the true boundary. (A naive "first separator ends the
+      // kind, last separator begins the name" split is NOT sufficient on its own: when the table
+      // name and the field name both contain a literal '|', the last '|' in the string can land
+      // inside the field name rather than at the true assembly/name boundary -- escaping is what
+      // actually makes every component position-independent.)
+      int firstSep = indexOfUnescapedSeparator(canonical, 0);
 
-      if(sep < 0) {
+      if(firstSep < 0) {
          throw new PairingException("Invalid target id: \"" + id + "\".");
       }
 
-      String assembly = canonical.substring(sep + 1);
-      return of(Kind.fromWire(canonical.substring(0, sep)), assembly.isEmpty() ? null : assembly);
+      Kind kind = Kind.fromWire(canonical.substring(0, firstSep));
+      int secondSep = indexOfUnescapedSeparator(canonical, firstSep + 1);
+
+      if(secondSep < 0) {
+         throw new PairingException("Invalid target id: \"" + id + "\".");
+      }
+
+      String assembly = unescape(canonical.substring(firstSep + 1, secondSep));
+      String name = unescape(canonical.substring(secondSep + 1));
+
+      return of(kind, assembly.isEmpty() ? null : assembly, name.isEmpty() ? null : name);
+   }
+
+   /** Escapes '\' and '|' so a literal '|' inside a component is never mistaken for a separator. */
+   private static String escape(String s) {
+      if(s == null || s.isEmpty()) {
+         return "";
+      }
+
+      StringBuilder sb = new StringBuilder(s.length());
+
+      for(int i = 0; i < s.length(); i++) {
+         char c = s.charAt(i);
+
+         if(c == '\\' || c == '|') {
+            sb.append('\\');
+         }
+
+         sb.append(c);
+      }
+
+      return sb.toString();
+   }
+
+   private static String unescape(String s) {
+      StringBuilder sb = new StringBuilder(s.length());
+
+      for(int i = 0; i < s.length(); i++) {
+         char c = s.charAt(i);
+
+         if(c == '\\' && i + 1 < s.length()) {
+            sb.append(s.charAt(++i));
+         }
+         else {
+            sb.append(c);
+         }
+      }
+
+      return sb.toString();
+   }
+
+   /**
+    * Index of the next {@code '|'} at or after {@code from} that is not preceded by an unpaired
+    * {@code '\'} escape, or {@code -1} if none.
+    */
+   private static int indexOfUnescapedSeparator(String s, int from) {
+      boolean escaped = false;
+
+      for(int i = from; i < s.length(); i++) {
+         char c = s.charAt(i);
+
+         if(escaped) {
+            escaped = false;
+         }
+         else if(c == '\\') {
+            escaped = true;
+         }
+         else if(c == '|') {
+            return i;
+         }
+      }
+
+      return -1;
    }
 
    public static ScriptTarget parse(String target) throws PairingException {
@@ -251,11 +387,14 @@ public final class ScriptTarget {
     * @param vs            the joined viewsheet, for the exact-name precedence fix; may be null
     * @param id            preferred for an existing target — the caller copies it back verbatim
     * @param kind          the wire kind name, with {@code assembly} when the kind needs one
-    * @param assembly      the assembly name, required for kinds that need one
+    * @param assembly      the assembly name, required for kinds that need one; the TABLE name for
+    *                      {@code calcField}
+    * @param name          the calc field's own name; required for (and only meaningful to)
+    *                      {@code calcField}
     * @param legacyTarget  the v1 delimited string, still accepted
     */
    public static ScriptTarget resolve(Viewsheet vs, String id, String kind, String assembly,
-                                      String legacyTarget)
+                                      String name, String legacyTarget)
       throws PairingException
    {
       if(id != null && !id.isBlank()) {
@@ -263,7 +402,7 @@ public final class ScriptTarget {
       }
 
       if(kind != null && !kind.isBlank()) {
-         return of(Kind.fromWire(kind), assembly);
+         return of(Kind.fromWire(kind), assembly, name);
       }
 
       if(legacyTarget != null && !legacyTarget.isBlank()) {
@@ -282,10 +421,19 @@ public final class ScriptTarget {
          case VS_LOAD -> "vs-load";
          case ASSEMBLY -> "assembly:" + assemblyName;
          case ASSEMBLY_ONCLICK -> "assembly:" + assemblyName + ":onClick";
+         // A calc field has no legacy PARSEABLE form -- parse(String) does not (and must not)
+         // recognize this -- the v1 grammar never addressed one, and coining a parseable
+         // "calc:Query1:Margin" would recreate the delimiter ambiguity this design removed. This
+         // is a display string only, e.g. for error messages built by callers that string-concat
+         // a target (see ScriptReadService's "Unsupported target: " + target on an unwired
+         // location) -- it must not throw, or every such message breaks instead of reporting
+         // the thing it was trying to report.
+         case CALC_FIELD -> "calcField:" + assemblyName + ":" + name;
       };
    }
 
    private final Kind kind;
    private final Location location;
    private final String assemblyName;
+   private final String name;
 }

--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptTarget.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptTarget.java
@@ -254,8 +254,8 @@ public final class ScriptTarget {
          throw new PairingException("Invalid target id: \"" + id + "\".");
       }
 
-      String assembly = unescape(canonical.substring(firstSep + 1, secondSep));
-      String name = unescape(canonical.substring(secondSep + 1));
+      String assembly = unescape(canonical.substring(firstSep + 1, secondSep), id);
+      String name = unescape(canonical.substring(secondSep + 1), id);
 
       return of(kind, assembly.isEmpty() ? null : assembly, name.isEmpty() ? null : name);
    }
@@ -281,13 +281,24 @@ public final class ScriptTarget {
       return sb.toString();
    }
 
-   private static String unescape(String s) {
+   /**
+    * Reverses {@link #escape}. A trailing unpaired {@code '\'} cannot come from anything
+    * {@code escape} produced -- it always emits {@code '\'} in a pair with the character it
+    * guards -- so one showing up here means the id is corrupted or was hand-crafted, and is
+    * refused rather than silently kept as a literal backslash.
+    */
+   private static String unescape(String s, String id) throws PairingException {
       StringBuilder sb = new StringBuilder(s.length());
 
       for(int i = 0; i < s.length(); i++) {
          char c = s.charAt(i);
 
-         if(c == '\\' && i + 1 < s.length()) {
+         if(c == '\\') {
+            if(i + 1 >= s.length()) {
+               throw new PairingException(
+                  "Invalid target id: \"" + id + "\" (dangling escape character).");
+            }
+
             sb.append(s.charAt(++i));
          }
          else {

--- a/core/src/main/java/inetsoft/web/wiz/script/ViewsheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ViewsheetAgentController.java
@@ -125,16 +125,17 @@ public class ViewsheetAgentController {
                                 @RequestParam(required = false) String id,
                                 @RequestParam(required = false) String kind,
                                 @RequestParam(required = false) String assembly,
+                                @RequestParam(required = false) String name,
                                 Principal user)
       throws PairingException
    {
       requireEnabled();
       RuntimeViewsheet rvs = editService.resolve(sessionToken, user);
-      return readService.read(rvs, target(rvs, id, kind, assembly, target));
+      return readService.read(rvs, target(rvs, id, kind, assembly, name, target));
    }
 
    public record WriteScriptRequest(String target, String id, String kind, String assembly,
-                                    String text) {}
+                                    String name, String text) {}
 
    /** Overwrites the script text at {@code target} and broadcasts a refresh. */
    @PostMapping("/api/wiz/v1/agent/script/{sessionToken}/script")
@@ -144,11 +145,12 @@ public class ViewsheetAgentController {
    {
       requireEnabled();
       editService.apply(sessionToken, user, rvs -> editService.write(
-         rvs, target(rvs, req.id(), req.kind(), req.assembly(), req.target()), req.text()));
+         rvs, target(rvs, req.id(), req.kind(), req.assembly(), req.name(), req.target()),
+         req.text()));
    }
 
    public record SetEnabledRequest(String target, String id, String kind, String assembly,
-                                   boolean enabled) {}
+                                   String name, boolean enabled) {}
 
    /** Toggles whether the script at {@code target} is enabled and broadcasts a refresh. */
    @PostMapping("/api/wiz/v1/agent/script/{sessionToken}/enable")
@@ -158,10 +160,12 @@ public class ViewsheetAgentController {
    {
       requireEnabled();
       editService.apply(sessionToken, user, rvs -> editService.setEnabled(
-         rvs, target(rvs, req.id(), req.kind(), req.assembly(), req.target()), req.enabled()));
+         rvs, target(rvs, req.id(), req.kind(), req.assembly(), req.name(), req.target()),
+         req.enabled()));
    }
 
-   public record ExecuteRequest(String target, String id, String kind, String assembly) {}
+   public record ExecuteRequest(String target, String id, String kind, String assembly,
+                                String name) {}
 
    /**
     * Dry-runs the script currently saved at {@code target} (see {@link ScriptExecuteService}).
@@ -179,12 +183,12 @@ public class ViewsheetAgentController {
       requireEnabled();
       return editService.applyOnRuntimeIfChanged(sessionToken, user,
          rvs -> executeService.dryRun(
-            rvs, target(rvs, req.id(), req.kind(), req.assembly(), req.target())),
+            rvs, target(rvs, req.id(), req.kind(), req.assembly(), req.name(), req.target())),
          result -> result.changed() != null && !result.changed().isEmpty());
    }
 
    public record ExecuteLiveRequest(String target, String id, String kind, String assembly,
-                                    boolean confirmed) {}
+                                    String name, boolean confirmed) {}
 
    /** Runs the script currently saved at {@code target} live and broadcasts a refresh. */
    @PostMapping("/api/wiz/v1/agent/script/{sessionToken}/execute-live")
@@ -195,7 +199,8 @@ public class ViewsheetAgentController {
       requireEnabled();
       return editService.applyOnRuntime(sessionToken, user,
          rvs -> executeService.runLive(
-            rvs, target(rvs, req.id(), req.kind(), req.assembly(), req.target()), req.confirmed()));
+            rvs, target(rvs, req.id(), req.kind(), req.assembly(), req.name(), req.target()),
+            req.confirmed()));
    }
 
    /** Live introspection of the joined viewsheet's scriptable surface, scoped to a target. */
@@ -205,6 +210,7 @@ public class ViewsheetAgentController {
                                 @RequestParam(required = false) String id,
                                 @RequestParam(required = false) String kind,
                                 @RequestParam(required = false) String assembly,
+                                @RequestParam(required = false) String name,
                                 Principal user)
       throws PairingException
    {
@@ -216,7 +222,7 @@ public class ViewsheetAgentController {
       // it routes that case to resolve(), which throws the error naming all three dialects.
       boolean noTarget = isBlank(target) && isBlank(id) && isBlank(kind) && isBlank(assembly);
       return contextService.context(
-         rvs, noTarget ? null : target(rvs, id, kind, assembly, target));
+         rvs, noTarget ? null : target(rvs, id, kind, assembly, name, target));
    }
 
    /**
@@ -242,6 +248,7 @@ public class ViewsheetAgentController {
                                    @RequestParam(required = false) String id,
                                    @RequestParam(required = false) String kind,
                                    @RequestParam(required = false) String assembly,
+                                   @RequestParam(required = false) String name,
                                    @RequestParam(required = false) Integer width,
                                    @RequestParam(required = false) Integer height,
                                    Principal user)
@@ -256,7 +263,7 @@ public class ViewsheetAgentController {
          img = imageService.getViewsheetImage(rvs, width, height, user);
       }
       else {
-         ScriptTarget t = target(rvs, id, kind, assembly, target);
+         ScriptTarget t = target(rvs, id, kind, assembly, name, target);
 
          if(t.location() != ScriptTarget.Location.ASSEMBLY) {
             throw new PairingException(
@@ -345,11 +352,11 @@ public class ViewsheetAgentController {
 
    /** Resolves a target against the joined viewsheet, so the exact-name fix applies everywhere. */
    private ScriptTarget target(RuntimeViewsheet rvs, String id, String kind, String assembly,
-                               String legacyTarget)
+                               String name, String legacyTarget)
       throws PairingException
    {
       return ScriptTarget.resolve(rvs == null ? null : rvs.getViewsheet(), id, kind, assembly,
-                                  legacyTarget);
+                                  name, legacyTarget);
    }
 
    private static String agentKey(Principal agent) {

--- a/core/src/main/java/inetsoft/web/wiz/script/model/ScriptTargetInfo.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/model/ScriptTargetInfo.java
@@ -23,14 +23,19 @@ package inetsoft.web.wiz.script.model;
  * @param id         opaque and stable; copy it back verbatim rather than composing an identifier
  * @param kind       the wire vocabulary, e.g. {@code assemblyOnClick}
  * @param assembly   the owning assembly, or {@code null} for viewsheet-level kinds
+ * @param name       the calculated field's own name, for {@code calcField}; {@code null} for every
+ *                   kind addressed by (kind, assembly) alone. Populated for exactly one kind today
+ *                   — it exists because a calc field is keyed by (table, field) and cannot be
+ *                   addressed without it.
  * @param label      human-readable; for display and logs only, never an identifier
  * @param runsWhen   when StyleBI executes this script, in plain words
  * @param enableScope the flag {@code enabled} reflects. onInit and onLoad share ONE viewsheet
  *                    flag, and an assembly's main and onClick scripts share ONE assembly flag --
  *                    so disabling "the onClick" also disables that assembly's main script
  * @param hostSheet  {@code viewsheet} or {@code worksheet}
- * @param target     the v1 delimited string, retained so an older plugin still reads this array
+ * @param target     the v1 delimited string, or {@code null} for a kind the legacy grammar never
+ *                   addressed
  */
-public record ScriptTargetInfo(String id, String kind, String assembly, String label,
+public record ScriptTargetInfo(String id, String kind, String assembly, String name, String label,
                                String runsWhen, boolean hasScript, boolean enabled,
                                String enableScope, String hostSheet, String target) {}

--- a/core/src/main/java/inetsoft/web/wiz/script/model/ScriptTargetInfo.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/model/ScriptTargetInfo.java
@@ -27,6 +27,14 @@ package inetsoft.web.wiz.script.model;
  *                   kind addressed by (kind, assembly) alone. Populated for exactly one kind today
  *                   — it exists because a calc field is keyed by (table, field) and cannot be
  *                   addressed without it.
+ * @param sql        {@code true} when a {@code calcField}'s expression is SQL rather than
+ *                   JavaScript; {@code null} for every kind that is not a calc field. It decides
+ *                   which language an edit must be written in — {@code PRICE - COST} is a valid
+ *                   SQL expression and rewriting it as {@code field['PRICE'] - field['COST']}
+ *                   corrupts the field silently, so the caller must be told before it edits
+ * @param baseOnDetail {@code true} when a {@code calcField} evaluates over detail rows rather than
+ *                   aggregated ones; {@code null} for every kind that is not a calc field. Like
+ *                   {@code sql}, it constrains which expression forms are valid
  * @param label      human-readable; for display and logs only, never an identifier
  * @param runsWhen   when StyleBI executes this script, in plain words
  * @param enableScope the flag {@code enabled} reflects. onInit and onLoad share ONE viewsheet
@@ -36,6 +44,7 @@ package inetsoft.web.wiz.script.model;
  * @param target     the v1 delimited string, or {@code null} for a kind the legacy grammar never
  *                   addressed
  */
-public record ScriptTargetInfo(String id, String kind, String assembly, String name, String label,
-                               String runsWhen, boolean hasScript, boolean enabled,
-                               String enableScope, String hostSheet, String target) {}
+public record ScriptTargetInfo(String id, String kind, String assembly, String name, Boolean sql,
+                               Boolean baseOnDetail, String label, String runsWhen,
+                               boolean hasScript, boolean enabled, String enableScope,
+                               String hostSheet, String target) {}

--- a/core/src/test/java/inetsoft/web/wiz/script/CalcFieldServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/CalcFieldServiceTest.java
@@ -1,0 +1,160 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.script;
+
+import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.asset.SourceInfo;
+import inetsoft.uql.erm.ExpressionRef;
+import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.internal.ChartVSAssemblyInfo;
+import inetsoft.web.wiz.pairing.PairingException;
+import inetsoft.web.wiz.pairing.WizAgentTestSupport;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@WizAgentTestSupport
+class CalcFieldServiceTest {
+   private final CalcFieldService service = new CalcFieldService();
+
+   private static CalculateRef calc(String name, String expression, boolean sql) {
+      ExpressionRef inner = new ExpressionRef();
+      inner.setName(name);
+      inner.setExpression(expression);
+
+      CalculateRef ref = new CalculateRef(true);
+      ref.setDataRef(inner);
+      ref.setSQL(sql);
+      return ref;
+   }
+
+   /** A viewsheet with one chart bound to Query1, which has two calc fields. */
+   private static Viewsheet vsWithCalcFields() {
+      ChartVSAssemblyInfo info = new ChartVSAssemblyInfo();
+      // There is NO setTableName. getTableName() derives from the SourceInfo, and returns null
+      // unless the type is ASSET or VS_ASSEMBLY -- so a fixture that skips this enumerates nothing.
+      info.setSourceInfo(new SourceInfo(SourceInfo.ASSET, null, "Query1"));
+
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      when(chart.getName()).thenReturn("Chart1");
+      when(chart.getVSAssemblyInfo()).thenReturn(info);
+
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssemblies()).thenReturn(new Assembly[]{ chart });
+      when(vs.getCalcFields("Query1")).thenReturn(new CalculateRef[]{
+         calc("Margin", "field['PRICE'] - field['COST']", false),
+         calc("TaxRate", "0.2", true),
+      });
+      return vs;
+   }
+
+   @Test
+   void enumeratesTablesFromTheBoundAssemblies() {
+      assertEquals(List.of("Query1"), service.tablesWithCalcFields(vsWithCalcFields()));
+   }
+
+   @Test
+   void listsEveryCalcFieldWithItsTableAndFlags() {
+      List<CalcFieldService.Found> found = service.list(vsWithCalcFields());
+
+      assertEquals(2, found.size());
+      assertEquals("Query1", found.get(0).table());
+      assertEquals("Margin", found.get(0).name());
+      assertFalse(found.get(0).sql(), "Margin is a JavaScript expression");
+      assertTrue(found.get(1).sql(), "TaxRate is a SQL expression");
+   }
+
+   /**
+    * The sql flag must come from ColumnRef, not from the wrapped ExpressionRef.
+    * ExpressionRef.isSQL() returns a hardcoded false, so reading it would report every calc field
+    * as JavaScript -- silently, and for the one field where it matters most.
+    */
+   @Test
+   void readsTheSqlFlagFromTheCalculateRefNotTheInnerExpression() {
+      CalculateRef sqlField = calc("TaxRate", "0.2", true);
+
+      assertTrue(sqlField.isSQL(), "guards the premise: ColumnRef carries the flag");
+      assertFalse(((ExpressionRef) sqlField.getDataRef()).isSQL(),
+                  "and the inner ref does not -- this is the trap");
+   }
+
+   @Test
+   void readsAnExpressionByTableAndName() throws Exception {
+      assertEquals("field['PRICE'] - field['COST']",
+                   service.read(vsWithCalcFields(), "Query1", "Margin"));
+   }
+
+   @Test
+   void writesAnExpressionThroughToTheInnerRef() throws Exception {
+      Viewsheet vs = vsWithCalcFields();
+
+      service.write(vs, "Query1", "Margin", "field['PRICE'] * 2");
+
+      assertEquals("field['PRICE'] * 2", service.read(vs, "Query1", "Margin"));
+   }
+
+   @Test
+   void anUnknownFieldNameFailsLoudRatherThanSilently() {
+      Viewsheet vs = vsWithCalcFields();
+
+      PairingException ex = assertThrows(
+         PairingException.class, () -> service.read(vs, "Query1", "Nope"));
+      assertTrue(ex.getMessage().contains("Nope"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("Margin"),
+                 "the refusal should say what IS there: " + ex.getMessage());
+   }
+
+   @Test
+   void anUnknownTableFailsLoud() {
+      assertThrows(PairingException.class,
+                   () -> service.read(vsWithCalcFields(), "NoSuchTable", "Margin"));
+   }
+
+   /**
+    * getCalcFields returns null, not an empty array, for a table with none. A null-blind
+    * implementation NPEs on the most ordinary viewsheet there is -- one with no calc fields.
+    */
+   @Test
+   void aTableWithNoCalcFieldsYieldsNothingRatherThanThrowing() {
+      Viewsheet vs = mock(Viewsheet.class);
+      ChartVSAssemblyInfo info = new ChartVSAssemblyInfo();
+      info.setSourceInfo(new SourceInfo(SourceInfo.ASSET, null, "Plain"));
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      when(chart.getName()).thenReturn("Chart1");
+      when(chart.getVSAssemblyInfo()).thenReturn(info);
+      when(vs.getAssemblies()).thenReturn(new Assembly[]{ chart });
+      when(vs.getCalcFields("Plain")).thenReturn(null);
+
+      assertTrue(service.list(vs).isEmpty());
+   }
+
+   @Test
+   void writingAFieldThatDoesNotExistIsRefusedRatherThanCreatingIt() {
+      Viewsheet vs = vsWithCalcFields();
+
+      PairingException ex = assertThrows(
+         PairingException.class,
+         () -> service.write(vs, "Query1", "BrandNew", "1"));
+      assertTrue(ex.getMessage().toLowerCase().contains("create"),
+                 "must say creation is out of scope, not just 'not found': " + ex.getMessage());
+      verify(vs, never()).addCalcField(anyString(), any());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/script/ScriptContextServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ScriptContextServiceTest.java
@@ -135,4 +135,23 @@ class ScriptContextServiceTest {
       assertThrows(inetsoft.web.wiz.pairing.PairingException.class,
                    () -> service.context(mock(RuntimeViewsheet.class), target));
    }
+
+   /**
+    * A calc field's context is genuinely different in kind, not a subset. It evaluates per row with
+    * field[...] and has NO assembly API — offering thisViewsheet or an apiTree here would advertise
+    * an API that is not in scope during evaluation.
+    */
+   @Test
+   void aCalcFieldGetsThePerRowContextAndNoAssemblyApi() throws Exception {
+      ScriptContext ctx = serviceReturning(FULL).context(
+         mock(RuntimeViewsheet.class),
+         ScriptTarget.of(ScriptTarget.Kind.CALC_FIELD, "Query1", "Margin"));
+
+      assertTrue(ctx.contextVars().contains("field"),
+                 "the per-row accessor must be offered: " + ctx.contextVars());
+      assertFalse(ctx.contextVars().contains("event"));
+      assertFalse(ctx.contextVars().contains("thisViewsheet"),
+                  "no viewsheet API during per-row evaluation");
+      assertTrue(ctx.assemblies().isEmpty(), "no assembly surface for a calc field");
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/script/ScriptEditServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ScriptEditServiceTest.java
@@ -18,6 +18,8 @@
 package inetsoft.web.wiz.script;
 
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.erm.ExpressionRef;
+import inetsoft.uql.viewsheet.CalculateRef;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.wiz.pairing.*;
 import inetsoft.web.wiz.pairing.TestPrincipals;
@@ -89,25 +91,31 @@ class ScriptEditServiceTest {
    }
 
    /**
-    * Not just "throws" -- a CALC_FIELD target matches no case in write()'s switch STATEMENT,
-    * so Java does not require exhaustiveness and an unhandled case would compile clean and
-    * silently do nothing. This is reachable today: of()/resolve() build CALC_FIELD targets
-    * happily since its Location is non-null. Refusing loudly here is the fix; asserting the
-    * specific message (naming Task 3, not permanent) is what proves it isn't just an
-    * accidental compile-time throw.
+    * write() now delegates a CALC_FIELD target to {@link CalcFieldService} for real, replacing
+    * the Task-3-placeholder throw. Verifies the wiring, not {@code CalcFieldService}'s own
+    * behavior (that is Task 2's coverage) -- the expression on the live {@link ExpressionRef}
+    * must actually change.
     */
    @Test
-   void writeRefusesACalcFieldTargetUntilTask3WiresItIn() throws Exception {
+   void writeDelegatesACalcFieldTargetToCalcFieldService() throws Exception {
+      ExpressionRef inner = new ExpressionRef();
+      inner.setName("Margin");
+      inner.setExpression("field['PRICE'] - field['COST']");
+      CalculateRef calc = new CalculateRef(true);
+      calc.setDataRef(inner);
+
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getCalcFields("Query1")).thenReturn(new CalculateRef[]{ calc });
+
       RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
-      when(rvs.getViewsheet()).thenReturn(new Viewsheet());
+      when(rvs.getViewsheet()).thenReturn(vs);
       ScriptEditService svc = new ScriptEditService(mock(SheetSessionService.class),
          mock(SheetRuntimeAccess.class), mock(SheetAgentBroadcastService.class));
       ScriptTarget target = ScriptTarget.of(ScriptTarget.Kind.CALC_FIELD, "Query1", "Margin");
 
-      PairingException ex = assertThrows(PairingException.class,
-         () -> svc.write(rvs, target, "new text"));
-      assertTrue(ex.getMessage().contains("Task 3"),
-                 "must name what's missing, not just refuse: " + ex.getMessage());
+      svc.write(rvs, target, "field['PRICE'] * 2");
+
+      assertEquals("field['PRICE'] * 2", inner.getExpression());
    }
 
    /** setEnabled's refusal is PERMANENT -- a calc field has no per-field enable flag at all. */

--- a/core/src/test/java/inetsoft/web/wiz/script/ScriptEditServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ScriptEditServiceTest.java
@@ -18,6 +18,7 @@
 package inetsoft.web.wiz.script;
 
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.wiz.pairing.*;
 import inetsoft.web.wiz.pairing.TestPrincipals;
 import inetsoft.web.wiz.pairing.WizAgentTestSupport;
@@ -85,5 +86,42 @@ class ScriptEditServiceTest {
 
       assertThrows(PairingException.class, () -> svc.applyOnRuntimeIfChanged(
          "BAD", TestPrincipals.user("alice", "host-org"), r -> "x", r -> true));
+   }
+
+   /**
+    * Not just "throws" -- a CALC_FIELD target matches no case in write()'s switch STATEMENT,
+    * so Java does not require exhaustiveness and an unhandled case would compile clean and
+    * silently do nothing. This is reachable today: of()/resolve() build CALC_FIELD targets
+    * happily since its Location is non-null. Refusing loudly here is the fix; asserting the
+    * specific message (naming Task 3, not permanent) is what proves it isn't just an
+    * accidental compile-time throw.
+    */
+   @Test
+   void writeRefusesACalcFieldTargetUntilTask3WiresItIn() throws Exception {
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(new Viewsheet());
+      ScriptEditService svc = new ScriptEditService(mock(SheetSessionService.class),
+         mock(SheetRuntimeAccess.class), mock(SheetAgentBroadcastService.class));
+      ScriptTarget target = ScriptTarget.of(ScriptTarget.Kind.CALC_FIELD, "Query1", "Margin");
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.write(rvs, target, "new text"));
+      assertTrue(ex.getMessage().contains("Task 3"),
+                 "must name what's missing, not just refuse: " + ex.getMessage());
+   }
+
+   /** setEnabled's refusal is PERMANENT -- a calc field has no per-field enable flag at all. */
+   @Test
+   void setEnabledRefusesACalcFieldTargetPermanently() throws Exception {
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(new Viewsheet());
+      ScriptEditService svc = new ScriptEditService(mock(SheetSessionService.class),
+         mock(SheetRuntimeAccess.class), mock(SheetAgentBroadcastService.class));
+      ScriptTarget target = ScriptTarget.of(ScriptTarget.Kind.CALC_FIELD, "Query1", "Margin");
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.setEnabled(rvs, target, true));
+      assertTrue(ex.getMessage().contains("enable flag"),
+                 "must explain there is nothing to enable, not just refuse: " + ex.getMessage());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/script/ScriptExecuteServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ScriptExecuteServiceTest.java
@@ -21,8 +21,10 @@ import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.report.script.viewsheet.ViewsheetScope;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.wiz.pairing.PairingException;
 import inetsoft.web.wiz.pairing.WizAgentTestSupport;
 import inetsoft.web.wiz.script.model.ScriptExecResult;
+import inetsoft.web.wiz.script.model.ScriptInfo;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
@@ -124,5 +126,50 @@ class ScriptExecuteServiceTest {
       assertTrue(result.ok());
       assertEquals(java.util.List.of(), result.changed());
       verify(scope, never()).execute(anyString(), nullable(String.class));
+   }
+
+   /**
+    * Mocks ScriptReadService (rather than using the real one, as every other test here does) so
+    * execution reaches ScriptExecuteService's OWN switch(target.location()) instead of being
+    * refused earlier by ScriptReadService's unrelated "Unsupported target" default case. That
+    * switch is a switch EXPRESSION with no default, so a fifth Location value made it fail to
+    * compile at all until CALC_FIELD was added — this proves the added case both compiles and
+    * refuses with the intended, permanent message (a calc field is an expression, not a script).
+    */
+   @Test
+   void dryRunRefusesACalcFieldTargetWithASpecificMessage() throws Exception {
+      ScriptReadService readService = mock(ScriptReadService.class);
+      ScriptTarget target = ScriptTarget.of(ScriptTarget.Kind.CALC_FIELD, "Query1", "Margin");
+      when(readService.read(any(), eq(target))).thenReturn(new ScriptInfo(null, "irrelevant", true));
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      ViewsheetSandbox box = mock(ViewsheetSandbox.class);
+      when(box.getScope()).thenReturn(mock(ViewsheetScope.class));
+      when(rvs.getViewsheetSandbox()).thenReturn(Optional.of(box));
+
+      ScriptExecuteService svc = new ScriptExecuteService(readService);
+
+      PairingException ex = assertThrows(PairingException.class, () -> svc.dryRun(rvs, target));
+      assertTrue(ex.getMessage().contains("not a runnable script"),
+                 "must explain WHY, not just refuse: " + ex.getMessage());
+   }
+
+   @Test
+   void runLiveRefusesACalcFieldTargetWithASpecificMessage() throws Exception {
+      ScriptReadService readService = mock(ScriptReadService.class);
+      ScriptTarget target = ScriptTarget.of(ScriptTarget.Kind.CALC_FIELD, "Query1", "Margin");
+      when(readService.read(any(), eq(target))).thenReturn(new ScriptInfo(null, "irrelevant", true));
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      ViewsheetSandbox box = mock(ViewsheetSandbox.class);
+      when(box.getScope()).thenReturn(mock(ViewsheetScope.class));
+      when(rvs.getViewsheetSandbox()).thenReturn(Optional.of(box));
+
+      ScriptExecuteService svc = new ScriptExecuteService(readService);
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.runLive(rvs, target, true));
+      assertTrue(ex.getMessage().contains("not a runnable script"),
+                 "must explain WHY, not just refuse: " + ex.getMessage());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/script/ScriptReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ScriptReadServiceTest.java
@@ -156,13 +156,22 @@ class ScriptReadServiceTest {
                   "a reserved kind must not be advertised as servable");
    }
 
+   private static CalculateRef calc(String name, String expression, boolean sql,
+                                    boolean baseOnDetail)
+   {
+      ExpressionRef inner = new ExpressionRef();
+      inner.setName(name);
+      inner.setExpression(expression);
+      // baseOnDetail is constructor-only; CalculateRef exposes no setter for it.
+      CalculateRef ref = new CalculateRef(baseOnDetail);
+      ref.setDataRef(inner);
+      ref.setSQL(sql);
+      return ref;
+   }
+
    /** A viewsheet whose Query1 carries one JS calc field. */
    private static RuntimeViewsheet runtimeWithCalcField() {
-      ExpressionRef inner = new ExpressionRef();
-      inner.setName("Margin");
-      inner.setExpression("field['PRICE'] - field['COST']");
-      CalculateRef calc = new CalculateRef(true);
-      calc.setDataRef(inner);
+      CalculateRef calc = calc("Margin", "field['PRICE'] - field['COST']", false, true);
 
       ChartVSAssemblyInfo info = new ChartVSAssemblyInfo();
       info.setSourceInfo(new SourceInfo(SourceInfo.ASSET, null, "Query1"));
@@ -218,5 +227,79 @@ class ScriptReadServiceTest {
       assertTrue(ScriptGrammar.supportedKinds().contains("calcField"));
       assertFalse(ScriptGrammar.supportedKinds().contains("worksheetExpression"),
                   "reserved kinds still must not be advertised");
+   }
+
+   /**
+    * Two calc fields on one table that differ in BOTH reported flags: Margin is JavaScript over
+    * detail rows, TaxRate is SQL over aggregated rows. A fixture where both fields agree could not
+    * tell "reported correctly" from "hardcoded".
+    */
+   private static RuntimeViewsheet runtimeWithSqlAndJsCalcFields() {
+      ChartVSAssemblyInfo info = new ChartVSAssemblyInfo();
+      info.setSourceInfo(new SourceInfo(SourceInfo.ASSET, null, "Query1"));
+      info.setScript("");
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      when(chart.getName()).thenReturn("Chart1");
+      when(chart.getVSAssemblyInfo()).thenReturn(info);
+
+      ViewsheetInfo vsInfo = new ViewsheetInfo();
+      vsInfo.setScriptEnabled(true);
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getViewsheetInfo()).thenReturn(vsInfo);
+      when(vs.getAssemblies()).thenReturn(new Assembly[]{ chart });
+      when(vs.getCalcFields("Query1")).thenReturn(new CalculateRef[]{
+         calc("Margin", "field['PRICE'] - field['COST']", false, true),
+         calc("TaxRate", "PRICE * 0.2", true, false),
+      });
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      return rvs;
+   }
+
+   private static ScriptTargetInfo calcNamed(List<ScriptTargetInfo> all, String name) {
+      return all.stream()
+         .filter(t -> "calcField".equals(t.kind()) && name.equals(t.name()))
+         .findFirst()
+         .orElseThrow(() -> new AssertionError("no calcField named " + name + " in " + all));
+   }
+
+   /**
+    * The flag that stops an agent rewriting a SQL expression as JavaScript. {@code PRICE * 0.2}
+    * and {@code field['PRICE'] - field['COST']} are told apart by this field, not by reading the
+    * text — and {@code update_script} writes whatever it is handed, verbatim.
+    */
+   @Test
+   void reportsWhetherACalcFieldIsSqlOrJavaScript() {
+      List<ScriptTargetInfo> all = service.list(runtimeWithSqlAndJsCalcFields());
+
+      assertEquals(Boolean.FALSE, calcNamed(all, "Margin").sql(), "Margin is JavaScript");
+      assertEquals(Boolean.TRUE, calcNamed(all, "TaxRate").sql(), "TaxRate is SQL");
+   }
+
+   @Test
+   void reportsWhetherACalcFieldEvaluatesOverDetailRows() {
+      List<ScriptTargetInfo> all = service.list(runtimeWithSqlAndJsCalcFields());
+
+      assertEquals(Boolean.TRUE, calcNamed(all, "Margin").baseOnDetail(), "Margin is per-detail");
+      assertEquals(Boolean.FALSE, calcNamed(all, "TaxRate").baseOnDetail(),
+                   "TaxRate evaluates over aggregated rows");
+   }
+
+   /**
+    * Neither flag is meaningful off a calc field, so the other four kinds report null rather than
+    * a default that reads as an answer — {@code sql=false} on an onInit script would claim the
+    * viewsheet's initializer is "JavaScript, not SQL", which is not a distinction it has.
+    */
+   @Test
+   void everyNonCalcTargetReportsNeitherFlag() {
+      List<ScriptTargetInfo> others = service.list(runtimeWithSqlAndJsCalcFields()).stream()
+         .filter(t -> !"calcField".equals(t.kind()))
+         .toList();
+
+      assertFalse(others.isEmpty(), "the fixture must carry non-calc targets to discriminate");
+      assertTrue(others.stream().allMatch(t -> t.sql() == null), "sql must be absent: " + others);
+      assertTrue(others.stream().allMatch(t -> t.baseOnDetail() == null),
+                 "baseOnDetail must be absent: " + others);
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/script/ScriptReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ScriptReadServiceTest.java
@@ -19,6 +19,8 @@ package inetsoft.web.wiz.script;
 
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.asset.SourceInfo;
+import inetsoft.uql.erm.ExpressionRef;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.TextVSAssemblyInfo;
 import inetsoft.uql.viewsheet.internal.ChartVSAssemblyInfo;
@@ -147,9 +149,74 @@ class ScriptReadServiceTest {
    @Test
    void advertisesOnlyTheKindsThisServerCanActuallyServe() {
       assertEquals(2, ScriptGrammar.VERSION);
-      assertEquals(List.of("viewsheetOnInit", "viewsheetOnLoad", "assemblyMain", "assemblyOnClick"),
+      assertEquals(List.of("viewsheetOnInit", "viewsheetOnLoad", "assemblyMain", "assemblyOnClick",
+                           "calcField"),
                    ScriptGrammar.supportedKinds());
       assertFalse(ScriptGrammar.supportedKinds().contains("worksheetExpression"),
                   "a reserved kind must not be advertised as servable");
+   }
+
+   /** A viewsheet whose Query1 carries one JS calc field. */
+   private static RuntimeViewsheet runtimeWithCalcField() {
+      ExpressionRef inner = new ExpressionRef();
+      inner.setName("Margin");
+      inner.setExpression("field['PRICE'] - field['COST']");
+      CalculateRef calc = new CalculateRef(true);
+      calc.setDataRef(inner);
+
+      ChartVSAssemblyInfo info = new ChartVSAssemblyInfo();
+      info.setSourceInfo(new SourceInfo(SourceInfo.ASSET, null, "Query1"));
+      info.setScript("");
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      when(chart.getName()).thenReturn("Chart1");
+      when(chart.getVSAssemblyInfo()).thenReturn(info);
+
+      ViewsheetInfo vsInfo = new ViewsheetInfo();
+      vsInfo.setScriptEnabled(true);
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getViewsheetInfo()).thenReturn(vsInfo);
+      when(vs.getAssemblies()).thenReturn(new Assembly[]{ chart });
+      when(vs.getCalcFields("Query1")).thenReturn(new CalculateRef[]{ calc });
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      return rvs;
+   }
+
+   @Test
+   void listsCalcFieldsAlongsideTheScriptTargets() {
+      ScriptTargetInfo calc = service.list(runtimeWithCalcField()).stream()
+         .filter(t -> "calcField".equals(t.kind()))
+         .findFirst()
+         .orElseThrow(() -> new AssertionError("no calcField target emitted"));
+
+      assertEquals("Query1", calc.assembly(), "the TABLE, for this kind");
+      assertEquals("Margin", calc.name());
+      assertEquals("per row, when the field is evaluated", calc.runsWhen());
+      assertTrue(calc.hasScript());
+      assertNull(calc.target(), "a calc field has no legacy string form");
+   }
+
+   @Test
+   void aCalcFieldsLabelSaysItIsAFieldOnATableNotAnAssemblyScript() {
+      ScriptTargetInfo calc = service.list(runtimeWithCalcField()).stream()
+         .filter(t -> "calcField".equals(t.kind())).findFirst().orElseThrow();
+
+      assertTrue(calc.label().contains("Margin") && calc.label().contains("Query1"),
+                 "label should name both: " + calc.label());
+   }
+
+   @Test
+   void everyNonCalcTargetStillReportsANullName() {
+      assertTrue(service.list(runtimeWithCalcField()).stream()
+                    .filter(t -> !"calcField".equals(t.kind()))
+                    .allMatch(t -> t.name() == null));
+   }
+
+   @Test
+   void calcFieldIsAdvertisedAsServableWithoutEditingScriptGrammar() {
+      assertTrue(ScriptGrammar.supportedKinds().contains("calcField"));
+      assertFalse(ScriptGrammar.supportedKinds().contains("worksheetExpression"),
+                  "reserved kinds still must not be advertised");
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/script/ScriptTargetTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ScriptTargetTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -179,21 +180,21 @@ class ScriptTargetTest {
       Viewsheet vs = mock(Viewsheet.class);
       String id = ScriptTarget.of(ScriptTarget.Kind.ASSEMBLY_MAIN, "Chart1").id();
 
-      ScriptTarget byId = ScriptTarget.resolve(vs, id, "viewsheetOnInit", null, "vs-load");
+      ScriptTarget byId = ScriptTarget.resolve(vs, id, "viewsheetOnInit", null, null, "vs-load");
       assertEquals("Chart1", byId.assemblyName(), "id must win over every other dialect");
 
-      ScriptTarget byKind = ScriptTarget.resolve(vs, null, "assemblyOnClick", "Text1", "vs-load");
+      ScriptTarget byKind = ScriptTarget.resolve(vs, null, "assemblyOnClick", "Text1", null, "vs-load");
       assertEquals(ScriptTarget.Location.ASSEMBLY_ONCLICK, byKind.location());
       assertEquals("Text1", byKind.assemblyName());
 
-      ScriptTarget byLegacy = ScriptTarget.resolve(vs, null, null, null, "vs-load");
+      ScriptTarget byLegacy = ScriptTarget.resolve(vs, null, null, null, null, "vs-load");
       assertEquals(ScriptTarget.Location.VS_LOAD, byLegacy.location());
    }
 
    @Test
    void resolveNamesEveryAcceptedDialectWhenNoneIsGiven() {
       PairingException ex = assertThrows(
-         PairingException.class, () -> ScriptTarget.resolve(null, null, null, null, null));
+         PairingException.class, () -> ScriptTarget.resolve(null, null, null, null, null, null));
 
       assertTrue(ex.getMessage().contains("id"), ex.getMessage());
       assertTrue(ex.getMessage().contains("kind"), ex.getMessage());
@@ -205,9 +206,71 @@ class ScriptTargetTest {
       Viewsheet vs = mock(Viewsheet.class);
       when(vs.getAssembly("Foo:onClick")).thenReturn(mock(TextVSAssembly.class));
 
-      ScriptTarget t = ScriptTarget.resolve(vs, null, null, null, "assembly:Foo:onClick");
+      ScriptTarget t = ScriptTarget.resolve(vs, null, null, null, null, "assembly:Foo:onClick");
 
       assertEquals(ScriptTarget.Location.ASSEMBLY, t.location());
       assertEquals("Foo:onClick", t.assemblyName());
+   }
+
+   @Test
+   void calcFieldIsAServableKindWithItsOwnLocation() throws PairingException {
+      assertEquals(ScriptTarget.Location.CALC_FIELD,
+                   ScriptTarget.Kind.CALC_FIELD.location());
+      assertEquals("calcField", ScriptTarget.Kind.CALC_FIELD.wireName());
+      assertEquals(ScriptTarget.Kind.CALC_FIELD, ScriptTarget.Kind.fromWire("calcField"));
+   }
+
+   @Test
+   void aCalcFieldCarriesATableAndAFieldName() throws PairingException {
+      ScriptTarget t = ScriptTarget.of(ScriptTarget.Kind.CALC_FIELD, "Query1", "Margin");
+
+      assertEquals("Query1", t.assemblyName(), "assembly carries the TABLE name for this kind");
+      assertEquals("Margin", t.name());
+   }
+
+   @Test
+   void aCalcFieldWithoutAFieldNameIsRefused() {
+      PairingException ex = assertThrows(
+         PairingException.class,
+         () -> ScriptTarget.of(ScriptTarget.Kind.CALC_FIELD, "Query1", null));
+      assertTrue(ex.getMessage().contains("name"),
+                 "the refusal must name the missing field: " + ex.getMessage());
+   }
+
+   @Test
+   void aCalcFieldWithoutATableIsRefused() {
+      assertThrows(PairingException.class,
+                   () -> ScriptTarget.of(ScriptTarget.Kind.CALC_FIELD, null, "Margin"));
+   }
+
+   @Test
+   void everyOtherKindStillReportsANullName() throws PairingException {
+      assertNull(ScriptTarget.of(ScriptTarget.Kind.VIEWSHEET_ON_INIT, null).name());
+      assertNull(ScriptTarget.of(ScriptTarget.Kind.ASSEMBLY_MAIN, "Chart1").name());
+   }
+
+   @Test
+   void aCalcFieldIdRoundTripsAllThreeComponents() throws PairingException {
+      ScriptTarget t = ScriptTarget.of(ScriptTarget.Kind.CALC_FIELD, "Query1", "Margin");
+      ScriptTarget back = ScriptTarget.fromId(t.id());
+
+      assertEquals(ScriptTarget.Kind.CALC_FIELD, back.kind());
+      assertEquals("Query1", back.assemblyName());
+      assertEquals("Margin", back.name());
+   }
+
+   /**
+    * The delimiter hazard, one component further on. The id encodes kind|assembly|name, so a table
+    * or field name containing '|' must still round-trip — the same class of bug the ':'-delimited
+    * grammar had, and the reason ids are decoded by position rather than by splitting on every
+    * separator.
+    */
+   @Test
+   void aCalcFieldIdSurvivesPipesInEitherName() throws PairingException {
+      ScriptTarget t = ScriptTarget.of(ScriptTarget.Kind.CALC_FIELD, "Od|d", "Ma|rgin");
+      ScriptTarget back = ScriptTarget.fromId(t.id());
+
+      assertEquals("Od|d", back.assemblyName());
+      assertEquals("Ma|rgin", back.name());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/script/ScriptTargetTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ScriptTargetTest.java
@@ -23,6 +23,9 @@ import inetsoft.web.wiz.pairing.PairingException;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -272,5 +275,21 @@ class ScriptTargetTest {
 
       assertEquals("Od|d", back.assemblyName());
       assertEquals("Ma|rgin", back.name());
+   }
+
+   /**
+    * A trailing unpaired '\' cannot come from escape() -- it always emits '\' paired with the
+    * character it guards -- so one showing up here means the id is corrupted or hand-crafted,
+    * and must be refused rather than silently kept as a literal backslash.
+    */
+   @Test
+   void aDanglingEscapeInAnIdIsRefused() {
+      String canonical = "calcField|Query1|Ma\\";
+      String id = Base64.getUrlEncoder().withoutPadding()
+         .encodeToString(canonical.getBytes(StandardCharsets.UTF_8));
+
+      PairingException ex = assertThrows(PairingException.class, () -> ScriptTarget.fromId(id));
+      assertTrue(ex.getMessage().contains(id),
+                 "the refusal must name the offending id: " + ex.getMessage());
    }
 }


### PR DESCRIPTION
Adds `calcField` as the first Tier 2 script kind: a viewsheet's calculated-field expressions become
readable and editable through the script tools that already serve `onInit`, `onLoad`, and assembly
scripts.

**Tier 2a — read and edit-existing only.** No create, no delete, no rename, and no JS↔SQL
conversion. `CalcFieldService.write()` refuses any field name not already present on the table, and
it refuses *before* any mutation: the exception propagates ahead of `broadcastRefresh`, so a failed
write cannot leave a half-applied change behind. Creating a field means registering it and
invalidating dependent columns, which is Tier 2b.

### The addressing asymmetry, which is the thing to review carefully

A calc field is the first kind that needs **three** components rather than two. It belongs to a
table, not to an assembly, so for `CALC_FIELD` alone `assemblyName()` carries a *table* name and the
new `name()` carries the field. Every other kind uses `assemblyName()` for an assembly.

That asymmetry is the main hazard here, and it produced a real defect during development: the
context path treated the table as an assembly name and had to be short-circuited. Every site that
reads `assemblyName()` is now either `CalcFieldService` (which correctly means "table") or gated
behind a `case ASSEMBLY[, _ONCLICK]` that `CALC_FIELD` never enters.

### Exhaustiveness

Adding a fifth `Location` broke one switch *expression* that did not compile from clean, and left
two switch *statements* silently matching nothing — the dangerous half, since a statement that
matches nothing returns success having done nothing. All five sites now handle `CALC_FIELD`:
`ScriptExecuteService`, `ScriptReadService`, `ScriptEditService` (×2), `ScriptTarget.toString()`,
plus the `ViewsheetAgentController` image path which correctly excludes it.

Two of those throws are **permanent, not "not yet"**: a calc field is not runnable
(`ScriptExecuteService`) and has no enable flag (`ScriptEditService.setEnabled`). Deleting either
silently reintroduces a method that reports success having done nothing.

### Ids

`ScriptTarget` ids encode `kind|assembly|name` with total escaping (`\`→`\\`, `|`→`\|`) and decode
by scanning for the first *unescaped* separator. A position-based decode is wrong — a table named
`Od|d` makes it silently mis-split — and there is deliberately no second implementation on the
TypeScript side, which treats ids as opaque.

### Testing

`inetsoft.web.wiz.**.*Test`: **157 suite files, 1544 tests, 0 failures**, from a `clean` build.
(An earlier round in this work reported a green suite off a stale incremental cache while the module
did not compile, so the final gate was re-run after clearing `core/target`.)

The `sql` flag is worth calling out. It was computed and unit-tested in isolation for three rounds
while **nothing read it** — a unit test of a value object proves the value is computed, never that
anyone consumes it. Caught in whole-branch review. Its tests now assert values on a fixture whose
two calc fields differ in both flags in opposite directions, so a hardcoded constant cannot pass.

Client side (proxy + MCP plugin): inetsoft-technology/stylebi-wiz#1641

🤖 Generated with [Claude Code](https://claude.com/claude-code)
