### PR TITLE
Create a worksheet table from one endpoint of a SaaS connector

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/model/WorksheetTable.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WorksheetTable.java
@@ -21,6 +21,7 @@ package inetsoft.web.wiz.model;
 import com.fasterxml.jackson.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * One table definition within a POST /api/wiz/ws/table batch request.
@@ -63,6 +64,20 @@ public class WorksheetTable {
     */
    private String sqlExpression;
 
+   // ─── Tabular-table field ──────────────────────────────────────────────────
+
+   /**
+    * Source of a {@code tableType == "tabular table"}: one endpoint of a SaaS/REST connector,
+    * plus the values for that endpoint's parameters.
+    *
+    * <p>Separate from {@link PhysicalSource} rather than an overload of it, because the two name
+    * different things. A physical source names a table that already exists with a known column
+    * list; a tabular source names an API CALL, and its column list does not exist until the call
+    * has been made — which is why {@code columns} is not honored for this table type, and why the
+    * response's column list is the first time anyone learns what the table holds.</p>
+    */
+   private TabularSource tabularSource;
+
    // ─── Mirror / join base tables ────────────────────────────────────────────
 
    /** Names of already-created tables in this worksheet to use as bases. */
@@ -100,6 +115,9 @@ public class WorksheetTable {
 
    public PhysicalSource getPhysicalSource() { return physicalSource; }
    public void setPhysicalSource(PhysicalSource physicalSource) { this.physicalSource = physicalSource; }
+
+   public TabularSource getTabularSource() { return tabularSource; }
+   public void setTabularSource(TabularSource tabularSource) { this.tabularSource = tabularSource; }
 
    public List<ColumnInfo> getColumns() { return columns; }
    public void setColumns(List<ColumnInfo> columns) { this.columns = columns; }
@@ -151,6 +169,58 @@ public class WorksheetTable {
       public void setTableName(String tableName) { this.tableName = tableName; }
       public String getCatalog() { return catalog; }
       public void setCatalog(String catalog) { this.catalog = catalog; }
+   }
+
+   // ─── Nested: tabular source ───────────────────────────────────────────────
+
+   @JsonIgnoreProperties(ignoreUnknown = true)
+   public static class TabularSource {
+      private String datasourcePath;
+      private String endpoint;
+      private Map<String, String> parameters;
+      private String jsonPath;
+      private Boolean expanded;
+      private String expandedPath;
+      private Integer maxRows;
+
+      /** Full repository path of the connector INSTANCE, e.g. "SaaS/Stripe Prod". */
+      public String getDatasourcePath() { return datasourcePath; }
+      public void setDatasourcePath(String datasourcePath) { this.datasourcePath = datasourcePath; }
+
+      /**
+       * The connector's own name for the endpoint, e.g. "Charges". Matched exactly against the
+       * connector's endpoint map, which is keyed by that name and rejects duplicates
+       * ({@code EndpointJsonQuery.Endpoints.toMap}).
+       */
+      public String getEndpoint() { return endpoint; }
+      public void setEndpoint(String endpoint) { this.endpoint = endpoint; }
+
+      /**
+       * Values by parameter NAME — the name part of a <code>{...}</code> token in the endpoint's URL
+       * suffix template, which is what {@code RestParameter.getName()} answers. A name this endpoint
+       * does not declare is rejected rather than ignored: silently dropping it would run a request
+       * narrower than the one that was asked for and report success.
+       */
+      public Map<String, String> getParameters() { return parameters; }
+      public void setParameters(Map<String, String> parameters) { this.parameters = parameters; }
+
+      /** JSON path to the row array, e.g. "$.data[*]". Null keeps the connector's default. */
+      public String getJsonPath() { return jsonPath; }
+      public void setJsonPath(String jsonPath) { this.jsonPath = jsonPath; }
+
+      public Boolean getExpanded() { return expanded; }
+      public void setExpanded(Boolean expanded) { this.expanded = expanded; }
+      public String getExpandedPath() { return expandedPath; }
+      public void setExpandedPath(String expandedPath) { this.expandedPath = expandedPath; }
+
+      /**
+       * Row cap for this query, persisted ON THE QUERY so EVERY later execution is bounded — not
+       * just the column-discovery one. Required in practice: {@code createTables} sets
+       * {@code designMaxRows = 0} (unlimited) for wiz analytics, which on a paginated metered API
+       * means paging to the end of the customer's data on every render.
+       */
+      public Integer getMaxRows() { return maxRows; }
+      public void setMaxRows(Integer maxRows) { this.maxRows = maxRows; }
    }
 
    // ─── Nested: column info ─────────────────────────────────────────────────

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -875,6 +875,14 @@ public class MetadataApiService {
       if(tableAssembly instanceof PhysicalBoundTableAssembly) {
          return "physical table";
       }
+      // TabularTableAssembly extends BoundTableAssembly, not PhysicalBoundTableAssembly, so the
+      // position of this branch is free; it is here to read in the same order as
+      // WorksheetTableService's switch. Without it a tabular table falls through to the
+      // getSimpleName() default and this endpoint answers "TabularTableAssembly", a type name
+      // no caller of the construction endpoint knows.
+      else if(tableAssembly instanceof TabularTableAssembly) {
+         return "tabular table";
+      }
       else if(tableAssembly instanceof MirrorTableAssembly) {
          return "mirror table";
       }

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -755,23 +755,24 @@ public class WorksheetTableService {
       }
 
       // Verify READ permission on the datasource before resolving/using it. physicalSource covers
-      // physical table and sql query table; tabularSource covers tabular table, and it is read
-      // here rather than inside the builder for the same reason the other one is — the check must
-      // precede every use of the path, including the one that dials a remote endpoint.
-      // Mirror/join tables only reference already-in-worksheet assemblies, so there is no new
-      // datasource to check for them.
+      // physical table and sql query table bind one through physicalSource; tabular table binds one
+      // through tabularSource. Read here rather than inside each builder for the same reason the
+      // physical check always was — it must precede every use of the path, including the one that
+      // dials a remote endpoint. Mirror/join tables only reference already-in-worksheet assemblies,
+      // so there is no new datasource to check for them.
       // Mirrors WorksheetAgentController.addLogicalModelTable's usage of DataSourceService.
+      //
+      // KEYED ON tableType, NEVER ON WHICH FIELD HAPPENS TO BE SET. tableType is what selects the
+      // builder below, so it is the only thing that can say which path will actually be used. Picking
+      // by field presence let a tabular request carrying BOTH fields be checked against its
+      // physicalSource — a path no tabular code path ever reads — and then reach the connector on its
+      // unchecked tabularSource path. buildTabularTable rejects the mismatched pair outright as well;
+      // this line is what makes the check itself correct.
       WorksheetTable.PhysicalSource src = request.getPhysicalSource();
-      String datasourcePath = null;
-
-      if(src != null && src.getDatasourcePath() != null) {
-         datasourcePath = src.getDatasourcePath();
-      }
-      else if(request.getTabularSource() != null &&
-              request.getTabularSource().getDatasourcePath() != null)
-      {
-         datasourcePath = request.getTabularSource().getDatasourcePath();
-      }
+      WorksheetTable.TabularSource tabularSrc = request.getTabularSource();
+      String datasourcePath = "tabular table".equals(tableType)
+         ? (tabularSrc != null ? tabularSrc.getDatasourcePath() : null)
+         : (src != null ? src.getDatasourcePath() : null);
 
       if(datasourcePath != null &&
          !dataSourceService.checkPermission(datasourcePath, ResourceAction.READ, user))
@@ -992,6 +993,17 @@ public class WorksheetTableService {
          throw new IllegalArgumentException("tabularSource.endpoint is required for tabular table");
       }
 
+      // Meaningless in every direction: nothing on this path reads physicalSource, so a request
+      // carrying both names two sources and gets one of them silently ignored. It is also the shape
+      // that made the READ gate checkable against the wrong path when the gate keyed on field
+      // presence, so it is refused rather than tolerated.
+      if(request.getPhysicalSource() != null) {
+         throw new IllegalArgumentException(
+            "a tabular table cannot carry physicalSource — it is bound through tabularSource. " +
+            "Remove physicalSource, or use tableType \"physical table\" if a database table is what " +
+            "was meant.");
+      }
+
       // Rejected rather than ignored, and checked before anything is dialed: a tabular table's
       // columns are discovered by the request below, so a caller cannot know them beforehand, and
       // silently dropping the list would answer a request nobody made.
@@ -1028,8 +1040,15 @@ public class WorksheetTableService {
          throw new IllegalArgumentException("Data source not found: " + dsName);
       }
 
+      // Not UnsupportedDatasourceException: its message is hard-coded to "Annotations are currently
+      // not supported for ... datasources", which is true where it was introduced and nonsense here.
+      // The type buys nothing on this path either — createTables catches per table and keeps only
+      // rootMessage(e), so it never reaches the handler that gives the type meaning.
       if(!(dataSource instanceof TabularDataSource)) {
-         throw new UnsupportedDatasourceException(dsName, dataSource.getType());
+         throw new IllegalArgumentException(
+            "'" + dsName + "' is a " + dataSource.getType() + " data source, not a tabular/REST one, " +
+            "so it has no endpoints to call. Use tableType \"physical table\" or \"sql query table\" " +
+            "for a database.");
       }
 
       // createQuery logs and returns null on every failure — a missing connector plugin, an
@@ -1055,6 +1074,9 @@ public class WorksheetTableService {
       // on a paginated metered API means paging to the end of the customer's data every time.
       if(src.getMaxRows() != null && src.getMaxRows() > 0) {
          query.setMaxRows(src.getMaxRows());
+      }
+      else {
+         requireRowCapWhenPaged(query, src.getEndpoint(), dsName);
       }
 
       TabularTableAssembly table = new TabularTableAssembly(worksheet, request.getTableName());
@@ -1221,6 +1243,44 @@ public class WorksheetTableService {
       }
 
       return s;
+   }
+
+   /**
+    * Refuse an unbounded row limit on an endpoint that paginates.
+    *
+    * <p>{@code XQuery.rowlimit} defaults to 0, meaning unlimited, and on a paginated connector that
+    * is not "read a lot" — it is "keep requesting pages until the service runs out", on every render
+    * of the table, against an API that bills per call. Neither obvious remedy is right: requiring a
+    * cap unconditionally makes a caller invent a number for an endpoint like {@code /v1/balance} that
+    * issues one request and returns one object, and defaulting silently trades a slow answer for a
+    * wrong one — a table that quietly returns 100 of 5000 rows answers "how many are there"
+    * incorrectly, with nothing in the response saying so.</p>
+    *
+    * <p>So the condition checked is the one that actually matters, and it is accurate by now:
+    * {@code setEndpoint} ran the connector's {@code updatePagination}, which is what establishes the
+    * pagination spec. {@code isPaged()} is public but not a {@code @Property}, so it is reached by
+    * name — the same reflection {@link #assertKnownEndpoint} uses for {@code getEndpoints}. A
+    * connector that does not answer it is left alone rather than blocked: this check exists to stop a
+    * known-unbounded query, not to reject an unfamiliar one.</p>
+    */
+   private void requireRowCapWhenPaged(TabularQuery query, String endpoint, String dsName) {
+      boolean paged;
+
+      try {
+         paged = (Boolean) query.getClass().getMethod("isPaged").invoke(query);
+      }
+      catch(Exception ex) {
+         LOG.debug("Could not determine whether endpoint '{}' of '{}' paginates; not requiring a " +
+                   "row cap", endpoint, dsName, ex);
+         return;
+      }
+
+      if(paged) {
+         throw new IllegalArgumentException(
+            "Endpoint '" + endpoint + "' of '" + dsName + "' is paginated, so tabularSource.maxRows " +
+            "is required: without it every render of this table requests pages until the service runs " +
+            "out of data. Choose a row cap for the question being asked.");
+      }
    }
 
    /** Set a property only when a value was supplied, leaving the connector's default otherwise. */

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -1002,6 +1002,20 @@ public class WorksheetTableService {
             "the response, then select or rename them on a mirror table over it.");
       }
 
+      // applyExpressionColumns/applyWindowColumns are reached from buildPhysicalTable and
+      // buildMirrorTable only, so on this type they would be accepted and then never applied — a
+      // table that reports success while quietly lacking the derived column the caller asked for.
+      // Rejected instead, and pointed at the mirror, which is where a derived column over an
+      // endpoint belongs anyway: it needs the column list this call has not produced yet.
+      if((request.getExpressionColumns() != null && !request.getExpressionColumns().isEmpty()) ||
+         (request.getWindowColumns() != null && !request.getWindowColumns().isEmpty()))
+      {
+         throw new IllegalArgumentException(
+            "expressionColumns/windowColumns are not supported for tableType \"tabular table\" — a " +
+            "derived column needs the endpoint's columns, which do not exist until this request has " +
+            "run. Put them on a mirror table over this one, in a later call.");
+      }
+
       String dsName = src.getDatasourcePath();
 
       // Answered before createQuery rather than inferred from its failure. Pointed at a JDBC

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -30,6 +30,7 @@ import inetsoft.uql.*;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.asset.internal.AssetUtil;
 import inetsoft.uql.asset.internal.SQLBoundTableAssemblyInfo;
+import inetsoft.uql.asset.internal.TabularTableAssemblyInfo;
 import inetsoft.uql.erm.*;
 import inetsoft.uql.jdbc.JDBCDataSource;
 import inetsoft.uql.jdbc.JDBCQuery;
@@ -39,6 +40,12 @@ import inetsoft.uql.jdbc.util.SQLTypes;
 import inetsoft.uql.schema.UserVariable;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.schema.XTypeNode;
+import inetsoft.uql.tabular.PropertyMeta;
+import inetsoft.uql.tabular.RestParameter;
+import inetsoft.uql.tabular.RestParameters;
+import inetsoft.uql.tabular.TabularDataSource;
+import inetsoft.uql.tabular.TabularQuery;
+import inetsoft.uql.tabular.TabularUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import inetsoft.util.Catalog;
@@ -54,6 +61,7 @@ import org.springframework.stereotype.Service;
 
 import java.security.Principal;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static inetsoft.web.wiz.service.GenerateWsService.WORKSHEET_ROOT_FOLDER_PATH;
 import static inetsoft.web.wiz.service.WizDateLevelUtil.getDateGroupLevel;
@@ -746,17 +754,30 @@ public class WorksheetTableService {
          throw new IllegalArgumentException("tableType is required");
       }
 
-      // Verify READ permission on the datasource before resolving/using it (physical table and
-      // sql query table both bind to one via physicalSource; mirror/join tables only reference
-      // already-in-worksheet assemblies, so there is no new datasource to check for them).
+      // Verify READ permission on the datasource before resolving/using it. physicalSource covers
+      // physical table and sql query table; tabularSource covers tabular table, and it is read
+      // here rather than inside the builder for the same reason the other one is — the check must
+      // precede every use of the path, including the one that dials a remote endpoint.
+      // Mirror/join tables only reference already-in-worksheet assemblies, so there is no new
+      // datasource to check for them.
       // Mirrors WorksheetAgentController.addLogicalModelTable's usage of DataSourceService.
       WorksheetTable.PhysicalSource src = request.getPhysicalSource();
+      String datasourcePath = null;
 
-      if(src != null && src.getDatasourcePath() != null &&
-         !dataSourceService.checkPermission(src.getDatasourcePath(), ResourceAction.READ, user))
+      if(src != null && src.getDatasourcePath() != null) {
+         datasourcePath = src.getDatasourcePath();
+      }
+      else if(request.getTabularSource() != null &&
+              request.getTabularSource().getDatasourcePath() != null)
+      {
+         datasourcePath = request.getTabularSource().getDatasourcePath();
+      }
+
+      if(datasourcePath != null &&
+         !dataSourceService.checkPermission(datasourcePath, ResourceAction.READ, user))
       {
          throw new IllegalArgumentException(
-            "Access denied: no READ permission on datasource " + src.getDatasourcePath());
+            "Access denied: no READ permission on datasource " + datasourcePath);
       }
 
       // Free-Form SQL action gate ("Visual Composer -> Free Form SQL"): a raw sql query table
@@ -776,6 +797,7 @@ public class WorksheetTableService {
          case "mirror table"          -> buildMirrorTable(worksheet, request);
          case "relational join table" -> buildJoinTable(worksheet, request);
          case "sql query table"       -> buildSqlTable(worksheet, request);
+         case "tabular table"         -> buildTabularTable(worksheet, request);
          default -> throw new IllegalArgumentException("Unknown tableType: " + tableType);
       };
 
@@ -936,6 +958,307 @@ public class WorksheetTableService {
 
       worksheet.addAssembly(table);
       return table;
+   }
+
+   /**
+    * Build a {@link TabularTableAssembly} bound to ONE endpoint of a SaaS/REST connector.
+    *
+    * <p>Follows the six steps {@code TabularQueryDialogService.setUpTable} takes, with the dialog's
+    * {@code TabularView} round trip left out. The dialog needs a view because a human drives it; the
+    * two things a caller supplies here — which endpoint, and what its parameters are — are plain
+    * annotated bean properties, so {@link TabularUtil#getPropertyMap} reaches them directly. That
+    * also keeps {@code TabularUtil.callButtonMethods} out of the path, which is the only reader of
+    * the {@code TabularUtil.sessionId} ThreadLocal — so unlike {@code WizTabularController}, this
+    * path needs no connector session bound around it.</p>
+    *
+    * <p>THIS METHOD SENDS A REAL REQUEST. {@code loadColumnSelection} is how the column list comes
+    * into existence — a tabular query has none until one response has been parsed
+    * ({@code TabularQuery.loadOutputColumns} runs it under {@code HINT_PREVIEW} at 100 rows). So the
+    * request is metered, and a failure there is a failure of the whole table. It is also why this
+    * type is left out of {@link #shouldProbe}: the probe would send a second request to answer a
+    * question the non-empty column check below already answers.</p>
+    */
+   private AbstractTableAssembly buildTabularTable(Worksheet worksheet, WorksheetTable request)
+      throws Exception
+   {
+      WorksheetTable.TabularSource src = request.getTabularSource();
+
+      if(src == null || src.getDatasourcePath() == null || src.getDatasourcePath().isBlank()) {
+         throw new IllegalArgumentException(
+            "tabularSource.datasourcePath is required for tabular table");
+      }
+
+      if(src.getEndpoint() == null || src.getEndpoint().isBlank()) {
+         throw new IllegalArgumentException("tabularSource.endpoint is required for tabular table");
+      }
+
+      // Rejected rather than ignored, and checked before anything is dialed: a tabular table's
+      // columns are discovered by the request below, so a caller cannot know them beforehand, and
+      // silently dropping the list would answer a request nobody made.
+      if(request.getColumns() != null && !request.getColumns().isEmpty()) {
+         throw new IllegalArgumentException(
+            "'columns' is not supported for tableType \"tabular table\" — an endpoint has no column " +
+            "list until its request has run. Create the tabular table first, read the columns from " +
+            "the response, then select or rename them on a mirror table over it.");
+      }
+
+      String dsName = src.getDatasourcePath();
+
+      // Answered before createQuery rather than inferred from its failure. Pointed at a JDBC
+      // database, createQuery resolves that type's query class and hands back a JDBCQuery — the
+      // property map below then simply has no "endpoint", and the caller is told the connector is
+      // not endpoint-based when the real answer is that this is not a tabular data source at all.
+      XDataSource dataSource = xrepository.getDataSource(dsName);
+
+      if(dataSource == null) {
+         throw new IllegalArgumentException("Data source not found: " + dsName);
+      }
+
+      if(!(dataSource instanceof TabularDataSource)) {
+         throw new UnsupportedDatasourceException(dsName, dataSource.getType());
+      }
+
+      // createQuery logs and returns null on every failure — a missing connector plugin, an
+      // unregistered type, an inaccessible query class all arrive as the same null. Absent this
+      // guard the NPE lands two frames down with no mention of the data source.
+      TabularQuery query = TabularUtil.createQuery(dsName);
+
+      if(query == null) {
+         throw new IllegalArgumentException(
+            "Could not create a query for data source '" + dsName + "' (type '" +
+            dataSource.getType() + "') — its connector plugin may not be loaded.");
+      }
+
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(query.getClass());
+
+      // Fills endpoint + parameters + parsing options, and returns the fully built URL suffix as
+      // proof that all of it landed. Throws with every problem named; see the method.
+      String suffix = applyEndpointContract(query, pmap, src);
+
+      // Persisted on the query (XQuery.rowlimit, written as <maxrows>) rather than passed as a
+      // HINT_MAX_ROWS hint: a hint bounds one execution, and what has to stay bounded is every
+      // future render of this table. createTables sets designMaxRows to 0 for wiz analytics, which
+      // on a paginated metered API means paging to the end of the customer's data every time.
+      if(src.getMaxRows() != null && src.getMaxRows() > 0) {
+         query.setMaxRows(src.getMaxRows());
+      }
+
+      TabularTableAssembly table = new TabularTableAssembly(worksheet, request.getTableName());
+      TabularTableAssemblyInfo info = (TabularTableAssemblyInfo) table.getTableInfo();
+      info.setQuery(query);
+
+      // Prefix and source are both the data source path, which is what the composer dialog writes
+      // too. The endpoint is NOT in the SourceInfo — it lives inside the query bean — so nothing
+      // reading only SourceInfo (notably MetadataApiService.extractStructureSource) can say which
+      // endpoint a tabular table came from.
+      info.setSourceInfo(new SourceInfo(SourceInfo.DATASOURCE, dsName, dsName));
+
+      // A fresh VariableTable and a null QueryManager, matching what
+      // TabularTableAssembly.dependencyChanged passes and what buildSqlTable uses for its own column
+      // resolution. Taking an AssetQuerySandbox instead would mean either disposing it — leaving the
+      // "queryManager" property pointing at a dead object on a query that outlives it — or leaking
+      // it. The cost is that this one column-discovery request cannot be cancelled, and that
+      // user-entered query variables are unavailable; the parameter values here are literals,
+      // already substituted into the suffix above.
+      table.loadColumnSelection(new VariableTable(), true, null);
+
+      // loadColumnSelection reports a failed request with LOG.warn and returns normally. Without
+      // this check the assembly is persisted with zero columns and /ws/table answers success=true
+      // with an empty column list — an error that first becomes visible when a chart is bound to
+      // the table and renders nothing.
+      ColumnSelection columns = table.getColumnSelection(false);
+
+      if(columns == null || columns.getAttributeCount() == 0) {
+         throw new IllegalArgumentException(
+            "The request to endpoint '" + src.getEndpoint() + "' of '" + dsName +
+            "' returned no columns. URL suffix sent: " + suffix +
+            ". Check the parameter values and that the data source's credentials are valid; the " +
+            "underlying cause is in the server log for this request.");
+      }
+
+      worksheet.addAssembly(table);
+      return table;
+   }
+
+   /**
+    * Set the endpoint and its parameter values on a tabular query, and return the URL suffix that
+    * results.
+    *
+    * <p>ORDER IS NOT INTERCHANGEABLE. {@code getParameters()} derives the contract from the endpoint
+    * currently set on the bean ({@code EndpointQueryDelegate.createParameters} scans that endpoint's
+    * suffix template with {@code RestParameter.fromToken}), so setting the endpoint has to come
+    * first — reversed, the contract comes back empty and every supplied value is reported as
+    * unknown. Setting the endpoint also does more than record a name: the connector's
+    * {@code updatePagination} runs from inside the setter and is what establishes the pagination
+    * spec, the request method and the content type.</p>
+    *
+    * <p>NOTHING HERE TRUSTS THAT A WRITE HAPPENED. {@code PropertyMeta.setValue} reports a failed
+    * invocation with {@code LOG.error} and returns, and {@code createParameters} skips a token its
+    * parser rejects with a {@code LOG.warn}. Both are silent to the caller, and the observable
+    * result of either is a request that goes out narrower than the one that was asked for. So every
+    * write is checked, by read-back where possible and by the suffix at the end.</p>
+    *
+    * @return the built URL suffix, with every parameter substituted.
+    */
+   private String applyEndpointContract(TabularQuery query,
+                                        Map<String, PropertyMeta> pmap,
+                                        WorksheetTable.TabularSource src)
+      throws Exception
+   {
+      PropertyMeta endpointProp = pmap.get("endpoint");
+
+      if(endpointProp == null) {
+         throw new IllegalArgumentException(
+            "Data source '" + src.getDatasourcePath() + "' (type '" + query.getType() +
+            "') is tabular but not endpoint-based, so it has no endpoint to select. Only connectors " +
+            "that ship an endpoint catalogue can be used as a tabular table this way.");
+      }
+
+      String endpoint = src.getEndpoint().trim();
+      assertKnownEndpoint(query, endpoint, src.getDatasourcePath());
+      endpointProp.setValue(query, endpoint);
+
+      // Read back, because setValue swallows a failed invocation. Everything below derives from the
+      // endpoint being set, so an unnoticed failure here produces an empty contract and a null
+      // suffix, both of which are much harder to attribute than this line.
+      if(!endpoint.equals(endpointProp.getValue(query))) {
+         throw new IllegalStateException(
+            "Failed to select endpoint '" + endpoint + "' on the query for '" +
+            src.getDatasourcePath() + "'; see the server log for the reflection failure.");
+      }
+
+      // Read AFTER the endpoint is set, because that is when the connector's updatePagination has
+      // decided it. A POST endpoint is refused rather than attempted: the body it needs is carried
+      // on a private field of the connector's query and is only moved into the request body by
+      // populateRequestBodyTemplate, a dialog BUTTON method this property-based path never runs.
+      // Attempting one sends an empty body, which most APIs answer with a 400 and some with an
+      // unfiltered full result.
+      PropertyMeta requestTypeProp = pmap.get("requestType");
+
+      if(requestTypeProp != null && "POST".equals(requestTypeProp.getValue(query))) {
+         throw new IllegalArgumentException(
+            "Endpoint '" + endpoint + "' of '" + src.getDatasourcePath() + "' is a POST endpoint, " +
+            "which cannot be created this way yet: its request body comes from a template that only " +
+            "the connector's own dialog populates. Choose a GET endpoint.");
+      }
+
+      PropertyMeta paramProp = pmap.get("parameters");
+      Object contract = paramProp == null ? null : paramProp.getValue(query);
+
+      if(!(contract instanceof RestParameters params)) {
+         throw new IllegalStateException(
+            "Could not read the parameter contract for endpoint '" + endpoint + "' of '" +
+            src.getDatasourcePath() + "'.");
+      }
+
+      Map<String, String> supplied = src.getParameters() == null
+         ? new LinkedHashMap<>() : new LinkedHashMap<>(src.getParameters());
+      List<String> missing = new ArrayList<>();
+
+      for(RestParameter parameter : params.getParameters()) {
+         String value = supplied.remove(parameter.getName());
+
+         if(value != null && !value.isBlank()) {
+            parameter.setValue(value.trim());
+         }
+         else if(parameter.isRequired()) {
+            missing.add(parameter.getName());
+         }
+      }
+
+      // Every missing required name at once. SuffixTemplate.build() does raise a clear
+      // IllegalStateException for a missing required parameter, but only for the FIRST one it walks
+      // into, so a caller filling three of five would need three round trips to learn all of them —
+      // and every round trip past this point is a metered request.
+      if(!missing.isEmpty()) {
+         throw new IllegalArgumentException(
+            "Endpoint '" + endpoint + "' requires parameter(s) with no value supplied: " +
+            String.join(", ", missing) + ". Supply them; do not guess an identifier.");
+      }
+
+      // A name the endpoint does not declare is an error, not something to drop. Dropping it runs a
+      // DIFFERENT query than the one that was asked for and reports success — and the likeliest
+      // cause is a caller using another endpoint's contract, which no later step can detect.
+      if(!supplied.isEmpty()) {
+         throw new IllegalArgumentException(
+            "Endpoint '" + endpoint + "' has no parameter(s) named: " +
+            String.join(", ", supplied.keySet()) + ". Its parameters are: " +
+            params.getParameters().stream()
+               .map(p -> p.getName() + (p.isRequired() ? " (required)" : ""))
+               .collect(Collectors.joining(", ")) + ".");
+      }
+
+      paramProp.setValue(query, params);
+      setOptionalProperty(pmap, query, "jsonPath", src.getJsonPath());
+      setOptionalProperty(pmap, query, "expanded", src.getExpanded());
+      setOptionalProperty(pmap, query, "expandedPath", src.getExpandedPath());
+
+      // The one end-to-end check, and the reason it is worth a line of its own: reading "suffix"
+      // back invokes the connector's getSuffix(), which rebuilds the URL from the endpoint template
+      // and the values just set. A null means one of the silent paths above fired after all — the
+      // endpoint name resolved to no template, or a parameter never made it onto the bean.
+      PropertyMeta suffixProp = pmap.get("suffix");
+      Object suffix = suffixProp == null ? null : suffixProp.getValue(query);
+
+      if(!(suffix instanceof String s) || s.isBlank()) {
+         throw new IllegalStateException(
+            "Endpoint '" + endpoint + "' of '" + src.getDatasourcePath() + "' produced no URL " +
+            "suffix after its parameters were set; see the server log.");
+      }
+
+      return s;
+   }
+
+   /** Set a property only when a value was supplied, leaving the connector's default otherwise. */
+   private void setOptionalProperty(Map<String, PropertyMeta> pmap, TabularQuery query,
+                                    String name, Object value)
+   {
+      PropertyMeta prop = value == null ? null : pmap.get(name);
+
+      if(prop != null) {
+         prop.setValue(query, value);
+      }
+   }
+
+   /**
+    * Fail on an unknown endpoint name, listing what the connector does offer.
+    *
+    * <p>Without this the name simply resolves to no suffix template and the failure surfaces as
+    * "produced no URL suffix", which does not say that the name was wrong. The tags method is
+    * reached by name because the interface declaring it lives in the connector plugin and is not
+    * visible from core; each row it returns is {@code {label, name}}.</p>
+    */
+   private void assertKnownEndpoint(TabularQuery query, String endpoint, String dsName) {
+      String[][] endpoints;
+
+      try {
+         endpoints = (String[][]) query.getClass().getMethod("getEndpoints").invoke(query);
+      }
+      catch(Exception ex) {
+         // Not fatal: a connector without this method still works, and applyEndpointContract's
+         // suffix check catches a bad name — just with a vaguer message.
+         LOG.debug("Could not list endpoints for '{}'; skipping the name check", dsName, ex);
+         return;
+      }
+
+      if(endpoints == null) {
+         return;
+      }
+
+      List<String> names = new ArrayList<>();
+
+      for(String[] tag : endpoints) {
+         if(tag != null && tag.length > 1 && tag[1] != null) {
+            names.add(tag[1]);
+         }
+      }
+
+      if(!names.isEmpty() && !names.contains(endpoint)) {
+         List<String> sample = names.stream().sorted().limit(20).toList();
+         throw new IllegalArgumentException(
+            "Data source '" + dsName + "' has no endpoint named '" + endpoint + "'. It has " +
+            names.size() + " endpoint(s), for example: " + String.join(", ", sample) + ".");
+      }
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceStructureTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServiceStructureTest.java
@@ -114,6 +114,18 @@ class MetadataApiServiceStructureTest {
    }
 
    @Test
+   void classifiesTabularTable() {
+      // Not a cosmetic branch: without it a tabular table reaches the getSimpleName() fallback
+      // below and this endpoint reports "TabularTableAssembly", a name that is not one of the
+      // tableType strings /ws/table accepts. Anything that reads a worksheet back and builds on it
+      // — incremental creation, reusing a table from an earlier turn — then fails to recognize its
+      // own table.
+      Worksheet ws = new Worksheet();
+      TabularTableAssembly t = new TabularTableAssembly(ws, "endpointTable");
+      assertEquals("tabular table", MetadataApiService.structureTableType(t));
+   }
+
+   @Test
    void fallsBackToSimpleClassNameForUnrecognizedType() {
       // UnpivotTableAssembly isn't one of the four classified types, so it exercises the
       // getClass().getSimpleName() fallback branch.

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServicePermissionTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServicePermissionTest.java
@@ -60,7 +60,8 @@ import static org.mockito.Mockito.when;
  *   <li>{@code checkWorksheetActionPermission} — the "Visual Composer -> Data Worksheet" action-level
  *       gate checked at the top of {@code createTables} and {@code deleteTables}.</li>
  *   <li>The datasource READ check inside {@code createTables}'s {@code buildTable} step, gating
- *       physical/sql-query tables bound to a {@code physicalSource.datasourcePath}.</li>
+ *       physical/sql-query tables bound to a {@code physicalSource.datasourcePath} and
+ *       tabular tables bound to a {@code tabularSource.datasourcePath}.</li>
  * </ul>
  *
  * <p>These tests only assert on the gate itself. The action-level WORKSHEET/ACCESS gate is checked
@@ -244,6 +245,73 @@ class WorksheetTableServicePermissionTest {
       verify(deps.dataSourceService).checkPermission(eq("myds"), eq(ResourceAction.READ), eq(USER));
    }
 
+   // ─── createTable -> buildTable: tabular table datasource READ gate ────────
+
+   /**
+    * The same gate, reached through {@code tabularSource} instead of {@code physicalSource}.
+    *
+    * <p>Worth its own pair rather than trusting the physical-table pair: the gate reads the path off
+    * whichever of the two fields carries one, and a tabular table supplies it in the other field. An
+    * earlier shape of this check looked only at {@code physicalSource}, which let a tabular table
+    * reach the connector — and dial its remote endpoint — with no READ check at all.</p>
+    */
+   @Test
+   void createTableTabularTableFailsWhenDatasourceReadDenied() throws Exception {
+      Deps deps = new Deps();
+      when(deps.securityEngine.checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                               eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      when(deps.dataSourceService.checkPermission(eq("myds"), eq(ResourceAction.READ), eq(USER)))
+         .thenReturn(false);
+
+      WorksheetTableRequest request = batchOf("""
+         {
+           "tableName": "t1",
+           "tableType": "tabular table",
+           "tabularSource": { "datasourcePath": "myds", "endpoint": "Charges" }
+         }
+         """);
+
+      WorksheetTableResponse table = only(deps.service().createTables(request, USER));
+      assertFalse(table.isSuccess());
+      assertTrue(table.getErrorMessage().contains("no READ permission on datasource myds"),
+                 "error should name the denied datasource, got: " + table.getErrorMessage());
+
+      // Denial short-circuits before the data source is even resolved, so nothing can reach the
+      // connector. This is the assertion that matters: past this point the next step dials a
+      // remote, metered endpoint.
+      verifyNoInteractions(deps.xrepository);
+   }
+
+   @Test
+   void createTableTabularTableProceedsWhenDatasourceReadGranted() throws Exception {
+      Deps deps = new Deps();
+      when(deps.securityEngine.checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                               eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      when(deps.dataSourceService.checkPermission(eq("myds"), eq(ResourceAction.READ), eq(USER)))
+         .thenReturn(true);
+
+      WorksheetTableRequest request = batchOf("""
+         {
+           "tableName": "t1",
+           "tableType": "tabular table",
+           "tabularSource": { "datasourcePath": "myds", "endpoint": "Charges" }
+         }
+         """);
+
+      // xrepository is an unstubbed mock, so getDataSource returns null and the table fails with
+      // "Data source not found" — proof execution proceeded past the datasource gate into
+      // buildTabularTable. Asserted on the message rather than on success, because a mock
+      // repository can never produce a real connector.
+      WorksheetTableResponse table = only(deps.service().createTables(request, USER));
+      assertFalse(table.isSuccess());
+      assertTrue(table.getErrorMessage().contains("Data source not found"),
+                 "should fail past the gate, got: " + table.getErrorMessage());
+
+      verify(deps.xrepository).getDataSource(eq("myds"));
+      verify(deps.dataSourceService).checkPermission(eq("myds"), eq(ResourceAction.READ), eq(USER));
+   }
    // ─── createTable -> buildTable: sql query table FREE_FORM_SQL gate ─────────
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServicePermissionTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServicePermissionTest.java
@@ -48,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -311,6 +312,76 @@ class WorksheetTableServicePermissionTest {
 
       verify(deps.xrepository).getDataSource(eq("myds"));
       verify(deps.dataSourceService).checkPermission(eq("myds"), eq(ResourceAction.READ), eq(USER));
+   }
+
+   /**
+    * The bypass the field-presence version of this gate allowed.
+    *
+    * <p>A tabular request carrying BOTH sources was checked against its {@code physicalSource} — a path
+    * nothing on the tabular path ever reads — and then reached the connector on its unchecked
+    * {@code tabularSource} path. Both halves are asserted: the gate must consult the tabular path
+    * (denied here), and the data source must never be resolved, because the step after that dials a
+    * remote, metered endpoint.</p>
+    */
+   @Test
+   void createTableTabularTableChecksTabularPathEvenWhenPhysicalSourceIsAlsoPresent() throws Exception {
+      Deps deps = new Deps();
+      when(deps.securityEngine.checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                               eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      // Readable: the path the old gate would have checked.
+      when(deps.dataSourceService.checkPermission(eq("readable"), eq(ResourceAction.READ), eq(USER)))
+         .thenReturn(true);
+      // Denied: the path the connector would actually be reached on.
+      when(deps.dataSourceService.checkPermission(eq("denied"), eq(ResourceAction.READ), eq(USER)))
+         .thenReturn(false);
+
+      WorksheetTableRequest request = batchOf("""
+         {
+           "tableName": "t1",
+           "tableType": "tabular table",
+           "physicalSource": { "datasourcePath": "readable", "tableName": "CUSTOMERS" },
+           "tabularSource": { "datasourcePath": "denied", "endpoint": "Charges" }
+         }
+         """);
+
+      WorksheetTableResponse table = only(deps.service().createTables(request, USER));
+      assertFalse(table.isSuccess());
+      assertTrue(table.getErrorMessage().contains("no READ permission on datasource denied"),
+                 "the tabular path must be the one checked, got: " + table.getErrorMessage());
+
+      verify(deps.dataSourceService).checkPermission(eq("denied"), eq(ResourceAction.READ), eq(USER));
+      verifyNoInteractions(deps.xrepository);
+   }
+
+   /**
+    * And with the tabular path readable, the pair is still refused — by the builder this time, because
+    * naming two sources gets one of them silently ignored whichever way the gate is written.
+    */
+   @Test
+   void createTableTabularTableRejectsAPhysicalSourceEvenWhenBothPathsAreReadable() throws Exception {
+      Deps deps = new Deps();
+      when(deps.securityEngine.checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                               eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      when(deps.dataSourceService.checkPermission(anyString(), eq(ResourceAction.READ), eq(USER)))
+         .thenReturn(true);
+
+      WorksheetTableRequest request = batchOf("""
+         {
+           "tableName": "t1",
+           "tableType": "tabular table",
+           "physicalSource": { "datasourcePath": "ds", "tableName": "CUSTOMERS" },
+           "tabularSource": { "datasourcePath": "ds", "endpoint": "Charges" }
+         }
+         """);
+
+      WorksheetTableResponse table = only(deps.service().createTables(request, USER));
+      assertFalse(table.isSuccess());
+      assertTrue(table.getErrorMessage().contains("cannot carry physicalSource"),
+                 "expected the mismatched-pair rejection, got: " + table.getErrorMessage());
+
+      verifyNoInteractions(deps.xrepository);
    }
    // ─── createTable -> buildTable: sql query table FREE_FORM_SQL gate ─────────
 

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceShouldProbeTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceShouldProbeTest.java
@@ -106,6 +106,22 @@ class WorksheetTableServiceShouldProbeTest {
    }
 
    @Test
+   void tabularTableIsNotProbed() throws Exception {
+      // Creating a tabular table ALREADY sends one metered request: a tabular query has no columns
+      // until a response has been parsed, so loadColumnSelection runs it under HINT_PREVIEW to
+      // discover them. Probing would send a second request to answer a question the non-empty
+      // column assertion in buildTabularTable already answers, against an API that bills per call.
+      WorksheetTable req = request("""
+         {
+           "tableName": "t", "tableType": "tabular table",
+           "tabularSource": { "datasourcePath": "myds", "endpoint": "Charges" }
+         }
+         """);
+
+      assertFalse(service().shouldProbe(req));
+   }
+
+   @Test
    void emptyWindowColumnsListIsNotProbed() throws Exception {
       WorksheetTable req = request("""
          { "tableName": "t", "tableType": "mirror table", "windowColumns": [] }


### PR DESCRIPTION
`/ws/table` accepted four table types and threw on anything else, so an endpoint the agent had already retrieved could not be built on. Adds a fifth, `tabular table`, bound as a `TabularTableAssembly`.

## The request

```json
{
  "tableName": "STRIPE_CHARGES",
  "tableType": "tabular table",
  "tabularSource": {
    "datasourcePath": "SaaS/Stripe Test",
    "endpoint": "Charges",
    "parameters": { "Created": "1735689600" },
    "jsonPath": "$.data[*]",
    "maxRows": 5000
  }
}
```

The caller supplies only what it can know: which endpoint, and what its parameters are. `suffix`, `paged` and the lookup relations are read off the connector when the endpoint is selected, so accepting a copy would let a stale value override the connector's own definition.

## No TabularView round trip

`TabularQueryDialogService` needs a view because a human drives it. Both things a caller supplies here are annotated bean properties, so `TabularUtil.getPropertyMap` reaches them directly, and `RestParameters` is a core type rather than a connector one — no reflection on connector classes.

That also keeps `TabularUtil.callButtonMethods` out of the path. It is the only reader of the `TabularUtil.sessionId` ThreadLocal, so unlike `WizTabularController` this path needs no connector session bound around it.

Order is not interchangeable: `getParameters()` derives the contract from the endpoint currently on the bean, so the endpoint is set first. Setting it also runs the connector's `updatePagination`, which is what establishes the pagination spec, request method and content type.

## Four silent paths, each answered rather than trusted

| Path | What it does on failure |
|---|---|
| `PropertyMeta.setValue` | logs and returns — so the endpoint is read back |
| `EndpointQueryDelegate.createParameters` | skips a token its parser rejects with a warning |
| `EndpointJsonQuery.setLookupEndpoint` | drops an invalid name |
| `TabularTableAssembly.loadColumnSelection` | reports a failed request with `LOG.warn` and returns normally |

The last one is the one that matters most: without an assertion it persists a zero-column table and answers `success=true`, an error first visible when a chart binds to it and renders nothing. A non-empty column selection is now required.

Reading the built URL suffix back covers the other three, and it is reported in the failure message so the caller can see the request that was actually made.

## Required parameters are validated before anything is dialed

Every missing one is named at once. `SuffixTemplate.build` does raise for a missing required parameter, but only the first it reaches, and every further round trip past this point is a metered request. A supplied name the endpoint does not declare is rejected for the same reason: dropping it runs a narrower query than the one asked for and reports success.

## POST endpoints are refused

Their body comes from a private field on the connector's query, moved into `requestBody` only by `populateRequestBodyTemplate` — a dialog button method this path never runs — so attempting one sends an empty body.

## Two defaults point the wrong way for a metered API

`createTables` sets `designMaxRows` to 0 for wiz analytics, which on a paginated endpoint means paging to the end of the customer's data on every render. `tabularSource.maxRows` is persisted on the query instead, so every later execution is bounded and no other table type is affected.

This type is also left out of `shouldProbe`: creating it already sends one request (`loadColumnSelection` runs the query under `HINT_PREVIEW` at 100 rows to discover the columns), and the probe would send a second to answer what the column assertion already answers.

## Two pre-existing gaps this type would have fallen through

**The datasource READ gate in `buildTable` read only `physicalSource`.** A `tabularSource` path bypassed it entirely — reaching the connector, and dialing a remote endpoint, with no check. It now reads whichever field carries a path. Both outcomes are covered in `WorksheetTableServicePermissionTest`, whose denial case asserts `verifyNoInteractions(xrepository)`: the check has to precede the data source even being resolved.

**`structureTableType` is an instanceof chain with no tabular branch.** Its javadoc promises the construction and introspection endpoints speak the same vocabulary; without the branch a tabular table falls through to `getSimpleName()` and `/ws/structure` answers `"TabularTableAssembly"`, a type name `/ws/table` does not accept — which breaks reading a worksheet back to build on it.

## `expressionColumns` / `windowColumns` are rejected

`applyExpressionColumns` and `applyWindowColumns` are reached from the physical-table and mirror-table builders only, so on a tabular table they were accepted and then never applied. A derived column also needs the endpoint's column list, which does not exist until the create call has run, so the mirror is where it belongs on the merits.

## Tests

Appended to the three existing classes that already cover the changed behaviour — the READ gate, `shouldProbe`, and `structureTableType` — rather than adding files. 60 tests green across `WorksheetTableServicePermissionTest`, `WorksheetTableServiceShouldProbeTest` and `MetadataApiServiceStructureTest`.

Design: `docs/superpowers/specs/2026-08-19-tabular-table-creation-design.md` in the stylebi-wiz repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
