### PR TITLE
fix(wiz-binding): refuse groups/aggregates/options on a plain Table

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/binding/TableBindingMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/TableBindingMutator.java
@@ -25,7 +25,6 @@ import inetsoft.web.binding.model.BDimensionRefModel;
 import inetsoft.uql.XConstants;
 import inetsoft.web.binding.model.table.BaseTableBindingModel;
 import inetsoft.web.binding.model.table.CrosstabOptionInfo;
-import inetsoft.web.binding.model.table.TableOptionInfo;
 import inetsoft.web.binding.model.table.CrosstabBindingModel;
 import inetsoft.web.binding.model.table.TableBindingModel;
 import inetsoft.web.wiz.binding.model.FieldRef;
@@ -45,10 +44,6 @@ import java.util.*;
  * else no tool here touches.
  */
 public final class TableBindingMutator {
-   /** Shelves holding dimensions, per object type. */
-   private static final List<String> CROSSTAB_DIMENSION_SHELVES = List.of("rows", "cols");
-   private static final List<String> TABLE_DIMENSION_SHELVES = List.of("groups");
-
    /**
     * Natural spellings an agent is likely to reach for. The canonical names match
     * {@code CrosstabConstants} rather than inventing new ones.
@@ -74,8 +69,16 @@ public final class TableBindingMutator {
          return List.of("rows", "cols", "aggregates");
       }
 
+      // TableVSAssemblyInfo has no grouping or aggregation of its own — that is Crosstab's job.
+      // TableBindingModel.getGroups()/getAggregates()/getOption() exist as wire-format fields
+      // that VSTableBindingFactory.updateTableAssembly never reads back into the real assembly
+      // (it only ever applies getDetails()), so accepting writes to them here silently dropped
+      // every one: set_table_fields/add_table_field returned {"ok":true} and applied nothing,
+      // and move_table_field lost the field entirely (removed from its source shelf, never
+      // landed on the target). Restricting a table to its one real shelf makes requireShelf
+      // refuse "groups"/"aggregates" by name instead — see docs/superpowers L5 findings 1-2.
       if(model instanceof TableBindingModel) {
-         return List.of("groups", "details", "aggregates");
+         return List.of("details");
       }
 
       throw new IllegalArgumentException(
@@ -604,25 +607,16 @@ public final class TableBindingMutator {
       }
    }
 
+   /**
+    * A plain Table has no options a write here can actually apply. {@code TableOptionInfo} /
+    * {@code TableBindingModel.getOption()} are wire-format leftovers nothing in
+    * {@code VSTableBindingFactory.updateTableAssembly} ever reads, so accepting {@code
+    * grandTotal}/{@code distinct} silently dropped both: {@code {"ok":true}}, nothing applied,
+    * read-back unchanged. {@code requireKnown} against an empty list refuses every key by name
+    * instead, reusing the same refusal a real unknown option already gets.
+    */
    private static void setTableOptions(TableBindingModel model, Map<String, Object> options) {
-      TableOptionInfo info = model.getOption();
-
-      if(info == null) {
-         info = new TableOptionInfo();
-         model.setOption(info);
-      }
-
-      requireKnown(options, List.of("grandTotal", "distinct"));
-
-      if(options.containsKey("grandTotal")) {
-         info.setGrandTotal(
-            Boolean.parseBoolean(stringBoolean(options.get("grandTotal"), "grandTotal")));
-      }
-
-      if(options.containsKey("distinct")) {
-         info.setDistinct(
-            Boolean.parseBoolean(stringBoolean(options.get("distinct"), "distinct")));
-      }
+      requireKnown(options, List.of());
    }
 
    /**
@@ -720,7 +714,7 @@ public final class TableBindingMutator {
       return Map.of(
          "crosstab", List.of("rowTotals", "colTotals", "percentageBy", "summarySideBySide",
                              "suppressGroupTotal"),
-         "table", List.of("grandTotal", "distinct"),
+         "table", List.of(),
          "percentageBy", List.of("none", "row", "col"),
          "sortDirections", DimensionSortRanking.sortTokens(),
          "rankingModes", DimensionSortRanking.rankingTokens());

--- a/core/src/test/java/inetsoft/web/wiz/binding/TableBindingMutatorTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/TableBindingMutatorTest.java
@@ -86,15 +86,27 @@ class TableBindingMutatorTest {
 
    // ── table shelves ─────────────────────────────────────────────────────────
 
+   /**
+    * A plain Table has no grouping or aggregation in StyleBI — that is Crosstab's job.
+    * {@code TableBindingModel.groups}/{@code aggregates} exist as wire-format fields, but
+    * {@code VSTableBindingFactory.updateTableAssembly} never reads them back into the real
+    * {@code TableVSAssemblyInfo}, so accepting a write here used to silently drop it: the call
+    * reported {@code {"ok":true}} and nothing was applied. Refusing by name is the fix.
+    */
    @Test
-   void setsTableGroupsAndAggregates() {
+   void refusesTableGroupsAndAggregatesShelves() {
       TableBindingModel model = new TableBindingModel();
 
-      TableBindingMutator.setShelf(model, "groups", List.of(dim("Region")));
-      TableBindingMutator.setShelf(model, "aggregates", List.of(measure("Sales", "Sum")));
+      Exception groups = assertThrows(IllegalArgumentException.class,
+         () -> TableBindingMutator.setShelf(model, "groups", List.of(dim("Region"))));
+      Exception aggregates = assertThrows(IllegalArgumentException.class,
+         () -> TableBindingMutator.setShelf(model, "aggregates",
+                                            List.of(measure("Sales", "Sum"))));
 
-      assertEquals(1, model.getGroups().size());
-      assertEquals(1, model.getAggregates().size());
+      assertTrue(groups.getMessage().contains("groups"));
+      assertTrue(aggregates.getMessage().contains("aggregates"));
+      assertTrue(groups.getMessage().contains("details"),
+                 "the refusal should name the one shelf a table actually has");
    }
 
    /**
@@ -134,7 +146,7 @@ class TableBindingMutatorTest {
          () -> TableBindingMutator.setShelf(new TableBindingModel(), "rows", List.of()));
 
       assertTrue(thrown.getMessage().contains("rows"));
-      assertTrue(thrown.getMessage().contains("groups"),
+      assertTrue(thrown.getMessage().contains("details"),
                  "the refusal should list the shelves this object type does have");
    }
 
@@ -577,14 +589,21 @@ class TableBindingMutatorTest {
                                                         Map.of("percentageBy", "diagonal")));
    }
 
+   /**
+    * A plain Table has no options a write here can actually apply — {@code grandTotal}/
+    * {@code distinct} on {@code TableOptionInfo} are wire-format leftovers nothing in
+    * {@code VSTableBindingFactory.updateTableAssembly} ever reads, so accepting them used to
+    * report {@code {"ok":true}} and apply nothing. Refusing by name is the fix.
+    */
    @Test
-   void setsTableOptions() {
-      TableBindingModel model = new TableBindingModel();
+   void refusesAnyTableOption() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> TableBindingMutator.setOptions(new TableBindingModel(),
+                                              Map.of("grandTotal", true, "distinct", false)));
 
-      TableBindingMutator.setOptions(model, Map.of("grandTotal", true, "distinct", false));
-
-      assertTrue(model.getOption().getGrandTotal());
-      assertFalse(model.getOption().getDistinct());
+      assertTrue(thrown.getMessage().contains("grandTotal"));
+      assertTrue(thrown.getMessage().contains("distinct"));
    }
 
    /** An option belonging to the other object type would be accepted and do nothing. */
@@ -596,7 +615,6 @@ class TableBindingMutatorTest {
                                               Map.of("rowTotals", true)));
 
       assertTrue(thrown.getMessage().contains("rowTotals"));
