### PR TITLE
fix(calc-table): numeric date-format leak, unwrapped detail expression, group scoping, formula-script field mapping

### DIFF
--- a/core/src/main/java/inetsoft/report/LayoutTool.java
+++ b/core/src/main/java/inetsoft/report/LayoutTool.java
@@ -2332,7 +2332,11 @@ public class LayoutTool {
             cell.getBType() == TableCellBinding.GROUP, sortOthersLast);
       }
       else if(cell.getBType() == TableCellBinding.DETAIL) {
-         exp = createDetailExpression(groups, gnames, createDetailField(cell, table), var);
+         // wrap in none(...) the same way the crosstab-supported branch does for the
+         // same bType (createCrosstabCalcExpression), so CellRange.getCollectionValue's
+         // raw Object[] array lookup gets reduced back to a scalar instead of leaking
+         // as "[Ljava.lang.Object;@<hash>".
+         exp = "none(" + createDetailExpression(groups, gnames, createDetailField(cell, table), var) + ")";
 
          // use noEmpty to avoid a row disappearing when there is not avoid
          // this should only be necessary when there is multi-source join and

--- a/core/src/main/java/inetsoft/report/internal/table/RuntimeCalcTableLens.java
+++ b/core/src/main/java/inetsoft/report/internal/table/RuntimeCalcTableLens.java
@@ -1064,7 +1064,7 @@ public class RuntimeCalcTableLens extends CalcTableLens implements MappedTableLe
 
          // do not apply default date format to non-date type column
          // fix bug1370224630687
-         if(cls == null || !XSchema.isDateType(dtype) && !XSchema.isNumericType(dtype)) {
+         if(cls == null || !XSchema.isDateType(dtype)) {
             return null;
          }
 

--- a/core/src/main/java/inetsoft/web/wiz/binding/CalcCellVocabulary.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/CalcCellVocabulary.java
@@ -131,10 +131,12 @@ public final class CalcCellVocabulary {
             "nothing renders blank, which reads as missing data rather than a binding error.");
       }
 
-      if(type == CellBinding.BIND_FORMULA && str(cell, "formula") == null) {
+      if(type == CellBinding.BIND_FORMULA && str(cell, "formula") == null &&
+         str(cell, "value") == null)
+      {
          throw new IllegalArgumentException(
-            "A cell with content 'formula' needs a 'formula'. A cell bound to nothing renders " +
-            "blank, which reads as missing data rather than a binding error.");
+            "A cell with content 'formula' needs a 'formula' (or 'value'). A cell bound to " +
+            "nothing renders blank, which reads as missing data rather than a binding error.");
       }
 
       if(type == CellBinding.BIND_TEXT && str(cell, "value") == null) {

--- a/core/src/main/java/inetsoft/web/wiz/binding/CalcTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/CalcTableService.java
@@ -18,8 +18,15 @@
 package inetsoft.web.wiz.binding;
 
 import inetsoft.report.CellBinding;
+import inetsoft.report.TableCellBinding;
 import inetsoft.report.TableLayout;
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.asset.AttachedAssembly;
+import inetsoft.uql.asset.DefaultNamedGroupAssembly;
+import inetsoft.uql.asset.SourceInfo;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.viewsheet.CalcTableVSAssembly;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
@@ -191,7 +198,7 @@ public class CalcTableService {
       }
 
       return sessions.read(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
-         requireCalcTable(rvs, assemblyName);
+         CalcTableVSAssembly assembly = requireCalcTable(rvs, assemblyName);
 
          GetPredefinedNamedGroupEvent event = new GetPredefinedNamedGroupEvent();
          event.setName(assemblyName);
@@ -211,15 +218,62 @@ public class CalcTableService {
             }
          }
 
+         // The above only sees repository-registered "predefined named group" assets
+         // (SummaryAttr.getAssetNamedGroupInfos), a different kind from the plain
+         // DefaultNamedGroupAssembly that add_named_group creates as an ordinary secondary
+         // assembly inside the calc table's own bound worksheet. Scan that worksheet too, so
+         // a group created through add_named_group is actually listed.
+         Set<String> seen = new LinkedHashSet<>(groups);
+         List<String> worksheetGroups = new ArrayList<>();
+         SourceInfo sinfo = ((CalcTableVSAssemblyInfo) assembly.getInfo()).getSourceInfo();
+         Worksheet ws = rvs.getViewsheet() == null ? null : rvs.getViewsheet().getBaseWorksheet();
+
+         if(sinfo != null && sinfo.getSource() != null && ws != null) {
+            for(Assembly wsAssembly : ws.getAssemblies()) {
+               if(!(wsAssembly instanceof DefaultNamedGroupAssembly ngAssembly) ||
+                  ngAssembly.getAttachedType() != AttachedAssembly.COLUMN_ATTACHED)
+               {
+                  continue;
+               }
+
+               SourceInfo attachedSource = ngAssembly.getAttachedSource();
+               DataRef attr = ngAssembly.getAttachedAttribute();
+
+               if(attachedSource == null || attr == null ||
+                  !sinfo.getSource().equals(attachedSource.getSource()) ||
+                  !column.equals(attr.getAttribute()))
+               {
+                  continue;
+               }
+
+               if(seen.add(ngAssembly.getName())) {
+                  worksheetGroups.add(ngAssembly.getName());
+               }
+            }
+         }
+
+         groups.addAll(worksheetGroups);
+
          Map<String, Object> out = new LinkedHashMap<>();
          out.put("assembly", assemblyName);
          out.put("column", column);
          out.put("namedGroups", groups);
 
-         if(groups.isEmpty()) {
+         if(!worksheetGroups.isEmpty()) {
+            // Listable here does not yet mean bindable: VSTableLayoutService.setNamedGroupInfo
+            // has no code path for a worksheet-local DefaultNamedGroupAssembly's plain
+            // NamedGroupInfo, only for the asset-repository named-group kinds above.
             out.put("note",
-                    "No predefined named groups exist for this column. Named groups are defined " +
-                    "on the data source, not created here.");
+                    "'" + String.join("', '", worksheetGroups) + "' " +
+                    (worksheetGroups.size() == 1 ? "was" : "were") +
+                    " created via add_named_group on this column's worksheet. It is listed " +
+                    "here, but set_cell_binding's 'namedGroup' parameter may not yet be able " +
+                    "to bind it — this has not been confirmed against a live server.");
+         }
+         else if(groups.isEmpty()) {
+            out.put("note",
+                    "No predefined named groups exist for this column. Named groups can be " +
+                    "defined on the data source, or created here with add_named_group.");
          }
 
          return out;
@@ -438,8 +492,13 @@ public class CalcTableService {
          info.setFormula(formula);
       }
       else if(type == CellBinding.BIND_FORMULA) {
-         info.setFormula(str(binding, "formula"));
-         info.setValue(str(binding, "value"));
+         String script = str(binding, "formula");
+         info.setValue(script != null ? script : str(binding, "value"));
+         // 'formula' on CellBinding is the aggregate name (Sum/Count/...) StyleBI generates for a
+         // BIND_COLUMN summary cell -- see CellBinding.setFormula's own javadoc. It has no meaning
+         // for a BIND_FORMULA cell's script and must not carry it; leaving it null here matches
+         // what get_cell_binding already reports back for a formula cell today when a script is
+         // genuinely absent.
       }
       else {
          info.setValue(str(binding, "value"));
@@ -449,8 +508,17 @@ public class CalcTableService {
          info.setMergeCells(merge);
       }
 
-      info.setRowGroup(str(binding, "rowGroup"));
-      info.setColGroup(str(binding, "colGroup"));
+      // rowGroup/colGroup aren't part of this seam's cell vocabulary, so they're always
+      // null here. null is the deliberate "no ancestor, grand total" sentinel elsewhere in
+      // StyleBI (TableCellBinding), which is wrong for a cell created through this seam --
+      // it must instead inherit its nearest enclosing expand ancestor by default, the same
+      // as a freshly drag-and-dropped cell (see TableLayoutHandler.createDefalutCellBinding).
+      String rowGroup = str(binding, "rowGroup");
+      info.setRowGroup(rowGroup != null ? rowGroup : TableCellBinding.DEFAULT_GROUP);
+      String colGroup = str(binding, "colGroup");
+      info.setColGroup(colGroup != null ? colGroup : TableCellBinding.DEFAULT_GROUP);
+      info.setMergeRowGroup(TableCellBinding.DEFAULT_GROUP);
+      info.setMergeColGroup(TableCellBinding.DEFAULT_GROUP);
       return info;
    }
 

--- a/core/src/test/java/inetsoft/report/LayoutToolTest.java
+++ b/core/src/test/java/inetsoft/report/LayoutToolTest.java
@@ -17,8 +17,12 @@
  */
 package inetsoft.report;
 
+import inetsoft.report.lens.CalcTableLens;
 import inetsoft.report.lens.DefaultTableLens;
 import inetsoft.test.*;
+import inetsoft.uql.VariableTable;
+import inetsoft.uql.viewsheet.CalcTableVSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,6 +33,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import java.lang.reflect.Method;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Regression guard for #75747 / #75801: converting a crosstab to a freehand table
@@ -113,5 +118,50 @@ class LayoutToolTest {
          "getGroupColumnName", TableLens.class, TableCellBinding.class);
       method.setAccessible(true);
       return (String) method.invoke(null, base, cell);
+   }
+
+   /**
+    * Regression guard for the "[Ljava.lang.Object;@&lt;hash&gt;" defect: a plain
+    * detail-grouping cell (no expand, no ancestor group), in the non-crosstab-supported
+    * branch of createCalcBindingExpression, must be wrapped in none(...) the same way
+    * its crosstab-supported sibling branch already wraps the identical DETAIL bType.
+    * Without the wrapper, CalcTableLens/CellRange.getCollectionValue always returns a
+    * raw Object[] for calc-table array lookups, and an unwrapped cell renders that
+    * array's toString() instead of a scalar value.
+    */
+   @Test
+   void wrapsPlainDetailCellExpressionInNoneToAvoidLeakingARawArray() throws Exception {
+      DefaultTableLens base = new DefaultTableLens(new Object[][] {
+         { "EMPLOYEE_ID" },
+         { 5 },
+         { 7 }
+      });
+
+      TableLayout layout = new TableLayout();
+      layout.setColCount(1);
+      TableDataDescriptor desc = base.getDescriptor();
+      TableDataPath rpath = desc.getRowDataPath(0);
+      BaseLayout.Region region = layout.new Region();
+      region.setRowCount(1);
+      layout.addRegion(rpath, region);
+
+      TableCellBinding cell = new TableCellBinding(CellBinding.BIND_COLUMN, "EMPLOYEE_ID");
+      cell.setBType(TableCellBinding.DETAIL);
+      layout.setCellBinding(0, 0, cell);
+
+      Viewsheet viewsheet = new Viewsheet();
+      CalcTableVSAssembly assembly = new CalcTableVSAssembly(viewsheet, "CalcTable1");
+      assembly.setTableLayout(layout);
+      viewsheet.addAssembly(assembly);
+
+      Method method = LayoutTool.class.getDeclaredMethod("fillCalcTableLens",
+         FormulaTable.class, TableLens.class, VariableTable.class, boolean.class);
+      method.setAccessible(true);
+      method.invoke(null, assembly, base, new VariableTable(), false);
+
+      CalcTableLens clens = (CalcTableLens) assembly.getBaseTable();
+      String exp = clens.getFormula(0, 0);
+      assertTrue(exp != null && exp.startsWith("none("),
+         "expected expression to be wrapped in none(...), was: " + exp);
    }
 }

