### PR TITLE
Bug #76161: org-scope SSO default roles on multi-tenant installs

### DIFF
--- a/core/src/main/java/inetsoft/web/security/AbstractSecurityFilter.java
+++ b/core/src/main/java/inetsoft/web/security/AbstractSecurityFilter.java
@@ -166,6 +166,81 @@ public abstract class AbstractSecurityFilter
    }
 
    /**
+    * Resolves a role name from an SSO default-role property into a role identity.
+    *
+    * <p>On a single tenant install every role lives in the default organization, except the
+    * built-in Administrator, which is the global (org-less) system administrator role.
+    *
+    * <p>On a multi tenant install the role is scoped to the organization the user is signing in
+    * to; stamping it with the default organization would grant a role owned by another tenant.
+    * Names that would confer administrator rights beyond that organization are ignored -- see
+    * {@link #isAssignableSSODefaultRole}.
+    *
+    * @param role      the role name from the property.
+    * @param principal the principal being logged in.
+    *
+    * @return the role identity, or {@code null} if the name must not be granted.
+    */
+   protected IdentityID getSSODefaultRoleID(String role, SRPrincipal principal) {
+      if(!SUtil.isMultiTenant()) {
+         return "Administrator".equals(role) ? new IdentityID(role, null) :
+            new IdentityID(role, Organization.getDefaultOrganizationID());
+      }
+
+      String orgID = principal.getOrgId();
+
+      if(orgID == null) {
+         // neither guess is safe: a null org is the global scope, and the default organization is
+         // the most privileged tenant. Drop the name rather than grant either.
+         LOG.warn("Ignoring role \"{}\" in the SSO default roles: the organization being signed " +
+                     "in to is unknown.", role);
+         return null;
+      }
+
+      IdentityID roleID = new IdentityID(role, orgID);
+      SecurityProvider provider = getSecurityProvider();
+
+      if(provider != null && !isAssignableSSODefaultRole(provider, roleID)) {
+         LOG.warn("Ignoring administrator role \"{}\" in the SSO default roles: administrator " +
+                     "roles cannot be granted to organization {}.", role, orgID);
+         return null;
+      }
+
+      return roleID;
+   }
+
+   /**
+    * Determines whether a role may be granted through an SSO default-role property.
+    *
+    * @param provider the security provider.
+    * @param roleID   the org-scoped role identity.
+    *
+    * @return {@code false} if granting the role would confer administrator rights.
+    */
+   private boolean isAssignableSSODefaultRole(SecurityProvider provider, IdentityID roleID) {
+      // the built-in Administrator and Organization Administrator roles are seeded org-less, so an
+      // org-scoped key never resolves to them (AuthenticationChain only consults a provider that
+      // returns non-null from getRole(), which is an exact name+org lookup). Test the global form
+      // by name so those two names are refused whatever organization is signing in.
+      IdentityID globalID = new IdentityID(roleID.name, null);
+
+      if(provider.isSystemAdministratorRole(globalID) ||
+         provider.isOrgAdministratorRole(globalID))
+      {
+         return false;
+      }
+
+      // an org-scoped role flagged as system administrator bypasses permission checks in EVERY
+      // organization, because DefaultCheckPermissionStrategy short-circuits on any resolved
+      // sysadmin role, so it is not assignable either.
+      //
+      // An org-scoped ORGANIZATION administrator role is deliberately still allowed: it confers
+      // admin rights only inside the user's own organization, which is what a self-service signup
+      // flow wants for the first user of a new organization.
+      return !provider.isSystemAdministratorRole(roleID);
+   }
+
+   /**
     * Create a session and add an audit login record when logging in with SSO
     */
    protected SRPrincipal createSSOSession(HttpServletRequest request,
@@ -174,9 +249,10 @@ public abstract class AbstractSecurityFilter
       final IdentityID pId = principal == null ? null : IdentityID.getIdentityIDFromKey(principal.getName());
       final IdentityID[] currentRoles = principal.getRoles();
       final String[] roles = getSSODefaultRole();
+      final SRPrincipal ssoPrincipal = principal;
       IdentityID[] defRoles = Arrays.stream(roles)
-         .map(role -> "Administrator".equals(role) ? new IdentityID(role, null)
-            : new IdentityID(role, Organization.getDefaultOrganizationID()))
+         .map(role -> getSSODefaultRoleID(role, ssoPrincipal))
+         .filter(Objects::nonNull)
          .toArray(IdentityID[]::new);
       final IdentityID[] newRoles =
          Stream.concat(Arrays.stream(defRoles), Arrays.stream(currentRoles)).toArray(IdentityID[]::new);

--- a/core/src/test/java/inetsoft/web/security/AbstractSecurityFilterTest.java
+++ b/core/src/test/java/inetsoft/web/security/AbstractSecurityFilterTest.java
@@ -1,0 +1,316 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.security;
+
+/*
+ * Covers AbstractSecurityFilter.getSSODefaultRoleID() -- the mapping from a name in an SSO
+ * default-role property to the IdentityID actually put on the session principal.
+ *
+ * Why this method is worth its own test class: the org stamping used to be an inline .map() inside
+ * createSSOSession() that hardcoded Organization.getDefaultOrganizationID() for every name and
+ * IdentityID(name, null) -- the GLOBAL system administrator role -- for the literal
+ * "Administrator". That was written on the assumption that multi-tenant installs never reach it,
+ * because getSSODefaultRole() returns an empty array under multi-tenancy (see community commit
+ * fceb855f7, "this property currently only takes effect in non-multi-tenant environments").
+ *
+ * StyleBIGoogleSSOFilter (enterprise) overrides getSSODefaultRole() without that guard -- see the
+ * javadoc there for why that is deliberate -- so the multi-tenant path IS reachable, and the
+ * hardcoded default org / null org became a cross-tenant role grant and a server-wide admin grant
+ * respectively. The stamping was extracted into getSSODefaultRoleID() so both branches can be
+ * pinned here directly, without standing up a servlet filter chain.
+ *
+ * The single-tenant assertions are regression guards, not new behaviour: on a single-tenant install
+ * the built-in Administrator exists ONLY as the global (null-org) role
+ * (FileAuthenticationProvider seeds it as new IdentityID("Administrator", null)), so the null-org
+ * special case is load-bearing for the existing "make all SSO users admin" configuration and must
+ * keep working.
+ *
+ * Mocking notes:
+ *  - SUtil.isMultiTenant() is a static reading SecurityEngine + LicenseManager + a SreeEnv
+ *    property, so it is stubbed via mockStatic(SUtil.class, CALLS_REAL_METHODS) -- the same approach
+ *    StyleBIGoogleSSOFilterTest uses -- leaving the rest of SUtil real.
+ *  - getSecurityProvider() resolves through the STATIC SecurityEngine.getSecurity(), not a
+ *    constructor-injected field, so SecurityEngine is mocked statically too.
+ *  - isSystemAdministratorRole()/isOrgAdministratorRole() must be stubbed explicitly: they are
+ *    interface DEFAULT methods and Mockito does not run default bodies on a mock. They are stubbed
+ *    to model AuthenticationChain's override (exact name+org key must resolve), NOT the name-only
+ *    interface default -- see stubRoleStore() for why that distinction decides the outcome.
+ *  - SRPrincipal's constructor calls XSessionService.getService().createSessionID(), hence the
+ *    third static mock.
+ */
+
+import inetsoft.sree.internal.SUtil;
+import inetsoft.sree.security.*;
+import inetsoft.sree.web.SessionLicenseServiceProvider;
+import inetsoft.uql.util.XSessionService;
+import jakarta.servlet.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@Tag("core")
+class AbstractSecurityFilterTest {
+
+   private static final String TENANT_ORG = "acme";
+   private static final String ROLE = "Analyst";
+
+   @Mock
+   private SecurityEngine securityEngine;
+   @Mock
+   private SecurityProvider securityProvider;
+
+   private TestSecurityFilter filter;
+   private MockedStatic<SecurityEngine> securityEngineMock;
+   private MockedStatic<SUtil> sUtilMock;
+   private MockedStatic<XSessionService> xSessionServiceMock;
+
+   /**
+    * AbstractSecurityFilter is abstract only because of Filter.doFilter(); everything this test
+    * exercises is concrete on the base class.
+    */
+   private static final class TestSecurityFilter extends AbstractSecurityFilter {
+      TestSecurityFilter(SessionLicenseServiceProvider provider, AuthenticationService service) {
+         super(provider, service);
+      }
+
+      @Override
+      public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+         throws IOException, ServletException
+      {
+         chain.doFilter(request, response);
+      }
+   }
+
+   @BeforeEach
+   void setUp() {
+      filter = new TestSecurityFilter(
+         mock(SessionLicenseServiceProvider.class), mock(AuthenticationService.class));
+
+      securityEngineMock = mockStatic(SecurityEngine.class);
+      securityEngineMock.when(SecurityEngine::getSecurity).thenReturn(securityEngine);
+      lenient().when(securityEngine.getSecurityProvider()).thenReturn(securityProvider);
+
+      sUtilMock = mockStatic(SUtil.class, Mockito.CALLS_REAL_METHODS);
+
+      XSessionService mockSessionService = mock(XSessionService.class);
+      lenient().when(mockSessionService.createSessionID(anyString(), any()))
+         .thenAnswer(inv -> inv.getArgument(0, String.class) + "-session");
+      xSessionServiceMock = mockStatic(XSessionService.class);
+      xSessionServiceMock.when(XSessionService::getService).thenReturn(mockSessionService);
+   }
+
+   @AfterEach
+   void tearDown() {
+      securityEngineMock.close();
+      sUtilMock.close();
+      xSessionServiceMock.close();
+   }
+
+   // ── fixtures ─────────────────────────────────────────────────────────────
+
+   private void stubMultiTenant(boolean multiTenant) {
+      sUtilMock.when(SUtil::isMultiTenant).thenReturn(multiTenant);
+   }
+
+   private static SRPrincipal principal(String orgId) {
+      SRPrincipal principal = new SRPrincipal(new IdentityID("alice@example.com", orgId));
+      principal.setOrgId(orgId);
+      return principal;
+   }
+
+   /**
+    * Models how the real provider answers isSystemAdministratorRole/isOrgAdministratorRole, which is
+    * NOT the name-only interface default: AbstractSecurityProvider delegates to AuthenticationChain,
+    * whose override is
+    * {@code stream().filter(p -> p.getRole(roleId) != null).findFirst()...} -- so the role must
+    * exist at that EXACT name+org key (FileAuthenticationProvider.getRole does
+    * roleStorage.get(id.convertToKey())) before its sysAdmin/orgAdmin flag is even consulted.
+    *
+    * <p>That distinction is the whole point of these tests: the built-in admin roles are seeded
+    * org-less (FileAuthenticationProvider seeds IdentityID("Administrator", null) and
+    * IdentityID("Organization Administrator", null)), so an org-scoped key never resolves to them
+    * and a guard that only asks about the org-scoped form silently never fires. Stubbing this
+    * name-only would make the admin-refusal tests pass against an implementation that does nothing.
+    *
+    * @param sysAdminRoles roles that exist AND are flagged system administrator.
+    * @param orgAdminRoles roles that exist AND are flagged organization administrator.
+    */
+   private void stubRoleStore(Set<IdentityID> sysAdminRoles, Set<IdentityID> orgAdminRoles) {
+      lenient().when(securityProvider.isSystemAdministratorRole(any(IdentityID.class)))
+         .thenAnswer(inv -> sysAdminRoles.contains(inv.getArgument(0, IdentityID.class)));
+      lenient().when(securityProvider.isOrgAdministratorRole(any(IdentityID.class)))
+         .thenAnswer(inv -> orgAdminRoles.contains(inv.getArgument(0, IdentityID.class)));
+   }
+
+   /** The out-of-the-box role store: both admin roles exist only in org-less (global) form. */
+   private void stubBuiltInRoleStore() {
+      stubRoleStore(Set.of(new IdentityID("Administrator", null)),
+                    Set.of(new IdentityID("Organization Administrator", null)));
+   }
+
+   // ── single tenant: unchanged behaviour ───────────────────────────────────
+
+   @Test
+   void singleTenant_ordinaryRole_stampedWithDefaultOrg() {
+      stubMultiTenant(false);
+
+      assertEquals(new IdentityID(ROLE, Organization.getDefaultOrganizationID()),
+                   filter.getSSODefaultRoleID(ROLE, principal(
+                      Organization.getDefaultOrganizationID())));
+   }
+
+   @Test
+   void singleTenant_administrator_stampedWithNullOrg() {
+      stubMultiTenant(false);
+
+      IdentityID roleID = filter.getSSODefaultRoleID(
+         "Administrator", principal(Organization.getDefaultOrganizationID()));
+
+      assertNotNull(roleID, "single-tenant sso.default.roles=Administrator must still grant admin");
+      assertNull(roleID.orgID,
+                 "the built-in Administrator role only exists as the global (null-org) role");
+      assertEquals("Administrator", roleID.name);
+   }
+
+   @Test
+   void singleTenant_neverConsultsSecurityProvider() {
+      stubMultiTenant(false);
+
+      filter.getSSODefaultRoleID(ROLE, principal(Organization.getDefaultOrganizationID()));
+
+      // the single-tenant branch must stay a pure mapping -- no provider lookup, so it cannot
+      // start failing on installs where security is not fully initialized yet
+      verify(securityProvider, never()).isSystemAdministratorRole(any());
+      verify(securityProvider, never()).isOrgAdministratorRole(any());
+   }
+
+   // ── multi tenant: scoped to the signing-in org ───────────────────────────
+
+   @Test
+   void multiTenant_ordinaryRole_scopedToSigningInOrg_notDefaultOrg() {
+      stubMultiTenant(true);
+      stubBuiltInRoleStore();
+
+      IdentityID roleID = filter.getSSODefaultRoleID(ROLE, principal(TENANT_ORG));
+
+      assertEquals(new IdentityID(ROLE, TENANT_ORG), roleID);
+      assertNotEquals(Organization.getDefaultOrganizationID(), roleID.orgID,
+                      "a tenant user must not be granted a role owned by the default organization");
+   }
+
+   @Test
+   void multiTenant_selfSignupOrg_scopedToSelfOrg() {
+      stubMultiTenant(true);
+      stubBuiltInRoleStore();
+
+      // Google self-signup lands brand new users in the SELF org; the starting role has to follow
+      assertEquals(new IdentityID(ROLE, Organization.getSelfOrganizationID()),
+                   filter.getSSODefaultRoleID(
+                      ROLE, principal(Organization.getSelfOrganizationID())));
+   }
+
+   /*
+    * These two are the regression guards for the review finding that the first cut of this fix got
+    * wrong: the guard asked the provider only about IdentityID(name, org). The built-in admin roles
+    * are seeded org-less, that key never resolves, AuthenticationChain's override therefore answered
+    * false, and both names sailed through un-dropped. Both tests fail against that version.
+    */
+
+   @Test
+   void multiTenant_builtInAdministrator_isDropped_despiteBeingSeededOrgLess() {
+      stubMultiTenant(true);
+      stubBuiltInRoleStore();
+
+      assertNull(filter.getSSODefaultRoleID("Administrator", principal(TENANT_ORG)),
+                 "the global system administrator role must never be grantable to a tenant");
+   }
+
+   @Test
+   void multiTenant_builtInOrganizationAdministrator_isDropped_despiteBeingSeededOrgLess() {
+      stubMultiTenant(true);
+      stubBuiltInRoleStore();
+
+      assertNull(filter.getSSODefaultRoleID("Organization Administrator", principal(TENANT_ORG)));
+   }
+
+   @Test
+   void multiTenant_orgScopedSysAdminRole_isDropped() {
+      stubMultiTenant(true);
+      // an operator-created role that exists in the tenant's own org but carries the sysAdmin flag:
+      // DefaultCheckPermissionStrategy short-circuits on ANY resolved sysadmin role, so this one
+      // would bypass permission checks in every organization, not just this tenant's
+      stubRoleStore(Set.of(new IdentityID(ROLE, TENANT_ORG)), Set.of());
+
+      assertNull(filter.getSSODefaultRoleID(ROLE, principal(TENANT_ORG)));
+   }
+
+   @Test
+   void multiTenant_orgScopedOrgAdminRole_isAllowed() {
+      stubMultiTenant(true);
+      // deliberate policy, not an oversight: an organization-administrator role scoped to the user's
+      // OWN org confers admin rights only inside that org, which is what a self-service signup flow
+      // wants for the first user of a new organization. Only the org-less built-in is refused.
+      stubRoleStore(Set.of(), Set.of(new IdentityID(ROLE, TENANT_ORG)));
+
+      assertEquals(new IdentityID(ROLE, TENANT_ORG),
+                   filter.getSSODefaultRoleID(ROLE, principal(TENANT_ORG)));
+   }
+
+   @Test
+   void multiTenant_unknownRole_passedThroughUnresolved() {
+      stubMultiTenant(true);
+      stubBuiltInRoleStore();
+
+      // matches the base-class contract: a name that does not resolve is not an error. It survives
+      // into XPrincipal.getAllRoles() but AuthenticationProvider.getRole() returns null for it, so
+      // it carries no permissions.
+      assertEquals(new IdentityID("NoSuchRole", TENANT_ORG),
+                   filter.getSSODefaultRoleID("NoSuchRole", principal(TENANT_ORG)));
+   }
+
+   @Test
+   void multiTenant_principalWithNoOrg_isDropped() {
+      stubMultiTenant(true);
+      stubBuiltInRoleStore();
+      SRPrincipal noOrg = new SRPrincipal(new IdentityID("alice@example.com", null));
+
+      // neither available guess is safe -- a null org is the global scope, and the default
+      // organization is the most privileged tenant -- so this degrades to granting nothing. The
+      // Google path always supplies an org, so this is the defensive path only.
+      assertNull(filter.getSSODefaultRoleID(ROLE, noOrg));
+   }
+
+   @Test
+   void multiTenant_noSecurityProvider_stillScopesToSigningInOrg() {
+      stubMultiTenant(true);
+      when(securityEngine.getSecurityProvider()).thenReturn(null);
+
+      // the admin check is skipped when there is no provider, but the org scoping must not be
+      assertEquals(new IdentityID(ROLE, TENANT_ORG),
+                   filter.getSSODefaultRoleID(ROLE, principal(TENANT_ORG)));
+   }
+}

--- a/core/src/test/resources/docs/permission-matrix-special.md
+++ b/core/src/test/resources/docs/permission-matrix-special.md
@@ -131,6 +131,35 @@ Google SSO 的整条 filter 链（`StyleBIGoogleSSOFilter`/`OpenIDFilterBaseFilt
 | `identityID` 不存在（新落地的 SELF 或 host-org 身份）+ `security.selfSignUp.enabled=false` | 拒绝（forward 到 `GOOGLE_USER_SIGN_UP_DENIED` 错误页） | `[M9]` `allowLogIn_newIdentity_selfSignUpDisabled_deniesAndForwardsToErrorPage` |
 | `identityID` 不存在 + `security.selfSignUp.enabled=true` | 放行 | `[M9]` `allowLogIn_newIdentity_selfSignUpEnabled_allows` |
 
+**`getSSODefaultRole()` / SSO 默认角色的 org 归属：**
+
+> 一处已确认的越权（已修复）：`StyleBIGoogleSSOFilter.getSSODefaultRole()` 是整个仓库里 `AbstractSecurityFilter.getSSODefaultRole()` 的**唯一** override，而它去掉了基类的 `SUtil.isMultiTenant()` 守卫。这个"去掉"本身是有意的——Google 登录是 self-service 注册路径，且 `StyleBIGoogleOpenIDConfig.getRoleClaim()` 返回 `null`，导致 `OpenIDFilterBaseFilter` 里那段按 org 过滤的默认角色逻辑（只在 `roleClaim != null` 时才跑）对 Google 永远不生效，所以 `styleBI.google.sso.default.roles` 是新租户用户拿到起始角色的唯一来源。
+>
+> 真正的缺陷在基类的 org 归属：原先 `createSSOSession()` 内联地把每个名字都盖上 `Organization.getDefaultOrganizationID()`，并把字面量 `"Administrator"` 映射成 `IdentityID("Administrator", null)`——**全局** sysadmin 角色。这段硬编码是按"多租户永远走不到这里"写的（见 community commit `fceb855f7`），而 Google 的 override 让它走到了。后果：多租户下 Google 用户会拿到属于 default org 的角色（跨租户），列表里写 `Administrator` 则直接拿到服务器级管理员（`DefaultCheckPermissionStrategy` 里解析出 sysadmin 角色会让 `checkPermission` 对所有 org 的所有资源短路成 `true`）。
+>
+> 修复方式是把 org 归属从 `createSSOSession()` 抽成 `AbstractSecurityFilter.getSSODefaultRoleID(role, principal)`：非多租户保持原样（单租户下内置 Administrator **只**以 null-org 全局角色存在，那个特例是必需的，不能删），多租户改为盖上 `principal.getOrgId()` 并拒绝管理员角色。管理员判断走 `SecurityProvider.isSystemAdministratorRole()` / `isOrgAdministratorRole()` 而不是字符串字面量，但**必须问对身份**：`AuthenticationChain` 的 override 是 `stream().filter(p -> p.getRole(roleId) != null).findFirst()...`，即精确的 `name@org` 键查找（`FileAuthenticationProvider.getRole` → `roleStorage.get(id.convertToKey())`）。而两个内置管理员角色是**无 org** 播种的（`IdentityID("Administrator", null)` / `IdentityID("Organization Administrator", null)`），所以拿 org 作用域的形式去问永远查不到、恒返回 `false`，守卫等于空转。因此这里问的是**全局（null-org）形式的名字**来挡这两个内置角色，另外再用 org 作用域形式检查 sysAdmin 标记。（这一点第一版改错过，见下表两个 `despiteBeingSeededOrgLess` 用例——它们在错误实现下会失败。）不匹配任何真实角色的名字按原基类语义原样放过（进得了 `getAllRoles()`，但 `getRole()` 返回 null，不带任何权限）。
+
+| 分层 | 场景 | 核心断言 | 测试方法 |
+|---|---|---|---|
+| enterprise（`StyleBIGoogleSSOFilterTest`）——守卫的缺失是有意的 | 属性未设置 | 返回空数组，不 NPE | `[M9]` `ssoDefaultRole_propertyUnset_returnsEmpty` |
+| | 多租户 + 属性有值 | 照样返回名字（基类会返回空数组，Google 有意不这样） | `[M9]` `ssoDefaultRole_multiTenant_guardIsDeliberatelyAbsent` |
+| | 非多租户 + 属性有值 | 同上，结果与租户模式无关 | `[M9]` `ssoDefaultRole_singleTenant_guardAbsenceIsNotTenancyConditional` |
+| | 同时设置 `sso.default.roles` 和 `styleBI.google.sso.default.roles` | 只读自己那个属性 | `[M9]` `ssoDefaultRole_readsItsOwnPropertyNotTheBaseOne` |
+| community（`AbstractSecurityFilterTest`）——org 归属矩阵 | 单租户 + 普通角色名 | `IdentityID(name, host-org)`（原行为不变） | `[M9]` `singleTenant_ordinaryRole_stampedWithDefaultOrg` |
+| | 单租户 + `Administrator` | `IdentityID("Administrator", null)`——**回归护栏**，单租户"让所有 SSO 用户当管理员"的既有配置必须继续可用 | `[M9]` `singleTenant_administrator_stampedWithNullOrg` |
+| | 单租户任意角色 | 不查 `SecurityProvider`（保持纯映射，不会在安全未初始化的环境里开始报错） | `[M9]` `singleTenant_neverConsultsSecurityProvider` |
+| | 多租户 + 普通角色名 | `IdentityID(name, principal.getOrgId())`，**不是** default org | `[M9]` `multiTenant_ordinaryRole_scopedToSigningInOrg_notDefaultOrg` |
+| | 多租户 + 用户落地 SELF（Google self-signup 的实际情形） | 角色跟着落到 SELF | `[M9]` `multiTenant_selfSignupOrg_scopedToSelfOrg` |
+| | 多租户 + 内置 `Administrator`（无 org 播种） | 丢弃（返回 `null`），并记 WARN——靠查全局形式命中 | `[M9]` `multiTenant_builtInAdministrator_isDropped_despiteBeingSeededOrgLess` |
+| | 多租户 + 内置 `Organization Administrator`（无 org 播种） | 丢弃 | `[M9]` `multiTenant_builtInOrganizationAdministrator_isDropped_despiteBeingSeededOrgLess` |
+| | 多租户 + org 作用域的角色但带 sysAdmin 标记 | 丢弃——`DefaultCheckPermissionStrategy` 对任何解析出的 sysadmin 角色短路，这种角色会绕过**所有** org 的权限检查 | `[M9]` `multiTenant_orgScopedSysAdminRole_isDropped` |
+| | 多租户 + org 作用域的角色带 orgAdmin 标记 | **放行**——有意的策略：只在用户自己 org 内生效，正是 self-signup 新组织第一个用户需要的；只有无 org 的内置那个才拒 | `[M9]` `multiTenant_orgScopedOrgAdminRole_isAllowed` |
+| | 多租户 + 不存在的角色名 | 原样放过为 `IdentityID(name, 登录 org)`——不是错误，也不带权限 | `[M9]` `multiTenant_unknownRole_passedThroughUnresolved` |
+| | 多租户 + principal 没有 org（`getOrgId()` 为 null） | 丢弃——两个可选值都不安全：null org 是全局作用域，default org 又是最高权限租户，所以宁可不授（Google 路径实际总有 org，这是防御性分支） | `[M9]` `multiTenant_principalWithNoOrg_isDropped` |
+| | 多租户 + `getSecurityProvider()` 返回 null | 跳过管理员检查，但 org 归属照旧生效 | `[M9]` `multiTenant_noSecurityProvider_stillScopesToSigningInOrg` |
+
+> 补充：这些角色只存在于 session（`createSSOSession()` 从不写 `EditableAuthenticationProvider`）。新 Google 用户持久化的默认角色来自另一条路径——filter 的 postprocessor 调 `UserSignupService.createUser()`，它选的是 provider 里 `isDefaultRole()` 且 org 等于 `userID.orgID` 的角色。两条路径不要混淆。
+
 ---
 
 ## 区四：特殊组织默认行为（host-org / SELF）


### PR DESCRIPTION
## Problem

`AbstractSecurityFilter.getSSODefaultRole()` returns an empty array on a multi-tenant install — the guard is explicit. `StyleBIGoogleSSOFilter.getSSODefaultRole()` (enterprise) is the **only** override of that method in either repo, and it drops the guard, so Google sign-in is the one SSO path that still assigns default roles under multi-tenancy.

`createSSOSession` then stamped every name with `Organization.getDefaultOrganizationID()`, and mapped the literal `Administrator` to `IdentityID(role, null)` — the global system administrator role. That hardcoding was written on the assumption that multi-tenant never reaches it (see `fceb855f7`, *"this property currently only takes effect in non-multi-tenant environments"*). The Google override invalidates the assumption.

Two consequences on a multi-tenant install with Google sign-in enabled:

1. A user signing in to tenant B was granted a role owned by the **default organization**.
2. The name `Administrator` resolved to the real global sysadmin `FSRole` (`FileAuthenticationProvider:1042`, `sysAdmin=true`), i.e. a **server-wide** grant.

This is not a no-op. Nothing filters principal roles by org — `XPrincipal.getAllRoles()` only hides `"Organization Administrator"` in single-tenant mode — and `DefaultCheckPermissionStrategy:216-221` short-circuits `checkPermission` to `true` for every resource in every org once a sysadmin role resolves. Aggravating factor: `AuthenticationProvider.isSystemAdministratorRole()`'s interface default is name-only and ignores `orgID`.

The grants are session-only (`createSSOSession` never writes to an `EditableAuthenticationProvider`), but the property is re-read on every login, so the grant recurs indefinitely.

## Intent

The override is **deliberate**, so the fix keeps it and corrects the org resolution instead of adding the guard:

- `StyleBIGoogleOpenIDConfig.getRoleClaim()` returns `null`, so the org-scoped default-role block in `OpenIDFilterBaseFilter` (which only runs when a role claim is configured) never executes for Google. `styleBI.google.sso.default.roles` is the *only* way a Google sign-in user gets a starting role.
- The Google path is explicitly multi-tenant-aware elsewhere: `createLoginIdentityID()` and `correctOrgForNewMultiTenantUser()` route brand-new self-signup users into the SELF org.

Adding the guard would have silently removed that capability.

## Change

Extracted the stamping into `getSSODefaultRoleID(role, principal)`:

| Install | Ordinary name | Built-in `Administrator` / `Organization Administrator` |
|---|---|---|
| Single tenant | `IdentityID(name, defaultOrgID)` — unchanged | `IdentityID("Administrator", null)` — unchanged |
| Multi tenant | `IdentityID(name, principal.getOrgId())` | dropped, with a WARN |

Single-tenant behaviour is byte-for-byte identical, including the null-org `Administrator` case. That case is **load-bearing, not a bug**: the built-in Administrator is seeded only as `IdentityID("Administrator", null)`, so removing it would break existing `sso.default.roles=Administrator` configurations.

This scoping follows the convention already used elsewhere — `OpenIDFilterBaseFilter:337-340` (`role.orgID == null || role.orgID.equals(principalOrgId)`), `UserSignupService:241-246`, `SSOSettingsService:171-178`, and `DefaultCheckPermissionStrategy:625-640` (org admin rights never extend to global roles).

### The subtle part

The refusal deliberately tests the **global (null-org) form** of the name. `AuthenticationChain` overrides `isSystemAdministratorRole` as `stream().filter(p -> p.getRole(roleId) != null).findFirst()...` — an exact `name@org` key lookup (`FileAuthenticationProvider:229` → `roleStorage.get(id.convertToKey())`) — and both built-in admin roles are seeded **org-less**. So asking about the org-scoped form never resolves to them and the check silently answers `false`, making the guard a no-op that still looks correct.

Also refused: an org-scoped role flagged `sysAdmin`, which would bypass checks in *every* org. Deliberately **allowed**: an org-scoped *organization* administrator role — it is confined to the user's own org, which is what a self-service signup flow wants for the first user of a new org.

A principal with no org drops the name rather than guessing: a null org is the global scope, and the default org is the most privileged tenant, so neither is safe.

## Tests

New `AbstractSecurityFilterTest` (12 tests) covering the full branch matrix. Two are explicit regression guards named `..._despiteBeingSeededOrgLess` — verified to **fail** against a version whose guard only asks about the org-scoped form, printing `expected: <null> but was: <IdentityID{name='Administrator', orgID='acme'}>`.

The fixture models `AuthenticationChain`'s exact-key semantics rather than the name-only interface default, because stubbing it name-only makes the admin-refusal tests pass against an implementation that does nothing.

- `inetsoft.web.security` package: **143/143 pass**
- Compiles under `-Pcommunity,enterprise`

`core/src/test/resources/docs/permission-matrix-special.md` updated — it is the traceability index for this filter.

## Related

Enterprise-side PR (javadoc on the override recording why the tenancy guard is absent, enterprise tests, `claude/` docs) follows and references this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
