### PR TITLE
Fix Bug #76167: give pdf.font.ratio a single value grammar

### DIFF
--- a/core/src/main/java/inetsoft/report/PDFPrinter.java
+++ b/core/src/main/java/inetsoft/report/PDFPrinter.java
@@ -1303,7 +1303,7 @@ public class PDFPrinter extends Graphics2D implements PDFDevice {
       }
 
       this.ofont = font;
-      this.font = fixFont(font);
+      this.font = font;
       fm = null;
       afm = null;
 
@@ -1313,26 +1313,6 @@ public class PDFPrinter extends Graphics2D implements PDFDevice {
       else {
          psFontName = null;
       }
-   }
-
-   private Font fixFont(Font font) {
-      if(fontRatio == 1.0) {
-         return font;
-      }
-
-      if(font instanceof StyleFont) {
-         StyleFont sf = (StyleFont) font;
-         sf = new StyleFont(sf.getName(), sf.getStyle(),
-                         (int) (sf.getSize() * fontRatio),
-                         sf.getUnderlineStyle(),
-                         sf.getStrikelineStyle());
-         return sf;
-      }
-      else if(font != null) {
-         font = font.deriveFont((float) (font.getSize2D() * fontRatio));
-      }
-
-      return font;
    }
 
    /**
@@ -7032,20 +7012,6 @@ public class PDFPrinter extends Graphics2D implements PDFDevice {
 
    private Font font; // current font
    private Font ofont = null; // current original font
-   private double fontRatio = 1.0;
-
-   {
-      try {
-         String prop = SreeEnv.getProperty("pdf.font.ratio");
-
-         if(prop != null) {
-            fontRatio = Double.parseDouble(prop);
-         }
-      }
-      catch(Exception ex) {
-         // ignore it
-      }
-   }
 
    protected FontMetrics fm = null; // cached font metrics
    protected FontMetrics afm = null; // cached afm font metrics

--- a/core/src/main/java/inetsoft/report/internal/Gop.java
+++ b/core/src/main/java/inetsoft/report/internal/Gop.java
@@ -23,6 +23,8 @@ import inetsoft.report.painter.ImagePainter;
 import inetsoft.sree.SreeEnv;
 import inetsoft.util.Catalog;
 import inetsoft.util.Tool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.awt.*;
 import java.awt.image.FilteredImageSource;
@@ -866,17 +868,32 @@ public class Gop implements StyleConstants {
       if(fontratios == null) {
          fontratios = new HashMap();
 
-         // get the user defined font ratio to adjust for pdf output, e.g.
-         // pdf.font.ratio=MS Hei:1.1;Algerian-bolditalic:1.02
+         // get the user defined per-font width ratio, e.g.
+         // font.ratio.x=MS Hei:1.1;Algerian-bolditalic:1.02
          String prop = SreeEnv.getProperty("font.ratio.x");
+         String propName = "font.ratio.x";
+         String obsolete = SreeEnv.getProperty("pdf.font.ratio");
 
          if(prop == null) {
-            // obsolete
-            prop = SreeEnv.getProperty("pdf.font.ratio");
+            // pdf.font.ratio is the obsolete name for font.ratio.x and takes
+            // the same name:ratio;name:ratio form
+            prop = obsolete;
+            propName = "pdf.font.ratio";
+
+            if(prop != null) {
+               LOG.warn("The pdf.font.ratio property is obsolete. Use " +
+                        "font.ratio.x instead, with the same list of " +
+                        "font-name:ratio pairs. A single ratio applied to " +
+                        "every font is not supported by either property.");
+            }
+         }
+         else if(obsolete != null) {
+            LOG.warn("Ignoring the obsolete pdf.font.ratio property because " +
+                     "font.ratio.x is also set.");
          }
 
          if(prop != null) {
-            parseRatios(fontratios, prop);
+            parseRatios(fontratios, prop, propName);
          }
 
          noratio = fontratios.size() == 0;
@@ -903,7 +920,7 @@ public class Gop implements StyleConstants {
          String prop = SreeEnv.getProperty("font.ratio.y");
 
          if(prop != null) {
-            parseRatios(vfontratios, prop);
+            parseRatios(vfontratios, prop, "font.ratio.y");
          }
 
          novratio = vfontratios.size() == 0;
@@ -939,17 +956,23 @@ public class Gop implements StyleConstants {
    /**
     * Parse ratio string, in the format as:
     * font-name:ratio;font-name:ration
+    *
+    * @param propName the name of the property the value came from, used to
+    * identify the source of a malformed value in the log.
     */
