### PR TITLE
fix compile error

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/properties/PropertiesController.java
+++ b/core/src/main/java/inetsoft/web/admin/properties/PropertiesController.java
@@ -200,8 +200,5 @@ public class PropertiesController {
       "log.level.inetsoft.web.portal.controller.ControllerErrorHandler",
       "log.level.inetsoft_audit");
 
-   private final AssetRepository assetRepository;
-   private final LogManager logManager;
-   private final SecurityEngine securityEngine;
    private final PropertyChangeSideEffects sideEffects;
 }


### PR DESCRIPTION
  Root cause: commit d99e7b337 (admin-chat Plan 1) refactored PropertiesController's constructor to take only
  PropertyChangeSideEffects, and correctly dropped the now-unused imports for AssetRepository and LogManager — but left
  the corresponding field declarations (assetRepository, logManager, securityEngine) behind as dead code. Nothing in the
  class ever read or assigned them, so they were pure leftovers referencing types with no import.

  Fix: removed the three unused field declarations in PropertiesController.java (kept only sideEffects). Verified with
  ./mvnw -pl core clean compile, which now succeeds.