### PR TITLE
Bug #76042, fix unresponsive mobile toolbar actions after selecting a selection value

### DIFF
--- a/web/projects/portal/src/app/vsobjects/viewer-app.component.risk.tl.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.component.risk.tl.spec.ts
@@ -59,6 +59,7 @@ import {
    FULL_SCREEN_SERVICE_MOCK,
    ASSET_LOADING_SERVICE_MOCK,
    HEARTBEAT_WORKER_SERVICE_MOCK,
+   ASSEMBLY_ACTION_FACTORY_MOCK,
    fullScreenChangeSubject,
    resetMocks,
    renderComponent,
@@ -648,6 +649,91 @@ describe("ViewerAppComponent — processRemoveVSObjectCommand()", () => {
 
       expect(states).toHaveLength(1);
       expect(states[0]).toEqual({ name: "Chart1", loading: false });
+   });
+});
+
+// ---------------------------------------------------------------------------
+// Group 8b — processAddVSObjectCommand: selectedActions resync [Risk 3]
+// ---------------------------------------------------------------------------
+
+describe("ViewerAppComponent — processAddVSObjectCommand() selectedActions resync", () => {
+   function makeObj(name: string, objectType: string = "VSChart"): VSObjectModel {
+      return {
+         absoluteName: name,
+         objectType,
+         visible: true,
+         objectFormat: { top: 0, left: 0, width: 100, height: 100 } as any,
+      } as unknown as VSObjectModel;
+   }
+
+   async function setup() {
+      const { comp } = await renderComponent();
+      // processAddVSObjectCommand touches these collaborators; the shared fixtures only
+      // stub the members needed by other groups.
+      (comp as any).dataTipService.registerDataTip = vi.fn();
+      (comp as any).dataTipService.registerDataTipVisible = vi.fn();
+      (comp as any).dataTipService.clearDataTipChild = vi.fn();
+      (comp as any).popComponentService.registerPopComponent = vi.fn();
+      (comp as any).popComponentService.registerPopComponentVisible = vi.fn();
+      (comp as any).calculateAllAssemblyBounds = vi.fn();
+      ASSEMBLY_ACTION_FACTORY_MOCK.createActions.mockImplementation((model: any) => ({
+         getModel: () => model,
+         menuActions: [],
+         toolbarActions: [],
+      }));
+      return comp;
+   }
+
+   // 🔁 Regression-sensitive: processAddVSObjectCommand rebuilds the WHOLE
+   // vsObjectActions array, so the actions instance for the selected assembly is
+   // replaced even when the command targets a different assembly. The assembly
+   // component re-subscribes to the new instance via its [actions] input; if
+   // selectedActions still points at the old instance, the mobile toolbar buttons
+   // emit onAssemblyActionEvent to nobody and appear dead.
+   // Repro: mobile → select a selection value (refreshes the filtered chart) →
+   // tap Sort in the mobile toolbar → nothing happens.
+   it("should re-point selectedActions when a DIFFERENT assembly is refreshed", async () => {
+      const comp = await setup();
+      const selection = makeObj("SelectionList1", "VSSelectionList");
+      const chart = makeObj("Chart1");
+      comp.vsObjects = [selection, chart];
+      const staleActions: any = { getModel: () => selection, menuActions: [], toolbarActions: [] };
+      comp.vsObjectActions = [staleActions, { getModel: () => chart } as any];
+      comp.selectedActions = staleActions;
+
+      comp.processAddVSObjectCommand({ name: "Chart1", model: makeObj("Chart1") } as any);
+
+      expect(comp.selectedActions).not.toBe(staleActions);
+      expect(comp.selectedActions).toBe(comp.vsObjectActions[0]);
+      expect(comp.selectedActions.getModel().absoluteName).toBe("SelectionList1");
+   });
+
+   it("should re-point selectedActions when the SELECTED assembly is refreshed", async () => {
+      const comp = await setup();
+      const selection = makeObj("SelectionList1", "VSSelectionList");
+      comp.vsObjects = [selection];
+      const staleActions: any = { getModel: () => selection, menuActions: [], toolbarActions: [] };
+      comp.vsObjectActions = [staleActions];
+      comp.selectedActions = staleActions;
+
+      comp.processAddVSObjectCommand({
+         name: "SelectionList1",
+         model: makeObj("SelectionList1", "VSSelectionList"),
+      } as any);
+
+      expect(comp.selectedActions).toBe(comp.vsObjectActions[0]);
+      expect(comp.selectedActions).not.toBe(staleActions);
+   });
+
+   it("should leave selectedActions null when nothing is selected", async () => {
+      const comp = await setup();
+      comp.vsObjects = [makeObj("Chart1")];
+      comp.vsObjectActions = [{ getModel: () => makeObj("Chart1") } as any];
+      comp.selectedActions = null;
+
+      comp.processAddVSObjectCommand({ name: "Chart1", model: makeObj("Chart1") } as any);
+
+      expect(comp.selectedActions).toBeNull();
    });
 });
 

--- a/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
+++ b/web/projects/portal/src/app/vsobjects/viewer-app.component.ts
@@ -2337,12 +2337,15 @@ export class ViewerAppComponent extends CommandProcessor implements OnInit, Afte
                return actions;
             });
 
