### PR TITLE
fix(wiz): move_resize honors partial x/y/width/height patches

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/LayoutMutationService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/LayoutMutationService.java
@@ -210,9 +210,21 @@ public class LayoutMutationService {
                VSAssemblyLayout assemblyLayout =
                   requireAssemblyLayout(layout, name, region, layoutName);
 
-               Point position = new Point(toInt(object.get("x")), toInt(object.get("y")));
-               Dimension size = new Dimension(toInt(object.get("width")),
-                                               toInt(object.get("height")));
+               // A move-only or resize-only call must leave the other dimension unchanged --
+               // merge onto the assembly's current position/size rather than defaulting an
+               // omitted field to 0, which would silently shrink/relocate it instead.
+               Point currentPosition = assemblyLayout.getPosition();
+               Dimension currentSize = assemblyLayout.getSize();
+               int x = object.containsKey("x") ? toInt(object.get("x")) :
+                  (currentPosition != null ? currentPosition.x : 0);
+               int y = object.containsKey("y") ? toInt(object.get("y")) :
+                  (currentPosition != null ? currentPosition.y : 0);
+               int width = object.containsKey("width") ? toInt(object.get("width")) :
+                  (currentSize != null ? currentSize.width : 0);
+               int height = object.containsKey("height") ? toInt(object.get("height")) :
+                  (currentSize != null ? currentSize.height : 0);
+               Point position = new Point(x, y);
+               Dimension size = new Dimension(width, height);
                assemblyLayout.setPosition(position);
                assemblyLayout.setSize(size);
 

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/LayoutMutationServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/LayoutMutationServiceTest.java
@@ -93,6 +93,45 @@ class LayoutMutationServiceTest {
    }
 
    /**
+    * A move-only call (only x/y, no width/height) must leave the object's existing size alone --
+    * the tool's own contract allows an omitted dimension to mean "unchanged", and the server must
+    * honor that rather than collapsing the omitted fields to zero.
+    */
+   @Test
+   void moveOnlyPreservesExistingSize() throws Exception {
+      Fixture fx = new Fixture();
+      fx.installPrintLayout();
+
+      fx.service.editObjects("tok1", AGENT, PRINT_LAYOUT, "move_resize", VSLayoutService.CONTENT,
+         List.of(Map.of("name", "Table1", "x", 555, "y", 666)), false);
+
+      LayoutObjectModelHolder table = fx.readTableObject();
+      assertEquals(555, table.layoutX());
+      assertEquals(666, table.layoutY());
+      assertEquals(50, table.layoutWidth(), "resize-omitted width must be preserved, not zeroed");
+      assertEquals(60, table.layoutHeight(), "resize-omitted height must be preserved, not zeroed");
+   }
+
+   /**
+    * A resize-only call (only width/height, no x/y) must leave the object's existing position
+    * alone, for the same reason as {@link #moveOnlyPreservesExistingSize}.
+    */
+   @Test
+   void resizeOnlyPreservesExistingPosition() throws Exception {
+      Fixture fx = new Fixture();
+      fx.installPrintLayout();
+
+      fx.service.editObjects("tok1", AGENT, PRINT_LAYOUT, "move_resize", VSLayoutService.CONTENT,
+         List.of(Map.of("name", "Table1", "width", 70, "height", 80)), false);
+
+      LayoutObjectModelHolder table = fx.readTableObject();
+      assertEquals(300, table.layoutX(), "move-omitted x must be preserved, not zeroed");
+      assertEquals(400, table.layoutY(), "move-omitted y must be preserved, not zeroed");
+      assertEquals(70, table.layoutWidth());
+      assertEquals(80, table.layoutHeight());
+   }
+
+   /**
     * The Hazard-1 exit criterion again, from this task's own entry point (not just
     * {@code LayoutSessionServiceTest}'s unit test in isolation) -- a full {@code
     * edit_layout_objects} call through {@code LayoutMutationService} leaves the master runtime's


### PR DESCRIPTION
## Summary
- `edit_layout_objects`' `move_resize` op requires only "at least one of x/y/width/height" client-side (a move-only or resize-only call is by design), but the server's `LayoutMutationService.moveResize` required all four and crashed with `NumberFormatException` (`toInt(null)` → `Integer.parseInt("null")`) on a partial patch.
- Fixed by merging omitted fields onto the assembly's *current* position/size (from `assemblyLayout.getPosition()`/`getSize()`), so an omitted field means "unchanged" — not a crash, and not a silent zero that would invisibly shrink/relocate the object.
- Motivated by blocking finding #3 on inetsoft-technology/stylebi-wiz#1720.

## Test plan
- [x] New regression tests in `LayoutMutationServiceTest`: `moveOnlyPreservesExistingSize`, `resizeOnlyPreservesExistingPosition`
- [x] `./mvnw -o test -pl core -Dtest='inetsoft.web.wiz.viewsheet.LayoutMutationServiceTest'` — 9/9 pass
- [x] `./mvnw -o test -pl core -Dtest='inetsoft.web.wiz.**.*Test'` — 2091 pass, 0 fail, 1 skipped (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)