### PR TITLE
Let a chart binding establish its own source table

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/binding/BindableColumns.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindableColumns.java
@@ -31,9 +31,18 @@ import java.util.*;
  * not exist". Verified live by binding {@code NO_SUCH_COLUMN_XYZ}, and hit for real by binding a
  * column belonging to a different worksheet than the one the assembly was pointed at.
  *
- * <p>The check is deliberately lenient about <em>where</em> a column lives: the listing groups
- * columns by table and the same name can appear in several, so matching on the name alone across
- * every table is enough to catch a name that exists nowhere without rejecting a legitimate one.
+ * <p>Scope depends on what the listing knows. When it marks one table {@linkplain BindableTable#current
+ * current}, only that table's columns count: an assembly binds fields from exactly one source, and
+ * the Composer enforces that by <em>deleting</em> any bound field missing from a newly chosen source
+ * ({@code VSAssemblyInfoHandler.validateChartColumns}). The agent write path never runs that
+ * validation, so a column belonging to a different table used to land as a ref that resolves to
+ * nothing — the same "reads as empty data" failure this class exists to stop, one step further in,
+ * and one the name-exists-somewhere check cannot see because such a column is perfectly real.
+ *
+ * <p>With no table marked current — an unscoped listing, or an assembly with no source yet — it
+ * falls back to matching the name across every table. That leniency is load-bearing there rather
+ * than lax: without a known source there is nothing to narrow to, and refusing on a guess would
+ * block legitimate columns.
  */
 public final class BindableColumns {
    private BindableColumns() {
@@ -54,9 +63,15 @@ public final class BindableColumns {
          return;
       }
 
+      List<BindableTable> listed = tables == null ? List.of() : tables;
+      String source = currentSourceOf(listed);
       Set<String> available = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
 
-      for(BindableTable table : tables == null ? List.<BindableTable>of() : tables) {
+      for(BindableTable table : listed) {
+         if(source != null && !Boolean.TRUE.equals(table.current())) {
+            continue;
+         }
+
          for(var field : table.fields()) {
             if(field.column() != null) {
                available.add(field.column());
@@ -77,11 +92,184 @@ public final class BindableColumns {
 
          if(!available.contains(field.column())) {
             throw new IllegalArgumentException(
-               "'" + field.column() + "' is not a column " + assembly + " can bind. Available: " +
+               "'" + field.column() + "' is not a column " + assembly + " can bind" +
+               (source == null ? "" : ", which is bound to '" + source + "'") + ". Available: " +
                String.join(", ", available) +
                ". A column the source does not have binds cleanly and then renders nothing, so " +
-               "it is refused here rather than left to look like empty data.");
+               "it is refused here rather than left to look like empty data." +
+               (source == null ? ""
+                  : " Every field on an assembly must come from its one source, so a column of " +
+                    "another table is not an option here — either pick one of the above, or " +
+                    "repoint the assembly, which discards every field already bound to it."));
          }
       }
+   }
+
+   /**
+    * Decides which table a write is against, and returns the one to establish as the source.
+    *
+    * <p>The Composer sets an assembly's source as a side effect of the drag — the drag event carries
+    * {@code event.getTable()}, so dropping a column says both "bind this" and "from here" in one
+    * gesture ({@code VSChartDndService}). The agent path lost the second half: the listing groups
+    * columns <em>by table</em>, so a caller always knew which table it picked from, and the write
+    * vocabulary had nowhere to say it. The source was therefore never established and a chart with a
+    * correct, readable binding rendered nothing at all. This is that missing half.
+    *
+    * @param requested the table the caller named, or {@code null} to infer it
+    * @return the table to establish, or {@code null} when there is nothing to establish — the
+    *         assembly already has a source, nothing is being written, or the listing is empty
+    * @throws IllegalArgumentException when the answer is genuinely ambiguous or contradictory.
+    *         Never guessed: a coin flip between two tables renders something plausible, which is
+    *         worse than refusing, and an implicit repoint would delete every field already bound.
+    */
+   public static String requireSource(List<BindableTable> tables, String assembly,
+                                      String requested, Collection<FieldRef> fields)
+   {
+      List<BindableTable> listed = tables == null ? List.of() : tables;
+      List<FieldRef> named = named(fields);
+
+      // No listing is a read failure, and nothing being written has no source to decide.
+      if(listed.isEmpty() || named.isEmpty()) {
+         return null;
+      }
+
+      String current = currentSourceOf(listed);
+
+      if(current != null) {
+         if(requested != null && !requested.equalsIgnoreCase(current)) {
+            throw new IllegalArgumentException(
+               "'" + assembly + "' is bound to '" + current + "', and '" + requested +
+               "' is a different table. Every field on an assembly comes from its one source, so " +
+               "this is either the wrong column or a deliberate repoint — and repointing discards " +
+               "every field already bound, so it is not done implicitly. Pick a column from '" +
+               current + "', or call set_chart_source with force: true to move the assembly.");
+         }
+
+         // Already sourced: nothing to establish, and require() narrows the column check to it.
+         return null;
+      }
+
+      if(requested != null) {
+         String resolved = matchListed(listed, requested, assembly);
+         requireHasAll(resolved, columnsOf(listed, resolved), named, assembly);
+
+         return resolved;
+      }
+
+      List<String> candidates = new ArrayList<>();
+
+      for(BindableTable table : listed) {
+         if(hasAll(columnsOf(listed, table.name()), named)) {
+            candidates.add(table.name());
+         }
+      }
+
+      if(candidates.size() == 1) {
+         return candidates.get(0);
+      }
+
+      if(candidates.isEmpty()) {
+         throw new IllegalArgumentException(
+            "No single table has " + describe(named) + ", and an assembly binds every field from " +
+            "one source. Pick fields that live together in one table — list_bindable_fields groups " +
+            "them by table — or bind them in separate assemblies.");
+      }
+
+      throw new IllegalArgumentException(
+         describe(named) + " exists in more than one table (" + String.join(", ", candidates) +
+         "), so which one to bind '" + assembly + "' to cannot be told from the column name alone. " +
+         "Pass 'table' to say which, the way dropping a column in the Composer does. Guessing " +
+         "would bind the wrong table and render something that looks right.");
+   }
+
+   private static List<FieldRef> named(Collection<FieldRef> fields) {
+      List<FieldRef> named = new ArrayList<>();
+
+      for(FieldRef field : fields == null ? List.<FieldRef>of() : fields) {
+         if(field != null && field.column() != null && !field.column().isBlank()) {
+            named.add(field);
+         }
+      }
+
+      return named;
+   }
+
+   private static String matchListed(List<BindableTable> listed, String requested,
+                                     String assembly)
+   {
+      List<String> names = new ArrayList<>();
+
+      for(BindableTable table : listed) {
+         names.add(table.name());
+
+         if(requested.equalsIgnoreCase(table.name())) {
+            return table.name();
+         }
+      }
+
+      throw new IllegalArgumentException(
+         "'" + assembly + "' cannot bind to '" + requested + "'. Available: " +
+         String.join(", ", names) +
+         ". A source the assembly cannot see binds nothing and renders an empty assembly.");
+   }
+
+   private static Set<String> columnsOf(List<BindableTable> listed, String name) {
+      Set<String> columns = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+
+      for(BindableTable table : listed) {
+         if(name.equalsIgnoreCase(table.name())) {
+            for(var field : table.fields()) {
+               if(field.column() != null) {
+                  columns.add(field.column());
+               }
+            }
+         }
+      }
+
+      return columns;
+   }
+
+   private static boolean hasAll(Set<String> columns, List<FieldRef> fields) {
+      for(FieldRef field : fields) {
+         if(!columns.contains(field.column())) {
+            return false;
+         }
+      }
+
+      return true;
+   }
+
+   private static void requireHasAll(String table, Set<String> columns, List<FieldRef> fields,
+                                     String assembly)
+   {
+      for(FieldRef field : fields) {
+         if(!columns.contains(field.column())) {
+            throw new IllegalArgumentException(
+               "'" + field.column() + "' is not a column of '" + table + "', so binding '" +
+               assembly + "' to it would leave that field resolving to nothing. Available in '" +
+               table + "': " + String.join(", ", columns) + ".");
+         }
+      }
+   }
+
+   private static String describe(List<FieldRef> fields) {
+      List<String> columns = new ArrayList<>();
+
+      for(FieldRef field : fields) {
+         columns.add("'" + field.column() + "'");
+      }
+
+      return columns.size() == 1 ? columns.get(0) : String.join(" + ", columns);
+   }
+
+   /** The table the assembly is bound to, or {@code null} when the listing does not say. */
+   private static String currentSourceOf(List<BindableTable> tables) {
+      for(BindableTable table : tables) {
+         if(Boolean.TRUE.equals(table.current())) {
+            return table.name();
+         }
+      }
+
+      return null;
    }
 }

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindableFieldsService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindableFieldsService.java
@@ -20,7 +20,10 @@ package inetsoft.web.wiz.binding;
 import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.SourceInfo;
 import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.viewsheet.DataVSAssembly;
+import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.binding.service.VSBindingTreeService;
 import inetsoft.web.composer.model.TreeNodeModel;
@@ -63,16 +66,21 @@ public class BindableFieldsService {
    public List<BindableTable> list(String runtimeId, String assembly, Principal user)
       throws Exception
    {
+      String source = null;
+
       if(assembly != null) {
          RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, user);
          Viewsheet vs = rvs == null ? null : rvs.getViewsheet();
+         VSAssembly target = vs == null ? null : vs.getAssembly(assembly);
 
-         if(vs == null || vs.getAssembly(assembly) == null) {
+         if(target == null) {
             throw new IllegalArgumentException(
                "'" + assembly + "' is not an assembly on this viewsheet. Omit 'assembly' to list " +
                "every table the viewsheet offers, or call read_viewsheet_model to see what " +
                "assemblies exist.");
          }
+
+         source = sourceNameOf(target);
       }
 
       TreeNodeModel root = tree.getBinding(runtimeId, assembly, false, user);
@@ -82,7 +90,39 @@ public class BindableFieldsService {
          collect(root, tables, null);
       }
 
-      return tables;
+      return assembly == null ? tables : marked(tables, source);
+   }
+
+   /** The table an assembly is bound to right now, or {@code null} if it has none yet. */
+   private static String sourceNameOf(VSAssembly assembly) {
+      if(!(assembly instanceof DataVSAssembly data)) {
+         return null;
+      }
+
+      SourceInfo source = data.getSourceInfo();
+
+      return source == null || source.isEmpty() ? null : source.getSource();
+   }
+
+   /**
+    * Flags the one live table, so the single-source rule can be followed from this call alone.
+    *
+    * <p>Only for a scoped call: unscoped, {@code current} stays null, because there is no assembly
+    * to be current for and {@code false} everywhere would read as "none of these is live" — the
+    * opposite of the truth. An assembly with no source yet does get {@code false} everywhere, which
+    * is accurate: nothing is live, and that is exactly the state where a shelf write would be
+    * accepted and render nothing.
+    */
+   private static List<BindableTable> marked(List<BindableTable> tables, String source) {
+      List<BindableTable> out = new ArrayList<>(tables.size());
+
+      for(BindableTable table : tables) {
+         // equalsIgnoreCase is null-safe on its argument, so a sourceless assembly yields false.
+         out.add(new BindableTable(table.name(), table.name().equalsIgnoreCase(source),
+                                   table.fields()));
+      }
+
+      return out;
    }
 
    /**
@@ -104,7 +144,7 @@ public class BindableFieldsService {
          gather(node, fields);
 
          if(!fields.isEmpty()) {
-            tables.add(new BindableTable(node.label(), fields));
+            tables.add(new BindableTable(node.label(), null, fields));
          }
 
          return;
@@ -126,7 +166,7 @@ public class BindableFieldsService {
       // group called "Dimensions". It survives only as a floor for tree shapes this does not
       // anticipate, where a wrong-but-present name beats a blank one.
       if(!direct.isEmpty()) {
-         tables.add(new BindableTable(sourceName != null ? sourceName : node.label(), direct));
+         tables.add(new BindableTable(sourceName != null ? sourceName : node.label(), null, direct));
       }
    }
 
@@ -168,9 +208,30 @@ public class BindableFieldsService {
     * instead of correctly reporting no fields for it. {@code isTable} was already the answer to
     * "is this a table" everywhere else in this class; the childlessness check must defer to it
     * rather than deciding leaf-ness on its own.
+    *
+    * <p>An empty grouping <em>folder</em> is the same trap a third time, and the reason each
+    * exclusion has to be stated rather than inferred: {@code VSTreeHandler} adds both a Dimensions
+    * and a Measures folder to every table as long as it has at least one ref of <em>either</em>
+    * kind, so a table whose columns are all measures carries an empty Dimensions folder. Childless
+    * and not a table, it satisfied everything above and turned into
+    * {@code {column: "Dimensions", dataType: null, role: null}} — a column no caller can bind,
+    * sitting first in the list where it is most likely to be picked.
     */
    private boolean isColumn(TreeNodeModel node) {
-      return node.children().isEmpty() && !isTable(node);
+      return node.children().isEmpty() && !isTable(node) && !isFolder(node);
+   }
+
+   /**
+    * Whether this node is a grouping folder rather than something bindable.
+    *
+    * <p>Keyed on the entry <em>type</em>, the way {@link #isTable} already decides, and not on
+    * whether the node carries a {@code dtype}: this class deliberately supports columns whose data
+    * type is absent — {@link #roleOf} has a whole fallback path for them — so treating a missing
+    * type as "not a column" would drop real columns to fix a fake one.
+    */
+   private boolean isFolder(TreeNodeModel node) {
+      return node.data() instanceof AssetEntry entry &&
+         entry.getType() == AssetEntry.Type.FOLDER;
    }
 
    private BindableField fieldOf(TreeNodeModel node) {

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
@@ -117,7 +117,15 @@ public class BindingAgentController {
       return readService.read(sessions.resolve(sessionToken, user), assembly);
    }
 
-   public record ShelfRequest(String assembly, String shelf, List<FieldRef> fields) {}
+   /**
+    * @param table the source these fields come from. Optional, and on the <em>request</em> rather
+    *              than on each field on purpose: an assembly binds every field from one source, so
+    *              a per-field table would let a caller express a state that cannot exist. Omit it
+    *              and the table is inferred when the columns name exactly one; a name several
+    *              tables share is refused rather than guessed.
+    */
+   public record ShelfRequest(String assembly, String shelf, List<FieldRef> fields,
+                              String table) {}
    public record ChartTypeRequest(String assembly, Integer type, Boolean multi,
                                   Boolean stackMeasures, Boolean separate) {}
    public record SwapRequest(String assembly) {}
@@ -131,12 +139,27 @@ public class BindingAgentController {
       throws Exception
    {
       requireEnabled();
+      String source = resolveSourceTable(sessionToken, user, request.assembly(), request.table(),
+                                         request.fields());
       chartService.setShelf(sessionToken, user, request.assembly(), request.shelf(),
-                            request.fields(), linkUri);
+                            request.fields(), source, linkUri);
+   }
+
+   @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/chart/source")
+   public void setChartSource(@PathVariable String sessionToken,
+                              @RequestBody ChartSourceRequest request,
+                              @RequestParam(required = false, defaultValue = "") String linkUri,
+                              Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      chartService.setSource(sessionToken, user, request.assembly(), request.table(),
+                             Boolean.TRUE.equals(request.force()), linkUri);
    }
 
    /** {@code field} may be null, which clears the shelf. */
-   public record SingleShelfRequest(String assembly, String shelf, FieldRef field) {}
+   /** @param table see {@link ShelfRequest#table()}. */
+   public record SingleShelfRequest(String assembly, String shelf, FieldRef field, String table) {}
 
    @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/chart/single-shelf")
    public void setChartSingleShelf(@PathVariable String sessionToken,
@@ -147,8 +170,14 @@ public class BindingAgentController {
       throws Exception
    {
       requireEnabled();
+
+      // A null field is a clear: nothing to validate, and no source to derive from it.
+      String source = request.field() == null ? null
+         : resolveSourceTable(sessionToken, user, request.assembly(), request.table(),
+                              List.of(request.field()));
+
       chartService.setSingleShelf(sessionToken, user, request.assembly(), request.shelf(),
-                                  request.field(), linkUri);
+                                  request.field(), source, linkUri);
    }
 
    @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/chart/type")
@@ -203,7 +232,9 @@ public class BindingAgentController {
                                      linkUri);
    }
 
-   public record AestheticFieldRequest(String assembly, String channel, FieldRef field) {}
+   /** @param table see {@link ShelfRequest#table()}. */
+   public record AestheticFieldRequest(String assembly, String channel, FieldRef field,
+                                       String table) {}
    public record AestheticFrameRequest(String assembly, String channel,
                                        Map<String, Object> frame) {}
 
@@ -238,8 +269,10 @@ public class BindingAgentController {
       throws Exception
    {
       requireEnabled();
+      String source = resolveSourceTable(sessionToken, user, request.assembly(), request.table(),
+                                         List.of(request.field()));
       aestheticService.setField(sessionToken, user, request.assembly(), request.channel(),
-                                request.field(), linkUri);
+                                request.field(), source, linkUri);
    }
 
    @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/chart/aesthetic-field/clear")
@@ -269,6 +302,7 @@ public class BindingAgentController {
    public record TableShelfRequest(String assembly, String shelf, List<FieldRef> fields) {}
 
    /** {@code force} discards fields already bound to the old source; absent means false. */
+   public record ChartSourceRequest(String assembly, String table, Boolean force) {}
    public record TableSourceRequest(String assembly, String table, Boolean force) {}
    public record TableFieldRequest(String assembly, String shelf, FieldRef field,
                                    Integer position) {}
@@ -598,6 +632,38 @@ public class BindingAgentController {
       }
       catch(Exception e) {
          LOG.debug("Could not list bindable columns for {}; skipping the check", assembly, e);
+      }
+   }
+
+   /**
+    * Validates the columns and answers which table the write is against, in one listing.
+    *
+    * <p>Both questions are decided from the same data and one round trip: whether these columns are
+    * bindable at all, and — for an assembly with no source yet — which table they come from, so it
+    * can be established the way the Composer's drag does.
+    *
+    * <p>A listing failure is logged and skipped rather than propagated, matching
+    * {@link #requireBindableColumns}: not being able to read the tree is a different fault, and
+    * refusing the write on the strength of it would turn a read problem into a write problem.
+    *
+    * @return the source table to establish, or {@code null} for none
+    */
+   private String resolveSourceTable(String sessionToken, Principal user, String assembly,
+                                     String table, java.util.Collection<FieldRef> fields)
+   {
+      try {
+         List<BindableTable> tables =
+            fieldsService.list(sessions.runtimeId(sessionToken, user), assembly, user);
+         BindableColumns.require(tables, assembly, fields);
+
+         return BindableColumns.requireSource(tables, assembly, table, fields);
+      }
+      catch(IllegalArgumentException e) {
+         throw e;
+      }
+      catch(Exception e) {
+         LOG.debug("Could not list bindable columns for {}; skipping the check", assembly, e);
+         return null;
       }
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingSources.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingSources.java
@@ -1,0 +1,89 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding;
+
+import inetsoft.web.binding.model.BindingModel;
+import inetsoft.web.binding.model.SourceInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Assigning a source table, shared by the chart and table binding services.
+ *
+ * <p>Both sit on {@link BindingModel}, which is where {@code getTables()} and {@code setSource()}
+ * live, so the operation is identical for a chart and for a crosstab — only the shelves that a
+ * repoint invalidates differ, and those stay with the service that knows them. Kept in one place
+ * rather than copied: the table half shipped first, and a second copy would drift the moment either
+ * learned something about how a source is addressed.
+ */
+final class BindingSources {
+   private BindingSources() {
+   }
+
+   /**
+    * Matches a requested table against what the assembly can actually bind to.
+    *
+    * @return the table's name as the assembly spells it, so a case-insensitive request is stored in
+    *         the canonical form rather than as typed
+    * @throws IllegalArgumentException naming what is available, when it cannot
+    */
+   static String resolve(BindingModel model, String table, String assemblyName) {
+      List<BindingModel.SourceTable> tables = model == null ? null : model.getTables();
+      List<String> names = new ArrayList<>();
+
+      if(tables != null) {
+         for(BindingModel.SourceTable candidate : tables) {
+            if(candidate.getName() != null) {
+               names.add(candidate.getName());
+
+               if(candidate.getName().equalsIgnoreCase(table)) {
+                  return candidate.getName();
+               }
+            }
+         }
+      }
+
+      throw new IllegalArgumentException(
+         "'" + assemblyName + "' cannot bind to '" + table + "'. Available: " + names + ". " +
+         "A source the assembly cannot see binds nothing and renders an empty assembly.");
+   }
+
+   /**
+    * The source to store for a worksheet table.
+    *
+    * <p>Only type, prefix and source survive the trip back — {@code VSBindingService.updateSourceInfo}
+    * calls {@code SourceInfo.toSourceAttr}, which rebuilds the asset source from exactly those three.
+    * Set directly rather than through the {@code SourceInfo(uql.SourceInfo)} convenience
+    * constructor, which also avoids that constructor's {@code toView()} call and the {@code VSUtil}
+    * it drags in for a display string nothing here reads.
+    */
+   static SourceInfo assetSource(String table) {
+      SourceInfo source = new SourceInfo();
+      source.setType(inetsoft.uql.asset.SourceInfo.ASSET);
+      source.setSource(table);
+      source.setView(table);
+
+      return source;
+   }
+
+   /** Whether the assembly is already pointed at this table, in which case nothing is discarded. */
+   static boolean alreadyPointedAt(SourceInfo current, String table) {
+      return current != null && table.equalsIgnoreCase(current.getSource());
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticAgentService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticAgentService.java
@@ -60,8 +60,14 @@ public class ChartAestheticAgentService {
       this.aestheticService = aestheticService;
    }
 
+   /**
+    * @param sourceTable the table to point the chart at as part of this write, or {@code null} to
+    *                    leave its source alone. Binding an aesthetic channel is the one way a chart
+    *                    can acquire its first field — a word cloud is nothing but a text channel —
+    *                    so it establishes a source on the same terms the shelf writes do.
+    */
    public void setField(String sessionToken, Principal user, String assemblyName, String channel,
-                        FieldRef field, String linkUri) throws Exception
+                        FieldRef field, String sourceTable, String linkUri) throws Exception
    {
       // Validated before the runtime is touched, so a bad channel costs nothing and does not
       // open a checkpoint the caller then has to undo. This still needs the chart itself — node
@@ -69,8 +75,10 @@ public class ChartAestheticAgentService {
       boolean relationChart = isRelationChart(sessionToken, user, assemblyName);
       String name = AestheticChannels.requireFieldChannel(channel, relationChart);
 
-      apply(sessionToken, user, assemblyName, name, linkUri,
-            model -> ChartAestheticMutator.setField(model, name, field, relationChart));
+      apply(sessionToken, user, assemblyName, name, linkUri, model -> {
+         ChartBindingService.applySource(model, sourceTable);
+         ChartAestheticMutator.setField(model, name, field, relationChart);
+      });
    }
 
    public void clearField(String sessionToken, Principal user, String assemblyName,

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticMutator.java
@@ -23,7 +23,9 @@ import inetsoft.web.binding.model.graph.AestheticInfo;
 import inetsoft.web.binding.model.graph.aesthetic.*;
 import inetsoft.web.wiz.binding.model.FieldRef;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -132,6 +134,45 @@ public final class ChartAestheticMutator {
       }
 
       return out;
+   }
+
+   /**
+    * The field channels currently holding a binding, in vocabulary order.
+    *
+    * <p>Lives here, not in the caller that needs it: the 2b/2c ownership split declared in
+    * {@link ChartBindingFields} gives these properties one reader, so a check elsewhere that kept
+    * its own list of channels would drift from {@link #assign} the first time one is added. A
+    * chart can be bound entirely through a channel — a word cloud is nothing but a text channel —
+    * and {@code VSAssemblyInfoHandler.validateAestheticFields} deletes exactly these when a chart
+    * is repointed, so anything asking "would this repoint discard fields?" has to count them.
+    *
+    * <p>Node channels are counted whatever the chart type. They only render on a relation chart,
+    * but a non-null one is still a binding a repoint would delete, and the read cannot invent one:
+    * {@code ChartAestheticService} populates them only for a {@code RelationChartInfo}.
+    *
+    * <p>A non-null {@code AestheticInfo} <em>is</em> the binding: the read path
+    * {@code AestheticRefModelFactory.createAestheticInfo} returns null for an absent
+    * {@code AestheticRef} rather than an empty wrapper. Counting the wrapper rather than the field
+    * name it resolves to is deliberate — a wrapper whose name cannot be read is still something
+    * the user bound, and over-reporting here costs a caller one {@code force}, while
+    * under-reporting costs them the binding.
+    */
+   public static List<String> boundFieldChannels(ChartBindingModel model) {
+      List<String> bound = new ArrayList<>();
+
+      for(String channel : AestheticChannels.FIELD_CHANNELS) {
+         if(read(model, channel) != null) {
+            bound.add(channel);
+         }
+      }
+
+      for(String channel : AestheticChannels.NODE_CHANNELS) {
+         if(read(model, channel) != null) {
+            bound.add(channel);
+         }
+      }
+
+      return bound;
    }
 
    private static boolean acceptsField(String channel) {

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingMutator.java
@@ -109,6 +109,20 @@ public final class ChartBindingMutator {
       }
    }
 
+   /** Reads one of the list shelves; never null, so a caller can count it without a guard. */
+   public static List<ChartRefModel> readShelf(ChartBindingModel model, String shelf) {
+      String name = shelf == null ? "" : shelf.trim().toLowerCase();
+      List<ChartRefModel> refs = switch(name) {
+         case "x" -> model.getXFields();
+         case "y" -> model.getYFields();
+         case "group" -> model.getGroupFields();
+         default -> throw new IllegalArgumentException(
+            "Unknown chart shelf '" + shelf + "'. Valid shelves: " + String.join(", ", SHELVES));
+      };
+
+      return refs == null ? List.of() : refs;
+   }
+
    /** Reads one single-field shelf, or null when nothing is bound to it. */
    public static ChartRefModel readSingleShelf(ChartBindingModel model, String shelf) {
       return switch(requireSingleShelf(shelf)) {

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingService.java
@@ -31,6 +31,7 @@ import inetsoft.web.binding.event.ChangeChartRefEvent;
 import inetsoft.web.binding.event.ChangeChartTypeEvent;
 import inetsoft.web.binding.event.ChangeSeparateStatusEvent;
 import inetsoft.web.binding.model.ChartBindingModel;
+import inetsoft.web.binding.model.graph.ChartRefModel;
 import inetsoft.web.binding.service.VSBindingService;
 import inetsoft.web.wiz.binding.model.FieldRef;
 import inetsoft.web.wiz.viewsheet.ViewsheetSessionService;
@@ -155,10 +156,22 @@ public class ChartBindingService {
    /**
     * Refuses to discard bound fields.
     *
-    * <p>Counts <b>all thirteen</b> places a chart keeps fields, not just x/y/group. A candlestick's
-    * entire binding lives on the single-field shelves with x and y empty, so a check that looked
-    * only at the three lists would report "nothing bound" and repoint without asking — silently
-    * discarding the whole binding of exactly the chart types whose binding is hardest to rebuild.
+    * <p>Counts <b>every</b> place a chart keeps a field, not just x/y/group: the three list
+    * shelves, the ten single-field shelves, the six aesthetic channels, and a map's geo fields.
+    * Each of those is a binding {@code VSAssemblyInfoHandler.validateChartColumns} deletes when a
+    * chart is repointed — it clears the shelves, then {@code validateAestheticFields} clears
+    * colour/shape/size/text and a relation chart's node channels, and {@code VSMapInfo}'s geo
+    * fields alongside them. A check that read fewer of them would report "nothing bound" for a
+    * chart that is fully bound and repoint without asking:
+    *
+    * <ul>
+    *   <li>A candlestick's entire binding lives on the single-field shelves, x and y empty.</li>
+    *   <li>A word cloud is nothing but a text channel — every shelf empty.</li>
+    *   <li>A map keeps its geography on {@code geoFields}, which is no shelf at all.</li>
+    * </ul>
+    *
+    * <p>Those are the chart types whose binding is hardest to rebuild, so they are the worst ones
+    * to discard silently.
     */
    private static void requireNoBoundFields(ChartBindingModel model, String assemblyName,
                                             String table)
@@ -177,6 +190,19 @@ public class ChartBindingService {
          if(ChartBindingMutator.readSingleShelf(model, shelf) != null) {
             populated.add(shelf);
          }
+      }
+
+      // Named as channels rather than shelves because that is the vocabulary the caller binds
+      // them with: set_aesthetic_field takes a channel, so a refusal reporting "color" tells it
+      // which call to undo.
+      for(String channel : ChartAestheticMutator.boundFieldChannels(model)) {
+         populated.add(channel + " channel");
+      }
+
+      List<ChartRefModel> geoFields = model.getGeoFields();
+
+      if(geoFields != null && !geoFields.isEmpty()) {
+         populated.add(geoFields.size() + " on geo");
       }
 
       if(!populated.isEmpty()) {

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingService.java
@@ -38,6 +38,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.security.Principal;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -69,12 +70,19 @@ public class ChartBindingService {
       this.separateStatusService = separateStatusService;
    }
 
+   /**
+    * @param sourceTable the table to point the chart at as part of this write, or {@code null} to
+    *                    leave its source alone. A chart with no source renders nothing however
+    *                    correctly its shelves are filled in, and the Composer avoids that by taking
+    *                    the source from the drag; this is the same thing, one call rather than two.
+    */
    public void setShelf(String sessionToken, Principal user, String assemblyName, String shelf,
-                        List<FieldRef> fields, String linkUri) throws Exception
+                        List<FieldRef> fields, String sourceTable, String linkUri) throws Exception
    {
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          ChartVSAssembly chart = requireChart(rvs, assemblyName);
          ChartBindingModel model = (ChartBindingModel) binding.createModel(chart);
+         applySource(model, sourceTable);
          ChartBindingMutator.setShelf(model, shelf, fields);
 
          ChangeChartRefEvent event = new ChangeChartRefEvent();
@@ -86,6 +94,101 @@ public class ChartBindingService {
    }
 
    /**
+    * Establishes the source, if one was worked out and the chart has none.
+    *
+    * <p>Guarded on the chart already being sourceless rather than trusting the caller: a repoint
+    * deletes bound fields, so it stays behind {@code set_chart_source}'s explicit {@code force} and
+    * can never happen as a side effect of binding a field.
+    */
+   static void applySource(ChartBindingModel model, String sourceTable) {
+      if(sourceTable != null && model != null && model.getSource() == null) {
+         model.setSource(BindingSources.assetSource(sourceTable));
+      }
+   }
+
+   /**
+    * Points a chart at a source table.
+    *
+    * <p>A chart added in the Composer starts with no source, and nothing on the agent path could
+    * assign one. Its shelves can be populated — {@code set_chart_shelf} reports success and
+    * {@code get_binding} reads the fields straight back — and it renders nothing at all, because
+    * shelves with no source have nothing to query. The Composer assigns one as a side effect of the
+    * drag ({@code VSChartDndService} takes it from the drag event's table); the agent's
+    * {@code FieldRef} carries no table, so the request has nothing to derive it from.
+    * {@code VSBindingService.updateSourceInfo} only ever <em>propagates</em> a source that is
+    * already there — it is a no-op when the model's source is null — which is preservation, not the
+    * ability to set one.
+    *
+    * <p>Repointing a bound chart invalidates its fields, since the columns belong to the old
+    * source; the Composer handles that by <em>deleting</em> the ones the new source does not have
+    * ({@code VSAssemblyInfoHandler.validateChartColumns}). So it is refused unless {@code force},
+    * rather than done silently on one call.
+    */
+   public void setSource(String sessionToken, Principal user, String assemblyName, String table,
+                         boolean force, String linkUri) throws Exception
+   {
+      if(table == null || table.isBlank()) {
+         throw new IllegalArgumentException(
+            "set_chart_source requires 'table' — the source table's name. " +
+            "list_bindable_fields reports what this chart can bind to.");
+      }
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         ChartVSAssembly chart = requireChart(rvs, assemblyName);
+         ChartBindingModel model = (ChartBindingModel) binding.createModel(chart);
+         String resolved = BindingSources.resolve(model, table, assemblyName);
+
+         if(!force && !BindingSources.alreadyPointedAt(model.getSource(), resolved)) {
+            requireNoBoundFields(model, assemblyName, resolved);
+         }
+
+         model.setSource(BindingSources.assetSource(resolved));
+
+         ChangeChartRefEvent event = new ChangeChartRefEvent();
+         event.setName(assemblyName);
+         // No fieldType: this changes no shelf, and changeChartRef never reads it.
+         event.setModel(model);
+         refService.changeChartRef(runtimeId, event, user, dispatcher, linkUri);
+      });
+   }
+
+   /**
+    * Refuses to discard bound fields.
+    *
+    * <p>Counts <b>all thirteen</b> places a chart keeps fields, not just x/y/group. A candlestick's
+    * entire binding lives on the single-field shelves with x and y empty, so a check that looked
+    * only at the three lists would report "nothing bound" and repoint without asking — silently
+    * discarding the whole binding of exactly the chart types whose binding is hardest to rebuild.
+    */
+   private static void requireNoBoundFields(ChartBindingModel model, String assemblyName,
+                                            String table)
+   {
+      List<String> populated = new ArrayList<>();
+
+      for(String shelf : ChartBindingMutator.SHELVES) {
+         int count = ChartBindingMutator.readShelf(model, shelf).size();
+
+         if(count > 0) {
+            populated.add(count + " on " + shelf);
+         }
+      }
+
+      for(String shelf : ChartBindingMutator.SINGLE_SHELVES) {
+         if(ChartBindingMutator.readSingleShelf(model, shelf) != null) {
+            populated.add(shelf);
+         }
+      }
+
+      if(!populated.isEmpty()) {
+         throw new IllegalArgumentException(
+            "'" + assemblyName + "' already has fields bound (" + String.join(", ", populated) +
+            ") and they belong to its current source, so repointing it to '" + table +
+            "' discards them. Pass force: true to do that deliberately, or bind the fields you " +
+            "want after the source is set.");
+      }
+   }
+
+   /**
     * Binds one of the single-field shelves — open/high/low/close, path, source/target,
     * start/end/milestone. A null {@code field} clears it.
     *
@@ -93,11 +196,13 @@ public class ChartBindingService {
     * snapshotted aesthetic fields are preserved identically.
     */
    public void setSingleShelf(String sessionToken, Principal user, String assemblyName,
-                              String shelf, FieldRef field, String linkUri) throws Exception
+                              String shelf, FieldRef field, String sourceTable, String linkUri)
+      throws Exception
    {
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          ChartVSAssembly chart = requireChart(rvs, assemblyName);
          ChartBindingModel model = (ChartBindingModel) binding.createModel(chart);
+         applySource(model, sourceTable);
          ChartBindingMutator.setSingleShelf(model, shelf, field);
 
          ChangeChartRefEvent event = new ChangeChartRefEvent();

--- a/core/src/main/java/inetsoft/web/wiz/binding/model/BindableTable.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/model/BindableTable.java
@@ -19,5 +19,16 @@ package inetsoft.web.wiz.binding.model;
 
 import java.util.List;
 
-/** One source table and the columns it offers. */
-public record BindableTable(String name, List<BindableField> fields) {}
+/**
+ * One source table and the columns it offers.
+ *
+ * @param current whether this is the table the scoped assembly is bound to right now, or
+ *                {@code null} when no assembly was named. Every field on an assembly's shelves has
+ *                to come from its single source — the Composer enforces that by deleting any bound
+ *                field absent from a newly chosen source — and listing all the tables is still
+ *                correct, since an assembly may be repointed to any of them. So the flag is what
+ *                makes the constraint followable without a second call to read the binding.
+ *                {@code null} rather than {@code false} for an unscoped call: there is no assembly
+ *                to be current for, and {@code false} would assert the opposite of the truth.
+ */
+public record BindableTable(String name, Boolean current, List<BindableField> fields) {}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetReadService.java
@@ -19,6 +19,7 @@ package inetsoft.web.wiz.viewsheet;
 
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.wiz.viewsheet.model.AssemblyNode;
@@ -53,7 +54,29 @@ public class ViewsheetReadService {
          }
       }
 
-      return new ViewsheetModel(vs.getName(), nodes);
+      return new ViewsheetModel(sheetName(rvs), nodes);
+   }
+
+   /**
+    * The sheet's name, from its asset entry.
+    *
+    * <p>Deliberately not {@code Viewsheet.getName()}, which is the <em>assembly</em> name: it is
+    * set only by {@code createVSAssembly(name)}, i.e. when a viewsheet is embedded in another
+    * viewsheet as an assembly, so for a top-level sheet it is legitimately null and never answered
+    * the question this field is asking.
+    *
+    * <p>It was worse than merely empty, because that null does not survive a save/reload.
+    * {@code AssemblyInfo.writeAttributes} emits {@code "<name><![CDATA[" + name + "]]></name>"},
+    * and concatenating a null yields the four characters {@code null} — so a reopened sheet
+    * reported the <b>string</b> {@code "null"}, which a caller testing {@code if(name)} accepts as
+    * a real name and renders to a user. Left the shared serialization alone: it is on the path of
+    * every assembly in every sheet, and the one field that already carries a hand-patch for this
+    * ({@code VSAssemblyInfo} maps {@code "null"} back to null when parsing {@code absoluteName2})
+    * shows the flaw is older and wider than this read.
+    */
+   private static String sheetName(RuntimeViewsheet rvs) {
+      AssetEntry entry = rvs.getEntry();
+      return entry == null ? null : entry.getName();
    }
 
    private AssemblyNode toNode(Viewsheet vs, VSAssembly assembly) {

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindableColumnsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindableColumnsTest.java
@@ -35,10 +35,33 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 @Tag("core")
 class BindableColumnsTest {
+   /** No table marked current — the shape an unscoped listing produces. */
    private static final List<BindableTable> TABLES = List.of(
-      new BindableTable("Query1", List.of(new BindableField("PRICE", null, null),
-                                          new BindableField("QUANTITY", null, null))),
-      new BindableTable("Products", List.of(new BindableField("PRODUCT_NAME", null, null))));
+      new BindableTable("Query1", null, List.of(new BindableField("PRICE", null, null),
+                                                new BindableField("QUANTITY", null, null))),
+      new BindableTable("Products", null,
+                        List.of(new BindableField("PRODUCT_NAME", null, null))));
+
+   /** The same tables, with the assembly known to be bound to Query1. */
+   private static final List<BindableTable> BOUND_TO_QUERY1 = List.of(
+      new BindableTable("Query1", true, List.of(new BindableField("PRICE", null, null),
+                                                new BindableField("QUANTITY", null, null))),
+      new BindableTable("Products", false,
+                        List.of(new BindableField("PRODUCT_NAME", null, null))));
+
+   /**
+    * A scoped listing for an assembly with no source yet — every table marked not-current.
+    *
+    * <p>{@code QUANTITY} deliberately appears in two of them: a worksheet that holds a join
+    * alongside its base tables duplicates nearly every column, which is the shape that makes
+    * inference ambiguous in practice rather than in theory.
+    */
+   private static final List<BindableTable> NO_SOURCE = List.of(
+      new BindableTable("Query1", false, List.of(new BindableField("PRICE", null, null),
+                                                 new BindableField("QUANTITY", null, null))),
+      new BindableTable("Details", false, List.of(new BindableField("QUANTITY", null, null))),
+      new BindableTable("Products", false,
+                        List.of(new BindableField("PRODUCT_NAME", null, null))));
 
    private static FieldRef dim(String column) {
       return new FieldRef(column, "dimension", null, null, null);
@@ -54,16 +77,206 @@ class BindableColumnsTest {
       assertTrue(thrown.getMessage().contains("PRICE"), "the message must list what is available");
    }
 
-   /** The listing groups by table, and a column only has to exist in one of them. */
+   /**
+    * With no table marked current, a column only has to exist in one of them.
+    *
+    * <p>This stays the right answer for the case it was written for — an assembly whose source is
+    * not known — and the leniency is load-bearing there: refusing on the strength of a guess would
+    * block legitimate columns. What changed is that the source often *is* knowable; see below.
+    */
    @Test
-   void acceptsAColumnFromAnyBindableTable() {
+   void acceptsAColumnFromAnyBindableTableWhenNoneIsMarkedCurrent() {
       assertDoesNotThrow(() -> BindableColumns.require(TABLES, "Crosstab1", dim("PRODUCT_NAME")));
       assertDoesNotThrow(() -> BindableColumns.require(TABLES, "Crosstab1", dim("PRICE")));
+   }
+
+   /**
+    * Once the live table is known, a column from a different one is refused.
+    *
+    * <p>An assembly binds fields from exactly one source, and the Composer enforces it by
+    * <em>deleting</em> bound fields absent from a newly chosen source
+    * ({@code VSAssemblyInfoHandler.validateChartColumns}). The agent write path never runs that
+    * validation, so a column from a second table used to land as a ref resolving to nothing —
+    * indistinguishable from empty data, which is the same failure this class was built to stop, one
+    * step further in.
+    *
+    * <p>The name-exists-somewhere check could not catch it: {@code PRODUCT_NAME} is a real column
+    * of a real table, just not of the one this assembly is bound to. Narrowing to the current table
+    * is what makes the difference, and it is only possible now that the listing says which that is.
+    */
+   @Test
+   void refusesAColumnFromATableTheAssemblyIsNotBoundTo() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> BindableColumns.require(BOUND_TO_QUERY1, "Chart1", dim("PRODUCT_NAME")));
+
+      assertTrue(thrown.getMessage().contains("PRODUCT_NAME"));
+      assertTrue(thrown.getMessage().contains("Query1"),
+                 "the message must name the source the assembly is actually bound to");
+   }
+
+   @Test
+   void acceptsAColumnFromTheTableTheAssemblyIsBoundTo() {
+      assertDoesNotThrow(() -> BindableColumns.require(BOUND_TO_QUERY1, "Chart1", dim("QUANTITY")));
+      assertDoesNotThrow(() -> BindableColumns.require(BOUND_TO_QUERY1, "Chart1", dim("price")),
+                         "narrowing must not cost the case-insensitive match");
    }
 
    @Test
    void isCaseInsensitiveRatherThanRejectingAKnownColumnOnItsSpelling() {
       assertDoesNotThrow(() -> BindableColumns.require(TABLES, "Crosstab1", dim("price")));
+   }
+
+   // ── which table the fields come from ──────────────────────────────────────
+   //
+   // The Composer sets an assembly's source as a side effect of the drag: the drag event carries
+   // event.getTable(), so dropping a column says both "bind this" and "from here" at once. The agent
+   // path lost the second half — list_bindable_fields groups columns BY TABLE, so the caller always
+   // knew which table it picked from, and the write vocabulary had nowhere to say it. So the source
+   // was never established, and a chart with a perfectly correct binding rendered nothing.
+   //
+   // requireSource is that missing half: it decides which table a write is against, and returns the
+   // one to establish (null when the assembly already has a source, or when nothing can be told).
+
+   /** Only a name is needed here; the listing is what these tests vary. */
+   private static FieldRef field(String column) {
+      return dim(column);
+   }
+
+   @Test
+   void establishesTheStatedTableWhenTheAssemblyHasNoSource() {
+      assertEquals("Query1",
+                   BindableColumns.requireSource(NO_SOURCE, "Chart1", "Query1",
+                                                 List.of(field("PRICE"))));
+   }
+
+   /** Case is normalized to how the listing spells it, not stored as typed. */
+   @Test
+   void establishesTheStatedTableInItsCanonicalSpelling() {
+      assertEquals("Query1",
+                   BindableColumns.requireSource(NO_SOURCE, "Chart1", "query1",
+                                                 List.of(field("PRICE"))));
+   }
+
+   /**
+    * With no table stated and the column in exactly one, there is nothing to guess — infer it.
+    *
+    * <p>This is the forgiving half of the rule the plugin is held to: unambiguous intent should not
+    * cost an extra call. A single-table worksheet — the common shape — always lands here.
+    */
+   @Test
+   void infersTheTableWhenOnlyOneHasEveryColumn() {
+      assertEquals("Products",
+                   BindableColumns.requireSource(NO_SOURCE, "Chart1", null,
+                                                 List.of(field("PRODUCT_NAME"))));
+   }
+
+   /**
+    * And the loud half: when several tables have the column, refuse and ask.
+    *
+    * <p>Picking one would be a coin flip that renders something plausible, which is worse than
+    * refusing. This is not a rare shape — a worksheet holding a join alongside its base tables
+    * duplicates nearly every column, so most names are ambiguous there.
+    */
+   @Test
+   void refusesToGuessWhenSeveralTablesHaveTheColumn() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> BindableColumns.requireSource(NO_SOURCE, "Chart1", null,
+                                             List.of(field("QUANTITY"))));
+
+      assertTrue(thrown.getMessage().contains("QUANTITY"));
+      assertTrue(thrown.getMessage().contains("Query1"), "name the candidates");
+      assertTrue(thrown.getMessage().contains("Details"), "name the candidates");
+      assertTrue(thrown.getMessage().contains("table"), "say how to resolve it");
+   }
+
+   /** All fields in one write share one table, so the inference is over their intersection. */
+   @Test
+   void infersFromTheIntersectionOfEveryFieldNotTheFirst() {
+      assertEquals("Query1",
+                   BindableColumns.requireSource(NO_SOURCE, "Chart1", null,
+                                                 List.of(field("PRICE"), field("QUANTITY"))),
+                   "only Query1 has both; QUANTITY alone would have been ambiguous");
+   }
+
+   @Test
+   void refusesWhenNoSingleTableHasAllTheFields() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> BindableColumns.requireSource(NO_SOURCE, "Chart1", null,
+                                             List.of(field("PRICE"), field("PRODUCT_NAME"))));
+
+      assertTrue(thrown.getMessage().contains("one source"),
+                 "explain the constraint, not just the failure");
+   }
+
+   @Test
+   void refusesAStatedTableThatDoesNotHaveOneOfTheColumns() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> BindableColumns.requireSource(NO_SOURCE, "Chart1", "Products",
+                                             List.of(field("PRICE"))));
+
+      assertTrue(thrown.getMessage().contains("PRICE"));
+      assertTrue(thrown.getMessage().contains("Products"));
+   }
+
+   @Test
+   void refusesAStatedTableThatIsNotListedAtAll() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> BindableColumns.requireSource(NO_SOURCE, "Chart1", "NOPE",
+                                            List.of(field("PRICE"))));
+
+      assertTrue(thrown.getMessage().contains("NOPE"));
+      assertTrue(thrown.getMessage().contains("Query1"), "list what it can bind to");
+   }
+
+   /** Already sourced: nothing to establish, and the column check stays narrowed to it. */
+   @Test
+   void establishesNothingWhenTheAssemblyAlreadyHasASource() {
+      assertNull(BindableColumns.requireSource(BOUND_TO_QUERY1, "Chart1", null,
+                                              List.of(field("QUANTITY"))));
+      assertNull(BindableColumns.requireSource(BOUND_TO_QUERY1, "Chart1", "Query1",
+                                              List.of(field("QUANTITY"))),
+                 "restating the source it already has is not a repoint");
+   }
+
+   /**
+    * Naming a different table for an already-bound chart is the one case that must not be resolved
+    * silently either way.
+    *
+    * <p>Repointing deletes every field already bound — the Composer's own
+    * {@code validateChartColumns} does exactly that — so doing it because a column looked like it
+    * came from elsewhere would destroy work nobody asked to lose. Binding the column into the
+    * current source instead is equally wrong: it is not there. Both readings are plausible, which
+    * is precisely when a tool has to ask.
+    */
+   @Test
+   void refusesToRepointAnAlreadyBoundAssemblyImplicitly() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> BindableColumns.requireSource(BOUND_TO_QUERY1, "Chart1", "Products",
+                                             List.of(field("PRODUCT_NAME"))));
+
+      assertTrue(thrown.getMessage().contains("Query1"), "name the source it has");
+      assertTrue(thrown.getMessage().contains("Products"), "name the source that was asked for");
+      assertTrue(thrown.getMessage().contains("set_chart_source"), "name the way through");
+   }
+
+   /** No listing means the tree could not be read — a read failure, not a write one. */
+   @Test
+   void establishesNothingWhenNothingCouldBeListed() {
+      assertNull(BindableColumns.requireSource(List.of(), "Chart1", null,
+                                              List.of(field("ANYTHING"))));
+      assertNull(BindableColumns.requireSource(null, "Chart1", null, List.of(field("ANYTHING"))));
+   }
+
+   /** Nothing being written means nothing to decide a source from. */
+   @Test
+   void establishesNothingWhenClearingAShelf() {
+      assertNull(BindableColumns.requireSource(NO_SOURCE, "Chart1", null, List.of()));
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindableFieldsServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindableFieldsServiceTest.java
@@ -20,6 +20,8 @@ package inetsoft.web.wiz.binding;
 import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.SourceInfo;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.binding.service.VSBindingTreeService;
 import inetsoft.web.composer.model.TreeNodeModel;
@@ -258,6 +260,204 @@ class BindableFieldsServiceTest {
 
       assertTrue(tables.isEmpty(),
                  "an empty table must report no fields, not a fabricated column named after it");
+   }
+
+   /**
+    * A childless Dimensions/Measures folder must yield nothing, not a field named after itself.
+    *
+    * <p>{@code VSTreeHandler} adds <em>both</em> grouping folders to every table unconditionally
+    * (it checks only that the table has at least one ref of either kind), so a table whose columns
+    * are all measures carries an <b>empty</b> Dimensions folder. Childless, and not a table, it
+    * satisfied {@link BindableFieldsService#isColumn} and its own label was fabricated into
+    * {@code {column: "Dimensions", dataType: null, role: null}}. Observed live on
+    * {@code ORDER_DETAILS1}, whose three columns are all integers, and reproduced on two separate
+    * viewsheets — but only through a scoped call, since the unscoped tree has no such folders.
+    *
+    * <p>This is the third instance of the class {@code isColumn}'s own Javadoc records fixing
+    * twice. Both previous fixes keyed on what the node <em>is</em> — a WORKSHEET container, then a
+    * table — and a folder is neither, so it kept slipping through.
+    */
+   @Test
+   void anEmptyDimensionsFolderYieldsNoFieldRatherThanFabricatingOneFromItsLabel()
+      throws Exception
+   {
+      TreeNodeModel qty = TreeNodeModel.builder().label("QUANTITY").leaf(true)
+         .data(entry(AssetEntry.Type.COLUMN, "QUANTITY", "integer", AssetEntry.MEASURES)).build();
+      // Empty, exactly as VSTreeHandler leaves it for a table with no dimension refs.
+      TreeNodeModel dimensions = TreeNodeModel.builder().label("Dimensions")
+         .data(entry(AssetEntry.Type.FOLDER, "Dimensions", null)).build();
+      TreeNodeModel measures = TreeNodeModel.builder().label("Measures")
+         .data(entry(AssetEntry.Type.FOLDER, "Measures", null)).addChildren(qty).build();
+      TreeNodeModel table = TreeNodeModel.builder()
+         .label("ORDER_DETAILS1").data(entry(AssetEntry.Type.TABLE, "ORDER_DETAILS1", null))
+         .addChildren(dimensions).addChildren(measures).build();
+      TreeNodeModel root = TreeNodeModel.builder().label("root").addChildren(table).build();
+
+      List<BindableField> fields = serviceReturning(root).list("rt1", null, principal())
+         .get(0).fields();
+
+      assertEquals(List.of("QUANTITY"), fields.stream().map(BindableField::column).toList(),
+                   "an empty grouping folder must not appear as a bindable column");
+   }
+
+   /**
+    * The mirror case, for a table with only dimensions and no measures.
+    *
+    * <p>Stated plainly: this passed the moment the fix above landed, so it drove nothing. It is
+    * here as a guard, because the tempting narrow fix is to special-case the literal label
+    * {@code "Dimensions"} — which is what the live reproduction happened to show — and that fix
+    * would leave the identical hole open on the other folder. Only the live case was ever
+    * observed; this one is derived from {@code VSTreeHandler} adding both folders unconditionally.
+    */
+   @Test
+   void anEmptyMeasuresFolderIsExcludedToo() throws Exception {
+      TreeNodeModel city = TreeNodeModel.builder().label("City").leaf(true)
+         .data(entry(AssetEntry.Type.COLUMN, "City", "string", AssetEntry.DIMENSIONS)).build();
+      TreeNodeModel dimensions = TreeNodeModel.builder().label("Dimensions")
+         .data(entry(AssetEntry.Type.FOLDER, "Dimensions", null)).addChildren(city).build();
+      TreeNodeModel measures = TreeNodeModel.builder().label("Measures")
+         .data(entry(AssetEntry.Type.FOLDER, "Measures", null)).build();
+      TreeNodeModel table = TreeNodeModel.builder()
+         .label("REGIONS").data(entry(AssetEntry.Type.TABLE, "REGIONS", null))
+         .addChildren(dimensions).addChildren(measures).build();
+      TreeNodeModel root = TreeNodeModel.builder().label("root").addChildren(table).build();
+
+      List<BindableField> fields = serviceReturning(root).list("rt1", null, principal())
+         .get(0).fields();
+
+      assertEquals(List.of("City"), fields.stream().map(BindableField::column).toList());
+   }
+
+   /**
+    * A table under a folder still reports its columns — the exclusion must not stop the walk.
+    *
+    * <p>{@link BindableFieldsService#collect} recurses into anything that is not a column, so
+    * excluding folders from {@code isColumn} only changes what becomes a <em>field</em>, never
+    * what gets descended into. This pins that down, because the obvious wrong way to write the
+    * fix — returning early for folders in {@code collect}/{@code gather} — would silently drop
+    * every column beneath the Dimensions and Measures folders and make the tool return nothing
+    * at all for a scoped call.
+    */
+   @Test
+   void aFolderWithChildrenIsStillWalkedIntoRatherThanSkipped() throws Exception {
+      TreeNodeModel qty = TreeNodeModel.builder().label("QUANTITY").leaf(true)
+         .data(entry(AssetEntry.Type.COLUMN, "QUANTITY", "integer", AssetEntry.MEASURES)).build();
+      TreeNodeModel measures = TreeNodeModel.builder().label("Measures")
+         .data(entry(AssetEntry.Type.FOLDER, "Measures", null)).addChildren(qty).build();
+      TreeNodeModel table = TreeNodeModel.builder()
+         .label("ORDER_DETAILS1").data(entry(AssetEntry.Type.FOLDER, "grouping", null))
+         .addChildren(TreeNodeModel.builder()
+                         .label("ORDER_DETAILS1")
+                         .data(entry(AssetEntry.Type.TABLE, "ORDER_DETAILS1", null))
+                         .addChildren(measures).build())
+         .build();
+      TreeNodeModel root = TreeNodeModel.builder().label("root").addChildren(table).build();
+
+      List<BindableTable> tables = serviceReturning(root).list("rt1", null, principal());
+
+      assertEquals(1, tables.size());
+      assertEquals("ORDER_DETAILS1", tables.get(0).name());
+      assertEquals(List.of("QUANTITY"),
+                   tables.get(0).fields().stream().map(BindableField::column).toList());
+   }
+
+   // ── which table the assembly is actually bound to ─────────────────────────
+
+   /**
+    * A scoped call marks the assembly's current source, because every field on a chart's shelves
+    * must come from that one table.
+    *
+    * <p>The constraint is enforced hard by the Composer and invisible here: dropping a column from
+    * a second table calls {@code VSAssemblyInfoHandler.changeSource} and then
+    * {@code validateChartColumns}, which <em>deletes</em> every bound field absent from the new
+    * source. So a chart holds fields from exactly one table, ever. The agent write path
+    * ({@code changeChartRef}) never calls {@code validateBinding} at all, so an off-source column
+    * lands there as a ref that resolves to nothing.
+    *
+    * <p>Listing every table is still right — a chart may be repointed to any of them — so the fix
+    * is not to narrow the list but to say which one is live. Otherwise the rule can only be obeyed
+    * by cross-referencing a second call to {@code get_binding}, and nothing tells a caller to make
+    * it: three tables come back, all of them look equally bindable, and the wrong choice is
+    * accepted silently.
+    */
+   @Test
+   void marksTheTableTheAssemblyIsCurrentlyBoundTo() throws Exception {
+      TreeNodeModel root = twoTableTree();
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      when(chart.getSourceInfo())
+         .thenReturn(new SourceInfo(SourceInfo.ASSET, null, "ORDERS1"));
+
+      List<BindableTable> tables = serviceFor(root, "Chart1", chart).list("rt1", "Chart1",
+                                                                         principal());
+
+      assertEquals(Boolean.TRUE, byName(tables, "ORDERS1").current());
+      assertEquals(Boolean.FALSE, byName(tables, "ORDER_DETAILS1").current(),
+                   "a table the assembly is not bound to must say so, not stay silent");
+   }
+
+   /**
+    * An unscoped call leaves it unset rather than saying {@code false} everywhere.
+    *
+    * <p>There is no assembly to be current *for*, so {@code false} would be an assertion the call
+    * is in no position to make — and the reading that matters ("none of these is the live one") is
+    * exactly wrong.
+    */
+   @Test
+   void leavesCurrentUnsetWhenNoAssemblyWasNamed() throws Exception {
+      List<BindableTable> tables = serviceReturning(twoTableTree()).list("rt1", null, principal());
+
+      assertNull(byName(tables, "ORDERS1").current());
+      assertNull(byName(tables, "ORDER_DETAILS1").current());
+   }
+
+   /** An assembly with no source yet — nothing is current, and nothing pretends to be. */
+   @Test
+   void marksNothingCurrentWhenTheAssemblyHasNoSourceYet() throws Exception {
+      TreeNodeModel root = twoTableTree();
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      when(chart.getSourceInfo()).thenReturn(null);
+
+      List<BindableTable> tables = serviceFor(root, "Chart1", chart).list("rt1", "Chart1",
+                                                                         principal());
+
+      assertEquals(Boolean.FALSE, byName(tables, "ORDERS1").current());
+      assertEquals(Boolean.FALSE, byName(tables, "ORDER_DETAILS1").current());
+   }
+
+   private static BindableTable byName(List<BindableTable> tables, String name) {
+      return tables.stream().filter(t -> name.equals(t.name())).findFirst().orElseThrow();
+   }
+
+   private static TreeNodeModel twoTableTree() {
+      TreeNodeModel paid = TreeNodeModel.builder().label("PAID").leaf(true)
+         .data(entry(AssetEntry.Type.COLUMN, "PAID", "integer", AssetEntry.MEASURES)).build();
+      TreeNodeModel orders = TreeNodeModel.builder()
+         .label("ORDERS1").data(entry(AssetEntry.Type.TABLE, "ORDERS1", null))
+         .addChildren(paid).build();
+      TreeNodeModel qty = TreeNodeModel.builder().label("QUANTITY").leaf(true)
+         .data(entry(AssetEntry.Type.COLUMN, "QUANTITY", "integer", AssetEntry.MEASURES)).build();
+      TreeNodeModel details = TreeNodeModel.builder()
+         .label("ORDER_DETAILS1").data(entry(AssetEntry.Type.TABLE, "ORDER_DETAILS1", null))
+         .addChildren(qty).build();
+
+      return TreeNodeModel.builder().label("root")
+         .addChildren(orders).addChildren(details).build();
+   }
+
+   private static BindableFieldsService serviceFor(TreeNodeModel root, String name,
+                                                   inetsoft.uql.viewsheet.VSAssembly assembly)
+      throws Exception
+   {
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssembly(name)).thenReturn(assembly);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      ViewsheetService engine = mock(ViewsheetService.class);
+      when(engine.getViewsheet(eq("rt1"), any(Principal.class))).thenReturn(rvs);
+      VSBindingTreeService tree = mock(VSBindingTreeService.class);
+      when(tree.getBinding(eq("rt1"), any(), anyBoolean(), any(Principal.class))).thenReturn(root);
+
+      return new BindableFieldsService(tree, engine);
    }
 
    // ── unknown assembly name (the D4 regression) ────────────────────────────

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticAgentServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticAgentServiceTest.java
@@ -62,7 +62,7 @@ class ChartAestheticAgentServiceTest {
 
       harness(existing, aesthetics)
          .setField("tok", principal(), "Chart1", "color",
-                   new FieldRef("Region", "dimension", null, null, null), "");
+                   new FieldRef("Region", "dimension", null, null, null), null, "");
 
       ChangeChartRefEvent event = captureEvent(aesthetics);
       assertEquals(42, event.getModel().getChartType(),
@@ -81,7 +81,7 @@ class ChartAestheticAgentServiceTest {
 
       harness(new ChartBindingModel(), aesthetics)
          .setField("tok", principal(), "Chart1", "color",
-                   new FieldRef("Region", "dimension", null, null, null), "");
+                   new FieldRef("Region", "dimension", null, null, null), null, "");
 
       assertEquals("color", captureEvent(aesthetics).getFieldType());
    }
