### PR TITLE
Bug #76011, apply the SMTP OAuth flags to the token requests

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/Mailer.java
+++ b/core/src/main/java/inetsoft/sree/internal/Mailer.java
@@ -470,7 +470,18 @@ public class Mailer {
       }
    }
 
-   private static String getAccessToken(SMTPAuthType authType) {
+   /**
+    * Gets the SMTP OAuth flags. The flags are stored as a plain text property, so they must be
+    * read with getProperty() and not getPassword(). Earlier versions read the flags from the
+    * misspelled "mail.smtp.outhFlags" property, so that name is still honored if the correctly
+    * spelled property is not set.
+    */
+   public static String getSmtpOAuthFlags() {
+      String flags = SreeEnv.getProperty("mail.smtp.oauthFlags");
+      return Tool.isEmptyString(flags) ? SreeEnv.getProperty("mail.smtp.outhFlags") : flags;
+   }
+
+   static String getAccessToken(SMTPAuthType authType) {
       String expiration = SreeEnv.getProperty("mail.smtp.tokenExpiration");
       String accessToken = SreeEnv.getPassword("mail.smtp.accessToken");
 
@@ -481,7 +492,15 @@ public class Mailer {
       Tokens tokens;
 
       try {
+         // the flags are only configurable for SASL XOAUTH2. the google auth settings are fixed
+         // and any flags left over from a previous SASL XOAUTH2 configuration must not be applied
+         // to a google token refresh.
          final Set<String> flagsSet = new HashSet<>();
+         final String flags = authType == SMTPAuthType.SASL_XOAUTH2 ? getSmtpOAuthFlags() : null;
+
+         if(!StringUtils.isBlank(flags)) {
+            flagsSet.addAll(Arrays.asList(flags.trim().split("\\s+")));
+         }
 
          final String refreshToken = SreeEnv.getPassword("mail.smtp.refreshToken");
          final String clientId = SreeEnv.getProperty("mail.smtp.clientId");

--- a/core/src/main/java/inetsoft/web/admin/general/EmailSettingsService.java
+++ b/core/src/main/java/inetsoft/web/admin/general/EmailSettingsService.java
@@ -14,6 +14,7 @@
 package inetsoft.web.admin.general;
 
 import inetsoft.sree.SreeEnv;
+import inetsoft.sree.internal.Mailer;
 import inetsoft.util.Tool;
 import inetsoft.util.audit.ActionRecord;
 import inetsoft.web.admin.general.model.*;
@@ -56,14 +57,11 @@ public class EmailSettingsService {
    }
 
    /**
-    * Gets the SMTP OAuth flags. The flags are stored as a plain text property, so they must be
-    * read with getProperty() and not getPassword(). Earlier versions read the flags from the
-    * misspelled "mail.smtp.outhFlags" property, so that name is still honored if the correctly
-    * spelled property is not set.
+    * Gets the SMTP OAuth flags. The property resolution is shared with the mailer, which applies
+    * the flags when it refreshes the access token.
     */
    private String getOAuthFlags() {
-      String flags = SreeEnv.getProperty("mail.smtp.oauthFlags");
-      return Tool.isEmptyString(flags) ? SreeEnv.getProperty("mail.smtp.outhFlags") : flags;
+      return Mailer.getSmtpOAuthFlags();
    }
 
    @Audited(
@@ -95,6 +93,10 @@ public class EmailSettingsService {
             SreeEnv.setProperty("mail.smtp.tokenUri", model.smtpTokenUri());
             SreeEnv.setProperty("mail.smtp.oauthScopes", model.smtpOAuthScopes());
             SreeEnv.setProperty("mail.smtp.oauthFlags", model.smtpOAuthFlags());
+            // the misspelled property is only honored as a legacy fallback when reading. once
+            // the flags have been saved under the correct name, the old name must not shadow a
+            // value that was cleared here, since the flags are now applied to the token refresh.
+            SreeEnv.remove("mail.smtp.outhFlags");
          }
       }
 
@@ -131,8 +133,11 @@ public class EmailSettingsService {
          builder.addScope(request.scope().split(" "));
       }
 
-      if(request.flags() != null) {
-         builder.addScope(request.flags().split(" "));
+      // the flags are a distinct parameter of the authorization request, not additional scopes
+      String flags = request.flags() == null ? "" : request.flags().trim();
+
+      if(!flags.isEmpty()) {
+         builder.addFlags(flags.split("\\s+"));
       }
 
       return builder.build();

--- a/core/src/test/java/inetsoft/sree/internal/MailerTest.java
+++ b/core/src/test/java/inetsoft/sree/internal/MailerTest.java
@@ -1,0 +1,138 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.sree.internal;
+
+import inetsoft.sree.SreeEnv;
+import inetsoft.uql.tabular.oauth.AuthorizationClient;
+import inetsoft.uql.tabular.oauth.Tokens;
+import inetsoft.web.admin.general.model.model.SMTPAuthType;
+import org.junit.jupiter.api.*;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class MailerTest {
+   private MockedStatic<SreeEnv> sreeEnvStatic;
+   private MockedStatic<AuthorizationClient> authorizationClientStatic;
+
+   @BeforeEach
+   void setUp() throws Exception {
+      sreeEnvStatic = mockStatic(SreeEnv.class, withSettings().lenient());
+      authorizationClientStatic =
+         mockStatic(AuthorizationClient.class, withSettings().lenient());
+
+      // no unexpired access token, so the token is always refreshed
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("mail.smtp.tokenExpiration")).thenReturn(null);
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("mail.smtp.tokenUri"))
+         .thenReturn("https://example.com/token");
+      sreeEnvStatic.when(() -> SreeEnv.getPassword("mail.smtp.refreshToken"))
+         .thenReturn("refresh-token");
+
+      authorizationClientStatic
+         .when(() -> AuthorizationClient.refresh(
+            any(), any(), any(), any(), any(), anySet(), anyBoolean(), any()))
+         .thenReturn(Tokens.builder()
+                        .accessToken("access-token")
+                        .refreshToken("refresh-token")
+                        .issued(0L)
+                        .expiration(0L)
+                        .build());
+   }
+
+   @AfterEach
+   void tearDown() {
+      authorizationClientStatic.close();
+      sreeEnvStatic.close();
+   }
+
+   // the flags configured in the EM must be applied when the access token is refreshed
+   @Test
+   void refreshAppliesConfiguredOAuthFlags() {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("mail.smtp.oauthFlags"))
+         .thenReturn("flag1 flag2");
+
+      Mailer.getAccessToken(SMTPAuthType.SASL_XOAUTH2);
+
+      assertEquals(Set.of("flag1", "flag2"), captureFlags());
+   }
+
+   // deployments that set the misspelled property directly must keep working
+   @Test
+   void refreshFallsBackToLegacyOAuthFlagsProperty() {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("mail.smtp.outhFlags")).thenReturn("legacyFlag");
+
+      Mailer.getAccessToken(SMTPAuthType.SASL_XOAUTH2);
+
+      assertEquals(Set.of("legacyFlag"), captureFlags());
+   }
+
+   @Test
+   void refreshSendsNoFlagsWhenNotConfigured() {
+      Mailer.getAccessToken(SMTPAuthType.SASL_XOAUTH2);
+
+      assertEquals(Set.of(), captureFlags());
+   }
+
+   // a blank value must not turn into a single empty flag
+   @Test
+   void refreshSendsNoFlagsWhenOAuthFlagsAreBlank() {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("mail.smtp.oauthFlags")).thenReturn("   ");
+
+      Mailer.getAccessToken(SMTPAuthType.SASL_XOAUTH2);
+
+      assertEquals(Set.of(), captureFlags());
+   }
+
+   // extra whitespace must not turn into empty flags
+   @Test
+   void refreshIgnoresExtraWhitespaceInOAuthFlags() {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("mail.smtp.oauthFlags"))
+         .thenReturn("  flag1   flag2  ");
+
+      Mailer.getAccessToken(SMTPAuthType.SASL_XOAUTH2);
+
+      assertEquals(Set.of("flag1", "flag2"), captureFlags());
+   }
+
+   // the flags are only configurable for SASL XOAUTH2. flags left over from a previous SASL
+   // XOAUTH2 configuration must not change the google token refresh.
+   @Test
+   void refreshSendsNoFlagsForGoogleAuth() {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("mail.smtp.oauthFlags"))
+         .thenReturn("flag1 flag2");
+
+      Mailer.getAccessToken(SMTPAuthType.GOOGLE_AUTH);
+
+      assertEquals(Set.of(), captureFlags());
+   }
+
+   @SuppressWarnings("unchecked")
+   private Set<String> captureFlags() {
+      ArgumentCaptor<Set<String>> captor = ArgumentCaptor.forClass(Set.class);
+      authorizationClientStatic.verify(() -> AuthorizationClient.refresh(
+         any(), any(), any(), any(), any(), captor.capture(), anyBoolean(), any()));
+      return captor.getValue();
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/general/EmailSettingsServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/general/EmailSettingsServiceTest.java
@@ -20,10 +20,15 @@ package inetsoft.web.admin.general;
 
 import inetsoft.sree.SreeEnv;
 import inetsoft.util.Tool;
+import inetsoft.web.admin.general.model.*;
+import inetsoft.web.admin.general.model.model.*;
 import org.junit.jupiter.api.*;
 import org.mockito.MockedStatic;
 
+import java.util.*;
+
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @Tag("core")
@@ -82,5 +87,73 @@ class EmailSettingsServiceTest {
    @Test
    void getModelReturnsNullOAuthFlagsWhenNotConfigured() {
       assertNull(service.getModel().smtpOAuthFlags());
+   }
+
+   // the flags are a distinct parameter of the authorization request, so they must not be
+   // folded into the requested scopes
+   @Test
+   void getOAuthParamsSendsFlagsAsFlags() {
+      OAuthParams params = service.getOAuthParams(oauthParamsRequest("scope1 scope2", "flag1 flag2"));
+
+      assertEquals(Set.of("flag1", "flag2"), params.flags());
+      assertEquals(List.of("scope1", "scope2"), params.scope());
+   }
+
+   @Test
+   void getOAuthParamsIgnoresExtraWhitespaceInFlags() {
+      OAuthParams params = service.getOAuthParams(oauthParamsRequest("scope1", "  flag1   flag2  "));
+
+      assertEquals(Set.of("flag1", "flag2"), params.flags());
+   }
+
+   // a blank value must not turn into a single empty flag
+   @Test
+   void getOAuthParamsSendsNoFlagsWhenNotConfigured() {
+      assertNull(service.getOAuthParams(oauthParamsRequest("scope1", null)).flags());
+      assertNull(service.getOAuthParams(oauthParamsRequest("scope1", "")).flags());
+      assertNull(service.getOAuthParams(oauthParamsRequest("scope1", "   ")).flags());
+   }
+
+   // the misspelled property is a read-only fallback, so saving must not leave it behind to
+   // shadow flags that were cleared in the EM
+   @Test
+   void setModelClearsLegacyOAuthFlagsProperty() throws Exception {
+      service.setModel(emailSettingsModel(SMTPAuthType.SASL_XOAUTH2, "flag1"), null);
+
+      sreeEnvStatic.verify(() -> SreeEnv.setProperty("mail.smtp.oauthFlags", "flag1"));
+      sreeEnvStatic.verify(() -> SreeEnv.remove("mail.smtp.outhFlags"));
+   }
+
+   @Test
+   void setModelLeavesOAuthFlagsAloneForGoogleAuth() throws Exception {
+      service.setModel(emailSettingsModel(SMTPAuthType.GOOGLE_AUTH, null), null);
+
+      sreeEnvStatic.verify(() -> SreeEnv.setProperty(eq("mail.smtp.oauthFlags"), any()), never());
+      sreeEnvStatic.verify(() -> SreeEnv.remove("mail.smtp.outhFlags"), never());
+   }
+
+   private EmailSettingsModel emailSettingsModel(SMTPAuthType authType, String flags) {
+      return EmailSettingsModel.builder()
+         .smtpAuthentication(authType)
+         .smtpHost("smtp.example.com")
+         .fromAddress("noreply@example.com")
+         .ssl(false)
+         .tls(false)
+         .smtpOAuthFlags(flags)
+         .build();
+   }
+
+   private OAuthParamsRequest oauthParamsRequest(String scope, String flags) {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("license.key")).thenReturn("LICENSE-KEY,OTHER");
+
+      return OAuthParamsRequest.builder()
+         .user("user@example.com")
+         .clientId("client-id")
+         .clientSecret("client-secret")
+         .authorizationUri("https://example.com/authorize")
+         .tokenUri("https://example.com/token")
+         .scope(scope)
+         .flags(flags)
+         .build();
    }
 }


