### PR TITLE
Fix concatenation subtable reorder stranding operator pairs

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/CompositeTableAssembly.java
+++ b/core/src/main/java/inetsoft/uql/asset/CompositeTableAssembly.java
@@ -222,16 +222,17 @@ public abstract class CompositeTableAssembly extends ComposedTableAssembly {
    /**
     * Reorder the subtables of this table
     *
-    * <p>Operators are keyed by ADJACENT pair, so a reorder strands every operator whose two
-    * tables stopped being neighbours -- {@code A UNION B MINUS C} reordered to {@code C, A, B}
-    * has nothing stored for its new first pair {@code (C,A)}. They are therefore carried over
-    * BY POSITION here, and the operator map is rebuilt rather than added to: it must never end
-    * up holding more pairs than {@code tnames} can index, because {@link #getOperatorCount()}
-    * reports the map's size while {@link #getOperator(int)} indexes {@code tnames}, and once
-    * those disagree a caller iterating them together reads past the end of the array.</p>
+    * <p>Operators are keyed by table PAIR, not by position, and for a join those pairs are
+    * arbitrary: a star join holds an operator between the fact table and each dimension, which no
+    * ordering makes all-adjacent. Reordering therefore leaves a join's operators alone here --
+    * they are still keyed by the same table names and still found by
+    * {@link #getOperator(String, String)}.</p>
     *
-    * <p>Callers must not re-apply the operators themselves afterwards. Writing them back adds
-    * the new pairs without removing the old ones, which is exactly the inconsistency above.</p>
+    * <p>{@link ConcatenatedTableAssembly} overrides this, because a concatenation is the one
+    * composite whose operators <em>are</em> one-per-adjacent-pair: reordering it strands the
+    * operators whose tables stopped being neighbours, so they have to be carried over by position.
+    * That rebuild must not be applied to a join, where it would drop every operator between two
+    * tables that are not adjacent.</p>
     *
     * @param tables the specified table assemblies containing the same elements as the current
     *               subtables
@@ -250,22 +251,8 @@ public abstract class CompositeTableAssembly extends ComposedTableAssembly {
       final List<String> oldTNames = Arrays.asList(tnames);
 
       if(oldTNames.containsAll(newTNamesList)) {
-         final TableAssemblyOperator[] ops = new TableAssemblyOperator[tnames.length - 1];
-
-         for(int i = 0; i < ops.length; i++) {
-            ops[i] = getOperator(i);
-         }
-
          tnames = newTNames;
          getCompositeTableInfo().resetOperators(newTNamesList);
-         getCompositeTableInfo().clearOperators();
-
-         for(int i = 0; i < ops.length; i++) {
-            if(ops[i] != null) {
-               setOperator(tnames[i], tnames[i + 1], ops[i]);
-            }
-         }
-
          return true;
       }
 

--- a/core/src/main/java/inetsoft/uql/asset/CompositeTableAssembly.java
+++ b/core/src/main/java/inetsoft/uql/asset/CompositeTableAssembly.java
@@ -221,6 +221,18 @@ public abstract class CompositeTableAssembly extends ComposedTableAssembly {
 
    /**
     * Reorder the subtables of this table
+    *
+    * <p>Operators are keyed by ADJACENT pair, so a reorder strands every operator whose two
+    * tables stopped being neighbours -- {@code A UNION B MINUS C} reordered to {@code C, A, B}
+    * has nothing stored for its new first pair {@code (C,A)}. They are therefore carried over
+    * BY POSITION here, and the operator map is rebuilt rather than added to: it must never end
+    * up holding more pairs than {@code tnames} can index, because {@link #getOperatorCount()}
+    * reports the map's size while {@link #getOperator(int)} indexes {@code tnames}, and once
+    * those disagree a caller iterating them together reads past the end of the array.</p>
+    *
+    * <p>Callers must not re-apply the operators themselves afterwards. Writing them back adds
+    * the new pairs without removing the old ones, which is exactly the inconsistency above.</p>
+    *
     * @param tables the specified table assemblies containing the same elements as the current
     *               subtables
     * @return false if change was rejected
@@ -238,8 +250,22 @@ public abstract class CompositeTableAssembly extends ComposedTableAssembly {
       final List<String> oldTNames = Arrays.asList(tnames);
 
       if(oldTNames.containsAll(newTNamesList)) {
+         final TableAssemblyOperator[] ops = new TableAssemblyOperator[tnames.length - 1];
+
+         for(int i = 0; i < ops.length; i++) {
+            ops[i] = getOperator(i);
+         }
+
          tnames = newTNames;
          getCompositeTableInfo().resetOperators(newTNamesList);
+         getCompositeTableInfo().clearOperators();
+
+         for(int i = 0; i < ops.length; i++) {
+            if(ops[i] != null) {
+               setOperator(tnames[i], tnames[i + 1], ops[i]);
+            }
+         }
+
          return true;
       }
 

--- a/core/src/main/java/inetsoft/uql/asset/ConcatenatedTableAssembly.java
+++ b/core/src/main/java/inetsoft/uql/asset/ConcatenatedTableAssembly.java
@@ -70,6 +70,54 @@ public class ConcatenatedTableAssembly extends CompositeTableAssembly {
    }
 
    /**
+    * Reorder the subtables, carrying the operators over BY POSITION.
+    *
+    * <p>A concatenation is the one composite whose operators are one per ADJACENT pair, so a
+    * reorder strands every operator whose two tables stopped being neighbours:
+    * {@code A UNION B MINUS C} reordered to {@code C, A, B} has nothing stored for its new first
+    * pair {@code (C,A)}. Position is what carries over -- the first pair keeps the first operation
+    * whichever tables now sit there.</p>
+    *
+    * <p>The map is <em>rebuilt</em> rather than added to, because it must never hold more pairs
+    * than {@code tnames} can index: {@link #getOperatorCount()} reports the map's size while
+    * {@link #getOperator(int)} indexes {@code tnames}, and once those disagree a caller iterating
+    * them together reads past the end of the array. That reached users as an
+    * {@code ArrayIndexOutOfBoundsException} which made a whole worksheet unreadable.</p>
+    *
+    * <p>Deliberately here and not in {@link CompositeTableAssembly}: a join's operators are keyed
+    * by arbitrary table pairs, and clearing them to rebuild by position would delete every join
+    * between two tables that are not adjacent. Callers must not re-apply the operators themselves
+    * afterwards either -- writing them back adds the new pairs without removing the stranded ones,
+    * which is the same inconsistency from the other direction.</p>
+    */
+   @Override
+   public boolean reorderTableAssemblies(TableAssembly[] tables) {
+      // Read against the CURRENT order, before super swaps tnames underneath.
+      TableAssemblyOperator[] ops = new TableAssemblyOperator[tnames.length - 1];
+
+      for(int i = 0; i < ops.length; i++) {
+         ops[i] = getOperator(i);
+      }
+
+      if(!super.reorderTableAssemblies(tables)) {
+         return false;
+      }
+
+      // super's resetOperators() only drops pairs naming a table that left the assembly, and a
+      // reorder changes no names -- so every pre-reorder pair is still in the map and has to go
+      // before the carried-over ones are written back against the new order.
+      getCompositeTableInfo().clearOperators();
+
+      for(int i = 0; i < ops.length; i++) {
+         if(ops[i] != null) {
+            setOperator(tnames[i], tnames[i + 1], ops[i]);
+         }
+      }
+
+      return true;
+   }
+
+   /**
     * Set the operator at an index.
     * @param ltable the specified left table.
     * @param rtable the specified right table.

--- a/core/src/main/java/inetsoft/uql/asset/internal/CompositeTableAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/asset/internal/CompositeTableAssemblyInfo.java
@@ -375,6 +375,19 @@ public class CompositeTableAssemblyInfo extends ComposedTableAssemblyInfo {
    }
 
    /**
+    * Drop every stored operator, leaving the subtables and the schema table infos alone.
+    *
+    * <p>For rebuilding the operator map from scratch — after a reorder, where the stored pairs
+    * describe adjacencies that no longer exist. Neither of the obvious alternatives does this:
+    * {@code resetOperators(null)} also clears the schema table infos, and removing the pairs one
+    * by one goes through {@code ConcatenatedTableAssembly.removeOperator}, which drops any
+    * subtable that is left unconnected.</p>
+    */
+   public void clearOperators() {
+      map.clear();
+   }
+
+   /**
     * Reset the operators.
     * @param tables the available tables.
     */

--- a/core/src/main/java/inetsoft/web/composer/ws/RenameColumnController.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/RenameColumnController.java
@@ -463,6 +463,14 @@ public class RenameColumnController extends WorksheetController {
          CompositeTableAssembly composite = (CompositeTableAssembly) mirror;
          String[] tableNames = composite.getTableNames();
 
+         // NOTE: the bound here counts OPERATORS while the indices address TABLES, of which there
+         // is one more -- so the last table is never reached, and with two tables (count 1, j
+         // starting at 1) the body does not run at all. Deliberately left as-is: disabling this
+         // loop entirely changes no observable behaviour, because renaming already propagates to
+         // join operators by another path (see RenameColumnControllerTest). Correcting the bound
+         // would start executing code that has effectively never run, on a rename path with no
+         // test coverage of its own -- a bigger risk than the wrong bound. Pinned by tests so the
+         // behaviour cannot regress silently if this is ever revisited.
          for(int i = 0; i < composite.getOperatorCount(); i++) {
             for(int j = i + 1; j < composite.getOperatorCount(); j++) {
                TableAssemblyOperator tableOperator = composite.getOperator(tableNames[i], tableNames[j]);

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/ReorderSubtableService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/ReorderSubtableService.java
@@ -61,10 +61,13 @@ public class ReorderSubtableService extends WorksheetControllerService {
          updateOperators(table, subtables);
       }
 
-      // The operators are carried over by position inside reorderTableAssemblies. They must not
-      // be re-applied here: writing them back adds the new adjacent pairs without removing the
-      // ones the reorder invalidated, leaving the operator map holding more pairs than there are
-      // subtables -- a state that later reads of the assembly cannot survive.
+      // Operators are handled by the assembly itself and must not be re-applied here. A
+      // concatenation carries them over by position inside its own reorderTableAssemblies
+      // override; writing them back afterwards would add the new adjacent pairs without removing
+      // the ones the reorder stranded, leaving the map holding more pairs than there are subtables
+      // -- a state later reads of the assembly cannot survive. A join needs nothing carried over
+      // at all: its operators are keyed by arbitrary table pairs, unaffected by order, and
+      // updateOperators above has already handled the join-specific part.
       table.reorderTableAssemblies(Arrays.stream(subtables).map(
             (subtable) -> (TableAssembly) rws.getWorksheet().getAssembly(subtable))
                                       .toArray(TableAssembly[]::new));

--- a/core/src/main/java/inetsoft/web/composer/ws/dialog/ReorderSubtableService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/dialog/ReorderSubtableService.java
@@ -61,25 +61,13 @@ public class ReorderSubtableService extends WorksheetControllerService {
          updateOperators(table, subtables);
       }
 
-      TableAssemblyOperator[] ops = null;
-
-      if(table instanceof ConcatenatedTableAssembly) {
-         ops = new TableAssemblyOperator[subtables.length - 1];
-
-         for(int i = 0; i < ops.length; i++) {
-            ops[i] = table.getOperator(i);
-         }
-      }
-
+      // The operators are carried over by position inside reorderTableAssemblies. They must not
+      // be re-applied here: writing them back adds the new adjacent pairs without removing the
+      // ones the reorder invalidated, leaving the operator map holding more pairs than there are
+      // subtables -- a state that later reads of the assembly cannot survive.
       table.reorderTableAssemblies(Arrays.stream(subtables).map(
             (subtable) -> (TableAssembly) rws.getWorksheet().getAssembly(subtable))
                                       .toArray(TableAssembly[]::new));
-
-      if(ops != null) {
-         for(int i = 0; i < ops.length; i++) {
-            table.setOperator(i, ops[i]);
-         }
-      }
 
       WorksheetEventUtil.refreshColumnSelection(rws, event.parentTable(), true);
       WorksheetEventUtil.loadTableData(rws, event.parentTable(), true, true);

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -1616,7 +1616,11 @@ public class WorksheetAgentController {
 
    /**
     * Reorders the subtables of a {@link ConcatenatedTableAssembly} (UNION/INTERSECT/MINUS).
-    * Operators are preserved after reordering by restoring them at their new positions.
+    *
+    * <p>Operators are carried over by position inside {@code reorderTableAssemblies}. Do not
+    * re-apply them here: writing them back adds the new adjacent pairs without removing the ones
+    * the reorder invalidated, and the operator map then holds more pairs than there are
+    * subtables — which used to make every subsequent read of the worksheet fail outright.</p>
     *
     * @param req.table    the ConcatenatedTableAssembly name
     * @param req.subtables the subtable names in the desired new order
@@ -1641,14 +1645,6 @@ public class WorksheetAgentController {
          }
 
          String[] subtables = req.subtables().toArray(new String[0]);
-
-         // Preserve existing operators (indexed by position) before reordering.
-         TableAssemblyOperator[] ops = new TableAssemblyOperator[subtables.length - 1];
-
-         for(int i = 0; i < ops.length; i++) {
-            ops[i] = table.getOperator(i);
-         }
-
          TableAssembly[] reordered = new TableAssembly[subtables.length];
 
          for(int i = 0; i < subtables.length; i++) {
@@ -1663,13 +1659,6 @@ public class WorksheetAgentController {
          }
 
          table.reorderTableAssemblies(reordered);
-
-         // Restore operators at new positions.
-         for(int i = 0; i < ops.length; i++) {
-            if(ops[i] != null) {
-               table.setOperator(i, ops[i]);
-            }
-         }
 
          WorksheetEventUtil.refreshColumnSelection(rws, req.table(), true);
          WorksheetEventUtil.loadTableData(rws, req.table(), true, true);

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
@@ -188,8 +188,17 @@ public class WorksheetReadService {
       }
 
       Set<String> operations = new LinkedHashSet<>();
+      String[] names = concat.getTableNames();
 
-      for(int i = 0; i < concat.getOperatorCount(); i++) {
+      // Bound by the SUBTABLES, not by getOperatorCount(): that reports the operator map's size
+      // while getOperator(int) indexes the subtable names, so the two disagree the moment the map
+      // holds a pair that is not adjacent, and iterating the count reads past the end of the
+      // names. One malformed assembly must not cost the caller every other table in the
+      // worksheet -- this is the call it makes to find out what is wrong. getOperator returns
+      // null for a pair with nothing stored, which concatOperation already handles.
+      int pairs = names == null ? 0 : names.length - 1;
+
+      for(int i = 0; i < pairs; i++) {
          operations.add(concatOperation(concat.getOperator(i)));
       }
 

--- a/core/src/test/java/inetsoft/uql/asset/CompositeTableAssemblyTest.java
+++ b/core/src/test/java/inetsoft/uql/asset/CompositeTableAssemblyTest.java
@@ -79,6 +79,106 @@ class CompositeTableAssemblyTest {
       assertEquals(TableAssemblyOperator.MINUS, operation(concat.getOperator(1)));
    }
 
+   /**
+    * The smallest concatenation, where {@code ops.length == 1}. Worth its own case because the
+    * two-source shape is both the most common and the one where the original defect was
+    * unrecoverable: the only call that clears a stale pair is removing a subtable, and below two
+    * sources that deletes the whole assembly.
+    */
+   @Test
+   void reorderingTwoSourcesKeepsTheirOperator() {
+      Worksheet ws = new Worksheet();
+      TableAssembly a = table(ws, "A");
+      TableAssembly b = table(ws, "B");
+      ConcatenatedTableAssembly concat = concat(
+         ws, "U", new int[]{ TableAssemblyOperator.UNION }, a, b);
+
+      assertTrue(concat.reorderTableAssemblies(new TableAssembly[]{ b, a }));
+
+      assertEquals(List.of("B", "A"), List.of(concat.getTableNames()));
+      assertEquals(1, concat.getOperatorCount(), "no stale pair may survive");
+      assertEquals(TableAssemblyOperator.UNION, operation(concat.getOperator(0)));
+   }
+
+   /**
+    * Reordering into the same order must be a no-op, not a rebuild that loses anything. This is
+    * the negative control for the whole fix: it is the one reorder that does NOT change which
+    * subtables are adjacent, and live reproduction confirmed it never triggered the defect -- so a
+    * failure here would mean the repair itself broke something the bug never touched.
+    */
+   @Test
+   void reorderingIntoTheSameOrderChangesNothing() {
+      Worksheet ws = new Worksheet();
+      TableAssembly a = table(ws, "A");
+      TableAssembly b = table(ws, "B");
+      TableAssembly c = table(ws, "C");
+      ConcatenatedTableAssembly concat = concat(
+         ws, "U", new int[]{ TableAssemblyOperator.UNION, TableAssemblyOperator.MINUS }, a, b, c);
+
+      assertTrue(concat.reorderTableAssemblies(new TableAssembly[]{ a, b, c }));
+
+      assertEquals(List.of("A", "B", "C"), List.of(concat.getTableNames()));
+      assertEquals(2, concat.getOperatorCount());
+      assertEquals(TableAssemblyOperator.UNION, operation(concat.getOperator(0)));
+      assertEquals(TableAssemblyOperator.MINUS, operation(concat.getOperator(1)));
+   }
+
+   /**
+    * A JOIN table's operator map is not a linear chain, and the positional carry-over must not be
+    * applied to one.
+    *
+    * <p>{@code CompositeTableAssemblyInfo.Pair} is an arbitrary {@code (ltable, rtable)} with no
+    * adjacency constraint, and the Composer creates joins between any two subtables -- a star join
+    * (one fact table joined directly to several dimensions) holds {@code n-1} operators that do
+    * <em>not</em> sit at consecutive {@code tnames} indices. Reading operators by position there
+    * finds nothing for most indices, so clearing the map to rebuild it from those readings would
+    * silently delete every join whose two tables are not neighbours -- and reordering does not
+    * even have to change anything for that to happen.</p>
+    *
+    * <p>Concatenations are the only assemblies where "one operator per adjacent pair" holds, which
+    * is why the carry-over belongs to {@code ConcatenatedTableAssembly} and not to this base
+    * class. It lived here briefly and this is the case that catches it.</p>
+    */
+   @Test
+   void reorderingAStarJoinKeepsTheOperatorBetweenNonAdjacentTables() {
+      Worksheet ws = new Worksheet();
+      TableAssembly f = table(ws, "F");
+      TableAssembly d1 = table(ws, "D1");
+      TableAssembly d2 = table(ws, "D2");
+
+      RelationalJoinTableAssembly star = new RelationalJoinTableAssembly(
+         ws, "J", new TableAssembly[]{ f, d1, d2 },
+         new TableAssemblyOperator[]{ join("F", "D1"), join("D1", "D2") });
+      ws.addAssembly(star);
+
+      // Reshape the chain the constructor built into a star: F joined to BOTH dimensions, so
+      // (F,D2) spans tnames positions 0 and 2 and no adjacent-index read can find it.
+      star.removeOperator("D1", "D2");
+      star.setOperator("F", "D2", join("F", "D2"));
+
+      assertTrue(star.reorderTableAssemblies(new TableAssembly[]{ d1, f, d2 }));
+
+      assertNotNull(star.getOperator("F", "D1"),
+                    "the adjacent join must survive the reorder");
+      assertNotNull(star.getOperator("F", "D2"),
+                    "the NON-adjacent join must survive it too -- dropping it deletes a join "
+                       + "condition the user never touched");
+   }
+
+   private static TableAssemblyOperator join(String ltable, String rtable) {
+      TableAssemblyOperator.Operator op = new TableAssemblyOperator.Operator();
+      op.setLeftTable(ltable);
+      op.setRightTable(rtable);
+      op.setLeftAttribute(new ColumnRef(new AttributeRef(ltable, "col")));
+      op.setRightAttribute(new ColumnRef(new AttributeRef(rtable, "col")));
+      op.setOperation(TableAssemblyOperator.INNER_JOIN);
+
+      TableAssemblyOperator top = new TableAssemblyOperator();
+      top.addOperator(op);
+
+      return top;
+   }
+
    private static int operation(TableAssemblyOperator operator) {
       assertNotNull(operator, "every adjacent pair must have an operator after a reorder");
       return operator.getKeyOperator().getOperation();

--- a/core/src/test/java/inetsoft/uql/asset/CompositeTableAssemblyTest.java
+++ b/core/src/test/java/inetsoft/uql/asset/CompositeTableAssemblyTest.java
@@ -1,0 +1,117 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.asset;
+
+import inetsoft.test.*;
+import inetsoft.uql.ColumnSelection;
+import inetsoft.uql.erm.AttributeRef;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(
+   classes = { BaseTestConfiguration.class, SwapperTestConfiguration.class },
+   initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class CompositeTableAssemblyTest {
+   /**
+    * Operators are keyed by ADJACENT pair, so reordering the subtables strands every operator
+    * whose two tables stopped being neighbours: {@code A UNION B MINUS C} reordered to
+    * {@code C, A, B} leaves nothing stored for the new first pair {@code (C,A)}.
+    *
+    * <p>Both callers of this method used to patch that up themselves -- read the operators by
+    * position, reorder, then write them back by position. That is the right intent (carry the
+    * operators over positionally) implemented in the one place it cannot be done safely: writing
+    * back does not remove what is already there, so the pre-reorder pairs survived alongside the
+    * new ones and the map ended up holding more operators than {@code tnames} can index. Since
+    * {@code getOperatorCount()} reports the map's size while {@code getOperator(int)} indexes
+    * {@code tnames}, the two then disagree and any caller iterating them together walks off the
+    * end of the array -- which reached users as an {@code ArrayIndexOutOfBoundsException} that
+    * made an entire worksheet unreadable after a single reorder.</p>
+    *
+    * <p>So the carry-over belongs here, where the map can be rebuilt rather than added to.</p>
+    */
+   @Test
+   void reorderingSubtablesCarriesOperatorsOverByPositionWithoutStrandingAny() {
+      Worksheet ws = new Worksheet();
+      TableAssembly a = table(ws, "A");
+      TableAssembly b = table(ws, "B");
+      TableAssembly c = table(ws, "C");
+      // A UNION B MINUS C -- mixed, so a lost or misplaced operator is visible.
+      ConcatenatedTableAssembly concat = concat(
+         ws, "U", new int[]{ TableAssemblyOperator.UNION, TableAssemblyOperator.MINUS }, a, b, c);
+
+      assertTrue(concat.reorderTableAssemblies(new TableAssembly[]{ c, a, b }));
+
+      assertEquals(List.of("C", "A", "B"), List.of(concat.getTableNames()),
+                   "the reorder itself must take effect");
+      assertEquals(concat.getTableNames().length - 1, concat.getOperatorCount(),
+                   "one operator per adjacent pair -- a larger count means a stale pair survived");
+
+      // Position is what carries over: the first pair keeps the first operation whichever
+      // tables now sit there.
+      assertEquals(TableAssemblyOperator.UNION, operation(concat.getOperator(0)));
+      assertEquals(TableAssemblyOperator.MINUS, operation(concat.getOperator(1)));
+   }
+
+   private static int operation(TableAssemblyOperator operator) {
+      assertNotNull(operator, "every adjacent pair must have an operator after a reorder");
+      return operator.getKeyOperator().getOperation();
+   }
+
+   private static TableAssembly table(Worksheet ws, String name) {
+      EmbeddedTableAssembly table = new EmbeddedTableAssembly(ws, name);
+      ColumnSelection cs = new ColumnSelection();
+      cs.addAttribute(new ColumnRef(new AttributeRef(null, "col")));
+      table.setColumnSelection(cs, false);
+      ws.addAssembly(table);
+
+      return table;
+   }
+
+   /** One operation per adjacent pair, so a mixed concatenation can be built. */
+   private static ConcatenatedTableAssembly concat(Worksheet ws, String name, int[] operations,
+                                                   TableAssembly... sources)
+   {
+      TableAssemblyOperator[] operators = new TableAssemblyOperator[sources.length - 1];
+
+      for(int i = 0; i < operators.length; i++) {
+         TableAssemblyOperator top = new TableAssemblyOperator();
+         TableAssemblyOperator.Operator op = new TableAssemblyOperator.Operator();
+         op.setOperation(operations[i]);
+         top.addOperator(op);
+         operators[i] = top;
+      }
+
+      ConcatenatedTableAssembly concat =
+         new ConcatenatedTableAssembly(ws, name, sources, operators);
+      ws.addAssembly(concat);
+
+      return concat;
+   }
+}

--- a/core/src/test/java/inetsoft/web/composer/ws/RenameColumnControllerTest.java
+++ b/core/src/test/java/inetsoft/web/composer/ws/RenameColumnControllerTest.java
@@ -1,0 +1,176 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.composer.ws;
+
+import inetsoft.test.*;
+import inetsoft.uql.ColumnSelection;
+import inetsoft.uql.asset.*;
+import inetsoft.uql.erm.*;
+import inetsoft.web.viewsheet.service.CommandDispatcher;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(
+   classes = { BaseTestConfiguration.class, SwapperTestConfiguration.class },
+   initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class RenameColumnControllerTest {
+   /**
+    * Renaming a column must carry into the join condition of every assembly built on it, or the
+    * join goes on referencing a column name that no longer exists.
+    *
+    * <p>Written while investigating the table-pair loop in {@code renameTableColumn0}, whose bound
+    * counts OPERATORS while its indices address TABLES -- one short, so the last table is never
+    * reached and a two-table join never enters the body at all. The investigation concluded that
+    * loop is <b>not</b> what makes this work: with it disabled outright, both tests here still
+    * pass, so the propagation comes from elsewhere and the wrong bound has no observable effect.
+    * These tests pin the <em>behaviour</em>, not that loop -- and they are what makes it safe to
+    * leave the bound alone.</p>
+    *
+    * <p>Driven through the public entry point deliberately. A rename is applied as an ALIAS on the
+    * existing column and the ref that gets propagated is the very object read back out of the base
+    * table's selection, so hand-building a separate "renamed" ColumnRef tests a state the product
+    * never produces -- the join validity check rightly rejects it as a cross join. Making exactly
+    * that mistake is what first made the loop look guilty.</p>
+    */
+   @Test
+   void renamingABaseColumnUpdatesATwoTableJoinsOperator() {
+      Worksheet ws = new Worksheet();
+      TableAssembly a = table(ws, "A", "col1");
+      TableAssembly b = table(ws, "B", "col2");
+
+      TableAssemblyOperator op = innerJoin("A", "col1", "B", "col2");
+      join(ws, "J", new TableAssembly[]{ a, b }, op);
+
+      boolean failed = RenameColumnController.renameColumn(
+         ws, mock(CommandDispatcher.class), a, column("A", "col1"), "renamed");
+
+      assertFalse(failed, "the rename itself must succeed");
+      assertEquals("renamed", leftName(op),
+                   "the join's left attribute must follow the rename");
+   }
+
+   /**
+    * The three-table case, kept because it covers the pair the suspect loop could never reach even
+    * in principle (with three tables its bound is 2, so it stops after pair {@code (0,1)}). It
+    * passing is the second half of the evidence that the loop is not carrying this behaviour.
+    */
+   @Test
+   void renamingABaseColumnUpdatesTheLastPairOfAThreeTableJoin() {
+      Worksheet ws = new Worksheet();
+      TableAssembly a = table(ws, "A", "col1");
+      TableAssembly b = table(ws, "B", "col2");
+      TableAssembly c = table(ws, "C", "col3");
+
+      TableAssemblyOperator ab = innerJoin("A", "col1", "B", "col2");
+      // The pair involving the LAST table, and the one carrying the column being renamed.
+      TableAssemblyOperator bc = innerJoin("B", "col2", "C", "col3");
+      join(ws, "J", new TableAssembly[]{ a, b, c }, ab, bc);
+
+      boolean failed = RenameColumnController.renameColumn(
+         ws, mock(CommandDispatcher.class), c, column("C", "col3"), "renamed");
+
+      assertFalse(failed, "the rename itself must succeed");
+      assertEquals("renamed", rightName(bc),
+                   "the last pair's attribute must follow the rename too");
+   }
+
+   private static TableAssembly table(Worksheet ws, String name, String... cols) {
+      EmbeddedTableAssembly table = new EmbeddedTableAssembly(ws, name);
+      table.setColumnSelection(selection(name, cols), false);
+      ws.addAssembly(table);
+
+      return table;
+   }
+
+   /** The join must expose the renamed column, or renameTableColumn0 returns before the loop. */
+   private static void join(Worksheet ws, String name, TableAssembly[] tables,
+                            TableAssemblyOperator... operators)
+   {
+      RelationalJoinTableAssembly j =
+         new RelationalJoinTableAssembly(ws, name, tables, operators);
+      ColumnSelection cs = new ColumnSelection();
+
+      for(TableAssembly table : tables) {
+         ColumnSelection tcs = table.getColumnSelection();
+
+         for(int i = 0; i < tcs.getAttributeCount(); i++) {
+            cs.addAttribute(tcs.getAttribute(i));
+         }
+      }
+
+      j.setColumnSelection(cs, false);
+      ws.addAssembly(j);
+   }
+
+   private static ColumnSelection selection(String entity, String... cols) {
+      ColumnSelection cs = new ColumnSelection();
+
+      for(String col : cols) {
+         cs.addAttribute(column(entity, col));
+      }
+
+      return cs;
+   }
+
+   private static ColumnRef column(String entity, String name) {
+      return new ColumnRef(new AttributeRef(entity, name));
+   }
+
+   private static TableAssemblyOperator innerJoin(String lt, String lc, String rt, String rc) {
+      TableAssemblyOperator.Operator op = new TableAssemblyOperator.Operator();
+      op.setLeftTable(lt);
+      op.setRightTable(rt);
+      op.setLeftAttribute(column(lt, lc));
+      op.setRightAttribute(column(rt, rc));
+      op.setOperation(TableAssemblyOperator.INNER_JOIN);
+
+      TableAssemblyOperator top = new TableAssemblyOperator();
+      top.addOperator(op);
+
+      return top;
+   }
+
+   private static String leftName(TableAssemblyOperator top) {
+      return effectiveName(top.getOperator(0).getLeftAttribute());
+   }
+
+   private static String rightName(TableAssemblyOperator top) {
+      return effectiveName(top.getOperator(0).getRightAttribute());
+   }
+
+   /**
+    * A rename sets an alias and leaves the underlying attribute alone, so the alias is the name
+    * that matters -- the same rule the production code applies when it decides what a column is
+    * currently called.
+    */
+   private static String effectiveName(DataRef ref) {
+      String alias = ref instanceof ColumnRef column ? column.getAlias() : null;
+      return alias == null || alias.isEmpty() ? ref.getAttribute() : alias;
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
@@ -168,6 +168,55 @@ class WorksheetReadServiceTest {
       assertEquals("UNION", u.concatType());
    }
 
+   /**
+    * A concatenation whose operator map disagrees with its subtable list must not take the whole
+    * worksheet down with it.
+    *
+    * <p>{@code getOperatorCount()} reports the map's size while {@code getOperator(int)} indexes
+    * {@code tnames}, so reading the operators by iterating {@code 0..getOperatorCount()} walks
+    * off the end of the array as soon as the map holds a pair that is not adjacent. That is how
+    * a single bad assembly turned every {@code read} of its worksheet into an HTTP 500 -- the
+    * agent could no longer see ANY table, including the ones it needed in order to repair the
+    * broken one.</p>
+    *
+    * <p>The way the map got into that state has been fixed (see
+    * {@code CompositeTableAssembly.reorderTableAssemblies}), but the read must not depend on
+    * that being the only way in: it is the one call an agent makes to find out what is wrong.
+    * Subtable count is the honest bound, and it is what {@code readConcatCompatible} already
+    * guards for the same reason.</p>
+    */
+   @Test
+   void inconsistentOperatorMapDoesNotFailTheWholeRead() {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly a = TestWorksheets.tableWithColumns(ws, "A", "col");
+      EmbeddedTableAssembly b = TestWorksheets.tableWithColumns(ws, "B", "col");
+      EmbeddedTableAssembly c = TestWorksheets.tableWithColumns(ws, "C", "col");
+      ws.addAssembly(a);
+      ws.addAssembly(b);
+      ws.addAssembly(c);
+
+      ConcatenatedTableAssembly u = concat(ws, "U", TableAssemblyOperator.UNION, a, b, c);
+      ws.addAssembly(u);
+
+      // (A,C) is not an adjacent pair, so the map now holds three operators for three subtables.
+      u.setOperator("A", "C", unionOperator());
+
+      WorksheetModel m = assertDoesNotThrow(() -> read(ws));
+
+      assertEquals("UNION", tableNamed(m, "U").concatType());
+      assertEquals(List.of("A", "B", "C"), tableNamed(m, "U").sources());
+      assertEquals(4, m.tables().size(), "the other tables must still be readable");
+   }
+
+   private static TableAssemblyOperator unionOperator() {
+      TableAssemblyOperator top = new TableAssemblyOperator();
+      TableAssemblyOperator.Operator op = new TableAssemblyOperator.Operator();
+      op.setOperation(TableAssemblyOperator.UNION);
+      top.addOperator(op);
+
+      return top;
+   }
+
    @Test
    void concatenationReportsIntersectAndMinus() {
       Worksheet ws = new Worksheet();


### PR DESCRIPTION
Operators are keyed by ADJACENT subtable pair, so a reorder strands every operator whose two tables stopped being neighbours. reorderTableAssemblies called resetOperators(newNames), which only drops pairs naming a table that LEFT the assembly -- a reorder changes no names, so nothing was dropped. Both callers then wrote the operators back by position, adding the new pairs on top of the surviving old ones, leaving the map holding more pairs than there are subtables. getOperatorCount() reports the map's size while getOperator(int) indexes the subtable names, so anything iterating the two together then read past the end of the array.

WorksheetReadService.readConcatType does exactly that, so one reordered concatenation made every read of its worksheet fail with an ArrayIndexOutOfBoundsException -- the caller could no longer see ANY table, including the ones needed to repair the broken one. Two subtables was enough to trigger it, and there it was unrecoverable: the only call that clears the stale pairs is removing a subtable, which below two sources deletes the whole concatenation.

The Composer's own reorder dialog had the identical restore loop and produced the same corrupt state. It does not call readConcatType, so it failed silently instead of on the spot.

Move the carry-over into reorderTableAssemblies, where the map can be rebuilt rather than added to, and drop both callers' restore loops. clearOperators() is new because neither existing option works here: removeOperator is overridden by ConcatenatedTableAssembly to also drop any subtable left unconnected, and resetOperators(null) would discard the schema table infos.

Also bound readConcatType by the subtable count rather than getOperatorCount(), so one malformed assembly can no longer cost the caller every other table in the worksheet -- the same guard readConcatCompatible already had.

RenameColumnController carries the same category error (getOperatorCount() bounding indices into getTableNames()). Investigated and deliberately left alone: disabling that loop outright changes no observable behaviour, because a rename already reaches join operators by another path. Correcting the bound would start executing code that has effectively never run, on a path that had no test coverage at all. Added that coverage and a comment recording why the bound stays instead.

Verified live on both paths: the agent reorder, and a human reorder through the Composer dialog, each read back with the operators intact and the assembly still executable.