### PR TITLE
Remove orphaned fields left by merge in PropertiesController

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/properties/PropertiesController.java
+++ b/core/src/main/java/inetsoft/web/admin/properties/PropertiesController.java
@@ -200,8 +200,5 @@ public class PropertiesController {
       "log.level.inetsoft.web.portal.controller.ControllerErrorHandler",
       "log.level.inetsoft_audit");
 
-   private final AssetRepository assetRepository;
-   private final LogManager logManager;
-   private final SecurityEngine securityEngine;
    private final PropertyChangeSideEffects sideEffects;
 }


### PR DESCRIPTION
## Problem

`PropertiesController` does not compile on `stylebi-wiz-main-rebase`.

The merge of `origin/main` into `stylebi-wiz-main-rebase` reinstated three field declarations that had been removed in #4428, when the property-change side effects were extracted into `PropertyChangeSideEffects`:

```java
private final AssetRepository assetRepository;
private final LogManager logManager;
private final SecurityEngine securityEngine;
```

Two compile errors follow:

1. The `inetsoft.uql.asset.AssetRepository` and `inetsoft.util.log.*` imports were removed along with the original code, so `AssetRepository` and `LogManager` cannot be resolved.
2. The constructor now only injects `PropertyChangeSideEffects`, so the three `final` fields are never assigned.

## Fix

Delete the three fields. Nothing in the class references them — the logic that used to need them now lives in `PropertyChangeSideEffects` (`applyPreRemoveSideEffects` / `applyPostRemoveSideEffects` / `applyEditSideEffects`).

## Verification

`./mvnw -o -pl core compile` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