-      assertTrue(thrown.getMessage().contains("grandTotal"), "list what this type does take");
    }
 
    @Test
@@ -610,6 +628,7 @@ class TableBindingMutatorTest {
       Map<String, Object> vocabulary = TableBindingMutator.optionVocabulary();
 
       assertTrue(String.valueOf(vocabulary.get("crosstab")).contains("rowTotals"));
-      assertTrue(String.valueOf(vocabulary.get("table")).contains("distinct"));
+      assertEquals(List.of(), vocabulary.get("table"),
+                   "a table has no options this write path can actually apply");
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/binding/TableBindingServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/TableBindingServiceTest.java
@@ -109,7 +109,7 @@ class TableBindingServiceTest {
    @Test
    void readReportsTheObjectTypeAndShelvesWithoutMutating() throws Exception {
       TableBindingModel existing = new TableBindingModel();
-      TableBindingMutator.setShelf(existing, "groups", List.of(dim("Region")));
+      TableBindingMutator.setShelf(existing, "details", List.of(dim("Region")));
       ViewsheetSessionService sessions = sessionsFor(mock(TableVSAssembly.class));
 
       Map<String, Object> read = serviceWith(sessions, existing,
@@ -119,8 +119,10 @@ class TableBindingServiceTest {
       assertEquals("table", read.get("objectType"));
       @SuppressWarnings("unchecked")
       Map<String, Object> shelves = (Map<String, Object>) read.get("shelves");
-      assertTrue(shelves.containsKey("groups"));
       assertTrue(shelves.containsKey("details"));
+      assertFalse(shelves.containsKey("groups"),
+                  "a table has no grouping — that is Crosstab's job — and this shelf can never " +
+                  "be written, so it should not be advertised as readable either");
       assertFalse(shelves.containsKey("rows"), "a table has no rows shelf");
       verify(sessions, never()).mutate(anyString(), any(Principal.class), any());
    }


### PR DESCRIPTION
## Summary
- A plain StyleBI `Table` assembly has no grouping or aggregation of its own — that's Crosstab's job — but `TableBindingModel` carried `groups`/`aggregates`/`option` fields that `VSTableBindingFactory.updateTableAssembly` never applied back to the real `TableVSAssemblyInfo`.
- The wiz agent's `set_table_fields`/`add_table_field`/`set_table_options` tools accepted writes to these and reported `{"ok":true}` while applying nothing (confirmed live via `get_table_binding` read-back and `get_viewsheet_image`).
- `move_table_field` compounded this into data loss: moving a field from a real shelf (`details`) onto one of these silently removed it from its source and never re-added it anywhere, while still reporting success.
- Fix: restrict `TableBindingModel` to its one real shelf (`details`) and to no options, reusing the existing "unknown shelf/option" refusal so both now fail loud by name instead of succeeding silently — the same pattern `set_column_labels` already uses for its own unimplemented-feature refusal.
- Found via the composer plugin test plan's L5 lane in stylebi-wiz (`docs/superpowers/plans/2026-08-17-consolidated-composer-plugin-test-plan.md`).

## Test plan
- [x] `./mvnw -o test -pl core -Dtest='TableBindingMutatorTest,TableBindingServiceTest'` — 58/58 pass
- [x] `./mvnw -o test -pl core -Dtest='inetsoft.web.wiz.**.*Test'` — 1929/1929 pass, no collateral breakage
- [ ] Live re-verification against a running Composer session (L5 cases 5.2-5.4) — pending rebuild/redeploy

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>