### PR TITLE
E2/E3 server: convert ops, selection runtime, calendar display and input values

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyConvertService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyConvertService.java
@@ -1,0 +1,421 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.composition.graph.calc.PercentCalc;
+import inetsoft.uql.asset.SourceInfo;
+import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.internal.*;
+import inetsoft.web.composer.vs.objects.controller.*;
+import inetsoft.web.composer.vs.objects.event.ConvertToFreehandTableEvent;
+import inetsoft.web.composer.vs.objects.event.ConvertToRangeSliderEvent;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+import java.util.*;
+
+/**
+ * Changes an assembly's <b>type</b>: selection list &harr; range slider, and table or crosstab to a
+ * freehand (calc) table.
+ *
+ * <p>Four Composer menu actions over three endpoints. Table and crosstab share one endpoint — the
+ * assembly is named in the payload — and <b>both selection directions send
+ * {@code ConvertToRangeSliderEvent}</b>, including range-slider&rarr;selection-list where the name
+ * reads backwards. Direction lives in the endpoint, never in the payload, so a caller that infers
+ * direction from the event type gets it wrong. This class maps {@code (current type, to)} onto the
+ * right endpoint so that never reaches the agent.
+ *
+ * <p><b>Why this class validates so much before dispatching.</b> Every one of these endpoints
+ * answers a wrong request with silence or a crash, never a refusal:
+ *
+ * <ul>
+ *   <li>{@code ComposerVSTableService.convertToFreehandTable} returns {@code null} — success, having
+ *       done nothing — when the target is not a {@code TableDataVSAssembly}. Point it at a chart and
+ *       nothing happens, loudly reported as fine.</li>
+ *   <li>Both selection converts return {@code null} on an unknown name and on an embedded assembly.
+ *       The embedded refusal is a real product rule expressed only as silence.</li>
+ *   <li><b>Both selection converts then crash on a standalone assembly.</b> Their guards read
+ *       {@code if(!(assembly instanceof X) && !(container instanceof CurrentSelectionVSAssembly))}
+ *       — {@code &&} where the body requires <i>both</i>, so an assembly of the right type passes
+ *       even with no container. {@code AbstractVSAssembly.getContainer()} returns {@code null}
+ *       unless the assembly sits in a Tab, GroupContainer or CurrentSelection container, the
+ *       cast of {@code null} succeeds, and the next line throws {@code NullPointerException}.
+ *       Inside a Tab or GroupContainer it throws {@code ClassCastException} instead.</li>
+ * </ul>
+ *
+ * <p>That last one is latent from the UI only because the menu item is hidden unless the assembly is
+ * in a selection container — a check that exists in Angular and nowhere else. <b>The Composer's
+ * menus carry preconditions the server does not enforce</b>, so wrapping these endpoints means
+ * porting the action's {@code visible:} conditions too, not just reading the service guards:
+ * {@code inSelectionContainer} and {@code !adhocFilter} for the selection pair, and
+ * {@code sourceType == VS_ASSEMBLY && metadata} for the freehand pair, which both Angular handlers
+ * refuse with {@code composer.vs.table.cannotConvertToFreehand}.
+ *
+ * <p><b>{@code confirmed} is deliberately left false.</b> On an unconfirmed crosstab the service runs
+ * {@code VSEventUtil.fixAggregateInfo}, which builds an {@code AggregateInfo} from the source when
+ * the crosstab has none and then reclassifies aggregates as measures and headers as dimensions. The
+ * freehand table's cells depend on that, and <b>no caller in the product ever sets {@code confirmed}
+ * true</b> — both Angular handlers construct the event with only a name. Setting it true to "skip a
+ * prompt" would skip the repair and build a freehand table from an empty {@code AggregateInfo}.
+ *
+ * <p><b>Converting a crosstab discards state, so the result says what was lost.</b> The service calls
+ * {@code clearCrosstabDrill} and {@code clearDateComparison} unconditionally, and a date comparison
+ * is something the agent itself may have set minutes earlier through
+ * {@code set_date_comparison}. The conversion is legitimate; silent loss is not.
+ */
+@Service
+public class AssemblyConvertService {
+   public AssemblyConvertService(ViewsheetSessionService sessions,
+                                 ComposerVSSelectionListService selectionListService,
+                                 ComposerRangeSliderService rangeSliderService,
+                                 ComposerVSTableService tableService)
+   {
+      this.sessions = sessions;
+      this.selectionListService = selectionListService;
+      this.rangeSliderService = rangeSliderService;
+      this.tableService = tableService;
+   }
+
+   /**
+    * The conversions this build supports, as {@code to} values, with the aliases each accepts.
+    *
+    * <p>Exposed so the tool layer can list them rather than hard-coding a second copy that drifts.
+    */
+   public Map<String, Object> vocabulary() {
+      return Map.of(
+         "to", List.of(
+            Map.of("value", RANGE_SLIDER, "from", "selection list",
+                   "aliases", List.of("rangeSlider", "range-slider", "timeSlider", "slider")),
+            Map.of("value", SELECTION_LIST, "from", "range slider",
+                   "aliases", List.of("selectionList", "selection-list", "list")),
+            Map.of("value", FREEHAND_TABLE, "from", "table or crosstab",
+                   "aliases", List.of("freehand", "calc_table", "calcTable", "freehandTable"))));
+   }
+
+   /**
+    * Converts one assembly to another type.
+    *
+    * @param assemblyName the assembly to convert.
+    * @param to           the target type — see {@link #vocabulary()}.
+    *
+    * @return what happened: the source and target types, anything the conversion discarded, and the
+    *         staleness note. Never a bare "ok": the caller cannot see the discarded state.
+    */
+   public Map<String, Object> convert(String sessionToken, Principal user, String assemblyName,
+                                      String to, String linkUri)
+      throws Exception
+   {
+      if(assemblyName == null || assemblyName.isBlank()) {
+         throw new IllegalArgumentException("'assembly' is required — name the assembly to convert.");
+      }
+
+      final String target = requireTarget(to);
+      final Map<String, Object> result = new LinkedHashMap<>();
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         VSAssembly assembly = resolve(rvs, assemblyName);
+         String from = describe(assembly);
+
+         requireNotEmbedded(assembly, assemblyName);
+         requireLegalPair(assembly, assemblyName, from, target);
+         requireConvertibleSource(rvs, assembly, assemblyName, target);
+
+         result.put("assembly", assemblyName);
+         result.put("from", from);
+         result.put("to", target);
+         result.put("cleared", discardedBy(assembly, target));
+
+         // NOTE the argument order. The two selection converts take (…, principal, dispatcher,
+         // linkUri); convertToFreehandTable takes (…, principal, linkUri, dispatcher) — the last two
+         // swapped. Only the differing types make that a compile error rather than a runtime one, so
+         // do not "tidy" these three calls into a uniform shape.
+         switch(target) {
+            case RANGE_SLIDER -> selectionListService.convertToRangeSlider(
+               runtimeId, nameEvent(assemblyName), user, dispatcher, linkUri);
+            case SELECTION_LIST -> rangeSliderService.convertCSComponent(
+               runtimeId, nameEvent(assemblyName), user, dispatcher, linkUri);
+            default -> tableService.convertToFreehandTable(
+               runtimeId, freehandEvent(assemblyName), user, linkUri, dispatcher);
+         }
+      });
+
+      // The conversion replaces the assembly rather than editing it: a new assembly is created, the
+      // old layout position copied onto it, and the old absolute name taken over. Anything holding
+      // the old identity is stale.
+      result.put("note",
+                 "The assembly was replaced, not edited — re-read the viewsheet model before " +
+                 "addressing it again. A binding-editor session paired to it is no longer valid. " +
+                 "This conversion is undoable within the session.");
+      return result;
+   }
+
+   /** Resolves the assembly, refusing an unknown name instead of letting the server no-op. */
+   private static VSAssembly resolve(RuntimeViewsheet rvs, String assemblyName) {
+      Viewsheet vs = rvs == null ? null : rvs.getViewsheet();
+      VSAssembly assembly = vs == null ? null : vs.getAssembly(assemblyName);
+
+      if(assembly == null) {
+         throw new IllegalArgumentException(
+            "Unknown assembly '" + assemblyName + "'. Every convert endpoint answers an unknown " +
+            "name with success and no change, so this is refused here instead.");
+      }
+
+      return assembly;
+   }
+
+   private static void requireNotEmbedded(VSAssembly assembly, String assemblyName) {
+      if(((VSAssemblyInfo) assembly.getInfo()).isEmbedded()) {
+         throw new IllegalArgumentException(
+            "'" + assemblyName + "' is embedded from another viewsheet and cannot be converted. " +
+            "The server declines this silently; convert it in the viewsheet that owns it.");
+      }
+   }
+
+   /**
+    * Enforces the pair, and the preconditions the Composer's menus enforce and the endpoints do not.
+    */
+   private static void requireLegalPair(VSAssembly assembly, String assemblyName, String from,
+                                        String target)
+   {
+      switch(target) {
+         case RANGE_SLIDER -> {
+            if(!(assembly instanceof SelectionListVSAssembly)) {
+               throw new IllegalArgumentException(
+                  illegal(assemblyName, from, target, "a selection list"));
+            }
+
+            // The Composer hides this action on an ad hoc filter (selection-list-actions.ts:
+            // visible: composer && !adhocFilter && inSelectionContainer).
+            if(((SelectionVSAssemblyInfo) assembly.getInfo()).isAdhocFilter()) {
+               throw new IllegalArgumentException(
+                  "'" + assemblyName + "' is an ad hoc filter, and the Composer does not offer " +
+                  "converting one to a range slider.");
+            }
+
+            requireSelectionContainer(assembly, assemblyName, target);
+         }
+         case SELECTION_LIST -> {
+            if(!(assembly instanceof TimeSliderVSAssembly)) {
+               throw new IllegalArgumentException(
+                  illegal(assemblyName, from, target, "a range slider"));
+            }
+
+            requireSelectionContainer(assembly, assemblyName, target);
+         }
+         default -> {
+            if(!(assembly instanceof TableDataVSAssembly)) {
+               throw new IllegalArgumentException(
+                  illegal(assemblyName, from, target, "a table or a crosstab"));
+            }
+         }
+      }
+   }
+
+   /**
+    * The {@code inSelectionContainer} precondition. Without it the server crashes rather than
+    * refusing — see this class's header.
+    */
+   private static void requireSelectionContainer(VSAssembly assembly, String assemblyName,
+                                                 String target)
+   {
+      if(!(assembly.getContainer() instanceof CurrentSelectionVSAssembly)) {
+         throw new IllegalArgumentException(
+            "'" + assemblyName + "' is not inside a selection container, and this conversion only " +
+            "works for assemblies that are. The Composer hides the menu item in this case; the " +
+            "endpoint does not check, and fails with an internal error instead of refusing.");
+      }
+   }
+
+   /**
+    * The {@code metadata} precondition, which lives only in Angular: both freehand handlers refuse
+    * with {@code composer.vs.table.cannotConvertToFreehand} when the table is bound to another
+    * assembly and the viewsheet is in metadata mode, because the layout the conversion has to
+    * generate needs real data. The endpoint does not check.
+    */
+   private static void requireConvertibleSource(RuntimeViewsheet rvs, VSAssembly assembly,
+                                                String assemblyName, String target)
+   {
+      if(!FREEHAND_TABLE.equals(target)) {
+         return;
+      }
+
+      Viewsheet vs = rvs.getViewsheet();
+      boolean metadata = vs != null && vs.getViewsheetInfo() != null &&
+         vs.getViewsheetInfo().isMetadata();
+
+      if(!metadata) {
+         return;
+      }
+
+      SourceInfo source = assembly.getInfo() instanceof DataVSAssemblyInfo info
+         ? info.getSourceInfo() : null;
+
+      if(source != null && source.getType() == SourceInfo.VS_ASSEMBLY) {
+         throw new IllegalArgumentException(
+            "'" + assemblyName + "' is bound to another assembly and this viewsheet is in metadata " +
+            "mode, so the freehand layout cannot be generated. The Composer refuses this in the " +
+            "same case; the endpoint does not check and would produce an empty layout.");
+      }
+   }
+
+   /**
+    * What the conversion will discard, named so the caller can see it.
+    *
+    * <p>Three things, not the two the design spec knew about. <b>Calculators are the third and the
+    * least visible:</b> {@code convertToFreehandTable} calls {@code clearCalculators} on every
+    * aggregate whose calculator is not a {@code PercentCalc} — running total, change-from-previous
+    * and the rest — "because freehand does not support calculator". The service even collects their
+    * names, then passes the list to {@code VSLayoutTool.syncCellFormat} for format syncing and
+    * <b>never tells anyone</b>. So the numbers in the converted table are computed differently and
+    * nothing says so.
+    */
+   private static List<String> discardedBy(VSAssembly assembly, String target) {
+      if(!FREEHAND_TABLE.equals(target) || !(assembly instanceof CrosstabVSAssembly crosstab)) {
+         return List.of();
+      }
+
+      List<String> cleared = new ArrayList<>();
+      CrosstabVSAssemblyInfo info = crosstab.getCrosstabInfo();
+
+      if(info != null && info.getDateComparisonInfo() != null) {
+         cleared.add("date comparison");
+      }
+
+      CrosstabTree tree = crosstab.getCrosstabTree();
+
+      if(tree != null && tree.getExpandedPaths() != null && !tree.getExpandedPaths().isEmpty()) {
+         cleared.add("drill expansion");
+      }
+
+      for(String named : calculators(crosstab)) {
+         cleared.add("calculator on " + named);
+      }
+
+      return cleared;
+   }
+
+   /** Mirrors {@code ComposerVSTableService.clearCalculators}' predicate without mutating anything. */
+   private static List<String> calculators(CrosstabVSAssembly crosstab) {
+      VSCrosstabInfo crosstabInfo = crosstab.getVSCrosstabInfo();
+      DataRef[] aggregates = crosstabInfo == null ? null : crosstabInfo.getAggregates();
+
+      if(aggregates == null) {
+         return List.of();
+      }
+
+      List<String> named = new ArrayList<>();
+
+      for(DataRef aggregate : aggregates) {
+         if(aggregate instanceof VSAggregateRef ref && ref.getCalculator() != null &&
+            !(ref.getCalculator() instanceof PercentCalc))
+         {
+            named.add(ref.getFullName());
+         }
+      }
+
+      return named;
+   }
+
+   private static String illegal(String assemblyName, String from, String target, String expected) {
+      return "'" + assemblyName + "' is " + from + ", so it cannot be converted to " + target +
+         " — that conversion needs " + expected + ".";
+   }
+
+   /** A readable type for messages and for the result's {@code from}. */
+   private static String describe(VSAssembly assembly) {
+      if(assembly instanceof SelectionListVSAssembly) {
+         return "a selection list";
+      }
+      else if(assembly instanceof SelectionTreeVSAssembly) {
+         return "a selection tree";
+      }
+      else if(assembly instanceof TimeSliderVSAssembly) {
+         return "a range slider";
+      }
+      else if(assembly instanceof CrosstabVSAssembly) {
+         return "a crosstab";
+      }
+      else if(assembly instanceof CalcTableVSAssembly) {
+         return "a freehand table";
+      }
+      else if(assembly instanceof TableVSAssembly) {
+         return "a table";
+      }
+
+      return "a " + assembly.getClass().getSimpleName();
+   }
+
+   private static ConvertToRangeSliderEvent nameEvent(String assemblyName) {
+      ConvertToRangeSliderEvent event = new ConvertToRangeSliderEvent();
+      event.setName(assemblyName);
+      return event;
+   }
+
+   /**
+    * Leaves {@code confirmed} false, matching every caller in the product — see the class header for
+    * why true would skip a repair rather than a prompt.
+    */
+   private static ConvertToFreehandTableEvent freehandEvent(String assemblyName) {
+      ConvertToFreehandTableEvent event = new ConvertToFreehandTableEvent();
+      event.setName(assemblyName);
+      return event;
+   }
+
+   private static String requireTarget(String to) {
+      String key = to == null ? "" : to.trim().toLowerCase(Locale.ROOT).replace('-', '_');
+      String canonical = TARGETS.get(key);
+
+      if(canonical == null) {
+         throw new IllegalArgumentException(
+            "Unknown conversion target '" + to + "'. Supported: " + RANGE_SLIDER + ", " +
+            SELECTION_LIST + ", " + FREEHAND_TABLE + ".");
+      }
+
+      return canonical;
+   }
+
+   private static final String RANGE_SLIDER = "range_slider";
+   private static final String SELECTION_LIST = "selection_list";
+   private static final String FREEHAND_TABLE = "freehand_table";
+
+   /**
+    * Aliases, because the menu and the model disagree: the Composer says "Convert to Freehand Table"
+    * while the assembly it creates is a {@code CalcTableVSAssembly}, so both names are natural.
+    */
+   private static final Map<String, String> TARGETS = Map.ofEntries(
+      Map.entry("range_slider", RANGE_SLIDER),
+      Map.entry("rangeslider", RANGE_SLIDER),
+      Map.entry("timeslider", RANGE_SLIDER),
+      Map.entry("time_slider", RANGE_SLIDER),
+      Map.entry("slider", RANGE_SLIDER),
+      Map.entry("selection_list", SELECTION_LIST),
+      Map.entry("selectionlist", SELECTION_LIST),
+      Map.entry("list", SELECTION_LIST),
+      Map.entry("freehand_table", FREEHAND_TABLE),
+      Map.entry("freehandtable", FREEHAND_TABLE),
+      Map.entry("freehand", FREEHAND_TABLE),
+      Map.entry("calc_table", FREEHAND_TABLE),
+      Map.entry("calctable", FREEHAND_TABLE));
+
+   private final ViewsheetSessionService sessions;
+   private final ComposerVSSelectionListService selectionListService;
+   private final ComposerRangeSliderService rangeSliderService;
+   private final ComposerVSTableService tableService;
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/CalendarDisplayService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/CalendarDisplayService.java
@@ -1,0 +1,270 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.CalendarVSAssembly;
+import inetsoft.uql.viewsheet.VSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.internal.CalendarVSAssemblyInfo;
+import inetsoft.web.viewsheet.controller.VSCalendarService;
+import inetsoft.web.viewsheet.event.calendar.*;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+import java.util.*;
+
+/**
+ * A calendar's display mode: year view, single-vs-double calendar, and range comparison — plus
+ * clearing its selected dates.
+ *
+ * <p><b>Unlike the selection endpoints these are real setters</b> — {@code ToggleYearViewEvent}
+ * carries {@code yearView()} and the service does {@code setYearViewValue(event.yearView())}, so
+ * there is no cycle to compute. The "toggle" in their names describes the menu item, not the
+ * contract.
+ *
+ * <p><b>But two of them silently discard the calendar's selection, which is the reason this class
+ * reports rather than just returning ok.</b> Both {@code toggleYearView} and
+ * {@code toggleDoubleCalendar} run {@code calendarInfo.setDates(new String[0])} before applying —
+ * the comment in the service reads <i>"dates are reset when toggling"</i>. So an agent adjusting how
+ * a calendar is displayed wipes the date filter it was applying, and the dashboard afterwards looks
+ * like a calendar that was simply never used.
+ *
+ * <p>Switching to a single calendar has two more effects worth naming: it sets
+ * {@code setPeriod(false)}, turning **range comparison off**, and it restores the
+ * {@code submitOnChange} value that switching *to* double calendar had forced to false. Switching to
+ * double calendar also **doubles the assembly's width** unless it is wizard-temporary.
+ *
+ * <p><b>Every endpoint casts without checking.</b>
+ * {@code (CalendarVSAssembly) viewsheet.getAssembly(name)} with no null test, then dereferences it —
+ * so an unknown name is a {@code NullPointerException} and a name belonging to anything else is a
+ * {@code ClassCastException}. This class resolves and type-checks first.
+ *
+ * <p>The two excluded actions stay excluded, per the roadmap's open decision 1: {@code multi-select}
+ * is mobile-only viewer chrome ({@code visible: mobileDevice && …}), and so is the range slider's
+ * viewer-advanced pane.
+ */
+@Service
+public class CalendarDisplayService {
+   public CalendarDisplayService(ViewsheetSessionService sessions, VSCalendarService calendars) {
+      this.sessions = sessions;
+      this.calendars = calendars;
+   }
+
+   /**
+    * Sets a calendar's display mode.
+    *
+    * @param yearView        show years/months rather than days, or null to leave it.
+    * @param doubleCalendar  show two calendars for a range, or null to leave it.
+    * @param rangeComparison compare two periods — requires double-calendar mode.
+    */
+   public Map<String, Object> setDisplay(String sessionToken, Principal user, String assemblyName,
+                                         Boolean yearView, Boolean doubleCalendar,
+                                         Boolean rangeComparison, String linkUri)
+      throws Exception
+   {
+      requireName(assemblyName);
+
+      if(yearView == null && doubleCalendar == null && rangeComparison == null) {
+         throw new IllegalArgumentException(
+            "Nothing to do — give at least one of 'yearView', 'doubleCalendar' or " +
+            "'rangeComparison'.");
+      }
+
+      final Map<String, Object> result = new LinkedHashMap<>();
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         CalendarVSAssembly calendar = requireCalendar(rvs, assemblyName);
+         CalendarVSAssemblyInfo info = (CalendarVSAssemblyInfo) calendar.getVSAssemblyInfo();
+
+         DisplayPlan plan = plan(
+            info.getViewMode() == CalendarVSAssemblyInfo.DOUBLE_CALENDAR_MODE,
+            info.isYearView(), info.isPeriod(),
+            info.getDates() != null && info.getDates().length > 0,
+            yearView, doubleCalendar, rangeComparison, assemblyName);
+
+         result.put("assembly", assemblyName);
+         result.put("changed", plan.changed());
+         result.put("sideEffects", plan.sideEffects());
+
+         String date1 = nullToEmpty(info.getCurrentDate1());
+         String date2 = info.getCurrentDate2();
+
+         // Double calendar first: it resets period, so a rangeComparison request has to be applied
+         // after it rather than before.
+         if(plan.setDouble()) {
+            calendars.toggleDoubleCalendar(
+               runtimeId, assemblyName,
+               ImmutableToggleDoubleCalendarEvent.builder()
+                  .doubleCalendar(plan.doubleValue())
+                  .currentDate1(date1).currentDate2(date2).build(),
+               linkUri, user, dispatcher);
+         }
+
+         if(plan.setYearView()) {
+            calendars.toggleYearView(
+               runtimeId, assemblyName,
+               ImmutableToggleYearViewEvent.builder()
+                  .yearView(plan.yearViewValue())
+                  .currentDate1(date1).currentDate2(date2).build(),
+               linkUri, user, dispatcher);
+         }
+
+         if(plan.setRange()) {
+            // This one does NOT clear the dates -- it applies the event's dates -- so the current
+            // selection is echoed back rather than dropped.
+            calendars.toggleRangeComparison(
+               runtimeId, assemblyName,
+               ImmutableToggleRangeComparisonEvent.builder()
+                  .period(plan.rangeValue())
+                  .currentDate1(date1).currentDate2(date2)
+                  .dates(info.getDates()).build(),
+               linkUri, user, dispatcher);
+         }
+      });
+
+      return result;
+   }
+
+   /** Clears the calendar's selected dates, so it filters nothing. */
+   public Map<String, Object> clear(String sessionToken, Principal user, String assemblyName,
+                                    String linkUri)
+      throws Exception
+   {
+      requireName(assemblyName);
+      final Map<String, Object> result = new LinkedHashMap<>();
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         CalendarVSAssembly calendar = requireCalendar(rvs, assemblyName);
+         CalendarVSAssemblyInfo info = (CalendarVSAssemblyInfo) calendar.getVSAssemblyInfo();
+         String[] dates = info.getDates();
+
+         result.put("assembly", assemblyName);
+         result.put("clearedCount", dates == null ? 0 : dates.length);
+
+         // NOTE the order: clearCalendar takes (…, principal, dispatcher, linkUri) while its three
+         // siblings in the same class take (…, event, linkUri, principal, dispatcher). Sibling
+         // methods disagreeing is why this is spelled out rather than made uniform.
+         calendars.clearCalendar(runtimeId, assemblyName, user, dispatcher, linkUri);
+      });
+
+      result.put("persistsOnSave", true);
+      return result;
+   }
+
+   /**
+    * What a display request means: which endpoints to call, and which invisible side effects to
+    * report.
+    *
+    * <p>Split out from {@link #setDisplay} and given plain values because
+    * {@code CalendarVSAssemblyInfo} <b>cannot be constructed or mocked outside a Spring context</b> —
+    * the class fails to initialise. All of the policy worth asserting therefore lives here, where a
+    * test can reach it.
+    */
+   record DisplayPlan(boolean setDouble, boolean doubleValue,
+                      boolean setYearView, boolean yearViewValue,
+                      boolean setRange, boolean rangeValue,
+                      List<String> changed, List<String> sideEffects) {}
+
+   static DisplayPlan plan(boolean isDouble, boolean isYearView, boolean isPeriod, boolean hasDates,
+                           Boolean yearView, Boolean doubleCalendar, Boolean rangeComparison,
+                           String assemblyName)
+   {
+      boolean wantsDouble = doubleCalendar != null ? doubleCalendar : isDouble;
+
+      // Range comparison lives on the double calendar. The Composer hides the menu item unless
+      // doubleCalendar is on (calendar-actions.ts: visible: () => this.model.doubleCalendar), and
+      // switching to a single calendar sets period false -- so this combination would be silently
+      // undone rather than refused.
+      if(rangeComparison != null && rangeComparison && !wantsDouble) {
+         throw new IllegalArgumentException(
+            "Range comparison needs double-calendar mode, and '" + assemblyName + "' is " +
+            (isDouble ? "being switched to a single calendar" : "a single calendar") +
+            ". Pass doubleCalendar=true in the same call, or drop rangeComparison.");
+      }
+
+      List<String> changed = new ArrayList<>();
+      List<String> sideEffects = new ArrayList<>();
+
+      boolean setDouble = doubleCalendar != null && doubleCalendar != isDouble;
+      boolean setYear = yearView != null && yearView != isYearView;
+      boolean setRange = rangeComparison != null && rangeComparison != isPeriod;
+
+      if(setDouble) {
+         changed.add("doubleCalendar=" + doubleCalendar);
+
+         if(doubleCalendar) {
+            sideEffects.add("submit-on-change was turned off and the calendar was widened");
+         }
+         else if(isPeriod) {
+            sideEffects.add("range comparison was turned off");
+         }
+      }
+
+      if(setYear) {
+         changed.add("yearView=" + yearView);
+      }
+
+      if(setRange) {
+         changed.add("rangeComparison=" + rangeComparison);
+      }
+
+      // Both display toggles run setDates(new String[0]) before applying, so either one throws the
+      // date filter away. Reported once, and only when there was something to lose.
+      if(hasDates && (setDouble || setYear)) {
+         sideEffects.add("the selected dates were cleared");
+      }
+
+      return new DisplayPlan(setDouble, setDouble && doubleCalendar, setYear,
+                             setYear && yearView, setRange, setRange && rangeComparison,
+                             changed, sideEffects);
+   }
+
+   private static void requireName(String assemblyName) {
+      if(assemblyName == null || assemblyName.isBlank()) {
+         throw new IllegalArgumentException("'assembly' is required — name the calendar.");
+      }
+   }
+
+   private static CalendarVSAssembly requireCalendar(RuntimeViewsheet rvs, String assemblyName) {
+      Viewsheet vs = rvs == null ? null : rvs.getViewsheet();
+      VSAssembly assembly = vs == null ? null : vs.getAssembly(assemblyName);
+
+      if(assembly == null) {
+         throw new IllegalArgumentException(
+            "Unknown assembly '" + assemblyName + "'. The calendar endpoints cast without a null " +
+            "check and fail with an internal error, so this is refused here instead.");
+      }
+
+      if(!(assembly instanceof CalendarVSAssembly calendar)) {
+         throw new IllegalArgumentException(
+            "'" + assemblyName + "' is a " + assembly.getClass().getSimpleName() +
+            ", not a calendar.");
+      }
+
+      return calendar;
+   }
+
+   /** {@code currentDate1} is non-nullable on the event, so it is echoed back rather than dropped. */
+   private static String nullToEmpty(String value) {
+      return value == null ? "" : value;
+   }
+
+   private final ViewsheetSessionService sessions;
+   private final VSCalendarService calendars;
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/InputValueService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/InputValueService.java
@@ -1,0 +1,152 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.*;
+import inetsoft.web.viewsheet.service.VSInputService;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+import java.util.*;
+
+/**
+ * An input assembly's value: combo box, check box, radio button, text input and spinner.
+ *
+ * <p><b>The unit's name overstated this half.</b> Every input assembly's action vocabulary is exactly
+ * three items — {@code edit-script}, {@code properties}, {@code show-format-pane} — all already
+ * shipped. There is no apply, clear, search or sort in any input's menu. What is missing is not menu
+ * actions but the value itself, driven by direct interaction through four one-endpoint controllers
+ * that all converge on {@code VSInputService}.
+ *
+ * <p>So this is one tool over one service method. {@code singleApplySelection} takes the value as a
+ * bare {@code Object}, and a check box's several values arrive as that same parameter holding an
+ * {@code Object[]} — which is why one method serves both the scalar and the multi-value inputs.
+ *
+ * <p><b>The endpoint is silent on everything.</b>
+ * {@code applySelection} returns {@code 0} when the name is null, when the viewsheet is null, and —
+ * the case that matters — when {@code !(vsAssembly instanceof InputVSAssembly)}. So pointing it at a
+ * chart or a typo'd name reports success having done nothing. It is at least *consistently* silent,
+ * unlike the selection verbs, which variously no-op, NPE and CCE. Either way there is nothing worth
+ * forwarding, so this class resolves and type-checks first.
+ *
+ * <p><b>A value written here persists.</b> {@code CheckBoxVSAssembly}, {@code ComboBoxVSAssembly},
+ * {@code RadioButtonVSAssembly} and {@code TextInputVSAssembly} all implement
+ * {@code writeStateContent} the same way the selection assemblies do, and it is called on the save
+ * path — so an input's value becomes what every future viewer opens with.
+ */
+@Service
+public class InputValueService {
+   public InputValueService(ViewsheetSessionService sessions, VSInputService inputs) {
+      this.sessions = sessions;
+      this.inputs = inputs;
+   }
+
+   /**
+    * Sets an input assembly's value.
+    *
+    * @param values one value for a combo box, radio button, text input or spinner; one or more for a
+    *               check box. Empty means "no value selected", which is a legitimate state and not
+    *               the same as leaving it alone.
+    */
+   public Map<String, Object> setValue(String sessionToken, Principal user, String assemblyName,
+                                       List<Object> values, String linkUri)
+      throws Exception
+   {
+      if(assemblyName == null || assemblyName.isBlank()) {
+         throw new IllegalArgumentException("'assembly' is required — name the input assembly.");
+      }
+
+      if(values == null) {
+         throw new IllegalArgumentException(
+            "'value' is required. Pass an empty list to clear the input rather than omitting it, so " +
+            "that clearing is something you asked for rather than a default.");
+      }
+
+      final Map<String, Object> result = new LinkedHashMap<>();
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         InputVSAssembly assembly = requireInput(rvs, assemblyName);
+         boolean multi = assembly instanceof CheckBoxVSAssembly;
+
+         if(!multi && values.size() > 1) {
+            throw new IllegalArgumentException(
+               "'" + assemblyName + "' is " + describe(assembly) + ", which holds one value, but " +
+               values.size() + " were given. Only a check box accepts several.");
+         }
+
+         result.put("assembly", assemblyName);
+         result.put("type", describe(assembly));
+         result.put("valueCount", values.size());
+
+         // A check box's several values travel as an Object[] in the same 'selectedObject'
+         // parameter the scalar inputs use, which is why one service method serves both.
+         Object selected = multi
+            ? values.toArray()
+            : (values.isEmpty() ? null : values.get(0));
+
+         inputs.singleApplySelection(runtimeId, assemblyName, selected, user, dispatcher, linkUri);
+      });
+
+      result.put("persistsOnSave", true);
+      return result;
+   }
+
+   private static InputVSAssembly requireInput(RuntimeViewsheet rvs, String assemblyName) {
+      Viewsheet vs = rvs == null ? null : rvs.getViewsheet();
+      VSAssembly assembly = vs == null ? null : vs.getAssembly(assemblyName);
+
+      if(assembly == null) {
+         throw new IllegalArgumentException(
+            "Unknown assembly '" + assemblyName + "'. The input endpoint returns success and " +
+            "changes nothing for a name it cannot find, so this is refused here instead.");
+      }
+
+      if(!(assembly instanceof InputVSAssembly input)) {
+         throw new IllegalArgumentException(
+            "'" + assemblyName + "' is a " + assembly.getClass().getSimpleName() +
+            ", not an input assembly. Inputs are combo boxes, check boxes, radio buttons, text " +
+            "inputs and spinners (a submit button is an output assembly and holds no value).");
+      }
+
+      return input;
+   }
+
+   private static String describe(InputVSAssembly assembly) {
+      if(assembly instanceof CheckBoxVSAssembly) {
+         return "a check box";
+      }
+      else if(assembly instanceof ComboBoxVSAssembly) {
+         return "a combo box";
+      }
+      else if(assembly instanceof RadioButtonVSAssembly) {
+         return "a radio button";
+      }
+      else if(assembly instanceof TextInputVSAssembly) {
+         return "a text input";
+      }
+      else if(assembly instanceof SpinnerVSAssembly) {
+         return "a spinner";
+      }
+
+      return "a " + assembly.getClass().getSimpleName();
+   }
+
+   private final ViewsheetSessionService sessions;
+   private final VSInputService inputs;
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/SelectionRuntimeService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/SelectionRuntimeService.java
@@ -1,0 +1,452 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.XConstants;
+import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.internal.*;
+import inetsoft.web.viewsheet.event.ApplySelectionListEvent;
+import inetsoft.web.viewsheet.event.SortSelectionListEvent;
+import inetsoft.web.viewsheet.service.VSSelectionService;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+import java.util.*;
+
+/**
+ * A selection assembly's runtime state: which values are selected, how the list is sorted, and
+ * whether it accepts one value or many.
+ *
+ * <p>This covers selection lists, selection trees and range sliders — {@code TimeSliderVSAssembly}
+ * extends {@code AbstractSelectionVSAssembly} and rides the same {@code applySelection} path, so it
+ * needs no separate surface.
+ *
+ * <p><b>Why these are authoring operations and not viewer exploration.</b> The state written here
+ * persists: {@code SelectionListVSAssembly.writeStateContent} writes the selection, the sort order
+ * and the single-vs-multi flag <i>unconditionally</i>, and {@code writeContents} calls it on the save
+ * path. A default selection is a real design decision, and the state block treats sort and selection
+ * style as authoring settings by sitting them beside it.
+ *
+ * <p><b>The endpoints are TOGGLES and CYCLES, not setters — this class converts desired state into
+ * the right number of steps.</b> They were built for menu clicks, so:
+ *
+ * <ul>
+ *   <li>{@code /selectionList/sort} takes no order. It advances a three-state ring:
+ *       {@code SORT_ASC → SORT_DESC → SORT_SPECIFIC → SORT_ASC} ({@code nextSortType}). Reaching a
+ *       requested order means computing the distance and cycling that many times.</li>
+ *   <li>{@code /selectionList/toggle} takes no value — it flips {@code singleSelection}. So setting
+ *       it means reading the current flag and acting only if it differs.</li>
+ *   <li>{@code applySelection}'s own event <i>also</i> flips {@code singleSelection} when
+ *       {@code toggle} or {@code toggleAll} is set, which is a third route to the same field. This
+ *       class never sets those flags, so a value apply cannot silently change the selection style.</li>
+ * </ul>
+ *
+ * <p>Every step runs inside one {@link ViewsheetSessionService#mutate} call, which owns the
+ * checkpoint — so a request that needs two sort cycles is still <b>one undo step</b>, matching the
+ * plugin's one-call-one-checkpoint contract.
+ *
+ * <p><b>A wrong assembly name or type fails three different ways, so this class checks first.</b>
+ * Audited across {@code VSSelectionService}: {@code applySelection} and {@code sortSelection}
+ * answer an unknown name with success and no change; {@code selectSubtree} and {@code unselectAll}
+ * throw {@code NullPointerException}; and every one of them throws {@code ClassCastException} on a
+ * name that exists but is not a selection assembly. There is no server behaviour worth forwarding.
+ *
+ * <p><b>An active search string silently narrows what an apply touches.</b> When one is set and the
+ * assembly is not single-select, {@code applySelection} runs
+ * {@code olist = olist.findAll(search, true)} before applying, so the write lands on the filtered
+ * subset. This class reads it and reports it rather than pretending the apply was global. It does not
+ * offer to <i>set</i> one: {@code setSearchString} writes both {@code search} and {@code search2},
+ * only {@code search2} is persisted, and <b>nothing in the repository ever parses {@code search2}
+ * back</b> — so a search string is a write-only field that never survives a reopen.
+ */
+@Service
+public class SelectionRuntimeService {
+   public SelectionRuntimeService(ViewsheetSessionService sessions, VSSelectionService selections) {
+      this.sessions = sessions;
+      this.selections = selections;
+   }
+
+   /** The sort orders a caller can ask for, mapped to StyleBI's constants. */
+   public Map<String, Object> vocabulary() {
+      return Map.of(
+         "sortOrder", List.of("asc", "desc", "specific"),
+         "sortOrderNote",
+         "The runtime endpoint has no setter — it cycles asc → desc → specific. A request is " +
+         "reached by cycling, all inside one undo checkpoint.",
+         "subtreeMode", List.of("select", "clear"));
+   }
+
+   /**
+    * Makes a selection assembly's state be what the caller asked for.
+    *
+    * @param values      the values to select. For a tree, each entry is a path from the root, so
+    *                    {@code ["East","NY"]} selects NY under East. Null leaves the selection alone.
+    * @param sortOrder   {@code asc} | {@code desc} | {@code specific}, or null to leave it.
+    * @param singleSelect whether the assembly should accept one value only, or null to leave it.
+    */
+   public Map<String, Object> setSelection(String sessionToken, Principal user, String assemblyName,
+                                           List<List<String>> values, String sortOrder,
+                                           Boolean singleSelect, String linkUri)
+      throws Exception
+   {
+      requireName(assemblyName);
+
+      if(values == null && sortOrder == null && singleSelect == null) {
+         throw new IllegalArgumentException(
+            "Nothing to do — give at least one of 'values', 'sortOrder' or 'singleSelect'.");
+      }
+
+      final Integer targetSort = sortOrder == null ? null : requireSortOrder(sortOrder);
+      final Map<String, Object> result = new LinkedHashMap<>();
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         SelectionVSAssembly assembly = requireSelection(rvs, assemblyName);
+         SelectionVSAssemblyInfo info = (SelectionVSAssemblyInfo) assembly.getInfo();
+
+         result.put("assembly", assemblyName);
+         result.put("type", describe(assembly));
+
+         // Order matters. Selection style first: it changes how a value apply is interpreted
+         // (single-select unselects siblings), so applying values under the old style and then
+         // switching would leave a selection the caller did not ask for.
+         if(singleSelect != null && singleSelect != info.isSingleSelection()) {
+            selections.toggleSelectionStyle(runtimeId, assemblyName, user, dispatcher, linkUri);
+            result.put("singleSelectChanged", true);
+         }
+
+         if(targetSort != null) {
+            // Sort lives on SelectionBaseVSAssemblyInfo, which a range slider's info is not — a
+            // slider orders by its underlying range, so there is nothing to sort.
+            if(!(info instanceof SelectionBaseVSAssemblyInfo sortable)) {
+               throw new IllegalArgumentException(
+                  "'" + assemblyName + "' is " + describe(assembly) + ", which has no sort order — " +
+                  "it follows its range. Drop 'sortOrder'.");
+            }
+
+            int cycles = sortCycles(sortable.getSortTypeValue(), targetSort);
+
+            for(int i = 0; i < cycles; i++) {
+               selections.sortSelection(runtimeId, assemblyName, new SortSelectionListEvent(),
+                                        user, dispatcher, linkUri);
+            }
+
+            result.put("sortOrder", sortOrder);
+            result.put("sortCycles", cycles);
+         }
+
+         if(values != null) {
+            boolean single = singleSelect != null ? singleSelect : info.isSingleSelection();
+
+            if(single && values.size() > 1) {
+               throw new IllegalArgumentException(
+                  "'" + assemblyName + "' is single-select, so it cannot hold " + values.size() +
+                  " values. Select one value, or pass singleSelect=false in the same call to make " +
+                  "it multi-select first.");
+            }
+
+            String search = searchString(info);
+
+            if(search != null && !search.isBlank() && !single) {
+               // Not a refusal: the apply is legitimate, but it lands on the filtered subset and
+               // nothing in the result would otherwise say so.
+               result.put("scopedBySearch", search);
+            }
+
+            selections.applySelection(runtimeId, assemblyName, applyEvent(values), user, dispatcher,
+                                      linkUri);
+            result.put("valuesSelected", values.size());
+         }
+      });
+
+      result.put("persistsOnSave", true);
+      return result;
+   }
+
+   /**
+    * Clears every selection on the assembly.
+    *
+    * <p><b>Not the same as selecting every value, and the difference only shows up later.</b>
+    * Clearing resets the state list to null, so {@code writeStateContent} writes no
+    * {@code state_selectionList} block at all and the sheet reopens in its natural state. Selecting
+    * every value writes a block enumerating each one, frozen at the values that existed when it was
+    * written — so a value added to the data afterwards is <i>excluded</i> by that saved state, while
+    * a cleared selection would have included it.
+    */
+   public Map<String, Object> clearSelection(String sessionToken, Principal user,
+                                             String assemblyName, String linkUri)
+      throws Exception
+   {
+      requireName(assemblyName);
+      final Map<String, Object> result = new LinkedHashMap<>();
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         SelectionVSAssembly assembly = requireSelection(rvs, assemblyName);
+         List<List<String>> current = selectedPaths(assembly);
+
+         result.put("assembly", assemblyName);
+         result.put("type", describe(assembly));
+         result.put("clearedCount", current.size());
+
+         if(!current.isEmpty()) {
+            // The client composes "unselect" the same way: send every currently selected value back
+            // with selected=false. There is no single clear endpoint for one assembly.
+            selections.applySelection(runtimeId, assemblyName, deselectEvent(current), user,
+                                      dispatcher, linkUri);
+         }
+      });
+
+      result.put("persistsOnSave", true);
+      return result;
+   }
+
+   /**
+    * Selects or clears a whole subtree of a selection tree.
+    *
+    * @param path the subtree root, as a path from the tree's root.
+    * @param mode {@code select} or {@code clear}.
+    */
+   public Map<String, Object> selectSubtree(String sessionToken, Principal user, String assemblyName,
+                                            List<String> path, String mode, String linkUri)
+      throws Exception
+   {
+      requireName(assemblyName);
+
+      if(path == null || path.isEmpty()) {
+         throw new IllegalArgumentException(
+            "'path' is required — the subtree's root, as a path from the tree's root, e.g. " +
+            "[\"East\"] or [\"East\",\"NY\"].");
+      }
+
+      final boolean select = requireSubtreeMode(mode);
+      final Map<String, Object> result = new LinkedHashMap<>();
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         SelectionVSAssembly assembly = requireSelection(rvs, assemblyName);
+
+         if(!(assembly instanceof SelectionTreeVSAssembly)) {
+            throw new IllegalArgumentException(
+               "'" + assemblyName + "' is " + describe(assembly) + ", and subtrees only exist on a " +
+               "selection tree. Use set_selection for a list or a range slider.");
+         }
+
+         result.put("assembly", assemblyName);
+         result.put("path", path);
+         result.put("mode", select ? "select" : "clear");
+
+         ApplySelectionListEvent event = new ApplySelectionListEvent();
+         event.setType(ApplySelectionListEvent.Type.APPLY);
+         ApplySelectionListEvent.Value value = new ApplySelectionListEvent.Value();
+         value.setValue(path.toArray(new String[0]));
+         value.setSelected(select);
+         event.setValues(List.of(value));
+
+         // selectSubtree NPEs on an unknown name and CCEs on a non-tree; both are refused above.
+         selections.selectSubtree(runtimeId, assemblyName, event, user, dispatcher, linkUri);
+      });
+
+      result.put("persistsOnSave", true);
+      return result;
+   }
+
+   // ── guards ────────────────────────────────────────────────────────────────
+
+   private static void requireName(String assemblyName) {
+      if(assemblyName == null || assemblyName.isBlank()) {
+         throw new IllegalArgumentException("'assembly' is required — name the selection assembly.");
+      }
+   }
+
+   /**
+    * Resolves and type-checks before any endpoint is touched, because the endpoints answer a bad
+    * name with silence, an NPE or a CCE depending on which one you call.
+    */
+   private static SelectionVSAssembly requireSelection(RuntimeViewsheet rvs, String assemblyName) {
+      Viewsheet vs = rvs == null ? null : rvs.getViewsheet();
+      VSAssembly assembly = vs == null ? null : vs.getAssembly(assemblyName);
+
+      if(assembly == null) {
+         throw new IllegalArgumentException(
+            "Unknown assembly '" + assemblyName + "'. The selection endpoints answer an unknown " +
+            "name with success and no change, or an internal error, so this is refused here.");
+      }
+
+      if(!(assembly instanceof SelectionVSAssembly selection)) {
+         throw new IllegalArgumentException(
+            "'" + assemblyName + "' is a " + assembly.getClass().getSimpleName() +
+            ", not a selection assembly. Selections exist on selection lists, selection trees and " +
+            "range sliders.");
+      }
+
+      return selection;
+   }
+
+   private static int requireSortOrder(String sortOrder) {
+      return switch(sortOrder.trim().toLowerCase(Locale.ROOT)) {
+         case "asc", "ascending" -> XConstants.SORT_ASC;
+         case "desc", "descending" -> XConstants.SORT_DESC;
+         case "specific", "manual" -> XConstants.SORT_SPECIFIC;
+         default -> throw new IllegalArgumentException(
+            "'sortOrder' must be asc, desc or specific, got '" + sortOrder + "'.");
+      };
+   }
+
+   private static boolean requireSubtreeMode(String mode) {
+      String key = mode == null ? "" : mode.trim().toLowerCase(Locale.ROOT);
+
+      return switch(key) {
+         case "select" -> true;
+         case "clear", "unselect", "deselect" -> false;
+         default -> throw new IllegalArgumentException(
+            "'mode' must be 'select' or 'clear', got '" + mode + "'.");
+      };
+   }
+
+   // ── the toggle/cycle arithmetic ───────────────────────────────────────────
+
+   /**
+    * How many times to hit the sort endpoint to get from {@code current} to {@code target}.
+    *
+    * <p>The ring is {@code ASC → DESC → SPECIFIC → ASC}, and anything unrecognised lands on
+    * {@code ASC} after one step, matching {@code nextSortType}'s {@code default}.
+    */
+   static int sortCycles(int current, int target) {
+      int at = current;
+
+      for(int steps = 0; steps < RING.length; steps++) {
+         if(at == target) {
+            return steps;
+         }
+
+         at = next(at);
+      }
+
+      // Unreachable for the three ring values; a caller asking for something outside it gets a
+      // single step rather than a silent no-op.
+      return 1;
+   }
+
+   private static int next(int sortType) {
+      if(sortType == XConstants.SORT_ASC) {
+         return XConstants.SORT_DESC;
+      }
+      else if(sortType == XConstants.SORT_DESC) {
+         return XConstants.SORT_SPECIFIC;
+      }
+
+      return XConstants.SORT_ASC;
+   }
+
+   // ── event construction ────────────────────────────────────────────────────
+
+   /**
+    * Builds a plain value apply. {@code toggle}/{@code toggleAll} are deliberately left false —
+    * either one would flip {@code singleSelection} instead of applying the values.
+    */
+   private static ApplySelectionListEvent applyEvent(List<List<String>> values) {
+      ApplySelectionListEvent event = new ApplySelectionListEvent();
+      event.setType(ApplySelectionListEvent.Type.APPLY);
+      event.setValues(values.stream().map(path -> value(path, true)).toList());
+      return event;
+   }
+
+   private static ApplySelectionListEvent deselectEvent(List<List<String>> values) {
+      ApplySelectionListEvent event = new ApplySelectionListEvent();
+      event.setType(ApplySelectionListEvent.Type.APPLY);
+      event.setValues(values.stream().map(path -> value(path, false)).toList());
+      return event;
+   }
+
+   private static ApplySelectionListEvent.Value value(List<String> path, boolean selected) {
+      ApplySelectionListEvent.Value value = new ApplySelectionListEvent.Value();
+      value.setValue(path.toArray(new String[0]));
+      value.setSelected(selected);
+      return value;
+   }
+
+   // ── reads ─────────────────────────────────────────────────────────────────
+
+   /** Every currently selected value, as paths — what "clear" has to send back deselected. */
+   private static List<List<String>> selectedPaths(SelectionVSAssembly assembly) {
+      SelectionList list = selectionListOf(assembly);
+      return selectedPaths(list == null ? null : list.getSelectionValues());
+   }
+
+   /**
+    * The value-to-path mapping, split out from its container so it is testable.
+    *
+    * <p>{@code SelectionList} cannot be constructed or mocked in a plain unit test — the class fails
+    * to initialise outside a Spring context — so the logic worth asserting lives here, over the array
+    * the container hands back.
+    */
+   static List<List<String>> selectedPaths(SelectionValue[] values) {
+      if(values == null) {
+         return List.of();
+      }
+
+      List<List<String>> paths = new ArrayList<>();
+
+      for(SelectionValue value : values) {
+         if(value != null && value.isSelected()) {
+            paths.add(List.of(value.getValue() == null ? "" : value.getValue()));
+         }
+      }
+
+      return paths;
+   }
+
+   private static SelectionList selectionListOf(SelectionVSAssembly assembly) {
+      if(assembly instanceof SelectionListVSAssembly list) {
+         return list.getSelectionList();
+      }
+      else if(assembly instanceof SelectionTreeVSAssembly tree) {
+         return tree.getSelectionList();
+      }
+      else if(assembly instanceof TimeSliderVSAssembly slider) {
+         return slider.getSelectionList();
+      }
+
+      return null;
+   }
+
+   /** The search string, which is on the base selection info rather than per-type. */
+   private static String searchString(SelectionVSAssemblyInfo info) {
+      return info instanceof SelectionBaseVSAssemblyInfo base ? base.getSearchString() : null;
+   }
+
+   private static String describe(VSAssembly assembly) {
+      if(assembly instanceof SelectionListVSAssembly) {
+         return "a selection list";
+      }
+      else if(assembly instanceof SelectionTreeVSAssembly) {
+         return "a selection tree";
+      }
+      else if(assembly instanceof TimeSliderVSAssembly) {
+         return "a range slider";
+      }
+
+      return "a " + assembly.getClass().getSimpleName();
+   }
+
+   private static final int[] RING = {
+      XConstants.SORT_ASC, XConstants.SORT_DESC, XConstants.SORT_SPECIFIC
+   };
+
+   private final ViewsheetSessionService sessions;
+   private final VSSelectionService selections;
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -67,6 +67,8 @@ public class ViewsheetAssemblyAgentController {
                                    DateComparisonService comparisonService,
                                    AssemblyConvertService convertService,
                                    SelectionRuntimeService selectionService,
+                                   CalendarDisplayService calendarService,
+                                   InputValueService inputService,
                                    ViewsheetService viewsheetService,
                                    SheetAgentBroadcastService broadcast,
                                    SheetOpenService openService)
