### PR TITLE
Bug #76168: serve all web-assets files, not just those before the first subdirectory

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/controller/HomePageController.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/HomePageController.java
@@ -243,7 +243,7 @@ public class HomePageController {
 
          if(dataSpace.isDirectory(path)) {
             addDataSpaceTags(model, linkUrl, path);
-            return;
+            continue;
          }
 
          // strip off leading 'web-assets/'


### PR DESCRIPTION
## Problem

`HomePageController.addDataSpaceTags` walks the data space's `web-assets` directory collecting `.css` and `.js` files into the tag lists injected into the User Portal page. On meeting a subdirectory it recursed and then `return`ed — out of the loop and out of the method — instead of continuing.

Because `return` also unwinds the recursion, the entries lost are the *caller's* remaining ones, at every level of the walk. `web-assets` was collected in full only when it contained no subdirectory, or when the only subdirectory happened to sort last. Adding one subdirectory near the front silently stopped the stylesheets and scripts after it from being injected.

There is no error and nothing in the log. Since these model keys are shared with the `portal.additional.styles` / `portal.additional.scripts` properties, the page still carries tags — just not all of them — so the loss is silent from the property side too.

## Fix

`return` → `continue`, so the walk resumes on the next sibling.

The recursive call already collects the subdirectory's contents in full, so this only restores the siblings; nothing is collected twice. The `path.substring(11)` that strips the leading `web-assets/` is applied only on the file branch and already yielded the correct relative URL for nested entries (`web-assets/sub/x.css` → `sub/x.css`), so previously-reachable assets are unaffected.

Tags from a subdirectory now appear at that directory's position in `dataSpace.list()` order, ahead of the later siblings. That is strictly additive — those siblings were absent entirely before, so nothing could have depended on their order.

The two-arg overload is the only entry point, guarded by `webAssetsExist`, so the blast radius is exactly this walk.

Fixes Bug #76168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
