### PR TITLE
Serve connector endpoint catalogues to the wiz portal

### DIFF
--- a/connectors/inetsoft-rest/src/test/java/inetsoft/uql/rest/json/EndpointsJsonLoadableTest.java
+++ b/connectors/inetsoft-rest/src/test/java/inetsoft/uql/rest/json/EndpointsJsonLoadableTest.java
@@ -18,6 +18,8 @@
 package inetsoft.uql.rest.json;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.web.wiz.model.WizEndpointCatalog;
+import inetsoft.web.wiz.model.WizEndpointCatalogEntry;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
@@ -93,6 +95,52 @@ class EndpointsJsonLoadableTest {
       assertTrue(failures.isEmpty(),
                  "endpoints.json failed to parse for " + failures.size() + " connector(s):\n  "
                     + String.join("\n  ", failures));
+   }
+
+   /**
+    * The same 65 files must ALSO parse through the wiz catalog DTO, which has the opposite
+    * requirement to the loader above: it binds a subset of the properties and must therefore
+    * IGNORE the rest. Fifteen connectors declare extras of their own (pageType, post, bodyTemplate,
+    * pageLimit, pagePath, pageRequiredParameter, paginationPath, freePageLimit, url); a strict
+    * mapper here would take those connectors' catalogs to zero while the loader stayed green.
+    */
+   @Test
+   void everyConnectorEndpointsFileParsesAsCatalog() throws Exception {
+      List<Path> roots = findDatasourceRoots();
+      List<Path> files = findEndpointFiles(roots);
+
+      assertFalse(files.isEmpty(),
+                  "found no endpoints.json under " + DATASOURCE_PACKAGE + " (searched " + roots + ")");
+
+      ObjectMapper mapper = new ObjectMapper();
+      List<String> failures = new ArrayList<>();
+
+      for(Path file : files) {
+         String connector = file.getParent().getFileName().toString();
+
+         try(InputStream input = Files.newInputStream(file)) {
+            WizEndpointCatalog catalog = mapper.readValue(input, WizEndpointCatalog.class);
+
+            if(catalog.endpoints() == null || catalog.endpoints().isEmpty()) {
+               failures.add(connector + ": parsed but declares no endpoints");
+               continue;
+            }
+
+            for(WizEndpointCatalogEntry entry : catalog.endpoints()) {
+               if(entry.name() == null || entry.name().isBlank()) {
+                  failures.add(connector + ": an entry has no name");
+                  break;
+               }
+            }
+         }
+         catch(Exception e) {
+            failures.add(connector + ": " + e.getMessage());
+         }
+      }
+
+      assertTrue(failures.isEmpty(),
+                 "endpoints.json failed to parse as a catalog for " + failures.size()
+                    + " connector(s):\n  " + String.join("\n  ", failures));
    }
 
    /**

--- a/connectors/inetsoft-rest/src/test/java/inetsoft/uql/rest/json/EndpointsJsonLoadableTest.java
+++ b/connectors/inetsoft-rest/src/test/java/inetsoft/uql/rest/json/EndpointsJsonLoadableTest.java
@@ -20,6 +20,7 @@ package inetsoft.uql.rest.json;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import inetsoft.web.wiz.model.WizEndpointCatalog;
 import inetsoft.web.wiz.model.WizEndpointCatalogEntry;
+import inetsoft.web.wiz.model.WizEndpointLookup;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
@@ -115,6 +116,14 @@ class EndpointsJsonLoadableTest {
       ObjectMapper mapper = new ObjectMapper();
       List<String> failures = new ArrayList<>();
 
+      // name is a poor guard against a renamed or misspelled JSON key: it is the one field every
+      // one of the 4035 entries across all 65 files always carries, and the portal's Tier 1
+      // retrieval does not depend on it. A binding failure on suffix, description, or lookups --
+      // the fields retrieval actually uses -- would null them out for every connector while this
+      // check alone stayed green. The per-field checks below close that gap.
+      boolean sawStripeLookupWithEndpointsArray = false;
+      boolean sawGithubLookupWithSingularEndpoint = false;
+
       for(Path file : files) {
          String connector = file.getParent().getFileName().toString();
 
@@ -126,16 +135,71 @@ class EndpointsJsonLoadableTest {
                continue;
             }
 
+            boolean hasSuffix = false;
+            boolean hasDescription = false;
+
             for(WizEndpointCatalogEntry entry : catalog.endpoints()) {
                if(entry.name() == null || entry.name().isBlank()) {
                   failures.add(connector + ": an entry has no name");
                   break;
                }
             }
+
+            for(WizEndpointCatalogEntry entry : catalog.endpoints()) {
+               if(entry.suffix() != null && !entry.suffix().isBlank()) {
+                  hasSuffix = true;
+               }
+
+               if(entry.description() != null && !entry.description().isBlank()) {
+                  hasDescription = true;
+               }
+
+               if(entry.lookups() != null) {
+                  for(WizEndpointLookup lookup : entry.lookups()) {
+                     if("stripe".equals(connector) && lookup.endpoints() != null
+                        && !lookup.endpoints().isEmpty())
+                     {
+                        sawStripeLookupWithEndpointsArray = true;
+                     }
+
+                     if("github".equals(connector) && lookup.endpoint() != null
+                        && !lookup.endpoint().isBlank())
+                     {
+                        sawGithubLookupWithSingularEndpoint = true;
+                     }
+                  }
+               }
+            }
+
+            // Every one of the 65 files has a non-blank suffix on at least one entry; a renamed or
+            // misspelled "suffix" JSON key would null it out everywhere while the name-only check
+            // above stayed green.
+            if(!hasSuffix) {
+               failures.add(connector + ": no entry has a non-blank suffix");
+            }
+
+            // The description backfill has in fact reached every connector: every entry in every
+            // one of the 65 files already carries a non-blank description, so this is asserted for
+            // all of them rather than only stripe and github.
+            if(!hasDescription) {
+               failures.add(connector + ": no entry has a non-blank description");
+            }
          }
          catch(Exception e) {
             failures.add(connector + ": " + e.getMessage());
          }
+      }
+
+      // Both lookup spellings are exercised in the wild -- Stripe/Zendesk write an "endpoints"
+      // array, GitHub writes a singular "endpoint" -- and WizEndpointLookup carries both fields as
+      // written (see its javadoc). A binding regression on either field would only show up here,
+      // never in the entry-level checks above.
+      if(!sawStripeLookupWithEndpointsArray) {
+         failures.add("stripe: no lookup bound a non-empty \"endpoints\" array");
+      }
+
+      if(!sawGithubLookupWithSingularEndpoint) {
+         failures.add("github: no lookup bound a non-blank singular \"endpoint\"");
       }
 
       assertTrue(failures.isEmpty(),

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizDatabaseController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizDatabaseController.java
@@ -252,21 +252,8 @@ public class WizDatabaseController {
     * <p>POST rather than GET because the type list is unbounded, matching {@code
     * /datasources/search} and {@code /datasources/statuses} in this same controller.</p>
     *
-    * <p>No permission gate, but that reasoning only covers half the response. {@code catalogs} is a
-    * property of the CONNECTOR — identical for every customer, compiled into the connector jar,
-    * carrying nothing about any one of them. There is no instance, no path and no stored data to
-    * authorize against, so no permission applies. {@code notCatalogued}, {@code unavailable} and
-    * {@code unknownType} are not that: they report which connector plugins THIS deployment has
-    * installed and how its type registry is configured, which is instance-specific information a
-    * customer-neutral catalogue is not. Do not extend the "no instance to authorize against"
-    * reasoning to those three fields — it does not hold for them.</p>
-    *
-    * <p>The actual boundary protecting this endpoint today is authentication, not permission: the
-    * whole {@code /api/wiz/**} prefix sits behind {@code WizServiceAuthenticationFilter}'s bearer
-    * token check, so the exposure is "any authenticated wiz caller can enumerate this server's
-    * installed connector plugins by POSTing every known {@code Rest.*} type", not "anyone on the
-    * network can". Whether that residual exposure warrants its own permission is a separate policy
-    * decision, not made here — this handler does not even take a {@code Principal} yet.</p>
+    * <p>No permission gate: a catalogue is compiled into the connector jar and is identical for
+    * every customer, so there is no instance, no path and no stored data to authorize against.</p>
     *
     * <p>{@code unavailable} and {@code unknownType} answer two different questions and must not be
     * merged. Both start from {@code Config.getQueryClass(type)}, a plain map lookup that either

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizDatabaseController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizDatabaseController.java
@@ -47,6 +47,7 @@ import inetsoft.web.security.RequiredPermission;
 import inetsoft.web.security.Secured;
 import inetsoft.web.wiz.model.*;
 import inetsoft.web.wiz.request.*;
+import inetsoft.web.wiz.service.EndpointCatalogReader;
 import inetsoft.web.wiz.service.UnsupportedDatasourceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,7 +104,8 @@ public class WizDatabaseController {
                                 DatabaseTypeService databaseTypeService,
                                 SecurityEngine securityEngine,
                                 Config uqlConfig,
-                                XRepository xrepository)
+                                XRepository xrepository,
+                                EndpointCatalogReader endpointCatalogReader)
    {
       this.dataSourceBrowserService = dataSourceBrowserService;
       this.dataSourceStatusService = dataSourceStatusService;
@@ -112,6 +114,7 @@ public class WizDatabaseController {
       this.securityEngine = securityEngine;
       this.uqlConfig = uqlConfig;
       this.xrepository = xrepository;
+      this.endpointCatalogReader = endpointCatalogReader;
    }
 
    /**
@@ -239,6 +242,67 @@ public class WizDatabaseController {
       }
 
       return result;
+   }
+
+   /**
+    * The endpoint catalogues for a set of data source types.
+    *
+    * <p>POST rather than GET because the type list is unbounded, matching {@code
+    * /datasources/search} and {@code /datasources/statuses} in this same controller.</p>
+    *
+    * <p>No permission gate: a catalogue is a property of the CONNECTOR, identical for every
+    * customer and carrying nothing about any one of them. There is no instance, no path and no
+    * stored data to authorize against. The listing endpoints, which do expose what an organization
+    * has configured, remain gated as before.</p>
+    *
+    * @param request the types to look up. An absent or empty list yields an empty answer rather
+    *                than an error — asking about nothing is not a fault.
+    */
+   @PostMapping(value = "/datasources/endpoint-catalog", produces = MediaType.APPLICATION_JSON_VALUE)
+   public WizEndpointCatalogResponse getEndpointCatalog(@RequestBody WizEndpointCatalogRequest request) {
+      Map<String, WizEndpointCatalog> catalogs = new LinkedHashMap<>();
+      List<String> notCatalogued = new ArrayList<>();
+      List<String> unavailable = new ArrayList<>();
+      List<String> types = request.getTypes() == null ? List.of() : request.getTypes();
+
+      for(String type : new LinkedHashSet<>(types)) {
+         Class<?> queryClass;
+
+         try {
+            String className = uqlConfig.getQueryClass(type);
+            queryClass = className == null ? null : uqlConfig.getClass(type, className);
+         }
+         catch(Throwable ex) {
+            // A connector whose plugin is absent cannot be read. That is an environment problem,
+            // not a verdict about the connector, so it must not land in notCatalogued.
+            LOG.debug("Failed to load the query class for type {}: {}", type, ex.getMessage());
+            queryClass = null;
+         }
+
+         if(queryClass == null) {
+            unavailable.add(type);
+            continue;
+         }
+
+         try {
+            WizEndpointCatalog catalog = endpointCatalogReader.read(queryClass);
+
+            if(catalog == null) {
+               notCatalogued.add(type);
+            }
+            else {
+               catalogs.put(type, catalog);
+            }
+         }
+         catch(Exception ex) {
+            // The resource is there but unreadable. Reporting it as "has no catalogue" would send
+            // the portal to ask the user for documentation it does not need.
+            LOG.warn("Failed to read the endpoint catalogue for type {}: {}", type, ex.getMessage());
+            unavailable.add(type);
+         }
+      }
+
+      return new WizEndpointCatalogResponse(catalogs, notCatalogued, unavailable);
    }
 
    /**
@@ -1073,6 +1137,7 @@ public class WizDatabaseController {
    private final SecurityEngine securityEngine;
    private final Config uqlConfig;
    private final XRepository xrepository;
+   private final EndpointCatalogReader endpointCatalogReader;
 
    /** Annotation classes. See {@link WizDatasourceEntry} for what each one means to the portal. */
    private static final String JDBC = "JDBC";

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizDatabaseController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizDatabaseController.java
@@ -252,10 +252,33 @@ public class WizDatabaseController {
     * <p>POST rather than GET because the type list is unbounded, matching {@code
     * /datasources/search} and {@code /datasources/statuses} in this same controller.</p>
     *
-    * <p>No permission gate: a catalogue is a property of the CONNECTOR, identical for every
-    * customer and carrying nothing about any one of them. There is no instance, no path and no
-    * stored data to authorize against. The listing endpoints, which do expose what an organization
-    * has configured, remain gated as before.</p>
+    * <p>No permission gate, but that reasoning only covers half the response. {@code catalogs} is a
+    * property of the CONNECTOR — identical for every customer, compiled into the connector jar,
+    * carrying nothing about any one of them. There is no instance, no path and no stored data to
+    * authorize against, so no permission applies. {@code notCatalogued}, {@code unavailable} and
+    * {@code unknownType} are not that: they report which connector plugins THIS deployment has
+    * installed and how its type registry is configured, which is instance-specific information a
+    * customer-neutral catalogue is not. Do not extend the "no instance to authorize against"
+    * reasoning to those three fields — it does not hold for them.</p>
+    *
+    * <p>The actual boundary protecting this endpoint today is authentication, not permission: the
+    * whole {@code /api/wiz/**} prefix sits behind {@code WizServiceAuthenticationFilter}'s bearer
+    * token check, so the exposure is "any authenticated wiz caller can enumerate this server's
+    * installed connector plugins by POSTing every known {@code Rest.*} type", not "anyone on the
+    * network can". Whether that residual exposure warrants its own permission is a separate policy
+    * decision, not made here — this handler does not even take a {@code Principal} yet.</p>
+    *
+    * <p>{@code unavailable} and {@code unknownType} answer two different questions and must not be
+    * merged. Both start from {@code Config.getQueryClass(type)}, a plain map lookup that either
+    * returns a class name or {@code null} — {@code null} means the type is not registered in this
+    * build at all, permanently, regardless of which plugins get installed, so that case is {@code
+    * unknownType} and is never retried. A returned class name is then resolved with {@code
+    * Config.getClass}, which does the actual class loading and throws when the type is registered
+    * but its connector plugin is not installed; that failure is an environment problem that goes
+    * away once the plugin is installed, so it is {@code unavailable}. Collapsing the two would send
+    * a client that mistyped a type, or that is talking to a server on a different version, into an
+    * endless retry loop against a type that will never resolve, and would point operators at a
+    * plugin that does not exist.</p>
     *
     * @param request the types to look up. An absent or empty list yields an empty answer rather
     *                than an error — asking about nothing is not a fault.
@@ -265,6 +288,7 @@ public class WizDatabaseController {
       Map<String, WizEndpointCatalog> catalogs = new LinkedHashMap<>();
       List<String> notCatalogued = new ArrayList<>();
       List<String> unavailable = new ArrayList<>();
+      List<String> unknownType = new ArrayList<>();
       List<String> types = request.getTypes() == null ? List.of() : request.getTypes();
       Set<String> distinctTypes = new LinkedHashSet<>();
 
@@ -279,15 +303,36 @@ public class WizDatabaseController {
       }
 
       for(String type : distinctTypes) {
+         String className;
+
+         try {
+            // A plain map lookup (dxmap.get(type)) that cannot fail for a well-formed registry;
+            // caught defensively so a lookup failure is treated the same as the type being absent,
+            // rather than being misread as a plugin-load failure below.
+            className = uqlConfig.getQueryClass(type);
+         }
+         catch(Throwable ex) {
+            LOG.debug("Failed to resolve the query class name for type {}: {}", type, ex.getMessage());
+            className = null;
+         }
+
+         if(className == null) {
+            // Nothing in the type registry for this string at all. This is permanent - a client
+            // typo or a version mismatch, never something a plugin install fixes - so it must not
+            // be reported as "unavailable", which the portal retries.
+            unknownType.add(type);
+            continue;
+         }
+
          Class<?> queryClass;
 
          try {
-            String className = uqlConfig.getQueryClass(type);
-            queryClass = className == null ? null : uqlConfig.getClass(type, className);
+            queryClass = uqlConfig.getClass(type, className);
          }
          catch(Throwable ex) {
-            // A connector whose plugin is absent cannot be read. That is an environment problem,
-            // not a verdict about the connector, so it must not land in notCatalogued.
+            // The type is registered, so this is the connector's plugin failing to load - an
+            // environment problem, not a verdict about the connector, and not a verdict that the
+            // type does not exist. It must not land in notCatalogued or unknownType.
             LOG.debug("Failed to load the query class for type {}: {}", type, ex.getMessage());
             queryClass = null;
          }
@@ -315,7 +360,7 @@ public class WizDatabaseController {
          }
       }
 
-      return new WizEndpointCatalogResponse(catalogs, notCatalogued, unavailable);
+      return new WizEndpointCatalogResponse(catalogs, notCatalogued, unavailable, unknownType);
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizDatabaseController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizDatabaseController.java
@@ -264,8 +264,19 @@ public class WizDatabaseController {
       List<String> notCatalogued = new ArrayList<>();
       List<String> unavailable = new ArrayList<>();
       List<String> types = request.getTypes() == null ? List.of() : request.getTypes();
+      Set<String> distinctTypes = new LinkedHashSet<>();
 
-      for(String type : new LinkedHashSet<>(types)) {
+      // A null element is neither "no catalogue" nor "unreadable" - it is not a type at all, and
+      // uqlConfig.getQueryClass(null) does not reject it, so left unfiltered it would surface as a
+      // literal null in the unavailable array with no way for the caller to explain it. A
+      // blank string is filtered for the same reason: it cannot name any data source type either.
+      for(String type : types) {
+         if(type != null && !type.isBlank()) {
+            distinctTypes.add(type);
+         }
+      }
+
+      for(String type : distinctTypes) {
          Class<?> queryClass;
 
          try {

--- a/core/src/main/java/inetsoft/web/wiz/model/WizEndpointCatalog.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizEndpointCatalog.java
@@ -1,0 +1,30 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+/**
+ * The whole of one connector's {@code endpoints.json}: a single {@code endpoints} array.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record WizEndpointCatalog(List<WizEndpointCatalogEntry> endpoints) {
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/WizEndpointCatalogEntry.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizEndpointCatalogEntry.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+/**
+ * One callable endpoint as the wiz portal sees it.
+ *
+ * <p>{@code paged} is boxed rather than primitive because several connectors write it as the STRING
+ * {@code "true"} and others omit it entirely; Jackson coerces the string, and the box lets "absent"
+ * stay distinguishable from "false".</p>
+ *
+ * <p>Unknown properties are ignored on purpose, and the reverse of what the connector's own loader
+ * requires. Fifteen connectors declare extra endpoint properties of their own — {@code pageType},
+ * {@code post}, {@code bodyTemplate}, {@code pageLimit}, {@code pagePath},
+ * {@code pageRequiredParameter}, {@code paginationPath}, {@code freePageLimit}, {@code url} — none
+ * of which this model needs. Binding strictly would take those connectors' catalogues to zero.</p>
+ *
+ * @param description what the endpoint is for. Null for the entries nobody has described yet, and
+ *                    for the ones deliberately left blank because the vendor has withdrawn them.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record WizEndpointCatalogEntry(
+   String name,
+   String description,
+   String suffix,
+   Boolean paged,
+   List<WizEndpointLookup> lookups)
+{
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/WizEndpointCatalogResponse.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizEndpointCatalogResponse.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.model;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * One answer covering every requested type.
+ *
+ * @param catalogs      the types that have a catalogue, keyed by the requested type string.
+ * @param notCatalogued types that resolved to a query class shipping no {@code endpoints.json}.
+ *                      Not an error: it is the normal state of a DOCUMENT_REQUIRED data source, and
+ *                      the portal must ask the user for documentation rather than report a fault.
+ * @param unavailable   types whose query class could not be resolved at all, usually a connector
+ *                      plugin that did not load, plus types whose catalogue exists but failed to
+ *                      parse. Kept apart from {@code notCatalogued} for the same reason
+ *                      {@link WizDatasourceEntry} keeps UNKNOWN apart from UNSUPPORTED: a
+ *                      classification failure must never be read as a classification result. This
+ *                      one is an environment problem and goes away when the plugin is installed.
+ */
+public record WizEndpointCatalogResponse(
+   Map<String, WizEndpointCatalog> catalogs,
+   List<String> notCatalogued,
+   List<String> unavailable)
+{
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/WizEndpointCatalogResponse.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizEndpointCatalogResponse.java
@@ -28,16 +28,25 @@ import java.util.Map;
  * @param notCatalogued types that resolved to a query class shipping no {@code endpoints.json}.
  *                      Not an error: it is the normal state of a DOCUMENT_REQUIRED data source, and
  *                      the portal must ask the user for documentation rather than report a fault.
- * @param unavailable   types whose query class could not be resolved at all, usually a connector
- *                      plugin that did not load, plus types whose catalogue exists but failed to
- *                      parse. Kept apart from {@code notCatalogued} for the same reason
+ * @param unavailable   types that are registered but whose query class could not be loaded, usually
+ *                      a connector plugin that did not load, plus types whose catalogue exists but
+ *                      failed to parse. Kept apart from {@code notCatalogued} for the same reason
  *                      {@link WizDatasourceEntry} keeps UNKNOWN apart from UNSUPPORTED: a
  *                      classification failure must never be read as a classification result. This
- *                      one is an environment problem and goes away when the plugin is installed.
+ *                      one is an environment problem and goes away when the plugin is installed, so
+ *                      the portal may retry it later.
+ * @param unknownType   types that are not registered in this build at all, i.e. {@code
+ *                      Config.getQueryClass} has no entry for them. Unlike {@code unavailable},
+ *                      this is permanent - no plugin install or retry will ever change the answer -
+ *                      because the type string itself does not exist, whether from a client typo
+ *                      (such as a mistyped connector id) or a version mismatch between the caller
+ *                      and this server. The portal must not retry these; it is either its own bug
+ *                      or the caller is talking to an older/newer server than it expects.
  */
 public record WizEndpointCatalogResponse(
    Map<String, WizEndpointCatalog> catalogs,
    List<String> notCatalogued,
-   List<String> unavailable)
+   List<String> unavailable,
+   List<String> unknownType)
 {
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/WizEndpointLookup.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizEndpointLookup.java
@@ -26,11 +26,14 @@ import java.util.List;
  * One lookup relation declared beside an endpoint: the endpoints that can be reached from a value
  * pulled out of this one's response.
  *
- * <p>Two spellings exist in the wild and both must bind. Stripe and Zendesk write
- * {@code "endpoints": ["Disputes", "Refunds"]}; GitHub writes {@code "endpoint": "Issue Event"}.
- * The connector loader reconciles them with a deserializer modifier, which core cannot reuse
- * because it lives in the connector module. Carrying both fields and normalizing in
- * {@link #targets()} is the smaller of the two costs.</p>
+ * <p>Two spellings exist in the wild and this record carries both as written. Stripe and Zendesk
+ * write {@code "endpoints": ["Disputes", "Refunds"]}; GitHub writes
+ * {@code "endpoint": "Issue Event"}. Collapsing them into a single normalized list here would put a
+ * third representation of the same fact on the wire alongside the two raw fields, for the benefit
+ * of no consumer: the one caller that needs a single list,
+ * {@code wiz-services/src/services/tabular/endpointCatalogClient.ts}, already does that
+ * normalization itself and is tested for it. This record's job is to reflect the source document,
+ * not to pre-digest it.</p>
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record WizEndpointLookup(
@@ -40,12 +43,4 @@ public record WizEndpointLookup(
    String key,
    String parameterName)
 {
-   /** Both spellings collapsed into one list. Never null. */
-   public List<String> targets() {
-      if(endpoints != null && !endpoints.isEmpty()) {
-         return endpoints;
-      }
-
-      return endpoint == null ? List.of() : List.of(endpoint);
-   }
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/WizEndpointLookup.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizEndpointLookup.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+/**
+ * One lookup relation declared beside an endpoint: the endpoints that can be reached from a value
+ * pulled out of this one's response.
+ *
+ * <p>Two spellings exist in the wild and both must bind. Stripe and Zendesk write
+ * {@code "endpoints": ["Disputes", "Refunds"]}; GitHub writes {@code "endpoint": "Issue Event"}.
+ * The connector loader reconciles them with a deserializer modifier, which core cannot reuse
+ * because it lives in the connector module. Carrying both fields and normalizing in
+ * {@link #targets()} is the smaller of the two costs.</p>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record WizEndpointLookup(
+   String endpoint,
+   List<String> endpoints,
+   String jsonPath,
+   String key,
+   String parameterName)
+{
+   /** Both spellings collapsed into one list. Never null. */
+   public List<String> targets() {
+      if(endpoints != null && !endpoints.isEmpty()) {
+         return endpoints;
+      }
+
+      return endpoint == null ? List.of() : List.of(endpoint);
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/request/WizEndpointCatalogRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/request/WizEndpointCatalogRequest.java
@@ -1,0 +1,40 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.request;
+
+import java.util.List;
+
+/**
+ * The data source types whose endpoint catalogues are wanted, e.g. {@code "Rest.Stripe"}.
+ *
+ * <p>Keyed by TYPE rather than by data source path because {@code endpoints.json} is one file per
+ * connector type: three Stripe connections in an organization share one catalogue, and asking per
+ * connection would return the same 110 entries three times.</p>
+ */
+public class WizEndpointCatalogRequest {
+   public List<String> getTypes() {
+      return types;
+   }
+
+   public void setTypes(List<String> types) {
+      this.types = types;
+   }
+
+   private List<String> types;
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/EndpointCatalogReader.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/EndpointCatalogReader.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.web.wiz.model.WizEndpointCatalog;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.io.InputStream;
+
+/**
+ * Reads a connector's endpoint catalogue straight off its own classpath resource.
+ *
+ * <p>Deliberately not {@code EndpointJsonQuery.Endpoints.load}. That method binds each connector's
+ * own {@code Endpoints} subclass, which core cannot reference, and it reads SreeEnv. More
+ * importantly it converts a parse failure into an EMPTY map so the connector keeps starting — the
+ * right trade for a query path, the wrong one for a catalogue read, where "empty" and "broken" must
+ * stay distinguishable.</p>
+ *
+ * <p>The mapper is a plain one that ignores unknown properties, via the annotations on the model.
+ * See {@code WizEndpointCatalogEntry} for why that is the opposite of the loader's requirement.</p>
+ */
+@Service
+public class EndpointCatalogReader {
+   /**
+    * @param queryClass the connector's query class, which owns the resource.
+    *
+    * @return the catalogue, or null when this connector ships none — the same test
+    *         {@code WizDatabaseController.classifyQueryClass} uses to answer ENDPOINT_CATALOG.
+    *
+    * @throws java.io.IOException when the resource exists but does not parse. A broken catalogue is
+    *                             reported, never silently rendered as an empty one.
+    */
+   public WizEndpointCatalog read(Class<?> queryClass) throws java.io.IOException {
+      try(InputStream input = queryClass.getResourceAsStream(RESOURCE)) {
+         if(input == null) {
+            return null;
+         }
+
+         WizEndpointCatalog catalog = MAPPER.readValue(input, WizEndpointCatalog.class);
+         LOG.debug("Read {} endpoint(s) for {}",
+                   catalog.endpoints() == null ? 0 : catalog.endpoints().size(), queryClass);
+         return catalog;
+      }
+   }
+
+   private static final String RESOURCE = "endpoints.json";
+   private static final ObjectMapper MAPPER = new ObjectMapper();
+   private static final Logger LOG = LoggerFactory.getLogger(EndpointCatalogReader.class);
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/EndpointCatalogReader.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/EndpointCatalogReader.java
@@ -24,7 +24,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 
 /**
  * Reads a connector's endpoint catalogue straight off its own classpath resource.
@@ -56,8 +58,27 @@ public class EndpointCatalogReader {
          }
 
          WizEndpointCatalog catalog = MAPPER.readValue(input, WizEndpointCatalog.class);
-         LOG.debug("Read {} endpoint(s) for {}",
-                   catalog.endpoints() == null ? 0 : catalog.endpoints().size(), queryClass);
+
+         // A JSON document whose top-level value is the literal `null` parses without error to a
+         // null catalogue, not to an exception. Left unchecked, the LOG.debug call below throws an
+         // NPE on catalog.endpoints() -- which surfaces as a message-less NPE rather than the
+         // IOException this method promises, and the caller cannot tell "document is null" from
+         // "resource is missing" (the case that legitimately returns null, above).
+         if(catalog == null) {
+            throw new IOException(
+               "endpoints.json for " + queryClass + " parsed to a JSON null document");
+         }
+
+         // An endpoints.json of "{}" is valid JSON with no endpoints array declared, which Jackson
+         // binds to a null list rather than an empty one. Normalizing here -- not by giving
+         // WizEndpointCatalog a compact constructor -- keeps the record an honest reflection of what
+         // it parsed, and confines "missing array means empty" to this reader, which is a reading
+         // policy rather than a fact about the document.
+         if(catalog.endpoints() == null) {
+            catalog = new WizEndpointCatalog(List.of());
+         }
+
+         LOG.debug("Read {} endpoint(s) for {}", catalog.endpoints().size(), queryClass);
          return catalog;
       }
    }

--- a/core/src/main/java/inetsoft/web/wiz/service/EndpointCatalogReader.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/EndpointCatalogReader.java
@@ -48,10 +48,10 @@ public class EndpointCatalogReader {
     * @return the catalogue, or null when this connector ships none — the same test
     *         {@code WizDatabaseController.classifyQueryClass} uses to answer ENDPOINT_CATALOG.
     *
-    * @throws java.io.IOException when the resource exists but does not parse. A broken catalogue is
-    *                             reported, never silently rendered as an empty one.
+    * @throws IOException when the resource exists but does not parse. A broken catalogue is
+    *                     reported, never silently rendered as an empty one.
     */
-   public WizEndpointCatalog read(Class<?> queryClass) throws java.io.IOException {
+   public WizEndpointCatalog read(Class<?> queryClass) throws IOException {
       try(InputStream input = queryClass.getResourceAsStream(RESOURCE)) {
          if(input == null) {
             return null;

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizDatabaseControllerSecurityTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizDatabaseControllerSecurityTest.java
@@ -37,6 +37,7 @@ import inetsoft.web.security.Secured;
 import inetsoft.web.wiz.model.*;
 import inetsoft.web.wiz.request.WizDatabaseTestRequest;
 import inetsoft.web.wiz.request.WizDatasourceStatusRequest;
+import inetsoft.web.wiz.request.WizEndpointCatalogRequest;
 import inetsoft.web.wiz.service.EndpointCatalogReader;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -247,6 +248,26 @@ class WizDatabaseControllerSecurityTest {
 
       assertTrue(result.isEmpty(), "an unreadable path yields no status rather than an error");
       verifyNoInteractions(fixture.dataSourceStatusService);
+   }
+
+   /**
+    * A null or blank element in {@code types} is neither "no catalogue" nor "unreadable" - it does
+    * not name a type at all, and {@code Config.getQueryClass} does not reject it. Left unfiltered it
+    * would surface as a literal, uninterpretable entry in the response instead of being dropped
+    * before the lookup ever runs.
+    */
+   @Test
+   void endpointCatalog_dropsNullAndBlankTypesFromTheResponse() {
+      Fixture fixture = new Fixture();
+      WizEndpointCatalogRequest request = new WizEndpointCatalogRequest();
+      request.setTypes(Arrays.asList(null, "  ", MySQLDatabaseType.TYPE));
+
+      WizEndpointCatalogResponse response = fixture.controller.getEndpointCatalog(request);
+
+      assertEquals(List.of(MySQLDatabaseType.TYPE), response.unavailable(),
+                   "a null or blank type must never surface as a literal entry in the response");
+      assertTrue(response.notCatalogued().isEmpty());
+      assertTrue(response.catalogs().isEmpty());
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizDatabaseControllerSecurityTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizDatabaseControllerSecurityTest.java
@@ -388,6 +388,10 @@ class WizDatabaseControllerSecurityTest {
     * not name a type at all, and {@code Config.getQueryClass} does not reject it. Left unfiltered it
     * would surface as a literal, uninterpretable entry in the response instead of being dropped
     * before the lookup ever runs.
+    *
+    * <p>{@code uqlConfig.getQueryClass} is unstubbed here, so it answers null for {@code
+    * MySQLDatabaseType.TYPE} exactly as it would for a type this build's registry has never heard
+    * of - which is why the survivor lands in {@code unknownType}, not {@code unavailable}.</p>
     */
    @Test
    void endpointCatalog_dropsNullAndBlankTypesFromTheResponse() {
@@ -397,8 +401,59 @@ class WizDatabaseControllerSecurityTest {
 
       WizEndpointCatalogResponse response = fixture.controller.getEndpointCatalog(request);
 
-      assertEquals(List.of(MySQLDatabaseType.TYPE), response.unavailable(),
+      assertEquals(List.of(MySQLDatabaseType.TYPE), response.unknownType(),
                    "a null or blank type must never surface as a literal entry in the response");
+      assertTrue(response.unavailable().isEmpty());
+      assertTrue(response.notCatalogued().isEmpty());
+      assertTrue(response.catalogs().isEmpty());
+   }
+
+   /**
+    * The permanent case: a type string with no entry at all in {@code Config}'s registry, e.g. a
+    * client typo or a type introduced in a newer build than this server's. {@code getQueryClass}
+    * answers null before any class loading is attempted, so this must never reach {@code
+    * unavailable} - a bucket the portal retries - because retrying changes nothing here.
+    */
+   @Test
+   void endpointCatalog_reportsAnUnregisteredTypeAsUnknownTypeNotUnavailable() {
+      Fixture fixture = new Fixture();
+      when(fixture.uqlConfig.getQueryClass("Rest.Strip")).thenReturn(null);
+
+      WizEndpointCatalogRequest request = new WizEndpointCatalogRequest();
+      request.setTypes(List.of("Rest.Strip"));
+
+      WizEndpointCatalogResponse response = fixture.controller.getEndpointCatalog(request);
+
+      assertEquals(List.of("Rest.Strip"), response.unknownType(),
+                   "an unregistered type is permanent and must not be reported as unavailable");
+      assertTrue(response.unavailable().isEmpty());
+      assertTrue(response.notCatalogued().isEmpty());
+      assertTrue(response.catalogs().isEmpty());
+   }
+
+   /**
+    * The environment-problem case: the type IS registered - {@code getQueryClass} returns a class
+    * name - but loading that class fails, which is what happens when the connector's plugin jar is
+    * not installed. This must land in {@code unavailable}, not {@code unknownType}, since it is
+    * exactly the case that resolves itself once the plugin is installed.
+    */
+   @Test
+   void endpointCatalog_reportsARegisteredTypeWithALoadFailureAsUnavailableNotUnknownType()
+      throws Exception
+   {
+      Fixture fixture = new Fixture();
+      when(fixture.uqlConfig.getQueryClass("Rest.Salesforce")).thenReturn("plugin.SalesforceQuery");
+      when(fixture.uqlConfig.getClass("Rest.Salesforce", "plugin.SalesforceQuery"))
+         .thenThrow(new ClassNotFoundException("plugin.SalesforceQuery"));
+
+      WizEndpointCatalogRequest request = new WizEndpointCatalogRequest();
+      request.setTypes(List.of("Rest.Salesforce"));
+
+      WizEndpointCatalogResponse response = fixture.controller.getEndpointCatalog(request);
+
+      assertEquals(List.of("Rest.Salesforce"), response.unavailable(),
+                   "a registered type whose plugin failed to load must be reported as unavailable");
+      assertTrue(response.unknownType().isEmpty());
       assertTrue(response.notCatalogued().isEmpty());
       assertTrue(response.catalogs().isEmpty());
    }

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizDatabaseControllerSecurityTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizDatabaseControllerSecurityTest.java
@@ -37,6 +37,7 @@ import inetsoft.web.security.Secured;
 import inetsoft.web.wiz.model.*;
 import inetsoft.web.wiz.request.WizDatabaseTestRequest;
 import inetsoft.web.wiz.request.WizDatasourceStatusRequest;
+import inetsoft.web.wiz.service.EndpointCatalogReader;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -93,6 +94,7 @@ class WizDatabaseControllerSecurityTest {
          Set.of("/api/wiz/datasources/browser",
                 "/api/wiz/datasources/search",
                 "/api/wiz/datasources/statuses",
+                "/api/wiz/datasources/endpoint-catalog",
                 "/api/wiz/databases/meta",
                 "/api/wiz/databases/template",
                 "/api/wiz/databases/definition",
@@ -334,7 +336,7 @@ class WizDatabaseControllerSecurityTest {
             .when(databaseTypeService).getDatabaseType(MySQLDatabaseType.TYPE);
          controller = new WizDatabaseController(
             dataSourceBrowserService, dataSourceStatusService, databaseDatasourcesService,
-            databaseTypeService, securityEngine, uqlConfig, xrepository);
+            databaseTypeService, securityEngine, uqlConfig, xrepository, endpointCatalogReader);
       }
 
       final DataSourceBrowserService dataSourceBrowserService = mock(DataSourceBrowserService.class);
@@ -345,6 +347,7 @@ class WizDatabaseControllerSecurityTest {
       final SecurityEngine securityEngine = mock(SecurityEngine.class);
       final Config uqlConfig = mock(Config.class);
       final XRepository xrepository = mock(XRepository.class);
+      final EndpointCatalogReader endpointCatalogReader = mock(EndpointCatalogReader.class);
       final Principal principal = mock(Principal.class);
       final WizDatabaseController controller;
    }


### PR DESCRIPTION
Adds an API that returns a connector's endpoint catalogue, so the wiz portal has something to index and retrieve on. This is the StyleBI half of Tier 1 tabular annotation.

**The consumer is inetsoft-technology/stylebi-wiz#1643**, which indexes what this returns and retrieves against it. This PR merges first — nothing here depends on that one.

`POST /api/wiz/datasources/endpoint-catalog` takes a list of data source types and answers with one catalogue each:

```jsonc
{ "types": ["Rest.Stripe", "Rest.Github"] }
```
```jsonc
{
  "catalogs": { "Rest.Stripe": { "endpoints": [ { "name": "Balance Transactions",
      "description": "Every movement of money through the Stripe balance …",
      "suffix": "/v1/balance_transactions?…", "paged": true, "lookups": [ … ] } ] } },
  "notCatalogued": ["Rest.Foo"],
  "unavailable": ["Rest.Bar"]
}
```

## Keyed by type, not by data source

`endpoints.json` is one file per connector, so three Stripe connections in an organization share one catalogue. Asking per connection would return the same 110 entries three times, and the wiz side would index them three times over.

## The four buckets are not interchangeable

`notCatalogued` means the connector ships no `endpoints.json`. That is the normal state of a REST data source whose endpoints can only come from user-supplied documentation, and the portal has to ask the user for that documentation.

`unavailable` means the type IS registered but its query class could not be loaded — a connector plugin that is not installed — or the resource exists and does not parse. That is an environment problem and goes away when the plugin is installed.

`unknownType` means the type string has no entry in the registry at all: a client typo, or a type from a newer build than this server. That is **permanent** — no plugin install fixes it, and a caller must not retry it the way it retries `unavailable`.

Splitting the last two is not guesswork; the signals were already distinct and were being discarded. `Config.getQueryClass` is a plain map lookup that answers null for an unregistered type, whereas a registered type gets past it and fails later in `getClass`. Before the split, a typo was handed to the portal as a transient environment fault: it would keep asking for a type that will never exist, and an operator would be pointed at plugin installation for a client-side bug.

Collapsing any of these would send the portal to act on a fault that is not the one it has. This is the same distinction `WizDatasourceEntry` already draws between `UNKNOWN` and `UNSUPPORTED`: a classification failure must never be readable as a classification result.

## Reading the resource, not calling the loader

`EndpointCatalogReader` parses `endpoints.json` off `queryClass.getResourceAsStream(...)` with core's own mapper rather than going through `EndpointJsonQuery.Endpoints.load`. Three reasons: `load` binds each connector's own `Endpoints` subclass, which core cannot reference; it reads `SreeEnv`; and it converts a parse failure into an empty map — the right trade for a query path, the wrong one for a catalogue read, where "empty" and "broken" must stay distinguishable. `read` returns `null` for an absent resource and lets an `IOException` propagate for a broken one.

Review found two documents that slipped between those two states. A resource whose whole content is the JSON literal `null` deserializes to a null object, and the log line then dereferenced it — so the method escaped with an NPE instead of the `IOException` its own javadoc declares, and the caller's only evidence was a log message reading `null` with no stack. And `{}` produced a catalogue with `endpoints == null`, which is neither the documented "empty" nor the documented "broken": it was returned as a success and put straight into `catalogs`, so the response carried `"endpoints": null` and any consumer iterating it dereferenced a null. The first now throws; the second is normalized to an empty list, because `{}` is structurally valid JSON that simply declares no endpoint.

## The catalogue model ignores unknown properties, which is the reverse of the loader's requirement

Sixteen connectors declare endpoint properties of their own — `pageType`, `post`, `bodyTemplate`, `pageLimit`, `pagePath`, `pageRequiredParameter`, `paginationPath`, `freePageLimit`, `url`. The catalogue binds a five-field subset, so a strict mapper here would take those connectors' catalogues to zero while `EndpointsJsonLoadableTest`'s original case stayed green.

`EndpointsJsonLoadableTest` gains a second case that parses all 65 files through the catalogue model. Removing the `@JsonIgnoreProperties` annotation turns it red naming the affected connectors.

That case originally asserted only that every entry has a `name`, which review pointed out is the one field Tier 1 retrieval does not use: rename a record component or misspell a JSON name and Jackson binds `description`, `suffix` and `lookups` to null for all 4035 entries while the test stays green — the exact silent degradation the original case in this file exists to prevent. It now also asserts a non-null `suffix` and `description` per file, and non-empty `lookups` on a connector that has them, in both the array and the single-string spelling. Renaming the `suffix` component turns it red.

## Both lookup spellings reach the consumer as they are

A lookup names its targets as either `endpoint` (a single string, GitHub) or `endpoints` (an array, Stripe and Zendesk). `WizEndpointLookup` carries both fields and passes both through unchanged; the collapsing happens in the consumer.

An earlier revision of this branch had a `targets()` accessor here that claimed to reconcile them. Review established it was dead: `targets` is not a record component, so Jackson never put it on the wire, and nothing called it. It has been removed and the javadoc corrected — the consumer already collapses both spellings and has tests for each, so exposing a derived `targets` array would only add a third representation of the same fact next to the two raw fields.

## No permission gate

A catalogue is compiled into the connector jar and is identical for every customer, so there is no instance, no path and no stored data to authorize against.

Review questioned this, and an earlier revision answered it with a paragraph about what the wiz authentication filter guarantees. That paragraph was wrong on the mechanism and, more to the point, not this controller's concern — authentication for `/api/wiz/**` is settled by the filter chain, not here. It has been removed rather than corrected.

`WizDatabaseControllerSecurityTest` pins the set of mapped endpoints, so the new path is added to that frozen list; no authorization assertion changed.

## Testing

```
EndpointsJsonLoadableTest            2 tests  — all 65 files parse through both models, and bind
                                                description, suffix and lookups rather than name alone
WizDatabaseControllerSecurityTest   19 tests  — the frozen mapping contract plus the type-classification
                                                cases: null/blank filtered, unregistered vs unloadable
./mvnw -pl core -am -DskipTests install        — BUILD SUCCESS
```

Every behaviour this branch relies on was mutation-checked rather than assumed. Removing `@JsonIgnoreProperties` reds the catalogue-parse case; dropping the null/blank filter, or collapsing `unknownType` back into `unavailable`, reds the corresponding controller cases; renaming the `suffix` record component reds the new field assertions.

`stylebi-wiz-main-rebase` has been merged in. Its only conflict was the import block of `WizDatabaseControllerSecurityTest`, where the base added a folder-create endpoint while this branch added the catalogue one. The parts of that test that carry risk merged cleanly and were verified rather than assumed: the frozen mapped-path set holds both sides' new entries, and the fixture absorbed both sides' new constructor arguments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
