### PR TITLE
Bug #76059, #76039, follow the dimension sort order for previous/next calc navigation

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/graph/data/DataSetRouter.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/data/DataSetRouter.java
@@ -23,6 +23,7 @@ import inetsoft.report.composition.graph.VSDataSet;
 import inetsoft.uql.XConstants;
 import inetsoft.uql.viewsheet.VSDataRef;
 import inetsoft.uql.viewsheet.XDimensionRef;
+import inetsoft.util.Tool;
 
 import java.util.*;
 
@@ -58,15 +59,17 @@ public class DataSetRouter extends AbstractRouter {
          }
       }
 
-      // Part-date-group fields (HourOfDay, DayOfWeek, MonthOfYear, Quarter) must navigate
-      // previous/next in natural calendar order regardless of any value-based sort/ranking
-      // comparator (e.g. a Top-N "Sort By Value" ranking) applied for display purposes —
-      // "previous hour" has no meaning in rank-value order. Only fall back to the dataset's
-      // own comparator for fields where no natural calendar order applies.
-      comp = getPartDateGroupComparator(data, field);
+      // Part-date-group fields (HourOfDay, DayOfWeek, MonthOfYear, Quarter) navigate
+      // previous/next in natural calendar order when the field has no display sort, or when
+      // its display sort is value-based (e.g. a Top-N "Sort By Value" ranking) — "previous
+      // hour" has no meaning in rank-value order. An explicit label sort (ascending,
+      // descending, or specific order) is honored instead, so that calc navigation stays
+      // aligned with the order the values are actually plotted in.
+      XDimensionRef partDateDim = getPartDateDimension(data, field);
+      comp = data.getComparator(field);
 
