### PR TITLE
feat(composer): Follow Focus push/pop wiring + toggle/indicator (Phases 2-3 frontend)

### DIFF
--- a/web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.html
+++ b/web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.html
@@ -7,6 +7,13 @@
 
   <div *ngIf="connected" role="status" class="wiz-connect-connected alert alert-success mt-2">
     ✓ Agent connected
+    <div class="wiz-connect-target">Target: {{ currentTargetLabel }}</div>
+  </div>
+
+  <div *ngIf="followFocusToggleVisible" class="wiz-follow-focus form-check mt-2">
+    <input type="checkbox" class="form-check-input" id="wiz-follow-focus-toggle"
+      [ngModel]="followFocusEnabled" (change)="toggleFollowFocus($event)">
+    <label class="form-check-label" for="wiz-follow-focus-toggle">Follow Focus</label>
   </div>
 
   <div *ngIf="code && !connected" class="wiz-connect-code mt-2">

--- a/web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.spec.ts
+++ b/web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.spec.ts
@@ -575,4 +575,158 @@ describe("ConnectToClaudeComponent", () => {
       });
    });
 
+   describe("Follow Focus toggle + live target indicator (Phase 3)", () => {
+      function notice(body: any): any {
+         return { frame: { body: JSON.stringify(body) } };
+      }
+
+      function handlerFor(dest: string): (msg: any) => void {
+         const call = mockStompConnection.subscribe.mock.calls
+            .filter((c: any[]) => c[0] === dest).pop();
+         expect(call).toBeTruthy();
+         return call[1];
+      }
+
+      /** Real toolbar mint + join, so hasMinted/mintedEditorContext land in the "whole-sheet
+       *  owner" state the toggle and the live-target tracking both require. */
+      function connectAsToolbar(): void {
+         let mintHandler: ((msg: any) => void) | null = null;
+         mockStompConnection.subscribe.mockImplementation(
+            (dest: string, h: (msg: any) => void) => {
+               if(dest === "/user/commands/wiz/pairing/mint") {
+                  mintHandler = h;
+               }
+
+               return { unsubscribe: vi.fn() };
+            });
+
+         component.requestCode();
+         mintHandler!(notice({ code: "ABC123" }));
+         handlerFor("/user/commands/wiz/pairing/joined")(
+            notice({ runtimeId: "rt-1", sheetType: "WORKSHEET", editorContext: null }));
+         fixture.detectChanges();
+      }
+
+      it("hides the toggle before a session is connected", () => {
+         expect(component.followFocusToggleVisible).toBe(false);
+      });
+
+      it("shows the toggle once the whole-sheet session is connected", () => {
+         connectAsToolbar();
+
+         expect(component.followFocusToggleVisible).toBe(true);
+         expect(fixture.nativeElement.querySelector("#wiz-follow-focus-toggle")).toBeTruthy();
+      });
+
+      it("hides the toggle on a pane instance even once connected", () => {
+         component.editorContext = { kind: "assemblyMain", assembly: "Chart1" };
+
+         let mintHandler: ((msg: any) => void) | null = null;
+         mockStompConnection.subscribe.mockImplementation(
+            (dest: string, h: (msg: any) => void) => {
+               if(dest === "/user/commands/wiz/pairing/mint") { mintHandler = h; }
+               return { unsubscribe: vi.fn() };
+            });
+         component.requestCode();
+         mintHandler!(notice({ code: "ABC123" }));
+         handlerFor("/user/commands/wiz/pairing/joined")(
+            notice({ runtimeId: "rt-1", sheetType: "WORKSHEET",
+                     editorContext: { kind: "assemblyMain", assembly: "Chart1",
+                                      name: null, table: null } }));
+
+         expect(component.connected).toBe(true);
+         expect(component.followFocusToggleVisible).toBe(false);
+      });
+
+      it("toggling sends the toggle request and flips followFocusEnabled", () => {
+         connectAsToolbar();
+         expect(component.followFocusEnabled).toBe(false);
+
+         component.toggleFollowFocus({ target: { checked: true } } as unknown as Event);
+
+         expect(component.followFocusEnabled).toBe(true);
+         expect(mockStompConnection.send).toHaveBeenCalledWith(
+            "/events/wiz/pairing/follow-focus", {},
+            JSON.stringify({ runtimeId: "rt-1", enabled: true }));
+      });
+
+      it("defaults the live target to Whole sheet on join", () => {
+         connectAsToolbar();
+
+         expect(component.currentTarget).toBeNull();
+         expect(component.currentTargetLabel).toBe("Whole sheet");
+      });
+
+      it("updates the live target label from a focusChanged notice on the toolbar instance", () => {
+         connectAsToolbar();
+
+         handlerFor("/user/commands/wiz/pairing/joined")(
+            notice({ runtimeId: "rt-1", sheetType: "WORKSHEET", focusChanged: true,
+                     editorContext: { kind: "onClick", assembly: "Chart1", name: null, table: null } }));
+
+         expect(component.currentTarget).toEqual(
+            { kind: "onClick", assembly: "Chart1", name: null, table: null });
+         expect(component.currentTargetLabel).toBe("Chart1 → onClick");
+      });
+
+      it("returns the live target to Whole sheet from a focusChanged pop notice", () => {
+         connectAsToolbar();
+         handlerFor("/user/commands/wiz/pairing/joined")(
+            notice({ runtimeId: "rt-1", sheetType: "WORKSHEET", focusChanged: true,
+                     editorContext: { kind: "onClick", assembly: "Chart1", name: null, table: null } }));
+
+         handlerFor("/user/commands/wiz/pairing/joined")(
+            notice({ runtimeId: "rt-1", sheetType: "WORKSHEET", focusChanged: true,
+                     editorContext: null }));
+
+         expect(component.currentTargetLabel).toBe("Whole sheet");
+      });
+
+      /*
+       * A pane's own ConnectToClaudeComponent (mintedEditorContext !== null) must never adopt a
+       * focusChanged notice as its own live target -- Follow Focus only ever retargets the
+       * whole-sheet session, and a pane instance has no "live target" concept of its own.
+       */
+      it("ignores a focusChanged notice on a pane instance", () => {
+         component.editorContext = { kind: "assemblyMain", assembly: "Chart1" };
+         let mintHandler: ((msg: any) => void) | null = null;
+         mockStompConnection.subscribe.mockImplementation(
+            (dest: string, h: (msg: any) => void) => {
+               if(dest === "/user/commands/wiz/pairing/mint") { mintHandler = h; }
+               return { unsubscribe: vi.fn() };
+            });
+         component.requestCode();
+         mintHandler!(notice({ code: "ABC123" }));
+         handlerFor("/user/commands/wiz/pairing/joined")(
+            notice({ runtimeId: "rt-1", sheetType: "WORKSHEET",
+                     editorContext: { kind: "assemblyMain", assembly: "Chart1",
+                                      name: null, table: null } }));
+
+         // The pane's own join must not populate currentTarget -- only the toolbar instance
+         // tracks a live target at all.
+         expect(component.currentTarget).toBeNull();
+
+         handlerFor("/user/commands/wiz/pairing/joined")(
+            notice({ runtimeId: "rt-1", sheetType: "WORKSHEET", focusChanged: true,
+                     editorContext: { kind: "onClick", assembly: "Chart2", name: null, table: null } }));
+
+         expect(component.currentTarget).toBeNull();
+      });
+
+      it("resets the live target and toggle visibility when the runtimeId changes", () => {
+         connectAsToolbar();
+         handlerFor("/user/commands/wiz/pairing/joined")(
+            notice({ runtimeId: "rt-1", sheetType: "WORKSHEET", focusChanged: true,
+                     editorContext: { kind: "onClick", assembly: "Chart1", name: null, table: null } }));
+
+         component.runtimeId = "rt-2";
+         component.ngOnChanges(
+            { runtimeId: { currentValue: "rt-2", previousValue: "rt-1",
+                           firstChange: false, isFirstChange: () => false } } as any);
+
+         expect(component.currentTarget).toBeNull();
+         expect(component.followFocusToggleVisible).toBe(false);
+      });
+   });
+
 });

