### PR TITLE
Add chart plot-size read and guard the chart-region targets

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartElementService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartElementService.java
@@ -21,11 +21,19 @@ import inetsoft.uql.viewsheet.ChartVSAssembly;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.graph.VGraph;
+import inetsoft.graph.coord.Coordinate;
+import inetsoft.graph.coord.RelationCoord;
+import inetsoft.graph.internal.GTool;
+import inetsoft.report.composition.execution.ViewsheetSandbox;
+import inetsoft.report.composition.graph.*;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
 import inetsoft.web.viewsheet.controller.chart.*;
 import inetsoft.web.viewsheet.event.chart.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.awt.geom.Rectangle2D;
 import java.security.Principal;
 import java.util.*;
 
@@ -166,6 +174,208 @@ public class ChartElementService {
       });
    }
 
+   /**
+    * Reads the plot's current sizing, so a {@link #resizePlot} call can be verified at all.
+    *
+    * <p>This exists because the write had <em>no</em> observable. The ratio scales the plot's
+    * <em>minimum</em> size, which a browser expresses as scrollbars inside a fixed-size assembly,
+    * while the agent-facing render asks for a graph fitted to the requested box
+    * ({@code ScriptImageService} passes the target box as both size and max size) - so an
+    * enlarged plot and a default one produce byte-identical images. Plot size is also absent from
+    * the chart's property dialog model and from its scriptable API, so before this method a plot
+    * resize could not be confirmed through any channel the agent has.
+    *
+    * <p>Two groups come back and they answer different questions.
+    *
+    * <p>The <b>ratios</b> are the stored intent: {@code ratio} is what {@link #resizePlot} wrote,
+    * {@code resized} is the flag that gates it in {@code VGraphPair} (a ratio stored with this
+    * false is inert), and {@code percent} is what {@code VGraphPair} re-applies the ratio from -
+    * it only does so while that value is {@code >= 1}, which is what decides whether a resize
+    * survives the next layout.
+    *
+    * <p>The <b>geometry</b> is what the last layout produced, and it is weaker evidence than the
+    * first version of this javadoc claimed. Verified live: a resize does not itself relayout, so
+    * {@code getVGraphPair} hands back a cached pair and {@code plot}/{@code expandedPlot}/
+    * {@code minPlot} did not move even with {@code percent} at 1.48. An expanded plot larger than
+    * the real-size one does prove an enlargement is live; equal sizes prove only that this graph
+    * has not been rebuilt with it.
+    *
+    * <p>Also verified live, and the reason {@code percent} is the field to compare:
+    * {@code ratio} and {@code initialRatio} are recomputed from whatever box was laid out last
+    * ({@code VGraphPair} does {@code setUnitHeightRatio(initialHeightRatio * percent)}), so a
+    * written 8 read back as 26.86 after one full-size render while {@code percent} stayed 1.48.
+    * And {@code resizePlot}'s reset clears the ratios and flags but <b>not</b> the percents, so a
+    * reset chart still reports the old ratio and re-derives it on the next layout - judge a reset
+    * by {@code resized}/{@code default}.
+    *
+    * <p>{@code scrollable}/{@code vScrollable}/{@code hScrollable} are the same
+    * {@code GraphUtil} calls the Composer uses to decide whether to draw scrollbars. They are
+    * reported because they are the user-visible effect, but they are <b>not</b> an independent
+    * check: for an ordinary chart {@code isVScrollable} falls through to
+    * {@code info.isHeightResized()}, so it largely restates the flag. The geometry is the
+    * stronger oracle.
+    *
+    * <p>Geometry needs a laid-out graph, which a chart with no data or no sandbox does not have.
+    * That case returns the ratios plus {@code geometryUnavailable} naming why, rather than nulls
+    * that would read as zero-sized.
+    */
+   public Map<String, Object> readPlotSize(String sessionToken, Principal user,
+                                           String assemblyName)
+      throws Exception
+   {
+      return sessions.read(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         ChartVSAssembly chart = requireChart(rvs, assemblyName);
+         VSChartInfo info = chart.getVSChartInfo();
+         Map<String, Object> result = new LinkedHashMap<>();
+
+         result.put("assembly", assemblyName);
+         result.put("default", !info.isWidthResized() && !info.isHeightResized());
+         result.put("width", ratios(info.getUnitWidthRatio(), info.getUnitWidthRatioPercent(),
+                                    info.getInitialWidthRatio(), info.getEffectiveWidthRatio(),
+                                    info.isWidthResized()));
+         result.put("height", ratios(info.getUnitHeightRatio(), info.getUnitHeightRatioPercent(),
+                                     info.getInitialHeightRatio(),
+                                     info.getEffectiveHeightRatio(), info.isHeightResized()));
+         result.put("toolMaxRatio", MAX_PLOT_RATIO);
+
+         ViewsheetSandbox box = rvs.getViewsheetSandbox().orElse(null);
+
+         if(box == null) {
+            result.put("geometryUnavailable",
+                       "the viewsheet has no sandbox, so no graph has been laid out");
+            return result;
+         }
+
+         VGraphPair pair;
+
+         box.lockRead();
+
+         try {
+            pair = box.getVGraphPair(chart.getAbsoluteName());
+         }
+         finally {
+            box.unlockRead();
+         }
+
+         VGraph real = pair == null ? null : pair.getRealSizeVGraph();
+
+         if(real == null) {
+            result.put("geometryUnavailable", pair == null
+               ? "no graph pair exists for this chart yet"
+               : "the chart has no laid-out graph - it is unbound, empty, or still computing");
+            return result;
+         }
+
+         VGraph expanded = pair.getExpandedVGraph();
+
+         result.put("plot", size(real.getPlotBounds()));
+         result.put("graph", size(real.getBounds()));
+         result.put("expandedPlot", size(expanded.getPlotBounds()));
+         result.put("expanded", expanded != real);
+         result.put("minPlot", Map.of("width", round(real.getMinPlotWidth()),
+                                      "height", round(real.getMinPlotHeight())));
+         result.put("scrollable", GraphUtil.isScrollable(real, info));
+         result.put("vScrollable", GraphUtil.isVScrollable(real, info));
+         result.put("hScrollable", GraphUtil.isHScrollable(real, info));
+         result.putAll(maxRatios(real, info));
+
+         return result;
+      });
+   }
+
+   /** One axis' worth of ratio state, in the order a reader needs it. */
+   private static Map<String, Object> ratios(double ratio, double percent, double initial,
+                                             double effective, boolean resized)
+   {
+      Map<String, Object> map = new LinkedHashMap<>();
+      map.put("ratio", round(ratio));
+      map.put("resized", resized);
+      map.put("percent", round(percent));
+      map.put("initialRatio", round(initial));
+      map.put("effectiveRatio", round(effective));
+      return map;
+   }
+
+   /**
+    * How far the plot can legitimately be enlarged, by the same formula the Composer's own
+    * chart-areas command sends to the browser - so a caller is not left guessing against this
+    * class' blunt {@link #MAX_PLOT_RATIO} cap, which is a typo guard rather than a real limit.
+    */
+   private static Map<String, Object> maxRatios(VGraph graph, VSChartInfo info) {
+      Coordinate coord = graph.getCoordinate();
+      double maxWidth;
+      double maxHeight;
+
+      if(coord instanceof RelationCoord || GraphTypeUtil.isWordCloud(info) ||
+         GraphTypeUtil.isDotPlot(info))
+      {
+         // these scale both directions together, and the Composer caps them at 5
+         maxWidth = maxHeight = 5;
+      }
+      else if(coord != null) {
+         maxWidth = info.getInitialWidthRatio() *
+            GTool.getUnitCount(coord, Coordinate.BOTTOM_AXIS, false);
+         maxHeight = info.getInitialHeightRatio() *
+            GTool.getUnitCount(coord, Coordinate.LEFT_AXIS, false);
+      }
+      else {
+         return Map.of();
+      }
+
+      return Map.of("maxWidthRatio", round(maxWidth), "maxHeightRatio", round(maxHeight));
+   }
+
+   private static Map<String, Object> size(Rectangle2D bounds) {
+      if(bounds == null) {
+         return Map.of();
+      }
+
+      return Map.of("width", round(bounds.getWidth()), "height", round(bounds.getHeight()));
+   }
+
+   /** Pixel and ratio values carry no meaning past 2 decimals, and full doubles read as noise. */
+   private static double round(double value) {
+      return Math.round(value * 100d) / 100d;
+   }
+
+   /**
+    * The vocabulary, narrowed to one chart's real axes when an assembly is named.
+    *
+    * <p>Without an assembly this is the flat vocabulary it always was — every element and every
+    * title target, the same for every chart in the product. That is kept because it is a valid
+    * question ("what can this tool address at all") and because it needs no runtime.
+    *
+    * <p>With an assembly, the title targets are filtered to the axes the chart actually has and
+    * {@code axes} names them, so the caller is no longer offered a {@code y2} on a chart with one
+    * measure. {@code axesBasis} says whether that came from the laid-out graph or was inferred
+    * from the binding, because the two are not equally trustworthy and hiding the difference is
+    * how a plausible-but-wrong answer gets believed.
+    */
+   public Map<String, Object> vocabulary(String sessionToken, Principal user, String assembly)
+      throws Exception
+   {
+      if(assembly == null || assembly.isBlank()) {
+         return vocabulary();
+      }
+
+      ChartRegionResolver.Axes axes = sessions.read(
+         sessionToken, user,
+         (rvs, runtimeId, dispatcher) ->
+            ChartRegionResolver.resolve(rvs, ChartRegionResolver.requireChart(rvs, assembly)));
+
+      Map<String, Object> out = new LinkedHashMap<>(vocabulary());
+      List<String> titleTargets = new ArrayList<>(axes.ordered());
+      // The chart title is not an axis title and does not depend on any axis existing.
+      titleTargets.add("chart");
+
+      out.put("assembly", assembly);
+      out.put("axes", axes.ordered());
+      out.put("titleTargets", titleTargets);
+      out.put("axesBasis", axes.basis());
+      out.put("axesMeasured", axes.measured());
+      return out;
+   }
+
    public Map<String, Object> vocabulary() {
       return Map.of(
          "elements", List.of("axis", "legend", "title"),
@@ -261,21 +471,11 @@ public class ChartElementService {
       return kind;
    }
 
-   private static void requireChart(inetsoft.report.composition.RuntimeViewsheet rvs,
-                                    String assemblyName)
+   /** Shared with {@link ChartRegionPropertyService} so both refuse a non-chart identically. */
+   private static ChartVSAssembly requireChart(
+      inetsoft.report.composition.RuntimeViewsheet rvs, String assemblyName)
    {
-      Viewsheet vs = rvs == null ? null : rvs.getViewsheet();
-      VSAssembly assembly = vs == null ? null : vs.getAssembly(assemblyName);
-
-      if(assembly == null) {
-         throw new IllegalArgumentException("Unknown assembly '" + assemblyName + "'.");
-      }
-
-      if(!(assembly instanceof ChartVSAssembly)) {
-         throw new IllegalArgumentException(
-            "'" + assemblyName + "' is a " + assembly.getClass().getSimpleName() +
-            ", not a chart. Axes, legends and titles only exist on charts.");
-      }
+      return ChartRegionResolver.requireChart(rvs, assemblyName);
    }
 
    private final ViewsheetSessionService sessions;

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyService.java
@@ -55,9 +55,13 @@ public class ChartRegionPropertyService {
       return Map.of(
          "regions", List.of("axis", "legend", "title"),
          "target", Map.of(
-            "axis", "the axis type — y, y2, x, x2 — as reported by list_chart_elements",
+            "axis", "the axis type — y, y2, x, x2 — but only the ones this chart has; pass " +
+               "the assembly to list_chart_elements to see which, since a y2 or x2 exists only " +
+               "when a measure uses the secondary axis",
             "legend", "the legend's 0-based index",
-            "title", "which title — x, x2, y, y2 or chart"),
+            "title", "which axis title — x, x2, y, y2, and only ones this chart has. NOT the " +
+               "chart's own title: that lives on the assembly, as set_assembly_properties " +
+               "'title' and 'titleVisible'"),
          "note", "An axis may also need 'field' when a chart has more than one axis of a type.");
    }
 
@@ -68,6 +72,7 @@ public class ChartRegionPropertyService {
    {
       String name = requireRegion(region);
       String key = requireTarget(target, name);
+      requireExistingTarget(sessionToken, user, assembly, name, key);
       Object model = readModel(sessionToken, user, assembly, name, key, field);
       Map<String, String> aliases = aliasesFor(name);
       List<Map<String, Object>> properties = new ArrayList<>();
@@ -101,6 +106,7 @@ public class ChartRegionPropertyService {
    {
       String name = requireRegion(region);
       String key = requireTarget(target, name);
+      requireExistingTarget(sessionToken, user, assembly, name, key);
 
       if(properties == null || properties.isEmpty()) {
          throw new IllegalArgumentException(
@@ -145,8 +151,8 @@ public class ChartRegionPropertyService {
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          switch(name) {
          case "axis" -> regions.setAxisPropertyDialogModel(
-            runtimeId, assembly, key, 0, field, (AxisPropertyDialogModel) written, linkUri, user,
-            dispatcher);
+            runtimeId, assembly, axisType(key), 0, field, (AxisPropertyDialogModel) written,
+            linkUri, user, dispatcher);
          case "legend" -> regions.setLegendFormatDialogModel(
             runtimeId, assembly, indexOf(key), (LegendFormatDialogModel) written, linkUri, user,
             dispatcher);
@@ -156,6 +162,59 @@ public class ChartRegionPropertyService {
       });
    }
 
+   /**
+    * Refuses an axis, or an axis title, that this chart does not have.
+    *
+    * <p>{@link #requireTarget} already rejects a target that names <em>no</em> axis type. This is
+    * the other half: a target that names a real type the <em>chart</em> does not have.
+    * {@code ChartRegionHandler.getAxisArea} maps {@code y2} onto an axis area {@code ChartArea}
+    * builds unconditionally, so a chart with one measure returned the full y1 property list for
+    * y2, accepted a write against it, and read the write straight back. Read and write are both
+    * guarded here rather than only the write, because the read is what talked the caller into the
+    * write.
+    *
+    * <p>Legends are not checked here — their target is an index, bounded by a different question,
+    * and an out-of-range one has its own defect to fix.
+    */
+   private void requireExistingTarget(String sessionToken, Principal user, String assembly,
+                                      String region, String target)
+      throws Exception
+   {
+      if("legend".equals(region)) {
+         ChartRegionResolver.Legends legends = sessions.read(
+            sessionToken, user,
+            (rvs, runtimeId, dispatcher) ->
+               ChartRegionResolver.legendCount(
+                  rvs, ChartRegionResolver.requireChart(rvs, assembly)));
+
+         ChartRegionResolver.requireLegend(legends, indexOf(target));
+         return;
+      }
+
+      if(!"axis".equals(region) && !"title".equals(region)) {
+         return;
+      }
+
+      // The chart title is not a region title at all, and asking for it here was a raw HTTP 500.
+      // TitlesDescriptor only holds x/x2/y/y2 descriptors, so ChartRegionHandler.getTitleDescriptor
+      // and getTitleArea both return null for "chart" and RegionPropertyDialogService then
+      // dereferences the null area. The chart title lives on the assembly instead.
+      if("title".equals(region) && "chart".equals(ChartRegionResolver.canonical(target))) {
+         throw new IllegalArgumentException(
+            "The chart title is not a chart region — only the axis titles (x, x2, y, y2) are. " +
+            "It lives on the assembly: set its text with set_assembly_properties 'title', and " +
+            "show or hide it with 'titleVisible' or with " +
+            "set_chart_element_visibility {element: 'title', target: 'chart'}.");
+      }
+
+      ChartRegionResolver.Axes axes = sessions.read(
+         sessionToken, user,
+         (rvs, runtimeId, dispatcher) ->
+            ChartRegionResolver.resolve(rvs, ChartRegionResolver.requireChart(rvs, assembly)));
+
+      ChartRegionResolver.requireAxis(axes, region, target);
+   }
+
    private Object readModel(String sessionToken, Principal user, String assembly, String region,
                             String target, String field)
       throws Exception
@@ -163,10 +222,41 @@ public class ChartRegionPropertyService {
       String runtimeId = sessions.runtimeId(sessionToken, user);
 
       return switch(region) {
-         case "axis" -> regions.getAxisPropertyDialogModel(runtimeId, assembly, target, "0", field,
-                                                           "", user);
+         case "axis" -> regions.getAxisPropertyDialogModel(runtimeId, assembly, axisType(target),
+                                                           "0", field, "", user);
          case "legend" -> regions.getLegendFormatDialogModel(runtimeId, assembly, target, "", user);
          default -> regions.getTitleFormatDialogModel(runtimeId, assembly, target, "", user);
+      };
+   }
+
+   /**
+    * Translates a secondary axis target to the <b>long</b> area form before it reaches StyleBI.
+    *
+    * <p><b>Found live 2026-08-20, image-confirmed.</b> Writing {@code showAxisLabel: false} to
+    * {@code y2} on a dual-axis chart hid the <em>primary</em> axis' labels instead, reported
+    * success naming y2, and reading {@code y} back afterwards showed the value there. Passing
+    * {@code field} did not help.
+    *
+    * <p>The cause is an asymmetry in {@code ChartRegionHandler}: {@code getAxisArea} accepts both
+    * the short forms ({@code Y2_TITLE = "y2"}) and the long ones
+    * ({@code RIGHT_Y_AXIS = "right_y_axis"}), so the <em>area</em> resolves either way and the read
+    * looks healthy — but {@code getChartRef} (which every {@code getAxisDescriptor} overload
+    * funnels through) knows {@code left_y_axis}, {@code right_y_axis}, {@code bottom_x_axis},
+    * {@code top_x_axis}, {@code "y"} and {@code "x"}, and <b>not</b> {@code "y2"} or {@code "x2"}.
+    * So the ref came back null, the descriptor chain fell through to its last branch —
+    * {@code info.getAxisDescriptor()}, the descriptor shared with the primary axis — and the
+    * secondary branch that exists for exactly this case
+    * ({@code isSecondaryY() -> info.getAxisDescriptor2()}) was never reached.
+    *
+    * <p>Only the secondary forms are translated. {@code "y"} and {@code "x"} are handled by
+    * {@code getChartRef} already, and mapping them to the long forms would change which shelf
+    * {@code findDataRef} searches on a scatter matrix — a real behaviour change for no gain.
+    */
+   private static String axisType(String target) {
+      return switch(ChartRegionResolver.canonical(target)) {
+         case "y2" -> "right_y_axis";
+         case "x2" -> "top_x_axis";
+         default -> target;
       };
    }
 
@@ -199,7 +289,8 @@ public class ChartRegionPropertyService {
             switch(region) {
                case "axis" -> "the axis type, such as y or x.";
                case "legend" -> "the legend's 0-based index.";
-               default -> "which title: x, x2, y, y2 or chart.";
+               default -> "which axis title: x, x2, y, y2. The chart's own title is not a " +
+                  "region — it is set_assembly_properties 'title'.";
             });
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionResolver.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionResolver.java
@@ -160,13 +160,18 @@ final class ChartRegionResolver {
          return;
       }
 
+      String range = legends.count() == 0
+         ? "This chart has no legends"
+         : legends.count() == 1
+            ? "This chart has 1 legend, so the only valid index is 0"
+            : "This chart has " + legends.count() + " legends, so the valid indexes are 0 to " +
+              (legends.count() - 1);
+
+      // No dash before the offending index: "valid indexes are 0 - '7'" reads as a range, which
+      // is the opposite of what it says. Seen in live output.
       throw new IllegalArgumentException(
-         "This chart has " + (legends.count() == 0 ? "no legends"
-            : legends.count() + (legends.count() == 1 ? " legend" : " legends") +
-              ", so the valid indexes are 0" +
-              (legends.count() > 1 ? " to " + (legends.count() - 1) : "")) +
-         " - '" + index + "' is out of range. A legend exists per aesthetic field bound to the " +
-         "chart; get_chart_aesthetics shows which.");
+         range + "; '" + index + "' is out of range. A legend exists per aesthetic field bound " +
+         "to the chart; get_chart_aesthetics shows which.");
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionResolver.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionResolver.java
@@ -1,0 +1,354 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.graph.VGraph;
+import inetsoft.graph.coord.Coordinate;
+import inetsoft.graph.guide.axis.Axis;
+import inetsoft.graph.guide.axis.DefaultAxis;
+import inetsoft.graph.guide.legend.LegendGroup;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.composition.execution.ViewsheetSandbox;
+import inetsoft.report.composition.graph.VGraphPair;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.VSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.graph.ChartAggregateRef;
+import inetsoft.uql.viewsheet.graph.ChartRef;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+/**
+ * Which axes and how many legends a chart actually has.
+ *
+ * <p><b>Why this exists.</b> Nothing else in the agent surface could answer that question, and
+ * three tools needed it: the element vocabulary offered {@code y2} on every chart, the region
+ * property read described that axis with a full, plausible property list, and the region property
+ * write stored a value against it which the read then confirmed. An agent could enumerate, read,
+ * write and verify, and be told yes at all four steps about an axis that is not there.
+ *
+ * <p><b>Why {@code ChartArea} cannot answer it.</b> The obvious place to look is where the
+ * property dialogs look — {@code ChartRegionHandler.getAxisArea} maps {@code y2} onto
+ * {@code ChartArea.getRightYAxisArea()} — but {@code ChartArea} builds all four axis areas
+ * <em>unconditionally</em>, so the area exists whether or not a y2 does and a phantom axis reads
+ * as real. (Its <em>title</em> areas are built conditionally, which is why a missing y2 title is
+ * detectable and a missing y2 axis is not.) So the answer has to come from the axes themselves —
+ * and, as the next paragraph but one records, not merely from whether one is present.
+ *
+ * <p><b>The binding is the base; the graph only adds to it.</b> The secondary axis is a property
+ * of a <em>measure</em> ({@link ChartAggregateRef#isSecondaryY()}), and it lands opposite
+ * whichever shelf holds the measures — so an inverted graph ({@link VSChartInfo#isInvertedGraph()})
+ * puts it on the top axis rather than the right one. On top of that, a laid-out graph can reveal a
+ * secondary axis the binding does not show, because one can be created by the engine rather than
+ * by the user (date comparison and the percent scale both call {@code RectCoord.setYScale2}), so
+ * the graph is consulted to <em>add</em> x2/y2 and never to remove anything.
+ *
+ * <p><b>Why the graph cannot simply be believed — this was a live bug in this class.</b> The first
+ * version took {@code getAxesAt(RIGHT_AXIS).length > 0} as proof of a y2, on the reasoning that
+ * the laid-out graph is what actually rendered. It reported y2 on an ordinary single-measure bar
+ * chart, so the phantom sailed straight through the guard. {@code RectCoord.createAxis} builds
+ * {@code yaxis2} <em>unconditionally</em> and only discards it when
+ * {@code zIndex < 0 && getGridLineCount() == 0} — so with y grid lines enabled the axis survives
+ * as a <b>grid-line carrier</b> and is added to the graph with no secondary scale behind it. That
+ * is the real shape of "the right y axis always exists": not an empty area, an actual axis object.
+ *
+ * <p>The discriminator is two lines further down the same method:
+ * {@code if(yscale2 == null) yaxis2.setPrimaryAxis(yaxis1);}. So an axis at the top or right whose
+ * {@link Axis#getPrimaryAxis()} is {@code null} has its own scale and is a genuine secondary axis,
+ * while one that points back at the primary is a mirror of it — a grid carrier, or the primary's
+ * labels moved to the opposite side. Neither mirror has an independent descriptor to edit, which
+ * is why neither counts.
+ *
+ * <p><b>And the graph is never allowed to subtract.</b> A hidden axis is dropped from the
+ * coordinate entirely, so a graph-only answer would report no x axis for a chart whose x axis was
+ * hidden — and then refuse to format or unhide it. Refusing a real axis is a worse failure than
+ * the phantom this class was written to stop, so the binding sets the floor.
+ */
+final class ChartRegionResolver {
+   /** The canonical axis names, in the order a reader expects them. */
+   static final List<String> AXES = List.of("x", "x2", "y", "y2");
+
+   /**
+    * @param count    how many legends the chart renders
+    * @param measured false when there was no laid-out graph to count from
+    */
+   record Legends(int count, boolean measured) {}
+
+   /**
+    * @param present  the canonical names of the axes this chart has
+    * @param measured true when read from a laid-out graph, false when inferred from the binding
+    * @param basis    where the answer came from, for a message the caller can act on
+    */
+   record Axes(Set<String> present, boolean measured, String basis) {
+      boolean has(String axis) {
+         return present.contains(canonical(axis));
+      }
+
+      /** In {@link #AXES} order rather than discovery order, so output is stable. */
+      List<String> ordered() {
+         return AXES.stream().filter(present::contains).toList();
+      }
+   }
+
+   private ChartRegionResolver() {
+   }
+
+   static Axes resolve(RuntimeViewsheet rvs, ChartVSAssembly chart) {
+      VGraphPair pair = laidOutPair(rvs, chart);
+
+      // ChartArea reads its axis areas from the EXPANDED graph, so resolve from the same one.
+      return resolve(chart, pair == null ? null : pair.getExpandedVGraph());
+   }
+
+   /**
+    * How many legends the chart has, counted where {@code ChartArea} counts them.
+    *
+    * <p>{@code LegendsArea} builds one area per {@code vgraph.getLegendGroup().getLegendCount()}
+    * and is not built at all when the group is null, so that count is exactly the valid index
+    * range for a legend target. It comes off the <b>real-size</b> graph, which is the one
+    * {@code ChartArea} passes to {@code LegendsArea} - unlike the axes, which come from the
+    * expanded graph.
+    *
+    * <p>An index outside it used to reach StyleBI and return a raw HTTP 500 page; a chart with no
+    * laid-out graph has no legends either, so {@code count 0} with the basis stated is a truthful
+    * answer rather than a guess.
+    */
+   static Legends legendCount(RuntimeViewsheet rvs, ChartVSAssembly chart) {
+      VGraphPair pair = laidOutPair(rvs, chart);
+      VGraph graph = pair == null ? null : pair.getRealSizeVGraph();
+
+      if(graph == null) {
+         return new Legends(0, false);
+      }
+
+      LegendGroup legends = graph.getLegendGroup();
+      return new Legends(legends == null ? 0 : legends.getLegendCount(), true);
+   }
+
+   /**
+    * Refuses a legend index outside the chart's range, naming the range.
+    *
+    * <p>The index is the one target in this vocabulary with a knowable bound, so it is also the
+    * easiest to check - and it was the one returning a bare 500.
+    *
+    * <p><b>Only when the count was actually measured.</b> An unmeasured count is zero because
+    * there was no graph to count, not because the chart has no legends, and refusing on that
+    * would block a legitimate write whenever the layout was unavailable - the same
+    * "never subtract on missing evidence" rule the axis side follows. Unmeasured lets the call
+    * through to whatever the server says, which is no worse than before this guard existed.
+    */
+   static void requireLegend(Legends legends, int index) {
+      if(!legends.measured() || index >= 0 && index < legends.count()) {
+         return;
+      }
+
+      throw new IllegalArgumentException(
+         "This chart has " + (legends.count() == 0 ? "no legends"
+            : legends.count() + (legends.count() == 1 ? " legend" : " legends") +
+              ", so the valid indexes are 0" +
+              (legends.count() > 1 ? " to " + (legends.count() - 1) : "")) +
+         " - '" + index + "' is out of range. A legend exists per aesthetic field bound to the " +
+         "chart; get_chart_aesthetics shows which.");
+   }
+
+   /**
+    * The decision rule, separated from fetching the graph so it can be exercised without a
+    * sandbox. The rule is where the live bug was; the plumbing is the live case's business.
+    */
+   static Axes resolve(ChartVSAssembly chart, VGraph graph) {
+      Set<String> present = new LinkedHashSet<>(fromBinding(chart.getVSChartInfo()));
+
+      if(graph == null || graph.getCoordinate() == null) {
+         return new Axes(present, false,
+                         "the binding alone, because this chart has no laid-out graph yet - it " +
+                         "is unbound, empty, or still computing");
+      }
+
+      // Additive only, and only for the secondary axes. The graph can reveal a y2 the binding
+      // does not (date comparison and the percent scale create one), but it cannot be used to
+      // rule an axis out: a hidden axis leaves the coordinate altogether.
+      if(hasOwnScaleAxis(graph, Coordinate.TOP_AXIS)) {
+         present.add("x2");
+      }
+
+      if(hasOwnScaleAxis(graph, Coordinate.RIGHT_AXIS)) {
+         present.add("y2");
+      }
+
+      return new Axes(present, true, "the binding plus the chart's laid-out graph");
+   }
+
+   /**
+    * Refuses an axis the chart does not have, naming the ones it does.
+    *
+    * <p>Refusing on an <em>inferred</em> answer is deliberate rather than an oversight: a chart
+    * with no laid-out graph has no rendered axis either, so accepting the write would store a
+    * value against something that does not exist — which is the defect this class was added for.
+    * The message says which basis was used so the caller can tell the two cases apart.
+    */
+   static void requireAxis(Axes axes, String region, String target) {
+      if(axes.has(target)) {
+         return;
+      }
+
+      List<String> present = axes.ordered();
+
+      throw new IllegalArgumentException(
+         "This chart has no '" + target + "' " + region + ". " +
+         (present.isEmpty()
+            ? "It has no axes at all"
+            : "Its axes are: " + String.join(", ", present)) +
+         " (from " + axes.basis() + "). A y2 or x2 axis exists only when a measure uses the " +
+         "secondary axis, or the engine created one (date comparison, percent scale) - the axis " +
+         "object at the right or top of an ordinary chart is a grid-line carrier, not a second " +
+         "axis. Asking for one that is not there used to return a full, plausible property list " +
+         "and accept a write against it.");
+   }
+
+   /**
+    * The long area forms {@code ChartRegionHandler.getAxisArea} accepts, folded onto the short
+    * names. Both reach the same axis there, so both have to reach the same answer here -
+    * {@code right_y_axis} is exactly the alias a caller reaching for a phantom y2 would use.
+    */
+   static String canonical(String target) {
+      if(target == null) {
+         return "";
+      }
+
+      return switch(target.trim().toLowerCase()) {
+         case "bottom_x_axis" -> "x";
+         case "top_x_axis" -> "x2";
+         case "left_y_axis" -> "y";
+         case "right_y_axis" -> "y2";
+         default -> target.trim().toLowerCase();
+      };
+   }
+
+   static ChartVSAssembly requireChart(RuntimeViewsheet rvs, String assemblyName) {
+      Viewsheet vs = rvs == null ? null : rvs.getViewsheet();
+      VSAssembly assembly = vs == null ? null : vs.getAssembly(assemblyName);
+
+      if(assembly == null) {
+         throw new IllegalArgumentException("Unknown assembly '" + assemblyName + "'.");
+      }
+
+      if(!(assembly instanceof ChartVSAssembly chart)) {
+         throw new IllegalArgumentException(
+            "'" + assemblyName + "' is a " + assembly.getClass().getSimpleName() +
+            ", not a chart. Axes, legends and titles only exist on charts.");
+      }
+
+      return chart;
+   }
+
+   /**
+    * Whether a genuine secondary axis sits at this position — one with its own scale rather than
+    * one mirroring the primary. See the class comment: presence alone is not evidence, because
+    * the secondary axis object is built unconditionally and survives as a grid-line carrier.
+    */
+   private static boolean hasOwnScaleAxis(VGraph graph, int position) {
+      DefaultAxis[] axes = graph.getAxesAt(position);
+
+      if(axes == null) {
+         return false;
+      }
+
+      for(DefaultAxis axis : axes) {
+         if(axis != null && axis.getPrimaryAxis() == null) {
+            return true;
+         }
+      }
+
+      return false;
+   }
+
+   private static Set<String> fromBinding(VSChartInfo info) {
+      Set<String> present = new LinkedHashSet<>();
+
+      if(info == null) {
+         return present;
+      }
+
+      ChartRef[] x = info.getXFields();
+      ChartRef[] y = info.getYFields();
+
+      if(x != null && x.length > 0) {
+         present.add("x");
+      }
+
+      if(y != null && y.length > 0) {
+         present.add("y");
+      }
+
+      // The secondary axis belongs to a measure, and it lands opposite whichever shelf holds the
+      // measures: the right axis normally, the top one on an inverted graph, where x and y swap
+      // roles. Reading isSecondaryY off the wrong shelf reports x2 as y2 and vice versa.
+      boolean inverted = info.isInvertedGraph();
+
+      if(hasSecondaryMeasure(inverted ? x : y)) {
+         present.add(inverted ? "x2" : "y2");
+      }
+
+      return present;
+   }
+
+   private static boolean hasSecondaryMeasure(ChartRef[] refs) {
+      if(refs == null) {
+         return false;
+      }
+
+      for(ChartRef ref : refs) {
+         if(ref instanceof ChartAggregateRef aggregate && aggregate.isSecondaryY()) {
+            return true;
+         }
+      }
+
+      return false;
+   }
+
+   private static VGraphPair laidOutPair(RuntimeViewsheet rvs, ChartVSAssembly chart) {
+      ViewsheetSandbox box = rvs == null ? null : rvs.getViewsheetSandbox().orElse(null);
+
+      if(box == null) {
+         return null;
+      }
+
+      try {
+         box.lockRead();
+
+         try {
+            return box.getVGraphPair(chart.getAbsoluteName());
+         }
+         finally {
+            box.unlockRead();
+         }
+      }
+      catch(Exception ex) {
+         // A graph that will not lay out is a reason to fall back to the binding and say so, not
+         // to fail a read the caller asked for.
+         LOG.debug("Failed to lay out {} while resolving its regions; falling back to the binding",
+                   chart.getAbsoluteName(), ex);
+         return null;
+      }
+   }
+
+   private static final Logger LOG = LoggerFactory.getLogger(ChartRegionResolver.class);
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -315,12 +315,20 @@ public class ViewsheetAssemblyAgentController {
 
    @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/chart/elements")
    public Map<String, Object> chartElementVocabulary(@PathVariable String sessionToken,
+                                                     @RequestParam(required = false)
+                                                     String assembly,
                                                      Principal user)
       throws Exception
    {
       requireEnabled();
-      sessions.resolve(sessionToken, user);
-      return chartElementService.vocabulary();
+
+      // With an assembly the service resolves the runtime itself, to read that chart's real axes.
+      if(assembly == null || assembly.isBlank()) {
+         sessions.resolve(sessionToken, user);
+         return chartElementService.vocabulary();
+      }
+
+      return chartElementService.vocabulary(sessionToken, user, assembly);
    }
 
    @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/chart/regions")
@@ -511,6 +519,21 @@ public class ViewsheetAssemblyAgentController {
       chartElementService.resizePlot(sessionToken, user, request.assembly(), request.ratio(),
                                      Boolean.TRUE.equals(request.vertical()),
                                      Boolean.TRUE.equals(request.reset()), linkUri);
+   }
+
+   /**
+    * The read half of the plot-size pair. It exists because the write above had no observable at
+    * all: the ratio scales the plot's minimum size, which shows up as scrollbars in the browser,
+    * and the agent's own render is fitted to the assembly box so it cannot show them.
+    */
+   @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/chart/plot-size")
+   public Map<String, Object> getChartPlotSize(@PathVariable String sessionToken,
+                                               @RequestParam String assembly,
+                                               Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return chartElementService.readPlotSize(sessionToken, user, assembly);
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartElementServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartElementServiceTest.java
@@ -20,6 +20,7 @@ package inetsoft.web.wiz.viewsheet;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.graph.*;
 import inetsoft.web.viewsheet.controller.chart.*;
 import inetsoft.web.viewsheet.event.chart.*;
 import org.junit.jupiter.api.Tag;
@@ -27,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.security.Principal;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -298,7 +300,134 @@ class ChartElementServiceTest {
    void vocabularyNamesTheTitleTargets() {
       Harness h = harness(mock(ChartVSAssembly.class));
 
-      assertTrue(String.valueOf(h.service.vocabulary().get("titleTargets")).contains("y2"));
+      assertTrue(String.valueOf(h.service.vocabulary().get("titleTargets")).contains("y2"),
+                 "without an assembly this is the flat what-can-this-tool-address answer");
+   }
+
+   /**
+    * <b>Why the assembly form exists.</b> The flat vocabulary offered {@code y2} on every chart
+    * in the product, and nothing downstream checked — which is how a caller was talked into
+    * reading and then writing an axis that is not there. Named a chart, it answers about that
+    * chart.
+    */
+   @Test
+   void vocabularyFiltersTitleTargetsToTheAxesTheChartActuallyHas() throws Exception {
+      Harness h = harness(boundChart(false));
+
+      Map<String, Object> out = h.service.vocabulary("tok", principal(), "Chart1");
+
+      assertEquals(java.util.List.of("x", "y"), out.get("axes"));
+      assertEquals(java.util.List.of("x", "y", "chart"), out.get("titleTargets"),
+                   "no y2 on the chart means no y2 in the vocabulary - and the chart title, " +
+                   "which is not an axis title, stays");
+   }
+
+   @Test
+   void vocabularyKeepsY2WhenAMeasureActuallyUsesTheSecondaryAxis() throws Exception {
+      Harness h = harness(boundChart(true));
+
+      Map<String, Object> out = h.service.vocabulary("tok", principal(), "Chart1");
+
+      assertEquals(java.util.List.of("x", "y", "y2"), out.get("axes"),
+                   "filtering must not amount to always hiding y2");
+   }
+
+   /**
+    * An inference is not a measurement. Reporting the basis is what lets a caller weigh the
+    * answer instead of trusting it, which is the difference between this and the phantom it
+    * replaces.
+    */
+   @Test
+   void vocabularySaysWhetherTheAxesWereMeasuredOrInferred() throws Exception {
+      Harness h = harness(boundChart(false));
+
+      Map<String, Object> out = h.service.vocabulary("tok", principal(), "Chart1");
+
+      assertEquals(false, out.get("axesMeasured"), "a mocked runtime has no laid-out graph");
+      assertTrue(String.valueOf(out.get("axesBasis")).contains("binding"));
+   }
+
+   @Test
+   void readingTheVocabularyForOneChartSpendsNoUndoCheckpoint() throws Exception {
+      Harness h = harness(boundChart(false));
+
+      h.service.vocabulary("tok", principal(), "Chart1");
+
+      verify(h.sessions, never()).mutate(anyString(), any(Principal.class), any());
+   }
+
+   // ── plot sizing: the read ─────────────────────────────────────────────────
+
+   /**
+    * <b>The point of this method.</b> A plot resize had no observable of any kind — the ratio
+    * scales the plot's minimum size, which the browser shows as scrollbars, while the agent's
+    * render is fitted to the assembly box — so the ratio and its resized flag have to come back
+    * verbatim for the write to be checkable at all.
+    */
+   @Test
+   void readsBackTheRatioAndTheFlagThatGatesIt() throws Exception {
+      Harness h = harness(chart(3d, true));
+
+      Map<String, Object> result = h.service.readPlotSize("tok", principal(), "Chart1");
+
+      @SuppressWarnings("unchecked")
+      Map<String, Object> height = (Map<String, Object>) result.get("height");
+      assertEquals(3d, height.get("ratio"));
+      assertEquals(true, height.get("resized"), "a ratio with this false is stored but inert");
+      assertEquals(false, result.get("default"));
+      assertEquals("Chart1", result.get("assembly"));
+   }
+
+   @Test
+   void reportsAnUnresizedChartAsDefault() throws Exception {
+      Harness h = harness(chart(1d, false));
+
+      Map<String, Object> result = h.service.readPlotSize("tok", principal(), "Chart1");
+
+      assertEquals(true, result.get("default"));
+   }
+
+   /**
+    * Reading must go through {@code read}, not {@code mutate}. {@code mutate} opens a checkpoint
+    * and broadcasts, so reading through it would put a stray Ctrl+Z step in the user's own
+    * history for having <em>looked</em> at the plot size, and tell their Composer to refresh for
+    * a change that never happened.
+    */
+   @Test
+   void readingSpendsNoUndoCheckpoint() throws Exception {
+      Harness h = harness(chart(1d, false));
+
+      h.service.readPlotSize("tok", principal(), "Chart1");
+
+      verify(h.sessions, never()).mutate(anyString(), any(Principal.class), any());
+      verify(h.sessions, times(1)).read(anyString(), any(Principal.class), any());
+   }
+
+   /**
+    * Geometry needs a laid-out graph. Saying so beats returning zeroes, which would read as a
+    * plot that had collapsed to nothing.
+    */
+   @Test
+   void saysWhyGeometryIsMissingRatherThanReturningZeroes() throws Exception {
+      Harness h = harness(chart(1d, false));
+
+      Map<String, Object> result = h.service.readPlotSize("tok", principal(), "Chart1");
+
+      assertTrue(result.containsKey("geometryUnavailable"),
+                 "no sandbox means no laid-out graph, and that has to be stated");
+      assertFalse(result.containsKey("plot"), "a missing plot must not be reported as 0x0");
+      assertTrue(result.containsKey("width"),
+                 "the ratios are still readable without geometry, and are the write's read-back");
+   }
+
+   @Test
+   void refusesToReadPlotSizeOfANonChart() {
+      Harness h = harness(mock(TextVSAssembly.class));
+
+      Exception thrown = assertThrows(
+         Exception.class, () -> h.service.readPlotSize("tok", principal(), "Text1"));
+
+      assertTrue(thrown.getMessage().contains("Text1"));
    }
 
    // ── harness ───────────────────────────────────────────────────────────────
@@ -336,6 +465,16 @@ class ChartElementServiceTest {
          throw new IllegalStateException(e);
       }
 
+      try {
+         doAnswer(invocation -> {
+            ViewsheetSessionService.Read<?> read = invocation.getArgument(2);
+            return read.run(rvs, "rt1", null);
+         }).when(sessions).read(anyString(), any(Principal.class), any());
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(e);
+      }
+
       VSChartAxesVisibilityService axes = mock(VSChartAxesVisibilityService.class);
       VSChartLegendsVisibilityService legends = mock(VSChartLegendsVisibilityService.class);
       VSChartTitlesVisibilityService titles = mock(VSChartTitlesVisibilityService.class);
@@ -344,6 +483,39 @@ class ChartElementServiceTest {
       return new Harness(new ChartElementService(sessions, new ObjectMapper(), axes,
                                                 legends, titles, plot),
                          sessions, axes, legends, titles, plot);
+   }
+
+   /** A chart bound with a dimension on x and one or two measures on y. */
+   private static ChartVSAssembly boundChart(boolean secondaryAxis) {
+      // Built before any stubbing: mocking inside a when(...) argument is nested stubbing.
+      VSChartAggregateRef primary = mock(VSChartAggregateRef.class);
+      when(primary.isSecondaryY()).thenReturn(false);
+      ChartRef[] y = new ChartRef[] { primary };
+
+      if(secondaryAxis) {
+         VSChartAggregateRef secondary = mock(VSChartAggregateRef.class);
+         when(secondary.isSecondaryY()).thenReturn(true);
+         y = new ChartRef[] { primary, secondary };
+      }
+
+      ChartRef[] x = new ChartRef[] { mock(VSChartDimensionRef.class) };
+      VSChartInfo info = mock(VSChartInfo.class);
+      when(info.getXFields()).thenReturn(x);
+      when(info.getYFields()).thenReturn(y);
+      when(info.isInvertedGraph()).thenReturn(false);
+      ChartVSAssembly assembly = mock(ChartVSAssembly.class);
+      when(assembly.getVSChartInfo()).thenReturn(info);
+      return assembly;
+   }
+
+   /** A chart whose info carries one height ratio, which is what the read has to hand back. */
+   private static ChartVSAssembly chart(double heightRatio, boolean heightResized) {
+      VSChartInfo info = mock(VSChartInfo.class);
+      when(info.getUnitHeightRatio()).thenReturn(heightRatio);
+      when(info.isHeightResized()).thenReturn(heightResized);
+      ChartVSAssembly assembly = mock(ChartVSAssembly.class);
+      when(assembly.getVSChartInfo()).thenReturn(info);
+      return assembly;
    }
 
    private static Principal principal() {

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyServiceTest.java
@@ -18,6 +18,9 @@
 package inetsoft.web.wiz.viewsheet;
 
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.graph.*;
 import inetsoft.web.composer.vs.dialog.RegionPropertyDialogService;
 import inetsoft.web.graph.model.dialog.*;
 import org.junit.jupiter.api.Tag;
@@ -218,6 +221,133 @@ class ChartRegionPropertyServiceTest {
       assertEquals("y2", listed.get("target"));
    }
 
+   // ── an axis the chart does not have ───────────────────────────────────────
+
+   /**
+    * <b>The phantom axis.</b> {@code ChartArea} builds all four axis areas unconditionally, so
+    * {@code ChartRegionHandler.getAxisArea} hands back an empty shell for {@code y2} on a chart
+    * with no secondary measure — and this service used to describe it with the full y1 property
+    * list. The read is guarded as well as the write, because the read is what talked the caller
+    * into the write.
+    */
+   @Test
+   void refusesToDescribeAnAxisTheChartDoesNotHave() {
+      Harness h = harness(false);
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> h.service.list("tok", principal(), "Chart1", "axis", "y2", null));
+
+      assertTrue(thrown.getMessage().contains("y2"));
+      assertTrue(thrown.getMessage().contains("x, y"), "name the axes it does have");
+   }
+
+   @Test
+   void refusesToWriteToAnAxisTheChartDoesNotHave() throws Exception {
+      Harness h = harness(false);
+
+      assertThrows(
+         IllegalArgumentException.class,
+         () -> h.service.set("tok", principal(), "Chart1", "axis", "y2", null,
+                             Map.of("logarithmicScale", true), ""));
+
+      verify(h.regions, never()).setAxisPropertyDialogModel(
+         anyString(), anyString(), anyString(), anyInt(), any(), any(), anyString(),
+         any(Principal.class), any());
+   }
+
+   /** The long alias must not be a way around the check — it reaches the same axis. */
+   @Test
+   void refusesTheLongAliasForAPhantomAxisToo() {
+      Harness h = harness(false);
+
+      assertThrows(
+         IllegalArgumentException.class,
+         () -> h.service.list("tok", principal(), "Chart1", "axis", "right_y_axis", null));
+   }
+
+   /** An axis title for an axis that is not there is the same fiction, one region over. */
+   @Test
+   void refusesATitleForAnAxisTheChartDoesNotHave() {
+      Harness h = harness(false);
+
+      assertThrows(
+         IllegalArgumentException.class,
+         () -> h.service.list("tok", principal(), "Chart1", "title", "y2", null));
+   }
+
+   /**
+    * <b>Found live, 2026-08-20.</b> {@code region: "title", target: "chart"} returned a raw HTTP
+    * 500: {@code TitlesDescriptor} holds only x/x2/y/y2 descriptors, so
+    * {@code ChartRegionHandler.getTitleArea} returns null for "chart" and
+    * {@code RegionPropertyDialogService} dereferences it. The chart's own title is an assembly
+    * property, not a region — so this is a refusal that names where the title actually lives,
+    * against the same clean-refusal standard the rest of this surface meets.
+    */
+   @Test
+   void refusesTheChartTitleAndSaysWhereItActuallyLives() {
+      Harness h = harness(false);
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> h.service.list("tok", principal(), "Chart1", "title", "chart", null));
+
+      assertTrue(thrown.getMessage().contains("set_assembly_properties"),
+                 "a refusal has to name the tool that does work");
+   }
+
+   /**
+    * <b>Found live 2026-08-20.</b> A y2 write landed on the primary axis, because
+    * {@code ChartRegionHandler.getChartRef} does not know the short {@code "y2"} form while
+    * {@code getAxisArea} does — so the area resolved, the descriptor did not, and the chain fell
+    * back to the descriptor shared with the primary axis. Both the read and the write have to
+    * send the long form, or they disagree with each other.
+    */
+   @Test
+   void sendsTheLongAxisFormForY2SoTheDescriptorResolves() throws Exception {
+      Harness h = harness();
+      when(h.regions.getAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyString(),
+                                                any(), anyString(), any(Principal.class)))
+         .thenReturn(axisModel());
+
+      Map<String, Object> listed =
+         h.service.list("tok", principal(), "Chart1", "axis", "y2", null);
+
+      verify(h.regions).getAxisPropertyDialogModel(anyString(), anyString(), eq("right_y_axis"),
+                                                   anyString(), any(), anyString(),
+                                                   any(Principal.class));
+      assertEquals("y2", listed.get("target"), "the caller's own vocabulary comes back unchanged");
+   }
+
+   @Test
+   void theWriteSendsTheSameLongFormAsTheRead() throws Exception {
+      Harness h = harness();
+      when(h.regions.getAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyString(),
+                                                any(), anyString(), any(Principal.class)))
+         .thenReturn(axisModel());
+
+      h.service.set("tok", principal(), "Chart1", "axis", "y2", null,
+                    Map.of("showAxisLabel", false), "");
+
+      verify(h.regions).setAxisPropertyDialogModel(anyString(), anyString(), eq("right_y_axis"),
+                                                   anyInt(), any(), any(), anyString(),
+                                                   any(Principal.class), any());
+   }
+
+   /** The primary forms are already understood downstream and must not be rewritten. */
+   @Test
+   void leavesThePrimaryAxisFormsAlone() throws Exception {
+      Harness h = harness();
+      when(h.regions.getAxisPropertyDialogModel(anyString(), anyString(), anyString(), anyString(),
+                                                any(), anyString(), any(Principal.class)))
+         .thenReturn(axisModel());
+
+      h.service.list("tok", principal(), "Chart1", "axis", "y", null);
+
+      verify(h.regions).getAxisPropertyDialogModel(anyString(), anyString(), eq("y"), anyString(),
+                                                   any(), anyString(), any(Principal.class));
+   }
+
    @Test
    void refusesAMissingTarget() {
       Harness h = harness();
@@ -255,8 +385,17 @@ class ChartRegionPropertyServiceTest {
    private record Harness(ChartRegionPropertyService service, RegionPropertyDialogService regions) {}
 
    private static Harness harness() {
+      // The default chart carries a secondary measure, so every pre-existing case that addresses
+      // y2 is still addressing an axis that exists. Pass false for the phantom-axis cases.
+      return harness(true);
+   }
+
+   private static Harness harness(boolean secondaryAxis) {
       ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
       RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      // Built first: calling viewsheet() inside the when(...) argument is nested stubbing.
+      Viewsheet vs = viewsheet(secondaryAxis);
+      when(rvs.getViewsheet()).thenReturn(vs);
 
       try {
          when(sessions.resolve(anyString(), any(Principal.class))).thenReturn(rvs);
@@ -266,6 +405,10 @@ class ChartRegionPropertyServiceTest {
             mutation.run(rvs, "rt1", null);
             return null;
          }).when(sessions).mutate(anyString(), any(Principal.class), any());
+         doAnswer(invocation -> {
+            ViewsheetSessionService.Read<?> read = invocation.getArgument(2);
+            return read.run(rvs, "rt1", null);
+         }).when(sessions).read(anyString(), any(Principal.class), any());
       }
       catch(Exception e) {
          throw new IllegalStateException(e);
@@ -273,6 +416,36 @@ class ChartRegionPropertyServiceTest {
 
       RegionPropertyDialogService regions = mock(RegionPropertyDialogService.class);
       return new Harness(new ChartRegionPropertyService(sessions, regions), regions);
+   }
+
+   /**
+    * A chart bound with a dimension on x and one or two measures on y. A mocked runtime has no
+    * sandbox, so the axis resolver falls back to the binding — which is the point: these tests
+    * pin what the binding implies, and the laid-out graph is the live case's business.
+    */
+   private static Viewsheet viewsheet(boolean secondaryAxis) {
+      // Built before any stubbing: mocking inside a when(...) argument is nested stubbing.
+      VSChartAggregateRef primary = mock(VSChartAggregateRef.class);
+      when(primary.isSecondaryY()).thenReturn(false);
+      ChartRef[] y = new ChartRef[] { primary };
+
+      if(secondaryAxis) {
+         VSChartAggregateRef secondary = mock(VSChartAggregateRef.class);
+         when(secondary.isSecondaryY()).thenReturn(true);
+         y = new ChartRef[] { primary, secondary };
+      }
+
+      ChartRef[] x = new ChartRef[] { mock(VSChartDimensionRef.class) };
+      VSChartInfo info = mock(VSChartInfo.class);
+      when(info.getXFields()).thenReturn(x);
+      when(info.getYFields()).thenReturn(y);
+      when(info.isInvertedGraph()).thenReturn(false);
+
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      when(chart.getVSChartInfo()).thenReturn(info);
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssembly(anyString())).thenReturn(chart);
+      return vs;
    }
 
    private static Principal principal() {

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionResolverTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionResolverTest.java
@@ -175,6 +175,9 @@ class ChartRegionResolverTest {
       assertTrue(thrown.getMessage().contains("7"), "and what was asked for");
       assertTrue(thrown.getMessage().contains("get_chart_aesthetics"),
                  "and where to look it up");
+      // "the valid indexes are 0 - '7'" read as a range in live output. A dash between the bound
+      // and the offending index is exactly the wrong punctuation here.
+      assertFalse(thrown.getMessage().contains("0 - "), "the bound must not read as a range");
    }
 
    @Test
@@ -182,6 +185,15 @@ class ChartRegionResolverTest {
       assertThrows(
          IllegalArgumentException.class,
          () -> ChartRegionResolver.requireLegend(new ChartRegionResolver.Legends(2, true), -1));
+   }
+
+   @Test
+   void spellsOutARangeWhenThereIsMoreThanOneLegend() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartRegionResolver.requireLegend(new ChartRegionResolver.Legends(3, true), 9));
+
+      assertTrue(thrown.getMessage().contains("0 to 2"), "a real range, spelled out");
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionResolverTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionResolverTest.java
@@ -1,0 +1,272 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.graph.VGraph;
+import inetsoft.graph.coord.Coordinate;
+import inetsoft.graph.coord.RectCoord;
+import inetsoft.graph.guide.axis.DefaultAxis;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.graph.*;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
+
+/**
+ * The binding fallback and the refusal. The laid-out-graph path is the primary source and needs a
+ * real graph, so it is covered by the live case rather than here; what is testable in isolation is
+ * the inference these tests pin — including the axis flip that is the whole reason the binding is
+ * a fallback and not the primary source.
+ */
+@Tag("core")
+class ChartRegionResolverTest {
+   @Test
+   void infersTheBoundAxesWhenThereIsNoLaidOutGraph() {
+      ChartRegionResolver.Axes axes = resolve(info(true, false, false));
+
+      assertEquals(java.util.List.of("x", "y"), axes.ordered());
+      assertFalse(axes.measured(), "an inference must not be reported as a measurement");
+      assertTrue(axes.basis().contains("binding"), "the caller has to be able to tell which");
+   }
+
+   @Test
+   void reportsY2OnlyWhenAMeasureUsesTheSecondaryAxis() {
+      assertFalse(resolve(info(true, false, false)).has("y2"),
+                  "this is the phantom the whole class exists to stop");
+      assertTrue(resolve(info(true, true, false)).has("y2"));
+   }
+
+   /**
+    * The flip. The secondary axis belongs to a measure and lands opposite whichever shelf holds
+    * the measures, so an inverted graph puts it on the top axis. Reading {@code isSecondaryY} off
+    * the y shelf regardless would report x2 as y2 — a plausible wrong answer, which is exactly
+    * the failure mode being fixed.
+    */
+   @Test
+   void anInvertedGraphPutsTheSecondaryAxisOnTopNotOnTheRight() {
+      ChartRegionResolver.Axes axes = resolve(info(true, false, true, true));
+
+      assertTrue(axes.has("x2"), "measures are on x when inverted, so the secondary is x2");
+      assertFalse(axes.has("y2"));
+   }
+
+   @Test
+   void anUnboundChartHasNoAxesAtAll() {
+      ChartRegionResolver.Axes axes = resolve(info(false, false, false));
+
+      assertTrue(axes.ordered().isEmpty());
+   }
+
+   /**
+    * {@code ChartRegionHandler.getAxisArea} accepts the long area names as well as the short
+    * ones, so both have to land on the same answer here. {@code right_y_axis} is the alias a
+    * caller reaching for a phantom y2 would most naturally use.
+    */
+   @Test
+   void foldsTheLongAreaNamesOntoTheShortOnes() {
+      assertEquals("y2", ChartRegionResolver.canonical("right_y_axis"));
+      assertEquals("x2", ChartRegionResolver.canonical("TOP_X_AXIS"));
+      assertEquals("y", ChartRegionResolver.canonical("left_y_axis"));
+      assertEquals("x", ChartRegionResolver.canonical(" bottom_x_axis "));
+      assertTrue(resolve(info(true, true, false)).has("right_y_axis"),
+                 "the alias must reach the same axis the short name does");
+   }
+
+   @Test
+   void refusalNamesTheAxesTheChartDoesHaveAndWhereThatCameFrom() {
+      ChartRegionResolver.Axes axes = resolve(info(true, false, false));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartRegionResolver.requireAxis(axes, "axis", "y2"));
+
+      assertTrue(thrown.getMessage().contains("y2"), "name what was asked for");
+      assertTrue(thrown.getMessage().contains("x, y"), "and what is actually there");
+      assertTrue(thrown.getMessage().contains("binding"), "and on what basis");
+   }
+
+   @Test
+   void anExistingAxisIsNotRefused() {
+      ChartRegionResolver.Axes axes = resolve(info(true, false, false));
+
+      assertDoesNotThrow(() -> ChartRegionResolver.requireAxis(axes, "axis", "y"));
+      assertDoesNotThrow(() -> ChartRegionResolver.requireAxis(axes, "axis", "left_y_axis"));
+   }
+
+   // ── the graph, which may only add ─────────────────────────────────────────
+
+   /**
+    * <b>The live bug this class shipped with.</b> The first version read
+    * {@code getAxesAt(RIGHT_AXIS).length > 0} as proof of a y2, and reported one on an ordinary
+    * single-measure bar chart — so the phantom went straight through the guard, confirmed against
+    * a real runtime. {@code RectCoord.createAxis} builds {@code yaxis2} unconditionally and keeps
+    * it whenever it carries grid lines, so an axis object at the right proves nothing; what
+    * distinguishes a real secondary axis is having its own scale, which the same method records by
+    * leaving {@code primaryAxis} null.
+    */
+   @Test
+   void aRightAxisThatMirrorsThePrimaryIsNotAY2() {
+      ChartRegionResolver.Axes axes = resolveWithGraph(info(true, false, false), true);
+
+      assertFalse(axes.has("y2"),
+                  "a grid-line carrier at the right is not a secondary axis");
+      assertEquals(java.util.List.of("x", "y"), axes.ordered());
+      assertTrue(axes.measured());
+   }
+
+   @Test
+   void aRightAxisWithItsOwnScaleIsAY2EvenWhenTheBindingDoesNotShowOne() {
+      // Date comparison and the percent scale both create a secondary scale the binding never
+      // mentions, which is the reason the graph is consulted at all.
+      ChartRegionResolver.Axes axes = resolveWithGraph(info(true, false, false), false);
+
+      assertTrue(axes.has("y2"));
+      assertTrue(axes.measured());
+   }
+
+   /**
+    * The graph must never subtract. A hidden axis leaves the coordinate entirely, and refusing to
+    * format or unhide a real axis because it is currently hidden would be worse than the phantom.
+    */
+   @Test
+   void anEmptyGraphDoesNotRemoveTheBoundAxes() {
+      VGraph graph = mock(VGraph.class);
+      RectCoord coord = mock(RectCoord.class);
+      when(graph.getCoordinate()).thenReturn(coord);
+      when(graph.getAxesAt(anyInt())).thenReturn(new DefaultAxis[0]);
+
+      ChartRegionResolver.Axes axes = resolve(info(true, false, false), graph);
+
+      assertEquals(java.util.List.of("x", "y"), axes.ordered());
+   }
+
+   // ── legends ────────────────────────────────────────────────────────────────────
+
+   /**
+    * The bound that was missing: an out-of-range legend index used to reach StyleBI and come back
+    * as a raw HTTP 500 page, in a tool whose whole purpose is to be called before writing.
+    */
+   @Test
+   void refusesALegendIndexOutsideTheChartsRange() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartRegionResolver.requireLegend(new ChartRegionResolver.Legends(1, true), 7));
+
+      assertTrue(thrown.getMessage().contains("1 legend"), "name the range");
+      assertTrue(thrown.getMessage().contains("7"), "and what was asked for");
+      assertTrue(thrown.getMessage().contains("get_chart_aesthetics"),
+                 "and where to look it up");
+   }
+
+   @Test
+   void refusesANegativeLegendIndex() {
+      assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartRegionResolver.requireLegend(new ChartRegionResolver.Legends(2, true), -1));
+   }
+
+   @Test
+   void allowsEveryIndexInRange() {
+      assertDoesNotThrow(
+         () -> ChartRegionResolver.requireLegend(new ChartRegionResolver.Legends(2, true), 1));
+   }
+
+   @Test
+   void refusesAnyLegendOnAChartThatRendersNone() {
+      assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartRegionResolver.requireLegend(new ChartRegionResolver.Legends(0, true), 0));
+   }
+
+   /**
+    * An unmeasured count is zero for want of a graph, not because the chart has no legends.
+    * Refusing on it would block a legitimate write whenever the layout was unavailable.
+    */
+   @Test
+   void doesNotRefuseWhenTheCountCouldNotBeMeasured() {
+      assertDoesNotThrow(
+         () -> ChartRegionResolver.requireLegend(new ChartRegionResolver.Legends(0, false), 5));
+   }
+
+   private static ChartRegionResolver.Axes resolveWithGraph(VSChartInfo info, boolean mirrored) {
+      DefaultAxis right = mock(DefaultAxis.class);
+
+      if(mirrored) {
+         when(right.getPrimaryAxis()).thenReturn(mock(DefaultAxis.class));
+      }
+
+      DefaultAxis[] rightAxes = new DefaultAxis[] { right };
+      DefaultAxis[] none = new DefaultAxis[0];
+      RectCoord coord = mock(RectCoord.class);
+      VGraph graph = mock(VGraph.class);
+
+      when(graph.getCoordinate()).thenReturn(coord);
+      when(graph.getAxesAt(anyInt())).thenReturn(none);
+      when(graph.getAxesAt(Coordinate.RIGHT_AXIS)).thenReturn(rightAxes);
+      return resolve(info, graph);
+   }
+
+   /**
+    * Reaches the graph branch without a sandbox by handing the resolver a graph directly — the
+    * sandbox plumbing is the live case's business; the decision rule is what these tests pin.
+    */
+   private static ChartRegionResolver.Axes resolve(VSChartInfo info, VGraph graph) {
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      when(chart.getVSChartInfo()).thenReturn(info);
+      return ChartRegionResolver.resolve(chart, graph);
+   }
+
+   private static ChartRegionResolver.Axes resolve(VSChartInfo info) {
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      when(chart.getVSChartInfo()).thenReturn(info);
+      // A mocked runtime returns an empty Optional for the sandbox, so there is no laid-out
+      // graph and the resolver falls back to the binding -- the path under test.
+      return ChartRegionResolver.resolve(mock(RuntimeViewsheet.class), chart);
+   }
+
+   private static VSChartInfo info(boolean bound, boolean secondary, boolean inverted) {
+      return info(bound, secondary, inverted, false);
+   }
+
+   private static VSChartInfo info(boolean bound, boolean secondary, boolean inverted,
+                                   boolean secondaryOnX)
+   {
+      // Every ref is built before any stubbing starts: mocking inside a when(...) argument is
+      // nested stubbing, which Mockito rejects as UnfinishedStubbing.
+      ChartRef[] x = !bound
+         ? new ChartRef[0]
+         : new ChartRef[] { secondaryOnX ? aggregate(true) : mock(VSChartDimensionRef.class) };
+      ChartRef[] y = bound ? new ChartRef[] { aggregate(secondary) } : new ChartRef[0];
+      VSChartInfo info = mock(VSChartInfo.class);
+
+      when(info.isInvertedGraph()).thenReturn(inverted);
+      when(info.getXFields()).thenReturn(x);
+      when(info.getYFields()).thenReturn(y);
+      return info;
+   }
+
+   private static VSChartAggregateRef aggregate(boolean secondary) {
+      VSChartAggregateRef ref = mock(VSChartAggregateRef.class);
+      when(ref.isSecondaryY()).thenReturn(secondary);
+      return ref;
+   }
+}


### PR DESCRIPTION
The agent-facing chart tools could report success for regions a chart does not have, and had no way to observe a plot resize at all. Five defects, one new read and one shared resolver. Every guard here was probed against a live Composer session, not just unit-tested.

## `get_chart_plot_size` — a plot resize had no observable

The ratio scales the plot's **minimum** size, which the browser shows as scrollbars, while the agent's render is fitted to the assembly box — so an enlarged plot and a default one render identically. The ratios are also absent from both the property dialog model and the scriptable API, so a resize could not be confirmed through any channel.

`readPlotSize` returns the stored intent (`ratio`, `resized`, `percent`, `initialRatio`, `effectiveRatio`) plus the last layout's geometry, and goes through `sessions.read` rather than `mutate` so *looking* at a plot size does not spend an undo checkpoint.

It earned its keep on the first live call: writing `ratio: 3` to a chart whose plot baseline is 5.4 reads back `resized: true, percent: 0.56` — accepted and inert, because `VGraphPair` only re-applies a ratio while the percent is >= 1. That is exactly the case that was previously invisible.

**What it does not do, stated plainly:** it does not prove a plot grew. The geometry comes from a cached pair that a resize does not relayout, and `ratio`/`initialRatio` are recomputed from whatever box was laid out last — a written `8` read back as `26.86` after one full-size render, while `percent` stayed `1.48`. The tool description and javadoc say this rather than the stronger claim the design started with.

## `ChartRegionResolver` — which axes and how many legends a chart actually has

`ChartArea` builds all four axis areas unconditionally, so a `y2` the chart does not have produced a full, plausible property list, accepted a write, and confirmed it on read-back. An agent could enumerate, read, write and verify and be told yes at all four steps.

Two rules worth stating, both learned the hard way:

- **The binding is the floor; the graph may only add.** A hidden axis leaves the coordinate entirely, so a graph-only answer would report no x axis for a chart whose x axis was hidden — then refuse to unhide it.
- **An axis object at the top or right is not evidence.** `RectCoord.createAxis` builds `yaxis2` unconditionally and keeps it whenever it carries grid lines, so it survives as a grid-line carrier with no secondary scale behind it. Only one with its own scale (`getPrimaryAxis() == null`) counts. The first version of this resolver believed the laid-out graph, shipped the same phantom it was meant to stop, and was caught by the live probe rather than by any test — the regression test for it is in `ChartRegionResolverTest`.

Used in three places: `list_chart_elements` filters its title targets and reports `axes`/`axesBasis`/`axesMeasured` for a named chart, and both region-property tools refuse an axis, or an axis title, the chart does not have. The read is guarded as well as the write, because the read is what talked the caller into the write.

## Three more, each found while verifying the one before it

- **A `y2` write landed on the primary axis.** `getAxisArea` accepts the short axis forms and the long ones, but `getChartRef` — which every `getAxisDescriptor` overload funnels through — knows only the long ones plus `"y"`/`"x"`. So `"y2"` left the ref null and the chain fell through to the descriptor shared with the primary axis, never reaching the `isSecondaryY() -> getAxisDescriptor2()` branch that exists for this case. Found by image A/B on a dual-axis chart: asking to hide the y2 labels hid the y1 labels, and passing `field` did not help. The secondary targets are now translated to the long area form on both the read and the write.
- **An out-of-range legend index returned a raw HTTP 500.** Now bounded by `vgraph.getLegendGroup().getLegendCount()`, where `ChartArea` itself counts, and refused only when that count was actually measured — an unmeasured count is zero for want of a graph, not because the chart has no legends.
- **`region: "title", target: "chart"` returned a raw HTTP 500.** `TitlesDescriptor` holds only x/x2/y/y2, so the chart's own title has no descriptor here; it is an assembly property, and the refusal now says so.

## Verified live

Against a running server, on two sheets and four charts:

| Probe | Result |
|---|---|
| `axis y2` / `title y2` / `right_y_axis` on a single-measure chart | refused, naming the axes it does have and the basis they came from |
| `axis y2` on a dual-axis chart | full property list, addressable normally |
| `set … axis y2 {showAxisLabel: false}` on a dual-axis chart | the **right-hand** ticks disappear; `axis y` reads back unchanged; restored to baseline |
| `set … axis y2` on a single-measure chart | still refused — the descriptor fix did not widen the guard |
| `legend/7` on a one-legend chart | "This chart has 1 legend, so the only valid index is 0; '7' is out of range…" |
| `title/chart` | a sentence naming `set_assembly_properties`, not a 500 |
| `get_chart_plot_size` before/after a resize | the stored-but-inert case, visible |

A wording defect in the legend refusal was also caught by reading its live output: `"the valid indexes are 0 - '7' is out of range"` reads as a range. Rewritten, with a test asserting the message never contains `0 - `.

## Tests

82 green across `ChartRegionResolverTest` (16, new), `ChartElementServiceTest` (29), `ChartRegionPropertyServiceTest` (19) and `ViewsheetAssemblyAgentControllerTest` (18).

## Deliberately not in this change

- Test case 4.3 still cannot be passed — nothing forces the relayout that would prove a plot actually grew. Needs a plot-region image (`VGraphPair.getPlotImage`) or a clear-and-rebuild read.
- `resizePlot`'s reset clears the ratios and flags but not `unitWidthRatioPercent`/`unitHeightRatioPercent` (`VSChartPlotResizeService:57-62`), so a reset chart still reports the old ratio and re-derives it on the next layout. One line, surfaced by the new read, recorded in the companion doc.

Companion PR (plugin + test plan): inetsoft-technology/stylebi-wiz#1719

🤖 Generated with [Claude Code](https://claude.com/claude-code)