### PR TITLE
Alias pointLine into set_assembly_properties's chart vocabulary

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyService.java
@@ -237,6 +237,8 @@ public class AssemblyPropertyService {
             resolved.put(key, PropertyAliases.resolveForWrite(type, key));
          }
 
+         requireApplicable(type, model, resolved.keySet(), assemblyName);
+
          // PropertyPath.set returns the root the caller must keep using: if a future alias
          // ever targets a direct top-level field of an Immutables dialog model (no nested pane
          // to absorb the rebuild — see PropertyPath's own note), the wither produces a new
@@ -287,6 +289,36 @@ public class AssemblyPropertyService {
          throw new IllegalArgumentException(
             "Setting " + type + " properties of '" + assemblyName + "' failed: " +
             rootMessage(e), e);
+      }
+   }
+
+   /**
+    * Refuses a property whose OWN dialog model says it does not apply to the assembly's CURRENT
+    * state — checked against the model just read, so it reflects this exact write, not a stale
+    * assumption. {@code pointLine} is the only alias this applies to today:
+    * {@code ChartPlotOptionsPaneModel.updateChartPlotOptionsPaneModel} calls
+    * {@code plotDesc.setPointLine(...)} unconditionally, regardless of chart type — the Composer
+    * UI hides the checkbox behind {@code isShowPointsVisible()} instead of the write path
+    * enforcing it, the same "menu precondition, not a server guard" shape found elsewhere in this
+    * plugin family (E3's selection-container guards). Without this, {@code set_assembly_properties}
+    * would report success for {@code pointLine} on, say, a bar chart, with no visible effect.
+    */
+   private static void requireApplicable(String type, Object model, Set<String> keys,
+                                         String assemblyName)
+   {
+      if(!"chart".equals(type) || !keys.contains("pointLine")) {
+         return;
+      }
+
+      Object visible = PropertyPath.get(
+         model, "chartAdvancedPaneModel.chartPlotOptionsPaneModel.showPointsVisible");
+
+      if(!Boolean.TRUE.equals(visible)) {
+         throw new IllegalArgumentException(
+            "'pointLine' only applies to a line, point, or radar chart type; '" + assemblyName +
+            "' does not support it right now, so this call would report success with no visible " +
+            "effect. Change the chart type first (set_chart_type) if points or connecting lines " +
+            "should show.");
       }
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
@@ -383,11 +383,25 @@ public final class PropertyAliases {
       aliases.put("glossyEffect", "chartAdvancedPaneModel.glossyEffect");
       aliases.put("sparkline", "chartAdvancedPaneModel.sparkline");
 
+      // PlotDescriptor.isPointLine()/setPointLine() — nested one level deeper than every other
+      // entry in this method (chartAdvancedPaneModel.chartPlotOptionsPaneModel.*, not
+      // chartAdvancedPaneModel.* directly). PropertyPath resolves a dotted path of any depth, so
+      // this needed only the alias itself, not new plumbing — a prior pass here concluded
+      // "ChartPropertyDialogModel never surfaces this" without checking that claim against
+      // PropertyPath's actual reach. The model's own field is named `showPoints` (the dialog's
+      // checkbox reads "Show Points" or "Show Lines" depending on chart type — see
+      // ChartPlotOptionsPaneModel.showPointsLabel); aliased as `pointLine` to match
+      // PlotDescriptor's own name and the term this capability is referred to by everywhere else
+      // (spec, roadmap). AssemblyPropertyService.set() separately refuses this alias when
+      // isShowPointsVisible() is false, since PlotDescriptor.setPointLine is applied
+      // unconditionally regardless of whether the current chart type can show it.
+      aliases.put("pointLine", "chartAdvancedPaneModel.chartPlotOptionsPaneModel.showPoints");
+
       // The line pane — trend lines, grid lines, facet grid. What a user means by "add a trend
       // line" lives here, one pane below the general/advanced panes.
       //
-      // Deliberately absent: pointLine and the word-cloud font scale are PlotDescriptor fields
-      // that ChartPropertyDialogModel never surfaces, so there is no path to alias. They are not
+      // Deliberately absent: the word-cloud font scale is a PlotDescriptor field that
+      // ChartPropertyDialogModel never surfaces, so there is no path to alias. It is not
       // reachable through this engine, and claiming otherwise would be worse than the gap.
       aliases.put("gridLineVisible", "chartLinePaneModel.gridLineVisible");
       aliases.put("innerLineVisible", "chartLinePaneModel.innerLineVisible");

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
@@ -18,11 +18,24 @@
 package inetsoft.web.wiz.viewsheet;
 
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
 import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.graph.GraphTypes;
+import inetsoft.uql.viewsheet.graph.PlotDescriptor;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
+import inetsoft.web.composer.model.vs.ChartAdvancedPaneModel;
+import inetsoft.web.composer.model.vs.ChartPropertyDialogModel;
 import inetsoft.web.composer.model.vs.GaugePropertyDialogModel;
 import inetsoft.web.composer.vs.dialog.*;
+import inetsoft.web.graph.model.dialog.ChartPlotOptionsPaneModel;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.security.Principal;
 import java.util.LinkedHashMap;
@@ -32,6 +45,16 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+/**
+ * Constructing a real {@code VSChartInfo}/{@code PlotDescriptor} for the pointLine tests below
+ * runs code that reads {@code SreeEnv} and therefore needs a Spring context — hence the harness
+ * annotations, which mirror {@code ViewsheetReadServiceTest} in this same package.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class },
+                      initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome()
 @Tag("core")
 class AssemblyPropertyServiceTest {
    /**
@@ -192,6 +215,133 @@ class AssemblyPropertyServiceTest {
       assertNull(model.getGaugeGeneralPaneModel() == null
                     ? null : model.getGaugeGeneralPaneModel().getNumberRangePaneModel().getMax(),
                  "the valid key must not have been written before the bad one was found");
+   }
+
+   // ── pointLine: a genuine three-level alias, refused when the chart type can't show it ─────
+
+   /**
+    * The alias resolves and writes through — this is the case
+    * {@code PropertyAliases.chart()}'s prior comment wrongly claimed was impossible.
+    */
+   @Test
+   void setsPointLineOnALineChart() throws Exception {
+      ChartPropertyDialogModel model = chartModelFor(GraphTypes.CHART_LINE);
+      ChartPropertyDialogService chartService = mock(ChartPropertyDialogService.class);
+      when(chartService.getChartPropertyDialogModel(anyString(), anyString(), any(Principal.class)))
+         .thenReturn(model);
+      AssemblyPropertyService service = chartServiceWith(chartService);
+
+      service.set("tok", principal(), "Chart1", Map.of("pointLine", true), "");
+
+      assertTrue(model.getChartAdvancedPaneModel().getChartPlotOptionsPaneModel().isShowPoints());
+      verify(chartService).setChartPropertyModel(any(), any(), any(), any(), any(), any());
+   }
+
+   /**
+    * {@code PlotDescriptor.setPointLine} is applied unconditionally by
+    * {@code ChartPlotOptionsPaneModel.updateChartPlotOptionsPaneModel} regardless of chart type
+    * — without {@code requireApplicable}, this would report success with no visible effect on a
+    * bar chart, the canonical CLAUDE.md robustness defect.
+    */
+   @Test
+   void refusesPointLineOnABarChartWithACallerLegibleMessage() {
+      ChartPropertyDialogModel model = chartModelFor(GraphTypes.CHART_BAR);
+      ChartPropertyDialogService chartService = mock(ChartPropertyDialogService.class);
+
+      try {
+         when(chartService.getChartPropertyDialogModel(
+            anyString(), anyString(), any(Principal.class))).thenReturn(model);
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(e);
+      }
+
+      AssemblyPropertyService service = chartServiceWith(chartService);
+
+      Exception thrown = assertThrows(IllegalArgumentException.class,
+         () -> service.set("tok", principal(), "Chart1", Map.of("pointLine", true), ""));
+
+      assertTrue(thrown.getMessage().contains("pointLine"), thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("Chart1"), thrown.getMessage());
+   }
+
+   /** The refusal must fire before any write — a bar chart must come back completely untouched. */
+   @Test
+   void writesNothingWhenPointLineIsRefused() throws Exception {
+      ChartPropertyDialogModel model = chartModelFor(GraphTypes.CHART_BAR);
+      ChartPropertyDialogService chartService = mock(ChartPropertyDialogService.class);
+      when(chartService.getChartPropertyDialogModel(anyString(), anyString(), any(Principal.class)))
+         .thenReturn(model);
+      AssemblyPropertyService service = chartServiceWith(chartService);
+
+      assertThrows(IllegalArgumentException.class,
+         () -> service.set("tok", principal(), "Chart1", Map.of("pointLine", true), ""));
+
+      assertFalse(model.getChartAdvancedPaneModel().getChartPlotOptionsPaneModel().isShowPoints());
+      verify(chartService, never()).setChartPropertyModel(any(), any(), any(), any(), any(), any());
+   }
+
+   /** A patch that never mentions pointLine must not trip the guard on an inapplicable chart. */
+   @Test
+   void aBarChartPatchNotTouchingPointLineIsUnaffectedByTheGuard() throws Exception {
+      ChartPropertyDialogModel model = chartModelFor(GraphTypes.CHART_BAR);
+      ChartPropertyDialogService chartService = mock(ChartPropertyDialogService.class);
+      when(chartService.getChartPropertyDialogModel(anyString(), anyString(), any(Principal.class)))
+         .thenReturn(model);
+      AssemblyPropertyService service = chartServiceWith(chartService);
+
+      assertDoesNotThrow(
+         () -> service.set("tok", principal(), "Chart1", Map.of("glossyEffect", true), ""));
+   }
+
+   private static ChartPropertyDialogModel chartModelFor(int chartType) {
+      VSChartInfo info = new VSChartInfo();
+      info.setChartType(chartType);
+      PlotDescriptor plotDesc = new PlotDescriptor();
+      ChartPlotOptionsPaneModel plotOptions = new ChartPlotOptionsPaneModel(info, plotDesc);
+
+      ChartAdvancedPaneModel advanced = new ChartAdvancedPaneModel();
+      advanced.setChartPlotOptionsPaneModel(plotOptions);
+
+      ChartPropertyDialogModel model = new ChartPropertyDialogModel();
+      model.setChartAdvancedPaneModel(advanced);
+      return model;
+   }
+
+   private static AssemblyPropertyService chartServiceWith(ChartPropertyDialogService chartService) {
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssembly(anyString())).thenReturn(mock(ChartVSAssembly.class));
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(rvs.getID()).thenReturn("rt1");
+
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+
+      try {
+         when(sessions.resolve(anyString(), any(Principal.class))).thenReturn(rvs);
+         doAnswer(invocation -> {
+            ViewsheetSessionService.Mutation mutation = invocation.getArgument(2);
+            mutation.run(rvs, "rt1", null);
+            return null;
+         }).when(sessions).mutate(anyString(), any(Principal.class), any());
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(e);
+      }
+
+      return new AssemblyPropertyService(
+         sessions, mock(GaugePropertyDialogService.class), mock(ImagePropertyDialogService.class),
+         mock(TextPropertyDialogService.class), chartService,
+         mock(TableViewPropertyDialogService.class), mock(CrosstabPropertyDialogService.class),
+         mock(SelectionListPropertyDialogService.class),
+         mock(SelectionTreePropertyDialogService.class),
+         mock(inetsoft.web.viewsheet.service.VSInputService.class),
+         mock(RangeSliderPropertyDialogService.class), mock(CalendarPropertyDialogService.class),
+         mock(TabPropertyDialogService.class), mock(CalcTablePropertyDialogService.class),
+         mock(GroupContainerPropertyDialogService.class), mock(LinePropertyDialogService.class),
+         mock(OvalPropertyDialogService.class), mock(RectanglePropertyDialogService.class),
+         mock(SelectionContainerPropertyDialogService.class),
+         mock(SubmitPropertyDialogService.class));
    }
 
    // ── harness ───────────────────────────────────────────────────────────────

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyAliasesTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyAliasesTest.java
@@ -189,9 +189,10 @@ class PropertyAliasesTest {
     * user means by "add a trend line", and they live one pane below the general/advanced panes
     * the first pass covered.
     *
-    * <p>Note what is deliberately absent: {@code pointLine} and the word-cloud font scale are
-    * {@code PlotDescriptor} fields that the chart property dialog never surfaces, so there is no
-    * path to alias. They are not reachable through this engine at all.
+    * <p>Note what is deliberately absent: the word-cloud font scale is a {@code PlotDescriptor}
+    * field that the chart property dialog never surfaces, so there is no path to alias. It is not
+    * reachable through this engine at all. {@code pointLine} used to be listed here too — see
+    * {@link #resolvesThePointLineAliasThreeLevelsDeep()} for why that was wrong.
     */
    @Test
    void coversTheChartLinePaneProperties() {
@@ -203,6 +204,20 @@ class PropertyAliasesTest {
          assertTrue(PropertyAliases.forType("chart").aliases().containsKey(alias),
                     "chart should expose '" + alias + "'");
       }
+   }
+
+   /**
+    * {@code pointLine} was flagged unreachable ("ChartPropertyDialogModel never surfaces this")
+    * without checking that {@link PropertyPath} already resolves a dotted path of ANY depth, not
+    * just the two segments every other chart alias happens to use. It is a real, three-segment
+    * path, and {@link #everyDeclaredAliasResolvesOnItsDialogModel()} already proves it resolves
+    * on the model — this pins the exact path so a future refactor of the alias notices if it
+    * silently starts pointing somewhere else.
+    */
+   @Test
+   void resolvesThePointLineAliasThreeLevelsDeep() {
+      assertEquals("chartAdvancedPaneModel.chartPlotOptionsPaneModel.showPoints",
+                   PropertyAliases.resolve("chart", "pointLine"));
    }
 
    @Test


### PR DESCRIPTION
## Summary

Closes 2b-P3's last open item (roadmap unit C2, `2026-08-17-chart-options-2b-p3-design.md`). The spec left `pointLine` unresolved pending two questions; this PR resolves both by tracing source rather than building the `set_chart_plot_options` tool the spec had reserved space for.

- **`PropertyAliases.chart()`'s "unreachable" comment was wrong.** `PropertyPath` already resolves a dotted path of any depth — `pointLine` (`PlotDescriptor.isPointLine()`/`setPointLine()`) just sits one level deeper than every other chart alias (`chartAdvancedPaneModel.chartPlotOptionsPaneModel.showPoints`, not `chartAdvancedPaneModel.*` directly), and nobody had checked that before writing the comment. The fix is the alias line itself — no new tool, no new endpoint, no TypeScript change, since `set_assembly_properties`/`list_assembly_properties`/`get_assembly_properties` already discover their vocabulary from this registry at runtime.
- **A real defect found while wiring it, fixed in the same change.** `ChartPlotOptionsPaneModel.updateChartPlotOptionsPaneModel` calls `plotDesc.setPointLine(...)` unconditionally regardless of chart type — the Composer UI hides the checkbox behind `isShowPointsVisible()` instead of the write path enforcing it (the same "menu precondition, not a server guard" shape E3 found in the selection-convert actions). Without a guard, `set_assembly_properties` would report success for `pointLine` on a bar chart with no visible effect. Added `AssemblyPropertyService.requireApplicable`, refusing the write up front with a caller-legible message naming the assembly — mirroring the precedent `set_chart_separate_status` established for the identical shape.
- **No new write-coordination work needed.** This reuses the existing `chart` binding (`ChartPropertyDialogService.setChartPropertyModel`), which already goes through `VSObjectPropertyService` — C1's shared chokepoint (#4626/#4640, merged) — so the write was already revision-checked before this change.

## Test plan

- [x] `PropertyAliasesTest` — new test pins the exact resolved path; existing reflective test (`everyDeclaredAliasResolvesOnItsDialogModel`) proves it resolves on the real model
- [x] `AssemblyPropertyServiceTest` — new tests: sets `pointLine` on a line chart end-to-end (real `VSChartInfo`/`PlotDescriptor`/model chain, not mocked), refuses on a bar chart with a caller-legible message, refusal writes nothing, an unrelated patch on a bar chart is unaffected by the guard
- [x] Verified per this branch's standard: removed the guard, confirmed both refusal tests fail and name themselves, restored
- [x] Full `inetsoft.web.wiz.**` sweep: 1760 tests / 0 failures, clean build (`./mvnw -pl core clean compile`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)