--- a/web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.ts
+++ b/web/projects/portal/src/app/composer/gui/wiz/connect-to-claude.component.ts
@@ -23,12 +23,14 @@ import { take } from "rxjs/operators";
 import { StompClientConnection } from "../../../../../../shared/stomp/stomp-client-connection";
 import { ViewsheetClientService } from "../../../common/viewsheet-client";
 import { EditorContext } from "./editor-context";
+import { FollowFocusService } from "./services/follow-focus.service";
+import { FormsModule } from "@angular/forms";
 
 @Component({
    selector: "wiz-connect-to-claude",
    templateUrl: "./connect-to-claude.component.html",
    standalone: true,
-   imports: [NgIf, ClipboardModule]
+   imports: [NgIf, ClipboardModule, FormsModule]
 })
 export class ConnectToClaudeComponent implements OnInit, OnChanges, OnDestroy {
    @Input() runtimeId!: string;
@@ -80,6 +82,18 @@ export class ConnectToClaudeComponent implements OnInit, OnChanges, OnDestroy {
    private mintedEditorContext: EditorContext | null = null;
 
    /**
+    * The session's LIVE target, tracked only on the whole-sheet (toolbar) instance --
+    * {@code mintedEditorContext === null} -- since that is the only instance Follow Focus ever
+    * retargets (a session must opt in, and only a whole-sheet session is ever pushed onto a
+    * pane; see the design spec). {@code null} means "whole sheet," the same meaning
+    * {@code editorContext}/{@code mintedEditorContext} give it elsewhere in this component.
+    *
+    * Set from the initial join notice and from every subsequent `focusChanged` notice
+    * ({@link FollowFocusService}'s push/pop) -- see {@link #onJoined}.
+    */
+   currentTarget: EditorContext | null = null;
+
+   /**
     * Whether this instance has an outstanding mint of its own.
     *
     * `mintedEditorContext === null` cannot answer that: it means both "I minted a whole-sheet
@@ -90,7 +104,40 @@ export class ConnectToClaudeComponent implements OnInit, OnChanges, OnDestroy {
     */
    private hasMinted = false;
 
-   constructor(private zone: NgZone) {}
+   constructor(private zone: NgZone, private followFocusService: FollowFocusService) {}
+
+   /**
+    * Whether the Follow Focus toggle should render at all -- only once connected, and only on
+    * the whole-sheet (toolbar) instance. A pane's own {@code ConnectToClaudeComponent} has
+    * nothing meaningful to toggle: Follow Focus opts in the OUTER session, not the pane session
+    * itself (see the design spec's "what this changes" section).
+    */
+   get followFocusToggleVisible(): boolean {
+      return this.connected && !this.editorContext;
+   }
+
+   get followFocusEnabled(): boolean {
+      return this.followFocusService.isEnabled(this.runtimeId);
+   }
+
+   toggleFollowFocus(event: Event): void {
+      const enabled = (event.target as HTMLInputElement).checked;
+      this.followFocusService.setEnabled(this.runtimeId, this.socketConnection, enabled);
+   }
+
+   /**
+    * Human-readable label for {@link currentTarget}, e.g. "Whole sheet" or "Chart1 → onClick" --
+    * the exact shape the design spec's indicator calls for.
+    */
+   get currentTargetLabel(): string {
+      if(!this.currentTarget) {
+         return "Whole sheet";
+      }
+
+      return this.currentTarget.assembly
+         ? `${this.currentTarget.assembly} → ${this.currentTarget.kind}`
+         : this.currentTarget.kind;
+   }
 
    /**
     * Opens the standing subscription for join notices.
@@ -119,6 +166,7 @@ export class ConnectToClaudeComponent implements OnInit, OnChanges, OnDestroy {
          this.connected = false;
          this.mintedEditorContext = null;
          this.hasMinted = false;
+         this.currentTarget = null;
          if(this.mintSubscription) {
             this.mintSubscription.unsubscribe();
             this.mintSubscription = null;
@@ -133,6 +181,7 @@ export class ConnectToClaudeComponent implements OnInit, OnChanges, OnDestroy {
       this.copied = false;
       this.connected = false;
       this.hasMinted = false;
+      this.currentTarget = null;
 
       // Read ONCE, here, and carry this exact value through to the response handler: the getters
       // that supply it are live, so re-reading it later (in detach, or even in this same
@@ -196,9 +245,29 @@ export class ConnectToClaudeComponent implements OnInit, OnChanges, OnDestroy {
          return;
       }
 
-      if(!this.hasMinted || body.runtimeId !== this.runtimeId ||
-         !this.sameEditorContext(body.editorContext, this.mintedEditorContext))
-      {
+      if(!this.hasMinted || body.runtimeId !== this.runtimeId) {
+         return;
+      }
+
+      /*
+       * Follow Focus retargeted/popped an already-connected session -- a DIFFERENT event from a
+       * fresh mint being redeemed, and one the strict editorContext match below cannot handle:
+       * the whole point of a retarget is that editorContext no longer matches what THIS instance
+       * originally minted. Only the whole-sheet (toolbar) instance tracks this live, since that
+       * is the only kind of session Follow Focus ever retargets (see currentTarget's doc).
+       */
+      if(body.focusChanged) {
+         if(this.mintedEditorContext !== null) {
+            return;
+         }
+
+         this.zone.run(() => {
+            this.currentTarget = body.editorContext ?? null;
+         });
+         return;
+      }
+
+      if(!this.sameEditorContext(body.editorContext, this.mintedEditorContext)) {
          return;
       }
 
@@ -208,6 +277,12 @@ export class ConnectToClaudeComponent implements OnInit, OnChanges, OnDestroy {
          // to redeem it again.
          this.code = null;
          this.error = null;
+
+         // currentTarget is meaningful only on the whole-sheet (toolbar) instance -- a pane
+         // instance's own join already IS its target, with no further movement to track.
+         if(this.mintedEditorContext === null) {
+            this.currentTarget = body.editorContext ?? null;
+         }
       });
    }
 

