### PR TITLE
Import CSV through StyleBI's own loader, with the dialog's settings

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -48,6 +48,7 @@ import inetsoft.uql.util.filereader.ExcelFileInfo;
 import inetsoft.uql.util.filereader.ExcelFileReader;
 import inetsoft.uql.util.filereader.ExcelFileSupport;
 import inetsoft.util.Catalog;
+import inetsoft.util.FileSystemService;
 import inetsoft.web.composer.ws.LayoutGraphService;
 import inetsoft.web.composer.ws.assembly.WorksheetEventUtil;
 import inetsoft.web.composer.ws.event.WSLayoutGraphEvent;
@@ -70,7 +71,9 @@ import org.springframework.web.server.ResponseStatusException;
 import java.awt.*;
 import java.io.*;
 import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.StandardCharsets;
+import java.nio.charset.UnsupportedCharsetException;
 import java.nio.file.Files;
 import java.security.Principal;
 import java.util.*;
@@ -636,6 +639,37 @@ public class WorksheetAgentController {
                               int headerCols) {}
 
    /**
+    * Whether a charset name can be used to decode with.
+    *
+    * <p>{@link Charset#isSupported} answers {@code false} only for a name that is well formed but
+    * unrecognized; a malformed one -- a name with a space in it, say -- throws
+    * {@link IllegalCharsetNameException} instead. Both are the same mistake from the caller's side,
+    * so both become the same 400 rather than one of them escaping as a 500.
+    */
+   private static boolean isSupportedCharset(String name) {
+      try {
+         return Charset.isSupported(name);
+      }
+      catch(IllegalCharsetNameException | UnsupportedCharsetException e) {
+         return false;
+      }
+   }
+
+   /**
+    * Whether a charset name names UTF-8, by resolving it rather than by comparing strings, so the
+    * aliases ("utf8", "UTF-8", "unicode-1-1-utf-8") all count. A name that resolves to nothing is
+    * not UTF-8 either, which is the answer the JSON route wants for it.
+    */
+   private static boolean isUtf8(String name) {
+      try {
+         return StandardCharsets.UTF_8.equals(Charset.forName(name));
+      }
+      catch(IllegalCharsetNameException | UnsupportedCharsetException e) {
+         return false;
+      }
+   }
+
+   /**
     * Resolves the dialog's settings, defaulting to what the previous hand-rolled parser did so an
     * existing caller that passes none sees no change: comma-separated, types detected, line 1 as
     * the header, quotes left alone, no unpivot.
@@ -646,7 +680,7 @@ public class WorksheetAgentController {
    {
       String encode = encoding == null || encoding.isBlank() ? "UTF-8" : encoding.trim();
 
-      if(!Charset.isSupported(encode)) {
+      if(!isSupportedCharset(encode)) {
          throw new ResponseStatusException(
             HttpStatus.BAD_REQUEST, "Unsupported encoding: " + encode);
       }
@@ -689,9 +723,10 @@ public class WorksheetAgentController {
    /**
     * Import CSV supplied inline as text.
     *
-    * <p>{@code encoding} is accepted but cannot mean anything on this route: the text arrived
-    * already decoded as part of a JSON body, so any mis-decoding happened before the request was
-    * built. Send the file's bytes to the multipart route when the charset matters.
+    * <p>{@code encoding} cannot mean anything on this route: the text arrived already decoded as
+    * part of a JSON body, so any mis-decoding happened before the request was built. Anything but
+    * UTF-8 is refused rather than quietly ignored -- a caller who set it has a file to re-send to
+    * the multipart route, not a setting to drop.
     */
    @PostMapping("/api/wiz/v1/agent/worksheet/{sessionToken}/import-csv")
    public ImportCsvResponse importCsv(@PathVariable String sessionToken,
@@ -705,12 +740,26 @@ public class WorksheetAgentController {
          throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "csv is required");
       }
 
+      if(body.encoding() != null && !body.encoding().isBlank() &&
+         !isUtf8(body.encoding().trim()))
+      {
+         throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST,
+            "encoding cannot be honoured here: the csv text was already decoded before this " +
+            "request was built. Post the file's bytes to import-csv-file with encoding=" +
+            body.encoding().trim() + " instead.");
+      }
+
       CsvSettings settings = csvSettings(
          "UTF-8", body.delimiter(), body.delimiterTab(), body.detectType(),
          body.firstRowAsHeader(), body.removeQuotes(), body.unpivot(), body.headerCols());
 