@@ -96,7 +96,7 @@ class ChartAestheticAgentServiceTest {
 
       harness(existing, aesthetics)
          .setField("tok", principal(), "Chart1", "color",
-                   new FieldRef("Category", "dimension", null, null, null), "");
+                   new FieldRef("Category", "dimension", null, null, null), null, "");
 
       assertSame(shelfBefore, captureEvent(aesthetics).getModel().getXFields(),
                  "an aesthetic write must not disturb the shelves spec 2b owns");
@@ -146,7 +146,7 @@ class ChartAestheticAgentServiceTest {
                                                   mock(ChangeChartAestheticService.class));
 
       service.setField("tok", principal(), "Chart1", "color",
-                       new FieldRef("Region", "dimension", null, null, null), "");
+                       new FieldRef("Region", "dimension", null, null, null), null, "");
 
       verify(sessions, times(1)).mutate(anyString(), any(Principal.class), any());
    }
@@ -177,7 +177,7 @@ class ChartAestheticAgentServiceTest {
       Exception thrown = assertThrows(
          Exception.class,
          () -> service.setField("tok", principal(), "Text1", "color",
-                                new FieldRef("Region", "dimension", null, null, null), ""));
+                                new FieldRef("Region", "dimension", null, null, null), null, ""));
       assertTrue(thrown.getMessage().contains("Text1"));
    }
 
