### PR TITLE
Bug #76095, prevent EM logout when a page requests a resource the user lacks permission for

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/schedule/EMScheduleController.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/EMScheduleController.java
@@ -221,12 +221,32 @@ public class EMScheduleController {
       this.usersChangeService.addSubscriber(stompHeaderAccessor);
    }
 
+   /**
+    * The user/group list returned here is not specific to schedule tasks: it also backs the
+    * email recipient pickers on the General settings page and the Security settings pages, all
+    * of which are reachable without any schedule permission. Gating it on
+    * "settings/schedule/tasks" alone made simply opening Settings fail for such users. Mirrors
+    * the permission set of {@code /api/em/settings/schedule/check-mail}.
+    */
    @Secured(
-      @RequiredPermission(
-         resourceType = ResourceType.EM_COMPONENT,
-         resource = "settings/schedule/tasks",
-         actions = ResourceAction.ACCESS
-      )
+      value = {
+         @RequiredPermission(
+            resourceType = ResourceType.EM_COMPONENT,
+            resource = "settings/general",
+            actions = ResourceAction.ACCESS
+         ),
+         @RequiredPermission(
+            resourceType = ResourceType.EM_COMPONENT,
+            resource = "settings/schedule/tasks",
+            actions = ResourceAction.ACCESS
+         ),
+         @RequiredPermission(
+            resourceType = ResourceType.EM_COMPONENT,
+            resource = "settings/security/users",
+            actions = ResourceAction.ACCESS
+         )
+      },
+      operator = "OR"
    )
    @GetMapping("/api/em/schedule/users-model")
    public UsersModel getUsersModel(@PermissionUser Principal principal) throws Exception

--- a/web/projects/em/src/app/invalid-session-interceptor.spec.ts
+++ b/web/projects/em/src/app/invalid-session-interceptor.spec.ts
@@ -1,0 +1,97 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { HTTP_INTERCEPTORS, HttpClient } from "@angular/common/http";
+import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing";
+import { TestBed } from "@angular/core/testing";
+import { LogoutService } from "../../../shared/util/logout.service";
+import { InvalidSessionInterceptor } from "./invalid-session-interceptor";
+
+describe("InvalidSessionInterceptor", () => {
+   let http: HttpClient;
+   let httpMock: HttpTestingController;
+   let logoutService: { sessionExpired: any };
+
+   beforeEach(() => {
+      logoutService = { sessionExpired: vi.fn() };
+
+      TestBed.configureTestingModule({
+         imports: [HttpClientTestingModule],
+         providers: [
+            { provide: LogoutService, useValue: logoutService },
+            { provide: HTTP_INTERCEPTORS, useClass: InvalidSessionInterceptor, multi: true }
+         ]
+      });
+
+      http = TestBed.inject(HttpClient);
+      httpMock = TestBed.inject(HttpTestingController);
+   });
+
+   afterEach(() => {
+      httpMock.verify();
+   });
+
+   function flushError(url: string, status: number): void {
+      http.get(url).subscribe({ next: () => {}, error: () => {} });
+      httpMock.expectOne(url).flush("", { status, statusText: "" });
+   }
+
+   it("should log out on a same-origin 401, which is how the server reports a lost session", () => {
+      flushError("../api/em/general/settings/model", 401);
+      expect(logoutService.sessionExpired).toHaveBeenCalled();
+   });
+
+   // 🔁 Regression-sensitive (Bug #76017): a 403 means the session is valid but the user is not
+   // permitted to access that resource. Treating it as an expired session logged EM users out of
+   // the whole application as soon as any page issued a request they lacked permission for --
+   // e.g. Settings > General eagerly fetching /api/em/schedule/users-model without the
+   // "settings/schedule/tasks" permission.
+   it("should NOT log out on a same-origin 403 permission denial", () => {
+      flushError("../api/em/schedule/users-model", 403);
+      expect(logoutService.sessionExpired).not.toHaveBeenCalled();
+   });
+
+   it("should not log out on other same-origin error statuses", () => {
+      flushError("../api/em/general/settings/model", 500);
+      flushError("../api/em/general/settings/model", 404);
+      expect(logoutService.sessionExpired).not.toHaveBeenCalled();
+   });
+
+   it("should not log out on a 401 from a cross-origin service", () => {
+      flushError("https://data.inetsoft.com/oauth/token", 401);
+      expect(logoutService.sessionExpired).not.toHaveBeenCalled();
+   });
+
+   it("should log out on a 401 from an absolute same-origin URL", () => {
+      flushError(`${window.location.origin}/api/em/general/settings/model`, 401);
+      expect(logoutService.sessionExpired).toHaveBeenCalled();
+   });
+
+   it("should mark GET requests as XHR so the server answers with 401 instead of a login redirect", () => {
+      http.get("../api/em/favorites").subscribe({ next: () => {}, error: () => {} });
+      const req = httpMock.expectOne("../api/em/favorites");
+      expect(req.request.headers.get("X-Requested-With")).toBe("XMLHttpRequest");
+      req.flush({});
+   });
+
+   it("should succeed without logging out", () => {
+      http.get("../api/em/favorites").subscribe();
+      httpMock.expectOne("../api/em/favorites").flush({});
+      expect(logoutService.sessionExpired).not.toHaveBeenCalled();
+   });
+});