### PR DESCRIPTION
Follow-up to #76008. That fix corrected the round-trip of the **Settings > General > Email > OAuth Flags** field, so it now saves and reloads correctly — but the value was still inert. Tracing it showed the flags never reach the authorization server on *either* path, not just the one reported.

## The problem

**Refresh path — flags dropped entirely.** `Mailer.getAccessToken` built `new HashSet<>()` and passed it straight to `AuthorizationClient.refresh`; `mail.smtp.oauthFlags` was never read. Every other caller reads and splits the flags — `ODataDataSource`, `OneDriveDataSource`, `AbstractRestDataSource`, `AuthorizationClient.refreshTokens` — the mail path was the sole outlier.

**Authorize path — flags sent in the wrong slot.** `EmailSettingsService.getOAuthParams` did `builder.addScope(request.flags().split(" "))`, leaving `OAuthParams.flags()` unset. The client posts `flags` as its own field, so the EM **Authorize** button was sending the operator's flags to the broker as extra OAuth *scopes*.

Both fail silently — no error at any point.

## The fix

- `Mailer.getSmtpOAuthFlags()` holds the single definition of the property resolution (canonical `mail.smtp.oauthFlags` plus the legacy misspelled `mail.smtp.outhFlags` fallback); `EmailSettingsService.getOAuthFlags()` delegates to it, so the rule cannot drift between the two layers. Dependency runs web → core.
- `getAccessToken` splits the flags into the set it already passes to `refresh`.
- `getOAuthParams` calls `addFlags` instead of `addScope`.