--- a/web/projects/portal/src/app/composer/gui/wiz/services/follow-focus.service.spec.ts
+++ b/web/projects/portal/src/app/composer/gui/wiz/services/follow-focus.service.spec.ts
@@ -1,0 +1,199 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { of } from "rxjs";
+import { FollowFocusService } from "./follow-focus.service";
+
+describe("FollowFocusService", () => {
+   let service: FollowFocusService;
+   let mockStompConnection: { subscribe: ReturnType<typeof vi.fn>; send: ReturnType<typeof vi.fn> };
+   let mockSocketConnection: any;
+
+   beforeEach(() => {
+      service = new FollowFocusService();
+      mockStompConnection = { subscribe: vi.fn(), send: vi.fn() };
+      mockSocketConnection = { whenConnected: vi.fn(() => of(mockStompConnection)) };
+   });
+
+   describe("isEnabled / setEnabled", () => {
+      it("defaults to disabled for a runtime nothing has touched", () => {
+         expect(service.isEnabled("rt-1")).toBe(false);
+      });
+
+      it("is per-runtime, not global", () => {
+         service.setEnabled("rt-1", mockSocketConnection, true);
+
+         expect(service.isEnabled("rt-1")).toBe(true);
+         expect(service.isEnabled("rt-2")).toBe(false);
+      });
+
+      it("sends the toggle over the follow-focus destination", () => {
+         service.setEnabled("rt-1", mockSocketConnection, true);
+
+         expect(mockStompConnection.send).toHaveBeenCalledWith(
+            "/events/wiz/pairing/follow-focus", {},
+            JSON.stringify({ runtimeId: "rt-1", enabled: true }));
+      });
+
+      it("can be turned back off", () => {
+         service.setEnabled("rt-1", mockSocketConnection, true);
+         service.setEnabled("rt-1", mockSocketConnection, false);
+
+         expect(service.isEnabled("rt-1")).toBe(false);
+      });
+
+      it("is a no-op with no runtimeId or no socket connection", () => {
+         expect(() => service.setEnabled("", mockSocketConnection, true)).not.toThrow();
+         expect(() => service.setEnabled("rt-1", undefined as any, true)).not.toThrow();
+         expect(mockStompConnection.send).not.toHaveBeenCalled();
+      });
+   });
+
+   describe("pushFocus", () => {
+      it("does nothing, and returns false, when Follow Focus is not enabled", () => {
+         const pushed = service.pushFocus(
+            "rt-1", mockSocketConnection, { kind: "assemblyMain", assembly: "Chart1" });
+
+         expect(pushed).toBe(false);
+         expect(mockStompConnection.send).not.toHaveBeenCalled();
+      });
+
+      it("sends a retarget request and returns true when enabled", () => {
+         service.setEnabled("rt-1", mockSocketConnection, true);
+
+         const pushed = service.pushFocus(
+            "rt-1", mockSocketConnection, { kind: "assemblyMain", assembly: "Chart1" });
+
+         expect(pushed).toBe(true);
+         expect(mockStompConnection.send).toHaveBeenCalledWith(
+            "/events/wiz/pairing/retarget", {},
+            JSON.stringify({
+               runtimeId: "rt-1",
+               editorContext: { kind: "assemblyMain", assembly: "Chart1" }
+            }));
+      });
+
+      it("is a no-op with no editorContext", () => {
+         service.setEnabled("rt-1", mockSocketConnection, true);
+
+         const pushed = service.pushFocus("rt-1", mockSocketConnection, undefined as any);
+
+         expect(pushed).toBe(false);
+         expect(mockStompConnection.send).not.toHaveBeenCalledWith(
+            "/events/wiz/pairing/retarget", expect.anything(), expect.anything());
+      });
+   });
+
+   describe("popFocus", () => {
+      it("sends a pop request naming just the runtimeId", () => {
+         service.setEnabled("rt-1", mockSocketConnection, true);
+         service.pushFocus("rt-1", mockSocketConnection, { kind: "assemblyMain", assembly: "Chart1" });
+
+         service.popFocus("rt-1", mockSocketConnection, { kind: "assemblyMain", assembly: "Chart1" });
+
+         expect(mockStompConnection.send).toHaveBeenCalledWith(
+            "/events/wiz/pairing/pop-focus", {}, JSON.stringify({ runtimeId: "rt-1" }));
+      });
+
+      it("still sends the pop request even when the closing pane does not match the tracked top", () => {
+         service.setEnabled("rt-1", mockSocketConnection, true);
+         service.pushFocus("rt-1", mockSocketConnection, { kind: "assemblyMain", assembly: "Chart1" });
+
+         service.popFocus("rt-1", mockSocketConnection, { kind: "assemblyMain", assembly: "Chart2" });
+
+         expect(mockStompConnection.send).toHaveBeenCalledWith(
+            "/events/wiz/pairing/pop-focus", {}, JSON.stringify({ runtimeId: "rt-1" }));
+      });
+
+      it("surfaces a mismatch loudly via the errors observable instead of silently guessing", () => {
+         const messages: string[] = [];
+         service.errors.subscribe(m => messages.push(m));
+         const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+         service.setEnabled("rt-1", mockSocketConnection, true);
+         service.pushFocus("rt-1", mockSocketConnection, { kind: "assemblyMain", assembly: "Chart1" });
+         service.popFocus("rt-1", mockSocketConnection, { kind: "assemblyMain", assembly: "Chart2" });
+
+         expect(messages.length).toBe(1);
+         expect(messages[0]).toContain("Chart1");
+         expect(messages[0]).toContain("Chart2");
+         expect(errorSpy).toHaveBeenCalled();
+
+         errorSpy.mockRestore();
+      });
+
+      it("reports no mismatch when the closing pane matches the tracked top", () => {
+         const messages: string[] = [];
+         service.errors.subscribe(m => messages.push(m));
+
+         service.setEnabled("rt-1", mockSocketConnection, true);
+         service.pushFocus("rt-1", mockSocketConnection, { kind: "assemblyMain", assembly: "Chart1" });
+         service.popFocus("rt-1", mockSocketConnection, { kind: "assemblyMain", assembly: "Chart1" });
+
+         expect(messages.length).toBe(0);
+      });
+
+      it("unwinds nesting in reverse order without a mismatch", () => {
+         const messages: string[] = [];
+         service.errors.subscribe(m => messages.push(m));
+
+         service.setEnabled("rt-1", mockSocketConnection, true);
+         service.pushFocus("rt-1", mockSocketConnection, { kind: "assemblyMain", assembly: "Chart1" });
+         service.pushFocus("rt-1", mockSocketConnection,
+                            { kind: "calcField", assembly: "Query1", name: "Margin" });
+
+         // Closing the inner (most recently pushed) frame first is not a mismatch.
+         service.popFocus("rt-1", mockSocketConnection,
+                           { kind: "calcField", assembly: "Query1", name: "Margin" });
+         // Then the outer frame.
+         service.popFocus("rt-1", mockSocketConnection, { kind: "assemblyMain", assembly: "Chart1" });
+
+         expect(messages.length).toBe(0);
+      });
+
+      it("is a no-op with no runtimeId or no socket connection", () => {
+         expect(() => service.popFocus("", mockSocketConnection,
+            { kind: "assemblyMain" })).not.toThrow();
+         expect(() => service.popFocus("rt-1", undefined as any,
+            { kind: "assemblyMain" })).not.toThrow();
+         expect(mockStompConnection.send).not.toHaveBeenCalled();
+      });
+   });
+
+   describe("toggling off mid-session (spec design question 3)", () => {
+      it("still pops an already-pushed pane after Follow Focus is disabled", () => {
+         service.setEnabled("rt-1", mockSocketConnection, true);
+         service.pushFocus("rt-1", mockSocketConnection, { kind: "assemblyMain", assembly: "Chart1" });
+
+         service.setEnabled("rt-1", mockSocketConnection, false);
+         service.popFocus("rt-1", mockSocketConnection, { kind: "assemblyMain", assembly: "Chart1" });
+
+         expect(mockStompConnection.send).toHaveBeenCalledWith(
+            "/events/wiz/pairing/pop-focus", {}, JSON.stringify({ runtimeId: "rt-1" }));
+      });
+
+      it("does not auto-push the next pane once disabled", () => {
+         service.setEnabled("rt-1", mockSocketConnection, true);
+         service.setEnabled("rt-1", mockSocketConnection, false);
+
+         const pushed = service.pushFocus(
+            "rt-1", mockSocketConnection, { kind: "assemblyMain", assembly: "Chart2" });
+
+         expect(pushed).toBe(false);
+      });
+   });
+});

