### PR TITLE
Bug #76060, restore the last period's full interval range in date comparison

### DIFF
--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/DateComparisonInfo.java
@@ -1709,6 +1709,19 @@ public class DateComparisonInfo implements Cloneable, XMLSerializable {
          calendar.add(calendarPeriodLevel, -(quarterCalendar ? 3 : 1));
       }
 
+      // The iteration below walks backwards from this calendar, so it has to start at the
+      // end of the last period. Otherwise the intervals of the last period that fall after
+      // the end day get no condition at all (e.g. Q3/Q4 missing when the end day is in Q2).
+      setDateToEndOfPeriod(calendar, periodLevel);
+
+      // ...but never past the end day itself. When the last period is the in-progress one
+      // (inclusive), its period end is in the future and would produce empty intervals. (75152)
+      Date runtimeEndDay = standardPeriods.getRuntimeEndDay();
+
+      if(runtimeEndDay != null && calendar.getTime().after(runtimeEndDay)) {
+         calendar.setTime(runtimeEndDay);
+      }
+
       setDateToLevelStart(calendar, dcInterval.getContextLevel());
       appendRangeToDateConditions(endDateCalendar, calendar, dcInterval.getContextLevel(),
                                   toDate, conditionList, ref);

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/DateComparisonIntervalConditionTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/DateComparisonIntervalConditionTest.java
@@ -1,0 +1,130 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.viewsheet.internal;
+
+import inetsoft.test.*;
+import inetsoft.uql.ConditionItem;
+import inetsoft.uql.ConditionList;
+import inetsoft.uql.XConstants;
+import inetsoft.uql.asset.AssetCondition;
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.schema.XSchema;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.text.SimpleDateFormat;
+import java.util.*;
+
+/**
+ * Verifies the quarter ranges generated for a "quarter to date" date comparison interval
+ * over yearly standard periods.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(
+   classes = { BaseTestConfiguration.class },
+   initializers = ConfigurationContextInitializer.class
+)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class DateComparisonIntervalConditionTest {
+   /**
+    * When the last period is a completed year, every quarter of that year must get an
+    * interval condition, even when the end day itself falls in an early quarter. Otherwise
+    * the quarters after the end day are silently dropped from the chart and crosstab.
+    */
+   @Test
+   void completedLastPeriodCoversAllItsQuarters() {
+      List<String> starts = intervalRangeStarts("2023-04-07", false);
+
+      Assertions.assertEquals(
+         List.of("2021-01-01", "2021-04-01", "2021-07-01", "2021-10-01",
+                 "2022-01-01", "2022-04-01", "2022-07-01", "2022-10-01"),
+         starts);
+   }
+
+   /**
+    * When the last period is the in-progress year, the iteration must stop at the quarter
+    * containing the end day rather than running out to the end of the year, which would
+    * add empty future quarters to the axis.
+    */
+   @Test
+   void inProgressLastPeriodStopsAtEndDay() {
+      List<String> starts = intervalRangeStarts("2023-04-07", true);
+
+      Assertions.assertEquals(
+         List.of("2021-01-01", "2021-04-01", "2021-07-01", "2021-10-01",
+                 "2022-01-01", "2022-04-01", "2022-07-01", "2022-10-01",
+                 "2023-01-01", "2023-04-01"),
+         starts);
+   }
+
+   /**
+    * Collect, in ascending order, the start date of every interval condition produced for a
+    * "previous 2 years / quarter to date / by quarter" comparison ending on the given day.
+    */
+   private List<String> intervalRangeStarts(String endDay, boolean inclusive) {
+      DateComparisonInfo dc = new DateComparisonInfo();
+      StandardPeriods periods = new StandardPeriods();
+      periods.setPreCountValue("2");
+      periods.setDateLevelValue(String.valueOf(XConstants.YEAR_DATE_GROUP));
+      periods.setToDate(false);
+      periods.setToDayAsEndDay(false);
+      periods.setEndDateValue(endDay);
+      periods.setInclusive(inclusive);
+      dc.setDateComparisonPeriods(periods);
+
+      DateComparisonInterval interval = new DateComparisonInterval();
+      interval.setLevelValue(String.valueOf(DateComparisonInfo.QUARTER_TO_DATE));
+      interval.setGranularityValue(String.valueOf(DateComparisonInfo.QUARTER));
+      interval.setContextLevelValue(String.valueOf(XConstants.QUARTER_DATE_GROUP));
+      interval.setEndDayAsToDate(true);
+      interval.setIntervalEndDateValue(endDay);
+      dc.setDateComparisonInterval(interval);
+      dc.setComparisonOption(DateComparisonInfo.VALUE);
+
+      ColumnRef ref = new ColumnRef(new AttributeRef(null, "Order Date"));
+      ref.setDataType(XSchema.DATE);
+
+      ConditionList conditions = dc.getDateComparisonConditions(ref);
+      Assertions.assertNotNull(conditions);
+
+      SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+      List<String> starts = new ArrayList<>();
+
+      for(int i = 0; i < conditions.getSize(); i++) {
+         Object item = conditions.getItem(i);
+
+         // level 0 is the overall period range; the per-quarter intervals are at level 1
+         if(item instanceof ConditionItem && ((ConditionItem) item).getLevel() == 1) {
+            List<?> values = ((AssetCondition) ((ConditionItem) item).getXCondition()).getValues();
+            starts.add(format.format((Date) values.get(0)));
+         }
+      }
+
+      Collections.sort(starts);
+
+      return starts;
+   }
+}


### PR DESCRIPTION
## Problem

In `RM3_2_4`, the "All - Qtr Granularity" chart and its crosstab were missing 2022 Q3 and Q4.

Because the rows are absent from the crosstab as well as the chart, this is a data problem, not an axis-label one: the query never asked for those quarters.

## Root cause

`DateComparisonInfo.getStandardPeriodsIntervalCondition()` builds a calendar and hands it to `appendRangeToDateConditions()`, which walks **backwards** from it emitting one condition per context-level interval. That calendar therefore has to start at the *end of the last period*.

7931b9068f (Bug #75152, #3818) removed the `setDateToEndOfPeriod(calendar, periodLevel)` call, so the walk started at the interval containing the raw end day instead. With end day `2023-04-07` and "previous 2 years, not inclusive" (last period = the completed year 2022), the iteration began at 2022-04-01 and walked back, producing only six quarter conditions:

```
2022-04-01..04-06, 2022-01-01..01-06, 2021-10-01.., 2021-07-01.., 2021-04-01.., 2021-01-01..
```

2022 Q3 and Q4 were never generated.

## Fix

Restore the `setDateToEndOfPeriod()` call, then clamp the calendar to the end day. The clamp only engages when the last period is still in progress (`inclusive = true` with a mid-period end day) — which is exactly the empty/future-interval case #75152 was addressing. When the last period is complete, the clamp is a no-op and all of its intervals are emitted.

## Verification

Executed the `RM3_2_4` viewsheet in a `RuntimeViewsheetExtension` harness and dumped the resulting data. Before the fix, both the chart and the crosstab stopped at 2022 Q2; after, all four 2022 quarters are present. (`Chart28`, whose interval is `All`, takes a different code path and was unaffected either way.)

## Tests

Added `DateComparisonIntervalConditionTest` covering both directions:

- a completed last period must cover all four of its quarters — fails on the unfixed code with exactly the reported 6-vs-8 gap
- an in-progress last period must stop at the quarter containing the end day — guards the #75152 behavior

`DCMergeDateFilterTest`, `DCMergeDatePartFilterTest`, and `DcFormatTableLensTest` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)