### PR TITLE
Bug #76081, apply ranking set on a tree chart's Node Color/Node Size field

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/ChartVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ChartVSAQuery.java
@@ -1548,6 +1548,57 @@ public class ChartVSAQuery extends CubeVSAQuery implements BindableVSAQuery {
                mergeDimRanking((VSDimensionRef) targetField, cols, ainfo, rconds,
                                 rankingFields, usedGroups);
             }
+
+            // VSDimensionRef-backed node color/size fields are excluded from
+            // getAestheticRefs() (bug #75253) and so never appear in cinfo.getRTFields()
+            // either, which means a RankingCondition set on the Node Color/Node Size well
+            // would never be merged into the query. Merge it here. Only source and target
+            // are actual groups in a relation chart query (the node dimension is added as a
+            // MAX aggregate), so a ranking is only meaningful when the node dimension is the
+            // same field as source or target - ranking on an ungrouped column can't be
+            // evaluated. rankingFields dedup keeps a ranking already merged from
+            // source/target from being applied twice.
+            String sourceName = sourceField instanceof VSDimensionRef ?
+               ((VSDimensionRef) sourceField).getFullName() : null;
+            String targetName = targetField instanceof VSDimensionRef ?
+               ((VSDimensionRef) targetField).getFullName() : null;
+            List<AestheticRef> nodeRankRefs = new ArrayList<>();
+
+            if(cinfo instanceof RelationVSChartInfo) {
+               nodeRankRefs.add(((RelationVSChartInfo) cinfo).getNodeColorField());
+               nodeRankRefs.add(((RelationVSChartInfo) cinfo).getNodeSizeField());
+            }
+
+            for(AestheticRef nodeARef : nodeRankRefs) {
+               if(nodeARef == null) {
+                  continue;
+               }
+
+               DataRef nodeRef = nodeARef.getRTDataRef() != null ?
+                  nodeARef.getRTDataRef() : nodeARef.getDataRef();
+
+               if(!(nodeRef instanceof VSDimensionRef)) {
+                  continue;
+               }
+
+               VSDimensionRef nodeDim = (VSDimensionRef) nodeRef;
+               String nodeName = nodeDim.getFullName();
+               boolean isSource = nodeName != null && nodeName.equals(sourceName);
+               boolean isTarget = nodeName != null && nodeName.equals(targetName);
+
+               if(!isSource && !isTarget) {
+                  continue;
+               }
+
+               boolean merged = mergeDimRanking(nodeDim, cols, ainfo, rconds,
+                                                 rankingFields, usedGroups);
+
+               // ranking on the outer (source) grouping while target is also bound isn't
+               // innermost, so it needs the same per-group post-processing as above.
+               if(merged && isSource && targetField instanceof VSDimensionRef) {
+                  mgrcond = false;
+               }
+            }
          }
       }
 


### PR DESCRIPTION
## Problem

In a tree (relation) chart, a Top N / Bottom N ranking set on the **Node Color** (or **Node Size**) field has no effect — all nodes are rendered instead of the top N.

Reproduced with the attached `tree.vso`: Source = `Customer:Region`, Target = `Customer:State`, Node Color = `Customer:State` with `Top 3 by Sum(Order:Paid)` and `rankPerGroup=true`. All 14 states render; only 3 per region should.

## Root cause

`AbstractChartInfo.getAestheticRefs()` deliberately excludes `VSDimensionRef`-backed node color/size fields (bug #75253) to keep the node dimension out of the `GROUP BY`; `ChartVSAQuery` re-adds the column later as a `MAX` aggregate instead.

The side effect is that those refs also never appear in `cinfo.getRTFields()`, so the ranking-merge loop in `ChartVSAQuery.createTableAssembly()` never sees them and the `RankingCondition` is silently dropped. The earlier tree chart ranking fix (#4186) only covered the Source/Target wells, so ranking set from the Node Color/Node Size well remained a no-op.

## Fix

Merge the node color/size `RankingCondition` inside the existing `RelationChartInfo` ranking block.

Scope guards, to avoid regressions:

- **Only when the node dimension is the same field as Source or Target.** Those are the only real groups in a relation chart query, so a ranking on any other node dimension can't be evaluated and is skipped rather than injected into the query as a condition on an ungrouped column.
- The existing `rankingFields` dedup prevents a ranking already merged from Source/Target from being applied twice on the same column.
- `mgrcond` is cleared when the ranking lands on Source while Target is bound, matching the existing non-innermost-dimension handling so per-group (`rankPerGroup`) ranking is still post-processed.
- Uses `getRTDataRef()` with a `getDataRef()` fallback, consistent with how `getRTFields()` resolves aesthetic refs.

No behavior change for charts without a `VSDimensionRef` node color/size field, or where that field carries no ranking.

## Testing

- `./mvnw -o compile -pl core` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
