### PR TITLE
Serve the endpoint catalogue's admin and type-listing views

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/WizDatabaseController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizDatabaseController.java
@@ -20,6 +20,7 @@ package inetsoft.web.wiz.controller;
 
 import inetsoft.report.internal.Util;
 import inetsoft.sree.RepositoryEntry;
+import inetsoft.sree.security.OrganizationManager;
 import inetsoft.sree.security.ResourceAction;
 import inetsoft.sree.security.ResourceType;
 import inetsoft.sree.security.SecurityEngine;
@@ -348,6 +349,138 @@ public class WizDatabaseController {
       }
 
       return new WizEndpointCatalogResponse(catalogs, notCatalogued, unavailable, unknownType);
+   }
+
+   /**
+    * Every connector type that could be ingested, with the size of its catalogue.
+    *
+    * <p>Exists because the catalogue administration page has to offer a choice before anything has
+    * been ingested, and nothing outside StyleBI knows which connector types this build registers.
+    * {@code /datasources/endpoint-catalog} answers only for types the caller can already name; this
+    * is the enumeration that produces those names.</p>
+    *
+    * <p>The type strings come from {@code Config.getTabularDataSourceTypes()} and are the same
+    * strings {@code XDataSource.getType()} returns, so they join directly against the {@code
+    * sourceType} of {@code /datasources/browser}. Non-tabular types are excluded: only a tabular
+    * connector can ship an {@code endpoints.json}.</p>
+    *
+    * <p>No permission gate, for the same reason as {@code /datasources/endpoint-catalog}: this
+    * describes the software installed on the server, not any customer's data. It names no instance,
+    * no path and no stored value.</p>
+    *
+    * @return one row per registered tabular type, catalogued or not, sorted by type so the page has
+    *         a stable order without doing its own locale-dependent sort.
+    */
+   @GetMapping(value = "/datasources/endpoint-catalog/types",
+               produces = MediaType.APPLICATION_JSON_VALUE)
+   public List<WizEndpointCatalogType> getEndpointCatalogTypes() {
+      List<String> types;
+
+      try {
+         types = uqlConfig.getTabularDataSourceTypes();
+      }
+      catch(Throwable ex) {
+         LOG.warn("Failed to enumerate the tabular data source types: {}", ex.getMessage());
+         types = List.of();
+      }
+
+      List<WizEndpointCatalogType> result = new ArrayList<>();
+
+      for(String type : types) {
+         if(type == null || type.isBlank()) {
+            continue;
+         }
+
+         result.add(summarizeCatalogue(type));
+      }
+
+      result.sort(Comparator.comparing(WizEndpointCatalogType::type));
+
+      return result;
+   }
+
+   /**
+    * Whether the caller may administer the deployment-wide endpoint catalogue.
+    *
+    * <p>Lives beside the catalogue endpoints rather than in some general identity API because that
+    * is the only question it answers: an ingest writes one catalogue shared by every organization on
+    * the deployment, so it is a site-administrator action, not an organization-scoped one.</p>
+    *
+    * <p>It has to be answered here and cannot be answered by the caller. {@code
+    * OrganizationManager.isSiteAdmin} asks the configured security provider whether any of the
+    * principal's roles — expanded through inheritance by {@code getAllRoles} — is the system
+    * administrator role, and which role that is, is provider configuration. Matching a role name
+    * against a token claim would give a different answer on any deployment that renamed the role,
+    * and would miss every user holding it by inheritance.</p>
+    *
+    * <p>The same call is the gate {@code AdminAiController.requireSiteAdmin} uses. As noted there,
+    * it answers true for the default principal when security is disabled, so a development install
+    * is not locked out and no separate {@code isSecurityEnabled()} branch is needed.</p>
+    *
+    * @param principal the current user.
+    *
+    * @return the verdict. Reported rather than enforced: the caller (wiz-services) owns the action
+    *         being gated, and a page that can ask beforehand can explain the refusal instead of
+    *         showing a bare 403 after the fact.
+    */
+   @GetMapping(value = "/datasources/endpoint-catalog/admin",
+               produces = MediaType.APPLICATION_JSON_VALUE)
+   public WizEndpointCatalogAdmin getEndpointCatalogAdmin(Principal principal) {
+      return new WizEndpointCatalogAdmin(
+         OrganizationManager.getInstance().isSiteAdmin(principal));
+   }
+
+   /**
+    * One type's catalogue reduced to counts, using the same resolution chain as {@code
+    * getEndpointCatalog} so a type cannot be CATALOGUED here and unavailable there.
+    *
+    * <p>{@code unknownType} has no counterpart: these types come out of the registry itself, so
+    * {@code getQueryClass} cannot be absent for one. A null answer would mean the registry changed
+    * underneath this loop, which is reported as UNAVAILABLE — retryable — rather than invented into
+    * a fourth state.</p>
+    */
+   private WizEndpointCatalogType summarizeCatalogue(String type) {
+      Class<?> queryClass;
+
+      try {
+         String className = uqlConfig.getQueryClass(type);
+         queryClass = className == null ? null : uqlConfig.getClass(type, className);
+      }
+      catch(Throwable ex) {
+         LOG.debug("Failed to load the query class for type {}: {}", type, ex.getMessage());
+         queryClass = null;
+      }
+
+      if(queryClass == null) {
+         return new WizEndpointCatalogType(type, WizEndpointCatalogType.UNAVAILABLE, 0, 0);
+      }
+
+      WizEndpointCatalog catalog;
+
+      try {
+         catalog = endpointCatalogReader.read(queryClass);
+      }
+      catch(Exception ex) {
+         LOG.warn("Failed to read the endpoint catalogue for type {}: {}", type, ex.getMessage());
+         return new WizEndpointCatalogType(type, WizEndpointCatalogType.UNAVAILABLE, 0, 0);
+      }
+
+      if(catalog == null) {
+         return new WizEndpointCatalogType(type, WizEndpointCatalogType.NOT_CATALOGUED, 0, 0);
+      }
+
+      int described = 0;
+
+      for(WizEndpointCatalogEntry entry : catalog.endpoints()) {
+         // Blank counts as absent: a description of whitespace carries no meaning to retrieve by,
+         // and reporting it as described would promise the ingest more than it can index.
+         if(entry != null && entry.description() != null && !entry.description().isBlank()) {
+            described++;
+         }
+      }
+
+      return new WizEndpointCatalogType(type, WizEndpointCatalogType.CATALOGUED,
+                                        catalog.endpoints().size(), described);
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/model/WizDatasourceEntry.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizDatasourceEntry.java
@@ -37,8 +37,14 @@ package inetsoft.web.wiz.model;
  * @param nodeType     the raw {@link inetsoft.web.portal.data.PortalDataType} name, untranslated.
  * @param folder       derived from {@code nodeType}; the client's branch between "enter" and
  *                     "select".
- * @param sourceType   {@code XDataSource.getType()}, e.g. {@code "jdbc"} / {@code "Rest"}. Null for
- *                     folders, and null when the data source could not be loaded.
+ * @param sourceType   {@code XDataSource.getType()}, which is the SPECIFIC connector type — {@code
+ *                     "jdbc"} for a database, {@code "Rest.Stripe"} rather than {@code "Rest"} for a
+ *                     REST connector. The coarse family name is {@code getBaseType()}, a different
+ *                     method that {@code AbstractRestDataSource} overrides to return {@code "Rest"};
+ *                     this field never carries it. That distinction is load-bearing: this value is
+ *                     what joins a data source to its endpoint catalogue, which is keyed by the
+ *                     specific type. Null for folders, and null when the data source could not be
+ *                     loaded.
  * @param databaseType {@code JDBCDataSource.getDatabaseTypeString()}, e.g. {@code "MYSQL"}. Null for
  *                     anything that is not a JDBC database.
  * @param annotationClass

--- a/core/src/main/java/inetsoft/web/wiz/model/WizEndpointCatalogAdmin.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizEndpointCatalogAdmin.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.model;
+
+/**
+ * Whether the caller may administer the deployment-wide endpoint catalogue.
+ *
+ * <p>Exists because the answer cannot be derived outside StyleBI. The system administrator role is
+ * named by the configured security provider, not by a fixed string, and role inheritance has to be
+ * expanded before the question can be answered — which is what
+ * {@code OrganizationManager.isSiteAdmin} does. A client that string-matched the {@code roles} claim
+ * of its token would get a different answer on every deployment that renamed the role, and would
+ * miss every user who holds it by inheritance.</p>
+ *
+ * @param siteAdmin true when the caller holds the system administrator role, directly or by
+ *                  inheritance. Deployments running without security answer true for the default
+ *                  admin principal, so a single-user development install is not locked out.
+ */
+public record WizEndpointCatalogAdmin(boolean siteAdmin) {
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/WizEndpointCatalogType.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizEndpointCatalogType.java
@@ -1,0 +1,52 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.model;
+
+/**
+ * One connector type as the catalogue administration page sees it: what it is called, and how much
+ * of it there is to ingest.
+ *
+ * <p>The type strings are {@code Config.getTabularDataSourceTypes()}, i.e. exactly what
+ * {@code XDataSource.getType()} returns for a data source of that connector — {@code "Rest.Stripe"},
+ * not the {@code "Rest"} of {@code getBaseType()}. That is what makes this list joinable with the
+ * types reported by the data source browser.</p>
+ *
+ * @param type           the registered data source type, e.g. {@code "Rest.Stripe"}.
+ * @param status         {@code CATALOGUED} when the connector ships an {@code endpoints.json};
+ *                       {@code NOT_CATALOGUED} when it loads but ships none — the normal state of a
+ *                       connector that needs user-supplied documentation; {@code UNAVAILABLE} when
+ *                       its plugin could not be loaded or its catalogue could not be read, which is
+ *                       an environment problem and may be retried. Kept as three values rather than
+ *                       a boolean for the reason spelled out on {@link WizEndpointCatalogResponse}:
+ *                       a classification failure must never read as a classification result.
+ * @param endpointCount  endpoints declared, 0 unless {@code CATALOGUED}.
+ * @param describedCount how many of those carry a description. Only described endpoints can be
+ *                       retrieved by meaning, so this is the number that decides what an ingest is
+ *                       worth.
+ */
+public record WizEndpointCatalogType(
+   String type,
+   String status,
+   int endpointCount,
+   int describedCount)
+{
+   public static final String CATALOGUED = "CATALOGUED";
+   public static final String NOT_CATALOGUED = "NOT_CATALOGUED";
+   public static final String UNAVAILABLE = "UNAVAILABLE";
+}

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizDatabaseControllerSecurityTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizDatabaseControllerSecurityTest.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.wiz.controller;
 
+import inetsoft.sree.security.OrganizationManager;
 import inetsoft.sree.security.ResourceAction;
 import inetsoft.sree.security.ResourceType;
 import inetsoft.sree.security.SecurityEngine;
@@ -44,6 +45,7 @@ import inetsoft.web.wiz.service.EndpointCatalogReader;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -99,6 +101,8 @@ class WizDatabaseControllerSecurityTest {
                 "/api/wiz/datasources/search",
                 "/api/wiz/datasources/statuses",
                 "/api/wiz/datasources/endpoint-catalog",
+                "/api/wiz/datasources/endpoint-catalog/types",
+                "/api/wiz/datasources/endpoint-catalog/admin",
                 "/api/wiz/databases/meta",
                 "/api/wiz/databases/template",
                 "/api/wiz/databases/definition",
@@ -456,6 +460,99 @@ class WizDatabaseControllerSecurityTest {
       assertTrue(response.unknownType().isEmpty());
       assertTrue(response.notCatalogued().isEmpty());
       assertTrue(response.catalogs().isEmpty());
+   }
+
+   /**
+    * The catalogue administration page has to offer a choice before anything has been ingested, so
+    * the type list has to come from the registry rather than from what has already been ingested.
+    * {@code getTabularDataSourceTypes} is the enumeration; a non-tabular type could not ship an
+    * {@code endpoints.json} at all and must not appear.
+    */
+   @Test
+   void endpointCatalogTypes_countsDescribedEndpointsSeparatelyFromTheTotal() throws Exception {
+      Fixture fixture = new Fixture();
+      when(fixture.uqlConfig.getTabularDataSourceTypes()).thenReturn(List.of("Rest.Stripe"));
+      when(fixture.uqlConfig.getQueryClass("Rest.Stripe")).thenReturn("plugin.StripeQuery");
+      doReturn(String.class).when(fixture.uqlConfig).getClass("Rest.Stripe", "plugin.StripeQuery");
+      when(fixture.endpointCatalogReader.read(String.class)).thenReturn(new WizEndpointCatalog(
+         List.of(new WizEndpointCatalogEntry("Charges", "Payment attempts.", "/v1/charges",
+                                             Boolean.TRUE, List.of()),
+                 new WizEndpointCatalogEntry("SKUs", null, "/v1/skus", null, List.of()),
+                 // Whitespace is not a description: nothing can be retrieved by it, so counting it
+                 // as described would promise the ingest more than it can index.
+                 new WizEndpointCatalogEntry("Plans", "   ", "/v1/plans", null, List.of()))));
+
+      List<WizEndpointCatalogType> types = fixture.controller.getEndpointCatalogTypes();
+
+      assertEquals(1, types.size());
+      assertEquals("Rest.Stripe", types.get(0).type());
+      assertEquals(WizEndpointCatalogType.CATALOGUED, types.get(0).status());
+      assertEquals(3, types.get(0).endpointCount());
+      assertEquals(1, types.get(0).describedCount(),
+                   "only a non-blank description makes an endpoint retrievable");
+   }
+
+   /**
+    * A connector whose plugin is not installed is an environment problem, and the page may retry it.
+    * Reporting it as NOT_CATALOGUED would tell the administrator the connector has nothing to
+    * ingest, which is a verdict this build is in no position to give.
+    */
+   @Test
+   void endpointCatalogTypes_reportsAnUnloadableConnectorAsUnavailableNotNotCatalogued()
+      throws Exception
+   {
+      Fixture fixture = new Fixture();
+      when(fixture.uqlConfig.getTabularDataSourceTypes()).thenReturn(List.of("Rest.Salesforce"));
+      when(fixture.uqlConfig.getQueryClass("Rest.Salesforce")).thenReturn("plugin.SalesforceQuery");
+      when(fixture.uqlConfig.getClass("Rest.Salesforce", "plugin.SalesforceQuery"))
+         .thenThrow(new ClassNotFoundException("plugin.SalesforceQuery"));
+
+      List<WizEndpointCatalogType> types = fixture.controller.getEndpointCatalogTypes();
+
+      assertEquals(WizEndpointCatalogType.UNAVAILABLE, types.get(0).status());
+      assertEquals(0, types.get(0).endpointCount());
+      verifyNoInteractions(fixture.endpointCatalogReader);
+   }
+
+   /**
+    * A connector that loads but ships no catalogue is the normal state of one needing user-supplied
+    * documentation, and must stay distinguishable from the failure above.
+    */
+   @Test
+   void endpointCatalogTypes_reportsAConnectorWithoutACatalogueAsNotCatalogued() throws Exception {
+      Fixture fixture = new Fixture();
+      when(fixture.uqlConfig.getTabularDataSourceTypes()).thenReturn(List.of("Rest.Custom"));
+      when(fixture.uqlConfig.getQueryClass("Rest.Custom")).thenReturn("plugin.CustomQuery");
+      doReturn(String.class).when(fixture.uqlConfig).getClass("Rest.Custom", "plugin.CustomQuery");
+      when(fixture.endpointCatalogReader.read(String.class)).thenReturn(null);
+
+      List<WizEndpointCatalogType> types = fixture.controller.getEndpointCatalogTypes();
+
+      assertEquals(WizEndpointCatalogType.NOT_CATALOGUED, types.get(0).status());
+   }
+
+   /**
+    * The verdict must come from {@code OrganizationManager}, not from anything the caller can
+    * assert about itself. The system administrator role is named by the configured security
+    * provider and is reachable by inheritance, so a client matching a role name against its own
+    * token claim would be wrong on any deployment that renamed it.
+    */
+   @Test
+   void endpointCatalogAdmin_reportsTheSiteAdminVerdictFromOrganizationManager() {
+      Fixture fixture = new Fixture();
+      OrganizationManager manager = mock(OrganizationManager.class);
+
+      try(MockedStatic<OrganizationManager> statics = mockStatic(OrganizationManager.class)) {
+         statics.when(OrganizationManager::getInstance).thenReturn(manager);
+         when(manager.isSiteAdmin(fixture.principal)).thenReturn(true);
+
+         assertTrue(fixture.controller.getEndpointCatalogAdmin(fixture.principal).siteAdmin());
+
+         when(manager.isSiteAdmin(fixture.principal)).thenReturn(false);
+
+         assertFalse(fixture.controller.getEndpointCatalogAdmin(fixture.principal).siteAdmin(),
+                     "a caller without the system administrator role must not be told it has it");
+      }
    }
 
    /**


### PR DESCRIPTION
Two views the wiz portal needs before it can offer a catalogue ingest. Follow-up to #4653, which added the catalogue itself.

Ingesting a connector's endpoint catalogue is a **deployment-wide** write: the catalogue ships in the connector jar, so every organization on one StyleBI install sees the same content. That makes it a site-administrator action against a global tick list — and neither the identity check nor the list is something wiz can derive on its own.

## `GET /api/wiz/datasources/endpoint-catalog/admin`

Returns `{"siteAdmin": true|false}`.

wiz cannot decide this itself. `OrganizationManager.isSiteAdmin` expands role inheritance through `getAllRoles` and tests each role with `isSystemAdministratorRole`, whose name is provider configuration — so matching role strings out of a JWT cannot reproduce it, and any wiz-side approximation would be wrong on exactly the deployments that configure their own role names.

It **reports rather than enforces**. wiz owns the action being gated; a page that can ask beforehand explains the refusal instead of showing a bare 403. Following `AdminAiController.requireSiteAdmin`, whose javadoc already records this, the call returns `true` for the default principal when security is off, so a development install is not locked out and no `isSecurityEnabled()` branch is needed.

## `GET /api/wiz/datasources/endpoint-catalog/types`

One row per registered tabular type: `type`, `status`, `endpointCount`, `describedCount`, where status is `CATALOGUED` / `NOT_CATALOGUED` / `UNAVAILABLE`.

The portal has to present a tick list *before* anything has been ingested, and only StyleBI knows which types this build registers. It reuses the existing `/endpoint-catalog` resolution chain (`getQueryClass` → `getClass` → `EndpointCatalogReader.read`) so the two endpoints cannot disagree about what a type is.

It carries no permission gate, for the same reason `/endpoint-catalog` does not: it describes installed software, naming no instance and no path. `UNAVAILABLE` connectors are listed rather than hidden — a plugin that failed to load is an environment problem, and hiding it would present that as a fact about the connector.

## A javadoc that said the opposite of what is true

`WizDatasourceEntry.sourceType` documented its value as coarse — `e.g. "jdbc" / "Rest"`. It is not. The field is `XDataSource.getType()`, which carries the **specific** type: `StripeDataSource` passes `TYPE = "Rest.Stripe"` through `super(TYPE, …)` into `XDataSource.type`, and the controller populates the field from `dataSource.getType()`. The coarse family name comes from `getBaseType()`, a different method that `AbstractRestDataSource` overrides to return `"Rest"`, and this field never carries it.

The distinction is load-bearing: this value is the join key between a data source and its endpoint catalogue, which is keyed by the specific type. Read as documented, it says the join is impossible and an API extension is needed — the javadoc is corrected to say which method is which and why it matters.

## Testing

`WizDatabaseControllerSecurityTest` gains 4 cases (existing file — no new test file added for a previously untested path). The site-admin verdict is exercised in both directions via `mockStatic(OrganizationManager.class)`, the idiom already used in `core/src/test`. The suite's frozen request-mapping set is updated so a future endpoint added without a deliberate permission decision still fails it.

```
mvn -pl core test -Dtest=WizDatabaseControllerSecurityTest
Tests run: 23, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)