### PR TITLE
fix(chart): resolve a named legend instead of hiding every legend

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartPlotResizeService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartPlotResizeService.java
@@ -57,6 +57,16 @@ public class VSChartPlotResizeService extends VSChartControllerService<VSChartPl
          if(reset) {
             chartInfo.setUnitWidthRatio(1);
             chartInfo.setUnitHeightRatio(1);
+            // The percents have to go too, and back to 0 rather than 1: VGraphPair re-derives
+            // unitWidthRatio/unitHeightRatio from them whenever they are >= 1, without consulting
+            // the resized flags, so a reset that left them behind reported default/not-resized
+            // while the old ratio was rebuilt on every subsequent layout. (1 is not the neutral
+            // value here - it would re-derive the ratio as the plot's own baseline. 0 is the
+            // field's declared default and the only value that turns the re-derivation off.) It
+            // was invisible only because the enlargement itself, minPlot *= ratio, is gated on
+            // the flag this branch does clear.
+            chartInfo.setUnitWidthRatioPercent(0);
+            chartInfo.setUnitHeightRatioPercent(0);
             chartInfo.setWidthResized(false);
             chartInfo.setHeightResized(false);
          }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartElementService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartElementService.java
@@ -25,6 +25,7 @@ import inetsoft.graph.VGraph;
 import inetsoft.graph.coord.Coordinate;
 import inetsoft.graph.coord.RelationCoord;
 import inetsoft.graph.internal.GTool;
+import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.report.composition.graph.*;
 import inetsoft.report.composition.region.ChartArea;