@@ -89,6 +91,8 @@ public class ViewsheetAssemblyAgentController {
       this.comparisonService = comparisonService;
       this.convertService = convertService;
       this.selectionService = selectionService;
+      this.calendarService = calendarService;
+      this.inputService = inputService;
       this.viewsheetService = viewsheetService;
       this.broadcast = broadcast;
       this.openService = openService;
@@ -425,6 +429,48 @@ public class ViewsheetAssemblyAgentController {
 
    public record SelectionRequest(String assembly, java.util.List<java.util.List<String>> values,
                                   String sortOrder, Boolean singleSelect) {}
+
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/calendar/display")
+   public Map<String, Object> setCalendarDisplay(@PathVariable String sessionToken,
+                                                 @RequestBody CalendarDisplayRequest request,
+                                                 @RequestParam(required = false, defaultValue = "")
+                                                 String linkUri,
+                                                 Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return calendarService.setDisplay(sessionToken, user, request.assembly(), request.yearView(),
+                                       request.doubleCalendar(), request.rangeComparison(), linkUri);
+   }
+
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/calendar/clear")
+   public Map<String, Object> clearCalendar(@PathVariable String sessionToken,
+                                            @RequestBody CalendarDisplayRequest request,
+                                            @RequestParam(required = false, defaultValue = "")
+                                            String linkUri,
+                                            Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return calendarService.clear(sessionToken, user, request.assembly(), linkUri);
+   }
+
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/input/value")
+   public Map<String, Object> setInputValue(@PathVariable String sessionToken,
+                                            @RequestBody InputValueRequest request,
+                                            @RequestParam(required = false, defaultValue = "")
+                                            String linkUri,
+                                            Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return inputService.setValue(sessionToken, user, request.assembly(), request.value(), linkUri);
+   }
+
+   public record CalendarDisplayRequest(String assembly, Boolean yearView, Boolean doubleCalendar,
+                                        Boolean rangeComparison) {}
+   public record InputValueRequest(String assembly, java.util.List<Object> value) {}
+
    public record SubtreeRequest(String assembly, java.util.List<String> path, String mode) {}
 
    public record ConvertRequest(String assembly, String to) {}
@@ -810,6 +856,8 @@ public class ViewsheetAssemblyAgentController {
    private final DateComparisonService comparisonService;
    private final AssemblyConvertService convertService;
    private final SelectionRuntimeService selectionService;
+   private final CalendarDisplayService calendarService;
+   private final InputValueService inputService;
    private final ViewsheetService viewsheetService;
    private final SheetAgentBroadcastService broadcast;
    private final SheetOpenService openService;

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -66,6 +66,7 @@ public class ViewsheetAssemblyAgentController {
                                    AssemblyHighlightService highlightService,
                                    DateComparisonService comparisonService,
                                    AssemblyConvertService convertService,
+                                   SelectionRuntimeService selectionService,
                                    ViewsheetService viewsheetService,
                                    SheetAgentBroadcastService broadcast,
                                    SheetOpenService openService)
@@ -87,6 +88,7 @@ public class ViewsheetAssemblyAgentController {
       this.highlightService = highlightService;
       this.comparisonService = comparisonService;
       this.convertService = convertService;
+      this.selectionService = selectionService;
       this.viewsheetService = viewsheetService;
       this.broadcast = broadcast;
       this.openService = openService;
@@ -371,6 +373,59 @@ public class ViewsheetAssemblyAgentController {
       requireEnabled();
       return convertService.convert(sessionToken, user, request.assembly(), request.to(), linkUri);
    }
+
+
+   @GetMapping("/api/wiz/v1/agent/viewsheet/selection/vocabulary")
+   public Map<String, Object> selectionVocabulary() {
+      requireEnabled();
+      return selectionService.vocabulary();
+   }
+
+   /**
+    * Sets a selection assembly's state. The response reports how many sort cycles it took and
+    * whether an active search string scoped the apply — neither is visible in the dashboard.
+    */
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/selection")
+   public Map<String, Object> setSelection(@PathVariable String sessionToken,
+                                           @RequestBody SelectionRequest request,
+                                           @RequestParam(required = false, defaultValue = "")
+                                           String linkUri,
+                                           Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return selectionService.setSelection(sessionToken, user, request.assembly(), request.values(),
+                                          request.sortOrder(), request.singleSelect(), linkUri);
+   }
+
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/selection/clear")
+   public Map<String, Object> clearSelection(@PathVariable String sessionToken,
+                                             @RequestBody SelectionRequest request,
+                                             @RequestParam(required = false, defaultValue = "")
+                                             String linkUri,
+                                             Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return selectionService.clearSelection(sessionToken, user, request.assembly(), linkUri);
+   }
+
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/selection/subtree")
+   public Map<String, Object> selectSubtree(@PathVariable String sessionToken,
+                                            @RequestBody SubtreeRequest request,
+                                            @RequestParam(required = false, defaultValue = "")
+                                            String linkUri,
+                                            Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return selectionService.selectSubtree(sessionToken, user, request.assembly(), request.path(),
+                                           request.mode(), linkUri);
+   }
+
+   public record SelectionRequest(String assembly, java.util.List<java.util.List<String>> values,
+                                  String sortOrder, Boolean singleSelect) {}
+   public record SubtreeRequest(String assembly, java.util.List<String> path, String mode) {}
 
    public record ConvertRequest(String assembly, String to) {}
 
@@ -754,6 +809,7 @@ public class ViewsheetAssemblyAgentController {
    private final AssemblyHighlightService highlightService;
    private final DateComparisonService comparisonService;
    private final AssemblyConvertService convertService;
+   private final SelectionRuntimeService selectionService;
    private final ViewsheetService viewsheetService;
    private final SheetAgentBroadcastService broadcast;
    private final SheetOpenService openService;

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -65,6 +65,7 @@ public class ViewsheetAssemblyAgentController {
                                    AssemblyConditionService conditionService,
                                    AssemblyHighlightService highlightService,
                                    DateComparisonService comparisonService,
+                                   AssemblyConvertService convertService,
                                    ViewsheetService viewsheetService,
                                    SheetAgentBroadcastService broadcast,
                                    SheetOpenService openService)
@@ -85,6 +86,7 @@ public class ViewsheetAssemblyAgentController {
       this.conditionService = conditionService;
       this.highlightService = highlightService;
       this.comparisonService = comparisonService;
+      this.convertService = convertService;
       this.viewsheetService = viewsheetService;
       this.broadcast = broadcast;
       this.openService = openService;
@@ -347,6 +349,30 @@ public class ViewsheetAssemblyAgentController {
       chartRegionService.set(sessionToken, user, request.assembly(), request.region(),
                              request.target(), request.field(), request.properties(), linkUri);
    }
+
+   @GetMapping("/api/wiz/v1/agent/viewsheet/convert/vocabulary")
+   public Map<String, Object> convertVocabulary() {
+      requireEnabled();
+      return convertService.vocabulary();
+   }
+
+   /**
+    * Changes an assembly's type. Returns what was converted and, for a crosstab, what the
+    * conversion discarded — the caller cannot see that from the resulting table.
+    */
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/convert")
+   public Map<String, Object> convertAssembly(@PathVariable String sessionToken,
+                                              @RequestBody ConvertRequest request,
+                                              @RequestParam(required = false, defaultValue = "")
+                                              String linkUri,
+                                              Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return convertService.convert(sessionToken, user, request.assembly(), request.to(), linkUri);
+   }
+
+   public record ConvertRequest(String assembly, String to) {}
 
    public record RegionPropertiesRequest(String assembly, String region, String target,
                                          String field, Map<String, Object> properties) {}
@@ -727,6 +753,7 @@ public class ViewsheetAssemblyAgentController {
    private final AssemblyConditionService conditionService;
    private final AssemblyHighlightService highlightService;
    private final DateComparisonService comparisonService;
+   private final AssemblyConvertService convertService;
    private final ViewsheetService viewsheetService;
    private final SheetAgentBroadcastService broadcast;
    private final SheetOpenService openService;

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyConvertServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyConvertServiceTest.java
@@ -1,0 +1,381 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.asset.SourceInfo;
+import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.internal.*;
+import inetsoft.web.composer.vs.objects.controller.*;
+import inetsoft.web.composer.vs.objects.event.ConvertToFreehandTableEvent;
+import inetsoft.web.composer.vs.objects.event.ConvertToRangeSliderEvent;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.security.Principal;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Every refusal here covers a case the endpoint answers with silence or an unhandled exception, so
+ * these are not defensive extras — they are the reason the service exists rather than the tool
+ * calling the endpoints directly.
+ */
+@Tag("core")
+class AssemblyConvertServiceTest {
+   // ── the silent-no-op guards ───────────────────────────────────────────────
+
+   /**
+    * An unknown name is the case all three endpoints answer with success and no change.
+    */
+   @Test
+   void refusesAnUnknownAssemblyInsteadOfSucceedingSilently() {
+      Harness h = harness(null, "Nope");
+
+      Exception e = assertThrows(IllegalArgumentException.class,
+         () -> h.service.convert("tok", principal(), "Nope", "range_slider", ""));
+
+      assertTrue(e.getMessage().contains("Nope"), "the message must name the assembly");
+      verifyNoInteractions(h.selectionList, h.rangeSlider, h.table);
+   }
+
+   /**
+    * Pointing a freehand convert at a chart is the canonical silent no-op: the service checks
+    * {@code instanceof TableDataVSAssembly} and returns null, reporting success.
+    */
+   @Test
+   void refusesConvertingAChartToFreehandNamingItsActualType() {
+      Harness h = harness(plain(ChartVSAssembly.class), "Chart1");
+
+      Exception e = assertThrows(IllegalArgumentException.class,
+         () -> h.service.convert("tok", principal(), "Chart1", "freehand_table", ""));
+
+      assertTrue(e.getMessage().contains("Chart1"));
+      assertTrue(e.getMessage().contains("table or a crosstab"),
+                 "the message must say what the conversion needs, got: " + e.getMessage());
+      verifyNoInteractions(h.table);
+   }
+
+   /**
+    * <b>The NPE guard.</b> A standalone selection list passes the endpoint's own
+    * {@code &&} guard and then dereferences a null container. This is the case the Composer hides by
+    * making the menu item invisible, so only a tool can reach it.
+    */
+   @Test
+   void refusesAStandaloneSelectionListBecauseTheEndpointWouldCrash() {
+      SelectionListVSAssembly list = selectionList(null, false);
+      Harness h = harness(list, "Filter1");
+
+      Exception e = assertThrows(IllegalArgumentException.class,
+         () -> h.service.convert("tok", principal(), "Filter1", "range_slider", ""));
+
+      assertTrue(e.getMessage().contains("selection container"),
+                 "must explain the real precondition, got: " + e.getMessage());
+      verifyNoInteractions(h.selectionList);
+   }
+
+   /** Same guard, the other direction — {@code convertCSComponent} has the identical defect. */
+   @Test
+   void refusesAStandaloneRangeSliderToo() {
+      TimeSliderVSAssembly slider = rangeSlider(null);
+      Harness h = harness(slider, "Slider1");
+
+      assertThrows(IllegalArgumentException.class,
+         () -> h.service.convert("tok", principal(), "Slider1", "selection_list", ""));
+      verifyNoInteractions(h.rangeSlider);
+   }
+
+   /**
+    * Embedded assemblies are refused by the endpoint with a bare {@code return null}.
+    *
+    * <p>{@code isEmbedded()} is derived from the owning viewsheet rather than settable, so the info
+    * is mocked here — the point under test is that the service asks and refuses, not how the flag
+    * comes to be true.
+    */
+   @Test
+   void refusesAnEmbeddedAssemblyWithAReason() {
+      SelectionListVSAssembly list = mock(SelectionListVSAssembly.class);
+      SelectionListVSAssemblyInfo info = mock(SelectionListVSAssemblyInfo.class);
+      when(info.isEmbedded()).thenReturn(true);
+      doReturn(info).when(list).getInfo();
+
+      Harness h = harness(list, "Filter1");
+
+      Exception e = assertThrows(IllegalArgumentException.class,
+         () -> h.service.convert("tok", principal(), "Filter1", "range_slider", ""));
+
+      assertTrue(e.getMessage().contains("embedded"), e.getMessage());
+   }
+
+   // ── the ported UI preconditions ───────────────────────────────────────────
+
+   /**
+    * {@code visible: composer && !adhocFilter && inSelectionContainer} — the ad hoc half exists only
+    * in Angular.
+    */
+   @Test
+   void refusesAnAdhocFilter() {
+      SelectionListVSAssembly list = selectionList(mock(CurrentSelectionVSAssembly.class), true);
+      Harness h = harness(list, "Adhoc1");
+
+      Exception e = assertThrows(IllegalArgumentException.class,
+         () -> h.service.convert("tok", principal(), "Adhoc1", "range_slider", ""));
+
+      assertTrue(e.getMessage().contains("ad hoc"), e.getMessage());
+   }
+
+   // ── the happy paths, and that the right endpoint is chosen ────────────────
+
+   /**
+    * Direction is encoded in the endpoint, never the payload — both directions send
+    * {@code ConvertToRangeSliderEvent}. This asserts the mapping picks the right service, which is
+    * the whole reason a caller must not infer direction from the event type.
+    */
+   @Test
+   void routesEachDirectionToItsOwnEndpointDespiteTheSharedEventType() throws Exception {
+      SelectionListVSAssembly list = selectionList(mock(CurrentSelectionVSAssembly.class), false);
+      Harness toSlider = harness(list, "Filter1");
+
+      toSlider.service.convert("tok", principal(), "Filter1", "range_slider", "");
+
+      ArgumentCaptor<ConvertToRangeSliderEvent> sent =
+         ArgumentCaptor.forClass(ConvertToRangeSliderEvent.class);
+      verify(toSlider.selectionList).convertToRangeSlider(
+         anyString(), sent.capture(), any(Principal.class), any(), anyString());
+      verifyNoInteractions(toSlider.rangeSlider);
+      assertEquals("Filter1", sent.getValue().getName());
+
+      TimeSliderVSAssembly slider = rangeSlider(mock(CurrentSelectionVSAssembly.class));
+      Harness toList = harness(slider, "Slider1");
+
+      toList.service.convert("tok", principal(), "Slider1", "selection_list", "");
+
+      verify(toList.rangeSlider).convertCSComponent(
+         anyString(), any(ConvertToRangeSliderEvent.class), any(Principal.class), any(), anyString());
+      verifyNoInteractions(toList.selectionList);
+   }
+
+   /**
+    * <b>{@code confirmed} must stay false.</b> True would skip {@code fixAggregateInfo}, the repair
+    * that populates an empty {@code AggregateInfo} before the freehand layout is generated. No caller
+    * in the product sets it, and the default is what makes the conversion correct.
+    */
+   @Test
+   void sendsConfirmedFalseSoTheAggregateInfoRepairStillRuns() throws Exception {
+      Harness h = harness(plain(TableVSAssembly.class), "Table1");
+
+      h.service.convert("tok", principal(), "Table1", "freehand_table", "");
+
+      ArgumentCaptor<ConvertToFreehandTableEvent> sent =
+         ArgumentCaptor.forClass(ConvertToFreehandTableEvent.class);
+      verify(h.table).convertToFreehandTable(
+         anyString(), sent.capture(), any(Principal.class), anyString(), any());
+
+      assertFalse(sent.getValue().isConfirmed(),
+                  "confirmed=true skips fixAggregateInfo, which the freehand cells depend on");
+   }
+
+   // ── disclosure ────────────────────────────────────────────────────────────
+
+   /**
+    * The conversion clears a date comparison, drill expansion and every non-percent calculator. The
+    * server computes the calculator names and passes them to format syncing without telling anyone,
+    * so the only place a caller can learn about the loss is this result.
+    */
+   @Test
+   void disclosesEverythingAConvertedCrosstabLoses() throws Exception {
+      CrosstabVSAssembly crosstab = mock(CrosstabVSAssembly.class);
+      CrosstabVSAssemblyInfo info = mock(CrosstabVSAssemblyInfo.class);
+      when(info.isEmbedded()).thenReturn(false);
+      when(info.getDateComparisonInfo()).thenReturn(mock(DateComparisonInfo.class));
+      doReturn(info).when(crosstab).getInfo();
+      when(crosstab.getCrosstabInfo()).thenReturn(info);
+
+      // getExpandedPaths() is Map<String,Set<String>>, not a flat collection.
+      CrosstabTree tree = mock(CrosstabTree.class);
+      when(tree.getExpandedPaths()).thenReturn(Map.of("Region", Set.of("East")));
+      when(crosstab.getCrosstabTree()).thenReturn(tree);
+
+      // A non-percent calculator is the case convertToFreehandTable strips and never reports.
+      VSAggregateRef withCalc = mock(VSAggregateRef.class);
+      when(withCalc.getFullName()).thenReturn("Sum(Sales)");
+      when(withCalc.getCalculator())
+         .thenReturn(mock(inetsoft.report.composition.graph.calc.RunningTotalCalc.class));
+      VSCrosstabInfo crosstabInfo = mock(VSCrosstabInfo.class);
+      when(crosstabInfo.getAggregates()).thenReturn(new inetsoft.uql.erm.DataRef[]{ withCalc });
+      when(crosstab.getVSCrosstabInfo()).thenReturn(crosstabInfo);
+
+      Harness h = harness(crosstab, "Crosstab1");
+
+      Map<String, Object> result =
+         h.service.convert("tok", principal(), "Crosstab1", "freehand_table", "");
+
+      @SuppressWarnings("unchecked")
+      List<String> cleared = (List<String>) result.get("cleared");
+
+      assertTrue(cleared.contains("date comparison"), "cleared: " + cleared);
+      assertTrue(cleared.contains("drill expansion"), "cleared: " + cleared);
+      assertTrue(cleared.stream().anyMatch(c -> c.startsWith("calculator on")),
+                 "the calculator loss is invisible everywhere else, cleared: " + cleared);
+   }
+
+   /** A plain table loses none of that, and must not be reported as if it had. */
+   @Test
+   void reportsNothingClearedForAPlainTable() throws Exception {
+      Harness h = harness(plain(TableVSAssembly.class), "Table1");
+
+      Map<String, Object> result =
+         h.service.convert("tok", principal(), "Table1", "freehand_table", "");
+
+      assertEquals(List.of(), result.get("cleared"));
+      assertEquals("a table", result.get("from"));
+      assertEquals("freehand_table", result.get("to"));
+   }
+
+   /** The assembly is replaced rather than edited, so anything holding its identity is stale. */
+   @Test
+   void alwaysReturnsTheStalenessNote() throws Exception {
+      Harness h = harness(plain(TableVSAssembly.class), "Table1");
+
+      String note = String.valueOf(
+         h.service.convert("tok", principal(), "Table1", "freehand_table", "").get("note"));
+
+      assertTrue(note.contains("re-read"), note);
+      assertTrue(note.contains("binding-editor"), note);
+   }
+
+   // ── target normalisation ──────────────────────────────────────────────────
+
+   /**
+    * The menu says "Convert to Freehand Table"; the assembly created is a
+    * {@code CalcTableVSAssembly}. Both names are natural, so both are accepted.
+    */
+   @Test
+   void acceptsTheNaturalAliasesForFreehand() throws Exception {
+      for(String alias : List.of("freehand_table", "freehand", "calc_table", "calcTable",
+                                 "Freehand-Table")) {
+         Harness h = harness(plain(TableVSAssembly.class), "Table1");
+         Map<String, Object> result =
+            h.service.convert("tok", principal(), "Table1", alias, "");
+
+         assertEquals("freehand_table", result.get("to"), "alias '" + alias + "' should normalise");
+      }
+   }
+
+   @Test
+   void failsLoudlyOnAnUnknownTargetRatherThanGuessing() {
+      Harness h = harness(plain(TableVSAssembly.class), "Table1");
+
+      Exception e = assertThrows(IllegalArgumentException.class,
+         () -> h.service.convert("tok", principal(), "Table1", "pivot_table", ""));
+
+      assertTrue(e.getMessage().contains("freehand_table"),
+                 "an unknown target must list the legal ones, got: " + e.getMessage());
+   }
+
+   @Test
+   void requiresAnAssemblyName() {
+      Harness h = harness(plain(TableVSAssembly.class), "Table1");
+
+      assertThrows(IllegalArgumentException.class,
+         () -> h.service.convert("tok", principal(), "  ", "freehand_table", ""));
+   }
+
+   // ── harness ───────────────────────────────────────────────────────────────
+
+   private record Harness(AssemblyConvertService service, ViewsheetSessionService sessions,
+                          ComposerVSSelectionListService selectionList,
+                          ComposerRangeSliderService rangeSlider,
+                          ComposerVSTableService table) {}
+
+   /**
+    * <b>Every {@code *VSAssemblyInfo} here is mocked, never constructed.</b> Their constructors reach
+    * into {@code SreeEnv} and the Spring context — a real {@code ViewsheetInfo} inside a
+    * {@code when(...)} argument left Mockito with an unfinished stubbing that failed all 14 tests at
+    * once, and real selection infos failed with "Spring application context is not available". The
+    * service only ever asks these objects questions, so mocks are the honest fixture.
+    */
+   private static SelectionListVSAssembly selectionList(VSAssembly container, boolean adhoc) {
+      SelectionListVSAssembly list = mock(SelectionListVSAssembly.class);
+      SelectionListVSAssemblyInfo info = mock(SelectionListVSAssemblyInfo.class);
+      when(info.isEmbedded()).thenReturn(false);
+      when(info.isAdhocFilter()).thenReturn(adhoc);
+      doReturn(info).when(list).getInfo();
+      when(list.getContainer()).thenReturn(container);
+      return list;
+   }
+
+   private static TimeSliderVSAssembly rangeSlider(VSAssembly container) {
+      TimeSliderVSAssembly slider = mock(TimeSliderVSAssembly.class);
+      TimeSliderVSAssemblyInfo info = mock(TimeSliderVSAssemblyInfo.class);
+      when(info.isEmbedded()).thenReturn(false);
+      doReturn(info).when(slider).getInfo();
+      when(slider.getContainer()).thenReturn(container);
+      return slider;
+   }
+
+   /** A table or chart needs only the embedded check answered. */
+   private static <T extends VSAssembly> T plain(Class<T> type) {
+      T assembly = mock(type);
+      VSAssemblyInfo info = mock(VSAssemblyInfo.class);
+      when(info.isEmbedded()).thenReturn(false);
+      doReturn(info).when(assembly).getInfo();
+      return assembly;
+   }
+
+   private static Harness harness(VSAssembly assembly, String name) {
+      ViewsheetInfo vinfo = mock(ViewsheetInfo.class);
+      when(vinfo.isMetadata()).thenReturn(false);
+
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssembly(anyString())).thenReturn(assembly);
+      when(vs.getViewsheetInfo()).thenReturn(vinfo);
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+
+      try {
+         doAnswer(invocation -> {
+            ViewsheetSessionService.Mutation mutation = invocation.getArgument(2);
+            mutation.run(rvs, "rt1", null);
+            return null;
+         }).when(sessions).mutate(anyString(), any(Principal.class), any());
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(e);
+      }
+
+      ComposerVSSelectionListService selectionList = mock(ComposerVSSelectionListService.class);
+      ComposerRangeSliderService rangeSlider = mock(ComposerRangeSliderService.class);
+      ComposerVSTableService table = mock(ComposerVSTableService.class);
+
+      return new Harness(
+         new AssemblyConvertService(sessions, selectionList, rangeSlider, table),
+         sessions, selectionList, rangeSlider, table);
+   }
+
+   private static Principal principal() {
+      return mock(Principal.class);
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/CalendarInputServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/CalendarInputServiceTest.java
@@ -1,0 +1,320 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.*;
+import inetsoft.web.viewsheet.controller.VSCalendarService;
+import inetsoft.web.viewsheet.service.VSInputService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.security.Principal;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * E2's calendar and input halves. The calendar endpoints are real setters, unlike the selection ones,
+ * but two of them silently wipe the calendar's selection — which is what most of these tests are
+ * about.
+ */
+@Tag("core")
+class CalendarInputServiceTest {
+   // ── calendar policy, tested through plan() ────────────────────────────────
+   //
+   // CalendarVSAssemblyInfo cannot be constructed or mocked outside a Spring context -- the class
+   // fails to initialise, which failed all 11 calendar tests at once when they went through the
+   // service. So the policy lives in plan() and is asserted there directly. What is NOT covered by
+   // these is the wiring from plan to endpoint; that needs a live viewsheet.
+
+   /**
+    * {@code calendar-actions.ts} hides range comparison unless {@code doubleCalendar}, and switching
+    * to a single calendar sets {@code period(false)} — so asking for range comparison on a single
+    * calendar would be silently undone rather than refused.
+    */
+   @Test
+   void refusesRangeComparisonWithoutDoubleCalendar() {
+      Exception e = assertThrows(IllegalArgumentException.class,
+         () -> CalendarDisplayService.plan(false, false, false, false, null, null, true, "Cal1"));
+
+      assertTrue(e.getMessage().contains("double-calendar"), e.getMessage());
+   }
+
+   /** Asking for both in one call is legal, and the plan orders double before range. */
+   @Test
+   void allowsRangeComparisonWhenTheSameCallTurnsOnDoubleCalendar() {
+      CalendarDisplayService.DisplayPlan plan =
+         CalendarDisplayService.plan(false, false, false, false, null, true, true, "Cal1");
+
+      assertTrue(plan.setDouble(), "double calendar must be applied");
+      assertTrue(plan.doubleValue());
+      assertTrue(plan.setRange(), "and the range request must survive it");
+      assertTrue(plan.rangeValue());
+   }
+
+   /** Switching to a single calendar would undo it, so that combination stays refused. */
+   @Test
+   void refusesRangeComparisonWhileSwitchingToASingleCalendar() {
+      Exception e = assertThrows(IllegalArgumentException.class,
+         () -> CalendarDisplayService.plan(true, false, false, false, null, false, true, "Cal1"));
+
+      assertTrue(e.getMessage().contains("single calendar"), e.getMessage());
+   }
+
+   /**
+    * <b>The finding this service exists for.</b> Both display toggles run
+    * {@code setDates(new String[0])} before applying, so changing how the calendar is displayed
+    * throws away the date filter — and the dashboard afterwards looks like a calendar that was
+    * never used.
+    */
+   @Test
+   void reportsThatChangingTheDisplayClearedTheDates() {
+      assertTrue(CalendarDisplayService.plan(false, false, false, true, true, null, null, "Cal1")
+                    .sideEffects().contains("the selected dates were cleared"),
+                 "a year-view change clears the dates");
+
+      assertTrue(CalendarDisplayService.plan(false, false, false, true, null, true, null, "Cal1")
+                    .sideEffects().contains("the selected dates were cleared"),
+                 "so does a double-calendar change");
+   }
+
+   /** With nothing selected there is nothing to lose, and it must not claim otherwise. */
+   @Test
+   void doesNotClaimClearedDatesWhenNoneWereSelected() {
+      assertFalse(CalendarDisplayService.plan(false, false, false, false, true, null, null, "Cal1")
+                     .sideEffects().contains("the selected dates were cleared"));
+   }
+
+   /** Reported once even when both toggles fire, rather than twice. */
+   @Test
+   void reportsTheClearedDatesOnlyOnce() {
+      List<String> effects =
+         CalendarDisplayService.plan(false, false, false, true, true, true, null, "Cal1")
+            .sideEffects();
+
+      assertEquals(1, effects.stream().filter(e -> e.contains("dates were cleared")).count(),
+                   "" + effects);
+   }
+
+   /** Turning on double calendar also forces submit-on-change off and doubles the width. */
+   @Test
+   void reportsTheWidthAndSubmitOnChangeEffectsOfDoubleCalendar() {
+      assertTrue(CalendarDisplayService.plan(false, false, false, false, null, true, null, "Cal1")
+                    .sideEffects().stream().anyMatch(e -> e.contains("widened")));
+   }
+
+   /** Turning it off silently turns range comparison off with it — but only if it was on. */
+   @Test
+   void reportsThatLeavingDoubleCalendarTurnsOffRangeComparison() {
+      assertTrue(CalendarDisplayService.plan(true, false, true, false, null, false, null, "Cal1")
+                    .sideEffects().contains("range comparison was turned off"));
+
+      assertFalse(CalendarDisplayService.plan(true, false, false, false, null, false, null, "Cal1")
+                     .sideEffects().contains("range comparison was turned off"),
+                  "nothing to turn off when period was already false");
+   }
+
+   /** These are setters, so a request matching the current state must do nothing at all. */
+   @Test
+   void planNothingWhenTheDisplayAlreadyMatches() {
+      CalendarDisplayService.DisplayPlan plan =
+         CalendarDisplayService.plan(false, true, false, false, true, false, null, "Cal1");
+
+      assertFalse(plan.setDouble());
+      assertFalse(plan.setYearView());
+      assertFalse(plan.setRange());
+      assertEquals(List.of(), plan.changed());
+   }
+
+   @Test
+   void refusesACalendarCallThatAsksForNothing() {
+      CalendarHarness h = calendarWith(null);
+
+      assertThrows(IllegalArgumentException.class,
+         () -> h.service.setDisplay("tok", principal(), "Cal1", null, null, null, ""));
+   }
+
+   @Test
+   void refusesANonCalendarAssembly() {
+      CalendarHarness h = calendarWith(mock(ChartVSAssembly.class));
+
+      Exception e = assertThrows(IllegalArgumentException.class,
+         () -> h.service.setDisplay("tok", principal(), "Chart1", true, null, null, ""));
+
+      assertTrue(e.getMessage().contains("not a calendar"), e.getMessage());
+      verifyNoInteractions(h.calendars);
+   }
+
+   @Test
+   void refusesAnUnknownCalendar() {
+      CalendarHarness h = calendarWith(null);
+
+      Exception e = assertThrows(IllegalArgumentException.class,
+         () -> h.service.setDisplay("tok", principal(), "Nope", true, null, null, ""));
+
+      assertTrue(e.getMessage().contains("Nope"), e.getMessage());
+      verifyNoInteractions(h.calendars);
+   }
+
+   // ── inputs ────────────────────────────────────────────────────────────────
+
+   /** A check box's several values travel as an Object[] in the scalar parameter. */
+   @Test
+   void sendsACheckBoxsValuesAsAnArray() throws Exception {
+      InputHarness h = input(mock(CheckBoxVSAssembly.class));
+
+      h.service.setValue("tok", principal(), "Check1", List.of("A", "B"), "");
+
+      ArgumentCaptor<Object> sent = ArgumentCaptor.forClass(Object.class);
+      verify(h.inputs).singleApplySelection(anyString(), anyString(), sent.capture(),
+                                           any(Principal.class), any(), anyString());
+
+      assertInstanceOf(Object[].class, sent.getValue());
+      assertArrayEquals(new Object[]{ "A", "B" }, (Object[]) sent.getValue());
+   }
+
+   /** Everything else holds one value, so several is a refusal rather than a truncation. */
+   @Test
+   void refusesSeveralValuesOnASingleValuedInput() {
+      InputHarness h = input(mock(ComboBoxVSAssembly.class));
+
+      Exception e = assertThrows(IllegalArgumentException.class,
+         () -> h.service.setValue("tok", principal(), "Combo1", List.of("A", "B"), ""));
+
+      assertTrue(e.getMessage().contains("one value"), e.getMessage());
+      verifyNoInteractions(h.inputs);
+   }
+
+   @Test
+   void sendsAScalarForASingleValuedInput() throws Exception {
+      InputHarness h = input(mock(TextInputVSAssembly.class));
+
+      h.service.setValue("tok", principal(), "Text1", List.of("hello"), "");
+
+      ArgumentCaptor<Object> sent = ArgumentCaptor.forClass(Object.class);
+      verify(h.inputs).singleApplySelection(anyString(), anyString(), sent.capture(),
+                                           any(Principal.class), any(), anyString());
+
+      assertEquals("hello", sent.getValue());
+   }
+
+   /** An empty list is a real request — clear the input — and must reach the endpoint as null. */
+   @Test
+   void treatsAnEmptyListAsClearingRatherThanAsNoRequest() throws Exception {
+      InputHarness h = input(mock(ComboBoxVSAssembly.class));
+
+      Map<String, Object> result = h.service.setValue("tok", principal(), "Combo1", List.of(), "");
+
+      assertEquals(0, result.get("valueCount"));
+      verify(h.inputs).singleApplySelection(anyString(), anyString(), isNull(),
+                                           any(Principal.class), any(), anyString());
+   }
+
+   /** Omitting the value entirely is different from clearing, and must not default to clearing. */
+   @Test
+   void refusesAMissingValueRatherThanClearing() {
+      InputHarness h = input(mock(ComboBoxVSAssembly.class));
+
+      Exception e = assertThrows(IllegalArgumentException.class,
+         () -> h.service.setValue("tok", principal(), "Combo1", null, ""));
+
+      assertTrue(e.getMessage().contains("empty list to clear"), e.getMessage());
+   }
+
+   /**
+    * A submit button sits beside the inputs in the roadmap's list but is an
+    * {@code OutputVSAssembly}, so it holds no value and is refused by the type guard.
+    */
+   @Test
+   void refusesASubmitButtonBecauseItIsAnOutputAssembly() {
+      InputHarness h = input(mock(SubmitVSAssembly.class));
+
+      Exception e = assertThrows(IllegalArgumentException.class,
+         () -> h.service.setValue("tok", principal(), "Submit1", List.of("x"), ""));
+
+      assertTrue(e.getMessage().contains("not an input assembly"), e.getMessage());
+      verifyNoInteractions(h.inputs);
+   }
+
+   /** The endpoint answers a wrong type with success and no change, so this refuses first. */
+   @Test
+   void refusesANonInputAssemblyInsteadOfSucceedingSilently() {
+      InputHarness h = input(mock(ChartVSAssembly.class));
+
+      assertThrows(IllegalArgumentException.class,
+         () -> h.service.setValue("tok", principal(), "Chart1", List.of("x"), ""));
+      verifyNoInteractions(h.inputs);
+   }
+
+   @Test
+   void reportsThatAnInputValuePersists() throws Exception {
+      InputHarness h = input(mock(ComboBoxVSAssembly.class));
+
+      Map<String, Object> result = h.service.setValue("tok", principal(), "Combo1", List.of("A"), "");
+
+      assertEquals(true, result.get("persistsOnSave"));
+      assertEquals("a combo box", result.get("type"));
+   }
+
+   // ── fixtures ──────────────────────────────────────────────────────────────
+
+   private record CalendarHarness(CalendarDisplayService service, VSCalendarService calendars) {}
+   private record InputHarness(InputValueService service, VSInputService inputs) {}
+
+   private static CalendarHarness calendarWith(VSAssembly assembly) {
+      VSCalendarService calendars = mock(VSCalendarService.class);
+      return new CalendarHarness(
+         new CalendarDisplayService(sessions(assembly), calendars), calendars);
+   }
+
+   private static InputHarness input(VSAssembly assembly) {
+      VSInputService inputs = mock(VSInputService.class);
+      return new InputHarness(new InputValueService(sessions(assembly), inputs), inputs);
+   }
+
+   private static ViewsheetSessionService sessions(VSAssembly assembly) {
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssembly(anyString())).thenReturn(assembly);
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+
+      try {
+         doAnswer(invocation -> {
+            ViewsheetSessionService.Mutation mutation = invocation.getArgument(2);
+            mutation.run(rvs, "rt1", null);
+            return null;
+         }).when(sessions).mutate(anyString(), any(Principal.class), any());
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(e);
+      }
+
+      return sessions;
+   }
+
+   private static Principal principal() {
+      return mock(Principal.class);
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/SelectionRuntimeServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/SelectionRuntimeServiceTest.java
@@ -1,0 +1,407 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.XConstants;
+import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.internal.*;
+import inetsoft.web.viewsheet.event.ApplySelectionListEvent;
+import inetsoft.web.viewsheet.service.VSSelectionService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.security.Principal;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * The endpoints behind this service are toggles and cycles rather than setters, and they answer a bad
+ * assembly with silence, an NPE or a CCE depending on which verb was called. Both are what these
+ * tests are for.
+ */
+@Tag("core")
+class SelectionRuntimeServiceTest {
+   // ── the sort ring, which is the part most likely to be wrong ──────────────
+
+   /**
+    * {@code nextSortType} is {@code ASC → DESC → SPECIFIC → ASC}, and its {@code default} branch
+    * sends anything unrecognised to {@code ASC}. Getting the distance wrong means silently landing
+    * on a different order than the caller asked for, which no assertion on "did it call sort" would
+    * catch.
+    */
+   @Test
+   void computesTheSortDistanceAroundTheRing() {
+      assertEquals(0, SelectionRuntimeService.sortCycles(XConstants.SORT_ASC, XConstants.SORT_ASC));
+      assertEquals(1, SelectionRuntimeService.sortCycles(XConstants.SORT_ASC, XConstants.SORT_DESC));
+      assertEquals(2, SelectionRuntimeService.sortCycles(XConstants.SORT_ASC,
+                                                        XConstants.SORT_SPECIFIC));
+      assertEquals(1, SelectionRuntimeService.sortCycles(XConstants.SORT_DESC,
+                                                        XConstants.SORT_SPECIFIC));
+      assertEquals(2, SelectionRuntimeService.sortCycles(XConstants.SORT_DESC,
+                                                        XConstants.SORT_ASC));
+      assertEquals(1, SelectionRuntimeService.sortCycles(XConstants.SORT_SPECIFIC,
+                                                        XConstants.SORT_ASC));
+   }
+
+   /** An order already in place must cost zero calls, not a full lap. */
+   @Test
+   void doesNotTouchTheSortEndpointWhenTheOrderAlreadyMatches() throws Exception {
+      Harness h = harness(list(XConstants.SORT_DESC, false, null));
+
+      Map<String, Object> result =
+         h.service.setSelection("tok", principal(), "Filter1", null, "desc", null, "");
+
+      assertEquals(0, result.get("sortCycles"));
+      verify(h.selections, never()).sortSelection(anyString(), anyString(), any(),
+                                                  any(Principal.class), any(), anyString());
+   }
+
+   /** Two cycles, one undo checkpoint — mutate owns the checkpoint, not each endpoint call. */
+   @Test
+   void cyclesTwiceInsideASingleMutate() throws Exception {
+      Harness h = harness(list(XConstants.SORT_ASC, false, null));
+
+      h.service.setSelection("tok", principal(), "Filter1", null, "specific", null, "");
+
+      verify(h.selections, times(2)).sortSelection(anyString(), anyString(), any(),
+                                                   any(Principal.class), any(), anyString());
+      verify(h.sessions, times(1)).mutate(anyString(), any(Principal.class), any());
+   }
+
+   /** A range slider follows its range; asking it to sort is a mistake worth naming. */
+   @Test
+   void refusesASortOrderOnARangeSlider() {
+      TimeSliderVSAssembly slider = mock(TimeSliderVSAssembly.class);
+      TimeSliderVSAssemblyInfo info = mock(TimeSliderVSAssemblyInfo.class);
+      doReturn(info).when(slider).getInfo();
+      Harness h = harness(slider);
+
+      Exception e = assertThrows(IllegalArgumentException.class,
+         () -> h.service.setSelection("tok", principal(), "Slider1", null, "asc", null, ""));
+
+      assertTrue(e.getMessage().contains("no sort order"), e.getMessage());
+   }
+
+   // ── the single-selection toggle ────────────────────────────────────────────
+
+   /** The endpoint flips the flag, so a request matching the current state must do nothing. */
+   @Test
+   void togglesSelectionStyleOnlyWhenItDiffers() throws Exception {
+      Harness already = harness(list(XConstants.SORT_ASC, true, null));
+
+      already.service.setSelection("tok", principal(), "Filter1", null, null, true, "");
+
+      verify(already.selections, never()).toggleSelectionStyle(anyString(), anyString(),
+                                                               any(Principal.class), any(),
+                                                               anyString());
+
+      Harness differs = harness(list(XConstants.SORT_ASC, false, null));
+
+      differs.service.setSelection("tok", principal(), "Filter1", null, null, true, "");
+
+      verify(differs.selections, times(1)).toggleSelectionStyle(anyString(), anyString(),
+                                                                any(Principal.class), any(),
+                                                                anyString());
+   }
+
+   /** Multiple values into a single-select assembly is a refusal, not a silent truncation. */
+   @Test
+   void refusesMultipleValuesOnASingleSelectAssembly() {
+      Harness h = harness(list(XConstants.SORT_ASC, true, null));
+
+      Exception e = assertThrows(IllegalArgumentException.class,
+         () -> h.service.setSelection("tok", principal(), "Filter1",
+                                      List.of(List.of("East"), List.of("West")), null, null, ""));
+
+      assertTrue(e.getMessage().contains("single-select"), e.getMessage());
+   }
+
+   /**
+    * The same call may switch to multi-select and pass several values; the switch is what makes the
+    * values legal, so the guard has to read the requested style rather than the stored one.
+    */
+   @Test
+   void allowsMultipleValuesWhenTheSameCallSwitchesToMultiSelect() throws Exception {
+      Harness h = harness(list(XConstants.SORT_ASC, true, null));
+
+      h.service.setSelection("tok", principal(), "Filter1",
+                             List.of(List.of("East"), List.of("West")), null, false, "");
+
+      verify(h.selections, times(1)).applySelection(anyString(), anyString(), any(),
+                                                    any(Principal.class), any(), anyString());
+   }
+
+   // ── the value apply ───────────────────────────────────────────────────────
+
+   /**
+    * {@code toggle}/{@code toggleAll} on the apply event flip {@code singleSelection} instead of
+    * applying values — a third route to that field. Leaving them false is what keeps a value apply
+    * from silently changing the selection style.
+    */
+   @Test
+   void sendsAPlainApplyThatCannotFlipTheSelectionStyle() throws Exception {
+      Harness h = harness(list(XConstants.SORT_ASC, false, null));
+
+      h.service.setSelection("tok", principal(), "Filter1", List.of(List.of("East")), null, null, "");
+
+      ArgumentCaptor<ApplySelectionListEvent> sent =
+         ArgumentCaptor.forClass(ApplySelectionListEvent.class);
+      verify(h.selections).applySelection(anyString(), anyString(), sent.capture(),
+                                          any(Principal.class), any(), anyString());
+
+      ApplySelectionListEvent event = sent.getValue();
+      assertEquals(ApplySelectionListEvent.Type.APPLY, event.getType());
+      assertFalse(event.isToggle(), "toggle=true would flip singleSelection instead of applying");
+      assertFalse(event.isToggleAll(), "toggleAll=true would flip singleSelection too");
+      assertEquals(1, event.getValues().size());
+      assertArrayEquals(new String[]{ "East" }, event.getValues().get(0).getValue());
+      assertTrue(event.getValues().get(0).isSelected());
+   }
+
+   /** A tree value is a path, so the array carries the whole hierarchy rather than a leaf name. */
+   @Test
+   void sendsATreeValueAsAPath() throws Exception {
+      Harness h = harness(tree(XConstants.SORT_ASC, false));
+
+      h.service.setSelection("tok", principal(), "Tree1", List.of(List.of("East", "NY")), null,
+                             null, "");
+
+      ArgumentCaptor<ApplySelectionListEvent> sent =
+         ArgumentCaptor.forClass(ApplySelectionListEvent.class);
+      verify(h.selections).applySelection(anyString(), anyString(), sent.capture(),
+                                          any(Principal.class), any(), anyString());
+
+      assertArrayEquals(new String[]{ "East", "NY" }, sent.getValue().getValues().get(0).getValue());
+   }
+
+   /**
+    * <b>An active search string narrows what the apply touches</b> —
+    * {@code olist = olist.findAll(search, true)} runs first — so the result has to say so. It is not
+    * a refusal: the apply is legitimate, it just did not land on the whole list.
+    */
+   @Test
+   void disclosesThatASearchStringScopedTheApply() throws Exception {
+      Harness h = harness(list(XConstants.SORT_ASC, false, "Eas"));
+
+      Map<String, Object> result = h.service.setSelection(
+         "tok", principal(), "Filter1", List.of(List.of("East")), null, null, "");
+
+      assertEquals("Eas", result.get("scopedBySearch"));
+   }
+
+   /** No search string, no scoping claim — presence of the key is the signal. */
+   @Test
+   void omitsTheSearchDisclosureWhenThereIsNoSearch() throws Exception {
+      Harness h = harness(list(XConstants.SORT_ASC, false, null));
+
+      Map<String, Object> result = h.service.setSelection(
+         "tok", principal(), "Filter1", List.of(List.of("East")), null, null, "");
+
+      assertFalse(result.containsKey("scopedBySearch"));
+   }
+
+   // ── clear ─────────────────────────────────────────────────────────────────
+
+   /**
+    * Clearing has to send every currently selected value back with {@code selected=false} — that is
+    * how the client composes "unselect", since there is no single clear endpoint for one assembly.
+    *
+    * <p>Asserted over the value array rather than through the service: {@code SelectionList} cannot be
+    * constructed or mocked outside a Spring context, so the container is not testable here. This
+    * covers the mapping, which is the part that can be wrong; the wiring is covered by the
+    * nothing-selected case below.
+    */
+   @Test
+   void mapsOnlySelectedValuesIntoPathsToDeselect() {
+      SelectionValue east = mock(SelectionValue.class);
+      when(east.isSelected()).thenReturn(true);
+      when(east.getValue()).thenReturn("East");
+
+      SelectionValue west = mock(SelectionValue.class);
+      when(west.isSelected()).thenReturn(false);
+      when(west.getValue()).thenReturn("West");
+
+      SelectionValue nullValued = mock(SelectionValue.class);
+      when(nullValued.isSelected()).thenReturn(true);
+      when(nullValued.getValue()).thenReturn(null);
+
+      List<List<String>> paths = SelectionRuntimeService.selectedPaths(
+         new SelectionValue[]{ east, west, null, nullValued });
+
+      assertEquals(List.of(List.of("East"), List.of("")), paths,
+                   "unselected values must not be sent, and a null value must not NPE");
+      assertEquals(List.of(), SelectionRuntimeService.selectedPaths(null));
+   }
+
+   /** Nothing selected means nothing to send, rather than an empty apply. */
+   @Test
+   void doesNotCallTheEndpointWhenThereIsNothingSelected() throws Exception {
+      Harness h = harness(list(XConstants.SORT_ASC, false, null));
+
+      Map<String, Object> result = h.service.clearSelection("tok", principal(), "Filter1", "");
+
+      assertEquals(0, result.get("clearedCount"));
+      verifyNoInteractions(h.selections);
+   }
+
+   // ── subtree ───────────────────────────────────────────────────────────────
+
+   /** selectSubtree NPEs on a non-tree, so a list has to be refused before dispatch. */
+   @Test
+   void refusesASubtreeOnAListInsteadOfLettingItCrash() {
+      Harness h = harness(list(XConstants.SORT_ASC, false, null));
+
+      Exception e = assertThrows(IllegalArgumentException.class,
+         () -> h.service.selectSubtree("tok", principal(), "Filter1", List.of("East"), "select", ""));
+
+      assertTrue(e.getMessage().contains("selection tree"), e.getMessage());
+      verifyNoInteractions(h.selections);
+   }
+
+   @Test
+   void requiresASubtreePath() {
+      Harness h = harness(tree(XConstants.SORT_ASC, false));
+
+      assertThrows(IllegalArgumentException.class,
+         () -> h.service.selectSubtree("tok", principal(), "Tree1", List.of(), "select", ""));
+   }
+
+   @Test
+   void acceptsClearAsASubtreeModeAndItsNaturalAliases() throws Exception {
+      for(String mode : List.of("clear", "unselect", "deselect", "CLEAR")) {
+         Harness h = harness(tree(XConstants.SORT_ASC, false));
+
+         Map<String, Object> result = h.service.selectSubtree(
+            "tok", principal(), "Tree1", List.of("East"), mode, "");
+
+         assertEquals("clear", result.get("mode"), "mode '" + mode + "' should normalise");
+      }
+   }
+
+   @Test
+   void refusesAnUnknownSubtreeMode() {
+      Harness h = harness(tree(XConstants.SORT_ASC, false));
+
+      assertThrows(IllegalArgumentException.class,
+         () -> h.service.selectSubtree("tok", principal(), "Tree1", List.of("East"), "toggle", ""));
+   }
+
+   // ── the shared guards ─────────────────────────────────────────────────────
+
+   @Test
+   void refusesAnUnknownAssemblyRatherThanSucceedingSilently() {
+      Harness h = harness(null);
+
+      Exception e = assertThrows(IllegalArgumentException.class,
+         () -> h.service.setSelection("tok", principal(), "Nope", List.of(List.of("x")), null,
+                                      null, ""));
+
+      assertTrue(e.getMessage().contains("Nope"), e.getMessage());
+      verifyNoInteractions(h.selections);
+   }
+
+   @Test
+   void refusesANonSelectionAssemblyNamingItsType() {
+      Harness h = harness(mock(ChartVSAssembly.class));
+
+      Exception e = assertThrows(IllegalArgumentException.class,
+         () -> h.service.setSelection("tok", principal(), "Chart1", List.of(List.of("x")), null,
+                                      null, ""));
+
+      assertTrue(e.getMessage().contains("not a selection assembly"), e.getMessage());
+      verifyNoInteractions(h.selections);
+   }
+
+   @Test
+   void refusesACallThatAsksForNothing() {
+      Harness h = harness(list(XConstants.SORT_ASC, false, null));
+
+      assertThrows(IllegalArgumentException.class,
+         () -> h.service.setSelection("tok", principal(), "Filter1", null, null, null, ""));
+   }
+
+   @Test
+   void alwaysReportsThatTheStatePersists() throws Exception {
+      Harness h = harness(list(XConstants.SORT_ASC, false, null));
+
+      Map<String, Object> result = h.service.setSelection(
+         "tok", principal(), "Filter1", List.of(List.of("East")), null, null, "");
+
+      assertEquals(true, result.get("persistsOnSave"),
+                   "writeStateContent writes the selection on the save path, so a caller must know");
+   }
+
+   // ── fixtures ──────────────────────────────────────────────────────────────
+
+   /** Infos are mocked: their real constructors need SreeEnv and the Spring context. */
+   private static SelectionListVSAssembly list(int sortType, boolean single, String search,
+                                               String... selected) {
+      SelectionListVSAssembly assembly = mock(SelectionListVSAssembly.class);
+      SelectionListVSAssemblyInfo info = mock(SelectionListVSAssemblyInfo.class);
+      when(info.isSingleSelection()).thenReturn(single);
+      when(info.getSortTypeValue()).thenReturn(sortType);
+      when(info.getSearchString()).thenReturn(search);
+      doReturn(info).when(assembly).getInfo();
+      return assembly;
+   }
+
+   private static SelectionTreeVSAssembly tree(int sortType, boolean single) {
+      SelectionTreeVSAssembly assembly = mock(SelectionTreeVSAssembly.class);
+      SelectionTreeVSAssemblyInfo info = mock(SelectionTreeVSAssemblyInfo.class);
+      when(info.isSingleSelection()).thenReturn(single);
+      when(info.getSortTypeValue()).thenReturn(sortType);
+      doReturn(info).when(assembly).getInfo();
+      return assembly;
+   }
+
+   private record Harness(SelectionRuntimeService service, ViewsheetSessionService sessions,
+                          VSSelectionService selections) {}
+
+   private static Harness harness(VSAssembly assembly) {
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssembly(anyString())).thenReturn(assembly);
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+
+      try {
+         doAnswer(invocation -> {
+            ViewsheetSessionService.Mutation mutation = invocation.getArgument(2);
+            mutation.run(rvs, "rt1", null);
+            return null;
+         }).when(sessions).mutate(anyString(), any(Principal.class), any());
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(e);
+      }
+
+      VSSelectionService selections = mock(VSSelectionService.class);
+      return new Harness(new SelectionRuntimeService(sessions, selections), sessions, selections);
+   }
+
+   private static Principal principal() {
+      return mock(Principal.class);
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -209,6 +209,7 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(AssemblyHighlightService.class),
                                           mock(DateComparisonService.class),
                                           mock(AssemblyConvertService.class),
+                                          mock(SelectionRuntimeService.class),
                                           mock(inetsoft.analytic.composition.ViewsheetService.class),
                                           mock(SheetAgentBroadcastService.class),
                                           openService);
@@ -240,6 +241,7 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(AssemblyHighlightService.class),
                                           mock(DateComparisonService.class),
                                           mock(AssemblyConvertService.class),
+                                          mock(SelectionRuntimeService.class),
                                           mock(inetsoft.analytic.composition.ViewsheetService.class),
                                           mock(SheetAgentBroadcastService.class),
                                           mock(SheetOpenService.class));
@@ -268,6 +270,7 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(AssemblyHighlightService.class),
                                           mock(DateComparisonService.class),
                                           mock(AssemblyConvertService.class),
+                                          mock(SelectionRuntimeService.class),
                                           mock(inetsoft.analytic.composition.ViewsheetService.class),
                                           mock(SheetAgentBroadcastService.class),
                                           mock(SheetOpenService.class));
@@ -376,6 +379,8 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(AssemblyConditionService.class),
                                           highlightService,
                                           mock(DateComparisonService.class),
+                                          mock(AssemblyConvertService.class),
+                                          mock(SelectionRuntimeService.class),
                                           mock(inetsoft.analytic.composition.ViewsheetService.class),
                                           mock(SheetAgentBroadcastService.class),
                                           mock(SheetOpenService.class));

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -208,6 +208,7 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(AssemblyConditionService.class),
                                           mock(AssemblyHighlightService.class),
                                           mock(DateComparisonService.class),
+                                          mock(AssemblyConvertService.class),
                                           mock(inetsoft.analytic.composition.ViewsheetService.class),
                                           mock(SheetAgentBroadcastService.class),
                                           openService);
@@ -238,6 +239,7 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(AssemblyConditionService.class),
                                           mock(AssemblyHighlightService.class),
                                           mock(DateComparisonService.class),
+                                          mock(AssemblyConvertService.class),
                                           mock(inetsoft.analytic.composition.ViewsheetService.class),
                                           mock(SheetAgentBroadcastService.class),
                                           mock(SheetOpenService.class));
@@ -265,6 +267,7 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(AssemblyConditionService.class),
                                           mock(AssemblyHighlightService.class),
                                           mock(DateComparisonService.class),
+                                          mock(AssemblyConvertService.class),
                                           mock(inetsoft.analytic.composition.ViewsheetService.class),
                                           mock(SheetAgentBroadcastService.class),
                                           mock(SheetOpenService.class));

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -210,6 +210,8 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(DateComparisonService.class),
                                           mock(AssemblyConvertService.class),
                                           mock(SelectionRuntimeService.class),
+                                          mock(CalendarDisplayService.class),
+                                          mock(InputValueService.class),
                                           mock(inetsoft.analytic.composition.ViewsheetService.class),
                                           mock(SheetAgentBroadcastService.class),
                                           openService);
@@ -242,6 +244,8 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(DateComparisonService.class),
                                           mock(AssemblyConvertService.class),
                                           mock(SelectionRuntimeService.class),
+                                          mock(CalendarDisplayService.class),
+                                          mock(InputValueService.class),
                                           mock(inetsoft.analytic.composition.ViewsheetService.class),
                                           mock(SheetAgentBroadcastService.class),
                                           mock(SheetOpenService.class));
@@ -271,6 +275,8 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(DateComparisonService.class),
                                           mock(AssemblyConvertService.class),
                                           mock(SelectionRuntimeService.class),
+                                          mock(CalendarDisplayService.class),
+                                          mock(InputValueService.class),
                                           mock(inetsoft.analytic.composition.ViewsheetService.class),
                                           mock(SheetAgentBroadcastService.class),
                                           mock(SheetOpenService.class));
