### PR TITLE
Bug #76164: encode Basic auth credentials as UTF-8

### DIFF
--- a/connectors/inetsoft-datagov/src/main/java/inetsoft/uql/datagov/DatagovRuntime.java
+++ b/connectors/inetsoft-datagov/src/main/java/inetsoft/uql/datagov/DatagovRuntime.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.json.*;
 import java.net.*;
+import java.nio.charset.StandardCharsets;
 import java.io.*;
 import java.util.Base64;
 
@@ -89,8 +90,8 @@ public class DatagovRuntime extends TabularRuntime {
       URLConnection conn = url.openConnection();
 
       if(user != null && password != null) {
-         String credential =
-            Base64.getEncoder().encodeToString((user + ":" + password).getBytes());
+         String credential = Base64.getEncoder().encodeToString(
+            (user + ":" + password).getBytes(StandardCharsets.UTF_8));
          conn.setRequestProperty("Authorization", "Basic " + credential);
       }
 

--- a/connectors/inetsoft-elastic/src/main/java/inetsoft/uql/elasticrest/ElasticRestRuntime.java
+++ b/connectors/inetsoft-elastic/src/main/java/inetsoft/uql/elasticrest/ElasticRestRuntime.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.net.*;
+import java.nio.charset.StandardCharsets;
 
 public class ElasticRestRuntime extends TabularRuntime {
    public XTableNode runQuery(TabularQuery query0, VariableTable params) {
@@ -99,7 +100,8 @@ public class ElasticRestRuntime extends TabularRuntime {
          conn = (HttpURLConnection) url.openConnection();
 
          String userpass = restDS.getUser() + ":" + restDS.getPassword();
-         String basicAuth = "Basic " + Base64.encodeBase64String(userpass.getBytes());
+         String basicAuth = "Basic " +
+            Base64.encodeBase64String(userpass.getBytes(StandardCharsets.UTF_8));
          conn.setRequestProperty("Authorization", basicAuth);
          conn.getInputStream();
       }
@@ -123,7 +125,8 @@ public class ElasticRestRuntime extends TabularRuntime {
 
       if(user != null && password != null) {
          String credential = new String(
-            Base64.encodeBase64((user + ":" + password).getBytes()));
+            Base64.encodeBase64((user + ":" + password).getBytes(StandardCharsets.UTF_8)),
+            StandardCharsets.US_ASCII);
          conn.setRequestProperty("Authorization", "Basic " + credential);
       }
 

--- a/connectors/inetsoft-odata/src/main/java/inetsoft/uql/odata/ODataRuntime.java
+++ b/connectors/inetsoft-odata/src/main/java/inetsoft/uql/odata/ODataRuntime.java
@@ -49,6 +49,7 @@ import org.slf4j.LoggerFactory;
 import org.w3c.dom.*;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 @SuppressWarnings("WeakerAccess")
@@ -376,7 +377,9 @@ public class ODataRuntime extends TabularRuntime {
 
          if(isUsingBasicAuth(ds)) {
             String credential = new String(
-               Base64.encodeBase64((ds.getUser() + ":" + ds.getPassword()).getBytes()));
+               Base64.encodeBase64((ds.getUser() + ":" + ds.getPassword())
+                                      .getBytes(StandardCharsets.UTF_8)),
+               StandardCharsets.US_ASCII);
             getRequest.setHeader("Authorization", "Basic " + credential);
          }
 

--- a/core/src/main/java/inetsoft/uql/xmla/XMLAHandler.java
+++ b/core/src/main/java/inetsoft/uql/xmla/XMLAHandler.java
@@ -37,6 +37,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.Principal;
 import java.util.*;
 
@@ -886,7 +887,8 @@ public class XMLAHandler extends XHandler {
     */
    private static String encode(String ticket) {
       return ticket == null ? null :
-         new String(Base64.encodeBase64(ticket.getBytes(), false));
+         new String(Base64.encodeBase64(ticket.getBytes(StandardCharsets.UTF_8), false),
+                    StandardCharsets.US_ASCII);
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/portal/service/PostSignUpUserData.java
+++ b/core/src/main/java/inetsoft/web/portal/service/PostSignUpUserData.java
@@ -56,7 +56,8 @@ public class PostSignUpUserData {
                .header("Content-Type", "application/json; charset=UTF-8");
 
             if(postUsername != null && postPassword != null) {
-               String credential = Base64.getEncoder().encodeToString((postUsername + ":" + postPassword).getBytes());
+               String credential = Base64.getEncoder().encodeToString(
+                  (postUsername + ":" + postPassword).getBytes(StandardCharsets.UTF_8));
                requestBuilder.header("Authorization", "Basic " + credential);
             }
 


### PR DESCRIPTION
## Problem

`PostSignUpUserData.sendUserData` builds the `Authorization: Basic` header with `String.getBytes()` and no charset argument, so the credential is encoded using whatever the JVM's default charset happens to be. A `selfSignUpPost.username` or `selfSignUpPost.password` containing a non-ASCII character therefore authenticates on one host and fails on another with the same configuration — and nothing in the log distinguishes it from a wrong password.

The request body two lines above is explicit about its charset and declares it in the content type. Only the credential was not.

RFC 7617 recommends UTF-8 as the Basic scheme's charset, and it is what receiving servers overwhelmingly assume.

The failure is environment-dependent and silent: same configuration, same endpoint, same credentials — working in one deployment and rejected in another, because one JVM defaulted to UTF-8 and the other to a platform encoding. Latent for ASCII-only credentials, which is presumably why it has not surfaced.

## Changes

Six sites in all. Every one builds `user:password` bytes with an unqualified `getBytes()`.

**`core/.../web/portal/service/PostSignUpUserData.java:59`** — the reported defect. `StandardCharsets` was already imported.

**`core/.../uql/xmla/XMLAHandler.java:889`** — the same defect in the OLAP Basic credential. `encode()` is the single chokepoint for both credential paths — `getTicketFromUser` (the `olap.security.enabled` ticket) and `getLocalTicket` (the data source user/password) — so one edit covers both. Its `new String(byte[])` is pinned to US-ASCII for symmetry: a no-op in practice since Base64 output is ASCII, but it removes the other unqualified platform-default conversion in the same expression.

**Connectors** — the same defect in four more places, all reached the same way:

- `connectors/inetsoft-odata/.../ODataRuntime.java:379`
- `connectors/inetsoft-elastic/.../ElasticRestRuntime.java:102` and `:126`
- `connectors/inetsoft-datagov/.../DatagovRuntime.java:93`

`connectors/inetsoft-rest/.../auth/BasicAuthenticator.java` already does this correctly, so the pattern was established in the tree — these were the stragglers.

Deliberately not touched: the `btoa(...)` calls in `login.js` and `main-base-element.ts`. Those run `encodeURIComponent` first and so are not exposed to this class of bug.

## Side effects

- Both sites build the credential per request and never persist or compare it against a previously encoded value, so there is no stored-value compatibility concern.
- On any JVM whose default charset is already UTF-8 (the JDK 18+ default, and what the Docker images run) the encoded bytes are byte-identical — the change is a no-op there and only corrects hosts with a divergent platform default.
- ASCII-only credentials are unaffected on every platform encoding.
- `PostSignUpUserData` has one caller (`UserSignupService:261`); `encode()` is private to `XMLAHandler`. The connector sites are each local to one connection-setup method.

## Testing

`./mvnw -o compile -pl core` and `./mvnw -o compile -pl connectors/inetsoft-odata,connectors/inetsoft-elastic,connectors/inetsoft-datagov` — clean.

No unit test added: every site constructs its `HttpClient` / `HttpURLConnection` / `HttpGet` internally, and `encode()` is private static, so asserting on the emitted header would require injecting the client or widening visibility — a refactor beyond the defect. None of these classes has an existing test.

Manual check: point `selfSignUpPost.url` at an echo endpoint, set `selfSignUpPost.username` to a value with a non-ASCII character, start the server with `-Dfile.encoding=windows-1252`, and complete a self-signup — the received `Authorization` header now decodes to the correct UTF-8 credential where it previously yielded mojibake.

## Note for the issue

The report writes the properties as `selfsignuppost.*`; the code reads camel-case `selfSignUpPost.url` / `.username` / `.password` / `.header` / `.secretKey`. Worth correcting in the property doc that prompted the finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

