### PR TITLE
Accept either accessor spelling when resolving a property

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyPath.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyPath.java
@@ -338,11 +338,26 @@ public final class PropertyPath {
             continue;
          }
 
-         if(method.getName().equals("get" + suffix) || method.getName().equals("is" + suffix)) {
+         String name = method.getName();
+
+         if(name.equals("get" + suffix) || name.equals("is" + suffix)) {
             return method;
          }
 
-         if(method.getName().equals(property)) {
+         // The same either-spelling match writerFor makes, for the same reason: a reader whose
+         // name carries a lowercase letter straight after get/is is what propertiesOf enumerated
+         // the property from, so it has to be findable by the name that enumeration produced.
+         // Fixing only the writer would leave a property that can be set but not read back by
+         // path, which is a worse state than the one this repaired.
+         if((name.startsWith("get") && name.length() > 3 &&
+             decapitalize(name.substring(3)).equals(property)) ||
+            (name.startsWith("is") && name.length() > 2 &&
+             decapitalize(name.substring(2)).equals(property)))
+         {
+            return method;
+         }
+
+         if(name.equals(property)) {
             bare = method;
          }
       }
@@ -355,22 +370,47 @@ public final class PropertyPath {
     * than mutating this one.
     */
    private static Method witherFor(Class<?> type, String property) {
-      String name = "with" + capitalize(property);
-
-      for(Method method : type.getMethods()) {
-         if(method.getParameterCount() == 1 && method.getName().equals(name)) {
-            return method;
-         }
-      }
-
-      return null;
+      return writerFor(type, "with", property);
    }
 
    private static Method setterFor(Class<?> type, String property) {
-      String name = "set" + capitalize(property);
+      return writerFor(type, "set", property);
+   }
+
+   /**
+    * Finds a one-argument writer, accepting <b>either</b> spelling of the accessor name.
+    *
+    * <p>Rebuilding the name as {@code prefix + capitalize(property)} is not the inverse of the
+    * way {@link #propertiesOf} produced it — strip the prefix, decapitalize — and a model with a
+    * lowercase letter straight after the prefix fell through the gap between them.
+    * {@code ChartLinePaneModel} declares {@code getxGridLineStyle}/{@code setxGridLineStyle}, so
+    * {@code propertiesOf} offered {@code xGridLineStyle} while this lookup asked for
+    * {@code setXGridLineStyle} and found nothing: the property was refused as unwritable and
+    * listed as available in the very same sentence. Four real, writable properties were
+    * unreachable that way — {@code xGridLineStyle}, {@code xGridLineColor},
+    * {@code yGridLineStyle}, {@code yGridLineColor}.
+    *
+    * <p><b>Both derivations are accepted rather than replacing one with the other</b>, because
+    * neither covers the whole tree on its own. Accessors that begin with two capitals —
+    * {@code getRTChartType}, {@code getVSChartInfo}, {@code getLTableDescriptions} — resolve only
+    * through the rebuilt form, since decapitalizing {@code RTChartType} yields
+    * {@code rTChartType}. Matching either way is a strict superset of the old behaviour, so no
+    * name that resolved before can stop resolving now.
+    */
+   private static Method writerFor(Class<?> type, String prefix, String property) {
+      String rebuilt = prefix + capitalize(property);
 
       for(Method method : type.getMethods()) {
-         if(method.getParameterCount() == 1 && method.getName().equals(name)) {
+         String name = method.getName();
+
+         if(method.getParameterCount() != 1) {
+            continue;
+         }
+
+         if(name.equals(rebuilt) ||
+            (name.length() > prefix.length() && name.startsWith(prefix) &&
+             decapitalize(name.substring(prefix.length())).equals(property)))
+         {
             return method;
          }
       }


### PR DESCRIPTION
- propertiesOf strips the prefix and decapitalizes; setterFor/witherFor rebuilt the name with capitalize, and the two are not inverses when an accessor carries a lowercase letter straight after the prefix
- ChartLinePaneModel declares getxGridLineStyle/setxGridLineStyle, so the enumerator offered xGridLineStyle while the lookup asked for setXGridLineStyle: the property was refused as unwritable and listed as available in the same sentence
- xGridLineStyle, xGridLineColor, yGridLineStyle and yGridLineColor were all real, writable properties unreachable through the path engine
- Both derivations are accepted rather than one replacing the other, since getRTChartType and getVSChartInfo resolve only through the rebuilt form; matching either way is a strict superset, so nothing that resolved before can stop resolving
- getterFor gets the same treatment, so a property is not settable by a path it cannot be read back by
- Found by the L7 lane of the composer plugin test plan (Finding 7)