### PR TITLE
Refuse snapshot table data and column edits, expose the type, add a properties read

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -52,6 +52,7 @@ import inetsoft.web.portal.controller.database.QueryManagerService;
 import inetsoft.web.wiz.pairing.*;
 import inetsoft.web.wiz.script.PaneScopeService;
 import inetsoft.web.wiz.worksheet.model.WorksheetModel;
+import inetsoft.web.wiz.worksheet.model.WorksheetPropertiesModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -1842,6 +1843,28 @@ public class WorksheetAgentController {
    // ---------------------------------------------------------------------------
 
    public record WorksheetPropertiesRequest(String alias, String description) {}
+
+   /**
+    * Read worksheet-level properties.
+    *
+    * <p>The read counterpart of {@link #setProperties}. Without it an agent could set a
+    * worksheet's display name or description but never read, verify or report the current value,
+    * only overwrite it blindly -- and {@code /model} carries none of these fields.
+    *
+    * @param sessionToken the token obtained at join time
+    * @param user         the authenticated agent principal
+    * @return the sheet's name, alias, description and data-source flag
+    * @throws PairingException if the session is invalid/expired or the runtime is not found
+    */
+   @GetMapping("/api/wiz/v1/agent/worksheet/{sessionToken}/properties")
+   public WorksheetPropertiesModel getProperties(@PathVariable String sessionToken, Principal user)
+      throws PairingException
+   {
+      requireEnabled();
+      requireWholeSheetSession(sessionToken, user);
+      RuntimeWorksheet rws = editService.resolve(sessionToken, user);
+      return readService.readProperties(rws);
+   }
 
    /**
     * Update worksheet-level properties (alias and description).

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -1518,6 +1518,9 @@ public class WorksheetAgentController {
             throw new PairingException("Not an embedded table: " + req.table());
          }
 
+         WorksheetMutationSupport.assertSnapshotAllowsColumnAdd(
+            assembly, req.table(), "insert_column");
+
          XEmbeddedTable data = assembly.getEmbeddedData();
          ColumnSelection columns = assembly.getColumnSelection();
          boolean insertBefore = req.insert() == null || req.insert();

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -310,8 +310,15 @@ public class WorksheetEditService {
          if(toRemove != null) {
             WorksheetMutationSupport.assertSnapshotAllowsColumnRemove(t, table, col, toRemove);
 
-            // For embedded tables, also remove the data column from XEmbeddedTable
-            if(t instanceof EmbeddedTableAssembly embedded) {
+            // For embedded tables, also remove the data column from XEmbeddedTable.
+            // Snapshots are excluded, and not just as an optimization: the guard above lets
+            // only an expression column through, an expression column has no data column, so
+            // findColumn could never match. What it WOULD do is call getEmbeddedData(), which
+            // on a snapshot goes through getTable() -> initTable() and can fault the whole
+            // swapped-out data file back in to answer a question already known to be "no".
+            if(t instanceof EmbeddedTableAssembly embedded &&
+               !(t instanceof SnapshotEmbeddedTableAssembly))
+            {
                XEmbeddedTable data = embedded.getEmbeddedData();
                int index = AssetUtil.findColumn(data, toRemove);
 

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -308,6 +308,8 @@ public class WorksheetEditService {
          DataRef toRemove = cs.getAttribute(col);
 
          if(toRemove != null) {
+            WorksheetMutationSupport.assertSnapshotAllowsColumnRemove(t, table, col, toRemove);
+
             // For embedded tables, also remove the data column from XEmbeddedTable
             if(t instanceof EmbeddedTableAssembly embedded) {
                XEmbeddedTable data = embedded.getEmbeddedData();
@@ -345,6 +347,7 @@ public class WorksheetEditService {
        */
       public void addColumn(String table, String name, String type) throws PairingException {
          TableAssembly t = requireTable(table);
+         WorksheetMutationSupport.assertSnapshotAllowsColumnAdd(t, table, "add_column");
          ColumnSelection cs = t.getColumnSelection();
 
          if(name == null || name.isBlank()) {

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -1291,30 +1291,72 @@ public class WorksheetEditService {
       // -----------------------------------------------------------------------
 
       /**
+       * Resolves a table that the cell/row edit ops are allowed to write to.
+       *
+       * <p>Two refusals, and the difference between them matters. A non-embedded table simply
+       * has no embedded data to edit. A <i>snapshot</i> embedded table does have data -- but
+       * every {@link XEmbeddedTable} mutator is copy-and-swap rather than in-place, and
+       * {@link SnapshotEmbeddedTableAssembly#getEmbeddedData()} hands out a freshly built
+       * wrapper on every call, so the swap lands on a throwaway object and the write is
+       * discarded. Before this check the three ops returned success and changed nothing.
+       *
+       * <p>Refusing is the right answer rather than adding a {@code setEmbeddedData} write-back:
+       * the Composer does not offer cell editing on a snapshot either (its
+       * {@code snapshot-embedded-table-assembly.ts} overrides {@code isEditable()} to false, so
+       * such a table never enters edit mode), and refusing is what makes the agent path agree
+       * with the UI. Filtering already refuses a snapshot the same way -- see the
+       * {@code composer.ws.filter-snapshopt} catalog string.
+       *
+       * @param table the assembly name
+       * @param op    the op name to quote back to the caller, e.g. {@code "edit_cell"}
+       * @return the embedded table assembly, safe to mutate
+       * @throws PairingException if the table is not embedded, or is a snapshot
+       */
+      private EmbeddedTableAssembly requireEditableEmbedded(String table, String op)
+         throws PairingException
+      {
+         TableAssembly t = requireTable(table);
+
+         if(t instanceof SnapshotEmbeddedTableAssembly) {
+            throw new PairingException(
+               op + " is not supported on a snapshot embedded table: " + table +
+               ". Every table imported through the Composer's own file-import wizard is a " +
+               "snapshot; its data lives in a swapped-out data file that the cell and row edit " +
+               "ops cannot write to. The Composer does not offer cell editing on a snapshot " +
+               "either, so there is no workaround in the UI. read_worksheet_model reports these " +
+               "tables as type \"EMBEDDED_SNAPSHOT\" - check that before editing. To get an " +
+               "editable copy of the data, re-import the source file with import_csv_table or " +
+               "import_excel_table: those build a plain embedded table, which does accept " +
+               "edit_cell, insert_row and delete_row.");
+         }
+
+         if(!(t instanceof EmbeddedTableAssembly embedded)) {
+            throw new PairingException(op + " only works on embedded tables: " + table);
+         }
+
+         return embedded;
+      }
+
+      /**
        * Edits a single cell in an embedded table.
        *
-       * @param table the assembly name (must be an embedded table)
+       * @param table the assembly name (must be an embedded table, and not a snapshot)
        * @param row   the 0-based data row index
        * @param col   the 0-based column index
        * @param value the new cell value as a string (parsed according to column type)
-       * @throws PairingException if the table is not embedded or indices are out of range
+       * @throws PairingException if the table is not editable or indices are out of range
        */
       public void editCell(String table, int row, int col, String value)
          throws Exception
       {
-         TableAssembly t = requireTable(table);
-
-         if(!(t instanceof EmbeddedTableAssembly embedded)) {
-            throw new PairingException("edit_cell only works on embedded tables: " + table);
-         }
-
+         EmbeddedTableAssembly embedded = requireEditableEmbedded(table, "edit_cell");
          XEmbeddedTable data = embedded.getEmbeddedData();
 
          if(data == null) {
             throw new PairingException("Table has no data: " + table);
          }
 
-         ColumnSelection cs = t.getColumnSelection(false);
+         ColumnSelection cs = embedded.getColumnSelection(false);
 
          if(col < 0 || col >= cs.getAttributeCount()) {
             throw new PairingException("Column index out of range: " + col);
@@ -1342,17 +1384,12 @@ public class WorksheetEditService {
       /**
        * Inserts a new empty row into an embedded table.
        *
-       * @param table the assembly name (must be an embedded table)
+       * @param table the assembly name (must be an embedded table, and not a snapshot)
        * @param index the 0-based data row index at which to insert
-       * @throws PairingException if the table is not embedded
+       * @throws PairingException if the table is not editable
        */
       public void insertRow(String table, int index) throws PairingException {
-         TableAssembly t = requireTable(table);
-
-         if(!(t instanceof EmbeddedTableAssembly embedded)) {
-            throw new PairingException("insert_row only works on embedded tables: " + table);
-         }
-
+         EmbeddedTableAssembly embedded = requireEditableEmbedded(table, "insert_row");
          XEmbeddedTable data = embedded.getEmbeddedData();
 
          if(data == null) {
@@ -1375,17 +1412,12 @@ public class WorksheetEditService {
       /**
        * Deletes a row from an embedded table.
        *
-       * @param table the assembly name (must be an embedded table)
+       * @param table the assembly name (must be an embedded table, and not a snapshot)
        * @param index the 0-based data row index to delete
-       * @throws PairingException if the table is not embedded or the index is out of range
+       * @throws PairingException if the table is not editable or the index is out of range
        */
       public void deleteRow(String table, int index) throws PairingException {
-         TableAssembly t = requireTable(table);
-
-         if(!(t instanceof EmbeddedTableAssembly embedded)) {
-            throw new PairingException("delete_row only works on embedded tables: " + table);
-         }
-
+         EmbeddedTableAssembly embedded = requireEditableEmbedded(table, "delete_row");
          XEmbeddedTable data = embedded.getEmbeddedData();
 
          if(data == null) {

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -795,6 +795,92 @@ public final class WorksheetMutationSupport {
    }
 
    // =========================================================================
+   // Snapshot column guards
+   // =========================================================================
+
+   /**
+    * Refuses adding a data column to a snapshot embedded table.
+    *
+    * <p>Shared by {@code add_column} and {@code insert_column}, which live in different classes
+    * but strand a snapshot the same way -- see {@link #snapshotColumnMessage}.
+    *
+    * @param t     the target table
+    * @param table the assembly name, for the message
+    * @param op    the op name to quote back, e.g. {@code "add_column"}
+    * @throws inetsoft.web.wiz.pairing.PairingException if {@code t} is a snapshot
+    */
+   public static void assertSnapshotAllowsColumnAdd(TableAssembly t, String table, String op)
+      throws inetsoft.web.wiz.pairing.PairingException
+   {
+      if(!(t instanceof SnapshotEmbeddedTableAssembly)) {
+         return;
+      }
+
+      throw new inetsoft.web.wiz.pairing.PairingException(
+         snapshotColumnMessage(op, table) +
+         " An expression column is the exception, because it lives only in the column selection " +
+         "and never in the data: add_expression_column works on a snapshot. For a column that " +
+         "has to hold data, re-import the source file with import_csv_table or " +
+         "import_excel_table, which builds a plain embedded table.");
+   }
+
+   /**
+    * Refuses removing a snapshot embedded table's data column, while allowing an expression one.
+    *
+    * <p>The carve-out is not arbitrary. An expression column exists only in the
+    * {@link ColumnSelection}, never in the data, so removing it touches nothing that could be
+    * lost. That is also exactly where the Composer draws the line: its
+    * {@code updateCanRemoveSelectedHeaders()} permits removal on a snapshot only when every
+    * selected column is an expression.
+    *
+    * @param t      the target table
+    * @param table  the assembly name, for the message
+    * @param column the column name, for the message
+    * @param target the column being removed; {@code null} is treated as not an expression
+    * @throws inetsoft.web.wiz.pairing.PairingException if the column is a snapshot's data column
+    */
+   public static void assertSnapshotAllowsColumnRemove(TableAssembly t, String table,
+                                                       String column, DataRef target)
+      throws inetsoft.web.wiz.pairing.PairingException
+   {
+      if(!(t instanceof SnapshotEmbeddedTableAssembly) || isExpressionColumn(target)) {
+         return;
+      }
+
+      throw new inetsoft.web.wiz.pairing.PairingException(
+         snapshotColumnMessage("remove_column", table) +
+         " Only an expression column can be removed from a snapshot -- \"" + column + "\" is a " +
+         "data column, and the Composer refuses this the same way. To drop a data column, " +
+         "re-import the source file with import_csv_table or import_excel_table, which builds a " +
+         "plain embedded table.");
+   }
+
+   /**
+    * Whether {@code ref} is an expression column, i.e. one with no backing data column.
+    */
+   private static boolean isExpressionColumn(DataRef ref) {
+      return ref instanceof ColumnRef cr && cr.isExpression();
+   }
+
+   /**
+    * The half of a snapshot column refusal that is the same whichever op asked.
+    *
+    * <p>Says what the caller cannot see: the op would half-apply. A snapshot's data lives in a
+    * swapped-out data file, every {@link inetsoft.uql.util.XEmbeddedTable} mutator is
+    * copy-and-swap, and {@link SnapshotEmbeddedTableAssembly#getEmbeddedData()} returns a fresh
+    * wrapper on each call -- so the column-selection change would persist while the data-layer
+    * change was discarded, leaving the table one column out of step with its own data and no
+    * error to show for it.
+    */
+   private static String snapshotColumnMessage(String op, String table) {
+      return op + " is not supported on a snapshot embedded table: " + table +
+         ". Every table imported through the Composer's own file-import wizard is a snapshot, and " +
+         "its data cannot be restructured in place -- the column would change while the data " +
+         "behind it did not. read_worksheet_model reports these tables as type " +
+         "\"EMBEDDED_SNAPSHOT\".";
+   }
+
+   // =========================================================================
    // Expression column helpers
    // =========================================================================
 

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
@@ -25,6 +25,7 @@ import inetsoft.uql.erm.ExpressionRef;
 import inetsoft.uql.schema.UserVariable;
 import inetsoft.uql.schema.XValueNode;
 import inetsoft.web.wiz.worksheet.model.WorksheetModel;
+import inetsoft.web.wiz.worksheet.model.WorksheetPropertiesModel;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
@@ -72,6 +73,32 @@ public class WorksheetReadService {
       return new WorksheetModel(tables, variables, namedGroups);
    }
 
+   /**
+    * Reads the worksheet's own properties -- the four fields behind the Composer's
+    * Worksheet Property dialog.
+    *
+    * <p>The alias and description fallbacks are copied deliberately from
+    * {@code WorksheetOptionPaneModel(RuntimeWorksheet)}: the {@link WorksheetInfo} value wins and
+    * the {@link AssetEntry} is only consulted when it is {@code null}. Reading them any other way
+    * would let this endpoint disagree with what the dialog shows the user for the same sheet.
+    * The properties POST writes {@link WorksheetInfo}, i.e. the side that wins here, so a value
+    * set through the agent is the value the dialog displays.</p>
+    *
+    * @param rws the live runtime worksheet; must not be {@code null}
+    * @return the sheet's name, alias, description and data-source flag
+    */
+   public WorksheetPropertiesModel readProperties(RuntimeWorksheet rws) {
+      WorksheetInfo winfo = rws.getWorksheet().getWorksheetInfo();
+      AssetEntry entry = rws.getEntry();
+
+      String alias = winfo.getAlias() != null ? winfo.getAlias() : entry.getAlias();
+      String description = winfo.getDescription() != null
+         ? winfo.getDescription() : entry.getProperty("description");
+
+      return new WorksheetPropertiesModel(
+         entry.getName(), alias, description, entry.isReportDataSource());
+   }
+
    // -------------------------------------------------------------------------
    // Table
    // -------------------------------------------------------------------------
@@ -97,7 +124,14 @@ public class WorksheetReadService {
    }
 
    private String tableType(TableAssembly t) {
-      if(t instanceof EmbeddedTableAssembly) {
+      // The snapshot check MUST stay ahead of the EmbeddedTableAssembly branch:
+      // SnapshotEmbeddedTableAssembly extends it, so reordering these two silently
+      // collapses the distinction again and an agent can no longer tell, before a
+      // write, that it is looking at a table whose cell/row edits are refused.
+      if(t instanceof SnapshotEmbeddedTableAssembly) {
+         return "EMBEDDED_SNAPSHOT";
+      }
+      else if(t instanceof EmbeddedTableAssembly) {
          return "EMBEDDED";
       }
       else if(t instanceof AbstractJoinTableAssembly) {

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/model/WorksheetModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/model/WorksheetModel.java
@@ -33,9 +33,12 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
     * A single table assembly inside the worksheet.
     *
     * @param name               assembly name
-    * @param type               one of {@code "EMBEDDED"}, {@code "JOIN"}, {@code "CONCAT"},
-    *                           {@code "MIRROR"}, {@code "UNPIVOT"},
-    *                           {@code "ROTATED"}, {@code "TABLE"}
+    * @param type               one of {@code "EMBEDDED"}, {@code "EMBEDDED_SNAPSHOT"},
+    *                           {@code "JOIN"}, {@code "CONCAT"}, {@code "MIRROR"},
+    *                           {@code "UNPIVOT"}, {@code "ROTATED"}, {@code "TABLE"}.
+    *                           {@code "EMBEDDED_SNAPSHOT"} is a table imported through the
+    *                           Composer's file-import wizard: its data is read-only, and
+    *                           {@code edit_cell}/{@code insert_row}/{@code delete_row} refuse it
     * @param columns            visible (public) columns
     * @param joins              join predicates; non-null, empty for non-join tables
     * @param preConditions      pre-aggregate filter conditions

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/model/WorksheetPropertiesModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/model/WorksheetPropertiesModel.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.worksheet.model;
+
+/**
+ * Read-model DTO for the worksheet's own properties, as seen by the agent.
+ *
+ * <p>These are exactly the four fields behind the Composer's Worksheet Property dialog
+ * ({@code WorksheetOptionPaneModel}), no more: the dialog is what defines what "worksheet
+ * property" means in this product, and returning extra {@code WorksheetInfo} internals
+ * ({@code designMaxRows}, {@code previewMaxRow}, {@code messageLevels}) would invent a
+ * vocabulary the UI does not have.</p>
+ *
+ * <p>Deliberately a separate DTO from {@link WorksheetModel} rather than a field on it: this
+ * describes the sheet, not the sheet's table structure.</p>
+ *
+ * @param name        the asset name; read-only
+ * @param alias       display name; writable via the properties POST
+ * @param description free-text description; writable via the properties POST
+ * @param dataSource  whether the worksheet is exposed as a report data source; read-only here
+ */
+public record WorksheetPropertiesModel(String name, String alias, String description,
+                                       boolean dataSource) {}

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -37,6 +37,7 @@ import inetsoft.web.portal.controller.database.QueryManagerService;
 import inetsoft.web.wiz.pairing.*;
 import inetsoft.web.wiz.service.MetadataApiService;
 import inetsoft.web.wiz.worksheet.model.WorksheetModel;
+import inetsoft.web.wiz.worksheet.model.WorksheetPropertiesModel;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -253,6 +254,58 @@ class WorksheetAgentControllerTest {
       assertNotNull(model);
       assertFalse(model.tables().isEmpty());
       assertEquals("T", model.tables().get(0).name());
+   }
+
+   // ---------------------------------------------------------------------------
+   // properties — read
+   // ---------------------------------------------------------------------------
+
+   /**
+    * The read counterpart of the properties POST. Without it an agent could set a worksheet's
+    * alias or description but never read it back, and /model carries neither field.
+    */
+   @Test
+   void getPropertiesReturnsTheSheetsOwnProperties() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      Worksheet ws = new Worksheet();
+      ws.getWorksheetInfo().setAlias("Quarterly revenue");
+      ws.getWorksheetInfo().setDescription("Set by the agent");
+
+      AssetEntry entry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET, "Folder/ws-1", null);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+      when(rws.getEntry()).thenReturn(entry);
+
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      when(editSvc.resolve(eq("TOK"), eq(agent))).thenReturn(rws);
+
+      WorksheetAgentController ctrl = controller(featureOn(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         new WorksheetReadService(), editSvc, mock(WorksheetService.class));
+
+      WorksheetPropertiesModel props = ctrl.getProperties("TOK", agent);
+
+      assertEquals("ws-1", props.name());
+      assertEquals("Quarterly revenue", props.alias());
+      assertEquals("Set by the agent", props.description());
+      assertTrue(props.dataSource(),
+         "AssetEntry.isReportDataSource() reads true unless the property is explicitly \"false\", "
+            + "so an untouched entry is a data source -- the same value the Composer dialog shows");
+   }
+
+   @Test
+   void getPropertiesIsRefusedWhenTheFeatureIsOff() {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      WorksheetAgentController ctrl = controller(featureOff(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         new WorksheetReadService(), mock(WorksheetEditService.class),
+         mock(WorksheetService.class));
+
+      assertThrows(Exception.class, () -> ctrl.getProperties("TOK", agent));
    }
 
    // ---------------------------------------------------------------------------

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -1370,7 +1370,7 @@ class WorksheetAgentControllerTest {
     * deliberately shared with the pane-scoped {@code WorksheetScriptService} caller, which has
     * ALREADY run its own narrow {@code PaneScopeService.check} and must not be refused again by
     * the broad whole-sheet check -- see {@link WorksheetAgentController#editOp} javadoc. So the
-    * guard here is 12 hand-written {@code requireWholeSheetSession(sessionToken, user)} calls,
+    * guard here is 13 hand-written {@code requireWholeSheetSession(sessionToken, user)} calls,
     * one per endpoint, and nothing before this test failed the build the day one of them went
     * missing.
     *
@@ -1380,7 +1380,7 @@ class WorksheetAgentControllerTest {
     * than trusting that the next endpoint's author remembers to add the call. {@code join} never
     * matches (no {@code {sessionToken}} in its path -- that is where one is minted); {@code
     * detach} matches but is explicitly exempted above, for the reason its own javadoc gives.
-    * Endpoint 13 fails THIS test the moment it omits the guard.
+    * Endpoint 14 fails THIS test the moment it omits the guard.
     */
    @Test
    void everySessionTokenEndpointRefusesAPaneScopedSessionOrIsExplicitlyExempt() {
@@ -1433,7 +1433,7 @@ class WorksheetAgentControllerTest {
          }
       }
 
-      assertTrue(checked >= 12, "Expected at least the 12 known session-scoped endpoints to " +
+      assertTrue(checked >= 13, "Expected at least the 13 known session-scoped endpoints to " +
          "be enumerated, found " + checked + " -- did WorksheetAgentController's mapping " +
          "annotations change shape?");
       assertTrue(notRefused.isEmpty(), "Endpoint(s) mapped with {sessionToken} did not refuse " +

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -154,6 +154,17 @@ class WorksheetAgentControllerTest {
       );
    }
 
+   /** Builds an {@code insert_column} EditRequest that routes to insertColumn(). */
+   private static EditRequest insertColumnRequest(String table) {
+      return new EditRequest(
+         "insert_column", table, null, null, null, null, null, null, null, null,
+         null, null, null, false, null, null, null, null, null, null, null, null, null, null,
+         null, null, null, null, null, null, null, null, null, null, null, null, null,
+         null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+         null, null
+      );
+   }
+
    /** Builds an {@code edit_sql_query} EditRequest that routes to editSqlQuery(). */
    private static EditRequest editSqlQueryRequest(String table, String expression) {
       return new EditRequest(
@@ -296,6 +307,14 @@ class WorksheetAgentControllerTest {
             + "so an untouched entry is a data source -- the same value the Composer dialog shows");
    }
 
+   /**
+    * Pinned to the exact 403 {@code requireEnabled()} throws, the way {@code joinRejectsFlagOff}
+    * is. A bare {@code assertThrows(Exception.class, ...)} would not test the flag at all: with
+    * both collaborators mocked, dropping {@code requireEnabled()} leaves the endpoint throwing
+    * anyway -- {@code requireWholeSheetSession} passes an unresolvable token straight through by
+    * design, so {@code editService.resolve} returns {@code null} and {@code readProperties}
+    * NPEs. Asserting the status is what tells those two outcomes apart.
+    */
    @Test
    void getPropertiesIsRefusedWhenTheFeatureIsOff() {
       Principal agent = TestPrincipals.user("alice", "host-org");
@@ -305,7 +324,9 @@ class WorksheetAgentControllerTest {
          new WorksheetReadService(), mock(WorksheetEditService.class),
          mock(WorksheetService.class));
 
-      assertThrows(Exception.class, () -> ctrl.getProperties("TOK", agent));
+      ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+         () -> ctrl.getProperties("TOK", agent));
+      assertEquals(403, ex.getStatusCode().value());
    }
 
    // ---------------------------------------------------------------------------
@@ -352,6 +373,49 @@ class WorksheetAgentControllerTest {
                  "column 'x' should have been removed");
       assertNotNull(t.getColumnSelection(false).getAttribute("y"),
                     "column 'y' should still be present");
+   }
+
+   /**
+    * The snapshot guard for {@code insert_column}, pinned here rather than in
+    * {@code WorksheetEditServiceMutatorsTest} because this op is the one that does not live in
+    * the {@code Editor}: it manipulates {@link inetsoft.uql.util.XEmbeddedTable} directly from
+    * the controller. That is exactly why it was missed when the sibling column ops were first
+    * swept, so it is the guard most likely to be dropped again -- and the only one no test
+    * covered.
+    */
+   @Test
+   void editInsertColumnRefusesSnapshotEmbeddedTable() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      Worksheet ws = new Worksheet();
+      SnapshotEmbeddedTableAssembly t =
+         TestWorksheets.snapshotTableWithColumns(ws, "S", "a", "b");
+      ws.addAssembly(t);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(sessions.resolve(eq("TOK-IC"), any())).thenReturn(session("TOK-IC"));
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+
+      WorksheetAgentController ctrl = controller(featureOn(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class));
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-IC", insertColumnRequest("S"), agent));
+
+      assertTrue(ex.getMessage().startsWith("insert_column"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("EMBEDDED_SNAPSHOT"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("add_expression_column"),
+         "the refusal must name the column kind that does work here: " + ex.getMessage());
+      assertEquals(2, t.getColumnSelection(false).getAttributeCount(),
+         "nothing may be added to the selection when the data cannot follow");
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -1932,4 +1932,86 @@ class WorksheetEditServiceMutatorsTest {
 
       assertEquals("edit_cell only works on embedded tables: B", ex.getMessage());
    }
+
+   // =========================================================================
+   // Column ops: snapshot write protection
+   // =========================================================================
+
+   @Test
+   void addColumnRefusesSnapshotEmbeddedTable() throws Exception {
+      // Same missing write-back as the cell/row ops: data.insertCol() lands on a throwaway
+      // wrapper, so the ColumnSelection would gain a column the data does not have.
+      Worksheet ws = new Worksheet();
+      SnapshotEmbeddedTableAssembly t = TestWorksheets.snapshotTableWithColumns(ws, "S", "a");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.addColumn("S", "newcol", "string")));
+
+      assertTrue(ex.getMessage().startsWith("add_column"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("EMBEDDED_SNAPSHOT"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("add_expression_column"),
+         "the refusal must name the column kind that does work here: " + ex.getMessage());
+      assertNull(t.getColumnSelection(false).getAttribute("newcol"),
+         "nothing may be added to the selection when the data cannot follow");
+   }
+
+   @Test
+   void addColumnStillWorksOnAPlainEmbeddedTable() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = embeddedWithData(ws, "T");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.addColumn("T", "newcol", "string"));
+
+      assertNotNull(t.getColumnSelection(false).getAttribute("newcol"),
+         "the snapshot guard must not widen into the plain embedded path");
+   }
+
+   @Test
+   void removeColumnRefusesASnapshotsDataColumn() throws Exception {
+      Worksheet ws = new Worksheet();
+      SnapshotEmbeddedTableAssembly t = TestWorksheets.snapshotTableWithColumns(ws, "S", "a", "b");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.removeColumn("S", "a")));
+
+      assertTrue(ex.getMessage().startsWith("remove_column"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("data column"), ex.getMessage());
+      assertNotNull(t.getColumnSelection(false).getAttribute("a"),
+         "the column must survive the refusal");
+   }
+
+   /**
+    * The carve-out, and the reason this could not be Finding 5's flat guard: an expression column
+    * exists only in the ColumnSelection, never in the data, so removing it strands nothing. The
+    * Composer allows exactly this and no more.
+    */
+   @Test
+   void removeColumnAllowsASnapshotsExpressionColumn() throws Exception {
+      Worksheet ws = new Worksheet();
+      SnapshotEmbeddedTableAssembly t = TestWorksheets.snapshotTableWithColumns(ws, "S", "a");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent,
+         ed -> ed.addExpressionColumn("S", "calc", "1 + 1", XSchema.INTEGER, false));
+      assertNotNull(t.getColumnSelection(false).getAttribute("calc"),
+         "precondition: an expression column can be added to a snapshot");
+
+      svc.apply("TOK", agent, ed -> ed.removeColumn("S", "calc"));
+
+      assertNull(t.getColumnSelection(false).getAttribute("calc"),
+         "an expression column has no data behind it, so removing it from a snapshot is safe");
+      assertNotNull(t.getColumnSelection(false).getAttribute("a"),
+         "the data column is untouched");
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -30,6 +30,7 @@ import inetsoft.uql.erm.AttributeRef;
 import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.erm.ExpressionRef;
 import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.util.XEmbeddedTable;
 import inetsoft.web.wiz.pairing.*;
 import org.junit.jupiter.api.*;
 import org.mockito.ArgumentCaptor;
@@ -1828,5 +1829,107 @@ class WorksheetEditServiceMutatorsTest {
          "an ambiguous bare-name collision must not silently drop a column");
       assertTrue(reordered.containsAttribute(customerId), "Customers.ID must survive reordering");
       assertTrue(reordered.containsAttribute(orderId), "Orders.ID must survive reordering");
+   }
+
+   // =========================================================================
+   // Cell/row edits: snapshot write protection
+   // =========================================================================
+
+   /**
+    * An embedded table carrying real data, so the cell/row ops reach their actual write and a
+    * failure to write shows up as an unchanged value rather than as an exception.
+    *
+    * <p>Row 0 of an {@link XEmbeddedTable} is the header row, which is where
+    * {@code setEmbeddedData} derives the column selection from.
+    */
+   private EmbeddedTableAssembly embeddedWithData(Worksheet ws, String name) {
+      EmbeddedTableAssembly t = new EmbeddedTableAssembly(ws, name);
+      t.setEmbeddedData(new XEmbeddedTable(
+         new String[] { XSchema.STRING, XSchema.STRING },
+         new Object[][] { { "a", "b" }, { "x1", "y1" }, { "x2", "y2" } }));
+      return t;
+   }
+
+   @Test
+   void editCellWritesToAPlainEmbeddedTable() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = embeddedWithData(ws, "T");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.editCell("T", 0, 0, "changed"));
+
+      assertEquals("changed", t.getEmbeddedData().getObject(1, 0),
+         "a plain embedded table must still accept edit_cell -- the snapshot guard must not "
+            + "widen into this path");
+   }
+
+   @Test
+   void editCellRefusesSnapshotEmbeddedTableInsteadOfDiscardingTheWrite() throws Exception {
+      // The defect this guards: SnapshotEmbeddedTableAssembly.getEmbeddedData() returns a freshly
+      // built wrapper on every call, and every XEmbeddedTable mutator is copy-and-swap rather than
+      // in-place, so the write landed on a throwaway object. The op reported success and changed
+      // nothing.
+      Worksheet ws = new Worksheet();
+      SnapshotEmbeddedTableAssembly t = TestWorksheets.snapshotTableWithColumns(ws, "S", "a", "b");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.editCell("S", 0, 0, "changed")));
+
+      assertTrue(ex.getMessage().contains("snapshot"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("EMBEDDED_SNAPSHOT"),
+         "the refusal must name the type an agent can check beforehand: " + ex.getMessage());
+      assertTrue(ex.getMessage().contains("import_csv_table"),
+         "the refusal must name the one workaround that actually exists: " + ex.getMessage());
+   }
+
+   @Test
+   void insertRowRefusesSnapshotEmbeddedTable() throws Exception {
+      Worksheet ws = new Worksheet();
+      SnapshotEmbeddedTableAssembly t = TestWorksheets.snapshotTableWithColumns(ws, "S", "a");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.insertRow("S", 0)));
+
+      assertTrue(ex.getMessage().startsWith("insert_row"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("snapshot"), ex.getMessage());
+   }
+
+   @Test
+   void deleteRowRefusesSnapshotEmbeddedTable() throws Exception {
+      Worksheet ws = new Worksheet();
+      SnapshotEmbeddedTableAssembly t = TestWorksheets.snapshotTableWithColumns(ws, "S", "a");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.deleteRow("S", 0)));
+
+      assertTrue(ex.getMessage().startsWith("delete_row"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("snapshot"), ex.getMessage());
+   }
+
+   @Test
+   void cellEditsKeepTheirOriginalNonEmbeddedRefusalWording() throws Exception {
+      // Pinned verbatim on purpose: the consolidated Composer plugin test plan cites this exact
+      // string as the live evidence for its L2 Finding 1 re-verification. Rewording it silently
+      // invalidates that record.
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(TestWorksheets.nonEmbeddedTableWithColumns(ws, "B", "a"));
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.editCell("B", 0, 0, "v")));
+
+      assertEquals("edit_cell only works on embedded tables: B", ex.getMessage());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
@@ -23,6 +23,7 @@ import inetsoft.uql.asset.internal.*;
 import inetsoft.web.wiz.pairing.TestWorksheets;
 import inetsoft.web.wiz.pairing.WizAgentTestSupport;
 import inetsoft.web.wiz.worksheet.model.WorksheetModel;
+import inetsoft.web.wiz.worksheet.model.WorksheetPropertiesModel;
 import org.junit.jupiter.api.*;
 
 import java.util.List;
@@ -105,5 +106,88 @@ class WorksheetReadServiceTest {
       when(rws.getWorksheet()).thenReturn(ws);
       WorksheetModel m = new WorksheetReadService().read(rws);
       assertEquals("EMBEDDED", m.tables().get(0).type());
+   }
+
+   @Test
+   void tableTypeDistinguishesSnapshotFromEditableEmbedded() {
+      // SnapshotEmbeddedTableAssembly extends EmbeddedTableAssembly, so the snapshot branch has
+      // to run first. Reported as plain "EMBEDDED", an agent had no way to tell before a write
+      // that edit_cell/insert_row/delete_row would be refused on this table.
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(TestWorksheets.tableWithColumns(ws, "E", "col"));
+      ws.addAssembly(TestWorksheets.snapshotTableWithColumns(ws, "S", "col"));
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      WorksheetModel m = new WorksheetReadService().read(rws);
+
+      assertEquals("EMBEDDED",
+         typeOf(m, "E"), "a plain embedded table must keep its existing type name");
+      assertEquals("EMBEDDED_SNAPSHOT",
+         typeOf(m, "S"), "a snapshot must not be collapsed into EMBEDDED");
+   }
+
+   private static String typeOf(WorksheetModel m, String name) {
+      return m.tables().stream()
+         .filter(t -> name.equals(t.name()))
+         .findFirst()
+         .orElseThrow()
+         .type();
+   }
+
+   // -------------------------------------------------------------------------
+   // Worksheet properties
+   // -------------------------------------------------------------------------
+
+   @Test
+   void readPropertiesReturnsTheWorksheetInfoValues() {
+      Worksheet ws = new Worksheet();
+      WorksheetInfo winfo = ws.getWorksheetInfo();
+      winfo.setAlias("Quarterly revenue");
+      winfo.setDescription("Set by the agent");
+
+      AssetEntry entry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET, "Folder/ws1", null);
+      entry.setAlias("entry alias");
+      entry.setProperty("description", "entry description");
+      entry.setReportDataSource(true);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+      when(rws.getEntry()).thenReturn(entry);
+
+      WorksheetPropertiesModel p = new WorksheetReadService().readProperties(rws);
+
+      assertEquals("ws1", p.name());
+      assertEquals("Quarterly revenue", p.alias(),
+         "WorksheetInfo wins over the AssetEntry -- that is the side the properties POST writes, "
+            + "and the side the Composer dialog reads first");
+      assertEquals("Set by the agent", p.description());
+      assertTrue(p.dataSource());
+   }
+
+   @Test
+   void readPropertiesFallsBackToTheAssetEntryWhenWorksheetInfoIsUnset() {
+      Worksheet ws = new Worksheet();
+      assertNull(ws.getWorksheetInfo().getAlias(), "precondition: nothing set on WorksheetInfo");
+
+      AssetEntry entry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET, "Folder/ws2", null);
+      entry.setAlias("entry alias");
+      entry.setProperty("description", "entry description");
+      // Set explicitly to the non-default value: isReportDataSource() reads true whenever the
+      // property is absent, so only an explicit false proves the flag is read rather than assumed.
+      entry.setReportDataSource(false);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+      when(rws.getEntry()).thenReturn(entry);
+
+      WorksheetPropertiesModel p = new WorksheetReadService().readProperties(rws);
+
+      assertEquals("ws2", p.name());
+      assertEquals("entry alias", p.alias());
+      assertEquals("entry description", p.description());
+      assertFalse(p.dataSource());
    }
 }


### PR DESCRIPTION
Four findings from the L2 lane of the consolidated Composer plugin test plan, all in the worksheet agent endpoints. Companion PR for the plugin half: inetsoft-technology/stylebi-wiz#1687 — neither is much use without the other, so land them together.

## Row and cell edits were silently discarded on a snapshot embedded table

Every `XEmbeddedTable` mutator is *copy-and-swap*, never in-place: `setObject` goes through `replaceRow`, and it, `insertRow` and `deleteRow` all build a new `XSwappableTable` and then `swapTable()` the reference. So a write only lands if the caller holds the live object. A plain `EmbeddedTableAssembly` hands back the live `XEmbeddedTable`, so the swap happens inside it and the edit sticks. `SnapshotEmbeddedTableAssembly.getEmbeddedData()` returns `new XEmbeddedTable(getTable())` on **every call** — the swap landed on a throwaway wrapper, the snapshot's own `stable` was never touched, and `edit_cell`/`insert_row`/`delete_row` returned success having changed nothing.

**Fixed by refusing, not by adding a `setEmbeddedData` write-back**, because the product does not allow this either: `snapshot-embedded-table-assembly.ts` overrides `isEditable()` to `false`, and `populateModes()` only offers `"edit"` mode when that is true — a snapshot table cannot enter cell-edit mode in the Composer at all. Refusing is what makes the agent path *agree* with the UI, and filtering already refuses a snapshot the same way (`composer.ws.filter-snapshopt`).

The new `requireEditableEmbedded()` gates all three ops from one place. Its message names the type an agent can check beforehand and the one workaround that exists — re-import via `import_csv_table`/`import_excel_table`, which build a plain editable embedded table. Two plausible-looking workarounds were checked and are **not** suggested, because neither works: `convert_to_embedded` demands a `BoundTableAssembly`, and `add_mirror` can filter but cannot edit base data.

Two things worth noting for review:

- **The existing non-embedded wording is unchanged**, and a test now pins it verbatim. The test plan cites `edit_cell only works on embedded tables: <T>` as the live evidence for a different finding's re-verification, so rewording it silently invalidates that record.
- **`delete_row` was never dangerous.** It is the same copy-and-swap path, so on a snapshot it was a harmless no-op rather than a real delete. The test lane deliberately never tried it, on the reasonable worry that it might be the one that worked; this closes that question from the source rather than by risking someone's data.

*Not fixed, and reachable only through the UI:* `InsertDataService`/`DeleteDataService` have the identical missing write-back, but the UI never offers edit mode on a snapshot so they cannot be reached there. `WSEditTableDataService` (the UI's cell edit) does write back correctly.

## The same defect in the column ops

A sweep of every write-side `getEmbeddedData()` call site put this surface at **three** ops, one more than the finding first recorded — `insert_column` lives in the controller rather than the `Editor`, and was missed on the first reading. `add_column` and `insert_column` call `data.insertCol()`, `remove_column` calls `data.deleteCol()`, and none of the three wrote back, so on a snapshot the `ColumnSelection` change persisted while the data-layer change was discarded. `add_column` left a column that existed in the model with nothing behind it. (`change_column_type` is the one that already writes back, and works on a snapshot.)

This was held out of the first pass because a flat refusal is wrong here — but the rule turned out not to be a judgment call either. The Composer permits removal on a snapshot when every selected column is an expression, and the mechanism draws the line in exactly the same place: an expression column exists only in the `ColumnSelection` and never in the data, so nothing at the data layer is even attempted and nothing can be lost. UI rule and safety boundary coincide, so the rule was discovered rather than invented:

- `add_column` / `insert_column` — refused, pointing at `add_expression_column`, which touches no data and does work there;
- `remove_column` — refused for a data column, **allowed** for an expression one, matching the Composer exactly.

The guards live in `WorksheetMutationSupport` because the three call sites span two classes.

## Nothing distinguished a snapshot from an editable embedded table

`tableType()` tested `EmbeddedTableAssembly` before the snapshot subclass, so the subclass was absorbed and both reported `type: "EMBEDDED"` — an agent could not tell, before writing, which one it had.

Now `EMBEDDED_SNAPSHOT`. Chosen over adding a boolean because `type` is already the subclass discriminator — JOIN / MIRROR / UNPIVOT / ROTATED / CONCAT each get their own token, and snapshot was the only subclass being swallowed — so this completes an existing convention and leaves one source of truth instead of two that can drift. Verified beforehand that nothing in the consuming plugin matches on `type === "EMBEDDED"`. The new branch carries a comment saying it must stay first, since reordering it is all it would take to silently restore the finding.

## Worksheet properties were write-only

The properties POST could set `alias` and `description`, but there was no GET and `/model` carries neither field, so an agent could never read, verify or report the current value.

`WorksheetReadService.readProperties` returns the four fields behind the Composer's Worksheet Property dialog, read with the dialog's own `WorksheetInfo`-then-`AssetEntry` precedence so the two cannot disagree for the same sheet. Scoped to those four deliberately: returning `WorksheetInfo` internals like `designMaxRows` would invent a vocabulary the dialog does not have.

The new endpoint is the 13th `{sessionToken}` mapping, so the reflective whole-sheet-guard test's floor moves with it — which is also what proves the endpoint is being enumerated by that guard rather than skipped.

## Verification

`./mvnw -pl community/core test -Dtest='inetsoft.web.wiz.**'` — 1899 tests, 0 failures, 0 errors, 1 pre-existing skip, BUILD SUCCESS.

**Confirmed against a running Composer on 2026-08-19**, with this branch installed and the server restarted, driven entirely through the agent tools rather than by calling the endpoints directly. The target was the wizard-imported `formats` table — the same `formats.csv` that produced the findings, not a stand-in:

- `read_worksheet_model` reports it `EMBEDDED_SNAPSHOT`; on the pre-deploy build every embedded table in the open sheet read `EMBEDDED`.
- `edit_cell`, `insert_row`, `delete_row`, `add_column`, `insert_column` and `remove_column` all refuse it, with the full message.
- `add_expression_column` **succeeds** on that same snapshot, and `remove_column` then drops the column it made while still refusing `col7`, a data column on the same table. The same guard giving opposite answers decided by the column is the only half of the column rule a refuse-everything implementation could have faked.
- `preview_worksheet_data` is byte-identical across all 7 rows before and after, so `delete_row` on a snapshot is now *measured* harmless rather than deduced from the copy-and-swap reading — the check the test lane declined to risk.
- `get_worksheet_properties` returned all four fields; a write read back verbatim; a write passing only `description` left `alias` untouched. `alias` came back `""` rather than `null`, so the `AssetEntry` fallback branch is the one that ran.
- `status` immediately after the refusals still reports `agentConnected: true`, `state: "valid"` — the earlier session-destroying reap regression has not returned now that six more ops can refuse.

Two things this pass did **not** establish, stated rather than implied:

1. **The plain-embedded happy path was not re-run live.** The paired sheet held only the snapshot, so nothing live confirms the three data ops still work on an ordinary embedded table — a guard that wrongly refused every `EmbeddedTableAssembly` would have produced identical output. `editCellWritesToAPlainEmbeddedTable` and `addColumnStillWorksOnAPlainEmbeddedTable` cover it in the suite, which is why this is a coverage gap rather than a doubt.
2. **The Worksheet Property dialog was not opened** to confirm it displays what `readProperties` returns. The precedence was copied from `WorksheetOptionPaneModel` deliberately so the two cannot disagree, but that is an argument from code, not an observation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