-      return importCsvBytes(sessionToken, user, body.name(),
-                            body.csv().getBytes(StandardCharsets.UTF_8), settings);
+      // The same guard the multipart route gets: a JSON body's csv string is no less capable of
+      // driving an unbounded temp-file write and loader scan than an uploaded file is.
+      byte[] bytes = body.csv().getBytes(StandardCharsets.UTF_8);
+      checkImportFileSize(bytes.length, "CSV");
+
+      return importCsvBytes(sessionToken, user, body.name(), bytes, settings);
    }
 
    /**
@@ -771,7 +820,16 @@ public class WorksheetAgentController {
                                             byte[] bytes, CsvSettings settings)
       throws Exception
    {
-      File temp = File.createTempFile("wiz-agent-import", ".csv");
+      // The product's cache directory rather than java.io.tmpdir: the bytes are the caller's data,
+      // and the system temp dir is shared with whatever else runs on the host, at whatever
+      // permissions the umask gives. This is the same convention the import dialog's own file
+      // handling follows.
+      File temp = FileSystemService.getInstance().getCacheTempFile("wiz-agent-import", "csv");
+
+      if(temp == null) {
+         throw new ResponseStatusException(
+            HttpStatus.INTERNAL_SERVER_ERROR, "Unable to create a temporary file for the import");
+      }
 
       try {
          Files.write(temp.toPath(), bytes);
@@ -788,6 +846,12 @@ public class WorksheetAgentController {
             Util.getOrganizationMaxColumn(), new DateParseInfo());
 
          if(loaded == null || loaded.getRowCount() < 2) {
+            if(loaded != null) {
+               // XSwappableTable can have spilled to disk even this small; every other exit from
+               // this method disposes, so this one does too.
+               loaded.dispose();
+            }
+
             throw new ResponseStatusException(
                HttpStatus.BAD_REQUEST,
                "CSV must have a header row and at least one data row" +

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -41,6 +41,9 @@ import inetsoft.uql.schema.XTypeNode;
 import inetsoft.uql.text.TextOutput;
 import inetsoft.uql.util.DefaultMetaDataProvider;
 import inetsoft.uql.util.XEmbeddedTable;
+import inetsoft.uql.table.XSwappableTable;
+import inetsoft.uql.util.filereader.CSVLoader;
+import inetsoft.uql.util.filereader.DateParseInfo;
 import inetsoft.uql.util.filereader.ExcelFileInfo;
 import inetsoft.uql.util.filereader.ExcelFileReader;
 import inetsoft.uql.util.filereader.ExcelFileSupport;
@@ -66,6 +69,9 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.awt.*;
 import java.io.*;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.security.Principal;
 import java.util.*;
 import java.util.List;
@@ -596,9 +602,97 @@ public class WorksheetAgentController {
     * @param body         name (optional) and csv string
     * @param user         the authenticated agent principal
     */
-   public record ImportCsvRequest(String name, String csv) {}
+   public record ImportCsvRequest(String name, String csv, String encoding, String delimiter,
+                                  Boolean delimiterTab, Boolean detectType,
+                                  Boolean firstRowAsHeader, Boolean removeQuotes,
+                                  Boolean unpivot, Integer headerCols)
+   {
+      /**
+       * The common case: text plus an optional name, every setting left to its default. Spelling
+       * out eight nulls at each call site would bury which ones a caller actually meant to set.
+       */
+      public ImportCsvRequest(String name, String csv) {
+         this(name, csv, null, null, null, null, null, null, null, null);
+      }
+   }
    public record ImportCsvResponse(String tableName, int rows, int columns) {}
 
+   /**
+    * The import settings the Composer's own Import Data File dialog exposes.
+    *
+    * <p>Normalized once, here, so both transports agree: the JSON endpoint below and the
+    * multipart one that follows it hand this to the same loader.
+    *
+    * @param encoding        charset name to decode the bytes with
+    * @param delimiter       the field separator, already resolved from the Tab checkbox
+    * @param detectType      convert values to a detected type; when false every column is string
+    * @param firstRowAsHeader take column names from line 1; when false they become col0, col1, ...
+    * @param removeQuotes    strip a value's surrounding quotes, treating them as escaping only
+    * @param unpivot         reshape crosstab-shaped input into a tabular table
+    * @param headerCols      with unpivot, how many leading columns stay as row identifiers
+    */
+   private record CsvSettings(String encoding, String delimiter, boolean detectType,
+                              boolean firstRowAsHeader, boolean removeQuotes, boolean unpivot,
+                              int headerCols) {}
+
+   /**
+    * Resolves the dialog's settings, defaulting to what the previous hand-rolled parser did so an
+    * existing caller that passes none sees no change: comma-separated, types detected, line 1 as
+    * the header, quotes left alone, no unpivot.
+    */
+   private CsvSettings csvSettings(String encoding, String delimiter, Boolean delimiterTab,
+                                   Boolean detectType, Boolean firstRowAsHeader,
+                                   Boolean removeQuotes, Boolean unpivot, Integer headerCols)
+   {
+      String encode = encoding == null || encoding.isBlank() ? "UTF-8" : encoding.trim();
+
+      if(!Charset.isSupported(encode)) {
+         throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST, "Unsupported encoding: " + encode);
+      }
+
+      String delim;
+
+      if(Boolean.TRUE.equals(delimiterTab)) {
+         delim = "\t";
+      }
+      else if(delimiter == null || delimiter.isEmpty()) {
+         delim = ",";
+      }
+      else if(delimiter.length() > 1) {
+         // The dialog's own input is maxlength=1; a multi-character separator would be silently
+         // truncated by the loader's splitter rather than honoured.
+         throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST,
+            "delimiter must be a single character (got \"" + delimiter + "\"). " +
+            "For a tab, set delimiterTab instead of passing an escape sequence.");
+      }
+      else {
+         delim = delimiter;
+      }
+
+      boolean pivot = Boolean.TRUE.equals(unpivot);
+      int hcol = headerCols == null ? 1 : headerCols;
+
+      if(hcol < 0) {
+         throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST, "headerCols cannot be negative (got " + hcol + ")");
+      }
+
+      return new CsvSettings(encode, delim,
+                             detectType == null || detectType,
+                             firstRowAsHeader == null || firstRowAsHeader,
+                             Boolean.TRUE.equals(removeQuotes),
+                             pivot, hcol);
+   }
+
+   /**
+    * Import CSV supplied inline as text.
+    *
+    * <p>{@code encoding} is accepted but cannot mean anything on this route: the text arrived
+    * already decoded as part of a JSON body, so any mis-decoding happened before the request was
+    * built. Send the file's bytes to the multipart route when the charset matters.
+    */
    @PostMapping("/api/wiz/v1/agent/worksheet/{sessionToken}/import-csv")
    public ImportCsvResponse importCsv(@PathVariable String sessionToken,
                                       @RequestBody ImportCsvRequest body,
@@ -611,33 +705,128 @@ public class WorksheetAgentController {
          throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "csv is required");
       }
 
