### PR TITLE
feat(pairing): show in the Composer that an agent connected

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/pairing/PairingJoinedNotice.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/PairingJoinedNotice.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.pairing;
+
+/**
+ * Tells the browser that minted a pairing code that an agent has redeemed it.
+ *
+ * <p>Pairing is split across two processes: the browser mints the code, and the agent joins over
+ * HTTP. Nothing else closes that loop, so without this notice the Composer cannot know the code it
+ * displayed was ever used, and the only evidence pairing worked is the agent saying so.
+ *
+ * <p>Carries exactly the three fields the client needs to decide whether a notice is addressed to
+ * it. The destination is per-user, not per-sheet and not per-pane, while
+ * {@code ConnectToClaudeComponent} is reused by the composer toolbar, the viewsheet script pane and
+ * the formula editor dialog — several instances can be alive at once on one page. Both
+ * {@code runtimeId} and {@code editorContext} are therefore load-bearing filters, not diagnostics.
+ *
+ * @param editorContext the paired location, or {@code null} for a whole-sheet ("Connect to Claude"
+ *                      toolbar) pairing. {@code null} is the normal case, never an error.
+ */
+public record PairingJoinedNotice(String runtimeId, SheetType sheetType,
+                                  EditorContext editorContext) {
+}

--- a/core/src/main/java/inetsoft/web/wiz/pairing/PairingJoinedNotice.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/PairingJoinedNotice.java
@@ -25,7 +25,7 @@ package inetsoft.web.wiz.pairing;
  * displayed was ever used, and the only evidence pairing worked is the agent saying so.
  *
  * <p>Carries exactly the three fields the client needs to decide whether a notice is addressed to
- * it. The destination is per-user, not per-sheet and not per-pane, while
+ * it. The destination is per socket session — not per sheet and not per pane — while
  * {@code ConnectToClaudeComponent} is reused by the composer toolbar, the viewsheet script pane and
  * the formula editor dialog — several instances can be alive at once on one page. Both
  * {@code runtimeId} and {@code editorContext} are therefore load-bearing filters, not diagnostics.