@@ -190,7 +190,7 @@ class ChartAestheticAgentServiceTest {
       assertThrows(Exception.class,
                    () -> service.setField("tok", principal(), "Chart1", "colour",
                                           new FieldRef("Region", "dimension", null, null, null),
-                                          ""));
+                                          null, ""));
    }
 
    // ── node channels (spec 2c Phase 3) ───────────────────────────────────────
@@ -204,7 +204,7 @@ class ChartAestheticAgentServiceTest {
       Exception thrown = assertThrows(
          Exception.class,
          () -> service.setField("tok", principal(), "Chart1", "node-color",
-                                new FieldRef("Region", "dimension", null, null, null), ""));
+                                new FieldRef("Region", "dimension", null, null, null), null, ""));
       assertTrue(thrown.getMessage().contains("relation"));
    }
 
@@ -215,7 +215,7 @@ class ChartAestheticAgentServiceTest {
 
       serviceWith(sessionsFor(relationChart), new ChartBindingModel(), aesthetics)
          .setField("tok", principal(), "Chart1", "node-color",
-                  new FieldRef("Region", "dimension", null, null, null), "");
+                  new FieldRef("Region", "dimension", null, null, null), null, "");
 
       assertEquals("Region", captureEvent(aesthetics).getModel().getNodeColorField().getFullName());
    }

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingServiceTest.java
@@ -301,6 +301,116 @@ class ChartBindingServiceTest {
       assertTrue(thrown.getMessage().contains("force"));
    }
 
