### PR TITLE
Bug #76047, fix typo hiding the AWS SDK log level property

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/properties/PropertiesController.java
+++ b/core/src/main/java/inetsoft/web/admin/properties/PropertiesController.java
@@ -253,9 +253,10 @@ public class PropertiesController {
 
    private static final String FLUENTD_PREFIX = "log.fluentd.";
    private static final Set<String> UNUSED_LOG_LEVELS = Set.of(
-      // NOTE: "intesoft" is a pre-existing typo in this key, corrected separately in bug-76047 /
-      // PR #4662. Left as-is here so this change stays scoped to the log.fluentd.* family.
-      "log.level.intesoft.storage.aws.com.amazonaws",
+      // Both AWS keys name packages shaded into inetsoft.storage.aws.* by the enterprise AWS
+      // integration module, and both are set in PropertiesEngine.initLogging(), so they belong
+      // on the same side of this filter.
+      "log.level.inetsoft.storage.aws.com.amazonaws",
       "log.level.inetsoft.storage.aws.org.apache",
       "log.level.inetsoft.web.portal.controller.ControllerErrorHandler",
       "log.level.inetsoft_audit");


### PR DESCRIPTION
## Summary

`PropertiesController.removeUnuseProperties` removed `log.level.intesoft.storage.aws.com.amazonaws` — `intesoft`, with the `n` and `e` transposed. No property by that name exists, so the removal was a no-op and the intended key, `log.level.inetsoft.storage.aws.com.amazonaws`, was never hidden. The adjacent line spells it correctly, which is what makes it a typo rather than a distinct key:

```java
properties.remove("log.level.intesoft.storage.aws.com.amazonaws");   // <-- intesoft
properties.remove("log.level.inetsoft.storage.aws.org.apache");      // <-- inetsoft
```

## Effect

On a non-Enterprise build the AWS SDK logger level stayed listed in Settings > Properties and in the defaults listing, where the neighbouring Apache one did not — the two halves of one intent behaved differently.

Note that this key is not a shipped default (`defaults.properties` carries only `log.level.inetsoft.performance`); it becomes a real property once the logger's level is set, via the EM Log Levels page or a deployment's `sree.properties`. The stale entry surfaced in that case rather than universally.

## Why these two keys belong together

Both name packages shaded into `inetsoft.storage.aws.*` by the enterprise AWS integration module (`integration/inetsoft-integration-aws/pom.xml`), and both are set side by side in `PropertiesEngine.initLogging()`:

```java
lm.setLevel("inetsoft.storage.aws.com.amazonaws", LogLevel.WARN);
lm.setLevel("inetsoft.storage.aws.org.apache", LogLevel.WARN);
```

`PropertiesEngine.setLogLevel()` builds the property name as `"log.level." + name`, confirming the corrected spelling is the key that can actually exist.

## Safety

A full-repository grep (community + enterprise) found the misspelled form on that one line and nowhere else, so nothing wrote or read it and nothing depended on the removal missing.

`removeUnuseProperties` only filters the `Properties` copy returned by the two read-only GET endpoints, and only when `!LicenseManager.isEnterprise()`. Enterprise builds, stored configuration, and the effective runtime log level are all unaffected.

Redmine: #76047

🤖 Generated with [Claude Code](https://claude.com/claude-code)