--- a/web/projects/portal/src/app/composer/gui/wiz/services/follow-focus.service.ts
+++ b/web/projects/portal/src/app/composer/gui/wiz/services/follow-focus.service.ts
@@ -71,8 +71,16 @@ export class FollowFocusService {
    private state = new Map<string, FollowFocusState>();
    private errorSubject = new Subject<string>();
 
-   /** Surfaces a client-side stack-integrity problem (plan Phase 2 task 4) so a host UI --
-    *  `ConnectToClaudeComponent`'s indicator -- can show it rather than let it pass silently. */
+   /**
+    * Surfaces a client-side stack-integrity problem (plan Phase 2 task 4), intended for a host
+    * UI -- `ConnectToClaudeComponent`'s indicator -- to show rather than let pass silently.
+    *
+    * <p><b>Not wired up to any UI yet.</b> Nothing in this codebase currently subscribes to this
+    * Observable, so a mismatch reaches only the `console.error` this service also logs, not any
+    * visible surface. Flagged by code review on stylebi#4683 so this doesn't read as
+    * already-done; wiring a subscriber into `ConnectToClaudeComponent`'s indicator is a
+    * follow-up, not part of this PR's Phase 3 scope.
+    */
    get errors(): Observable<string> {
       return this.errorSubject.asObservable();
    }

--- a/web/projects/portal/src/app/composer/gui/wiz/services/follow-focus.service.ts
+++ b/web/projects/portal/src/app/composer/gui/wiz/services/follow-focus.service.ts
@@ -1,0 +1,201 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { Injectable } from "@angular/core";
+import { Observable, Subject } from "rxjs";
+import { take } from "rxjs/operators";
+import { StompClientConnection } from "../../../../../../../shared/stomp/stomp-client-connection";
+import { ViewsheetClientService } from "../../../../common/viewsheet-client";
+import { EditorContext } from "../editor-context";
+
+/**
+ * Per-runtime Follow Focus state: whether the human has opted in, and the client's own shadow
+ * of "which panes are currently pushed," most-recently-opened last.
+ *
+ * Deliberately per-`runtimeId`, not a single global flag -- see the design spec's question 1
+ * ("per-session ... rather than a sticky global preference"). Never persisted (no storage
+ * read/write anywhere in this service): a fresh page load or a fresh pairing starts back at
+ * `enabled: false`, by design.
+ */
+interface FollowFocusState {
+   enabled: boolean;
+   stack: EditorContext[];
+}
+
+/**
+ * Client-side half of Follow Focus (spec: `2026-08-19-follow-focus-pane-targeting-design.md`;
+ * plan: `2026-08-19-follow-focus-pane-targeting-implementation.md`, Phase 2).
+ *
+ * Holds the opt-in toggle and talks to the Phase 1 STOMP endpoints that retarget an
+ * *already-live* pairing session in place. This service never mints, joins, or detaches a
+ * session itself -- `ConnectToClaudeComponent` still owns that lifecycle -- it only asks the
+ * server to move an existing session's target, which is a strictly narrower operation.
+ *
+ * A single root-provided instance spans every `ScriptPane` / `FormulaEditorDialog` /
+ * `ConnectToClaudeComponent` on the page, keyed internally by `runtimeId`, because the toggle
+ * (surfaced on the toolbar's `ConnectToClaudeComponent`) and the push/pop calls (fired from the
+ * script pane / formula editor host components) live on different component instances that do
+ * not otherwise share state.
+ *
+ * Wire contract assumed against the Phase 1 plan (Phase 1 lands in a sibling worktree on
+ * `feat/follow-focus-pane-targeting-java`, not present here):
+ * - toggle: send `{runtimeId, enabled}` to `/events/wiz/pairing/follow-focus`, fire-and-forget
+ *   (mirrors `detach`'s shape, per plan Phase 1 task 4).
+ * - push: send `{runtimeId, editorContext}` to `/events/wiz/pairing/retarget`, fire-and-forget
+ *   (mirrors `MintRequest`'s shape, per plan Phase 1 task 5).
+ * - pop: send `{runtimeId}` to `/events/wiz/pairing/pop-focus`, fire-and-forget. The plan names
+ *   the toggle and retarget destinations literally but only describes the pop endpoint's payload
+ *   shape, not its literal path -- `/wiz/pairing/pop-focus` is this file's own choice, picked to
+ *   mirror `follow-focus`'s kebab-case naming. Confirm this string against whatever
+ *   `SheetPairingController` actually ships once Phase 1 lands; a mismatch here is a naming
+ *   typo to fix, not a sign the contract itself is wrong.
+ */
+@Injectable({
+   providedIn: "root"
+})
+export class FollowFocusService {
+   private state = new Map<string, FollowFocusState>();
+   private errorSubject = new Subject<string>();
+
+   /** Surfaces a client-side stack-integrity problem (plan Phase 2 task 4) so a host UI --
+    *  `ConnectToClaudeComponent`'s indicator -- can show it rather than let it pass silently. */
+   get errors(): Observable<string> {
+      return this.errorSubject.asObservable();
+   }
+
+   isEnabled(runtimeId: string): boolean {
+      return !!runtimeId && !!this.state.get(runtimeId)?.enabled;
+   }
+
+   /**
+    * Turns Follow Focus on/off for this runtime and tells the server. Off is always safe to
+    * request (a session that already has no pushed focus simply has nothing to pop later); on
+    * only takes effect for the *next* pane opened -- an already-open pane does not retroactively
+    * push (spec test 3).
+    */
+   setEnabled(runtimeId: string, socketConnection: ViewsheetClientService, enabled: boolean): void {
+      if(!runtimeId || !socketConnection) {
+         return;
+      }
+
+      this.stateFor(runtimeId).enabled = enabled;
+
+      socketConnection.whenConnected().pipe(take(1)).subscribe((conn: StompClientConnection) => {
+         conn.send("/events/wiz/pairing/follow-focus", {},
+                   JSON.stringify({ runtimeId, enabled }));
+      });
+   }
+
+   /**
+    * Pushes the session's target to `editorContext`, if Follow Focus is enabled for this
+    * runtime. A no-op (never sends anything) when it is not -- opening a pane with Follow Focus
+    * off must behave exactly as it does today (spec design question 2/3).
+    *
+    * Returns whether a push was actually issued, so the caller (a host component's lifecycle
+    * hook) knows whether it owes a matching `popFocus` on close.
+    */
+   pushFocus(runtimeId: string, socketConnection: ViewsheetClientService,
+             editorContext: EditorContext): boolean
+   {
+      if(!runtimeId || !socketConnection || !editorContext || !this.isEnabled(runtimeId)) {
+         return false;
+      }
+
+      this.stateFor(runtimeId).stack.push(editorContext);
+
+      socketConnection.whenConnected().pipe(take(1)).subscribe((conn: StompClientConnection) => {
+         conn.send("/events/wiz/pairing/retarget", {},
+                   JSON.stringify({ runtimeId, editorContext }));
+      });
+
+      return true;
+   }
+
+   /**
+    * Pops the session's target back to whatever it was before the matching `pushFocus`. Callers
+    * pass the `editorContext` they *expect* to be the current top of the stack -- i.e. the exact
+    * location their own `pushFocus` call pushed -- purely as a client-side integrity check
+    * (plan Phase 2 task 4): the server's own stack (Phase 1) is the actual authority and pops
+    * unconditionally on `runtimeId` alone, so this call is always sent regardless of whether the
+    * check passes. A mismatch never changes what gets sent; it only means something upstream of
+    * this call sequenced pushes/pops incorrectly, which is a bug to surface loudly, not to guess
+    * around by silently reordering or skipping the pop.
+    *
+    * Must be called even if Follow Focus has since been toggled off mid-session (spec test 3):
+    * an already-pushed pane still owes its pop when it closes. Only call this when the matching
+    * `pushFocus` actually returned `true` -- a pane that never pushed owes no pop, and calling
+    * this unconditionally from `ngOnDestroy` would send a spurious pop for every pane close.
+    */
+   popFocus(runtimeId: string, socketConnection: ViewsheetClientService,
+            editorContext: EditorContext): void
+   {
+      if(!runtimeId || !socketConnection) {
+         return;
+      }
+
+      const stack = this.state.get(runtimeId)?.stack;
+      const top = stack && stack.length > 0 ? stack[stack.length - 1] : null;
+
+      if(!this.sameEditorContext(top, editorContext)) {
+         const message = `Follow Focus close mismatch for runtime ${runtimeId}: expected to be` +
+            ` closing ${JSON.stringify(top)} but got ${JSON.stringify(editorContext)}.`;
+         // eslint-disable-next-line no-console
+         console.error(message);
+         this.errorSubject.next(message);
+      }
+
+      if(stack && stack.length > 0) {
+         stack.pop();
+      }
+
+      socketConnection.whenConnected().pipe(take(1)).subscribe((conn: StompClientConnection) => {
+         conn.send("/events/wiz/pairing/pop-focus", {}, JSON.stringify({ runtimeId }));
+      });
+   }
+
+   private stateFor(runtimeId: string): FollowFocusState {
+      let state = this.state.get(runtimeId);
+
+      if(!state) {
+         state = { enabled: false, stack: [] };
+         this.state.set(runtimeId, state);
+      }
+
+      return state;
+   }
+
+   /**
+    * Same absent-vs-null-tolerant comparison `ConnectToClaudeComponent` uses for the joined
+    * notice -- kept as an independent copy rather than a shared import so this service has no
+    * compile-time dependency on that component (only the reverse should ever be true).
+    */
+   private sameEditorContext(a: EditorContext | null | undefined,
+                              b: EditorContext | null | undefined): boolean {
+      if(!a && !b) {
+         return true;
+      }
+
+      if(!a || !b) {
+         return false;
+      }
+
+      return a.kind === b.kind &&
+         (a.assembly ?? null) === (b.assembly ?? null) &&
+         (a.name ?? null) === (b.name ?? null) &&
+         (a.table ?? null) === (b.table ?? null);
+   }
+}

--- a/web/projects/portal/src/app/widget/dialog/script-pane/script-pane.component.interaction.tl.spec.ts
+++ b/web/projects/portal/src/app/widget/dialog/script-pane/script-pane.component.interaction.tl.spec.ts
@@ -279,4 +279,97 @@ describe("ScriptPane - pane-scoped pairing runtime/socket inputs [Group 5, Risk 
 
       expect(() => comp.ngOnDestroy()).not.toThrow();
    });