Three judgment calls worth review:

1. **The refresh applies flags only for `SASL_XOAUTH2`.** `setModel` writes `mail.smtp.oauthFlags` only in that branch, and the EM's `authorizeGoogle()` hardcodes no flags. Without the gate, someone who once configured SASL XOAUTH2 and later switched to Google Auth would start sending stale flags on a Google refresh that previously sent none.
2. **`setModel` now clears the legacy misspelled property.** Nothing ever wrote or cleared it, so on an install with that key hand-edited into `sree.properties`, blanking the field in the EM got the old value back on reload. That was cosmetic before this change and becomes live behavior once the flags are applied. Clearing it also migrates such installs on first save.
3. **Blank values are ignored rather than split.** `"".split("\s+")` returns a one-element array containing `""`, so a whitespace-only field would otherwise post a bogus empty flag.

## Testing

New `MailerTest` (6 tests) and 3 added cases in `EmailSettingsServiceTest` (9 total), all passing. Verified they are real regression guards: reverting each source change reproduces failures in the corresponding tests. The four existing #76008 tests pass unchanged through the delegation.

```
./mvnw test -pl core -Dtest='MailerTest,EmailSettingsServiceTest'
```

## Not addressed

Two lines above the flags block, `request.scope().split(" ")` has the same latent defect — no trim, single-literal-space delimiter — so `"scope1  scope2"` yields an empty scope entry. It is pre-existing and changing it would alter what is sent on the authorize path for existing configurations, so it is left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