-            if(this.selectedActions &&
-               this.selectedActions.getModel().absoluteName == command.name)
-            {
-               this.selectedActions = this.vsObjectActions[i];
-               this.addMobileActionSubsciption();
-            }
+            // vsObjectActions is rebuilt in full above, so *every* actions instance is
+            // replaced -- including the one for the currently selected assembly, even when
+            // this command targets a different assembly (e.g. a chart refreshed as a result
+            // of applying a selection). The assembly component re-subscribes to the new
+            // instance through its [actions] input, so a selectedActions still pointing at
+            // the old instance would emit action events that nobody listens to, and the
+            // mobile toolbar buttons would do nothing. Re-point it by name, not by
+            // command.name.
+            this.resyncSelectedActions();
          }
          else if(this.vsObjects[i].objectType != "VSViewsheet"){
             // sheetMaxMode is global so should apply it to all
@@ -2409,15 +2412,32 @@ export class ViewerAppComponent extends CommandProcessor implements OnInit, Afte
 
             this.calculateAllAssemblyBounds();
 
-            if(this.selectedActions &&
-               this.selectedActions.getModel().absoluteName == this.vsObjects[i].absoluteName)
-            {
-               this.selectedActions = this.vsObjectActions[i];
-               this.addMobileActionSubsciption();
-            }
+            this.resyncSelectedActions();
 
             break;
          }
+      }
+   }
+
+   /**
+    * Re-point selectedActions (the source of the mobile toolbar buttons) at the current
+    * actions instance for the selected assembly. Must be called whenever vsObjectActions
+    * entries are replaced, otherwise selectedActions keeps an orphaned instance whose
+    * onAssemblyActionEvent no longer has any subscriber.
+    */
+   private resyncSelectedActions(): void {
+      if(!this.selectedActions) {
+         return;
+      }
+
+      const name = this.selectedActions.getModel()?.absoluteName;
+      const index = this.vsObjects.findIndex(obj => obj?.absoluteName == name);
+
+      if(index >= 0 && this.vsObjectActions[index] &&
+         this.selectedActions != this.vsObjectActions[index])
+      {
+         this.selectedActions = this.vsObjectActions[index];
+         this.addMobileActionSubsciption();
       }
    }
 
@@ -2796,6 +2816,8 @@ export class ViewerAppComponent extends CommandProcessor implements OnInit, Afte
             }
          }
       }
+
+      this.resyncSelectedActions();
    }
 
    private processExpiredSheetCommand(command: ExpiredSheetCommand) {


### PR DESCRIPTION
## Problem

Repro (from the report):
1. Open `Example/Sales Summary` on mobile — the mobile layout is applied.
2. Select a selection value, then tap an action in the toolbar (e.g. Sort).
3. Nothing happens.

## Root cause

On mobile the assembly mini-toolbar is not rendered at all — `mini-toolbar.component.html` guards the whole button row with `@if (!mobileDevice)`. Mobile gets `viewer-mobile-toolbar` in the top bar instead, driven by `ViewerAppComponent.selectedActions`.

Those buttons work by emitting on the actions object's `onAssemblyActionEvent`. The only subscriber is the assembly component itself — `VSSelection` subscribes inside its `actions` input setter and unsubscribes from the previous instance every time the input changes.

`processAddVSObjectCommand` rebuilds the **entire** `vsObjectActions` array with fresh instances whenever any assembly is added or updated, but it only re-pointed `selectedActions` when `command.name` matched the selected assembly. So:

1. Tap the selection list → `selectedActions` = instance A. Toolbar works.
2. Tap a selection value → the server applies the filter and pushes `AddVSObjectCommand`s for the **dependent** assemblies (the chart/table being filtered).
3. Each of those rebuilds all actions. `VSSelection` receives instance B via `[actions]` and re-subscribes to B; `selectedActions` still holds A.
4. Tapping Sort emits on A, which now has zero subscribers → silent no-op.

`processRefreshVSObjectCommand` had the same name-equality guard, but since it only replaces `vsObjectActions[i]` it happened to be correct.

## Fix

Replaced both guards with a `resyncSelectedActions()` helper that re-points `selectedActions` at the current actions instance for the selected assembly **by name**, regardless of which assembly the command targeted, and re-arms the mobile action subscription only when the instance actually changed.

## Testing

- Added three regression tests to `viewer-app.component.risk.tl.spec.ts`. The key one — *"should re-point selectedActions when a DIFFERENT assembly is refreshed"* — was confirmed to **fail on the unpatched code** and pass with the fix, so it is not vacuous.
- All 181 tests across `viewer-app.component.*.tl.spec.ts` pass.
- `ng lint portal`: 0 errors.

Note: running all 78 `vsobjects/**/*.tl.spec.ts` suites together shows 9–12 suites crashing at import time (`Class extends value undefined` in `sort-column-event.ts`, a circular-import issue). This is pre-existing and flaky — unmodified `main` produces 12 such failures on the same command, with 0 actual test failures in both cases.

Not verified on a physical device; the analysis is from the code path, and the added test reproduces the exact command sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
