### PR TITLE
75871, multi-chart hover and animation problems with point and area.

### DIFF
--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
@@ -196,17 +196,12 @@ public class SVGAnimationDOMInjector {
          if(!annotAreas.isEmpty()) {
             Map<String, Integer> areaColorRank = buildAreaColorRank(annotAreas);
 
-            // Only the area measures' own border lines, still in DOM order.  An independent line
-            // measure (bar + area + line binds three) also lands in comboLines, and
-            // injectAreaFillAnimation pairs annotAreas[i] with annotLines[i] positionally —
-            // an interleaved line group shifts that pairing, which silently leaves stacked
-            // fills un-reshaped into bands.
-            List<Element> areaBorderLines = comboLines.stream()
-               .filter(g -> areaColorRank.containsKey(g.getAttribute("data-" + SVGSupport.ATTR_COLOR)))
-               .toList();
+            // An independent line measure (bar + area + line binds three) also lands in comboLines,
+            // so drop it: injectAreaFillAnimation needs the areas' own border lines alone.
+            List<Element> borderLines = areaBorderLines(comboLines, areaColorRank);
 
-            injectAreaFillAnimation(annotAreas, areaBorderLines, doc,
-                                    alignAreaRankToLines(areaColorRank, areaBorderLines,
+            injectAreaFillAnimation(annotAreas, borderLines, doc,
+                                    alignAreaRankToLines(areaColorRank, borderLines,
                                                          comboSeriesRank),
                                     Math.max(comboSeriesRank.size(), areaColorRank.size()));
          }
@@ -1347,8 +1342,25 @@ public class SVGAnimationDOMInjector {
 
       int numLineSeries = lineSeriesRank.size();
       int numAreaSeries = areaColorRank.size();
-      int numSeries     = Math.max(numLineSeries, numAreaSeries);
       boolean isAreaChart = !annotAreas.isEmpty();
+
+      // The hint reaches here whenever the graph has a LineVO or an AreaVO and no bar, so an area
+      // measure can arrive beside an independent line measure ("area + trend line", no bars).  Rank
+      // the areas first, then give each remaining line colour a slot of its own after them: matching
+      // every line through areaColorRank alone would collapse an independent line to the default 0
+      // and draw it on top of the first area's timeline.  Area colours keep the ranks
+      // buildAreaColorRank gave them, so a pure area or pure line chart is unaffected.
+      Map<String, Integer> areaChartLineRank = new LinkedHashMap<>(areaColorRank);
+
+      if(isAreaChart) {
+         for(Element g : annotLines) {
+            areaChartLineRank.putIfAbsent(g.getAttribute("data-" + SVGSupport.ATTR_COLOR),
+                                          areaChartLineRank.size());
+         }
+      }
+
+      int numSeries = isAreaChart ? areaChartLineRank.size()
+                                  : Math.max(numLineSeries, numAreaSeries);
       // Dots and value labels appear after all series have finished their line animation.
       double dotDelay = AnimationConstants.staggerDelay(numSeries - 1, numSeries)
                         + AnimationConstants.DURATION + AnimationConstants.READY_BUFFER;
@@ -1377,7 +1389,7 @@ public class SVGAnimationDOMInjector {
 
          if(isAreaChart) {
             String color = g.getAttribute("data-" + SVGSupport.ATTR_COLOR);
-            seriesIdx = areaColorRank.getOrDefault(color, 0);
+            seriesIdx = areaChartLineRank.getOrDefault(color, 0);
          }
          else {
             seriesIdx = lineSeriesRank.getOrDefault(seriesKey(g), 0);
@@ -1414,8 +1426,12 @@ public class SVGAnimationDOMInjector {
          applyLineDrawAnimation(g, path, delay);
       }
 
-      // Area fill groups — wipe left-to-right, then reshape stacked fills into bands.
-      injectAreaFillAnimation(annotAreas, annotLines, doc, areaColorRank, numSeries);
+      // Area fill groups — wipe left-to-right, then reshape stacked fills into bands.  Only the
+      // areas' own border lines: injectAreaFillAnimation pairs them with annotAreas positionally,
+      // and an independent line measure interleaved in DOM order would shift that pairing and
+      // silently skip the band reshaping (same reason the multi-style branch filters).
+      injectAreaFillAnimation(annotAreas, areaBorderLines(annotLines, areaColorRank), doc,
+                              areaColorRank, numSeries);
 
       // Inject ghost fills in reverse so earlier (lower-indexed) series render behind later ones.
       for(int gi = ghostFills.size() - 1; gi >= 0; gi--) {
@@ -1501,6 +1517,22 @@ public class SVGAnimationDOMInjector {
    }
 
    /**
+    * The area measures' own border lines, in DOM order — the line groups whose {@code data-color}
+    * belongs to an area series, with any independent line measure's groups dropped.
+    *
+    * <p>{@link #injectAreaFillAnimation} pairs {@code annotAreas[i]} with {@code annotLines[i]}
+    * positionally, so an unrelated line group interleaved in DOM order shifts the pairing and makes
+    * the band reshaping fall through its colour-equality guard.
+    */
+   private static List<Element> areaBorderLines(List<Element> annotLines,
+                                                Map<String, Integer> areaColorRank)
+   {
+      return annotLines.stream()
+         .filter(g -> areaColorRank.containsKey(g.getAttribute("data-" + SVGSupport.ATTR_COLOR)))
+         .toList();
+   }
+
+   /**
     * Re-point an area color rank at the stagger ranks its border lines actually got, so a fill and
     * its own border line animate at the same moment.
     *
@@ -1556,7 +1588,8 @@ public class SVGAnimationDOMInjector {
     *
     * <p>{@code annotLines} must hold only the areas' border lines, in DOM order: {@code annotAreas}
     * and {@code annotLines} are paired by position (see below), so any unrelated line group mixed in
-    * would shift the pairing and skip band reshaping.
+    * would shift the pairing and skip band reshaping.  Both call sites narrow the list through
+    * {@link #areaBorderLines} to satisfy this.
     *
     * <p>The caller must have emitted the {@code inetsoft-line-wipe} keyframes.
     *

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
@@ -183,21 +183,32 @@ public class SVGAnimationDOMInjector {
             .filter(g -> !"true".equals(g.getAttribute("data-" + SVGSupport.ATTR_PARETO)))
             .toList();
 
-         int numComboSeries = 0;
+         Map<String, Integer> comboSeriesRank = Map.of();
 
          if(!comboLines.isEmpty()) {
-            numComboSeries = injectComboLineAnimation(comboLines, svgRoot, doc);
+            comboSeriesRank = injectComboLineAnimation(comboLines, svgRoot, doc);
          }
 
          // An area measure's border line is a LineVO annotation animated as a combo line above,
          // but AreaVO's fill polygon is a separate inetsoft-area group that no branch here
          // touched — so the fill appeared instantly while everything around it animated.  Wipe it
-         // in on the same timeline, reusing the denominator the border lines were staggered with
-         // so a fill and its own border move in step.
+         // in on the same timeline as its own border line so the two move in step.
          if(!annotAreas.isEmpty()) {
             Map<String, Integer> areaColorRank = buildAreaColorRank(annotAreas);
-            injectAreaFillAnimation(annotAreas, comboLines, doc, areaColorRank,
-                                    Math.max(numComboSeries, areaColorRank.size()));
+
+            // Only the area measures' own border lines, still in DOM order.  An independent line
+            // measure (bar + area + line binds three) also lands in comboLines, and
+            // injectAreaFillAnimation pairs annotAreas[i] with annotLines[i] positionally —
+            // an interleaved line group shifts that pairing, which silently leaves stacked
+            // fills un-reshaped into bands.
+            List<Element> areaBorderLines = comboLines.stream()
+               .filter(g -> areaColorRank.containsKey(g.getAttribute("data-" + SVGSupport.ATTR_COLOR)))
+               .toList();
+
+            injectAreaFillAnimation(annotAreas, areaBorderLines, doc,
+                                    alignAreaRankToLines(areaColorRank, areaBorderLines,
+                                                         comboSeriesRank),
+                                    Math.max(comboSeriesRank.size(), areaColorRank.size()));
          }
 
          // Gantt charts have interval bars plus a milestone point marker (a separate
@@ -1256,11 +1267,12 @@ public class SVGAnimationDOMInjector {
     *
     * <p>The caller must have emitted the keyframes via {@link #appendLineDrawKeyframes}.
     *
-    * @return the stagger denominator used, so an area measure's fills can be wiped in on the
-    *         same timeline as their border lines.
+    * @return the {@link #buildSeriesRank} map these lines were staggered with, so an area
+    *         measure's fills can be wiped in on the same timeline as their own border lines
+    *         (see {@link #alignAreaRankToLines}).  Its size is the stagger denominator.
     */
-   private static int injectComboLineAnimation(List<Element> comboLines,
-                                               Element svgRoot, Document doc)
+   private static Map<String, Integer> injectComboLineAnimation(List<Element> comboLines,
+                                                                Element svgRoot, Document doc)
    {
       Map<String, Integer> seriesRank = buildSeriesRank(comboLines);
       int numSeries = seriesRank.size();
@@ -1277,7 +1289,7 @@ public class SVGAnimationDOMInjector {
          applyLineDrawAnimation(g, path, delay);
       }
 
-      return numSeries;
+      return seriesRank;
    }
 
    /**
@@ -1489,24 +1501,76 @@ public class SVGAnimationDOMInjector {
    }
 
    /**
+    * Re-point an area color rank at the stagger ranks its border lines actually got, so a fill and
+    * its own border line animate at the same moment.
+    *
+    * <p>Needed because the two rank maps count different populations.  In the multi-style branch of
+    * {@link #injectAnimation} the border lines are ranked by {@link #buildSeriesRank} over
+    * <em>every</em> combo line, which includes any independent line measure; {@code areaColorRank}
+    * is built from the area groups alone and never sees that extra line.  A third measure therefore
+    * shifts the border line's ordinal without shifting the fill's.  Sharing the stagger denominator
+    * is not enough to cover that: {@link AnimationConstants#staggerDelay(int, int)} multiplies the
+    * <em>index</em> by the window, so differing indices mean differing delays — the exact fill/border
+    * desync this alignment prevents.
+    *
+    * <p>Keys are preserved verbatim, so the returned map still has one entry per area series and can
+    * stand in for {@code areaColorRank} wherever its size drives panel chunking.  A color with no
+    * matching border line keeps its DOM rank.
+    *
+    * @param areaColorRank   {@code data-color} → DOM rank, from {@link #buildAreaColorRank}.
+    * @param areaBorderLines the areas' border line groups.
+    * @param lineSeriesRank  the rank map the border lines were staggered with.
+    */
+   private static Map<String, Integer> alignAreaRankToLines(Map<String, Integer> areaColorRank,
+                                                           List<Element> areaBorderLines,
+                                                           Map<String, Integer> lineSeriesRank)
+   {
+      Map<String, Integer> lineRankByColor = new LinkedHashMap<>();
+
+      for(Element g : areaBorderLines) {
+         Integer rank = lineSeriesRank.get(seriesKey(g));
+
+         if(rank != null) {
+            lineRankByColor.putIfAbsent(g.getAttribute("data-" + SVGSupport.ATTR_COLOR), rank);
+         }
+      }
+
+      Map<String, Integer> aligned = new LinkedHashMap<>();
+
+      for(Map.Entry<String, Integer> e : areaColorRank.entrySet()) {
+         aligned.put(e.getKey(), lineRankByColor.getOrDefault(e.getKey(), e.getValue()));
+      }
+
+      return aligned;
+   }
+
+   /**
     * Animate area fill groups: a left-to-right wipe per series, then reshape stacked fills into
     * non-overlapping bands.
     *
     * <p>Shared by {@link #injectLineAnimationFromAnnotations} (standalone area chart) and the
     * multi-style branch of {@link #injectAnimation}, where an area measure is drawn beside bars.
     * That branch animates the fill's border line through {@link #injectComboLineAnimation} and
-    * passes the same {@code numSeries} denominator here, so a fill and its border stay in step.
+    * runs the resulting ranks through {@link #alignAreaRankToLines}, so a fill and its own border
+    * stay in step.
     *
-    * <p>{@code numSeries} is the stagger denominator, which may exceed the number of area series
-    * when line measures are present; panel chunking uses {@code areaColorRank} instead.
+    * <p>{@code annotLines} must hold only the areas' border lines, in DOM order: {@code annotAreas}
+    * and {@code annotLines} are paired by position (see below), so any unrelated line group mixed in
+    * would shift the pairing and skip band reshaping.
     *
     * <p>The caller must have emitted the {@code inetsoft-line-wipe} keyframes.
+    *
+    * @param areaStaggerRank {@code data-color} → 0-based stagger index, one entry per area series.
+    *                        Values set each fill's delay; the map's size drives panel chunking.
+    * @param numSeries       the stagger denominator, which may exceed the number of area series when
+    *                        line measures are present.
     */
    private static void injectAreaFillAnimation(List<Element> annotAreas, List<Element> annotLines,
-                                               Document doc, Map<String, Integer> areaColorRank,
+                                               Document doc,
+                                               Map<String, Integer> areaStaggerRank,
                                                int numSeries)
    {
-      int numAreaSeries = areaColorRank.size();
+      int numAreaSeries = areaStaggerRank.size();
 
       // Area fill groups — wipe left-to-right; reshape into non-overlapping bands.
       //
@@ -1527,7 +1591,7 @@ public class SVGAnimationDOMInjector {
          }
 
          String color     = g.getAttribute("data-" + SVGSupport.ATTR_COLOR);
-         int    seriesIdx = areaColorRank.getOrDefault(color, 0);
+         int    seriesIdx = areaStaggerRank.getOrDefault(color, 0);
          double delay     = AnimationConstants.staggerDelay(seriesIdx, numSeries);
 
          // Collect the panel-local line path for band polygon computation below.

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
@@ -65,7 +65,7 @@ public class SVGAnimationDOMInjector {
 
       String base = animHint.split(":")[0];
 
-      appendHoverCSS(svgRoot, doc);
+      appendHoverCSS(svgRoot, doc, animHint);
 
       // Hover-only mode (design-time surfaces): the hover-dim CSS injected above is enough for
       // highlighting to work, but the entrance animation must be suppressed. Return before
@@ -149,12 +149,14 @@ public class SVGAnimationDOMInjector {
          animated = true;
 
          List<Element> annotLines = collectAnnotationGroups(svgRoot, SVGSupport.ANNOTATION_LINE);
+         List<Element> annotAreas = collectAnnotationGroups(svgRoot, SVGSupport.ANNOTATION_AREA);
 
          // Both line helpers below use the same draw-on/wipe keyframes and can run in the same
          // invocation (a chart with a Pareto line and an unrelated multi-style line measure), so
-         // the keyframes are emitted here exactly once.  Guarded on annotLines so a plain bar
-         // chart is not given line CSS it never references.
-         if(!annotLines.isEmpty()) {
+         // the keyframes are emitted here exactly once.  Guarded on annotLines/annotAreas so a
+         // plain bar chart is not given line CSS it never references.  An area measure always
+         // brings its own border lines, so the annotAreas half of the guard is belt-and-braces.
+         if(!annotLines.isEmpty() || !annotAreas.isEmpty()) {
             appendLineDrawKeyframes(svgRoot, doc);
          }
 
@@ -181,8 +183,21 @@ public class SVGAnimationDOMInjector {
             .filter(g -> !"true".equals(g.getAttribute("data-" + SVGSupport.ATTR_PARETO)))
             .toList();
 
+         int numComboSeries = 0;
+
          if(!comboLines.isEmpty()) {
-            injectComboLineAnimation(comboLines, svgRoot, doc);
+            numComboSeries = injectComboLineAnimation(comboLines, svgRoot, doc);
+         }
+
+         // An area measure's border line is a LineVO annotation animated as a combo line above,
+         // but AreaVO's fill polygon is a separate inetsoft-area group that no branch here
+         // touched — so the fill appeared instantly while everything around it animated.  Wipe it
+         // in on the same timeline, reusing the denominator the border lines were staggered with
+         // so a fill and its own border move in step.
+         if(!annotAreas.isEmpty()) {
+            Map<String, Integer> areaColorRank = buildAreaColorRank(annotAreas);
+            injectAreaFillAnimation(annotAreas, comboLines, doc, areaColorRank,
+                                    Math.max(numComboSeries, areaColorRank.size()));
          }
 
          // Gantt charts have interval bars plus a milestone point marker (a separate
@@ -1240,9 +1255,12 @@ public class SVGAnimationDOMInjector {
     * the line would obscure the bars it overlays.
     *
     * <p>The caller must have emitted the keyframes via {@link #appendLineDrawKeyframes}.
+    *
+    * @return the stagger denominator used, so an area measure's fills can be wiped in on the
+    *         same timeline as their border lines.
     */
-   private static void injectComboLineAnimation(List<Element> comboLines,
-                                                Element svgRoot, Document doc)
+   private static int injectComboLineAnimation(List<Element> comboLines,
+                                               Element svgRoot, Document doc)
    {
       Map<String, Integer> seriesRank = buildSeriesRank(comboLines);
       int numSeries = seriesRank.size();
@@ -1258,6 +1276,8 @@ public class SVGAnimationDOMInjector {
             seriesRank.getOrDefault(seriesKey(g), 0), numSeries);
          applyLineDrawAnimation(g, path, delay);
       }
+
+      return numSeries;
    }
 
    /**
@@ -1311,16 +1331,7 @@ public class SVGAnimationDOMInjector {
       // documented for area below).
       Map<String, Integer> lineSeriesRank = buildSeriesRank(annotLines);
 
-      // Area rank: data-color in DOM first-seen order.
-      // AreaVO.getColIndex() is unreliable for ordering — in stacked area charts all AreaVO
-      // instances share the same measure column index.  data-color is unique per series and
-      // preserves DOM (visual) order, so it gives the correct stagger without extra metadata.
-      Map<String, Integer> areaColorRank = new LinkedHashMap<>();
-
-      for(Element g : annotAreas) {
-         String color = g.getAttribute("data-" + SVGSupport.ATTR_COLOR);
-         areaColorRank.putIfAbsent(color, areaColorRank.size());
-      }
+      Map<String, Integer> areaColorRank = buildAreaColorRank(annotAreas);
 
       int numLineSeries = lineSeriesRank.size();
       int numAreaSeries = areaColorRank.size();
@@ -1390,6 +1401,112 @@ public class SVGAnimationDOMInjector {
 
          applyLineDrawAnimation(g, path, delay);
       }
+
+      // Area fill groups — wipe left-to-right, then reshape stacked fills into bands.
+      injectAreaFillAnimation(annotAreas, annotLines, doc, areaColorRank, numSeries);
+
+      // Inject ghost fills in reverse so earlier (lower-indexed) series render behind later ones.
+      for(int gi = ghostFills.size() - 1; gi >= 0; gi--) {
+         GhostFillInfo gf = ghostFills.get(gi);
+         injectGhostFill(doc, gf.panel, gf.insertBeforeGroup, gf.polygon,
+                         gf.rgb, gf.delay, ghostFills.size(), gi, gf.transform,
+                         gf.clipPath);
+      }
+
+      // Dot groups: siblings of annotated line groups that contain point markers.
+      // Only look within panels that already have annotated lines — avoids full-SVG scan.
+      Set<Element> processedParents = Collections.newSetFromMap(new IdentityHashMap<>());
+
+      for(Element g : annotLines) {
+         Element parent = (Element) g.getParentNode();
+
+         if(parent == null || !processedParents.add(parent)) {
+            continue;
+         }
+
+         NodeList siblings = parent.getChildNodes();
+
+         for(int i = 0; i < siblings.getLength(); i++) {
+            if(!(siblings.item(i) instanceof Element sibling)) {
+               continue;
+            }
+
+            String sibClass = sibling.getAttribute("class");
+
+            // inetsoft-point annotation groups on a line chart (PointVO paints markers that
+            // sit on top of the line). Fade them in after all series have started drawing so
+            // the dot appears after, not before, its line.
+            if(SVGSupport.ANNOTATION_POINT.equals(sibClass)) {
+               mergeStyle(sibling, String.format(
+                  "opacity:0;animation:inetsoft-line-fade %.2fs %s %.2fs both",
+                  AnimationConstants.DURATION, AnimationConstants.EASING, dotDelay));
+               continue;
+            }
+
+            // Skip all other annotated groups (they have an inetsoft-* class) and non-<g> elements.
+            if(!"g".equals(sibling.getLocalName()) || !sibClass.isEmpty()) {
+               continue;
+            }
+
+            if(classifyLineGroup(sibling) == LineGroupType.DOTS) {
+               for(Element circle : childCircles(sibling)) {
+                  mergeStyle(circle, String.format(
+                     "opacity:0;animation:inetsoft-line-fade %.2fs %s %.2fs both",
+                     AnimationConstants.DURATION, AnimationConstants.EASING, dotDelay));
+               }
+            }
+         }
+      }
+
+      // Pass 5: data value label groups — delay until after all lines have drawn.
+      List<Element> valueLabelGroups = new ArrayList<>();
+      collectTextGroups(svgRoot, valueLabelGroups);
+
+      for(Element labelG : valueLabelGroups) {
+         mergeStyle(labelG, String.format(java.util.Locale.US,
+            "opacity:0;animation:inetsoft-line-fade %.2fs %s %.2fs both",
+            AnimationConstants.DURATION, AnimationConstants.EASING, dotDelay));
+      }
+
+   }
+
+   /**
+    * Rank area fill groups into stagger order: {@code data-color} → 0-based rank in DOM
+    * first-seen order.
+    *
+    * <p>{@code AreaVO.getColIndex()} is unreliable for ordering — in a stacked area chart every
+    * AreaVO shares the same measure column index, so every fill would rank 0 and wipe at once.
+    * {@code data-color} is unique per series and preserves DOM (visual) order.
+    */
+   private static Map<String, Integer> buildAreaColorRank(List<Element> annotAreas) {
+      Map<String, Integer> rank = new LinkedHashMap<>();
+
+      for(Element g : annotAreas) {
+         rank.putIfAbsent(g.getAttribute("data-" + SVGSupport.ATTR_COLOR), rank.size());
+      }
+
+      return rank;
+   }
+
+   /**
+    * Animate area fill groups: a left-to-right wipe per series, then reshape stacked fills into
+    * non-overlapping bands.
+    *
+    * <p>Shared by {@link #injectLineAnimationFromAnnotations} (standalone area chart) and the
+    * multi-style branch of {@link #injectAnimation}, where an area measure is drawn beside bars.
+    * That branch animates the fill's border line through {@link #injectComboLineAnimation} and
+    * passes the same {@code numSeries} denominator here, so a fill and its border stay in step.
+    *
+    * <p>{@code numSeries} is the stagger denominator, which may exceed the number of area series
+    * when line measures are present; panel chunking uses {@code areaColorRank} instead.
+    *
+    * <p>The caller must have emitted the {@code inetsoft-line-wipe} keyframes.
+    */
+   private static void injectAreaFillAnimation(List<Element> annotAreas, List<Element> annotLines,
+                                               Document doc, Map<String, Integer> areaColorRank,
+                                               int numSeries)
+   {
+      int numAreaSeries = areaColorRank.size();
 
       // Area fill groups — wipe left-to-right; reshape into non-overlapping bands.
       //
@@ -1492,70 +1609,6 @@ public class SVGAnimationDOMInjector {
             }
          }
       }
-
-      // Inject ghost fills in reverse so earlier (lower-indexed) series render behind later ones.
-      for(int gi = ghostFills.size() - 1; gi >= 0; gi--) {
-         GhostFillInfo gf = ghostFills.get(gi);
-         injectGhostFill(doc, gf.panel, gf.insertBeforeGroup, gf.polygon,
-                         gf.rgb, gf.delay, ghostFills.size(), gi, gf.transform,
-                         gf.clipPath);
-      }
-
-      // Dot groups: siblings of annotated line groups that contain point markers.
-      // Only look within panels that already have annotated lines — avoids full-SVG scan.
-      Set<Element> processedParents = Collections.newSetFromMap(new IdentityHashMap<>());
-
-      for(Element g : annotLines) {
-         Element parent = (Element) g.getParentNode();
-
-         if(parent == null || !processedParents.add(parent)) {
-            continue;
-         }
-
-         NodeList siblings = parent.getChildNodes();
-
-         for(int i = 0; i < siblings.getLength(); i++) {
-            if(!(siblings.item(i) instanceof Element sibling)) {
-               continue;
-            }
-
-            String sibClass = sibling.getAttribute("class");
-
-            // inetsoft-point annotation groups on a line chart (PointVO paints markers that
-            // sit on top of the line). Fade them in after all series have started drawing so
-            // the dot appears after, not before, its line.
-            if(SVGSupport.ANNOTATION_POINT.equals(sibClass)) {
-               mergeStyle(sibling, String.format(
-                  "opacity:0;animation:inetsoft-line-fade %.2fs %s %.2fs both",
-                  AnimationConstants.DURATION, AnimationConstants.EASING, dotDelay));
-               continue;
-            }
-
-            // Skip all other annotated groups (they have an inetsoft-* class) and non-<g> elements.
-            if(!"g".equals(sibling.getLocalName()) || !sibClass.isEmpty()) {
-               continue;
-            }
-
-            if(classifyLineGroup(sibling) == LineGroupType.DOTS) {
-               for(Element circle : childCircles(sibling)) {
-                  mergeStyle(circle, String.format(
-                     "opacity:0;animation:inetsoft-line-fade %.2fs %s %.2fs both",
-                     AnimationConstants.DURATION, AnimationConstants.EASING, dotDelay));
-               }
-            }
-         }
-      }
-
-      // Pass 5: data value label groups — delay until after all lines have drawn.
-      List<Element> valueLabelGroups = new ArrayList<>();
-      collectTextGroups(svgRoot, valueLabelGroups);
-
-      for(Element labelG : valueLabelGroups) {
-         mergeStyle(labelG, String.format(java.util.Locale.US,
-            "opacity:0;animation:inetsoft-line-fade %.2fs %s %.2fs both",
-            AnimationConstants.DURATION, AnimationConstants.EASING, dotDelay));
-      }
-
    }
 
    // -------------------------------------------------------------------------
@@ -3423,7 +3476,7 @@ public class SVGAnimationDOMInjector {
     * <p>The {@code :has()} selector requires Chrome 105+, Firefox 121+, Safari 15.4+.
     * On older browsers the dim rules are silently ignored.
     */
-   private static void appendHoverCSS(Element svgRoot, Document doc) {
+   private static void appendHoverCSS(Element svgRoot, Document doc, String animHint) {
       String dim = String.format(java.util.Locale.US, "%.2f", AnimationConstants.HOVER_DIM_OPACITY);
       String tr  = AnimationConstants.HOVER_TRANSITION;
       appendStyle(svgRoot, doc,
@@ -3507,6 +3560,54 @@ public class SVGAnimationDOMInjector {
          // applies to area charts as well. That is intentional — the opacity transition gives
          // area series a smooth fade-in/fade-out on hover, exactly as for pure line series.
          ".inetsoft-line{pointer-events:all;transition:" + tr + "}");
+
+      appendMultiStyleHoverCSS(svgRoot, doc, animHint, dim);
+   }
+
+   /**
+    * Inject the cross-chart-type hover dim rules for a multi-style chart.
+    *
+    * <p>Every rule emitted by {@link #appendHoverCSS} has the same annotation class in its
+    * {@code :has()} trigger as in its target, so an active bar can only ever dim other bars and an
+    * active point only other points.  A multi-style chart binds a chart type per measure, so one
+    * SVG holds a bar measure's {@code inetsoft-bar} groups next to a point measure's
+    * {@code inetsoft-point} groups, and hovering either left the other fully lit.  These rules dim
+    * across the two types so the hovered VO is the only bright thing in the plot.
+    *
+    * <p>Emitted only when the SVG really is a bar+point multi-style chart, because two
+    * <em>single</em>-style charts also draw both annotations and must keep their current behavior:
+    * <ul>
+    *   <li>Gantt — interval bars plus a {@code PointElement} milestone per bar.  A milestone marks
+    *       the end of its own bar, so a bar hover must not fade it.  Excluded by the gantt flag.</li>
+    *   <li>Box plot — boxes plus outlier points.  Excluded implicitly: {@code BoxVO} emits
+    *       {@code inetsoft-box}, so no {@code inetsoft-bar} group is present.</li>
+    * </ul>
+    *
+    * <p>Both directions are gated on {@code svg.ready} like every other point rule: point markers
+    * animate their own opacity (A1), so dimming them before the entrance animation completes would
+    * fight its fill-mode.  Line/area measures of a multi-style chart are not covered here — they
+    * carry no {@code inetsoft-active} class at all and are dimmed by the Angular directive's
+    * inline-opacity mechanism instead.
+    */
+   private static void appendMultiStyleHoverCSS(Element svgRoot, Document doc, String animHint,
+                                                String dim)
+   {
+      // The base hint is the first token and ":" is the separator, so a ":gantt" substring match is
+      // unambiguous (no base hint or other flag contains "gantt").
+      boolean gantt = animHint.contains(":" + SVGSupport.ANIMATION_FLAG_GANTT);
+
+      if(gantt || collectAnnotationGroups(svgRoot, SVGSupport.ANNOTATION_BAR).isEmpty() ||
+         collectAnnotationGroups(svgRoot, SVGSupport.ANNOTATION_POINT).isEmpty())
+      {
+         return;
+      }
+
+      appendStyle(svgRoot, doc,
+         "svg.ready:has(.inetsoft-bar.inetsoft-active) .inetsoft-point:not(.inetsoft-active)," +
+         "svg.ready:has(.inetsoft-bar.inetsoft-active) .inetsoft-point-label:not(.inetsoft-active)," +
+         "svg.ready:has(.inetsoft-point.inetsoft-active) .inetsoft-bar:not(.inetsoft-active)," +
+         "svg.ready:has(.inetsoft-point.inetsoft-active) .inetsoft-bar-label:not(.inetsoft-active)" +
+         "{opacity:" + dim + "!important}");
    }
 
    // -------------------------------------------------------------------------

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
@@ -1294,6 +1294,62 @@ class SVGAnimationDOMInjectorTest {
                  "both kept their original d (A=" + newA + ", B=" + newB + ")");
    }
 
+   /**
+    * The ANIMATION_LINE hint is not limited to a pure area chart: VGraphPair.hasLineVO is true for
+    * an AreaVO as well as a LineVO, so an area measure bound beside an independent line measure with
+    * no bar ("area + trend line") lands here too.  Every line was then ranked through the area
+    * colour rank, which the independent line's colour is absent from — it fell back to 0 and drew on
+    * the first area's timeline instead of taking a slot of its own.
+    */
+   @Test
+   void areaChartIndependentLineMeasureGetsItsOwnStaggerSlot() throws Exception {
+      Document doc = newDocument();
+      Element svg = doc.getDocumentElement();
+      addLineAreaPair(doc, svg, "10,20,30", "0", "M0 100 L50 60 L100 80 L100 100 L0 100 Z",
+                      "M0 100 L50 60 L100 80");
+      addLineGroup(doc, svg, "200,10,10", "2", "M0 90 L50 40 L100 70");
+      addLineAreaPair(doc, svg, "40,50,60", "1", "M0 60 L50 30 L100 50 L100 100 L0 100 Z",
+                      "M0 60 L50 30 L100 50");
+
+      SVGAnimationDOMInjector.injectAnimation(svg, SVGSupport.ANIMATION_LINE);
+
+      double areaADelay = animationDelayOf(
+         firstDescendantPathOf(borderLineOf(svg, "10,20,30")).getAttribute("style"));
+      double lineDelay = animationDelayOf(
+         firstDescendantPathOf(borderLineOf(svg, "200,10,10")).getAttribute("style"));
+
+      // Two areas plus the line measure — three slots, so the line ranks last at the full window.
+      assertEquals(2.0, lineDelay, 0.001,
+                   "an independent line measure must stagger after both area series");
+      assertNotEquals(areaADelay, lineDelay,
+                      "an independent line measure must not share the first area's delay");
+   }
+
+   /**
+    * Band reshaping pairs annotAreas[i] with annotLines[i] positionally, so the ANIMATION_LINE call
+    * site needs the areas' own border lines alone — exactly like the multi-style branch.  An
+    * interleaved independent line measure shifted the pairing and the colour-equality guard then
+    * silently skipped the reshaping, leaving stacked fills overlapping.
+    */
+   @Test
+   void areaChartStackedFillsAreStillReshapedWhenALineMeasureIsBound() throws Exception {
+      Document doc = newDocument();
+      Element svg = doc.getDocumentElement();
+      String fillA = "M0 100 L50 60 L100 80 L100 100 L0 100 Z";
+      String fillB = "M0 60 L50 30 L100 50 L100 100 L0 100 Z";
+      Element areaA = addLineAreaPair(doc, svg, "10,20,30", "0", fillA, "M0 100 L50 60 L100 80");
+      addLineGroup(doc, svg, "200,10,10", "2", "M0 90 L50 40 L100 70");
+      Element areaB = addLineAreaPair(doc, svg, "40,50,60", "1", fillB, "M0 60 L50 30 L100 50");
+
+      SVGAnimationDOMInjector.injectAnimation(svg, SVGSupport.ANIMATION_LINE);
+
+      String newA = firstDescendantPathOf(areaA).getAttribute("d");
+      String newB = firstDescendantPathOf(areaB).getAttribute("d");
+      assertTrue(!fillA.equals(newA) || !fillB.equals(newB),
+                 "one of two overlapping area fills must be rewritten into a band polygon, but " +
+                 "both kept their original d (A=" + newA + ", B=" + newB + ")");
+   }
+
    /** A plain bar chart references no line/area keyframes, so none may be emitted. */
    @Test
    void plainBarChartGetsNoLineOrWipeKeyframes() throws Exception {

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
@@ -1226,6 +1226,74 @@ class SVGAnimationDOMInjectorTest {
                  "the wipe keyframes must be emitted for a multi-style area measure");
    }
 
+   /**
+    * Bar + area + an independent line measure — three measures, three chart types.  The border
+    * lines are staggered by a rank over every combo line, which counts that third measure, while
+    * the fills were staggered by a rank built from the area groups alone, which does not.  The
+    * extra line shifted the border line's index without shifting its fill's, and since
+    * staggerDelay multiplies the index by the window, sharing the denominator did not save them:
+    * an area's fill wiped in while its own outline was still waiting to draw.
+    */
+   @Test
+   void multiStyleAreaFillStaysInStepWithItsBorderLineWhenALineMeasureIsBound() throws Exception {
+      Document doc = newDocument();
+      Element svg = doc.getDocumentElement();
+      addAnnotGroup(doc, SVGSupport.ANNOTATION_BAR, Map.of("row", "0", "col", "0"),
+                    10, 10, 20, 100);
+      // DOM order: area A + its border, the independent line measure, then area B + its border.
+      // The interleaved line is what pushes area B's border line rank past its fill's.
+      Element areaA = addLineAreaPair(doc, svg, "10,20,30", "0",
+                                      "M0 100 L50 60 L100 80 L100 100 L0 100 Z",
+                                      "M0 100 L50 60 L100 80");
+      addLineGroup(doc, svg, "200,10,10", "2", "M0 90 L50 40 L100 70");
+      Element areaB = addLineAreaPair(doc, svg, "40,50,60", "1",
+                                      "M0 60 L50 30 L100 50 L100 100 L0 100 Z",
+                                      "M0 60 L50 30 L100 50");
+
+      SVGAnimationDOMInjector.injectAnimation(svg, SVGSupport.ANIMATION_GROW);
+
+      for(Element area : List.of(areaA, areaB)) {
+         String color      = area.getAttribute("data-color");
+         Element fillPath  = firstDescendantPathOf(area);
+         Element borderPath = firstDescendantPathOf(borderLineOf(svg, color));
+         assertNotNull(fillPath, "area " + color + " must still hold its fill path");
+         assertNotNull(borderPath, "area " + color + " must still hold its border line path");
+
+         double fillDelay   = animationDelayOf(fillPath.getAttribute("style"));
+         double borderDelay = animationDelayOf(borderPath.getAttribute("style"));
+         assertEquals(borderDelay, fillDelay, 0.001,
+                      "area " + color + " fill must wipe in at the same moment its own border " +
+                      "line draws, but fill was " + fillDelay + "s and border " + borderDelay + "s");
+      }
+   }
+
+   /**
+    * Area fills are reshaped into non-overlapping bands by pairing annotAreas[i] with
+    * annotLines[i] positionally.  An independent line measure lands in the same combo-line list,
+    * so it shifted that pairing: the color-equality guard then found no matching border line and
+    * the band reshaping was silently skipped, leaving stacked fills overlapping.
+    */
+   @Test
+   void multiStyleStackedAreaFillsAreStillReshapedWhenALineMeasureIsBound() throws Exception {
+      Document doc = newDocument();
+      Element svg = doc.getDocumentElement();
+      addAnnotGroup(doc, SVGSupport.ANNOTATION_BAR, Map.of("row", "0", "col", "0"),
+                    10, 10, 20, 100);
+      String fillA = "M0 100 L50 60 L100 80 L100 100 L0 100 Z";
+      String fillB = "M0 60 L50 30 L100 50 L100 100 L0 100 Z";
+      Element areaA = addLineAreaPair(doc, svg, "10,20,30", "0", fillA, "M0 100 L50 60 L100 80");
+      addLineGroup(doc, svg, "200,10,10", "2", "M0 90 L50 40 L100 70");
+      Element areaB = addLineAreaPair(doc, svg, "40,50,60", "1", fillB, "M0 60 L50 30 L100 50");
+
+      SVGAnimationDOMInjector.injectAnimation(svg, SVGSupport.ANIMATION_GROW);
+
+      String newA = firstDescendantPathOf(areaA).getAttribute("d");
+      String newB = firstDescendantPathOf(areaB).getAttribute("d");
+      assertTrue(!fillA.equals(newA) || !fillB.equals(newB),
+                 "one of two overlapping area fills must be rewritten into a band polygon, but " +
+                 "both kept their original d (A=" + newA + ", B=" + newB + ")");
+   }
+
    /** A plain bar chart references no line/area keyframes, so none may be emitted. */
    @Test
    void plainBarChartGetsNoLineOrWipeKeyframes() throws Exception {
@@ -1251,11 +1319,21 @@ class SVGAnimationDOMInjectorTest {
    private static Element addLineAreaPair(Document doc, Element svg,
                                            String color, String fillD, String lineD)
    {
+      return addLineAreaPair(doc, svg, color, "0", fillD, lineD);
+   }
+
+   /**
+    * As {@link #addLineAreaPair(Document, Element, String, String, String)}, with an explicit
+    * {@code data-series} index so a chart can hold more than one area measure.
+    */
+   private static Element addLineAreaPair(Document doc, Element svg, String color, String series,
+                                           String fillD, String lineD)
+   {
       // Area annotation group: outer g → inner Batik style g → clip g → path
       Element areaAnnot = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "g");
       areaAnnot.setAttribute("class", SVGSupport.ANNOTATION_AREA);
       areaAnnot.setAttribute("data-color", color);
-      areaAnnot.setAttribute("data-series", "0");
+      areaAnnot.setAttribute("data-series", series);
 
       Element batikStyleG = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "g");
       batikStyleG.setAttribute("text-rendering", "geometricPrecision");
@@ -1268,11 +1346,22 @@ class SVGAnimationDOMInjectorTest {
       areaAnnot.appendChild(batikStyleG);
       svg.appendChild(areaAnnot);
 
-      // Line annotation group: outer g → inner g → path
+      addLineGroup(doc, svg, color, series, lineD);
+
+      return areaAnnot;
+   }
+
+   /**
+    * Adds a standalone {@code inetsoft-line} annotation group (outer g → inner g → path) to the
+    * SVG root — an area measure's border line, or a line measure of its own.
+    */
+   private static Element addLineGroup(Document doc, Element svg, String color, String series,
+                                       String lineD)
+   {
       Element lineAnnot = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "g");
       lineAnnot.setAttribute("class", SVGSupport.ANNOTATION_LINE);
       lineAnnot.setAttribute("data-color", color);
-      lineAnnot.setAttribute("data-series", "0");
+      lineAnnot.setAttribute("data-series", series);
 
       Element lineInner = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "g");
       Element linePath = doc.createElementNS(SVGAnimationDOMInjector.SVG_NS, "path");
@@ -1283,7 +1372,33 @@ class SVGAnimationDOMInjectorTest {
       lineAnnot.appendChild(lineInner);
       svg.appendChild(lineAnnot);
 
-      return areaAnnot;
+      return lineAnnot;
+   }
+
+   /** The {@code inetsoft-line} group carrying the given {@code data-color}. */
+   private static Element borderLineOf(Element svg, String color) {
+      NodeList children = svg.getChildNodes();
+
+      for(int i = 0; i < children.getLength(); i++) {
+         if(children.item(i) instanceof Element c
+            && SVGSupport.ANNOTATION_LINE.equals(c.getAttribute("class"))
+            && color.equals(c.getAttribute("data-color")))
+         {
+            return c;
+         }
+      }
+
+      return null;
+   }
+
+   /**
+    * The {@code animation-delay} of an {@code animation:} shorthand, in seconds — the injector
+    * always emits it as the last {@code Ns} token before the fill mode.
+    */
+   private static double animationDelayOf(String style) {
+      Matcher m = Pattern.compile("animation:[^;]*?([0-9]+\\.[0-9]+)s both").matcher(style);
+      assertTrue(m.find(), "no animation delay found in style: " + style);
+      return Double.parseDouble(m.group(1));
    }
 
    /** DFS traversal to find the first {@code <path>} descendant of the given element. */

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
@@ -271,6 +271,79 @@ class SVGAnimationDOMInjectorTest {
                  "hover CSS must contain ready-gated cross-tile dim rule for A1 types");
    }
 
+   /**
+    * Redmine #75871: a multi-style chart binds a chart type per measure, so one SVG holds a bar
+    * measure's groups next to a point measure's.  Every other dim rule has the same class in its
+    * trigger and its target, so hovering either style left the other fully lit.
+    */
+   @Test
+   void hoverCssMultiStyleCrossTypeDimRulesPresent() throws Exception {
+      Document doc = newDocument();
+      addAnnotGroup(doc, SVGSupport.ANNOTATION_BAR, Map.of("row", "0", "col", "0"),
+                    10, 10, 20, 100);
+      addAnnotGroup(doc, SVGSupport.ANNOTATION_POINT, Map.of("row", "0", "col", "1"),
+                    50, 50, 6, 6);
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_GROW);
+      String css = allStyleContent(doc.getDocumentElement());
+
+      assertTrue(
+         css.contains("svg.ready:has(.inetsoft-bar.inetsoft-active) " +
+                      ".inetsoft-point:not(.inetsoft-active)"),
+         "an active bar must dim a multi-style chart's point measure");
+      assertTrue(
+         css.contains("svg.ready:has(.inetsoft-point.inetsoft-active) " +
+                      ".inetsoft-bar:not(.inetsoft-active)"),
+         "an active point must dim a multi-style chart's bar measure");
+   }
+
+   /**
+    * A plain bar chart has no point measure to dim, so the cross-type rules must not be emitted
+    * (and vice versa for a plain point chart).
+    */
+   @Test
+   void hoverCssMultiStyleCrossTypeDimSkippedForSingleStyleCharts() throws Exception {
+      Document barOnly = newDocument();
+      addAnnotGroup(barOnly, SVGSupport.ANNOTATION_BAR, Map.of("row", "0", "col", "0"),
+                    10, 10, 20, 100);
+      SVGAnimationDOMInjector.injectAnimation(barOnly.getDocumentElement(), SVGSupport.ANIMATION_GROW);
+      assertFalse(
+         allStyleContent(barOnly.getDocumentElement())
+            .contains("svg.ready:has(.inetsoft-bar.inetsoft-active) .inetsoft-point"),
+         "a plain bar chart must not get the cross-type dim rule");
+
+      Document pointOnly = newDocument();
+      addAnnotGroup(pointOnly, SVGSupport.ANNOTATION_POINT, Map.of("row", "0", "col", "0"),
+                    50, 50, 6, 6);
+      SVGAnimationDOMInjector.injectAnimation(pointOnly.getDocumentElement(), SVGSupport.ANIMATION_POINT);
+      assertFalse(
+         allStyleContent(pointOnly.getDocumentElement())
+            .contains("svg.ready:has(.inetsoft-point.inetsoft-active) .inetsoft-bar"),
+         "a plain point chart must not get the cross-type dim rule");
+   }
+
+   /**
+    * Gantt charts draw interval bars plus one {@code PointElement} milestone per bar.  A milestone
+    * marks the end of its own bar, so hovering the bar must not fade it — the cross-type rules are
+    * suppressed for the gantt hint even though both annotation classes are present.
+    */
+   @Test
+   void hoverCssMultiStyleCrossTypeDimSkippedForGantt() throws Exception {
+      Document doc = newDocument();
+      addAnnotGroup(doc, SVGSupport.ANNOTATION_BAR, Map.of("row", "0", "col", "0"),
+                    10, 10, 60, 20);
+      addAnnotGroup(doc, SVGSupport.ANNOTATION_POINT, Map.of("row", "0", "col", "0"),
+                    70, 12, 6, 6);
+      SVGAnimationDOMInjector.injectAnimation(
+         doc.getDocumentElement(),
+         SVGSupport.ANIMATION_GROW + ":" + SVGSupport.ANIMATION_FLAG_GANTT);
+      String css = allStyleContent(doc.getDocumentElement());
+
+      assertFalse(css.contains("svg.ready:has(.inetsoft-bar.inetsoft-active) .inetsoft-point"),
+                  "a gantt bar hover must not fade its own milestone");
+      assertFalse(css.contains("svg.ready:has(.inetsoft-point.inetsoft-active) .inetsoft-bar"),
+                  "a gantt milestone hover must not fade the bars");
+   }
+
    @Test
    void hoverCssTransitionIsUniform() throws Exception {
       Document doc = newDocument();
@@ -1123,6 +1196,49 @@ class SVGAnimationDOMInjectorTest {
          assertFalse(style.contains("inetsoft-line-fade"),
             "inner Batik style group inside inetsoft-area must not carry a label fade animation");
       }
+   }
+
+   /**
+    * A multi-style chart binds a chart type per measure, so hasBarVO wins the animation hint and
+    * the bar branch runs.  That branch animated bars, combo lines and point measures but never
+    * touched AreaVO fill polygons, so an area measure's fill popped in at full opacity while its
+    * own border line drew on around it.
+    */
+   @Test
+   void multiStyleAreaMeasureFillIsAnimated() throws Exception {
+      Document doc = newDocument();
+      Element svg = doc.getDocumentElement();
+      addAnnotGroup(doc, SVGSupport.ANNOTATION_BAR, Map.of("row", "0", "col", "0"),
+                    10, 10, 20, 100);
+      Element areaAnnot = addLineAreaPair(doc, svg, "10,20,30",
+                                          "M0 100 L50 60 L100 80 L100 100 L0 100 Z",
+                                          "M0 100 L50 60 L100 80");
+      SVGAnimationDOMInjector.injectAnimation(svg, SVGSupport.ANIMATION_GROW);
+
+      Element fillPath = firstDescendantPathOf(areaAnnot);
+      assertNotNull(fillPath, "area annotation must still hold its fill path");
+      String style = fillPath.getAttribute("style");
+      assertTrue(style.contains("inetsoft-line-wipe"),
+                 "a multi-style chart area fill must wipe in, but style was: " + style);
+
+      // The wipe keyframes must be defined, or the animation name resolves to nothing.
+      assertTrue(allStyleContent(svg).contains("@keyframes inetsoft-line-wipe"),
+                 "the wipe keyframes must be emitted for a multi-style area measure");
+   }
+
+   /** A plain bar chart references no line/area keyframes, so none may be emitted. */
+   @Test
+   void plainBarChartGetsNoLineOrWipeKeyframes() throws Exception {
+      Document doc = newDocument();
+      addAnnotGroup(doc, SVGSupport.ANNOTATION_BAR, Map.of("row", "0", "col", "0"),
+                    10, 10, 20, 100);
+      SVGAnimationDOMInjector.injectAnimation(doc.getDocumentElement(), SVGSupport.ANIMATION_GROW);
+      String css = allStyleContent(doc.getDocumentElement());
+
+      assertFalse(css.contains("@keyframes inetsoft-line-wipe"),
+                  "a plain bar chart must not carry the line wipe keyframes");
+      assertFalse(css.contains("@keyframes inetsoft-line-draw"),
+                  "a plain bar chart must not carry the line draw keyframes");
    }
 
    /**

--- a/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.spec.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.spec.ts
@@ -517,6 +517,126 @@ describe("ChartInlineSvgDirective cross-tile dim", () => {
       });
    });
 
+   describe("multi-style chart (bars + area + point measure in one SVG)", () => {
+      // Redmine #75871: three measures, three styles. The area measure takes the area branch of
+      // afterSvgInjected, so the mixed-hover setup has to run there too; and its own markers are
+      // not series-owned (an AreaElement emits no PointElement), so the point measure's markers
+      // must fade with the bars rather than be skipped the way a line series' markers are.
+      const html = `
+         <svg>
+            <g class="inetsoft-bar" data-row="0" data-col="0"></g>
+            <g class="inetsoft-bar-label" data-row="0" data-col="0"></g>
+            <g class="inetsoft-area" data-color="1,2,3"></g>
+            <g class="inetsoft-line" data-color="1,2,3"><path></path></g>
+            <g class="inetsoft-point" data-row="0" data-col="2" data-color="4,5,6"></g>
+            <g class="inetsoft-point-label" data-row="0" data-col="2"></g>
+         </svg>`;
+
+      // jsdom implements no SVG geometry interfaces, so setupAreaHover's
+      // `path instanceof SVGGeometryElement` guard would throw. Alias it to SVGElement, which
+      // jsdom's <path> is an instance of, so the area branch can be exercised at all.
+      const noGeometryElement = !("SVGGeometryElement" in globalThis);
+
+      beforeAll(() => {
+         if(noGeometryElement) {
+            (globalThis as any).SVGGeometryElement = (globalThis as any).SVGElement;
+         }
+      });
+
+      afterAll(() => {
+         if(noGeometryElement) {
+            delete (globalThis as any).SVGGeometryElement;
+         }
+      });
+
+      function activeFlags(host: HTMLElement, sel: string): boolean[] {
+         return Array.from(host.querySelectorAll(sel)).map(e => e.classList.contains("inetsoft-active"));
+      }
+
+      function makeMixedTile(): { dir: ChartInlineSvgDirective, host: HTMLElement } {
+         const { dir, host } = makeDirective(html);
+         (dir as any).afterSvgInjected();
+         return { dir, host };
+      }
+
+      it("treats an area measure drawn beside class-hover VOs as a mixed tile", () => {
+         const { dir } = makeMixedTile();
+         expect((dir as any).mixedHover).toBe(true);
+         // The point measure's markers and labels are not owned by the area series, so they are
+         // dimmed along with the bars when the series is hovered.
+         const mixed = (dir as any).mixedClassHoverElements as Element[];
+         expect(mixed.map(e => e.getAttribute("class"))).toEqual(
+            ["inetsoft-bar", "inetsoft-point", "inetsoft-bar-label", "inetsoft-point-label"]);
+      });
+
+      it("dims the area series while a bar is highlighted, and releases it after", () => {
+         vi.useFakeTimers();
+
+         try {
+            const { dir, host } = makeMixedTile();
+            dir.highlightElement(0, 0);
+            expect(activeFlags(host, ".inetsoft-bar")).toEqual([true]);
+            expect(opacities(host, ".inetsoft-area,.inetsoft-line")).toEqual(["0.2", "0.2"]);
+            dir.highlightElement(null, null);
+            vi.advanceTimersByTime(ChartInlineSvgDirective["CLEAR_DELAY_MS"]);
+            expect(opacities(host, ".inetsoft-area,.inetsoft-line")).toEqual(["", ""]);
+         }
+         finally {
+            vi.useRealTimers();
+         }
+      });
+
+      it("dims the area series when the point measure is highlighted", () => {
+         const { dir, host } = makeMixedTile();
+         // Points stay in elementGroupMap on an area tile — they belong to a point measure, not to
+         // the area's own hover, so the canvas-driven highlight must still resolve them.
+         dir.highlightElement(0, 2);
+         expect(activeFlags(host, ".inetsoft-point")).toEqual([true]);
+         expect(opacities(host, ".inetsoft-area,.inetsoft-line")).toEqual(["0.2", "0.2"]);
+      });
+
+      it("dims the bars and the point measure when the cursor resolves the area series", () => {
+         const { dir, host } = makeMixedTile();
+         // jsdom has no path geometry, so stub the per-series y at the cursor x.
+         (dir as any).getScreenYAtX = () => 100;
+         (dir as any).onAreaMouseMove({ clientX: 10, clientY: 200 } as MouseEvent);
+         expect((dir as any).activeSeriesIdx).toBe(0);
+         expect(opacities(host, ".inetsoft-bar,.inetsoft-bar-label")).toEqual(["0.2", "0.2"]);
+         expect(opacities(host, ".inetsoft-point,.inetsoft-point-label")).toEqual(["0.2", "0.2"]);
+         // Cursor moves out of every series' band — the whole plot comes back.
+         (dir as any).getScreenYAtX = () => NaN;
+         (dir as any).onAreaMouseMove({ clientX: 10, clientY: 200 } as MouseEvent);
+         expect(opacities(host, ".inetsoft-bar,.inetsoft-point")).toEqual(["", ""]);
+      });
+
+      it("leaves a pure area chart on its single-mechanism path", () => {
+         const { dir } = makeDirective(`
+            <svg>
+               <g class="inetsoft-area" data-color="1,2,3"></g>
+               <g class="inetsoft-line" data-color="1,2,3"><path></path></g>
+            </svg>`);
+         (dir as any).afterSvgInjected();
+         expect((dir as any).mixedHover).toBe(false);
+         expect((dir as any).mixedClassHoverElements).toEqual([]);
+      });
+
+      it("still skips a line series' own markers, which setAllSeriesDim owns", () => {
+         // Line branch: the marker matches the line by data-col/data-series, so it and its label
+         // belong to the series and must not be listed as class-hover elements.
+         const { dir } = makeDirective(`
+            <svg>
+               <g class="inetsoft-bar" data-row="0" data-col="0"></g>
+               <g class="inetsoft-line" data-series="1" data-color="1,2,3"><path></path></g>
+               <g class="inetsoft-point" data-row="0" data-col="1" data-color="1,2,3"></g>
+               <g class="inetsoft-point-label" data-row="0" data-col="1"></g>
+            </svg>`);
+         (dir as any).afterSvgInjected();
+         expect((dir as any).mixedHover).toBe(true);
+         const mixed = (dir as any).mixedClassHoverElements as Element[];
+         expect(mixed.map(e => e.getAttribute("class"))).toEqual(["inetsoft-bar"]);
+      });
+   });
+
    describe("highlightSnapSeries (line chart snap dim)", () => {
       // Stacked line chart: one measure (data-series 2) split into two color groups, each with a
       // line and a point marker. Points carry row+col+color; the snapped point resolves to a color.

--- a/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-inline-svg.directive.ts
@@ -781,24 +781,18 @@ export class ChartInlineSvgDirective implements OnDestroy {
                .filter(c => c !== ".inetsoft-point"));
             this.element.nativeElement.style.zIndex = "1";
             this.setupLineHover(lineOnlyGroups);
-
-            // Multi-style chart: a line measure drawn beside class-hover VOs (bars, candles, ...).
-            // Both mechanisms must stay live, and each must dim the other's elements so the hovered
-            // VO is the only bright thing in the plot.
-            if(this.areaSeries.length > 0 && this.elementGroupMap.size > 0) {
-               this.mixedHover = true;
-               this.mixedClassHoverElements = ChartInlineSvgDirective.HOVER_CLASSES
-                  .concat(ChartInlineSvgDirective.HOVER_LABEL_CLASSES)
-                  .filter(c => c !== ".inetsoft-point" && c !== ".inetsoft-point-label")
-                  .flatMap(c => Array.from(
-                     this.element.nativeElement.querySelectorAll(c) as NodeListOf<Element>));
-            }
          }
          else {
             // Non-radar, non-area, non-line chart — reset in case SVG was replaced.
             this.element.nativeElement.style.zIndex = "";
          }
       }
+
+      // Multi-style chart: a line or area measure drawn beside class-hover VOs (a bar measure, a
+      // point measure, ...). Runs after the branch above so both the area and the line setup are
+      // covered — an area measure beside a bar measure has the same two-mechanism split a line
+      // measure does.
+      this.setupMixedHover();
 
       // Build relation connectivity maps so activateKeys can highlight connected edges/neighbors.
       const relationNodes = Array.from(
@@ -861,6 +855,70 @@ export class ChartInlineSvgDirective implements OnDestroy {
             }
          }
       }
+   }
+
+   /**
+    * Flag this tile as mixing both hover mechanisms and collect the class-hover elements a series
+    * hover has to dim. A multi-style chart binds a chart type per measure, so one SVG can hold a
+    * line/area series (cursor-resolved, dimmed by inline opacity) beside bars or a point measure
+    * (dimmed by the server :has() rule on inetsoft-active). Both stay live and dim each other.
+    *
+    * No-op unless the tile holds both, so a pure line/area chart (nothing in elementGroupMap — an
+    * AreaElement draws no point markers, and the line branch drops its own from the map) and a pure
+    * bar/point chart (no series) keep their single-mechanism behavior untouched.
+    */
+   private setupMixedHover(): void {
+      if(this.areaSeries.length === 0 || this.elementGroupMap.size === 0) {
+         return;
+      }
+
+      this.mixedHover = true;
+
+      // Point markers owned by a line series are dimmed by setAllSeriesDim along with the series
+      // they belong to, and the hovered series' own must stay bright, so they are left out here.
+      // Their value labels carry the marker's data-row/data-col, so they are matched by key.
+      // On an area measure no marker is series-owned (AreaElement emits no PointElement), which is
+      // what lets a point measure drawn beside it fade together with the bars.
+      const seriesPointKeys = new Set<string>();
+
+      for(const s of this.areaSeries) {
+         for(const p of s.points) {
+            this.addElementKey(seriesPointKeys, p);
+         }
+      }
+
+      for(const p of this.hoverDimOnlyElements) {
+         this.addElementKey(seriesPointKeys, p);
+      }
+
+      this.mixedClassHoverElements = ChartInlineSvgDirective.HOVER_CLASSES
+         .concat(ChartInlineSvgDirective.HOVER_LABEL_CLASSES)
+         .flatMap(c => Array.from(
+            this.element.nativeElement.querySelectorAll(c) as NodeListOf<Element>))
+         .filter(el => !this.isSeriesOwnedPoint(el, seriesPointKeys));
+   }
+
+   /** Add el's "data-row-data-col" key to keys, if it carries both attributes. */
+   private addElementKey(keys: Set<string>, el: Element): void {
+      const row = el.getAttribute("data-row");
+      const col = el.getAttribute("data-col");
+
+      if(row != null && col != null) {
+         keys.add(`${row}-${col}`);
+      }
+   }
+
+   /** True when el is a point marker (or its value label) belonging to a line series. */
+   private isSeriesOwnedPoint(el: Element, seriesPointKeys: Set<string>): boolean {
+      if(!el.classList.contains("inetsoft-point") &&
+         !el.classList.contains("inetsoft-point-label"))
+      {
+         return false;
+      }
+
+      const row = el.getAttribute("data-row");
+      const col = el.getAttribute("data-col");
+      return row != null && col != null && seriesPointKeys.has(`${row}-${col}`);
    }
 
    /**


### PR DESCRIPTION
Root Cause:
A multi-style chart binds a chart type per measure, so a single SVG holds a bar measure's .inetsoft-bar groups alongside an area measure's .inetsoft-area/.inetsoft-line groups and a point measure's .inetsoft-point groups. Two independent defects left every measure except the hovered one fully lit.

1. Every hover-dim rule emitted by SVGAnimationDOMInjector.appendHoverCSS carries the same annotation class in its :has() trigger as in its target, e.g. svg:has(.inetsoft-bar.inetsoft-active) .inetsoft-bar:not(.inetsoft-active) so an active bar could only ever dim other bars, and an active point only other points. Bar and point had no way to dim each other.

2. The mixed-hover mechanism added for #75641 - which makes the cursor-resolved series hover and the class-based (inetsoft-active) hover dim each other - was enabled only inside the lineOnlyGroups branch of afterSvgInjected() in chart-inline-svg.directive.ts. An SVG containing .inetsoft-area groups takes the earlier areaFillGroups branch, so mixedHover stayed false and mixedClassHoverElements stayed empty: a bar hover never faded the area, and an area hover never faded the bars or the points.

Fix:
Backend (SVGAnimationDOMInjector): new appendMultiStyleHoverCSS emits bar<->point cross-type dim rules. It is gated on the SVG holding both .inetsoft-bar and .inetsoft-point and not being a gantt chart, because two single-style charts legitimately draw both annotations and must keep their existing behaviour - gantt (interval bars plus one PointElement milestone per bar, where a bar hover must not fade its own milestone) and box plot (excluded implicitly, since BoxVO emits .inetsoft-box rather than .inetsoft-bar). Both directions are gated on svg.ready like every other point rule, so dimming cannot fight the entrance animation's fill-mode.

Frontend (chart-inline-svg.directive.ts): the mixed-hover setup moved out of the line branch into setupMixedHover(), called after the whole radar/area/line branch chain, so an area measure drawn beside bars or a point measure is covered too. Point markers and their value labels are no longer excluded wholesale from mixedClassHoverElements; only markers a line series actually owns are excluded. An AreaElement emits no PointElement, so on an area tile no marker is series-owned and a genuine point measure now fades along with the bars, while a line measure's own markers keep behaving exactly as they did after #75641.

Result: hovering a bar, a point, or the area now dims the other two measures in all directions.

Covered by 3 new cases in SVGAnimationDOMInjectorTest and 6 in chart-inline-svg.directive.spec.ts.