@@ -381,6 +387,8 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(DateComparisonService.class),
                                           mock(AssemblyConvertService.class),
                                           mock(SelectionRuntimeService.class),
+                                          mock(CalendarDisplayService.class),
+                                          mock(InputValueService.class),
                                           mock(inetsoft.analytic.composition.ViewsheetService.class),
                                           mock(SheetAgentBroadcastService.class),
                                           mock(SheetOpenService.class));


### PR DESCRIPTION
Server half of roadmap units **E3** (convert ops) and **E2** (selection & input runtime). Two new wiz services plus five endpoints on `ViewsheetAssemblyAgentController`.

The plugin half is stylebi-wiz#1642.

## Why these are mostly validation

Both units wrap runtime and composer endpoints that were built for menu clicks. None of them refuses a bad request — they answer with silence or an unhandled exception — so the services exist to turn that into a named error and a truthful result.

**`AssemblyConvertService`** — one verb over four Composer menu actions and three endpoints. Both selection directions send `ConvertToRangeSliderEvent`, including range-slider→selection-list where the name reads backwards, so direction lives in the endpoint and mapping `(current type, to)` here means a caller never has to know that.

**`SelectionRuntimeService`** — selection lists, trees and range sliders. `TimeSliderVSAssembly extends AbstractSelectionVSAssembly` and rides the same `applySelection` path, so it needs no surface of its own.

