### PR TITLE
feat(wiz-worksheet): expose table composition, and check column types when concatenating

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -929,17 +929,46 @@ public class WorksheetEditService {
             sources[i] = requireTable(tables.get(i));
          }
 
-         // Validate that all tables have the same number of columns.
-         int colCount = sources[0].getColumnSelection(true).getAttributeCount();
+         // Validate that all tables line up: same column count, and column i of each table
+         // mergeable with column i of the first. Sources are concatenated BY POSITION, not by
+         // name, so a pair that does not line up produces a column carrying two unrelated kinds
+         // of value — which renders as an ordinary column and reports no error anywhere. The
+         // Composer runs the same check (ConcatenatedTableAssembly.tableAssembliesAreCompatible,
+         // surfaced as concatenationWarning); this path previously checked only the count.
+         ColumnSelection firstColumns = sources[0].getColumnSelection(true);
+         int colCount = firstColumns.getAttributeCount();
 
          for(int i = 1; i < sources.length; i++) {
-            int otherCount = sources[i].getColumnSelection(true).getAttributeCount();
+            ColumnSelection otherColumns = sources[i].getColumnSelection(true);
+            int otherCount = otherColumns.getAttributeCount();
 
             if(otherCount != colCount) {
                throw new PairingException(
                   "Data blocks that do not have the same number of columns cannot be " +
                   "concatenated. \"" + sources[0].getName() + "\" has " + colCount +
                   " columns but \"" + sources[i].getName() + "\" has " + otherCount + ".");
+            }
+
+            for(int c = 0; c < colCount; c++) {
+               DataRef first = firstColumns.getAttribute(c);
+               DataRef other = otherColumns.getAttribute(c);
+
+               if(!(first instanceof ColumnRef fcol) || !(other instanceof ColumnRef ocol)) {
+                  continue;
+               }
+
+               String ftype = fcol.getDataType();
+               String otype = ocol.getDataType();
+
+               if(!AssetUtil.isMergeable(ftype, otype)) {
+                  throw new PairingException(
+                     "Columns are concatenated by position, and position " + (c + 1) +
+                     " does not line up: \"" + sources[0].getName() + "\" has \"" +
+                     fcol.getAttribute() + "\" (" + ftype + ") while \"" + sources[i].getName() +
+                     "\" has \"" + ocol.getAttribute() + "\" (" + otype + "), and those types " +
+                     "cannot be merged. Reorder the columns so matching ones share a position, " +
+                     "or change one column's type with change_column_type.");
+               }
             }
          }
 

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -909,7 +909,9 @@ public class WorksheetEditService {
        * @param tables    the source table assembly names (at least two)
        * @param opType    one of {@code "UNION"}, {@code "INTERSECT"}, {@code "MINUS"}
        *                  (case-insensitive; defaults to {@code "UNION"})
-       * @throws PairingException if fewer than two tables are given or a source is not found
+       * @throws PairingException if fewer than two tables are given, a source is not found, or the
+       *                          sources do not line up — same number of visible columns, and
+       *                          position-by-position mergeable types
        */
       public void addConcatenation(String name, List<String> tables, String opType)
          throws PairingException
@@ -935,6 +937,16 @@ public class WorksheetEditService {
          // of value — which renders as an ordinary column and reports no error anywhere. The
          // Composer runs the same check (ConcatenatedTableAssembly.tableAssembliesAreCompatible,
          // surfaced as concatenationWarning); this path previously checked only the count.
+         //
+         // Comparing every table against the first rather than against its predecessor (which is
+         // what ConcatenatedTableAssembly.areCompatible does) is equivalent, since isMergeable
+         // partitions types into disjoint classes — string {string, char}, number {float, double,
+         // byte, short, integer, long}, date {date, timeInstant}, identity otherwise — and is
+         // therefore transitive. Anchoring on the first also matches getDefaultColumnSelection,
+         // which takes the resulting column list from subtables[0].
+         //
+         // Both counts and positions come from the PUBLIC column selection, so hidden columns are
+         // excluded — exactly what the server itself concatenates.
          ColumnSelection firstColumns = sources[0].getColumnSelection(true);
          int colCount = firstColumns.getAttributeCount();
 
@@ -946,26 +958,32 @@ public class WorksheetEditService {
                throw new PairingException(
                   "Data blocks that do not have the same number of columns cannot be " +
                   "concatenated. \"" + sources[0].getName() + "\" has " + colCount +
-                  " columns but \"" + sources[i].getName() + "\" has " + otherCount + ".");
+                  " visible column" + (colCount == 1 ? "" : "s") + " but \"" +
+                  sources[i].getName() + "\" has " + otherCount + " visible column" +
+                  (otherCount == 1 ? "" : "s") + ".");
             }
 
             for(int c = 0; c < colCount; c++) {
+               // Read the type off DataRef rather than narrowing to ColumnRef: skipping a position
+               // whose ref is some other kind would silently leave it unchecked, which is the very
+               // failure this validation exists to prevent.
                DataRef first = firstColumns.getAttribute(c);
                DataRef other = otherColumns.getAttribute(c);
+               String ftype = first.getDataType();
+               String otype = other.getDataType();
 
-               if(!(first instanceof ColumnRef fcol) || !(other instanceof ColumnRef ocol)) {
+               // isMergeable dereferences both arguments; a ref with no type at all is not
+               // something this check can speak to, so leave it to the server.
+               if(ftype == null || otype == null) {
                   continue;
                }
-
-               String ftype = fcol.getDataType();
-               String otype = ocol.getDataType();
 
                if(!AssetUtil.isMergeable(ftype, otype)) {
                   throw new PairingException(
                      "Columns are concatenated by position, and position " + (c + 1) +
                      " does not line up: \"" + sources[0].getName() + "\" has \"" +
-                     fcol.getAttribute() + "\" (" + ftype + ") while \"" + sources[i].getName() +
-                     "\" has \"" + ocol.getAttribute() + "\" (" + otype + "), and those types " +
+                     first.getAttribute() + "\" (" + ftype + ") while \"" + sources[i].getName() +
+                     "\" has \"" + other.getAttribute() + "\" (" + otype + "), and those types " +
                      "cannot be merged. Reorder the columns so matching ones share a position, " +
                      "or change one column's type with change_column_type.");
                }
@@ -1820,9 +1838,17 @@ public class WorksheetEditService {
       /**
        * Toggles the auto-update flag on a mirror table assembly.
        *
+       * <p>Only an <em>outer</em> mirror — one of an asset in another worksheet — actually carries
+       * the flag: {@code MirrorAssemblyImpl.setAutoUpdate} returns early for anything else, and
+       * {@code isAutoUpdate} then answers {@code true} regardless. Since
+       * {@link #addMirror(String, String)} builds inner mirrors, that is the normal case for an
+       * agent, and accepting a write that is silently discarded would leave the caller believing a
+       * setting took when it never did — so the write is verified and refused instead.</p>
+       *
        * @param table      the mirror assembly name
        * @param autoUpdate {@code true} to enable auto-update, {@code false} to disable
-       * @throws PairingException if the assembly is not a mirror table
+       * @throws PairingException if the assembly is not a mirror table, or is a mirror that cannot
+       *                          carry the flag
        */
       public void setMirrorAutoUpdate(String table, boolean autoUpdate)
          throws PairingException
@@ -1834,6 +1860,13 @@ public class WorksheetEditService {
          }
 
          mirror.setAutoUpdate(autoUpdate);
+
+         if(mirror.isAutoUpdate() != autoUpdate) {
+            throw new PairingException(
+               "autoUpdate cannot be set to " + autoUpdate + " on \"" + table + "\": its source " +
+               "is in this worksheet, and such a mirror always tracks its source. Only a mirror " +
+               "of an asset in another worksheet carries the flag.");
+         }
       }
 
       // -----------------------------------------------------------------------

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
@@ -92,7 +92,7 @@ public class WorksheetReadService {
 
       return new WorksheetModel.TableModel(
          name, type, columns, joins,
-         readSources(t), readConcatType(t), readAutoUpdate(t),
+         readSources(t), readConcatType(t), readConcatCompatible(t), readAutoUpdate(t),
          preConditions, postConditions, rankingConditions,
          aggregates, sorts, primary);
    }
@@ -111,44 +111,80 @@ public class WorksheetReadService {
     * which table is subtracted from which. Reporting the names without their order would be
     * useless for both.</p>
     *
-    * <p>Covers joins as well as concatenations: both extend {@link CompositeTableAssembly}. That
-    * matters most for cross and merge joins, which carry no join predicates and therefore report
-    * an empty {@code joins} list — before this, nothing in the model distinguished those from a
-    * table with no sources at all. A mirror reaches its single source by a different route, since
-    * it extends {@code ComposedTableAssembly} rather than {@code CompositeTableAssembly}.</p>
+    * <p>Covers every kind of table built on another: {@link ComposedTableAssembly} declares
+    * {@code getTableNames()} and joins, concatenations, mirrors, rotates and unpivots all implement
+    * it. Branching on {@link CompositeTableAssembly} instead would miss rotates and unpivots, which
+    * extend {@code ComposedTableAssembly} directly and would then be reported as having no sources
+    * at all. It matters most for cross and merge joins, which carry no join predicates and therefore
+    * report an empty {@code joins} list — nothing else in the model distinguishes those from a table
+    * with no sources.</p>
+    *
+    * <p>Empty for a table whose source has since been deleted: {@code getTableNames()} resolves the
+    * name against the worksheet, so a dangling reference reports nothing rather than a name that no
+    * longer exists.</p>
     */
    private List<String> readSources(TableAssembly t) {
-      if(t instanceof CompositeTableAssembly composite) {
-         String[] names = composite.getTableNames();
-         return names == null ? List.of() : List.of(names);
+      if(!(t instanceof ComposedTableAssembly composed)) {
+         return List.of();
       }
 
-      if(t instanceof MirrorTableAssembly mirror) {
-         String source = mirror.getAssemblyName();
-         return source == null ? List.of() : List.of(source);
+      String[] names = composed.getTableNames();
+
+      if(names == null) {
+         return List.of();
       }
 
-      return List.of();
+      // MirrorTableAssembly.getTableNames() wraps its source name without checking it, so a
+      // half-initialized mirror can produce a null entry — and List.of rejects those outright.
+      return Arrays.stream(names).filter(Objects::nonNull).toList();
    }
 
    /**
-    * {@code UNION}, {@code INTERSECT} or {@code MINUS} for a concatenation, {@code null} otherwise.
+    * {@code UNION}, {@code INTERSECT} or {@code MINUS} for a concatenation, {@code "MIXED"} when its
+    * pairs do not all use the same operation, {@code null} for anything else.
     *
     * <p>The three behave very differently — adding a source to a UNION can add rows while adding
     * one to an INTERSECT can only remove them — so a caller reasoning about a concatenation needs
     * to know which it is looking at.</p>
+    *
+    * <p>One operation is held per <em>adjacent pair</em> of subtables, and Composer sets it per
+    * connection, so {@code A UNION B MINUS C} is a legal assembly. Reporting the first pair's
+    * operation as though it described the whole thing would hand the caller a confidently wrong
+    * answer, which is worse than none — hence {@code "MIXED"}. The individual per-pair operations
+    * are deliberately not exposed: no agent tool can set them separately
+    * ({@code add_concatenation} applies one operation to every pair), so naming which pair is which
+    * would not let a caller act on it.</p>
     */
    private String readConcatType(TableAssembly t) {
-      if(!(t instanceof ConcatenatedTableAssembly concat) || concat.getOperatorCount() == 0) {
+      if(!(t instanceof ConcatenatedTableAssembly concat)) {
          return null;
       }
 
-      TableAssemblyOperator operator = concat.getOperator(0);
+      Set<String> operations = new LinkedHashSet<>();
 
-      if(operator == null || operator.getKeyOperator() == null) {
+      for(int i = 0; i < concat.getOperatorCount(); i++) {
+         operations.add(concatOperation(concat.getOperator(i)));
+      }
+
+      if(operations.isEmpty()) {
          return null;
       }
 
+      // One operation, and it was recognized — otherwise the pairs disagree, or the single
+      // operation is not a concatenation at all and reports nothing rather than a guess.
+      return operations.size() == 1 ? operations.iterator().next() : "MIXED";
+   }
+
+   /**
+    * The concatenation operation a single pair uses, or {@code null} if it is not one of the three.
+    */
+   private String concatOperation(TableAssemblyOperator operator) {
+      if(operator == null) {
+         return null;
+      }
+
+      // getKeyOperator() never returns null: with no operator marked as the key one it synthesizes
+      // a JOIN, which falls through to null below.
       return switch(operator.getKeyOperator().getOperation()) {
          case TableAssemblyOperator.UNION -> "UNION";
          case TableAssemblyOperator.INTERSECT -> "INTERSECT";
@@ -158,11 +194,35 @@ public class WorksheetReadService {
    }
 
    /**
-    * A mirror's auto-update flag, or {@code null} for anything that is not a mirror.
+    * For a concatenation, whether its sources line up by type as well as by count; {@code null} for
+    * anything else.
     *
-    * <p>Settable through the agent API but, until now, not readable through it — so a caller had
-    * no way to confirm the setting took, or to tell whether a mirror it did not create is
-    * tracking its source.</p>
+    * <p>Sources are combined by position, so a pair that lines up numerically but not by type
+    * produces a column carrying two unrelated kinds of value — and it renders as an ordinary column
+    * and reports no error anywhere. Composer computes this same predicate and draws it as a warning
+    * on the connection ({@code ConcatenatedTableAssemblyModel.concatenationWarning}), and
+    * {@code add_concatenation} now refuses to build one, so reading it here is the only way an agent
+    * can see the problem in a concatenation it did not create.</p>
+    */
+   private Boolean readConcatCompatible(TableAssembly t) {
+      if(!(t instanceof ConcatenatedTableAssembly concat)) {
+         return null;
+      }
+
+      // getTableAssemblies() returns null once any subtable has gone missing from the worksheet,
+      // and tableAssembliesAreCompatible() would then throw. Reading one dangling concatenation
+      // must not fail the read for the whole worksheet.
+      return concat.getTableAssemblies() == null ? null : concat.tableAssembliesAreCompatible();
+   }
+
+   /**
+    * A mirror's <b>effective</b> auto-update flag, or {@code null} for anything that is not a
+    * mirror.
+    *
+    * <p>Effective, not stored: {@code MirrorAssemblyImpl} answers {@code auto || !isOuterMirror()},
+    * so a mirror whose source lives in the same worksheet always reports {@code true} however the
+    * flag was set. Settable through the agent API but, until now, not readable through it — so a
+    * caller had no way to tell whether a mirror it did not create is tracking its source.</p>
     */
    private Boolean readAutoUpdate(TableAssembly t) {
       return t instanceof MirrorTableAssembly mirror ? mirror.isAutoUpdate() : null;

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
@@ -92,8 +92,80 @@ public class WorksheetReadService {
 
       return new WorksheetModel.TableModel(
          name, type, columns, joins,
+         readSources(t), readConcatType(t), readAutoUpdate(t),
          preConditions, postConditions, rankingConditions,
          aggregates, sorts, primary);
+   }
+
+   // -------------------------------------------------------------------------
+   // Composition — which assemblies a table is built from
+   // -------------------------------------------------------------------------
+
+   /**
+    * The assemblies this table is built from, in order.
+    *
+    * <p>Order is not cosmetic. A concatenation takes its entire column list from its first
+    * subtable alone — {@link ConcatenatedTableAssembly#getDefaultColumnSelection} walks
+    * {@code subtables[0]}'s columns and consults the rest only to merge numeric types, by
+    * position — so the first entry is what decides the shape, and for a MINUS the order decides
+    * which table is subtracted from which. Reporting the names without their order would be
+    * useless for both.</p>
+    *
+    * <p>Covers joins as well as concatenations: both extend {@link CompositeTableAssembly}. That
+    * matters most for cross and merge joins, which carry no join predicates and therefore report
+    * an empty {@code joins} list — before this, nothing in the model distinguished those from a
+    * table with no sources at all. A mirror reaches its single source by a different route, since
+    * it extends {@code ComposedTableAssembly} rather than {@code CompositeTableAssembly}.</p>
+    */
+   private List<String> readSources(TableAssembly t) {
+      if(t instanceof CompositeTableAssembly composite) {
+         String[] names = composite.getTableNames();
+         return names == null ? List.of() : List.of(names);
+      }
+
+      if(t instanceof MirrorTableAssembly mirror) {
+         String source = mirror.getAssemblyName();
+         return source == null ? List.of() : List.of(source);
+      }
+
+      return List.of();
+   }
+
+   /**
+    * {@code UNION}, {@code INTERSECT} or {@code MINUS} for a concatenation, {@code null} otherwise.
+    *
+    * <p>The three behave very differently — adding a source to a UNION can add rows while adding
+    * one to an INTERSECT can only remove them — so a caller reasoning about a concatenation needs
+    * to know which it is looking at.</p>
+    */
+   private String readConcatType(TableAssembly t) {
+      if(!(t instanceof ConcatenatedTableAssembly concat) || concat.getOperatorCount() == 0) {
+         return null;
+      }
+
+      TableAssemblyOperator operator = concat.getOperator(0);
+
+      if(operator == null || operator.getKeyOperator() == null) {
+         return null;
+      }
+
+      return switch(operator.getKeyOperator().getOperation()) {
+         case TableAssemblyOperator.UNION -> "UNION";
+         case TableAssemblyOperator.INTERSECT -> "INTERSECT";
+         case TableAssemblyOperator.MINUS -> "MINUS";
+         default -> null;
+      };
+   }
+
+   /**
+    * A mirror's auto-update flag, or {@code null} for anything that is not a mirror.
+    *
+    * <p>Settable through the agent API but, until now, not readable through it — so a caller had
+    * no way to confirm the setting took, or to tell whether a mirror it did not create is
+    * tracking its source.</p>
+    */
+   private Boolean readAutoUpdate(TableAssembly t) {
+      return t instanceof MirrorTableAssembly mirror ? mirror.isAutoUpdate() : null;
    }
 
    private String tableType(TableAssembly t) {
@@ -160,7 +232,8 @@ public class WorksheetReadService {
          expression = exprRef.getExpression();
       }
 
-      return new WorksheetModel.ColumnModel(name, type, alias, expression, description);
+      return new WorksheetModel.ColumnModel(name, type, alias, expression, description,
+                                            ref.isVisible());
    }
 
    // -------------------------------------------------------------------------

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/model/WorksheetModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/model/WorksheetModel.java
@@ -38,6 +38,23 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
     *                           {@code "ROTATED"}, {@code "TABLE"}
     * @param columns            visible (public) columns
     * @param joins              join predicates; non-null, empty for non-join tables
+    * @param sources            the assemblies this one is built from, <b>in order</b>; empty for a
+    *                           table with no sources. Order carries meaning: for a
+    *                           {@code CONCAT} the first entry supplies the whole column list (see
+    *                           {@code ConcatenatedTableAssembly.getDefaultColumnSelection}) and,
+    *                           for a MINUS, decides which table is subtracted from which. Without
+    *                           this an agent cannot tell which tables a concatenation combines,
+    *                           cannot supply the full subtable list that reordering requires, and
+    *                           cannot tell that editing a table will reshape a concatenation
+    *                           downstream. A cross or merge join also reports its sources here,
+    *                           since those carry no join predicates and so leave {@code joins}
+    *                           empty — an empty {@code joins} means "no predicates", never "no
+    *                           sources".
+    * @param concatType         {@code "UNION"}, {@code "INTERSECT"} or {@code "MINUS"} for a
+    *                           {@code CONCAT}; {@code null} otherwise
+    * @param autoUpdate         a mirror's auto-update flag; {@code null} for anything else. Only
+    *                           readable here — settable through the agent API but previously
+    *                           impossible to read back, so no caller could confirm it.
     * @param preConditions      pre-aggregate filter conditions
     * @param postConditions     post-aggregate filter conditions
     * @param rankingConditions  ranking / top-N conditions
@@ -50,6 +67,9 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
       String type,
       List<ColumnModel> columns,
       List<JoinModel> joins,
+      List<String> sources,
+      String concatType,
+      Boolean autoUpdate,
       List<FilterModel> preConditions,
       List<FilterModel> postConditions,
       List<FilterModel> rankingConditions,
@@ -59,7 +79,10 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
    ) {}
 
    /**
-    * A single visible column in a table.
+    * A single column in a table.
+    *
+    * <p>Hidden columns are included: the list is read from the private column selection, not the
+    * public one, which is why {@code visible} is needed to tell them apart.</p>
     *
     * @param name        attribute (column) name
     * @param type        XSchema data-type string (e.g. {@code "string"}, {@code "integer"})
@@ -67,9 +90,15 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
     * @param expression  script expression when the column is an expression column;
     *                    {@code null} for plain attribute columns
     * @param description user-defined column description; may be {@code null}
+    * @param visible     {@code false} once a column is hidden. A hidden column stays in this list
+    *                    but drops out of the assembly's data, and is excluded from the public
+    *                    column selection that a concatenation counts when it checks its sources
+    *                    match — so anything comparing column counts has to filter on this rather
+    *                    than take the list length, and anything comparing the model against real
+    *                    rows has to expect hidden columns to be missing from the data.
     */
    public record ColumnModel(String name, String type, String alias, String expression,
-                             String description) {}
+                             String description, boolean visible) {}
 
    /**
     * A join predicate between two tables.

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/model/WorksheetModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/model/WorksheetModel.java
@@ -36,7 +36,8 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
     * @param type               one of {@code "EMBEDDED"}, {@code "JOIN"}, {@code "CONCAT"},
     *                           {@code "MIRROR"}, {@code "UNPIVOT"},
     *                           {@code "ROTATED"}, {@code "TABLE"}
-    * @param columns            visible (public) columns
+    * @param columns            the table's columns, hidden ones included — see
+    *                           {@link ColumnModel#visible()}
     * @param joins              join predicates; non-null, empty for non-join tables
     * @param sources            the assemblies this one is built from, <b>in order</b>; empty for a
     *                           table with no sources. Order carries meaning: for a
@@ -49,12 +50,25 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
     *                           downstream. A cross or merge join also reports its sources here,
     *                           since those carry no join predicates and so leave {@code joins}
     *                           empty — an empty {@code joins} means "no predicates", never "no
-    *                           sources".
+    *                           sources". A {@code MIRROR}, {@code ROTATED} or {@code UNPIVOT}
+    *                           reports the single table it is built on.
     * @param concatType         {@code "UNION"}, {@code "INTERSECT"} or {@code "MINUS"} for a
-    *                           {@code CONCAT}; {@code null} otherwise
-    * @param autoUpdate         a mirror's auto-update flag; {@code null} for anything else. Only
-    *                           readable here — settable through the agent API but previously
-    *                           impossible to read back, so no caller could confirm it.
+    *                           {@code CONCAT}; {@code null} otherwise. A concatenation carries one
+    *                           operation per adjacent pair of {@code sources} and they need not
+    *                           agree, so {@code "MIXED"} is reported when they differ (the
+    *                           per-pair operations are not exposed).
+    * @param concatCompatible   for a {@code CONCAT}, whether its sources line up by type as well as
+    *                           by count; {@code null} otherwise. Sources are combined by position,
+    *                           so a pair that lines up numerically but not by type produces a
+    *                           column carrying two unrelated kinds of value. {@code false} is what
+    *                           Composer draws as a warning on the connection, and it is the only
+    *                           way to see the problem in a concatenation the agent did not build —
+    *                           {@code add_concatenation} refuses to create one.
+    * @param autoUpdate         a mirror's <b>effective</b> auto-update flag; {@code null} for
+    *                           anything that is not a mirror. Effective, not stored: a mirror whose
+    *                           source is in the same worksheet always reports {@code true} however
+    *                           the flag was set, since {@code MirrorAssemblyImpl} answers
+    *                           {@code auto || !isOuterMirror()}.
     * @param preConditions      pre-aggregate filter conditions
     * @param postConditions     post-aggregate filter conditions
     * @param rankingConditions  ranking / top-N conditions
@@ -69,6 +83,7 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
       List<JoinModel> joins,
       List<String> sources,
       String concatType,
+      Boolean concatCompatible,
       Boolean autoUpdate,
       List<FilterModel> preConditions,
       List<FilterModel> postConditions,

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/model/WorksheetModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/model/WorksheetModel.java
@@ -17,6 +17,8 @@
  */
 package inetsoft.web.wiz.worksheet.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.util.List;
 
 /**
@@ -25,7 +27,16 @@ import java.util.List;
  * <p>All fields are plain Java records — no Spring / JPA dependencies — so the
  * class can be constructed anywhere (tests, service, controller) without a
  * container.</p>
+ *
+ * <p>Every record here omits its null fields, matching the sibling DTOs under
+ * {@code inetsoft.web.wiz.model}. This payload is read by an LLM, and a field that is absent says
+ * exactly what a field that is {@code null} says while costing nothing —
+ * {@code "concatType": null, "concatCompatible": null, "autoUpdate": null} on every plain table
+ * adds up. {@code NON_NULL} and deliberately not {@code NON_EMPTY}: an empty {@code sources} or
+ * {@code joins} list is a meaningful answer ("built on nothing", "no predicates") and must stay on
+ * the wire.</p>
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record WorksheetModel(List<TableModel> tables, List<VariableModel> variables,
                              List<NamedGroupModel> namedGroups) {
 
@@ -76,6 +87,7 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
     * @param sorts              sort directives; empty when none
     * @param primary            {@code true} if this is the worksheet's primary assembly
     */
+   @JsonInclude(JsonInclude.Include.NON_NULL)
    public record TableModel(
       String name,
       String type,
@@ -112,6 +124,7 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
     *                    than take the list length, and anything comparing the model against real
     *                    rows has to expect hidden columns to be missing from the data.
     */
+   @JsonInclude(JsonInclude.Include.NON_NULL)
    public record ColumnModel(String name, String type, String alias, String expression,
                              String description, boolean visible) {}
 
@@ -124,6 +137,7 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
     * @param rightKey   attribute name from the right table
     * @param op         join operator name (e.g. {@code "INNER_JOIN"}, {@code "LEFT_JOIN"})
     */
+   @JsonInclude(JsonInclude.Include.NON_NULL)
    public record JoinModel(
       String leftTable,
       String leftKey,
@@ -147,6 +161,7 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
     * @param junction  {@code "AND"} or {@code "OR"} — the junction that precedes
     *                  this condition in the list (may be {@code null} for the first item)
     */
+   @JsonInclude(JsonInclude.Include.NON_NULL)
    public record FilterModel(
       String field,
       String operation,
@@ -160,6 +175,7 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
     * @param groups     group-by dimensions
     * @param aggregates measure aggregate definitions
     */
+   @JsonInclude(JsonInclude.Include.NON_NULL)
    public record AggregateModel(List<GroupModel> groups, List<AggregateRefModel> aggregates) {
 
       /**
@@ -171,6 +187,7 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
        *                  {@code dateLevel} / add_date_range_column's {@code dateOption};
        *                  {@code null} for a plain (non-date-bucketed) group
        */
+      @JsonInclude(JsonInclude.Include.NON_NULL)
       public record GroupModel(String field, String dateLevel) {}
 
       /**
@@ -180,6 +197,7 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
        * @param formula formula name (e.g. {@code "Sum"}, {@code "Count"})
        * @param alias   output alias; may be {@code null}
        */
+      @JsonInclude(JsonInclude.Include.NON_NULL)
       public record AggregateRefModel(String column, String formula, String alias) {}
    }
 
@@ -189,6 +207,7 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
     * @param field column name
     * @param order {@code "ASC"} or {@code "DESC"}
     */
+   @JsonInclude(JsonInclude.Include.NON_NULL)
    public record SortModel(String field, String order) {}
 
    /**
@@ -199,6 +218,7 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
     * @param type         XSchema data-type string; may be {@code null}
     * @param defaultValue stringified default value; may be {@code null}
     */
+   @JsonInclude(JsonInclude.Include.NON_NULL)
    public record VariableModel(String name, String label, String type, String defaultValue) {}
 
    /**
@@ -210,6 +230,7 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
     * @param groupMappings list of group name to values mappings
     * @param groupOthers   {@code true} if unmapped values are grouped as "Others"
     */
+   @JsonInclude(JsonInclude.Include.NON_NULL)
    public record NamedGroupModel(
       String name,
       String table,
@@ -224,5 +245,6 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
     * @param groupName the name of the group
     * @param values    the values assigned to this group
     */
+   @JsonInclude(JsonInclude.Include.NON_NULL)
    public record GroupMappingModel(String groupName, List<String> values) {}
 }

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -1829,4 +1829,177 @@ class WorksheetEditServiceMutatorsTest {
       assertTrue(reordered.containsAttribute(customerId), "Customers.ID must survive reordering");
       assertTrue(reordered.containsAttribute(orderId), "Orders.ID must survive reordering");
    }
+
+   // =========================================================================
+   // Concatenation tests
+   // =========================================================================
+
+   private static ColumnRef col(String name, String dataType) {
+      return col(name, dataType, true);
+   }
+
+   private static ColumnRef col(String name, String dataType, boolean visible) {
+      ColumnRef ref = new ColumnRef(new AttributeRef(null, name));
+      ref.setDataType(dataType);
+      ref.setVisible(visible);
+      return ref;
+   }
+
+   /**
+    * Builds a table from already-configured columns. The types and visibility have to be set
+    * <em>before</em> the private selection is installed: {@code setColumnSelection} regenerates the
+    * public selection from clones of the visible private columns, and it is the public selection
+    * the concatenation checks read — so a type set on a private column afterwards never reaches
+    * them.
+    */
+   private static EmbeddedTableAssembly table(Worksheet ws, String name, ColumnRef... cols) {
+      EmbeddedTableAssembly t = new EmbeddedTableAssembly(ws, name);
+      ColumnSelection cs = new ColumnSelection();
+
+      for(ColumnRef c : cols) {
+         cs.addAttribute(c);
+      }
+
+      t.setColumnSelection(cs, false);
+      return t;
+   }
+
+   /**
+    * Different types are not automatically a mismatch: {@code AssetUtil.isMergeable} — and
+    * therefore Composer — treats all the number types as interchangeable, and likewise the string
+    * types. Refusing these would block concatenations the product itself considers valid.
+    */
+   @Test
+   void addConcatenationAcceptsColumnTypesThatMerge() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly a = table(ws, "A", col("n", XSchema.INTEGER), col("s", XSchema.STRING));
+      EmbeddedTableAssembly b = table(ws, "B", col("n", XSchema.DOUBLE), col("s", XSchema.CHAR));
+      ws.addAssembly(a);
+      ws.addAssembly(b);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.addConcatenation("U", List.of("A", "B"), "UNION"));
+
+      assertTrue(ws.getAssembly("U") instanceof ConcatenatedTableAssembly);
+   }
+
+   /**
+    * Sources are combined BY POSITION, so a pair that lines up numerically but not by type produces
+    * a column carrying two unrelated kinds of value — which renders as an ordinary column and
+    * reports no error anywhere. The message has to name the position and both sides, since that is
+    * what tells the caller which column to reorder or retype.
+    */
+   @Test
+   void addConcatenationRejectsColumnsThatDoNotLineUpByType() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly a =
+         table(ws, "A", col("id", XSchema.INTEGER), col("name", XSchema.STRING));
+      EmbeddedTableAssembly b =
+         table(ws, "B", col("id", XSchema.INTEGER), col("amount", XSchema.INTEGER));
+      ws.addAssembly(a);
+      ws.addAssembly(b);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.addConcatenation("U", List.of("A", "B"), "UNION")));
+
+      assertTrue(ex.getMessage().contains("position 2"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("name"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("amount"), ex.getMessage());
+      assertNull(ws.getAssembly("U"), "nothing may be added when the sources do not line up");
+   }
+
+   /**
+    * The counts come from the PUBLIC column selection — visible columns only — while the read
+    * model's column list includes hidden ones. Saying "visible" keeps the number in the refusal
+    * reconcilable with the number a caller counts in the model it just read.
+    */
+   @Test
+   void addConcatenationRejectsDifferentColumnCountsAndSaysTheyAreVisibleCounts() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly a = TestWorksheets.tableWithColumns(ws, "A", "id", "name");
+      EmbeddedTableAssembly b = TestWorksheets.tableWithColumns(ws, "B", "id");
+      ws.addAssembly(a);
+      ws.addAssembly(b);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.addConcatenation("U", List.of("A", "B"), "UNION")));
+
+      assertTrue(ex.getMessage().contains("2 visible columns"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("1 visible column"), ex.getMessage());
+      assertNull(ws.getAssembly("U"));
+   }
+
+   /**
+    * Hidden columns are excluded from the public selection, so hiding one really does change which
+    * columns line up: {@code A(id, hidden:integer, name)} concatenates with {@code B(id, name)}
+    * because the hidden column is not there as far as the server is concerned. A check reading the
+    * private selection instead would see three columns against two and refuse it.
+    */
+   @Test
+   void addConcatenationLinesUpVisibleColumnsOnly() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly a = table(ws, "A", col("id", XSchema.INTEGER),
+                                     col("hidden", XSchema.INTEGER, false),
+                                     col("name", XSchema.STRING));
+      EmbeddedTableAssembly b =
+         table(ws, "B", col("id", XSchema.INTEGER), col("name", XSchema.STRING));
+      ws.addAssembly(a);
+      ws.addAssembly(b);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.addConcatenation("U", List.of("A", "B"), "UNION"));
+
+      assertTrue(ws.getAssembly("U") instanceof ConcatenatedTableAssembly);
+   }
+
+   // =========================================================================
+   // Mirror auto-update tests
+   // =========================================================================
+
+   /**
+    * {@code MirrorAssemblyImpl.setAutoUpdate} returns early for anything that is not an outer
+    * mirror, and {@code isAutoUpdate} then answers {@code true} regardless — so the write is
+    * accepted and discarded without a word. Every mirror {@code add_mirror} creates is an inner
+    * mirror ({@code MirrorTableAssembly(ws, name, assembly)} passes {@code outer = false}), so this
+    * is the normal case for an agent, not an edge case.
+    */
+   @Test
+   void setMirrorAutoUpdateRefusesAMirrorThatCannotHonourIt() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly base = TestWorksheets.tableWithColumns(ws, "BASE", "col");
+      ws.addAssembly(base);
+      MirrorTableAssembly mirror = new MirrorTableAssembly(ws, "M", base);
+      ws.addAssembly(mirror);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.setMirrorAutoUpdate("M", false)));
+
+      assertTrue(ex.getMessage().contains("autoUpdate"), ex.getMessage());
+      assertTrue(mirror.isAutoUpdate(), "the flag was never actually changed");
+   }
+
+   @Test
+   void setMirrorAutoUpdateStillWorksOnAnOuterMirror() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly base = TestWorksheets.tableWithColumns(ws, "BASE", "col");
+      ws.addAssembly(base);
+      AssetEntry entry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET, "/other-ws", null);
+      MirrorTableAssembly mirror = new MirrorTableAssembly(ws, "M", entry, true, base);
+      ws.addAssembly(mirror);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.setMirrorAutoUpdate("M", false));
+
+      assertFalse(mirror.isAutoUpdate());
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -1912,6 +1912,40 @@ class WorksheetEditServiceMutatorsTest {
    }
 
    /**
+    * With three sources the mismatch is between the third and the first, which pins down that the
+    * loop keeps checking past the first pair and names the offending source rather than whichever
+    * one happened to come second.
+    *
+    * <p>It does not distinguish anchoring on {@code sources[0]} from anchoring on the predecessor,
+    * and no test can: {@code isMergeable} is an equivalence relation over disjoint type classes, so
+    * a third source that clashes with the first necessarily clashes with the second as well.</p>
+    */
+   @Test
+   void addConcatenationChecksEverySourceNotJustTheFirstPair() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly a =
+         table(ws, "A", col("id", XSchema.INTEGER), col("name", XSchema.STRING));
+      EmbeddedTableAssembly b =
+         table(ws, "B", col("id", XSchema.INTEGER), col("name", XSchema.STRING));
+      EmbeddedTableAssembly c =
+         table(ws, "C", col("id", XSchema.INTEGER), col("amount", XSchema.INTEGER));
+      ws.addAssembly(a);
+      ws.addAssembly(b);
+      ws.addAssembly(c);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent,
+                         ed -> ed.addConcatenation("U", List.of("A", "B", "C"), "UNION")));
+
+      assertTrue(ex.getMessage().contains("position 2"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("\"C\""),
+                 "the third source is the one that clashes and has to be named: " + ex.getMessage());
+      assertNull(ws.getAssembly("U"));
+   }
+
+   /**
     * The counts come from the PUBLIC column selection — visible columns only — while the read
     * model's column list includes hidden ones. Saying "visible" keeps the number in the refusal
     * reconcilable with the number a caller counts in the model it just read.

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
@@ -120,12 +120,25 @@ class WorksheetReadServiceTest {
    private static ConcatenatedTableAssembly concat(Worksheet ws, String name, int operation,
                                                    TableAssembly... sources)
    {
+      int[] operations = new int[sources.length - 1];
+
+      for(int i = 0; i < operations.length; i++) {
+         operations[i] = operation;
+      }
+
+      return concat(ws, name, operations, sources);
+   }
+
+   /** One operation per adjacent pair, so a mixed concatenation can be built. */
+   private static ConcatenatedTableAssembly concat(Worksheet ws, String name, int[] operations,
+                                                   TableAssembly... sources)
+   {
       TableAssemblyOperator[] operators = new TableAssemblyOperator[sources.length - 1];
 
       for(int i = 0; i < operators.length; i++) {
          TableAssemblyOperator top = new TableAssemblyOperator();
          TableAssemblyOperator.Operator op = new TableAssemblyOperator.Operator();
-         op.setOperation(operation);
+         op.setOperation(operations[i]);
          top.addOperator(op);
          operators[i] = top;
       }
@@ -232,6 +245,98 @@ class WorksheetReadServiceTest {
 
       assertTrue(t.sources().isEmpty());
       assertNull(t.concatType());
+      assertNull(t.concatCompatible());
       assertNull(t.autoUpdate());
+   }
+
+   /**
+    * A rotate has exactly one source but is <em>not</em> a {@code CompositeTableAssembly} — it
+    * extends {@code ComposedTableAssembly} directly, as does an unpivot. A source lookup written
+    * against composites and mirrors alone reports both as having no sources at all, which is the
+    * ambiguity this field exists to remove, on table types {@code add_rotate} / {@code add_unpivot}
+    * let an agent create.
+    */
+   @Test
+   void rotatedTableReportsItsSource() {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly base = TestWorksheets.tableWithColumns(ws, "BASE", "col");
+      ws.addAssembly(base);
+      ws.addAssembly(new RotatedTableAssembly(ws, "R", base));
+
+      WorksheetModel.TableModel r = tableNamed(read(ws), "R");
+
+      assertEquals("ROTATED", r.type());
+      assertEquals(List.of("BASE"), r.sources());
+      assertNull(r.autoUpdate());
+   }
+
+   @Test
+   void unpivotTableReportsItsSource() {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly base = TestWorksheets.tableWithColumns(ws, "BASE", "a", "b");
+      ws.addAssembly(base);
+      ws.addAssembly(new UnpivotTableAssembly(ws, "P", base));
+
+      WorksheetModel.TableModel p = tableNamed(read(ws), "P");
+
+      assertEquals("UNPIVOT", p.type());
+      assertEquals(List.of("BASE"), p.sources());
+      assertNull(p.autoUpdate());
+   }
+
+   /**
+    * A concatenation holds one operator per adjacent pair and Composer sets the operation per
+    * connection, so {@code A UNION B MINUS C} is a legal worksheet. Reporting the first pair's
+    * operation as though it described the whole assembly hands the caller a confidently wrong
+    * answer about row semantics — worse than reporting nothing, since the caller cannot tell it is
+    * wrong.
+    */
+   @Test
+   void concatenationWithDifferentOperationPerPairReportsMixed() {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly a = TestWorksheets.tableWithColumns(ws, "A", "col");
+      EmbeddedTableAssembly b = TestWorksheets.tableWithColumns(ws, "B", "col");
+      EmbeddedTableAssembly c = TestWorksheets.tableWithColumns(ws, "C", "col");
+      ws.addAssembly(a);
+      ws.addAssembly(b);
+      ws.addAssembly(c);
+      ws.addAssembly(concat(ws, "X",
+         new int[]{ TableAssemblyOperator.UNION, TableAssemblyOperator.MINUS }, a, b, c));
+
+      WorksheetModel.TableModel x = tableNamed(read(ws), "X");
+
+      assertEquals(List.of("A", "B", "C"), x.sources());
+      assertEquals("MIXED", x.concatType());
+   }
+
+   /**
+    * Sources are combined by position, so a pair that lines up numerically but not by type produces
+    * a column carrying two unrelated kinds of value. Composer computes exactly this predicate into
+    * a non-blocking warning ({@code ConcatenatedTableAssemblyModel.concatenationWarning}); without
+    * it on the read model, an agent cannot see the problem in a concatenation it did not create,
+    * since {@code add_concatenation} now refuses to build one.
+    */
+   @Test
+   void concatenationReportsWhetherItsSourcesLineUpByType() {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly a = TestWorksheets.tableWithColumns(ws, "A", "col");
+      EmbeddedTableAssembly b = TestWorksheets.tableWithColumns(ws, "B", "col");
+      EmbeddedTableAssembly c = TestWorksheets.tableWithColumns(ws, "C", "col");
+      ((ColumnRef) c.getColumnSelection(false).getAttribute("col"))
+         .setDataType(inetsoft.uql.schema.XSchema.INTEGER);
+      // The public selection holds clones taken when the private one was installed, and it is the
+      // public selection the compatibility check reads — so it has to be regenerated for the new
+      // type to reach it.
+      c.setColumnSelection(c.getColumnSelection(false), false);
+      ws.addAssembly(a);
+      ws.addAssembly(b);
+      ws.addAssembly(c);
+      ws.addAssembly(concat(ws, "OK", TableAssemblyOperator.UNION, a, b));
+      ws.addAssembly(concat(ws, "BAD", TableAssemblyOperator.UNION, a, c));
+
+      WorksheetModel m = read(ws);
+
+      assertEquals(Boolean.TRUE, tableNamed(m, "OK").concatCompatible());
+      assertEquals(Boolean.FALSE, tableNamed(m, "BAD").concatCompatible());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
@@ -250,6 +250,28 @@ class WorksheetReadServiceTest {
    }
 
    /**
+    * What the agent actually receives on the wire. A {@code null} field tells an LLM nothing that an
+    * absent field does not, and there are three of them on every plain table; an <em>empty list</em>
+    * is a real answer ("built on nothing", "no predicates") and has to survive, which is why the
+    * model asks for {@code NON_NULL} and not {@code NON_EMPTY}.
+    */
+   @Test
+   void serializedModelOmitsNullFieldsButKeepsEmptyLists() throws Exception {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(TestWorksheets.tableWithColumns(ws, "T", "col"));
+
+      String json = new com.fasterxml.jackson.databind.ObjectMapper()
+         .writeValueAsString(read(ws));
+
+      assertFalse(json.contains("concatType"), json);
+      assertFalse(json.contains("concatCompatible"), json);
+      assertFalse(json.contains("autoUpdate"), json);
+      assertFalse(json.contains("aggregates"), json);
+      assertTrue(json.contains("\"sources\":[]"), json);
+      assertTrue(json.contains("\"joins\":[]"), json);
+   }
+
+   /**
     * A rotate has exactly one source but is <em>not</em> a {@code CompositeTableAssembly} — it
     * extends {@code ComposedTableAssembly} directly, as does an unpivot. A source lookup written
     * against composites and mirrors alone reports both as having no sources at all, which is the

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
@@ -106,4 +106,132 @@ class WorksheetReadServiceTest {
       WorksheetModel m = new WorksheetReadService().read(rws);
       assertEquals("EMBEDDED", m.tables().get(0).type());
    }
+
+   private static WorksheetModel.TableModel tableNamed(WorksheetModel m, String name) {
+      return m.tables().stream().filter(t -> name.equals(t.name())).findFirst().orElseThrow();
+   }
+
+   private static WorksheetModel read(Worksheet ws) {
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+      return new WorksheetReadService().read(rws);
+   }
+
+   private static ConcatenatedTableAssembly concat(Worksheet ws, String name, int operation,
+                                                   TableAssembly... sources)
+   {
+      TableAssemblyOperator[] operators = new TableAssemblyOperator[sources.length - 1];
+
+      for(int i = 0; i < operators.length; i++) {
+         TableAssemblyOperator top = new TableAssemblyOperator();
+         TableAssemblyOperator.Operator op = new TableAssemblyOperator.Operator();
+         op.setOperation(operation);
+         top.addOperator(op);
+         operators[i] = top;
+      }
+
+      return new ConcatenatedTableAssembly(ws, name, sources, operators);
+   }
+
+   /**
+    * The order is the point, not just the membership: a concatenation takes its whole column list
+    * from whichever subtable is first, so a caller that knows the names but not their order still
+    * cannot tell which table decides the shape.
+    */
+   @Test
+   void concatenationReportsItsSubtablesInOrder() {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly a = TestWorksheets.tableWithColumns(ws, "A", "col");
+      EmbeddedTableAssembly b = TestWorksheets.tableWithColumns(ws, "B", "col");
+      ws.addAssembly(a);
+      ws.addAssembly(b);
+      ws.addAssembly(concat(ws, "U", TableAssemblyOperator.UNION, a, b));
+
+      WorksheetModel.TableModel u = tableNamed(read(ws), "U");
+
+      assertEquals("CONCAT", u.type());
+      assertEquals(List.of("A", "B"), u.sources());
+      assertEquals("UNION", u.concatType());
+   }
+
+   @Test
+   void concatenationReportsIntersectAndMinus() {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly a = TestWorksheets.tableWithColumns(ws, "A", "col");
+      EmbeddedTableAssembly b = TestWorksheets.tableWithColumns(ws, "B", "col");
+      ws.addAssembly(a);
+      ws.addAssembly(b);
+      ws.addAssembly(concat(ws, "I", TableAssemblyOperator.INTERSECT, a, b));
+      ws.addAssembly(concat(ws, "M", TableAssemblyOperator.MINUS, a, b));
+
+      WorksheetModel m = read(ws);
+
+      assertEquals("INTERSECT", tableNamed(m, "I").concatType());
+      assertEquals("MINUS", tableNamed(m, "M").concatType());
+   }
+
+   /**
+    * Reports the flag's <em>effective</em> value, which for a mirror whose source lives in the same
+    * worksheet is always {@code true} no matter what was set: {@code MirrorAssemblyImpl} answers
+    * {@code auto || !isOuterMirror()} and its setter returns early for anything that is not an
+    * outer mirror, so the assignment is dropped without a word. That is exactly why this field is
+    * worth exposing — a caller that sets the flag and reads back {@code true} can tell the setting
+    * did not take, which was previously unknowable through any API.
+    */
+   @Test
+   void mirrorReportsItsSourceAndEffectiveAutoUpdateFlag() {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly base = TestWorksheets.tableWithColumns(ws, "BASE", "col");
+      ws.addAssembly(base);
+      MirrorTableAssembly mirror = new MirrorTableAssembly(ws, "M", base);
+      ws.addAssembly(mirror);
+      mirror.setAutoUpdate(false);
+
+      WorksheetModel.TableModel m = tableNamed(read(ws), "M");
+
+      assertEquals("MIRROR", m.type());
+      assertEquals(List.of("BASE"), m.sources());
+      assertEquals(Boolean.TRUE, m.autoUpdate());
+      assertNull(m.concatType());
+   }
+
+   /**
+    * A hidden column stays in the model but leaves the data, and is also excluded from the public
+    * column selection a concatenation counts. Without this flag a caller comparing the model
+    * against real rows reads a hidden column as a missing one, and a caller comparing source
+    * column counts gets a number the server would not agree with.
+    */
+   @Test
+   void hiddenColumnIsReportedButMarkedNotVisible() {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "keep", "hide");
+      ((ColumnRef) t.getColumnSelection(false).getAttribute("hide")).setVisible(false);
+      ws.addAssembly(t);
+
+      WorksheetModel.TableModel tm = tableNamed(read(ws), "T");
+
+      assertEquals(2, tm.columns().size());
+      assertTrue(columnNamed(tm, "keep").visible());
+      assertFalse(columnNamed(tm, "hide").visible());
+   }
+
+   private static WorksheetModel.ColumnModel columnNamed(WorksheetModel.TableModel t, String name) {
+      return t.columns().stream().filter(c -> name.equals(c.name())).findFirst().orElseThrow();
+   }
+
+   /**
+    * A plain table has no sources, and must not be confused with a composite whose sources simply
+    * were not reported — which is exactly the ambiguity this field exists to remove.
+    */
+   @Test
+   void plainTableReportsNoSourcesAndNoCompositeFields() {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(TestWorksheets.tableWithColumns(ws, "T", "col"));
+
+      WorksheetModel.TableModel t = tableNamed(read(ws), "T");
+
+      assertTrue(t.sources().isEmpty());
+      assertNull(t.concatType());
+      assertNull(t.autoUpdate());
+   }
 }