+
+   /*
+    * Follow Focus (plan `2026-08-19-follow-focus-pane-targeting-implementation.md`, Phase 2 task
+    * 2/3): push/pop is a distinct signal from detach() above, fired independently, not a
+    * replacement for it.
+    */
+   describe("Follow Focus push/pop [Phase 2]", () => {
+      it("pushes focus on ngOnInit when Follow Focus is enabled", () => {
+         const { comp, followFocusService } = createScriptPane();
+         comp.runtimeId = "vs-1";
+         comp.socketConnection = {} as any;
+         comp.editorContext = { kind: "assemblyMain", assembly: "Chart1" };
+         (followFocusService.pushFocus as any).mockReturnValue(true);
+
+         comp.ngOnInit();
+
+         expect(followFocusService.pushFocus).toHaveBeenCalledWith(
+            "vs-1", comp.socketConnection, { kind: "assemblyMain", assembly: "Chart1" });
+      });
+
+      it("does not push when there is no editorContext (a pane with no script location)", () => {
+         const { comp, followFocusService } = createScriptPane();
+         comp.runtimeId = "vs-1";
+         comp.socketConnection = {} as any;
+         comp.editorContext = undefined;
+
+         comp.ngOnInit();
+
+         expect(followFocusService.pushFocus).not.toHaveBeenCalled();
+      });
+
+      it("does not push when there is no runtime/socket to push against", () => {
+         const { comp, followFocusService } = createScriptPane();
+         comp.editorContext = { kind: "assemblyMain", assembly: "Chart1" };
+
+         comp.ngOnInit();
+
+         expect(followFocusService.pushFocus).not.toHaveBeenCalled();
+      });
+
+      it("pops focus on ngOnDestroy when this pane's own push took effect", () => {
+         const { comp, codeMirror, ternServer, followFocusService } = createScriptPane();
+         (comp as any).codemirrorInstance = codeMirror;
+         (comp as any).ternServer = ternServer;
+         (comp as any).cancelAutocomplete = vi.fn();
+         comp.runtimeId = "vs-1";
+         comp.socketConnection = {} as any;
+         comp.editorContext = { kind: "assemblyMain", assembly: "Chart1" };
+         (followFocusService.pushFocus as any).mockReturnValue(true);
+         comp.ngOnInit();
+
+         comp.ngOnDestroy();
+
+         expect(followFocusService.popFocus).toHaveBeenCalledWith(
+            "vs-1", comp.socketConnection, { kind: "assemblyMain", assembly: "Chart1" });
+      });
+
+      it("does not pop on ngOnDestroy when Follow Focus was off at open (no push happened)", () => {
+         const { comp, codeMirror, ternServer, followFocusService } = createScriptPane();
+         (comp as any).codemirrorInstance = codeMirror;
+         (comp as any).ternServer = ternServer;
+         (comp as any).cancelAutocomplete = vi.fn();
+         comp.runtimeId = "vs-1";
+         comp.socketConnection = {} as any;
+         comp.editorContext = { kind: "assemblyMain", assembly: "Chart1" };
+         (followFocusService.pushFocus as any).mockReturnValue(false);
+         comp.ngOnInit();
+
+         comp.ngOnDestroy();
+
+         expect(followFocusService.popFocus).not.toHaveBeenCalled();
+      });
+
+      it("fires pop independently of detach -- both run, neither implies the other", () => {
+         const { comp, codeMirror, ternServer, followFocusService } = createScriptPane();
+         (comp as any).codemirrorInstance = codeMirror;
+         (comp as any).ternServer = ternServer;
+         (comp as any).cancelAutocomplete = vi.fn();
+         comp.runtimeId = "vs-1";
+         comp.socketConnection = {} as any;
+         comp.editorContext = { kind: "assemblyMain", assembly: "Chart1" };
+         (followFocusService.pushFocus as any).mockReturnValue(true);
+         comp.ngOnInit();
+         // This pane never itself minted a pairing code (no Connect-to-Claude control present),
+         // so detach() has nothing to do -- but the Follow Focus pop must still fire, because the
+         // pane pushed an existing OUTER session's target here, not a session of its own.
+         (comp as any).connectToClaude = undefined;
+
+         comp.ngOnDestroy();
+
+         expect(followFocusService.popFocus).toHaveBeenCalledTimes(1);
+      });
+   });
 });

--- a/web/projects/portal/src/app/widget/dialog/script-pane/script-pane.component.interaction.tl.spec.ts
+++ b/web/projects/portal/src/app/widget/dialog/script-pane/script-pane.component.interaction.tl.spec.ts
@@ -336,6 +336,35 @@ describe("ScriptPane - pane-scoped pairing runtime/socket inputs [Group 5, Risk 
             "vs-1", comp.socketConnection, { kind: "assemblyMain", assembly: "Chart1" });
       });
 