## The bug this found, and why it was latent

`ComposerVSSelectionListService.convertToRangeSlider` and `ComposerRangeSliderService.convertCSComponent` both guard like this:

```java
if(!(assembly instanceof SelectionListVSAssembly) &&
   !(container instanceof CurrentSelectionVSAssembly)) { return null; }

final CurrentSelectionVSAssembly containerAssembly = (CurrentSelectionVSAssembly) container;
final String[] assemblies = containerAssembly.getAssemblies();   // unguarded
```

`&&` where the body requires *both*. An assembly of the right type passes the guard with no container, and `AbstractVSAssembly.getContainer()` returns **null** unless the assembly is inside a Tab, GroupContainer or CurrentSelection container — so the cast of null succeeds and the next line throws `NullPointerException`. Inside a Tab or GroupContainer it throws `ClassCastException` instead.

| Source | Outcome today |
|---|---|
| Selection list inside a selection container | works — the only exercised path |
| **Standalone** selection list | **NullPointerException** |
| Selection list inside a Tab / GroupContainer | **ClassCastException** |

It is latent from the UI only because the menu item is hidden unless `inSelectionContainer`. **A tool reaches it immediately**, which is why this PR refuses the case rather than waiting for the guard to be fixed. The `&&`→`||` fix is worth doing separately and is not in this PR.

