### PR TITLE
Fix duplicate-primary and mislabeled action buttons across composer dialogs

### DIFF
--- a/web/projects/em/src/app/settings/presentation/presentation-themes-view/theme-css-view/theme-css-view.component.ts
+++ b/web/projects/em/src/app/settings/presentation/presentation-themes-view/theme-css-view/theme-css-view.component.ts
@@ -232,6 +232,7 @@ export class ThemeCssViewComponent implements OnInit, OnDestroy, OnChanges {
       {name: "--inet-schema-column-incompatible-bg-color", color: true},
       {name: "--inet-ws-header-primary-bg-color", color: true},
       {name: "--inet-ws-header-secondary-bg-color", color: true},
+      {name: "--inet-ws-schema-title-bg", color: true},
       {name: "--inet-ws-table-odd-row-bg-color", color: true},
       {name: "--inet-ws-table-even-row-bg-color", color: true},
       {name: "--inet-ws-schema-highlight-bg", color: true},

--- a/web/projects/portal/src/app/composer/gui/ws/editor/ws-composite-table-breadcrumb.component.html
+++ b/web/projects/portal/src/app/composer/gui/ws/editor/ws-composite-table-breadcrumb.component.html
@@ -29,7 +29,7 @@
     <button type="button" class="btn-toolbar btn btn-sm help-button"
       [helpLink]="'ChangingtheConcatenationType'">
     </button>
-    <button type="button" class="btn btn-primary btn-sm" (click)="cancel()">
+    <button type="button" class="btn btn-default btn-sm" (click)="cancel()">
       _#(Cancel)
     </button>
     <button type="button" class="btn btn-primary btn-sm" (click)="close()">

--- a/web/projects/portal/src/app/composer/gui/ws/editor/ws-details-pane.component.html
+++ b/web/projects/portal/src/app/composer/gui/ws/editor/ws-details-pane.component.html
@@ -24,8 +24,8 @@
       <span>{{tableStatus}}</span>
     </div>
     <div class="ws-table-buttons me-3">
-      <button type="button" class="btn btn-sm btn-primary me-1" (click)="openConsoleDialog()">
-        Console <span class="badge console-count-badge">{{consoleMessages ? consoleMessages.length : 0}}</span>
+      <button type="button" class="btn btn-sm btn-default rounded-pill me-1" (click)="openConsoleDialog()">
+        Console <span class="badge console-count-badge ms-2">{{consoleMessages ? consoleMessages.length : 0}}</span>
       </button>
       @for (_button of tableButtons; track _button.id) {
         @if (isTableButtonVisible(_button)) {

--- a/web/projects/portal/src/app/composer/gui/ws/editor/ws-details-pane.component.scss
+++ b/web/projects/portal/src/app/composer/gui/ws/editor/ws-details-pane.component.scss
@@ -21,8 +21,8 @@
 }
 
 .console-count-badge {
-  color: var(--inet-button-light-text-color);
-  background-color: var(--inet-button-light-bg-color);
+  color: var(--inet-text-muted-color);
+  background-color: var(--inet-shell-surface-hover);
 }
 
 .ws-details-dropdown-button {

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-graph-pane/physical-graph-pane.component.html
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-physical-model/physical-graph-pane/physical-graph-pane.component.html
@@ -87,7 +87,7 @@
       }
       @if (physicalGraph.joinEdit) {
         <div class="join-edit-button-container">
-          <button type="button" class="btn btn-primary btn-sm" (click)="closeJoinEditPane(false)">
+          <button type="button" class="btn btn-default btn-sm" (click)="closeJoinEditPane(false)">
             _#(Cancel)
           </button>
           <button type="button" class="btn btn-primary btn-sm" (click)="closeJoinEditPane(true)">

--- a/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-query/query-main/query-link-pane/query-link-graph-pane/query-link-graph-pane.component.html
+++ b/web/projects/portal/src/app/portal/data/data-datasource-browser/datasources-database/database-query/query-main/query-link-pane/query-link-graph-pane/query-link-graph-pane.component.html
@@ -20,7 +20,7 @@
     @if (graphPaneModel.joinEdit) {
       <div class="graph-toolbar graph-toolbar--surface w-100 px-2 py-1">
         <div class="join-edit-button-container">
-          <button type="button" class="btn btn-primary btn-sm" (click)="closeJoinEditPane(false)">
+          <button type="button" class="btn btn-default btn-sm" (click)="closeJoinEditPane(false)">
             _#(Cancel)
           </button>
           <button type="button" class="btn btn-primary btn-sm" (click)="closeJoinEditPane(true)">

--- a/web/projects/portal/src/app/widget/console-dialog/console-dialog.component.html
+++ b/web/projects/portal/src/app/widget/console-dialog/console-dialog.component.html
@@ -81,15 +81,15 @@
 
   <ng-template wDialogButtons>
     <button type="button" class="btn btn-primary" [disabled]="!messages || messages.length == 0"
-      (click)="clearMessages()">
-      _#(Clear)
-    </button>
-    <button type="button" class="btn btn-primary" [disabled]="!messages || messages.length == 0"
       (click)="ok()">
       _#(OK)
     </button>
+    <button type="button" class="btn btn-default" [disabled]="!messages || messages.length == 0"
+      (click)="clearMessages()">
+      _#(Clear)
+    </button>
     <button type="button" class="btn btn-default" (click)="closeDialog()">
-      _#(Close)
+      _#(Cancel)
     </button>
   </ng-template>
 </w-standard-dialog>

--- a/web/projects/portal/src/app/widget/parameter/parameter-dialog/parameter-dialog.component.html
+++ b/web/projects/portal/src/app/widget/parameter/parameter-dialog/parameter-dialog.component.html
@@ -23,6 +23,6 @@
 </div>
 <div class="modal-footer">
   <button type="button" class="btn btn-primary" (click)="parameterPage.ok()" [disabled]="!parameterPage.canSubmit()">_#(OK)</button>
-  <button type="button" class="btn btn-primary" (click)="parameterPage.clear()">_#(Clear)</button>
-  <button type="button" class="btn btn-primary" (click)="parameterPage.cancel()">_#(Cancel)</button>
+  <button type="button" class="btn btn-default" (click)="parameterPage.clear()">_#(Clear)</button>
+  <button type="button" class="btn btn-default" (click)="parameterPage.cancel()">_#(Cancel)</button>
 </div>

--- a/web/projects/portal/src/app/widget/parameter/parameter-page/parameter-page.component.html
+++ b/web/projects/portal/src/app/widget/parameter/parameter-page/parameter-page.component.html
@@ -151,8 +151,8 @@
                 <div class="row justify-content-end g-0 align-items-baseline">
                   <div class="col-sm-12 col-md-8 col-lg-6 d-flex flex-row align-items-baseline">
                     <button type="button" class="btn btn-primary flex-grow-1 flex-shrink-1" (click)="ok()" [disabled]="!canSubmit()">_#(OK)</button>
-                    <button type="button" class="btn btn-primary ms-2 flex-grow-1 flex-shrink-1" (click)="clear()">_#(Clear)</button>
-                    <button type="button" class="btn btn-primary ms-2 flex-grow-1 flex-shrink-1" (click)="cancel()">_#(Cancel)</button>
+                    <button type="button" class="btn btn-default ms-2 flex-grow-1 flex-shrink-1" (click)="clear()">_#(Clear)</button>
+                    <button type="button" class="btn btn-default ms-2 flex-grow-1 flex-shrink-1" (click)="cancel()">_#(Cancel)</button>
                   </div>
                 </div>
               }

--- a/web/projects/portal/src/scss/_themeable.scss
+++ b/web/projects/portal/src/scss/_themeable.scss
@@ -629,7 +629,7 @@ div.disable-link, a.disable-link {
 }
 
 .schema-table-title {
-  background-color: var(--inet-ws-header-secondary-bg-color);
+  background-color: var(--inet-ws-schema-title-bg);
 }
 
 .ws-assembly-graph-element--dimmed .ws-graph-thumbnail__title {

--- a/web/projects/portal/src/scss/_variables.scss
+++ b/web/projects/portal/src/scss/_variables.scss
@@ -387,11 +387,16 @@ $sqrt2: 1.41421356;
   --inet-schema-column-compatible-bg-color: var(--inet-ws-schema-compatible-bg);
   --inet-schema-column-incompatible-bg-color: var(--inet-ws-schema-incompatible-bg);
   // these two also drive the primary/secondary distinction in edit-join-table's
-  // dragging state, join-node-graph's alias-node state, and the schema/concat
-  // table title bars, so keep them at their original rose family here; the
-  // detail pane's own selected-bg treatment is scoped to ws-header-cell.component.scss
+  // dragging state and join-node-graph's alias-node state, so keep them at
+  // their original rose family here; the detail pane's own selected-bg
+  // treatment is scoped to ws-header-cell.component.scss
   --inet-ws-header-primary-bg-color: var(--inet-third-color);
   --inet-ws-header-secondary-bg-color: var(--inet-third-color-light);
+  // schema/concat table title bars (see _themeable.scss .schema-table-title):
+  // kept separate from the rose family above (too close to danger-soft) -
+  // aliases the same neutral surface the physical-model join editor's
+  // table titles use (edit-join-table.component.scss)
+  --inet-ws-schema-title-bg: var(--inet-shell-surface-subtle);
   --inet-ws-table-odd-row-bg-color: #{$worksheet-row-odd-bg};
   --inet-ws-table-even-row-bg-color: #{$worksheet-row-even-bg};
   --inet-ws-schema-highlight-bg: #{$ws-schema-highlight-bg};


### PR DESCRIPTION
## Summary
- Worksheet join/union editor, physical-model join editor, and query editor join pane all had the same `joinEdit` Cancel+Done footer where both buttons were `btn-primary` — Cancel is now `btn-default` in all three.
- Parameter dialog/page had OK+Clear+Cancel all `btn-primary` — Clear and Cancel are now `btn-default`.
- Console dialog had Clear+OK both `btn-primary` (with the surviving primary button sandwiched between two secondary ones) — Clear is now `btn-default` and OK is reordered to lead the footer.
- Console dialog's "Close" button relabeled to "Cancel" — it actually discards the pending message-level filter change rather than committing it like OK does, so the old label was misleading.
- Worksheet schema/concat table title background moved off the rose family (`--inet-ws-header-secondary-bg-color`, too close in hue to the danger/incompatible-red used in the same schema editor) onto a neutral surface token (`--inet-ws-schema-title-bg`, aliasing `--inet-shell-surface-subtle`) matching the physical-model join editor's table titles. Exposed the new token in the EM theme editor.

## Test plan
- [ ] Open a worksheet, create a relational join / merge join / concatenation, verify Cancel is no longer primary-colored and table titles are neutral gray instead of pink
- [ ] Open the physical model join editor and the query editor's join pane, verify Cancel is no longer primary-colored
- [ ] Open a viewsheet parameter prompt dialog, verify only OK is primary
- [ ] Open the composer console dialog, verify button order is OK/Clear/Cancel with only OK primary, and Cancel actually discards level-filter changes
- [ ] Spot-check EM theme editor's Worksheet section for the new `--inet-ws-schema-title-bg` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)