### PR TITLE
Bug #76166, skip pdf.font.mapping entries with no colon in getModel

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/presentation/PresentationFontMappingSettingsService.java
+++ b/core/src/main/java/inetsoft/web/admin/presentation/PresentationFontMappingSettingsService.java
@@ -39,6 +39,12 @@ public class PresentationFontMappingSettingsService {
 
          for(String fontMapping : fontMappings) {
             int index = fontMapping.indexOf(":");
+
+            // skip malformed entries, matching PDF3Generator.getPDFGenerator()
+            if(index < 0) {
+               continue;
+            }
+
             fontMappingModels.add(PresentationFontMappingModel.builder()
                                      .trueTypeFont(fontMapping.substring(0, index))
                                      .cidFont(fontMapping.substring(index + 1))

--- a/core/src/test/java/inetsoft/web/admin/presentation/PresentationFontMappingSettingsServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/presentation/PresentationFontMappingSettingsServiceTest.java
@@ -1,0 +1,103 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.presentation;
+
+/*
+ * Test strategy
+ *
+ * getModel() parses the "pdf.font.mapping" property, a ';'-separated list of
+ * "trueTypeFont:cidFont" pairs. The property can hold values that the Font Mapping
+ * card never writes (Settings > All Properties, INETSOFTENV_PDF_FONT_MAPPING, a direct
+ * property-store edit), so a malformed entry must not propagate out of the model build --
+ * that failed the whole Presentation settings page, not just the Font Mapping card.
+ *
+ * PDF3Generator.getPDFGenerator() reads the same property and silently skips any entry
+ * that does not yield a font pair, so getModel() skips them too.
+ *
+ * Behavioral guarantees covered:
+ *
+ * [G1] A well-formed list parses into one model per entry, split at the first colon.
+ * [G2] An entry with no colon is skipped instead of throwing.
+ * [G3] Null or empty property yields an empty list.
+ */
+
+import inetsoft.sree.SreeEnv;
+import inetsoft.web.admin.presentation.model.PresentationFontMappingModel;
+import inetsoft.web.admin.presentation.model.PresentationFontMappingSettingsModel;
+import org.junit.jupiter.api.*;
+import org.mockito.MockedStatic;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class PresentationFontMappingSettingsServiceTest {
+   private PresentationFontMappingSettingsService service;
+   private MockedStatic<SreeEnv> sreeEnvStatic;
+
+   @BeforeEach
+   void setUp() {
+      sreeEnvStatic = mockStatic(SreeEnv.class, withSettings().lenient());
+      service = new PresentationFontMappingSettingsService();
+   }
+
+   @AfterEach
+   void tearDown() {
+      sreeEnvStatic.close();
+   }
+
+   private List<PresentationFontMappingModel> parse(String property) {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("pdf.font.mapping")).thenReturn(property);
+      PresentationFontMappingSettingsModel model = service.getModel();
+      return model.fontMappings();
+   }
+
+   @Test
+   void wellFormedEntriesAreParsed() {
+      List<PresentationFontMappingModel> mappings = parse("Arial:STSong-Light;Courier:MSung-Light");
+
+      assertEquals(2, mappings.size());
+      assertEquals("Arial", mappings.get(0).trueTypeFont());
+      assertEquals("STSong-Light", mappings.get(0).cidFont());
+      assertEquals("Courier", mappings.get(1).trueTypeFont());
+      assertEquals("MSung-Light", mappings.get(1).cidFont());
+   }
+
+   @Test
+   void entryWithoutColonIsSkipped() {
+      List<PresentationFontMappingModel> mappings =
+         assertDoesNotThrow(() -> parse("Arial:STSong-Light;NoColonHere;Courier:MSung-Light"));
+
+      assertEquals(2, mappings.size());
+      assertEquals("Arial", mappings.get(0).trueTypeFont());
+      assertEquals("Courier", mappings.get(1).trueTypeFont());
+   }
+
+   @Test
+   void onlyMalformedEntryYieldsEmptyList() {
+      assertTrue(assertDoesNotThrow(() -> parse("NoColonHere")).isEmpty());
+   }
+
+   @Test
+   void nullOrEmptyPropertyYieldsEmptyList() {
+      assertTrue(parse(null).isEmpty());
+      assertTrue(parse("").isEmpty());
+   }
+}


### PR DESCRIPTION
Fixes Bug #76166.

## Problem

`PresentationFontMappingSettingsService.getModel()` split `pdf.font.mapping` on `;` and then took `substring(0, indexOf(":"))` for each entry with no check that the colon was found. An entry without one gives `substring(0, -1)` and a `StringIndexOutOfBoundsException` out of the model build — which fails the whole Presentation settings page, not just the Font Mapping card.

`PDF3Generator.getPDFGenerator()` reads the same property and silently skips any entry that does not yield two non-empty parts, so the property could hold a value the PDF path accepts and the settings page could not load.

Not reachable from the Font Mapping card, which writes `name:value` pairs. Reachable from Settings > All Properties, from `INETSOFTENV_PDF_FONT_MAPPING` at first storage initialisation, and from a direct property-store edit.

## Fix

`getModel()` skips an entry whose `indexOf(":")` is `-1` instead of calling `substring(0, -1)`, matching what the generator already does.

The guard is limited to `index < 0`. The generator also drops `a:b:c` and `a:`; `getModel` renders those today without throwing, and tightening them would silently remove rows the Font Mapping card can currently display and round-trip. The defect in scope is the exception, and that is what is guarded.

## Out of scope

The secondary note in the issue about `resetSettings` writing `""` rather than calling `SreeEnv.resetProperty` was withdrawn on triage as a non-issue, so it is not changed here. `PresentationSettingsControllerTest` already pins the current reset behavior.

## Tests

New `PresentationFontMappingSettingsServiceTest` — 4 tests, all passing via `./mvnw -o test -pl core -Dtest=PresentationFontMappingSettingsServiceTest`:

- well-formed list parses one model per entry, split at the first colon
- a colon-less entry mixed with good ones is skipped, the good ones survive
- a lone colon-less entry yields an empty list instead of throwing
- null / empty property yields an empty list

🤖 Generated with [Claude Code](https://claude.com/claude-code)