--- a/web/projects/em/src/app/invalid-session-interceptor.ts
+++ b/web/projects/em/src/app/invalid-session-interceptor.ts
@@ -40,15 +40,26 @@ export class InvalidSessionInterceptor implements HttpInterceptor {
       );
    }
 
+   /**
+    * Only 401 indicates that the session is gone. When the session has expired or been
+    * invalidated, the security filter chain answers XHR requests with 401
+    * (AbstractSecurityFilter.shouldSendAuthenticationRedirect); this interceptor marks every
+    * request as an XHR (see intercept() above), so that path always applies.
+    *
+    * 403 means the opposite: the session is valid and the user is authenticated, but is not
+    * permitted to access that particular resource. SecuredAspect throws on an @Secured denial
+    * and AdminExceptionHandler maps it to 403, so treating 403 as an expired session logs the
+    * user out of the EM entirely whenever any page issues a request they lack permission for.
+    */
    private handleInvalidSession(req: HttpRequest<any>, error: HttpErrorResponse): void {
-      if((error.status === 401 || error.status === 403) && this.isSameOrigin(req.url)) {
+      if(error.status === 401 && this.isSameOrigin(req.url)) {
          this.logoutService.sessionExpired();
       }
    }
 
    /**
     * Only the application's own (same-origin) responses indicate an expired
-    * session. A 401/403 from an absolute URL pointing at an external service
+    * session. A 401 from an absolute URL pointing at an external service
     * (e.g. the OAuth proxy at data.inetsoft.com) is unrelated to the StyleBI
     * session and must not trigger a logout.
     */

--- a/web/projects/em/src/app/navbar/navbar.component.ts
+++ b/web/projects/em/src/app/navbar/navbar.component.ts
@@ -285,10 +285,11 @@ export class NavbarComponent implements OnInit, OnDestroy {
    }
 
    private handleHelpLinkError(error: HttpErrorResponse): Observable<HelpLinks> {
-      // A 401/403 here means the session expired or was invalidated (e.g. by a cross-tab
-      // logout) while this request was in flight. InvalidSessionInterceptor already redirects
-      // to the login page for that case, so showing a permission error on top of it is
-      // redundant and misleading.
+      // A 401 here means the session expired or was invalidated (e.g. by a cross-tab logout)
+      // while this request was in flight; InvalidSessionInterceptor already redirects to the
+      // login page for that case. A 403 means EM access was revoked, in which case the help
+      // links are the least of the user's concerns. Either way, showing a permission error on
+      // top of it is redundant and misleading.
       if(error.status !== 401 && error.status !== 403) {
          this.snackBar.open("_#(js:em.helpLinks.error)", null, { duration: Tool.SNACKBAR_DURATION });
       }


### PR DESCRIPTION
## Issue

Enable security (multi-tenancy off), then:

1. Create `user0` and `user1`
2. Grant `user0` permission on **Portal Tabs / Schedule**
3. Grant `user0` permission on **Enterprise Manager**
4. Grant `user1` permission on **Enterprise Manager / Settings / Schedule / Tasks**
5. Log into the EM as `user0` and click the **Settings** tab

Expected: the Settings page opens. Actual: the EM logs the user out.

It looks intermittent, which is why the report suggests clearing the cache and re-entering the EM URL — see below.

## Root cause

Two defects stacked.

**1. Settings/General eagerly requests a task-gated endpoint.** Clicking Settings always lands on `/settings/general` (`settings.routes.ts` — `{ path: "**", redirectTo: "general" }`). That page renders `EmailSettingsViewComponent`, which injects the root-provided `ScheduleUsersService`; its *constructor* issues `GET /api/em/schedule/users-model`. That endpoint was secured on `EM_COMPONENT "settings/schedule/tasks"` alone, so `user0` gets a 403. The service's error callback is empty, so nothing surfaces in the UI.

**2. `InvalidSessionInterceptor` treated 403 as an expired session.** It fired `LogoutService.sessionExpired()` on any same-origin **401 or 403**, hard-redirecting to `../sessionexpired`. That is the logout.

Because the service is a singleton constructed once, the request never repeats after the first bootstrap — hence the apparent flakiness and the "clear the cache" workaround.

This surfaced as a regression from #4355 (Bug #75734), which correctly changed `@Secured` denials from 500 to 403. Before it, the interceptor ignored the 500. That commit is right; it just exposed the latent interceptor bug.

## Fix

**`invalid-session-interceptor.ts` — only 401 triggers `sessionExpired()`.**

Only 401 indicates a lost session: when a session expires or is invalidated, the filter chain answers XHR requests with 401 (`AbstractSecurityFilter.shouldSendAuthenticationRedirect`), and this interceptor stamps `X-Requested-With: XMLHttpRequest` on every request, so that path always applies. A 403 means the session is valid but the user is not permitted to access that resource.

This is the important half — the same failure mode was latent across a large set of schedule/task-secured EM endpoints (`EMScheduleTaskController`, `EMScheduleTaskActionController`, `EMScheduleBatchActionController`, `ExportTaskController`, `ImportTaskController`, `EMScheduleTaskFolderController`, …). It also un-breaks call sites that already handle 403 themselves but were losing the race against the logout, e.g. the "Unauthorized" dialog in `schedule-task-list.component.ts`.

**`EMScheduleController.getUsersModel` — widen the permission to match its callers.**

The user/group list is not specific to schedule tasks: it also backs the email recipient pickers on the General settings page and the Security settings pages, none of which require any schedule permission. Now requires `settings/general` **OR** `settings/schedule/tasks` **OR** `settings/security/users` — the same set already used by `/api/em/settings/schedule/check-mail`.

`/api/em/schedule/task-names` is deliberately left alone: `ScheduleTaskNamesService` is only injected by the task-editor pages, which are already behind the tasks permission.

**`navbar.component.ts`** — corrected a comment that claimed the interceptor redirects on 403.

## Testing

New `invalid-session-interceptor.spec.ts`, 7 tests, passing via `ng test em`:

- 401 logs out (server's signal for a lost session)
- **403 does not log out** (regression-sensitive)
- 500 / 404 do not log out
- cross-origin 401 does not log out (preserves #3933 / Bug #75252)
- absolute same-origin 401 does log out
- GET requests carry `X-Requested-With: XMLHttpRequest`
- success responses do not log out

`./mvnw -o compile -pl core` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