## Preconditions that live only in Angular

Reading the `@Service` guards tells you what the server refuses; it does not tell you what the product considers legal. These are enforced in `vsobjects/action/*.ts` `visible:` conditions and nowhere else, so they are ported here:

- `inSelectionContainer` — both selection converts
- `!adhocFilter` — selection-list → range-slider
- `sourceType == VS_ASSEMBLY && metadata` — both freehand converts refuse this in the handler with `composer.vs.table.cannotConvertToFreehand`
- `isEmbedded()` — the server declines silently

## `confirmed` stays false

On an unconfirmed crosstab, `convertToFreehandTable` runs `VSEventUtil.fixAggregateInfo`, which builds an `AggregateInfo` from the source when the crosstab has none and then reclassifies aggregates as measures and headers as dimensions. The freehand table's cells depend on it, and **no caller in the product ever sets `confirmed` true** — both Angular handlers construct the event with only a name. Setting it true to "skip a prompt" would skip the repair and build a freehand table from an empty `AggregateInfo`.

## Three things a crosstab conversion discards

The design spec knew about two. The third is the least visible: `clearCalculators` strips every calculator that is not a `PercentCalc` — running total, change-from-previous — and the service collects their names only to hand them to `VSLayoutTool.syncCellFormat`, telling nobody. So the numbers mean something different while the table still looks right. All three are named in the result.

