### PR TITLE
feat(pairing): Follow Focus pane retargeting (Phases 1, 3 backend, and Phase 4 fix)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/pairing/JoinSession.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/JoinSession.java
@@ -21,14 +21,40 @@ package inetsoft.web.wiz.pairing;
  * A reusable session opened after a successful pairing join.
  * Edits reuse this; the code stays single-use.
  *
- * @param editorContext the script/formula location this session is scoped to, carried over
- *                      from the {@link PairingGrant} that opened it, or {@code null} for a
- *                      whole-sheet ("Connect to Claude" toolbar) session
+ * @param editorContext the script/formula location this session is scoped to -- carried over
+ *                      from the {@link PairingGrant} that opened it at mint time, or moved by
+ *                      {@code SheetSessionService.retarget}/{@code popFocus} (Follow Focus)
+ *                      thereafter -- or {@code null} for a whole-sheet ("Connect to Claude"
+ *                      toolbar) session
+ * @param followFocusEnabled whether this session has opted in to Follow Focus -- see
+ *                      {@code SheetSessionService.setFollowFocus}. {@code false} until a session
+ *                      explicitly turns it on; {@code SheetSessionService.retarget} refuses to
+ *                      move a session's target while this is {@code false}, independent of
+ *                      whatever the Angular UI shows. Never {@code true} at construction --
+ *                      opting in is always a separate, later act.
  */
 public record JoinSession(String sessionToken, String runtimeId, String ownerIdentity,
                           SheetType sheetType, long lastAccess, long ttlMillis,
                           ConnectionMode connectionMode, String socketSessionId,
-                          String socketUserName, EditorContext editorContext) {
+                          String socketUserName, EditorContext editorContext,
+                          boolean followFocusEnabled) {
+
+   /**
+    * Back-compat constructor predating {@code followFocusEnabled} (Follow Focus) -- defaults it
+    * to {@code false}, the same default {@code SheetSessionService.open} relies on. Kept so the
+    * wide set of hand-built {@code new JoinSession(...)} fixtures across the
+    * worksheet/viewsheet/script/binding test packages -- none of which exercise Follow Focus --
+    * do not all need updating for one new field on a record none of them otherwise touch.
+    */
+   public JoinSession(String sessionToken, String runtimeId, String ownerIdentity,
+                      SheetType sheetType, long lastAccess, long ttlMillis,
+                      ConnectionMode connectionMode, String socketSessionId,
+                      String socketUserName, EditorContext editorContext)
+   {
+      this(sessionToken, runtimeId, ownerIdentity, sheetType, lastAccess, ttlMillis,
+           connectionMode, socketSessionId, socketUserName, editorContext, false);
+   }
+
    public boolean isExpired(long now) { return now - lastAccess > ttlMillis; }
 
    /** Forward-compat slot: PAIRED = browser owns + agent joins; AGENT_OWNED reserved for future viz. */

--- a/core/src/main/java/inetsoft/web/wiz/pairing/PairingJoinedNotice.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/PairingJoinedNotice.java
@@ -32,7 +32,26 @@ package inetsoft.web.wiz.pairing;
  *
  * @param editorContext the paired location, or {@code null} for a whole-sheet ("Connect to Claude"
  *                      toolbar) pairing. {@code null} is the normal case, never an error.
+ * @param focusChanged  {@code false} for the original "an agent just joined" event this record
+ *                      was created for; {@code true} when a session already known to be joined
+ *                      had its target MOVED by Follow Focus ({@code SheetSessionService.retarget}/
+ *                      {@code popFocus}), not by a fresh mint-and-join. The client's connected
+ *                      indicator uses this to tell "someone else's pane just got paired" (which
+ *                      must not light up an unrelated toolbar instance -- see
+ *                      {@code ConnectToClaudeComponent}'s exact-editorContext-match filter) apart
+ *                      from "my own already-connected session's live target changed" (which the
+ *                      toolbar instance DOES want to track, by {@code runtimeId} alone, regardless
+ *                      of what the new {@code editorContext} is).
  */
 public record PairingJoinedNotice(String runtimeId, SheetType sheetType,
-                                  EditorContext editorContext) {
+                                  EditorContext editorContext, boolean focusChanged) {
+
+   /**
+    * Back-compat constructor predating {@code focusChanged} (Follow Focus) -- defaults it to
+    * {@code false}, i.e. the original "an agent joined" event shape every existing caller and
+    * test constructs.
+    */
+   public PairingJoinedNotice(String runtimeId, SheetType sheetType, EditorContext editorContext) {
+      this(runtimeId, sheetType, editorContext, false);
+   }
 }

--- a/core/src/main/java/inetsoft/web/wiz/pairing/SheetAgentBroadcastService.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/SheetAgentBroadcastService.java
@@ -261,12 +261,35 @@ public class SheetAgentBroadcastService {
     * valid, so a failure here costs the browser's indicator and nothing more.
     */
    public void sendPairingJoined(JoinSession session) {
+      sendPairingNotice(session, new PairingJoinedNotice(session.runtimeId(), session.sheetType(),
+                                                          session.editorContext(), false));
+   }
+
+   /**
+    * Tell the browser holding this session that Follow Focus moved its target -- via
+    * {@code SheetSessionService.retarget}/{@code popFocus} -- without a fresh mint-and-join.
+    *
+    * <p>Reuses {@link #sendPairingJoined}'s exact topic and addressing (per the design plan:
+    * "reusing the same broadcast channel #4669 already wired rather than inventing a second
+    * one"), distinguished only by {@link PairingJoinedNotice#focusChanged()}. This is load-bearing
+    * on the client: {@code ConnectToClaudeComponent}'s toolbar instance tracks a
+    * {@code focusChanged} notice for its OWN session by {@code runtimeId} alone (the target has
+    * moved, so the editorContext can no longer be expected to match anything that instance itself
+    * minted), while a plain {@code sendPairingJoined} notice keeps requiring an exact
+    * editorContext match so an unrelated pane's fresh pairing never lights up the toolbar.
+    */
+   public void sendFocusChanged(JoinSession session) {
+      sendPairingNotice(session, new PairingJoinedNotice(session.runtimeId(), session.sheetType(),
+                                                          session.editorContext(), true));
+   }
+
+   private void sendPairingNotice(JoinSession session, PairingJoinedNotice notice) {
       // Nothing to notify. The REST mint path can record a null destination user (a null
       // principal), and Spring answers that with Assert.notNull — a stack trace the caller then
       // logs as "notifying the browser failed", which is misleading: nothing failed to send, there
       // was simply nobody to send to. broadcastRefresh guards its own null user for the same reason.
       if(session.socketUserName() == null) {
-         LOG.debug("Pairing joined notice skipped — no destination user recorded (runtimeId={})",
+         LOG.debug("Pairing notice skipped — no destination user recorded (runtimeId={})",
                    session.runtimeId());
          return;
       }
@@ -277,10 +300,7 @@ public class SheetAgentBroadcastService {
       headers.setLeaveMutable(true);
 
       commandDispatcherService.convertAndSendToUser(
-         session.socketUserName(), PAIRING_JOINED_TOPIC,
-         new PairingJoinedNotice(session.runtimeId(), session.sheetType(),
-                                 session.editorContext()),
-         headers.getMessageHeaders());
+         session.socketUserName(), PAIRING_JOINED_TOPIC, notice, headers.getMessageHeaders());
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/pairing/SheetPairingController.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/SheetPairingController.java
@@ -167,6 +167,104 @@ public class SheetPairingController {
       sessions.detach(accessor.getSessionId(), req.editorContext());
    }
 
+   /**
+    * Payload for the STOMP Follow Focus toggle.
+    *
+    * @param runtimeId the sheet the toggle applies to -- matched against the caller's own
+    *                  socket-bound session, same as {@link #retargetViaSocket}
+    * @param enabled   the new opt-in state
+    */
+   public record FollowFocusRequest(String runtimeId, boolean enabled) {}
+
+   /**
+    * STOMP Follow Focus toggle -- turns the opt-in on or off for the caller's own session on
+    * {@code runtimeId}. Mirrors {@link #detachViaSocket}'s fire-and-forget shape: no reply is
+    * sent, since there is nothing to report back for a toggle (unlike {@link #retargetViaSocket},
+    * which can be refused for reasons the browser needs to show a human). {@code socketSessionId}
+    * is derived from the accessor, never trusted from the client, same as every other STOMP
+    * endpoint in this controller.
+    *
+    * <p>Send to: {@code /app/wiz/pairing/follow-focus}
+    */
+   @MessageMapping("/wiz/pairing/follow-focus")
+   public void followFocusViaSocket(@Payload FollowFocusRequest req, SimpMessageHeaderAccessor accessor) {
+      if(req == null || req.runtimeId() == null) {
+         return;
+      }
+
+      sessions.setFollowFocus(accessor.getSessionId(), req.runtimeId(), req.enabled());
+   }
+
+   /**
+    * Payload for the STOMP retarget push -- mirrors {@link MintRequest}'s shape.
+    *
+    * @param runtimeId    the sheet whose session should be retargeted
+    * @param editorContext the script/formula location to push the session's target to
+    */
+   public record RetargetRequest(String runtimeId, EditorContext editorContext) {}
+
+   /** Response DTO for the STOMP retarget push. {@code error} is non-null on failure. */
+   public record RetargetResponse(boolean ok, String error) {
+      // Named success()/failure(), not ok()/err(), because ok() would collide with this
+      // record's own generated accessor for the `ok` component (same clash MintResponse avoids
+      // by not naming a component `code` the same as its factory).
+      public static RetargetResponse success()      { return new RetargetResponse(true, null); }
+      public static RetargetResponse failure(String msg) { return new RetargetResponse(false, msg); }
+   }
+
+   /**
+    * STOMP retarget -- the client-asserted "a pane-eligible editor opened" signal Follow Focus
+    * sends on the caller's behalf once they have opted in ({@link #followFocusViaSocket}), in
+    * place of the human clicking "Connect Agent" inside that pane. Unlike {@link #detachViaSocket}
+    * this DOES reply: a retarget can be refused (not opted in, no matching session, or
+    * {@code editorContext} names a location the runtime does not have) for reasons the browser
+    * needs to surface to a human, not just log.
+    *
+    * <p>{@code socketSessionId} is derived from the accessor, never trusted from the client.
+    *
+    * <p>Send to: {@code /app/wiz/pairing/retarget}<br>
+    * Reply arrives on: {@code /user/queue/wiz/pairing/retarget}
+    */
+   @MessageMapping("/wiz/pairing/retarget")
+   @SendToUser("/commands/wiz/pairing/retarget")
+   public RetargetResponse retargetViaSocket(@Payload RetargetRequest req, SimpMessageHeaderAccessor accessor) {
+      if(req == null || req.runtimeId() == null || req.editorContext() == null) {
+         return RetargetResponse.failure("runtimeId and editorContext are required");
+      }
+
+      try {
+         sessions.retarget(accessor.getSessionId(), req.runtimeId(), req.editorContext());
+         return RetargetResponse.success();
+      }
+      catch(PairingException e) {
+         return RetargetResponse.failure(e.getMessage());
+      }
+   }
+
+   /**
+    * Payload for the STOMP pop-focus. The {@code editorContext} being popped TO is
+    * server-determined, not client-asserted -- the browser doesn't need to know it, only that
+    * the operation is "leave the pane I'm currently in", so only {@code runtimeId} is sent.
+    */
+   public record PopFocusRequest(String runtimeId) {}
+
+   /**
+    * STOMP pop-focus -- the client-asserted "a pane-eligible editor closed" signal, popping the
+    * caller's session back to whatever preceded its most recent {@link #retargetViaSocket}. No
+    * reply is sent -- like {@link #detachViaSocket}, popping past an empty stack is defined as a
+    * harmless no-op, not a failure mode the browser needs reported.
+    *
+    * <p>Send to: {@code /app/wiz/pairing/pop-focus}
+    */
+   @MessageMapping("/wiz/pairing/pop-focus")
+   public void popFocusViaSocket(@Payload PopFocusRequest req, SimpMessageHeaderAccessor accessor) {
+      if(req == null || req.runtimeId() == null) {
+         return;
+      }
+
+      sessions.popFocus(accessor.getSessionId(), req.runtimeId());
+   }
+
    @ExceptionHandler(PairingException.class)
    public ResponseEntity<Map<String, String>> handlePairingException(PairingException e) {
       HttpStatus status = switch(e.getKind()) {

--- a/core/src/main/java/inetsoft/web/wiz/pairing/SheetPairingController.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/SheetPairingController.java
@@ -53,11 +53,13 @@ public class SheetPairingController {
    @Autowired
    public SheetPairingController(SheetPairingService pairing, SheetSessionService sessions,
                                  SheetAgentFeature feature,
+                                 SheetAgentBroadcastService broadcast,
                                  @Value("${wiz.agent.rest-mint.enabled:false}") boolean restMintEnabled)
    {
       this.pairing = pairing;
       this.sessions = sessions;
       this.feature = feature;
+      this.broadcast = broadcast;
       this.restMintEnabled = restMintEnabled;
    }
 
@@ -233,7 +235,9 @@ public class SheetPairingController {
       }
 
       try {
-         sessions.retarget(accessor.getSessionId(), req.runtimeId(), req.editorContext());
+         JoinSession retargeted =
+            sessions.retarget(accessor.getSessionId(), req.runtimeId(), req.editorContext());
+         broadcast.sendFocusChanged(retargeted);
          return RetargetResponse.success();
       }
       catch(PairingException e) {
@@ -262,7 +266,11 @@ public class SheetPairingController {
          return;
       }
 
-      sessions.popFocus(accessor.getSessionId(), req.runtimeId());
+      JoinSession restored = sessions.popFocus(accessor.getSessionId(), req.runtimeId());
+
+      if(restored != null) {
+         broadcast.sendFocusChanged(restored);
+      }
    }
 
    @ExceptionHandler(PairingException.class)
@@ -309,6 +317,7 @@ public class SheetPairingController {
    private final SheetPairingService pairing;
    private final SheetSessionService sessions;
    private final SheetAgentFeature feature;
+   private final SheetAgentBroadcastService broadcast;
    private final boolean restMintEnabled;
 
    private static final Logger LOG = LoggerFactory.getLogger(SheetPairingController.class);

--- a/core/src/main/java/inetsoft/web/wiz/pairing/SheetPairingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/SheetPairingService.java
@@ -147,9 +147,14 @@ public class SheetPairingService {
    /**
     * Refuses an editorContext naming a location the runtime does not actually have. Named after
     * what was asked for, so the error is useful back in the editor that produced it.
+    *
+    * <p>Package-private (not {@code private}): {@code SheetSessionService.retarget} (Follow
+    * Focus) reuses this exact check before moving a live session's target, rather than
+    * re-deriving it -- a retarget to a location the runtime doesn't actually have must fail the
+    * same way a mint to one does today, not silently store garbage.
     */
-   private void validateEditorContext(SheetType sheetType, String runtimeId, String ownerIdentity,
-                                      EditorContext ctx)
+   void validateEditorContext(SheetType sheetType, String runtimeId, String ownerIdentity,
+                              EditorContext ctx)
       throws PairingException
    {
       if(isBlank(ctx.kind())) {

--- a/core/src/main/java/inetsoft/web/wiz/pairing/SheetSessionService.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/SheetSessionService.java
@@ -17,11 +17,14 @@
  */
 package inetsoft.web.wiz.pairing;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.security.SecureRandom;
+import java.util.Deque;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.function.LongSupplier;
 
 @Service
@@ -30,20 +33,70 @@ public class SheetSessionService {
    private static final String ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
 
    private final ConcurrentHashMap<String, JoinSession> sessions;
+
+   /**
+    * Follow Focus's stack storage -- keyed by {@code sessionToken}, holding the *previous*
+    * {@code editorContext} values a session has been {@link #retarget}ed through, most recent on
+    * top. An absent/empty deque means "nothing left to pop" -- {@link #popFocus} then leaves the
+    * session exactly as it is, which is what makes an EXHAUSTED stack idempotent under repeated
+    * pops, whatever the session's original scope happened to be (including a non-null one, for a
+    * session that was itself opened already pane-scoped). {@code JoinSession} stays one flat
+    * value, unaware this history exists.
+    *
+    * <p>Wrapped in {@link FocusFrame} rather than storing {@code EditorContext} directly:
+    * {@link java.util.concurrent.ConcurrentLinkedDeque} refuses {@code null} elements, and the
+    * FIRST retarget away from a whole-sheet session legitimately needs to push {@code null} (that
+    * session's original, whole-sheet scope) -- {@code FocusFrame} is a non-null box around a
+    * possibly-null value, exactly so "a frame exists, and it holds null" stays distinguishable
+    * from "no frame exists at all".
+    */
+   private final ConcurrentHashMap<String, Deque<FocusFrame>> focusStacks;
+
+   /** Non-null wrapper around a possibly-null {@code editorContext} -- see {@link #focusStacks}. */
+   private record FocusFrame(EditorContext editorContext) {}
+
    private final SecureRandom random = new SecureRandom();
    private final LongSupplier clock;
 
-   public SheetSessionService() { this(System::currentTimeMillis); }
+   /**
+    * The {@link SheetPairingService} whose {@code validateEditorContext} {@link #retarget}
+    * reuses before moving a live session's target -- a retarget to a location the runtime
+    * doesn't actually have must fail the same way a mint to one does today.
+    */
+   private final SheetPairingService pairing;
 
-   SheetSessionService(LongSupplier clock) {
-      this.clock = clock;
-      this.sessions = new ConcurrentHashMap<>();
+   /** Production constructor -- Spring injects the real, runtime-validating SheetPairingService. */
+   @Autowired
+   public SheetSessionService(SheetPairingService pairing) {
+      this(System::currentTimeMillis, pairing);
    }
 
-   /** Test constructor: shares the sessions map of an existing service with a different clock. */
+   /**
+    * Back-compat/convenience constructor: builds its own {@link SheetPairingService} using ITS
+    * OWN back-compat constructor, which validates against no configured runtime (mirrors
+    * {@code SheetPairingService()}'s own javadoc). Fine for the wide set of existing tests that
+    * construct a bare {@code new SheetSessionService()} and never exercise {@link #retarget}'s
+    * validation branch; retarget on one of these simply refuses any editorContext naming a real
+    * assembly, exactly like an unconfigured mint would.
+    */
+   public SheetSessionService() { this(System::currentTimeMillis, new SheetPairingService()); }
+
+   SheetSessionService(LongSupplier clock) { this(clock, new SheetPairingService()); }
+
+   SheetSessionService(LongSupplier clock, SheetPairingService pairing) {
+      this.clock = clock;
+      this.pairing = pairing;
+      this.sessions = new ConcurrentHashMap<>();
+      this.focusStacks = new ConcurrentHashMap<>();
+   }
+
+   /** Test constructor: shares the sessions map (and focus stacks) of an existing service with a
+    *  different clock. */
    SheetSessionService(LongSupplier clock, SheetSessionService source) {
       this.clock = clock;
+      this.pairing = source.pairing;
       this.sessions = source.sessions;
+      this.focusStacks = source.focusStacks;
    }
 
    public JoinSession open(String runtimeId, String ownerIdentity, SheetType sheetType,
@@ -63,10 +116,14 @@ public class SheetSessionService {
       if (token == null) return null;
       JoinSession s = sessions.get(token);
       if (s == null || s.isExpired(clock.getAsLong()) || !s.ownerIdentity().equals(agentIdentity)) return null;
+      // Full 11-arg canonical constructor, NOT the 10-arg back-compat overload -- that overload
+      // defaults followFocusEnabled to false, which would silently un-opt-in every session on
+      // its very next refresh. Must carry s.followFocusEnabled() through explicitly.
       JoinSession refreshed = new JoinSession(s.sessionToken(), s.runtimeId(), s.ownerIdentity(),
                                               s.sheetType(), clock.getAsLong(), s.ttlMillis(),
                                               s.connectionMode(), s.socketSessionId(),
-                                              s.socketUserName(), s.editorContext());
+                                              s.socketUserName(), s.editorContext(),
+                                              s.followFocusEnabled());
       sessions.put(token, refreshed);
       return refreshed;
    }
@@ -133,6 +190,155 @@ public class SheetSessionService {
       }
 
       return null;
+   }
+
+   /**
+    * Returns the unexpired session bound to both {@code socketSessionId} and {@code runtimeId},
+    * or {@code null} if none is held.
+    *
+    * <p>The browser-known identity Follow Focus retargets by (see the plan's "Design refinement"
+    * section): the browser never holds the agent's own {@code sessionToken} -- only the agent
+    * that joined does -- so a client-driven retarget/pop/toggle has to address a session by what
+    * the browser DOES know: {@code socketSessionId} (server-derived from the STOMP session,
+    * unspoofable by the client) plus {@code runtimeId} (the sheet it is editing). Sibling to
+    * {@link #findOpen}, which keys on {@code (ownerIdentity, sheetType)} instead -- a different
+    * lookup, not an overload of that one into ambiguity.
+    */
+   public JoinSession findBySocketAndRuntime(String socketSessionId, String runtimeId) {
+      if(socketSessionId == null || runtimeId == null) {
+         return null;
+      }
+
+      long now = clock.getAsLong();
+
+      for(JoinSession s : sessions.values()) {
+         if(!s.isExpired(now) && runtimeId.equals(s.runtimeId()) &&
+            socketSessionId.equals(s.socketSessionId()))
+         {
+            return s;
+         }
+      }
+
+      return null;
+   }
+
+   /**
+    * Turns Follow Focus on or off for the session bound to {@code (socketSessionId, runtimeId)}.
+    * This is the server-side half of "explicit" (see the design doc): {@link #retarget} refuses
+    * to move a session's target while this is {@code false}, independent of whatever the
+    * Angular UI shows -- even a compromised or buggy browser tab cannot retarget a session that
+    * never had Follow Focus turned on for it.
+    *
+    * <p>A no-op (returns {@code null}, touches nothing) if no session matches -- mirroring
+    * {@link #detach}'s silent-no-op shape for a non-matching case, since the caller (the STOMP
+    * toggle endpoint) is fire-and-forget with no reply to report a refusal on.
+    */
+   public JoinSession setFollowFocus(String socketSessionId, String runtimeId, boolean enabled) {
+      JoinSession session = findBySocketAndRuntime(socketSessionId, runtimeId);
+
+      if(session == null) {
+         return null;
+      }
+
+      JoinSession updated = withFollowFocusEnabled(session, enabled);
+      sessions.put(session.sessionToken(), updated);
+      return updated;
+   }
+
+   /**
+    * Retargets an opted-in session's {@code editorContext} in place, keyed by
+    * {@code (socketSessionId, runtimeId)} -- see {@link #findBySocketAndRuntime}. This is the
+    * mechanism that removes per-pane re-pairing friction: the session's {@code sessionToken}
+    * never changes, so the agent's very next tool call against that SAME token simply resolves
+    * against the new target, with no {@code connect_sheet} and no action on the agent side at
+    * all (the Phase 1 exit criterion).
+    *
+    * <p>Refuses, named, rather than silently no-opping, and touches nothing on any refusal:
+    * <ul>
+    *   <li>no session matches {@code (socketSessionId, runtimeId)};</li>
+    *   <li>the matched session has never had Follow Focus enabled ({@link #setFollowFocus}) --
+    *       the server-side half of "explicit and visible" this whole mechanism depends on;</li>
+    *   <li>{@code next} names a location the runtime does not actually have, per
+    *       {@link SheetPairingService#validateEditorContext} -- reused, not re-derived, so a
+    *       retarget to a location that does not exist fails the same way a mint to one does
+    *       today, rather than silently storing garbage.</li>
+    * </ul>
+    *
+    * <p>On success: the session's CURRENT {@code editorContext} (possibly {@code null}, for a
+    * session still at its original whole-sheet scope) is pushed onto its focus stack before the
+    * session is reconstructed with {@code editorContext = next} and stored back under the same
+    * token -- the reconstruct-and-replace shape {@link #resolve} already uses to refresh
+    * {@code lastAccess}.
+    */
+   public JoinSession retarget(String socketSessionId, String runtimeId, EditorContext next)
+      throws PairingException
+   {
+      JoinSession session = findBySocketAndRuntime(socketSessionId, runtimeId);
+
+      if(session == null) {
+         throw new PairingException(PairingException.Kind.SESSION_EXPIRED,
+            "No live session for socket " + socketSessionId + " and runtime " + runtimeId);
+      }
+
+      if(!session.followFocusEnabled()) {
+         throw new PairingException(PairingException.Kind.INVALID_ARGUMENT,
+            "Follow Focus is not enabled for this session -- enable it before retargeting.");
+      }
+
+      pairing.validateEditorContext(session.sheetType(), runtimeId, session.ownerIdentity(), next);
+
+      focusStacks.computeIfAbsent(session.sessionToken(), k -> new ConcurrentLinkedDeque<>())
+         .push(new FocusFrame(session.editorContext()));
+      JoinSession retargeted = withEditorContext(session, next);
+      sessions.put(session.sessionToken(), retargeted);
+      return retargeted;
+   }
+
+   /**
+    * Pops the session bound to {@code (socketSessionId, runtimeId)} back to whatever
+    * {@code editorContext} preceded its most recent {@link #retarget}.
+    *
+    * <p>Popping past the bottom of an already-empty (or never-pushed) stack is a no-op that
+    * leaves the session's {@code editorContext} <b>exactly as it already is</b> -- not an error
+    * and not a further change. This is deliberately NOT "reset to null": a session's original
+    * scope is whatever it was AT OPEN TIME, which is only null for a whole-sheet session --
+    * forcing null here would incorrectly widen a session that was itself opened already
+    * pane-scoped, the first time its stack ran out. A no-op (returns {@code null}) if no session
+    * matches {@code (socketSessionId, runtimeId)} either, mirroring {@link #detach}'s
+    * silent-no-op shape.
+    */
+   public JoinSession popFocus(String socketSessionId, String runtimeId) {
+      JoinSession session = findBySocketAndRuntime(socketSessionId, runtimeId);
+
+      if(session == null) {
+         return null;
+      }
+
+      Deque<FocusFrame> stack = focusStacks.get(session.sessionToken());
+      FocusFrame frame = stack == null ? null : stack.poll();
+
+      if(frame == null) {
+         // Exhausted (or never pushed): a real no-op, not a forced reset to null -- see the
+         // javadoc above.
+         return session;
+      }
+
+      JoinSession restored = withEditorContext(session, frame.editorContext());
+      sessions.put(session.sessionToken(), restored);
+      return restored;
+   }
+
+   private static JoinSession withEditorContext(JoinSession s, EditorContext editorContext) {
+      return new JoinSession(s.sessionToken(), s.runtimeId(), s.ownerIdentity(), s.sheetType(),
+                             s.lastAccess(), s.ttlMillis(), s.connectionMode(),
+                             s.socketSessionId(), s.socketUserName(), editorContext,
+                             s.followFocusEnabled());
+   }
+
+   private static JoinSession withFollowFocusEnabled(JoinSession s, boolean enabled) {
+      return new JoinSession(s.sessionToken(), s.runtimeId(), s.ownerIdentity(), s.sheetType(),
+                             s.lastAccess(), s.ttlMillis(), s.connectionMode(),
+                             s.socketSessionId(), s.socketUserName(), s.editorContext(), enabled);
    }
 
    @Scheduled(fixedDelay = 10 * 60_000)

--- a/core/src/main/java/inetsoft/web/wiz/pairing/SheetSessionService.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/SheetSessionService.java
@@ -26,6 +26,7 @@ import java.util.Deque;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.function.LongSupplier;
+import java.util.function.Predicate;
 
 @Service
 public class SheetSessionService {
@@ -128,7 +129,12 @@ public class SheetSessionService {
       return refreshed;
    }
 
-   public void close(String token) { if (token != null) sessions.remove(token); }
+   public void close(String token) {
+      if(token != null) {
+         sessions.remove(token);
+         focusStacks.remove(token);
+      }
+   }
 
    /**
     * Ends every pane-scoped session bound to {@code socketSessionId} -- called when that
@@ -146,7 +152,7 @@ public class SheetSessionService {
     */
    public void socketClosed(String socketSessionId) {
       if(socketSessionId == null) return;
-      sessions.values().removeIf(
+      removeSessionsIf(
          s -> s.editorContext() != null && socketSessionId.equals(s.socketSessionId()));
    }
 
@@ -162,7 +168,7 @@ public class SheetSessionService {
     */
    public void detach(String socketSessionId, EditorContext editorContext) {
       if(socketSessionId == null || editorContext == null) return;
-      sessions.values().removeIf(
+      removeSessionsIf(
          s -> editorContext.equals(s.editorContext()) && socketSessionId.equals(s.socketSessionId()));
    }
 
@@ -303,9 +309,16 @@ public class SheetSessionService {
     * and not a further change. This is deliberately NOT "reset to null": a session's original
     * scope is whatever it was AT OPEN TIME, which is only null for a whole-sheet session --
     * forcing null here would incorrectly widen a session that was itself opened already
-    * pane-scoped, the first time its stack ran out. A no-op (returns {@code null}) if no session
-    * matches {@code (socketSessionId, runtimeId)} either, mirroring {@link #detach}'s
-    * silent-no-op shape.
+    * pane-scoped, the first time its stack ran out.
+    *
+    * <p>Returns {@code null} both when no session matches {@code (socketSessionId, runtimeId)}
+    * and when a session matched but its stack was already exhausted. Those two cases differ in
+    * what happened to STATE (nothing existed to touch, versus a genuine no-op on a real
+    * session) but are identical in what a caller needs to do about the RETURN VALUE: nothing
+    * moved, so there is nothing to react to. {@link SheetPairingController#popFocusViaSocket}
+    * depends on this -- it broadcasts a {@code focusChanged} notice whenever this returns
+    * non-null -- so returning the unchanged session on an exhausted stack (as an earlier
+    * version of this method did) fired a spurious broadcast on every no-op pop.
     */
    public JoinSession popFocus(String socketSessionId, String runtimeId) {
       JoinSession session = findBySocketAndRuntime(socketSessionId, runtimeId);
@@ -318,9 +331,12 @@ public class SheetSessionService {
       FocusFrame frame = stack == null ? null : stack.poll();
 
       if(frame == null) {
-         // Exhausted (or never pushed): a real no-op, not a forced reset to null -- see the
-         // javadoc above.
-         return session;
+         // Exhausted (or never pushed): the session's editorContext is left untouched -- see
+         // the javadoc above -- but null is still returned, same as "no session matched", so a
+         // caller with no other use for the return value (popFocusViaSocket) sees one signal
+         // for "nothing changed" rather than having to compare the returned session against
+         // what it already had.
+         return null;
       }
 
       JoinSession restored = withEditorContext(session, frame.editorContext());
@@ -341,10 +357,39 @@ public class SheetSessionService {
                              s.socketSessionId(), s.socketUserName(), s.editorContext(), enabled);
    }
 
+   /**
+    * Test-only: whether {@code token} still has a live {@link #focusStacks} entry. No
+    * production caller needs this -- it exists purely so a leak-regression test can observe
+    * {@link #removeSessionsIf}'s cleanup without a public accessor on production code.
+    */
+   boolean hasFocusStackEntryForTesting(String token) {
+      return focusStacks.containsKey(token);
+   }
+
    @Scheduled(fixedDelay = 10 * 60_000)
    void evictExpired() {
       long now = clock.getAsLong();
-      sessions.values().removeIf(s -> s.isExpired(now));
+      removeSessionsIf(s -> s.isExpired(now));
+   }
+
+   /**
+    * Removes every session matching {@code predicate} from {@link #sessions}, and its
+    * {@link #focusStacks} entry alongside it. Every removal path in this class (explicit
+    * {@link #close}, socket-close/detach cleanup, and scheduled {@link #evictExpired}) must go
+    * through this rather than calling {@code sessions.values().removeIf(...)} directly --
+    * {@code sessionToken}s are never reused, so a {@code focusStacks} entry left behind after
+    * its owning session is gone is a permanent leak for the remaining life of the process, not
+    * a harmless stale value some later {@code retarget} will overwrite.
+    */
+   private void removeSessionsIf(Predicate<JoinSession> predicate) {
+      sessions.values().removeIf(s -> {
+         if(predicate.test(s)) {
+            focusStacks.remove(s.sessionToken());
+            return true;
+         }
+
+         return false;
+      });
    }
 
    private String newToken() {

--- a/core/src/main/java/inetsoft/web/wiz/script/ViewsheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ViewsheetAgentController.java
@@ -111,6 +111,40 @@ public class ViewsheetAgentController {
                               String sheetType, EditorContext editorContext) {}
 
    /**
+    * @param editorContext the session's CURRENT scope -- {@code null} for whole-sheet -- read
+    *                      fresh from the live {@link JoinSession} on every call, never cached.
+    * @param followFocusEnabled whether Follow Focus is opted in for this session (see
+    *                      {@code SheetSessionService.setFollowFocus}).
+    */
+   public record SessionInfo(String runtimeId, String sheetType, EditorContext editorContext,
+                             boolean followFocusEnabled) {}
+
+   /**
+    * Reports this session's OWN current scope, resolved fresh from the live {@link JoinSession}
+    * on every call.
+    *
+    * <p>Exists because Follow Focus ({@code SheetSessionService.retarget}/{@code popFocus}) can
+    * move a session's target without the agent doing anything -- there is no server-to-agent
+    * push channel a headless HTTP client can listen on, unlike the browser's STOMP
+    * {@code focusChanged} broadcast (see {@code SheetAgentBroadcastService.sendFocusChanged}).
+    * A plugin that cached {@code editorContext} from {@code join}'s response and never refreshed
+    * it would silently drift from the truth the instant a browser retargets the session out from
+    * under it -- this endpoint is the one place an agent-side client can ask "what is my scope
+    * RIGHT NOW" and get a live answer, independent of whatever it minted or cached at connect
+    * time. Requires no pane-scope check of its own: a session is always entitled to know its own
+    * scope, whole-sheet or pane-scoped alike.
+    */
+   @GetMapping("/api/wiz/v1/agent/script/{sessionToken}/session")
+   public SessionInfo session(@PathVariable String sessionToken, Principal user)
+      throws PairingException
+   {
+      requireEnabled();
+      JoinSession session = resolveSession(sessionToken, user);
+      return new SessionInfo(session.runtimeId(), session.sheetType().name().toLowerCase(),
+                             session.editorContext(), session.followFocusEnabled());
+   }
+
+   /**
     * Enumerates every scriptable target on the joined viewsheet, with the grammar it speaks.
     *
     * <p>Not excluded from pane scoping just because it takes no single {@code target} to check —

--- a/core/src/test/java/inetsoft/web/wiz/pairing/SheetAgentBroadcastServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/pairing/SheetAgentBroadcastServiceTest.java
@@ -121,6 +121,32 @@ class SheetAgentBroadcastServiceTest {
    }
 
    /*
+    * sendFocusChanged reuses sendPairingJoined's exact topic/addressing (Follow Focus's design
+    * plan: "reusing the same broadcast channel #4669 already wired rather than inventing a second
+    * one"), distinguished only by PairingJoinedNotice.focusChanged() -- the client-side signal
+    * that this is an already-connected session's target moving, not a fresh join.
+    */
+   @Test
+   void focusChangedNoticeReusesTheJoinedTopicWithTheFlagSet() {
+      CommandDispatcherService dispatcher = mock(CommandDispatcherService.class);
+      SheetAgentBroadcastService svc = new SheetAgentBroadcastService(dispatcher, noopModelFactory());
+      EditorContext context = new EditorContext("viewsheetOnInit", null, null, null);
+      JoinSession session = new JoinSession("tok-1", "vs-9", "alice~;~host-org",
+                                            SheetType.VIEWSHEET, 0L, 0L,
+                                            JoinSession.ConnectionMode.PAIRED,
+                                            "stomp-1", "alice-dest", context);
+
+      svc.sendFocusChanged(session);
+
+      ArgumentCaptor<Object> payloadCap = ArgumentCaptor.forClass(Object.class);
+      verify(dispatcher).convertAndSendToUser(
+         eq("alice-dest"), eq("/commands/wiz/pairing/joined"), payloadCap.capture(), any());
+
+      assertEquals(new PairingJoinedNotice("vs-9", SheetType.VIEWSHEET, context, true),
+                   payloadCap.getValue());
+   }
+
+   /*
     * A null destination user reaches Spring's Assert.notNull, which the caller logs as "notifying
     * the browser failed" — misleading, since nothing failed to send and there was nobody to send
     * to. Mirrors nullSocketSessionSkipsBroadcast above.

--- a/core/src/test/java/inetsoft/web/wiz/pairing/SheetPairingControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/pairing/SheetPairingControllerTest.java
@@ -248,4 +248,29 @@ class SheetPairingControllerTest {
 
       verifyNoInteractions(broadcast);
    }
+
+   /**
+    * Distinct from {@link #popFocusViaSocketDoesNotBroadcastWhenNoSessionMatches}: here a real
+    * session exists and matches, but its focus stack has nothing left to pop (never retargeted
+    * at all). This is the exhausted-but-found case the original defect report singled out as
+    * uncovered -- popFocus used to return the unchanged session for it, which this controller
+    * would have (wrongly) treated as "something changed, broadcast it".
+    */
+   @Test
+   void popFocusViaSocketDoesNotBroadcastWhenTheSessionsStackIsAlreadyExhausted() {
+      SheetPairingService pairing = new SheetPairingService();
+      SheetSessionService sessions = new SheetSessionService();
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      SheetAgentBroadcastService broadcast = mock(SheetAgentBroadcastService.class);
+      SheetPairingController c = new SheetPairingController(pairing, sessions, feature, broadcast, true);
+
+      sessions.open("Viewsheet/vs-1", "alice~;~host-org", SheetType.VIEWSHEET, "stomp-9",
+                   "alice", null);
+      SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.create();
+      accessor.setSessionId("stomp-9");
+
+      c.popFocusViaSocket(new SheetPairingController.PopFocusRequest("Viewsheet/vs-1"), accessor);
+
+      verifyNoInteractions(broadcast);
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/pairing/SheetPairingControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/pairing/SheetPairingControllerTest.java
@@ -19,6 +19,7 @@ package inetsoft.web.wiz.pairing;
 
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.http.HttpStatus;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.web.server.ResponseStatusException;
@@ -36,7 +37,7 @@ class SheetPairingControllerTest {
       SheetPairingService pairing = new SheetPairingService();
       SheetAgentFeature feature = mock(SheetAgentFeature.class);
       when(feature.isEnabled()).thenReturn(true);
-      SheetPairingController c = new SheetPairingController(pairing, new SheetSessionService(), feature, true);
+      SheetPairingController c = new SheetPairingController(pairing, new SheetSessionService(), feature, mock(SheetAgentBroadcastService.class), true);
       Principal owner = TestPrincipals.user("alice", "host-org");
 
       String code = c.mint("Worksheet/foo-7", "stomp-1", SheetType.WORKSHEET, owner).code();
@@ -54,7 +55,7 @@ class SheetPairingControllerTest {
       SheetPairingService pairing = new SheetPairingService();
       SheetAgentFeature feature = mock(SheetAgentFeature.class);
       when(feature.isEnabled()).thenReturn(false);
-      SheetPairingController c = new SheetPairingController(pairing, new SheetSessionService(), feature, true);
+      SheetPairingController c = new SheetPairingController(pairing, new SheetSessionService(), feature, mock(SheetAgentBroadcastService.class), true);
       Principal owner = TestPrincipals.user("alice", "host-org");
 
       assertThrows(ResponseStatusException.class,
@@ -66,7 +67,7 @@ class SheetPairingControllerTest {
       SheetPairingService pairing = new SheetPairingService();
       SheetAgentFeature feature = mock(SheetAgentFeature.class);
       when(feature.isEnabled()).thenReturn(true);
-      SheetPairingController c = new SheetPairingController(pairing, new SheetSessionService(), feature, true);
+      SheetPairingController c = new SheetPairingController(pairing, new SheetSessionService(), feature, mock(SheetAgentBroadcastService.class), true);
 
       ResponseStatusException ex = assertThrows(ResponseStatusException.class,
          () -> c.mint("Worksheet/foo-7", "stomp-1", SheetType.WORKSHEET, null));
@@ -78,7 +79,7 @@ class SheetPairingControllerTest {
       SheetPairingService pairing = new SheetPairingService();
       SheetAgentFeature feature = mock(SheetAgentFeature.class);
       when(feature.isEnabled()).thenReturn(true);
-      SheetPairingController c = new SheetPairingController(pairing, new SheetSessionService(), feature, true);
+      SheetPairingController c = new SheetPairingController(pairing, new SheetSessionService(), feature, mock(SheetAgentBroadcastService.class), true);
       Principal owner = TestPrincipals.user("alice", "host-org");
 
       // Build a SimpMessageHeaderAccessor with a known session id
@@ -97,7 +98,7 @@ class SheetPairingControllerTest {
       SheetPairingService pairing = new SheetPairingService();
       SheetAgentFeature feature = mock(SheetAgentFeature.class);
       when(feature.isEnabled()).thenReturn(false);
-      SheetPairingController c = new SheetPairingController(pairing, new SheetSessionService(), feature, true);
+      SheetPairingController c = new SheetPairingController(pairing, new SheetSessionService(), feature, mock(SheetAgentBroadcastService.class), true);
       Principal owner = TestPrincipals.user("alice", "host-org");
       SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.create();
       accessor.setSessionId("stomp-x");
@@ -114,7 +115,7 @@ class SheetPairingControllerTest {
       SheetPairingService pairing = new SheetPairingService();
       SheetSessionService sessions = new SheetSessionService();
       SheetAgentFeature feature = mock(SheetAgentFeature.class);
-      SheetPairingController c = new SheetPairingController(pairing, sessions, feature, true);
+      SheetPairingController c = new SheetPairingController(pairing, sessions, feature, mock(SheetAgentBroadcastService.class), true);
 
       EditorContext ctx = new EditorContext("assemblyMain", "Chart1", null, null);
       JoinSession pane = sessions.open("Viewsheet/vs-1", "alice~;~host-org", SheetType.VIEWSHEET,
@@ -134,7 +135,7 @@ class SheetPairingControllerTest {
       SheetPairingService pairing = new SheetPairingService();
       SheetSessionService sessions = new SheetSessionService();
       SheetAgentFeature feature = mock(SheetAgentFeature.class);
-      SheetPairingController c = new SheetPairingController(pairing, sessions, feature, true);
+      SheetPairingController c = new SheetPairingController(pairing, sessions, feature, mock(SheetAgentBroadcastService.class), true);
 
       JoinSession sheet = sessions.open("Viewsheet/vs-1", "alice~;~host-org", SheetType.VIEWSHEET,
                                         "stomp-9", "alice", null);
@@ -155,7 +156,7 @@ class SheetPairingControllerTest {
       SheetPairingService pairing = new SheetPairingService();
       SheetSessionService sessions = new SheetSessionService();
       SheetAgentFeature feature = mock(SheetAgentFeature.class);
-      SheetPairingController c = new SheetPairingController(pairing, sessions, feature, true);
+      SheetPairingController c = new SheetPairingController(pairing, sessions, feature, mock(SheetAgentBroadcastService.class), true);
 
       JoinSession sheet = sessions.open("Viewsheet/vs-1", "alice~;~host-org", SheetType.VIEWSHEET,
                                         "stomp-9", "alice", null);
@@ -173,7 +174,8 @@ class SheetPairingControllerTest {
       SheetPairingService pairing = new SheetPairingService();
       SheetSessionService sessions = new SheetSessionService();
       SheetAgentFeature feature = mock(SheetAgentFeature.class);
-      SheetPairingController c = new SheetPairingController(pairing, sessions, feature, true);
+      SheetAgentBroadcastService broadcast = mock(SheetAgentBroadcastService.class);
+      SheetPairingController c = new SheetPairingController(pairing, sessions, feature, broadcast, true);
 
       JoinSession sheet = sessions.open("Viewsheet/vs-1", "alice~;~host-org", SheetType.VIEWSHEET,
                                         "stomp-9", "alice", null);
@@ -188,6 +190,7 @@ class SheetPairingControllerTest {
       assertNotNull(resp.error());
       assertNull(sessions.resolve(sheet.sessionToken(), "alice~;~host-org").editorContext(),
                 "a refused retarget must never move the session's target");
+      verifyNoInteractions(broadcast);
    }
 
    @Test
@@ -195,7 +198,8 @@ class SheetPairingControllerTest {
       SheetPairingService pairing = new SheetPairingService();
       SheetSessionService sessions = new SheetSessionService();
       SheetAgentFeature feature = mock(SheetAgentFeature.class);
-      SheetPairingController c = new SheetPairingController(pairing, sessions, feature, true);
+      SheetAgentBroadcastService broadcast = mock(SheetAgentBroadcastService.class);
+      SheetPairingController c = new SheetPairingController(pairing, sessions, feature, broadcast, true);
 
       JoinSession sheet = sessions.open("Viewsheet/vs-1", "alice~;~host-org", SheetType.VIEWSHEET,
                                         "stomp-9", "alice", null);
@@ -213,9 +217,35 @@ class SheetPairingControllerTest {
       assertNull(resp.error());
       assertEquals(pane, sessions.resolve(sheet.sessionToken(), "alice~;~host-org").editorContext());
 
+      ArgumentCaptor<JoinSession> afterRetarget = ArgumentCaptor.forClass(JoinSession.class);
+      verify(broadcast).sendFocusChanged(afterRetarget.capture());
+      assertEquals(pane, afterRetarget.getValue().editorContext(),
+                  "the retarget broadcast must carry the NEW target, not the one it replaced");
+
       c.popFocusViaSocket(new SheetPairingController.PopFocusRequest("Viewsheet/vs-1"), accessor);
 
       assertNull(sessions.resolve(sheet.sessionToken(), "alice~;~host-org").editorContext(),
                 "pop-focus must restore the session's original (whole-sheet) target");
+
+      ArgumentCaptor<JoinSession> afterPop = ArgumentCaptor.forClass(JoinSession.class);
+      verify(broadcast, times(2)).sendFocusChanged(afterPop.capture());
+      assertNull(afterPop.getValue().editorContext(),
+                "the pop-focus broadcast must carry the restored (whole-sheet) target");
+   }
+
+   @Test
+   void popFocusViaSocketDoesNotBroadcastWhenNoSessionMatches() {
+      SheetPairingService pairing = new SheetPairingService();
+      SheetSessionService sessions = new SheetSessionService();
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      SheetAgentBroadcastService broadcast = mock(SheetAgentBroadcastService.class);
+      SheetPairingController c = new SheetPairingController(pairing, sessions, feature, broadcast, true);
+
+      SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.create();
+      accessor.setSessionId("no-such-socket");
+
+      c.popFocusViaSocket(new SheetPairingController.PopFocusRequest("Viewsheet/vs-1"), accessor);
+
+      verifyNoInteractions(broadcast);
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/pairing/SheetPairingControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/pairing/SheetPairingControllerTest.java
@@ -147,4 +147,75 @@ class SheetPairingControllerTest {
       assertNotNull(sessions.resolve(sheet.sessionToken(), "alice~;~host-org"),
                     "a whole-sheet session must never be reachable from the detach endpoint");
    }
+
+   // ---- Follow Focus: follow-focus / retarget / pop-focus STOMP endpoints --------------------
+
+   @Test
+   void followFocusViaSocketTogglesTheCallersOwnSocketBoundSession() {
+      SheetPairingService pairing = new SheetPairingService();
+      SheetSessionService sessions = new SheetSessionService();
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      SheetPairingController c = new SheetPairingController(pairing, sessions, feature, true);
+
+      JoinSession sheet = sessions.open("Viewsheet/vs-1", "alice~;~host-org", SheetType.VIEWSHEET,
+                                        "stomp-9", "alice", null);
+      SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.create();
+      accessor.setSessionId("stomp-9");
+
+      c.followFocusViaSocket(new SheetPairingController.FollowFocusRequest("Viewsheet/vs-1", true),
+                             accessor);
+
+      assertTrue(sessions.resolve(sheet.sessionToken(), "alice~;~host-org").followFocusEnabled());
+   }
+
+   @Test
+   void retargetViaSocketRefusesWhenTheSessionNeverOptedIn() {
+      SheetPairingService pairing = new SheetPairingService();
+      SheetSessionService sessions = new SheetSessionService();
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      SheetPairingController c = new SheetPairingController(pairing, sessions, feature, true);
+
+      JoinSession sheet = sessions.open("Viewsheet/vs-1", "alice~;~host-org", SheetType.VIEWSHEET,
+                                        "stomp-9", "alice", null);
+      SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.create();
+      accessor.setSessionId("stomp-9");
+
+      EditorContext pane = new EditorContext("viewsheetOnInit", null, null, null);
+      SheetPairingController.RetargetResponse resp = c.retargetViaSocket(
+         new SheetPairingController.RetargetRequest("Viewsheet/vs-1", pane), accessor);
+
+      assertFalse(resp.ok());
+      assertNotNull(resp.error());
+      assertNull(sessions.resolve(sheet.sessionToken(), "alice~;~host-org").editorContext(),
+                "a refused retarget must never move the session's target");
+   }
+
+   @Test
+   void retargetViaSocketMovesAnOptedInSessionAndPopFocusRestoresIt() {
+      SheetPairingService pairing = new SheetPairingService();
+      SheetSessionService sessions = new SheetSessionService();
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      SheetPairingController c = new SheetPairingController(pairing, sessions, feature, true);
+
+      JoinSession sheet = sessions.open("Viewsheet/vs-1", "alice~;~host-org", SheetType.VIEWSHEET,
+                                        "stomp-9", "alice", null);
+      SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.create();
+      accessor.setSessionId("stomp-9");
+
+      c.followFocusViaSocket(new SheetPairingController.FollowFocusRequest("Viewsheet/vs-1", true),
+                             accessor);
+
+      EditorContext pane = new EditorContext("viewsheetOnInit", null, null, null);
+      SheetPairingController.RetargetResponse resp = c.retargetViaSocket(
+         new SheetPairingController.RetargetRequest("Viewsheet/vs-1", pane), accessor);
+
+      assertTrue(resp.ok());
+      assertNull(resp.error());
+      assertEquals(pane, sessions.resolve(sheet.sessionToken(), "alice~;~host-org").editorContext());
+
+      c.popFocusViaSocket(new SheetPairingController.PopFocusRequest("Viewsheet/vs-1"), accessor);
+
+      assertNull(sessions.resolve(sheet.sessionToken(), "alice~;~host-org").editorContext(),
+                "pop-focus must restore the session's original (whole-sheet) target");
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/pairing/SheetSessionServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/pairing/SheetSessionServiceTest.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.wiz.pairing;
 
+import inetsoft.web.wiz.script.PaneScopeService;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -35,6 +36,26 @@ import static org.junit.jupiter.api.Assertions.*;
  * [Socket close: pane]    socketClosed expires a pane-scoped session on that socket
  * [Socket close: toolbar] socketClosed leaves a whole-sheet session's TTL behaviour alone
  * [Detach]                detach ends the one session matching socket + editorContext
+ *
+ * Follow Focus (retarget/popFocus/setFollowFocus):
+ * [Follow focus: default off]     a freshly opened session has followFocusEnabled == false
+ * [Follow focus: toggle]          setFollowFocus flips the flag; resolve reflects it and does
+ *                                 not reset it back to false on its own TTL-refresh reconstruct
+ * [Retarget: opt-in required]     retarget refuses a session that never opted in, named, and
+ *                                 leaves the session untouched
+ * [Retarget: happy path]          retarget on an opted-in session moves editorContext, visible
+ *                                 through a fresh resolve(); popFocus recovers the prior value
+ * [Retarget: nesting]             two sequential retargets push twice; two pops restore in
+ *                                 reverse order, ending at the session's original editorContext
+ * [Retarget: unknown session]     retarget naming a (socketSessionId, runtimeId) pair with no
+ *                                 matching live session refuses, named, and touches nothing
+ * [Retarget: invalid target]      retarget with an editorContext validateEditorContext rejects
+ *                                 refuses before mutating anything
+ * [PopFocus: empty stack]         popFocus past the bottom of an empty stack is a no-op, not an
+ *                                 error, leaving the session at its original scope
+ * [Exit criterion]                after a successful retarget, PaneScopeService.requireWholeSheetSession
+ *                                 against a FRESH resolve() of the same token reflects the new
+ *                                 pane-scoped target -- proving enforcement needed no code change
  */
 @Tag("core")
 class SheetSessionServiceTest {
@@ -223,5 +244,168 @@ class SheetSessionServiceTest {
          () -> FIXED_NOW + SheetSessionService.TTL_MILLIS + 1, svc);
       assertNull(svcLater.findOpen("frank~;~org", SheetType.WORKSHEET),
                  "an expired session must not be reported as held");
+   }
+
+   // ---- Follow Focus: retarget / popFocus / setFollowFocus -----------------------------------
+
+   @Test
+   void freshlyOpenedSessionHasFollowFocusDisabledByDefault() {
+      SheetSessionService svc = serviceAt(FIXED_NOW);
+      JoinSession session = svc.open("vs-1", "owner~;~org", SheetType.VIEWSHEET, "sock-1",
+                                     "owner", null);
+      assertFalse(session.followFocusEnabled());
+   }
+
+   @Test
+   void setFollowFocusFlipsTheFlagAndSurvivesAResolveRefresh() {
+      SheetSessionService svc = serviceAt(FIXED_NOW);
+      JoinSession session = svc.open("vs-1", "owner~;~org", SheetType.VIEWSHEET, "sock-1",
+                                     "owner", null);
+
+      JoinSession updated = svc.setFollowFocus("sock-1", "vs-1", true);
+      assertNotNull(updated);
+      assertTrue(updated.followFocusEnabled());
+
+      // resolve() reconstructs the session to refresh lastAccess -- it must carry
+      // followFocusEnabled through, not silently reset it to the record's default.
+      JoinSession resolved = svc.resolve(session.sessionToken(), "owner~;~org");
+      assertTrue(resolved.followFocusEnabled(),
+                 "resolve()'s TTL-refresh reconstruct must not un-opt-in a session");
+   }
+
+   @Test
+   void retargetRefusesASessionThatNeverOptedIn() {
+      SheetSessionService svc = serviceAt(FIXED_NOW);
+      JoinSession session = svc.open("vs-1", "owner~;~org", SheetType.VIEWSHEET, "sock-1",
+                                     "owner", null);
+      EditorContext pane = new EditorContext("viewsheetOnInit", null, null, null);
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.retarget("sock-1", "vs-1", pane));
+      assertNotNull(ex.getMessage());
+      assertTrue(ex.getMessage().toLowerCase().contains("follow focus"),
+                "refusal must name the real reason (Follow Focus not enabled), not a generic error");
+
+      JoinSession stillUnchanged = svc.resolve(session.sessionToken(), "owner~;~org");
+      assertNull(stillUnchanged.editorContext(), "a refused retarget must leave the session untouched");
+      assertFalse(stillUnchanged.followFocusEnabled());
+   }
+
+   @Test
+   void retargetMovesAnOptedInSessionsTargetAndPopFocusRecoversThePrior() throws PairingException {
+      SheetSessionService svc = serviceAt(FIXED_NOW);
+      JoinSession session = svc.open("vs-1", "owner~;~org", SheetType.VIEWSHEET, "sock-1",
+                                     "owner", null);
+      svc.setFollowFocus("sock-1", "vs-1", true);
+      EditorContext pane = new EditorContext("viewsheetOnInit", null, null, null);
+
+      svc.retarget("sock-1", "vs-1", pane);
+
+      JoinSession afterRetarget = svc.resolve(session.sessionToken(), "owner~;~org");
+      assertEquals(pane, afterRetarget.editorContext());
+
+      svc.popFocus("sock-1", "vs-1");
+
+      JoinSession afterPop = svc.resolve(session.sessionToken(), "owner~;~org");
+      assertNull(afterPop.editorContext(), "popFocus must restore the session's original scope");
+   }
+
+   @Test
+   void twoSequentialRetargetsNestAndTwoPopsUnwindInReverseOrder() throws PairingException {
+      SheetSessionService svc = serviceAt(FIXED_NOW);
+      JoinSession session = svc.open("vs-1", "owner~;~org", SheetType.VIEWSHEET, "sock-1",
+                                     "owner", null);
+      svc.setFollowFocus("sock-1", "vs-1", true);
+      EditorContext outer = new EditorContext("viewsheetOnInit", null, null, null);
+      EditorContext inner = new EditorContext("viewsheetOnLoad", null, null, null);
+
+      svc.retarget("sock-1", "vs-1", outer);
+      svc.retarget("sock-1", "vs-1", inner);
+
+      JoinSession atInner = svc.resolve(session.sessionToken(), "owner~;~org");
+      assertEquals(inner, atInner.editorContext());
+
+      svc.popFocus("sock-1", "vs-1");
+      JoinSession backToOuter = svc.resolve(session.sessionToken(), "owner~;~org");
+      assertEquals(outer, backToOuter.editorContext(),
+                  "first pop must restore the ENCLOSING target, not jump straight to whole-sheet");
+
+      svc.popFocus("sock-1", "vs-1");
+      JoinSession backToOriginal = svc.resolve(session.sessionToken(), "owner~;~org");
+      assertNull(backToOriginal.editorContext(),
+                "second pop must restore the session's original (whole-sheet) scope");
+   }
+
+   @Test
+   void retargetWithNoMatchingSessionRefusesAndTouchesNothing() {
+      SheetSessionService svc = serviceAt(FIXED_NOW);
+      svc.open("vs-1", "owner~;~org", SheetType.VIEWSHEET, "sock-1", "owner", null);
+      EditorContext pane = new EditorContext("viewsheetOnInit", null, null, null);
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.retarget("wrong-socket", "vs-1", pane));
+      assertNotNull(ex.getMessage());
+   }
+
+   @Test
+   void retargetRefusesAnEditorContextTheRuntimeDoesNotHave() {
+      // The back-compat SheetPairingService validates against no configured runtime accessor --
+      // any editorContext naming a non-blank assembly therefore fails validateEditorContext's
+      // "does the runtime actually have this" check, exactly like an unconfigured mint would.
+      SheetSessionService svc = serviceAt(FIXED_NOW);
+      JoinSession session = svc.open("vs-1", "owner~;~org", SheetType.VIEWSHEET, "sock-1",
+                                     "owner", null);
+      svc.setFollowFocus("sock-1", "vs-1", true);
+      EditorContext ghost = new EditorContext("assemblyMain", "GhostChart", null, null);
+
+      assertThrows(PairingException.class, () -> svc.retarget("sock-1", "vs-1", ghost));
+
+      JoinSession stillUnchanged = svc.resolve(session.sessionToken(), "owner~;~org");
+      assertNull(stillUnchanged.editorContext(),
+                "a retarget refused by validateEditorContext must leave the session untouched");
+   }
+
+   @Test
+   void popFocusPastAnEmptyStackIsANoOpAtOriginalScope() {
+      SheetSessionService svc = serviceAt(FIXED_NOW);
+      JoinSession session = svc.open("vs-1", "owner~;~org", SheetType.VIEWSHEET, "sock-1",
+                                     "owner", null);
+
+      svc.popFocus("sock-1", "vs-1");
+
+      JoinSession stillOriginal = svc.resolve(session.sessionToken(), "owner~;~org");
+      assertNull(stillOriginal.editorContext());
+      assertFalse(stillOriginal.followFocusEnabled(), "popFocus must not itself flip followFocusEnabled");
+   }
+
+   /**
+    * The Phase-1-row-4 exit criterion, written as a test: after a successful retarget, a call
+    * through PaneScopeService.requireWholeSheetSession against a FRESH resolve() of the same
+    * token reflects the new scope -- proving enforcement needed no code change because it never
+    * caches. If this ever surprises us by failing, that is a real caching bug to fix, not a
+    * reason to add a parallel enforcement path.
+    */
+   @Test
+   void retargetIsVisibleToPaneScopeServiceThroughAFreshResolveWithNoEnforcementChange()
+      throws PairingException
+   {
+      SheetSessionService svc = serviceAt(FIXED_NOW);
+      JoinSession session = svc.open("vs-1", "owner~;~org", SheetType.VIEWSHEET, "sock-1",
+                                     "owner", null);
+      svc.setFollowFocus("sock-1", "vs-1", true);
+
+      // Before retargeting: a whole-sheet session must pass requireWholeSheetSession.
+      JoinSession beforeResolved = svc.resolve(session.sessionToken(), "owner~;~org");
+      assertDoesNotThrow(() -> PaneScopeService.requireWholeSheetSession(beforeResolved));
+
+      EditorContext pane = new EditorContext("viewsheetOnInit", null, null, null);
+      svc.retarget("sock-1", "vs-1", pane);
+
+      // After retargeting: the SAME token, freshly resolved, must now be refused as a
+      // whole-sheet session by PaneScopeService -- with zero changes to that class.
+      JoinSession afterResolved = svc.resolve(session.sessionToken(), "owner~;~org");
+      assertThrows(PairingException.class,
+                  () -> PaneScopeService.requireWholeSheetSession(afterResolved),
+                  "a fresh resolve() after retarget must reflect the new pane-scoped target");
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/pairing/SheetSessionServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/pairing/SheetSessionServiceTest.java
@@ -53,6 +53,13 @@ import static org.junit.jupiter.api.Assertions.*;
  *                                 refuses before mutating anything
  * [PopFocus: empty stack]         popFocus past the bottom of an empty stack is a no-op, not an
  *                                 error, leaving the session at its original scope
+ * [PopFocus: null on no-op]       popFocus returns null (not the unchanged session) both when
+ *                                 nothing was ever pushed and once a real push has been drained --
+ *                                 the caller has one signal for "nothing to broadcast"
+ * [FocusStacks cleanup: close]        close() removes the matching focusStacks entry, not just
+ *                                     the session, or a retargeted session leaks one forever
+ * [FocusStacks cleanup: socketClosed] socketClosed() does the same for a pane-scoped session
+ * [FocusStacks cleanup: evictExpired] the scheduled sweep does the same for an expired session
  * [Exit criterion]                after a successful retarget, PaneScopeService.requireWholeSheetSession
  *                                 against a FRESH resolve() of the same token reflects the new
  *                                 pane-scoped target -- proving enforcement needed no code change
@@ -376,6 +383,109 @@ class SheetSessionServiceTest {
       JoinSession stillOriginal = svc.resolve(session.sessionToken(), "owner~;~org");
       assertNull(stillOriginal.editorContext());
       assertFalse(stillOriginal.followFocusEnabled(), "popFocus must not itself flip followFocusEnabled");
+   }
+
+   /**
+    * A session found but with nothing left to pop must return null, not the unchanged session --
+    * SheetPairingController.popFocusViaSocket broadcasts a focusChanged notice on any non-null
+    * return, so returning the unchanged session here (an earlier version of this method did)
+    * fires a spurious broadcast for every no-op pop, e.g. a pane that closes without ever having
+    * been retargeted.
+    */
+   @Test
+   void popFocusOnAnExhaustedStackReturnsNullNotTheUnchangedSession() {
+      SheetSessionService svc = serviceAt(FIXED_NOW);
+      svc.open("vs-1", "owner~;~org", SheetType.VIEWSHEET, "sock-1", "owner", null);
+
+      assertNull(svc.popFocus("sock-1", "vs-1"),
+                "a session with an empty/never-pushed stack must pop to null, exactly like " +
+                "'no session found', so the caller has one signal for 'nothing to broadcast'");
+   }
+
+   /**
+    * Same exhausted-stack case, but after the stack genuinely HAD an entry and it was already
+    * consumed -- distinct from "never pushed at all" above, and the case the original defect
+    * report singled out as uncovered.
+    */
+   @Test
+   void popFocusReturnsNullOnceTheStackIsDrainedEvenAfterARealPush() throws PairingException {
+      SheetSessionService svc = serviceAt(FIXED_NOW);
+      svc.open("vs-1", "owner~;~org", SheetType.VIEWSHEET, "sock-1", "owner", null);
+      svc.setFollowFocus("sock-1", "vs-1", true);
+      svc.retarget("sock-1", "vs-1", new EditorContext("viewsheetOnInit", null, null, null));
+
+      assertNotNull(svc.popFocus("sock-1", "vs-1"), "the first pop drains a real pushed frame");
+      assertNull(svc.popFocus("sock-1", "vs-1"),
+                "the second pop, on the now-exhausted stack, must return null rather than the " +
+                "unchanged session");
+   }
+
+   /**
+    * SheetSessionService.focusStacks is keyed by sessionToken, and tokens are never reused --
+    * so every removal path that forgets to clear the matching focusStacks entry leaks it for
+    * the remaining life of the process. Covers close() directly; socketClosed/detach/
+    * evictExpired all route through the same private removeSessionsIf helper this exercises.
+    */
+   @Test
+   void closeRemovesTheFocusStacksEntryTooRatherThanLeakingIt() throws PairingException {
+      SheetSessionService svc = serviceAt(FIXED_NOW);
+      JoinSession session = svc.open("vs-1", "owner~;~org", SheetType.VIEWSHEET, "sock-1",
+                                     "owner", null);
+      svc.setFollowFocus("sock-1", "vs-1", true);
+      svc.retarget("sock-1", "vs-1", new EditorContext("viewsheetOnInit", null, null, null));
+
+      assertTrue(svc.hasFocusStackEntryForTesting(session.sessionToken()),
+                "retarget should have pushed a focus-stack entry to observe cleanup against");
+
+      svc.close(session.sessionToken());
+
+      assertFalse(svc.hasFocusStackEntryForTesting(session.sessionToken()),
+                 "close must remove the focusStacks entry too, or every retargeted session " +
+                 "leaks one for the remaining life of the process");
+   }
+
+   /**
+    * The Follow Focus-specific leak path the defect report called out by name: pane-scoped
+    * sessions churn constantly as panes open/close, and socketClosed (not close()) is what
+    * actually ends one when its browser socket drops.
+    */
+   @Test
+   void socketClosedRemovesTheFocusStacksEntryForAPaneScopedSessionToo() throws PairingException {
+      SheetSessionService svc = serviceAt(FIXED_NOW);
+      EditorContext pane = new EditorContext("viewsheetOnInit", null, null, null);
+      JoinSession session = svc.open("vs-1", "owner~;~org", SheetType.VIEWSHEET, "sock-1",
+                                     "owner", pane);
+      svc.setFollowFocus("sock-1", "vs-1", true);
+      svc.retarget("sock-1", "vs-1", new EditorContext("viewsheetOnLoad", null, null, null));
+
+      assertTrue(svc.hasFocusStackEntryForTesting(session.sessionToken()));
+
+      svc.socketClosed("sock-1");
+
+      assertFalse(svc.hasFocusStackEntryForTesting(session.sessionToken()),
+                 "socketClosed must remove the focusStacks entry for the pane session it ends");
+   }
+
+   /**
+    * The scheduled sweep must not be the one removal path that forgets the same cleanup --
+    * proven by advancing the clock past TTL rather than asserting on evictExpired() in isolation
+    * from a real expiry.
+    */
+   @Test
+   void evictExpiredRemovesTheFocusStacksEntryForAnExpiredSessionToo() throws PairingException {
+      SheetSessionService svc = serviceAt(FIXED_NOW);
+      JoinSession session = svc.open("vs-1", "owner~;~org", SheetType.VIEWSHEET, "sock-1",
+                                     "owner", null);
+      svc.setFollowFocus("sock-1", "vs-1", true);
+      svc.retarget("sock-1", "vs-1", new EditorContext("viewsheetOnInit", null, null, null));
+      assertTrue(svc.hasFocusStackEntryForTesting(session.sessionToken()));
+
+      SheetSessionService afterTtl = new SheetSessionService(
+         () -> FIXED_NOW + SheetSessionService.TTL_MILLIS + 1, svc);
+      afterTtl.evictExpired();
+
+      assertFalse(svc.hasFocusStackEntryForTesting(session.sessionToken()),
+                 "evictExpired must remove the focusStacks entry for a session it expires too");
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/script/ViewsheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ViewsheetAgentControllerTest.java
@@ -246,6 +246,52 @@ class ViewsheetAgentControllerTest {
          controller.context(PANE_TOKEN, null, null, "calcField", "Query1", "Margin", agent));
    }
 
+   /*
+    * session() exists specifically so a headless agent client can learn its OWN current scope
+    * without relying on whatever it cached at connect time -- see the endpoint's own javadoc for
+    * why (Follow Focus retargets with no server-to-agent push channel a plain HTTP client can
+    * listen on). This proves it resolves fresh from the live JoinSession on each call, not from
+    * a value captured once.
+    */
+   @Test
+   void sessionReportsTheLiveEditorContextOnEveryCall() throws Exception {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      when(feature.isEnabled()).thenReturn(true);
+      SheetSessionService sessionService = mock(SheetSessionService.class);
+
+      JoinSession wholeSheet = new JoinSession(PANE_TOKEN, PANE_RUNTIME_ID, "admin",
+         SheetType.VIEWSHEET, 0L, Long.MAX_VALUE, JoinSession.ConnectionMode.PAIRED, null, null,
+         null, true);
+      when(sessionService.resolve(eq(PANE_TOKEN), eq("admin"))).thenReturn(wholeSheet);
+
+      ViewsheetAgentController controller = new ViewsheetAgentController(feature,
+         mock(SheetJoinService.class), sessionService, mock(ScriptEditService.class),
+         mock(ScriptReadService.class), mock(ScriptExecuteService.class),
+         mock(ScriptContextService.class), mock(ScriptApiService.class),
+         mock(ScriptImageService.class), mock(ViewsheetService.class),
+         mock(SheetAgentBroadcastService.class));
+      Principal agent = principal();
+
+      ViewsheetAgentController.SessionInfo before = controller.session(PANE_TOKEN, agent);
+      assertNull(before.editorContext());
+      assertTrue(before.followFocusEnabled());
+
+      // Simulate a Follow Focus retarget having happened server-side between two calls on the
+      // SAME token -- the mock stands in for SheetSessionService.retarget's reconstruct-and-
+      // replace, which session() has no way to distinguish from any other resolve().
+      EditorContext pane = new EditorContext("assemblyOnClick", "Chart1", null, null);
+      JoinSession retargeted = new JoinSession(PANE_TOKEN, PANE_RUNTIME_ID, "admin",
+         SheetType.VIEWSHEET, 0L, Long.MAX_VALUE, JoinSession.ConnectionMode.PAIRED, null, null,
+         pane, true);
+      when(sessionService.resolve(eq(PANE_TOKEN), eq("admin"))).thenReturn(retargeted);
+
+      ViewsheetAgentController.SessionInfo after = controller.session(PANE_TOKEN, agent);
+      assertEquals(pane, after.editorContext(),
+                  "session() must reflect the NEW target with no caching of its own");
+      assertEquals("viewsheet", after.sheetType());
+      assertEquals(PANE_RUNTIME_ID, after.runtimeId());
+   }
+
    @Test
    void imageRefusesACalcFieldFromAWholeSheetSession() throws Exception {
       ViewsheetAgentController controller = wholeSheetController();


### PR DESCRIPTION
## Summary
- **Phase 1**: Retargets an already-held pairing session's `editorContext` in place, keyed by `(socketSessionId, runtimeId)`, instead of minting a new token per pane — `SheetSessionService.retarget`/`popFocus`/`setFollowFocus`, a per-token focus stack, gated behind a per-session `followFocusEnabled` opt-in, plus three new STOMP endpoints.
- **Phase 3 (backend half)**: `PairingJoinedNotice.focusChanged` discriminator + `SheetAgentBroadcastService.sendFocusChanged`, reusing the existing `/commands/wiz/pairing/joined` topic so the toolbar's connected indicator can show the live target as it moves.
- **Phase 4 fix**: new `GET /api/wiz/v1/agent/script/{sessionToken}/session` endpoint reporting a session's own live scope with no pane-scope check of its own — lets a headless agent client (which has no push channel, unlike the browser's STOMP broadcast) learn its scope has drifted after a Follow Focus retarget. Consumed by the companion stylebi-wiz plugin fix.

PaneScopeService/ScriptTarget need no change for Phase 1: both re-resolve the `JoinSession` per call rather than caching, so a retarget is visible immediately — proven by a dedicated exit-criterion test rather than assumed.

## Test plan
- [x] `SheetSessionServiceTest`/`SheetPairingControllerTest`/`SheetAgentBroadcastServiceTest`/`ViewsheetAgentControllerTest`: all new tests green
- [x] Full `inetsoft.web.wiz.**` suite: 1,944 tests, 0 failures, 0 errors (rebased onto current `stylebi-wiz-main-rebase`)
- [ ] Live browser pass (Phase 5) — not run, needs the LIVE STACK token; tracked in `docs/superpowers/plans/2026-08-19-follow-focus-pane-targeting-implementation.md` in stylebi-wiz

## Related
- Companion PR in stylebi-wiz: https://github.com/inetsoft-technology/stylebi-wiz/pull/1709 (plugin-side consumer of the new `/session` endpoint)
- Angular Phase 2/3 frontend work: separate branch `feat/follow-focus-pane-targeting-angular`, not yet pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)