### PR TITLE
Bug #76066, fix circular network node fixed color mapping dialog not opening

### DIFF
--- a/core/src/main/java/inetsoft/web/binding/controller/ColorMappingDialogService.java
+++ b/core/src/main/java/inetsoft/web/binding/controller/ColorMappingDialogService.java
@@ -25,6 +25,7 @@ import inetsoft.report.composition.WorksheetEngine;
 import inetsoft.report.composition.graph.GraphUtil;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.graph.AestheticRef;
+import inetsoft.uql.viewsheet.graph.RelationChartInfo;
 import inetsoft.uql.viewsheet.graph.VSChartInfo;
 import inetsoft.uql.viewsheet.internal.DateComparisonUtil;
 import inetsoft.util.Tool;
@@ -76,6 +77,19 @@ public class ColorMappingDialogService {
       }
 
       AestheticRef cfield = (AestheticRef) GraphUtil.getChartAesRef(cinfo, dimensionName, false);
+
+      // Relation (e.g. circular network) chart node color fields bound to a dimension are
+      // excluded from getAestheticRefs() (bug #75253, to keep them out of the query GROUP BY),
+      // so getChartAesRef() above never finds them. Fall back to the node color field directly
+      // so the "assign fixed mapping" dialog can still open for it. (Bug #76066)
+      if(cfield == null && cinfo instanceof RelationChartInfo) {
+         AestheticRef nodeColorField = ((RelationChartInfo) cinfo).getNodeColorField();
+
+         if(nodeColorField != null && GraphUtil.equalsName(nodeColorField, dimensionName)) {
+            cfield = nodeColorField;
+         }
+      }
+
       List list = null;
 
       if(cfield == null) {


### PR DESCRIPTION
## Summary

For a circular network (relation) chart, binding a plain dimension column (e.g. "state") as the node color field and clicking "assign fixed mapping" in the node pane's color editor silently failed to open the dialog — no error, no console output.

## Root Cause

`ColorMappingDialogService.getColorMappingDialogModel()` looks up the aesthetic ref via `GraphUtil.getChartAesRef(cinfo, dimensionName, false)`, which searches `cinfo.getAestheticRefs(false)`. For relation charts, `AbstractChartInfo.getAestheticRefs(ChartBindable)` intentionally excludes the node color field when it is `VSDimensionRef`-backed (a deliberate fix for bug #75253, to keep it out of the query's GROUP BY). Because "state" is a dimension (not an aggregate), the lookup returned `null`, and the service returned `null` after logging a warning. The Angular frontend (`categorical-color-pane.component.ts`) filters out `null` responses before opening the dialog (`filter(data => data.body != null)`), so the failure was silent.

## Fix

In `ColorMappingDialogService.getColorMappingDialogModel`, when the standard `getChartAesRef` lookup misses and `cinfo instanceof RelationChartInfo`, fall back to `RelationChartInfo.getNodeColorField()` directly (matched by name via `GraphUtil.equalsName`). This only changes what the color-mapping dialog can find — `getAestheticRefs()` itself is untouched, so the GROUP BY exclusion from bug #75253 remains intact.

## Test Plan

- [x] Imported `circular_network.zip`, opened the viewsheet in Composer, edited the node pane's "state" color field, clicked "assign fixed mapping" — dialog now opens correctly.
- [x] `mvn compile -pl core -am` succeeds.
- [x] Code review found no issues.
- [x] User manually verified the fix resolves the reported behavior.

Fixes Redmine #76066.