### PR TITLE
Bug #76113, enforce the monitoring/summary/debug EM component permission

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/server/DebugMonitoringController.java
+++ b/core/src/main/java/inetsoft/web/admin/server/DebugMonitoringController.java
@@ -53,7 +53,7 @@ public class DebugMonitoringController {
    @Secured(
       @RequiredPermission(
          resourceType = ResourceType.EM_COMPONENT,
-         resource = "monitoring/summary",
+         resource = "monitoring/summary/debug",
          actions = ResourceAction.ACCESS
       )
    )
@@ -99,7 +99,7 @@ public class DebugMonitoringController {
    @Secured(
       @RequiredPermission(
          resourceType = ResourceType.EM_COMPONENT,
-         resource = "monitoring/summary",
+         resource = "monitoring/summary/debug",
          actions = ResourceAction.ACCESS
       )
    )

--- a/web/projects/em/src/app/monitoring/summary/debug-monitoring-page/debug-monitoring-page.component.ts
+++ b/web/projects/em/src/app/monitoring/summary/debug-monitoring-page/debug-monitoring-page.component.ts
@@ -26,7 +26,8 @@ import { MatButton } from "@angular/material/button";
 
 @Secured({
    route: "/monitoring/summary/debug",
-   label: "Debug"
+   label: "Debug",
+   hiddenForMultiTenancy: true
 })
 @Component({
     selector: "em-debug-monitoring-page",

--- a/web/projects/em/src/app/monitoring/summary/summary.routes.spec.ts
+++ b/web/projects/em/src/app/monitoring/summary/summary.routes.spec.ts
@@ -1,0 +1,78 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { TestBed } from "@angular/core/testing";
+import {
+   ActivatedRouteSnapshot,
+   provideRouter,
+   Router,
+   RouterStateSnapshot,
+   UrlTree
+} from "@angular/router";
+import { firstValueFrom, Observable, of } from "rxjs";
+import { AuthorizationService } from "../../authorization/authorization.service";
+import { ComponentPermissions } from "../../authorization/component-permissions";
+import { canActivateDebugPage } from "./summary.routes";
+
+function permissions(debug: boolean): ComponentPermissions {
+   return {
+      // the sibling widget-level children of monitoring/summary are always permitted here so
+      // that only the debug flag varies between cases
+      permissions: {debug, cpuUsage: true, heapMemory: true},
+      labels: {debug: "Debug"},
+      multiTenancyHiddenComponents: {}
+   };
+}
+
+function runGuard(debug: boolean): Promise<boolean | UrlTree> {
+   const authzMock = {
+      getPermissions: (path: string) => {
+         expect(path).toBe("monitoring/summary");
+         return of(permissions(debug));
+      }
+   };
+
+   TestBed.configureTestingModule({
+      providers: [
+         provideRouter([]),
+         {provide: AuthorizationService, useValue: authzMock}
+      ]
+   });
+
+   const result = TestBed.runInInjectionContext(() => canActivateDebugPage(
+      {} as ActivatedRouteSnapshot, {} as RouterStateSnapshot));
+
+   return firstValueFrom(result as Observable<boolean | UrlTree>);
+}
+
+describe("canActivateDebugPage", () => {
+   afterEach(() => TestBed.resetTestingModule());
+
+   it("should allow the debug page when monitoring/summary/debug is permitted", async () => {
+      expect(await runGuard(true)).toBe(true);
+   });
+
+   // Bug: the debug page was reachable by any user with monitoring/summary access, ignoring the
+   // monitoring/summary/debug permission shown on the EM Actions tab.
+   it("should redirect to the summary page when monitoring/summary/debug is denied", async () => {
+      const result = await runGuard(false);
+
+      expect(result).not.toBe(true);
+      expect(TestBed.inject(Router).serializeUrl(result as UrlTree))
+         .toBe("/monitoring/summary");
+   });
+});

--- a/web/projects/em/src/app/monitoring/summary/summary.routes.ts
+++ b/web/projects/em/src/app/monitoring/summary/summary.routes.ts
@@ -15,15 +15,35 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { Routes } from "@angular/router";
+import { CanActivateFn, Router, Routes, UrlTree } from "@angular/router";
+import { inject } from "@angular/core";
+import { Observable } from "rxjs";
+import { map } from "rxjs/operators";
+import { AuthorizationService } from "../../authorization/authorization.service";
 import { ClusterNodesService } from "../cluster/cluster-nodes.service";
 import { DebugMonitoringPageComponent } from "./debug-monitoring-page/debug-monitoring-page.component";
 import { SummaryMonitoringPageComponent } from "./summary-monitoring-page/summary-monitoring-page.component";
 
+/**
+ * Guards the debug page with the monitoring/summary/debug EM component permission. The generic
+ * authorizationGuard is not used here because the other children of monitoring/summary are
+ * widget-level permissions with no route of their own, so its redirect-to-first-permitted-child
+ * fallback would navigate to a path that does not exist.
+ */
+export const canActivateDebugPage: CanActivateFn = (): Observable<boolean | UrlTree> => {
+   const service = inject(AuthorizationService);
+   const router = inject(Router);
+
+   return service.getPermissions("monitoring/summary").pipe(
+      map(p => !!p.permissions["debug"] || router.parseUrl("/monitoring/summary"))
+   );
+};
+
 export const SUMMARY_ROUTES: Routes = [
    {
       path: "debug",
-      component: DebugMonitoringPageComponent
+      component: DebugMonitoringPageComponent,
+      canActivate: [canActivateDebugPage]
    },
    {
       path: "",


### PR DESCRIPTION
## Problem

With security enabled and multi-tenancy off, a user granted EM access but explicitly **denied** `Monitoring/Summary/Debug` on the Actions tab could still open `em/monitoring/summary/debug` and download both dumps.

The Debug page is registered as a permissible EM component by its `@Secured` decorator — `em-metadata.js` scrapes that into `view-components.json`, which is what renders the node on the Actions tab. But nothing enforced it:

1. **The route had no guard.** `summary.routes.ts` declared `path: "debug"` with no `canActivate` and no `data.permission*`, unlike every other secured EM route. The only check that ran was the parent `summary` route's guard, so `monitoring/summary` access alone was sufficient.
2. **The endpoints checked the wrong resource.** Both `@Secured` blocks in `DebugMonitoringController` declared `resource = "monitoring/summary"`, so `/em/monitoring/server/debug/key-value-storage-dump` and `/blob-path-dump` stayed directly fetchable even with the route guarded.

## Fix

- Add `canActivateDebugPage`, which reads `monitoring/summary/debug` from `/api/em/authz` and returns a `UrlTree` to `/monitoring/summary` when denied.
- Correct the resource on both endpoints to `monitoring/summary/debug`.
- Mark the node `hiddenForMultiTenancy: true`, matching `/monitoring/summary` — the blob dump enumerates the blobs of every organization, so it should not be reachable by an org admin.
- Add `summary.routes.spec.ts` covering the allow and deny/redirect paths.

### Why not the generic `authorizationGuard`?

Its deny path picks the first permitted sibling and calls `router.navigate` on it. The other 10 children of `monitoring/summary` (`heapMemory`, `cpuUsage`, `swapping`, …) are widget-level permission nodes with **no route**, so it would have navigated to a nonexistent path. Returning a `UrlTree` to the parent page is the correct deny behavior, and follows the existing custom-guard precedent in `log.routes.ts`.

## Side effects considered

`ComponentAuthorizationController.anyChildAvailable` hides a parent node when all of its children are denied, so adding an enforced child under `monitoring/summary` could in principle have hidden **Summary itself** from the monitoring sidenav. I regenerated `view-components.json` and confirmed `summary` still has its 10 widget children alongside `debug`, so denying only `debug` leaves Summary visible. `SecuredAspect.isComponentAccessible()` resolves the new resource string against that same tree; the `debug` node is present, so the change does not hit the deny-by-default path.

## Testing

- `npx ng test em --include=…/summary.routes.spec.ts` — 2/2 passing
- `npx tsc --noEmit -p projects/em/tsconfig.app.json` — clean
- `npx eslint` on all changed TS files — clean
- `npx gulp em:metadata` — node emits as `{"name":"debug","label":"Debug","children":{},"hiddenForMultiTenancy":true}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
