### PR TITLE
Point the enabled alias at the field the dialog actually uses

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
@@ -320,7 +320,13 @@ public final class PropertyAliases {
       String basic = generalPrefix + ".basicGeneralPaneModel";
       aliases.put("name", basic + ".name");
       aliases.put("visible", basic + ".visible");
-      aliases.put("enabled", basic + ".enabled");
+      // Deliberately NOT basicGeneralPaneModel.enabled, one level down with its siblings.
+      // That field is the Editable flag wearing the wrong name -- its own setter is declared
+      // setEnabled(boolean editable) and toString() prints it as editable= -- and nothing in the
+      // tree ever writes it, so an alias pointing there read a permanent default of false and
+      // wrote somewhere no one reads. The live switch is GeneralPropPaneModel.enabled, which
+      // every property dialog service fills from VSAssemblyInfo.getEnabledValue().
+      aliases.put("enabled", generalPrefix + ".enabled");
       aliases.put("shadow", basic + ".shadow");
       aliases.put("primary", basic + ".primary");
       aliases.put("refresh", basic + ".refresh");


### PR DESCRIPTION
- basicGeneralPaneModel.enabled is the Editable flag under a misleading name: its setter is declared setEnabled(boolean editable) and toString() prints it as editable=
- Nothing in the tree ever calls basicGeneralPaneModel.setEnabled, so the alias read a permanent default of false and wrote a field no one consumes; set_assembly_properties {enabled: true} returned ok and changed nothing
- The live switch is GeneralPropPaneModel.enabled, filled by every property dialog service from VSAssemblyInfo.getEnabledValue()
- One line covers all five assembly types, since outputGeneral() and dataGeneral() both delegate here; shapes are untouched because shapeGeneral() never registered enabled at all
- Callers need no change: PropertyPath.coerce already turns a JSON true into "true" for a String setter
- Found by the L7 lane of the composer plugin test plan (Finding 1)