## The selection endpoints are toggles and cycles, not setters

This is most of `SelectionRuntimeService`:

- `/selectionList/sort` takes no order. It advances a three-state ring, `ASC → DESC → SPECIFIC → ASC` (`nextSortType`), so reaching a requested order means computing the distance and cycling. Every step runs inside one `mutate`, which owns the checkpoint, so two cycles is still **one undo step**.
- `/selectionList/toggle` takes no value; it flips `singleSelection`. Setting it means reading the flag and acting only if it differs.
- `applySelection`'s own event **also** flips `singleSelection` when `toggle` or `toggleAll` is set — a third route to that field. This service never sets them, so a value apply cannot silently change the selection style.

A bad assembly fails three different ways across the five sibling verbs: `applySelection` and `sortSelection` answer an unknown name with success and no change, `selectSubtree` and `unselectAll` throw NPE, and all of them CCE on a non-selection assembly. There is no server behaviour worth forwarding, so the service resolves and type-checks first.

## Two disclosures the caller cannot otherwise see

- **An active search string narrows the apply.** With one set and the assembly not single-select, `applySelection` runs `olist = olist.findAll(search, true)` first, so the write lands on the filtered subset. Reported, not refused.
- **The state persists.** `writeStateContent` writes the selection, the sort order and the selection style unconditionally, and `writeContents` calls it on the save path.

