### PR TITLE
Resolve a crosstab highlight condition against the cell's own headers

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -1073,7 +1073,7 @@ public class WizVsService {
     * caller, whereas a miss here silently falls back to EVERY ref — reproducing the very bug this method
     * exists to fix. Leniency is the safer default when the penalty for a miss is a wrong render rather
     * than an error. A genuinely mis-cased request is still caught: the condition fields are resolved
-    * case-sensitively against the chart columns by rebindChartConditionFields, which throws first.
+    * case-sensitively against the chart columns by rebindConditionFieldsToViewColumns, which throws first.
     *
     * The plain form is ambiguous when a chart binds two aggregates over the same column (e.g. both
     * {@code Sum(Sales)} and {@code Avg(Sales)}, each of whose {@code getName()} is "Sales"): a rule using
@@ -1201,7 +1201,8 @@ public class WizVsService {
     * BASE column, and no such header exists at render time. The second match arm is what turns that into
     * the header the data actually carries.
     */
-   private Set<String> rebindConditionFieldsToViewColumns(ConditionList conds, ColumnSelection viewCols) {
+   // Package-private for unit testing (WizVsServiceHighlightRebindTest).
+   Set<String> rebindConditionFieldsToViewColumns(ConditionList conds, ColumnSelection viewCols) {
       // LinkedHashSet: dedup while preserving first-seen order, so the same bad field name appearing in
       // several condition leaves (e.g. "Profit > 5 AND Profit < 100") is listed once in the error message.
       Set<String> unresolved = new LinkedHashSet<>();
@@ -1280,21 +1281,54 @@ public class WizVsService {
     * The header an aggregate condition names, composed from the formula the caller gave: an
     * AggregateRef(SALES, Average) -> "Average(SALES)". Null when the ref carries no formula.
     *
+    * Covers all three arities AggregateRef.toView() composes, since the result is compared against a
+    * header that method produced: one column ("Average(SALES)"), two for a two-column formula
+    * ("Correlation(SALES, PROFIT)"), and a column plus N for an N-parameter one ("NthLargest(SALES, 3)").
+    *
     * Exists because a column can be bound MORE THAN ONCE under different aggregates — "Sum(SALES)" and
     * "Average(SALES)" side by side in the same crosstab or chart. The base name alone cannot say which of
     * them was meant, so the loose scan in findAggregatedColumn answers with whichever the view lists
     * first: an Average condition silently lands on the Sum column, and the highlight colors cells chosen
     * by a number nobody asked about.
     */
-   private static String aggregateHeaderOf(DataRef ref) {
+   // Package-private for unit testing (WizVsServiceHighlightRebindTest).
+   static String aggregateHeaderOf(DataRef ref) {
       if(!(ref instanceof AggregateRef aggregateRef) || aggregateRef.getFormula() == null) {
          return null;
       }
 
       String base = ref.getName();
 
-      return base == null || base.isEmpty()
-         ? null : aggregateRef.getFormula().getFormulaName() + "(" + base + ")";
+      if(base == null || base.isEmpty()) {
+         return null;
+      }
+
+      AggregateFormula formula = aggregateRef.getFormula();
+      String name = formula.getFormulaName();
+
+      // Mirrors AggregateRef.toView(), which is what composes the header at render time — including its
+      // two extra arities, both of which a wiz condition can carry (buildConditionItem sets secondaryRef
+      // for isTwoColumns and N for hasN). Composed with the SAME argument order and separator, because
+      // this string is compared for EQUALITY against a header the view already produced: a one-argument
+      // "Correlation(SALES)" never matches the real "Correlation(SALES, PROFIT)", the lookup falls back to
+      // the loose base-name scan, and the ambiguity this preferred name exists to remove comes back for
+      // exactly these formulas.
+      if(formula.isTwoColumns()) {
+         DataRef secondary = aggregateRef.getSecondaryColumn();
+         String secondaryName = secondary != null ? secondary.getName() : null;
+
+         // No secondary column to name: toView() falls through to the one-argument form here too, so the
+         // header composed below still matches it.
+         return secondaryName == null || secondaryName.isEmpty()
+            ? name + "(" + base + ")"
+            : name + "(" + base + ", " + secondaryName + ")";
+      }
+
+      if(formula.hasN()) {
+         return name + "(" + base + ", " + aggregateRef.getN() + ")";
+      }
+
+      return name + "(" + base + ")";
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -1293,6 +1293,12 @@ public class WizVsService {
     * them was meant, so the loose scan in findAggregatedColumn answers with whichever the view lists
     * first: an Average condition silently lands on the Sum column, and the highlight colors cells chosen
     * by a number nobody asked about.
+    *
+    * Answers null — no preferred name, leaving that scan to decide — whenever the condition does not
+    * carry enough to name a header the view could have produced: no formula at all, a two-column formula
+    * with no secondary column, or an N-parameter formula whose N is 0. Those are the cases where the
+    * remaining ambiguity is real rather than something a spelling can resolve, so this returns nothing
+    * instead of inventing a header and matching the wrong column with confidence.
     */
    // Package-private for unit testing (WizVsServiceHighlightRebindTest).
    static String aggregateHeaderOf(DataRef ref) {
@@ -1320,14 +1326,19 @@ public class WizVsService {
          return null;
       }
 
-      // An AggregateRef stores N as a primitive and leaves it 0 when the caller named none, but the view
-      // side is a VSAggregateRef whose nValue defaults to "1" — so an unset N must be passed as null to
-      // reach that same default. Passing the 0 through composes "NthLargest(SALES, 0)", a header no view
-      // ever produces, and the lookup falls back to the loose base-name scan for every such condition.
+      // Same for an N-parameter formula whose N is 0. An AggregateRef stores N as a bare primitive, so 0
+      // is both "the caller named none" and "the caller named zero" — and for PthPercentile the latter is
+      // a real P the view can carry. Composing either reading picks a header the condition may not have
+      // meant: "NthLargest(SALES, 0)" is one no view produces (VSAggregateRef's nValue defaults to "1"),
+      // and substituting that 1 would spell a P=0 condition as P=1. Neither guess is safe, so answer none
+      // and let the base-name scan decide, the same way the missing secondary column above does.
       int n = aggregateRef.getN();
 
-      return buildVSAggregateRefFullName(base, formula.getFormulaName(), secondaryName,
-                                         n > 0 ? n : null);
+      if(formula.hasN() && n <= 0) {
+         return null;
+      }
+
+      return buildVSAggregateRefFullName(base, formula.getFormulaName(), secondaryName, n);
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -805,6 +805,33 @@ public class WizVsService {
          String name = uniqueName(rule.getName(), usedNames);
          Highlight hl = buildHighlight(rule, name, condCols, false);
 
+         // A crosstab evaluates its highlight condition against the cell's own headers — aggregates named
+         // by their FULL name ("DistinctCount(ORDER_ID)"), never the base column. So a caller naming the
+         // base column plus an aggregateFormula, the shape a HAVING filter takes, produces an AggregateRef
+         // whose name is "ORDER_ID"; no such header exists here, the condition resolves to nothing at
+         // render time, and the rule is stored on the right cell and colors nothing. The apply returns 200
+         // with no error, so neither the caller nor the user can tell it from a rule that worked.
+         //
+         // The chart path has always rebound-then-verified for exactly this reason; the crosstab path
+         // passed the columns to buildHighlight for value COERCION only and never checked the field
+         // resolved. Same treatment here: rebind what is unambiguous, fail loud on the rest.
+         //
+         // Crosstab only. A plain table's condition is evaluated against its base columns — the very
+         // selection already passed in — so there is nothing to rebind and no aggregated form to fall
+         // back to.
+         if(crosstab) {
+            Set<String> unresolved =
+               rebindConditionFieldsToViewColumns(hl.getConditionGroup(), condCols);
+
+            if(!unresolved.isEmpty()) {
+               throw new IllegalArgumentException(
+                  "highlight '" + name + "' references field(s) not available at the target cell: " +
+                  String.join(", ", unresolved) + ". Name a crosstab dimension by its header (e.g. " +
+                  "\"COMPANY_NAME\") or a measure by its aggregated form (e.g. " +
+                  "\"DistinctCount(ORDER_ID)\"). Available fields: " + columnNames(condCols) + ".");
+            }
+         }
+
          // A regular table can style the whole row (a row-level path keyed by level+type); a crosstab
          // has no row data path, so it always styles the measure's cells.
          TableDataPath key = !crosstab && rule.isApplyRow()
@@ -982,7 +1009,7 @@ public class WizVsService {
       ConditionList conditionGroup = buildConditionList(cm, columns, null);
 
       if(chartRebind) {
-         Set<String> unresolved = rebindChartConditionFields(conditionGroup, columns);
+         Set<String> unresolved = rebindConditionFieldsToViewColumns(conditionGroup, columns);
 
          // A chart highlight condition is matched against the aggregated chart DataSet, whose headers are
          // the fields' full names (a dimension like "State", a measure like "Sum(Sales)"). A condition
@@ -1162,18 +1189,24 @@ public class WizVsService {
    }
 
    /**
-    * Rebinds each condition item's field to the matching chart column (by name) so the highlight
-    * resolves against the aggregated chart DataSet. Match order: exact full-name ("Sum(Sales)"), then
-    * a chart column that aggregates the requested base column ("Sales" -> "Sum(Sales)"). Returns the
-    * names of any condition fields that matched NEITHER form, so the caller can fail loud rather than
-    * apply a highlight whose condition can never resolve against the chart DataSet (a silent no-op).
+    * Rebinds each condition item's field to the matching VIEW column (by name) so the highlight resolves
+    * against the aggregated data the assembly actually renders. Match order: exact full-name
+    * ("Sum(Sales)"), then a view column that aggregates the requested base column ("Sales" ->
+    * "Sum(Sales)"). Returns the names of any condition fields that matched NEITHER form, so the caller
+    * can fail loud rather than apply a highlight whose condition can never resolve (a silent no-op).
+    *
+    * Used by the chart AND crosstab paths, which share the problem: both evaluate a highlight condition
+    * POST-aggregation, against headers named by the fields' full names. A caller naming the base column
+    * plus an aggregate — the shape a HAVING filter takes — yields an AggregateRef whose getName() is the
+    * BASE column, and no such header exists at render time. The second match arm is what turns that into
+    * the header the data actually carries.
     */
-   private Set<String> rebindChartConditionFields(ConditionList conds, ColumnSelection chartCols) {
+   private Set<String> rebindConditionFieldsToViewColumns(ConditionList conds, ColumnSelection viewCols) {
       // LinkedHashSet: dedup while preserving first-seen order, so the same bad field name appearing in
       // several condition leaves (e.g. "Profit > 5 AND Profit < 100") is listed once in the error message.
       Set<String> unresolved = new LinkedHashSet<>();
 
-      if(conds == null || chartCols == null) {
+      if(conds == null || viewCols == null) {
          return unresolved;
       }
 
@@ -1189,10 +1222,10 @@ public class WizVsService {
             continue;
          }
 
-         DataRef match = chartCols.getAttribute(attr.getName());
+         DataRef match = viewCols.getAttribute(attr.getName());
 
          if(match == null) {
-            match = findAggregatedColumn(chartCols, attr.getName());
+            match = findAggregatedColumn(viewCols, attr.getName());
          }
 
          if(match != null) {
@@ -1243,14 +1276,14 @@ public class WizVsService {
       return sb.length() > 0 ? sb.toString() : "none";
    }
 
-   /** Find a chart column whose full name aggregates the given base column, e.g. "Sales" -> "Sum(Sales)". */
-   private DataRef findAggregatedColumn(ColumnSelection chartCols, String baseName) {
+   /** Find a view column whose full name aggregates the given base column, e.g. "Sales" -> "Sum(Sales)". */
+   private DataRef findAggregatedColumn(ColumnSelection viewCols, String baseName) {
       if(baseName == null) {
          return null;
       }
 
-      for(int i = 0; i < chartCols.getAttributeCount(); i++) {
-         DataRef ref = chartCols.getAttribute(i);
+      for(int i = 0; i < viewCols.getAttributeCount(); i++) {
+         DataRef ref = viewCols.getAttribute(i);
          String full = ref.getName();
          int open = full.indexOf('(');
          int close = full.lastIndexOf(')');

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -1225,7 +1225,7 @@ public class WizVsService {
          DataRef match = viewCols.getAttribute(attr.getName());
 
          if(match == null) {
-            match = findAggregatedColumn(viewCols, attr.getName());
+            match = findAggregatedColumn(viewCols, attr.getName(), aggregateHeaderOf(attr));
          }
 
          if(match != null) {
@@ -1276,10 +1276,48 @@ public class WizVsService {
       return sb.length() > 0 ? sb.toString() : "none";
    }
 
-   /** Find a view column whose full name aggregates the given base column, e.g. "Sales" -> "Sum(Sales)". */
-   private DataRef findAggregatedColumn(ColumnSelection viewCols, String baseName) {
+   /**
+    * The header an aggregate condition names, composed from the formula the caller gave: an
+    * AggregateRef(SALES, Average) -> "Average(SALES)". Null when the ref carries no formula.
+    *
+    * Exists because a column can be bound MORE THAN ONCE under different aggregates — "Sum(SALES)" and
+    * "Average(SALES)" side by side in the same crosstab or chart. The base name alone cannot say which of
+    * them was meant, so the loose scan in findAggregatedColumn answers with whichever the view lists
+    * first: an Average condition silently lands on the Sum column, and the highlight colors cells chosen
+    * by a number nobody asked about.
+    */
+   private static String aggregateHeaderOf(DataRef ref) {
+      if(!(ref instanceof AggregateRef aggregateRef) || aggregateRef.getFormula() == null) {
+         return null;
+      }
+
+      String base = ref.getName();
+
+      return base == null || base.isEmpty()
+         ? null : aggregateRef.getFormula().getFormulaName() + "(" + base + ")";
+   }
+
+   /**
+    * Find a view column that carries the given base column under an aggregate, e.g. "Sales" ->
+    * "Sum(Sales)".
+    *
+    * {@code preferredFullName} — the formula-qualified header the condition itself named — is tried
+    * first and is the only answer that can be trusted when the base column is bound more than once; the
+    * scan below is the fallback for a condition that named no formula at all.
+    */
+   private DataRef findAggregatedColumn(ColumnSelection viewCols, String baseName,
+                                        String preferredFullName)
+   {
       if(baseName == null) {
          return null;
+      }
+
+      if(preferredFullName != null) {
+         DataRef exact = viewCols.getAttribute(preferredFullName);
+
+         if(exact != null) {
+            return exact;
+         }
       }
 
       for(int i = 0; i < viewCols.getAttributeCount(); i++) {

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -1294,11 +1294,14 @@ public class WizVsService {
     * first: an Average condition silently lands on the Sum column, and the highlight colors cells chosen
     * by a number nobody asked about.
     *
-    * Answers null — no preferred name, leaving that scan to decide — whenever the condition does not
-    * carry enough to name a header the view could have produced: no formula at all, a two-column formula
-    * with no secondary column, or an N-parameter formula whose N is 0. Those are the cases where the
-    * remaining ambiguity is real rather than something a spelling can resolve, so this returns nothing
-    * instead of inventing a header and matching the wrong column with confidence.
+    * Answers null — no preferred name — whenever the condition does not carry enough to name a header the
+    * view could have produced: no formula at all, a two-column formula with no secondary column, or an
+    * N-parameter formula whose N is 0. For the latter two that means the field ends up REPORTED as
+    * unresolved and the caller fails loud, because findAggregatedColumn's fallback scan compares the
+    * whole parenthesised text to the base name and so cannot match "Correlation(SALES, PROFIT)" or
+    * "NthLargest(SALES, 3)" either. That is the honest answer: the condition never said which of those
+    * columns it meant, and an error naming the available headers is worth more than a highlight quietly
+    * keyed to the wrong one.
     */
    // Package-private for unit testing (WizVsServiceHighlightRebindTest).
    static String aggregateHeaderOf(DataRef ref) {
@@ -1318,10 +1321,8 @@ public class WizVsService {
 
       // A two-column formula with no secondary column names no header any view produced: getFullName
       // composes the missing half as "Correlation(SALES, null)", and nothing binds a Correlation without
-      // its second column in the first place. There is no preferred name to be had, so answer none and
-      // let findAggregatedColumn fall back to its base-name scan — what it did before a preferred name
-      // existed. Composing a one-argument "Correlation(SALES)" here would only invent a third spelling
-      // that matches neither.
+      // its second column in the first place. Composing the one-argument "Correlation(SALES)" instead
+      // only invents a third spelling that matches neither, so answer none.
       if(formula.isTwoColumns() && (secondaryName == null || secondaryName.isEmpty())) {
          return null;
       }
@@ -1331,7 +1332,7 @@ public class WizVsService {
       // a real P the view can carry. Composing either reading picks a header the condition may not have
       // meant: "NthLargest(SALES, 0)" is one no view produces (VSAggregateRef's nValue defaults to "1"),
       // and substituting that 1 would spell a P=0 condition as P=1. Neither guess is safe, so answer none
-      // and let the base-name scan decide, the same way the missing secondary column above does.
+      // the same way the missing secondary column above does.
       int n = aggregateRef.getN();
 
       if(formula.hasN() && n <= 0) {

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVsService.java
@@ -1281,9 +1281,12 @@ public class WizVsService {
     * The header an aggregate condition names, composed from the formula the caller gave: an
     * AggregateRef(SALES, Average) -> "Average(SALES)". Null when the ref carries no formula.
     *
-    * Covers all three arities AggregateRef.toView() composes, since the result is compared against a
-    * header that method produced: one column ("Average(SALES)"), two for a two-column formula
-    * ("Correlation(SALES, PROFIT)"), and a column plus N for an N-parameter one ("NthLargest(SALES, 3)").
+    * Composed by {@link #buildVSAggregateRefFullName}, i.e. by VSAggregateRef.getFullName — the very
+    * method that produced the header this string is compared against (buildChartHighlightColumns reads
+    * VSDataRef.getFullName, and a crosstab cell's available fields carry the same name). Going through it
+    * rather than concatenating here means every arity a wiz condition can carry — a second column for
+    * isTwoColumns, an N for hasN, both set by buildConditionItem — is spelled with the argument order,
+    * separator and defaults the view already used, instead of a copy that has to be kept in step with it.
     *
     * Exists because a column can be bound MORE THAN ONCE under different aggregates — "Sum(SALES)" and
     * "Average(SALES)" side by side in the same crosstab or chart. The base name alone cannot say which of
@@ -1304,31 +1307,27 @@ public class WizVsService {
       }
 
       AggregateFormula formula = aggregateRef.getFormula();
-      String name = formula.getFormulaName();
+      DataRef secondary = aggregateRef.getSecondaryColumn();
+      String secondaryName = secondary != null ? secondary.getName() : null;
 
-      // Mirrors AggregateRef.toView(), which is what composes the header at render time — including its
-      // two extra arities, both of which a wiz condition can carry (buildConditionItem sets secondaryRef
-      // for isTwoColumns and N for hasN). Composed with the SAME argument order and separator, because
-      // this string is compared for EQUALITY against a header the view already produced: a one-argument
-      // "Correlation(SALES)" never matches the real "Correlation(SALES, PROFIT)", the lookup falls back to
-      // the loose base-name scan, and the ambiguity this preferred name exists to remove comes back for
-      // exactly these formulas.
-      if(formula.isTwoColumns()) {
-         DataRef secondary = aggregateRef.getSecondaryColumn();
-         String secondaryName = secondary != null ? secondary.getName() : null;
-
-         // No secondary column to name: toView() falls through to the one-argument form here too, so the
-         // header composed below still matches it.
-         return secondaryName == null || secondaryName.isEmpty()
-            ? name + "(" + base + ")"
-            : name + "(" + base + ", " + secondaryName + ")";
+      // A two-column formula with no secondary column names no header any view produced: getFullName
+      // composes the missing half as "Correlation(SALES, null)", and nothing binds a Correlation without
+      // its second column in the first place. There is no preferred name to be had, so answer none and
+      // let findAggregatedColumn fall back to its base-name scan — what it did before a preferred name
+      // existed. Composing a one-argument "Correlation(SALES)" here would only invent a third spelling
+      // that matches neither.
+      if(formula.isTwoColumns() && (secondaryName == null || secondaryName.isEmpty())) {
+         return null;
       }
 
-      if(formula.hasN()) {
-         return name + "(" + base + ", " + aggregateRef.getN() + ")";
-      }
+      // An AggregateRef stores N as a primitive and leaves it 0 when the caller named none, but the view
+      // side is a VSAggregateRef whose nValue defaults to "1" — so an unset N must be passed as null to
+      // reach that same default. Passing the 0 through composes "NthLargest(SALES, 0)", a header no view
+      // ever produces, and the lookup falls back to the loose base-name scan for every such condition.
+      int n = aggregateRef.getN();
 
-      return name + "(" + base + ")";
+      return buildVSAggregateRefFullName(base, formula.getFormulaName(), secondaryName,
+                                         n > 0 ? n : null);
    }
 
    /**
@@ -4732,8 +4731,8 @@ public class WizVsService {
     *
     * @return the computed fullName from VSAggregateRef
     */
-   private String buildVSAggregateRefFullName(String columnValue, String formulaValue,
-                                              String secondaryField, Integer nOrP)
+   private static String buildVSAggregateRefFullName(String columnValue, String formulaValue,
+                                                    String secondaryField, Integer nOrP)
    {
       VSAggregateRef ref = new VSAggregateRef();
       ref.setColumnValue(columnValue);

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceHighlightRebindTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceHighlightRebindTest.java
@@ -199,9 +199,10 @@ class WizVsServiceHighlightRebindTest {
    }
 
    @Test
-   void composesAOneColumnHeaderForATwoColumnFormulaMissingItsSecondaryField() {
-      // toView() falls through to the one-argument form here too, so this must match it.
-      assertEquals("Correlation(SALES)", WizVsService.aggregateHeaderOf(
+   void composesNoHeaderForATwoColumnFormulaMissingItsSecondaryField() {
+      // No view binds a two-column formula without its second column, so there is no header to prefer;
+      // the caller falls back to the base-name scan rather than matching an invented spelling.
+      assertEquals(null, WizVsService.aggregateHeaderOf(
          new AggregateRef(new ColumnRef(new AttributeRef(null, "SALES")), null,
                           AggregateFormula.CORRELATION)));
    }

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceHighlightRebindTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceHighlightRebindTest.java
@@ -180,9 +180,9 @@ class WizVsServiceHighlightRebindTest {
 
    // ── header composition ─────────────────────────────────────────────────────
    //
-   // Each arity AggregateRef.toView() composes, because the preferred name is compared for EQUALITY
-   // against a header that method produced. A missed match is not an error — it degrades to the loose
-   // base-name scan — which is exactly why it has to be pinned: the degradation is invisible.
+   // Each arity VSAggregateRef.getFullName composes, because the preferred name is compared for EQUALITY
+   // against a header that method produced. A missed match raises nothing on its own — it degrades to the
+   // loose base-name scan — which is exactly why it has to be pinned: the degradation is invisible.
 
    @Test
    void composesAOneColumnHeader() {
@@ -214,6 +214,57 @@ class WizVsServiceHighlightRebindTest {
       ref.setN(3);
 
       assertEquals("NthLargest(SALES, 3)", WizVsService.aggregateHeaderOf(ref));
+   }
+
+   @Test
+   void composesNoHeaderForAnNParameterFormulaWhoseNIsUnset() {
+      // AggregateRef leaves N at 0 when the caller named none, and no view carries "NthLargest(SALES, 0)"
+      // — a VSAggregateRef defaults its N to 1. Substituting that 1 would be a guess at which of the
+      // view's N columns was meant, so no name is offered.
+      assertEquals(null, WizVsService.aggregateHeaderOf(new AggregateRef(
+         new ColumnRef(new AttributeRef(null, "SALES")), null, AggregateFormula.NTH_LARGEST)));
+   }
+
+   @Test
+   void composesNoHeaderForAPercentileWhoseNIsZero() {
+      // The other reading of that same 0, and why it cannot simply be replaced by the default: for
+      // PthPercentile a P of 0 is a real percentile a view can carry, so spelling it as 1 would name a
+      // DIFFERENT column with full confidence. N is a bare primitive here, so the two readings cannot be
+      // told apart and neither is guessed.
+      AggregateRef ref = new AggregateRef(
+         new ColumnRef(new AttributeRef(null, "SALES")), null, AggregateFormula.PTH_PERCENTILE);
+      ref.setN(0);
+
+      assertEquals(null, WizVsService.aggregateHeaderOf(ref));
+   }
+
+   @Test
+   void resolvesAnNParameterFormulaAgainstItsRealHeader() {
+      // The same end the two-column case below serves: two N-parameter aggregates over the SAME base
+      // column are separated only by N, so the preferred name is the only thing that can tell them apart.
+      AggregateRef ref = new AggregateRef(
+         new ColumnRef(new AttributeRef(null, "SALES")), null, AggregateFormula.NTH_LARGEST);
+      ref.setN(3);
+
+      ConditionList conds = aggregateCondition(ref);
+      Set<String> unresolved = service.rebindConditionFieldsToViewColumns(
+         conds, viewColumns("NthLargest(SALES, 1)", "NthLargest(SALES, 3)"));
+
+      assertTrue(unresolved.isEmpty());
+      assertEquals("NthLargest(SALES, 3)", fieldOf(conds));
+   }
+
+   @Test
+   void reportsAnNParameterFormulaWhoseNWasNeverNamed() {
+      // Withholding the preferred name is not a silent degradation here: the fallback scan compares the
+      // whole parenthesised text to the base name, so it cannot match "NthLargest(SALES, 5)" either and
+      // the field is REPORTED. The caller turns that into an error naming the available headers, which is
+      // the honest answer to a condition that never said which N it meant.
+      ConditionList conds = aggregateCondition("SALES", AggregateFormula.NTH_LARGEST);
+      Set<String> unresolved =
+         service.rebindConditionFieldsToViewColumns(conds, viewColumns("STATE", "NthLargest(SALES, 5)"));
+
+      assertEquals(Set.of("SALES"), unresolved);
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceHighlightRebindTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVsServiceHighlightRebindTest.java
@@ -1,0 +1,239 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.uql.ColumnSelection;
+import inetsoft.uql.Condition;
+import inetsoft.uql.ConditionItem;
+import inetsoft.uql.ConditionList;
+import inetsoft.uql.XCondition;
+import inetsoft.uql.asset.AggregateFormula;
+import inetsoft.uql.asset.AggregateRef;
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Resolving a highlight condition's field against the columns the view actually renders.
+ *
+ * A highlight condition is evaluated POST-aggregation, against headers named by each field's FULL name
+ * ("Sum(SALES)"). A caller naming the base column plus an aggregate — the shape a HAVING filter takes —
+ * produces an {@link AggregateRef} whose {@code getName()} is the BASE column, and no such header exists
+ * at render time. Left unresolved the condition matches nothing: the highlight is stored on the right
+ * cell, the request answers 200 with no error, and not one cell is colored. That is the failure this
+ * rebind exists to remove, and the reason it must FAIL LOUD when it cannot rebind rather than pass a
+ * condition through that can never resolve.
+ *
+ * The unit under test is the resolution itself. applyHighlight's crosstab branch reaches it through a
+ * live {@code VSTableLens} and the static {@code TableHighlightAttr.getAvailableFields}, which is why
+ * {@link WizVsServiceApplyHighlightCopyTest} drives that method with a TEXT assembly instead; the
+ * end-to-end lens path stays out of scope here.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WizVsServiceHighlightRebindTest {
+   private final WizVsService service = new WizVsService(null, null, null, null, null);
+
+   private static ColumnSelection viewColumns(String... names) {
+      ColumnSelection cols = new ColumnSelection();
+
+      for(String name : names) {
+         ColumnRef col = new ColumnRef(new AttributeRef(null, name));
+         col.setDataType(XSchema.INTEGER);
+         cols.addAttribute(col);
+      }
+
+      return cols;
+   }
+
+   /** A one-item condition list whose field is an aggregate over {@code base} — the HAVING-ish shape. */
+   private static ConditionList aggregateCondition(String base, AggregateFormula formula) {
+      return aggregateCondition(new AggregateRef(new ColumnRef(new AttributeRef(null, base)), null, formula));
+   }
+
+   private static ConditionList aggregateCondition(AggregateRef ref) {
+      Condition condition = new Condition();
+      condition.setOperation(XCondition.GREATER_THAN);
+      condition.addValue(20);
+
+      ConditionList conds = new ConditionList();
+      conds.append(new ConditionItem(ref, condition, 0));
+      return conds;
+   }
+
+   /** A one-item condition list on a plain column, the shape a dimension condition takes. */
+   private static ConditionList plainCondition(String field) {
+      Condition condition = new Condition();
+      condition.setOperation(XCondition.EQUAL_TO);
+      condition.addValue("A");
+
+      ConditionList conds = new ConditionList();
+      conds.append(new ConditionItem(new AttributeRef(null, field), condition, 0));
+      return conds;
+   }
+
+   private static String fieldOf(ConditionList conds) {
+      DataRef attr = conds.getConditionItem(0).getAttribute();
+      return attr == null ? null : attr.getName();
+   }
+
+   // ── rebinding ──────────────────────────────────────────────────────────────
+
+   @Test
+   void rebindsABaseColumnOntoItsAggregatedHeader() {
+      ConditionList conds = aggregateCondition("SALES", AggregateFormula.SUM);
+      Set<String> unresolved =
+         service.rebindConditionFieldsToViewColumns(conds, viewColumns("STATE", "Sum(SALES)"));
+
+      assertTrue(unresolved.isEmpty(), "a bound measure must resolve");
+      assertEquals("Sum(SALES)", fieldOf(conds));
+   }
+
+   @Test
+   void leavesAnExactHeaderMatchAlone() {
+      ConditionList conds = plainCondition("Sum(SALES)");
+      Set<String> unresolved =
+         service.rebindConditionFieldsToViewColumns(conds, viewColumns("STATE", "Sum(SALES)"));
+
+      assertTrue(unresolved.isEmpty());
+      assertEquals("Sum(SALES)", fieldOf(conds));
+   }
+
+   @Test
+   void resolvesADimensionByItsOwnName() {
+      ConditionList conds = plainCondition("STATE");
+      Set<String> unresolved =
+         service.rebindConditionFieldsToViewColumns(conds, viewColumns("STATE", "Sum(SALES)"));
+
+      assertTrue(unresolved.isEmpty());
+      assertEquals("STATE", fieldOf(conds));
+   }
+
+   @Test
+   void reportsAFieldTheViewDoesNotCarry() {
+      // Reported rather than silently dropped: the caller turns this into an IllegalArgumentException
+      // naming the field and the available headers, so an unresolvable condition never reaches a cell.
+      ConditionList conds = plainCondition("PROFIT");
+      Set<String> unresolved =
+         service.rebindConditionFieldsToViewColumns(conds, viewColumns("STATE", "Sum(SALES)"));
+
+      assertEquals(Set.of("PROFIT"), unresolved);
+   }
+
+   @Test
+   void picksTheAggregateTheConditionNamedWhenTheBaseColumnIsBoundTwice() {
+      // The regression this guards: matching on the base name alone answered with whichever header the
+      // view listed FIRST, so an Average condition landed on the Sum column and the highlight colored
+      // cells chosen by a number nobody asked about.
+      ConditionList conds = aggregateCondition("SALES", AggregateFormula.AVG);
+      Set<String> unresolved =
+         service.rebindConditionFieldsToViewColumns(conds, viewColumns("Sum(SALES)", "Average(SALES)"));
+
+      assertTrue(unresolved.isEmpty());
+      assertEquals("Average(SALES)", fieldOf(conds));
+   }
+
+   @Test
+   void fallsBackToTheBaseNameScanWhenTheNamedAggregateIsNotBound() {
+      // The scan is still the right answer when the base column is bound exactly once: the condition
+      // names the measure the view has, just under a different aggregate than the caller assumed.
+      ConditionList conds = aggregateCondition("SALES", AggregateFormula.AVG);
+      Set<String> unresolved =
+         service.rebindConditionFieldsToViewColumns(conds, viewColumns("STATE", "Sum(SALES)"));
+
+      assertTrue(unresolved.isEmpty());
+      assertEquals("Sum(SALES)", fieldOf(conds));
+   }
+
+   // ── header composition ─────────────────────────────────────────────────────
+   //
+   // Each arity AggregateRef.toView() composes, because the preferred name is compared for EQUALITY
+   // against a header that method produced. A missed match is not an error — it degrades to the loose
+   // base-name scan — which is exactly why it has to be pinned: the degradation is invisible.
+
+   @Test
+   void composesAOneColumnHeader() {
+      assertEquals("Sum(SALES)", WizVsService.aggregateHeaderOf(
+         new AggregateRef(new ColumnRef(new AttributeRef(null, "SALES")), null, AggregateFormula.SUM)));
+   }
+
+   @Test
+   void composesATwoColumnHeaderWithItsSecondaryField() {
+      assertEquals("Correlation(SALES, PROFIT)", WizVsService.aggregateHeaderOf(
+         new AggregateRef(new ColumnRef(new AttributeRef(null, "SALES")),
+                          new ColumnRef(new AttributeRef(null, "PROFIT")),
+                          AggregateFormula.CORRELATION)));
+   }
+
+   @Test
+   void composesAOneColumnHeaderForATwoColumnFormulaMissingItsSecondaryField() {
+      // toView() falls through to the one-argument form here too, so this must match it.
+      assertEquals("Correlation(SALES)", WizVsService.aggregateHeaderOf(
+         new AggregateRef(new ColumnRef(new AttributeRef(null, "SALES")), null,
+                          AggregateFormula.CORRELATION)));
+   }
+
+   @Test
+   void composesAnNParameterHeaderWithItsN() {
+      AggregateRef ref = new AggregateRef(
+         new ColumnRef(new AttributeRef(null, "SALES")), null, AggregateFormula.NTH_LARGEST);
+      ref.setN(3);
+
+      assertEquals("NthLargest(SALES, 3)", WizVsService.aggregateHeaderOf(ref));
+   }
+
+   @Test
+   void resolvesATwoColumnFormulaAgainstItsRealHeader() {
+      // The end this composition serves: two two-column aggregates over the SAME base column are
+      // separated only by the secondary field, so a one-argument name would fall back to the scan and
+      // pick whichever came first.
+      ConditionList conds = aggregateCondition(new AggregateRef(
+         new ColumnRef(new AttributeRef(null, "SALES")),
+         new ColumnRef(new AttributeRef(null, "DISCOUNT")),
+         AggregateFormula.CORRELATION));
+
+      Set<String> unresolved = service.rebindConditionFieldsToViewColumns(
+         conds, viewColumns("Correlation(SALES, PROFIT)", "Correlation(SALES, DISCOUNT)"));
+
+      assertTrue(unresolved.isEmpty());
+      assertEquals("Correlation(SALES, DISCOUNT)", fieldOf(conds));
+   }
+
+   @Test
+   void namesNothingForARefThatCarriesNoFormula() {
+      assertEquals(null, WizVsService.aggregateHeaderOf(new ColumnRef(new AttributeRef(null, "SALES"))));
+   }
+}


### PR DESCRIPTION
A crosstab highlight naming the base column plus an aggregateFormula was stored on the correct cell and colored nothing, and the apply returned 200 with no error — so neither the caller nor the user could tell it from a rule that worked.

- A crosstab evaluates a highlight condition against the target cell's available fields, where aggregates are named by their FULL name ("DistinctCount(ORDER_ID)"). The base-column-plus-formula shape is a HAVING filter's, and buildConditionItem turns it into an AggregateRef whose getName() is the base column, so no such header exists at render time and the condition resolves to nothing
- The chart path has always rebound-then-verified for exactly this reason. The crosstab path passed its condition columns to buildHighlight for value COERCION only and never checked the field resolved at all
- Give it the same treatment: rebind what is unambiguous, and fail loud naming the field and the available headers on the rest
- rebindChartConditionFields is now rebindConditionFieldsToViewColumns — it was never chart-specific, and its second match arm ("Sales" -> "Sum(Sales)") is exactly what converts the base-column shape into the header the data carries
- Crosstab only. A plain table's condition is evaluated against the base columns already passed in, so there is nothing to rebind there