### PR TITLE
Bug #76070, track shape picker items by index to avoid NG0956 full view re-creation

### DIFF
--- a/web/projects/portal/src/app/binding/editor/chart/aesthetic/static-shape-pane.component.html
+++ b/web/projects/portal/src/app/binding/editor/chart/aesthetic/static-shape-pane.component.html
@@ -36,7 +36,7 @@
     </i>
 
     <div class="shape-pane">
-      @for (i of currentViewIndices; track i) {
+      @for (i of currentViewIndices; track $index) {
         @if (shapes[i]) {
           <shape-item class="m-1" [shapeStr]="shapes[i]" (click)="selectShape(shapes[i])"
             [class.bd-gray]="shapes[i] == shapeStr">


### PR DESCRIPTION
## Problem

Repeated `NG0956` warnings in the browser console while editing a chart:

> NG0956: The configured tracking expression (track by identity) caused re-creation of the entire collection of size 16.

## Cause

`static-shape-pane.component.html` paged its shape swatches with a track-by-identity expression:

```html
@for (i of currentViewIndices; track i) {
```

where `currentViewIndices` returns `i + NUM_SHAPES * currentPage` and `NUM_SHAPES = 16`. Advancing a page shifts every key by a full 16, so no key in the new collection overlaps the old one and all 16 `shape-item` component views are destroyed and recreated rather than having their bindings updated. `currentPage` changes on the paging chevrons and inside `initCurrentPage()`, which runs from the `shapeStr` input setter and after `loadShapes()` — so selecting a shape that lives on page 2 or later also triggers it.

## Fix

The 16 slots are positional, so `$index` is the correct key. Angular now reuses the views and only updates `[shapeStr]` / `[class.bd-gray]`.

```diff
-      @for (i of currentViewIndices; track i) {
+      @for (i of currentViewIndices; track $index) {
```

The `@if (shapes[i])` guard inside the loop is unaffected — `i` is still the loop variable, only the tracking key changed.

## Notes on the original report

- The report attributed the warning to every change-detection pass. That part does not hold: the items are numbers, so identity reconciliation matches them by value and reuses the views; re-creation only occurs when `currentPage` actually changes.
- The report also listed "axis swap / change chart type" as a trigger. The chart render tree (`chart-area`, `chart-plot-area`, `chart-axis-area`, `chart-legend-area`, `chart-facet`, `chart-title-area`) tracks by `$index` throughout, so it cannot emit `NG0956`.

Scope is therefore the shape picker only, and the impact is a redundant rebuild of 16 swatch components per page change rather than a change-detection hot path.

## Testing

Template-only change; not exercised in a running build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
