### PR TITLE
Refuse chart capability flags and canonicalize constrained tokens

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
@@ -50,6 +50,24 @@ public final class PropertyAliases {
    public record TypeAliases(String assemblyType, Class<?> modelClass,
                              Map<String, String> aliases) {}
 
+   /**
+    * The chart line pane's read-only capability flags — what the dialog uses to decide which
+    * controls to <i>show</i>, not what any of them is set to.
+    *
+    * <p>{@code ChartLinePaneModel} recomputes every one of these from the chart type on each read
+    * ({@code initPlotComVisible}, {@code getPlotComsEnable}, and the constructor's own tail), and
+    * {@code updateChartLinePaneModel} writes none of them anywhere. A write therefore could not
+    * work even in principle: it lands on a field the next read overwrites. They stay in the
+    * vocabulary because reading them is genuinely useful — a caller learns that a treemap has no
+    * grid lines to configure — but writing one is refused rather than accepted and lost.
+    *
+    * <p>Note which name is <b>not</b> here: {@code facetGrid} is the real setting and is applied.
+    * Only {@code facetGridVisible}, the flag saying whether the control appears, is refused.
+    */
+   private static final Set<String> CHART_READ_ONLY_FLAGS = Set.of(
+      "gridLineVisible", "innerLineVisible", "trendLineVisible", "facetGridVisible",
+      "facetGridEnabled", "projectForwardEnabled", "lineTabVisible");
+
    private static final Map<String, TypeAliases> REGISTRY = registry();
 
    private PropertyAliases() {
@@ -94,20 +112,57 @@ public final class PropertyAliases {
     */
    public static String resolveForWrite(String assemblyType, String key) {
       String normalizedType = normalize(assemblyType);
-      String refusal = viewsheetWriteRefusal(normalizedType, key);
+      String refusal = writeRefusal(normalizedType, key);
 
       if(refusal != null) {
          throw new IllegalArgumentException(refusal);
       }
 
       String path = resolve(assemblyType, key);
-      refusal = viewsheetWriteRefusal(normalizedType, path);
+      refusal = writeRefusal(normalizedType, path);
 
       if(refusal != null) {
          throw new IllegalArgumentException(refusal);
       }
 
       return path;
+   }
+
+   /**
+    * Every write refusal, checked against both the input key and the resolved path so the
+    * raw-dotted-path escape hatch cannot reach a refused field under a different spelling.
+    */
+   private static String writeRefusal(String normalizedType, String pathOrKey) {
+      String refusal = viewsheetWriteRefusal(normalizedType, pathOrKey);
+
+      return refusal != null ? refusal : chartWriteRefusal(normalizedType, pathOrKey);
+   }
+
+   /**
+    * Refuses a write to one of the chart line pane's derived capability flags.
+    *
+    * <p>This is the first assembly-type refusal to exist; the mechanism was already routed for it.
+    * The message names the flag and says what to change instead, because "it did not work" with no
+    * reason is what sent someone reading {@code ChartLinePaneModel} to find out that these fields
+    * are recomputed on every read.
+    */
+   private static String chartWriteRefusal(String normalizedType, String pathOrKey) {
+      if(!"chart".equals(normalizedType) || pathOrKey == null) {
+         return null;
+      }
+
+      String leaf = pathOrKey.substring(pathOrKey.lastIndexOf('.') + 1);
+
+      if(!CHART_READ_ONLY_FLAGS.contains(leaf)) {
+         return null;
+      }
+
+      return "'" + leaf + "' is read-only. It reports whether this chart TYPE offers that " +
+         "control -- the dialog uses it to decide what to show -- and is recomputed from the " +
+         "chart type on every read, so a write to it cannot survive. Setting it would have " +
+         "reported success and changed nothing. To change whether grid or trend lines apply, " +
+         "set the properties themselves (gridLine/trendLine colours and styles, facetGrid) or " +
+         "change the chart type with set_chart_type.";
    }
 
    /**
@@ -404,6 +459,10 @@ public final class PropertyAliases {
       aliases.put("diagonalLineColor", "chartLinePaneModel.diagonalLineColor");
       aliases.put("quadrantGridLineStyle", "chartLinePaneModel.quadrantGridLineStyle");
       aliases.put("quadrantGridLineColor", "chartLinePaneModel.quadrantGridLineColor");
+      // Readable so a caller can see WHY projectForward reads back as 0: getPlotComsEnable()
+      // zeroes it on read whenever the chart cannot project forward. Exposing the setting without
+      // its gate left that looking like a dropped write. Refused for write, with the flags below.
+      aliases.put("projectForwardEnabled", "chartLinePaneModel.projectForwardEnabled");
       return aliases;
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyPath.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyPath.java
@@ -233,10 +233,17 @@ public final class PropertyPath {
 
       // Checked before the pass-through below, which would otherwise hand a String straight to a
       // String setter without ever consulting the value domain.
-      requireAllowedValue(text, value, target, path);
+      //
+      // The result is also the CANONICAL spelling from that domain, not just a yes/no. The check
+      // is deliberately case-insensitive, so a token differing only in case passes it -- and then
+      // used to be written through verbatim, which is no better than not checking: StyleBI matches
+      // these tokens case-sensitively and silently keeps the default for anything it does not
+      // recognise. Live, trendLineType: "LINEAR" passed the check, stored "LINEAR", and left the
+      // chart on "NONE" while reporting success.
+      String canonical = requireAllowedValue(text, value, target, path);
 
       if(target.isInstance(value) && !(value instanceof Number && target != value.getClass())) {
-         return value;
+         return target == String.class ? canonical : value;
       }
 
       if(target == boolean.class || target == Boolean.class) {
@@ -277,7 +284,7 @@ public final class PropertyPath {
       }
 
       if(target == String.class) {
-         return text;
+         return canonical;
       }
 
       if(target.isEnum()) {
@@ -422,21 +429,29 @@ public final class PropertyPath {
     * produces the worst outcome available — a clean "ok" for a setting that was never applied.
     * Live, {@code visible: "no"} stored "no" and left the assembly on screen.
     */
-   private static void requireAllowedValue(String text, Object value, Class<?> target,
-                                           String path)
+   private static String requireAllowedValue(String text, Object value, Class<?> target,
+                                             String path)
    {
       if(target != String.class) {
-         return;
+         return text;
       }
 
       Set<String> allowed = CONSTRAINED_STRINGS.get(leafName(path));
 
-      if(allowed != null && allowed.stream().noneMatch(v -> v.equalsIgnoreCase(text))) {
-         throw new IllegalArgumentException(
+      if(allowed == null) {
+         return text;
+      }
+
+      // Returns the domain's own spelling rather than the caller's. Matching case-insensitively
+      // and then storing what the caller typed is the worst of both: the value looks accepted and
+      // StyleBI, which compares these tokens exactly, keeps the default.
+      return allowed.stream()
+         .filter(v -> v.equalsIgnoreCase(text))
+         .findFirst()
+         .orElseThrow(() -> new IllegalArgumentException(
             "'" + path + "' accepts only " + new TreeSet<>(allowed) + "; '" + value + "' is not " +
             "one of them. StyleBI ignores an unrecognised value and keeps the default, so this " +
-            "would have reported success without changing anything.");
-      }
+            "would have reported success without changing anything."));
    }
 
    /** The last segment of a dotted path — the property's own name. */
@@ -454,5 +469,9 @@ public final class PropertyPath {
     * reported success for {@code visible: "no"} and the assembly stayed on screen.
     */
    private static final Map<String, Set<String>> CONSTRAINED_STRINGS = Map.of(
-      "visible", Set.of("true", "show", "false", "hide", "hide on print and export"));
+      "visible", Set.of("true", "show", "false", "hide", "hide on print and export"),
+      // ChartLinePaneModel.getIndexByName walks TRENDLINE_NAMES with equals() and starts its
+      // index at 0, so anything it does not match exactly becomes "NONE" with no complaint.
+      "trendLineType", Set.of("NONE", "Linear", "Quadratic", "Cubic", "Exponential",
+                              "Logarithmic", "Power"));
 }


### PR DESCRIPTION
- gridLineVisible, innerLineVisible, trendLineVisible, facetGridVisible, facetGridEnabled, projectForwardEnabled and lineTabVisible are flags the dialog uses to decide which controls to show, recomputed from the chart type on every read; updateChartLinePaneModel writes none of them
- They stayed settable, so a write reported success and was overwritten by the next read. They are now readable and refused for write, naming what to change instead
- Uses the assembly-type refusal hook resolveForWrite already routed for this and never had a user; refusals check the resolved path too, so a raw dotted path cannot reach a refused flag
- facetGrid is deliberately not in the set: it is the real setting and applies
- requireAllowedValue now returns the domain's own spelling rather than only validating. The check is case-insensitive, so trendLineType: "LINEAR" passed it, stored verbatim, and left the chart on NONE, since ChartLinePaneModel.getIndexByName matches exactly and defaults to index 0
- trendLineType joins visible in CONSTRAINED_STRINGS with its seven tokens
- projectForwardEnabled is exposed readable so a caller can see why projectForward reads back 0: getPlotComsEnable zeroes it when the chart cannot project forward, which is gating, not a dropped write
- Found by the L7 lane of the composer plugin test plan (Finding 2)