--- a/core/src/test/java/inetsoft/report/internal/table/RuntimeCalcTableLensTest.java
+++ b/core/src/test/java/inetsoft/report/internal/table/RuntimeCalcTableLensTest.java
@@ -18,9 +18,19 @@
 
 package inetsoft.report.internal.table;
 
+import inetsoft.report.BaseLayout;
+import inetsoft.report.CellBinding;
+import inetsoft.report.TableCellBinding;
+import inetsoft.report.TableDataDescriptor;
+import inetsoft.report.TableDataPath;
+import inetsoft.report.TableLayout;
+import inetsoft.report.internal.binding.OrderInfo;
 import inetsoft.report.lens.CalcTableLens;
+import inetsoft.report.lens.DefaultTableLens;
 import inetsoft.test.*;
+import inetsoft.uql.XFormatInfo;
 import inetsoft.uql.XTable;
+import inetsoft.uql.viewsheet.CalcTableVSAssembly;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,5 +55,48 @@ public class RuntimeCalcTableLensTest {
       originalTable.addCalcColumn(0, calcCellContext);
       XTable deserializedTable = TestSerializeUtils.serializeAndDeserialize(originalTable);
       Assertions.assertEquals(RuntimeCalcTableLens.class, deserializedTable.getClass());
+   }
+
+   /**
+    * Bug: a GROUP cell bound to a numeric column (with the date option left at its
+    * unconditional default of DAY_DATE_GROUP) must not have a date format auto-applied.
+    * Doing so makes createXFormatInfo() report a "yyyy-MM-dd" date format for the cell,
+    * and DateFormat.format(Object) treats the numeric value as epoch-millis, rendering
+    * e.g. EMPLOYEE_ID=5 as a date near 1970-01-01.
+    */
+   @Test
+   public void testNoAutoDateFormatForNumericGroupColumn() {
+      DefaultTableLens data = new DefaultTableLens(new Object[][] {
+         { "EMPLOYEE_ID" },
+         { 5 }
+      });
+
+      TableLayout layout = new TableLayout();
+      layout.setColCount(1);
+      TableDataDescriptor desc = data.getDescriptor();
+      TableDataPath rpath = desc.getRowDataPath(0);
+      BaseLayout.Region region = layout.new Region();
+      region.setRowCount(1);
+      layout.addRegion(rpath, region);
+
+      TableCellBinding cell = new TableCellBinding(CellBinding.BIND_COLUMN, "EMPLOYEE_ID");
+      cell.setBType(TableCellBinding.GROUP);
+      // a freshly-created OrderInfo defaults its date option to DAY_DATE_GROUP
+      // (OrderInfo's constructor), matching how a real GROUP cell's binding
+      // ends up with an unset-but-non-null OrderInfo.
+      cell.setOrderInfo(new OrderInfo());
+      layout.setCellBinding(0, 0, cell);
+
+      CalcTableVSAssembly assembly = new CalcTableVSAssembly();
+      assembly.setTableLayout(layout);
+      assembly.setScriptTable(data);
+
+      CalcTableLens calc = new CalcTableLens(data);
+      calc.setElement(assembly);
+
+      RuntimeCalcTableLens runtime = new RuntimeCalcTableLens(calc);
+
+      XFormatInfo finfo = runtime.createXFormatInfo(0, 0);
+      Assertions.assertNull(finfo);
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/binding/CalcCellVocabularyTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/CalcCellVocabularyTest.java
@@ -228,4 +228,16 @@ class CalcCellVocabularyTest {
       assertDoesNotThrow(
          () -> CalcCellVocabulary.validate(spec("content", "text", "value", "Total")));
    }
+
+   /**
+    * get_cell_binding echoes a formula cell's script back under 'value' (see
+    * CalcCellVocabulary.describe), so a caller that feeds that read straight back into
+    * set_cell_binding supplies 'value' rather than 'formula'. That must round-trip without
+    * the caller renaming the key.
+    */
+   @Test
+   void acceptsValueAsAnAliasForFormulaContent() {
+      assertDoesNotThrow(
+         () -> CalcCellVocabulary.validate(spec("content", "formula", "value", "Sum(Sales)")));
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/binding/CalcTableServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/CalcTableServiceTest.java
@@ -26,8 +26,15 @@ import inetsoft.web.binding.command.GetCellScriptCommand;
 import inetsoft.report.internal.binding.AssetNamedGroupInfo;
 import inetsoft.report.CellBinding;
 import inetsoft.report.GroupableCellBinding;
+import inetsoft.report.TableCellBinding;
 import inetsoft.report.TableLayout;
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.asset.AttachedAssembly;
+import inetsoft.uql.asset.DefaultNamedGroupAssembly;
+import inetsoft.uql.asset.SourceInfo;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.erm.AttributeRef;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.CalcTableVSAssemblyInfo;
 import inetsoft.web.binding.controller.VSTableLayoutService;
@@ -112,6 +119,31 @@ class CalcTableServiceTest {
       assertEquals(1, event.getSelectCells()[0].getCol());
       assertEquals(CellBinding.BIND_COLUMN, event.getBinding().getType());
       assertEquals("Region", event.getBinding().getValue());
+   }
+
+   /**
+    * rowGroup/colGroup aren't part of this seam's cell vocabulary, so a spec that omits them
+    * must not leave the binding's group ancestry at null (StyleBI's "no ancestor, grand
+    * total" sentinel). It must default to TableCellBinding.DEFAULT_GROUP instead, the same as
+    * a freshly drag-and-dropped cell (TableLayoutHandler.createDefalutCellBinding), so
+    * SUMMARY/GROUP/DETAIL cells built through this tool inherit their nearest enclosing
+    * expand ancestor rather than silently becoming table-wide grand totals.
+    */
+   @Test
+   void defaultsRowAndColGroupToTheDefaultGroupSentinelWhenOmitted() throws Exception {
+      Harness h = harness(3, 3);
+
+      h.service.setCellBinding("tok", principal(), "Calc1", 2, 1, columnCell("Region"));
+
+      ArgumentCaptor<SetCellBindingEvent> captor =
+         ArgumentCaptor.forClass(SetCellBindingEvent.class);
+      verify(h.layoutService).setCellBinding(eq("rt1"), captor.capture(), any(Principal.class),
+                                             any());
+      SetCellBindingEvent event = captor.getValue();
+      assertEquals(TableCellBinding.DEFAULT_GROUP, event.getBinding().getRowGroup());
+      assertEquals(TableCellBinding.DEFAULT_GROUP, event.getBinding().getColGroup());
+      assertEquals(TableCellBinding.DEFAULT_GROUP, event.getBinding().getMergeRowGroup());
+      assertEquals(TableCellBinding.DEFAULT_GROUP, event.getBinding().getMergeColGroup());
    }
 
    /**
@@ -218,6 +250,48 @@ class CalcTableServiceTest {
       assertEquals("Total", captor.getValue().getBinding().getValue());
    }
 
+   /**
+    * The regression test for the confirmed silent-drop defect: a formula cell's script is
+    * CellBinding.value, the field LayoutTool/get_calc_cell_script actually reads -- not
+    * .formula, which is exclusively the BIND_COLUMN summary-cell aggregate name (Sum/Count/...).
+    * Before the fix this stored the script in .formula and left .value null, so
+    * get_calc_cell_script silently read back no script at all.
+    */
+   @Test
+   void bindsAFormulaCellStoringTheScriptInValueNotFormula() throws Exception {
+      Harness h = harness(2, 2);
+
+      h.service.setCellBinding("tok", principal(), "Calc1", 0, 0,
+                               spec("content", "formula", "formula", "Sum(Sales)"));
+
+      ArgumentCaptor<SetCellBindingEvent> captor =
+         ArgumentCaptor.forClass(SetCellBindingEvent.class);
+      verify(h.layoutService).setCellBinding(eq("rt1"), captor.capture(), any(Principal.class),
+                                             any());
+      assertEquals(CellBinding.BIND_FORMULA, captor.getValue().getBinding().getType());
+      assertEquals("Sum(Sales)", captor.getValue().getBinding().getValue());
+      assertNull(captor.getValue().getBinding().getFormula());
+   }
+
+   /**
+    * get_cell_binding echoes a formula cell's script back under 'value', so a caller that
+    * feeds a read straight back into set_cell_binding supplies 'value' with no 'formula' key.
+    * That must still bind, and it must still land in .value.
+    */
+   @Test
+   void acceptsValueAsAnAliasForFormulaContent() throws Exception {
+      Harness h = harness(2, 2);
+
+      h.service.setCellBinding("tok", principal(), "Calc1", 0, 0,
+                               spec("content", "formula", "value", "Sum(Sales)"));
+
+      ArgumentCaptor<SetCellBindingEvent> captor =
+         ArgumentCaptor.forClass(SetCellBindingEvent.class);
+      verify(h.layoutService).setCellBinding(eq("rt1"), captor.capture(), any(Principal.class),
+                                             any());
+      assertEquals("Sum(Sales)", captor.getValue().getBinding().getValue());
+   }
+
    @Test
    void refusesANonCalcAssemblyPointingAtTheShelfTools() {
       Harness h = harnessFor(mock(CrosstabVSAssembly.class), 0, 0);
@@ -242,7 +316,8 @@ class CalcTableServiceTest {
    // ── harness ───────────────────────────────────────────────────────────────
 
    private record Harness(CalcTableService service, ViewsheetSessionService sessions,
-                          VSTableLayoutService layoutService) {}
+                          VSTableLayoutService layoutService, Viewsheet viewsheet,
+                          CalcTableVSAssemblyInfo assemblyInfo) {}
 
    private static Harness harness(int rows, int cols) {
       CalcTableVSAssembly assembly = mock(CalcTableVSAssembly.class);
@@ -252,10 +327,16 @@ class CalcTableServiceTest {
       when(layout.getColCount()).thenReturn(cols);
       when(info.getTableLayout()).thenReturn(layout);
       when(assembly.getInfo()).thenReturn(info);
-      return harnessFor(assembly, rows, cols);
+      return harnessFor(assembly, info, rows, cols);
    }
 
    private static Harness harnessFor(VSAssembly assembly, int rows, int cols) {
+      return harnessFor(assembly, null, rows, cols);
+   }
+
+   private static Harness harnessFor(VSAssembly assembly, CalcTableVSAssemblyInfo info,
+                                     int rows, int cols)
+   {
       Viewsheet vs = mock(Viewsheet.class);
       when(vs.getAssembly(anyString())).thenReturn(assembly);
       RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
@@ -285,7 +366,8 @@ class CalcTableServiceTest {
       }
 
       VSTableLayoutService layoutService = mock(VSTableLayoutService.class);
-      return new Harness(new CalcTableService(sessions, layoutService), sessions, layoutService);
+      return new Harness(new CalcTableService(sessions, layoutService), sessions, layoutService,
+                         vs, info);
    }
 
    private static Principal principal() {
@@ -347,6 +429,37 @@ class CalcTableServiceTest {
 
       assertEquals(List.of("Regions", "Tiers"), read.get("namedGroups"));
       assertEquals("REGION", read.get("column"));
+   }
+
+   /**
+    * add_named_group creates a {@code DefaultNamedGroupAssembly} as an ordinary secondary
+    * assembly inside the calc table's own bound worksheet -- a completely different code path
+    * from the asset-repository "predefined named group" kind the block above already covers.
+    * Without also scanning the worksheet, a group created via add_named_group would never be
+    * listed here even though it genuinely exists.
+    */
+   @Test
+   void includesWorksheetLocalNamedGroupsCreatedByAddNamedGroup() throws Exception {
+      Harness h = harness(3, 3);
+      when(h.assemblyInfo().getSourceInfo())
+         .thenReturn(new SourceInfo(SourceInfo.ASSET, null, "Query1"));
+
+      DefaultNamedGroupAssembly ngAssembly = mock(DefaultNamedGroupAssembly.class);
+      when(ngAssembly.getName()).thenReturn("Regions");
+      when(ngAssembly.getAttachedType()).thenReturn(AttachedAssembly.COLUMN_ATTACHED);
+      when(ngAssembly.getAttachedSource())
+         .thenReturn(new SourceInfo(SourceInfo.ASSET, null, "Query1"));
+      when(ngAssembly.getAttachedAttribute()).thenReturn(new AttributeRef(null, "REGION"));
+
+      Worksheet ws = mock(Worksheet.class);
+      when(ws.getAssemblies()).thenReturn(new Assembly[]{ ngAssembly });
+      when(h.viewsheet().getBaseWorksheet()).thenReturn(ws);
+
+      Map<String, Object> read = h.service.namedGroups("tok", principal(), "Calc1", "REGION");
+
+      @SuppressWarnings("unchecked")
+      List<String> groups = (List<String>) read.get("namedGroups");
+      assertTrue(groups.contains("Regions"), "expected worksheet-local group in: " + groups);
    }
 
    @Test


### PR DESCRIPTION
## Summary

Four StyleBI-side defects found while running the composer-chat agent plugin's L6 test lane (calc/freehand tables) against this build, plus one plugin-gap-turned-defect found while designing the write-tool for calc-cell scripts. No branch naming issue number was available for this — named descriptively (`bug/l6-calc-table-stylebi-defects-v2`) since this came out of an internal agent test-plan pass, not a filed Redmine ticket.

- **`RuntimeCalcTableLens`**: a `GROUP` cell bound to a numeric column auto-applied a date format (the dtype guard let numeric types through alongside date types), so `DateFormat.format(Object)` coerced the raw number as epoch-millis, rendering a constant epoch-adjacent date instead of the real value. Tightened the guard to date types only.
- **`LayoutTool`**: a plain `DETAIL` cell's non-crosstab expression branch had no aggregate wrapper, so `CellRange.getCollectionValue`'s raw `Object[]` leaked into rendered output as `[Ljava.lang.Object;@<hash>`. Wrapped it in `none(...)`, matching how the crosstab-supported branch already handles the same `bType`.
- **`CalcTableService`**: the wiz agent seam never set `rowGroup`/`colGroup` on cell creation, so every cell got the "explicit grand total, no ancestor" `null` sentinel instead of the "inherit nearest enclosing expand ancestor" `DEFAULT_GROUP` sentinel — breaking per-group summary scoping (every expanded row showed the whole-table total). Defaulted to `DEFAULT_GROUP`, matching `TableLayoutHandler.createDefalutCellBinding`'s existing behavior for browser-created cells.
- **`CalcTableService.namedGroups`**: also scans the calc table's bound worksheet for `DefaultNamedGroupAssembly` instances (the kind `add_named_group` creates), which the prior asset-repository-only lookup never saw. Note: listing a group here does not yet guarantee `set_cell_binding` can bind it — flagged in the response's `note` field pending live-server verification; not fixed further in this PR.
- **`CalcTableService`/`CalcCellVocabulary`**: a `BIND_FORMULA` cell's script was stored on `CellBindingInfo.formula` (meaningful only for a `BIND_COLUMN` summary cell's aggregate name, e.g. Sum/Count) instead of `.value`, so a cell created with `content: "formula"` silently stored a `null` script. Fixed the field mapping and loosened validation to accept either `formula` or `value` (a `get_cell_binding` read already echoes the script back under `value`, so a read-then-write round trip needs both accepted).

## Test plan

- [x] `./mvnw -pl community/core -Dtest=RuntimeCalcTableLensTest,LayoutToolTest,CalcTableLensTest,CalcCellVocabularyTest,CalcTableServiceTest test` — 67/67 passing, including new regression tests added for each defect
- [x] Verified pre-fix each regression test fails, post-fix passes
- [ ] Not verified against a live running StyleBI server/browser — unit/Maven-level testing was the ceiling available in this environment; the PR description flags this per defect above where it matters (mainly the named-groups listing-vs-bindable gap)

🤖 Generated with a multi-agent debugger/fixer/implementer pass (Claude Code)