--- a/core/src/main/java/inetsoft/web/wiz/pairing/SheetAgentBroadcastService.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/SheetAgentBroadcastService.java
@@ -53,6 +53,17 @@ import java.util.List;
 public class SheetAgentBroadcastService {
    private static final Logger LOG = LoggerFactory.getLogger(SheetAgentBroadcastService.class);
 
+   /**
+    * Where a paired browser learns that an agent joined. The client subscribes to this prefixed
+    * with {@code /user}, exactly as it does for mint's {@code @SendToUser} destination.
+    *
+    * <p>Deliberately neither {@code CommandDispatcher.COMMANDS_TOPIC} nor
+    * {@code ComposerClientService.COMMANDS_TOPIC} — see {@link #sendToComposer}'s javadoc for why
+    * confusing those two is a silent failure. This is a pairing-domain destination with its own
+    * client handler.
+    */
+   static final String PAIRING_JOINED_TOPIC = "/commands/wiz/pairing/joined";
+
    @Autowired
    public SheetAgentBroadcastService(CommandDispatcherService commandDispatcherService,
                                      VSObjectModelFactoryService vsObjectModelFactoryService)
@@ -236,6 +247,29 @@ public class SheetAgentBroadcastService {
 
       commandDispatcherService.convertAndSendToUser(
          socketSessionId, ComposerClientService.COMMANDS_TOPIC, command,
+         headers.getMessageHeaders());
+   }
+
+   /**
+    * Tell the browser that minted the code that an agent has now joined with it.
+    *
+    * <p>Addresses {@code socketUserName} — the destination user resolved at mint time, the same
+    * value mint's {@code @SendToUser} resolved to — and sets the session id header as the other
+    * senders here do.
+    *
+    * <p>Callers must treat this as best-effort. By the time it runs the agent's session is open and
+    * valid, so a failure here costs the browser's indicator and nothing more.
+    */
+   public void sendPairingJoined(JoinSession session) {
+      SimpMessageHeaderAccessor headers =
+         SimpMessageHeaderAccessor.create(SimpMessageType.MESSAGE);
+      headers.setSessionId(session.socketSessionId());
+      headers.setLeaveMutable(true);
+
+      commandDispatcherService.convertAndSendToUser(
+         session.socketUserName(), PAIRING_JOINED_TOPIC,
+         new PairingJoinedNotice(session.runtimeId(), session.sheetType(),
+                                 session.editorContext()),
          headers.getMessageHeaders());
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/pairing/SheetAgentBroadcastService.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/SheetAgentBroadcastService.java
@@ -261,6 +261,16 @@ public class SheetAgentBroadcastService {
     * valid, so a failure here costs the browser's indicator and nothing more.
     */
    public void sendPairingJoined(JoinSession session) {
+      // Nothing to notify. The REST mint path can record a null destination user (a null
+      // principal), and Spring answers that with Assert.notNull — a stack trace the caller then
+      // logs as "notifying the browser failed", which is misleading: nothing failed to send, there
+      // was simply nobody to send to. broadcastRefresh guards its own null user for the same reason.
+      if(session.socketUserName() == null) {
+         LOG.debug("Pairing joined notice skipped — no destination user recorded (runtimeId={})",
+                   session.runtimeId());
+         return;
+      }
+
       SimpMessageHeaderAccessor headers =
          SimpMessageHeaderAccessor.create(SimpMessageType.MESSAGE);
       headers.setSessionId(session.socketSessionId());

--- a/core/src/main/java/inetsoft/web/wiz/pairing/SheetJoinService.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/SheetJoinService.java
@@ -59,11 +59,13 @@ public class SheetJoinService {
    public SheetJoinService(SheetPairingService pairing,
                            SheetSessionService sessions,
                            SheetAgentFeature feature,
-                           SheetRuntimeAccess runtimeAccess) {
+                           SheetRuntimeAccess runtimeAccess,
+                           SheetAgentBroadcastService broadcast) {
       this.pairing = pairing;
       this.sessions = sessions;
       this.feature = feature;
       this.runtimeAccess = runtimeAccess;
+      this.broadcast = broadcast;
    }
 
    /**
@@ -129,6 +131,19 @@ public class SheetJoinService {
                                           grant.sheetType(), grant.socketSessionId(),
                                           grant.socketUserName(), grant.editorContext());
       failedAttempts.remove(throttleKey);
+
+      // Close the loop back to the browser that minted this code — it has no other way to learn
+      // the code was redeemed, since the join arrived over HTTP from the agent. Best-effort by
+      // design: the session above is already open and valid, so a lost notice degrades the
+      // Composer's indicator and must never turn a successful pairing into a failed one.
+      try {
+         broadcast.sendPairingJoined(session);
+      }
+      catch(Exception ex) {
+         LOG.warn("Pairing joined, but notifying the browser failed (runtimeId={})",
+                  grant.runtimeId(), ex);
+      }
+
       LOG.info("Sheet agent pairing join granted (runtimeId={}, sheetType={}, agent={})",
                grant.runtimeId(), grant.sheetType(), agentUser.getName());
       return session;
@@ -211,5 +226,6 @@ public class SheetJoinService {
    private final SheetSessionService sessions;
    private final SheetAgentFeature feature;
    private final SheetRuntimeAccess runtimeAccess;
+   private final SheetAgentBroadcastService broadcast;
    private final ConcurrentHashMap<String, AttemptWindow> failedAttempts = new ConcurrentHashMap<>();
 }

--- a/core/src/test/java/inetsoft/web/wiz/pairing/SheetAgentBroadcastServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/pairing/SheetAgentBroadcastServiceTest.java
@@ -89,6 +89,56 @@ class SheetAgentBroadcastServiceTest {
       verifyNoInteractions(dispatcher);
    }
 
+   /*
+    * The destination string and the destination user are the entire contract of this method, and
+    * each is one word away from a silent failure: this class's own javadoc records that a wrong
+    * topic is delivered to a destination with no handler and dropped while every call up the stack
+    * still reports success, and the adjacent sendToComposer genuinely does pass socketSessionId as
+    * the user. Asserting the LITERAL strings is what makes either swap fail here — asserting
+    * PAIRING_JOINED_TOPIC against itself would test nothing at all.
+    */
+   @Test
+   void pairingJoinedNoticeAddressesTheMintingBrowser() {
+      CommandDispatcherService dispatcher = mock(CommandDispatcherService.class);
+      SheetAgentBroadcastService svc = new SheetAgentBroadcastService(dispatcher, noopModelFactory());
+      EditorContext context = new EditorContext("assemblyMain", "Chart1", null, null);
+      JoinSession session = new JoinSession("tok-1", "vs-9", "alice~;~host-org",
+                                            SheetType.VIEWSHEET, 0L, 0L,
+                                            JoinSession.ConnectionMode.PAIRED,
+                                            "stomp-1", "alice-dest", context);
+
+      svc.sendPairingJoined(session);
+
+      ArgumentCaptor<MessageHeaders> headersCap = ArgumentCaptor.forClass(MessageHeaders.class);
+      ArgumentCaptor<Object> payloadCap = ArgumentCaptor.forClass(Object.class);
+      verify(dispatcher).convertAndSendToUser(
+         eq("alice-dest"), eq("/commands/wiz/pairing/joined"), payloadCap.capture(),
+         headersCap.capture());
+
+      assertEquals("stomp-1", SimpMessageHeaderAccessor.getSessionId(headersCap.getValue()));
+      assertEquals(new PairingJoinedNotice("vs-9", SheetType.VIEWSHEET, context),
+                   payloadCap.getValue());
+   }
+
+   /*
+    * A null destination user reaches Spring's Assert.notNull, which the caller logs as "notifying
+    * the browser failed" — misleading, since nothing failed to send and there was nobody to send
+    * to. Mirrors nullSocketSessionSkipsBroadcast above.
+    */
+   @Test
+   void pairingJoinedNoticeSkippedWithoutADestinationUser() {
+      CommandDispatcherService dispatcher = mock(CommandDispatcherService.class);
+      SheetAgentBroadcastService svc = new SheetAgentBroadcastService(dispatcher, noopModelFactory());
+      JoinSession session = new JoinSession("tok-1", "vs-9", "alice~;~host-org",
+                                            SheetType.VIEWSHEET, 0L, 0L,
+                                            JoinSession.ConnectionMode.PAIRED,
+                                            "stomp-1", null, null);
+
+      svc.sendPairingJoined(session);
+
+      verifyNoInteractions(dispatcher);
+   }
+
    @Test
    void viewsheetBroadcastSendsOneRefreshVSObjectCommandPerVisibleAssembly() {
       CommandDispatcherService dispatcher = mock(CommandDispatcherService.class);

--- a/core/src/test/java/inetsoft/web/wiz/pairing/SheetJoinServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/pairing/SheetJoinServiceTest.java
@@ -25,13 +25,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.security.Principal;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -48,6 +52,9 @@ import static org.mockito.Mockito.when;
  * [differentKeys]   lockout of one caller does not affect a different caller
  * [resetOnSuccess]  a successful join resets the failure counter for that caller
  * [editorContext]   a pane-scoped grant's editorContext is carried through to the JoinSession
+ * [notifiesBrowser] a successful join pushes a PairingJoinedNotice to the minting browser
+ * [toolbarNotice]   a whole-sheet grant notifies with a null editorContext
+ * [notifyFailure]   a throwing broadcast does not fail the join
  */
 @Tag("core")
 @ExtendWith(MockitoExtension.class)
@@ -63,6 +70,9 @@ class SheetJoinServiceTest {
    @Mock
    private SheetRuntimeAccess runtimeAccess;
 
+   @Mock
+   private SheetAgentBroadcastService broadcast;
+
    private SheetPairingService pairing;
    private SheetSessionService sessions;
    private SheetJoinService svc;
@@ -71,7 +81,7 @@ class SheetJoinServiceTest {
    void setUp() {
       pairing  = new SheetPairingService(() -> FIXED_NOW);
       sessions = new SheetSessionService(() -> FIXED_NOW);
-      svc      = new SheetJoinService(pairing, sessions, feature, runtimeAccess);
+      svc      = new SheetJoinService(pairing, sessions, feature, runtimeAccess, broadcast);
    }
 
    // ---------------------------------------------------------------------------
@@ -324,7 +334,7 @@ class SheetJoinServiceTest {
       SheetPairingService paneScopedPairing = new SheetPairingService(
          () -> FIXED_NOW, runtimeId -> null, runtimeId -> "vs-1".equals(runtimeId) ? rvs : null);
       SheetJoinService paneScopedSvc =
-         new SheetJoinService(paneScopedPairing, sessions, feature, runtimeAccess);
+         new SheetJoinService(paneScopedPairing, sessions, feature, runtimeAccess, broadcast);
 
       EditorContext ctx = new EditorContext("assemblyMain", "Chart1", null, null);
       String code = paneScopedPairing.mint("vs-1", ALICE_KEY, "sock-pane-1", null,
@@ -334,5 +344,78 @@ class SheetJoinServiceTest {
       JoinSession session = paneScopedSvc.join(code, alice);
 
       assertEquals(ctx, session.editorContext());
+   }
+
+   // ---------------------------------------------------------------------------
+   // notifiesBrowserOnJoin
+   //
+   // Minted with a VIEWSHEET editorContext, so mint()'s own validation (added for pane-scoped
+   // grants) requires a real runtime lookup that resolves the named assembly -- the shared
+   // `pairing` field's accessors always return null, so this uses a locally-scoped pairing
+   // service configured the same way carriesTheEditorContextFromGrantToSession is.
+   // ---------------------------------------------------------------------------
+   @Test
+   void notifiesBrowserOnJoin() throws PairingException {
+      when(feature.isEnabled()).thenReturn(true);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(vs.getAssembly("Chart1")).thenReturn(mock(VSAssembly.class));
+      SheetPairingService paneScopedPairing = new SheetPairingService(
+         () -> FIXED_NOW, runtimeId -> null, runtimeId -> "vs-9".equals(runtimeId) ? rvs : null);
+      SheetJoinService paneScopedSvc =
+         new SheetJoinService(paneScopedPairing, sessions, feature, runtimeAccess, broadcast);
+
+      EditorContext context = new EditorContext("assemblyMain", "Chart1", null, null);
+      String code = paneScopedPairing.mint("vs-9", ALICE_KEY, "sock-1", "alice-dest",
+                                           SheetType.VIEWSHEET, context);
+      Principal alice = TestPrincipals.user("alice", "host-org");
+
+      paneScopedSvc.join(code, alice);
+
+      ArgumentCaptor<JoinSession> sent = ArgumentCaptor.forClass(JoinSession.class);
+      verify(broadcast).sendPairingJoined(sent.capture());
+      assertEquals("vs-9", sent.getValue().runtimeId());
+      assertEquals(SheetType.VIEWSHEET, sent.getValue().sheetType());
+      assertEquals(context, sent.getValue().editorContext());
+      assertEquals("sock-1", sent.getValue().socketSessionId());
+      assertEquals("alice-dest", sent.getValue().socketUserName());
+   }
+
+   // ---------------------------------------------------------------------------
+   // toolbarJoinNotifiesWithNoEditorContext
+   // ---------------------------------------------------------------------------
+   @Test
+   void toolbarJoinNotifiesWithNoEditorContext() throws PairingException {
+      when(feature.isEnabled()).thenReturn(true);
+      String code = pairing.mint("Worksheet/foo-7", ALICE_KEY, "sock-1", "alice-dest",
+                                 SheetType.WORKSHEET, null);
+      Principal alice = TestPrincipals.user("alice", "host-org");
+
+      svc.join(code, alice);
+
+      ArgumentCaptor<JoinSession> sent = ArgumentCaptor.forClass(JoinSession.class);
+      verify(broadcast).sendPairingJoined(sent.capture());
+      assertNull(sent.getValue().editorContext());
+   }
+
+   // ---------------------------------------------------------------------------
+   // notifyFailureDoesNotFailTheJoin
+   //
+   // The session is already open and valid by the time the notice is sent, so a broken
+   // notification must cost the indicator and nothing else.
+   // ---------------------------------------------------------------------------
+   @Test
+   void notifyFailureDoesNotFailTheJoin() throws PairingException {
+      when(feature.isEnabled()).thenReturn(true);
+      doThrow(new RuntimeException("socket gone")).when(broadcast).sendPairingJoined(any());
+      String code = pairing.mint("vs-9", ALICE_KEY, "sock-1", "alice-dest",
+                                 SheetType.VIEWSHEET, null);
+      Principal alice = TestPrincipals.user("alice", "host-org");
+
+      JoinSession session = svc.join(code, alice);
+
+      assertNotNull(session);
+      assertEquals("vs-9", session.runtimeId());
    }
 }

--- a/docs/superpowers/plans/2026-08-19-composer-pairing-connected-indicator.md
+++ b/docs/superpowers/plans/2026-08-19-composer-pairing-connected-indicator.md
@@ -633,7 +633,12 @@ Then start the server as usual and confirm the feature flag is on: `wiz.agent.pa
 3. Redeem it from a Claude Code session: `connect_sheet` with that code.
 4. Expected: the button area now shows **✓ Agent connected**, and the pairing code is gone.
 
-If nothing appears, check the server log for `Pairing joined, but notifying the browser failed`. If that line is absent, the push succeeded and was dropped at the destination — re-check `PAIRING_JOINED_TOPIC` against the client's subscription string, which is the silent-failure mode the spec warns about.
+If nothing appears, grep the server log for **both** of these before concluding anything:
+
+- `Pairing joined, but notifying the browser failed` — the push itself threw; the stack trace names why.
+- `session not found, message dropped` — `CommandDispatcherService.convertAndSendToUser` logs this and **returns without throwing** when the STOMP session is no longer registered, which a browser reconnect between mint and join produces. The destination is fine in this case; re-pair and retry.
+
+Only when **neither** line appears does suspicion fall on the destination string — then re-check `PAIRING_JOINED_TOPIC` against the client's subscription, which is the silent-failure mode the spec warns about. Checking for the first line alone gives a false "the destination must be wrong" on every reconnect.
 
 - [ ] **Step 3: A pane pairing must not light the toolbar**
 

--- a/docs/superpowers/plans/2026-08-19-composer-pairing-connected-indicator.md
+++ b/docs/superpowers/plans/2026-08-19-composer-pairing-connected-indicator.md
@@ -1,0 +1,672 @@
+# Composer Pairing Connected Indicator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** After an agent redeems a pairing code, the Composer that minted it visibly says an agent connected, instead of continuing to read "Connect to Claude".
+
+**Architecture:** `SheetJoinService.join()` pushes a `PairingJoinedNotice` over STOMP to the minting browser's user destination, best-effort so a lost notice can never fail the join. `ConnectToClaudeComponent` holds a standing subscription and accepts a notice only when both `runtimeId` and the minted `editorContext` match, because the component is reused by three hosts and several instances can be alive on one page.
+
+**Tech Stack:** Java 17 records + Spring `SimpMessagingTemplate` via `CommandDispatcherService`; Angular standalone component with STOMP over `ViewsheetClientService`; JUnit 5 + Mockito; Vitest via `ng test`.
+
+**Design spec:** `docs/superpowers/specs/2026-08-19-composer-pairing-connected-indicator-design.md`
+
+## Global Constraints
+
+- **Scope is one-shot confirmation only.** Do not add continuous state, an agent count, TTL tracking, or agent identity. The spec records why each is out of scope.
+- **A push failure must never fail `join()`.** The session is already open and valid when the notice is sent.
+- **Destination errors are silent, not exceptions.** `SheetAgentBroadcastService`'s own javadoc records that addressing the wrong topic delivers to a destination with no handler and is dropped "while every call up the stack still reports success". Unit tests cannot prove this works; Task 3's live check is mandatory.
+- **All code, comments and test names in English.**
+- Java tests carry `@Tag("core")`, matching every other test in `inetsoft.web.wiz.pairing`.
+- Repository root for every path below is the `community` submodule (remote `inetsoft-technology/stylebi`), **not** the outer `stylebi-enterprise` checkout.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `core/src/main/java/inetsoft/web/wiz/pairing/PairingJoinedNotice.java` | **Create.** Wire payload: the three fields the browser needs to decide if a notice is for it. |
+| `core/src/main/java/inetsoft/web/wiz/pairing/SheetAgentBroadcastService.java` | **Modify.** Add `sendPairingJoined(JoinSession)`; owns the destination constant and header shape. |
+| `core/src/main/java/inetsoft/web/wiz/pairing/SheetJoinService.java` | **Modify.** Call the push after `sessions.open(...)`, wrapped so it cannot escape. |
+| `core/src/test/java/inetsoft/web/wiz/pairing/SheetJoinServiceTest.java` | **Modify.** Constructor gains a 5th argument; add three cases. |
+| `web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.ts` | **Modify.** `connected` flag, standing subscription, two-way filter, lifecycle. |
+| `web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.html` | **Modify.** Show the connected line, hide the consumed code. |
+| `web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.spec.ts` | **Modify.** Add filter and lifecycle cases. |
+
+---
+
+## Task 1: Backend pushes a notice when an agent joins
+
+**Files:**
+- Create: `core/src/main/java/inetsoft/web/wiz/pairing/PairingJoinedNotice.java`
+- Modify: `core/src/main/java/inetsoft/web/wiz/pairing/SheetAgentBroadcastService.java`
+- Modify: `core/src/main/java/inetsoft/web/wiz/pairing/SheetJoinService.java` (constructor, and `join()` after `sessions.open`)
+- Test: `core/src/test/java/inetsoft/web/wiz/pairing/SheetJoinServiceTest.java`
+
+**Interfaces:**
+- Consumes: `JoinSession(sessionToken, runtimeId, ownerIdentity, sheetType, lastAccess, ttlMillis, connectionMode, socketSessionId, socketUserName, editorContext)`; `EditorContext(kind, assembly, name, table)`; `CommandDispatcherService.convertAndSendToUser(user, destination, payload, headers)`.
+- Produces: `PairingJoinedNotice(String runtimeId, SheetType sheetType, EditorContext editorContext)` serialized to `/user/commands/wiz/pairing/joined`; `SheetAgentBroadcastService.sendPairingJoined(JoinSession)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `SheetJoinServiceTest.java`, add the mock and change the constructor call in `setUp`:
+
+```java
+   @Mock
+   private SheetAgentBroadcastService broadcast;
+```
+
+```java
+      svc      = new SheetJoinService(pairing, sessions, feature, runtimeAccess, broadcast);
+```
+
+Add these imports alongside the existing ones:
+
+```java
+import org.mockito.ArgumentCaptor;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+```
+
+Append these three tests to the class:
+
+```java
+   // ---------------------------------------------------------------------------
+   // notifiesBrowserOnJoin
+   // ---------------------------------------------------------------------------
+   @Test
+   void notifiesBrowserOnJoin() throws PairingException {
+      when(feature.isEnabled()).thenReturn(true);
+      EditorContext context = new EditorContext("assemblyMain", "Chart1", null, null);
+      String code = pairing.mint("vs-9", ALICE_KEY, "sock-1", "alice-dest",
+                                 SheetType.VIEWSHEET, context);
+      Principal alice = TestPrincipals.user("alice", "host-org");
+
+      svc.join(code, alice);
+
+      ArgumentCaptor<JoinSession> sent = ArgumentCaptor.forClass(JoinSession.class);
+      verify(broadcast).sendPairingJoined(sent.capture());
+      assertEquals("vs-9", sent.getValue().runtimeId());
+      assertEquals(SheetType.VIEWSHEET, sent.getValue().sheetType());
+      assertEquals(context, sent.getValue().editorContext());
+      assertEquals("sock-1", sent.getValue().socketSessionId());
+      assertEquals("alice-dest", sent.getValue().socketUserName());
+   }
+
+   // ---------------------------------------------------------------------------
+   // toolbarJoinNotifiesWithNoEditorContext
+   // ---------------------------------------------------------------------------
+   @Test
+   void toolbarJoinNotifiesWithNoEditorContext() throws PairingException {
+      when(feature.isEnabled()).thenReturn(true);
+      String code = pairing.mint("Worksheet/foo-7", ALICE_KEY, "sock-1", "alice-dest",
+                                 SheetType.WORKSHEET, null);
+      Principal alice = TestPrincipals.user("alice", "host-org");
+
+      svc.join(code, alice);
+
+      ArgumentCaptor<JoinSession> sent = ArgumentCaptor.forClass(JoinSession.class);
+      verify(broadcast).sendPairingJoined(sent.capture());
+      assertNull(sent.getValue().editorContext());
+   }
+
+   // ---------------------------------------------------------------------------
+   // notifyFailureDoesNotFailTheJoin
+   //
+   // The session is already open and valid by the time the notice is sent, so a broken
+   // notification must cost the indicator and nothing else.
+   // ---------------------------------------------------------------------------
+   @Test
+   void notifyFailureDoesNotFailTheJoin() throws PairingException {
+      when(feature.isEnabled()).thenReturn(true);
+      doThrow(new RuntimeException("socket gone")).when(broadcast).sendPairingJoined(any());
+      String code = pairing.mint("vs-9", ALICE_KEY, "sock-1", "alice-dest",
+                                 SheetType.VIEWSHEET, null);
+      Principal alice = TestPrincipals.user("alice", "host-org");
+
+      JoinSession session = svc.join(code, alice);
+
+      assertNotNull(session);
+      assertEquals("vs-9", session.runtimeId());
+   }
+```
+
+Add `any` to the Mockito static imports:
+
+```java
+import static org.mockito.ArgumentMatchers.any;
+```
+
+Also extend the class javadoc's case index, matching the existing style:
+
+```java
+ * [notifiesBrowser] a successful join pushes a PairingJoinedNotice to the minting browser
+ * [toolbarNotice]   a whole-sheet grant notifies with a null editorContext
+ * [notifyFailure]   a throwing broadcast does not fail the join
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run from the `community` directory:
+
+```bash
+mvn test -pl core -Dtest=SheetJoinServiceTest
+```
+
+Expected: compilation failure — `SheetJoinService` has no 5-argument constructor and `SheetAgentBroadcastService` has no `sendPairingJoined`.
+
+- [ ] **Step 3: Create the notice record**
+
+`core/src/main/java/inetsoft/web/wiz/pairing/PairingJoinedNotice.java` — copy the AGPL header from `JoinSession.java` verbatim, then:
+
+```java
+package inetsoft.web.wiz.pairing;
+
+/**
+ * Tells the browser that minted a pairing code that an agent has redeemed it.
+ *
+ * <p>Pairing is split across two processes: the browser mints the code, and the agent joins over
+ * HTTP. Nothing else closes that loop, so without this notice the Composer cannot know the code it
+ * displayed was ever used, and the only evidence pairing worked is the agent saying so.
+ *
+ * <p>Carries exactly the three fields the client needs to decide whether a notice is addressed to
+ * it. The destination is per-user, not per-sheet and not per-pane, while
+ * {@code ConnectToClaudeComponent} is reused by the composer toolbar, the viewsheet script pane and
+ * the formula editor dialog — several instances can be alive at once on one page. Both
+ * {@code runtimeId} and {@code editorContext} are therefore load-bearing filters, not diagnostics.
+ *
+ * @param editorContext the paired location, or {@code null} for a whole-sheet ("Connect to Claude"
+ *                      toolbar) pairing. {@code null} is the normal case, never an error.
+ */
+public record PairingJoinedNotice(String runtimeId, SheetType sheetType,
+                                  EditorContext editorContext) {
+}
+```
+
+- [ ] **Step 4: Add the push to SheetAgentBroadcastService**
+
+In `SheetAgentBroadcastService.java`, add the constant next to the class's other fields:
+
+```java
+   /**
+    * Where a paired browser learns that an agent joined. The client subscribes to this prefixed
+    * with {@code /user}, exactly as it does for mint's {@code @SendToUser} destination.
+    *
+    * <p>Deliberately neither {@code CommandDispatcher.COMMANDS_TOPIC} nor
+    * {@code ComposerClientService.COMMANDS_TOPIC} — see {@link #sendToComposer}'s javadoc for why
+    * confusing those two is a silent failure. This is a pairing-domain destination with its own
+    * client handler.
+    */
+   static final String PAIRING_JOINED_TOPIC = "/commands/wiz/pairing/joined";
+```
+
+Add the method after `sendToComposer`:
+
+```java
+   /**
+    * Tell the browser that minted the code that an agent has now joined with it.
+    *
+    * <p>Addresses {@code socketUserName} — the destination user resolved at mint time, the same
+    * value mint's {@code @SendToUser} resolved to — and sets the session id header as the other
+    * senders here do.
+    *
+    * <p>Callers must treat this as best-effort. By the time it runs the agent's session is open and
+    * valid, so a failure here costs the browser's indicator and nothing more.
+    */
+   public void sendPairingJoined(JoinSession session) {
+      SimpMessageHeaderAccessor headers =
+         SimpMessageHeaderAccessor.create(SimpMessageType.MESSAGE);
+      headers.setSessionId(session.socketSessionId());
+      headers.setLeaveMutable(true);
+
+      commandDispatcherService.convertAndSendToUser(
+         session.socketUserName(), PAIRING_JOINED_TOPIC,
+         new PairingJoinedNotice(session.runtimeId(), session.sheetType(),
+                                 session.editorContext()),
+         headers.getMessageHeaders());
+   }
+```
+
+- [ ] **Step 5: Call it from join()**
+
+In `SheetJoinService.java`, add the field and constructor parameter:
+
+```java
+   private final SheetAgentBroadcastService broadcast;
+```
+
+```java
+   @Autowired
+   public SheetJoinService(SheetPairingService pairing,
+                           SheetSessionService sessions,
+                           SheetAgentFeature feature,
+                           SheetRuntimeAccess runtimeAccess,
+                           SheetAgentBroadcastService broadcast) {
+      this.pairing = pairing;
+      this.sessions = sessions;
+      this.feature = feature;
+      this.runtimeAccess = runtimeAccess;
+      this.broadcast = broadcast;
+   }
+```
+
+In `join()`, between `failedAttempts.remove(throttleKey);` and the existing `LOG.info(...)`:
+
+```java
+      // Close the loop back to the browser that minted this code — it has no other way to learn
+      // the code was redeemed, since the join arrived over HTTP from the agent. Best-effort by
+      // design: the session above is already open and valid, so a lost notice degrades the
+      // Composer's indicator and must never turn a successful pairing into a failed one.
+      try {
+         broadcast.sendPairingJoined(session);
+      }
+      catch(Exception ex) {
+         LOG.warn("Pairing joined, but notifying the browser failed (runtimeId={})",
+                  grant.runtimeId(), ex);
+      }
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+```bash
+mvn test -pl core -Dtest=SheetJoinServiceTest
+```
+
+Expected: PASS, all cases including the three new ones.
+
+- [ ] **Step 7: Run the neighbouring suites for regressions**
+
+The constructor changed, so anything building a `SheetJoinService` is affected.
+
+```bash
+mvn test -pl core -Dtest='Sheet*Test,Pairing*Test'
+```
+
+Expected: PASS. If another test constructs `SheetJoinService` directly, add a mock `SheetAgentBroadcastService` there the same way.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add core/src/main/java/inetsoft/web/wiz/pairing/PairingJoinedNotice.java \
+        core/src/main/java/inetsoft/web/wiz/pairing/SheetAgentBroadcastService.java \
+        core/src/main/java/inetsoft/web/wiz/pairing/SheetJoinService.java \
+        core/src/test/java/inetsoft/web/wiz/pairing/SheetJoinServiceTest.java
+git commit -m "feat(pairing): notify the minting browser when an agent joins"
+```
+
+---
+
+## Task 2: Composer shows that an agent connected
+
+**Files:**
+- Modify: `web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.ts`
+- Modify: `web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.html`
+- Test: `web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.spec.ts`
+
+**Interfaces:**
+- Consumes: notices on `/user/commands/wiz/pairing/joined` shaped `{runtimeId, sheetType, editorContext}` from Task 1; the existing `EditorContext { kind: string; assembly?: string; name?: string; table?: string }`.
+- Produces: `ConnectToClaudeComponent.connected: boolean`, true only for a notice matching this instance.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `connect-to-claude.component.spec.ts`, inside the top-level `describe`:
+
+```ts
+   describe("connected indicator", () => {
+      /** Captures the handler for a given destination, since the component now holds two. */
+      function handlerFor(dest: string): (msg: any) => void {
+         const call = mockStompConnection.subscribe.mock.calls
+            .filter((c: any[]) => c[0] === dest).pop();
+         expect(call).toBeTruthy();
+         return call[1];
+      }
+
+      function notice(body: any): any {
+         return { frame: { body: JSON.stringify(body) } };
+      }
+
+      it("subscribes to the joined destination on init", () => {
+         expect(mockStompConnection.subscribe).toHaveBeenCalledWith(
+            "/user/commands/wiz/pairing/joined",
+            expect.any(Function)
+         );
+      });
+
+      it("shows connected and drops the consumed code for a matching notice", () => {
+         component.code = "ABC123";
+
+         handlerFor("/user/commands/wiz/pairing/joined")(
+            notice({ runtimeId: "rt-1", sheetType: "WORKSHEET", editorContext: null }));
+         fixture.detectChanges();
+
+         expect(component.connected).toBe(true);
+         expect(component.code).toBeNull();
+         expect(fixture.nativeElement.querySelector(".wiz-connect-connected")).toBeTruthy();
+         expect(fixture.nativeElement.querySelector(".wiz-connect-code")).toBeNull();
+      });
+
+      it("ignores a notice for another runtime", () => {
+         handlerFor("/user/commands/wiz/pairing/joined")(
+            notice({ runtimeId: "rt-other", sheetType: "WORKSHEET", editorContext: null }));
+
+         expect(component.connected).toBe(false);
+      });
+
+      /*
+       * The failure this filter exists for: the destination is per-user, so a pane pairing is
+       * delivered to the toolbar instance too. Without the editorContext check the toolbar would
+       * claim an agent joined it, which is a false statement rather than a missing feature.
+       */
+      it("ignores a pane notice on a toolbar instance", () => {
+         handlerFor("/user/commands/wiz/pairing/joined")(
+            notice({ runtimeId: "rt-1", sheetType: "WORKSHEET",
+                     editorContext: { kind: "calcField", assembly: "Query1", name: "Margin" } }));
+
+         expect(component.connected).toBe(false);
+      });
+
+      /*
+       * Jackson serializes a Java record's absent components as explicit nulls, while the browser
+       * never sent those keys at all. Comparing them naively (JSON.stringify, or === on each key)
+       * makes every pane notice a mismatch and the indicator never appears.
+       */
+      it("matches a pane notice whose absent fields arrive as explicit nulls", () => {
+         let handler: ((msg: any) => void) | null = null;
+         mockStompConnection.subscribe.mockImplementation(
+            (dest: string, h: (msg: any) => void) => {
+               if(dest === "/user/commands/wiz/pairing/mint") { handler = h; }
+               return { unsubscribe: vi.fn() };
+            });
+         component.editorContext = { kind: "assemblyMain", assembly: "Chart1" };
+         component.requestCode();
+         handler!(notice({ code: "ABC123" }));
+
+         handlerFor("/user/commands/wiz/pairing/joined")(
+            notice({ runtimeId: "rt-1", sheetType: "WORKSHEET",
+                     editorContext: { kind: "assemblyMain", assembly: "Chart1",
+                                      name: null, table: null } }));
+
+         expect(component.connected).toBe(true);
+      });
+
+      it("clears the indicator when the runtimeId changes", () => {
+         handlerFor("/user/commands/wiz/pairing/joined")(
+            notice({ runtimeId: "rt-1", sheetType: "WORKSHEET", editorContext: null }));
+         expect(component.connected).toBe(true);
+
+         component.runtimeId = "rt-2";
+         component.ngOnChanges(
+            { runtimeId: { currentValue: "rt-2", previousValue: "rt-1",
+                           firstChange: false, isFirstChange: () => false } } as any);
+
+         expect(component.connected).toBe(false);
+      });
+
+      it("releases the joined subscription on destroy", () => {
+         const subs: Array<{ unsubscribe: ReturnType<typeof vi.fn> }> = [];
+         mockStompConnection.subscribe.mockImplementation(() => {
+            const s = { unsubscribe: vi.fn() };
+            subs.push(s);
+            return s;
+         });
+
+         const f = TestBed.createComponent(ConnectToClaudeComponent);
+         f.componentInstance.runtimeId = "rt-1";
+         f.componentInstance.sheetType = "WORKSHEET";
+         f.componentInstance.socketConnection = mockSocketConnection;
+         f.detectChanges();
+         f.destroy();
+
+         expect(subs.some(s => s.unsubscribe.mock.calls.length > 0)).toBe(true);
+      });
+   });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run from the `community/web` directory:
+
+```bash
+npm run test:portal
+```
+
+Expected: FAIL — `component.connected` is undefined and nothing subscribes to the joined destination.
+
+- [ ] **Step 3: Implement the component changes**
+
+In `connect-to-claude.component.ts`, change the class declaration and add `OnInit` to the imports:
+
+```ts
+import { Component, Input, NgZone, OnChanges, OnDestroy, OnInit, SimpleChanges } from "@angular/core";
+```
+
+```ts
+export class ConnectToClaudeComponent implements OnInit, OnChanges, OnDestroy {
+```
+
+Add the state and subscription field next to the existing ones:
+
+```ts
+   /**
+    * An agent has redeemed a code minted from this exact component instance.
+    *
+    * One-shot by design: this says a pairing happened, not that one is still live. Tracking
+    * liveness would mean reacting to a TTL that expires with no server-side event, which the
+    * design spec records as deliberately out of scope.
+    */
+   connected = false;
+
+   private joinedSubscription: Subscription | null = null;
+```
+
+Add `ngOnInit`:
+
+```ts
+   /**
+    * Opens the standing subscription for join notices.
+    *
+    * Standing, not per-mint: the agent may redeem the code seconds or minutes after it is
+    * displayed, long after the mint round-trip has completed and unsubscribed itself.
+    */
+   ngOnInit(): void {
+      this.socketConnection.whenConnected().pipe(take(1)).subscribe(
+         (conn: StompClientConnection) => {
+            this.joinedSubscription = conn.subscribe(
+               "/user/commands/wiz/pairing/joined", (msg: any) => this.onJoined(msg));
+         });
+   }
+```
+
+Add the handler and the comparison, after `requestCode()`:
+
+```ts
+   /**
+    * Accepts a join notice only when it is for this sheet AND this location.
+    *
+    * The destination is per-user, so every instance on the page receives every notice. This
+    * component is reused by the composer toolbar, the viewsheet script pane and the formula editor
+    * dialog, so more than one instance is routinely alive at once. Dropping either filter makes an
+    * instance announce a pairing that did not happen to it — a false statement, which is worse
+    * than the missing indicator this whole change exists to fix.
+    */
+   private onJoined(msg: any): void {
+      let body: any;
+
+      try {
+         body = JSON.parse(msg.frame.body);
+      }
+      catch(e) {
+         return;
+      }
+
+      if(body.runtimeId !== this.runtimeId ||
+         !this.sameEditorContext(body.editorContext, this.mintedEditorContext))
+      {
+         return;
+      }
+
+      this.zone.run(() => {
+         this.connected = true;
+         // The code is single-use and has now been used. Leaving it on screen invites an attempt
+         // to redeem it again.
+         this.code = null;
+         this.error = null;
+      });
+   }
+
+   /**
+    * Compares two editor contexts, treating an absent field and an explicit null as equal.
+    *
+    * Required, not defensive: the server sends a Java record, and Jackson writes its unset
+    * components as explicit nulls, while the browser omits those keys from the mint payload
+    * entirely. A structural comparison (JSON.stringify, or === per key) would therefore never
+    * match a pane pairing, and the indicator would never appear for one.
+    */
+   private sameEditorContext(a: EditorContext | null | undefined,
+                             b: EditorContext | null | undefined): boolean {
+      if(!a && !b) {
+         return true;
+      }
+
+      if(!a || !b) {
+         return false;
+      }
+
+      return a.kind === b.kind &&
+         (a.assembly ?? null) === (b.assembly ?? null) &&
+         (a.name ?? null) === (b.name ?? null) &&
+         (a.table ?? null) === (b.table ?? null);
+   }
+```
+
+In `ngOnChanges`, reset the flag alongside the existing resets (add one line inside the existing `if` block):
+
+```ts
+            this.connected = false;
+```
+
+Do **not** tear down `joinedSubscription` there — the destination is per-user, not per-runtime, so only the filter input changed, never the channel.
+
+In `ngOnDestroy`, release it:
+
+```ts
+   ngOnDestroy(): void {
+      if(this.mintSubscription) {
+         this.mintSubscription.unsubscribe();
+         this.mintSubscription = null;
+      }
+
+      // The formula editor dialog creates and destroys this component repeatedly; a standing
+      // subscription that outlives its component is a leak.
+      if(this.joinedSubscription) {
+         this.joinedSubscription.unsubscribe();
+         this.joinedSubscription = null;
+      }
+   }
+```
+
+- [ ] **Step 4: Update the template**
+
+Replace the code block in `connect-to-claude.component.html` so the connected line takes its place:
+
+```html
+<div class="wiz-connect-to-claude">
+  <button (click)="requestCode()" [disabled]="loading" class="btn btn-primary btn-sm">
+    {{ loading ? 'Generating...' : 'Connect to Claude' }}
+  </button>
+
+  <div *ngIf="error" class="wiz-connect-error alert alert-danger mt-2">{{ error }}</div>
+
+  <div *ngIf="connected" class="wiz-connect-connected alert alert-success mt-2">
+    ✓ Agent connected
+  </div>
+
+  <div *ngIf="code && !connected" class="wiz-connect-code mt-2">
+    <span class="wiz-connect-label">Pairing Code:</span>
+    <code class="wiz-connect-value ms-2">{{ code }}</code>
+    <button ngxClipboard [cbContent]="code" (cbOnSuccess)="onCopySuccess()" (cbOnError)="onCopyError()"
+      class="btn btn-sm btn-outline-secondary ms-2">
+      {{ copied ? 'Copied!' : 'Copy' }}
+    </button>
+  </div>
+</div>
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+npm run test:portal
+```
+
+Expected: PASS, including every pre-existing case in this spec file.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.ts \
+        web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.html \
+        web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.spec.ts
+git commit -m "feat(pairing): show in the Composer that an agent connected"
+```
+
+---
+
+## Task 3: Verify live and close test-plan case 0.11
+
+Mandatory, not optional. A wrong STOMP destination is dropped silently while every call reports success, so Tasks 1 and 2 passing their unit tests does **not** establish that this works.
+
+**Files:**
+- Modify (in the `stylebi-wiz` repo): `docs/superpowers/plans/2026-08-17-consolidated-composer-plugin-test-plan.md`
+
+- [ ] **Step 1: Build and start StyleBI with both changes**
+
+```bash
+mvn -pl core install -DskipTests
+```
+
+Then start the server as usual and confirm the feature flag is on: `wiz.agent.pairing.enabled=true`.
+
+- [ ] **Step 2: Toolbar pairing shows connected**
+
+1. Open a viewsheet in the Composer.
+2. Click **Connect to Claude**; note the code.
+3. Redeem it from a Claude Code session: `connect_sheet` with that code.
+4. Expected: the button area now shows **✓ Agent connected**, and the pairing code is gone.
+
+If nothing appears, check the server log for `Pairing joined, but notifying the browser failed`. If that line is absent, the push succeeded and was dropped at the destination — re-check `PAIRING_JOINED_TOPIC` against the client's subscription string, which is the silent-failure mode the spec warns about.
+
+- [ ] **Step 3: A pane pairing must not light the toolbar**
+
+1. On the same viewsheet, open a calculated field's formula editor and click **Connect Agent** there.
+2. Redeem that code with `connect_sheet`.
+3. Expected: the **formula editor's** indicator shows connected; the **toolbar** instance does not change.
+
+This is the case the `editorContext` filter exists for; a failure here means the filter is not doing its job even though every unit test passed.
+
+- [ ] **Step 4: Record the result in the test plan**
+
+In the `stylebi-wiz` repo, update case 0.11 in the Human table and the L0 Status Board Notes: change `FAIL — the indication does not exist` to PASS with the date, and drop 0.11 from the "Still outstanding for L0" list.
+
+Note that another session may be editing that document concurrently — make a narrow, exact edit rather than replacing whole sections.
+
+- [ ] **Step 5: Commit and open the PR**
+
+The spec and this plan are already committed on `composer-plugin-l0-pairing-indicator`, so this step
+only pushes and opens the PR:
+
+```bash
+git push -u origin composer-plugin-l0-pairing-indicator
+gh pr create --title "feat(pairing): show in the Composer that an agent connected" --body-file <path to a body describing the three tasks and the live verification result>
+```
+
+The `stylebi-wiz` test-plan edit is a separate repo and belongs in its own commit there.
+
+---
+
+## Self-Review
+
+**Spec coverage.** Backend push (Task 1 steps 3–5), the `socketUserName` destination and header shape (Task 1 step 4), best-effort push (Task 1 step 5 plus its test), the `PairingJoinedNotice` field list (Task 1 step 3), standing subscription with `ngOnInit` (Task 2 step 3), both filters (Task 2 step 3, tested in step 1), no timeout and reset on `runtimeId` change (Task 2 step 3), `ngOnDestroy` release (Task 2 step 3), template swap (Task 2 step 4), the two live checks the spec marks as required (Task 3 steps 2–3). The spec's out-of-scope list is carried into Global Constraints so no task drifts into it.
+
+**Type consistency.** `PairingJoinedNotice(runtimeId, sheetType, editorContext)` is produced in Task 1 step 3 and consumed by the exact same three keys in Task 2's tests and handler. `sendPairingJoined(JoinSession)` is defined in Task 1 step 4 and called with a `JoinSession` in step 5, and the test verifies it with `ArgumentCaptor<JoinSession>`. `connected` is the same name in the component, the template and every test.
+
+**One gap deliberately left to the implementer:** Task 1 step 7 says to add a mock if another test constructs `SheetJoinService` directly, without naming which — `SheetPairingControllerTest` is the likely one, but that depends on whether it builds the service or mocks it, and the grep in step 7 finds the truth faster than a guess here would.

--- a/docs/superpowers/plans/2026-08-19-composer-pairing-connected-indicator.md
+++ b/docs/superpowers/plans/2026-08-19-composer-pairing-connected-indicator.md
@@ -618,7 +618,7 @@ Mandatory, not optional. A wrong STOMP destination is dropped silently while eve
 **Files:**
 - Modify (in the `stylebi-wiz` repo): `docs/superpowers/plans/2026-08-17-consolidated-composer-plugin-test-plan.md`
 
-- [ ] **Step 1: Build and start StyleBI with both changes**
+- [x] **Step 1: Build and start StyleBI with both changes**
 
 ```bash
 mvn -pl core install -DskipTests
@@ -626,7 +626,7 @@ mvn -pl core install -DskipTests
 
 Then start the server as usual and confirm the feature flag is on: `wiz.agent.pairing.enabled=true`.
 
-- [ ] **Step 2: Toolbar pairing shows connected**
+- [x] **Step 2: Toolbar pairing shows connected**
 
 1. Open a viewsheet in the Composer.
 2. Click **Connect to Claude**; note the code.
@@ -648,7 +648,15 @@ Only when **neither** line appears does suspicion fall on the destination string
 
 This is the case the `editorContext` filter exists for; a failure here means the filter is not doing its job even though every unit test passed.
 
-- [ ] **Step 4: Record the result in the test plan**
+**NOT RUN — the one piece of live evidence still owed.** Step 2's toolbar path was confirmed by the
+operator; this pane-isolation check was not exercised separately. Neither was the `hasMinted`
+scenario the whole-branch review uncovered: mint from the toolbar, open a formula editor **before**
+the agent redeems, then redeem — only the toolbar may light up. Both behaviours are covered by unit
+tests (the minted-vs-live filter and the `hasMinted` guard are mutation-verified), but this plan's
+own Global Constraints state that unit tests are not sufficient evidence here, and these two cases
+are precisely where that applies. Whoever picks this up runs both and updates this step.
+
+- [x] **Step 4: Record the result in the test plan**
 
 In the `stylebi-wiz` repo, update case 0.11 in the Human table and the L0 Status Board Notes: change `FAIL — the indication does not exist` to PASS with the date, and drop 0.11 from the "Still outstanding for L0" list.
 

--- a/docs/superpowers/plans/2026-08-19-composer-pairing-connected-indicator.md
+++ b/docs/superpowers/plans/2026-08-19-composer-pairing-connected-indicator.md
@@ -640,7 +640,7 @@ If nothing appears, grep the server log for **both** of these before concluding 
 
 Only when **neither** line appears does suspicion fall on the destination string — then re-check `PAIRING_JOINED_TOPIC` against the client's subscription, which is the silent-failure mode the spec warns about. Checking for the first line alone gives a false "the destination must be wrong" on every reconnect.
 
-- [ ] **Step 3: A pane pairing must not light the toolbar**
+- [x] **Step 3: A pane pairing must not light the toolbar**
 
 1. On the same viewsheet, open a calculated field's formula editor and click **Connect Agent** there.
 2. Redeem that code with `connect_sheet`.
@@ -648,13 +648,14 @@ Only when **neither** line appears does suspicion fall on the destination string
 
 This is the case the `editorContext` filter exists for; a failure here means the filter is not doing its job even though every unit test passed.
 
-**NOT RUN — the one piece of live evidence still owed.** Step 2's toolbar path was confirmed by the
-operator; this pane-isolation check was not exercised separately. Neither was the `hasMinted`
-scenario the whole-branch review uncovered: mint from the toolbar, open a formula editor **before**
-the agent redeems, then redeem — only the toolbar may light up. Both behaviours are covered by unit
-tests (the minted-vs-live filter and the `hasMinted` guard are mutation-verified), but this plan's
-own Global Constraints state that unit tests are not sufficient evidence here, and these two cases
-are precisely where that applies. Whoever picks this up runs both and updates this step.
+**PASS — verified live by the operator 2026-08-19, case by case in the UI.** Pairing from a formula
+editor lights that editor and leaves the toolbar unchanged, and the `hasMinted` case the whole-branch
+review uncovered also holds: a formula editor opened while a toolbar code was still outstanding stays
+dark when the agent redeems, and only the toolbar lights up.
+
+These two are the entire reason the `editorContext` filter and the `hasMinted` guard exist, and they
+are the part no unit test can settle — a wrong destination or a too-loose filter fails silently while
+every layer reports success. This is the evidence the Global Constraints ask for, and it is now in.
 
 - [x] **Step 4: Record the result in the test plan**
 

--- a/docs/superpowers/specs/2026-08-19-composer-pairing-connected-indicator-design.md
+++ b/docs/superpowers/specs/2026-08-19-composer-pairing-connected-indicator-design.md
@@ -110,9 +110,9 @@ Three mechanics this implies, none of which the component does today:
 - **The component has no `ngOnInit`** — it implements only `OnChanges` and `OnDestroy`. Add
   `OnInit` and open the subscription there, via the same
   `socketConnection.whenConnected().pipe(take(1))` handshake `requestCode()` already uses.
-- **Do not tear the subscription down on a `runtimeId` change.** The destination is per-user, not
-  per-runtime, so the existing `ngOnChanges` reset should clear `connected` and leave the
-  subscription alone. Only the *filter input* changed, not the channel.
+- **Do not tear the subscription down on a `runtimeId` change.** The destination is per socket
+  session, not per runtime, so the existing `ngOnChanges` reset should clear `connected` and leave
+  the subscription alone. Only the *filter input* changed, not the channel.
 - **`ngOnDestroy` must release it.** Today it only unsubscribes `mintSubscription`; a standing
   subscription that outlives its component is a leak, and this component is created and destroyed
   repeatedly by the formula-editor dialog.

--- a/docs/superpowers/specs/2026-08-19-composer-pairing-connected-indicator-design.md
+++ b/docs/superpowers/specs/2026-08-19-composer-pairing-connected-indicator-design.md
@@ -1,0 +1,184 @@
+# Composer pairing: tell the browser an agent joined
+
+## Problem
+
+After a successful `connect_sheet`, the Composer gives no sign whatsoever that pairing worked — the
+toolbar button still reads **"Connect to Claude"**, unchanged, and nothing anywhere distinguishes a
+paired sheet from an unpaired one. Confirmed by operator observation 2026-08-19 while running the L0
+lane of `stylebi-wiz`'s `docs/superpowers/plans/2026-08-17-consolidated-composer-plugin-test-plan.md`
+(case 0.11, recorded there as FAIL).
+
+The cause is structural, not a missing element in a template. **The browser mints the code; the agent
+joins over HTTP.** The two halves of pairing happen in different processes, and nothing closes the
+loop back to the browser, so the browser has no way to know the code it displayed was ever redeemed.
+
+The consequence is precisely what case 0.11 exists to rule out: the only evidence that pairing
+succeeded is the agent's own claim that it succeeded.
+
+## Scope
+
+**One-shot confirmation only.** When an agent joins, the browser that minted the code says so.
+
+Deliberately **not** in scope. Each is a real capability, each was considered and dropped as YAGNI
+until someone asks for it:
+
+- **Continuous connected/disconnected state.** Would require reacting to three separate ways a
+  session ends, one of which produces no server-side event at all (see TTL below).
+- **A count of concurrent agents.** The server permits unlimited agents per sheet — `sessions` in
+  `SheetSessionService` is keyed by `sessionToken`, and `open()` never deduplicates by `runtimeId`.
+  Showing a count is therefore meaningful, but it is a different feature.
+- **TTL expiry tracking.** TTL is 30 minutes, refreshed on every `resolve()`, and `evictExpired()`
+  runs on a 10-minute fixed delay — so "expired" and "removed from the map" differ by up to 10
+  minutes. Any count would have to filter by `isExpired()` itself rather than trust map size.
+- **Agent identity.** `ownerIdentity` is the logged-in StyleBI user, not the Claude session. Two
+  agents paired by the same user are indistinguishable, so "who is connected" is not answerable
+  today regardless of UI.
+
+## Approach
+
+Push on successful join to the browser that minted the code; the component already on screen
+subscribes and updates.
+
+Rejected alternatives:
+
+- **A new Command on the `/commands` sheet channel.** Filtered by `RUNTIME_ID_ATTR`, which would be
+  convenient, but it requires defining a Command type and adding a branch to the sheet-level command
+  handler — a larger change into a channel whose semantics are *sheet content*. "A pairing
+  completed" is not sheet content.
+- **Polling a new REST status endpoint.** Correct after a page refresh and needs no push, but
+  over-built for one-shot confirmation. This is the right foundation for continuous state later, and
+  is deliberately left for that work.
+
+## Backend
+
+**Hook point**: `SheetJoinService.join()`, immediately after `sessions.open(...)` returns.
+
+Everything required is already in hand at that line — this is the part that makes the change small:
+
+- `grant.socketSessionId()` — the minting browser's STOMP session, carried through `PairingGrant`
+- `JoinSession.socketUserName()` — the destination user resolved at mint time
+- `grant.editorContext()` / `session.editorContext()` — the paired location, `null` for a toolbar mint
+
+**Payload** — a new record (e.g. `PairingJoinedNotice`) carrying exactly the three things the client
+needs to decide whether the notice is for it:
+
+| Field | Notes |
+|---|---|
+| `runtimeId` | which sheet runtime was paired |
+| `sheetType` | `VIEWSHEET` / `WORKSHEET` |
+| `editorContext` | nullable; `null` is the normal whole-sheet toolbar case, never an error |
+
+**Destination**: `/commands/wiz/pairing/joined`, sent via `convertAndSendToUser` so the client
+subscribes to `/user/commands/wiz/pairing/joined`. This mirrors mint's
+`@SendToUser("/commands/wiz/pairing/mint")` exactly, which is why the client already has the
+subscription machinery for it.
+
+**Why not `@SendToUser`**: join arrives over HTTP, not as a STOMP inbound message. There is no
+inbound message to annotate, so this must be an active push.
+
+### The trap: a wrong destination fails silently
+
+`SheetAgentBroadcastService` already documents this hazard against itself. Its two helpers address
+*different* users and *different* topics — `sendToComposer` uses `socketSessionId` as the
+destination user with `ComposerClientService.COMMANDS_TOPIC`, while `sendToBrowser` uses
+`socketUserName` with `CommandDispatcher.COMMANDS_TOPIC` plus a runtime header. **Both constants are
+named `COMMANDS_TOPIC`.** Its javadoc records the outcome of picking the wrong one: the message is
+delivered to a destination with no handler and dropped, "while every call up the stack still reports
+success."
+
+This notice uses **neither** constant — its destination is the pairing-specific
+`/commands/wiz/pairing/joined`. Use `socketUserName` as the destination user (the value mint's
+`@SendToUser` resolved to) and set the session id header, as both existing helpers do.
+
+Because the failure mode is silence rather than an exception, **this cannot be considered working on
+the strength of unit tests.** See Testing.
+
+### Push failure must never fail the join
+
+By the time the notice is sent, the agent's session is open and valid. A lost notification degrades
+the UI; it does not invalidate the pairing. Wrap the push and log — never let it propagate out of
+`join()`.
+
+## Frontend
+
+`ConnectToClaudeComponent` gains a `connected` flag and a **standing** subscription to
+`/user/commands/wiz/pairing/joined` — not only while a mint is in flight, because the agent may join
+seconds or minutes after the code is displayed.
+
+Three mechanics this implies, none of which the component does today:
+
+- **The component has no `ngOnInit`** — it implements only `OnChanges` and `OnDestroy`. Add
+  `OnInit` and open the subscription there, via the same
+  `socketConnection.whenConnected().pipe(take(1))` handshake `requestCode()` already uses.
+- **Do not tear the subscription down on a `runtimeId` change.** The destination is per-user, not
+  per-runtime, so the existing `ngOnChanges` reset should clear `connected` and leave the
+  subscription alone. Only the *filter input* changed, not the channel.
+- **`ngOnDestroy` must release it.** Today it only unsubscribes `mintSubscription`; a standing
+  subscription that outlives its component is a leak, and this component is created and destroyed
+  repeatedly by the formula-editor dialog.
+
+On a message, accept it only if **both** hold:
+
+1. `body.runtimeId === this.runtimeId`
+2. the notice's `editorContext` equals `this.mintedEditorContext` (both `null` for a toolbar mint)
+
+Then set `connected = true` and clear `code`.
+
+### Why both filters are load-bearing
+
+The component is reused by three hosts — the composer toolbar, the viewsheet script pane, and the
+formula editor dialog — and **more than one instance can be alive on one page**. A user-destination
+is delivered per *user*, not per sheet and not per pane. So:
+
+- without the `runtimeId` filter, pairing one sheet lights up every open sheet;
+- without the `editorContext` filter, pairing from a formula editor lights up the toolbar button too,
+  and vice versa.
+
+Either failure produces an indicator asserting something untrue — worse than having no indicator,
+because the whole point of 0.11 is to obtain trustworthy independent confirmation.
+
+Compare against `mintedEditorContext`, **not** the live `editorContext` input, for the reason that
+field's own javadoc already documents: several hosts derive `editorContext` from mutable state
+(`viewsheet-script-pane` follows the onInit/onLoad radio; `formula-editor-dialog` includes the
+editable `formulaName`), so the current value can differ from what was actually sent.
+
+### Template and persistence
+
+Replace the `Pairing Code: XXXX` + Copy block with a `✓ Agent connected` line once connected. The
+code has been consumed; continuing to show it invites an attempt to reuse it. The button keeps its
+label — it remains the "pair another one" entry point.
+
+**No timeout.** The indicator clears via the existing `ngOnChanges` reset on `runtimeId` change, and
+when `requestCode()` starts a new mint. A confirmation that erases itself after two seconds is barely
+more independent than the agent saying so, which is the thing 0.11 already does not accept.
+
+## Error handling
+
+| Situation | Behaviour |
+|---|---|
+| Push throws | Logged; `join()` unaffected and still returns the session |
+| Notice arrives for another runtime or another pane | Ignored by the filters; nothing surfaced |
+| Socket down at join time | Notice lost. No confirmation shown, pairing still live. Accepted for one-shot scope — the future continuous-state work is what closes this |
+
+## Testing
+
+**Backend unit** — join pushes once carrying the grant's `runtimeId`, `sheetType` and
+`editorContext`; a toolbar grant pushes `editorContext == null`; a push that throws does not fail
+`join()`.
+
+**Frontend unit** — a notice matching both filters sets `connected` and clears `code`; a mismatched
+`runtimeId` is ignored; a mismatched `editorContext` is ignored, specifically that a pane-scoped
+notice does not light a toolbar instance.
+
+**Live, and required** — because a wrong destination is silent, not an error:
+
+1. Pair from the toolbar; confirm the button area shows connected.
+2. Pair from a formula editor; confirm the **toolbar** instance does not change.
+
+Step 1 is what closes case 0.11 in the consolidated test plan.
+
+## Recorded for later
+
+Continuous state needs a "which sessions are live for this `runtimeId`" query, which does not exist
+today — `findOpen()` searches by `ownerIdentity` + `sheetType`, not by runtime — plus a decision on
+how to present a TTL that expires with no event. Deferred deliberately, not overlooked.

--- a/web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.html
+++ b/web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.html
@@ -5,7 +5,7 @@
 
   <div *ngIf="error" class="wiz-connect-error alert alert-danger mt-2">{{ error }}</div>
 
-  <div *ngIf="connected" class="wiz-connect-connected alert alert-success mt-2">
+  <div *ngIf="connected" role="status" class="wiz-connect-connected alert alert-success mt-2">
     ✓ Agent connected
   </div>
 

--- a/web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.html
+++ b/web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.html
@@ -5,7 +5,11 @@
 
   <div *ngIf="error" class="wiz-connect-error alert alert-danger mt-2">{{ error }}</div>
 
-  <div *ngIf="code" class="wiz-connect-code mt-2">
+  <div *ngIf="connected" class="wiz-connect-connected alert alert-success mt-2">
+    ✓ Agent connected
+  </div>
+
+  <div *ngIf="code && !connected" class="wiz-connect-code mt-2">
     <span class="wiz-connect-label">Pairing Code:</span>
     <code class="wiz-connect-value ms-2">{{ code }}</code>
     <button ngxClipboard [cbContent]="code" (cbOnSuccess)="onCopySuccess()" (cbOnError)="onCopyError()"

--- a/web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.spec.ts
+++ b/web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.spec.ts
@@ -222,7 +222,11 @@ describe("ConnectToClaudeComponent", () => {
 
          component.detach();
 
-         expect(mockSocketConnection.whenConnected).not.toHaveBeenCalled();
+         // Asserts the behaviour directly rather than via "no socket was opened": ngOnInit now
+         // opens one for the join-notice subscription, so the old proxy assertion measured the
+         // component's startup instead of detach(). What matters is that no detach was sent.
+         expect(mockStompConnection.send).not.toHaveBeenCalledWith(
+            "/events/wiz/pairing/detach", expect.anything(), expect.anything());
       });
 
       it("is a no-op when there is no socket connection", () => {
@@ -415,6 +419,21 @@ describe("ConnectToClaudeComponent", () => {
          component.ngOnChanges(
             { runtimeId: { currentValue: "rt-2", previousValue: "rt-1",
                            firstChange: false, isFirstChange: () => false } } as any);
+
+         expect(component.connected).toBe(false);
+      });
+
+      /*
+       * The template renders the code with `*ngIf="code && !connected"`, so a stale connected flag
+       * hides the next code completely. One sheet can be paired by more than one agent, so
+       * re-pairing is an ordinary flow rather than an edge case.
+       */
+      it("clears the indicator when a new code is requested", () => {
+         handlerFor("/user/commands/wiz/pairing/joined")(
+            notice({ runtimeId: "rt-1", sheetType: "WORKSHEET", editorContext: null }));
+         expect(component.connected).toBe(true);
+
+         component.requestCode();
 
          expect(component.connected).toBe(false);
       });

--- a/web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.spec.ts
+++ b/web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.spec.ts
@@ -346,6 +346,27 @@ describe("ConnectToClaudeComponent", () => {
          return { frame: { body: JSON.stringify(body) } };
       }
 
+      /**
+       * Performs a real toolbar mint (no editorContext) so `hasMinted` is set, mirroring what a
+       * user does before a notice can legitimately reach this instance. Also leaves
+       * `component.code` populated the way a real mint would, for tests that assert it gets
+       * cleared.
+       */
+      function mintFromToolbar(): void {
+         let mintHandler: ((msg: any) => void) | null = null;
+         mockStompConnection.subscribe.mockImplementation(
+            (dest: string, h: (msg: any) => void) => {
+               if(dest === "/user/commands/wiz/pairing/mint") {
+                  mintHandler = h;
+               }
+
+               return { unsubscribe: vi.fn() };
+            });
+
+         component.requestCode();
+         mintHandler!(notice({ code: "ABC123" }));
+      }
+
       it("subscribes to the joined destination on init", () => {
          expect(mockStompConnection.subscribe).toHaveBeenCalledWith(
             "/user/commands/wiz/pairing/joined",
@@ -354,7 +375,7 @@ describe("ConnectToClaudeComponent", () => {
       });
 
       it("shows connected and drops the consumed code for a matching notice", () => {
-         component.code = "ABC123";
+         mintFromToolbar();
 
          handlerFor("/user/commands/wiz/pairing/joined")(
             notice({ runtimeId: "rt-1", sheetType: "WORKSHEET", editorContext: null }));
@@ -367,6 +388,8 @@ describe("ConnectToClaudeComponent", () => {
       });
 
       it("ignores a notice for another runtime", () => {
+         mintFromToolbar();
+
          handlerFor("/user/commands/wiz/pairing/joined")(
             notice({ runtimeId: "rt-other", sheetType: "WORKSHEET", editorContext: null }));
 
@@ -379,6 +402,8 @@ describe("ConnectToClaudeComponent", () => {
        * claim an agent joined it, which is a false statement rather than a missing feature.
        */
       it("ignores a pane notice on a toolbar instance", () => {
+         mintFromToolbar();
+
          handlerFor("/user/commands/wiz/pairing/joined")(
             notice({ runtimeId: "rt-1", sheetType: "WORKSHEET",
                      editorContext: { kind: "calcField", assembly: "Query1", name: "Margin" } }));
@@ -411,6 +436,8 @@ describe("ConnectToClaudeComponent", () => {
       });
 
       it("clears the indicator when the runtimeId changes", () => {
+         mintFromToolbar();
+
          handlerFor("/user/commands/wiz/pairing/joined")(
             notice({ runtimeId: "rt-1", sheetType: "WORKSHEET", editorContext: null }));
          expect(component.connected).toBe(true);
@@ -429,6 +456,8 @@ describe("ConnectToClaudeComponent", () => {
        * re-pairing is an ordinary flow rather than an edge case.
        */
       it("clears the indicator when a new code is requested", () => {
+         mintFromToolbar();
+
          handlerFor("/user/commands/wiz/pairing/joined")(
             notice({ runtimeId: "rt-1", sheetType: "WORKSHEET", editorContext: null }));
          expect(component.connected).toBe(true);
@@ -531,6 +560,18 @@ describe("ConnectToClaudeComponent", () => {
                            firstChange: false, isFirstChange: () => false } } as any);
 
          expect(joined!.unsubscribe).not.toHaveBeenCalled();
+      });
+
+      /*
+       * The ambiguity hasMinted resolves. A formula editor opened while a toolbar code was still
+       * outstanding has mintedEditorContext === null, and a toolbar notice carries
+       * editorContext: null -- so without the flag it would light up for someone else's pairing.
+       */
+      it("ignores a toolbar notice on an instance that never minted", () => {
+         handlerFor("/user/commands/wiz/pairing/joined")(
+            notice({ runtimeId: "rt-1", sheetType: "WORKSHEET", editorContext: null }));
+
+         expect(component.connected).toBe(false);
       });
    });
 

--- a/web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.spec.ts
+++ b/web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.spec.ts
@@ -455,6 +455,83 @@ describe("ConnectToClaudeComponent", () => {
 
          expect(subs.some(s => s.unsubscribe.mock.calls.length > 0)).toBe(true);
       });
+
+      /*
+       * The distinction the context filter turns on. detach() shipped a real bug by reading the
+       * live input instead of the minted one, which is why mintedEditorContext exists at all;
+       * without these two cases, onJoined could regress to the live value and stay green.
+       */
+      describe("keys on the context the code was minted with", () => {
+         /** Mints with one context, then leaves the live input pointing at another. */
+         function mintThenDrift(minted: any, drifted: any): void {
+            let mintHandler: ((msg: any) => void) | null = null;
+            mockStompConnection.subscribe.mockImplementation(
+               (dest: string, h: (msg: any) => void) => {
+                  if(dest === "/user/commands/wiz/pairing/mint") {
+                     mintHandler = h;
+                  }
+
+                  return { unsubscribe: vi.fn() };
+               });
+
+            component.editorContext = minted;
+            component.requestCode();
+            mintHandler!(notice({ code: "ABC123" }));
+            component.editorContext = drifted;
+         }
+
+         it("accepts a notice for the minted context after the live input drifted", () => {
+            mintThenDrift({ kind: "viewsheetOnInit" }, { kind: "viewsheetOnLoad" });
+
+            handlerFor("/user/commands/wiz/pairing/joined")(
+               notice({ runtimeId: "rt-1", sheetType: "WORKSHEET",
+                        editorContext: { kind: "viewsheetOnInit", assembly: null,
+                                         name: null, table: null } }));
+
+            expect(component.connected).toBe(true);
+         });
+
+         it("rejects a notice matching the drifted live context but not the minted one", () => {
+            mintThenDrift({ kind: "viewsheetOnInit" }, { kind: "viewsheetOnLoad" });
+
+            handlerFor("/user/commands/wiz/pairing/joined")(
+               notice({ runtimeId: "rt-1", sheetType: "WORKSHEET",
+                        editorContext: { kind: "viewsheetOnLoad", assembly: null,
+                                         name: null, table: null } }));
+
+            expect(component.connected).toBe(false);
+         });
+      });
+
+      /*
+       * The joined destination is per-user, not per-runtime, so a runtimeId change must reset the
+       * filter input and nothing else. Releasing the subscription here would leave the component
+       * permanently deaf with no error anywhere.
+       */
+      it("keeps the joined subscription across a runtimeId change", () => {
+         const byDest = new Map<string, { unsubscribe: ReturnType<typeof vi.fn> }>();
+         mockStompConnection.subscribe.mockImplementation((dest: string) => {
+            const sub = { unsubscribe: vi.fn() };
+            byDest.set(dest, sub);
+            return sub;
+         });
+
+         const f = TestBed.createComponent(ConnectToClaudeComponent);
+         f.componentInstance.runtimeId = "rt-1";
+         f.componentInstance.sheetType = "WORKSHEET";
+         f.componentInstance.socketConnection = mockSocketConnection;
+         f.detectChanges();
+
+         const joined = byDest.get("/user/commands/wiz/pairing/joined");
+         expect(joined).toBeTruthy();
+
+         f.componentInstance.runtimeId = "rt-2";
+         f.componentInstance.ngOnChanges(
+            { runtimeId: { currentValue: "rt-2", previousValue: "rt-1",
+                           firstChange: false, isFirstChange: () => false } } as any);
+
+         expect(joined!.unsubscribe).not.toHaveBeenCalled();
+      });
    });
 
 });

--- a/web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.spec.ts
+++ b/web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.spec.ts
@@ -329,4 +329,113 @@ describe("ConnectToClaudeComponent", () => {
       });
    });
 
+   describe("connected indicator", () => {
+      /** Captures the handler for a given destination, since the component now holds two. */
+      function handlerFor(dest: string): (msg: any) => void {
+         const call = mockStompConnection.subscribe.mock.calls
+            .filter((c: any[]) => c[0] === dest).pop();
+         expect(call).toBeTruthy();
+         return call[1];
+      }
+
+      function notice(body: any): any {
+         return { frame: { body: JSON.stringify(body) } };
+      }
+
+      it("subscribes to the joined destination on init", () => {
+         expect(mockStompConnection.subscribe).toHaveBeenCalledWith(
+            "/user/commands/wiz/pairing/joined",
+            expect.any(Function)
+         );
+      });
+
+      it("shows connected and drops the consumed code for a matching notice", () => {
+         component.code = "ABC123";
+
+         handlerFor("/user/commands/wiz/pairing/joined")(
+            notice({ runtimeId: "rt-1", sheetType: "WORKSHEET", editorContext: null }));
+         fixture.detectChanges();
+
+         expect(component.connected).toBe(true);
+         expect(component.code).toBeNull();
+         expect(fixture.nativeElement.querySelector(".wiz-connect-connected")).toBeTruthy();
+         expect(fixture.nativeElement.querySelector(".wiz-connect-code")).toBeNull();
+      });
+
+      it("ignores a notice for another runtime", () => {
+         handlerFor("/user/commands/wiz/pairing/joined")(
+            notice({ runtimeId: "rt-other", sheetType: "WORKSHEET", editorContext: null }));
+
+         expect(component.connected).toBe(false);
+      });
+
+      /*
+       * The failure this filter exists for: the destination is per-user, so a pane pairing is
+       * delivered to the toolbar instance too. Without the editorContext check the toolbar would
+       * claim an agent joined it, which is a false statement rather than a missing feature.
+       */
+      it("ignores a pane notice on a toolbar instance", () => {
+         handlerFor("/user/commands/wiz/pairing/joined")(
+            notice({ runtimeId: "rt-1", sheetType: "WORKSHEET",
+                     editorContext: { kind: "calcField", assembly: "Query1", name: "Margin" } }));
+
+         expect(component.connected).toBe(false);
+      });
+
+      /*
+       * Jackson serializes a Java record's absent components as explicit nulls, while the browser
+       * never sent those keys at all. Comparing them naively (JSON.stringify, or === on each key)
+       * makes every pane notice a mismatch and the indicator never appears.
+       */
+      it("matches a pane notice whose absent fields arrive as explicit nulls", () => {
+         let handler: ((msg: any) => void) | null = null;
+         mockStompConnection.subscribe.mockImplementation(
+            (dest: string, h: (msg: any) => void) => {
+               if(dest === "/user/commands/wiz/pairing/mint") { handler = h; }
+               return { unsubscribe: vi.fn() };
+            });
+         component.editorContext = { kind: "assemblyMain", assembly: "Chart1" };
+         component.requestCode();
+         handler!(notice({ code: "ABC123" }));
+
+         handlerFor("/user/commands/wiz/pairing/joined")(
+            notice({ runtimeId: "rt-1", sheetType: "WORKSHEET",
+                     editorContext: { kind: "assemblyMain", assembly: "Chart1",
+                                      name: null, table: null } }));
+
+         expect(component.connected).toBe(true);
+      });
+
+      it("clears the indicator when the runtimeId changes", () => {
+         handlerFor("/user/commands/wiz/pairing/joined")(
+            notice({ runtimeId: "rt-1", sheetType: "WORKSHEET", editorContext: null }));
+         expect(component.connected).toBe(true);
+
+         component.runtimeId = "rt-2";
+         component.ngOnChanges(
+            { runtimeId: { currentValue: "rt-2", previousValue: "rt-1",
+                           firstChange: false, isFirstChange: () => false } } as any);
+
+         expect(component.connected).toBe(false);
+      });
+
+      it("releases the joined subscription on destroy", () => {
+         const subs: Array<{ unsubscribe: ReturnType<typeof vi.fn> }> = [];
+         mockStompConnection.subscribe.mockImplementation(() => {
+            const s = { unsubscribe: vi.fn() };
+            subs.push(s);
+            return s;
+         });
+
+         const f = TestBed.createComponent(ConnectToClaudeComponent);
+         f.componentInstance.runtimeId = "rt-1";
+         f.componentInstance.sheetType = "WORKSHEET";
+         f.componentInstance.socketConnection = mockSocketConnection;
+         f.detectChanges();
+         f.destroy();
+
+         expect(subs.some(s => s.unsubscribe.mock.calls.length > 0)).toBe(true);
+      });
+   });
+
 });

--- a/web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.ts
+++ b/web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.ts
@@ -56,6 +56,13 @@ export class ConnectToClaudeComponent implements OnInit, OnChanges, OnDestroy {
    private mintSubscription: Subscription | null = null;
    private joinedSubscription: Subscription | null = null;
    /**
+    * The outer `whenConnected()` subscription that `ngOnInit` uses to obtain the STOMP
+    * connection. `take(1)` normally completes it on its own, but a component created before the
+    * socket connects and destroyed before it does would otherwise leave this callback pending --
+    * it would later open `joinedSubscription` on behalf of a component that no longer exists.
+    */
+   private connectSubscription: Subscription | null = null;
+   /**
     * The `editorContext` that was actually SENT with the mint that produced `code` -- captured
     * when the code comes back, and what `detach()` sends.
     *
@@ -72,6 +79,17 @@ export class ConnectToClaudeComponent implements OnInit, OnChanges, OnDestroy {
     */
    private mintedEditorContext: EditorContext | null = null;
 
+   /**
+    * Whether this instance has an outstanding mint of its own.
+    *
+    * `mintedEditorContext === null` cannot answer that: it means both "I minted a whole-sheet
+    * code" and "I never minted anything". Since a toolbar notice carries `editorContext: null`,
+    * without this flag any instance that never minted -- a formula editor opened while a toolbar
+    * code was still outstanding -- would match that notice and claim a pairing that was not its
+    * own.
+    */
+   private hasMinted = false;
+
    constructor(private zone: NgZone) {}
 
    /**
@@ -81,7 +99,11 @@ export class ConnectToClaudeComponent implements OnInit, OnChanges, OnDestroy {
     * displayed, long after the mint round-trip has completed and unsubscribed itself.
     */
    ngOnInit(): void {
-      this.socketConnection.whenConnected().pipe(take(1)).subscribe(
+      if(!this.socketConnection) {
+         return;
+      }
+
+      this.connectSubscription = this.socketConnection.whenConnected().pipe(take(1)).subscribe(
          (conn: StompClientConnection) => {
             this.joinedSubscription = conn.subscribe(
                "/user/commands/wiz/pairing/joined", (msg: any) => this.onJoined(msg));
@@ -96,6 +118,7 @@ export class ConnectToClaudeComponent implements OnInit, OnChanges, OnDestroy {
          this.copied = false;
          this.connected = false;
          this.mintedEditorContext = null;
+         this.hasMinted = false;
          if(this.mintSubscription) {
             this.mintSubscription.unsubscribe();
             this.mintSubscription = null;
@@ -109,6 +132,7 @@ export class ConnectToClaudeComponent implements OnInit, OnChanges, OnDestroy {
       this.error = null;
       this.copied = false;
       this.connected = false;
+      this.hasMinted = false;
 
       // Read ONCE, here, and carry this exact value through to the response handler: the getters
       // that supply it are live, so re-reading it later (in detach, or even in this same
@@ -128,6 +152,7 @@ export class ConnectToClaudeComponent implements OnInit, OnChanges, OnDestroy {
                   if(body.code) {
                      this.code = body.code;
                      this.mintedEditorContext = requestedContext ?? null;
+                     this.hasMinted = true;
                   }
                   else {
                      this.error = body.error ?? "Failed to generate pairing code";
@@ -151,13 +176,15 @@ export class ConnectToClaudeComponent implements OnInit, OnChanges, OnDestroy {
    }
 
    /**
-    * Accepts a join notice only when it is for this sheet AND this location.
+    * Accepts a join notice only when this instance minted the code AND it is for this sheet AND
+    * this location.
     *
-    * The destination is per-user, so every instance on the page receives every notice. This
-    * component is reused by the composer toolbar, the viewsheet script pane and the formula editor
-    * dialog, so more than one instance is routinely alive at once. Dropping either filter makes an
-    * instance announce a pairing that did not happen to it — a false statement, which is worse
-    * than the missing indicator this whole change exists to fix.
+    * The destination is per socket session, not per sheet and not per pane, so every instance on
+    * the page receives every notice. This component is reused by the composer toolbar, the
+    * viewsheet script pane and the formula editor dialog, so more than one instance is routinely
+    * alive at once. Dropping any of these filters makes an instance announce a pairing that did
+    * not happen to it — a false statement, which is worse than the missing indicator this whole
+    * change exists to fix.
     */
    private onJoined(msg: any): void {
       let body: any;
@@ -169,7 +196,7 @@ export class ConnectToClaudeComponent implements OnInit, OnChanges, OnDestroy {
          return;
       }
 
-      if(body.runtimeId !== this.runtimeId ||
+      if(!this.hasMinted || body.runtimeId !== this.runtimeId ||
          !this.sameEditorContext(body.editorContext, this.mintedEditorContext))
       {
          return;
@@ -250,6 +277,14 @@ export class ConnectToClaudeComponent implements OnInit, OnChanges, OnDestroy {
       if(this.mintSubscription) {
          this.mintSubscription.unsubscribe();
          this.mintSubscription = null;
+      }
+
+      // Releases the outer whenConnected() wait itself, not just what it produces -- otherwise a
+      // component destroyed before the socket connects still has its callback fire later and open
+      // joinedSubscription on behalf of a component that is already gone.
+      if(this.connectSubscription) {
+         this.connectSubscription.unsubscribe();
+         this.connectSubscription = null;
       }
 
       // The formula editor dialog creates and destroys this component repeatedly; a standing

--- a/web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.ts
+++ b/web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.ts
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { Component, Input, NgZone, OnChanges, OnDestroy, SimpleChanges } from "@angular/core";
+import { Component, Input, NgZone, OnChanges, OnDestroy, OnInit, SimpleChanges } from "@angular/core";
 import { NgIf } from "@angular/common";
 import { ClipboardModule } from "ngx-clipboard";
 import { Subscription } from "rxjs";
@@ -30,7 +30,7 @@ import { EditorContext } from "./editor-context";
    standalone: true,
    imports: [NgIf, ClipboardModule]
 })
-export class ConnectToClaudeComponent implements OnChanges, OnDestroy {
+export class ConnectToClaudeComponent implements OnInit, OnChanges, OnDestroy {
    @Input() runtimeId!: string;
    @Input() sheetType!: "WORKSHEET" | "VIEWSHEET";
    @Input() socketConnection!: ViewsheetClientService;
@@ -44,7 +44,17 @@ export class ConnectToClaudeComponent implements OnChanges, OnDestroy {
    error: string | null = null;
    copied = false;
 
+   /**
+    * An agent has redeemed a code minted from this exact component instance.
+    *
+    * One-shot by design: this says a pairing happened, not that one is still live. Tracking
+    * liveness would mean reacting to a TTL that expires with no server-side event, which the
+    * design spec records as deliberately out of scope.
+    */
+   connected = false;
+
    private mintSubscription: Subscription | null = null;
+   private joinedSubscription: Subscription | null = null;
    /**
     * The `editorContext` that was actually SENT with the mint that produced `code` -- captured
     * when the code comes back, and what `detach()` sends.
@@ -64,12 +74,27 @@ export class ConnectToClaudeComponent implements OnChanges, OnDestroy {
 
    constructor(private zone: NgZone) {}
 
+   /**
+    * Opens the standing subscription for join notices.
+    *
+    * Standing, not per-mint: the agent may redeem the code seconds or minutes after it is
+    * displayed, long after the mint round-trip has completed and unsubscribed itself.
+    */
+   ngOnInit(): void {
+      this.socketConnection.whenConnected().pipe(take(1)).subscribe(
+         (conn: StompClientConnection) => {
+            this.joinedSubscription = conn.subscribe(
+               "/user/commands/wiz/pairing/joined", (msg: any) => this.onJoined(msg));
+         });
+   }
+
    ngOnChanges(changes: SimpleChanges): void {
       if(changes["runtimeId"] && !changes["runtimeId"].firstChange) {
          this.code = null;
          this.error = null;
          this.loading = false;
          this.copied = false;
+         this.connected = false;
          this.mintedEditorContext = null;
          if(this.mintSubscription) {
             this.mintSubscription.unsubscribe();
@@ -124,6 +149,64 @@ export class ConnectToClaudeComponent implements OnChanges, OnDestroy {
       });
    }
 
+   /**
+    * Accepts a join notice only when it is for this sheet AND this location.
+    *
+    * The destination is per-user, so every instance on the page receives every notice. This
+    * component is reused by the composer toolbar, the viewsheet script pane and the formula editor
+    * dialog, so more than one instance is routinely alive at once. Dropping either filter makes an
+    * instance announce a pairing that did not happen to it — a false statement, which is worse
+    * than the missing indicator this whole change exists to fix.
+    */
+   private onJoined(msg: any): void {
+      let body: any;
+
+      try {
+         body = JSON.parse(msg.frame.body);
+      }
+      catch(e) {
+         return;
+      }
+
+      if(body.runtimeId !== this.runtimeId ||
+         !this.sameEditorContext(body.editorContext, this.mintedEditorContext))
+      {
+         return;
+      }
+
+      this.zone.run(() => {
+         this.connected = true;
+         // The code is single-use and has now been used. Leaving it on screen invites an attempt
+         // to redeem it again.
+         this.code = null;
+         this.error = null;
+      });
+   }
+
+   /**
+    * Compares two editor contexts, treating an absent field and an explicit null as equal.
+    *
+    * Required, not defensive: the server sends a Java record, and Jackson writes its unset
+    * components as explicit nulls, while the browser omits those keys from the mint payload
+    * entirely. A structural comparison (JSON.stringify, or === per key) would therefore never
+    * match a pane pairing, and the indicator would never appear for one.
+    */
+   private sameEditorContext(a: EditorContext | null | undefined,
+                             b: EditorContext | null | undefined): boolean {
+      if(!a && !b) {
+         return true;
+      }
+
+      if(!a || !b) {
+         return false;
+      }
+
+      return a.kind === b.kind &&
+         (a.assembly ?? null) === (b.assembly ?? null) &&
+         (a.name ?? null) === (b.name ?? null) &&
+         (a.table ?? null) === (b.table ?? null);
+   }
+
    onCopySuccess(): void {
       this.copied = true;
       setTimeout(() => {
@@ -166,6 +249,13 @@ export class ConnectToClaudeComponent implements OnChanges, OnDestroy {
       if(this.mintSubscription) {
          this.mintSubscription.unsubscribe();
          this.mintSubscription = null;
+      }
+
+      // The formula editor dialog creates and destroys this component repeatedly; a standing
+      // subscription that outlives its component is a leak.
+      if(this.joinedSubscription) {
+         this.joinedSubscription.unsubscribe();
+         this.joinedSubscription = null;
       }
    }
 }

--- a/web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.ts
+++ b/web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.ts
@@ -108,6 +108,7 @@ export class ConnectToClaudeComponent implements OnInit, OnChanges, OnDestroy {
       this.code = null;
       this.error = null;
       this.copied = false;
+      this.connected = false;
 
       // Read ONCE, here, and carry this exact value through to the response handler: the getters
       // that supply it are live, so re-reading it later (in detach, or even in this same


### PR DESCRIPTION
## What

The Composer gave **no sign at all** that a pairing succeeded. The browser mints the code, the agent joins over HTTP, and nothing closed the loop back — so after a successful `connect_sheet` the toolbar still read "Connect to Claude", and the only evidence pairing worked was the agent claiming it did.

That is exactly what case **0.11** of `stylebi-wiz`s consolidated composer-plugin test plan exists to rule out, and it was recorded there as FAIL. This closes it.

## Changes

**Backend** — `SheetJoinService.join()` pushes a new `PairingJoinedNotice` to the browser that minted the code, wrapped so a failed push can never fail the join: by the time it runs the session is already open and valid, so a lost notice costs the indicator and nothing else.

**Frontend** — `ConnectToClaudeComponent` holds a standing STOMP subscription and shows an agent-connected indication in place of the consumed code.

Four judgement calls that a less careful implementation would have gotten wrong and shipped silently broken:

- **`socketUserName`, not `socketSessionId`**, as the destination user. `sendToBrowser` already ships this pair and demonstrably reaches the browser; `sendToComposer`s use of `socketSessionId` is the anomaly, needed because an `OpenComposerAssetCommand` has no open sheet.
- **`mintedEditorContext`, not the live `editorContext` input.** Several hosts derive the context from mutable state, and `detach()` shipped a real bug this way once already.
- **A `hasMinted` flag**, because `mintedEditorContext === null` means both "I minted a whole-sheet code" and "I never minted anything" — and a toolbar notice carries `editorContext: null`, so without it a formula editor opened while a toolbar code was outstanding lit up for someone elses pairing.
- **`sameEditorContext` treats an absent field and an explicit `null` as equal**, because Jackson writes a records unset components as nulls while the browser omits those keys entirely. A structural comparison would never match a pane pairing.

## Testing

| Suite | Result |
|---|---|
| Java (`SheetJoinServiceTest` + `SheetAgentBroadcastServiceTest`) | 24/24 |
| Frontend (`connect-to-claude.component.spec.ts`) | 31/31 |

Three regression guards were **mutation-verified** rather than assumed — each was confirmed to fail when the behaviour it guards is removed:

- swapping `socketUserName` for `socketSessionId` in `sendPairingJoined` → 1 failure
- comparing against `editorContext` instead of `mintedEditorContext` → 2 failures
- adding `joinedSubscription?.unsubscribe()` to `ngOnChanges` → 1 failure

The destination test asserts the **literal** `"/commands/wiz/pairing/joined"`, not the constant — asserting a constant against itself proves nothing, and this classs own javadoc records that a wrong topic is delivered to a destination with no handler and dropped while every call up the stack still reports success.

## Live verification

**All three live checks confirmed by the operator, case by case in the UI:**

- toolbar pairing shows the connected indication
- pairing from a formula editor lights that editor and leaves the toolbar unchanged
- a formula editor opened while a toolbar code is still outstanding stays dark when the agent redeems; only the toolbar lights up

The last two are the entire reason the `editorContext` filter and the `hasMinted` guard exist, and they are the part no unit test can settle — a wrong destination or a too-loose filter fails silently while every layer reports success. That is why this PR treated a live check as mandatory rather than optional, and the evidence is now in.

## Review history

Executed task-by-task with a review after each and one whole-branch review at the end. Worth noting: the `hasMinted` defect above was found only by the **whole-branch** review — both per-task reviews approved the code without catching it, and it was a real correctness gap against a guarantee the design spec states in writing.

One reviewer finding was deliberately not fixed and is recorded in the plan: the pane-scoped setup block in `SheetJoinServiceTest` is duplicated verbatim across two tests and wants a helper. Test-only DRY, no correctness impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
