### PR TITLE
Test L7 and fix issues on it

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/HyperlinkDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/HyperlinkDialogService.java
@@ -817,7 +817,15 @@ public class HyperlinkDialogService {
    private final VSObjectPropertyService vsObjectPropertyService;
    private final ViewsheetService viewsheetService;
    private final VSTrapService trapService;
-   private final int NONE = 9;
+   /**
+    * The dialog's "no link selected" sentinel. <b>Not a {@link Hyperlink} constant</b> — it is the
+    * value {@code getHyperlinkDialogModel} reports when an assembly has no hyperlink, and the value
+    * {@code getHyperlink} tests to decide to clear one. Public because any caller driving this
+    * service without the Angular dialog has to speak it: sending anything else (0, say) makes
+    * {@code getHyperlink} build a real {@code Hyperlink} carrying that bogus type instead of
+    * clearing, so the link survives and only looks cleared.
+    */
+   public static final int NONE = 9;
    private final VSAssemblyInfoHandler assemblyInfoHandler;
    private final HighlightService highlightService;
    private final DataRefModelFactoryService dataRefModelService;

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHyperlinkService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHyperlinkService.java
@@ -18,6 +18,9 @@
 package inetsoft.web.wiz.viewsheet;
 
 import inetsoft.report.Hyperlink;
+import inetsoft.sree.security.IdentityID;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.AssetRepository;
 import inetsoft.web.composer.model.vs.HyperlinkDialogModel;
 import inetsoft.web.composer.vs.dialog.HyperlinkDialogService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,9 +48,21 @@ import java.util.*;
  */
 @Service
 public class AssemblyHyperlinkService {
-   /** Agent-facing link types. The integers never appear in either direction. */
+   /**
+    * Agent-facing link types. The integers never appear in either direction.
+    *
+    * <p><b>{@code none} is {@link HyperlinkDialogService#NONE}, not 0.</b> That sentinel is what the
+    * dialog service reports for an assembly with no link and what it tests to decide to clear one,
+    * and mapping {@code none} to 0 instead broke this class in both directions at once. A read of a
+    * never-linked assembly carried the sentinel 9, which matched no entry here and so reported
+    * itself as {@code "unknown(9)"} rather than as {@code none}. A write of {@code none} sent 0, which
+    * {@code HyperlinkDialogService.getHyperlink} does not recognise as "clear", so it built a real
+    * {@code Hyperlink} carrying type 0. The link survived with its tooltip and target frame intact
+    * while {@code tokenOf(0)} read it back as {@code "none"}: a clear that reported success and
+    * cleared nothing.
+    */
    private static final Map<String, Integer> LINK_TYPES = Map.of(
-      "none", 0,
+      "none", HyperlinkDialogService.NONE,
       "web", Hyperlink.WEB_LINK,
       "viewsheet", Hyperlink.VIEWSHEET_LINK,
       "message", Hyperlink.MESSAGE_LINK);
@@ -99,7 +114,7 @@ public class AssemblyHyperlinkService {
          target.colName(), target.axis(), target.text(), target.titleLink(),
          target.emptyPlotLink(), user);
 
-      return describe(assemblyName, model);
+      return describe(assemblyName, model, target);
    }
 
    /** One {@code sessions.mutate}, so one undo checkpoint. */
@@ -111,13 +126,21 @@ public class AssemblyHyperlinkService {
       String type = requireType(link);
       requireValueForType(type, link);
 
+      // Resolved here for the same reason, and it is the reason this ordering matters rather than
+      // being tidy. A viewsheet link is stored by asset ID; resolving inside the mutate meant an
+      // unresolvable target threw with the model already half-written, leaving the assembly
+      // carrying linkType=viewsheet with a null destination -- precisely the broken link the
+      // validation above exists to prevent, arrived at by another road.
+      String assetId = "viewsheet".equals(type)
+         ? resolveViewsheetTarget(link, sessionToken, user) : null;
+
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          Region target = region == null ? Region.whole() : region;
          HyperlinkDialogModel model = hyperlinkService.getHyperlinkDialogModel(
             runtimeId, assemblyName, target.row(), target.col(), target.colName(),
             target.axis(), target.text(), target.titleLink(), target.emptyPlotLink(), user);
 
-         apply(model, type, link);
+         apply(model, type, link, assetId);
          hyperlinkService.setHyperlinkDialogModel(runtimeId, assemblyName, model, linkUri, user,
                                                  dispatcher);
       });
@@ -158,6 +181,59 @@ public class AssemblyHyperlinkService {
       }
    }
 
