### PR TITLE
Bug #76036, fix unresponsive mobile mini-toolbar actions on a selected chart

### DIFF
--- a/web/projects/portal/src/app/graph/objects/chart-area.component.interaction.tl.spec.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-area.component.interaction.tl.spec.ts
@@ -148,18 +148,53 @@ describe("ChartArea — model setter", () => {
 // ---------------------------------------------------------------------------
 
 describe("ChartArea — selected setter", () => {
+   // Bug #76036: the paging control model is published after the current change detection
+   // pass (the setter runs while the parent view is being checked), so the call is deferred.
    it("should call showPagingControl when selected becomes true on a mobile device", () => {
-      const { comp, pagingControlService } = createComponent();
-      (comp as any).mobileDevice = true;
-      comp.selected = true;
-      expect(pagingControlService.setPagingControlModel).toHaveBeenCalled();
+      vi.useFakeTimers();
+
+      try {
+         const { comp, pagingControlService } = createComponent();
+         (comp as any).mobileDevice = true;
+         comp.selected = true;
+         expect(pagingControlService.setPagingControlModel).not.toHaveBeenCalled();
+         vi.runAllTimers();
+         expect(pagingControlService.setPagingControlModel).toHaveBeenCalled();
+      }
+      finally {
+         vi.useRealTimers();
+      }
    });
 
    it("should NOT call showPagingControl when selected becomes false", () => {
-      const { comp, pagingControlService } = createComponent();
-      (comp as any).mobileDevice = true;
-      comp.selected = false;
-      expect(pagingControlService.setPagingControlModel).not.toHaveBeenCalled();
+      vi.useFakeTimers();
+
+      try {
+         const { comp, pagingControlService } = createComponent();
+         (comp as any).mobileDevice = true;
+         comp.selected = false;
+         vi.runAllTimers();
+         expect(pagingControlService.setPagingControlModel).not.toHaveBeenCalled();
+      }
+      finally {
+         vi.useRealTimers();
+      }
+   });
+
+   it("should not publish the paging control model if deselected before the deferred call runs", () => {
+      vi.useFakeTimers();
+
+      try {
+         const { comp, pagingControlService } = createComponent();
+         (comp as any).mobileDevice = true;
+         comp.selected = true;
+         comp.selected = false;
+         vi.runAllTimers();
+         expect(pagingControlService.setPagingControlModel).not.toHaveBeenCalled();
+      }
+      finally {
+         vi.useRealTimers();
+      }
    });
 
    it("should reflect the assigned value via the getter", () => {

--- a/web/projects/portal/src/app/graph/objects/chart-area.component.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-area.component.ts
@@ -142,6 +142,7 @@ export class ChartArea implements OnInit, OnChanges, OnDestroy {
    private clearCanvasSubscription: Subscription;
    private scrollTopSubscription: Subscription;
    private scrollLeftSubscription: Subscription;
+   private pagingControlTimeout: number = null;
    private flyoverApplied = false;
 
    @Input() set model(model: ChartModel) {
@@ -228,7 +229,18 @@ export class ChartArea implements OnInit, OnChanges, OnDestroy {
       this._selected = selected;
 
       if(selected) {
-         this.showPagingControl();
+         // this setter runs while the parent view is being checked, and showPagingControl()
+         // writes the model that viewer-app reads for its paging-control bindings. Writing it
+         // synchronously changes an already-checked parent expression (NG0100), so publish it
+         // after the current change detection pass instead. (Bug #76036)
+         clearTimeout(this.pagingControlTimeout);
+         this.pagingControlTimeout = window.setTimeout(() => {
+            this.pagingControlTimeout = null;
+
+            if(this._selected) {
+               this.showPagingControl();
+            }
+         });
       }
    }
 
@@ -400,6 +412,11 @@ export class ChartArea implements OnInit, OnChanges, OnDestroy {
 
       if(this.scrollLeftSubscription) {
          this.scrollLeftSubscription.unsubscribe();
+      }
+
+      if(this.pagingControlTimeout != null) {
+         clearTimeout(this.pagingControlTimeout);
+         this.pagingControlTimeout = null;
       }
    }
 

--- a/web/projects/portal/src/app/vsobjects/viewer-app.component.risk.tl.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.component.risk.tl.spec.ts
@@ -637,6 +637,45 @@ describe("ViewerAppComponent — processRemoveVSObjectCommand()", () => {
       expect(comp.selectedActions).toBe(actions);
    });
 
+   // 🔁 Regression-sensitive (Bug #76036): processAddVSObjectCommand recreates the actions
+   // object for EVERY assembly, not just the updated one, and the assembly components
+   // re-subscribe to their new instance. If selectedActions is not re-pointed at the new
+   // instance, the mobile toolbar keeps firing events on an orphaned emitter and its
+   // buttons silently do nothing.
+   it("should re-point selectedActions after an update to a DIFFERENT assembly", async () => {
+      const { comp } = await renderComponent();
+      const chart = makeObj("Chart1");
+      const text = makeObj("Text1");
+      const staleChartActions: any = { getModel: () => ({ absoluteName: "Chart1" }) };
+      comp.vsObjects = [chart, text];
+      comp.vsObjectActions = [staleChartActions, {} as any];
+      comp.selectedActions = staleChartActions;
+
+      const freshChartActions: any = { getModel: () => ({ absoluteName: "Chart1" }) };
+      ASSEMBLY_ACTION_FACTORY_MOCK.createActions.mockImplementation((model: any) =>
+         model?.absoluteName === "Chart1" ? freshChartActions : {});
+
+      comp.processAddVSObjectCommand(
+         { name: "Text1", model: { ...text, genTime: 1 } } as any);
+
+      expect(comp.vsObjectActions[0]).toBe(freshChartActions);
+      expect(comp.selectedActions).toBe(freshChartActions);
+   });
+
+   it("should leave selectedActions alone when the selected assembly is gone", async () => {
+      const { comp } = await renderComponent();
+      const text = makeObj("Text1");
+      const orphaned: any = { getModel: () => ({ absoluteName: "Chart1" }) };
+      comp.vsObjects = [text];
+      comp.vsObjectActions = [{} as any];
+      comp.selectedActions = orphaned;
+
+      comp.processAddVSObjectCommand(
+         { name: "Text1", model: { ...text, genTime: 1 } } as any);
+
+      expect(comp.selectedActions).toBe(orphaned);
+   });
+
    it("should emit onLoadingStateChanged(false) when globalLoadingIndicator=true", async () => {
       const { comp } = await renderComponent();
       comp.vsObjects = [makeObj("Chart1")];

--- a/web/projects/portal/src/app/vsobjects/viewer-app.test-fixtures.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.test-fixtures.ts
@@ -423,9 +423,26 @@ export async function renderComponent(opts: RenderOptions = {}): Promise<RenderR
       ],
       componentProviders: [
          { provide: ViewsheetClientService, useValue: VS_CLIENT_MOCK },
-         { provide: DataTipService, useValue: { viewerOffsetFunc: null } },
+         {
+            provide: DataTipService,
+            useValue: {
+               viewerOffsetFunc: null,
+               registerDataTip: vi.fn(),
+               registerDataTipVisible: vi.fn(),
+               clearDataTipChild: vi.fn()
+            }
+         },
          { provide: AdhocFilterService, useValue: {} },
-         { provide: PopComponentService, useValue: { viewerOffsetFunc: null, getComponentModelFunc: null } },
+         {
+            provide: PopComponentService,
+            useValue: {
+               viewerOffsetFunc: null,
+               getComponentModelFunc: null,
+               registerPopComponent: vi.fn(),
+               registerPopComponentVisible: vi.fn(),
+               setPopLocation: vi.fn()
+            }
+         },
          { provide: VSChartService, useValue: {} },
          { provide: AssemblyActionFactory, useValue: ASSEMBLY_ACTION_FACTORY_MOCK },
          { provide: SelectionContainerChildrenService, useValue: {} },


### PR DESCRIPTION
Redmine #76036 — *\<Mobile\> open Example/Return Analysis in mobile, select chart plot, then click some action in minitoolbar, no response.*

## Symptoms

1. On a mobile layout, select a chart plot in `Examples/Return Analysis`, then tap an action in the mini-toolbar (e.g. Brush) — nothing happens.
2. `NG0100: ExpressionChangedAfterItHasBeenCheckedError` is logged (previous `null`, current `true`, `viewer-app.component.html:40`).

These turned out to be two independent defects.

## 1. Dead mini-toolbar buttons — stale `AbstractVSActions` instance

On mobile, `MiniToolbar` renders nothing (its button block is inside `@if (!mobileDevice)`); the toolbar shown is `viewer-mobile-toolbar`, bound to `viewer-app`'s `selectedActions`. Its buttons only call `onAssemblyActionEvent.emit(...)` on that one instance, and the sole subscriber is `VSChart`, whose `actions` input setter **unsubscribes from the previous instance** whenever a new one is assigned.

`processAddVSObjectCommand` recreates `vsObjectActions` for **every** assembly whenever **any** single assembly updates, but only re-pointed `selectedActions` when the incoming command happened to name the selected assembly:

```ts
this.vsObjectActions = this.vsObjects.map(model => ...);   // rebuilds ALL

if(this.selectedActions &&
   this.selectedActions.getModel().absoluteName == command.name)   // only the updated one
```

So: tap the chart plot → flyover fires → the server refreshes the output assemblies → each resulting `AddVSObjectCommand` hands `VSChart` a fresh `ChartActions` (its setter drops the old subscription) while `selectedActions` keeps pointing at the old one → tapping Brush emits into an emitter with zero subscribers. No error, no response.

**Fix:** re-point `selectedActions` by assembly name after the rebuild, regardless of which assembly triggered the command (new `refreshSelectedActions()`). This also removes a latent NPE — the old condition dereferenced `getModel()` unguarded.

The desktop mini-toolbar was never affected; it binds `[actions]="vsObjectActions[i]"` straight from the live array.

## 2. NG0100 — parent binding written by a descendant

`viewer-app` reads `pagingControlModel?.enabled` for its `paging-control` bindings. That model is written by a descendant during the same change-detection pass: `ChartArea`'s `@Input() set selected` called `showPagingControl()` synchronously, after the parent had already evaluated the expression as `null`.

**Fix:** publish the paging control model after the current change-detection pass, re-checking `_selected` in case the chart was deselected in between; the timeout handle is cleared in `ngOnDestroy`. The table components were already safe — they call `showPagingControl()` from an `(onClick)` handler rather than an input setter.

## Tests

- `viewer-app.component.risk.tl.spec.ts` — new regression tests: `selectedActions` is re-pointed after an update to a *different* assembly, and left alone when the selected assembly no longer exists.
- `chart-area.component.interaction.tl.spec.ts` — the two `selected`-setter tests now use fake timers (they asserted synchronous behavior); added one covering select-then-deselect before the deferred call fires.
- `viewer-app.test-fixtures.ts` — filled in the `DataTipService` / `PopComponentService` mocks so `processAddVSObjectCommand` is reachable from tests.

373 TL tests pass across the six chart-area + viewer-app suites; `tsc --noEmit` clean; no new lint output on the changed files. Manually verified in mobile emulation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)