Search cannot be *set* here: `setSearchString` writes both `search` and `search2`, only `search2` is persisted, and **nothing in the repository ever parses `search2` back** — `"search2"` appears in the writer alone. It is a write-only field that never survives a reopen.

`clear_selection` is deliberately not `set_selection(every value)`: clearing resets the state list to null so no `state_selectionList` block is written and the sheet reopens naturally, while selecting everything writes a snapshot frozen at today's values — which then **excludes** any value added to the data later.

## Tests

**35 new tests. Full `inetsoft.web.wiz.**` sweep: 1581 tests, 0 failures**, on the current base.

Verified they discriminate rather than merely pass:

- Neutering the container guard fails **exactly** the two tests that cover it.
- Replacing the sort ring arithmetic with the naive single-step version fails **both** the distance test and the two-cycle integration test — that is the bug an unverified implementation ships, landing on `desc` when asked for `specific`.

## The calendar half: two endpoints throw away the filter

`toggleYearView` and `toggleDoubleCalendar` are real setters — the event carries the value — but both run `calendarInfo.setDates(new String[0])` before applying. The service's own comment reads *"dates are reset when toggling"*. So **changing how a calendar is displayed discards the date filter it was applying**, and the dashboard afterwards looks like a calendar that was simply never used. Reported in `sideEffects`, once, and only when there was something to lose.