-   protected void parseRatios(HashMap fontratios, String prop) {
+   protected void parseRatios(HashMap fontratios, String prop, String propName) {
       String[] pairs = Tool.split(prop, ';');
 
       for(int i = 0; i < pairs.length; i++) {
          String[] pair = Tool.split(pairs[i], ':');
 
-         if(pair.length == 2 && pair[0].length() > 0) {
+         if(pair.length == 2 && pair[0].trim().length() > 0) {
             try {
-               Double ratio = Double.valueOf(pair[1]);
-               String name = pair[0];
+               // trim so that a space after the ';' separator, which is the
+               // natural way to write the list, does not produce a font name
+               // that getNameWithStyle() can never match
+               Double ratio = Double.valueOf(pair[1].trim());
+               String name = pair[0].trim();
 
                if(name.indexOf('-') < 0) {
                   // add all font styles
@@ -961,7 +984,17 @@ public class Gop implements StyleConstants {
                fontratios.put(name, ratio);
             }
             catch(Exception e) {
+               LOG.warn("Ignoring \"" + pairs[i] + "\" in the " +
+                        propName + " property value: \"" + pair[1] +
+                        "\" is not a number.");
             }
+         }
+         else if(pairs[i].trim().length() > 0) {
+            LOG.warn("Ignoring \"" + pairs[i] + "\" in the " +
+                     propName + " property value. Expected a list of " +
+                     "font-name:ratio pairs separated by ';', for example " +
+                     "\"MS Hei:1.1;Algerian-bolditalic:1.02\". A single ratio " +
+                     "that applies to every font is not supported.");
          }
       }
    }
@@ -989,6 +1022,8 @@ public class Gop implements StyleConstants {
    public String reorderBidi(String str) {
       return str;
    }
+
+   private static final Logger LOG = LoggerFactory.getLogger(Gop.class);
 
    static String[] fonts = null; // font list
    HashMap fontratios = null; // font name -> spacing ratio

--- a/core/src/test/java/inetsoft/report/internal/GopFontRatioTest.java
+++ b/core/src/test/java/inetsoft/report/internal/GopFontRatioTest.java
@@ -1,0 +1,116 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.internal;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests the font.ratio.x/font.ratio.y value grammar. pdf.font.ratio is the
+ * obsolete name for font.ratio.x and takes the same name:ratio;name:ratio
+ * form; a bare scalar is not a supported value.
+ */
+@Tag("core")
+class GopFontRatioTest {
+   @Test
+   void nameWithoutStyleAppliesToEveryStyle() {
+      HashMap ratios = parse("Arial:1.1");
+
+      assertEquals(4, ratios.size());
+      assertEquals(Double.valueOf(1.1), ratios.get("Arial"));
+      assertEquals(Double.valueOf(1.1), ratios.get("Arial-bold"));
+      assertEquals(Double.valueOf(1.1), ratios.get("Arial-italic"));
+      assertEquals(Double.valueOf(1.1), ratios.get("Arial-bolditalic"));
+   }
+
+   @Test
+   void nameWithStyleAppliesToThatStyleOnly() {
+      HashMap ratios = parse("Arial-bold:1.1");
+
+      assertEquals(1, ratios.size());
+      assertEquals(Double.valueOf(1.1), ratios.get("Arial-bold"));
+      assertNull(ratios.get("Arial"));
+   }
+
+   @Test
+   void multiplePairsAreAllParsed() {
+      HashMap ratios = parse("MS Hei:1.1;Algerian-bolditalic:1.02");
+
+      assertEquals(Double.valueOf(1.1), ratios.get("MS Hei"));
+      assertEquals(Double.valueOf(1.02), ratios.get("Algerian-bolditalic"));
+      // "MS Hei" has no style suffix, so it also covers the three styles
+      assertEquals(Double.valueOf(1.1), ratios.get("MS Hei-bold"));
+      assertNull(ratios.get("Algerian"));
+   }
+
+   /**
+    * A bare scalar is the grammar the obsolete pdf.font.ratio reader in
+    * PDFPrinter used to accept. It scaled the glyphs without scaling the
+    * layout that measures them, so it is no longer supported anywhere.
+    */
+   @Test
+   void bareScalarIsIgnored() {
+      assertTrue(parse("1.1").isEmpty());
+      assertTrue(parse("0.95").isEmpty());
+   }
+
+   @Test
+   void malformedPairsAreIgnored() {
+      assertTrue(parse("Arial:notanumber").isEmpty());
+      assertTrue(parse(":1.1").isEmpty());
+      assertTrue(parse("Arial").isEmpty());
+   }
+
+   @Test
+   void goodPairsSurviveAlongsideBadOnes() {
+      HashMap ratios = parse("Arial-bold:1.1;garbage;Times-italic:oops");
+
+      assertEquals(1, ratios.size());
+      assertEquals(Double.valueOf(1.1), ratios.get("Arial-bold"));
+   }
+
+   /**
+    * A space after the ';' separator is the natural way to write the list,
+    * so the font name must be trimmed or the key can never match the name
+    * getNameWithStyle() builds from the font.
+    */
+   @Test
+   void whitespaceAroundPairsIsIgnored() {
+      HashMap ratios = parse("MS Hei:1.1; Algerian-bolditalic:1.02");
+
+      assertEquals(Double.valueOf(1.02), ratios.get("Algerian-bolditalic"));
+      assertNull(ratios.get(" Algerian-bolditalic"));
+   }
+
+   @Test
+   void whitespaceAroundRatioIsIgnored() {
+      HashMap ratios = parse("Arial-bold: 1.1 ");
+
+      assertEquals(Double.valueOf(1.1), ratios.get("Arial-bold"));
+   }
+
+   private static HashMap parse(String prop) {
+      HashMap ratios = new HashMap();
+      new Gop().parseRatios(ratios, prop, "font.ratio.x");
+      return ratios;
+   }
+}


### PR DESCRIPTION
## Problem

`pdf.font.ratio` was read in two places that expected mutually exclusive value shapes, and both failed silently on the other's shape:

| Reader | Grammar | Effect |
|---|---|---|
| `PDFPrinter` instance initialiser → `fontRatio` | bare scalar (`Double.parseDouble`) | scaled the **drawn glyphs only** |
| `Gop.adjustSpacing` → `parseRatios` | `name:ratio;name:ratio` | scaled **measured width**, so layout follows |

A name-keyed value made `Double.parseDouble` throw into an ignored catch, leaving the ratio at 1.0. A bare scalar left `Gop`'s map empty, which set its `noratio` short-circuit.

The scalar reader was the damaging one: it scaled the glyphs without scaling the layout that measures them.

- Pagination is `Graphics`-free — `ReportSheet.printNext` takes a `StylePage`, so `PDFPrinter` first sees the text at `paint()` time, after every box is frozen.
- `TextPaintable.paint` takes its clip, alignment width and baseline from the unscaled `attr.font`, while the glyphs came from the font `PDFPrinter` substituted.

So a ratio above 1.0 drew text larger than the box reserved for it and truncated it at the clip; below 1.0 it under-filled and mispositioned centred and right-aligned text. **There was no safe non-1.0 value for that form.**

## Fix

Retire the scalar reader, so `pdf.font.ratio` means only what `Gop` already treats it as — the obsolete alias of `font.ratio.x`. The surviving form is the one that is integrated with layout.

A device-specific factor cannot be fed into `Common` instead: its measurement API is static and format-agnostic, and is shared with Excel, HTML, PNG and screen output. Making it device-aware would change pagination for every format.

Removing `fixFont` also fixes two related hazards, with no edits at those sites:

- `PDFPrinter.getFontMetrics()` returned metrics for the *scaled* font while `getFontMetrics(Font)` returned *unscaled* metrics for its argument — and ~20 painters (gauges, cylinders, thermometers, sliding scales, `VSCalendar`, `GraphUtil`) call `g.getFontMetrics()` directly.
- `PDFVSExporter` saved `printer.getFont()` and set it back, compounding the ratio to **ratio²**.

## Diagnosability

The remaining reader failed silently too, so `parseRatios` now warns instead of dropping input:

- a segment that is not a `name:ratio` pair (which is what a bare scalar looks like);
- a non-numeric ratio;
- use of the obsolete name, and the case where it is set but ignored because `font.ratio.x` is also set.

## Whitespace bug found while adding the above

`Tool.split` does no trimming, so `font.ratio.x=MS Hei:1.1; Algerian-bolditalic:1.02` — a space after the `;`, the natural way to write a list — stored the key `" Algerian-bolditalic"`, which `getNameWithStyle()` can never match. The pair was well-formed enough that the new warning did not fire either, so the ratio was dropped in silence. The name and ratio are now trimmed, with regression tests.

## Compatibility

- **`pdf.font.ratio=<scalar>`** — PDF text returns to the size layout was computed for. **This is an intentional rendering change**; the previous output was clipped or mispositioned.
- **`pdf.font.ratio=Name:1.1;…`** — unaffected. The `Gop` path is unchanged, and `PDFPrinter` previously threw into the ignored catch and left the ratio at 1.0 anyway.
- **Unset** (the common case) — byte-identical; `fixFont` already early-returned at `1.0`.

## Testing

- `core` `clean install`: **BUILD SUCCESS**; full suite **4359 tests, 0 failures, 0 errors** (67 skips all pre-existing and unrelated — Ignite cluster tests, `$KnownBugs` classes).
- Enterprise layer compiles clean against the rebuilt core, confirming nothing referenced the removed `fixFont`/`fontRatio` or the old 2-arg `parseRatios`.
- New `GopFontRatioTest` (8 cases) covers the pair grammar, style expansion, bare-scalar rejection, malformed input, and the whitespace regression. Tagged `@Tag("core")` so surefire's `<groups>core</groups>` filter actually runs it.

## Note for reviewers

Two pre-existing issues found but deliberately **not** changed here:

1. The lazy init of `fontratios`/`noratio` in `adjustSpacing` is unsynchronized on a singleton `Gop`, so two threads can both parse and both log. Shared with `font.ratio.y`; fixing it means touching a per-measurement hot path.
2. `PDFPrinterRoundRectTest` and `BoundsTest` — and ~71 other test files — lack `@Tag("core")`, so they never run in the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)