-      if(comp == null) {
-         comp = data.getComparator(field);
+      if(partDateDim != null && (comp == null || isSortByValue(partDateDim))) {
+         comp = PART_DATE_ORDER;
       }
 
       if(comp != null) {
@@ -78,15 +81,10 @@ public class DataSetRouter extends AbstractRouter {
    }
 
    /**
-    * Natural-order comparator for part-date-group dimensions (HourOfDay, DayOfWeek,
-    * MonthOfYear, Quarter, etc.), used in preference to any value-based sort/ranking
-    * comparator configured on the field (e.g. a Top-N "Sort By Value" ranking). Values for
-    * these dimensions are always emitted as Integer, so numeric order is the natural calendar
-    * order, and previous/next navigation only makes sense in that order. Scoped to
-    * previous/next calc navigation only (this router) — does not affect axis/legend
-    * ordering, which is controlled separately by CategoricalScale.
+    * Get the dimension backing the field if it is a part-date-group dimension (HourOfDay,
+    * DayOfWeek, MonthOfYear, Quarter, etc.), or null if the field is not one.
     */
-   private static Comparator getPartDateGroupComparator(DataSet data, String field) {
+   private static XDimensionRef getPartDateDimension(DataSet data, String field) {
       DataSet root = data instanceof DataSetFilter
          ? ((DataSetFilter) data).getRootDataSet() : data;
 
@@ -101,13 +99,43 @@ public class DataSetRouter extends AbstractRouter {
       }
 
       XDimensionRef dim = (XDimensionRef) ref;
+      return (dim.getDateLevel() & XConstants.PART_DATE_GROUP) != 0 ? dim : null;
+   }
 
-      if((dim.getDateLevel() & XConstants.PART_DATE_GROUP) == 0) {
-         return null;
+   /**
+    * Check if the dimension is sorted by an aggregate value (as set by a Top-N/Bottom-N
+    * "Sort By Value" ranking) rather than by its own labels.
+    */
+   private static boolean isSortByValue(XDimensionRef dim) {
+      int order = dim.getOrder();
+      return order == XConstants.SORT_VALUE_ASC || order == XConstants.SORT_VALUE_DESC;
+   }
+
+   /**
+    * Natural calendar order for part-date-group dimension values. Values are normally
+    * emitted as Integer, so numeric order is calendar order. Nulls sort first to match the
+    * position the null group occupies on an ascending axis, and any non-numeric label (e.g.
+    * the "Others" group produced by a Top-N ranking) sorts after all numeric values rather
+    * than failing the comparison.
+    */
+   private static final Comparator PART_DATE_ORDER = (a, b) -> {
+      if(a == null || b == null) {
+         return a == b ? 0 : (a == null ? -1 : 1);
       }
 
-      return Comparator.nullsLast(Comparator.comparingInt(val -> ((Number) val).intValue()));
-   }
+      boolean anum = a instanceof Number;
+      boolean bnum = b instanceof Number;
+
+      if(anum && bnum) {
+         return Double.compare(((Number) a).doubleValue(), ((Number) b).doubleValue());
+      }
+
+      if(anum != bnum) {
+         return anum ? -1 : 1;
+      }
+
+      return Tool.compare(a, b);
+   };
 
    @Override
    public Object[] getValues() {

--- a/core/src/main/java/inetsoft/report/composition/graph/data/DataSetRouter.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/data/DataSetRouter.java
@@ -59,16 +59,15 @@ public class DataSetRouter extends AbstractRouter {
          }
       }
 
-      // Part-date-group fields (HourOfDay, DayOfWeek, MonthOfYear, Quarter) navigate
-      // previous/next in natural calendar order when the field has no display sort, or when
-      // its display sort is value-based (e.g. a Top-N "Sort By Value" ranking) — "previous
-      // hour" has no meaning in rank-value order. An explicit label sort (ascending,
-      // descending, or specific order) is honored instead, so that calc navigation stays
-      // aligned with the order the values are actually plotted in.
-      XDimensionRef partDateDim = getPartDateDimension(data, field);
+      // Any display sort configured on the field — ascending, descending, specific order, or
+      // value-based (a Top-N "Sort By Value" ranking) — defines the order that previous/next
+      // navigation follows, so that the calc stays aligned with the order the values are
+      // actually plotted in. Part-date-group fields (HourOfDay, DayOfWeek, MonthOfYear,
+      // Quarter) fall back to natural calendar order only when no sort is configured, since
+      // raw row-appearance order is arbitrary there. (76039)
       comp = data.getComparator(field);
 
-      if(partDateDim != null && (comp == null || isSortByValue(partDateDim))) {
+      if(comp == null && getPartDateDimension(data, field) != null) {
          comp = PART_DATE_ORDER;
       }
 
@@ -100,15 +99,6 @@ public class DataSetRouter extends AbstractRouter {
 
       XDimensionRef dim = (XDimensionRef) ref;
       return (dim.getDateLevel() & XConstants.PART_DATE_GROUP) != 0 ? dim : null;
-   }
-
-   /**
-    * Check if the dimension is sorted by an aggregate value (as set by a Top-N/Bottom-N
-    * "Sort By Value" ranking) rather than by its own labels.
-    */
-   private static boolean isSortByValue(XDimensionRef dim) {
-      int order = dim.getOrder();
-      return order == XConstants.SORT_VALUE_ASC || order == XConstants.SORT_VALUE_DESC;
    }
 
    /**

--- a/core/src/test/java/inetsoft/report/composition/graph/calc/ValueOfColumnTest.java
+++ b/core/src/test/java/inetsoft/report/composition/graph/calc/ValueOfColumnTest.java
@@ -41,6 +41,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -412,6 +413,7 @@ public class ValueOfColumnTest {
       when(hourRef.getDateLevel()).thenReturn(XConstants.HOUR_OF_DAY_DATE_GROUP);
       // Simulates a Top-N ranking's "Sort By Value" comparator: orders by id desc
       // (11, 5, 2) rather than by natural hour order (2, 5, 11).
+      when(hourRef.getOrder()).thenReturn(XConstants.SORT_VALUE_DESC);
       when(hourRef.createComparator(org.mockito.ArgumentMatchers.any()))
          .thenReturn((a, b) -> Integer.compare((Integer) b, (Integer) a));
 
@@ -424,6 +426,95 @@ public class ValueOfColumnTest {
       // Row 1 = hour 2, the earliest hour → no previous → INVALID.
       result = valueOfColumn.calculate(vsDataSet, 1, false, false);
       assertEquals(CalcColumn.INVALID, result);
+   }
+
+   /**
+    * Regression test for Bug #75743: PREVIOUS navigation on a part-date-group dimension that
+    * carries a plain label sort (Sort Ascending) must follow that sort — including the
+    * position of the null group — instead of an internally-imposed numeric/nulls-last order.
+    *
+    * With "As time series" off there is no ScaleRouter, so navigation falls back to
+    * DataSetRouter. Ascending order puts the null group first (matching both the physical
+    * row order and the axis), so the smallest non-null second (1) has the null group as its
+    * previous value (id=28) rather than no previous value at all.
+    */
+   @Test
+   void testPreviousOnPartDateGroupFollowsLabelSortWithNullGroup() {
+      final String dim = "SecondOfMinute(order_datetime)";
+      valueOfColumn = new ValueOfColumn("id", "NthSmallest(id, 1)");
+      valueOfColumn.setChangeType(ValueOfCalc.PREVIOUS);
+      valueOfColumn.setDim(dim);
+      valueOfColumn.setInnerDim(dim);
+
+      DefaultTableLens tb = new DefaultTableLens(new Object[][]{
+         { dim, "id" },
+         { null, 28 },
+         { 1, 13 },
+         { 10, 8 },
+         { 11, 20 }
+      });
+
+      VSDimensionRef secRef = mock(VSDimensionRef.class);
+      when(secRef.getFullName()).thenReturn(dim);
+      when(secRef.getDateLevel()).thenReturn(XConstants.SECOND_OF_MINUTE_DATE_GROUP);
+      when(secRef.getOrder()).thenReturn(XConstants.SORT_ASC);
+      when(secRef.createComparator(org.mockito.ArgumentMatchers.any()))
+         .thenReturn(Comparator.nullsFirst(
+            Comparator.comparingInt(v -> ((Number) v).intValue())));
+
+      vsDataSet = new VSDataSet(tb, new VSDataRef[]{ secRef });
+
+      // Row 1 = second 1. Previous in ascending order is the null group (id=28).
+      Object result = valueOfColumn.calculate(vsDataSet, 1, false, false);
+      assertEquals(28, result);
+
+      // Row 2 = second 10. Previous is second 1 (id=13).
+      result = valueOfColumn.calculate(vsDataSet, 2, false, false);
+      assertEquals(13, result);
+
+      // Row 0 = the null group, first in ascending order → no previous → INVALID.
+      result = valueOfColumn.calculate(vsDataSet, 0, true, false);
+      assertEquals(CalcColumn.INVALID, result);
+   }
+
+   /**
+    * Regression test for Bug #75743: the natural calendar order applied to an unsorted
+    * part-date-group dimension must tolerate non-numeric group labels. A Top-N ranking with
+    * "group others" emits the "Others" string into an otherwise Integer part-date column,
+    * which previously threw ClassCastException while building the router.
+    */
+   @Test
+   void testPreviousOnPartDateGroupWithOthersLabel() {
+      final String dim = "HourOfDay(order_time)";
+      valueOfColumn = new ValueOfColumn("id", "sum(id)");
+      valueOfColumn.setChangeType(ValueOfCalc.PREVIOUS);
+      valueOfColumn.setDim(dim);
+      valueOfColumn.setInnerDim(dim);
+
+      DefaultTableLens tb = new DefaultTableLens(new Object[][]{
+         { dim, "id" },
+         { 5, 10 },
+         { 2, 20 },
+         { "Others", 30 }
+      });
+
+      VSDimensionRef hourRef = mock(VSDimensionRef.class);
+      when(hourRef.getFullName()).thenReturn(dim);
+      when(hourRef.getDateLevel()).thenReturn(XConstants.HOUR_OF_DAY_DATE_GROUP);
+
+      vsDataSet = new VSDataSet(tb, new VSDataRef[]{ hourRef });
+
+      // Numeric hours keep calendar order (2, 5) with "Others" sorted after them.
+      Object result = valueOfColumn.calculate(vsDataSet, 0, false, false);
+      assertEquals(20, result);
+
+      // Hour 2 is the earliest → no previous → INVALID.
+      result = valueOfColumn.calculate(vsDataSet, 1, false, false);
+      assertEquals(CalcColumn.INVALID, result);
+
+      // "Others" sorts last, so its previous is hour 5 (id=10).
+      result = valueOfColumn.calculate(vsDataSet, 2, false, false);
+      assertEquals(10, result);
    }
 
    /**

--- a/core/src/test/java/inetsoft/report/composition/graph/calc/ValueOfColumnTest.java
+++ b/core/src/test/java/inetsoft/report/composition/graph/calc/ValueOfColumnTest.java
@@ -383,20 +383,24 @@ public class ValueOfColumnTest {
    }
 
    /**
-    * Regression test for Bug #75664 (ranking follow-up): PREVIOUS navigation on a
-    * part-date-group dimension (e.g. HourOfDay) must use natural calendar order even when
-    * the dimension has an explicit value-based sort comparator — as set by a Top-N/Bottom-N
-    * "Sort By Value" ranking. Without the fix, DataSetRouter would sort by the ranking's
-    * value order (e.g. by Sum(contact_id) desc) instead of numeric hour order, so "previous
-    * hour" would resolve to the wrong row or incorrectly return INVALID.
+    * Regression test for Bug #76039: PREVIOUS navigation on a part-date-group dimension
+    * (e.g. HourOfDay) must follow the dimension's display sort even when that sort is
+    * value-based, as set by a Top-N/Bottom-N "Sort By Value" ranking. The calc has to agree
+    * with the order the values are plotted in and with the order scripts see them in via
+    * getData() — so the value that is first in display order has no previous value, even
+    * though a numerically-earlier one exists elsewhere in the data.
     *
-    * Data is intentionally NOT in either row order or hour order (row order: 5, 2, 11), and
-    * the mock comparator sorts by an unrelated ranking value (id desc: 11, 5, 2) rather than
-    * by hour. Natural hour order is 2, 5, 11 — so "previous" of hour 5 must resolve to hour 2
-    * (id=20), not to whatever the ranking comparator would place before it.
+    * This deliberately reverses the follow-up fix for Bug #75664 ("bug-75664-1"), which gave
+    * natural calendar order priority over a value-based sort comparator. The two cannot both
+    * hold: for a sort-by-value part-date dimension, calendar order and display order differ.
+    * The natural-order fallback still applies when no sort is configured — see
+    * {@link #testPreviousOnPartDateGroupWithOthersLabel()}.
+    *
+    * Row order is 5, 2, 11; the ranking comparator puts the hours in descending order
+    * (11, 5, 2), which is neither row order nor calendar order.
     */
    @Test
-   void testPreviousOnPartDateGroupIgnoresRankingSortComparator() {
+   void testPreviousOnPartDateGroupFollowsRankingSortOrder() {
       valueOfColumn = new ValueOfColumn("id", "sum(id)");
       valueOfColumn.setChangeType(ValueOfCalc.PREVIOUS);
       valueOfColumn.setDim("HourOfDay(order_time)");
@@ -411,20 +415,24 @@ public class ValueOfColumnTest {
       VSDimensionRef hourRef = mock(VSDimensionRef.class);
       when(hourRef.getFullName()).thenReturn("HourOfDay(order_time)");
       when(hourRef.getDateLevel()).thenReturn(XConstants.HOUR_OF_DAY_DATE_GROUP);
-      // Simulates a Top-N ranking's "Sort By Value" comparator: orders by id desc
-      // (11, 5, 2) rather than by natural hour order (2, 5, 11).
+      // Simulates a Top-N ranking's "Sort By Value" comparator, ordering the hours 11, 5, 2
+      // rather than in natural hour order 2, 5, 11.
       when(hourRef.getOrder()).thenReturn(XConstants.SORT_VALUE_DESC);
       when(hourRef.createComparator(org.mockito.ArgumentMatchers.any()))
          .thenReturn((a, b) -> Integer.compare((Integer) b, (Integer) a));
 
       vsDataSet = new VSDataSet(tb, new VSDataRef[] { hourRef });
 
-      // Row 0 = hour 5. Natural-order previous is hour 2 (id=20).
+      // Row 0 = hour 5; previous in display order (11, 5, 2) is hour 11 (id=30).
       Object result = valueOfColumn.calculate(vsDataSet, 0, false, false);
-      assertEquals(20, result);
+      assertEquals(30, result);
 
-      // Row 1 = hour 2, the earliest hour → no previous → INVALID.
+      // Row 1 = hour 2; previous in display order is hour 5 (id=10).
       result = valueOfColumn.calculate(vsDataSet, 1, false, false);
+      assertEquals(10, result);
+
+      // Row 2 = hour 11, first in display order → no previous → INVALID.
+      result = valueOfColumn.calculate(vsDataSet, 2, false, false);
       assertEquals(CalcColumn.INVALID, result);
    }
 


### PR DESCRIPTION
Fixes Bug #76059 and Bug #76039.

## Problem

On an auto chart with `SecondOfMinute(order_datetime)` on X, Sort (Ascending), and **"As time series" off**, `Value of previous` and `Moving Average of 5` did not agree with the chart's own axis ordering:

- `SecondOfMinute = 1` lost its previous value — null instead of 28
- every moving-average window at the leading edge slid by one position (2.6667 / 2.25 / 2 instead of 2.25 / 2 / 2 for seconds 1 / 10 / 11)

## Cause

`DataSetRouter` imposed a hard-coded `nullsLast(comparingInt(...))` order on **every** part-date-group dimension (`HourOfDay`, `DayOfWeek`, `MonthOfYear`, `SecondOfMinute`, …), discarding the dimension's own display comparator.

`SecondOfMinute` is `SECOND_OF_MINUTE_DATE_GROUP = 11 | PART_DATE_GROUP`, so the configured Sort (Ascending) comparator was dropped and the null group moved from the front of the value list to the back:

```
display / physical order : [null, 1, 10, 11, ...]
router order (buggy)     : [1, 10, 11, ..., null]
```

`ValueOfColumn` then sees `1` at index 0 → no previous → `INVALID`. `MovingColumn.getCondData` builds its window from `router.getIndex()` / `router.getValues()` rather than physical rows, so the same reordering shifts every window.

**Why "As time series" off is the gate:** `VSDataSet.prepareGraph` only installs a `ScaleRouter` for a `TimeScale`, and constructs it as `new ScaleRouter(s, getComparator(f))` — the time-series path already honors display order. With time series off the axis is categorical, no `ScaleRouter` exists, and navigation falls through to `DataSetRouter`.

## Fix

The sort configured on the field defines the order previous/next navigation walks — ascending, descending, specific order, or value-based as set by a Top-N/Bottom-N "Sort By Value" ranking. The calc then agrees with the order the values are plotted in, and with the order scripts see them in through `getData()`.

Part-date-group fields keep a natural calendar order as the fallback for when no sort is configured at all, since raw row-appearance order is arbitrary for those. That fallback comparator is also total and null-safe:

- nulls sort **first**, matching the position the null group occupies on an ascending axis
- a non-numeric label sorts after all numeric values instead of throwing. A Top-N "group others" emits the `"Others"` string into an otherwise-Integer part-date column, which previously threw `ClassCastException` while building the router.

Totality/transitivity matters here because `AbstractRouter.search()` binary-searches `values` with this comparator.

## Tests

- `testPreviousOnPartDateGroupFollowsLabelSortWithNullGroup` — ascending part-date dimension with a null group (Bug #76059).
- `testPreviousOnPartDateGroupFollowsRankingSortOrder` — part-date dimension under a "Sort By Value" ranking, where display order is neither row order nor calendar order (Bug #76039).
- `testPreviousOnPartDateGroupWithOthersLabel` — the no-sort natural-order fallback, and the `"Others"` label `ClassCastException`.

`ValueOfColumnTest` 22/22 pass. `MovingColumn` / `Change` / `RunningTotal` / `Percent` / `CompoundGrowth` 42/42 pass. Both bugs confirmed fixed in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
