### PR TITLE
Bug #76165, tolerate a malformed schedule.time.ranges value

### DIFF
--- a/core/src/main/java/inetsoft/sree/schedule/TimeRange.java
+++ b/core/src/main/java/inetsoft/sree/schedule/TimeRange.java
@@ -20,12 +20,16 @@ package inetsoft.sree.schedule;
 import inetsoft.sree.SreeEnv;
 import inetsoft.util.Tool;
 import inetsoft.util.XMLSerializable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
 
 import java.io.*;
 import java.time.Duration;
 import java.time.LocalTime;
+import java.time.format.DateTimeParseException;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
@@ -222,8 +226,14 @@ public final class TimeRange implements XMLSerializable, Serializable, Comparabl
     */
    public static List<TimeRange> getTimeRanges() {
       String property = SreeEnv.getProperty("schedule.time.ranges");
+
+      if(property == null || property.trim().isEmpty()) {
+         return new ArrayList<>();
+      }
+
       return Arrays.stream(property.split(";"))
          .map(TimeRange::parse)
+         .filter(Objects::nonNull)
          .collect(Collectors.toList());
    }
 
@@ -293,19 +303,59 @@ public final class TimeRange implements XMLSerializable, Serializable, Comparabl
       return matched.orElse(range);
    }
 
+   /**
+    * Parses a single time range definition. The property may be set by hand or through the
+    * generic property editor, neither of which validates it, so a malformed definition is
+    * ignored instead of being propagated to the callers of {@link #getTimeRanges()}.
+    *
+    * @param text the time range definition.
+    *
+    * @return the time range or {@code null} if the definition is malformed.
+    */
    private static TimeRange parse(String text) {
       String[] values = text.split(",");
+
+      if(values.length < 4) {
+         logInvalidRange(text, "expected 4 comma-separated fields, found " + values.length);
+         return null;
+      }
+
       String name = values[0];
       String def = values[1];
-      String start = values[2];
-      String end = values[3];
+      LocalTime startTime;
+      LocalTime endTime;
+
+      try {
+         startTime = LocalTime.parse(values[2]);
+         endTime = LocalTime.parse(values[3]);
+      }
+      catch(DateTimeParseException e) {
+         logInvalidRange(text, "invalid time \"" + e.getParsedString() + "\"");
+         return null;
+      }
 
       TimeRange range = new TimeRange();
       range.setName(name);
       range.setDefault("1".equals(def));
-      range.setStartTime(LocalTime.parse(start));
-      range.setEndTime(LocalTime.parse(end));
+      range.setStartTime(startTime);
+      range.setEndTime(endTime);
       return range;
+   }
+
+   /**
+    * Logs a malformed time range definition. Each distinct definition is only logged once,
+    * because the time ranges are read on every scheduler tick.
+    *
+    * @param text   the malformed definition.
+    * @param reason the reason that it could not be parsed.
+    */
+   private static void logInvalidRange(String text, String reason) {
+      if(loggedInvalidRanges.size() < 100 && loggedInvalidRanges.add(text)) {
+         LOG.warn(
+            "Ignoring malformed time range \"{}\" in the schedule.time.ranges property: {}. " +
+            "Each time range must be in the form \"name,default,startTime,endTime\", for " +
+            "example \"Morning,0,06:00,12:00\".", text, reason);
+      }
    }
 
    private static String format(TimeRange range) {
@@ -324,4 +374,7 @@ public final class TimeRange implements XMLSerializable, Serializable, Comparabl
    private LocalTime startTime;
    private LocalTime endTime;
    private boolean defaultRange;
+
+   private static final Set<String> loggedInvalidRanges = ConcurrentHashMap.newKeySet();
+   private static final Logger LOG = LoggerFactory.getLogger(TimeRange.class);
 }

--- a/core/src/test/java/inetsoft/sree/schedule/TaskBalancerConditionTest.java
+++ b/core/src/test/java/inetsoft/sree/schedule/TaskBalancerConditionTest.java
@@ -55,14 +55,6 @@ import static org.junit.jupiter.api.Assertions.*;
  *              Rebalance may still run a few minutes after range start.
  *   Status   : Deferred. Covered by CheckTests minute-boundary parameters.
  *
- * [BUG-TBC-2] getTimeRanges() NPE when schedule.time.ranges property is null
- *   Location : TimeRange.java:223 (getTimeRanges)
- *   Actual   : property.split(";") NPEs when property is null (e.g. after setTimeRanges(empty));
- *              if stream were empty, check() would return false instead.
- *   UI risk  : Medium — EM Time Ranges allows deleting all ranges and saving, which clears the
- *              property; reopening Scheduler settings may then fail.
- *   Status   : Deferred. noNearbyRangeStartReturnsFalse() covers non-trigger path only.
- *
  * [BUG-TBC-3] getRetryTime() mutates lastRun, not only check()
  *   Location : TaskBalancerCondition.java:56 (getRetryTime debounce branch)
  *   Actual   : Quartz getFireTimeAfter() calls getRetryTime(), which sets lastRun for the

