### PR TITLE
Fix the selection converts' container guard: AND where it needed OR

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerRangeSliderService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerRangeSliderService.java
@@ -71,14 +71,15 @@ public class ComposerRangeSliderService {
 
       final VSAssembly container = assembly.getContainer();
 
-      // The type test is an either-or; the container is mandatory, because the body below
-      // dereferences it unconditionally. Chaining all three with && let an assembly of the right type
-      // through with no container, whereupon the cast of getContainer()'s null succeeded and
-      // getAssemblies() threw NullPointerException -- or ClassCastException inside a Tab or
-      // GroupContainer. Unreachable from the Composer, which hides the menu item unless
-      // inSelectionContainer, but reachable by any other caller.
-      if((!(assembly instanceof SelectionListVSAssembly) &&
-          !(assembly instanceof TimeSliderVSAssembly)) ||
+      // The container is mandatory, because the body below dereferences it unconditionally, and
+      // createSelectionListVSAssembly's only caller (below) unconditionally casts to
+      // TimeSliderVSAssembly -- this converts a time slider TO a selection list, not the other
+      // way around, so a SelectionListVSAssembly must be refused here rather than accepted
+      // alongside it. Accepting either type (as this once did, mirroring
+      // ComposerVSSelectionListService's own guard for its own single type) let a
+      // SelectionListVSAssembly with a valid container reach the cast below and throw
+      // ClassCastException.
+      if(!(assembly instanceof TimeSliderVSAssembly) ||
          !(container instanceof CurrentSelectionVSAssembly))
       {
          return null;

--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerRangeSliderService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerRangeSliderService.java
@@ -71,8 +71,14 @@ public class ComposerRangeSliderService {
 
       final VSAssembly container = assembly.getContainer();
 
-      if(!(assembly instanceof SelectionListVSAssembly) &&
-         !(assembly instanceof TimeSliderVSAssembly) &&
+      // The type test is an either-or; the container is mandatory, because the body below
+      // dereferences it unconditionally. Chaining all three with && let an assembly of the right type
+      // through with no container, whereupon the cast of getContainer()'s null succeeded and
+      // getAssemblies() threw NullPointerException -- or ClassCastException inside a Tab or
+      // GroupContainer. Unreachable from the Composer, which hides the menu item unless
+      // inSelectionContainer, but reachable by any other caller.
+      if((!(assembly instanceof SelectionListVSAssembly) &&
+          !(assembly instanceof TimeSliderVSAssembly)) ||
          !(container instanceof CurrentSelectionVSAssembly))
       {
          return null;

--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerVSSelectionListService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerVSSelectionListService.java
@@ -195,7 +195,13 @@ public class ComposerVSSelectionListService {
 
       final VSAssembly container = assembly.getContainer();
 
-      if(!(assembly instanceof SelectionListVSAssembly) &&
+      // Both are required, not either: the body below dereferences the container unconditionally.
+      // With && a standalone selection list passed this guard, and getContainer() returns null unless
+      // the assembly is inside a Tab, GroupContainer or CurrentSelection container -- so the cast of
+      // null succeeded and getAssemblies() threw NullPointerException. Inside a Tab or
+      // GroupContainer it threw ClassCastException instead. Unreachable from the Composer, whose menu
+      // item is hidden unless inSelectionContainer, but reachable by any other caller.
+      if(!(assembly instanceof SelectionListVSAssembly) ||
          !(container instanceof CurrentSelectionVSAssembly))
       {
          return null;

--- a/core/src/test/java/inetsoft/web/composer/vs/objects/controller/ConvertContainerGuardTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/objects/controller/ConvertContainerGuardTest.java
@@ -115,6 +115,29 @@ class ConvertContainerGuardTest {
    }
 
    /**
+    * The type check accepted either {@code SelectionListVSAssembly} or {@code TimeSliderVSAssembly},
+    * but {@code createSelectionListVSAssembly} — the only thing the guard protects — unconditionally
+    * casts to {@code TimeSliderVSAssembly}: this converts a time slider TO a selection list, not the
+    * other way around. A {@code SelectionListVSAssembly} with a valid container passed the guard and
+    * hit that cast. {@code container = null} above declines it before the cast is ever reached, so it
+    * cannot catch this — a valid container is required to reach it.
+    */
+   @Test
+   void aSelectionListWithAValidContainerIsDeclinedRatherThanCastExceptioning() throws Exception {
+      SelectionListVSAssembly list = mock(SelectionListVSAssembly.class);
+      SelectionListVSAssemblyInfo info = mock(SelectionListVSAssemblyInfo.class);
+      when(info.isEmbedded()).thenReturn(false);
+      doReturn(info).when(list).getInfo();
+      when(list.getContainer()).thenReturn(mock(CurrentSelectionVSAssembly.class));
+
+      ComposerRangeSliderService service =
+         new ComposerRangeSliderService(engineFor(list), mock(CoreLifecycleService.class));
+
+      assertDoesNotThrow(() -> service.convertCSComponent(
+         "rt1", event("Filter1"), principal(), null, ""));
+   }
+
+   /**
     * The guard must still decline a wrong type, which is the behaviour the {@code &&} version did get
     * right — so the fix must not have widened what is accepted.
     */

--- a/core/src/test/java/inetsoft/web/composer/vs/objects/controller/ConvertContainerGuardTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/objects/controller/ConvertContainerGuardTest.java
@@ -1,0 +1,157 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.composer.vs.objects.controller;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.internal.*;
+import inetsoft.web.composer.vs.objects.event.ConvertToRangeSliderEvent;
+import inetsoft.web.viewsheet.service.CoreLifecycleService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * The container guard on both selection conversions.
+ *
+ * <p>Each guard chained its type test and its container test with {@code &&}, while the body below
+ * dereferences the container unconditionally. So an assembly of the <i>right</i> type passed the
+ * guard with no container at all, and {@code AbstractVSAssembly.getContainer()} returns {@code null}
+ * unless the assembly sits inside a Tab, GroupContainer or CurrentSelection container — the cast of
+ * {@code null} succeeded and the next line threw {@code NullPointerException}. Inside a Tab or
+ * GroupContainer it threw {@code ClassCastException} instead.
+ *
+ * <p>It was unreachable from the Composer, whose menu item is hidden unless
+ * {@code inSelectionContainer} (`selection-list-actions.ts`, `range-slider-actions.ts`), which is why
+ * it survived. Any other caller reaches it immediately.
+ *
+ * <p>These tests assert the standalone case is declined rather than crashing. Restore either
+ * {@code &&} and they fail with the original exception, which is what makes them worth having.
+ */
+@Tag("core")
+class ConvertContainerGuardTest {
+   /** A selection list on the canvas, not inside a selection container. */
+   @Test
+   void aStandaloneSelectionListIsDeclinedRatherThanCrashing() throws Exception {
+      SelectionListVSAssembly list = mock(SelectionListVSAssembly.class);
+      SelectionListVSAssemblyInfo info = mock(SelectionListVSAssemblyInfo.class);
+      when(info.isEmbedded()).thenReturn(false);
+      doReturn(info).when(list).getInfo();
+      when(list.getContainer()).thenReturn(null);
+
+      ComposerVSSelectionListService service =
+         new ComposerVSSelectionListService(engineFor(list), mock(CoreLifecycleService.class));
+
+      assertDoesNotThrow(() -> service.convertToRangeSlider(
+         "rt1", event("Filter1"), principal(), null, ""));
+   }
+
+   /** Inside a Tab the container is non-null but the wrong type — the CCE case. */
+   @Test
+   void aSelectionListInsideATabIsDeclinedRatherThanCrashing() throws Exception {
+      SelectionListVSAssembly list = mock(SelectionListVSAssembly.class);
+      SelectionListVSAssemblyInfo info = mock(SelectionListVSAssemblyInfo.class);
+      when(info.isEmbedded()).thenReturn(false);
+      doReturn(info).when(list).getInfo();
+      when(list.getContainer()).thenReturn(mock(TabVSAssembly.class));
+
+      ComposerVSSelectionListService service =
+         new ComposerVSSelectionListService(engineFor(list), mock(CoreLifecycleService.class));
+
+      assertDoesNotThrow(() -> service.convertToRangeSlider(
+         "rt1", event("Filter1"), principal(), null, ""));
+   }
+
+   /** The mirror defect: convertCSComponent chained three tests with &&. */
+   @Test
+   void aStandaloneRangeSliderIsDeclinedRatherThanCrashing() throws Exception {
+      TimeSliderVSAssembly slider = mock(TimeSliderVSAssembly.class);
+      TimeSliderVSAssemblyInfo info = mock(TimeSliderVSAssemblyInfo.class);
+      when(info.isEmbedded()).thenReturn(false);
+      doReturn(info).when(slider).getInfo();
+      when(slider.getContainer()).thenReturn(null);
+
+      ComposerRangeSliderService service =
+         new ComposerRangeSliderService(engineFor(slider), mock(CoreLifecycleService.class));
+
+      assertDoesNotThrow(() -> service.convertCSComponent(
+         "rt1", event("Slider1"), principal(), null, ""));
+   }
+
+   @Test
+   void aStandaloneSelectionListIsDeclinedByTheRangeSliderConvertToo() throws Exception {
+      SelectionListVSAssembly list = mock(SelectionListVSAssembly.class);
+      SelectionListVSAssemblyInfo info = mock(SelectionListVSAssemblyInfo.class);
+      when(info.isEmbedded()).thenReturn(false);
+      doReturn(info).when(list).getInfo();
+      when(list.getContainer()).thenReturn(null);
+
+      ComposerRangeSliderService service =
+         new ComposerRangeSliderService(engineFor(list), mock(CoreLifecycleService.class));
+
+      assertDoesNotThrow(() -> service.convertCSComponent(
+         "rt1", event("Filter1"), principal(), null, ""));
+   }
+
+   /**
+    * The guard must still decline a wrong type, which is the behaviour the {@code &&} version did get
+    * right — so the fix must not have widened what is accepted.
+    */
+   @Test
+   void aChartIsStillDeclined() throws Exception {
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      VSAssemblyInfo info = mock(VSAssemblyInfo.class);
+      when(info.isEmbedded()).thenReturn(false);
+      doReturn(info).when(chart).getInfo();
+      when(chart.getContainer()).thenReturn(mock(CurrentSelectionVSAssembly.class));
+
+      ComposerVSSelectionListService service =
+         new ComposerVSSelectionListService(engineFor(chart), mock(CoreLifecycleService.class));
+
+      assertDoesNotThrow(() -> service.convertToRangeSlider(
+         "rt1", event("Chart1"), principal(), null, ""));
+   }
+
+   private static ViewsheetService engineFor(VSAssembly assembly) throws Exception {
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssembly(anyString())).thenReturn(assembly);
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      ViewsheetService engine = mock(ViewsheetService.class);
+      when(engine.getViewsheet(anyString(), any(Principal.class))).thenReturn(rvs);
+      return engine;
+   }
+
+   private static ConvertToRangeSliderEvent event(String name) {
+      ConvertToRangeSliderEvent event = new ConvertToRangeSliderEvent();
+      event.setName(name);
+      return event;
+   }
+
+   private static Principal principal() {
+      return mock(Principal.class);
+   }
+}


### PR DESCRIPTION
Both selection conversions guard with `&&` where the body requires **both** conditions, so the guard lets through exactly the cases it exists to stop.

```java
// ComposerVSSelectionListService.convertToRangeSlider
if(!(assembly instanceof SelectionListVSAssembly) &&
   !(container instanceof CurrentSelectionVSAssembly)) { return null; }

final CurrentSelectionVSAssembly containerAssembly = (CurrentSelectionVSAssembly) container;
final String[] assemblies = containerAssembly.getAssemblies();   // unguarded
```

It fails in **both** directions, which is more than the obvious one:

| Case | Old behaviour |
|---|---|
| Right type, **no container** — a standalone selection list, the common case | `getContainer()` returns `null`, the cast of null succeeds, `getAssemblies()` → **NullPointerException** |
| Right type, container is a **Tab / GroupContainer** | **ClassCastException** on the cast |
| **Wrong** type, right container — e.g. a chart inside a selection container | container half satisfied ⇒ passes ⇒ **ClassCastException** casting to `SelectionListVSAssembly` |

`ComposerRangeSliderService.convertCSComponent` has the same defect with three tests chained instead of two.

## Why it survived

Unreachable from the Composer: both menu items are hidden unless the assembly is in a selection container — `visible: () => this.composer && !this.model.adhocFilter && this.inSelectionContainer` (`selection-list-actions.ts`) and `visible: () => this.composer && this.inSelectionContainer` (`range-slider-actions.ts`). **That precondition lives only in Angular.** Any caller that isn't the menu reaches the bug immediately.

Found while wrapping these endpoints for the composer plugin (`stylebi#4645`). The plugin tier now refuses the case with a named error; this guard is the backstop underneath it, and the right place for the invariant.

## The fix

Require both. The type test stays an either-or for `convertCSComponent`, which legitimately accepts a selection list **or** a time slider — only the container is mandatory:

```java
if((!(assembly instanceof SelectionListVSAssembly) &&
    !(assembly instanceof TimeSliderVSAssembly)) ||
   !(container instanceof CurrentSelectionVSAssembly)) { return null; }
```

Behaviour on the paths the Composer actually exercises is unchanged: a selection list or time slider inside a `CurrentSelectionVSAssembly` still converts. `return null` is kept rather than raised to an exception, since that matches the surrounding style and the UI never sends these cases.

## Tests

5 new tests — there were none for either service — and **they discriminate**: restoring either `&&` fails all five with the original exceptions, three `NullPointerException`s naming `containerAssembly` and two `ClassCastException`s. That includes the wrong-type-with-container case, which the old guard also got wrong.

**Composer + wiz sweep: 1695 tests, 183 classes, 0 failures.**