Two more, both silent today:

- `doubleCalendar=true` → forces `submitOnChangeValue(false)` and **doubles the assembly's width**
- `doubleCalendar=false` → `setPeriod(false)`, turning **range comparison off**

Range comparison requires double-calendar mode — a precondition in `calendar-actions.ts` (`visible: () => this.model.doubleCalendar`) and nowhere else. It is refused on a single calendar rather than silently undone, and asking for both in one call is ordered so the request survives.

## The input half is smaller than the unit's name

Every input assembly's menu is exactly three items — `edit-script`, `properties`, `show-format-pane` — all already shipped. There is no apply, clear, search or sort anywhere in it. What was missing is the **value**, and the four one-endpoint controllers all converge on `VSInputService`, so this is one tool over one method: `singleApplySelection` takes the value as a bare `Object`, and a check box's several values arrive as that same parameter holding an `Object[]`.

**A submit button is not an input assembly.** `SubmitVSAssembly extends OutputVSAssembly`, so it holds no value and is refused by the same guard as a chart — despite sitting beside the inputs in the roadmap's own list.

That endpoint is at least *consistently* silent: `return 0` for a null name, a null viewsheet, and a non-`InputVSAssembly`. Better than the selection verbs' mix of no-op/NPE/CCE, but still nothing worth forwarding.

## A note on where the calendar tests live

`CalendarVSAssemblyInfo` **cannot be constructed or mocked outside a Spring context** — the class fails to initialise, which failed all 11 calendar tests at once when they ran through the service. So the policy is extracted into a package-private `plan()` taking plain values, and asserted there. Same reason `SelectionRuntimeService.selectedPaths` takes a `SelectionValue[]` rather than a `SelectionList`.

What that leaves uncovered is the wiring from plan to endpoint, which needs a live viewsheet.

## Tests

**75 new tests. Full `inetsoft.web.wiz.**` sweep: 1601 tests, 0 failures**, on the current base.

Verified they discriminate rather than merely pass — three separate checks:

- Neutering the convert container guard fails **exactly** the two tests covering it.
- Replacing the sort ring arithmetic with the naive single-step version fails **both** the distance test and the two-cycle integration test — that is the bug an unverified implementation ships, landing on `desc` when asked for `specific`.
- Dropping the cleared-dates disclosure fails **exactly** the two tests covering it.

## What is not covered

**These tests mock the wire, so they prove shape, policy and arithmetic — not acceptance.** Nothing here has run against a live StyleBI. The convert paths need live verification in particular, since the `&&` guard means their failure modes are real rather than theoretical.