-      List<String[]> rows = parseCsv(body.csv());
+      CsvSettings settings = csvSettings(
+         "UTF-8", body.delimiter(), body.delimiterTab(), body.detectType(),
+         body.firstRowAsHeader(), body.removeQuotes(), body.unpivot(), body.headerCols());
 
-      if(rows.size() < 2) {
-         throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-                                           "CSV must have a header row and at least one data row");
+      return importCsvBytes(sessionToken, user, body.name(),
+                            body.csv().getBytes(StandardCharsets.UTF_8), settings);
+   }
+
+   /**
+    * Import CSV supplied as raw file bytes.
+    *
+    * <p>Separate from the JSON route rather than a flag on it, because the two differ in what they
+    * can honour rather than only in shape: bytes are decoded here with the caller's {@code
+    * encoding}, which is the only way a non-UTF-8 file survives the trip at all. Mirrors how
+    * {@code import-excel} already takes its file.
+    */
+   @PostMapping(value = "/api/wiz/v1/agent/worksheet/{sessionToken}/import-csv-file",
+                consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+   public ImportCsvResponse importCsvFile(@PathVariable String sessionToken,
+                                          @RequestPart(value = "file", required = false)
+                                          MultipartFile file,
+                                          @RequestParam(required = false) String name,
+                                          @RequestParam(required = false) String encoding,
+                                          @RequestParam(required = false) String delimiter,
+                                          @RequestParam(required = false) Boolean delimiterTab,
+                                          @RequestParam(required = false) Boolean detectType,
+                                          @RequestParam(required = false) Boolean firstRowAsHeader,
+                                          @RequestParam(required = false) Boolean removeQuotes,
+                                          @RequestParam(required = false) Boolean unpivot,
+                                          @RequestParam(required = false) Integer headerCols,
+                                          Principal user) throws Exception
+   {
+      requireEnabled();
+      requireWholeSheetSession(sessionToken, user);
+
+      if(file == null || file.isEmpty()) {
+         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "file is required");
       }
 
-      String[] headers = rows.get(0);
-      int ncols = headers.length;
-      int nrows = rows.size();
+      checkImportFileSize(file.getSize(), "CSV");
 
-      String[] types = new String[ncols];
-      for(int c = 0; c < ncols; c++) {
-         types[c] = inferType(rows, c);
+      CsvSettings settings = csvSettings(encoding, delimiter, delimiterTab, detectType,
+                                         firstRowAsHeader, removeQuotes, unpivot, headerCols);
+
+      return importCsvBytes(sessionToken, user, name, file.getBytes(), settings);
+   }
+
+   /**
+    * The one CSV import path, shared by both transports.
+    *
+    * <p>Delegates to {@link CSVLoader#readCSV}, the same loader the Composer's own import dialog
+    * uses, rather than parsing here. The hand-rolled parser this replaced was the origin of a
+    * cluster of findings in the L2 test lane -- it could not honour an encoding, a delimiter, a
+    * quote-stripping choice or a "first row is data" file at all, and its own type coercion
+    * dropped values the loader keeps. A second implementation of a format this fiddly earns
+    * nothing.
+    *
+    * <p>The result is deliberately a plain {@link EmbeddedTableAssembly} and **not** the
+    * {@link SnapshotEmbeddedTableAssembly} the dialog builds. An agent-imported table has to stay
+    * editable: it is the documented way to get an editable copy of data that arrived as a
+    * snapshot, so turning this into a snapshot would quietly remove the only workaround there is.
+    */
+   private ImportCsvResponse importCsvBytes(String sessionToken, Principal user, String name,
+                                            byte[] bytes, CsvSettings settings)
+      throws Exception
+   {
+      File temp = File.createTempFile("wiz-agent-import", ".csv");
+
+      try {
+         Files.write(temp.toPath(), bytes);
+
+         List<String> types = new ArrayList<>();
+         // oldTypes carries the column types of a table being re-imported over. A fresh import has
+         // none -- but the loader reads and writes through this map, so it must be an empty mutable
+         // map rather than null.
+         Map<Object, String> oldTypes = new HashMap<>();
+         XSwappableTable loaded = CSVLoader.readCSV(
+            temp, settings.encoding(), settings.removeQuotes(), settings.delimiter(),
+            settings.firstRowAsHeader(), settings.unpivot(), oldTypes, types,
+            settings.detectType(), null, CSV_TYPE_SCAN_ROWS, 0,
+            Util.getOrganizationMaxColumn(), new DateParseInfo());
+
+         if(loaded == null || loaded.getRowCount() < 2) {
+            throw new ResponseStatusException(
+               HttpStatus.BAD_REQUEST,
+               "CSV must have a header row and at least one data row" +
+               (settings.firstRowAsHeader()
+                  ? "" : " (firstRowAsHeader is false, so line 1 counts as data)"));
+         }
+
+         XEmbeddedTable table;
+
+         if(settings.unpivot()) {
+            XSwappableTable pivoted = AssetUtil.unpivot(loaded, settings.headerCols());
+
+            if(pivoted != loaded) {
+               loaded.dispose();
+            }
+
+            // Unpivoting reshapes the columns, so the type list readCSV produced describes a
+            // table that no longer exists. Let XEmbeddedTable derive types from the new shape.
+            table = new XEmbeddedTable(pivoted);
+         }
+         else {
+            table = new XEmbeddedTable(types.toArray(new String[0]), loaded);
+         }
+
+         return createEmbeddedTable(sessionToken, user, name, table,
+                                    table.getRowCount(), table.getColCount());
       }
-
-      Object[][] data = new Object[nrows][ncols];
-      for(int r = 0; r < nrows; r++) {
-         String[] srcRow = rows.get(r);
-         for(int c = 0; c < ncols; c++) {
-            String cell = c < srcRow.length ? srcRow[c] : "";
-            data[r][c] = r == 0 ? cell : convertCell(cell, types[c]);
+      finally {
+         if(!temp.delete()) {
+            temp.deleteOnExit();
          }
       }
-
-      return createEmbeddedTable(sessionToken, user, body.name(), types, data, nrows, ncols);
    }
+
+   /**
+    * How many rows {@link CSVLoader#readCSV} may scan while settling a column's type, matching
+    * what the Composer's dialog passes for a full import.
+    */
+   private static final int CSV_TYPE_SCAN_ROWS = 50000;
 
    /**
     * Import an Excel file (.xls/.xlsx) as a new embedded table assembly in the worksheet.
@@ -683,7 +872,7 @@ public class WorksheetAgentController {
                                            "fileType must be either \"XLS\" or \"XLSX\"");
       }
 
-      checkExcelFileSize(file.getSize());
+      checkImportFileSize(file.getSize(), "Excel");
 
       byte[] bytes = file.getBytes();
 
@@ -783,7 +972,7 @@ public class WorksheetAgentController {
       return createEmbeddedTable(sessionToken, user, name, types, data, nrows, ncols);
    }
 
-   private void checkExcelFileSize(long size) {
+   private void checkImportFileSize(long size, String what) {
       String excelImportMax = SreeEnv.getProperty("excel.import.max");
       String max = excelImportMax != null ? excelImportMax : SreeEnv.getProperty("csv.import.max");
 
@@ -806,7 +995,8 @@ public class WorksheetAgentController {
          long sizeM = sizeK / 1024;
          String sizeStr = sizeM > 0 ? sizeM + "M" : sizeK + "K";
          throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-                                           "Excel file exceeds the maximum allowed size (" + sizeStr + ")");
+                                           what + " file exceeds the maximum allowed size (" +
+                                              sizeStr + ")");
       }
    }
 
@@ -819,8 +1009,19 @@ public class WorksheetAgentController {
     * {@link EmbeddedTableAssembly} from already-typed header+data rows and adds it to the
     * worksheet.
     */
+   /**
+    * The Excel route's shape: a type array plus a rectangular value block, row 0 being the header.
+    */
    private ImportCsvResponse createEmbeddedTable(String sessionToken, Principal user, String name,
                                                  String[] types, Object[][] data, int nrows, int ncols)
+      throws Exception
+   {
+      return createEmbeddedTable(sessionToken, user, name, new XEmbeddedTable(types, data),
+                                 nrows, ncols);
+   }
+
+   private ImportCsvResponse createEmbeddedTable(String sessionToken, Principal user, String name,
+                                                 XEmbeddedTable table, int nrows, int ncols)
       throws Exception
    {
       return editService.applyOnRuntime(sessionToken, user, rws -> {
@@ -848,7 +1049,6 @@ public class WorksheetAgentController {
          assembly.setPixelOffset(new Point(10, maxY + 10));
          assembly.setPixelSize(new Dimension(AssetUtil.defw, nrows + 1));
 
-         XEmbeddedTable table = new XEmbeddedTable(types, data);
          assembly.setEmbeddedData(table);
          ws.addAssembly(assembly);
 
@@ -861,88 +1061,6 @@ public class WorksheetAgentController {
 
          return new ImportCsvResponse(tableName, nrows - 1, ncols);
       });
-   }
-
-   /**
-    * Parse a CSV string into a list of string arrays (one per row).
-    * Handles quoted fields and escaped double-quotes per RFC 4180.
-    *
-    * <p><strong>Limitation:</strong> embedded newlines inside quoted fields are not
-    * supported — the parser reads line-by-line, so a newline inside a quoted value
-    * will be treated as a row boundary.  Callers should ensure cell values do not
-    * contain newlines.</p>
-    */
-   private static List<String[]> parseCsv(String csv) {
-      List<String[]> result = new ArrayList<>();
-      try(BufferedReader reader = new BufferedReader(new StringReader(csv))) {
-         String line;
-         while((line = reader.readLine()) != null) {
-            if(line.isBlank()) continue;
-            result.add(parseCsvLine(line));
-         }
-      }
-      catch(IOException e) {
-         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Failed to parse CSV: " + e.getMessage());
-      }
-      return result;
-   }
-
-   private static String[] parseCsvLine(String line) {
-      List<String> fields = new ArrayList<>();
-      StringBuilder sb = new StringBuilder();
-      boolean inQuotes = false;
-      for(int i = 0; i < line.length(); i++) {
-         char c = line.charAt(i);
-         if(c == '"') {
-            if(inQuotes && i + 1 < line.length() && line.charAt(i + 1) == '"') {
-               sb.append('"');
-               i++;
-            }
-            else {
-               inQuotes = !inQuotes;
-            }
-         }
-         else if(c == ',' && !inQuotes) {
-            fields.add(sb.toString());
-            sb.setLength(0);
-         }
-         else {
-            sb.append(c);
-         }
-      }
-      fields.add(sb.toString());
-      return fields.toArray(new String[0]);
-   }
-
-   /**
-    * Infer XSchema type for a column by scanning data rows (row 0 is header, skip it).
-    *
-    * <p>Known limitation: only DOUBLE and STRING are returned. Integer columns become DOUBLE
-    * (acceptable for most comparisons but loses integer-precision semantics), and
-    * date/boolean columns become STRING (may affect sort order and aggregate operations).
-    * This is sufficient for CSV import but is not a general type-inference solution.</p>
-    */
-   private static String inferType(List<String[]> rows, int col) {
-      boolean allNumeric = true;
-      for(int r = 1; r < rows.size(); r++) {
-         String[] row = rows.get(r);
-         String cell = col < row.length ? row[col].trim() : "";
-         if(cell.isEmpty()) continue;
-         try { Double.parseDouble(cell); }
-         catch(NumberFormatException e) { allNumeric = false; break; }
-      }
-      return allNumeric ? XSchema.DOUBLE : XSchema.STRING;
-   }
-
-   private static Object convertCell(String cell, String type) {
-      if(cell == null || cell.isBlank()) return null;
-      if(XSchema.DOUBLE.equals(type) || XSchema.FLOAT.equals(type) ||
-         XSchema.INTEGER.equals(type) || XSchema.LONG.equals(type))
-      {
-         try { return Double.parseDouble(cell.trim()); }
-         catch(NumberFormatException e) { return cell; }
-      }
-      return cell;
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -25,6 +25,7 @@ import inetsoft.sree.security.ResourceAction;
 import inetsoft.sree.security.ResourceType;
 import inetsoft.sree.security.SecurityEngine;
 import inetsoft.sree.security.SecurityException;
+import inetsoft.uql.ColumnSelection;
 import inetsoft.uql.XRepository;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.asset.internal.SQLBoundTableAssemblyInfo;
@@ -858,6 +859,195 @@ class WorksheetAgentControllerTest {
       assertNotNull(ws.getAssembly("Imported"));
    }
 
+   /**
+    * The import settings the Composer's Import Data File dialog exposes, now reachable through the
+    * agent too. Before this, the CSV route had its own hand-rolled parser that could honour none of
+    * them -- the origin of a cluster of L2 findings. These assert the settings actually reach
+    * {@code CSVLoader}, the loader the dialog itself uses.
+    */
+   private static WorksheetAgentController.ImportCsvRequest csvRequest(
+      String name, String csv, String encoding, String delimiter, Boolean tab, Boolean detectType,
+      Boolean firstRow, Boolean removeQuotes, Boolean unpivot, Integer headerCols)
+   {
+      return new WorksheetAgentController.ImportCsvRequest(
+         name, csv, encoding, delimiter, tab, detectType, firstRow, removeQuotes, unpivot,
+         headerCols);
+   }
+
+   private static EmbeddedTableAssembly importedTable(Worksheet ws, String name) {
+      Assembly a = ws.getAssembly(name);
+      assertNotNull(a, "expected an imported table named " + name);
+      assertInstanceOf(EmbeddedTableAssembly.class, a);
+      return (EmbeddedTableAssembly) a;
+   }
+
+   private static WorksheetAgentController importCtrl(Worksheet ws, String token) throws Exception {
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+      when(rws.getAssetQuerySandbox()).thenReturn(mock(AssetQuerySandbox.class));
+      return importController(token, rws);
+   }
+
+   /**
+    * The guard the owner asked for explicitly: an agent-imported table must stay a plain
+    * {@link EmbeddedTableAssembly}. The dialog builds a {@link SnapshotEmbeddedTableAssembly} from
+    * the same loader, and re-importing through this route is the documented way to get an editable
+    * copy of snapshot data -- so copying the dialog's choice here would quietly delete the only
+    * workaround L2 Finding 5 has.
+    */
+   @Test
+   void importCsvStaysAPlainEmbeddedTableRatherThanASnapshot() throws Exception {
+      Worksheet ws = new Worksheet();
+      WorksheetAgentController ctrl = importCtrl(ws, "TOK-PLAIN");
+
+      ctrl.importCsv("TOK-PLAIN",
+         new WorksheetAgentController.ImportCsvRequest("Plain", "a,b\n1,x"),
+         TestPrincipals.user("alice", "host-org"));
+
+      EmbeddedTableAssembly t = importedTable(ws, "Plain");
+      assertFalse(t instanceof SnapshotEmbeddedTableAssembly,
+         "an agent import must remain editable; a snapshot refuses edit_cell/insert_row/delete_row");
+   }
+
+   @Test
+   void importCsvDetectTypeFalseMakesEveryColumnString() throws Exception {
+      Worksheet ws = new Worksheet();
+      WorksheetAgentController ctrl = importCtrl(ws, "TOK-DT");
+
+      // The same file twice, differing only in detectType. With detection on, "$499.99" cannot be
+      // coerced to a number; with it off the column is text and the value survives intact -- which
+      // is the answer L2 Finding 8 was missing.
+      ctrl.importCsv("TOK-DT", csvRequest("Typed", "price\n299.99\n$499.99",
+                                          null, null, null, true, null, null, null, null),
+                     TestPrincipals.user("alice", "host-org"));
+      ctrl.importCsv("TOK-DT", csvRequest("AsText", "price\n299.99\n$499.99",
+                                          null, null, null, false, null, null, null, null),
+                     TestPrincipals.user("alice", "host-org"));
+
+      ColumnSelection typed = importedTable(ws, "Typed").getColumnSelection(false);
+      ColumnSelection text = importedTable(ws, "AsText").getColumnSelection(false);
+
+      assertEquals(XSchema.STRING, ((ColumnRef) text.getAttribute(0)).getDataType(),
+         "detectType=false must leave the column as string");
+      assertNotEquals(XSchema.STRING, ((ColumnRef) typed.getAttribute(0)).getDataType(),
+         "detectType=true must still detect a numeric column");
+   }
+
+   @Test
+   void importCsvFirstRowAsHeaderFalseGeneratesColumnNamesAndKeepsLineOne() throws Exception {
+      Worksheet ws = new Worksheet();
+      WorksheetAgentController ctrl = importCtrl(ws, "TOK-FR");
+
+      WorksheetAgentController.ImportCsvResponse resp = ctrl.importCsv(
+         "TOK-FR", csvRequest("NoHeader", "a,b\n1,x", null, null, null, null, false, null, null,
+                              null),
+         TestPrincipals.user("alice", "host-org"));
+
+      assertEquals(2, resp.rows(), "line 1 counts as data when it is not the header");
+      ColumnSelection cs = importedTable(ws, "NoHeader").getColumnSelection(false);
+      assertNotNull(cs.getAttribute("col0"), "generated names replace the missing header");
+      assertNotNull(cs.getAttribute("col1"));
+   }
+
+   @Test
+   void importCsvHonoursAnAlternateDelimiter() throws Exception {
+      Worksheet ws = new Worksheet();
+      WorksheetAgentController ctrl = importCtrl(ws, "TOK-DELIM");
+
+      WorksheetAgentController.ImportCsvResponse resp = ctrl.importCsv(
+         "TOK-DELIM", csvRequest("Semi", "a;b;c\n1;2;3", null, ";", null, null, null, null, null,
+                                 null),
+         TestPrincipals.user("alice", "host-org"));
+
+      assertEquals(3, resp.columns(), "a semicolon file is three columns, not one");
+      assertNotNull(importedTable(ws, "Semi").getColumnSelection(false).getAttribute("a"));
+   }
+
+   @Test
+   void importCsvHonoursTabAsTheDelimiter() throws Exception {
+      Worksheet ws = new Worksheet();
+      WorksheetAgentController ctrl = importCtrl(ws, "TOK-TAB");
+
+      WorksheetAgentController.ImportCsvResponse resp = ctrl.importCsv(
+         "TOK-TAB", csvRequest("Tabbed", "a\tb\n1\t2", null, null, true, null, null, null, null,
+                               null),
+         TestPrincipals.user("alice", "host-org"));
+
+      assertEquals(2, resp.columns());
+   }
+
+   @Test
+   void importCsvUnpivotReshapesCrosstabInput() throws Exception {
+      Worksheet ws = new Worksheet();
+      WorksheetAgentController ctrl = importCtrl(ws, "TOK-UP");
+
+      // A crosstab: one identifier column plus two measure columns. Unpivoting with one header
+      // column turns each measure cell into its own row.
+      WorksheetAgentController.ImportCsvResponse resp = ctrl.importCsv(
+         "TOK-UP", csvRequest("Unpivoted", "region,q1,q2\nEast,1,2\nWest,3,4",
+                              null, null, null, null, null, null, true, 1),
+         TestPrincipals.user("alice", "host-org"));
+
+      assertEquals(3, resp.columns(),
+         "unpivot yields the header column plus a name/value pair");
+      assertEquals(4, resp.rows(), "two rows times two measures");
+      importedTable(ws, "Unpivoted");
+   }
+
+   @Test
+   void importCsvRejectsAnUnsupportedEncoding() throws Exception {
+      Worksheet ws = new Worksheet();
+      WorksheetAgentController ctrl = importCtrl(ws, "TOK-ENC");
+
+      ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+         () -> ctrl.importCsvFile("TOK-ENC",
+            new MockMultipartFile("file", "d.csv", "text/csv", "a,b\n1,2".getBytes()),
+            "Bad", "NOT-A-CHARSET", null, null, null, null, null, null, null,
+            TestPrincipals.user("alice", "host-org")));
+
+      assertEquals(400, ex.getStatusCode().value());
+      assertTrue(ex.getReason().contains("NOT-A-CHARSET"), ex.getReason());
+   }
+
+   @Test
+   void importCsvRejectsAMultiCharacterDelimiter() throws Exception {
+      Worksheet ws = new Worksheet();
+      WorksheetAgentController ctrl = importCtrl(ws, "TOK-BADDELIM");
+
+      ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+         () -> ctrl.importCsv("TOK-BADDELIM",
+            csvRequest("X", "a,b\n1,2", null, "\\t", null, null, null, null, null, null),
+            TestPrincipals.user("alice", "host-org")));
+
+      assertEquals(400, ex.getStatusCode().value());
+      assertTrue(ex.getReason().contains("delimiterTab"),
+         "the refusal should point at the flag that does what the caller meant: " + ex.getReason());
+   }
+
+   /**
+    * The whole reason the multipart route exists: text handed over as JSON has already been
+    * decoded, so a non-UTF-8 file can only survive if its bytes make the trip. This is L2
+    * Finding 13.
+    */
+   @Test
+   void importCsvFileDecodesTheBytesWithTheGivenEncoding() throws Exception {
+      Worksheet ws = new Worksheet();
+      WorksheetAgentController ctrl = importCtrl(ws, "TOK-GBK");
+      // Built from code points so this source file stays ASCII: two CJK ideographs, which no
+      // single-byte charset can represent, so a wrong decode cannot round-trip by accident.
+      String header = new String(new char[] { 0x4ef7, 0x683c });
+      byte[] utf16 = (header + ",b\n1,2").getBytes(java.nio.charset.StandardCharsets.UTF_16LE);
+
+      ctrl.importCsvFile("TOK-GBK",
+         new MockMultipartFile("file", "d.csv", "text/csv", utf16),
+         "Encoded", "UTF-16LE", null, null, null, null, null, null, null,
+         TestPrincipals.user("alice", "host-org"));
+
+      ColumnSelection cs = importedTable(ws, "Encoded").getColumnSelection(false);
+      assertNotNull(cs.getAttribute(header),
+         "the header should decode back to its original characters");
+   }
+
    @Test
    void importCsvRejectsBlankCsv() {
       WorksheetAgentController ctrl = controller(featureOn(),
@@ -1434,7 +1624,7 @@ class WorksheetAgentControllerTest {
     * deliberately shared with the pane-scoped {@code WorksheetScriptService} caller, which has
     * ALREADY run its own narrow {@code PaneScopeService.check} and must not be refused again by
     * the broad whole-sheet check -- see {@link WorksheetAgentController#editOp} javadoc. So the
-    * guard here is 13 hand-written {@code requireWholeSheetSession(sessionToken, user)} calls,
+    * guard here is 14 hand-written {@code requireWholeSheetSession(sessionToken, user)} calls,
     * one per endpoint, and nothing before this test failed the build the day one of them went
     * missing.
     *
@@ -1444,7 +1634,7 @@ class WorksheetAgentControllerTest {
     * than trusting that the next endpoint's author remembers to add the call. {@code join} never
     * matches (no {@code {sessionToken}} in its path -- that is where one is minted); {@code
     * detach} matches but is explicitly exempted above, for the reason its own javadoc gives.
-    * Endpoint 14 fails THIS test the moment it omits the guard.
+    * Endpoint 15 fails THIS test the moment it omits the guard.
     */
    @Test
    void everySessionTokenEndpointRefusesAPaneScopedSessionOrIsExplicitlyExempt() {
@@ -1497,7 +1687,7 @@ class WorksheetAgentControllerTest {
          }
       }
 
-      assertTrue(checked >= 13, "Expected at least the 13 known session-scoped endpoints to " +
+      assertTrue(checked >= 14, "Expected at least the 14 known session-scoped endpoints to " +
          "be enumerated, found " + checked + " -- did WorksheetAgentController's mapping " +
          "annotations change shape?");
       assertTrue(notRefused.isEmpty(), "Endpoint(s) mapped with {sessionToken} did not refuse " +

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -1009,6 +1009,63 @@ class WorksheetAgentControllerTest {
       assertTrue(ex.getReason().contains("NOT-A-CHARSET"), ex.getReason());
    }
 
+   /**
+    * A name that is not merely unrecognized but syntactically illegal takes a different route out
+    * of {@code Charset}: it throws {@code IllegalCharsetNameException} instead of answering false.
+    * Unguarded that escapes as a 500; the caller made the same mistake either way, so it has to
+    * land on the same 400 as {@code importCsvRejectsAnUnsupportedEncoding}.
+    */
+   @Test
+   void importCsvRejectsAMalformedEncodingNameRatherThanThrowing() throws Exception {
+      Worksheet ws = new Worksheet();
+      WorksheetAgentController ctrl = importCtrl(ws, "TOK-BADENC");
+
+      ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+         () -> ctrl.importCsvFile("TOK-BADENC",
+            new MockMultipartFile("file", "d.csv", "text/csv", "a,b\n1,2".getBytes()),
+            "Bad", "not a charset", null, null, null, null, null, null, null,
+            TestPrincipals.user("alice", "host-org")));
+
+      assertEquals(400, ex.getStatusCode().value());
+      assertTrue(ex.getReason().contains("not a charset"), ex.getReason());
+   }
+
+   /**
+    * The JSON route cannot honour an encoding at all -- its text was decoded before the request
+    * existed. Refusing says so; silently ignoring it would leave a caller with mojibake and no
+    * indication of why their setting did nothing.
+    */
+   @Test
+   void importCsvRejectsANonUtf8EncodingOnTheJsonRoute() throws Exception {
+      Worksheet ws = new Worksheet();
+      WorksheetAgentController ctrl = importCtrl(ws, "TOK-JSONENC");
+
+      ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+         () -> ctrl.importCsv("TOK-JSONENC",
+            csvRequest("X", "a,b\n1,2", "ISO-8859-1", null, null, null, null, null, null, null),
+            TestPrincipals.user("alice", "host-org")));
+
+      assertEquals(400, ex.getStatusCode().value());
+      assertTrue(ex.getReason().contains("import-csv-file"),
+         "the refusal should point at the route that can honour it: " + ex.getReason());
+   }
+
+   /**
+    * UTF-8 spelled any of the ways the JDK accepts is what this route already does, so it is not a
+    * setting being ignored and must not be refused.
+    */
+   @Test
+   void importCsvAcceptsUtf8SpelledAsAnAliasOnTheJsonRoute() throws Exception {
+      Worksheet ws = new Worksheet();
+      WorksheetAgentController ctrl = importCtrl(ws, "TOK-UTF8");
+
+      ctrl.importCsv("TOK-UTF8",
+         csvRequest("Utf8", "a,b\n1,2", "utf8", null, null, null, null, null, null, null),
+         TestPrincipals.user("alice", "host-org"));
+
+      importedTable(ws, "Utf8");
+   }
+
    @Test
    void importCsvRejectsAMultiCharacterDelimiter() throws Exception {
       Worksheet ws = new Worksheet();


### PR DESCRIPTION
Closes L2 Finding 9 (and, with the plugin half, Finding 13) of the consolidated Composer plugin test plan. Plugin companion: inetsoft-technology/stylebi-wiz#1693.

## The finding's diagnosis was wrong, and that is most of what it was about

Finding 9 recorded that a stray quote in an unquoted field was stripped **in opposite directions** by the two import paths — the UI turning `'…"…"'` into `…"…"`, `import_csv_table` turning `'quoted "inner"'` into `'quoted inner'` — and concluded both parsers violate RFC 4180.

Neither was a parser defect:

- The **UI's** behaviour was the **Remove Quotation Marks** checkbox doing exactly what it says. Surrounding quotes are treated as escaping and dropped because the value inside is what was meant. Configured, not broken.
- The two paths "disagreeing" was not two buggy parsers. It was **one configured importer compared against a completely different one.**

## The second implementation is the defect

`importCsv` had its own `parseCsv` / `inferType` / `convertCell` — 83 lines whose own javadoc admitted that a newline inside a quoted field would be read as a row boundary. It could honour no encoding, no delimiter, no quote-stripping choice and no "first row is data" file, because none of those existed as inputs.

The Excel route immediately beside it had always done the opposite: multipart bytes, delegated to the product's `ExcelFileReader`. **CSV was the odd one out**, and this PR makes it consistent rather than introducing a new pattern.

The helpers are deleted. Both CSV routes now delegate to `CSVLoader.readCSV(...)`, the same loader `ImportCSVDialogService` calls, with every setting the Import Data File dialog exposes forwarded: `encoding`, `delimiter` (or Tab), `detectType`, `firstRowAsHeader`, `removeQuotes`, and `unpivot` with `headerCols`.

**Defaults reproduce the previous behaviour** — comma, header row, types detected, quotes untouched. The evidence for that claim is that the pre-existing `importCsvCreatesEmbeddedTable` round-trip test passed against the new implementation without being edited.

## Why a second endpoint rather than a flag

`import-csv-file` is separate from `import-csv` because the two differ in **what they can honour**, not merely in shape. The JSON route receives text that something else already decoded, so `encoding` cannot mean anything on it. Only bytes can carry a non-UTF-8 file — which is Finding 13, and it needed the transport, not a parameter.

## Two choices worth seeing in review

1. **The result stays a plain `EmbeddedTableAssembly` and is deliberately NOT the `SnapshotEmbeddedTableAssembly` the dialog builds from the same loader.** An agent import has to remain editable: re-importing is the documented workaround for a snapshot's read-only data (Finding 5), so copying the dialog's choice here would quietly delete the only workaround there is. A test pins it.
2. **`oldTypes` is an empty mutable map, not `null`.** The loader reads *and writes* through it; `null` throws inside `AssetUtil.initDefaultTypes`. Found by a test, not by reading.

Also here: `checkExcelFileSize` became `checkImportFileSize(size, what)`. It already consulted both `excel.import.max` and `csv.import.max`, so only its name and message were Excel-specific.

## What this closes downstream

One weak parser was the parent of several siblings in that test plan: Finding 13's mojibake is `encoding` plus byte transport; Finding 8's currency-to-`null` now has an answer on the agent side in `detectType: false` (the UI half remains Bug #76203); and 2.11's `Column0…Column11` surprise was `firstRowAsHeader`.

## Verification

`./mvnw -pl community/core test -Dtest='inetsoft.web.wiz.**'` — **1931 tests, 0 failures, 0 errors**, 1 pre-existing skip, BUILD SUCCESS.

Ten new tests cover: the plain-embedded guard above; `detectType:false` keeping `$499.99` as text where detection turns it to `null`; `firstRowAsHeader:false` generating `col0`/`col1` and keeping line 1 as data; a semicolon delimiter; Tab; unpivot reshaping a crosstab; a UTF-16LE file round-tripping its CJK header through the multipart route; and refusals for an unsupported charset name and a multi-character delimiter. The reflective whole-sheet-guard test's floor moved 13 → 14, which is also what proves the new endpoint is enumerated by it.

Not yet exercised against a running Composer — that needs this branch installed and the server restarted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