+   /**
+    * The aesthetic half: a chart can be bound entirely through a channel, with every shelf empty.
+    *
+    * <p>A word cloud is nothing but a text channel. {@code validateAestheticFields} clears exactly
+    * these on a repoint, so a check that read only the shelves would report "nothing bound" for a
+    * fully bound chart and discard its one binding without asking.
+    */
+   @Test
+   void setSourceCountsTheAestheticChannelsNotJustTheShelves() {
+      ChartBindingModel existing = chartWithTables("ORDERS1", "ORDER_DETAILS1");
+      existing.setSource(assetSource("ORDERS1"));
+      ChartAestheticMutator.setField(existing, "text",
+                                     new FieldRef("Product", "dimension", null, null, null));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> harness(existing, mock(ChangeChartRefService.class),
+                       mock(ChangeChartTypeService.class), mock(SwapXYBindingService.class),
+                       mock(ChangeSeparateStatusService.class))
+            .setSource("tok", principal(), "Chart1", "ORDER_DETAILS1", false, ""));
+
+      assertTrue(thrown.getMessage().contains("force"), "name the way through");
+      assertTrue(thrown.getMessage().contains("text"), "name which channel would be lost");
+   }
+
+   /**
+    * A relation chart's node channels are the same story on a second pair of properties, and
+    * {@code validateAestheticFields} clears them too.
+    */
+   @Test
+   void setSourceCountsARelationChartsNodeChannels() {
+      ChartBindingModel existing = chartWithTables("ORDERS1", "ORDER_DETAILS1");
+      existing.setSource(assetSource("ORDERS1"));
+      ChartAestheticMutator.setField(existing, "node-color",
+                                     new FieldRef("Region", "dimension", null, null, null), true);
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> harness(existing, mock(ChangeChartRefService.class),
+                       mock(ChangeChartTypeService.class), mock(SwapXYBindingService.class),
+                       mock(ChangeSeparateStatusService.class))
+            .setSource("tok", principal(), "Chart1", "ORDER_DETAILS1", false, ""));
+
+      assertTrue(thrown.getMessage().contains("force"));
+      assertTrue(thrown.getMessage().contains("node-color"));
+   }
+
+   /**
+    * A map keeps its geography on {@code geoFields}, which is no shelf and no channel —
+    * {@code validateChartColumns} removes those on a repoint alongside everything else.
+    */
+   @Test
+   void setSourceCountsAMapsGeoFields() {
+      ChartBindingModel existing = chartWithTables("ORDERS1", "ORDER_DETAILS1");
+      existing.setSource(assetSource("ORDERS1"));
+      existing.setGeoFields(List.of(new ChartDimensionRefModel()));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> harness(existing, mock(ChangeChartRefService.class),
+                       mock(ChangeChartTypeService.class), mock(SwapXYBindingService.class),
+                       mock(ChangeSeparateStatusService.class))
+            .setSource("tok", principal(), "Chart1", "ORDER_DETAILS1", false, ""));
+
+      assertTrue(thrown.getMessage().contains("force"));
+      assertTrue(thrown.getMessage().contains("geo"));
+   }
+
+   /** An aesthetic-only binding is discardable on the same terms as a shelf one: with force. */
+   @Test
+   void setSourceProceedsWhenForcedOverAnAestheticOnlyBinding() throws Exception {
+      ChartBindingModel existing = chartWithTables("ORDERS1", "ORDER_DETAILS1");
+      existing.setSource(assetSource("ORDERS1"));
+      ChartAestheticMutator.setField(existing, "text",
+                                     new FieldRef("Product", "dimension", null, null, null));
+      ChangeChartRefService refs = mock(ChangeChartRefService.class);
+
+      harness(existing, refs, mock(ChangeChartTypeService.class),
+              mock(SwapXYBindingService.class), mock(ChangeSeparateStatusService.class))
+         .setSource("tok", principal(), "Chart1", "ORDER_DETAILS1", true, "");
+
+      ArgumentCaptor<ChangeChartRefEvent> captor =
+         ArgumentCaptor.forClass(ChangeChartRefEvent.class);
+      verify(refs).changeChartRef(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                  anyString());
+      ChartBindingModel posted = captor.getValue().getModel();
+      assertEquals("ORDER_DETAILS1", posted.getSource().getSource());
+      assertNotNull(posted.getTextField(),
+                    "the repoint must not clear the channel itself — validateChartColumns " +
+                    "decides what survives, this write only moves the source");
+   }
+
+   /**
+    * A chart with no binding at all still repoints without {@code force} — the check must not
+    * become "anything non-null anywhere", or the very case {@code set_chart_source} exists for
+    * (a fresh chart that has no source yet) would be refused.
+    */
+   @Test
+   void setSourceOnAnUnboundChartNeedsNoForce() throws Exception {
+      ChartBindingModel existing = chartWithTables("ORDERS1", "ORDER_DETAILS1");
+      existing.setSource(assetSource("ORDERS1"));
+      ChangeChartRefService refs = mock(ChangeChartRefService.class);
+
+      harness(existing, refs, mock(ChangeChartTypeService.class),
+              mock(SwapXYBindingService.class), mock(ChangeSeparateStatusService.class))
+         .setSource("tok", principal(), "Chart1", "ORDER_DETAILS1", false, "");
+
+      verify(refs).changeChartRef(eq("rt1"), any(), any(Principal.class), any(), anyString());
+   }
+
    @Test
    void setSourceProceedsWhenForced() throws Exception {
       ChartBindingModel existing = chartWithTables("ORDERS1", "ORDER_DETAILS1");

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingServiceTest.java
@@ -30,6 +30,8 @@ import inetsoft.web.binding.event.ChangeChartRefEvent;
 import inetsoft.web.binding.event.ChangeChartTypeEvent;
 import inetsoft.web.binding.event.ChangeSeparateStatusEvent;
 import inetsoft.web.binding.model.ChartBindingModel;
+import inetsoft.web.binding.model.graph.ChartAggregateRefModel;
+import inetsoft.web.binding.model.graph.ChartDimensionRefModel;
 import inetsoft.web.binding.service.VSBindingService;
 import inetsoft.web.wiz.binding.model.FieldRef;
 import inetsoft.web.wiz.viewsheet.ViewsheetSessionService;
@@ -38,6 +40,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.security.Principal;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -58,7 +61,7 @@ class ChartBindingServiceTest {
       harness(existing, refs, mock(ChangeChartTypeService.class), mock(SwapXYBindingService.class),
               mock(ChangeSeparateStatusService.class))
          .setShelf("tok", principal(), "Chart1", "x",
-                   List.of(new FieldRef("Region", "dimension", null, null, null)), "");
+                   List.of(new FieldRef("Region", "dimension", null, null, null)), null, "");
 
       ArgumentCaptor<ChangeChartRefEvent> captor =
          ArgumentCaptor.forClass(ChangeChartRefEvent.class);
@@ -79,7 +82,7 @@ class ChartBindingServiceTest {
       harness(existing, refs, mock(ChangeChartTypeService.class), mock(SwapXYBindingService.class),
               mock(ChangeSeparateStatusService.class))
          .setShelf("tok", principal(), "Chart1", "y",
-                   List.of(new FieldRef("Sales", "measure", "Sum", null, null)), "");
+                   List.of(new FieldRef("Sales", "measure", "Sum", null, null)), null, "");
 
       ArgumentCaptor<ChangeChartRefEvent> captor =
          ArgumentCaptor.forClass(ChangeChartRefEvent.class);
@@ -209,6 +212,155 @@ class ChartBindingServiceTest {
          Exception.class,
          () -> service.swapAxes("tok", principal(), "Text1", ""));
       assertTrue(thrown.getMessage().contains("Text1"));
+   }
+
+   // ── set_chart_source ──────────────────────────────────────────────────────
+   //
+   // A chart added in the Composer starts with no source. Its shelves can be populated —
+   // set_chart_shelf reports success, get_binding reads the fields back correctly — and it renders
+   // nothing at all, because shelves with no source have nothing to query. The Composer assigns one
+   // as a side effect of the drag (VSChartDndService takes it from the drag event's table); the
+   // agent's FieldRef carries no table, so nothing on this path could assign one.
+
+   @Test
+   void setSourceAssignsAnAssetSourceByName() throws Exception {
+      ChartBindingModel existing = chartWithTables("ORDERS1", "ORDER_DETAILS1");
+      ChangeChartRefService refs = mock(ChangeChartRefService.class);
+
+      harness(existing, refs, mock(ChangeChartTypeService.class),
+              mock(SwapXYBindingService.class), mock(ChangeSeparateStatusService.class))
+         .setSource("tok", principal(), "Chart1", "ORDERS1", false, "");
+
+      ArgumentCaptor<ChangeChartRefEvent> captor =
+         ArgumentCaptor.forClass(ChangeChartRefEvent.class);
+      verify(refs).changeChartRef(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                  anyString());
+      ChartBindingModel posted = captor.getValue().getModel();
+      assertNotNull(posted.getSource(), "the model must carry a source after the write");
+      assertEquals("ORDERS1", posted.getSource().getSource());
+      assertEquals(inetsoft.uql.asset.SourceInfo.ASSET, posted.getSource().getType(),
+                   "worksheet tables bind as ASSET — the form the DnD path uses too");
+   }
+
+   @Test
+   void setSourceRefusesATableTheChartCannotSee() {
+      ChartBindingModel existing = chartWithTables("ORDERS1", "ORDER_DETAILS1");
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> harness(existing, mock(ChangeChartRefService.class),
+                       mock(ChangeChartTypeService.class), mock(SwapXYBindingService.class),
+                       mock(ChangeSeparateStatusService.class))
+            .setSource("tok", principal(), "Chart1", "NOPE", false, ""));
+
+      assertTrue(thrown.getMessage().contains("NOPE"));
+      assertTrue(thrown.getMessage().contains("ORDERS1"), "list what it can bind to");
+   }
+
+   /**
+    * Repointing discards the bound fields, because they belong to the old source — the Composer
+    * does exactly that, via {@code validateChartColumns}. Doing it silently on one call is the
+    * failure this plugin family exists to avoid, so it takes {@code force}.
+    */
+   @Test
+   void setSourceRefusesToDiscardBoundFieldsUnlessForced() {
+      ChartBindingModel existing = chartWithTables("ORDERS1", "ORDER_DETAILS1");
+      existing.setSource(assetSource("ORDERS1"));
+      existing.setXFields(List.of(new ChartDimensionRefModel()));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> harness(existing, mock(ChangeChartRefService.class),
+                       mock(ChangeChartTypeService.class), mock(SwapXYBindingService.class),
+                       mock(ChangeSeparateStatusService.class))
+            .setSource("tok", principal(), "Chart1", "ORDER_DETAILS1", false, ""));
+
+      assertTrue(thrown.getMessage().contains("force"), "name the way through");
+   }
+
+   /**
+    * The chart-specific half of that check: fields live in <b>thirteen</b> places, not three.
+    *
+    * <p>A candlestick's whole binding is on the single-field shelves and its x/y are empty, so a
+    * check that counted only x/y/group would report "nothing bound" and repoint without asking —
+    * discarding the entire binding of exactly the charts whose binding is hardest to rebuild.
+    */
+   @Test
+   void setSourceCountsTheSingleFieldShelvesNotJustXYAndGroup() {
+      ChartBindingModel existing = chartWithTables("ORDERS1", "ORDER_DETAILS1");
+      existing.setSource(assetSource("ORDERS1"));
+      existing.setCloseField(new ChartAggregateRefModel());
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> harness(existing, mock(ChangeChartRefService.class),
+                       mock(ChangeChartTypeService.class), mock(SwapXYBindingService.class),
+                       mock(ChangeSeparateStatusService.class))
+            .setSource("tok", principal(), "Chart1", "ORDER_DETAILS1", false, ""));
+
+      assertTrue(thrown.getMessage().contains("force"));
+   }
+
+   @Test
+   void setSourceProceedsWhenForced() throws Exception {
+      ChartBindingModel existing = chartWithTables("ORDERS1", "ORDER_DETAILS1");
+      existing.setSource(assetSource("ORDERS1"));
+      existing.setXFields(List.of(new ChartDimensionRefModel()));
+      ChangeChartRefService refs = mock(ChangeChartRefService.class);
+
+      harness(existing, refs, mock(ChangeChartTypeService.class),
+              mock(SwapXYBindingService.class), mock(ChangeSeparateStatusService.class))
+         .setSource("tok", principal(), "Chart1", "ORDER_DETAILS1", true, "");
+
+      ArgumentCaptor<ChangeChartRefEvent> captor =
+         ArgumentCaptor.forClass(ChangeChartRefEvent.class);
+      verify(refs).changeChartRef(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                  anyString());
+      assertEquals("ORDER_DETAILS1", captor.getValue().getModel().getSource().getSource());
+   }
+
+   /**
+    * Re-stating the source a chart already has discards nothing, so it must not demand
+    * {@code force}. Without this an agent that re-reads and re-applies its own intended state —
+    * the read-first habit this plugin asks for — gets refused for making no change.
+    */
+   @Test
+   void setSourceToTheSameTableDoesNotDemandForce() throws Exception {
+      ChartBindingModel existing = chartWithTables("ORDERS1", "ORDER_DETAILS1");
+      existing.setSource(assetSource("ORDERS1"));
+      existing.setXFields(List.of(new ChartDimensionRefModel()));
+      ChangeChartRefService refs = mock(ChangeChartRefService.class);
+
+      harness(existing, refs, mock(ChangeChartTypeService.class),
+              mock(SwapXYBindingService.class), mock(ChangeSeparateStatusService.class))
+         .setSource("tok", principal(), "Chart1", "ORDERS1", false, "");
+
+      verify(refs).changeChartRef(eq("rt1"), any(), any(Principal.class), any(), anyString());
+   }
+
+   private static inetsoft.web.binding.model.SourceInfo assetSource(String table) {
+      inetsoft.web.binding.model.SourceInfo source = new inetsoft.web.binding.model.SourceInfo();
+      source.setType(inetsoft.uql.asset.SourceInfo.ASSET);
+      source.setSource(table);
+      source.setView(table);
+
+      return source;
+   }
+
+   private static ChartBindingModel chartWithTables(String... names) {
+      ChartBindingModel model = new ChartBindingModel();
+      List<inetsoft.web.binding.model.BindingModel.SourceTable> tables = new ArrayList<>();
+
+      for(String name : names) {
+         inetsoft.web.binding.model.BindingModel.SourceTable table =
+            new inetsoft.web.binding.model.BindingModel.SourceTable();
+         table.setName(name);
+         tables.add(table);
+      }
+
+      model.setTables(tables);
+
+      return model;
    }
 
    private static ChartBindingService harness(ChartBindingModel model,

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetReadServiceTest.java
@@ -21,6 +21,8 @@ import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.test.BaseTestConfiguration;
 import inetsoft.test.ConfigurationContextInitializer;
 import inetsoft.test.SreeHome;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.AssetRepository;
 import inetsoft.uql.viewsheet.GaugeVSAssembly;
 import inetsoft.uql.viewsheet.TextVSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
@@ -80,5 +82,47 @@ class ViewsheetReadServiceTest {
       when(rvs.getViewsheet()).thenReturn(new Viewsheet());
 
       assertTrue(new ViewsheetReadService().read(rvs).assemblies().isEmpty());
+   }
+
+   /**
+    * The sheet's name comes from its asset entry, not from {@code Viewsheet.getName()}.
+    *
+    * <p>{@code Viewsheet.getName()} is the <em>assembly</em> name — it is set only by
+    * {@code createVSAssembly(name)}, i.e. when a viewsheet is embedded inside another viewsheet as
+    * an assembly. For a top-level sheet nobody ever sets it, so it is legitimately null and was
+    * never the right field to answer "what is this viewsheet called".
+    *
+    * <p>Reading it was also actively misleading, because null does not survive a save/reload:
+    * {@code AssemblyInfo.writeAttributes} emits {@code "<name><![CDATA[" + name + "]]></name>"},
+    * and Java string concatenation turns a null into the four characters {@code null}. So a
+    * reopened sheet reports the <b>string</b> {@code "null"} — worse than a JSON null, since a
+    * caller writing {@code if(name)} gets a truthy value and renders "null" to a user. Observed
+    * live: an unsaved viewsheet reported {@code null}, and the saved {@code TestVS_L3} reported
+    * {@code "null"}. The sibling field already carries a hand-patch for the identical flaw
+    * ({@code VSAssemblyInfo} normalizes {@code "null"} back to null when parsing
+    * {@code absoluteName2}), which is left alone here: repairing the shared serialization would
+    * change the written XML for every assembly of every sheet, far beyond what this read needs.
+    */
+   @Test
+   void namesTheSheetFromItsAssetEntryRatherThanTheAssemblyName() {
+      Viewsheet vs = new Viewsheet();
+      // What a reopened top-level sheet actually holds, per the serialization above.
+      vs.createVSAssembly("null");
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(rvs.getEntry()).thenReturn(new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET, "Test/TestVS_L3", null));
+
+      assertEquals("TestVS_L3", new ViewsheetReadService().read(rvs).name());
+   }
+
+   /** A sheet with no entry at all — never saved — reports no name rather than a fabricated one. */
+   @Test
+   void reportsNoNameWhenTheSheetHasNoAssetEntry() {
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(new Viewsheet());
+      when(rvs.getEntry()).thenReturn(null);
+
+      assertNull(new ViewsheetReadService().read(rvs).name());
    }
 }


