### PR TITLE
feat(wiz): eight layout tools — LayoutSessionService, read/property/mutation/undo services

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/controller/VSLayoutService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/VSLayoutService.java
@@ -472,8 +472,12 @@ public class VSLayoutService {
 
    /**
     * Check if current assembly support editing tablelayout in printlayout.
+    *
+    * <p>Widened from {@code private} to {@code public} for {@code inetsoft.web.wiz.viewsheet
+    * .LayoutReadService} (2026-08-20-layout-implementation.md, Task 2), which projects this same
+    * check onto the agent-facing {@code get_layout} response rather than re-deriving it.
     */
-   private boolean supportTableLayout(VSAssembly assembly) {
+   public boolean supportTableLayout(VSAssembly assembly) {
       if(assembly == null) {
          return false;
       }

--- a/core/src/main/java/inetsoft/web/wiz/pairing/SheetSessionService.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/SheetSessionService.java
@@ -74,6 +74,23 @@ public class SheetSessionService {
    public void close(String token) { if (token != null) sessions.remove(token); }
 
    /**
+    * Whether {@code token} still names a live (present, unexpired) session -- regardless of
+    * owner. For internal cleanup use only (see {@code LayoutSessionService}'s own scheduled
+    * sweep, which has no {@code Principal} to check against and no need for one: it is deciding
+    * whether to free a resource, not authorizing an action). NOT an authorization check --
+    * callers that need to verify the caller actually owns the session must still use
+    * {@link #resolve}.
+    */
+   public boolean isLive(String token) {
+      if(token == null) {
+         return false;
+      }
+
+      JoinSession s = sessions.get(token);
+      return s != null && !s.isExpired(clock.getAsLong());
+   }
+
+   /**
     * Ends every pane-scoped session bound to {@code socketSessionId} -- called when that
     * WebSocket session disconnects (crash, network drop, or a killed tab; see
     * {@code SheetSessionSocketCleanup}). A pane-scoped session (nullable

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/LayoutMutationService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/LayoutMutationService.java
@@ -1,0 +1,388 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.asset.AbstractSheet;
+import inetsoft.uql.viewsheet.VSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.internal.VSAssemblyInfo;
+import inetsoft.uql.viewsheet.vslayout.AbstractLayout;
+import inetsoft.uql.viewsheet.vslayout.VSAssemblyLayout;
+import inetsoft.uql.viewsheet.vslayout.VSEditableAssemblyLayout;
+import inetsoft.web.composer.vs.controller.VSLayoutControllerServiceProxy;
+import inetsoft.web.composer.vs.controller.VSLayoutService;
+import inetsoft.web.composer.vs.event.AddVSLayoutObjectEvent;
+import inetsoft.web.viewsheet.DataTipInLayoutCheckResult;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.awt.Dimension;
+import java.awt.Point;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Phase 3 of the layout implementation plan (2026-08-20-layout-implementation.md), Task 4:
+ * {@code edit_layout_objects} (add/remove/move_resize) and {@code set_layout_table_options}.
+ *
+ * <h2>Why this does not delegate to {@code VSLayoutControllerService}'s own
+ * {@code addObject}/{@code removeObject}/{@code moveResizeLayoutObjects}</h2>
+ *
+ * <p>The plan's own Interfaces note for this task says to "call the underlying logic, not the
+ * STOMP controller ... widen visibility or extract the shared body ... check at implementation
+ * time rather than assuming." Having checked: those three methods are already {@code public} and
+ * already reachable off a generated {@code @ClusterProxy} bean ({@link
+ * VSLayoutControllerServiceProxy}) exactly the way {@code WizComposerController}/
+ * {@code WizDashboardService} already call sibling {@code @ClusterProxy} services in this
+ * codebase -- no visibility widening turned out to be necessary. But calling them as-is with our
+ * clone's runtime id is still wrong, for a reason specific to this plugin's calling shape:
+ *
+ * <ul>
+ *   <li>{@code moveResizeLayoutObjects} resolves {@code parentRvs} from the clone's
+ *   {@code getOriginalID()} (set to the master's id by {@link LayoutSessionService}), then calls
+ *   {@code layoutClone.apply(parentRvs.getViewsheet())} -- {@code apply()} directly on the
+ *   <b>master's own, live</b> {@code Viewsheet}. That is exactly the Hazard-1 corruption {@link
+ *   LayoutSessionService}'s own class doc describes: {@code apply()}'s shallow clone shares
+ *   {@code VSAssemblyInfo}/{@code FormatInfo} instances with its argument, so master's real
+ *   assemblies' {@code layoutPosition}/{@code layoutSize}/{@code RScaleFont} get overwritten as a
+ *   side effect, even though the *result* is only ever installed onto the clone via
+ *   {@code rvs.setViewsheet(...)}. (By contrast, {@code addObject} happens to be safe -- its own
+ *   {@code apply()} call runs against {@code rvs.getViewsheet().clone()}, a second, throwaway
+ *   clone of the clone -- and {@code removeObject} never calls {@code apply()} at all. But relying
+ *   on that today-only accident of one method's plumbing while the sibling method two lines away
+ *   in the same class corrupts master would leave the safety of this whole task's exit criterion
+ *   resting on an implementation detail nobody signed up to keep stable.)</li>
+ *   <li>All three methods also call {@link VSLayoutService#makeUndoable} themselves, taking a
+ *   checkpoint. {@link LayoutSessionService#mutateLayout} <em>already</em> takes exactly one
+ *   checkpoint after the mutation runs (Global Constraint 4). Delegating to the STOMP-facing
+ *   bodies as well would double-checkpoint every edit, corrupting the very undo/redo count Task 5
+ *   depends on.</li>
+ * </ul>
+ *
+ * <p>The fix used here: call {@link VSLayoutService}'s already-{@code public}, non-checkpointing,
+ * non-{@code apply()}-calling granular methods directly ({@code findViewsheetLayout},
+ * {@code getVSAssemblyLayouts}/{@code setVSAssemblyLayouts}, {@code createVSAssembly}/
+ * {@code createAssemblyLayout}, {@code findAssemblyLayout}) against the <b>master's</b>
+ * {@code LayoutInfo} -- which is exactly right to mutate directly, since a layout's stored object
+ * list *is* the definitional data {@code edit_layout_objects} exists to change, and none of these
+ * calls ever invokes {@code apply()} on anything. The one thing deliberately NOT reproduced here
+ * is the STOMP path's {@code apply()}-based live-preview refresh and {@code
+ * fixAssemblyLayoutsPosition} auto-repositioning (print-layout collision avoidance): this plugin
+ * has no connected browser to refresh, {@link LayoutReadService} reads positions straight off
+ * {@code LayoutInfo} rather than off a rendered preview, and skipping it removes the only
+ * remaining path back to an {@code apply()} call on a live runtime. A caller that needs several
+ * objects not to overlap in a print layout is responsible for spacing them; this is a known,
+ * deliberate scope cut from the interactive Composer's behavior, not an oversight.
+ *
+ * <h2>The {@code check_assembly_in_layout} guard on remove</h2>
+ *
+ * <p>{@link VSLayoutControllerServiceProxy#checkAssemblyInLayout} is a pure read (no {@code
+ * apply()}, no checkpoint) -- safe to call with the master's own runtime id. Its real-world
+ * semantics for "does removing this object break a data-tip relationship" could not be fully
+ * pinned down from source alone (it reports whether an assembly is present in a given/{@code
+ * "null"}-sentinel runtime layout, which is a narrower question than "is this assembly some other
+ * object's data-tip target"); this class treats {@code isAssemblyInLayout() == true} on the
+ * layout being edited as "yes, something depends on this," which is the interpretation the unit
+ * tests below fix in place via mocking. <b>Flagged for the Phase 5 live-verification pass</b> to
+ * confirm this polarity against a real data-tip setup before relying on it in production.
+ */
+@Service
+public class LayoutMutationService {
+   @Autowired
+   public LayoutMutationService(LayoutSessionService layoutSessions,
+                                 ViewsheetSessionService viewsheetSessions,
+                                 VSLayoutService vsLayoutService,
+                                 VSLayoutControllerServiceProxy vsLayoutControllerService)
+   {
+      this.layoutSessions = layoutSessions;
+      this.viewsheetSessions = viewsheetSessions;
+      this.vsLayoutService = vsLayoutService;
+      this.vsLayoutControllerService = vsLayoutControllerService;
+   }
+
+   public static final String OP_ADD = "add";
+   public static final String OP_REMOVE = "remove";
+   public static final String OP_MOVE_RESIZE = "move_resize";
+
+   /**
+    * {@code edit_layout_objects}: {@code op} is one of {@link #OP_ADD}, {@link #OP_REMOVE},
+    * {@link #OP_MOVE_RESIZE}. {@code objects} is a list of per-object patches:
+    * <ul>
+    *   <li>{@code move_resize}: {@code name}, {@code x}, {@code y}, {@code width}, {@code height}.
+    *   </li>
+    *   <li>{@code add}: {@code name}; {@code type} ({@code "text"}/{@code "image"}/
+    *   {@code "pagebreak"}, omitted if {@code name} already names an existing assembly on this
+    *   viewsheet); {@code x}, {@code y}.</li>
+    *   <li>{@code remove}: {@code name}.</li>
+    * </ul>
+    *
+    * <p>Returns {@code {"requiresConfirmation": false}} on success, or
+    * {@code {"requiresConfirmation": true, "reason": ..., "objectNames": [...]}} when the remove
+    * path's data-tip guard blocks the call -- re-call with {@code confirmed: true} to proceed
+    * anyway.
+    */
+   public Map<String, Object> editObjects(String sessionToken, Principal agent, String layoutName,
+                                           String op, int region, List<Map<String, Object>> objects,
+                                           boolean confirmed)
+      throws Exception
+   {
+      if(objects == null || objects.isEmpty()) {
+         throw new IllegalArgumentException(
+            "edit_layout_objects needs at least one object in \"objects\".");
+      }
+
+      switch(op == null ? "" : op) {
+      case OP_MOVE_RESIZE:
+         moveResize(sessionToken, agent, layoutName, region, objects);
+         return okResult();
+      case OP_ADD:
+         addObjects(sessionToken, agent, layoutName, region, objects);
+         return okResult();
+      case OP_REMOVE:
+         return removeObjects(sessionToken, agent, layoutName, region, objects, confirmed);
+      default:
+         throw new IllegalArgumentException(
+            "edit_layout_objects: unknown op \"" + op + "\" -- expected \"" + OP_ADD + "\", \"" +
+            OP_REMOVE + "\", or \"" + OP_MOVE_RESIZE + "\".");
+      }
+   }
+
+   /**
+    * {@code set_layout_table_options}: wraps the same {@code VSAssemblyLayout.tableLayout} field
+    * {@code table-layout-property-dialog} sets, but refuses up front -- before {@link
+    * LayoutSessionService#mutateLayout} ever opens a mutation seam or takes a checkpoint -- when
+    * {@code objectName} does not report {@code supportsTableLayout} on the master, rather than
+    * forwarding a request that would silently no-op.
+    */
+   public void setTableLayoutOptions(String sessionToken, Principal agent, String layoutName,
+                                      String objectName, int region, int tableLayout)
+      throws Exception
+   {
+      RuntimeViewsheet master = viewsheetSessions.resolve(sessionToken, agent);
+      VSAssembly assembly = master.getViewsheet().getAssembly(objectName);
+
+      if(!vsLayoutService.supportTableLayout(assembly)) {
+         throw new IllegalArgumentException(
+            "\"" + objectName + "\" does not support table layout options -- only a table, " +
+            "crosstab, or a tab/group container whose content is one of those does. Call " +
+            "get_layout to see which objects report supportsTableLayout: true.");
+      }
+
+      layoutSessions.mutateLayout(sessionToken, agent, layoutName,
+         (clone, mutMaster, cloneRuntimeId, dispatcher) -> {
+            AbstractLayout layout = requireLayout(mutMaster, layoutName);
+            VSAssemblyLayout assemblyLayout = requireAssemblyLayout(layout, objectName, region,
+                                                                     layoutName);
+            assemblyLayout.setTableLayout(tableLayout);
+         });
+   }
+
+   // ── op: move_resize ──────────────────────────────────────────────────────
+
+   private void moveResize(String sessionToken, Principal agent, String layoutName, int region,
+                            List<Map<String, Object>> objects) throws Exception
+   {
+      layoutSessions.mutateLayout(sessionToken, agent, layoutName,
+         (clone, master, cloneRuntimeId, dispatcher) -> {
+            AbstractLayout layout = requireLayout(master, layoutName);
+
+            for(Map<String, Object> object : objects) {
+               String name = requireName(object);
+               VSAssemblyLayout assemblyLayout =
+                  requireAssemblyLayout(layout, name, region, layoutName);
+
+               Point position = new Point(toInt(object.get("x")), toInt(object.get("y")));
+               Dimension size = new Dimension(toInt(object.get("width")),
+                                               toInt(object.get("height")));
+               assemblyLayout.setPosition(position);
+               assemblyLayout.setSize(size);
+
+               // A layout-only ("editable") object's own self-contained VSAssemblyInfo tracks its
+               // layout position/size too -- keep both in sync, mirroring
+               // VSLayoutControllerService.moveResizeLayoutObjects. This info lives inside the
+               // VSAssemblyLayout entry itself, not on any real viewsheet assembly, so updating it
+               // is not a Hazard-1 concern.
+               if(assemblyLayout instanceof VSEditableAssemblyLayout editable) {
+                  VSAssemblyInfo info = editable.getInfo();
+                  info.setLayoutPosition(position);
+                  info.setLayoutSize(size);
+               }
+            }
+         });
+   }
+
+   // ── op: add ───────────────────────────────────────────────────────────────
+
+   private void addObjects(String sessionToken, Principal agent, String layoutName, int region,
+                            List<Map<String, Object>> objects) throws Exception
+   {
+      layoutSessions.mutateLayout(sessionToken, agent, layoutName,
+         (clone, master, cloneRuntimeId, dispatcher) -> {
+            Viewsheet masterVs = master.getViewsheet();
+            AbstractLayout layout = requireLayout(master, layoutName);
+            List<VSAssemblyLayout> layouts =
+               new ArrayList<>(vsLayoutService.getVSAssemblyLayouts(layout, region));
+
+            for(Map<String, Object> object : objects) {
+               String name = requireName(object);
+               AddVSLayoutObjectEvent event = new AddVSLayoutObjectEvent();
+               event.setLayoutName(layoutName);
+               event.setRegion(region);
+               event.setxOffset(toInt(object.getOrDefault("x", 0)));
+               event.setyOffset(toInt(object.getOrDefault("y", 0)));
+               event.setNames(new String[] { name });
+
+               VSAssembly assembly = masterVs.getAssembly(name);
+               boolean existAssembly = assembly != null;
+
+               if(!existAssembly) {
+                  event.setType(parseAssetType(object.get("type"), name));
+                  assembly = vsLayoutService.createVSAssembly(event, layout, masterVs, name);
+               }
+
+               VSAssemblyLayout assemblyLayout = vsLayoutService
+                  .createAssemblyLayout(event, masterVs, name, assembly, existAssembly);
+               layouts.add(assemblyLayout);
+            }
+
+            vsLayoutService.setVSAssemblyLayouts(layout, layouts, region);
+         });
+   }
+
+   private static int parseAssetType(Object type, String name) {
+      if(type == null) {
+         throw new IllegalArgumentException(
+            "edit_layout_objects add: \"" + name + "\" is not an existing assembly on this " +
+            "viewsheet, so a \"type\" (\"text\", \"image\", or \"pagebreak\") is required to " +
+            "create it as a layout-only object.");
+      }
+
+      String normalized = String.valueOf(type).trim().toLowerCase();
+
+      return switch(normalized) {
+         case "text" -> AbstractSheet.TEXT_ASSET;
+         case "image" -> AbstractSheet.IMAGE_ASSET;
+         case "pagebreak", "page_break", "page-break" -> AbstractSheet.PAGEBREAK_ASSET;
+         default -> throw new IllegalArgumentException(
+            "edit_layout_objects add: unknown type \"" + type + "\" -- expected \"text\", " +
+            "\"image\", or \"pagebreak\".");
+      };
+   }
+
+   // ── op: remove ────────────────────────────────────────────────────────────
+
+   private Map<String, Object> removeObjects(String sessionToken, Principal agent,
+                                              String layoutName, int region,
+                                              List<Map<String, Object>> objects, boolean confirmed)
+      throws Exception
+   {
+      List<String> names = new ArrayList<>();
+
+      for(Map<String, Object> object : objects) {
+         names.add(requireName(object));
+      }
+
+      if(!confirmed) {
+         RuntimeViewsheet master = viewsheetSessions.resolve(sessionToken, agent);
+         List<String> dependent = new ArrayList<>();
+
+         for(String name : names) {
+            DataTipInLayoutCheckResult check = vsLayoutControllerService
+               .checkAssemblyInLayout(master.getID(), layoutName, name, agent);
+
+            if(check.isAssemblyInLayout()) {
+               dependent.add(name);
+            }
+         }
+
+         if(!dependent.isEmpty()) {
+            Map<String, Object> result = new LinkedHashMap<>();
+            result.put("requiresConfirmation", true);
+            result.put("reason",
+               "Removing " + dependent + " from \"" + layoutName + "\" may break a data-tip " +
+               "relationship that depends on " + (dependent.size() == 1 ? "it" : "them") +
+               " -- call again with confirmed: true to remove anyway.");
+            result.put("objectNames", dependent);
+            return result;
+         }
+      }
+
+      layoutSessions.mutateLayout(sessionToken, agent, layoutName,
+         (clone, master, cloneRuntimeId, dispatcher) -> {
+            AbstractLayout layout = requireLayout(master, layoutName);
+            List<VSAssemblyLayout> layouts =
+               new ArrayList<>(vsLayoutService.getVSAssemblyLayouts(layout, region));
+            layouts.removeIf(l -> names.contains(l.getName()));
+            vsLayoutService.setVSAssemblyLayouts(layout, layouts, region);
+         });
+
+      return okResult();
+   }
+
+   // ── shared helpers ────────────────────────────────────────────────────────
+
+   private AbstractLayout requireLayout(RuntimeViewsheet master, String layoutName) {
+      return vsLayoutService.findViewsheetLayout(master.getViewsheet(), layoutName)
+         .orElseThrow(() -> new IllegalArgumentException(
+            "Unknown layout \"" + layoutName + "\" -- call list_layouts to see the print and " +
+            "device layouts defined on this viewsheet."));
+   }
+
+   private VSAssemblyLayout requireAssemblyLayout(AbstractLayout layout, String objectName,
+                                                   int region, String layoutName)
+   {
+      return vsLayoutService.findAssemblyLayout(layout, objectName, region)
+         .orElseThrow(() -> new IllegalArgumentException(
+            "\"" + objectName + "\" is not placed in layout \"" + layoutName + "\" -- add it " +
+            "first with edit_layout_objects (op: \"add\")."));
+   }
+
+   private static String requireName(Map<String, Object> object) {
+      Object name = object.get("name");
+
+      if(name == null || String.valueOf(name).isBlank()) {
+         throw new IllegalArgumentException(
+            "edit_layout_objects: every entry in \"objects\" needs a \"name\".");
+      }
+
+      return String.valueOf(name);
+   }
+
+   private static Map<String, Object> okResult() {
+      Map<String, Object> result = new LinkedHashMap<>();
+      result.put("requiresConfirmation", false);
+      return result;
+   }
+
+   private static int toInt(Object value) {
+      if(value instanceof Number number) {
+         return number.intValue();
+      }
+
+      return Integer.parseInt(String.valueOf(value));
+   }
+
+   private final LayoutSessionService layoutSessions;
+   private final ViewsheetSessionService viewsheetSessions;
+   private final VSLayoutService vsLayoutService;
+   private final VSLayoutControllerServiceProxy vsLayoutControllerService;
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/LayoutReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/LayoutReadService.java
@@ -1,0 +1,189 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.VSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.vslayout.*;
+import inetsoft.util.Catalog;
+import inetsoft.web.composer.vs.controller.VSLayoutService;
+import inetsoft.web.wiz.viewsheet.model.DeviceCatalogEntry;
+import inetsoft.web.wiz.viewsheet.model.LayoutModel;
+import inetsoft.web.wiz.viewsheet.model.LayoutObjectModel;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.awt.Dimension;
+import java.awt.Point;
+import java.security.Principal;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Read-only projection of a viewsheet's print/device layouts and the shared device catalogue --
+ * {@code list_layouts}/{@code get_layout}. A projection over {@link VSLayoutService}'s own
+ * traversal/computation methods, the same relationship {@code ViewsheetReadService} has to a
+ * plain {@code Viewsheet} -- this class does not re-walk {@code LayoutInfo} or re-derive
+ * {@code supportTableLayout}/the device catalogue from scratch.
+ *
+ * <p>Unlike every mutation-side layout service in this package, {@code LayoutReadService} never
+ * calls {@code AbstractLayout.apply(Viewsheet)}, so Hazard 1 (spec #11) does not arise here the
+ * way it does for {@code LayoutMutationService}/{@code LayoutUndoService}: both coordinate-space
+ * readings {@link #get} reports come from data already sitting on the paired session's own master
+ * {@code Viewsheet} -- the layout-space reading from the layout's own stored
+ * {@code VSAssemblyLayout} entry, the viewsheet-space reading from the same-named assembly's own
+ * {@code pixelOffset}/{@code pixelSize} -- neither of which {@code apply()} would touch even if
+ * this class did call it (it mutates {@code layoutPosition}/{@code layoutSize}/
+ * {@code layoutVisible} instead). {@link LayoutSessionService#resolveForRead} is still consulted
+ * first, purely so an unknown {@code layoutName} fails with the exact same message every other
+ * layout tool gives (and warms the same clone {@link LayoutMutationService}/
+ * {@link LayoutUndoService} would reuse for the same layout) -- its returned runtime is otherwise
+ * unused here.
+ */
+@Service
+public class LayoutReadService {
+   @Autowired
+   public LayoutReadService(ViewsheetSessionService viewsheetSessions,
+                             LayoutSessionService layoutSessions,
+                             VSLayoutService vsLayoutService,
+                             DeviceRegistry deviceRegistry)
+   {
+      this.viewsheetSessions = viewsheetSessions;
+      this.layoutSessions = layoutSessions;
+      this.vsLayoutService = vsLayoutService;
+      this.deviceRegistry = deviceRegistry;
+   }
+
+   /**
+    * Every print/device layout defined on the paired viewsheet, by name and type, plus the
+    * shared device catalogue. {@code devices}/{@code editDevicesAllowed} come straight from
+    * {@link DeviceRegistry} -- Global Constraint 7: this plugin family reads that catalogue, it
+    * never re-derives or writes it.
+    */
+   public Map<String, Object> list(String sessionToken, Principal agent) throws Exception {
+      RuntimeViewsheet master = viewsheetSessions.resolve(sessionToken, agent);
+      LayoutInfo info = master.getViewsheet().getLayoutInfo();
+      List<Map<String, Object>> layouts = new ArrayList<>();
+
+      if(info != null) {
+         if(info.getPrintLayout() != null) {
+            layouts.add(summarize(printLayoutName(), "print", null, null));
+         }
+
+         for(ViewsheetLayout layout : info.getViewsheetLayouts()) {
+            layouts.add(summarize(layout.getName(), "device", layout.isMobileOnly(),
+                                   Arrays.asList(layout.getDeviceIds())));
+         }
+      }
+
+      List<DeviceCatalogEntry> devices = Arrays.stream(deviceRegistry.getDevices())
+         .map(d -> new DeviceCatalogEntry(d.getId(), d.getName(), d.getMinWidth(), d.getMaxWidth()))
+         .collect(Collectors.toList());
+
+      Map<String, Object> out = new LinkedHashMap<>();
+      out.put("layouts", layouts);
+      out.put("devices", devices);
+      out.put("editDevicesAllowed", DeviceRegistry.isOrgAllowedToEditDevices(agent));
+      return out;
+   }
+
+   /**
+    * One layout's full detail: every object it places, in both coordinate spaces (see
+    * {@link LayoutObjectModel}), plus whether each one supports a print-layout table layout.
+    */
+   public LayoutModel get(String sessionToken, Principal agent, String layoutName)
+      throws Exception
+   {
+      RuntimeViewsheet master = viewsheetSessions.resolve(sessionToken, agent);
+
+      // Fails loud on an unknown layoutName with the same message every layout-mutating tool
+      // gives (see the class doc) -- the returned clone itself is not used below.
+      layoutSessions.resolveForRead(sessionToken, agent, layoutName);
+
+      Viewsheet masterVs = master.getViewsheet();
+      LayoutInfo info = masterVs.getLayoutInfo();
+      AbstractLayout layout = vsLayoutService.getViewsheetLayout(info, layoutName);
+      boolean print = vsLayoutService.isPrintLayout(layoutName);
+
+      List<LayoutObjectModel> objects = vsLayoutService
+         .getVSAssemblyLayouts(layout, VSLayoutService.CONTENT)
+         .stream()
+         .map(assemblyLayout -> toObjectModel(masterVs, assemblyLayout))
+         .collect(Collectors.toList());
+
+      Boolean mobileOnly = print ? null : ((ViewsheetLayout) layout).isMobileOnly();
+      List<String> selectedDevices = print ? null
+         : Arrays.asList(((ViewsheetLayout) layout).getDeviceIds());
+
+      return new LayoutModel(layoutName, print ? "print" : "device", mobileOnly, selectedDevices,
+                              objects);
+   }
+
+   private LayoutObjectModel toObjectModel(Viewsheet masterVs, VSAssemblyLayout assemblyLayout) {
+      VSAssembly assembly = masterVs.getAssembly(assemblyLayout.getName());
+      Point layoutPos = assemblyLayout.getPosition();
+      Dimension layoutSize = assemblyLayout.getSize();
+      // Read off the MASTER, never a layout-preview clone, so this is a genuinely independent
+      // reading from the layout-space one above -- see the class doc.
+      Point vsPos = assembly == null ? null : assembly.getPixelOffset();
+      Dimension vsSize = assembly == null ? null : assembly.getPixelSize();
+
+      return new LayoutObjectModel(
+         assemblyLayout.getName(),
+         layoutPos.x, layoutPos.y, layoutSize.width, layoutSize.height,
+         vsPos == null ? 0 : vsPos.x,
+         vsPos == null ? 0 : vsPos.y,
+         vsSize == null ? 0 : vsSize.width,
+         vsSize == null ? 0 : vsSize.height,
+         vsLayoutService.supportTableLayout(assembly));
+   }
+
+   private Map<String, Object> summarize(String name, String type, Boolean mobileOnly,
+                                         List<String> selectedDevices)
+   {
+      Map<String, Object> summary = new LinkedHashMap<>();
+      summary.put("name", name);
+      summary.put("type", type);
+
+      if(mobileOnly != null) {
+         summary.put("mobileOnly", mobileOnly);
+      }
+
+      if(selectedDevices != null) {
+         summary.put("selectedDevices", selectedDevices);
+      }
+
+      return summary;
+   }
+
+   /**
+    * Not cached statically -- {@code VSLayoutService.isPrintLayout} itself re-resolves this from
+    * {@link Catalog} on every call rather than caching it once, since the catalog is locale-
+    * dependent per request; this mirrors that rather than risking a stale translation baked in
+    * at class-load time.
+    */
+   private String printLayoutName() {
+      return Catalog.getCatalog().getString("Print Layout");
+   }
+
+   private final ViewsheetSessionService viewsheetSessions;
+   private final LayoutSessionService layoutSessions;
+   private final VSLayoutService vsLayoutService;
+   private final DeviceRegistry deviceRegistry;
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/LayoutSessionService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/LayoutSessionService.java
@@ -1,0 +1,214 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.viewsheet.vslayout.AbstractLayout;
+import inetsoft.web.composer.vs.controller.VSLayoutService;
+import inetsoft.web.viewsheet.service.CommandDispatcher;
+import inetsoft.web.wiz.dispatch.CapturingCommandDispatcher;
+import inetsoft.web.wiz.pairing.PairingException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Resolves spec #11's Hazard 1: a layout edit must never mutate the paired session's own
+ * (Master) {@code Viewsheet} as a side effect.
+ *
+ * <p>{@code AbstractLayout.apply(Viewsheet)} deep-copies the {@code Viewsheet} argument's own
+ * container object, but that copy is shallow ({@code AbstractSheet.clone()} is
+ * {@code super.clone()}) -- the argument's assemblies, their {@code VSAssemblyInfo}, and their
+ * {@code FormatInfo}/{@code VSCompositeFormat} objects are the *same* instances, not copies.
+ * {@code apply()} then mutates those shared objects in place (layout position/size/visibility via
+ * {@code applyBaseAssembly}, per-format {@code RScaleFont} via {@code applyScaleFont}) before
+ * returning the new top-level container. Every layout service method that calls it
+ * ({@code moveResizeLayoutObjects}, {@code layoutUndo}, {@code layoutRedo},
+ * {@code changeViewsheetLayout}) then installs the result via {@code setViewsheet(...)}. Passing
+ * the paired session's own master {@code Viewsheet} as that argument -- even if the *result* is
+ * only ever installed onto a clone -- silently rewrites the master's own assemblies' layout
+ * position and scale font as a side effect of computing that result.
+ *
+ * <p>The interactive Composer tolerates this because there is exactly one browser tab and one
+ * runtime id shared between "editing Master" and "editing a layout": the human's own view is
+ * expected to show layout-preview content while a layout tab is focused, and
+ * {@code coreLifecycleService.layoutViewsheet(...)} restores true Master state when they switch
+ * back. This plugin has no such mode switch -- the human's Composer must show the true Master at
+ * all times while the agent works a layout in the background -- so this service deliberately
+ * deviates from {@code changeViewsheetLayout}'s literal argument choice: every {@code apply()}
+ * call here targets the <b>clone's own</b>, independently-loaded {@code Viewsheet} (obtained via
+ * {@link ViewsheetService#openTemporaryViewsheet}, which reloads the persisted asset fresh and
+ * therefore shares no object graph with the master), never the master's. The master's
+ * {@code Viewsheet} is read only (via {@code VSLayoutService.findViewsheetLayout}) to locate the
+ * layout definition to clone -- it is never handed to {@code apply()}.
+ *
+ * <p>One clone runtime is cached per {@code (sessionToken, layoutName)} (Global Constraint /
+ * design decision: Option A in the layout implementation plan) -- reused across calls for the same
+ * layout, flushed and re-minted on a genuine switch to a different layout for the same token. This
+ * mirrors {@code changeViewsheetLayout}'s own reset rule
+ * ({@code if(!layoutName.equals(currLayout)) { rvs.resetLayoutUndoRedo(); ... }}), which already
+ * depends on remembering the previous layout -- a fresh mint on every call would have to reinvent
+ * that bookkeeping to avoid resetting the layout undo stack on every single mutating call.
+ *
+ * <p>Per Global Constraint 4, the layout undo/redo checkpoint for a mutation goes through
+ * {@link VSLayoutService#makeUndoable}, never {@code master.addCheckpoint(...)} -- that would
+ * checkpoint a layout edit onto the viewsheet's main (Master) undo stack, corrupting it exactly as
+ * spec #11's Hazard 2 describes.
+ */
+@Service
+public class LayoutSessionService {
+   @Autowired
+   public LayoutSessionService(ViewsheetSessionService viewsheetSessions,
+                                ViewsheetService viewsheetService,
+                                VSLayoutService vsLayoutService)
+   {
+      this.viewsheetSessions = viewsheetSessions;
+      this.viewsheetService = viewsheetService;
+      this.vsLayoutService = vsLayoutService;
+   }
+
+   /**
+    * Resolves the preview-clone runtime for {@code layoutName}, minting or reusing it exactly as
+    * {@link #mutateLayout} would, but without touching the master's layout undo/redo stack -- a
+    * read must not create an undo step, or a caller that only ever calls {@code get_layout} would
+    * see one appear from nowhere.
+    */
+   public RuntimeViewsheet resolveForRead(String sessionToken, Principal agent, String layoutName)
+      throws PairingException
+   {
+      RuntimeViewsheet master = viewsheetSessions.resolve(sessionToken, agent);
+
+      try {
+         return resolveClone(sessionToken, agent, master, layoutName, false).cloneRvs();
+      }
+      catch(PairingException | RuntimeException e) {
+         throw e;
+      }
+      catch(Exception e) {
+         throw new IllegalStateException(
+            "Failed to resolve layout \"" + layoutName + "\" for reading", e);
+      }
+   }
+
+   /**
+    * Resolves the clone runtime for {@code layoutName} (minting/reusing/switching per the class
+    * doc), runs {@code mutation} against it, then checkpoints via
+    * {@link VSLayoutService#makeUndoable} -- never {@code master.addCheckpoint(...)}, per Global
+    * Constraint 4.
+    */
+   public void mutateLayout(String sessionToken, Principal agent, String layoutName,
+                             LayoutMutation mutation) throws Exception
+   {
+      RuntimeViewsheet master = viewsheetSessions.resolve(sessionToken, agent);
+      Resolved resolved = resolveClone(sessionToken, agent, master, layoutName, true);
+
+      CapturingCommandDispatcher.withCapturingDispatcher(agent, dispatcher -> {
+         mutation.run(resolved.cloneRvs(), master, resolved.cloneRuntimeId(), dispatcher);
+         vsLayoutService.makeUndoable(master, dispatcher, layoutName);
+         return null;
+      });
+   }
+
+   /**
+    * Flushes the cached clone for {@code sessionToken}, if any, without touching any other
+    * token's clone. Called from {@code ViewsheetAssemblyAgentController.detach} (the endpoint
+    * every wiz viewsheet session already closes through -- see {@code detach_sheet}) so a layout
+    * clone never outlives the session it was minted for.
+    */
+   public void disposeAll(String sessionToken) {
+      ActiveClone active = clones.remove(sessionToken);
+
+      if(active != null) {
+         viewsheetService.flushRuntimeSheet(active.cloneRuntimeId());
+      }
+   }
+
+   /**
+    * Reuses the cached clone for {@code (sessionToken, layoutName)} if one is already active;
+    * otherwise flushes whatever clone WAS active for this token (a genuine switch, including the
+    * very first mint, which "switches" away from no clone at all) and mints a fresh one.
+    *
+    * <p>{@code checkpoint} is {@code false} for {@link #resolveForRead} -- a read must mint/reuse
+    * the same way a mutation would (so a read against a freshly-switched-to layout doesn't see
+    * stale content), but must not reset or seed the master's layout undo/redo stack, which is an
+    * editing concept.
+    */
+   private Resolved resolveClone(String sessionToken, Principal agent, RuntimeViewsheet master,
+                                  String layoutName, boolean checkpoint) throws Exception
+   {
+      ActiveClone active = clones.get(sessionToken);
+
+      if(active != null && active.layoutName().equals(layoutName)) {
+         return new Resolved(viewsheetService.getViewsheet(active.cloneRuntimeId(), agent),
+                              active.cloneRuntimeId());
+      }
+
+      if(active != null) {
+         viewsheetService.flushRuntimeSheet(active.cloneRuntimeId());
+         clones.remove(sessionToken);
+      }
+
+      String cloneRuntimeId = viewsheetService.openTemporaryViewsheet(
+         master.getID(), (AssetEntry) master.getEntry().clone(), agent);
+      RuntimeViewsheet clone = viewsheetService.getViewsheet(cloneRuntimeId, agent);
+      clone.setOriginalID(master.getID());
+
+      AbstractLayout found = vsLayoutService.findViewsheetLayout(master.getViewsheet(), layoutName)
+         .orElseThrow(() -> new IllegalArgumentException(
+            "Unknown layout \"" + layoutName + "\" -- call list_layouts to see the print and " +
+            "device layouts defined on this viewsheet."));
+
+      AbstractLayout layoutClone = found.clone();
+      // Use scale font 1 when editing layouts, mirroring changeViewsheetLayout /
+      // moveResizeLayoutObjects. Applied onto the CLONE's own Viewsheet, never the master's --
+      // see the class doc for why that argument choice is the whole point of this service.
+      layoutClone.setScaleFont(1);
+      clone.setViewsheet(layoutClone.apply(clone.getViewsheet()));
+
+      if(checkpoint) {
+         master.resetLayoutUndoRedo();
+         master.addLayoutCheckPoint(layoutClone);
+      }
+
+      clones.put(sessionToken, new ActiveClone(layoutName, cloneRuntimeId));
+      return new Resolved(clone, cloneRuntimeId);
+   }
+
+   /** One mutation against a layout's preview-clone runtime. */
+   @FunctionalInterface
+   public interface LayoutMutation {
+      void run(RuntimeViewsheet clone, RuntimeViewsheet master, String cloneRuntimeId,
+               CommandDispatcher dispatcher) throws Exception;
+   }
+
+   private record ActiveClone(String layoutName, String cloneRuntimeId) {
+   }
+
+   private record Resolved(RuntimeViewsheet cloneRvs, String cloneRuntimeId) {
+   }
+
+   private final ViewsheetSessionService viewsheetSessions;
+   private final ViewsheetService viewsheetService;
+   private final VSLayoutService vsLayoutService;
+   private final Map<String, ActiveClone> clones = new ConcurrentHashMap<>();
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/LayoutSessionService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/LayoutSessionService.java
@@ -26,6 +26,7 @@ import inetsoft.web.viewsheet.service.CommandDispatcher;
 import inetsoft.web.wiz.dispatch.CapturingCommandDispatcher;
 import inetsoft.web.wiz.pairing.PairingException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.security.Principal;
@@ -166,6 +167,32 @@ public class LayoutSessionService {
 
       if(active != null) {
          viewsheetService.flushRuntimeSheet(active.cloneRuntimeId());
+      }
+   }
+
+   /**
+    * Sweeps {@link #clones} for entries whose owning session is no longer live, and disposes
+    * them.
+    *
+    * <p>{@link #disposeAll} alone only covers the explicit {@code detach_sheet} path. A session
+    * that instead goes idle past {@code SheetSessionService.TTL_MILLIS} -- an agent that finishes
+    * its task and simply stops, or crashes, without ever calling {@code detach_sheet} -- is
+    * reaped by {@code SheetSessionService.evictExpired()}'s own scheduled sweep, which has no
+    * knowledge of this class's {@link #clones} map at all (different package, no dependency
+    * either way -- and deliberately so: the pairing layer should not need to know this plugin
+    * family exists). Without this sweep, that path leaves a <b>live {@code RuntimeViewsheet}
+    * runtime</b> cached under a token nothing will ever resolve again -- a real resource leak,
+    * heavier than a small map entry, for the remaining life of the process. Same cadence as
+    * {@code SheetSessionService.evictExpired()} (10 minutes) for consistency, though the two are
+    * not required to run in lockstep -- this sweep simply finds nothing to do until that one has
+    * already run.
+    */
+   @Scheduled(fixedDelay = 10 * 60_000)
+   void evictOrphanedClones() {
+      for(String token : clones.keySet()) {
+         if(!viewsheetSessions.isSessionLive(token)) {
+            disposeAll(token);
+         }
       }
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/LayoutSessionService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/LayoutSessionService.java
@@ -89,9 +89,12 @@ public class LayoutSessionService {
 
    /**
     * Resolves the preview-clone runtime for {@code layoutName}, minting or reusing it exactly as
-    * {@link #mutateLayout} would, but without touching the master's layout undo/redo stack -- a
-    * read must not create an undo step, or a caller that only ever calls {@code get_layout} would
-    * see one appear from nowhere.
+    * {@link #mutateLayout} would. A read never seeds a new baseline checkpoint itself (that would
+    * make an undo step "appear from nowhere" for a caller that only ever calls {@code get_layout}),
+    * but if resolving this read causes a genuine switch away from whatever layout (or lack of one)
+    * was previously focused for this token, the master's layout undo/redo stack is still reset to
+    * empty first -- see {@link #resolveClone}'s doc for why a read-triggered switch must reset the
+    * stack just as a mutation-triggered one does, even though it must not go on to seed it.
     */
    public RuntimeViewsheet resolveForRead(String sessionToken, Principal agent, String layoutName)
       throws PairingException
@@ -108,6 +111,29 @@ public class LayoutSessionService {
          throw new IllegalStateException(
             "Failed to resolve layout \"" + layoutName + "\" for reading", e);
       }
+   }
+
+   /**
+    * Focuses the preview-clone runtime for {@code layoutName} -- mints, reuses, or switches
+    * exactly as {@link #mutateLayout} does before running its mutation, including the
+    * reset-and-seed-baseline effect a genuine switch has on the master's layout undo/redo stack --
+    * without running any mutation of its own.
+    *
+    * <p>This plugin has no {@code RuntimeViewsheetRef.getFocusedLayoutName()} equivalent: the
+    * interactive Composer's {@code layoutUndo}/{@code layoutRedo} trust the client's own focused
+    * tab and never themselves cause a layout switch, but this plugin's {@code layout_undo}/
+    * {@code layout_redo} tools take an explicit {@code layoutName} argument on every call instead,
+    * so they must (re-)establish focus on that layout -- via this method -- before consulting the
+    * master's undo stack, rather than trusting whatever layout that stack happens to still reflect
+    * from a previous, unrelated call. Calling this when {@code layoutName} is already focused is a
+    * pure no-op read (the early-return branch in {@link #resolveClone} short-circuits before the
+    * reset/seed logic runs at all), so a normal "undo the edit I just made" call pays no extra cost.
+    */
+   public RuntimeViewsheet focusLayout(String sessionToken, Principal agent, String layoutName)
+      throws Exception
+   {
+      RuntimeViewsheet master = viewsheetSessions.resolve(sessionToken, agent);
+      return resolveClone(sessionToken, agent, master, layoutName, true).cloneRvs();
    }
 
    /**
@@ -148,10 +174,18 @@ public class LayoutSessionService {
     * otherwise flushes whatever clone WAS active for this token (a genuine switch, including the
     * very first mint, which "switches" away from no clone at all) and mints a fresh one.
     *
-    * <p>{@code checkpoint} is {@code false} for {@link #resolveForRead} -- a read must mint/reuse
-    * the same way a mutation would (so a read against a freshly-switched-to layout doesn't see
-    * stale content), but must not reset or seed the master's layout undo/redo stack, which is an
-    * editing concept.
+    * <p>Every genuine switch resets the master's layout undo/redo stack unconditionally --
+    * {@code layoutPoints} is one flat list per runtime, not one per layout (Hazard 2), so leaving
+    * it as-is across a switch would let a caller "undo" into a checkpoint that belongs to whatever
+    * layout was previously focused, or -- worse -- hand a {@code PrintLayout} checkpoint to
+    * {@code updateVSLayouts} for a {@code ViewsheetLayout} name and blow up with a
+    * {@code ClassCastException}. {@code checkpoint} only controls whether a fresh <em>baseline</em>
+    * is then seeded ({@code addLayoutCheckPoint}): {@link #resolveForRead} (checkpoint {@code
+    * false}) must not create an undo step of its own (a caller that only ever calls
+    * {@code get_layout} should never see one appear from nowhere), so after the reset it leaves the
+    * stack genuinely empty ({@code getLayoutPointsSize() == 0}) -- which is still exactly right for
+    * {@code layout_undo}/{@code layout_redo} to treat as "nothing to undo yet" the next time this
+    * layout is focused for editing.
     */
    private Resolved resolveClone(String sessionToken, Principal agent, RuntimeViewsheet master,
                                   String layoutName, boolean checkpoint) throws Exception
@@ -185,8 +219,11 @@ public class LayoutSessionService {
       layoutClone.setScaleFont(1);
       clone.setViewsheet(layoutClone.apply(clone.getViewsheet()));
 
+      // Unconditional: see the class doc above for why a read-triggered switch must reset the
+      // stack too, even though (per checkpoint) it must not go on to seed a baseline.
+      master.resetLayoutUndoRedo();
+
       if(checkpoint) {
-         master.resetLayoutUndoRedo();
          master.addLayoutCheckPoint(layoutClone);
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/LayoutUndoService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/LayoutUndoService.java
@@ -1,0 +1,194 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.vslayout.AbstractLayout;
+import inetsoft.web.composer.vs.controller.VSLayoutService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Phase 3 of the layout implementation plan (2026-08-20-layout-implementation.md), Task 5:
+ * {@code layout_undo}/{@code layout_redo}.
+ *
+ * <h2>Why this does not delegate to {@code VSLayoutControllerService.layoutUndo}/{@code
+ * layoutRedo} as-is</h2>
+ *
+ * <p>Both bodies are already public and reachable off {@code VSLayoutControllerServiceProxy}
+ * (same finding as {@link LayoutMutationService}'s class doc for its own siblings), but calling
+ * them with this plugin's runtime ids would reproduce Hazard 1: they resolve the historical
+ * {@code AbstractLayout} off the <b>master</b>'s own undo stack (correct -- that stack lives on
+ * the master, not any clone) but then call {@code apply()} directly on the <b>master's own live
+ * {@code Viewsheet}</b> (via {@code parentRvs.getViewsheet()}), exactly the corruption {@link
+ * LayoutSessionService}'s class doc exists to prevent:
+ *
+ * <pre>{@code
+ * // VSLayoutControllerService.layoutUndo
+ * AbstractLayout layoutClone = (AbstractLayout) parentRvs.layoutUndo().clone();
+ * this.vsLayoutService.updateVSLayouts(parentRvs, layoutClone, layoutName);
+ * rvs.setViewsheet(layoutClone.apply(parentRvs.getViewsheet()));   // <-- apply() on the MASTER
+ * }</pre>
+ *
+ * <p>The fix mirrors {@link LayoutMutationService}'s: call the master's undo-stack primitives
+ * ({@code RuntimeViewsheet.layoutUndo()}/{@code layoutRedo()} -- pure bookkeeping, no {@code
+ * apply()} inside them) and {@link VSLayoutService#updateVSLayouts} (a {@code LayoutInfo} write,
+ * not an {@code apply()} call) directly against the master, exactly as the interactive path does
+ * for those two steps -- then redirect only the {@code apply()} call itself onto {@link
+ * LayoutSessionService}'s clone instead of the master.
+ *
+ * <h2>Why this does not go through {@link LayoutSessionService#mutateLayout}</h2>
+ *
+ * <p>{@code mutateLayout} unconditionally calls {@link VSLayoutService#makeUndoable} (which itself
+ * calls {@code addLayoutCheckPoint}) once its mutation lambda returns -- exactly right for a new
+ * edit, but wrong for undo/redo: {@code addLayoutCheckPoint} truncates anything after the current
+ * pointer and appends a fresh entry there. Running undo/redo's own pointer move through {@code
+ * mutateLayout} would immediately re-push a checkpoint identical to the one just moved to,
+ * silently discarding the rest of the redo (for undo) or corrupting the pointer bookkeeping (for
+ * redo) on every single call -- one undo would work, but a second undo, or any redo, would not.
+ * This class instead uses {@link LayoutSessionService#focusLayout}, which performs the same
+ * mint/reuse/switch resolution {@code mutateLayout} does but runs no mutation and takes no
+ * checkpoint of its own -- the undo-stack pointer move IS this call's only state change.
+ *
+ * <h2>Hazard 2 -- the explicit {@code layoutName}, and why every call re-focuses first</h2>
+ *
+ * <p>This plugin has no {@code RuntimeViewsheetRef.getFocusedLayoutName()} equivalent (the
+ * interactive client tracks which layout tab is focused and never itself causes a layout switch
+ * from inside {@code layoutUndo}/{@code layoutRedo}); callers here pass {@code layoutName}
+ * explicitly on every call instead. Because {@code RuntimeViewsheet.layoutPoints} is one flat
+ * stack per runtime, not one per layout, this class must (re-)establish {@code layoutName} as
+ * focused -- via {@link LayoutSessionService#focusLayout}, which resets the stack on a genuine
+ * switch -- <em>before</em> reading {@code getLayoutPoint()}/{@code getLayoutPointsSize()} or
+ * calling {@code layoutUndo()}/{@code layoutRedo()}. Skipping that and consulting the master's
+ * stack first would let a caller "undo" into a checkpoint that belongs to whatever layout was
+ * previously focused for this session -- the exact stale-cross-layout-entry failure Hazard 2
+ * warns about -- and, when the previously-focused layout was a print layout and the requested one
+ * is a device layout (or vice versa), {@code updateVSLayouts} would try to cast that stale
+ * checkpoint to the wrong {@code AbstractLayout} subtype and throw {@code ClassCastException}.
+ *
+ * <p>Per the spec's own error-handling table, undoing/redoing past the available history for the
+ * current focus is a no-op, not an error -- {@code RuntimeViewsheet.layoutUndo()}/{@code
+ * layoutRedo()} do not bounds-check themselves (the interactive client instead disables the
+ * button; this plugin has no such client), so this class checks {@code getLayoutPoint()} against
+ * the stack bounds itself before ever calling them.
+ */
+@Service
+public class LayoutUndoService {
+   @Autowired
+   public LayoutUndoService(LayoutSessionService layoutSessions,
+                             ViewsheetSessionService viewsheetSessions,
+                             VSLayoutService vsLayoutService)
+   {
+      this.layoutSessions = layoutSessions;
+      this.viewsheetSessions = viewsheetSessions;
+      this.vsLayoutService = vsLayoutService;
+   }
+
+   /**
+    * {@code layout_undo}: reverts {@code layoutName} to its state one edit before the current
+    * one, scoped to edits made since this layout was last focused in this session (Hazard 2). A
+    * no-op (not an error) when there is nothing earlier to revert to for the current focus.
+    */
+   public Map<String, Object> layoutUndo(String sessionToken, Principal agent, String layoutName)
+      throws Exception
+   {
+      return move(sessionToken, agent, layoutName, Direction.UNDO);
+   }
+
+   /**
+    * {@code layout_redo}: reapplies the edit most recently undone for {@code layoutName}. A no-op
+    * (not an error) when there is nothing later to reapply.
+    */
+   public Map<String, Object> layoutRedo(String sessionToken, Principal agent, String layoutName)
+      throws Exception
+   {
+      return move(sessionToken, agent, layoutName, Direction.REDO);
+   }
+
+   private Map<String, Object> move(String sessionToken, Principal agent, String layoutName,
+                                     Direction direction) throws Exception
+   {
+      RuntimeViewsheet master = viewsheetSessions.resolve(sessionToken, agent);
+
+      // Re-focus BEFORE consulting the stack -- see the class doc's Hazard 2 section for why
+      // this order matters: focusLayout resets the stack on a genuine switch, so only after this
+      // call does master.getLayoutPoint()/getLayoutPointsSize() genuinely describe layoutName's
+      // own history rather than whatever layout was previously focused for this token.
+      RuntimeViewsheet clone = layoutSessions.focusLayout(sessionToken, agent, layoutName);
+
+      if(!direction.available(master)) {
+         return result(false, master);
+      }
+
+      AbstractLayout layoutClone = (AbstractLayout) direction.pop(master).clone();
+      vsLayoutService.updateVSLayouts(master, layoutClone, layoutName);
+      // apply() onto the CLONE's own Viewsheet only -- never the master's, per Hazard 1 (see the
+      // class doc).
+      clone.setViewsheet(layoutClone.apply(clone.getViewsheet()));
+
+      return result(true, master);
+   }
+
+   private static Map<String, Object> result(boolean applied, RuntimeViewsheet master) {
+      Map<String, Object> result = new LinkedHashMap<>();
+      result.put("applied", applied);
+      result.put("layoutPoint", master.getLayoutPoint());
+      result.put("layoutPoints", master.getLayoutPointsSize());
+      return result;
+   }
+
+   /**
+    * {@code RuntimeViewsheet.layoutUndo()}/{@code layoutRedo()} do not bounds-check the pointer
+    * move themselves (see the class doc), so {@code available} must be checked first.
+    */
+   private enum Direction {
+      UNDO {
+         @Override
+         boolean available(RuntimeViewsheet master) {
+            return master.getLayoutPoint() > 0;
+         }
+
+         @Override
+         AbstractLayout pop(RuntimeViewsheet master) {
+            return master.layoutUndo();
+         }
+      },
+      REDO {
+         @Override
+         boolean available(RuntimeViewsheet master) {
+            return master.getLayoutPoint() < master.getLayoutPointsSize() - 1;
+         }
+
+         @Override
+         AbstractLayout pop(RuntimeViewsheet master) {
+            return master.layoutRedo();
+         }
+      };
+
+      abstract boolean available(RuntimeViewsheet master);
+      abstract AbstractLayout pop(RuntimeViewsheet master);
+   }
+
+   private final LayoutSessionService layoutSessions;
+   private final ViewsheetSessionService viewsheetSessions;
+   private final VSLayoutService vsLayoutService;
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PrintDeviceLayoutPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PrintDeviceLayoutPropertyService.java
@@ -1,0 +1,358 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.vslayout.DeviceInfo;
+import inetsoft.uql.viewsheet.vslayout.DeviceRegistry;
+import inetsoft.web.composer.model.vs.*;
+import inetsoft.web.composer.vs.dialog.ViewsheetPropertyDialogService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.security.Principal;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * {@code set_print_layout}/{@code manage_device_layout} -- patches {@code ScreensPaneModel}
+ * inside the existing {@code ViewsheetPropertyDialogModel} through {@link
+ * ViewsheetPropertyDialogService#getViewsheetInfo}/{@link
+ * ViewsheetPropertyDialogService#setViewsheetInfo}, the <b>same</b> method {@link
+ * SheetPropertyService} already wraps for {@code set_viewsheet_properties}. A sibling of that
+ * class, not a new dialog controller (Global Constraint 6).
+ *
+ * <p>{@code screensPane} is a whole-viewsheet property, not layout-object geometry, so this task
+ * operates on the paired session's master runtime directly via {@link ViewsheetSessionService} --
+ * Hazard 1 (spec #11) and {@link LayoutSessionService} do not apply here.
+ *
+ * <p>Two hazards this class exists to guard against:
+ * <ul>
+ *   <li><b>Hazard 3 ({@code scaleFont}).</b> {@link VSPrintLayoutDialogModel#getScaleFont()} is a
+ *   bare {@code float}, defaulting to Java's {@code 0.0f}. {@code VSCompositeFormat.getFont()}
+ *   multiplies every cell's font size by this value, so a print layout whose {@code scaleFont}
+ *   reaches the write as {@code 0} renders every table/crosstab cell's text at font size zero --
+ *   blank, not merely small. {@link #setPrintLayout} refuses an explicit {@code 0} before writing
+ *   anything, and seeds a brand-new print layout's {@code scaleFont} at {@code 1.0f} before
+ *   applying the caller's patch, so an omitted key on a first-ever {@code set_print_layout} call
+ *   never falls through to Java's bare-field default.</li>
+ *   <li><b>Risk 2 (device catalogue vs. device layout).</b> {@link DeviceRegistry}/{@link
+ *   ScreenSizeDialogModel} are global, org-wide infrastructure with their own admin-gated REST
+ *   surface ({@code DeviceController}), entirely outside this plugin's session model (Global
+ *   Constraint 7). {@link #manageDeviceLayout} only ever creates/updates/deletes a named {@link
+ *   VSDeviceLayoutDialogModel} -- a device LAYOUT on <em>this</em> viewsheet, referencing existing
+ *   catalogue ids by {@code selectedDevices} -- and refuses a request shaped like a catalogue
+ *   write (a {@code ScreenSizeDialogModel}-shaped payload with no device-layout {@code name})
+ *   rather than silently forwarding it anywhere near {@code DeviceController}.</li>
+ * </ul>
+ */
+@Service
+public class PrintDeviceLayoutPropertyService {
+   @Autowired
+   public PrintDeviceLayoutPropertyService(ViewsheetSessionService sessions,
+                                            ViewsheetPropertyDialogService dialogService,
+                                            DeviceRegistry deviceRegistry)
+   {
+      this.sessions = sessions;
+      this.dialogService = dialogService;
+      this.deviceRegistry = deviceRegistry;
+   }
+
+   /**
+    * Patches {@code screensPane.printLayout}'s fields (paper size, margins, orientation,
+    * header/footer-from-edge, numbering start, custom size, units, {@code scaleFont}) --
+    * read-merge-write, exactly like {@link SheetPropertyService#set}: every field not named in
+    * {@code patch} survives exactly as read.
+    */
+   public void setPrintLayout(String sessionToken, Principal user, Map<String, Object> patch,
+                               String linkUri) throws Exception
+   {
+      if(patch == null || patch.isEmpty()) {
+         throw new IllegalArgumentException(
+            "set_print_layout needs at least one print-layout property to set.");
+      }
+
+      // Validated BEFORE the mutation seam opens at all -- a refusal here must never reach
+      // setViewsheetInfo and must never open an undo checkpoint for a write that never happened.
+      if(patch.containsKey("scaleFont") && toFloat(patch.get("scaleFont")) == 0f) {
+         throw new IllegalArgumentException(
+            "set_print_layout: scaleFont cannot be 0 -- table and crosstab cell text renders " +
+            "at font size 0 (i.e. blank) when a print layout's scale factor is zero. Omit " +
+            "scaleFont to keep the default (1.0) or pass a positive value.");
+      }
+
+      Map<String, Object> resolvedPatch = new LinkedHashMap<>(patch);
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         ViewsheetPropertyDialogModel model = dialogService.getViewsheetInfo(runtimeId, user);
+         ScreensPaneModel screensPane = model.screensPane();
+         VSPrintLayoutDialogModel printLayout = screensPane.getPrintLayout();
+
+         if(printLayout == null) {
+            // No print layout configured on this viewsheet yet: seed scaleFont at the safe
+            // default BEFORE applying the patch, so an omitted "scaleFont" key lands on 1.0f
+            // rather than the bare-field 0.0f a freshly-constructed model would otherwise carry
+            // through to the write untouched (the Hazard-3 regression this class exists to
+            // close).
+            printLayout = new VSPrintLayoutDialogModel();
+            printLayout.setScaleFont(1.0f);
+         }
+
+         applyPrintLayoutPatch(printLayout, resolvedPatch);
+         screensPane.setPrintLayout(printLayout);
+         dialogService.setViewsheetInfo(runtimeId, model, user, dispatcher, linkUri, null);
+      });
+   }
+
+   /**
+    * Creates, updates, or deletes a device LAYOUT (a named {@link VSDeviceLayoutDialogModel}) on
+    * this viewsheet. {@code selectedDevices} picks ids from the existing, read-only device
+    * catalogue ({@code list_layouts}) -- every id is validated against {@link
+    * DeviceRegistry#getDevices()} before anything is written, and a request shaped like a
+    * catalogue write (no device-layout {@code name}) is refused outright (Risk 2).
+    *
+    * @param action one of {@code create}, {@code update}, {@code delete} (case-insensitive).
+    */
+   public void manageDeviceLayout(String sessionToken, Principal user, String action,
+                                   Map<String, Object> patch, String linkUri) throws Exception
+   {
+      if(action == null || action.isBlank()) {
+         throw new IllegalArgumentException(
+            "manage_device_layout needs an action: create, update, or delete.");
+      }
+
+      String normalizedAction = action.trim().toLowerCase();
+
+      if(!VALID_ACTIONS.contains(normalizedAction)) {
+         throw new IllegalArgumentException(
+            "manage_device_layout: unknown action \"" + action + "\" -- expected one of " +
+            VALID_ACTIONS + ".");
+      }
+
+      Map<String, Object> safePatch = patch == null ? Map.of() : patch;
+
+      // Risk 2: refuse anything shaped like a device CATALOGUE write (a ScreenSizeDialogModel --
+      // label/description/minWidth/maxWidth) rather than a device LAYOUT write (a
+      // VSDeviceLayoutDialogModel -- name/mobileOnly/selectedDevices). Every device-layout
+      // request carries "name"; a catalogue-entry request never does, since catalogue entries are
+      // identified by "id"/"label", not "name". This check happens before any DeviceRegistry
+      // lookup or write, since this tool has no business forwarding such a request anywhere near
+      // DeviceController at all.
+      boolean looksLikeCatalogueWrite = !safePatch.containsKey("name") &&
+         (safePatch.containsKey("label") || safePatch.containsKey("minWidth") ||
+          safePatch.containsKey("maxWidth") || safePatch.containsKey("description"));
+
+      if(looksLikeCatalogueWrite) {
+         throw new IllegalArgumentException(
+            "manage_device_layout manages device LAYOUTS on this viewsheet, not the device " +
+            "catalogue itself. Creating or editing a device size (id/label/min/max width) is " +
+            "an org-admin operation outside this tool's scope -- that has to go through " +
+            "Composer's Device admin screen. Pick an existing device id from list_layouts's " +
+            "catalogue for selectedDevices instead.");
+      }
+
+      String name = asString(safePatch.get("name"));
+
+      if(name == null || name.isBlank()) {
+         throw new IllegalArgumentException(
+            "manage_device_layout needs a \"name\" identifying the device layout.");
+      }
+
+      List<String> selectedDevices = asStringList(safePatch.get("selectedDevices"));
+
+      if(selectedDevices != null) {
+         Set<String> knownIds = Arrays.stream(deviceRegistry.getDevices())
+            .map(DeviceInfo::getId)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+
+         for(String id : selectedDevices) {
+            if(!knownIds.contains(id)) {
+               throw new IllegalArgumentException(
+                  "manage_device_layout: \"" + id + "\" is not a known device id -- valid ids " +
+                  "are " + knownIds + " (see list_layouts's device catalogue).");
+            }
+         }
+      }
+
+      Boolean mobileOnly = safePatch.containsKey("mobileOnly")
+         ? Boolean.TRUE.equals(safePatch.get("mobileOnly")) : null;
+
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         ViewsheetPropertyDialogModel model = dialogService.getViewsheetInfo(runtimeId, user);
+         ScreensPaneModel screensPane = model.screensPane();
+         List<VSDeviceLayoutDialogModel> layouts = screensPane.getDeviceLayouts();
+         VSDeviceLayoutDialogModel existing = layouts.stream()
+            .filter(l -> name.equals(l.getName()))
+            .findFirst()
+            .orElse(null);
+
+         switch(normalizedAction) {
+            case "create": {
+               if(existing != null) {
+                  throw new IllegalArgumentException(
+                     "manage_device_layout: a device layout named \"" + name +
+                     "\" already exists -- use action \"update\" instead.");
+               }
+
+               VSDeviceLayoutDialogModel created = new VSDeviceLayoutDialogModel();
+               created.setName(name);
+               created.setMobileOnly(Boolean.TRUE.equals(mobileOnly));
+               created.setSelectedDevices(
+                  selectedDevices != null ? selectedDevices : new ArrayList<>());
+               layouts.add(created);
+               break;
+            }
+            case "update": {
+               if(existing == null) {
+                  throw new IllegalArgumentException(
+                     "manage_device_layout: no device layout named \"" + name + "\" -- call " +
+                     "list_layouts to see what's defined on this viewsheet.");
+               }
+
+               if(mobileOnly != null) {
+                  existing.setMobileOnly(mobileOnly);
+               }
+
+               if(selectedDevices != null) {
+                  existing.setSelectedDevices(selectedDevices);
+               }
+
+               break;
+            }
+            case "delete": {
+               if(existing == null) {
+                  throw new IllegalArgumentException(
+                     "manage_device_layout: no device layout named \"" + name + "\" -- call " +
+                     "list_layouts to see what's defined on this viewsheet.");
+               }
+
+               layouts.remove(existing);
+               break;
+            }
+            default:
+               // Unreachable: normalizedAction was already validated against VALID_ACTIONS above.
+               throw new IllegalStateException("Unknown action: " + normalizedAction);
+         }
+
+         screensPane.setDeviceLayouts(layouts);
+         dialogService.setViewsheetInfo(runtimeId, model, user, dispatcher, linkUri, null);
+      });
+   }
+
+   /** Applies every key present in {@code patch} onto {@code printLayout}; leaves the rest. */
+   private void applyPrintLayoutPatch(VSPrintLayoutDialogModel printLayout,
+                                       Map<String, Object> patch)
+   {
+      for(Map.Entry<String, Object> entry : patch.entrySet()) {
+         Object value = entry.getValue();
+
+         switch(entry.getKey()) {
+            case "paperSize":
+               printLayout.setPaperSize(asString(value));
+               break;
+            case "marginTop":
+               printLayout.setMarginTop(toDouble(value));
+               break;
+            case "marginLeft":
+               printLayout.setMarginLeft(toDouble(value));
+               break;
+            case "marginBottom":
+               printLayout.setMarginBottom(toDouble(value));
+               break;
+            case "marginRight":
+               printLayout.setMarginRight(toDouble(value));
+               break;
+            case "footerFromEdge":
+               printLayout.setFooterFromEdge(toFloat(value));
+               break;
+            case "headerFromEdge":
+               printLayout.setHeaderFromEdge(toFloat(value));
+               break;
+            case "landscape":
+               printLayout.setLandscape(Boolean.TRUE.equals(value));
+               break;
+            case "scaleFont":
+               printLayout.setScaleFont(toFloat(value));
+               break;
+            case "numberingStart":
+               printLayout.setNumberingStart(toInt(value));
+               break;
+            case "customWidth":
+               printLayout.setCustomWidth(toDouble(value));
+               break;
+            case "customHeight":
+               printLayout.setCustomHeight(toDouble(value));
+               break;
+            case "units":
+               printLayout.setUnits(asString(value));
+               break;
+            default:
+               throw new IllegalArgumentException(
+                  "set_print_layout: unknown print-layout property \"" + entry.getKey() + "\".");
+         }
+      }
+   }
+
+   private static String asString(Object value) {
+      return value == null ? null : String.valueOf(value);
+   }
+
+   @SuppressWarnings("unchecked")
+   private static List<String> asStringList(Object value) {
+      if(value == null) {
+         return null;
+      }
+
+      if(value instanceof List<?> list) {
+         return list.stream().map(String::valueOf).collect(Collectors.toList());
+      }
+
+      throw new IllegalArgumentException(
+         "manage_device_layout: selectedDevices must be a list of device ids.");
+   }
+
+   private static float toFloat(Object value) {
+      if(value instanceof Number number) {
+         return number.floatValue();
+      }
+
+      return Float.parseFloat(String.valueOf(value));
+   }
+
+   private static double toDouble(Object value) {
+      if(value instanceof Number number) {
+         return number.doubleValue();
+      }
+
+      return Double.parseDouble(String.valueOf(value));
+   }
+
+   private static int toInt(Object value) {
+      if(value instanceof Number number) {
+         return number.intValue();
+      }
+
+      return Integer.parseInt(String.valueOf(value));
+   }
+
+   private static final Set<String> VALID_ACTIONS = Set.of("create", "update", "delete");
+
+   private final ViewsheetSessionService sessions;
+   private final ViewsheetPropertyDialogService dialogService;
+   private final DeviceRegistry deviceRegistry;
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -71,7 +71,8 @@ public class ViewsheetAssemblyAgentController {
                                    InputValueService inputService,
                                    ViewsheetService viewsheetService,
                                    SheetAgentBroadcastService broadcast,
-                                   SheetOpenService openService)
+                                   SheetOpenService openService,
+                                   LayoutSessionService layoutSessionService)
    {
       this.feature = feature;
       this.joinService = joinService;
@@ -96,6 +97,7 @@ public class ViewsheetAssemblyAgentController {
       this.viewsheetService = viewsheetService;
       this.broadcast = broadcast;
       this.openService = openService;
+      this.layoutSessionService = layoutSessionService;
    }
 
    public record JoinRequest(String code) {}
@@ -821,6 +823,11 @@ public class ViewsheetAssemblyAgentController {
     * could terminate their pairing -- {@code Principal} was accepted and ignored while every other
     * endpoint binds the token through {@code resolve}. Skipping {@code requireEnabled()} is
     * deliberate and stays: disconnecting is always allowed.
+    *
+    * <p>Also flushes any layout preview-clone runtime {@link LayoutSessionService} is holding for
+    * this token. This is the one real detach hook every wiz viewsheet session already closes
+    * through (see the class doc), so a layout clone is disposed here rather than through a second,
+    * parallel cleanup path.
     */
    @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/detach")
    public void detach(@PathVariable String sessionToken, Principal user) {
@@ -828,6 +835,7 @@ public class ViewsheetAssemblyAgentController {
 
       if(session != null) {
          sessionService.close(sessionToken);
+         layoutSessionService.disposeAll(sessionToken);
       }
    }
 
@@ -886,4 +894,5 @@ public class ViewsheetAssemblyAgentController {
    private final ViewsheetService viewsheetService;
    private final SheetAgentBroadcastService broadcast;
    private final SheetOpenService openService;
+   private final LayoutSessionService layoutSessionService;
 }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -18,7 +18,9 @@
 package inetsoft.web.wiz.viewsheet;
 
 import inetsoft.sree.security.IdentityID;
+import inetsoft.web.composer.vs.controller.VSLayoutService;
 import inetsoft.web.wiz.pairing.*;
+import inetsoft.web.wiz.viewsheet.model.LayoutModel;
 import inetsoft.web.wiz.viewsheet.model.ViewsheetModel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -72,7 +74,11 @@ public class ViewsheetAssemblyAgentController {
                                    ViewsheetService viewsheetService,
                                    SheetAgentBroadcastService broadcast,
                                    SheetOpenService openService,
-                                   LayoutSessionService layoutSessionService)
+                                   LayoutSessionService layoutSessionService,
+                                   LayoutReadService layoutReadService,
+                                   PrintDeviceLayoutPropertyService printDeviceLayoutPropertyService,
+                                   LayoutMutationService layoutMutationService,
+                                   LayoutUndoService layoutUndoService)
    {
       this.feature = feature;
       this.joinService = joinService;
@@ -98,6 +104,10 @@ public class ViewsheetAssemblyAgentController {
       this.broadcast = broadcast;
       this.openService = openService;
       this.layoutSessionService = layoutSessionService;
+      this.layoutReadService = layoutReadService;
+      this.printDeviceLayoutPropertyService = printDeviceLayoutPropertyService;
+      this.layoutMutationService = layoutMutationService;
+      this.layoutUndoService = layoutUndoService;
    }
 
    public record JoinRequest(String code) {}
@@ -755,6 +765,127 @@ public class ViewsheetAssemblyAgentController {
       comparisonService.clear(sessionToken, user, request.assembly(), linkUri);
    }
 
+   // ── Layout: list_layouts, get_layout, set_print_layout, manage_device_layout, ──────────
+   // ── edit_layout_objects, set_layout_table_options, layout_undo, layout_redo ────────────
+   //
+   // Validation and delegation only, exactly like every other family in this file (Global
+   // Constraint 3 of the layout implementation plan) -- every hazard this family exists to
+   // guard against (Hazard 1's preview-clone isolation, Hazard 2's undo-stack-reset-on-switch,
+   // Hazard 3's scaleFont-zero refusal) is handled inside the five services below, never here.
+   //
+   // edit_layout_objects/set_layout_table_options address CONTENT-region objects only -- the
+   // spec never surfaces "region" (header/footer/content) as a caller-facing concept, and
+   // LayoutReadService.get() itself only ever projects VSLayoutService.CONTENT, so this
+   // controller passes that same constant through rather than inventing a region parameter
+   // nothing else in this plugin family exposes.
+
+   /** {@code list_layouts}. */
+   @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/layout/list")
+   public Map<String, Object> listLayouts(@PathVariable String sessionToken, Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return layoutReadService.list(sessionToken, user);
+   }
+
+   /** {@code get_layout}. */
+   @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/layout/{layoutName}")
+   public LayoutModel getLayout(@PathVariable String sessionToken,
+                                @PathVariable String layoutName, Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return layoutReadService.get(sessionToken, user, layoutName);
+   }
+
+   public record LayoutPrintPatchRequest(Map<String, Object> properties) {}
+
+   /** {@code set_print_layout}. */
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/layout/print")
+   public void setPrintLayout(@PathVariable String sessionToken,
+                              @RequestBody LayoutPrintPatchRequest request,
+                              @RequestParam(required = false, defaultValue = "") String linkUri,
+                              Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      printDeviceLayoutPropertyService.setPrintLayout(sessionToken, user, request.properties(),
+                                                       linkUri);
+   }
+
+   public record LayoutDevicePatchRequest(String action, Map<String, Object> properties) {}
+
+   /** {@code manage_device_layout}. */
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/layout/device")
+   public void manageDeviceLayout(@PathVariable String sessionToken,
+                                  @RequestBody LayoutDevicePatchRequest request,
+                                  @RequestParam(required = false, defaultValue = "")
+                                  String linkUri,
+                                  Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      printDeviceLayoutPropertyService.manageDeviceLayout(sessionToken, user, request.action(),
+                                                           request.properties(), linkUri);
+   }
+
+   public record LayoutObjectsRequest(String layoutName, String op,
+                                      List<Map<String, Object>> objects, Boolean confirmed) {}
+
+   /** {@code edit_layout_objects}. */
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/layout/objects")
+   public Map<String, Object> editLayoutObjects(@PathVariable String sessionToken,
+                                                @RequestBody LayoutObjectsRequest request,
+                                                Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return layoutMutationService.editObjects(sessionToken, user, request.layoutName(),
+                                               request.op(), VSLayoutService.CONTENT,
+                                               request.objects(),
+                                               Boolean.TRUE.equals(request.confirmed()));
+   }
+
+   public record LayoutTableOptionsRequest(String layoutName, String objectName,
+                                           int tableLayout) {}
+
+   /** {@code set_layout_table_options}. */
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/layout/table-options")
+   public void setLayoutTableOptions(@PathVariable String sessionToken,
+                                     @RequestBody LayoutTableOptionsRequest request,
+                                     Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      layoutMutationService.setTableLayoutOptions(sessionToken, user, request.layoutName(),
+                                                  request.objectName(), VSLayoutService.CONTENT,
+                                                  request.tableLayout());
+   }
+
+   public record LayoutUndoRedoRequest(String layoutName) {}
+
+   /** {@code layout_undo}. */
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/layout/undo")
+   public Map<String, Object> layoutUndo(@PathVariable String sessionToken,
+                                         @RequestBody LayoutUndoRedoRequest request,
+                                         Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return layoutUndoService.layoutUndo(sessionToken, user, request.layoutName());
+   }
+
+   /** {@code layout_redo}. */
+   @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/layout/redo")
+   public Map<String, Object> layoutRedo(@PathVariable String sessionToken,
+                                         @RequestBody LayoutUndoRedoRequest request,
+                                         Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return layoutUndoService.layoutRedo(sessionToken, user, request.layoutName());
+   }
+
    @PostMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/save")
    public void save(@PathVariable String sessionToken, Principal user) throws PairingException {
       requireEnabled();
@@ -895,4 +1026,8 @@ public class ViewsheetAssemblyAgentController {
    private final SheetAgentBroadcastService broadcast;
    private final SheetOpenService openService;
    private final LayoutSessionService layoutSessionService;
+   private final LayoutReadService layoutReadService;
+   private final PrintDeviceLayoutPropertyService printDeviceLayoutPropertyService;
+   private final LayoutMutationService layoutMutationService;
+   private final LayoutUndoService layoutUndoService;
 }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetSessionService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetSessionService.java
@@ -109,6 +109,17 @@ public class ViewsheetSessionService {
    }
 
    /**
+    * Whether {@code sessionToken} still names a live session, with no owner/pane-scope check --
+    * a pure liveness probe for {@code LayoutSessionService}'s own scheduled cleanup sweep, which
+    * has no {@code Principal} to check against and no need for one: it is deciding whether to
+    * free a preview-clone resource, not authorizing an action. Do not use this for anything that
+    * needs an authorization decision -- use {@link #resolve} for that.
+    */
+   public boolean isSessionLive(String sessionToken) {
+      return sessions.isLive(sessionToken);
+   }
+
+   /**
     * The runtime id for a paired session.
     *
     * <p>Grants the ownership bypass as a side effect, because every caller of this method hands the

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/model/DeviceCatalogEntry.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/model/DeviceCatalogEntry.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet.model;
+
+/**
+ * One entry from the read-only device catalogue ({@code DeviceRegistry}) — id/label/min/max
+ * width, exactly as {@code DeviceRegistry.getDevices()} reports it. Global Constraint 7: this
+ * plugin family reads the catalogue but never writes to it, so there is no corresponding "create
+ * a device" model or tool.
+ */
+public record DeviceCatalogEntry(String id, String label, int minWidth, int maxWidth) {
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/model/LayoutModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/model/LayoutModel.java
@@ -1,0 +1,31 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet.model;
+
+import java.util.List;
+
+/**
+ * One print or device layout, as the agent sees it — {@code get_layout}'s full response.
+ *
+ * <p>{@code mobileOnly}/{@code selectedDevices} are {@code null} for a print layout ({@code type
+ * == "print"}) — those fields exist only on a {@code ViewsheetLayout} (a device layout), never on
+ * a {@code PrintLayout}.
+ */
+public record LayoutModel(String name, String type, Boolean mobileOnly,
+                           List<String> selectedDevices, List<LayoutObjectModel> objects) {
+}

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/model/LayoutObjectModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/model/LayoutObjectModel.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet.model;
+
+/**
+ * One object's placement inside a layout, reported in <b>both</b> coordinate spaces so a caller
+ * can tell them apart:
+ *
+ * <ul>
+ *   <li>{@code layoutX/Y/Width/Height} — where this layout places the object, read directly off
+ *   the layout's own {@code VSAssemblyLayout} entry.</li>
+ *   <li>{@code viewsheetX/Y/Width/Height} — where the <b>same</b> assembly currently sits on the
+ *   live (Master) viewsheet, read off the master, never a layout preview clone — independent of
+ *   whatever this or any other layout says, and 0 for a layout-only object (e.g. a Text/Image/
+ *   PageBreak object that exists only inside this layout and has no assembly on the viewsheet at
+ *   all).</li>
+ * </ul>
+ */
+public record LayoutObjectModel(String name, int layoutX, int layoutY, int layoutWidth,
+                                int layoutHeight, int viewsheetX, int viewsheetY,
+                                int viewsheetWidth, int viewsheetHeight,
+                                boolean supportsTableLayout) {
+}

--- a/core/src/test/java/inetsoft/web/wiz/pairing/SheetSessionServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/pairing/SheetSessionServiceTest.java
@@ -92,6 +92,25 @@ class SheetSessionServiceTest {
       assertNull(svcLater.resolve(token, "alice~;~org"));
    }
 
+   /**
+    * {@code isLive} is a pure presence+non-expiry check with NO owner match -- unlike
+    * {@code resolve}, it exists for internal cleanup callers (e.g. a sibling service's own
+    * scheduled sweep) that have no {@code Principal} to check against and no need for one.
+    */
+   @Test
+   void isLiveIgnoresOwnerButRespectsPresenceAndExpiry() {
+      SheetSessionService svc = serviceAt(FIXED_NOW);
+      JoinSession session = svc.open("rt-live", "alice~;~org", SheetType.WORKSHEET, null, null, null);
+      String token = session.sessionToken();
+
+      assertTrue(svc.isLive(token), "a fresh session must be live");
+      assertFalse(svc.isLive("NONEXISTENT_TOKEN"), "an unknown token is never live");
+
+      SheetSessionService svcLater = new SheetSessionService(
+         () -> FIXED_NOW + SheetSessionService.TTL_MILLIS + 1, svc);
+      assertFalse(svcLater.isLive(token), "isLive must respect expiry just like resolve does");
+   }
+
    @Test
    void resolveRefreshesTtl() {
       long[] clock = { FIXED_NOW };

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/LayoutMutationServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/LayoutMutationServiceTest.java
@@ -1,0 +1,344 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.viewsheet.TableVSAssembly;
+import inetsoft.uql.viewsheet.TextVSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.vslayout.LayoutInfo;
+import inetsoft.uql.viewsheet.vslayout.PrintInfo;
+import inetsoft.uql.viewsheet.vslayout.PrintLayout;
+import inetsoft.uql.viewsheet.vslayout.VSAssemblyLayout;
+import inetsoft.web.composer.vs.controller.VSLayoutControllerServiceProxy;
+import inetsoft.web.composer.vs.controller.VSLayoutService;
+import inetsoft.web.viewsheet.DataTipInLayoutCheckResult;
+import inetsoft.web.wiz.pairing.TestPrincipals;
+import inetsoft.web.wiz.pairing.WizAgentTestSupport;
+import org.junit.jupiter.api.Test;
+
+import java.awt.Dimension;
+import java.awt.Point;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Phase 3 of the layout implementation plan (2026-08-20-layout-implementation.md), Task 4:
+ * {@code edit_layout_objects}/{@code set_layout_table_options}.
+ *
+ * <p>Uses a REAL {@link LayoutSessionService} (mocked only at the {@code ViewsheetSessionService}/
+ * {@code ViewsheetService} boundary, exactly like {@code LayoutSessionServiceTest}'s own fixture)
+ * rather than a mock, so the Hazard-1 re-assertion below actually exercises {@code mutateLayout}'s
+ * real clone-mint-and-checkpoint mechanism from this task's own entry point -- proving this task
+ * calls it correctly, not just that the mechanism works in isolation (Task 1 already proved that).
+ */
+@WizAgentTestSupport
+class LayoutMutationServiceTest {
+   private static final Principal AGENT = TestPrincipals.user("alice", "host-org");
+   private static final String PRINT_LAYOUT = "Print Layout";
+
+   /**
+    * The coordinate-space test: moving/resizing "Table1" through {@code edit_layout_objects}
+    * updates the layout-space reading ({@link LayoutReadService#get}, off the master's
+    * {@code LayoutInfo}) but leaves that same object's viewsheet-space reading -- its real
+    * {@code pixelOffset}/{@code pixelSize} on the master -- exactly as it was.
+    */
+   @Test
+   void moveResizeUpdatesLayoutSpaceButNotViewsheetSpace() throws Exception {
+      Fixture fx = new Fixture();
+      fx.installPrintLayout();
+
+      Point viewsheetPosBefore = fx.masterTable.getPixelOffset();
+      Dimension viewsheetSizeBefore = fx.masterTable.getPixelSize();
+
+      Map<String, Object> result = fx.service.editObjects("tok1", AGENT, PRINT_LAYOUT, "move_resize",
+         VSLayoutService.CONTENT,
+         List.of(Map.of("name", "Table1", "x", 555, "y", 666, "width", 70, "height", 80)), false);
+
+      assertEquals(false, result.get("requiresConfirmation"));
+
+      LayoutObjectModelHolder table = fx.readTableObject();
+      assertEquals(555, table.layoutX());
+      assertEquals(666, table.layoutY());
+      assertEquals(70, table.layoutWidth());
+      assertEquals(80, table.layoutHeight());
+
+      assertEquals(viewsheetPosBefore, fx.masterTable.getPixelOffset(),
+                   "the master's own assembly pixel position must be untouched by a layout edit");
+      assertEquals(viewsheetSizeBefore, fx.masterTable.getPixelSize(),
+                   "the master's own assembly pixel size must be untouched by a layout edit");
+   }
+
+   /**
+    * The Hazard-1 exit criterion again, from this task's own entry point (not just
+    * {@code LayoutSessionServiceTest}'s unit test in isolation) -- a full {@code
+    * edit_layout_objects} call through {@code LayoutMutationService} leaves the master runtime's
+    * {@code Viewsheet} untouched: same layout-position bookkeeping, same per-format
+    * {@code RScaleFont}, on an assembly the edit did not even target.
+    */
+   @Test
+   void editObjectsNeverTouchesTheMasterViewsheetsRuntimeState() throws Exception {
+      Fixture fx = new Fixture();
+      fx.installPrintLayout();
+
+      Point masterLayoutPositionBefore =
+         fx.masterText.getVSAssemblyInfo().getLayoutPosition();
+      Point masterPixelOffsetBefore = fx.masterText.getPixelOffset();
+      float masterFormatScaleBefore =
+         fx.masterText.getVSAssemblyInfo().getFormat().getRScaleFont();
+      float masterTopLevelScaleBefore = fx.masterVs.getRScaleFont();
+
+      fx.service.editObjects("tok1", AGENT, PRINT_LAYOUT, "move_resize", VSLayoutService.CONTENT,
+         List.of(Map.of("name", "Table1", "x", 1, "y", 2, "width", 3, "height", 4)), false);
+
+      // Re-resolve the master INDEPENDENTLY -- a fresh call into the mocked
+      // ViewsheetSessionService, not anything the call above handed back.
+      RuntimeViewsheet masterAfter = fx.viewsheetSessions.resolve("tok1", AGENT);
+      TextVSAssembly textAfter = (TextVSAssembly) masterAfter.getViewsheet().getAssembly("Text1");
+
+      assertEquals(masterLayoutPositionBefore, textAfter.getVSAssemblyInfo().getLayoutPosition(),
+                   "an assembly the edit did not target must keep its layout-position bookkeeping");
+      assertEquals(masterPixelOffsetBefore, textAfter.getPixelOffset(),
+                   "the master's own assembly pixel position must be untouched");
+      assertEquals(masterFormatScaleBefore, textAfter.getVSAssemblyInfo().getFormat().getRScaleFont(),
+                   "the master's own per-assembly RScaleFont must be untouched");
+      assertEquals(masterTopLevelScaleBefore, masterAfter.getViewsheet().getRScaleFont(),
+                   "the master's own top-level RScaleFont must be untouched");
+   }
+
+   @Test
+   void removeWithADataTipDependencyRequiresConfirmationAndDoesNotRemove() throws Exception {
+      Fixture fx = new Fixture();
+      fx.installPrintLayout();
+      when(fx.vsLayoutControllerService.checkAssemblyInLayout(eq("master-1"), eq(PRINT_LAYOUT),
+                                                              eq("Table1"), eq(AGENT)))
+         .thenReturn(DataTipInLayoutCheckResult.builder().isAssemblyInLayout(true).build());
+
+      Map<String, Object> result = fx.service.editObjects("tok1", AGENT, PRINT_LAYOUT, "remove",
+         VSLayoutService.CONTENT, List.of(Map.of("name", "Table1")), false);
+
+      assertEquals(true, result.get("requiresConfirmation"));
+      assertNotNull(result.get("reason"));
+      assertEquals(List.of("Table1"), result.get("objectNames"));
+
+      // The underlying remove was never reached: no clone was even minted for the attempt.
+      verify(fx.viewsheetService, never())
+         .openTemporaryViewsheet(anyString(), any(AssetEntry.class), eq(AGENT));
+      assertTrue(fx.printLayoutObjectNames().contains("Table1"),
+                 "a blocked remove must leave the layout's object list untouched");
+   }
+
+   @Test
+   void removeWithConfirmedTrueProceedsPastTheDataTipGuard() throws Exception {
+      Fixture fx = new Fixture();
+      fx.installPrintLayout();
+      when(fx.vsLayoutControllerService.checkAssemblyInLayout(anyString(), anyString(), anyString(),
+                                                              eq(AGENT)))
+         .thenReturn(DataTipInLayoutCheckResult.builder().isAssemblyInLayout(true).build());
+
+      Map<String, Object> result = fx.service.editObjects("tok1", AGENT, PRINT_LAYOUT, "remove",
+         VSLayoutService.CONTENT, List.of(Map.of("name", "Table1")), true);
+
+      assertEquals(false, result.get("requiresConfirmation"));
+      assertFalse(fx.printLayoutObjectNames().contains("Table1"),
+                  "confirmed: true must proceed with the removal");
+      // The guard itself must not even be consulted once already confirmed.
+      verify(fx.vsLayoutControllerService, never())
+         .checkAssemblyInLayout(anyString(), anyString(), anyString(), any());
+   }
+
+   @Test
+   void removeWithNoDependencySucceedsCleanlyWithoutConfirmation() throws Exception {
+      Fixture fx = new Fixture();
+      fx.installPrintLayout();
+      when(fx.vsLayoutControllerService.checkAssemblyInLayout(anyString(), anyString(), anyString(),
+                                                              eq(AGENT)))
+         .thenReturn(DataTipInLayoutCheckResult.builder().isAssemblyInLayout(false).build());
+
+      Map<String, Object> result = fx.service.editObjects("tok1", AGENT, PRINT_LAYOUT, "remove",
+         VSLayoutService.CONTENT, List.of(Map.of("name", "Table1")), false);
+
+      assertEquals(false, result.get("requiresConfirmation"));
+      assertFalse(fx.printLayoutObjectNames().contains("Table1"));
+   }
+
+   @Test
+   void setLayoutTableOptionsRefusedForAnObjectThatDoesNotSupportIt() throws Exception {
+      Fixture fx = new Fixture();
+      fx.installPrintLayout();
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> fx.service.setTableLayoutOptions("tok1", AGENT, PRINT_LAYOUT, "Text1",
+                                                 VSLayoutService.CONTENT, 1));
+
+      assertTrue(thrown.getMessage().contains("Text1"), thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("supportsTableLayout"), thrown.getMessage());
+      // Refused before any service call: no clone minted, no checkpoint attempted.
+      verify(fx.viewsheetService, never())
+         .openTemporaryViewsheet(anyString(), any(AssetEntry.class), eq(AGENT));
+   }
+
+   @Test
+   void setLayoutTableOptionsSucceedsForATableObject() throws Exception {
+      Fixture fx = new Fixture();
+      fx.installPrintLayout();
+
+      fx.service.setTableLayoutOptions("tok1", AGENT, PRINT_LAYOUT, "Table1",
+                                        VSLayoutService.CONTENT, 2);
+
+      VSAssemblyLayout tableLayout = fx.printLayoutObject("Table1");
+      assertEquals(2, tableLayout.getTableLayout());
+   }
+
+   // ── fixture ───────────────────────────────────────────────────────────────
+
+   /**
+    * Wires one {@code LayoutMutationService} against a REAL {@code LayoutSessionService}/
+    * {@code VSLayoutService} (mocked only at the {@code ViewsheetSessionService}/
+    * {@code ViewsheetService} boundary -- the same fixture shape {@code LayoutSessionServiceTest}
+    * uses) and a mocked {@code VSLayoutControllerServiceProxy} (the data-tip guard's only
+    * dependency, a pure read this class calls directly against the master).
+    */
+   private static final class Fixture {
+      final ViewsheetSessionService viewsheetSessions = mock(ViewsheetSessionService.class);
+      final ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      final VSLayoutService vsLayoutService = new VSLayoutService();
+      final VSLayoutControllerServiceProxy vsLayoutControllerService =
+         mock(VSLayoutControllerServiceProxy.class);
+      final LayoutSessionService layoutSessions =
+         new LayoutSessionService(viewsheetSessions, viewsheetService, vsLayoutService);
+      final LayoutMutationService service = new LayoutMutationService(
+         layoutSessions, viewsheetSessions, vsLayoutService, vsLayoutControllerService);
+
+      final Viewsheet masterVs = new Viewsheet();
+      final TextVSAssembly masterText = new TextVSAssembly(masterVs, "Text1");
+      final TableVSAssembly masterTable = new TableVSAssembly(masterVs, "Table1");
+      final RuntimeViewsheet masterRvs = spy(new RuntimeViewsheet());
+      final AssetEntry masterEntry = mock(AssetEntry.class);
+
+      private int cloneCounter;
+
+      Fixture() throws Exception {
+         masterText.setPixelOffset(new Point(10, 20));
+         masterText.setPixelSize(new Dimension(15, 10));
+         masterVs.addAssembly(masterText);
+
+         masterTable.setPixelOffset(new Point(50, 60));
+         masterTable.setPixelSize(new Dimension(80, 40));
+         masterVs.addAssembly(masterTable);
+
+         doReturn(masterVs).when(masterRvs).getViewsheet();
+         doReturn("master-1").when(masterRvs).getID();
+         doReturn(masterEntry).when(masterRvs).getEntry();
+         when(masterEntry.clone()).thenReturn(masterEntry);
+         when(viewsheetSessions.resolve(eq("tok1"), eq(AGENT))).thenReturn(masterRvs);
+
+         when(viewsheetService.openTemporaryViewsheet(anyString(), any(AssetEntry.class), eq(AGENT)))
+            .thenAnswer(inv -> {
+               String id = "clone-" + (++cloneCounter);
+               RuntimeViewsheet clone = spy(new RuntimeViewsheet());
+
+               // A genuinely separate object graph from master's -- see LayoutSessionServiceTest's
+               // fixture doc for why this matters. LayoutMutationService's own mutations never
+               // read/write the clone's content (they operate on master's LayoutInfo directly, per
+               // this class's own class doc), so a minimal same-shape stand-in is enough here.
+               Viewsheet initialCloneVs = new Viewsheet();
+               TextVSAssembly cloneText = new TextVSAssembly(initialCloneVs, "Text1");
+               cloneText.setPixelOffset(new Point(10, 20));
+               initialCloneVs.addAssembly(cloneText);
+               TableVSAssembly cloneTable = new TableVSAssembly(initialCloneVs, "Table1");
+               cloneTable.setPixelOffset(new Point(50, 60));
+               initialCloneVs.addAssembly(cloneTable);
+
+               Viewsheet[] cloneVsHolder = { initialCloneVs };
+               doAnswer(getVs -> cloneVsHolder[0]).when(clone).getViewsheet();
+               doAnswer(setVs -> {
+                  cloneVsHolder[0] = setVs.getArgument(0);
+                  return null;
+               }).when(clone).setViewsheet(any());
+               doReturn(id).when(clone).getID();
+
+               when(viewsheetService.getViewsheet(eq(id), eq(AGENT))).thenReturn(clone);
+               return id;
+            });
+
+         doAnswer(inv -> {
+            String flushedId = inv.getArgument(0);
+            when(viewsheetService.getViewsheet(eq(flushedId), any()))
+               .thenThrow(new IllegalStateException("runtime " + flushedId + " has been flushed"));
+            return null;
+         }).when(viewsheetService).flushRuntimeSheet(anyString());
+      }
+
+      /**
+       * A real print layout with a Text object (does not support table layout) and a Table
+       * object (does), each placed at a distinct layout position from its own master/viewsheet
+       * position -- mirrors {@code LayoutReadServiceTest}'s fixture.
+       */
+      void installPrintLayout() {
+         LayoutInfo info = new LayoutInfo();
+         PrintLayout layout = new PrintLayout();
+         layout.setPrintInfo(new PrintInfo("Letter", new inetsoft.graph.internal.DimensionD(8.5, 11),
+                                            0.5f, 0.5f, 0.5f, 0.5f, "inches"));
+         List<VSAssemblyLayout> objects = new ArrayList<>();
+         objects.add(new VSAssemblyLayout("Text1", new Point(100, 200), new Dimension(30, 40)));
+         objects.add(new VSAssemblyLayout("Table1", new Point(300, 400), new Dimension(50, 60)));
+         layout.setVSAssemblyLayouts(objects);
+         info.setPrintLayout(layout);
+         masterVs.setLayoutInfo(info);
+      }
+
+      List<String> printLayoutObjectNames() {
+         List<String> names = new ArrayList<>();
+
+         for(VSAssemblyLayout layout : masterVs.getLayoutInfo().getPrintLayout()
+            .getVSAssemblyLayouts())
+         {
+            names.add(layout.getName());
+         }
+
+         return names;
+      }
+
+      VSAssemblyLayout printLayoutObject(String name) {
+         return masterVs.getLayoutInfo().getPrintLayout().getVSAssemblyLayouts().stream()
+            .filter(l -> l.getName().equals(name))
+            .findFirst()
+            .orElseThrow();
+      }
+
+      /** Reads "Table1"'s layout-space geometry straight off the master's LayoutInfo. */
+      LayoutObjectModelHolder readTableObject() {
+         VSAssemblyLayout layout = printLayoutObject("Table1");
+         return new LayoutObjectModelHolder(layout.getPosition().x, layout.getPosition().y,
+                                             layout.getSize().width, layout.getSize().height);
+      }
+   }
+
+   private record LayoutObjectModelHolder(int layoutX, int layoutY, int layoutWidth,
+                                           int layoutHeight) {
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/LayoutReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/LayoutReadServiceTest.java
@@ -1,0 +1,242 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.graph.internal.DimensionD;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.TableVSAssembly;
+import inetsoft.uql.viewsheet.TextVSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.vslayout.*;
+import inetsoft.util.Catalog;
+import inetsoft.web.composer.vs.controller.VSLayoutService;
+import inetsoft.web.wiz.pairing.TestPrincipals;
+import inetsoft.web.wiz.pairing.WizAgentTestSupport;
+import inetsoft.web.wiz.viewsheet.model.DeviceCatalogEntry;
+import inetsoft.web.wiz.viewsheet.model.LayoutModel;
+import inetsoft.web.wiz.viewsheet.model.LayoutObjectModel;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.awt.Dimension;
+import java.awt.Point;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Phase 1 of the layout implementation plan (2026-08-20-layout-implementation.md), Task 2:
+ * {@code list_layouts}/{@code get_layout}. A pure projection -- this service never mints or
+ * mutates anything, so Hazard 1 does not apply here the way it does to the mutation tasks; the
+ * test that matters instead is that {@code get_layout} reports a layout object's two coordinate
+ * spaces (layout position/size vs. the same object's live viewsheet position/size) as genuinely
+ * independent readings, and that the device catalogue/{@code editDevicesAllowed} pass through
+ * {@link DeviceRegistry} unmodified rather than being re-derived.
+ */
+@WizAgentTestSupport
+class LayoutReadServiceTest {
+   private static final Principal AGENT = TestPrincipals.user("alice", "host-org");
+   private static final String PRINT_LAYOUT = Catalog.getCatalog().getString("Print Layout");
+
+   @Test
+   void listReportsEveryLayoutAndThePassThroughDeviceCatalogue() throws Exception {
+      Fixture fx = new Fixture();
+      fx.installPrintLayout();
+      fx.installDeviceLayout("Phone", true, "wiz-mobile");
+
+      try(MockedStatic<DeviceRegistry> registryStatic = mockStatic(DeviceRegistry.class)) {
+         registryStatic.when(() -> DeviceRegistry.isOrgAllowedToEditDevices(AGENT))
+            .thenReturn(true);
+
+         Map<String, Object> result = fx.service.list("tok1", AGENT);
+
+         @SuppressWarnings("unchecked")
+         List<Map<String, Object>> layouts = (List<Map<String, Object>>) result.get("layouts");
+         assertEquals(2, layouts.size());
+
+         Map<String, Object> print = layouts.stream()
+            .filter(l -> PRINT_LAYOUT.equals(l.get("name"))).findFirst().orElseThrow();
+         assertEquals("print", print.get("type"));
+
+         Map<String, Object> device = layouts.stream()
+            .filter(l -> "Phone".equals(l.get("name"))).findFirst().orElseThrow();
+         assertEquals("device", device.get("type"));
+         assertEquals(true, device.get("mobileOnly"));
+         assertEquals(List.of("wiz-mobile"), device.get("selectedDevices"));
+
+         // devices/editDevicesAllowed come through DeviceRegistry unmodified, not re-derived.
+         @SuppressWarnings("unchecked")
+         List<DeviceCatalogEntry> devices = (List<DeviceCatalogEntry>) result.get("devices");
+         assertEquals(List.of(new DeviceCatalogEntry("wiz-mobile", "Wiz Mobile", 0, 767)),
+                      devices);
+         assertEquals(true, result.get("editDevicesAllowed"));
+      }
+   }
+
+   @Test
+   void listReportsNoLayoutsOnAFreshViewsheetRatherThanFailing() throws Exception {
+      Fixture fx = new Fixture();
+      // No installPrintLayout()/installDeviceLayout() call -- a brand-new Viewsheet's LayoutInfo
+      // has no print layout configured yet and an empty device-layout list.
+
+      try(MockedStatic<DeviceRegistry> registryStatic = mockStatic(DeviceRegistry.class)) {
+         registryStatic.when(() -> DeviceRegistry.isOrgAllowedToEditDevices(AGENT))
+            .thenReturn(false);
+
+         Map<String, Object> result = fx.service.list("tok1", AGENT);
+
+         assertTrue(((List<?>) result.get("layouts")).isEmpty());
+         assertEquals(false, result.get("editDevicesAllowed"));
+      }
+   }
+
+   @Test
+   void getReportsBothCoordinateSpacesAndSupportsTableLayoutOnlyForTheTableObject()
+      throws Exception
+   {
+      Fixture fx = new Fixture();
+      fx.installPrintLayout();
+
+      LayoutModel model = fx.service.get("tok1", AGENT, PRINT_LAYOUT);
+
+      assertEquals(PRINT_LAYOUT, model.name());
+      assertEquals("print", model.type());
+      assertNull(model.mobileOnly(), "a print layout has no mobileOnly flag");
+      assertNull(model.selectedDevices(), "a print layout has no device selection");
+      assertEquals(2, model.objects().size());
+
+      LayoutObjectModel text = model.objects().stream()
+         .filter(o -> "Text1".equals(o.name())).findFirst().orElseThrow();
+      // Text1 was moved in the LAYOUT only (installPrintLayout places it at (100, 200)) -- the
+      // viewsheet-space reading must still be its untouched master position (10, 20). If this
+      // service ever conflated the two, or read viewsheet-space off a layout-applied clone
+      // instead of the master, this would silently start reporting (100, 200) here too.
+      assertEquals(100, text.layoutX());
+      assertEquals(200, text.layoutY());
+      assertEquals(30, text.layoutWidth());
+      assertEquals(40, text.layoutHeight());
+      assertEquals(10, text.viewsheetX());
+      assertEquals(20, text.viewsheetY());
+      assertFalse(text.supportsTableLayout(), "a Text object does not support table layout");
+
+      LayoutObjectModel table = model.objects().stream()
+         .filter(o -> "Table1".equals(o.name())).findFirst().orElseThrow();
+      assertEquals(300, table.layoutX());
+      assertEquals(400, table.layoutY());
+      assertEquals(50, table.viewsheetX());
+      assertEquals(60, table.viewsheetY());
+      assertTrue(table.supportsTableLayout(),
+                 "a TableDataVSAssembly-backed object supports table layout");
+   }
+
+   @Test
+   void getValidatesTheLayoutNameThroughLayoutSessionService() throws Exception {
+      Fixture fx = new Fixture();
+      fx.installPrintLayout();
+      when(fx.layoutSessions.resolveForRead(eq("tok1"), eq(AGENT), eq("Does Not Exist")))
+         .thenThrow(new IllegalArgumentException(
+            "Unknown layout \"Does Not Exist\" -- call list_layouts to see the print and " +
+            "device layouts defined on this viewsheet."));
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> fx.service.get("tok1", AGENT, "Does Not Exist"));
+
+      assertTrue(thrown.getMessage().contains("Does Not Exist"), thrown.getMessage());
+   }
+
+   // ── fixture ───────────────────────────────────────────────────────────────
+
+   /**
+    * Wires one {@code LayoutReadService} against a mocked {@code ViewsheetSessionService}/
+    * {@code LayoutSessionService}/{@code DeviceRegistry} and a real {@code VSLayoutService},
+    * backed by a real master {@code Viewsheet}.
+    */
+   private static final class Fixture {
+      final ViewsheetSessionService viewsheetSessions = mock(ViewsheetSessionService.class);
+      final LayoutSessionService layoutSessions = mock(LayoutSessionService.class);
+      final VSLayoutService vsLayoutService = new VSLayoutService();
+      final DeviceRegistry deviceRegistry = mock(DeviceRegistry.class);
+      final LayoutReadService service =
+         new LayoutReadService(viewsheetSessions, layoutSessions, vsLayoutService, deviceRegistry);
+
+      final Viewsheet masterVs = new Viewsheet();
+      final RuntimeViewsheet masterRvs = mock(RuntimeViewsheet.class);
+
+      Fixture() throws Exception {
+         when(masterRvs.getViewsheet()).thenReturn(masterVs);
+         when(viewsheetSessions.resolve(eq("tok1"), eq(AGENT))).thenReturn(masterRvs);
+         // resolveForRead's own clone content is never used by LayoutReadService -- both
+         // coordinate-space readings come off the master directly (see the class doc) -- so a
+         // bare mock standing in for "the layout name is known" is enough here.
+         when(layoutSessions.resolveForRead(anyString(), eq(AGENT), anyString()))
+            .thenReturn(mock(RuntimeViewsheet.class));
+
+         DeviceInfo mobile = new DeviceInfo();
+         mobile.setId("wiz-mobile");
+         mobile.setName("Wiz Mobile");
+         mobile.setMinWidth(0);
+         mobile.setMaxWidth(767);
+         when(deviceRegistry.getDevices()).thenReturn(new DeviceInfo[] { mobile });
+      }
+
+      /**
+       * A real print layout with a Text object (does not support table layout) and a Table
+       * object (does), each placed at a distinct layout position from its own master/viewsheet
+       * position -- the fixture data the coordinate-space-independence test depends on.
+       */
+      void installPrintLayout() {
+         TextVSAssembly text = new TextVSAssembly(masterVs, "Text1");
+         text.setPixelOffset(new Point(10, 20));
+         text.setPixelSize(new Dimension(15, 10));
+         masterVs.addAssembly(text);
+
+         TableVSAssembly table = new TableVSAssembly(masterVs, "Table1");
+         table.setPixelOffset(new Point(50, 60));
+         table.setPixelSize(new Dimension(80, 40));
+         masterVs.addAssembly(table);
+
+         PrintLayout layout = new PrintLayout();
+         layout.setPrintInfo(new PrintInfo("Letter", new DimensionD(8.5, 11),
+                                            0.5f, 0.5f, 0.5f, 0.5f, "inches"));
+         List<VSAssemblyLayout> objects = new ArrayList<>();
+         objects.add(new VSAssemblyLayout("Text1", new Point(100, 200), new Dimension(30, 40)));
+         objects.add(new VSAssemblyLayout("Table1", new Point(300, 400), new Dimension(50, 60)));
+         layout.setVSAssemblyLayouts(objects);
+
+         masterVs.getLayoutInfo().setPrintLayout(layout);
+      }
+
+      /** Adds a real device (viewsheet) layout named {@code name} to the master's LayoutInfo. */
+      void installDeviceLayout(String name, boolean mobileOnly, String... deviceIds) {
+         LayoutInfo info = masterVs.getLayoutInfo();
+         ViewsheetLayout layout = new ViewsheetLayout();
+         layout.setName(name);
+         layout.setMobileOnly(mobileOnly);
+         layout.setDeviceIds(deviceIds);
+         layout.setVSAssemblyLayouts(new ArrayList<>());
+         List<ViewsheetLayout> layouts = new ArrayList<>(info.getViewsheetLayouts());
+         layouts.add(layout);
+         info.setViewsheetLayouts(layouts);
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/LayoutSessionServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/LayoutSessionServiceTest.java
@@ -186,6 +186,38 @@ class LayoutSessionServiceTest {
       verify(fx.viewsheetService, never()).flushRuntimeSheet(cloneIdTok2);
    }
 
+   /**
+    * A read-triggered switch (the shape {@code LayoutReadService.get} produces via
+    * {@link LayoutSessionService#resolveForRead}) must reset the master's layout undo/redo stack
+    * just as a mutation-triggered switch does -- otherwise a later {@code layout_undo}/
+    * {@code layout_redo} call on the newly-focused layout would consult stale checkpoints that
+    * belong to whatever layout was previously focused (Hazard 2), and -- for a switch between a
+    * print layout and a device layout specifically -- {@code updateVSLayouts} would try to cast a
+    * stale {@code PrintLayout} checkpoint to {@code ViewsheetLayout} (or vice versa) and throw
+    * {@code ClassCastException}. {@code resolveForRead} must NOT go on to seed a fresh baseline
+    * checkpoint the way a mutation-triggered switch does, though -- a read must never manufacture
+    * an undo step of its own.
+    */
+   @Test
+   void aReadTriggeredSwitchResetsTheUndoStackWithoutSeedingABaseline() throws Exception {
+      Fixture fx = new Fixture();
+      fx.installNamedLayout("A");
+      fx.installNamedLayout("B");
+
+      fx.service.mutateLayout("tok1", AGENT, "A", (clone, master, cloneRuntimeId, dispatcher) -> {});
+      assertEquals(2, fx.masterRvs.getLayoutPointsSize(),
+                   "sanity check: mint seeds one baseline, then mutateLayout's own " +
+                   "makeUndoable call always appends a second checkpoint after the mutation runs");
+
+      RuntimeViewsheet cloneB = fx.service.resolveForRead("tok1", AGENT, "B");
+
+      assertNotNull(cloneB);
+      assertEquals(0, fx.masterRvs.getLayoutPointsSize(),
+                   "a read-triggered switch to B must reset the stack, not merely leave A's " +
+                   "checkpoint in place");
+      assertEquals(-1, fx.masterRvs.getLayoutPoint());
+   }
+
    /** An unknown layout name fails loud, before any clone is minted or cached. */
    @Test
    void mutateLayoutOnAnUnknownLayoutNameFailsLoud() throws Exception {

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/LayoutSessionServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/LayoutSessionServiceTest.java
@@ -187,6 +187,43 @@ class LayoutSessionServiceTest {
    }
 
    /**
+    * {@code disposeAll} alone only fires on an explicit {@code detach_sheet} call. A session that
+    * instead goes idle past its TTL -- an agent that finishes and simply stops, or crashes --
+    * is reaped by {@code SheetSessionService.evictExpired()}, which has no knowledge of this
+    * class's own {@code clones} map. Without {@code evictOrphanedClones}, that path would leave a
+    * live {@code RuntimeViewsheet} runtime cached forever under a token nothing will ever resolve
+    * again -- a real leak, heavier than a small map entry.
+    */
+   @Test
+   void evictOrphanedClonesFlushesACloneWhoseOwningSessionIsNoLongerLive() throws Exception {
+      Fixture fx = new Fixture();
+      fx.installPrintLayout();
+
+      fx.service.mutateLayout("tok1", AGENT, PRINT_LAYOUT, (clone, master, cloneRuntimeId, dispatcher) -> {});
+      String cloneId = fx.lastMintedCloneId();
+      when(fx.viewsheetSessions.isSessionLive("tok1")).thenReturn(false);
+
+      fx.service.evictOrphanedClones();
+
+      verify(fx.viewsheetService).flushRuntimeSheet(cloneId);
+   }
+
+   /** The sweep must not flush a clone whose owning session is still alive and well. */
+   @Test
+   void evictOrphanedClonesLeavesALiveSessionsCloneAlone() throws Exception {
+      Fixture fx = new Fixture();
+      fx.installPrintLayout();
+
+      fx.service.mutateLayout("tok1", AGENT, PRINT_LAYOUT, (clone, master, cloneRuntimeId, dispatcher) -> {});
+      String cloneId = fx.lastMintedCloneId();
+      when(fx.viewsheetSessions.isSessionLive("tok1")).thenReturn(true);
+
+      fx.service.evictOrphanedClones();
+
+      verify(fx.viewsheetService, never()).flushRuntimeSheet(cloneId);
+   }
+
+   /**
     * A read-triggered switch (the shape {@code LayoutReadService.get} produces via
     * {@link LayoutSessionService#resolveForRead}) must reset the master's layout undo/redo stack
     * just as a mutation-triggered switch does -- otherwise a later {@code layout_undo}/

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/LayoutSessionServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/LayoutSessionServiceTest.java
@@ -1,0 +1,317 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.viewsheet.TextVSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.vslayout.LayoutInfo;
+import inetsoft.uql.viewsheet.vslayout.PrintInfo;
+import inetsoft.uql.viewsheet.vslayout.PrintLayout;
+import inetsoft.uql.viewsheet.vslayout.ViewsheetLayout;
+import inetsoft.web.composer.vs.controller.VSLayoutService;
+import inetsoft.web.wiz.pairing.TestPrincipals;
+import inetsoft.web.wiz.pairing.WizAgentTestSupport;
+import org.junit.jupiter.api.Test;
+
+import java.awt.Point;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Phase 0 of the layout implementation plan (2026-08-20-layout-implementation.md): every later
+ * layout tool resolves its runtime through this service, and none of them may start until the
+ * Hazard-1 exit criterion below passes -- a layout edit must never mutate the paired session's
+ * own (Master) {@code Viewsheet} as a side effect.
+ *
+ * <p>Mocks {@code RuntimeViewsheet} directly for identity/id-level behavior (getID, getEntry,
+ * setOriginalID -- none of which this service's own tests need to be "real"), but uses REAL
+ * {@code Viewsheet}/{@code LayoutInfo}/{@code PrintLayout}/{@code ViewsheetLayout} objects, since
+ * those are what {@code AbstractLayout.apply(Viewsheet)} actually operates on and the whole point
+ * of the exit-criterion test is observing what that real method does to real objects. A bare
+ * {@code new RuntimeViewsheet()} has a working layout-undo-stack ({@code layoutPoints}/
+ * {@code layoutPoint} are field-initialized, not constructor-initialized) but a {@code null box},
+ * which makes the real {@code setViewsheet}/{@code setOriginalID} silently no-op -- so
+ * {@code getViewsheet}/{@code setViewsheet} are stubbed with a mutable holder (real behavior,
+ * simulated), while {@code resetLayoutUndoRedo}/{@code addLayoutCheckPoint}/
+ * {@code getLayoutPointsSize} are left as genuine, unstubbed calls on the spy.
+ */
+@WizAgentTestSupport
+class LayoutSessionServiceTest {
+   private static final Principal AGENT = TestPrincipals.user("alice", "host-org");
+   private static final String PRINT_LAYOUT = "Print Layout";
+
+   /**
+    * The Hazard-1 exit criterion -- first because it's what everything else exists to satisfy.
+    *
+    * <p>Mints a clone for a print layout, runs a mutation that moves the clone's own assembly and
+    * rescales it (exactly what a real layout edit does, and exactly what would corrupt the
+    * master's Master-view rendering if this service handed the mutation the wrong runtime), then
+    * re-resolves the master INDEPENDENTLY (a fresh call to {@code ViewsheetSessionService.resolve},
+    * not reusing anything the mutation touched) and asserts its assembly's layout position, pixel
+    * position, and per-format scale font are byte-for-byte what they were before the call.
+    */
+   @Test
+   void mutationNeverTouchesTheMasterViewsheet() throws Exception {
+      Fixture fx = new Fixture();
+      fx.installPrintLayout();
+
+      Point masterLayoutPositionBefore = fx.masterText.getVSAssemblyInfo().getLayoutPosition();
+      Point masterPixelOffsetBefore = fx.masterText.getPixelOffset();
+      float masterFormatScaleBefore =
+         fx.masterText.getVSAssemblyInfo().getFormat().getRScaleFont();
+
+      fx.service.mutateLayout("tok1", AGENT, PRINT_LAYOUT, (clone, master, cloneRuntimeId, dispatcher) -> {
+         // A real edit: move the clone's own copy of the assembly and rescale it. If this
+         // service ever hands a mutation the master runtime instead of a genuine clone, this is
+         // exactly the kind of call that would silently corrupt the human's Master view.
+         Viewsheet cloneVs = clone.getViewsheet();
+         TextVSAssembly cloneText = (TextVSAssembly) cloneVs.getAssembly("Text1");
+         cloneText.setPixelOffset(new Point(999, 999));
+         cloneText.getVSAssemblyInfo().setLayoutPosition(new Point(999, 999));
+         cloneVs.setRScaleFont(0.25f);
+      });
+
+      // Re-resolve the master INDEPENDENTLY -- a fresh call into the mocked
+      // ViewsheetSessionService, not anything handed to us by mutateLayout above.
+      RuntimeViewsheet masterAfter = fx.viewsheetSessions.resolve("tok1", AGENT);
+      TextVSAssembly masterTextAfter = (TextVSAssembly) masterAfter.getViewsheet().getAssembly("Text1");
+
+      assertEquals(masterLayoutPositionBefore, masterTextAfter.getVSAssemblyInfo().getLayoutPosition(),
+                   "the master's own assembly layout-position must be untouched");
+      assertEquals(masterPixelOffsetBefore, masterTextAfter.getPixelOffset(),
+                   "the master's own assembly pixel position must be untouched");
+      assertEquals(masterFormatScaleBefore,
+                   masterTextAfter.getVSAssemblyInfo().getFormat().getRScaleFont(),
+                   "the master's own per-assembly RScaleFont must be untouched");
+      assertEquals(fx.masterRScaleFontBefore, fx.masterRvs.getViewsheet().getRScaleFont(),
+                   "the master's own top-level RScaleFont must be untouched");
+   }
+
+   /** Two calls for the same (sessionToken, layoutName) reuse one clone, not two. */
+   @Test
+   void reuseResolvesToTheSameCloneRuntimeIdAcrossCalls() throws Exception {
+      Fixture fx = new Fixture();
+      fx.installPrintLayout();
+
+      List<String> seenRuntimeIds = new ArrayList<>();
+      fx.service.mutateLayout("tok1", AGENT, PRINT_LAYOUT,
+                               (clone, master, cloneRuntimeId, dispatcher) ->
+                                  seenRuntimeIds.add(cloneRuntimeId));
+      fx.service.mutateLayout("tok1", AGENT, PRINT_LAYOUT,
+                               (clone, master, cloneRuntimeId, dispatcher) ->
+                                  seenRuntimeIds.add(cloneRuntimeId));
+
+      assertEquals(2, seenRuntimeIds.size());
+      assertEquals(seenRuntimeIds.get(0), seenRuntimeIds.get(1), "must reuse, not mint a second clone");
+      // Minted exactly once: openTemporaryViewsheet is stubbed with a single fixed return value
+      // in the fixture, so a second, distinct call would have returned null and NPE'd instead of
+      // silently passing -- this verify is the direct proof rather than relying on that as a trap.
+      verify(fx.viewsheetService, times(1))
+         .openTemporaryViewsheet(anyString(), any(AssetEntry.class), eq(AGENT));
+      verify(fx.viewsheetService, never()).flushRuntimeSheet(anyString());
+   }
+
+   /**
+    * Switching layouts for the same token flushes the old clone and reseeds the master's layout
+    * undo/redo stack with one baseline checkpoint before the new layout's edit lands.
+    */
+   @Test
+   void switchingLayoutsFlushesTheOldCloneAndResetsTheUndoStack() throws Exception {
+      Fixture fx = new Fixture();
+      fx.installNamedLayout("A");
+      fx.installNamedLayout("B");
+
+      List<String> sizesSeenDuringB = new ArrayList<>();
+      fx.service.mutateLayout("tok1", AGENT, "A", (clone, master, cloneRuntimeId, dispatcher) -> {});
+      String cloneIdForA = fx.lastMintedCloneId();
+
+      assertNotNull(cloneIdForA);
+      verify(fx.viewsheetService, never()).flushRuntimeSheet(anyString());
+
+      fx.service.mutateLayout("tok1", AGENT, "B", (clone, master, cloneRuntimeId, dispatcher) ->
+         sizesSeenDuringB.add(String.valueOf(fx.masterRvs.getLayoutPointsSize())));
+
+      verify(fx.viewsheetService).flushRuntimeSheet(cloneIdForA);
+      assertEquals(List.of("1"), sizesSeenDuringB,
+                   "one baseline checkpoint must already be in place before B's edit runs");
+
+      // A subsequent read against the flushed clone's id fails the way a flushed runtime does --
+      // the fixture wires flushRuntimeSheet to break that id's stub, mirroring the real registry.
+      assertThrows(IllegalStateException.class,
+                   () -> fx.viewsheetService.getViewsheet(cloneIdForA, AGENT));
+   }
+
+   /** {@code disposeAll} flushes every clone open for one token without touching another's. */
+   @Test
+   void disposeAllFlushesOnlyItsOwnTokensClone() throws Exception {
+      Fixture fx = new Fixture();
+      fx.installPrintLayout();
+      // A second token paired to the same master -- disposeAll's isolation is about the
+      // sessionToken key in this service's own cache, not about which master a token points to.
+      when(fx.viewsheetSessions.resolve(eq("tok2"), eq(AGENT))).thenReturn(fx.masterRvs);
+
+      fx.service.mutateLayout("tok1", AGENT, PRINT_LAYOUT, (clone, master, cloneRuntimeId, dispatcher) -> {});
+      String cloneIdTok1 = fx.lastMintedCloneId();
+      fx.service.mutateLayout("tok2", AGENT, PRINT_LAYOUT, (clone, master, cloneRuntimeId, dispatcher) -> {});
+      String cloneIdTok2 = fx.lastMintedCloneId();
+
+      assertNotEquals(cloneIdTok1, cloneIdTok2);
+
+      fx.service.disposeAll("tok1");
+
+      verify(fx.viewsheetService).flushRuntimeSheet(cloneIdTok1);
+      verify(fx.viewsheetService, never()).flushRuntimeSheet(cloneIdTok2);
+   }
+
+   /** An unknown layout name fails loud, before any clone is minted or cached. */
+   @Test
+   void mutateLayoutOnAnUnknownLayoutNameFailsLoud() throws Exception {
+      Fixture fx = new Fixture();
+      fx.installPrintLayout();
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> fx.service.mutateLayout("tok1", AGENT, "Does Not Exist",
+                                        (clone, master, cloneRuntimeId, dispatcher) -> {}));
+
+      assertTrue(thrown.getMessage().contains("Does Not Exist"), thrown.getMessage());
+   }
+
+   // ── fixture ───────────────────────────────────────────────────────────────
+
+   /**
+    * Wires one {@code LayoutSessionService} against a mocked {@code ViewsheetSessionService}/
+    * {@code ViewsheetService} and a real {@code VSLayoutService}, backed by a real master
+    * {@code Viewsheet} with one real {@code TextVSAssembly} ("Text1") and a real
+    * {@code LayoutInfo}.
+    */
+   private static final class Fixture {
+      final ViewsheetSessionService viewsheetSessions = mock(ViewsheetSessionService.class);
+      final ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      final VSLayoutService vsLayoutService = new VSLayoutService();
+      final LayoutSessionService service =
+         new LayoutSessionService(viewsheetSessions, viewsheetService, vsLayoutService);
+
+      final Viewsheet masterVs = new Viewsheet();
+      final TextVSAssembly masterText = new TextVSAssembly(masterVs, "Text1");
+      final RuntimeViewsheet masterRvs = spy(new RuntimeViewsheet());
+      final float masterRScaleFontBefore = 2.5f;
+      final AssetEntry masterEntry = mock(AssetEntry.class);
+
+      private int cloneCounter;
+      private String lastCloneId;
+
+      Fixture() throws Exception {
+         masterText.setPixelOffset(new Point(10, 20));
+         masterVs.addAssembly(masterText);
+         masterVs.setRScaleFont(masterRScaleFontBefore);
+
+         doReturn(masterVs).when(masterRvs).getViewsheet();
+         doReturn("master-1").when(masterRvs).getID();
+         doReturn(masterEntry).when(masterRvs).getEntry();
+         when(masterEntry.clone()).thenReturn(masterEntry);
+         when(viewsheetSessions.resolve(eq("tok1"), eq(AGENT))).thenReturn(masterRvs);
+
+         when(viewsheetService.openTemporaryViewsheet(anyString(), any(AssetEntry.class), eq(AGENT)))
+            .thenAnswer(inv -> {
+               String id = "clone-" + (++cloneCounter);
+               lastCloneId = id;
+               RuntimeViewsheet clone = spy(new RuntimeViewsheet());
+
+               // A genuinely separate object graph, not master's -- mirrors what
+               // openTemporaryViewsheet really does (reload the persisted asset fresh). Same
+               // logical shape (an assembly named "Text1") so a mutation can address it by name,
+               // but a distinct instance, so mutating it can never reach master's.
+               Viewsheet initialCloneVs = new Viewsheet();
+               TextVSAssembly cloneText = new TextVSAssembly(initialCloneVs, "Text1");
+               cloneText.setPixelOffset(new Point(10, 20));
+               initialCloneVs.addAssembly(cloneText);
+
+               Viewsheet[] cloneVsHolder = { initialCloneVs };
+               doAnswer(getVs -> cloneVsHolder[0]).when(clone).getViewsheet();
+               doAnswer(setVs -> {
+                  cloneVsHolder[0] = setVs.getArgument(0);
+                  return null;
+               }).when(clone).setViewsheet(any());
+               doReturn(id).when(clone).getID();
+
+               when(viewsheetService.getViewsheet(eq(id), eq(AGENT))).thenReturn(clone);
+               return id;
+            });
+
+         // Mirrors a flushed runtime: once flushRuntimeSheet(id) is called, a subsequent
+         // getViewsheet(id, ...) fails instead of quietly returning the disposed clone.
+         doAnswer(inv -> {
+            String flushedId = inv.getArgument(0);
+            when(viewsheetService.getViewsheet(eq(flushedId), any()))
+               .thenThrow(new IllegalStateException("runtime " + flushedId + " has been flushed"));
+            return null;
+         }).when(viewsheetService).flushRuntimeSheet(anyString());
+      }
+
+      /** Adds a real, empty {@code PrintLayout} named "Print Layout" to the master's LayoutInfo. */
+      void installPrintLayout() {
+         LayoutInfo info = new LayoutInfo();
+         info.setPrintLayout(newEmptyPrintLayout());
+         masterVs.setLayoutInfo(info);
+      }
+
+      /**
+       * {@code PrintLayout}/{@code AbstractLayout}'s no-arg constructors leave
+       * {@code printInfo}/{@code vsAssemblyLayouts} null -- fine for XML-loaded production
+       * instances (the loader always populates them) but not for one built by hand here, where
+       * {@code clone()}/{@code apply()} would NPE on the un-set fields.
+       */
+      private static PrintLayout newEmptyPrintLayout() {
+         PrintLayout layout = new PrintLayout();
+         layout.setPrintInfo(new PrintInfo("Letter", new inetsoft.graph.internal.DimensionD(8.5, 11),
+                                            0.5f, 0.5f, 0.5f, 0.5f, "inches"));
+         layout.setVSAssemblyLayouts(new ArrayList<>());
+         return layout;
+      }
+
+      /** Adds a real, empty {@code ViewsheetLayout} named {@code name} to the master's LayoutInfo. */
+      void installNamedLayout(String name) {
+         LayoutInfo info = masterVs.getLayoutInfo();
+
+         if(info == null) {
+            info = new LayoutInfo();
+            info.setPrintLayout(newEmptyPrintLayout());
+            masterVs.setLayoutInfo(info);
+         }
+
+         ViewsheetLayout layout = new ViewsheetLayout();
+         layout.setName(name);
+         layout.setVSAssemblyLayouts(new ArrayList<>());
+         List<ViewsheetLayout> layouts = new ArrayList<>(info.getViewsheetLayouts());
+         layouts.add(layout);
+         info.setViewsheetLayouts(layouts);
+      }
+
+      String lastMintedCloneId() {
+         return lastCloneId;
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/LayoutUndoServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/LayoutUndoServiceTest.java
@@ -1,0 +1,309 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.viewsheet.TableVSAssembly;
+import inetsoft.uql.viewsheet.TextVSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.vslayout.DeviceRegistry;
+import inetsoft.uql.viewsheet.vslayout.LayoutInfo;
+import inetsoft.uql.viewsheet.vslayout.PrintInfo;
+import inetsoft.uql.viewsheet.vslayout.PrintLayout;
+import inetsoft.uql.viewsheet.vslayout.VSAssemblyLayout;
+import inetsoft.uql.viewsheet.vslayout.ViewsheetLayout;
+import inetsoft.web.composer.vs.controller.VSLayoutControllerServiceProxy;
+import inetsoft.web.composer.vs.controller.VSLayoutService;
+import inetsoft.web.wiz.pairing.TestPrincipals;
+import inetsoft.web.wiz.pairing.WizAgentTestSupport;
+import org.junit.jupiter.api.Test;
+
+import java.awt.Dimension;
+import java.awt.Point;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Phase 3 of the layout implementation plan (2026-08-20-layout-implementation.md), Task 5:
+ * {@code layout_undo}/{@code layout_redo}.
+ *
+ * <p>Uses REAL {@link LayoutSessionService}/{@link LayoutMutationService}/{@link
+ * LayoutReadService} instances (mocked only at the {@code ViewsheetSessionService}/{@code
+ * ViewsheetService}/{@code VSLayoutControllerServiceProxy}/{@code DeviceRegistry} boundary --
+ * the same fixture shape {@code LayoutMutationServiceTest} established), so the Hazard-2
+ * reset-on-switch test below genuinely exercises {@code LayoutSessionService}'s real clone
+ * lifecycle -- including a read-triggered switch through {@code LayoutReadService.get} -- from
+ * {@code LayoutUndoService}'s own entry point, not a mocked stand-in for it.
+ */
+@WizAgentTestSupport
+class LayoutUndoServiceTest {
+   private static final Principal AGENT = TestPrincipals.user("alice", "host-org");
+   private static final String PRINT_LAYOUT = "Print Layout";
+   private static final String DEVICE_A = "Device A";
+
+   @Test
+   void undoRevertsTheMostRecentEditAndRedoReappliesIt() throws Exception {
+      Fixture fx = new Fixture();
+      fx.installPrintLayout();
+
+      fx.mutationService.editObjects("tok1", AGENT, PRINT_LAYOUT, "move_resize",
+         VSLayoutService.CONTENT,
+         List.of(Map.of("name", "Table1", "x", 555, "y", 666, "width", 70, "height", 80)), false);
+      assertPosition(fx.printLayoutObject("Table1"), 555, 666, 70, 80);
+
+      Map<String, Object> undone = fx.undoService.layoutUndo("tok1", AGENT, PRINT_LAYOUT);
+
+      assertEquals(true, undone.get("applied"));
+      assertPosition(fx.printLayoutObject("Table1"), 300, 400, 50, 60);
+
+      Map<String, Object> redone = fx.undoService.layoutRedo("tok1", AGENT, PRINT_LAYOUT);
+
+      assertEquals(true, redone.get("applied"));
+      assertPosition(fx.printLayoutObject("Table1"), 555, 666, 70, 80);
+   }
+
+   @Test
+   void undoPastAvailableHistoryIsANoOpNotAnError() throws Exception {
+      Fixture fx = new Fixture();
+      fx.installPrintLayout();
+
+      // No edit at all yet -- this call itself establishes focus (mints the clone, seeds one
+      // baseline), but there is nothing earlier than the baseline to revert to.
+      Map<String, Object> result = fx.undoService.layoutUndo("tok1", AGENT, PRINT_LAYOUT);
+
+      assertEquals(false, result.get("applied"));
+      assertPosition(fx.printLayoutObject("Table1"), 300, 400, 50, 60);
+   }
+
+   @Test
+   void redoPastAvailableHistoryIsANoOpNotAnError() throws Exception {
+      Fixture fx = new Fixture();
+      fx.installPrintLayout();
+
+      fx.mutationService.editObjects("tok1", AGENT, PRINT_LAYOUT, "move_resize",
+         VSLayoutService.CONTENT,
+         List.of(Map.of("name", "Table1", "x", 555, "y", 666, "width", 70, "height", 80)), false);
+
+      // Nothing has been undone yet, so there is nothing to redo.
+      Map<String, Object> result = fx.undoService.layoutRedo("tok1", AGENT, PRINT_LAYOUT);
+
+      assertEquals(false, result.get("applied"));
+      assertPosition(fx.printLayoutObject("Table1"), 555, 666, 70, 80);
+
+      // Undo once, redo once (consuming the only redo available), then redo again -- the second
+      // redo must be a no-op too.
+      fx.undoService.layoutUndo("tok1", AGENT, PRINT_LAYOUT);
+      fx.undoService.layoutRedo("tok1", AGENT, PRINT_LAYOUT);
+      Map<String, Object> secondRedo = fx.undoService.layoutRedo("tok1", AGENT, PRINT_LAYOUT);
+
+      assertEquals(false, secondRedo.get("applied"));
+      assertPosition(fx.printLayoutObject("Table1"), 555, 666, 70, 80);
+   }
+
+   /**
+    * The Hazard-2 reset-on-switch test, exercised end to end through this task's own entry point
+    * (not only at {@code LayoutSessionServiceTest}'s unit level): edit Print Layout, switch focus
+    * to a device layout ("Device A") via a plain read ({@code LayoutReadService.get} -- the same
+    * call {@code get_layout} makes), assert {@code layout_undo} on Device A has no history from
+    * Print Layout's edit, then switch back to Print Layout and assert its own undo history was
+    * not resurrected either.
+    */
+   @Test
+   void undoOnADifferentlyFocusedLayoutHasNoHistoryFromTheOneJustLeft() throws Exception {
+      Fixture fx = new Fixture();
+      fx.installPrintLayout();
+      fx.installDeviceLayout(DEVICE_A, 10, 10, 20, 20);
+
+      fx.mutationService.editObjects("tok1", AGENT, PRINT_LAYOUT, "move_resize",
+         VSLayoutService.CONTENT,
+         List.of(Map.of("name", "Table1", "x", 999, "y", 999, "width", 9, "height", 9)), false);
+      assertPosition(fx.printLayoutObject("Table1"), 999, 999, 9, 9);
+
+      // A plain read on a different layout -- LayoutReadService.get's own call chain
+      // (LayoutSessionService.resolveForRead) -- switches focus away from Print Layout.
+      fx.readService.get("tok1", AGENT, DEVICE_A);
+
+      Map<String, Object> undoOnDeviceA = fx.undoService.layoutUndo("tok1", AGENT, DEVICE_A);
+
+      assertEquals(false, undoOnDeviceA.get("applied"),
+                   "Device A has no history of its own yet -- Print Layout's edit must not leak in");
+      assertPosition(fx.namedLayoutObject(DEVICE_A, "Table1"), 10, 10, 20, 20);
+
+      // Switch back to Print Layout via layout_undo itself (its own entry point re-focuses
+      // before consulting the stack) -- its earlier edit was persisted directly to the master's
+      // LayoutInfo by LayoutMutationService, independent of the undo-stack reset, so it is still
+      // there; what must NOT reappear is the now-discarded UNDO HISTORY for that edit.
+      Map<String, Object> undoOnPrintAfterSwitchBack =
+         fx.undoService.layoutUndo("tok1", AGENT, PRINT_LAYOUT);
+
+      assertEquals(false, undoOnPrintAfterSwitchBack.get("applied"),
+                   "switching back to Print Layout must not resurrect its old undo history");
+      assertPosition(fx.printLayoutObject("Table1"), 999, 999, 9, 9);
+   }
+
+   private static void assertPosition(VSAssemblyLayout layout, int x, int y, int width,
+                                       int height)
+   {
+      assertEquals(new Point(x, y), layout.getPosition());
+      assertEquals(new Dimension(width, height), layout.getSize());
+   }
+
+   // ── fixture ───────────────────────────────────────────────────────────────
+
+   /**
+    * Wires one {@code LayoutUndoService} against REAL {@code LayoutSessionService}/{@code
+    * LayoutMutationService}/{@code LayoutReadService}/{@code VSLayoutService} instances (mocked
+    * only at the {@code ViewsheetSessionService}/{@code ViewsheetService}/{@code
+    * VSLayoutControllerServiceProxy}/{@code DeviceRegistry} boundary), the same fixture shape
+    * {@code LayoutMutationServiceTest} uses.
+    */
+   private static final class Fixture {
+      final ViewsheetSessionService viewsheetSessions = mock(ViewsheetSessionService.class);
+      final ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      final VSLayoutService vsLayoutService = new VSLayoutService();
+      final VSLayoutControllerServiceProxy vsLayoutControllerService =
+         mock(VSLayoutControllerServiceProxy.class);
+      final DeviceRegistry deviceRegistry = mock(DeviceRegistry.class);
+      final LayoutSessionService layoutSessions =
+         new LayoutSessionService(viewsheetSessions, viewsheetService, vsLayoutService);
+      final LayoutMutationService mutationService = new LayoutMutationService(
+         layoutSessions, viewsheetSessions, vsLayoutService, vsLayoutControllerService);
+      final LayoutReadService readService = new LayoutReadService(
+         viewsheetSessions, layoutSessions, vsLayoutService, deviceRegistry);
+      final LayoutUndoService undoService =
+         new LayoutUndoService(layoutSessions, viewsheetSessions, vsLayoutService);
+
+      final Viewsheet masterVs = new Viewsheet();
+      final TextVSAssembly masterText = new TextVSAssembly(masterVs, "Text1");
+      final TableVSAssembly masterTable = new TableVSAssembly(masterVs, "Table1");
+      final RuntimeViewsheet masterRvs = spy(new RuntimeViewsheet());
+      final AssetEntry masterEntry = mock(AssetEntry.class);
+
+      private int cloneCounter;
+
+      Fixture() throws Exception {
+         masterText.setPixelOffset(new Point(10, 20));
+         masterText.setPixelSize(new Dimension(15, 10));
+         masterVs.addAssembly(masterText);
+
+         masterTable.setPixelOffset(new Point(50, 60));
+         masterTable.setPixelSize(new Dimension(80, 40));
+         masterVs.addAssembly(masterTable);
+
+         doReturn(masterVs).when(masterRvs).getViewsheet();
+         doReturn("master-1").when(masterRvs).getID();
+         doReturn(masterEntry).when(masterRvs).getEntry();
+         when(masterEntry.clone()).thenReturn(masterEntry);
+         when(viewsheetSessions.resolve(eq("tok1"), eq(AGENT))).thenReturn(masterRvs);
+
+         when(viewsheetService.openTemporaryViewsheet(anyString(), any(AssetEntry.class), eq(AGENT)))
+            .thenAnswer(inv -> {
+               String id = "clone-" + (++cloneCounter);
+               RuntimeViewsheet clone = spy(new RuntimeViewsheet());
+
+               // A genuinely separate object graph from master's -- see LayoutSessionServiceTest's
+               // fixture doc for why this matters. Neither LayoutMutationService's nor
+               // LayoutUndoService's own mutations read/write the clone's content by name (they
+               // operate on master's LayoutInfo directly, redirecting only the apply() call onto
+               // the clone), so a minimal same-shape stand-in is enough here.
+               Viewsheet initialCloneVs = new Viewsheet();
+               TextVSAssembly cloneText = new TextVSAssembly(initialCloneVs, "Text1");
+               cloneText.setPixelOffset(new Point(10, 20));
+               initialCloneVs.addAssembly(cloneText);
+               TableVSAssembly cloneTable = new TableVSAssembly(initialCloneVs, "Table1");
+               cloneTable.setPixelOffset(new Point(50, 60));
+               initialCloneVs.addAssembly(cloneTable);
+
+               Viewsheet[] cloneVsHolder = { initialCloneVs };
+               doAnswer(getVs -> cloneVsHolder[0]).when(clone).getViewsheet();
+               doAnswer(setVs -> {
+                  cloneVsHolder[0] = setVs.getArgument(0);
+                  return null;
+               }).when(clone).setViewsheet(any());
+               doReturn(id).when(clone).getID();
+
+               when(viewsheetService.getViewsheet(eq(id), eq(AGENT))).thenReturn(clone);
+               return id;
+            });
+
+         doAnswer(inv -> {
+            String flushedId = inv.getArgument(0);
+            when(viewsheetService.getViewsheet(eq(flushedId), any()))
+               .thenThrow(new IllegalStateException("runtime " + flushedId + " has been flushed"));
+            return null;
+         }).when(viewsheetService).flushRuntimeSheet(anyString());
+      }
+
+      /**
+       * A real print layout with a Text object (does not support table layout) and a Table
+       * object (does), each placed at a distinct layout position from its own master/viewsheet
+       * position -- mirrors {@code LayoutMutationServiceTest}'s fixture.
+       */
+      void installPrintLayout() {
+         LayoutInfo info = new LayoutInfo();
+         PrintLayout layout = new PrintLayout();
+         layout.setPrintInfo(new PrintInfo("Letter", new inetsoft.graph.internal.DimensionD(8.5, 11),
+                                            0.5f, 0.5f, 0.5f, 0.5f, "inches"));
+         List<VSAssemblyLayout> objects = new ArrayList<>();
+         objects.add(new VSAssemblyLayout("Text1", new Point(100, 200), new Dimension(30, 40)));
+         objects.add(new VSAssemblyLayout("Table1", new Point(300, 400), new Dimension(50, 60)));
+         layout.setVSAssemblyLayouts(objects);
+         info.setPrintLayout(layout);
+         masterVs.setLayoutInfo(info);
+      }
+
+      /** Adds a real device (viewsheet) layout named {@code name} with one Table1 placement. */
+      void installDeviceLayout(String name, int x, int y, int width, int height) {
+         LayoutInfo info = masterVs.getLayoutInfo();
+         ViewsheetLayout layout = new ViewsheetLayout();
+         layout.setName(name);
+         List<VSAssemblyLayout> objects = new ArrayList<>();
+         objects.add(new VSAssemblyLayout("Table1", new Point(x, y), new Dimension(width, height)));
+         layout.setVSAssemblyLayouts(objects);
+         List<ViewsheetLayout> layouts = new ArrayList<>(info.getViewsheetLayouts());
+         layouts.add(layout);
+         info.setViewsheetLayouts(layouts);
+      }
+
+      VSAssemblyLayout printLayoutObject(String name) {
+         return masterVs.getLayoutInfo().getPrintLayout().getVSAssemblyLayouts().stream()
+            .filter(l -> l.getName().equals(name))
+            .findFirst()
+            .orElseThrow();
+      }
+
+      VSAssemblyLayout namedLayoutObject(String layoutName, String name) {
+         return masterVs.getLayoutInfo().getViewsheetLayouts().stream()
+            .filter(l -> l.getName().equals(layoutName))
+            .findFirst()
+            .orElseThrow()
+            .getVSAssemblyLayouts().stream()
+            .filter(l -> l.getName().equals(name))
+            .findFirst()
+            .orElseThrow();
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/PrintDeviceLayoutPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/PrintDeviceLayoutPropertyServiceTest.java
@@ -1,0 +1,329 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet;
+
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.vslayout.DeviceInfo;
+import inetsoft.uql.viewsheet.vslayout.DeviceRegistry;
+import inetsoft.web.composer.model.vs.*;
+import inetsoft.web.composer.vs.dialog.ViewsheetPropertyDialogService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Phase 2 of the layout implementation plan (2026-08-20-layout-implementation.md), Task 3:
+ * {@code set_print_layout}/{@code manage_device_layout}, patching {@code ScreensPaneModel} inside
+ * the existing {@code ViewsheetPropertyDialogModel} via the same {@code
+ * ViewsheetPropertyDialogService.getViewsheetInfo}/{@code setViewsheetInfo} pair {@code
+ * SheetPropertyService} already wraps.
+ *
+ * <p>This task operates on the paired session's master runtime directly through {@code
+ * ViewsheetSessionService} -- {@code screensPane} is a whole-viewsheet property, not layout-object
+ * geometry, so Hazard 1 (and {@code LayoutSessionService}) does not apply here.
+ *
+ * <p>Two named regressions this file exists to pin down:
+ * <ul>
+ *   <li><b>Hazard 3</b> -- {@code VSPrintLayoutDialogModel.scaleFont} is a bare {@code float},
+ *   defaulting to Java's {@code 0.0f}. {@code VSCompositeFormat.getFont()} multiplies every cell's
+ *   font size by this value, so an unset scale font renders every crosstab/table cell at font size
+ *   zero -- blank. {@code set_print_layout} must refuse an explicit {@code 0} outright and must
+ *   default an omitted one to {@code 1.0f}, never let Java's bare-field default reach the write.</li>
+ *   <li><b>Risk 2</b> -- the device catalogue ({@code DeviceRegistry}/{@code ScreenSizeDialogModel})
+ *   is global/org-wide infrastructure with its own admin-gated REST surface ({@code
+ *   DeviceController}), entirely outside this plugin's session model. {@code manage_device_layout}
+ *   may only create/update/delete a named device LAYOUT on this viewsheet ({@code
+ *   VSDeviceLayoutDialogModel}) referencing existing catalogue ids -- it must refuse anything
+ *   shaped like a catalogue write instead of silently forwarding it.</li>
+ * </ul>
+ */
+@Tag("core")
+class PrintDeviceLayoutPropertyServiceTest {
+   // ── set_print_layout ─────────────────────────────────────────────────────
+
+   @Test
+   void omittedScaleFontOnANewPrintLayoutDefaultsToOneNotJavasZero() throws Exception {
+      // No existing print layout at all -- screensPane.getPrintLayout() reads back null, exactly
+      // as ViewsheetPropertyDialogService.getViewsheetInfo leaves it when the viewsheet has never
+      // had a print layout configured. A naive "new VSPrintLayoutDialogModel(), copy over the
+      // patched fields" implementation leaves scaleFont at Java's bare-field default of 0.0f here,
+      // which is the exact blank-text bug (Hazard 3) this test exists to catch.
+      Harness h = new Harness(screensPaneWithNoPrintLayout());
+
+      h.service.setPrintLayout("tok", h.principal, Map.of("paperSize", "Letter"), "");
+
+      ArgumentCaptor<ViewsheetPropertyDialogModel> captor =
+         ArgumentCaptor.forClass(ViewsheetPropertyDialogModel.class);
+      verify(h.dialog).setViewsheetInfo(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                        anyString(), any());
+      VSPrintLayoutDialogModel written = captor.getValue().screensPane().getPrintLayout();
+      assertNotNull(written);
+      assertEquals(1.0f, written.getScaleFont(), 0.0001f);
+      assertEquals("Letter", written.getPaperSize());
+   }
+
+   @Test
+   void refusesAnExplicitZeroScaleFontBeforeWritingAnything() throws Exception {
+      Harness h = new Harness(screensPaneWithNoPrintLayout());
+
+      Exception thrown = assertThrows(Exception.class,
+         () -> h.service.setPrintLayout("tok", h.principal, Map.of("scaleFont", 0f), ""));
+
+      assertTrue(thrown.getMessage().toLowerCase().contains("scalefont") ||
+                 thrown.getMessage().toLowerCase().contains("blank"),
+                 thrown.getMessage());
+
+      // The refusal happens before any write is attempted -- not a silent clamp after the fact.
+      verify(h.dialog, never())
+         .setViewsheetInfo(anyString(), any(), any(), any(), anyString(), any());
+      // And before the mutation seam even opens: no checkpoint should be attempted for a request
+      // that never applies.
+      verify(h.sessions, never()).mutate(anyString(), any(Principal.class), any());
+   }
+
+   @Test
+   void aPatchTouchingOnlyScaleFontLeavesEveryOtherPrintLayoutFieldExactlyAsRead()
+      throws Exception
+   {
+      VSPrintLayoutDialogModel existing = new VSPrintLayoutDialogModel();
+      existing.setPaperSize("Legal");
+      existing.setMarginTop(1.5);
+      existing.setMarginLeft(2.5);
+      existing.setMarginBottom(1.0);
+      existing.setMarginRight(0.5);
+      existing.setFooterFromEdge(0.3f);
+      existing.setHeaderFromEdge(0.2f);
+      existing.setLandscape(true);
+      existing.setNumberingStart(5);
+      existing.setCustomWidth(10);
+      existing.setCustomHeight(20);
+      existing.setUnits("inches");
+      existing.setScaleFont(1.0f);
+
+      ScreensPaneModel screensPane = new ScreensPaneModel();
+      screensPane.setPrintLayout(existing);
+      Harness h = new Harness(screensPane);
+
+      h.service.setPrintLayout("tok", h.principal, Map.of("scaleFont", 2.0f), "");
+
+      ArgumentCaptor<ViewsheetPropertyDialogModel> captor =
+         ArgumentCaptor.forClass(ViewsheetPropertyDialogModel.class);
+      verify(h.dialog).setViewsheetInfo(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                        anyString(), any());
+      VSPrintLayoutDialogModel written = captor.getValue().screensPane().getPrintLayout();
+
+      assertEquals(2.0f, written.getScaleFont(), 0.0001f);
+      // Everything else survives untouched -- the read-merge-write contract.
+      assertEquals("Legal", written.getPaperSize());
+      assertEquals(1.5, written.getMarginTop(), 0.0001);
+      assertEquals(2.5, written.getMarginLeft(), 0.0001);
+      assertEquals(1.0, written.getMarginBottom(), 0.0001);
+      assertEquals(0.5, written.getMarginRight(), 0.0001);
+      assertEquals(0.3f, written.getFooterFromEdge(), 0.0001f);
+      assertEquals(0.2f, written.getHeaderFromEdge(), 0.0001f);
+      assertTrue(written.isLandscape());
+      assertEquals(5, written.getNumberingStart());
+      assertEquals(10, written.getCustomWidth(), 0.0001);
+      assertEquals(20, written.getCustomHeight(), 0.0001);
+      assertEquals("inches", written.getUnits());
+   }
+
+   @Test
+   void refusesAnEmptyPatchRatherThanOpeningACheckpointForNothing() {
+      Harness h = new Harness(screensPaneWithNoPrintLayout());
+
+      assertThrows(Exception.class,
+         () -> h.service.setPrintLayout("tok", h.principal, Map.of(), ""));
+   }
+
+   // ── manage_device_layout ─────────────────────────────────────────────────
+
+   @Test
+   void refusesASelectedDeviceIdNotInTheCatalogueListingTheRealIds() throws Exception {
+      Harness h = new Harness(screensPaneWithNoPrintLayout());
+      h.registerDevices("wiz-mobile", "wiz-wide", "wiz-ultrawide");
+
+      Exception thrown = assertThrows(Exception.class, () -> h.service.manageDeviceLayout(
+         "tok", h.principal, "create",
+         Map.of("name", "Phone", "selectedDevices", List.of("not-a-real-device")), ""));
+
+      assertTrue(thrown.getMessage().contains("not-a-real-device"), thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("wiz-mobile"), thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("wiz-wide"), thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("wiz-ultrawide"), thrown.getMessage());
+      verify(h.dialog, never())
+         .setViewsheetInfo(anyString(), any(), any(), any(), anyString(), any());
+   }
+
+   @Test
+   void refusesABareDeviceCatalogueShapedPayloadWithNoDeviceLayoutName() throws Exception {
+      Harness h = new Harness(screensPaneWithNoPrintLayout());
+      h.registerDevices("wiz-mobile", "wiz-wide", "wiz-ultrawide");
+
+      // Shaped like a ScreenSizeDialogModel (a device catalogue ENTRY -- label/min/max width),
+      // not a VSDeviceLayoutDialogModel (a device LAYOUT on this viewsheet) -- and critically,
+      // has no "name", the one field every device-layout request carries.
+      Exception thrown = assertThrows(Exception.class, () -> h.service.manageDeviceLayout(
+         "tok", h.principal, "create",
+         Map.of("label", "My New Phone Size", "minWidth", 100, "maxWidth", 400), ""));
+
+      assertTrue(thrown.getMessage().toLowerCase().contains("admin"), thrown.getMessage());
+      verify(h.dialog, never())
+         .setViewsheetInfo(anyString(), any(), any(), any(), anyString(), any());
+   }
+
+   @Test
+   void createsANewDeviceLayoutWithValidatedDeviceIds() throws Exception {
+      Harness h = new Harness(screensPaneWithNoPrintLayout());
+      h.registerDevices("wiz-mobile", "wiz-wide", "wiz-ultrawide");
+
+      h.service.manageDeviceLayout("tok", h.principal, "create",
+         Map.of("name", "Phone", "mobileOnly", true, "selectedDevices", List.of("wiz-mobile")),
+         "");
+
+      ArgumentCaptor<ViewsheetPropertyDialogModel> captor =
+         ArgumentCaptor.forClass(ViewsheetPropertyDialogModel.class);
+      verify(h.dialog).setViewsheetInfo(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                        anyString(), any());
+      List<VSDeviceLayoutDialogModel> layouts = captor.getValue().screensPane().getDeviceLayouts();
+      assertEquals(1, layouts.size());
+      assertEquals("Phone", layouts.get(0).getName());
+      assertTrue(layouts.get(0).isMobileOnly());
+      assertEquals(List.of("wiz-mobile"), layouts.get(0).getSelectedDevices());
+   }
+
+   @Test
+   void updatesAnExistingDeviceLayoutByName() throws Exception {
+      VSDeviceLayoutDialogModel existing = new VSDeviceLayoutDialogModel();
+      existing.setName("Phone");
+      existing.setMobileOnly(true);
+      existing.setSelectedDevices(List.of("wiz-mobile"));
+      ScreensPaneModel screensPane = screensPaneWithNoPrintLayout();
+      screensPane.getDeviceLayouts().add(existing);
+      Harness h = new Harness(screensPane);
+      h.registerDevices("wiz-mobile", "wiz-wide", "wiz-ultrawide");
+
+      h.service.manageDeviceLayout("tok", h.principal, "update",
+         Map.of("name", "Phone", "selectedDevices", List.of("wiz-wide")), "");
+
+      ArgumentCaptor<ViewsheetPropertyDialogModel> captor =
+         ArgumentCaptor.forClass(ViewsheetPropertyDialogModel.class);
+      verify(h.dialog).setViewsheetInfo(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                        anyString(), any());
+      List<VSDeviceLayoutDialogModel> layouts = captor.getValue().screensPane().getDeviceLayouts();
+      assertEquals(1, layouts.size());
+      assertEquals(List.of("wiz-wide"), layouts.get(0).getSelectedDevices());
+      // mobileOnly untouched by a patch that didn't mention it.
+      assertTrue(layouts.get(0).isMobileOnly());
+   }
+
+   @Test
+   void deletesAnExistingDeviceLayoutByName() throws Exception {
+      VSDeviceLayoutDialogModel existing = new VSDeviceLayoutDialogModel();
+      existing.setName("Phone");
+      ScreensPaneModel screensPane = screensPaneWithNoPrintLayout();
+      screensPane.getDeviceLayouts().add(existing);
+      Harness h = new Harness(screensPane);
+      h.registerDevices("wiz-mobile");
+
+      h.service.manageDeviceLayout("tok", h.principal, "delete", Map.of("name", "Phone"), "");
+
+      ArgumentCaptor<ViewsheetPropertyDialogModel> captor =
+         ArgumentCaptor.forClass(ViewsheetPropertyDialogModel.class);
+      verify(h.dialog).setViewsheetInfo(eq("rt1"), captor.capture(), any(Principal.class), any(),
+                                        anyString(), any());
+      assertTrue(captor.getValue().screensPane().getDeviceLayouts().isEmpty());
+   }
+
+   @Test
+   void updateOnAnUnknownDeviceLayoutNameThrowsRatherThanSilentlyNoOpping() throws Exception {
+      Harness h = new Harness(screensPaneWithNoPrintLayout());
+      h.registerDevices("wiz-mobile");
+
+      Exception thrown = assertThrows(Exception.class, () -> h.service.manageDeviceLayout(
+         "tok", h.principal, "update", Map.of("name", "Does Not Exist"), ""));
+
+      assertTrue(thrown.getMessage().contains("Does Not Exist"), thrown.getMessage());
+      verify(h.dialog, never())
+         .setViewsheetInfo(anyString(), any(), any(), any(), anyString(), any());
+   }
+
+   // ── harness ───────────────────────────────────────────────────────────────
+
+   private static ScreensPaneModel screensPaneWithNoPrintLayout() {
+      return new ScreensPaneModel();
+   }
+
+   /**
+    * Wires one {@code PrintDeviceLayoutPropertyService} against a mocked {@code
+    * ViewsheetSessionService} (whose {@code mutate} runs the mutation synchronously, exactly as
+    * {@code SheetPropertyServiceTest}'s own harness does), a mocked {@code
+    * ViewsheetPropertyDialogService} that reads back a model built around the given {@code
+    * ScreensPaneModel}, and a mocked {@code DeviceRegistry}.
+    */
+   private static final class Harness {
+      final Principal principal = () -> "admin";
+      final ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      final ViewsheetPropertyDialogService dialog = mock(ViewsheetPropertyDialogService.class);
+      final DeviceRegistry deviceRegistry = mock(DeviceRegistry.class);
+      final PrintDeviceLayoutPropertyService service =
+         new PrintDeviceLayoutPropertyService(sessions, dialog, deviceRegistry);
+
+      Harness(ScreensPaneModel screensPane) {
+         try {
+            RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+            when(rvs.getID()).thenReturn("rt1");
+            when(sessions.resolve(anyString(), any(Principal.class))).thenReturn(rvs);
+            doAnswer(invocation -> {
+               ViewsheetSessionService.Mutation mutation = invocation.getArgument(2);
+               mutation.run(rvs, "rt1", null);
+               return null;
+            }).when(sessions).mutate(anyString(), any(Principal.class), any());
+
+            ViewsheetPropertyDialogModel model =
+               ViewsheetPropertyDialogModel.builder().screensPane(screensPane).build();
+            when(dialog.getViewsheetInfo(anyString(), any(Principal.class))).thenReturn(model);
+            when(deviceRegistry.getDevices()).thenReturn(new DeviceInfo[0]);
+         }
+         catch(Exception e) {
+            throw new IllegalStateException(e);
+         }
+      }
+
+      void registerDevices(String... ids) {
+         DeviceInfo[] devices = new DeviceInfo[ids.length];
+
+         for(int i = 0; i < ids.length; i++) {
+            DeviceInfo device = new DeviceInfo();
+            device.setId(ids[i]);
+            device.setName(ids[i]);
+            devices[i] = device;
+         }
+
+         when(deviceRegistry.getDevices()).thenReturn(devices);
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -18,7 +18,9 @@
 package inetsoft.web.wiz.viewsheet;
 
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.web.composer.vs.controller.VSLayoutService;
 import inetsoft.web.wiz.pairing.*;
+import inetsoft.web.wiz.viewsheet.model.LayoutModel;
 import inetsoft.web.wiz.viewsheet.model.ViewsheetModel;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -309,7 +311,11 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(inetsoft.analytic.composition.ViewsheetService.class),
                                           mock(SheetAgentBroadcastService.class),
                                           openService,
-                                          mock(LayoutSessionService.class));
+                                          mock(LayoutSessionService.class),
+                                          mock(LayoutReadService.class),
+                                          mock(PrintDeviceLayoutPropertyService.class),
+                                          mock(LayoutMutationService.class),
+                                          mock(LayoutUndoService.class));
    }
 
    private static ViewsheetAssemblyAgentController controllerWith(SheetAgentFeature feature,
@@ -345,7 +351,11 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(inetsoft.analytic.composition.ViewsheetService.class),
                                           mock(SheetAgentBroadcastService.class),
                                           mock(SheetOpenService.class),
-                                          mock(LayoutSessionService.class));
+                                          mock(LayoutSessionService.class),
+                                          mock(LayoutReadService.class),
+                                          mock(PrintDeviceLayoutPropertyService.class),
+                                          mock(LayoutMutationService.class),
+                                          mock(LayoutUndoService.class));
    }
 
    private static ViewsheetAssemblyAgentController controllerWith(SheetAgentFeature feature,
@@ -384,7 +394,11 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(inetsoft.analytic.composition.ViewsheetService.class),
                                           mock(SheetAgentBroadcastService.class),
                                           mock(SheetOpenService.class),
-                                          layoutSessionService);
+                                          layoutSessionService,
+                                          mock(LayoutReadService.class),
+                                          mock(PrintDeviceLayoutPropertyService.class),
+                                          mock(LayoutMutationService.class),
+                                          mock(LayoutUndoService.class));
    }
 
    /** Feature enabled, only {@code propertyService} wired -- for the property-trio tests. */
@@ -416,7 +430,11 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(inetsoft.analytic.composition.ViewsheetService.class),
                                           mock(SheetAgentBroadcastService.class),
                                           mock(SheetOpenService.class),
-                                          mock(LayoutSessionService.class));
+                                          mock(LayoutSessionService.class),
+                                          mock(LayoutReadService.class),
+                                          mock(PrintDeviceLayoutPropertyService.class),
+                                          mock(LayoutMutationService.class),
+                                          mock(LayoutUndoService.class));
    }
 
    /**
@@ -529,7 +547,191 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(inetsoft.analytic.composition.ViewsheetService.class),
                                           mock(SheetAgentBroadcastService.class),
                                           mock(SheetOpenService.class),
-                                          mock(LayoutSessionService.class));
+                                          mock(LayoutSessionService.class),
+                                          mock(LayoutReadService.class),
+                                          mock(PrintDeviceLayoutPropertyService.class),
+                                          mock(LayoutMutationService.class),
+                                          mock(LayoutUndoService.class));
+   }
+
+   // ---------------------------------------------------------------------------
+   // Task 6 (layout implementation plan) -- wiring assertions for the eight new
+   // layout endpoints. Each test only checks that the right service is called with the
+   // right arguments for the right path; every hazard/validation behavior is already
+   // covered by that service's own unit tests (Tasks 1-5).
+   // ---------------------------------------------------------------------------
+
+   @Test
+   void listLayoutsDelegatesToTheReadService() throws Exception {
+      LayoutReadService readService = mock(LayoutReadService.class);
+      Map<String, Object> expected = Map.of("layouts", List.of());
+      when(readService.list(eq("tok"), any(Principal.class))).thenReturn(expected);
+
+      ViewsheetAssemblyAgentController controller = controllerWithLayoutServices(
+         readService, mock(PrintDeviceLayoutPropertyService.class),
+         mock(LayoutMutationService.class), mock(LayoutUndoService.class));
+
+      assertSame(expected, controller.listLayouts("tok", principal()));
+   }
+
+   @Test
+   void getLayoutDelegatesToTheReadService() throws Exception {
+      LayoutReadService readService = mock(LayoutReadService.class);
+      LayoutModel expected = new LayoutModel("Print Layout", "print", null, null, List.of());
+      when(readService.get(eq("tok"), any(Principal.class), eq("Print Layout")))
+         .thenReturn(expected);
+
+      ViewsheetAssemblyAgentController controller = controllerWithLayoutServices(
+         readService, mock(PrintDeviceLayoutPropertyService.class),
+         mock(LayoutMutationService.class), mock(LayoutUndoService.class));
+
+      assertSame(expected, controller.getLayout("tok", "Print Layout", principal()));
+   }
+
+   @Test
+   void setPrintLayoutDelegatesToThePropertyService() throws Exception {
+      PrintDeviceLayoutPropertyService propertyService =
+         mock(PrintDeviceLayoutPropertyService.class);
+      Map<String, Object> patch = Map.of("scaleFont", 1.0);
+
+      ViewsheetAssemblyAgentController controller = controllerWithLayoutServices(
+         mock(LayoutReadService.class), propertyService, mock(LayoutMutationService.class),
+         mock(LayoutUndoService.class));
+
+      controller.setPrintLayout("tok",
+         new ViewsheetAssemblyAgentController.LayoutPrintPatchRequest(patch), "link",
+         principal());
+
+      verify(propertyService).setPrintLayout(eq("tok"), any(Principal.class), eq(patch),
+                                             eq("link"));
+   }
+
+   @Test
+   void manageDeviceLayoutDelegatesToThePropertyService() throws Exception {
+      PrintDeviceLayoutPropertyService propertyService =
+         mock(PrintDeviceLayoutPropertyService.class);
+      Map<String, Object> patch = Map.of("name", "Phone");
+
+      ViewsheetAssemblyAgentController controller = controllerWithLayoutServices(
+         mock(LayoutReadService.class), propertyService, mock(LayoutMutationService.class),
+         mock(LayoutUndoService.class));
+
+      controller.manageDeviceLayout("tok",
+         new ViewsheetAssemblyAgentController.LayoutDevicePatchRequest("create", patch), "link",
+         principal());
+
+      verify(propertyService).manageDeviceLayout(eq("tok"), any(Principal.class), eq("create"),
+                                                 eq(patch), eq("link"));
+   }
+
+   @Test
+   void editLayoutObjectsDelegatesToTheMutationServiceWithTheContentRegion() throws Exception {
+      LayoutMutationService mutationService = mock(LayoutMutationService.class);
+      Map<String, Object> expected = Map.of("requiresConfirmation", false);
+      List<Map<String, Object>> objects = List.of(Map.of("name", "Text1"));
+      when(mutationService.editObjects(eq("tok"), any(Principal.class), eq("Print Layout"),
+                                       eq("move_resize"), eq(VSLayoutService.CONTENT),
+                                       eq(objects), eq(false)))
+         .thenReturn(expected);
+
+      ViewsheetAssemblyAgentController controller = controllerWithLayoutServices(
+         mock(LayoutReadService.class), mock(PrintDeviceLayoutPropertyService.class),
+         mutationService, mock(LayoutUndoService.class));
+
+      Map<String, Object> result = controller.editLayoutObjects("tok",
+         new ViewsheetAssemblyAgentController.LayoutObjectsRequest(
+            "Print Layout", "move_resize", objects, null),
+         principal());
+
+      assertSame(expected, result);
+   }
+
+   @Test
+   void setLayoutTableOptionsDelegatesToTheMutationServiceWithTheContentRegion() throws Exception {
+      LayoutMutationService mutationService = mock(LayoutMutationService.class);
+
+      ViewsheetAssemblyAgentController controller = controllerWithLayoutServices(
+         mock(LayoutReadService.class), mock(PrintDeviceLayoutPropertyService.class),
+         mutationService, mock(LayoutUndoService.class));
+
+      controller.setLayoutTableOptions("tok",
+         new ViewsheetAssemblyAgentController.LayoutTableOptionsRequest(
+            "Print Layout", "Table1", 1),
+         principal());
+
+      verify(mutationService).setTableLayoutOptions(eq("tok"), any(Principal.class),
+                                                    eq("Print Layout"), eq("Table1"),
+                                                    eq(VSLayoutService.CONTENT), eq(1));
+   }
+
+   @Test
+   void layoutUndoDelegatesToTheUndoService() throws Exception {
+      LayoutUndoService undoService = mock(LayoutUndoService.class);
+      Map<String, Object> expected = Map.of("applied", true);
+      when(undoService.layoutUndo(eq("tok"), any(Principal.class), eq("Print Layout")))
+         .thenReturn(expected);
+
+      ViewsheetAssemblyAgentController controller = controllerWithLayoutServices(
+         mock(LayoutReadService.class), mock(PrintDeviceLayoutPropertyService.class),
+         mock(LayoutMutationService.class), undoService);
+
+      Map<String, Object> result = controller.layoutUndo("tok",
+         new ViewsheetAssemblyAgentController.LayoutUndoRedoRequest("Print Layout"), principal());
+
+      assertSame(expected, result);
+   }
+
+   @Test
+   void layoutRedoDelegatesToTheUndoService() throws Exception {
+      LayoutUndoService undoService = mock(LayoutUndoService.class);
+      Map<String, Object> expected = Map.of("applied", true);
+      when(undoService.layoutRedo(eq("tok"), any(Principal.class), eq("Print Layout")))
+         .thenReturn(expected);
+
+      ViewsheetAssemblyAgentController controller = controllerWithLayoutServices(
+         mock(LayoutReadService.class), mock(PrintDeviceLayoutPropertyService.class),
+         mock(LayoutMutationService.class), undoService);
+
+      Map<String, Object> result = controller.layoutRedo("tok",
+         new ViewsheetAssemblyAgentController.LayoutUndoRedoRequest("Print Layout"), principal());
+
+      assertSame(expected, result);
+   }
+
+   /** Feature enabled, only the four Task 6 layout services wired -- for the layout-endpoint tests. */
+   private static ViewsheetAssemblyAgentController controllerWithLayoutServices(
+      LayoutReadService layoutReadService,
+      PrintDeviceLayoutPropertyService printDeviceLayoutPropertyService,
+      LayoutMutationService layoutMutationService, LayoutUndoService layoutUndoService)
+   {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      when(feature.isEnabled()).thenReturn(true);
+
+      return new ViewsheetAssemblyAgentController(feature, mock(SheetJoinService.class),
+                                          mock(SheetSessionService.class),
+                                          mock(ViewsheetSessionService.class),
+                                          mock(ViewsheetReadService.class),
+                                          mock(ViewsheetEditService.class),
+                                          mock(ViewsheetFormatService.class),
+                                          mock(inetsoft.web.wiz.script.ScriptImageService.class),
+                                          mock(AssemblyPropertyService.class),
+                                          mock(SheetPropertyService.class),
+                                          mock(AssemblyHyperlinkService.class),
+                                          mock(ChartElementService.class),
+                                          mock(ChartRegionPropertyService.class),
+                                          mock(AssemblyConditionService.class),
+                                          mock(AssemblyHighlightService.class),
+                                          mock(DateComparisonService.class),
+                                          mock(AssemblyConvertService.class),
+                                          mock(SelectionRuntimeService.class),
+                                          mock(CalendarDisplayService.class),
+                                          mock(InputValueService.class),
+                                          mock(inetsoft.analytic.composition.ViewsheetService.class),
+                                          mock(SheetAgentBroadcastService.class),
+                                          mock(SheetOpenService.class),
+                                          mock(LayoutSessionService.class),
+                                          layoutReadService, printDeviceLayoutPropertyService,
+                                          layoutMutationService, layoutUndoService);
    }
 
    private static Principal principal() {

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -129,6 +129,50 @@ class ViewsheetAssemblyAgentControllerTest {
    }
 
    /**
+    * Task 1 (layout implementation plan, Phase 0): {@code LayoutSessionService} caches a preview
+    * clone per session token, and this is the one real detach hook every wiz viewsheet session
+    * already closes through -- so a layout clone must be flushed here rather than through a
+    * second, parallel cleanup path.
+    */
+   @Test
+   void detachDisposesTheLayoutSessionCacheForTheClosedToken() {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      SheetSessionService sessionService = mock(SheetSessionService.class);
+      when(sessionService.resolve(anyString(), anyString()))
+         .thenReturn(mock(JoinSession.class));
+      LayoutSessionService layoutSessionService = mock(LayoutSessionService.class);
+
+      ViewsheetAssemblyAgentController controller =
+         controllerWith(feature, mock(ViewsheetSessionService.class),
+                        mock(ViewsheetReadService.class), sessionService, layoutSessionService);
+
+      controller.detach("my-token", principal());
+
+      verify(layoutSessionService).disposeAll("my-token");
+   }
+
+   /**
+    * A refused detach (not the caller's own session) must not dispose anything -- naming a
+    * token that resolves to someone else's session should not let an outsider flush a layout
+    * clone they never opened.
+    */
+   @Test
+   void detachRefusalDoesNotDisposeTheLayoutSessionCache() {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      SheetSessionService sessionService = mock(SheetSessionService.class);
+      when(sessionService.resolve(anyString(), anyString())).thenReturn(null);
+      LayoutSessionService layoutSessionService = mock(LayoutSessionService.class);
+
+      ViewsheetAssemblyAgentController controller =
+         controllerWith(feature, mock(ViewsheetSessionService.class),
+                        mock(ViewsheetReadService.class), sessionService, layoutSessionService);
+
+      controller.detach("someone-elses-token", principal());
+
+      verify(layoutSessionService, never()).disposeAll(anyString());
+   }
+
+   /**
     * {@code list_viewsheet_properties} / {@code get_viewsheet_properties} /
     * {@code set_viewsheet_properties} delegate straight through to {@link SheetPropertyService},
     * exactly as the assembly property trio delegates to {@link AssemblyPropertyService} — no
@@ -264,7 +308,8 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(InputValueService.class),
                                           mock(inetsoft.analytic.composition.ViewsheetService.class),
                                           mock(SheetAgentBroadcastService.class),
-                                          openService);
+                                          openService,
+                                          mock(LayoutSessionService.class));
    }
 
    private static ViewsheetAssemblyAgentController controllerWith(SheetAgentFeature feature,
@@ -299,13 +344,25 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(InputValueService.class),
                                           mock(inetsoft.analytic.composition.ViewsheetService.class),
                                           mock(SheetAgentBroadcastService.class),
-                                          mock(SheetOpenService.class));
+                                          mock(SheetOpenService.class),
+                                          mock(LayoutSessionService.class));
    }
 
    private static ViewsheetAssemblyAgentController controllerWith(SheetAgentFeature feature,
                                                           ViewsheetSessionService sessions,
                                                           ViewsheetReadService reader,
                                                           SheetSessionService sessionService)
+   {
+      return controllerWith(feature, sessions, reader, sessionService,
+                            mock(LayoutSessionService.class));
+   }
+
+   /** Overload that exposes {@code layoutSessionService} -- for the detach/disposeAll tests. */
+   private static ViewsheetAssemblyAgentController controllerWith(SheetAgentFeature feature,
+                                                          ViewsheetSessionService sessions,
+                                                          ViewsheetReadService reader,
+                                                          SheetSessionService sessionService,
+                                                          LayoutSessionService layoutSessionService)
    {
       return new ViewsheetAssemblyAgentController(feature, mock(SheetJoinService.class),
                                           sessionService, sessions, reader,
@@ -326,7 +383,8 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(InputValueService.class),
                                           mock(inetsoft.analytic.composition.ViewsheetService.class),
                                           mock(SheetAgentBroadcastService.class),
-                                          mock(SheetOpenService.class));
+                                          mock(SheetOpenService.class),
+                                          layoutSessionService);
    }
 
    /** Feature enabled, only {@code propertyService} wired -- for the property-trio tests. */
@@ -357,7 +415,8 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(InputValueService.class),
                                           mock(inetsoft.analytic.composition.ViewsheetService.class),
                                           mock(SheetAgentBroadcastService.class),
-                                          mock(SheetOpenService.class));
+                                          mock(SheetOpenService.class),
+                                          mock(LayoutSessionService.class));
    }
 
    /**
@@ -469,7 +528,8 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(InputValueService.class),
                                           mock(inetsoft.analytic.composition.ViewsheetService.class),
                                           mock(SheetAgentBroadcastService.class),
-                                          mock(SheetOpenService.class));
+                                          mock(SheetOpenService.class),
+                                          mock(LayoutSessionService.class));
    }
 
    private static Principal principal() {

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetSessionServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetSessionServiceTest.java
@@ -95,4 +95,24 @@ class ViewsheetSessionServiceTest {
 
       verify(rvs).bumpWriteRevision();
    }
+
+   /**
+    * {@code isSessionLive} is a bare passthrough to {@code SheetSessionService.isLive} -- no
+    * owner/pane-scope check of its own -- for {@code LayoutSessionService}'s scheduled cleanup
+    * sweep, which has no {@code Principal} and needs none: it is deciding whether to free a
+    * cached preview-clone runtime, not authorizing an agent action.
+    */
+   @Test
+   void isSessionLiveIsABarePassthroughToTheUnderlyingSessionStore() {
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      SheetAgentBroadcastService broadcast = mock(SheetAgentBroadcastService.class);
+      when(sessions.isLive("live-token")).thenReturn(true);
+      when(sessions.isLive("dead-token")).thenReturn(false);
+
+      ViewsheetSessionService svc = new ViewsheetSessionService(sessions, runtimeAccess, broadcast);
+
+      assertTrue(svc.isSessionLive("live-token"));
+      assertFalse(svc.isSessionLive("dead-token"));
+   }
 }


### PR DESCRIPTION
## Summary
- Spec #11 (Layout) split out of spec #5, Lane I — its own hazards (undo stack, coordinate space, `scaleFont`) had nothing in common with bookmarks/parameters/export.
- Five new services under `inetsoft.web.wiz.viewsheet`, wired into `ViewsheetAssemblyAgentController` via 8 new endpoints under `/api/wiz/v1/agent/viewsheet/{sessionToken}/layout/...`:
  - `LayoutSessionService` — resolves Hazard 1 (a layout edit must never mutate the paired session's Master `Viewsheet`) via a disposable preview-clone runtime per `(sessionToken, layoutName)`, reused across calls and flushed on switch-away or session end.
  - `LayoutReadService` — `list_layouts`/`get_layout`, dual coordinate-space projection (layout-space and viewsheet-space read independently).
  - `PrintDeviceLayoutPropertyService` — `set_print_layout`/`manage_device_layout` via the existing `ViewsheetPropertyDialogService.setViewsheetInfo`, refusing `scaleFont: 0` (would blank crosstab text) and any device-catalogue-shaped write attempt.
  - `LayoutMutationService` — `edit_layout_objects`/`set_layout_table_options`.
  - `LayoutUndoService` — `layout_undo`/`layout_redo`, scoped per layout with a real stack (nested opens pop to the enclosing target, not straight to whole-sheet).
- Companion TS PR (stylebi-wiz): inetsoft-technology/stylebi-wiz#1720 (`layoutTools.ts`, 8 MCP tools).

## Real findings during implementation
- **`LayoutMutationService`'s task found the plan's own suggested approach was a Hazard-1 violation.** Delegating directly to `VSLayoutControllerService`'s `moveResizeLayoutObjects` would `apply()` a layout onto the master's own live `Viewsheet` (that method resolves `parentRvs` via the clone's `getOriginalID()`, i.e. the master's id). Fixed by calling `VSLayoutService`'s smaller, non-`apply()`-calling primitives directly against the master's `LayoutInfo` instead — verified with a manual red/green check (temporarily neutering the write, confirming the coordinate-space test fails, restoring it).
- **A real bug found and fixed at the root in the already-committed `LayoutSessionService`**: a read-only `resolveForRead` switch (e.g. a plain `get_layout` call that changes focus to a different layout) never reset the master's `layoutPoints` undo stack — only a mutating switch did. Since that stack is one flat structure per runtime, not per layout, a subsequent `layout_undo` could pop a checkpoint belonging to a *different* layout, and switching between a print and device layout specifically could throw a `ClassCastException`. Fixed unconditionally resetting the stack on every genuine switch, with new regression tests in both `LayoutSessionServiceTest` and `LayoutUndoServiceTest` (exercised end to end through the undo service's own entry point, not just the session service in isolation).
- **Task 6 hardcodes the layout `region` to `CONTENT`** rather than exposing header/footer/content as a caller-facing parameter, since `get_layout` also only ever projects `CONTENT` and the design spec never mentions region as a tool concept — avoiding a Jackson silent-zero-default landmine (`HEADER`, not `CONTENT`) of the same class as the `scaleFont` hazard.

## Test plan
- [x] Full `inetsoft.web.wiz.**` suite: 2,064 tests, 0 failures, 0 errors (rebased onto current `stylebi-wiz-main-rebase`)
- [ ] Live verification (Phase 5: Hazards 1–4 confirmed against a real running Composer + pairing session) — not run, needs the LIVE STACK token; tracked in `docs/superpowers/plans/2026-08-20-layout-implementation.md` in stylebi-wiz

🤖 Generated with [Claude Code](https://claude.com/claude-code)