### PR TITLE
D4 remainder: unscoped list_bindable_fields fabricates a field instead of listing tables

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/binding/BindableFieldsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindableFieldsService.java
@@ -113,7 +113,7 @@ public class BindableFieldsService {
       List<BindableField> direct = new ArrayList<>();
 
       for(TreeNodeModel child : node.children()) {
-         if(child.leaf()) {
+         if(hasNoDescendants(child)) {
             direct.add(fieldOf(child));
          }
          else {
@@ -133,13 +133,36 @@ public class BindableFieldsService {
    /** Every column at or below this node, however deeply the Composer nests them. */
    private void gather(TreeNodeModel node, List<BindableField> out) {
       for(TreeNodeModel child : node.children()) {
-         if(child.leaf()) {
+         if(hasNoDescendants(child)) {
             out.add(fieldOf(child));
          }
          else {
             gather(child, out);
          }
       }
+   }
+
+   /**
+    * Whether a node is safe to treat as a column, checked by its actual children rather than the
+    * tree's own {@code leaf} flag.
+    *
+    * <p>{@code leaf} is a UI hint, not a structural guarantee, and the two can disagree:
+    * {@code VSTreeHandler.isLeaf} marks every {@code AssetEntry.Type.WORKSHEET} entry as a leaf so
+    * the Composer's asset browser does not expand into a referenced worksheet inline. But
+    * {@code VSEventUtil.refreshBaseWSTree} — the tree an unscoped {@code list_bindable_fields}
+    * reads — reuses a WORKSHEET-typed entry as the *container* holding the viewsheet's actual
+    * tables, which does have real children. {@code createNodeFromEntry} sets {@code .leaf(...)}
+    * and {@code .children(...)} independently, so that container node ends up {@code leaf: true}
+    * with real table children underneath it at the same time.
+    *
+    * <p>Trusting {@code leaf()} there treated the container itself as one column — {@code
+    * fieldOf(wsNode)} turned the worksheet's own label into a fabricated {@code {column, dataType:
+    * null, role: null}} — and never walked into the real tables beneath it, so an unscoped call
+    * returned that one manufactured field instead of the viewsheet's tables. A node with children
+    * is never a column regardless of what {@code leaf()} claims; only genuine childlessness is.
+    */
+   private static boolean hasNoDescendants(TreeNodeModel node) {
+      return node.children().isEmpty();
    }
 
    private BindableField fieldOf(TreeNodeModel node) {

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindableFieldsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindableFieldsService.java
@@ -113,7 +113,7 @@ public class BindableFieldsService {
       List<BindableField> direct = new ArrayList<>();
 
       for(TreeNodeModel child : node.children()) {
-         if(hasNoDescendants(child)) {
+         if(isColumn(child)) {
             direct.add(fieldOf(child));
          }
          else {
@@ -133,7 +133,7 @@ public class BindableFieldsService {
    /** Every column at or below this node, however deeply the Composer nests them. */
    private void gather(TreeNodeModel node, List<BindableField> out) {
       for(TreeNodeModel child : node.children()) {
-         if(hasNoDescendants(child)) {
+         if(isColumn(child)) {
             out.add(fieldOf(child));
          }
          else {
@@ -143,8 +143,8 @@ public class BindableFieldsService {
    }
 
    /**
-    * Whether a node is safe to treat as a column, checked by its actual children rather than the
-    * tree's own {@code leaf} flag.
+    * Whether a node is safe to treat as a column — checked by its actual children rather than the
+    * tree's own {@code leaf} flag, and never true for a table, columns or not.
     *
     * <p>{@code leaf} is a UI hint, not a structural guarantee, and the two can disagree:
     * {@code VSTreeHandler.isLeaf} marks every {@code AssetEntry.Type.WORKSHEET} entry as a leaf so
@@ -160,9 +160,17 @@ public class BindableFieldsService {
     * null, role: null}} — and never walked into the real tables beneath it, so an unscoped call
     * returned that one manufactured field instead of the viewsheet's tables. A node with children
     * is never a column regardless of what {@code leaf()} claims; only genuine childlessness is.
+    *
+    * <p>Childlessness alone is not sufficient, though: a table with nothing exposed under it
+    * (permission-filtered, a fresh embedded table, mid-load metadata) has no children either, and
+    * without the {@link #isTable} exclusion this reintroduces the exact defect it fixes one level
+    * up — an empty table's own label gets fabricated into a column standing in for the table,
+    * instead of correctly reporting no fields for it. {@code isTable} was already the answer to
+    * "is this a table" everywhere else in this class; the childlessness check must defer to it
+    * rather than deciding leaf-ness on its own.
     */
-   private static boolean hasNoDescendants(TreeNodeModel node) {
-      return node.children().isEmpty();
+   private boolean isColumn(TreeNodeModel node) {
+      return node.children().isEmpty() && !isTable(node);
    }
 
    private BindableField fieldOf(TreeNodeModel node) {

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindableFieldsServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindableFieldsServiceTest.java
@@ -202,6 +202,43 @@ class BindableFieldsServiceTest {
       assertTrue(serviceReturning(null).list("rt1", null, principal()).isEmpty());
    }
 
+   /**
+    * The B3-observed live shape: an unscoped call's tree has a WORKSHEET-typed container node
+    * between the root and the real tables, and {@code VSTreeHandler.isLeaf} marks every
+    * {@code AssetEntry.Type.WORKSHEET} entry a leaf unconditionally -- so this container node is
+    * {@code leaf: true} at the same time as carrying real table children, because
+    * {@code createNodeFromEntry} sets the two independently.
+    *
+    * <p>Trusting {@code leaf()} treated the container itself as a column: {@code
+    * fieldOf(wsContainer)} turned its own label into a fabricated {@code {column, dataType: null,
+    * role: null}}, and the real table beneath it was never visited. Observed live as
+    * {@code {name: null, fields: [{column: "a1", dataType: null, role: null}]}} in place of the
+    * viewsheet's actual tables.
+    */
+   @Test
+   void walksIntoAWorksheetTypedContainerNodeDespiteItClaimingToBeALeaf() throws Exception {
+      TreeNodeModel column = TreeNodeModel.builder().label("Sales").leaf(true)
+         .data(entry(AssetEntry.Type.COLUMN, "Sales", "double")).build();
+      TreeNodeModel table = TreeNodeModel.builder()
+         .label("Orders").data(entry(AssetEntry.Type.TABLE, "Orders", null))
+         .addChildren(column).build();
+      // The container: WORKSHEET-typed (so VSTreeHandler.isLeaf marks it leaf: true) but carrying
+      // the real table as a child regardless -- exactly what refreshBaseWSTree's non-direct-source
+      // branch builds.
+      TreeNodeModel wsContainer = TreeNodeModel.builder()
+         .label("MyWorksheet").leaf(true)
+         .data(entry(AssetEntry.Type.WORKSHEET, "MyWorksheet", null))
+         .addChildren(table).build();
+      TreeNodeModel root = TreeNodeModel.builder().label("root").addChildren(wsContainer).build();
+
+      List<BindableTable> tables = serviceReturning(root).list("rt1", null, principal());
+
+      assertEquals(1, tables.size(),
+                   "must not fabricate a field from the WORKSHEET container's own label");
+      assertEquals("Orders", tables.get(0).name());
+      assertEquals("Sales", tables.get(0).fields().get(0).column());
+   }
+
    // ── unknown assembly name (the D4 regression) ────────────────────────────
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindableFieldsServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindableFieldsServiceTest.java
@@ -239,6 +239,27 @@ class BindableFieldsServiceTest {
       assertEquals("Sales", tables.get(0).fields().get(0).column());
    }
 
+   /**
+    * Review finding (larryliang-inetsoft): trusting childlessness alone reintroduces the same
+    * defect one level up. A table with nothing exposed under it -- permission-filtered, a fresh
+    * embedded table, mid-load metadata -- has no children either, so without excluding tables
+    * from {@code isColumn} its own label gets fabricated into a column standing in for it, the
+    * same shape as the WORKSHEET-container bug this fix closes. The old {@code leaf()}-based code
+    * never had this failure mode, because {@code leaf()} is hardcoded false for table types
+    * regardless of children.
+    */
+   @Test
+   void anEmptyTableYieldsNoFieldsRatherThanFabricatingOneFromItsOwnLabel() throws Exception {
+      TreeNodeModel emptyTable = TreeNodeModel.builder()
+         .label("EmptyTable").data(entry(AssetEntry.Type.TABLE, "EmptyTable", null)).build();
+      TreeNodeModel root = TreeNodeModel.builder().label("root").addChildren(emptyTable).build();
+
+      List<BindableTable> tables = serviceReturning(root).list("rt1", null, principal());
+
+      assertTrue(tables.isEmpty(),
+                 "an empty table must report no fields, not a fabricated column named after it");
+   }
+
    // ── unknown assembly name (the D4 regression) ────────────────────────────
 
    /**


### PR DESCRIPTION
## Summary
Closes the second known-live D4 (silent-acceptance audit) instance: unscoped `list_bindable_fields` returns a single fabricated field instead of the viewsheet's actual tables.

**Root cause**, traced entirely by static reading (no live access needed to diagnose): `VSTreeHandler.isLeaf()` marks every `AssetEntry.Type.WORKSHEET` entry a leaf unconditionally — correct for a standalone worksheet reference, but `VSEventUtil.refreshBaseWSTree`'s non-direct-source branch reuses a WORKSHEET-typed entry as the **container** node holding the viewsheet's real tables, which does have children. `createNodeFromEntry` sets `.leaf(...)` and `.children(...)` independently, so that container node ends up `leaf: true` while still carrying real table children.

`BindableFieldsService`'s tree-walker trusted `.leaf()` blindly to decide "is this a column" — so the container itself got treated as one: `fieldOf(container)` turned its own label into a fabricated `{column, dataType: null, role: null}`, and the real tables beneath it were never visited. This is exactly the live shape B3 recorded: unscoped `list_bindable_fields` returning `{name: null, fields: [{column: "a1", dataType: null, role: null}]}` instead of the viewsheet's tables — a well-formed call, accepted, plausible-but-wrong result.

**Fix**: trust actual children (`node.children().isEmpty()`) rather than the tree's own `leaf` hint, which is a UI signal that can (and here does) disagree with structure. A node with children is never a column, regardless of what `leaf()` claims.

## Wider D4 triage (this pass)
- `convertToFreehandTable`'s silent no-op on the wrong assembly type and `VSObjectPropertyService.checkScript`'s dual-null ambiguity are real but **not reachable from any `wiz/` tool today** — neither is wrapped by a plugin tool yet (E3 owns building that, and its own spec already commits to guarding this).
- `VSConditionDialogService.browseData` and `RegionPropertyDialogService.getChartArea` both have a bare `catch(Exception) { return null; }` and are reachable live, but touch shared human-facing Composer code — left unfixed pending live verification, since swallow-and-log may be deliberate ("don't crash a live editing session over a transient hiccup") rather than a wiz-specific defect.
- Everything else sampled (`removeObject`, `moveObject`, `resizeObject`, etc.) is already pre-guarded by wiz's own `requireExisting` checks before the call.

## Test plan
- [x] New regression test reproduces the exact container shape (WORKSHEET-typed, `leaf: true`, real table children) end to end
- [x] `BindableFieldsServiceTest` — 11/11
- [x] Full `inetsoft.web.wiz.**` sweep — 157 test classes, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)