### PR TITLE
Bug #76053, remove misleading dead clause in reloadLoggingFramework

### DIFF
--- a/core/src/main/java/inetsoft/sree/PropertiesEngine.java
+++ b/core/src/main/java/inetsoft/sree/PropertiesEngine.java
@@ -705,8 +705,7 @@ public class PropertiesEngine {
       long maxSize = Long.parseLong(getProperty("report.log.max"));
       int maxCount = Integer.parseInt(Objects.toString(getProperty("report.log.count"), "10"));
       boolean performance = performanceLevel != null &&
-         !LogLevel.OFF.level().equalsIgnoreCase(performanceLevel) &&
-         LogManager.parseLevel(prop) != null;
+         !LogLevel.OFF.level().equalsIgnoreCase(performanceLevel);
       logManagerProvider.ifAvailable(lm -> lm.initialize(
          logFile, discriminator, console, maxSize, maxCount, performance));
    }


### PR DESCRIPTION
## Summary

`PropertiesEngine.reloadLoggingFramework` gated the performance appender on three clauses, the third of which tested the wrong variable:

```java
boolean performance = performanceLevel != null &&
   !LogLevel.OFF.level().equalsIgnoreCase(performanceLevel) &&
   LogManager.parseLevel(prop) != null;
```

`performanceLevel` is `log.level.inetsoft.performance` — what the first two clauses correctly test. `prop` is the log *filename*, assembled a few lines earlier (`log.output.file` on a server, `getPath("schedule.log.file", "schedule.log")` on a scheduler). The third clause handed a filename to a level parser.

## No behavior change

`LogManager.parseLevel` has no null return path — it matches case-insensitively against the `LogLevel` constants and its legacy `switch` has a `default` arm returning `LogLevel.ERROR`. So the clause could only evaluate to `true` or throw, never to `false`, and both `prop` sources are non-null in practice. Substituting `performanceLevel` for `prop` would be equally inert, so the clause is dropped rather than repointed.

Incidentally this also removes a latent NPE: on the server branch `prop = getProperty("log.output.file")` has no fallback, so a null there would have thrown inside `parseLevel`. It ships in `defaults.properties`, so it could not happen as configured.

## Why fix it

It is a trap for the next person to touch `parseLevel`. Making it reject an unrecognized level instead of coercing to `ERROR` — a reasonable change, and the kind someone makes while fixing something else — would silently activate this clause against a filename, switching performance logging on or off according to whether a log filename happens to parse as a level. The line is also actively misleading to read: it looks like a deliberate validation of the performance level, and it is not.

## Testing

None — a single-conjunct deletion that is provably unreachable as `false`. No build was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)