+      /*
+       * The bug the automated review on stylebi#4683 found: `editorContext` is a plain @Input()
+       * here, but the REAL ViewsheetScriptPane host rebinds it live off `initScriptVisible` --
+       * a flag the onInit/onRefresh radio buttons flip on the SAME persistent <script-pane>
+       * instance (no *ngIf* recreation). Simulated here by mutating comp.editorContext directly
+       * between ngOnInit and ngOnDestroy, exactly as that live rebinding would.
+       */
+      it("pops with the ORIGINALLY PUSHED context, not whatever editorContext changed to " +
+         "before close (tab-switch hazard)", () => {
+         const { comp, codeMirror, ternServer, followFocusService } = createScriptPane();
+         (comp as any).codemirrorInstance = codeMirror;
+         (comp as any).ternServer = ternServer;
+         (comp as any).cancelAutocomplete = vi.fn();
+         comp.runtimeId = "vs-1";
+         comp.socketConnection = {} as any;
+         comp.editorContext = { kind: "viewsheetOnInit" };
+         (followFocusService.pushFocus as any).mockReturnValue(true);
+         comp.ngOnInit();
+
+         // Simulates switching from the onInit tab to the onRefresh tab on this same, persistent
+         // pane instance -- the exact rebinding the review flagged as tripping the mismatch.
+         comp.editorContext = { kind: "viewsheetOnLoad" };
+
+         comp.ngOnDestroy();
+
+         expect(followFocusService.popFocus).toHaveBeenCalledWith(
+            "vs-1", comp.socketConnection, { kind: "viewsheetOnInit" });
+      });
+
       it("does not pop on ngOnDestroy when Follow Focus was off at open (no push happened)", () => {
          const { comp, codeMirror, ternServer, followFocusService } = createScriptPane();
          (comp as any).codemirrorInstance = codeMirror;

--- a/web/projects/portal/src/app/widget/dialog/script-pane/script-pane.component.test-helpers.ts
+++ b/web/projects/portal/src/app/widget/dialog/script-pane/script-pane.component.test-helpers.ts
@@ -18,6 +18,7 @@
 
 import { Subject } from "rxjs";
 import { CodemirrorService } from "../../../../../../shared/util/codemirror/codemirror.service";
+import { FollowFocusService } from "../../../composer/gui/wiz/services/follow-focus.service";
 import { ScriptPane } from "./script-pane.component";
 
 export interface MockCodeMirror {
@@ -180,6 +181,13 @@ export function createScriptPane(options: {
    } as any;
 
    const host = { nativeElement: hostElement } as any;
+   const followFocusService = {
+      isEnabled: vi.fn(() => false),
+      setEnabled: vi.fn(),
+      pushFocus: vi.fn(() => false),
+      popFocus: vi.fn(),
+      errors: new Subject<string>().asObservable()
+   } as unknown as FollowFocusService;
    const comp = new ScriptPane(
       codemirrorService,
       zone,
@@ -187,7 +195,8 @@ export function createScriptPane(options: {
       helpService,
       scriptSettingsService,
       renderer,
-      host
+      host,
+      followFocusService
    );
 
    (comp as any).scriptEditor = { nativeElement: textarea };
@@ -209,6 +218,7 @@ export function createScriptPane(options: {
       helpService,
       scriptSettingsService,
       renderer,
+      followFocusService,
       rendererCleanups,
       helpUrl$,
       cursorTop$,

--- a/web/projects/portal/src/app/widget/dialog/script-pane/script-pane.component.ts
+++ b/web/projects/portal/src/app/widget/dialog/script-pane/script-pane.component.ts
@@ -37,6 +37,7 @@ import { DataRef } from "../../../common/data/data-ref";
 import { ViewsheetClientService } from "../../../common/viewsheet-client";
 import { EditorContext } from "../../../composer/gui/wiz/editor-context";
 import { ConnectToClaudeComponent } from "../../../composer/gui/wiz/connect-to-claude.component";
+import { FollowFocusService } from "../../../composer/gui/wiz/services/follow-focus.service";
 import { FormulaFunctionAnalyzerService } from "./formula-function-analyzer.service";
 import { HelpUrlService } from "../../help-link/help-url.service";
 import { TreeNodeModel } from "../../tree/tree-node-model";
@@ -114,6 +115,11 @@ export class ScriptPane implements AfterViewInit, AfterViewChecked, OnInit, OnDe
    private cursorTop: boolean = false;
    helpURL = "";
    needUseVirtualScroll: boolean = true;
+   /** Whether this pane's own `pushFocus` call actually took effect (Follow Focus was enabled
+    *  for this runtime at the time this pane opened). Only set when true so `ngOnDestroy` knows
+    *  it owes a matching `popFocus` -- a pane that never pushed, because Follow Focus was off
+    *  when it opened, must not send a spurious pop when it closes. */
+   private followFocusPushed = false;
 
    @Input()
    set expression(value: string) {
@@ -226,7 +232,8 @@ export class ScriptPane implements AfterViewInit, AfterViewChecked, OnInit, OnDe
                private analyzerService: FormulaFunctionAnalyzerService,
                private helpService: HelpUrlService,
                private scriptSettingsService: ScriptSettingsService,
-               private renderer: Renderer2, private host: ElementRef)
+               private renderer: Renderer2, private host: ElementRef,
+               private followFocusService: FollowFocusService)
    {
    }
 
@@ -241,6 +248,15 @@ export class ScriptPane implements AfterViewInit, AfterViewChecked, OnInit, OnDe
          this.cursorTopLoaded = true;
          this.applyCursorPosition();
       });
+
+      // Follow Focus (separate from, and in addition to, the ConnectToClaudeComponent#detach()
+      // call in ngOnDestroy below): if the human has opted in, this pane opening pushes an
+      // already-live session's target here for the duration this pane is open. A no-op when
+      // Follow Focus is off, or when this pane has no runtime/socket/location to push to.
+      if(this.runtimeId && this.socketConnection && this.editorContext) {
+         this.followFocusPushed = this.followFocusService.pushFocus(
+            this.runtimeId, this.socketConnection, this.editorContext);
+      }
    }
 
    ngOnChanges(changes: SimpleChanges): void {
@@ -288,6 +304,15 @@ export class ScriptPane implements AfterViewInit, AfterViewChecked, OnInit, OnDe
       // handle behind. No-op when this pane never showed a Connect-to-Claude control, or when
       // it did but editorContext is a whole-sheet (null) mint.
       this.connectToClaude?.detach();
+
+      // Follow Focus's pop is a distinct signal from detach() above, not a replacement for it:
+      // detach ends a session THIS pane itself minted; pop restores an already-live session's
+      // target to whatever enclosing scope it had before this pane pushed it here. Only fires
+      // when ngOnInit's pushFocus actually took effect -- a pane that opened with Follow Focus
+      // off owes no pop.
+      if(this.followFocusPushed) {
+         this.followFocusService.popFocus(this.runtimeId, this.socketConnection, this.editorContext);
+      }
    }
 
    private isEditorElementDisplayed(): boolean {

--- a/web/projects/portal/src/app/widget/dialog/script-pane/script-pane.component.ts
+++ b/web/projects/portal/src/app/widget/dialog/script-pane/script-pane.component.ts
@@ -121,6 +121,21 @@ export class ScriptPane implements AfterViewInit, AfterViewChecked, OnInit, OnDe
     *  when it opened, must not send a spurious pop when it closes. */
    private followFocusPushed = false;
 
+   /**
+    * The exact `editorContext` value this pane actually pushed in `ngOnInit`, captured once and
+    * reused in `ngOnDestroy` -- NOT re-read live from `this.editorContext` at pop time.
+    *
+    * `editorContext` is an `@Input()` bound from `ViewsheetScriptPane.editorContext`, a getter
+    * derived from `initScriptVisible`, a flag the user flips via the onInit/onRefresh radio
+    * buttons on the SAME persistent `<script-pane>` instance (no `*ngIf` recreation). So opening
+    * this pane on the onInit tab, switching to onRefresh, then closing pushes `viewsheetOnInit`
+    * but would pop `viewsheetOnLoad` if `ngOnDestroy` re-read the live input -- tripping
+    * `FollowFocusService.popFocus`'s stack-integrity check for entirely normal tab-switching.
+    * Same `mintedEditorContext` pattern `ConnectToClaudeComponent` already uses for the identical
+    * live-getter-at-a-later-time hazard.
+    */
+   private pushedEditorContext: EditorContext | null = null;
+
    @Input()
    set expression(value: string) {
       this._expression = value;
@@ -254,8 +269,16 @@ export class ScriptPane implements AfterViewInit, AfterViewChecked, OnInit, OnDe
       // already-live session's target here for the duration this pane is open. A no-op when
       // Follow Focus is off, or when this pane has no runtime/socket/location to push to.
       if(this.runtimeId && this.socketConnection && this.editorContext) {
+         // Read ONCE, here, and carry this exact value through to ngOnDestroy -- see
+         // pushedEditorContext's doc. The live this.editorContext getter can disagree with this
+         // by the time the pane closes.
+         const pushedContext = this.editorContext;
          this.followFocusPushed = this.followFocusService.pushFocus(
-            this.runtimeId, this.socketConnection, this.editorContext);
+            this.runtimeId, this.socketConnection, pushedContext);
+
+         if(this.followFocusPushed) {
+            this.pushedEditorContext = pushedContext;
+         }
       }
    }
 
@@ -311,7 +334,9 @@ export class ScriptPane implements AfterViewInit, AfterViewChecked, OnInit, OnDe
       // when ngOnInit's pushFocus actually took effect -- a pane that opened with Follow Focus
       // off owes no pop.
       if(this.followFocusPushed) {
-         this.followFocusService.popFocus(this.runtimeId, this.socketConnection, this.editorContext);
+         // pushedEditorContext, not the live this.editorContext -- see its doc.
+         this.followFocusService.popFocus(
+            this.runtimeId, this.socketConnection, this.pushedEditorContext);
       }
    }
 

--- a/web/projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.interaction.tl.spec.ts
+++ b/web/projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.interaction.tl.spec.ts
@@ -438,6 +438,34 @@ describe("FormulaEditorDialog — lifecycle and initForm [Group 5, Risk 3]", () 
             { kind: "calcField", assembly: "Query1", name: "Margin" });
       });
 
+      /*
+       * The bug the automated review on stylebi#4683 found: `editorContext`'s getter derives
+       * from `formulaName`, which the form binds/updates while this dialog is open (renaming a
+       * calc field). Simulated here by mutating comp.formulaName directly between ngOnInit and
+       * ngOnDestroy, exactly as the form would on a rename.
+       */
+      it("pops with the ORIGINALLY PUSHED name, not whatever formulaName was renamed to " +
+         "before close (mid-edit rename hazard)", () => {
+         const { comp, followFocusService } = createDialog();
+         comp.runtimeId = "vs-1";
+         comp.socketConnection = {} as any;
+         comp.isCalc = true;
+         comp.assemblyName = "Query1";
+         comp.formulaName = "OldName";
+         (followFocusService.pushFocus as any).mockReturnValue(true);
+         comp.ngOnInit();
+
+         // Simulates the form renaming the calc field mid-edit -- the exact hazard the review
+         // flagged, since editorContext's getter re-derives from this field live.
+         comp.formulaName = "NewName";
+
+         comp.ngOnDestroy();
+
+         expect(followFocusService.popFocus).toHaveBeenCalledWith(
+            "vs-1", comp.socketConnection,
+            { kind: "calcField", assembly: "Query1", name: "OldName" });
+      });
+
       it("does not pop on ngOnDestroy when Follow Focus was off at open (no push happened)", () => {
          const { comp, followFocusService } = createDialog();
          comp.runtimeId = "vs-1";

--- a/web/projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.interaction.tl.spec.ts
+++ b/web/projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.interaction.tl.spec.ts
@@ -375,6 +375,103 @@ describe("FormulaEditorDialog — lifecycle and initForm [Group 5, Risk 3]", () 
       expect(() => comp.ngOnDestroy()).not.toThrow();
    });
 
+   /*
+    * Follow Focus (plan `2026-08-19-follow-focus-pane-targeting-implementation.md`, Phase 2 task
+    * 2/3): push/pop is a distinct signal from detach() above, fired independently, not a
+    * replacement for it.
+    */
+   describe("Follow Focus push/pop [Phase 2]", () => {
+      it("pushes focus on ngOnInit when canPair and Follow Focus is enabled", () => {
+         const { comp, followFocusService } = createDialog();
+         comp.runtimeId = "vs-1";
+         comp.socketConnection = {} as any;
+         comp.isCalc = true;
+         comp.assemblyName = "Query1";
+         comp.formulaName = "Margin";
+         (followFocusService.pushFocus as any).mockReturnValue(true);
+
+         comp.ngOnInit();
+
+         expect(followFocusService.pushFocus).toHaveBeenCalledWith(
+            "vs-1", comp.socketConnection,
+            { kind: "calcField", assembly: "Query1", name: "Margin" });
+      });
+
+      it("does not push when the location is not addressable (canPair is false)", () => {
+         const { comp, followFocusService } = createDialog();
+         comp.runtimeId = "vs-1";
+         comp.socketConnection = {} as any;
+         comp.isCalc = true;
+         comp.assemblyName = "Query1";
+         comp.formulaName = ""; // no name yet -- unaddressable, see COLUMN_ADDRESSED_KINDS
+
+         comp.ngOnInit();
+
+         expect(followFocusService.pushFocus).not.toHaveBeenCalled();
+      });
+
+      it("does not push when there is no runtime/socket to pair against", () => {
+         const { comp, followFocusService } = createDialog();
+         comp.isCalc = true;
+         comp.assemblyName = "Query1";
+         comp.formulaName = "Margin";
+
+         comp.ngOnInit();
+
+         expect(followFocusService.pushFocus).not.toHaveBeenCalled();
+      });
+
+      it("pops focus on ngOnDestroy when this dialog's own push took effect", () => {
+         const { comp, followFocusService } = createDialog();
+         comp.runtimeId = "vs-1";
+         comp.socketConnection = {} as any;
+         comp.isCalc = true;
+         comp.assemblyName = "Query1";
+         comp.formulaName = "Margin";
+         (followFocusService.pushFocus as any).mockReturnValue(true);
+         comp.ngOnInit();
+
+         comp.ngOnDestroy();
+
+         expect(followFocusService.popFocus).toHaveBeenCalledWith(
+            "vs-1", comp.socketConnection,
+            { kind: "calcField", assembly: "Query1", name: "Margin" });
+      });
+
+      it("does not pop on ngOnDestroy when Follow Focus was off at open (no push happened)", () => {
+         const { comp, followFocusService } = createDialog();
+         comp.runtimeId = "vs-1";
+         comp.socketConnection = {} as any;
+         comp.isCalc = true;
+         comp.assemblyName = "Query1";
+         comp.formulaName = "Margin";
+         (followFocusService.pushFocus as any).mockReturnValue(false);
+         comp.ngOnInit();
+
+         comp.ngOnDestroy();
+
+         expect(followFocusService.popFocus).not.toHaveBeenCalled();
+      });
+
+      it("fires pop independently of detach -- both run, neither implies the other", () => {
+         const { comp, followFocusService } = createDialog();
+         comp.runtimeId = "vs-1";
+         comp.socketConnection = {} as any;
+         comp.isCalc = true;
+         comp.assemblyName = "Query1";
+         comp.formulaName = "Margin";
+         (followFocusService.pushFocus as any).mockReturnValue(true);
+         comp.ngOnInit();
+         // No Connect-to-Claude control mounted -- this dialog never minted its own pairing
+         // code, so detach() has nothing to do -- but the Follow Focus pop must still fire.
+         (comp as any).connectToClaude = undefined;
+
+         comp.ngOnDestroy();
+
+         expect(followFocusService.popFocus).toHaveBeenCalledTimes(1);
+      });
+   });
+
    it("should run checkValid after view init when formulaType control exists", async () => {
       const { comp } = createDialog();
       comp.resizeable = false;

--- a/web/projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.test-helpers.ts
+++ b/web/projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.test-helpers.ts
@@ -25,6 +25,7 @@ import { FixedDropdownService } from "../fixed-dropdown/fixed-dropdown.service";
 import { TreeNodeModel } from "../tree/tree-node-model";
 import { FormulaEditorDialog } from "./formula-editor-dialog.component";
 import { FormulaEditorService } from "./formula-editor.service";
+import { FollowFocusService } from "../../composer/gui/wiz/services/follow-focus.service";
 
 export function flushPromises(): Promise<void> {
    return new Promise(resolve => setTimeout(resolve, 0));
@@ -50,12 +51,20 @@ export function createDialog() {
       appendChild: vi.fn(),
       listen: vi.fn(() => vi.fn()),
    };
+   const followFocusService = {
+      isEnabled: vi.fn(() => false),
+      setEnabled: vi.fn(),
+      pushFocus: vi.fn(() => false),
+      popFocus: vi.fn(),
+      errors: of(undefined as unknown as string),
+   } as unknown as FollowFocusService;
    const comp = new FormulaEditorDialog(
       editorService as unknown as FormulaEditorService,
       modalService as unknown as NgbModal,
       renderer as unknown as Renderer2,
       { nativeElement: document.createElement("form") } as ElementRef,
       dropdownService as unknown as FixedDropdownService,
+      followFocusService,
    );
    comp.formulaName = "CalcField1";
    comp.formulaType = FormulaType.SCRIPT;
@@ -72,7 +81,7 @@ export function createDialog() {
    comp._columnTreeRoot = comp.columnTreeRoot;
    comp.originalColumnTreeRoot = comp.columnTreeRoot;
    comp.submitCallback = () => Promise.resolve(true);
-   return { comp, editorService, modalService, dropdownService, renderer };
+   return { comp, editorService, modalService, dropdownService, renderer, followFocusService };
 }
 
 export function prepareExpressionEditor(comp: FormulaEditorDialog) {

--- a/web/projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.ts
+++ b/web/projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.ts
@@ -212,6 +212,20 @@ export class FormulaEditorDialog extends BaseResizeableDialogComponent implement
     *  owes a matching `popFocus` -- see `ScriptPane`'s identical field for the full rationale. */
    private followFocusPushed = false;
 
+   /**
+    * The exact `editorContext` value this dialog actually pushed in `ngOnInit`, captured once
+    * and reused in `ngOnDestroy` -- NOT re-read live from `this.editorContext` at pop time.
+    *
+    * `editorContext`'s getter derives from `deriveEditorContext()`, which reads `this.formulaName`
+    * -- editable via the form while this dialog is open. So editing a calc field named "OldName"
+    * with Follow Focus on (pushing `{kind: "calcField", ..., name: "OldName"}`), renaming it via
+    * the form, then closing would pop with the NEW name if `ngOnDestroy` re-read the live getter
+    * -- tripping `FollowFocusService.popFocus`'s stack-integrity check for an entirely normal
+    * rename. Same `mintedEditorContext` pattern `ConnectToClaudeComponent` already uses, and the
+    * same fix `ScriptPane` needed for its own live-getter-at-pop-time hazard.
+    */
+   private pushedEditorContext: EditorContext | null = null;
+
    get title(): string {
       return this.isCube ? "_#(js:Create Measure)" : this.isCalc ? "_#(js:Edit Calculated Field)" :
          "_#(js:Formula Editor)";
@@ -367,8 +381,16 @@ export class FormulaEditorDialog extends BaseResizeableDialogComponent implement
       // doc comment); pushing an unaddressable context would retarget the session to a place no
       // tool call could ever resolve against.
       if(this.canPair) {
+         // Read ONCE, here, and carry this exact value through to ngOnDestroy -- see
+         // pushedEditorContext's doc. The live this.editorContext getter can disagree with this
+         // by the time the dialog closes, since it derives from the editable formulaName.
+         const pushedContext = this.editorContext;
          this.followFocusPushed = this.followFocusService.pushFocus(
-            this.runtimeId, this.socketConnection, this.editorContext);
+            this.runtimeId, this.socketConnection, pushedContext);
+
+         if(this.followFocusPushed) {
+            this.pushedEditorContext = pushedContext;
+         }
       }
    }
 
@@ -383,7 +405,9 @@ export class FormulaEditorDialog extends BaseResizeableDialogComponent implement
       // see ScriptPane.ngOnDestroy for the same distinction. Only fires when ngOnInit's
       // pushFocus actually took effect.
       if(this.followFocusPushed) {
-         this.followFocusService.popFocus(this.runtimeId, this.socketConnection, this.editorContext);
+         // pushedEditorContext, not the live this.editorContext -- see its doc.
+         this.followFocusService.popFocus(
+            this.runtimeId, this.socketConnection, this.pushedEditorContext);
       }
 
       if(!!this.subscriptions) {

--- a/web/projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.ts
+++ b/web/projects/portal/src/app/widget/formula-editor/formula-editor-dialog.component.ts
@@ -64,6 +64,7 @@ import { ModalHeaderComponent } from "../modal-header/modal-header.component";
 import { ViewsheetClientService } from "../../common/viewsheet-client";
 import { EditorContext } from "../../composer/gui/wiz/editor-context";
 import { ConnectToClaudeComponent } from "../../composer/gui/wiz/connect-to-claude.component";
+import { FollowFocusService } from "../../composer/gui/wiz/services/follow-focus.service";
 
 const DATE_PARTS: any[] = [
    { label: "_#(js:Year)", data: "year" },
@@ -206,6 +207,10 @@ export class FormulaEditorDialog extends BaseResizeableDialogComponent implement
    public static DATE_PART_COLUMN: string = "date_part_column";
    subscriptions: Subscription = new Subscription();
    private init: boolean = false;
+   /** Whether this dialog's own `pushFocus` call actually took effect (Follow Focus was enabled
+    *  for this runtime when this dialog opened). Only set when true so `ngOnDestroy` knows it
+    *  owes a matching `popFocus` -- see `ScriptPane`'s identical field for the full rationale. */
+   private followFocusPushed = false;
 
    get title(): string {
       return this.isCube ? "_#(js:Create Measure)" : this.isCalc ? "_#(js:Edit Calculated Field)" :
@@ -341,7 +346,8 @@ export class FormulaEditorDialog extends BaseResizeableDialogComponent implement
                private modalService: NgbModal,
                protected renderer: Renderer2,
                protected element: ElementRef,
-               private dropdownService: FixedDropdownService)
+               private dropdownService: FixedDropdownService,
+               private followFocusService: FollowFocusService)
    {
       super(renderer, element);
    }
@@ -352,6 +358,18 @@ export class FormulaEditorDialog extends BaseResizeableDialogComponent implement
       this.oname = this.formulaName;
       this.returnTypes = FormulaEditorService.returnTypes;
       this.init = true;
+
+      // Follow Focus (separate from, and in addition to, the ConnectToClaudeComponent#detach()
+      // call in ngOnDestroy below): if the human has opted in, this dialog opening pushes an
+      // already-live session's target here for as long as it stays open. Gated on `canPair`,
+      // not just `editorContext` being truthy -- `editorContext` answers "which location is
+      // this dialog editing" even when that location is not addressable (see its own getter's
+      // doc comment); pushing an unaddressable context would retarget the session to a place no
+      // tool call could ever resolve against.
+      if(this.canPair) {
+         this.followFocusPushed = this.followFocusService.pushFocus(
+            this.runtimeId, this.socketConnection, this.editorContext);
+      }
    }
 
    ngOnDestroy(): void {
@@ -360,6 +378,13 @@ export class FormulaEditorDialog extends BaseResizeableDialogComponent implement
       // handle behind. No-op when this dialog never showed a Connect-to-Claude control, or when
       // it did but editorContext is a whole-sheet (null) mint.
       this.connectToClaude?.detach();
+
+      // Follow Focus's pop is a distinct signal from detach() above, not a replacement for it --
+      // see ScriptPane.ngOnDestroy for the same distinction. Only fires when ngOnInit's
+      // pushFocus actually took effect.
+      if(this.followFocusPushed) {
+         this.followFocusService.popFocus(this.runtimeId, this.socketConnection, this.editorContext);
+      }
 
       if(!!this.subscriptions) {
          this.subscriptions.unsubscribe();


### PR DESCRIPTION
## Summary
- **Phase 2**: New `FollowFocusService` holds the per-runtime opt-in (default off, not persisted) and talks to the Java backend's STOMP endpoints (`/wiz/pairing/follow-focus`, `/wiz/pairing/retarget`, `/wiz/pairing/pop-focus`) to retarget an already-live pairing session. Wired into `ScriptPane`/`FormulaEditorDialog`'s `ngOnInit`/`ngOnDestroy`, alongside (not replacing) their existing `detach()` call.
- **Phase 3 (frontend half)**: `ConnectToClaudeComponent` gained a Follow Focus toggle and a live "current target" line (`Whole sheet` / `Chart1 → onClick`), gated to the whole-sheet (toolbar) instance only — a pane's own instance has nothing to toggle, since Follow Focus always retargets the OUTER session, never the pane's own. `onJoined` branches on a new `focusChanged` flag on the joined-notice payload to distinguish "someone else's pane got paired" from "my own session's live target changed."

## Test plan
- [x] `follow-focus.service.spec.ts`: 16/16
- [x] `connect-to-claude.component.spec.ts`: 40/40 (12 new)
- [x] Both components' full `.tl.spec.ts` suites (hand-scoped `--include`, per the repo's documented `portal:test-tl` gap): 100/100
- [ ] Live browser pass (Phase 5) — not run, needs the LIVE STACK token; tracked in `docs/superpowers/plans/2026-08-19-follow-focus-pane-targeting-implementation.md` in stylebi-wiz

## Related
- Backend PR: https://github.com/inetsoft-technology/stylebi/pull/4682 (Phase 1, Phase 3 backend, Phase 4 fix)
- Companion plugin-side PR in stylebi-wiz: https://github.com/inetsoft-technology/stylebi-wiz/pull/1709

🤖 Generated with [Claude Code](https://claude.com/claude-code)