### PR TITLE
Report an endpoint's response shape from the request the table build already makes

### DIFF
--- a/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/EndpointJsonQueryRunner.java
+++ b/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/EndpointJsonQueryRunner.java
@@ -27,6 +27,7 @@ import inetsoft.uql.rest.json.RestJsonQuery;
 import inetsoft.uql.rest.json.lookup.*;
 import inetsoft.uql.rest.json.lookup.LookupService;
 import inetsoft.uql.util.BaseJsonTable;
+import inetsoft.uql.util.JsonShapeDistiller;
 import inetsoft.uql.util.LookupList;
 import inetsoft.uql.util.LookupMap;
 import org.slf4j.Logger;
@@ -57,11 +58,35 @@ public class EndpointJsonQueryRunner extends RestJsonQueryRunner {
          strategy.setLiveMode(isLiveMode());
          strategy.setTouchTimestamp(getTouchTimestamp());
 
+         boolean shaped = false;
+
          while(hasNext(strategy, table)) {
             final Object json = strategy.next();
 
             if(json == null) {
                break;
+            }
+
+            // Distil the response's SHAPE before jsonPath narrows it, and before doLookups mutates
+            // it by grafting lookup responses in. Three things make this the right point and no
+            // other:
+            //
+            //  - It costs NO EXTRA REQUEST. This page has already been fetched and paid for. The
+            //    alternative -- RestJsonQuery.getJsonMetadata() -- dials the endpoint a second time
+            //    from inside a getter, caches a failure permanently as "{}", persists real records
+            //    into the worksheet XML, and changes the column set by merging the metadata table's
+            //    own headers in. None of that applies here.
+            //  - It is BEFORE selectData, so a wrong jsonPath cannot corrupt it. That is the point:
+            //    when the caller guessed the row path wrong and built a table of envelope columns,
+            //    this shape is what tells it where the rows actually are.
+            //  - It is the FIRST page only. Later pages repeat the same structure, and a shape is a
+            //    statement about the endpoint rather than about how much of it was read.
+            //
+            // Values are dropped by the distiller, never carried here: the shape is a property of
+            // the connector, the body is customer data. See JsonShapeDistiller.
+            if(!shaped) {
+               shaped = true;
+               shapeResponse(json);
             }
 
             doLookups(query, json);
@@ -78,4 +103,25 @@ public class EndpointJsonQueryRunner extends RestJsonQueryRunner {
 
       return table;
    }
+
+   /**
+    * Record the response shape on the query, swallowing anything that goes wrong.
+    *
+    * <p>The shape is a BY-PRODUCT. A malformed response, an unexpected object model, a cap that
+    * fires -- none of it may cost the caller the table it asked for, which is the thing it actually
+    * requested and already paid a request for. So a failure here is logged and dropped, and the
+    * caller simply sees no shape.</p>
+    */
+   private void shapeResponse(Object json) {
+      try {
+         JsonShapeDistiller.Result result = JsonShapeDistiller.distill(json);
+         query.setResponseShape(result.getShape(), result.isTruncated());
+      }
+      catch(Exception ex) {
+         LOG.debug("Failed to distil the response shape for " + query.getClass().getSimpleName(), ex);
+      }
+   }
+
+   private static final Logger LOG =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 }

--- a/connectors/inetsoft-tabular-util/src/main/java/inetsoft/uql/util/JsonShapeDistiller.java
+++ b/connectors/inetsoft-tabular-util/src/main/java/inetsoft/uql/util/JsonShapeDistiller.java
@@ -1,0 +1,360 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.util;
+
+import inetsoft.util.CoreTool;
+
+import javax.json.JsonValue;
+import java.util.*;
+import java.util.regex.Pattern;
+
+/**
+ * Reduce a parsed JSON response to its SHAPE: which paths exist and what type each leaf is,
+ * carrying none of the values.
+ *
+ * <p>This exists so a caller can be told what an endpoint returns without being handed what it
+ * returned. The distinction is the whole point: a REST response body is customer data — a page of
+ * charges, of contacts, of tickets — while its shape is a property of the connector. Only the
+ * latter is safe to record once and reuse for everyone.</p>
+ *
+ * <p>VALUES ARE DROPPED, BUT THAT IS NOT SUFFICIENT. Object keys become part of the shape, and some
+ * responses key an object BY DATA — {@code {"cus_9f2a": {...}, "cus_71bd": {...}}}. Enumerating
+ * those keys would record thousands of customer ids under the guise of structure, and produce a
+ * shape nobody can use besides. Such objects are collapsed to a single {@link #WILDCARD_KEY} entry;
+ * see {@link #isDictionary}.</p>
+ *
+ * <p>TYPES ARE BEST-EFFORT AND DELIBERATELY SO. They come from {@link JsonTable#getTypeClass}, the
+ * same function the table itself uses, so a number is reported as {@code double} exactly as the
+ * built table will report it. What is NOT reproduced is date detection on string values: that lives
+ * in {@link BaseJsonTable#parseValue} and depends on per-column state accumulated across rows
+ * ({@code colTypes2}), so a string holding a date may be reported here as {@code string} while the
+ * table types it as {@code date}. Structure is what this is for; a type that reads narrower than
+ * the table's costs a caller nothing it cannot recover by looking at the built table.</p>
+ */
+public final class JsonShapeDistiller {
+   /**
+    * The key standing in for every key of an object that is keyed by data rather than by field
+    * name. A caller must treat a path through this segment as NOT referenceable as a column: the
+    * real segment is a value, and it differs per response.
+    */
+   public static final String WILDCARD_KEY = "*";
+
+   /** Beyond this many nodes the shape is cut off and reported truncated. */
+   public static final int DEFAULT_MAX_NODES = 2000;
+
+   /** Beyond this depth recursion stops and the subtree is reported truncated. */
+   public static final int DEFAULT_MAX_DEPTH = 16;
+
+   /**
+    * An object with more children than this whose children all share one shape is read as a
+    * dictionary rather than a record. Deliberately high: the count alone must not decide, because
+    * some APIs return a record with dozens of flat fields. See {@link #isDictionary}.
+    */
+   static final int DICTIONARY_MIN_KEYS = 50;
+
+   /**
+    * Keys that are values rather than field names. Matched against a SINGLE key, and one match
+    * collapses the whole object — a dictionary with three entries is still a dictionary, and no
+    * count-based rule can see it.
+    *
+    * <p>This is a heuristic and it will miss: a small map keyed by person names or by user-defined
+    * labels reads as a record. It narrows the exposure from certain to rare, and does not remove
+    * it.</p>
+    */
+   private static final Pattern[] DATA_LIKE_KEY = {
+      // uuid
+      Pattern.compile("(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"),
+      // Prefixed opaque id: cus_9f2aB1, evt_00Ab, acct_1H2x.
+      //
+      // THE SUFFIX MUST CONTAIN A DIGIT. Without that requirement this pattern matches ordinary
+      // snake_case field names -- has_more, fee_details, available_on, reporting_category are all
+      // "two-to-six lowercase letters, underscore, four-plus alphanumerics" -- and a single such
+      // key collapses the whole record, replacing every real field name with "*". snake_case is
+      // the most common JSON field convention there is, so that is not an edge case; it is most
+      // responses. A digit is what separates an opaque id from a word.
+      Pattern.compile("^[a-z]{2,6}_(?=[A-Za-z0-9]*[0-9])[A-Za-z0-9]{4,}$"),
+      // bare opaque id / long hex / digits
+      Pattern.compile("^[0-9]+$"),
+      Pattern.compile("(?i)^[0-9a-f]{16,}$"),
+      // ISO date or timestamp
+      Pattern.compile("^\\d{4}-\\d{2}-\\d{2}([T ].*)?$"),
+      // email
+      Pattern.compile("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$")
+   };
+
+   private JsonShapeDistiller() {
+   }
+
+   /** The distilled shape, plus whether a cap cut it short. */
+   public static final class Result {
+      private final Object shape;
+      private final boolean truncated;
+
+      Result(Object shape, boolean truncated) {
+         this.shape = shape;
+         this.truncated = truncated;
+      }
+
+      /**
+       * A {@code Map<String, Object>} for an object, a single-element {@code List} for an array, or
+       * a type name for a leaf. Never null.
+       */
+      public Object getShape() {
+         return shape;
+      }
+
+      /**
+       * True when a node or depth cap stopped the walk. A consumer MUST distinguish this from a
+       * complete shape: under truncation, "this path is absent" means "not reached", not "not there".
+       */
+      public boolean isTruncated() {
+         return truncated;
+      }
+   }
+
+   public static Result distill(Object json) {
+      return distill(json, DEFAULT_MAX_NODES, DEFAULT_MAX_DEPTH);
+   }
+
+   public static Result distill(Object json, int maxNodes, int maxDepth) {
+      Budget budget = new Budget(maxNodes, maxDepth);
+      Object shape = shapeOf(json, budget, 0);
+      return new Result(shape, budget.truncated);
+   }
+
+   private static Object shapeOf(Object value, Budget budget, int depth) {
+      if(depth > budget.maxDepth) {
+         budget.truncated = true;
+         return CoreTool.STRING;
+      }
+
+      if(!budget.spend()) {
+         return CoreTool.STRING;
+      }
+
+      if(value instanceof Map) {
+         return objectShape((Map<?, ?>) value, budget, depth);
+      }
+
+      if(value instanceof List) {
+         return arrayShape((List<?>) value, budget, depth);
+      }
+
+      return leafType(value);
+   }
+
+   private static Object objectShape(Map<?, ?> map, Budget budget, int depth) {
+      Map<String, Object> children = new LinkedHashMap<>();
+
+      for(Map.Entry<?, ?> entry : map.entrySet()) {
+         if(!(entry.getKey() instanceof String)) {
+            continue;
+         }
+
+         children.put((String) entry.getKey(), shapeOf(entry.getValue(), budget, depth + 1));
+      }
+
+      if(children.isEmpty() || !isDictionary(children)) {
+         return children;
+      }
+
+      // Collapse. The keys were data, so they are dropped rather than recorded, and the values --
+      // which are homogeneous by the very test that got us here -- are merged into one entry.
+      Object merged = null;
+
+      for(Object child : children.values()) {
+         merged = merged == null ? child : merge(merged, child);
+      }
+
+      Map<String, Object> collapsed = new LinkedHashMap<>();
+      collapsed.put(WILDCARD_KEY, merged);
+      return collapsed;
+   }
+
+   /**
+    * An array contributes ONE element shape, merged across every element present.
+    *
+    * <p>Merged rather than taken from the first element because an optional field is exactly what a
+    * caller needs to know about and exactly what the first element may omit. The merge is still
+    * bounded by the response: a field absent from every element here is absent from the shape.</p>
+    */
+   private static Object arrayShape(List<?> list, Budget budget, int depth) {
+      Object merged = null;
+
+      for(Object element : list) {
+         Object shape = shapeOf(element, budget, depth + 1);
+         merged = merged == null ? shape : merge(merged, shape);
+      }
+
+      List<Object> result = new ArrayList<>(1);
+
+      if(merged != null) {
+         result.add(merged);
+      }
+
+      return result;
+   }
+
+   /**
+    * Whether an object is keyed by data rather than by field name.
+    *
+    * <p>TWO RULES, because they catch different things and neither catches both:</p>
+    *
+    * <ul>
+    *   <li><b>Key shape</b> — any single key that reads as an id, a date or an email. This is the
+    *   only rule that can see a LOW-CARDINALITY dictionary: a tenant with three customers produces
+    *   three keys, and no threshold will ever fire on that.</li>
+    *   <li><b>Homogeneity and count</b> — many children that all share one shape. This catches a
+    *   dictionary whose keys look perfectly ordinary (country codes, month names, SKUs), which the
+    *   key-shape rule cannot.</li>
+    * </ul>
+    *
+    * <p>The second rule requires homogeneity and not merely a count, so that a WIDE RECORD is not
+    * mistaken for a dictionary and stripped of its real field names. A record's children differ in
+    * shape — a number here, an object there; a dictionary's values are alike, and that is the
+    * discriminator.</p>
+    */
+   private static boolean isDictionary(Map<String, Object> children) {
+      for(String key : children.keySet()) {
+         for(Pattern pattern : DATA_LIKE_KEY) {
+            if(pattern.matcher(key).matches()) {
+               return true;
+            }
+         }
+      }
+
+      if(children.size() < DICTIONARY_MIN_KEYS) {
+         return false;
+      }
+
+      Object first = null;
+
+      for(Object child : children.values()) {
+         if(first == null) {
+            first = child;
+         }
+         else if(!first.equals(child)) {
+            return false;
+         }
+      }
+
+      return true;
+   }
+
+   /**
+    * Combine two shapes for the same path.
+    *
+    * <p>Kinds that disagree collapse to {@code string}, which is what the table does too: a column
+    * seen with two types is typed {@code String} ({@link JsonTable} walkRecord's mixed-type
+    * branch).</p>
+    */
+   @SuppressWarnings("unchecked")
+   static Object merge(Object a, Object b) {
+      if(a.equals(b)) {
+         return a;
+      }
+
+      if(a instanceof Map && b instanceof Map) {
+         Map<String, Object> left = (Map<String, Object>) a;
+         Map<String, Object> right = (Map<String, Object>) b;
+         Map<String, Object> merged = new LinkedHashMap<>(left);
+
+         for(Map.Entry<String, Object> entry : right.entrySet()) {
+            Object existing = merged.get(entry.getKey());
+            merged.put(entry.getKey(),
+                       existing == null ? entry.getValue() : merge(existing, entry.getValue()));
+         }
+
+         return merged;
+      }
+
+      if(a instanceof List && b instanceof List) {
+         List<Object> left = (List<Object>) a;
+         List<Object> right = (List<Object>) b;
+
+         if(left.isEmpty()) {
+            return right;
+         }
+
+         if(right.isEmpty()) {
+            return left;
+         }
+
+         List<Object> merged = new ArrayList<>(1);
+         merged.add(merge(left.get(0), right.get(0)));
+         return merged;
+      }
+
+      // A leaf against a leaf, or a leaf against a container. Either way there is no shape both
+      // agree on, and the table's own answer for a column of mixed type is String.
+      if(CoreTool.NULL.equals(a)) {
+         return b;
+      }
+
+      if(CoreTool.NULL.equals(b)) {
+         return a;
+      }
+
+      return CoreTool.STRING;
+   }
+
+   /**
+    * The XSchema type name for a leaf, taken from the same function the table uses so the two
+    * agree. A JSON number therefore reports as {@code double}, never {@code integer}.
+    */
+   private static String leafType(Object value) {
+      if(value == null || isJsonNull(value)) {
+         return CoreTool.NULL;
+      }
+
+      return CoreTool.getDataType(JsonTable.getTypeClass(value));
+   }
+
+   /**
+    * JSON-P models null as a VALUE ({@link JsonValue#NULL}) rather than as a Java null, and
+    * {@code getTypeClass} has no branch for it — it would fall through and report the
+    * implementation class as the type.
+    */
+   private static boolean isJsonNull(Object value) {
+      return value instanceof JsonValue
+         && ((JsonValue) value).getValueType() == JsonValue.ValueType.NULL;
+   }
+
+   /** Node and depth caps, carried through the walk so one place records that a cap fired. */
+   private static final class Budget {
+      private final int maxNodes;
+      private final int maxDepth;
+      private int nodes;
+      private boolean truncated;
+
+      Budget(int maxNodes, int maxDepth) {
+         this.maxNodes = maxNodes;
+         this.maxDepth = maxDepth;
+      }
+
+      boolean spend() {
+         if(nodes >= maxNodes) {
+            truncated = true;
+            return false;
+         }
+
+         nodes++;
+         return true;
+      }
+   }
+}

--- a/connectors/inetsoft-tabular-util/src/main/java/inetsoft/uql/util/JsonShapeDistiller.java
+++ b/connectors/inetsoft-tabular-util/src/main/java/inetsoft/uql/util/JsonShapeDistiller.java
@@ -81,13 +81,22 @@ public final class JsonShapeDistiller {
       Pattern.compile("(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"),
       // Prefixed opaque id: cus_9f2aB1, evt_00Ab, acct_1H2x.
       //
-      // THE SUFFIX MUST CONTAIN A DIGIT. Without that requirement this pattern matches ordinary
-      // snake_case field names -- has_more, fee_details, available_on, reporting_category are all
-      // "two-to-six lowercase letters, underscore, four-plus alphanumerics" -- and a single such
-      // key collapses the whole record, replacing every real field name with "*". snake_case is
-      // the most common JSON field convention there is, so that is not an edge case; it is most
-      // responses. A digit is what separates an opaque id from a word.
-      Pattern.compile("^[a-z]{2,6}_(?=[A-Za-z0-9]*[0-9])[A-Za-z0-9]{4,}$"),
+      // THE SUFFIX MUST MIX LETTERS AND DIGITS, and both halves of that requirement are there to
+      // stop a false positive -- which is the expensive direction here, because a single matching key
+      // collapses its whole parent object and every real field name in it becomes "*".
+      //
+      //  - Without the DIGIT requirement the pattern matches ordinary snake_case: has_more,
+      //    fee_details, available_on, reporting_category are all "two-to-six lowercase letters,
+      //    underscore, four-plus alphanumerics". snake_case is the prevailing JSON field convention,
+      //    so that is not an edge case, it is most responses.
+      //  - Without the LETTER requirement it matches a word followed by a number -- batch_2024,
+      //    fy_2023 -- which is how fiscal-year, quarter and batch fields are commonly named.
+      //
+      // The cost is an id whose suffix is purely numeric (order_123456) no longer matching. That is
+      // the cheaper way to be wrong: a missed key leaves a few keys recorded in a small dictionary,
+      // and a large one is still caught by the homogeneity rule below, whereas a false positive
+      // destroys a legitimate record's field names outright.
+      Pattern.compile("^[a-z]{2,6}_(?=[A-Za-z0-9]*[0-9])(?=[A-Za-z0-9]*[A-Za-z])[A-Za-z0-9]{4,}$"),
       // bare opaque id / long hex / digits
       Pattern.compile("^[0-9]+$"),
       Pattern.compile("(?i)^[0-9a-f]{16,}$"),
@@ -113,6 +122,10 @@ public final class JsonShapeDistiller {
       /**
        * A {@code Map<String, Object>} for an object, a single-element {@code List} for an array, or
        * a type name for a leaf. Never null.
+       *
+       * UNMODIFIABLE, recursively. It is held by a query, shared with every clone of that query and
+       * with the response that reports it, so in-place mutation anywhere would corrupt state shared
+       * across query instances. See {@link #freeze}.
        */
       public Object getShape() {
          return shape;
@@ -134,7 +147,46 @@ public final class JsonShapeDistiller {
    public static Result distill(Object json, int maxNodes, int maxDepth) {
       Budget budget = new Budget(maxNodes, maxDepth);
       Object shape = shapeOf(json, budget, 0);
-      return new Result(shape, budget.truncated);
+      return new Result(freeze(shape), budget.truncated);
+   }
+
+   /**
+    * Make the shape unmodifiable, all the way down.
+    *
+    * The result outlives this call by a long way: {@code TabularQuery} holds it, every clone of that
+    * query shares the same reference, {@code TabularHandler} copies the reference back onto the
+    * original, and the web layer serializes it. Nothing mutates it today, and "immutable once set"
+    * was documented as an invariant -- so it is enforced rather than left as convention, because a
+    * single in-place `put` anywhere in that chain would corrupt state shared across query instances
+    * with no failure at the point of the mistake.
+    *
+    * Recursive, not just the top level: a shape is a tree, and wrapping only the root would leave
+    * every nested object mutable while claiming the whole thing was not. Applied once here rather
+    * than inside the walk, so the merging the walk does still operates on writable maps.
+    */
+   @SuppressWarnings("unchecked")
+   private static Object freeze(Object shape) {
+      if(shape instanceof Map) {
+         Map<String, Object> frozen = new LinkedHashMap<>();
+
+         for(Map.Entry<String, Object> entry : ((Map<String, Object>) shape).entrySet()) {
+            frozen.put(entry.getKey(), freeze(entry.getValue()));
+         }
+
+         return Collections.unmodifiableMap(frozen);
+      }
+
+      if(shape instanceof List) {
+         List<Object> frozen = new ArrayList<>();
+
+         for(Object element : (List<Object>) shape) {
+            frozen.add(freeze(element));
+         }
+
+         return Collections.unmodifiableList(frozen);
+      }
+
+      return shape;
    }
 
    private static Object shapeOf(Object value, Budget budget, int depth) {

--- a/connectors/inetsoft-tabular-util/src/test/java/inetsoft/uql/util/JsonShapeDistillerTest.java
+++ b/connectors/inetsoft-tabular-util/src/test/java/inetsoft/uql/util/JsonShapeDistillerTest.java
@@ -1,0 +1,298 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.util;
+
+import inetsoft.util.CoreTool;
+import org.junit.jupiter.api.Test;
+
+import javax.json.Json;
+import javax.json.JsonStructure;
+import java.io.StringReader;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * No Spring context here, unlike {@link JsonTableTest}: the distiller is a pure function over a
+ * parsed JSON value and stands up nothing.
+ *
+ * <p>Every case is driven through the JSON-P reader rather than through hand-built maps, because
+ * JSON-P is one of the two object models that reach {@code distill} in production and it is the one
+ * whose types need the special handling ({@code JsonNumber}, {@code JsonValue.NULL}). The plain-map
+ * model is covered separately in {@link #distillsPlainJavaModelToo()}.</p>
+ */
+public class JsonShapeDistillerTest {
+   private static Object parse(String json) {
+      try(javax.json.JsonReader reader = Json.createReader(new StringReader(json))) {
+         JsonStructure structure = reader.read();
+         return structure;
+      }
+   }
+
+   @SuppressWarnings("unchecked")
+   private static Map<String, Object> shapeOf(String json) {
+      Object shape = JsonShapeDistiller.distill(parse(json)).getShape();
+      assertInstanceOf(Map.class, shape);
+      return (Map<String, Object>) shape;
+   }
+
+   @Test
+   public void keepsEnvelopeAndRowArraySeparate() {
+      Map<String, Object> shape = shapeOf(
+         "{\"object\":\"list\",\"has_more\":false,\"data\":["
+            + "{\"id\":\"ch_1\",\"amount\":2000,\"currency\":\"usd\"}]}");
+
+      assertEquals(CoreTool.STRING, shape.get("object"));
+      assertEquals(CoreTool.BOOLEAN, shape.get("has_more"));
+
+      List<?> data = assertInstanceOf(List.class, shape.get("data"));
+      assertEquals(1, data.size());
+
+      Map<?, ?> row = assertInstanceOf(Map.class, data.get(0));
+      assertEquals(CoreTool.STRING, row.get("id"));
+      assertEquals(CoreTool.STRING, row.get("currency"));
+   }
+
+   @Test
+   public void typesEveryJsonNumberAsDouble() {
+      // Not integer, even for a whole number: JsonTable.getTypeClass maps every JsonNumber to
+      // Double, so this is what the built table will report and the shape has to agree.
+      Map<String, Object> shape = shapeOf("{\"amount\":2000,\"rate\":1.5}");
+
+      assertEquals(CoreTool.DOUBLE, shape.get("amount"));
+      assertEquals(CoreTool.DOUBLE, shape.get("rate"));
+   }
+
+   @Test
+   public void carriesNoValues() {
+      String json = "{\"id\":\"ch_1KsecretID\",\"email\":\"someone@example.com\"}";
+      String rendered = shapeOf(json).toString();
+
+      assertFalse(rendered.contains("ch_1KsecretID"));
+      assertFalse(rendered.contains("someone@example.com"));
+   }
+
+   @Test
+   public void mergesArrayElementsSoAnOptionalFieldSurvives() {
+      // The first element omits "refunded". Taking element 0 alone would lose it, which is exactly
+      // the field a caller most needs to be told about.
+      Map<String, Object> shape = shapeOf(
+         "{\"data\":[{\"id\":\"a\"},{\"id\":\"b\",\"refunded\":true}]}");
+
+      List<?> data = assertInstanceOf(List.class, shape.get("data"));
+      Map<?, ?> row = assertInstanceOf(Map.class, data.get(0));
+
+      assertEquals(CoreTool.STRING, row.get("id"));
+      assertEquals(CoreTool.BOOLEAN, row.get("refunded"));
+   }
+
+   @Test
+   public void emptyArrayYieldsNoElementShape() {
+      Map<String, Object> shape = shapeOf("{\"data\":[]}");
+      assertEquals(Collections.emptyList(), shape.get("data"));
+   }
+
+   @Test
+   public void nestedArrayKeepsItsElementShapeForExpansion() {
+      Map<String, Object> shape = shapeOf(
+         "{\"data\":[{\"id\":\"a\",\"fee_details\":[{\"amount\":30,\"type\":\"fee\"}]}]}");
+
+      Map<?, ?> row = (Map<?, ?>) ((List<?>) shape.get("data")).get(0);
+      List<?> fees = assertInstanceOf(List.class, row.get("fee_details"));
+      Map<?, ?> fee = assertInstanceOf(Map.class, fees.get(0));
+
+      assertEquals(CoreTool.DOUBLE, fee.get("amount"));
+      assertEquals(CoreTool.STRING, fee.get("type"));
+   }
+
+   @Test
+   public void collapsesDictionaryKeyedByOpaqueId() {
+      // Three entries only -- no count threshold could ever see this, so the key-shape rule is the
+      // only thing standing between a global catalogue and three real customer ids.
+      Map<String, Object> shape = shapeOf(
+         "{\"balances\":{"
+            + "\"cus_9f2aB1\":{\"available\":400},"
+            + "\"cus_71bdX9\":{\"available\":0},"
+            + "\"cus_44kkQ2\":{\"available\":12}}}");
+
+      Map<?, ?> balances = assertInstanceOf(Map.class, shape.get("balances"));
+      assertEquals(Set.of(JsonShapeDistiller.WILDCARD_KEY), balances.keySet());
+
+      Map<?, ?> element = assertInstanceOf(Map.class, balances.get(JsonShapeDistiller.WILDCARD_KEY));
+      assertEquals(CoreTool.DOUBLE, element.get("available"));
+      assertFalse(shape.toString().contains("cus_"));
+   }
+
+   @Test
+   public void collapsesDictionaryKeyedByDate() {
+      Map<String, Object> shape = shapeOf(
+         "{\"daily\":{\"2026-08-01\":{\"count\":3},\"2026-08-02\":{\"count\":9}}}");
+
+      Map<?, ?> daily = assertInstanceOf(Map.class, shape.get("daily"));
+      assertEquals(Set.of(JsonShapeDistiller.WILDCARD_KEY), daily.keySet());
+   }
+
+   @Test
+   public void collapsesLargeHomogeneousDictionaryWithOrdinaryKeys() {
+      // Keys are plain words, so the key-shape rule cannot fire; count plus homogeneity must.
+      StringBuilder json = new StringBuilder("{\"byRegion\":{");
+
+      for(int i = 0; i < JsonShapeDistiller.DICTIONARY_MIN_KEYS + 5; i++) {
+         json.append(i > 0 ? "," : "").append("\"region").append((char) ('a' + i % 26))
+            .append(i).append("\":{\"total\":1}");
+      }
+
+      json.append("}}");
+
+      Map<?, ?> byRegion = assertInstanceOf(Map.class, shapeOf(json.toString()).get("byRegion"));
+      assertEquals(Set.of(JsonShapeDistiller.WILDCARD_KEY), byRegion.keySet());
+   }
+
+   @Test
+   public void doesNotCollapseAWideRecord() {
+      // 60 flat fields with MIXED shapes. Over the count threshold, so only the homogeneity
+      // requirement keeps the real field names from being stripped to "*".
+      StringBuilder json = new StringBuilder("{");
+
+      for(int i = 0; i < 60; i++) {
+         json.append(i > 0 ? "," : "").append("\"field").append(i).append("\":")
+            .append(i % 3 == 0 ? "1" : (i % 3 == 1 ? "\"s\"" : "{\"nested\":true}"));
+      }
+
+      json.append("}");
+      Map<String, Object> shape = shapeOf(json.toString());
+
+      assertFalse(shape.containsKey(JsonShapeDistiller.WILDCARD_KEY));
+      assertEquals(60, shape.size());
+      assertEquals(CoreTool.DOUBLE, shape.get("field0"));
+      assertEquals(CoreTool.STRING, shape.get("field1"));
+   }
+
+   @Test
+   public void doesNotMistakeSnakeCaseFieldNamesForIds() {
+      // Regression. The prefixed-id pattern once read "two-to-six lowercase letters, underscore,
+      // four-plus alphanumerics", which is also the shape of has_more / fee_details /
+      // available_on / reporting_category. One such key collapsed the entire record and replaced
+      // every real field name with "*" -- on the majority of real responses, since snake_case is
+      // the prevailing JSON field convention.
+      Map<String, Object> shape = shapeOf(
+         "{\"has_more\":false,\"available_on\":1,\"reporting_category\":\"x\","
+            + "\"fee_details\":[{\"amount\":1}]}");
+
+      assertFalse(shape.containsKey(JsonShapeDistiller.WILDCARD_KEY));
+      assertEquals(CoreTool.BOOLEAN, shape.get("has_more"));
+      assertEquals(CoreTool.DOUBLE, shape.get("available_on"));
+      assertEquals(CoreTool.STRING, shape.get("reporting_category"));
+      assertInstanceOf(List.class, shape.get("fee_details"));
+   }
+
+   @Test
+   public void stillCollapsesPrefixedIdsThatCarryADigit() {
+      Map<String, Object> shape = shapeOf(
+         "{\"m\":{\"evt_00Ab\":{\"n\":1},\"acct_1H2x\":{\"n\":2}}}");
+
+      Map<?, ?> m = assertInstanceOf(Map.class, shape.get("m"));
+      assertEquals(Set.of(JsonShapeDistiller.WILDCARD_KEY), m.keySet());
+   }
+
+   @Test
+   public void doesNotCollapseAUniformNarrowRecord() {
+      // Homogeneous but far under the threshold, and the keys are field names. A record.
+      Map<String, Object> shape = shapeOf("{\"first\":\"a\",\"last\":\"b\",\"city\":\"c\"}");
+
+      assertFalse(shape.containsKey(JsonShapeDistiller.WILDCARD_KEY));
+      assertEquals(3, shape.size());
+   }
+
+   @Test
+   public void mixedTypesDegradeToStringLikeTheTableDoes() {
+      Map<String, Object> shape = shapeOf("{\"data\":[{\"v\":1},{\"v\":\"text\"}]}");
+
+      Map<?, ?> row = (Map<?, ?>) ((List<?>) shape.get("data")).get(0);
+      assertEquals(CoreTool.STRING, row.get("v"));
+   }
+
+   @Test
+   public void jsonNullIsNotTypedFromItsImplementationClass() {
+      Map<String, Object> shape = shapeOf("{\"note\":null}");
+      assertEquals(CoreTool.NULL, shape.get("note"));
+   }
+
+   @Test
+   public void nullMergesAwayWhenAnotherElementHasTheType() {
+      Map<String, Object> shape = shapeOf("{\"data\":[{\"note\":null},{\"note\":\"text\"}]}");
+
+      Map<?, ?> row = (Map<?, ?>) ((List<?>) shape.get("data")).get(0);
+      assertEquals(CoreTool.STRING, row.get("note"));
+   }
+
+   @Test
+   public void topLevelArrayShapesToASingleElement() {
+      Object shape = JsonShapeDistiller.distill(parse("[{\"id\":\"a\"},{\"id\":\"b\"}]")).getShape();
+      List<?> list = assertInstanceOf(List.class, shape);
+
+      assertEquals(1, list.size());
+      assertEquals(CoreTool.STRING, ((Map<?, ?>) list.get(0)).get("id"));
+   }
+
+   @Test
+   public void reportsTruncationWhenTheNodeCapFires() {
+      JsonShapeDistiller.Result result = JsonShapeDistiller.distill(
+         parse("{\"a\":1,\"b\":2,\"c\":3,\"d\":4}"), 3, JsonShapeDistiller.DEFAULT_MAX_DEPTH);
+
+      assertTrue(result.isTruncated());
+   }
+
+   @Test
+   public void reportsTruncationWhenTheDepthCapFires() {
+      JsonShapeDistiller.Result result = JsonShapeDistiller.distill(
+         parse("{\"a\":{\"b\":{\"c\":{\"d\":1}}}}"), JsonShapeDistiller.DEFAULT_MAX_NODES, 2);
+
+      assertTrue(result.isTruncated());
+   }
+
+   @Test
+   public void doesNotReportTruncationOnAnOrdinaryResponse() {
+      JsonShapeDistiller.Result result = JsonShapeDistiller.distill(
+         parse("{\"data\":[{\"id\":\"a\",\"amount\":1}]}"));
+
+      assertFalse(result.isTruncated());
+   }
+
+   @Test
+   @SuppressWarnings("unchecked")
+   public void distillsPlainJavaModelToo() {
+      // jayway's Jackson provider hands back plain maps and lists rather than JSON-P values, and
+      // both models reach this code depending on the path the response took.
+      Map<String, Object> row = new LinkedHashMap<>();
+      row.put("id", "ch_1");
+      row.put("amount", 2000);
+      row.put("live", Boolean.TRUE);
+
+      Map<String, Object> response = new LinkedHashMap<>();
+      response.put("data", new ArrayList<>(List.of(row)));
+
+      Map<String, Object> shape =
+         (Map<String, Object>) JsonShapeDistiller.distill(response).getShape();
+      Map<?, ?> shapedRow = (Map<?, ?>) ((List<?>) shape.get("data")).get(0);
+
+      assertEquals(CoreTool.STRING, shapedRow.get("id"));
+      assertEquals(CoreTool.INTEGER, shapedRow.get("amount"));
+      assertEquals(CoreTool.BOOLEAN, shapedRow.get("live"));
+   }
+}

--- a/connectors/inetsoft-tabular-util/src/test/java/inetsoft/uql/util/JsonShapeDistillerTest.java
+++ b/connectors/inetsoft-tabular-util/src/test/java/inetsoft/uql/util/JsonShapeDistillerTest.java
@@ -202,6 +202,30 @@ public class JsonShapeDistillerTest {
    }
 
    @Test
+   public void doesNotMistakeAWordFollowedByANumberForAnId() {
+      // Fiscal-year, quarter and batch fields are named this way. The id pattern once required only
+      // a digit in the suffix, which batch_2024 and fy_2023 satisfy -- and one matching key collapses
+      // the whole record, so a single such field cost every real field name in it.
+      Map<String, Object> shape = shapeOf(
+         "{\"batch_2024\":1,\"fy_2023\":2,\"revenue\":3,\"detail\":{\"n\":1}}");
+
+      assertFalse(shape.containsKey(JsonShapeDistiller.WILDCARD_KEY));
+      assertEquals(CoreTool.DOUBLE, shape.get("batch_2024"));
+      assertEquals(CoreTool.DOUBLE, shape.get("fy_2023"));
+   }
+
+   @Test
+   public void doesNotCollapseFieldNamesThatFallOutsideThePattern() {
+      // Two more that were raised as suspects and do NOT match: q1_2025's prefix carries a digit, so
+      // it is not `[a-z]{2,6}`, and week_52's suffix is under the four-character minimum. Pinned so
+      // the pattern cannot widen into them later.
+      Map<String, Object> shape = shapeOf("{\"q1_2025\":1,\"week_52\":2}");
+
+      assertFalse(shape.containsKey(JsonShapeDistiller.WILDCARD_KEY));
+      assertEquals(2, shape.size());
+   }
+
+   @Test
    public void stillCollapsesPrefixedIdsThatCarryADigit() {
       Map<String, Object> shape = shapeOf(
          "{\"m\":{\"evt_00Ab\":{\"n\":1},\"acct_1H2x\":{\"n\":2}}}");
@@ -264,6 +288,29 @@ public class JsonShapeDistillerTest {
          parse("{\"a\":{\"b\":{\"c\":{\"d\":1}}}}"), JsonShapeDistiller.DEFAULT_MAX_NODES, 2);
 
       assertTrue(result.isTruncated());
+   }
+
+   @Test
+   @SuppressWarnings("unchecked")
+   public void returnsAnUnmodifiableShape() {
+      // The shape is held by a query, shared by reference with every clone of it and with the
+      // response that reports it, so "immutable once set" has to be enforced rather than documented:
+      // one in-place put would corrupt state shared across query instances, and nothing would fail
+      // where the mistake was made.
+      Map<String, Object> shape = shapeOf(
+         "{\"data\":[{\"id\":\"a\",\"customer\":{\"city\":\"x\"}}]}");
+
+      assertThrows(UnsupportedOperationException.class, () -> shape.put("extra", "string"));
+
+      // ...and all the way down, not just at the root.
+      List<Object> data = (List<Object>) shape.get("data");
+      assertThrows(UnsupportedOperationException.class, () -> data.add("string"));
+
+      Map<String, Object> row = (Map<String, Object>) data.get(0);
+      assertThrows(UnsupportedOperationException.class, () -> row.put("extra", "string"));
+
+      Map<String, Object> customer = (Map<String, Object>) row.get("customer");
+      assertThrows(UnsupportedOperationException.class, () -> customer.put("extra", "string"));
    }
 
    @Test

--- a/core/src/main/java/inetsoft/uql/tabular/TabularQuery.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularQuery.java
@@ -387,12 +387,30 @@ public abstract class TabularQuery extends XQuery {
          copy.variableTable = variableTable.clone();
       }
 
+      // CLEARED, not carried over. A shape describes ONE execution, and the clone is the object that
+      // executes -- so it has to start with nothing to report, or "the runner recorded no shape this
+      // time" becomes indistinguishable from "the runner recorded the same shape again".
+      //
+      // Without this the guarantee TabularHandler.execute's copy-back is written for does not hold.
+      // super.clone() is shallow, so the clone would inherit whatever the ORIGINAL had from an
+      // earlier run; a re-execution whose request then fails never reaches setResponseShape --
+      // EndpointJsonQueryRunner.runStream catches its own exceptions and returns the table -- and the
+      // copy-back would write the previous run's shape back onto the original as if it were current.
+      copy.responseShape = null;
+      copy.responseShapeTruncated = false;
+
       return copy;
    }
 
    private XTypeNode[] cols;
-   // Not cleared in clone(): the clone is what executes, so it is the copy that needs to be able to
-   // record a shape. Deliberately shallow-copied like the rest -- the shape is immutable once set.
+   /**
+    * See {@link #getResponseShape}. Cleared by {@link #clone()} rather than shallow-copied, so it
+    * always describes the execution that produced it.
+    *
+    * The tree itself is shared by reference once set (with the caller, and with whatever
+    * {@code TabularHandler} copied it from), so it must not be mutated in place. That is enforced at
+    * the producing end: {@code JsonShapeDistiller} returns a recursively unmodifiable structure.
+    */
    private Object responseShape;
    private boolean responseShapeTruncated;
    private Map<String, String> typemap = new HashMap<>();

--- a/core/src/main/java/inetsoft/uql/tabular/TabularQuery.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularQuery.java
@@ -327,6 +327,46 @@ public abstract class TabularQuery extends XQuery {
    }
 
    /**
+    * The shape of the response this query's last execution parsed: which paths exist and what type
+    * each leaf is, carrying none of the values.
+    *
+    * <p>A SLOT, not a computation. Core defines it and never fills it, because only the connector
+    * sees a raw response and only the connector knows its format; the JSON connectors distil theirs
+    * with {@code JsonShapeDistiller} (which lives beside the JSON tables, in a module core does not
+    * depend on). Anything absent means the connector does not report a shape, which is the normal
+    * state for most tabular types and never an error.</p>
+    *
+    * <p>It describes ONE EXECUTION, not the query, so it is deliberately not written to XML by
+    * {@link #writeContents} and not read back by {@link #parseContents}. A saved query carries no
+    * shape; running it produces one again.</p>
+    *
+    * <p>Note for anyone tracing why this is null: {@code TabularHandler.execute} runs a CLONE of the
+    * query and only writes back to the original through {@code setOutputColumns}. A shape set by a
+    * runner therefore lands on the clone, and reaches the caller only because that method copies it
+    * across explicitly. Removing that copy makes this silently null on every path.</p>
+    */
+   public Object getResponseShape() {
+      return responseShape;
+   }
+
+   /**
+    * @param shape     the distilled shape, or null to report none.
+    * @param truncated whether a node or depth cap cut the distillation short — a consumer has to
+    *                  tell "this path is not in the response" from "this path was not reached".
+    */
+   public void setResponseShape(Object shape, boolean truncated) {
+      this.responseShape = shape;
+      this.responseShapeTruncated = truncated;
+   }
+
+   /**
+    * Whether {@link #getResponseShape} was cut off by a cap rather than completed.
+    */
+   public boolean isResponseShapeTruncated() {
+      return responseShapeTruncated;
+   }
+
+   /**
     * Copy query properties from an existing query.
     */
    public void copyInfo(TabularQuery query) {
@@ -351,6 +391,10 @@ public abstract class TabularQuery extends XQuery {
    }
 
    private XTypeNode[] cols;
+   // Not cleared in clone(): the clone is what executes, so it is the copy that needs to be able to
+   // record a shape. Deliberately shallow-copied like the rest -- the shape is immutable once set.
+   private Object responseShape;
+   private boolean responseShapeTruncated;
    private Map<String, String> typemap = new HashMap<>();
    private Map<String, String> fmtmap = new HashMap<>();
    private Map<String, String> extentmap = new HashMap<>();

--- a/core/src/main/java/inetsoft/uql/tabular/impl/TabularHandler.java
+++ b/core/src/main/java/inetsoft/uql/tabular/impl/TabularHandler.java
@@ -87,6 +87,17 @@ public class TabularHandler extends XHandler {
          tbl = runtime.runQuery((TabularQuery) query, params);
       }
 
+      // Carry the response shape across the clone made above. A runner sees only the clone, so
+      // anything it records there is otherwise dropped the moment this method returns -- and
+      // dropped silently, which reads as "this connector reports no shape" rather than as a lost
+      // write. Copied unconditionally, including when it is null, so a re-execution that produced
+      // no shape clears a stale one rather than leaving the previous run's answer in place.
+      //
+      // Untyped on purpose: core defines the slot and never interprets it (see
+      // TabularQuery.getResponseShape). Whatever the connector put there is what the caller gets.
+      oquery.setResponseShape(((TabularQuery) query).getResponseShape(),
+                              ((TabularQuery) query).isResponseShapeTruncated());
+
       if(tbl != null && tbl.getColCount() > 0) {
          int max = TabularUtil.getMaxRows(query, params);
 

--- a/core/src/main/java/inetsoft/uql/tabular/impl/TabularHandler.java
+++ b/core/src/main/java/inetsoft/uql/tabular/impl/TabularHandler.java
@@ -90,8 +90,13 @@ public class TabularHandler extends XHandler {
       // Carry the response shape across the clone made above. A runner sees only the clone, so
       // anything it records there is otherwise dropped the moment this method returns -- and
       // dropped silently, which reads as "this connector reports no shape" rather than as a lost
-      // write. Copied unconditionally, including when it is null, so a re-execution that produced
-      // no shape clears a stale one rather than leaving the previous run's answer in place.
+      // write.
+      //
+      // Copied unconditionally, including when it is null, so a re-execution that produced no shape
+      // clears a stale one rather than leaving the previous run's answer in place. That only holds
+      // because TabularQuery.clone() clears the field: super.clone() is shallow, so without it the
+      // clone would arrive carrying the ORIGINAL's shape from an earlier run and this line would
+      // copy it straight back -- a no-op dressed as a clear.
       //
       // Untyped on purpose: core defines the slot and never interprets it (see
       // TabularQuery.getResponseShape). Whatever the connector put there is what the caller gets.

--- a/core/src/main/java/inetsoft/web/wiz/model/WorksheetTableResponse.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WorksheetTableResponse.java
@@ -46,6 +46,29 @@ public class WorksheetTableResponse {
     */
    private List<WorksheetColumnInfo> primaryTableFields;
 
+   /**
+    * The shape of the response the endpoint returned — which paths exist and what type each leaf
+    * is, carrying none of the values. Present only for a {@code tabular table}, and only when the
+    * connector reported one.
+    *
+    * <p>Distinct from {@code columns}, and not a duplicate of it. {@code columns} is what the row
+    * path actually produced, flattened; this is the WHOLE response before that path was applied,
+    * nested. A caller reads it to pick {@code jsonPath} (which of the response's arrays holds the
+    * rows) and {@code expandedPath} (which nested array to expand), neither of which the flat
+    * column list can answer.</p>
+    *
+    * <p>Untyped because core does not interpret it: the connector produced it, the caller consumes
+    * it. See {@code TabularQuery.getResponseShape}.</p>
+    */
+   private Object responseSchema;
+
+   /**
+    * True when {@code responseSchema} was cut off by a node or depth cap. Under truncation a path's
+    * absence means "not reached", not "not present" — a consumer that conflates the two will report
+    * a field as nonexistent when it was merely beyond the cap.
+    */
+   private boolean responseSchemaTruncated;
+
    private boolean success;
    private String errorMessage;
 
@@ -61,6 +84,15 @@ public class WorksheetTableResponse {
    public List<WorksheetColumnInfo> getPrimaryTableFields() { return primaryTableFields; }
    public void setPrimaryTableFields(List<WorksheetColumnInfo> primaryTableFields) {
       this.primaryTableFields = primaryTableFields;
+   }
+
+   public Object getResponseSchema() { return responseSchema; }
+   public void setResponseSchema(Object responseSchema) { this.responseSchema = responseSchema; }
+
+   public boolean isResponseSchemaTruncated() { return responseSchemaTruncated; }
+
+   public void setResponseSchemaTruncated(boolean responseSchemaTruncated) {
+      this.responseSchemaTruncated = responseSchemaTruncated;
    }
 
    public boolean isSuccess() { return success; }

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -298,6 +298,7 @@ public class WorksheetTableService {
       WorksheetTableResponse response = new WorksheetTableResponse();
       response.setTableName(table.getName());
       response.setColumns(columns);
+      applyResponseShape(response, table);
 
       if(request.isAsPrimaryTable()) {
          String dbTableOverride = request.getPhysicalSource() != null
@@ -315,6 +316,46 @@ public class WorksheetTableService {
       }
 
       return response;
+   }
+
+   /**
+    * Report the shape of the response the endpoint returned, when this table came from one.
+    *
+    * <p>Only a {@code tabular table} has one: it is the only table type built by sending a request,
+    * and {@code loadColumnSelection} has already sent it by the time this runs. So the shape is a
+    * BY-PRODUCT of work already done and already paid for — no second request, and nothing to
+    * enable. See {@code EndpointJsonQueryRunner} for where it is distilled and why there.</p>
+    *
+    * <p>WHY THE CALLER NEEDS IT, given it also gets {@code columns}: the columns are what the row
+    * path it chose produced, and {@code jsonPath} defaults to {@code "$"}
+    * ({@code RestJsonQuery.getValidJsonPath}). A caller that guessed wrong against an envelope
+    * response — {@code {object, url, has_more, data:[...]}} — gets a one-row table of envelope
+    * columns and no way to tell that from a correct result. The shape is distilled BEFORE the row
+    * path is applied, so it is unaffected by that mistake and is what identifies the real rows.</p>
+    *
+    * <p>Absent is normal and not an error: a non-tabular table has no response, a connector may
+    * report no shape, and {@code getQuery()} is {@code @Nullable} when the data source plugin is
+    * missing.</p>
+    */
+   private void applyResponseShape(WorksheetTableResponse response, AbstractTableAssembly table) {
+      if(!(table.getTableInfo() instanceof TabularTableAssemblyInfo info)) {
+         return;
+      }
+
+      TabularQuery query = info.getQuery();
+
+      if(query == null || query.getResponseShape() == null) {
+         return;
+      }
+
+      response.setResponseSchema(query.getResponseShape());
+
+      // Only set when true. A truncated shape is the exceptional case, and a caller has to be able
+      // to tell "this path is not in the response" from "this path was not reached" — the flag is
+      // the only thing that carries the difference.
+      if(query.isResponseShapeTruncated()) {
+         response.setResponseSchemaTruncated(true);
+      }
    }
 
    // ─── Probe: execute a freshly-built table to surface render-time query failures ──────────

--- a/core/src/test/java/inetsoft/uql/tabular/impl/TabularHandlerTest.java
+++ b/core/src/test/java/inetsoft/uql/tabular/impl/TabularHandlerTest.java
@@ -33,6 +33,8 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.security.Principal;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -87,6 +89,47 @@ class TabularHandlerTest {
       VariableTable vars = new VariableTable();
       vars.put("param", "A");
       return vars;
+   }
+
+   /**
+    * The invariant {@link TabularHandler#execute} depends on and cannot state for itself: it runs a
+    * CLONE of the query and copies the clone's response shape back onto the original, so that copy
+    * only clears a stale shape if the clone arrives without one.
+    *
+    * Shallow-copied, this failed silently. A query re-executed in place kept the shape from its last
+    * successful run, and because a runner that fails never reaches {@code setResponseShape}
+    * ({@code EndpointJsonQueryRunner.runStream} catches its own exceptions), the copy-back wrote that
+    * earlier shape straight back — reporting it as current with nothing to mark it stale.
+    */
+   @Test
+   void cloneDoesNotInheritTheOriginalsResponseShape() {
+      TestTabularQuery original = new TestTabularQuery();
+      original.setResponseShape(Map.of("data", List.of(Map.of("id", "string"))), true);
+
+      TabularQuery copy = original.clone();
+
+      assertNull(copy.getResponseShape(), "a clone must not report a shape it did not produce");
+      assertFalse(copy.isResponseShapeTruncated());
+
+      // Clearing the clone must not clear the source: the original is what TabularHandler copies
+      // back ONTO, and every other reader of an executed query holds it.
+      assertNotNull(original.getResponseShape());
+      assertTrue(original.isResponseShapeTruncated());
+   }
+
+   /**
+    * The other half of the same invariant: the clone is the object that executes, so it has to be
+    * able to record a shape without that leaking into the original before the copy-back decides.
+    */
+   @Test
+   void aCloneRecordsItsOwnShapeIndependently() {
+      TestTabularQuery original = new TestTabularQuery();
+      TabularQuery copy = original.clone();
+
+      copy.setResponseShape(Map.of("object", "string"), false);
+
+      assertEquals(Map.of("object", "string"), copy.getResponseShape());
+      assertNull(original.getResponseShape(), "the original must not see the clone's execution");
    }
 
    private static Principal principal(String name, String orgID) {


### PR DESCRIPTION
## What this adds

`JsonShapeDistiller` (`inetsoft-tabular-util`) reduces a parsed JSON response to its **shape** — which paths exist and what type each leaf is — carrying none of the values. `EndpointJsonQueryRunner` runs it on the first page and records the result on the query; `TabularHandler` carries it across the clone it makes; `WorksheetTableService` returns it on `/ws/table` as `responseSchema` for a `tabular table`.

## Why

Creating a tabular table sends a request, parses one page, and reports the flattened columns the chosen row path produced. What it cannot report is **where the rows were**, and that matters because `tabularSource.jsonPath` is a caller-supplied input that defaults to `"$"` (`RestJsonQuery.getValidJsonPath`). Against an envelope response — `{object, url, has_more, data:[...]}` — a caller that guessed wrong gets a one-row table whose columns are the envelope's fields, and nothing in the result distinguishes that from a correct build.

The shape is also the only way to see inside a nested array. `JsonTable.walkRecord` stops recursing at anything that is not a `Map`, so a nested array flattens to one opaque column — `expandedPath` cannot be chosen from the column list at all.

## Why the runner, and not `getJsonMetadata()`

`RestJsonQuery.getJsonMetadata()` also returns the whole response, and taking it would have cost four things this placement does not:

- **A second billed request.** It is generated lazily inside the getter, and generating it is another `strategy.next()` (`RestJsonQueryRunner:233`). A property read dials the endpoint.
- **A failure cached permanently as success.** `generateMetadata()` returns `"{}"` on both the exception and the `json == null` branch, and the regeneration guard is `Tool.isEmptyString(jsonMetadata)` — `"{}"` is not empty, so it never retries.
- **Real records persisted into the worksheet.** `writeContents` writes the field as CDATA whenever `metadataEnabled` is set, so a page of customer data lands in the saved ws XML.
- **A changed column set.** `JsonTable.beginStreamedLoading` builds a metadata table from it and `transformRow` puts its columns first (`JsonTable.java:86-88`); `ExpandedJsonTable.finishStreamedLoading` does `headers.addAll(metadata.headers)`. Enabling it changes the columns of the very table being built.

Distilling in `runStream` costs none of these: the page has already been fetched and paid for. It also sits **before** `selectData`, so a wrong `jsonPath` cannot corrupt what is captured — which is the point, since that is exactly when the caller needs to be told where the rows really are.

## Why dropping values is not enough

Object keys become part of the shape, and some responses key an object **by data** — `{"cus_9f2aB1": {...}, "cus_71bdX9": {...}}`. Enumerating those keys would record thousands of customer ids under the guise of structure, and produce a shape no caller can use. Such objects collapse to a single `"*"` entry, decided by two rules that catch different things:

- **Key shape** — a key that reads as an id, a UUID, a date or an email. This is the only rule that can see a *three-entry* dictionary, which no count threshold ever will.
- **Homogeneity and count** — many children that all share one shape. This catches a dictionary whose keys look perfectly ordinary (country codes, month names, SKUs).

The second requires homogeneity rather than a bare count so that a **wide record** is not mistaken for a dictionary and stripped of its real field names: a record's children differ in shape, a dictionary's values are alike.

The id pattern requires a **digit in the suffix**. Without that it also matches ordinary snake_case — `has_more`, `fee_details`, `available_on`, `reporting_category` are all "two-to-six lowercase letters, underscore, four-plus alphanumerics" — and one such key would collapse the whole record on the majority of real responses. A regression test covers it.

## Why the clone boundary is called out

`TabularHandler.execute` clones the query before running it and writes back to the original only through `setOutputColumns` (`impl/TabularHandler.java:61,107`). A shape recorded by a runner therefore lands on the clone and is dropped when the method returns — silently, reading as "this connector reports no shape" rather than as a lost write. That method now copies it across explicitly. The slot is declared on `TabularQuery` and never interpreted by core, since only a connector sees a raw response.

Types come from `JsonTable.getTypeClass`, the same function the table itself uses, so a JSON number reports as `double` exactly as the built table will report it. Date detection on string values is deliberately not reproduced: it lives in `BaseJsonTable.parseValue` and depends on per-column state accumulated across rows, so a string holding a date may report as `string` here. Structure is what this is for.

Distillation failures are logged and dropped — the shape is a by-product, and the caller already has the table it asked for.

## Tests

`JsonShapeDistillerTest` (21 cases) covers the envelope/row split, number-to-`double` typing, that no value survives, array-element merging so an optional field is not lost, the three dictionary-collapse paths, the wide-record and snake_case false positives, JSON-P null, both object models, and both caps.

`mvn -pl community/connectors/inetsoft-tabular-util test` — 37 pass. `mvn -pl community/core test -Dtest='WorksheetTableService*Test'` — 86 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)