### PR TITLE
Bug #76203, keep mixed number/currency CSV columns as string

### DIFF
--- a/core/src/main/java/inetsoft/uql/util/filereader/CSVLoader.java
+++ b/core/src/main/java/inetsoft/uql/util/filereader/CSVLoader.java
@@ -153,6 +153,7 @@ public final class CSVLoader {
             }
 
             String newType = null;
+            Format prevFmt = fmtMap.get(header[i]);
 
             if(XSchema.BOOLEAN.equals(types.get(i)) && !"".equals(data) &&
                (!(data instanceof String) || !"true".equalsIgnoreCase((String) data) &&
@@ -162,6 +163,15 @@ public final class CSVLoader {
             }
             else {
                newType = AssetUtil.getType(header[i], types.get(i), data, fmtMap, isDmyOrder);
+
+               // a column that mixes plain numbers (299.99) with currency or percent
+               // formatted values ($24.99) can't be represented by a single column format.
+               // keep the values as-is instead of nulling out the ones that don't match
+               // the format picked for the column.
+               if(prevFmt != null && fmtMap.get(header[i]) != prevFmt) {
+                  newType = XSchema.STRING;
+                  fmtMap.remove(header[i]);
+               }
             }
 
             // @by stephenwebster, For Bug #16268
@@ -202,7 +212,7 @@ public final class CSVLoader {
       input = new FileInputStream(csvTemp);
 
       if("UTF-8".equals(encode)) {
-         input = consumeBOM(new FileInputStream(csvTemp));
+         input = consumeBOM(input);
       }
 
       reader = new BufferedReader(new InputStreamReader(input, encode));
@@ -524,7 +534,13 @@ public final class CSVLoader {
             fmt = fmtMap.get(header[c]);
 
             if(fmt != null) {
-               val = rdata[c] = fmt.parseObject((String) val, new ParsePosition(0));
+               Object nval = fmt.parseObject((String) val, new ParsePosition(0));
+
+               // parseObject returns null instead of throwing when the value doesn't
+               // match the column format, don't discard the value in that case.
+               if(nval != null) {
+                  val = rdata[c] = nval;
+               }
             }
 
             if(XSchema.STRING.equals(type)) {

--- a/core/src/test/java/inetsoft/uql/util/filereader/CSVLoaderTest.java
+++ b/core/src/test/java/inetsoft/uql/util/filereader/CSVLoaderTest.java
@@ -1,0 +1,137 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.util.filereader;
+
+import inetsoft.test.*;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.table.XSwappableTable;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.util.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class, SwapperTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+public class CSVLoaderTest {
+   /**
+    * Bug: a column mixing plain numbers with currency formatted values had the values
+    * that didn't match the column format replaced with null. The column should be
+    * detected as a string column and all values kept as-is.
+    */
+   @Test
+   public void mixedNumberAndCurrencyKeptAsString() throws Exception {
+      String[] values = { "299.99", "89.5", "149", "$499.99", "12.99", "$24.99", "9.99" };
+      List<String> types = new ArrayList<>();
+      XSwappableTable table = readColumn("price", values, types);
+
+      Assertions.assertEquals(XSchema.STRING, types.get(0));
+
+      for(int i = 0; i < values.length; i++) {
+         Assertions.assertEquals(values[i], table.getObject(i + 1, 0));
+      }
+   }
+
+   /**
+    * Same as above but the currency value comes first, so the column format changes
+    * from currency to plain number instead.
+    */
+   @Test
+   public void mixedCurrencyAndNumberKeptAsString() throws Exception {
+      String[] values = { "$499.99", "299.99", "$24.99" };
+      List<String> types = new ArrayList<>();
+      XSwappableTable table = readColumn("price", values, types);
+
+      Assertions.assertEquals(XSchema.STRING, types.get(0));
+
+      for(int i = 0; i < values.length; i++) {
+         Assertions.assertEquals(values[i], table.getObject(i + 1, 0));
+      }
+   }
+
+   @Test
+   public void currencyOnlyDetectedAsNumber() throws Exception {
+      List<String> types = new ArrayList<>();
+      XSwappableTable table = readColumn("price", new String[]{ "$499.99", "$24.99" }, types);
+
+      Assertions.assertEquals(XSchema.DOUBLE, types.get(0));
+      Assertions.assertEquals(499.99, ((Number) table.getObject(1, 0)).doubleValue(), 0.001);
+      Assertions.assertEquals(24.99, ((Number) table.getObject(2, 0)).doubleValue(), 0.001);
+   }
+
+   @Test
+   public void percentOnlyDetectedAsNumber() throws Exception {
+      List<String> types = new ArrayList<>();
+      XSwappableTable table = readColumn("rate", new String[]{ "15.50%", "8.25%" }, types);
+
+      Assertions.assertEquals(XSchema.DOUBLE, types.get(0));
+      Assertions.assertEquals(0.155, ((Number) table.getObject(1, 0)).doubleValue(), 0.001);
+      Assertions.assertEquals(0.0825, ((Number) table.getObject(2, 0)).doubleValue(), 0.001);
+   }
+
+   @Test
+   public void plainNumberOnlyDetectedAsNumber() throws Exception {
+      List<String> types = new ArrayList<>();
+      XSwappableTable table = readColumn("price", new String[]{ "299.99", "89.5" }, types);
+
+      Assertions.assertEquals(XSchema.DOUBLE, types.get(0));
+      Assertions.assertEquals(299.99, ((Number) table.getObject(1, 0)).doubleValue(), 0.001);
+      Assertions.assertEquals(89.5, ((Number) table.getObject(2, 0)).doubleValue(), 0.001);
+   }
+
+   @Test
+   public void integerOnlyDetectedAsInteger() throws Exception {
+      List<String> types = new ArrayList<>();
+      XSwappableTable table = readColumn("qty", new String[]{ "342", "856" }, types);
+
+      Assertions.assertEquals(XSchema.INTEGER, types.get(0));
+      Assertions.assertEquals(342, table.getObject(1, 0));
+      Assertions.assertEquals(856, table.getObject(2, 0));
+   }
+
+   /**
+    * Read a single column csv file, the returned table has the header in row 0.
+    */
+   private XSwappableTable readColumn(String header, String[] values, List<String> types)
+      throws Exception
+   {
+      StringBuilder content = new StringBuilder(header).append('\n');
+
+      for(String value : values) {
+         content.append(value).append('\n');
+      }
+
+      File file = Files.write(tempDir.resolve(header + ".csv"),
+                              content.toString().getBytes(StandardCharsets.UTF_8)).toFile();
+
+      return CSVLoader.readCSV(file, "UTF-8", true, ",", true, false, new HashMap<>(), types,
+                               true, null, 50000, 0, -1, new DateParseInfo());
+   }
+
+   @TempDir
+   Path tempDir;
+}


### PR DESCRIPTION
Importing a CSV into a worksheet where one column contains both plain numbers (`299.99`) and currency formatted values (`$24.99`) silently replaced some of the cells with `null`. The column should instead be recognized as a string column with every value preserved as-is.

## Root cause

`CSVLoader.readCSV` detects types in one pass and converts values in a second.

`AssetUtil.getType` classifies both `299.99` and `$24.99` as `DOUBLE`, but it also records **one `java.text.Format` per column** in `fmtMap` — `NFMT` (`#,###.#`) for plain numbers, `CFMT` (`$#,##0.##`) for `$…`, `PFMT` for `…%` — and each scanned row overwrites the previous entry. Because both forms yield the same type, the mixed-type guard added for Bug #16268 never fired, so the column stayed `DOUBLE` holding whichever format the *last* scanned row happened to match.

`parseRow` then applied that single column format to every cell:

```java
val = rdata[c] = fmt.parseObject((String) val, new ParsePosition(0));
```

`DecimalFormat.parseObject(String, ParsePosition)` returns `null` instead of throwing when the text doesn't match, and every branch below is guarded by `val != null` / `val instanceof Number`, so nothing recovered it — `NFMT` + `"$24.99"` became `null`. (Symmetrically, had a `$` value been scanned last, the plain numbers would have been nulled instead.)

## Changes

All in `CSVLoader`:

1. **Type detection** — capture the column's format before `AssetUtil.getType` and, if the value selected a different format, demote the column to `XSchema.STRING` and drop the `fmtMap` entry. Dropping it is required, not cosmetic: `parseRow` applies the format *before* looking at the type, so a stale `CFMT` would rewrite `$24.99` to `24.99`. This mirrors what the existing Bug #16268 demotion already does. The four formats are static singletons in `AssetUtil`, so reference identity is the right test.
2. **Value conversion** — only overwrite the cell when `parseObject` actually returned something. This covers what the type scan can't see: a currency value first appearing beyond the 50 000-row detection window, or a column type pinned by `oldTypes` on a re-import. Numeric columns are unaffected — they fall through to the existing `NumberParserWrapper` branch, and a genuine failure still ends at the existing `catch`. It also removes a latent NPE at the `val.toString()` below.
3. **Incidental**, same code path: the second read pass created a fresh `FileInputStream` inside `consumeBOM(...)` and leaked the one assigned a few lines above, holding the CSV file open for the life of the JVM on Windows. Now reuses `input`, matching the first pass.

No `prospectTypeMap` entry is added — the outcome is lossless, so the "values could not be converted" confirm dialog isn't wanted here, consistent with the existing demotion path.

## Verification

New `CSVLoaderTest` — 6 tests: mixed number→currency and currency→number both detect as `STRING` with all values preserved, plus regression coverage keeping all-`$`, all-`%` and all-decimal columns at `DOUBLE` and all-integer at `INTEGER`.

Ran the loader against the reported file (GBK-encoded, mixed `价格(USD)` column), before and after:

| | `价格(USD)` type | `$499.99` row | `$24.99` row |
|---|---|---|---|
| before | `double` | **null** | **null** |
| after | `string` | `$499.99` | `$24.99` |

Every other column's output is byte-identical between the two runs. `XEmbeddedTableTest`, `EmbeddedQueryTest`, `TableAssemblyScriptableTest` and `VSTableModelTest` also pass.

Known remaining gap, unchanged by this PR: if the first currency value in a column falls beyond the 50 000-row detection window, or a re-import pins the column to a numeric type, that value still ends up `null` — change 2 keeps the text, but the numeric parse of `"$24.99"` then fails.