+   /**
+    * Turns the {@code assetLinkPath} a caller naturally supplies into the asset ID a viewsheet link
+    * is actually stored by.
+    *
+    * <p>{@code HyperlinkDialogService.getHyperlink} stores {@code getAssetLinkId()} as the link
+    * value and hands the same string to {@code VSUtil.getBookmarks}. Nothing here ever set it, so
+    * every viewsheet link died inside that lookup on a null — a raw
+    * {@code NullPointerException: … because "this.text" is null} reaching the caller, with the
+    * dialog model already partly written.
+    *
+    * <p>Both scopes are tried, because a path alone does not say which one it means: global first,
+    * then the caller's own user scope, which is where a sheet under My Dashboards lives. An
+    * explicit {@code assetLinkId} short-circuits the whole thing for a caller that already holds
+    * one — the Composer's own dialog works that way, from its asset tree.
+    *
+    * <p>A path that resolves to nothing is refused, naming both scopes that were tried. That is the
+    * one behaviour this method must not soften: the tool's contract says a link with no matching
+    * destination is refused, because such a link is accepted by the dialog and then does nothing
+    * when clicked.
+    */
+   private String resolveViewsheetTarget(Map<String, Object> link, String sessionToken,
+                                         Principal user) throws Exception
+   {
+      String explicit = str(link, "assetLinkId");
+
+      if(explicit != null) {
+         return explicit;
+      }
+
+      String path = str(link, "assetLinkPath");
+      AssetRepository repository = sessions.resolve(sessionToken, user).getAssetRepository();
+      AssetEntry global = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET, path, null);
+
+      if(repository.containsEntry(global)) {
+         return global.toIdentifier();
+      }
+
+      IdentityID owner = IdentityID.getIdentityIDFromKey(user.getName());
+      AssetEntry personal = new AssetEntry(
+         AssetRepository.USER_SCOPE, AssetEntry.Type.VIEWSHEET, path, owner);
+
+      if(repository.containsEntry(personal)) {
+         return personal.toIdentifier();
+      }
+
+      throw new IllegalArgumentException(
+         "No viewsheet at '" + path + "'. Looked in the global scope and in " + owner.getName() +
+         "'s own scope. A link to a viewsheet that does not exist is accepted by the dialog and " +
+         "then does nothing when clicked, so it is refused here instead. Pass 'assetLinkId' " +
+         "directly if you already hold the asset identifier.");
+   }
+
    private static void require(Map<String, Object> link, String field, String type) {
       if(str(link, field) == null) {
          throw new IllegalArgumentException(
@@ -168,14 +244,21 @@ public class AssemblyHyperlinkService {
    }
 
    private static void apply(HyperlinkDialogModel model, String type,
-                             Map<String, Object> link)
+                             Map<String, Object> link, String assetId)
    {
       model.setLinkType(LINK_TYPES.get(type));
 
       if("none".equals(type)) {
+         // With the type now set to the sentinel the dialog service recognises, it discards the
+         // whole Hyperlink and none of this model survives -- so these nulls, and the tooltip and
+         // target frame that used to linger beside them, no longer decide anything. Kept because a
+         // model handed on with a stale destination still reads wrong to anything that looks.
          model.setWebLink(null);
          model.setAssetLinkPath(null);
          model.setAssetLinkId(null);
+         model.setBookmark(null);
+         model.setTargetFrame(null);
+         model.setTooltip(null);
          return;
       }
 
@@ -185,6 +268,12 @@ public class AssemblyHyperlinkService {
 
       if(link.containsKey("assetLinkPath")) {
          model.setAssetLinkPath(str(link, "assetLinkPath"));
+      }
+
+      // The ID is what getHyperlink actually stores and what VSUtil.getBookmarks looks up; the path
+      // is the display half. Setting only the path is what made every viewsheet link fail.
+      if(assetId != null) {
+         model.setAssetLinkId(assetId);
       }
 
       if(link.containsKey("bookmark")) {
@@ -216,7 +305,9 @@ public class AssemblyHyperlinkService {
       }
    }
 
-   private static Map<String, Object> describe(String assemblyName, HyperlinkDialogModel model) {
+   private static Map<String, Object> describe(String assemblyName, HyperlinkDialogModel model,
+                                               Region asked)
+   {
       Map<String, Object> out = new LinkedHashMap<>();
       out.put("assembly", assemblyName);
 
@@ -236,7 +327,12 @@ public class AssemblyHyperlinkService {
       out.put("sendSelectionsAsParameters", model.isSendSelectionsAsParameters());
       out.put("row", model.getRow());
       out.put("col", model.getCol());
-      out.put("colName", model.getColName());
+      // The dialog service does not echo colName back into the model, so reporting only the model's
+      // value meant a caller that addressed a cell BY NAME read back null and could not confirm it
+      // had read the same cell it wrote. Falling back to what was asked for is the honest answer:
+      // it is the name this read was scoped to, whether or not the model repeats it.
+      out.put("colName", model.getColName() != null ? model.getColName()
+                 : asked == null ? null : asked.colName());
       return out;
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHyperlinkService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHyperlinkService.java
@@ -19,6 +19,7 @@ package inetsoft.web.wiz.viewsheet;
 
 import inetsoft.report.Hyperlink;
 import inetsoft.sree.security.IdentityID;
+import inetsoft.sree.security.ResourceAction;
 import inetsoft.uql.asset.AssetEntry;
 import inetsoft.uql.asset.AssetRepository;
 import inetsoft.web.composer.model.vs.HyperlinkDialogModel;
@@ -151,6 +152,95 @@ public class AssemblyHyperlinkService {
       Collections.sort(names);
       return Map.of("linkTypes", names);
    }
+
+   /**
+    * Enumerates the viewsheet asset paths a {@code "viewsheet"}-type {@link #set} call will
+    * actually accept as {@code assetLinkPath} — the same two scopes, same
+    * {@link AssetEntry.Type#VIEWSHEET} filter, same resolution order {@link #resolveViewsheetTarget}
+    * uses, so a path this method returns can never be one the write path then refuses.
+    *
+    * <p>Deliberately does not dedupe a name that exists in both scopes: a caller needs to see the
+    * collision in order to reach for {@code assetLinkId} instead, and silently picking one (even by
+    * {@code resolveViewsheetTarget}'s own global-first tie-break) would hide exactly the ambiguity
+    * {@code assetLinkId} exists to resolve.
+    */
+   public Map<String, Object> listLinkTargets(String sessionToken, Principal user, String folder,
+                                              String query, Integer limit) throws Exception
+   {
+      AssetRepository repository = sessions.resolve(sessionToken, user).getAssetRepository();
+      IdentityID owner = IdentityID.getIdentityIDFromKey(user.getName());
+      int cap = limit == null ? 200 : limit;
+      String root = folder == null || folder.isEmpty() ? "/" : folder;
+      List<Map<String, Object>> targets = new ArrayList<>();
+      boolean truncated = false;
+
+      List<Map.Entry<String, AssetEntry>> scopes = List.of(
+         Map.entry("global", new AssetEntry(
+            AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.REPOSITORY_FOLDER, root, null)),
+         Map.entry("user", new AssetEntry(
+            AssetRepository.USER_SCOPE, AssetEntry.Type.REPOSITORY_FOLDER, root, owner)));
+
+      for(Map.Entry<String, AssetEntry> scope : scopes) {
+         // A folder that only exists in one scope is normal, not a mistake -- so the scope
+         // missing it is skipped rather than erroring.
+         if(!repository.containsEntry(scope.getValue())) {
+            continue;
+         }
+
+         truncated |= walk(repository, user, scope.getValue(), scope.getKey(), query, cap, targets);
+      }
+
+      targets.sort(Comparator.comparing(t -> (String) t.get("path")));
+      Map<String, Object> out = new LinkedHashMap<>();
+      out.put("targets", targets);
+      out.put("truncated", truncated);
+      return out;
+   }
+
+   /**
+    * Plain DFS over {@code getEntries}, collecting {@code VIEWSHEET} leaves whose name matches
+    * {@code query} and descending into every {@code REPOSITORY_FOLDER} regardless of its own
+    * name's match, since a match can be several levels deeper. Returns {@code true} once
+    * {@code targets} hits {@code cap} — the same signal the caller reports back as {@code truncated}.
+    */
+   private static boolean walk(AssetRepository repository, Principal user, AssetEntry folder,
+                               String scope, String query, int cap,
+                               List<Map<String, Object>> targets) throws Exception
+   {
+      AssetEntry[] entries = repository.getEntries(folder, user, ResourceAction.READ, SELECTOR);
+
+      for(AssetEntry entry : entries) {
+         if("Recycle Bin".equals(entry.getName())) {
+            continue;
+         }
+
+         if(entry.getType() == AssetEntry.Type.REPOSITORY_FOLDER) {
+            if(walk(repository, user, entry, scope, query, cap, targets)) {
+               return true;
+            }
+         }
+         else if(entry.getType() == AssetEntry.Type.VIEWSHEET) {
+            if(query != null && !entry.getName().toLowerCase().contains(query.toLowerCase())) {
+               continue;
+            }
+
+            Map<String, Object> target = new LinkedHashMap<>();
+            target.put("path", entry.getPath());
+            target.put("assetLinkId", entry.toIdentifier());
+            target.put("scope", scope);
+            targets.add(target);
+
+            if(targets.size() >= cap) {
+               return true;
+            }
+         }
+      }
+
+      return false;
+   }
+
+   private static final AssetEntry.Selector SELECTOR = new AssetEntry.Selector(
+      AssetEntry.Type.REPOSITORY_FOLDER, AssetEntry.Type.VIEWSHEET);
 
    // ── vocabulary ────────────────────────────────────────────────────────────
 

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
@@ -50,6 +50,24 @@ public final class PropertyAliases {
    public record TypeAliases(String assemblyType, Class<?> modelClass,
                              Map<String, String> aliases) {}
 
+   /**
+    * The chart line pane's read-only capability flags — what the dialog uses to decide which
+    * controls to <i>show</i>, not what any of them is set to.
+    *
+    * <p>{@code ChartLinePaneModel} recomputes every one of these from the chart type on each read
+    * ({@code initPlotComVisible}, {@code getPlotComsEnable}, and the constructor's own tail), and
+    * {@code updateChartLinePaneModel} writes none of them anywhere. A write therefore could not
+    * work even in principle: it lands on a field the next read overwrites. They stay in the
+    * vocabulary because reading them is genuinely useful — a caller learns that a treemap has no
+    * grid lines to configure — but writing one is refused rather than accepted and lost.
+    *
+    * <p>Note which name is <b>not</b> here: {@code facetGrid} is the real setting and is applied.
+    * Only {@code facetGridVisible}, the flag saying whether the control appears, is refused.
+    */
+   private static final Set<String> CHART_READ_ONLY_FLAGS = Set.of(
+      "gridLineVisible", "innerLineVisible", "trendLineVisible", "facetGridVisible",
+      "facetGridEnabled", "projectForwardEnabled", "lineTabVisible");
+
    private static final Map<String, TypeAliases> REGISTRY = registry();
 
    private PropertyAliases() {
@@ -94,20 +112,57 @@ public final class PropertyAliases {
     */
    public static String resolveForWrite(String assemblyType, String key) {
       String normalizedType = normalize(assemblyType);
-      String refusal = viewsheetWriteRefusal(normalizedType, key);
+      String refusal = writeRefusal(normalizedType, key);
 
       if(refusal != null) {
          throw new IllegalArgumentException(refusal);
       }
 
       String path = resolve(assemblyType, key);
-      refusal = viewsheetWriteRefusal(normalizedType, path);
+      refusal = writeRefusal(normalizedType, path);
 
       if(refusal != null) {
          throw new IllegalArgumentException(refusal);
       }
 
       return path;
+   }
+
+   /**
+    * Every write refusal, checked against both the input key and the resolved path so the
+    * raw-dotted-path escape hatch cannot reach a refused field under a different spelling.
+    */
+   private static String writeRefusal(String normalizedType, String pathOrKey) {
+      String refusal = viewsheetWriteRefusal(normalizedType, pathOrKey);
+
+      return refusal != null ? refusal : chartWriteRefusal(normalizedType, pathOrKey);
+   }
+
+   /**
+    * Refuses a write to one of the chart line pane's derived capability flags.
+    *
+    * <p>This is the first assembly-type refusal to exist; the mechanism was already routed for it.
+    * The message names the flag and says what to change instead, because "it did not work" with no
+    * reason is what sent someone reading {@code ChartLinePaneModel} to find out that these fields
+    * are recomputed on every read.
+    */
+   private static String chartWriteRefusal(String normalizedType, String pathOrKey) {
+      if(!"chart".equals(normalizedType) || pathOrKey == null) {
+         return null;
+      }
+
+      String leaf = pathOrKey.substring(pathOrKey.lastIndexOf('.') + 1);
+
+      if(!CHART_READ_ONLY_FLAGS.contains(leaf)) {
+         return null;
+      }
+
+      return "'" + leaf + "' is read-only. It reports whether this chart TYPE offers that " +
+         "control -- the dialog uses it to decide what to show -- and is recomputed from the " +
+         "chart type on every read, so a write to it cannot survive. Setting it would have " +
+         "reported success and changed nothing. To change whether grid or trend lines apply, " +
+         "set the properties themselves (gridLine/trendLine colours and styles, facetGrid) or " +
+         "change the chart type with set_chart_type.";
    }
 
    /**
@@ -410,6 +465,10 @@ public final class PropertyAliases {
       aliases.put("diagonalLineColor", "chartLinePaneModel.diagonalLineColor");
       aliases.put("quadrantGridLineStyle", "chartLinePaneModel.quadrantGridLineStyle");
       aliases.put("quadrantGridLineColor", "chartLinePaneModel.quadrantGridLineColor");
+      // Readable so a caller can see WHY projectForward reads back as 0: getPlotComsEnable()
+      // zeroes it on read whenever the chart cannot project forward. Exposing the setting without
+      // its gate left that looking like a dropped write. Refused for write, with the flags below.
+      aliases.put("projectForwardEnabled", "chartLinePaneModel.projectForwardEnabled");
       return aliases;
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
@@ -320,7 +320,13 @@ public final class PropertyAliases {
       String basic = generalPrefix + ".basicGeneralPaneModel";
       aliases.put("name", basic + ".name");
       aliases.put("visible", basic + ".visible");
-      aliases.put("enabled", basic + ".enabled");
+      // Deliberately NOT basicGeneralPaneModel.enabled, one level down with its siblings.
+      // That field is the Editable flag wearing the wrong name -- its own setter is declared
+      // setEnabled(boolean editable) and toString() prints it as editable= -- and nothing in the
+      // tree ever writes it, so an alias pointing there read a permanent default of false and
+      // wrote somewhere no one reads. The live switch is GeneralPropPaneModel.enabled, which
+      // every property dialog service fills from VSAssemblyInfo.getEnabledValue().
+      aliases.put("enabled", generalPrefix + ".enabled");
       aliases.put("shadow", basic + ".shadow");
       aliases.put("primary", basic + ".primary");
       aliases.put("refresh", basic + ".refresh");

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyPath.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyPath.java
@@ -233,10 +233,17 @@ public final class PropertyPath {
 
       // Checked before the pass-through below, which would otherwise hand a String straight to a
       // String setter without ever consulting the value domain.
-      requireAllowedValue(text, value, target, path);
+      //
+      // The result is also the CANONICAL spelling from that domain, not just a yes/no. The check
+      // is deliberately case-insensitive, so a token differing only in case passes it -- and then
+      // used to be written through verbatim, which is no better than not checking: StyleBI matches
+      // these tokens case-sensitively and silently keeps the default for anything it does not
+      // recognise. Live, trendLineType: "LINEAR" passed the check, stored "LINEAR", and left the
+      // chart on "NONE" while reporting success.
+      String canonical = requireAllowedValue(text, value, target, path);
 
       if(target.isInstance(value) && !(value instanceof Number && target != value.getClass())) {
-         return value;
+         return target == String.class ? canonical : value;
       }
 
       if(target == boolean.class || target == Boolean.class) {
@@ -277,7 +284,7 @@ public final class PropertyPath {
       }
 
       if(target == String.class) {
-         return text;
+         return canonical;
       }
 
       if(target.isEnum()) {
@@ -462,21 +469,29 @@ public final class PropertyPath {
     * produces the worst outcome available — a clean "ok" for a setting that was never applied.
     * Live, {@code visible: "no"} stored "no" and left the assembly on screen.
     */
-   private static void requireAllowedValue(String text, Object value, Class<?> target,
-                                           String path)
+   private static String requireAllowedValue(String text, Object value, Class<?> target,
+                                             String path)
    {
       if(target != String.class) {
-         return;
+         return text;
       }
 
       Set<String> allowed = CONSTRAINED_STRINGS.get(leafName(path));
 
-      if(allowed != null && allowed.stream().noneMatch(v -> v.equalsIgnoreCase(text))) {
-         throw new IllegalArgumentException(
+      if(allowed == null) {
+         return text;
+      }
+
+      // Returns the domain's own spelling rather than the caller's. Matching case-insensitively
+      // and then storing what the caller typed is the worst of both: the value looks accepted and
+      // StyleBI, which compares these tokens exactly, keeps the default.
+      return allowed.stream()
+         .filter(v -> v.equalsIgnoreCase(text))
+         .findFirst()
+         .orElseThrow(() -> new IllegalArgumentException(
             "'" + path + "' accepts only " + new TreeSet<>(allowed) + "; '" + value + "' is not " +
             "one of them. StyleBI ignores an unrecognised value and keeps the default, so this " +
-            "would have reported success without changing anything.");
-      }
+            "would have reported success without changing anything."));
    }
 
    /** The last segment of a dotted path — the property's own name. */
@@ -494,5 +509,9 @@ public final class PropertyPath {
     * reported success for {@code visible: "no"} and the assembly stayed on screen.
     */
    private static final Map<String, Set<String>> CONSTRAINED_STRINGS = Map.of(
-      "visible", Set.of("true", "show", "false", "hide", "hide on print and export"));
+      "visible", Set.of("true", "show", "false", "hide", "hide on print and export"),
+      // ChartLinePaneModel.getIndexByName walks TRENDLINE_NAMES with equals() and starts its
+      // index at 0, so anything it does not match exactly becomes "NONE" with no complaint.
+      "trendLineType", Set.of("NONE", "Linear", "Quadratic", "Cubic", "Exponential",
+                              "Logarithmic", "Power"));
 }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyPath.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyPath.java
@@ -338,11 +338,26 @@ public final class PropertyPath {
             continue;
          }
 
-         if(method.getName().equals("get" + suffix) || method.getName().equals("is" + suffix)) {
+         String name = method.getName();
+
+         if(name.equals("get" + suffix) || name.equals("is" + suffix)) {
             return method;
          }
 
-         if(method.getName().equals(property)) {
+         // The same either-spelling match writerFor makes, for the same reason: a reader whose
+         // name carries a lowercase letter straight after get/is is what propertiesOf enumerated
+         // the property from, so it has to be findable by the name that enumeration produced.
+         // Fixing only the writer would leave a property that can be set but not read back by
+         // path, which is a worse state than the one this repaired.
+         if((name.startsWith("get") && name.length() > 3 &&
+             decapitalize(name.substring(3)).equals(property)) ||
+            (name.startsWith("is") && name.length() > 2 &&
+             decapitalize(name.substring(2)).equals(property)))
+         {
+            return method;
+         }
+
+         if(name.equals(property)) {
             bare = method;
          }
       }
@@ -355,22 +370,47 @@ public final class PropertyPath {
     * than mutating this one.
     */
    private static Method witherFor(Class<?> type, String property) {
-      String name = "with" + capitalize(property);
-
-      for(Method method : type.getMethods()) {
-         if(method.getParameterCount() == 1 && method.getName().equals(name)) {
-            return method;
-         }
-      }
-
-      return null;
+      return writerFor(type, "with", property);
    }
 
    private static Method setterFor(Class<?> type, String property) {
-      String name = "set" + capitalize(property);
+      return writerFor(type, "set", property);
+   }
+
+   /**
+    * Finds a one-argument writer, accepting <b>either</b> spelling of the accessor name.
+    *
+    * <p>Rebuilding the name as {@code prefix + capitalize(property)} is not the inverse of the
+    * way {@link #propertiesOf} produced it — strip the prefix, decapitalize — and a model with a
+    * lowercase letter straight after the prefix fell through the gap between them.
+    * {@code ChartLinePaneModel} declares {@code getxGridLineStyle}/{@code setxGridLineStyle}, so
+    * {@code propertiesOf} offered {@code xGridLineStyle} while this lookup asked for
+    * {@code setXGridLineStyle} and found nothing: the property was refused as unwritable and
+    * listed as available in the very same sentence. Four real, writable properties were
+    * unreachable that way — {@code xGridLineStyle}, {@code xGridLineColor},
+    * {@code yGridLineStyle}, {@code yGridLineColor}.
+    *
+    * <p><b>Both derivations are accepted rather than replacing one with the other</b>, because
+    * neither covers the whole tree on its own. Accessors that begin with two capitals —
+    * {@code getRTChartType}, {@code getVSChartInfo}, {@code getLTableDescriptions} — resolve only
+    * through the rebuilt form, since decapitalizing {@code RTChartType} yields
+    * {@code rTChartType}. Matching either way is a strict superset of the old behaviour, so no
+    * name that resolved before can stop resolving now.
+    */
+   private static Method writerFor(Class<?> type, String prefix, String property) {
+      String rebuilt = prefix + capitalize(property);
 
       for(Method method : type.getMethods()) {
-         if(method.getParameterCount() == 1 && method.getName().equals(name)) {
+         String name = method.getName();
+
+         if(method.getParameterCount() != 1) {
+            continue;
+         }
+
+         if(name.equals(rebuilt) ||
+            (name.length() > prefix.length() && name.startsWith(prefix) &&
+             decapitalize(name.substring(prefix.length())).equals(property)))
+         {
             return method;
          }
       }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -320,6 +320,18 @@ public class ViewsheetAssemblyAgentController {
                            request.link(), linkUri);
    }
 
+   @GetMapping("/api/wiz/v1/agent/viewsheet/{sessionToken}/hyperlink/link-targets")
+   public Map<String, Object> listHyperlinkTargets(
+      @PathVariable String sessionToken,
+      @RequestParam(required = false) String folder,
+      @RequestParam(required = false) String query,
+      @RequestParam(required = false) Integer limit,
+      Principal user) throws Exception
+   {
+      requireEnabled();
+      return hyperlinkService.listLinkTargets(sessionToken, user, folder, query, limit);
+   }
+
    public record ElementVisibilityRequest(String assembly, String element, String target,
                                           Boolean visible) {}
    public record PlotResizeRequest(String assembly, Double ratio, Boolean vertical,

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHyperlinkServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHyperlinkServiceTest.java
@@ -19,6 +19,10 @@ package inetsoft.web.wiz.viewsheet;
 
 import inetsoft.report.Hyperlink;
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.sree.security.IdentityID;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.uql.asset.AssetEntry;
+import inetsoft.uql.asset.AssetRepository;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.composer.model.vs.HyperlinkDialogModel;
 import inetsoft.web.composer.vs.dialog.HyperlinkDialogService;
@@ -28,6 +32,7 @@ import org.mockito.ArgumentCaptor;
 
 import java.security.Principal;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -88,7 +93,7 @@ class AssemblyHyperlinkServiceTest {
       h.service.set("tok", principal(), "Chart1", null, link("linkType", "none"), "");
 
       HyperlinkDialogModel posted = capture(h.links);
-      assertEquals(0, posted.getLinkType());
+      assertEquals(HyperlinkDialogService.NONE, posted.getLinkType());
       assertNull(posted.getWebLink(), "clearing the type must clear the destination with it");
    }
 
@@ -251,10 +256,248 @@ class AssemblyHyperlinkServiceTest {
       assertTrue(String.valueOf(types.get("linkTypes")).contains("viewsheet"));
    }
 
+   // ── list_hyperlink_targets ───────────────────────────────────────────────
+
+   private static final IdentityID OWNER = IdentityID.getIdentityIDFromKey("admin");
+
+   private static AssetEntry folderEntry(int scope, String path, IdentityID owner) {
+      return new AssetEntry(scope, AssetEntry.Type.REPOSITORY_FOLDER, path, owner);
+   }
+
+   private static AssetEntry vsEntry(int scope, String path, IdentityID owner) {
+      return new AssetEntry(scope, AssetEntry.Type.VIEWSHEET, path, owner);
+   }
+
+   private static AssetEntry globalRoot() {
+      return folderEntry(AssetRepository.GLOBAL_SCOPE, "/", null);
+   }
+
+   private static AssetEntry userRoot() {
+      return folderEntry(AssetRepository.USER_SCOPE, "/", OWNER);
+   }
+
+   @SuppressWarnings("unchecked")
+   private static List<Map<String, Object>> targetsOf(Map<String, Object> result) {
+      return (List<Map<String, Object>>) result.get("targets");
+   }
+
+   @Test
+   void returnsGlobalScopeViewsheetsUnderTheRoot() throws Exception {
+      Harness h = harness(new HyperlinkDialogModel());
+      when(h.repository.containsEntry(globalRoot())).thenReturn(true);
+      when(h.repository.containsEntry(userRoot())).thenReturn(false);
+      AssetEntry detail = vsEntry(AssetRepository.GLOBAL_SCOPE, "Detail", null);
+      when(h.repository.getEntries(eq(globalRoot()), any(Principal.class),
+                                   eq(ResourceAction.READ), any()))
+         .thenReturn(new AssetEntry[]{ detail });
+
+      Map<String, Object> result = h.service.listLinkTargets("tok", principal(), null, null, null);
+
+      List<Map<String, Object>> targets = targetsOf(result);
+      assertEquals(1, targets.size());
+      assertEquals("Detail", targets.get(0).get("path"));
+      assertEquals(detail.toIdentifier(), targets.get(0).get("assetLinkId"));
+      assertEquals("global", targets.get(0).get("scope"));
+      assertEquals(false, result.get("truncated"));
+   }
+
+   @Test
+   void returnsUserScopeViewsheetsUnderTheRoot() throws Exception {
+      Harness h = harness(new HyperlinkDialogModel());
+      when(h.repository.containsEntry(globalRoot())).thenReturn(false);
+      when(h.repository.containsEntry(userRoot())).thenReturn(true);
+      AssetEntry mine = vsEntry(AssetRepository.USER_SCOPE, "MyReport", OWNER);
+      when(h.repository.getEntries(eq(userRoot()), any(Principal.class),
+                                   eq(ResourceAction.READ), any()))
+         .thenReturn(new AssetEntry[]{ mine });
+
+      Map<String, Object> result = h.service.listLinkTargets("tok", principal(), null, null, null);
+
+      List<Map<String, Object>> targets = targetsOf(result);
+      assertEquals(1, targets.size());
+      assertEquals("MyReport", targets.get(0).get("path"));
+      assertEquals("user", targets.get(0).get("scope"));
+   }
+
+   /**
+    * Deduping by name would hide exactly the ambiguity {@code assetLinkId} exists to resolve, so
+    * a name present in both scopes comes back twice.
+    */
+   @Test
+   void aNameInBothScopesIsReturnedOncePerScope() throws Exception {
+      Harness h = harness(new HyperlinkDialogModel());
+      when(h.repository.containsEntry(globalRoot())).thenReturn(true);
+      when(h.repository.containsEntry(userRoot())).thenReturn(true);
+      when(h.repository.getEntries(eq(globalRoot()), any(Principal.class),
+                                   eq(ResourceAction.READ), any()))
+         .thenReturn(new AssetEntry[]{ vsEntry(AssetRepository.GLOBAL_SCOPE, "Shared", null) });
+      when(h.repository.getEntries(eq(userRoot()), any(Principal.class),
+                                   eq(ResourceAction.READ), any()))
+         .thenReturn(new AssetEntry[]{ vsEntry(AssetRepository.USER_SCOPE, "Shared", OWNER) });
+
+      Map<String, Object> result = h.service.listLinkTargets("tok", principal(), null, null, null);
+
+      List<Map<String, Object>> targets = targetsOf(result);
+      assertEquals(2, targets.size());
+      assertTrue(targets.stream().anyMatch(t -> "global".equals(t.get("scope"))));
+      assertTrue(targets.stream().anyMatch(t -> "user".equals(t.get("scope"))));
+      assertTrue(targets.stream().allMatch(t -> "Shared".equals(t.get("path"))));
+   }
+
+   /** A folder that exists in only one scope is normal, so the other scope is skipped, not refused. */
+   @Test
+   void folderRestrictsToTheSubtreeAndIsSkippedInTheScopeThatLacksIt() throws Exception {
+      Harness h = harness(new HyperlinkDialogModel());
+      AssetEntry globalFolder = folderEntry(AssetRepository.GLOBAL_SCOPE, "Reports", null);
+      AssetEntry userFolder = folderEntry(AssetRepository.USER_SCOPE, "Reports", OWNER);
+      when(h.repository.containsEntry(globalFolder)).thenReturn(true);
+      when(h.repository.containsEntry(userFolder)).thenReturn(false);
+      when(h.repository.getEntries(eq(globalFolder), any(Principal.class),
+                                   eq(ResourceAction.READ), any()))
+         .thenReturn(new AssetEntry[]{
+            vsEntry(AssetRepository.GLOBAL_SCOPE, "Reports/Detail", null) });
+
+      Map<String, Object> result =
+         h.service.listLinkTargets("tok", principal(), "Reports", null, null);
+
+      List<Map<String, Object>> targets = targetsOf(result);
+      assertEquals(1, targets.size());
+      assertEquals("Reports/Detail", targets.get(0).get("path"));
+      verify(h.repository, never()).getEntries(eq(userFolder), any(Principal.class), any(), any());
+   }
+
+   /** A match several levels deep is still found even though its containing folder's name does not match. */
+   @Test
+   void queryMatchesCaseInsensitivelyEvenNestedUnderANonMatchingFolder() throws Exception {
+      Harness h = harness(new HyperlinkDialogModel());
+      AssetEntry misc = folderEntry(AssetRepository.GLOBAL_SCOPE, "Misc", null);
+      when(h.repository.containsEntry(globalRoot())).thenReturn(true);
+      when(h.repository.containsEntry(userRoot())).thenReturn(false);
+      when(h.repository.getEntries(eq(globalRoot()), any(Principal.class),
+                                   eq(ResourceAction.READ), any()))
+         .thenReturn(new AssetEntry[]{ misc });
+      when(h.repository.getEntries(eq(misc), any(Principal.class),
+                                   eq(ResourceAction.READ), any()))
+         .thenReturn(new AssetEntry[]{
+            vsEntry(AssetRepository.GLOBAL_SCOPE, "Misc/TargetVS", null) });
+
+      Map<String, Object> result =
+         h.service.listLinkTargets("tok", principal(), null, "target", null);
+
+      List<Map<String, Object>> targets = targetsOf(result);
+      assertEquals(1, targets.size());
+      assertEquals("Misc/TargetVS", targets.get(0).get("path"));
+   }
+
+   @Test
+   void neverDescendsIntoAFolderNamedRecycleBin() throws Exception {
+      Harness h = harness(new HyperlinkDialogModel());
+      AssetEntry recycleBin = folderEntry(AssetRepository.GLOBAL_SCOPE, "Recycle Bin", null);
+      when(h.repository.containsEntry(globalRoot())).thenReturn(true);
+      when(h.repository.containsEntry(userRoot())).thenReturn(false);
+      when(h.repository.getEntries(eq(globalRoot()), any(Principal.class),
+                                   eq(ResourceAction.READ), any()))
+         .thenReturn(new AssetEntry[]{
+            recycleBin, vsEntry(AssetRepository.GLOBAL_SCOPE, "Keep", null) });
+
+      Map<String, Object> result = h.service.listLinkTargets("tok", principal(), null, null, null);
+
+      List<Map<String, Object>> targets = targetsOf(result);
+      assertEquals(1, targets.size());
+      assertEquals("Keep", targets.get(0).get("path"));
+      verify(h.repository, never()).getEntries(eq(recycleBin), any(Principal.class), any(), any());
+   }
+
+   @Test
+   void limitTruncatesAndReportsTruncatedTrue() throws Exception {
+      Harness h = harness(new HyperlinkDialogModel());
+      when(h.repository.containsEntry(globalRoot())).thenReturn(true);
+      when(h.repository.containsEntry(userRoot())).thenReturn(false);
+      when(h.repository.getEntries(eq(globalRoot()), any(Principal.class),
+                                   eq(ResourceAction.READ), any()))
+         .thenReturn(new AssetEntry[]{
+            vsEntry(AssetRepository.GLOBAL_SCOPE, "A", null),
+            vsEntry(AssetRepository.GLOBAL_SCOPE, "B", null) });
+
+      Map<String, Object> result = h.service.listLinkTargets("tok", principal(), null, null, 1);
+
+      assertEquals(1, targetsOf(result).size());
+      assertEquals(true, result.get("truncated"));
+   }
+
+   @Test
+   void aResultSetUnderTheLimitReportsTruncatedFalse() throws Exception {
+      Harness h = harness(new HyperlinkDialogModel());
+      when(h.repository.containsEntry(globalRoot())).thenReturn(true);
+      when(h.repository.containsEntry(userRoot())).thenReturn(false);
+      when(h.repository.getEntries(eq(globalRoot()), any(Principal.class),
+                                   eq(ResourceAction.READ), any()))
+         .thenReturn(new AssetEntry[]{ vsEntry(AssetRepository.GLOBAL_SCOPE, "A", null) });
+
+      Map<String, Object> result = h.service.listLinkTargets("tok", principal(), null, null, 200);
+
+      assertEquals(false, result.get("truncated"));
+   }
+
+   /**
+    * This is the test that actually enforces "this tool's output is a contract with the write
+    * path" -- every path this method returns must round-trip through {@code set} without hitting
+    * the "No viewsheet at ..." refusal {@code resolveViewsheetTarget} raises on a miss.
+    */
+   @Test
+   void everyReturnedPathRoundTripsThroughSetHyperlink() throws Exception {
+      Harness h = harness(new HyperlinkDialogModel());
+      reset(h.repository);
+      AssetEntry viewsheet = vsEntry(AssetRepository.GLOBAL_SCOPE, "Reports/Detail", null);
+      when(h.repository.containsEntry(globalRoot())).thenReturn(true);
+      when(h.repository.getEntries(eq(globalRoot()), any(Principal.class),
+                                   eq(ResourceAction.READ), any()))
+         .thenReturn(new AssetEntry[]{ viewsheet });
+      // What resolveViewsheetTarget itself checks to accept the path.
+      when(h.repository.containsEntry(viewsheet)).thenReturn(true);
+
+      Map<String, Object> result = h.service.listLinkTargets("tok", principal(), null, null, null);
+      String path = (String) targetsOf(result).get(0).get("path");
+
+      assertDoesNotThrow(() -> h.service.set(
+         "tok", principal(), "Chart1", null,
+         link("linkType", "viewsheet", "assetLinkPath", path), ""));
+   }
+
+   /**
+    * A mock repository could hand back an entry of a type the selector was never meant to admit
+    * (a {@code WORKSHEET}, say); this confirms such an entry is excluded, and that the correct
+    * selector -- {@code REPOSITORY_FOLDER}/{@code VIEWSHEET} only -- is what was actually passed
+    * to {@code getEntries}, rather than a client-side type check standing in for it.
+    */
+   @Test
+   void nonFolderNonViewsheetEntriesAreExcludedAndTheSelectorIsPassedThrough() throws Exception {
+      Harness h = harness(new HyperlinkDialogModel());
+      when(h.repository.containsEntry(globalRoot())).thenReturn(true);
+      when(h.repository.containsEntry(userRoot())).thenReturn(false);
+      AssetEntry worksheet = new AssetEntry(AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.WORKSHEET,
+                                            "SomeWorksheet", null);
+      when(h.repository.getEntries(eq(globalRoot()), any(Principal.class),
+                                   eq(ResourceAction.READ), any()))
+         .thenReturn(new AssetEntry[]{ worksheet,
+                                       vsEntry(AssetRepository.GLOBAL_SCOPE, "Keep", null) });
+
+      Map<String, Object> result = h.service.listLinkTargets("tok", principal(), null, null, null);
+
+      List<Map<String, Object>> targets = targetsOf(result);
+      assertEquals(1, targets.size());
+      assertEquals("Keep", targets.get(0).get("path"));
+      verify(h.repository).getEntries(eq(globalRoot()), any(Principal.class),
+                                      eq(ResourceAction.READ),
+                                      argThat(sel -> sel.matches(AssetEntry.Type.VIEWSHEET) &&
+                                                    sel.matches(AssetEntry.Type.REPOSITORY_FOLDER) &&
+                                                    !sel.matches(AssetEntry.Type.WORKSHEET)));
+   }
+
    // ── harness ───────────────────────────────────────────────────────────────
 
    private record Harness(AssemblyHyperlinkService service, ViewsheetSessionService sessions,
-                          HyperlinkDialogService links) {}
+                          HyperlinkDialogService links, AssetRepository repository) {}
 
    private static HyperlinkDialogModel capture(HyperlinkDialogService links) throws Exception {
       ArgumentCaptor<HyperlinkDialogModel> captor =
@@ -271,9 +514,15 @@ class AssemblyHyperlinkServiceTest {
 
       ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
       HyperlinkDialogService links = mock(HyperlinkDialogService.class);
+      AssetRepository repository = mock(AssetRepository.class);
 
       try {
          when(sessions.resolve(anyString(), any(Principal.class))).thenReturn(rvs);
+         when(rvs.getAssetRepository()).thenReturn(repository);
+         // A lenient default -- resolveViewsheetTarget's own tests below stub containsEntry
+         // precisely, but the write-path tests above (setsAViewsheetLink) only need resolution
+         // to succeed, not to exercise scope precedence, so any entry matches.
+         when(repository.containsEntry(any())).thenReturn(true);
          doAnswer(invocation -> {
             ViewsheetSessionService.Mutation mutation = invocation.getArgument(2);
             mutation.run(rvs, "rt1", null);
@@ -288,7 +537,8 @@ class AssemblyHyperlinkServiceTest {
          throw new IllegalStateException(e);
       }
 
-      return new Harness(new AssemblyHyperlinkService(sessions, links), sessions, links);
+      return new Harness(new AssemblyHyperlinkService(sessions, links), sessions, links,
+                         repository);
    }
 
    private static Principal principal() {

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHyperlinkServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHyperlinkServiceTest.java
@@ -494,6 +494,167 @@ class AssemblyHyperlinkServiceTest {
                                                     !sel.matches(AssetEntry.Type.WORKSHEET)));
    }
 
+   // ── regressions for the four hyperlink defects ────────────────────────
+
+   /**
+    * The read half of the sentinel mismatch. {@code LINK_TYPES} mapped {@code "none"} to 0, but
+    * the dialog service carries its own private {@code NONE = 9}, so a never-linked assembly --
+    * which is every assembly until someone links it -- reported itself as {@code "unknown(9)"}.
+    * That is the first thing a caller sees on any assembly, and it read as a bug in the tool.
+    */
+   @Test
+   void aNeverLinkedAssemblyReadsBackAsNoneNotAnUnknownConstant() throws Exception {
+      HyperlinkDialogModel model = new HyperlinkDialogModel();
+      model.setLinkType(HyperlinkDialogService.NONE);
+
+      Map<String, Object> read = harness(model).service.read("tok", principal(), "Chart1", null);
+
+      assertEquals("none", read.get("linkType"));
+   }
+
+   /** The token the read reports has to be the one {@link AssemblyHyperlinkService#set} accepts. */
+   @Test
+   void theNoneTokenRoundTripsBetweenReadAndWrite() throws Exception {
+      HyperlinkDialogModel model = new HyperlinkDialogModel();
+      model.setLinkType(HyperlinkDialogService.NONE);
+      Harness h = harness(model);
+
+      Object token = h.service.read("tok", principal(), "Chart1", null).get("linkType");
+      h.service.set("tok", principal(), "Chart1", null, link("linkType", token), "");
+
+      assertEquals(HyperlinkDialogService.NONE, capture(h.links).getLinkType());
+   }
+
+   /**
+    * A cleared link must not keep its destination fields. Tooltip and target frame surviving a
+    * clear is what made a cleared link read differently from a never-linked one.
+    */
+   @Test
+   void clearingDropsTheTooltipAndTargetFrameToo() throws Exception {
+      HyperlinkDialogModel model = new HyperlinkDialogModel();
+      model.setWebLink("https://old.example.com");
+      model.setTooltip("stale tooltip");
+      model.setTargetFrame("_blank");
+      Harness h = harness(model);
+
+      h.service.set("tok", principal(), "Chart1", null, link("linkType", "none"), "");
+
+      HyperlinkDialogModel posted = capture(h.links);
+      assertNull(posted.getTooltip(), "a stale tooltip beside a cleared link reads wrong");
+      assertNull(posted.getTargetFrame());
+      assertNull(posted.getAssetLinkId());
+      assertNull(posted.getAssetLinkPath());
+   }
+
+   /**
+    * A viewsheet link is stored by {@code assetLinkId}, and nothing ever set it -- it reached
+    * {@code VSUtil.getBookmarks} as null and surfaced as a raw NPE. Asserting the link type alone
+    * would still pass with the id left null, which is exactly the state that crashed.
+    */
+   @Test
+   void aViewsheetLinkCarriesTheResolvedAssetIdNotJustThePath() throws Exception {
+      Harness h = harness(new HyperlinkDialogModel());
+
+      h.service.set("tok", principal(), "Chart1", null,
+                    link("linkType", "viewsheet", "assetLinkPath", "Reports/Detail"), "");
+
+      HyperlinkDialogModel posted = capture(h.links);
+      assertNotNull(posted.getAssetLinkId(), "the id is the half getHyperlink actually stores");
+      assertEquals("Reports/Detail", posted.getAssetLinkPath(), "the path is the display half");
+   }
+
+   /**
+    * An explicit id short-circuits resolution, for a caller that already holds the identifier --
+    * the Composer's own dialog works that way, from its asset tree. {@code assetLinkPath} is still
+    * required, because it is the display half of the same link.
+    */
+   @Test
+   void anExplicitAssetLinkIdIsUsedVerbatimWithoutConsultingTheRepository() throws Exception {
+      Harness h = harness(new HyperlinkDialogModel());
+
+      h.service.set("tok", principal(), "Chart1", null,
+                    link("linkType", "viewsheet", "assetLinkPath", "Reports/Detail",
+                         "assetLinkId", "1^128^__NULL__^Reports/Detail"), "");
+
+      assertEquals("1^128^__NULL__^Reports/Detail", capture(h.links).getAssetLinkId());
+      verify(h.repository, never()).containsEntry(any());
+   }
+
+   /**
+    * <b>The assertion that matters most in this file.</b> Resolving the target inside
+    * {@code sessions.mutate} meant an unresolvable path threw with the model already half-written,
+    * leaving the assembly carrying {@code linkType=viewsheet} and a null destination -- worse than
+    * the refusal it was trying to report. Resolution now runs first, so nothing is mutated.
+    */
+   @Test
+   void anUnresolvablePathIsRefusedWithoutMutatingAnything() throws Exception {
+      Harness h = harness(new HyperlinkDialogModel());
+      when(h.repository.containsEntry(any())).thenReturn(false);
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> h.service.set("tok", principal(), "Chart1", null,
+                             link("linkType", "viewsheet", "assetLinkPath", "Reports/Gone"), ""));
+
+      verify(h.sessions, never()).mutate(anyString(), any(Principal.class), any());
+      verifyNoInteractions(h.links);
+      assertTrue(thrown.getMessage().contains("Reports/Gone"), "name the path that was not found");
+   }
+
+   /** The refusal names both scopes it looked in, so the caller knows where to put the sheet. */
+   @Test
+   void theRefusalNamesBothScopesItSearched() throws Exception {
+      Harness h = harness(new HyperlinkDialogModel());
+      when(h.repository.containsEntry(any())).thenReturn(false);
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> h.service.set("tok", principal(), "Chart1", null,
+                             link("linkType", "viewsheet", "assetLinkPath", "Reports/Gone"), ""));
+
+      assertTrue(thrown.getMessage().contains("global"), "name the global scope");
+      assertTrue(thrown.getMessage().contains("admin"), "name the caller's own scope");
+   }
+
+   /**
+    * The dialog service does not echo {@code colName} back into the model, so a caller that
+    * addressed a cell BY NAME read back null and could not confirm it had read the cell it wrote.
+    * Falling back to what was asked for is the honest answer.
+    */
+   @Test
+   void echoesBackTheColNameTheReadWasScopedTo() throws Exception {
+      Harness h = harness(new HyperlinkDialogModel());
+
+      Map<String, Object> read = h.service.read(
+         "tok", principal(), "Table1",
+         new AssemblyHyperlinkService.Region(2, 1, "Sales", false, false, false, false));
+
+      assertEquals("Sales", read.get("colName"),
+                   "the model does not carry it; the name this read was scoped to is the answer");
+   }
+
+   /** The model's own value wins when it has one -- the fallback must not overwrite it. */
+   @Test
+   void theModelsOwnColNameTakesPrecedenceOverTheRequested() throws Exception {
+      HyperlinkDialogModel model = new HyperlinkDialogModel();
+      model.setColName("Revenue");
+
+      Map<String, Object> read = harness(model).service.read(
+         "tok", principal(), "Table1",
+         new AssemblyHyperlinkService.Region(2, 1, "Sales", false, false, false, false));
+
+      assertEquals("Revenue", read.get("colName"));
+   }
+
+   /** No region, no name asked for, nothing to fall back to -- null, not a fabricated value. */
+   @Test
+   void reportsANullColNameWhenNoneWasAskedForOrCarried() throws Exception {
+      Map<String, Object> read = harness(new HyperlinkDialogModel())
+         .service.read("tok", principal(), "Chart1", null);
+
+      assertNull(read.get("colName"));
+   }
+
    // ── harness ───────────────────────────────────────────────────────────────
 
    private record Harness(AssemblyHyperlinkService service, ViewsheetSessionService sessions,

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyAliasesTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyAliasesTest.java
@@ -385,10 +385,16 @@ class PropertyAliasesTest {
                    () -> PropertyAliases.resolveForWrite("chart", "projectForwardEnabled"));
    }
 
-   /** The refusal is scoped to charts -- it is keyed on the assembly type, not the leaf alone. */
+   /**
+    * The refusal is keyed on the assembly type, not on the leaf name alone. The very leaf that is
+    * refused on a chart has to pass on a type that has no chart line pane -- otherwise the check
+    * would be vetoing a name it knows nothing about, on models where it means something else.
+    */
    @Test
    void theChartRefusalDoesNotReachAnotherAssemblyType() {
-      assertEquals("vsOptionsPane.maxRows",
-                   PropertyAliases.resolveForWrite(PropertyAliases.SHEET, "maxRows"));
+      assertEquals("chartLinePaneModel.gridLineVisible",
+                   PropertyAliases.resolveForWrite(PropertyAliases.SHEET,
+                                                   "chartLinePaneModel.gridLineVisible"),
+                   "refused on 'chart', but nothing to refuse on a viewsheet");
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyAliasesTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyAliasesTest.java
@@ -280,4 +280,115 @@ class PropertyAliasesTest {
    void refusesAPropertyThatBelongsToADifferentType() {
       assertThrows(IllegalArgumentException.class, () -> PropertyAliases.resolve("text", "min"));
    }
+
+   // ── 'enabled' points at the live field, not the Editable flag ─────────────
+
+   /**
+    * {@code basicGeneralPaneModel.enabled} is the Editable flag wearing the wrong name — its own
+    * setter is declared {@code setEnabled(boolean editable)} — and nothing in the tree ever writes
+    * it. Aliased there, {@code enabled} reported success, wrote a field no one reads, and always
+    * read back false. The live switch is {@code GeneralPropPaneModel.enabled}, one level up.
+    *
+    * <p>The registry's own invariant test cannot catch this: both paths resolve on the model, so a
+    * write to either "works". Only the level is wrong, which is why it needs naming explicitly.
+    */
+   @Test
+   void enabledResolvesToTheGeneralPropPaneFieldNotTheEditableFlagBelowIt() {
+      assertEquals("textGeneralPaneModel.outputGeneralPaneModel.generalPropPaneModel.enabled",
+                   PropertyAliases.resolve("text", "enabled"),
+                   "an output assembly nests generalPropPaneModel one level deeper");
+      assertEquals("chartGeneralPaneModel.generalPropPaneModel.enabled",
+                   PropertyAliases.resolve("chart", "enabled"),
+                   "a data assembly holds generalPropPaneModel directly");
+   }
+
+   @Test
+   void enabledIsNotTheBasicGeneralPaneEnabled() {
+      for(String type : java.util.List.of("text", "chart", "gauge", "image", "table")) {
+         assertFalse(PropertyAliases.resolve(type, "enabled").endsWith("basicGeneralPaneModel.enabled"),
+                     type + " must not alias enabled onto the Editable flag");
+      }
+   }
+
+   /** {@code visible} is the sibling that genuinely does live on the basic pane. */
+   @Test
+   void visibleStillResolvesOntoTheBasicGeneralPane() {
+      assertTrue(PropertyAliases.resolve("chart", "visible").endsWith("basicGeneralPaneModel.visible"));
+   }
+
+   // ── the chart line pane's read-only capability flags ──────────────────────
+   //
+   // These report whether the chart TYPE offers a control. ChartLinePaneModel recomputes each one
+   // from the chart type on every read and updateChartLinePaneModel writes none of them, so a
+   // write could not survive even in principle -- it reported success and changed nothing.
+
+   @Test
+   void refusesToWriteEveryChartReadOnlyCapabilityFlag() {
+      for(String flag : java.util.List.of("gridLineVisible", "innerLineVisible", "trendLineVisible",
+                                          "facetGridVisible", "facetGridEnabled",
+                                          "projectForwardEnabled", "lineTabVisible"))
+      {
+         Exception thrown = assertThrows(
+            IllegalArgumentException.class,
+            () -> PropertyAliases.resolveForWrite("chart", flag),
+            flag + " is recomputed on every read, so a write to it cannot survive");
+
+         assertTrue(thrown.getMessage().contains(flag), "name the flag: " + flag);
+         assertTrue(thrown.getMessage().contains("read-only"), "say why, for " + flag);
+         assertTrue(thrown.getMessage().contains("set_chart_type"),
+                    "say what to do instead, for " + flag);
+      }
+   }
+
+   /** The raw-path escape hatch must not reach a refused flag under a different spelling. */
+   @Test
+   void refusesAChartReadOnlyFlagEvenAsARawDottedPath() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> PropertyAliases.resolveForWrite("chart", "chartLinePaneModel.gridLineVisible"));
+
+      assertTrue(thrown.getMessage().contains("gridLineVisible"));
+   }
+
+   /**
+    * The boundary that matters: {@code facetGrid} is the real setting and applies, so only the
+    * flag saying whether its control appears is refused. Refusing both would have removed a
+    * working property.
+    */
+   @Test
+   void facetGridItselfStaysWritable() {
+      assertEquals("chartLinePaneModel.facetGrid",
+                   PropertyAliases.resolveForWrite("chart", "facetGrid"));
+   }
+
+   @Test
+   void theRealLinePaneSettingsStayWritable() {
+      for(String alias : java.util.List.of("trendLineType", "trendLineStyle", "trendLineColor",
+                                           "projectForward", "facetGridColor"))
+      {
+         assertEquals("chartLinePaneModel." + alias,
+                      PropertyAliases.resolveForWrite("chart", alias),
+                      alias + " is a real setting, not a capability flag");
+      }
+   }
+
+   /**
+    * {@code projectForwardEnabled} is exposed readable on purpose: it is the gate that explains
+    * why {@code projectForward} reads back 0. Readable and refused on write is the whole point,
+    * so both halves are asserted together.
+    */
+   @Test
+   void projectForwardEnabledIsReadableButNotWritable() {
+      assertEquals("chartLinePaneModel.projectForwardEnabled",
+                   PropertyAliases.resolve("chart", "projectForwardEnabled"));
+      assertThrows(IllegalArgumentException.class,
+                   () -> PropertyAliases.resolveForWrite("chart", "projectForwardEnabled"));
+   }
+
+   /** The refusal is scoped to charts -- it is keyed on the assembly type, not the leaf alone. */
+   @Test
+   void theChartRefusalDoesNotReachAnotherAssemblyType() {
+      assertEquals("vsOptionsPane.maxRows",
+                   PropertyAliases.resolveForWrite(PropertyAliases.SHEET, "maxRows"));
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyPathTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyPathTest.java
@@ -439,4 +439,117 @@ class PropertyPathTest {
       assertTrue(properties.contains("title"));
       assertFalse(properties.contains("class"), "Object's own getters are not properties");
    }
+
+   // ── accessor-name spellings (the writer/reader lookup fix) ────────────────
+   //
+   // propertiesOf derives a name by stripping get/is and decapitalizing; the writer lookup used
+   // to rebuild it with capitalize. Those are not inverses when a lowercase letter follows the
+   // prefix, so ChartLinePaneModel.setxGridLineStyle was invisible: xGridLineStyle was refused as
+   // unwritable and listed as available in the same message. Both derivations are accepted now,
+   // which has to stay a strict superset -- a name that resolved before must not stop resolving.
+
+   /**
+    * Mirrors {@code ChartLinePaneModel}: a lowercase letter straight after the prefix
+    * ({@code getxGridLineStyle}) alongside a two-capital accessor ({@code getRTChartType}) that
+    * only the rebuilt spelling can reach, since decapitalizing {@code RTChartType} yields
+    * {@code rTChartType}.
+    */
+   public static class AwkwardAccessors {
+      public String getxGridLineStyle() { return xGridLineStyle; }
+      public void setxGridLineStyle(String style) { this.xGridLineStyle = style; }
+      public String getRTChartType() { return rtChartType; }
+      public void setRTChartType(String type) { this.rtChartType = type; }
+
+      private String xGridLineStyle = "";
+      private String rtChartType = "";
+   }
+
+   @Test
+   void writesThroughAnAccessorWhoseNameIsLowercaseAfterThePrefix() {
+      AwkwardAccessors target = new AwkwardAccessors();
+
+      PropertyPath.set(target, "xGridLineStyle", "THIN_LINE");
+
+      assertEquals("THIN_LINE", target.getxGridLineStyle(),
+                   "setxGridLineStyle is the real writer; asking for setXGridLineStyle found nothing");
+   }
+
+   @Test
+   void readsBackTheSameLowercaseAfterPrefixPropertyItCanWrite() {
+      AwkwardAccessors target = new AwkwardAccessors();
+      target.setxGridLineStyle("THIN_LINE");
+
+      assertEquals("THIN_LINE", PropertyPath.get(target, "xGridLineStyle"),
+                   "writable but unreadable by path would be worse than the bug this repaired");
+   }
+
+   @Test
+   void theAwkwardNameIsTheOnePropertiesOfAdvertises() {
+      assertTrue(PropertyPath.propertiesOf(AwkwardAccessors.class).contains("xGridLineStyle"),
+                 "the lookup must accept the spelling the enumeration hands out");
+   }
+
+   @Test
+   void aTwoCapitalAccessorStillResolvesThroughTheRebuiltSpelling() {
+      AwkwardAccessors target = new AwkwardAccessors();
+
+      PropertyPath.set(target, "RTChartType", "BAR");
+
+      assertEquals("BAR", target.getRTChartType(),
+                   "decapitalizing RTChartType gives rTChartType, so only the rebuilt form reaches it");
+   }
+
+   // ── constrained strings return the domain's own spelling ──────────────────
+
+   /** Mirrors {@code ChartLinePaneModel.trendLineType}. */
+   public static class TrendLine {
+      public String getTrendLineType() { return trendLineType; }
+      public void setTrendLineType(String type) { this.trendLineType = type; }
+
+      private String trendLineType = "NONE";
+   }
+
+   /**
+    * The check is case-insensitive, so {@code "LINEAR"} passes it. Storing the caller's spelling
+    * anyway is no better than not checking: {@code getIndexByName} compares with {@code equals}
+    * and starts at 0, so the chart stayed on {@code NONE} while the write reported success.
+    */
+   @Test
+   void storesTheDomainsSpellingNotTheCallersForAConstrainedString() {
+      TrendLine target = new TrendLine();
+
+      PropertyPath.set(target, "trendLineType", "LINEAR");
+
+      assertEquals("Linear", target.getTrendLineType(),
+                   "StyleBI matches this token exactly; 'LINEAR' would have silently meant NONE");
+   }
+
+   @Test
+   void anExactlySpelledConstrainedStringIsUnchanged() {
+      TrendLine target = new TrendLine();
+
+      PropertyPath.set(target, "trendLineType", "Quadratic");
+
+      assertEquals("Quadratic", target.getTrendLineType());
+   }
+
+   @Test
+   void refusesATrendLineTypeOutsideTheDomainListingTheValid() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> PropertyPath.set(new TrendLine(), "trendLineType", "spline"));
+
+      assertTrue(thrown.getMessage().contains("trendLineType"), "name the property");
+      assertTrue(thrown.getMessage().contains("Linear"), "list the tokens that do work");
+   }
+
+   @Test
+   void anUnconstrainedStringKeepsTheCallersSpelling() {
+      Leaf leaf = new Leaf();
+
+      PropertyPath.set(leaf, "title", "MiXeD Case");
+
+      assertEquals("MiXeD Case", leaf.getTitle(),
+                   "only names with a declared domain get canonicalized");
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -216,6 +216,25 @@ class ViewsheetAssemblyAgentControllerTest {
    }
 
    /**
+    * {@code list_hyperlink_targets} — the query params are forwarded exactly as received and the
+    * service's return value passes through unchanged, matching every other read endpoint in this
+    * file.
+    */
+   @Test
+   void listHyperlinkTargetsDelegatesToTheService() throws Exception {
+      AssemblyHyperlinkService hyperlinkService = mock(AssemblyHyperlinkService.class);
+      Map<String, Object> expected = Map.of("targets", List.of(), "truncated", false);
+      when(hyperlinkService.listLinkTargets(eq("tok"), any(Principal.class), eq("Reports"),
+                                            eq("detail"), eq(50)))
+         .thenReturn(expected);
+
+      ViewsheetAssemblyAgentController controller = controllerWith(hyperlinkService);
+
+      assertSame(expected, controller.listHyperlinkTargets(
+         "tok", "Reports", "detail", 50, principal()));
+   }
+
+   /**
     * A refused patch (a bad key, or the {@code vsScriptPane} refusal) must surface as the same
     * named-field {@code IllegalArgumentException} the global {@code WizControllerErrorHandler}
     * turns into a 400 — never a bare 500 that reads as a server bug.
@@ -418,6 +437,42 @@ class ViewsheetAssemblyAgentControllerTest {
                                           mock(AssemblyPropertyService.class),
                                           propertyService,
                                           mock(AssemblyHyperlinkService.class),
+                                          mock(ChartElementService.class),
+                                          mock(ChartRegionPropertyService.class),
+                                          mock(AssemblyConditionService.class),
+                                          mock(AssemblyHighlightService.class),
+                                          mock(DateComparisonService.class),
+                                          mock(AssemblyConvertService.class),
+                                          mock(SelectionRuntimeService.class),
+                                          mock(CalendarDisplayService.class),
+                                          mock(InputValueService.class),
+                                          mock(inetsoft.analytic.composition.ViewsheetService.class),
+                                          mock(SheetAgentBroadcastService.class),
+                                          mock(SheetOpenService.class),
+                                          mock(LayoutSessionService.class),
+                                          mock(LayoutReadService.class),
+                                          mock(PrintDeviceLayoutPropertyService.class),
+                                          mock(LayoutMutationService.class),
+                                          mock(LayoutUndoService.class));
+   }
+
+   /** Feature enabled, only {@code hyperlinkService} wired -- for the hyperlink-targets test. */
+   private static ViewsheetAssemblyAgentController controllerWith(
+      AssemblyHyperlinkService hyperlinkService)
+   {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      when(feature.isEnabled()).thenReturn(true);
+
+      return new ViewsheetAssemblyAgentController(feature, mock(SheetJoinService.class),
+                                          mock(SheetSessionService.class),
+                                          mock(ViewsheetSessionService.class),
+                                          mock(ViewsheetReadService.class),
+                                          mock(ViewsheetEditService.class),
+                                          mock(ViewsheetFormatService.class),
+                                          mock(inetsoft.web.wiz.script.ScriptImageService.class),
+                                          mock(AssemblyPropertyService.class),
+                                          mock(SheetPropertyService.class),
+                                          hyperlinkService,
                                           mock(ChartElementService.class),
                                           mock(ChartRegionPropertyService.class),
                                           mock(AssemblyConditionService.class),


### PR DESCRIPTION
**Eight defects, four commits**, all found by live-testing the composer agent tools against a running Composer. Every one is name/value mapping or validation — no business logic changes.

| Commit | Defects |
|---|---|
| `c637d358a` | `enabled` written to a dead field |
| `af3ee3b1f` | four writable properties refused as unwritable |
| `6e9d9976f` | seven read-only flags accepted writes; a mistyped token silently defaulted |
| `e6b186a4e` | a clear that cleared nothing; `unknown(9)` reads; viewsheet links always threw; `colName` never echoed |

All eight are **verified live** — see Verification.

## 1. `enabled` was mapped to a dead field (`c637d358a`)

The alias pointed at `basicGeneralPaneModel.enabled`, which is the Editable flag under a misleading name (its setter is declared `setEnabled(boolean editable)`) and which nothing in the tree ever writes. So `{enabled: true}` reported success, wrote a field no one reads, and always read back `false`. Now points at `GeneralPropPaneModel.enabled`, the field every property dialog service fills from `VSAssemblyInfo.getEnabledValue()`.

## 2. Writable properties were refused as unwritable (`af3ee3b1f`)

`propertiesOf` derives a name by stripping `get` and decapitalizing; `setterFor` rebuilt it with `capitalize`. Not inverses when an accessor has a lowercase letter right after the prefix, so `ChartLinePaneModel.setxGridLineStyle` was invisible: `xGridLineStyle`, `xGridLineColor`, `yGridLineStyle` and `yGridLineColor` were refused as unwritable *and listed as available in the same message*. Both spellings are now accepted rather than one replacing the other, since `getRTChartType`-style accessors resolve only through the rebuilt form — a strict superset. `getterFor` gets the same treatment.

## 3. Read-only flags accepted writes; a mistyped token failed silently (`6e9d9976f`)

`gridLineVisible`, `innerLineVisible`, `trendLineVisible`, `facetGridVisible`, `facetGridEnabled`, `projectForwardEnabled` and `lineTabVisible` are flags the dialog uses to decide which controls to show. They are recomputed from the chart type on every read and `updateChartLinePaneModel` writes none of them, so a write could not survive. Now readable and refused on write, naming what to change instead. (`facetGrid` is deliberately not in that set — it is the real setting and applies.)

`requireAllowedValue` also returns the domain's own spelling instead of only validating: the check is case-insensitive, so `trendLineType: "LINEAR"` passed it, was stored verbatim, and left the chart on `NONE`, because `getIndexByName` matches exactly and defaults to index 0. `projectForwardEnabled` is exposed readable so a caller can see why `projectForward` reads back 0 — that is gating, not a lost write.

## 4. Hyperlinks — five defects on two root causes (`e6b186a4e`)

`LINK_TYPES` mapped `"none"` to `0`, but `HyperlinkDialogService` uses a private `NONE = 9` sentinel. That single wrong value broke both directions: a never-linked assembly carries 9 and reported itself as `unknown(9)`; and a write of `"none"` sent 0, which `getHyperlink` does not treat as clear, so it built a real `Hyperlink` of type 0 — tooltip and target frame survived, while `tokenOf(0)` read it back as `"none"`. `NONE` is now `public static final` and documented as a dialog sentinel, not a `Hyperlink` constant.

A viewsheet link is stored by `assetLinkId`, which nothing ever set — it reached `VSUtil.getBookmarks` as null and surfaced as a raw NPE. `resolveViewsheetTarget` derives the id from `assetLinkPath` (global scope, then the caller's own), verifies it with `containsEntry`, and refuses a path that resolves to nothing. It runs **before** `sessions.mutate`, so an unresolvable target no longer throws with the model half-written — that half-write is what left assemblies carrying `linkType=viewsheet` with a null destination. `get_hyperlink` also echoes the requested `colName` when the dialog model does not carry it.

## Verification

Verified live in two passes, each against a rebuilt server, and read-backs were required throughout — an `{"ok": true}` was not accepted as evidence, which is what caught three of these in the first place.

**Pass 1 (`6e9d9976f`)** — commits 1–3: `enabled` round-trips both ways on both nesting shapes (`Text1` via `outputGeneral`, `Crosstab1` via `dataGeneral`); `xGridLineStyle`/`yGridLineColor` are accepted where they were refused, **and the render draws the red gridline**, not just the read-back; all nine of the chart line pane's real settings round-trip in one patch, with the yellow quadrant and blue diagonal lines visible; `gridLineVisible` is refused with its explanation; `trendLineType: "LINEAR"` canonicalizes to `"Linear"` and takes effect.

**Pass 2 (`e6b186a4e`)** — commit 4: a never-linked assembly reports `none`; **a cleared link reads back byte-identical to a never-linked one**, which is the real proof it was dropped rather than replaced by a type-0 link; a viewsheet link succeeds and reads back complete; a bad path is refused naming both scopes tried, **and a good link written moments earlier survives that refusal untouched** — the half-apply was the actual defect, so this read-after-refusal is the assertion that matters; `colName` echoes back.

## Known: two tests need updating

Left alone deliberately, both in `AssemblyHyperlinkServiceTest`:

- `clearingALinkNeedsNoDestination` asserts `linkType == 0`, which pinned the bug — it should expect `HyperlinkDialogService.NONE`.
- `harness()` must stub `getAssetRepository()` (and `containsEntry`) for `setsAViewsheetLink`, since the target now resolves through the repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