--- a/core/src/test/java/inetsoft/sree/schedule/TimeRangeTest.java
+++ b/core/src/test/java/inetsoft/sree/schedule/TimeRangeTest.java
@@ -46,13 +46,15 @@ import static org.mockito.Mockito.mockStatic;
  *
  * Known source bugs (documented below; NOT fixed at this time — tests record current behavior):
  *
- * [BUG-TR-1] getTimeRanges() NPE when schedule.time.ranges property is null
- *   Location : TimeRange.java:223 (getTimeRanges)
- *   Actual   : property.split(";") NPEs when getProperty returns null. Under @SreeHome,
- *              setTimeRanges(null/empty) removes the user override and falls back to
- *              defaults.properties instead.
- *   UI risk  : Medium — EM Time Ranges allows deleting all ranges; Scheduler settings may fail on reload.
- *   Status   : Deferred. Same root cause as BUG-TBC-2 in TaskBalancerConditionTest.
+ * [BUG-TR-1] getTimeRanges() threw on a malformed schedule.time.ranges value
+ *   Location : TimeRange.java (getTimeRanges / parse)
+ *   Was      : property.split(";") NPEd when getProperty returned null, parse() indexed four
+ *              fields without a length check (AIOOBE) and called LocalTime.parse without
+ *              catching DateTimeParseException. Every caller went down with it, including
+ *              SchedulerConfigurationService — the page holding the card that would repair it.
+ *   Now      : a null/blank property yields an empty list and a malformed segment is skipped
+ *              with a logged warning. Covered by MalformedPropertyTests.
+ *   Status   : Fixed. Same root cause as BUG-TBC-2 in TaskBalancerConditionTest.
  *
  * [BUG-TR-2] equals() / hashCode() ignore defaultRange flag
  *   Location : TimeRange.java:197 (equals)
@@ -244,16 +246,6 @@ class TimeRangeTest {
       }
 
       @Test
-      @DisplayName("BUG-TR-1 (deferred): getTimeRanges NPEs when property is null")
-      void getTimeRangesNullPropertyThrows() {
-         try(MockedStatic<SreeEnv> sreeEnv = mockStatic(SreeEnv.class)) {
-            sreeEnv.when(() -> SreeEnv.getProperty("schedule.time.ranges")).thenReturn(null);
-
-            assertThrows(NullPointerException.class, TimeRange::getTimeRanges);
-         }
-      }
-
-      @Test
       @DisplayName("duplicate names rejected")
       void duplicateNamesRejected() {
          TimeRange duplicateName = new TimeRange("tr2", "20:00:00", "09:00:00", true);
@@ -275,6 +267,63 @@ class TimeRangeTest {
             () -> TimeRange.setTimeRanges(Arrays.asList(MORNING, secondDefault)));
 
          assertEquals("Multiple default time ranges", ex.getMessage());
+      }
+   }
+
+   // -------------------------------------------------------------------------
+   // BUG-TR-1 — malformed schedule.time.ranges must not break every caller
+   // -------------------------------------------------------------------------
+
+   @Nested
+   @DisplayName("malformed schedule.time.ranges property")
+   class MalformedPropertyTests {
+
+      @Test
+      @DisplayName("null property yields an empty list")
+      void nullPropertyYieldsEmptyList() {
+         assertEquals(Collections.emptyList(), getRangesForProperty(null));
+      }
+
+      @Test
+      @DisplayName("blank property yields an empty list")
+      void blankPropertyYieldsEmptyList() {
+         assertEquals(Collections.emptyList(), getRangesForProperty(""));
+         assertEquals(Collections.emptyList(), getRangesForProperty("   "));
+      }
+
+      @Test
+      @DisplayName("segment with too few fields is skipped")
+      void shortSegmentIsSkipped() {
+         List<TimeRange> ranges = getRangesForProperty("Morning,0,06:00");
+
+         assertEquals(Collections.emptyList(), ranges);
+      }
+
+      @Test
+      @DisplayName("segment with a non-ISO time is skipped")
+      void nonIsoTimeSegmentIsSkipped() {
+         List<TimeRange> ranges = getRangesForProperty("Morning,0,6am,12:00");
+
+         assertEquals(Collections.emptyList(), ranges);
+      }
+
+      @Test
+      @DisplayName("well-formed segments survive a malformed sibling")
+      void wellFormedSegmentsSurviveMalformedSibling() {
+         List<TimeRange> ranges = getRangesForProperty(
+            "Morning,0,06:00,12:00;Broken,0,noon;Overnight,1,18:00,06:00");
+
+         assertEquals(2, ranges.size());
+         assertEquals("Morning", ranges.get(0).getName());
+         assertEquals("Overnight", ranges.get(1).getName());
+         assertTrue(ranges.get(1).isDefault());
+      }
+
+      private List<TimeRange> getRangesForProperty(String value) {
+         try(MockedStatic<SreeEnv> sreeEnv = mockStatic(SreeEnv.class)) {
+            sreeEnv.when(() -> SreeEnv.getProperty("schedule.time.ranges")).thenReturn(value);
+            return TimeRange.getTimeRanges();
+         }
       }
    }
 