@@ -94,39 +95,53 @@ public class ChartElementService {
     * @param element {@code axis}, {@code legend} or {@code title}
     * @param target  which one — an axis column name, a legend field, or an axis title
     *                ({@code x}, {@code x2}, {@code y}, {@code y2}) or {@code chart} for the
-    *                chart title. Null means all of that element.
+    *                chart title. Null, or blank, means all of that element.
     */
    public void setVisibility(String sessionToken, Principal user, String assemblyName,
                              String element, String target, boolean visible, String linkUri)
       throws Exception
    {
       String kind = requireElement(element);
+      // A blank target is no target, and the two layers have to agree on that: the tool's own
+      // show-with-a-target guard already treats "" as absent, so a server that read it as present
+      // refused the very call the tool had let through, and on the legend path the refusal named
+      // an empty legend. Not trimmed otherwise - only the blank case is unambiguous, and a column
+      // name's own spacing is its own business.
+      String target0 = target != null && target.isBlank() ? null : target;
 
       // Resolved before the runtime is touched: "show the y title" and "show every title" are
       // different requests, and the event cannot express the first one, so a caller naming a
       // target it cannot honour has to be told rather than quietly given the second.
-      if(visible && target != null && !"title".equals(kind)) {
+      if(visible && target0 != null && !"title".equals(kind)) {
          throw new IllegalArgumentException(
             "Showing a single " + kind + " is not supported by the Composer — showing restores " +
             "all of them at once. Call this without 'target' to show every " + kind + ", or " +
             "hide the ones you do not want.");
       }
 
+      // Resolved before the runtime is mutated, for the same reason as the guard above and by the
+      // same route ChartRegionPropertyService takes for its own refusals: sessions.mutate
+      // checkpoints and broadcasts in a finally, deliberately, because a composer service can
+      // partially apply before it ERRORs. Nothing is applied when the resolution itself refuses,
+      // so refusing inside the mutation would spend an undo step and a Composer refresh on a call
+      // that changed nothing.
+      VSChartLegendsVisibilityEvent legendEvent = "legend".equals(kind)
+         ? legendEvent(sessionToken, user, assemblyName, target0, visible) : null;
+
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
-         ChartVSAssembly chart = requireChart(rvs, assemblyName);
+         requireChart(rvs, assemblyName);
 
          switch(kind) {
             case "axis" -> axesService.eventHandler(
                runtimeId,
-               event(Map.of("chartName", assemblyName, "hide", !visible), "columnName", target,
+               event(Map.of("chartName", assemblyName, "hide", !visible), "columnName", target0,
                      VSChartAxesVisibilityEvent.class),
                linkUri, user, dispatcher);
             case "legend" -> legendsService.eventHandler(
-               runtimeId, legendEvent(rvs, chart, target, visible),
-               linkUri, user, dispatcher);
+               runtimeId, legendEvent, linkUri, user, dispatcher);
             default -> titlesService.eventHandler(
                runtimeId,
-               convert(titleFields(assemblyName, target, visible),
+               convert(titleFields(assemblyName, target0, visible),
                        VSChartTitlesVisibilityEvent.class),
                linkUri, user, dispatcher);
          }
@@ -362,17 +377,15 @@ public class ChartElementService {
          return vocabulary();
       }
 
-      // One read for both answers: they come off the same laid-out graph, and two reads could
-      // disagree with each other if the chart relaid out between them.
-      Chart chart = sessions.read(
+      // One laid-out pair for both answers, via regions() rather than the two single-answer
+      // entry points: those fetch the pair each, so the axes and the legends could describe two
+      // layouts either side of a relayout while being reported as one chart's.
+      ChartRegionResolver.Regions regions = sessions.read(
          sessionToken, user,
-         (rvs, runtimeId, dispatcher) -> {
-            ChartVSAssembly assembly0 = ChartRegionResolver.requireChart(rvs, assembly);
-            return new Chart(ChartRegionResolver.resolve(rvs, assembly0),
-                             ChartRegionResolver.legends(rvs, assembly0));
-         });
+         (rvs, runtimeId, dispatcher) ->
+            ChartRegionResolver.regions(rvs, ChartRegionResolver.requireChart(rvs, assembly)));
 
-      ChartRegionResolver.Axes axes = chart.axes();
+      ChartRegionResolver.Axes axes = regions.axes();
       Map<String, Object> out = new LinkedHashMap<>(vocabulary());
       List<String> titleTargets = new ArrayList<>(axes.ordered());
       // The chart title is not an axis title and does not depend on any axis existing.
@@ -383,13 +396,10 @@ public class ChartElementService {
       out.put("titleTargets", titleTargets);
       out.put("axesBasis", axes.basis());
       out.put("axesMeasured", axes.measured());
-      out.put("legends", describe(chart.legends()));
-      out.put("legendsMeasured", chart.legends().measured());
+      out.put("legends", describe(regions.legends()));
+      out.put("legendsMeasured", regions.legends().measured());
       return out;
    }
-
-   /** Both answers off one laid-out graph. */
-   private record Chart(ChartRegionResolver.Axes axes, ChartRegionResolver.Legends legends) {}
 
    /**
     * The legends as targets a caller can name.
@@ -406,10 +416,15 @@ public class ChartElementService {
          ChartRegionResolver.LegendTarget legend = legends.legends().get(i);
          Map<String, Object> one = new LinkedHashMap<>();
          one.put("index", i);
-         one.put("channel", legend.channel());
 
-         // Omitted rather than reported as empty: a legend with no field cannot be named as a
-         // target at all, and an empty string reads like one that can.
+         // Omitted rather than reported as empty, both of them and on the same rule: a legend
+         // with no describable frame has no field and no channel, so neither can be named as a
+         // target, and an empty string reads like one that can. The entry stays, because its
+         // index is addressable even when nothing else about it is.
+         if(legend.aestheticType() != null) {
+            one.put("channel", legend.channel());
+         }
+
          if(legend.field() != null) {
             one.put("field", legend.field());
          }
@@ -427,9 +442,10 @@ public class ChartElementService {
          // Spelled out because the same word means two things across two tools: here a target
          // names the column whose axis is hidden, while set_chart_region_properties takes the
          // axis TYPE (y, y2, x, x2). Following this note over there addressed no axis at all.
-         "note", "For hiding and showing, an axis target is a column name and a legend target is " +
-            "a field name; call get_binding for those, or name an assembly here to get this " +
-            "chart's own axes and legends. Showing a single axis or legend is not " +
+         "note", "For hiding and showing, an axis target is a column name (call get_binding) and " +
+            "a legend target is an aesthetic field name, or its channel when the chart has only " +
+            "one legend on it — name an assembly here for this chart's own axes and rendered " +
+            "legends, or call get_chart_aesthetics. Showing a single axis or legend is not " +
             "supported — showing restores all of them. Note that " +
             "set_chart_region_properties addresses an axis by TYPE (y, y2, x, x2) instead, not " +
             "by column — it takes the column separately, as 'field'.");
@@ -456,27 +472,36 @@ public class ChartElementService {
     * from the same graph it reads them from: {@code targetFields} to tell two same-channel
     * legends apart, {@code nodeAesthetic} for a relation chart's node aesthetic, and
     * {@code colorMerged} for the case below.
+    *
+    * <p><b>It reads through its own session read rather than the caller's mutation</b>, so that a
+    * refusal costs nothing. See the note at the call site: the mutation checkpoints and
+    * broadcasts even when it throws, on purpose, and a resolution that refuses has applied
+    * nothing for that undo step to cover.
     */
-   private VSChartLegendsVisibilityEvent legendEvent(
-      inetsoft.report.composition.RuntimeViewsheet rvs, ChartVSAssembly chart, String target,
-      boolean visible)
+   private VSChartLegendsVisibilityEvent legendEvent(String sessionToken, Principal user,
+                                                     String assemblyName, String target,
+                                                     boolean visible)
+      throws Exception
    {
-      Map<String, Object> fields = new LinkedHashMap<>();
-      fields.put("chartName", chart.getAbsoluteName());
-      fields.put("hide", !visible);
-
       // No target is the one case where hide-all is what was asked for, and showing is always all
       // of them - the event has no way to express showing one, which setVisibility refuses above.
+      // Neither needs the graph, so neither reads the runtime here.
       if(target == null) {
+         Map<String, Object> fields = new LinkedHashMap<>();
+         fields.put("chartName", assemblyName);
+         fields.put("hide", !visible);
          return convert(fields, VSChartLegendsVisibilityEvent.class);
       }
 
-      ChartRegionResolver.Legends legends = ChartRegionResolver.legends(rvs, chart);
+      return sessions.read(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         ChartVSAssembly chart = requireChart(rvs, assemblyName);
+         ChartRegionResolver.Legends legends = ChartRegionResolver.legends(rvs, chart);
 
-      return convert(
-         legendFields(chart.getAbsoluteName(), visible,
-                      ChartRegionResolver.requireLegendField(legends, target), legends),
-         VSChartLegendsVisibilityEvent.class);
+         return convert(
+            legendFields(assemblyName, visible,
+                         ChartRegionResolver.requireLegendField(legends, target), legends),
+            VSChartLegendsVisibilityEvent.class);
+      });
    }
 
    /**
@@ -595,9 +620,7 @@ public class ChartElementService {
    }
 
    /** Shared with {@link ChartRegionPropertyService} so both refuse a non-chart identically. */
-   private static ChartVSAssembly requireChart(
-      inetsoft.report.composition.RuntimeViewsheet rvs, String assemblyName)
-   {
+   private static ChartVSAssembly requireChart(RuntimeViewsheet rvs, String assemblyName) {
       return ChartRegionResolver.requireChart(rvs, assemblyName);
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartElementService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartElementService.java
@@ -27,6 +27,7 @@ import inetsoft.graph.coord.RelationCoord;
 import inetsoft.graph.internal.GTool;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.report.composition.graph.*;
+import inetsoft.report.composition.region.ChartArea;
 import inetsoft.uql.viewsheet.graph.VSChartInfo;
 import inetsoft.web.viewsheet.controller.chart.*;
 import inetsoft.web.viewsheet.event.chart.*;
@@ -112,7 +113,7 @@ public class ChartElementService {
       }
 
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
-         requireChart(rvs, assemblyName);
+         ChartVSAssembly chart = requireChart(rvs, assemblyName);
 
          switch(kind) {
             case "axis" -> axesService.eventHandler(
@@ -121,9 +122,7 @@ public class ChartElementService {
                      VSChartAxesVisibilityEvent.class),
                linkUri, user, dispatcher);
             case "legend" -> legendsService.eventHandler(
-               runtimeId,
-               event(Map.of("chartName", assemblyName, "hide", !visible), "field", target,
-                     VSChartLegendsVisibilityEvent.class),
+               runtimeId, legendEvent(rvs, chart, target, visible),
                linkUri, user, dispatcher);
             default -> titlesService.eventHandler(
                runtimeId,
@@ -350,6 +349,11 @@ public class ChartElementService {
     * measure. {@code axesBasis} says whether that came from the laid-out graph or was inferred
     * from the binding, because the two are not equally trustworthy and hiding the difference is
     * how a plausible-but-wrong answer gets believed.
+    *
+    * <p>{@code legends} names the chart's legends for the same reason, and it is the answer to a
+    * different question than {@code get_chart_aesthetics}: that reports which channels are
+    * <em>bound</em>, while this reports which legends are <em>rendered</em>, which is what the
+    * visibility and region tools can address.
     */
    public Map<String, Object> vocabulary(String sessionToken, Principal user, String assembly)
       throws Exception
@@ -358,11 +362,17 @@ public class ChartElementService {
          return vocabulary();
       }
 
-      ChartRegionResolver.Axes axes = sessions.read(
+      // One read for both answers: they come off the same laid-out graph, and two reads could
+      // disagree with each other if the chart relaid out between them.
+      Chart chart = sessions.read(
          sessionToken, user,
-         (rvs, runtimeId, dispatcher) ->
-            ChartRegionResolver.resolve(rvs, ChartRegionResolver.requireChart(rvs, assembly)));
+         (rvs, runtimeId, dispatcher) -> {
+            ChartVSAssembly assembly0 = ChartRegionResolver.requireChart(rvs, assembly);
+            return new Chart(ChartRegionResolver.resolve(rvs, assembly0),
+                             ChartRegionResolver.legends(rvs, assembly0));
+         });
 
+      ChartRegionResolver.Axes axes = chart.axes();
       Map<String, Object> out = new LinkedHashMap<>(vocabulary());
       List<String> titleTargets = new ArrayList<>(axes.ordered());
       // The chart title is not an axis title and does not depend on any axis existing.
@@ -373,6 +383,40 @@ public class ChartElementService {
       out.put("titleTargets", titleTargets);
       out.put("axesBasis", axes.basis());
       out.put("axesMeasured", axes.measured());
+      out.put("legends", describe(chart.legends()));
+      out.put("legendsMeasured", chart.legends().measured());
+      return out;
+   }
+
+   /** Both answers off one laid-out graph. */
+   private record Chart(ChartRegionResolver.Axes axes, ChartRegionResolver.Legends legends) {}
+
+   /**
+    * The legends as targets a caller can name.
+    *
+    * <p>Reported for the same reason the axes are: the write now refuses a legend the chart does
+    * not have, and a refusal with nowhere to look it up would just move the guessing. The
+    * {@code index} is the legend's own position, which is what the region property tools address,
+    * so the two vocabularies line up here rather than in the caller's head.
+    */
+   private static List<Map<String, Object>> describe(ChartRegionResolver.Legends legends) {
+      List<Map<String, Object>> out = new ArrayList<>();
+
+      for(int i = 0; i < legends.count(); i++) {
+         ChartRegionResolver.LegendTarget legend = legends.legends().get(i);
+         Map<String, Object> one = new LinkedHashMap<>();
+         one.put("index", i);
+         one.put("channel", legend.channel());
+
+         // Omitted rather than reported as empty: a legend with no field cannot be named as a
+         // target at all, and an empty string reads like one that can.
+         if(legend.field() != null) {
+            one.put("field", legend.field());
+         }
+
+         out.add(one);
+      }
+
       return out;
    }
 
@@ -384,10 +428,89 @@ public class ChartElementService {
          // names the column whose axis is hidden, while set_chart_region_properties takes the
          // axis TYPE (y, y2, x, x2). Following this note over there addressed no axis at all.
          "note", "For hiding and showing, an axis target is a column name and a legend target is " +
-            "a field name; call get_binding for those. Showing a single axis or legend is not " +
+            "a field name; call get_binding for those, or name an assembly here to get this " +
+            "chart's own axes and legends. Showing a single axis or legend is not " +
             "supported — showing restores all of them. Note that " +
             "set_chart_region_properties addresses an axis by TYPE (y, y2, x, x2) instead, not " +
             "by column — it takes the column separately, as 'field'.");
+   }
+
+   // ── the legend footgun, contained ─────────────────────────────────────────
+
+   /**
+    * Builds the legends event, resolving a named legend to the channel the event needs.
+    *
+    * <p><b>Why the resolution is not optional.</b> {@code aestheticType} is the event's
+    * discriminator, and {@code VSChartLegendsVisibilityService} reads a hide that omits it as
+    * "hide every legend" — it routes straight to {@code showAllLegends(false)}. This class used
+    * to send {@code field} alone, so the field was dead on arrival: naming one legend of two hid
+    * <em>both</em>, and the summary reported having hidden the one that was named. It looked like
+    * a no-op on a single-legend chart, which is why reading the source was the only way to tell
+    * the two behaviours apart.
+    *
+    * <p>So a named legend is resolved against the ones the chart actually renders, and an
+    * unresolvable name is refused — the one case where "a bogus target is an accepted no-op"
+    * does not hold, because here it is not a no-op.
+    *
+    * <p>The remaining fields are the same ones the Composer's own {@code hideLegend} sends, taken
+    * from the same graph it reads them from: {@code targetFields} to tell two same-channel
+    * legends apart, {@code nodeAesthetic} for a relation chart's node aesthetic, and
+    * {@code colorMerged} for the case below.
+    */
+   private VSChartLegendsVisibilityEvent legendEvent(
+      inetsoft.report.composition.RuntimeViewsheet rvs, ChartVSAssembly chart, String target,
+      boolean visible)
+   {
+      Map<String, Object> fields = new LinkedHashMap<>();
+      fields.put("chartName", chart.getAbsoluteName());
+      fields.put("hide", !visible);
+
+      // No target is the one case where hide-all is what was asked for, and showing is always all
+      // of them - the event has no way to express showing one, which setVisibility refuses above.
+      if(target == null) {
+         return convert(fields, VSChartLegendsVisibilityEvent.class);
+      }
+
+      ChartRegionResolver.Legends legends = ChartRegionResolver.legends(rvs, chart);
+
+      return convert(
+         legendFields(chart.getAbsoluteName(), visible,
+                      ChartRegionResolver.requireLegendField(legends, target), legends),
+         VSChartLegendsVisibilityEvent.class);
+   }
+
+   /**
+    * The event's fields for hiding one named legend, separated from fetching the graph so the
+    * values can be pinned in a test. This map is where the defect lived: it is one missing key
+    * away from meaning "hide them all".
+    */
+   static Map<String, Object> legendFields(String chartName, boolean visible,
+                                           ChartRegionResolver.LegendTarget legend,
+                                           ChartRegionResolver.Legends legends)
+   {
+      Map<String, Object> fields = new LinkedHashMap<>();
+      fields.put("chartName", chartName);
+      fields.put("hide", !visible);
+      fields.put("field", legend.field());
+      fields.put("targetFields", legend.targetFields());
+      fields.put("aestheticType", legend.aestheticType());
+      fields.put("nodeAesthetic", legend.nodeAesthetic());
+      fields.put("colorMerged", colorMerged(legends, legend.aestheticType()));
+      return fields;
+   }
+
+   /**
+    * Whether the colour legend is merged into the one being hidden, so its descriptor has to go
+    * too — the same test the Composer's own {@code VSChartService.hideLegend} makes, over the same
+    * legend list. A colour legend that is not rendered separately is drawn inside another
+    * legend's box, and hiding that box without it leaves the colour swatches behind.
+    */
+   private static boolean colorMerged(ChartRegionResolver.Legends legends, String aestheticType) {
+      long colors = legends.legends().stream()
+         .filter(legend -> ChartArea.COLOR_LEGEND.equals(legend.aestheticType()))
+         .count();
+
+      return colors < (ChartArea.COLOR_LEGEND.equals(aestheticType) ? 2 : 1);
    }
 
    // ── the titles footgun, contained ─────────────────────────────────────────

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionPropertyService.java
@@ -184,7 +184,7 @@ public class ChartRegionPropertyService {
          ChartRegionResolver.Legends legends = sessions.read(
             sessionToken, user,
             (rvs, runtimeId, dispatcher) ->
-               ChartRegionResolver.legendCount(
+               ChartRegionResolver.legends(
                   rvs, ChartRegionResolver.requireChart(rvs, assembly)));
 
          ChartRegionResolver.requireLegend(legends, indexOf(target));

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionResolver.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionResolver.java
@@ -43,7 +43,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * Which axes and how many legends a chart actually has.
+ * Which axes a chart actually has, and which legends it actually renders.
  *
  * <p><b>Why this exists.</b> Nothing else in the agent surface could answer that question, and
  * three tools needed it: the element vocabulary offered {@code y2} on every chart, the region
@@ -97,8 +97,11 @@ final class ChartRegionResolver {
     *
     * @param field         the aesthetic field it is bound to, as the frame itself reports it;
     *                      null for a legend that carries no field (a measure or static frame)
-    * @param aestheticType {@code Color}, {@code Shape} or {@code Size} — the event's own
-    *                      discriminator, and the value whose absence hid every legend
+    * @param aestheticType the event's own discriminator, and the value whose absence hid every
+    *                      legend. {@code Legend.createLegend} builds a legend for five frame
+    *                      families only, so this is {@code Color}, {@code Size}, {@code Shape},
+    *                      {@code Texture} or {@code Line} — the last three being one target,
+    *                      see {@link #channelFamily}
     * @param targetFields  the measures this legend applies to, which is what tells two legends
     *                      of the same channel apart on a multi-aesthetic chart
     * @param nodeAesthetic true when this is a relation chart's node aesthetic rather than its edge
@@ -106,7 +109,12 @@ final class ChartRegionResolver {
    record LegendTarget(String field, String aestheticType, List<String> targetFields,
                        boolean nodeAesthetic)
    {
-      /** Lower-cased, to match the channel names {@code get_chart_aesthetics} reports. */
+      /**
+       * Lower-cased, to match the channel names {@code get_chart_aesthetics} reports — which is
+       * not to say the two always agree on <em>which</em> channel: a line chart renders the field
+       * on its shape channel as a {@code line} legend. Empty for a legend with no describable
+       * frame, which is also a legend with no field, so neither can be named.
+       */
       String channel() {
          return aestheticType == null ? "" : aestheticType.toLowerCase();
       }
@@ -121,12 +129,17 @@ final class ChartRegionResolver {
       int count() {
          return legends.size();
       }
-
-      /** The nameable legends, for a message that tells the caller what to say instead. */
-      List<String> fields() {
-         return legends.stream().map(LegendTarget::field).filter(Objects::nonNull).toList();
-      }
    }
+
+   /**
+    * A chart's axes and legends read from one laid-out graph.
+    *
+    * <p>They come from different halves of the same {@link VGraphPair} - the axes from the
+    * expanded graph, the legends from the real-size one, each where {@code ChartArea} reads them -
+    * so fetching the pair once is what makes the two answers describe the same layout rather than
+    * two layouts either side of a relayout.
+    */
+   record Regions(Axes axes, Legends legends) {}
 
    /**
     * @param present  the canonical names of the axes this chart has
@@ -148,10 +161,25 @@ final class ChartRegionResolver {
    }
 
    static Axes resolve(RuntimeViewsheet rvs, ChartVSAssembly chart) {
+      return regions(rvs, chart).axes();
+   }
+
+   static Legends legends(RuntimeViewsheet rvs, ChartVSAssembly chart) {
+      return regions(rvs, chart).legends();
+   }
+
+   /**
+    * Both answers off one laid-out pair, for a caller that reports them together.
+    *
+    * <p>The two halves are read from different graphs on purpose - see {@link Regions}.
+    */
+   static Regions regions(RuntimeViewsheet rvs, ChartVSAssembly chart) {
       VGraphPair pair = laidOutPair(rvs, chart);
 
-      // ChartArea reads its axis areas from the EXPANDED graph, so resolve from the same one.
-      return resolve(chart, pair == null ? null : pair.getExpandedVGraph());
+      // ChartArea reads its axis areas from the EXPANDED graph and its legend areas from the
+      // REAL-SIZE one, so each half is resolved from the same graph its areas come from.
+      return new Regions(resolve(chart, pair == null ? null : pair.getExpandedVGraph()),
+                         legends(pair == null ? null : pair.getRealSizeVGraph()));
    }
 
    /**
@@ -176,10 +204,7 @@ final class ChartRegionResolver {
     * <p>A legend whose frame cannot be described still occupies its slot in the list. Dropping it
     * would renumber every legend after it, and the index is a target the region tools address.
     */
-   static Legends legends(RuntimeViewsheet rvs, ChartVSAssembly chart) {
-      VGraphPair pair = laidOutPair(rvs, chart);
-      VGraph graph = pair == null ? null : pair.getRealSizeVGraph();
-
+   static Legends legends(VGraph graph) {
       if(graph == null) {
          return new Legends(List.of(), false);
       }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionResolver.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionResolver.java
@@ -17,13 +17,18 @@
  */
 package inetsoft.web.wiz.viewsheet;
 
+import inetsoft.graph.EGraph;
 import inetsoft.graph.VGraph;
+import inetsoft.graph.aesthetic.VisualFrame;
 import inetsoft.graph.coord.Coordinate;
 import inetsoft.graph.guide.axis.Axis;
 import inetsoft.graph.guide.axis.DefaultAxis;
+import inetsoft.graph.guide.legend.Legend;
 import inetsoft.graph.guide.legend.LegendGroup;
+import inetsoft.graph.internal.GTool;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
+import inetsoft.report.composition.graph.GraphUtil;
 import inetsoft.report.composition.graph.VGraphPair;
 import inetsoft.uql.viewsheet.ChartVSAssembly;
 import inetsoft.uql.viewsheet.VSAssembly;
@@ -35,6 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Which axes and how many legends a chart actually has.
@@ -87,10 +93,40 @@ final class ChartRegionResolver {
    static final List<String> AXES = List.of("x", "x2", "y", "y2");
 
    /**
-    * @param count    how many legends the chart renders
-    * @param measured false when there was no laid-out graph to count from
+    * One legend the chart actually renders, in the vocabulary its visibility event needs.
+    *
+    * @param field         the aesthetic field it is bound to, as the frame itself reports it;
+    *                      null for a legend that carries no field (a measure or static frame)
+    * @param aestheticType {@code Color}, {@code Shape} or {@code Size} — the event's own
+    *                      discriminator, and the value whose absence hid every legend
+    * @param targetFields  the measures this legend applies to, which is what tells two legends
+    *                      of the same channel apart on a multi-aesthetic chart
+    * @param nodeAesthetic true when this is a relation chart's node aesthetic rather than its edge
     */
-   record Legends(int count, boolean measured) {}
+   record LegendTarget(String field, String aestheticType, List<String> targetFields,
+                       boolean nodeAesthetic)
+   {
+      /** Lower-cased, to match the channel names {@code get_chart_aesthetics} reports. */
+      String channel() {
+         return aestheticType == null ? "" : aestheticType.toLowerCase();
+      }
+   }
+
+   /**
+    * @param legends  the chart's legends in the graph's own order, so a position here is the
+    *                 0-based legend index the region tools address
+    * @param measured false when there was no laid-out graph to read them from
+    */
+   record Legends(List<LegendTarget> legends, boolean measured) {
+      int count() {
+         return legends.size();
+      }
+
+      /** The nameable legends, for a message that tells the caller what to say instead. */
+      List<String> fields() {
+         return legends.stream().map(LegendTarget::field).filter(Objects::nonNull).toList();
+      }
+   }
 
    /**
     * @param present  the canonical names of the axes this chart has
@@ -119,7 +155,7 @@ final class ChartRegionResolver {
    }
 
    /**
-    * How many legends the chart has, counted where {@code ChartArea} counts them.
+    * The legends the chart has, read where {@code ChartArea} reads them.
     *
     * <p>{@code LegendsArea} builds one area per {@code vgraph.getLegendGroup().getLegendCount()}
     * and is not built at all when the group is null, so that count is exactly the valid index
@@ -128,19 +164,143 @@ final class ChartRegionResolver {
     * expanded graph.
     *
     * <p>An index outside it used to reach StyleBI and return a raw HTTP 500 page; a chart with no
-    * laid-out graph has no legends either, so {@code count 0} with the basis stated is a truthful
+    * laid-out graph has no legends either, so an empty list with the basis stated is a truthful
     * answer rather than a guess.
+    *
+    * <p><b>Each legend is described, not just counted</b>, because the count alone cannot answer
+    * the question the visibility event actually asks: which aesthetic channel is this field's
+    * legend on. Every fact here is taken from the same place {@link
+    * inetsoft.report.composition.region.LegendArea} takes it, so the answer matches what the
+    * Composer sends for the same legend rather than being a second opinion about it.
+    *
+    * <p>A legend whose frame cannot be described still occupies its slot in the list. Dropping it
+    * would renumber every legend after it, and the index is a target the region tools address.
     */
-   static Legends legendCount(RuntimeViewsheet rvs, ChartVSAssembly chart) {
+   static Legends legends(RuntimeViewsheet rvs, ChartVSAssembly chart) {
       VGraphPair pair = laidOutPair(rvs, chart);
       VGraph graph = pair == null ? null : pair.getRealSizeVGraph();
 
       if(graph == null) {
-         return new Legends(0, false);
+         return new Legends(List.of(), false);
       }
 
-      LegendGroup legends = graph.getLegendGroup();
-      return new Legends(legends == null ? 0 : legends.getLegendCount(), true);
+      LegendGroup group = graph.getLegendGroup();
+
+      if(group == null) {
+         return new Legends(List.of(), true);
+      }
+
+      EGraph egraph = graph.getEGraph();
+      List<LegendTarget> targets = new ArrayList<>();
+
+      for(int i = 0; i < group.getLegendCount(); i++) {
+         Legend legend = group.getLegend(i);
+         VisualFrame frame = legend == null ? null : legend.getVisualFrame();
+
+         if(frame == null) {
+            targets.add(new LegendTarget(null, null, List.of(), false));
+            continue;
+         }
+
+         targets.add(new LegendTarget(
+            frame.getField(),
+            GTool.getFrameType(frame.getClass()),
+            egraph == null ? List.of() : GraphUtil.getTargetFields(frame, egraph),
+            GraphUtil.isNodeAestheticFrame(frame, legend.getGraphElement())));
+      }
+
+      return new Legends(targets, true);
+   }
+
+   /**
+    * The legend a caller named, or a refusal naming the ones the chart has.
+    *
+    * <p><b>Why this has to refuse rather than fall through.</b> The event reads a hide with no
+    * {@code aestheticType} as "hide every legend" — see {@code VSChartLegendsVisibilityService},
+    * which routes it to {@code showAllLegends(false)}. So an unresolved target is not an inert
+    * no-op the way an unknown axis column is: it hides the chart's real legends and reports
+    * success naming the one the caller asked for. That is what made this the one part of the
+    * "a bogus target is an accepted no-op" ruling that could not be closed with it.
+    *
+    * <p>Forgiving where the intent is unambiguous, per this repo's own rule: the field is matched
+    * ignoring case and surrounding space, and a caller who names the <em>channel</em> instead
+    * ({@code color}, {@code shape}, {@code size}) is taken to mean that legend when the chart has
+    * exactly one of them — with {@code shape}, {@code line} and {@code texture} folded together,
+    * because the event does not tell them apart either and the two names for the same legend are
+    * both put in front of the caller (see {@link #channelFamily}). Two legends in the same family
+    * make it ambiguous, so that is refused with both fields named rather than resolved to the
+    * first.
+    */
+   static LegendTarget requireLegendField(Legends legends, String target) {
+      String wanted = target == null ? "" : target.trim();
+
+      if(!legends.measured()) {
+         throw new IllegalArgumentException(
+            "This chart has no laid-out graph yet - it is unbound, empty, or still computing - so " +
+            "its legends cannot be resolved, and hiding one by name would hide them all. Call " +
+            "this without 'target' to hide every legend deliberately, or retry once the chart " +
+            "has rendered.");
+      }
+
+      for(LegendTarget legend : legends.legends()) {
+         if(legend.field() != null && legend.field().equals(wanted)) {
+            return legend;
+         }
+      }
+
+      for(LegendTarget legend : legends.legends()) {
+         if(legend.field() != null && legend.field().equalsIgnoreCase(wanted)) {
+            return legend;
+         }
+      }
+
+      String family = channelFamily(wanted);
+      List<LegendTarget> byChannel = family.isEmpty() ? List.of() : legends.legends().stream()
+         .filter(legend -> channelFamily(legend.aestheticType()).equals(family))
+         .toList();
+
+      if(byChannel.size() == 1) {
+         return byChannel.get(0);
+      }
+
+      throw new IllegalArgumentException(describeLegends(legends, target, byChannel.size() > 1));
+   }
+
+   /**
+    * The channel names that address the same legend, folded onto one.
+    *
+    * <p>{@code GraphUtil.getLegendDescriptor} maps {@code Shape}, {@code Line} and {@code Texture}
+    * onto the same shape legend descriptor, so for hiding they are one target rather than three.
+    * Folding them matters because the caller meets both names: {@code get_chart_aesthetics}
+    * reports the field on the <b>shape</b> channel, while a line chart renders that legend as
+    * <b>Line</b> — so a caller who read the aesthetics and said "shape" was naming this legend
+    * correctly and being refused for it.
+    */
+   private static String channelFamily(String channel) {
+      String name = channel == null ? "" : channel.trim().toLowerCase();
+
+      return switch(name) {
+         case "shape", "line", "texture" -> "shape";
+         default -> name;
+      };
+   }
+
+   private static String describeLegends(Legends legends, String target, boolean ambiguousChannel) {
+      String have = legends.legends().isEmpty()
+         ? "This chart renders no legends"
+         : "Its legends are: " + legends.legends().stream()
+            .map(legend -> (legend.field() == null ? "(unnamed)" : legend.field()) +
+               " (" + (legend.aestheticType() == null ? "unknown channel" : legend.channel()) + ")")
+            .collect(Collectors.joining(", "));
+
+      return (ambiguousChannel
+         ? "This chart has more than one '" + target + "' legend, so naming the channel does not " +
+           "say which. Name the field instead. "
+         : "This chart has no '" + target + "' legend. ") +
+         have + ". A legend target is the aesthetic FIELD name - list_chart_elements on this " +
+         "chart, or get_chart_aesthetics, reports them - or the channel above when only one " +
+         "legend is on it. Omit 'target' to hide every legend, which is what a target the chart " +
+         "does not have used to do while reporting that it had hidden the one you named.";
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartElementServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartElementServiceTest.java
@@ -130,6 +130,45 @@ class ChartElementServiceTest {
    }
 
    /**
+    * A blank target is no target. The tool layer's own show-with-a-target guard already reads
+    * {@code ""} as absent, so a server reading it as present refused a call the tool had passed —
+    * and on the legend path it refused it by naming an empty legend.
+    */
+   @Test
+   void readsABlankTargetAsNoTarget() throws Exception {
+      Harness h = harness(mock(ChartVSAssembly.class));
+
+      h.service.setVisibility("tok", principal(), "Chart1", "legend", "  ", false, "");
+
+      ArgumentCaptor<VSChartLegendsVisibilityEvent> captor =
+         ArgumentCaptor.forClass(VSChartLegendsVisibilityEvent.class);
+      verify(h.legends).eventHandler(eq("rt1"), captor.capture(), anyString(),
+                                     any(Principal.class), any());
+      assertNull(captor.getValue().getAestheticType(), "which is the event's hide-all");
+      assertDoesNotThrow(
+         () -> h.service.setVisibility("tok", principal(), "Chart1", "legend", "", true, ""),
+         "and showing with a blank target is showing them all, not a refused single show");
+   }
+
+   /**
+    * And it costs nothing. {@code ViewsheetSessionService.mutate} adds an undo checkpoint and
+    * broadcasts a refresh in a {@code finally} — deliberately, because a composer service can
+    * partially apply before it ERRORs — so resolving the target inside the mutation would spend
+    * a Ctrl+Z step and a Composer refresh on a call that applied nothing.
+    */
+   @Test
+   void refusingALegendTargetDoesNotOpenAMutation() throws Exception {
+      Harness h = harness(mock(ChartVSAssembly.class));
+
+      assertThrows(
+         Exception.class,
+         () -> h.service.setVisibility("tok", principal(), "Chart1", "legend", "Category", false,
+                                       ""));
+
+      verify(h.sessions, never()).mutate(anyString(), any(Principal.class), any());
+   }
+
+   /**
     * {@code aestheticType} is the whole fix: without it the event hides every legend. Pinned on
     * the field map for the same reason the titles event is — an all-default event is the
     * destructive case, so the values have to be asserted rather than assumed.

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartElementServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartElementServiceTest.java
@@ -95,17 +95,84 @@ class ChartElementServiceTest {
    }
 
    @Test
-   void hidesOneLegendByField() throws Exception {
+   void hidesEveryLegendWhenNoneIsNamed() throws Exception {
       Harness h = harness(mock(ChartVSAssembly.class));
 
-      h.service.setVisibility("tok", principal(), "Chart1", "legend", "Category", false, "");
+      h.service.setVisibility("tok", principal(), "Chart1", "legend", null, false, "");
 
       ArgumentCaptor<VSChartLegendsVisibilityEvent> captor =
          ArgumentCaptor.forClass(VSChartLegendsVisibilityEvent.class);
       verify(h.legends).eventHandler(eq("rt1"), captor.capture(), anyString(),
                                      any(Principal.class), any());
-      assertEquals("Category", captor.getValue().getField());
       assertTrue(captor.getValue().isHide());
+      assertNull(captor.getValue().getAestheticType(),
+                 "no aestheticType IS the event's hide-all, which is what was asked for");
+   }
+
+   /**
+    * The defect this path was rewritten for. A named legend used to be sent as {@code field}
+    * alone, and the event reads a hide with no {@code aestheticType} as "hide every legend" — so
+    * naming one legend of two hid both and reported success naming the one. With no laid-out
+    * graph there is nothing to resolve the name against, so the call is refused rather than
+    * quietly becoming hide-all.
+    */
+   @Test
+   void refusesToHideANamedLegendItCannotResolve() {
+      Harness h = harness(mock(ChartVSAssembly.class));
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> h.service.setVisibility("tok", principal(), "Chart1", "legend", "Category", false,
+                                       ""));
+
+      assertTrue(thrown.getMessage().contains("without 'target'"), "and say what to call instead");
+      verifyNoInteractions(h.legends);
+   }
+
+   /**
+    * {@code aestheticType} is the whole fix: without it the event hides every legend. Pinned on
+    * the field map for the same reason the titles event is — an all-default event is the
+    * destructive case, so the values have to be asserted rather than assumed.
+    */
+   @Test
+   void aNamedLegendCarriesItsChannelOntoTheEvent() {
+      ChartRegionResolver.Legends legends = twoLegends();
+      VSChartLegendsVisibilityEvent event = new ObjectMapper().convertValue(
+         ChartElementService.legendFields("Chart1", false, legends.legends().get(1), legends),
+         VSChartLegendsVisibilityEvent.class);
+
+      assertTrue(event.isHide());
+      assertEquals("Customer:Reseller", event.getField());
+      assertEquals("Shape", event.getAestheticType(),
+                   "without this the event hides every legend on the chart");
+   }
+
+   /**
+    * The Composer's own rule, over the same legend list: a colour legend that is not rendered
+    * separately is drawn inside another legend's box, so hiding that box has to take it too.
+    */
+   @Test
+   void marksTheColourLegendMergedOnTheSameTestTheComposerMakes() {
+      ChartRegionResolver.Legends legends = twoLegends();
+
+      // One colour legend, hiding the colour legend: merged, so its descriptor goes too.
+      assertTrue((Boolean) ChartElementService
+         .legendFields("Chart1", false, legends.legends().get(0), legends).get("colorMerged"));
+
+      // One colour legend, hiding the SHAPE legend: the colour legend stands on its own and must
+      // survive. This is the case StyleBI's own bug 58639 was about.
+      assertFalse((Boolean) ChartElementService
+         .legendFields("Chart1", false, legends.legends().get(1), legends).get("colorMerged"));
+   }
+
+   private static ChartRegionResolver.Legends twoLegends() {
+      return new ChartRegionResolver.Legends(
+         java.util.List.of(
+            new ChartRegionResolver.LegendTarget("Customer:Region", "Color",
+                                                 java.util.List.of(), false),
+            new ChartRegionResolver.LegendTarget("Customer:Reseller", "Shape",
+                                                 java.util.List.of(), false)),
+         true);
    }
 
    // ── the titles footgun ────────────────────────────────────────────────────

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionResolverTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionResolverTest.java
@@ -346,8 +346,13 @@ class ChartRegionResolverTest {
          true);
 
       assertEquals(2, legends.count(), "both slots counted");
-      assertEquals(List.of("Region"), legends.fields(), "but only one can be named");
-      assertDoesNotThrow(() -> ChartRegionResolver.requireLegend(legends, 1));
+      assertDoesNotThrow(() -> ChartRegionResolver.requireLegend(legends, 1),
+                         "and the empty slot's index is still addressable");
+      assertEquals("Region", ChartRegionResolver.requireLegendField(legends, "color").field(),
+                   "but only the described one can be named");
+      assertThrows(IllegalArgumentException.class,
+                   () -> ChartRegionResolver.requireLegendField(legends, ""),
+                   "and the unnamed one is reachable by no target at all");
    }
 
    private static ChartRegionResolver.Legends twoLegends() {

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionResolverTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionResolverTest.java
@@ -27,6 +27,9 @@ import inetsoft.uql.viewsheet.graph.*;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.*;
@@ -169,7 +172,7 @@ class ChartRegionResolverTest {
    void refusesALegendIndexOutsideTheChartsRange() {
       Exception thrown = assertThrows(
          IllegalArgumentException.class,
-         () -> ChartRegionResolver.requireLegend(new ChartRegionResolver.Legends(1, true), 7));
+         () -> ChartRegionResolver.requireLegend(legends(1, true), 7));
 
       assertTrue(thrown.getMessage().contains("1 legend"), "name the range");
       assertTrue(thrown.getMessage().contains("7"), "and what was asked for");
@@ -184,14 +187,14 @@ class ChartRegionResolverTest {
    void refusesANegativeLegendIndex() {
       assertThrows(
          IllegalArgumentException.class,
-         () -> ChartRegionResolver.requireLegend(new ChartRegionResolver.Legends(2, true), -1));
+         () -> ChartRegionResolver.requireLegend(legends(2, true), -1));
    }
 
    @Test
    void spellsOutARangeWhenThereIsMoreThanOneLegend() {
       Exception thrown = assertThrows(
          IllegalArgumentException.class,
-         () -> ChartRegionResolver.requireLegend(new ChartRegionResolver.Legends(3, true), 9));
+         () -> ChartRegionResolver.requireLegend(legends(3, true), 9));
 
       assertTrue(thrown.getMessage().contains("0 to 2"), "a real range, spelled out");
    }
@@ -199,14 +202,14 @@ class ChartRegionResolverTest {
    @Test
    void allowsEveryIndexInRange() {
       assertDoesNotThrow(
-         () -> ChartRegionResolver.requireLegend(new ChartRegionResolver.Legends(2, true), 1));
+         () -> ChartRegionResolver.requireLegend(legends(2, true), 1));
    }
 
    @Test
    void refusesAnyLegendOnAChartThatRendersNone() {
       assertThrows(
          IllegalArgumentException.class,
-         () -> ChartRegionResolver.requireLegend(new ChartRegionResolver.Legends(0, true), 0));
+         () -> ChartRegionResolver.requireLegend(legends(0, true), 0));
    }
 
    /**
@@ -216,7 +219,155 @@ class ChartRegionResolverTest {
    @Test
    void doesNotRefuseWhenTheCountCouldNotBeMeasured() {
       assertDoesNotThrow(
-         () -> ChartRegionResolver.requireLegend(new ChartRegionResolver.Legends(0, false), 5));
+         () -> ChartRegionResolver.requireLegend(legends(0, false), 5));
+   }
+
+   // ── naming a legend ────────────────────────────────────────────────────────────
+   //
+   // The index above is the region tools' vocabulary. These are the visibility tool's: it names
+   // the aesthetic FIELD, and an unresolved one is the case that hid every legend.
+
+   @Test
+   void resolvesALegendByItsField() {
+      ChartRegionResolver.LegendTarget legend =
+         ChartRegionResolver.requireLegendField(twoLegends(), "Customer:Reseller");
+
+      assertEquals("Shape", legend.aestheticType(), "the channel is what the event needs");
+      assertEquals("shape", legend.channel(), "reported lower-cased, as the aesthetic tools do");
+   }
+
+   @Test
+   void resolvesALegendFieldIgnoringCaseAndSpace() {
+      assertEquals(
+         "Color",
+         ChartRegionResolver.requireLegendField(twoLegends(), "  customer:region ").aestheticType(),
+         "forgiving where the intent is unambiguous");
+   }
+
+   /** A caller who says "the color legend" means the one colour legend, when there is only one. */
+   @Test
+   void resolvesALegendByItsChannelWhenOnlyOneIsOnThatChannel() {
+      assertEquals("Customer:Region",
+                   ChartRegionResolver.requireLegendField(twoLegends(), "color").field());
+      assertEquals("Customer:Reseller",
+                   ChartRegionResolver.requireLegendField(twoLegends(), "Shape").field());
+   }
+
+   /**
+    * A line chart renders its shape aesthetic as a Line legend, while get_chart_aesthetics reports
+    * the field on the shape channel — so a caller who read the aesthetics and said "shape" is
+    * naming this legend correctly. The event folds Shape, Line and Texture onto one descriptor
+    * anyway, so there is nothing ambiguous to protect here. Found live on a line chart.
+    */
+   @Test
+   void takesShapeToMeanTheLegendALineChartRendersAsLine() {
+      ChartRegionResolver.Legends legends = new ChartRegionResolver.Legends(
+         List.of(new ChartRegionResolver.LegendTarget("Customer:Region", "Color", List.of(), false),
+                 new ChartRegionResolver.LegendTarget("Customer:Reseller", "Line", List.of(),
+                                                      false)),
+         true);
+
+      assertEquals("Customer:Reseller",
+                   ChartRegionResolver.requireLegendField(legends, "shape").field());
+      assertEquals("Customer:Reseller",
+                   ChartRegionResolver.requireLegendField(legends, "texture").field(),
+                   "the same fold in the other direction");
+      assertEquals("Customer:Region",
+                   ChartRegionResolver.requireLegendField(legends, "color").field(),
+                   "and colour is still its own family");
+   }
+
+   @Test
+   void refusesAChannelNameWhenTwoLegendsShareIt() {
+      ChartRegionResolver.Legends legends = new ChartRegionResolver.Legends(
+         List.of(new ChartRegionResolver.LegendTarget("Sales", "Color", List.of(), false),
+                 new ChartRegionResolver.LegendTarget("Region", "Color", List.of(), false)),
+         true);
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartRegionResolver.requireLegendField(legends, "color"));
+
+      assertTrue(thrown.getMessage().contains("more than one"), "say why it cannot be resolved");
+      assertTrue(thrown.getMessage().contains("Sales") && thrown.getMessage().contains("Region"),
+                 "and name both, so the caller can pick one");
+   }
+
+   /**
+    * The finding this whole path exists for: a target the chart has never heard of did not no-op,
+    * it hid the chart's real legends and reported success naming the one asked for. So an
+    * unknown field has to be refused, not passed through.
+    */
+   @Test
+   void refusesAFieldNoLegendHas() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartRegionResolver.requireLegendField(twoLegends(), "NoSuchField"));
+
+      assertTrue(thrown.getMessage().contains("NoSuchField"), "name what was asked for");
+      assertTrue(thrown.getMessage().contains("Customer:Region") &&
+                 thrown.getMessage().contains("Customer:Reseller"),
+                 "and the legends it does have");
+      assertTrue(thrown.getMessage().contains("color") && thrown.getMessage().contains("shape"),
+                 "with their channels, since a channel is also accepted");
+   }
+
+   /**
+    * Without a graph there is nothing to resolve against, and passing through would hide every
+    * legend - the exact defect. Unlike the index check, silence here is not the safe side.
+    */
+   @Test
+   void refusesToResolveAFieldWithNoLaidOutGraph() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartRegionResolver.requireLegendField(
+            new ChartRegionResolver.Legends(List.of(), false), "Customer:Region"));
+
+      assertTrue(thrown.getMessage().contains("without 'target'"),
+                 "and say what to call instead");
+   }
+
+   @Test
+   void refusesAnyFieldOnAChartThatRendersNoLegends() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartRegionResolver.requireLegendField(
+            new ChartRegionResolver.Legends(List.of(), true), "Customer:Region"));
+
+      assertTrue(thrown.getMessage().contains("no legends"), "say so plainly");
+   }
+
+   /** A legend with no field of its own keeps its slot, because the index addresses it. */
+   @Test
+   void keepsAnUnnamedLegendInThePositionTheIndexAddresses() {
+      ChartRegionResolver.Legends legends = new ChartRegionResolver.Legends(
+         List.of(new ChartRegionResolver.LegendTarget(null, null, List.of(), false),
+                 new ChartRegionResolver.LegendTarget("Region", "Color", List.of(), false)),
+         true);
+
+      assertEquals(2, legends.count(), "both slots counted");
+      assertEquals(List.of("Region"), legends.fields(), "but only one can be named");
+      assertDoesNotThrow(() -> ChartRegionResolver.requireLegend(legends, 1));
+   }
+
+   private static ChartRegionResolver.Legends twoLegends() {
+      return new ChartRegionResolver.Legends(
+         List.of(new ChartRegionResolver.LegendTarget("Customer:Region", "Color", List.of(), false),
+                 new ChartRegionResolver.LegendTarget("Customer:Reseller", "Shape", List.of(),
+                                                      false)),
+         true);
+   }
+
+   /** A chart with {@code count} legends, for the index checks that predate fields. */
+   private static ChartRegionResolver.Legends legends(int count, boolean measured) {
+      List<ChartRegionResolver.LegendTarget> legends = new ArrayList<>();
+
+      for(int i = 0; i < count; i++) {
+         legends.add(
+            new ChartRegionResolver.LegendTarget("Field" + i, "Color", List.of(), false));
+      }
+
+      return new ChartRegionResolver.Legends(legends, measured);
    }
 
    private static ChartRegionResolver.Axes resolveWithGraph(VSChartInfo info, boolean mirrored) {


### PR DESCRIPTION
## The defect

`set_chart_element_visibility` with `element: "legend"` and a `target` hid **every** legend on the chart, while the summary reported having hidden the one that was named.

Root cause is a missing field on one event. `VSChartLegendsVisibilityService` reads a hide whose `aestheticType` is null as *hide all* and routes it to `showAllLegends(false)`; `ChartElementService` only ever sent `field`, so `target` was dead on the legend path for every caller.

This was reviewed once before and accepted as "a bogus target is an inert no-op". That reading was wrong, and the reason it survived is worth stating: on a **single-legend** chart, "hides the one you named" and "hides them all" produce the identical image, so only reading the source separated them. Reproduced on a two-legend chart, naming a real field killed both legends.

## The fix

Same shape as the axis resolver already in this file: **enumerate what the chart has, then refuse what it does not.**

- `ChartRegionResolver.legends` reads the real-size graph's `LegendGroup` and describes each legend — field, channel, target fields, node-aesthetic flag — taking every value from where `LegendArea` takes it, so the answer *is* what the Composer sends for that legend rather than a second opinion about it. A legend whose frame cannot be described keeps its slot, because the index is a target the region tools address.
- `ChartElementService` resolves a named legend to its `aestheticType` and computes `colorMerged` by the same test `VSChartService.hideLegend` makes over the same list.

Three decisions worth review attention:

1. **An unresolvable name is refused, not passed through.** This is the one target in this family where a wrong value was never inert, so the accepted-no-op rule cannot apply to it.
2. **A chart with no laid-out graph is refused too** — deliberately the *opposite* of the rule `requireLegend` follows for the legend index. There, an unmeasured count is zero for want of a graph and refusing would block a legitimate write, so silence is the safe side; here the fallback *is* the destructive behaviour.
3. **`shape`, `line` and `texture` are one family.** Found while verifying: `get_chart_aesthetics` reports the field on the **shape** channel while a line chart renders that legend as **line**, so a caller who read the aesthetics and said `shape` was naming the legend correctly and being refused for it. `GraphUtil.getLegendDescriptor` maps all three onto the same descriptor, so there was nothing ambiguous to protect. Two legends in one family are still refused with both fields named.

`list_chart_elements` reports the legends as well — filtering only the write would have moved the guessing rather than removed it.

## Also fixed

`resize_chart_plot`'s `reset: true` cleared `unitWidthRatio`/`unitHeightRatio` and both resized flags but left `unitWidthRatioPercent`/`unitHeightRatioPercent` behind. `VGraphPair` re-derives the ratio from the percent whenever it is `>= 1` **without consulting the flags**, so a reset chart reported `default: true, resized: false` while rebuilding the old ratio on every subsequent layout — visually inert only because the enlargement itself is gated on the flag this branch does clear.

Cleared back to `0`, the field's declared default. `1` is not the neutral value here: it would re-derive the ratio as the plot's own baseline, which looks like a reset that did not take.

## Verification

Unit: `ChartElementServiceTest` and `ChartRegionResolverTest`, 57 green (15 new).

Live, against a running server on a chart with two legends (`Customer:Region` on colour, `Customer:Reseller` on shape) and a real y2, every step confirmed by rendered image:

| Call | Before | After |
|---|---|---|
| `target: "Customer:Region"` | both legends hidden, summary named one | only that one hidden |
| `target: "Customer:Reseller"` | both legends hidden | only that one hidden — the colour legend survives, which is bug 58639's case and what `colorMerged` decides |
| `target: "NoSuchField"` | **hid the real legends**, reported success | refused, listing the real legends |
| `visible: true`, no target | shows all | unchanged |
| `reset: true` after `ratio: 6` | `percent` stayed 1.1 | `ratio: 1, resized: false, percent: 0, default: true` |

`list_chart_elements` reported both legends and, after one was hidden, only the other — read and write agreeing.

**Not yet exercised live:** the shape/line/texture fold, which was written after the restart the live run used. It is unit-tested. Also no live coverage for a **relation chart** (the node-aesthetic branch) or for **two legends on the same channel** (the ambiguity refusal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review round (e4c26c3)

Four things found reviewing the above.

**A refusal cost an undo step.** The resolution ran inside `sessions.mutate`, which adds a checkpoint and broadcasts a refresh in a `finally` — deliberately, because a composer service can partially apply before it ERRORs. A resolution that refuses has applied nothing, so it was spending a Ctrl+Z step and a Composer refresh on a call that changed nothing. It now runs in its own session read ahead of the mutation, the route `ChartRegionPropertyService` already takes for its own refusals. Regression-tested (`refusingALegendTargetDoesNotOpenAMutation`).

**A blank target meant two different things at the two layers.** The tool's show-with-a-target guard reads `""` as absent, so a server reading it as present refused the very call the tool had let through — and on the legend path it refused it by naming an empty legend. Blank is now no target, for all three elements. Not trimmed otherwise: only the blank case is unambiguous, and a column name's own spacing is its own business.

**"One read for both answers" was not what the code did.** `resolve` and `legends` each fetched their own `VGraphPair`, so the axes and the legends could describe two layouts either side of a relayout while being reported as one chart's. They now come off one pair, through `regions()` — the two halves still read from different graphs (expanded for the axes, real-size for the legends), which is why the record documents that rather than hiding it.

**Two reporting inaccuracies.** `channel` was emitted as `""` for a legend with no describable frame while `field` was omitted on the stated ground that an empty string reads like a nameable target — the same ground covers both, so both are omitted now and the index stands alone. And `aestheticType` was documented as `Color`, `Shape` or `Size`; `Legend.createLegend` also builds `Texture` and `Line` legends, which is the whole reason `channelFamily` exists.

Also dropped `Legends.fields()`, which no production caller had, and used the `RuntimeViewsheet` import instead of naming the class in full.

Verified: `ChartElementServiceTest` + `ChartRegionResolverTest` 59 green (2 new); the whole `inetsoft.web.wiz` package 2103 green.