### PR DESCRIPTION
A chart bound through the agent rendered nothing. set_chart_shelf returned ok, get_binding read the fields straight back, and the chart was blank; rendering that one assembly answered HTTP 500.

The Composer sets an assembly's source as a side effect of the drag -- VSChartDndService takes it from event.getTable(), so dropping a column says both "bind this" and "from here" in one gesture. The agent path lost the second half: the field vocabulary had nowhere to name a table, so the request carried no source to set, and updateSourceInfo is a no-op when the model's source is null -- it propagates a source, which is not the same as being able to set one. With the source missing, createDataRef also produced refs with no dataType and no dataRef, which is why the Composer's own dialog dropped the date-level selector for a date column: with no data type it cannot tell that it is one.

The information was never missing. list_bindable_fields groups columns BY TABLE, so a caller always knew which table it picked from. So rather than reconstruct the table server-side from the column name, let the write say it, the way the drag does:

  - `table` on the request, not on each field. All the fields in one call share one source, so a per-field table would let a caller describe a state that cannot exist.
  - Given, establish it. Omitted, infer it when the columns name exactly one table -- over the INTERSECTION of every field, not the first, since a column that is ambiguous alone is often unique in company.
  - Ambiguous, refuse and name the candidates. Every wrong guess here is a real table and renders something plausible.
  - Never repoint a bound chart as a side effect of binding a field. applySource only fires on a chart with no source; moving a bound one needs set_chart_source with explicit force, and the refusal names what would be lost. That check counts all thirteen places a chart keeps fields: a candlestick's whole binding is on the single-field shelves with x/y empty, so counting only x/y/group would report "nothing bound" and discard it without asking.

list_bindable_fields now marks the live table current: true -- null, not false, when unscoped, since there is no assembly to be current for and false everywhere would read as "none of these is live". That flag closed two gaps found on the way: BindableColumns can narrow its check to the one source instead of accepting any real column from any table, and the chart write endpoints got that check at all, having had none while the table endpoints have had it since it was built.

Two smaller fixes in the same area:

  - An empty Dimensions or Measures folder was fabricated into a bindable column. VSTreeHandler adds both folders to every table as long as it has a ref of either kind, so a table of only measures carries an empty Dimensions folder -- childless, not a table, and so a "column" named Dimensions. Third instance of one class of defect in isColumn, whose own javadoc records the previous two; excluded by entry type, the way isTable already decides.
  - ViewsheetReadService reported a saved viewsheet's name as the STRING "null". It read Viewsheet.getName(), which is the ASSEMBLY name and is legitimately null on a top-level sheet, and AssemblyInfo writes it by concatenation, so a reopened sheet reads back four characters of text. Now from the asset entry, which is what WorksheetReadService already did. The shared serialization is deliberately left alone: it is on the path of every assembly of every sheet, and the one field that already carries a hand-patch for this shows the flaw is older and wider than this read.

1957 tests green in inetsoft.web.wiz.**.