### PR DESCRIPTION
## Problem

`TimeRange.parse` indexed four comma-separated fields without checking how many were present and called `LocalTime.parse` without catching `DateTimeParseException`. `TimeRange.getTimeRanges` split the property with no null guard. A single malformed segment in `schedule.time.ranges` therefore threw out of every caller.

The recovery path was the problem: `SchedulerConfigurationService.getConfiguration` calls `getTimeRanges()` while building the Scheduler settings model, so the page holding the Time Ranges card an operator would use to repair the value was itself unloadable.

The blast radius went well past that page. `getTimeRanges()` has eight production call sites, and two matter more than the settings page:

- `FileAuthorizationProvider.java:408` — inside default-permission map construction. Not a page failing to render; security-provider initialization failing.
- `TaskBalancer` / `TaskBalancerCondition` / `TaskBalancerAction` — the scheduler's background rebalancing loop, which fails silently rather than surfacing to anyone.

Also `ScheduleTaskAsset` (deployment export), `ScheduleDialogController` / `ScheduleDialogService` (the **end-user** viewsheet schedule dialog, not just EM), and enterprise `ScheduleApiService`.

`defaults.properties:219` ships a well-formed value and `setTimeRanges` formats what it writes, so this is not reachable from the EM card. It is reachable from `PropertiesController.editProperty` (`/api/admin/properties/edit` does a bare `SreeEnv.setProperty` with no per-key validation), from `INETSOFTENV_SCHEDULE_TIME_RANGES` at first storage initialisation, and from any hand edit.

## Fix

- `getTimeRanges()` returns an empty list for a null or blank property, and filters out segments that failed to parse.
- `parse()` checks `values.length < 4` before indexing and wraps the two `LocalTime.parse` calls in a `catch(DateTimeParseException)`; a malformed segment returns `null` and is skipped.
- `logInvalidRange()` logs each distinct bad segment once, guarded by a `ConcurrentHashMap.newKeySet()` capped at 100 entries — `TaskBalancerCondition.check` reads the ranges on every scheduler tick, so an unthrottled warning would flood the log for as long as the value stayed broken.

The catch is deliberately narrow (`DateTimeParseException`, not `Exception`) so a future precondition failure in `setName`/`setStartTime` still surfaces rather than being silently swallowed into a dropped range.

An empty or short list is safe downstream: `TaskBalancerCondition.check` degrades to `anyMatch` → false, `getRetryTime` has an `orElse(null)` branch, and `getMatchingTimeRange` returns the input range when `min()` finds nothing.

## Tests

`TimeRangeTest` gains a `MalformedPropertyTests` nested class: null property, blank property, too-few-fields, non-ISO time, and the mixed case where `Morning,0,06:00,12:00;Broken,0,noon;Overnight,1,18:00,06:00` yields the two good ranges with `Overnight` still flagged default.

The old `getTimeRangesNullPropertyThrows` test asserted `assertThrows(NullPointerException.class, ...)` — it pinned exactly the behavior being fixed, so it is removed. The `[BUG-TR-1]` header comment in `TimeRangeTest` and the matching `[BUG-TBC-2]` block in `TaskBalancerConditionTest` are updated from "Deferred" to "Fixed".

`TimeRangeTest` (24), `TaskBalancerConditionTest` (15), `TaskBalancerTest` (31) — all pass.

## Follow-up, not addressed here

An operator with one malformed segment now gets a loadable card showing two of their three ranges. Saving from that card writes back the truncated set via `setTimeRanges`, making the loss permanent — the logged warning is the only trace. Surfacing skipped segments in `TimeRangeModel` so the card can flag them would fix that, but it means touching the service, the model, and the Angular card. Worth a separate issue.

Separately, `setTimeRanges` validates duplicate names and multiple defaults only on the EM path, so `/api/admin/properties/edit` remains an unvalidated write to this key. That is a broader question about the generic property editor rather than something to solve inside `TimeRange`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