### PR DESCRIPTION
Two gaps in the agent-facing worksheet layer, both found running L1 of the composer plugin test plan against a live Composer.

The read model described every table in isolation. TableModel now reports `sources` — the assemblies a table is built from, in order. Order carries the meaning: a concatenation takes its whole column list from its first subtable (ConcatenatedTableAssembly.getDefaultColumnSelection walks subtables[0] and consults the rest only to merge numeric types, by position), and for a MINUS the order decides which table is subtracted from which. It covers joins as well, which matters most for cross and merge joins: those carry no join predicates, so they reported an empty `joins` list and were indistinguishable from a table with no sources at all.

Also adds `concatType` (UNION/INTERSECT/MINUS), `autoUpdate` for mirrors, and `visible` on every column. `autoUpdate` was settable through the agent API but not readable, so no caller could confirm a setting took — and it silently never does for a mirror whose source is in the same worksheet, since MirrorAssemblyImpl returns `auto || !isOuterMirror()` and its setter returns early otherwise. `visible` matters because the column list is read from the private column selection and so includes hidden columns, while both the data and the count a concatenation checks its sources against exclude them; ColumnModel's javadoc claimed to describe "a single visible column" and was simply wrong. These fields are additive — no existing behaviour or caller is affected.

Separately, add_concatenation validated that the sources had the same number of columns and stopped there. Sources are combined BY POSITION, so a pair that lines up numerically but not by type produces a column carrying two unrelated kinds of value — which renders as an ordinary column and reports no error anywhere. The Composer already runs this check (ConcatenatedTableAssembly.areCompatible, via AssetUtil.isMergeable, surfaced as concatenationWarning); the agent path had none of it, so a pairing the UI warns a human about was built silently for an agent. The refusal names the position and both sides, since the caller needs to know which column to reorder or retype.