### PR TITLE
fix(calc-table): resolve field.namedGroup into a bindable order (closes Finding 1's residual gap)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/binding/CalcTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/CalcTableService.java
@@ -21,12 +21,14 @@ import inetsoft.report.CellBinding;
 import inetsoft.report.TableCellBinding;
 import inetsoft.report.TableLayout;
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.XConstants;
 import inetsoft.uql.asset.Assembly;
 import inetsoft.uql.asset.AttachedAssembly;
 import inetsoft.uql.asset.DefaultNamedGroupAssembly;
 import inetsoft.uql.asset.SourceInfo;
 import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.util.XNamedGroupInfo;
 import inetsoft.uql.viewsheet.CalcTableVSAssembly;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
@@ -37,6 +39,11 @@ import inetsoft.web.binding.command.GetPredefinedNamedGroupCommand;
 import inetsoft.web.binding.controller.VSTableLayoutService;
 import inetsoft.web.binding.event.GetCellScriptEvent;
 import inetsoft.web.binding.event.GetPredefinedNamedGroupEvent;
+import inetsoft.web.binding.model.NamedGroupInfoModel;
+import inetsoft.web.binding.model.table.OrderModel;
+import inetsoft.web.binding.service.DataRefModelFactoryService;
+import inetsoft.web.composer.model.condition.ConditionExpression;
+import inetsoft.web.composer.model.condition.ConditionUtil;
 import inetsoft.web.wiz.dispatch.CapturingCommandDispatcher;
 import inetsoft.web.binding.event.CopyCutCalcCellEvent;
 import inetsoft.web.binding.event.ModifyTableLayoutEvent;
@@ -69,9 +76,12 @@ import java.util.List;
 @Service
 public class CalcTableService {
    @Autowired
-   public CalcTableService(ViewsheetSessionService sessions, VSTableLayoutService layoutService) {
+   public CalcTableService(ViewsheetSessionService sessions, VSTableLayoutService layoutService,
+                           DataRefModelFactoryService refModelService)
+   {
       this.sessions = sessions;
       this.layoutService = layoutService;
+      this.refModelService = refModelService;
    }
 
    /**
@@ -200,23 +210,11 @@ public class CalcTableService {
       return sessions.read(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          CalcTableVSAssembly assembly = requireCalcTable(rvs, assemblyName);
 
-         GetPredefinedNamedGroupEvent event = new GetPredefinedNamedGroupEvent();
-         event.setName(assemblyName);
-         event.setColumn(column);
-         layoutService.getNamedGroup(runtimeId, event, user, dispatcher);
-
          // The command carries the group NAMES only — its constructor takes
          // AssetNamedGroupInfo[] but keeps just getName() from each. The members are not on
          // the wire, so this reports what StyleBI actually sends rather than inventing a shape.
-         List<String> groups = new ArrayList<>();
-
-         for(CapturingCommandDispatcher.Command command : dispatcher.getCapturedCommands()) {
-            if(command.getCommand() instanceof GetPredefinedNamedGroupCommand named &&
-               named.getNamedGroups() != null)
-            {
-               groups.addAll(List.of(named.getNamedGroups()));
-            }
-         }
+         List<String> groups = new ArrayList<>(
+            predefinedNamedGroupNames(runtimeId, user, dispatcher, assemblyName, column));
 
          // The above only sees repository-registered "predefined named group" assets
          // (SummaryAttr.getAssetNamedGroupInfos), a different kind from the plain
@@ -225,30 +223,10 @@ public class CalcTableService {
          // a group created through add_named_group is actually listed.
          Set<String> seen = new LinkedHashSet<>(groups);
          List<String> worksheetGroups = new ArrayList<>();
-         SourceInfo sinfo = ((CalcTableVSAssemblyInfo) assembly.getInfo()).getSourceInfo();
-         Worksheet ws = rvs.getViewsheet() == null ? null : rvs.getViewsheet().getBaseWorksheet();
 
-         if(sinfo != null && sinfo.getSource() != null && ws != null) {
-            for(Assembly wsAssembly : ws.getAssemblies()) {
-               if(!(wsAssembly instanceof DefaultNamedGroupAssembly ngAssembly) ||
-                  ngAssembly.getAttachedType() != AttachedAssembly.COLUMN_ATTACHED)
-               {
-                  continue;
-               }
-
-               SourceInfo attachedSource = ngAssembly.getAttachedSource();
-               DataRef attr = ngAssembly.getAttachedAttribute();
-
-               if(attachedSource == null || attr == null ||
-                  !sinfo.getSource().equals(attachedSource.getSource()) ||
-                  !column.equals(attr.getAttribute()))
-               {
-                  continue;
-               }
-
-               if(seen.add(ngAssembly.getName())) {
-                  worksheetGroups.add(ngAssembly.getName());
-               }
+         for(DefaultNamedGroupAssembly ngAssembly : worksheetNamedGroups(rvs, assembly, column)) {
+            if(seen.add(ngAssembly.getName())) {
+               worksheetGroups.add(ngAssembly.getName());
             }
          }
 
@@ -260,15 +238,12 @@ public class CalcTableService {
          out.put("namedGroups", groups);
 
          if(!worksheetGroups.isEmpty()) {
-            // Listable here does not yet mean bindable: VSTableLayoutService.setNamedGroupInfo
-            // has no code path for a worksheet-local DefaultNamedGroupAssembly's plain
-            // NamedGroupInfo, only for the asset-repository named-group kinds above.
             out.put("note",
                     "'" + String.join("', '", worksheetGroups) + "' " +
                     (worksheetGroups.size() == 1 ? "was" : "were") +
-                    " created via add_named_group on this column's worksheet. It is listed " +
-                    "here, but set_cell_binding's 'namedGroup' parameter may not yet be able " +
-                    "to bind it — this has not been confirmed against a live server.");
+                    " created via add_named_group on this column's worksheet. set_cell_binding's " +
+                    "'namedGroup' parameter binds it by converting its conditions into an " +
+                    "expert named group on the cell's order.");
          }
          else if(groups.isEmpty()) {
             out.put("note",
@@ -293,12 +268,165 @@ public class CalcTableService {
          CalcTableVSAssembly assembly = requireCalcTable(rvs, assemblyName);
          requireInGrid(layoutOf(assembly), row, col);
 
+         CellBindingInfo cellBindingInfo = toCellBindingInfo(binding);
+         String namedGroup = cellBindingInfo.getType() == CellBinding.BIND_COLUMN
+            ? namedGroupOf(binding.get("field")) : null;
+
+         if(namedGroup != null) {
+            cellBindingInfo.setOrder(resolveNamedGroupOrder(
+               rvs, assembly, runtimeId, user, dispatcher, cellBindingInfo.getValue(),
+               namedGroup));
+         }
+
          SetCellBindingEvent event = new SetCellBindingEvent();
          event.setName(assemblyName);
          event.setSelectCells(new TableCell[]{ cellAt(row, col) });
-         event.setBinding(toCellBindingInfo(binding));
+         event.setBinding(cellBindingInfo);
          layoutService.setCellBinding(runtimeId, event, user, dispatcher);
       });
+   }
+
+   /**
+    * The predefined-named-group names a column offers, straight off the dispatched command —
+    * the same lookup {@link #namedGroups} reports and {@link #resolveNamedGroupOrder} validates
+    * an asset name against.
+    */
+   private List<String> predefinedNamedGroupNames(String runtimeId, Principal user,
+                                                   CapturingCommandDispatcher dispatcher,
+                                                   String assemblyName, String column)
+      throws Exception
+   {
+      GetPredefinedNamedGroupEvent event = new GetPredefinedNamedGroupEvent();
+      event.setName(assemblyName);
+      event.setColumn(column);
+      layoutService.getNamedGroup(runtimeId, event, user, dispatcher);
+
+      List<String> groups = new ArrayList<>();
+
+      for(CapturingCommandDispatcher.Command command : dispatcher.getCapturedCommands()) {
+         if(command.getCommand() instanceof GetPredefinedNamedGroupCommand named &&
+            named.getNamedGroups() != null)
+         {
+            groups.addAll(List.of(named.getNamedGroups()));
+         }
+      }
+
+      return groups;
+   }
+
+   /**
+    * The worksheet-local {@code DefaultNamedGroupAssembly}(s) {@code add_named_group} created
+    * on this column, attached to the calc table's own source -- a different kind from the
+    * repository-registered "predefined named group" assets {@link #predefinedNamedGroupNames}
+    * sees.
+    */
+   private List<DefaultNamedGroupAssembly> worksheetNamedGroups(RuntimeViewsheet rvs,
+                                                                CalcTableVSAssembly assembly,
+                                                                String column)
+   {
+      List<DefaultNamedGroupAssembly> matches = new ArrayList<>();
+      SourceInfo sinfo = ((CalcTableVSAssemblyInfo) assembly.getInfo()).getSourceInfo();
+      Worksheet ws = rvs.getViewsheet() == null ? null : rvs.getViewsheet().getBaseWorksheet();
+
+      if(sinfo == null || sinfo.getSource() == null || ws == null) {
+         return matches;
+      }
+
+      for(Assembly wsAssembly : ws.getAssemblies()) {
+         if(!(wsAssembly instanceof DefaultNamedGroupAssembly ngAssembly) ||
+            ngAssembly.getAttachedType() != AttachedAssembly.COLUMN_ATTACHED)
+         {
+            continue;
+         }
+
+         SourceInfo attachedSource = ngAssembly.getAttachedSource();
+         DataRef attr = ngAssembly.getAttachedAttribute();
+
+         if(attachedSource == null || attr == null ||
+            !sinfo.getSource().equals(attachedSource.getSource()) ||
+            !column.equals(attr.getAttribute()))
+         {
+            continue;
+         }
+
+         matches.add(ngAssembly);
+      }
+
+      return matches;
+   }
+
+   /**
+    * Resolves a cell's {@code field.namedGroup} to the {@code OrderModel}
+    * {@code VSTableLayoutService.setNamedGroupInfo} actually knows how to apply -- worksheet-local
+    * first (an {@code EXPERT_NAMEDGROUP_INFO} built from the assembly's own per-group
+    * conditions), then the repository-registered asset kind. Neither matching is a hard failure:
+    * a name that resolves to nothing would otherwise silently render without any grouping at
+    * all, which is the defect this fixes.
+    */
+   private OrderModel resolveNamedGroupOrder(RuntimeViewsheet rvs, CalcTableVSAssembly assembly,
+                                             String runtimeId, Principal user,
+                                             CapturingCommandDispatcher dispatcher,
+                                             String column, String namedGroup)
+      throws Exception
+   {
+      for(DefaultNamedGroupAssembly ngAssembly : worksheetNamedGroups(rvs, assembly, column)) {
+         if(namedGroup.equals(ngAssembly.getName())) {
+            return worksheetLocalOrder(ngAssembly);
+         }
+      }
+
+      List<String> registered = predefinedNamedGroupNames(
+         runtimeId, user, dispatcher, assembly.getAbsoluteName(), column);
+
+      if(registered.contains(namedGroup)) {
+         NamedGroupInfoModel ngInfoModel = new NamedGroupInfoModel();
+         ngInfoModel.setType(XNamedGroupInfo.ASSET_NAMEDGROUP_INFO);
+         ngInfoModel.setName(namedGroup);
+         OrderModel orderModel = new OrderModel();
+         orderModel.setType(XConstants.SORT_SPECIFIC);
+         orderModel.setInfo(ngInfoModel);
+         return orderModel;
+      }
+
+      throw new IllegalArgumentException(
+         "'" + namedGroup + "' is not a named group on column '" + column + "' -- it matches " +
+         "neither a worksheet-local group created by add_named_group nor a repository-" +
+         "registered predefined named group. list_named_groups reports what is available.");
+   }
+
+   /**
+    * Converts a worksheet-local {@code DefaultNamedGroupAssembly}'s per-group conditions into
+    * the {@code EXPERT_NAMEDGROUP_INFO} shape {@code VSTableLayoutService.setNamedGroupInfo}
+    * consumes.
+    *
+    * <p>This cannot reuse {@code NamedGroupInfoModel.fixNamedGroupInfoModel} -- that method skips
+    * anything whose {@code getType()} isn't {@code EXPERT}/{@code SIMPLE}, and a worksheet-local
+    * assembly's {@code NamedGroupInfo.getType()} hard-codes {@code ASSET_NAMEDGROUP_INFO} even
+    * though it holds inline per-group {@code ConditionList}s. The conversion itself is the same
+    * technique that method uses.
+    *
+    * <p>{@code SORT_SPECIFIC} on the order is not optional decoration: {@code OrderInfo.isSpecific()}
+    * -- which reads this exact bit -- gates whether {@code OrderInfo.createSortOrder} ever folds
+    * the named-group conditions into the {@code SortOrder} StyleBI actually groups by. Without
+    * it the named group is attached but never takes effect.
+    */
+   private OrderModel worksheetLocalOrder(DefaultNamedGroupAssembly ngAssembly) throws Exception {
+      NamedGroupInfoModel ngInfoModel = new NamedGroupInfoModel();
+      ngInfoModel.setType(XNamedGroupInfo.EXPERT_NAMEDGROUP_INFO);
+
+      for(String group : ngAssembly.getNamedGroupInfo().getGroups(false)) {
+         Object[] conditions = ConditionUtil.fromConditionListToModel(
+            ngAssembly.getNamedGroupInfo().getGroupCondition(group), refModelService);
+         ConditionExpression conditionExpression = new ConditionExpression();
+         conditionExpression.setName(group);
+         conditionExpression.setList(conditions);
+         ngInfoModel.addCondition(conditionExpression);
+      }
+
+      OrderModel orderModel = new OrderModel();
+      orderModel.setType(XConstants.SORT_SPECIFIC);
+      orderModel.setInfo(ngInfoModel);
+      return orderModel;
    }
 
    /**
@@ -551,6 +679,14 @@ public class CalcTableService {
          "A cell's 'field' must be an object such as {column: \"Region\", type: \"dimension\"}.");
    }
 
+   /** A field's named-group name, if it carries one. {@code null} means none was given. */
+   private static String namedGroupOf(Object field) {
+      Object namedGroup = field instanceof FieldRef ref ? ref.namedGroup()
+         : field instanceof Map<?, ?> map ? map.get("namedGroup") : null;
+      String text = namedGroup == null ? "" : String.valueOf(namedGroup).trim();
+      return text.isEmpty() ? null : text;
+   }
+
    private static TableCell cellAt(int row, int col) {
       TableCell cell = new TableCell();
       cell.setRow(row);
@@ -609,4 +745,5 @@ public class CalcTableService {
 
    private final ViewsheetSessionService sessions;
    private final VSTableLayoutService layoutService;
+   private final DataRefModelFactoryService refModelService;
 }

--- a/core/src/test/java/inetsoft/web/wiz/binding/CalcTableServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/CalcTableServiceTest.java
@@ -29,19 +29,27 @@ import inetsoft.report.GroupableCellBinding;
 import inetsoft.report.TableCellBinding;
 import inetsoft.report.TableLayout;
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.Condition;
+import inetsoft.uql.ConditionItem;
+import inetsoft.uql.ConditionList;
+import inetsoft.uql.XConstants;
 import inetsoft.uql.asset.Assembly;
 import inetsoft.uql.asset.AttachedAssembly;
 import inetsoft.uql.asset.DefaultNamedGroupAssembly;
+import inetsoft.uql.asset.NamedGroupInfo;
 import inetsoft.uql.asset.SourceInfo;
 import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.util.XNamedGroupInfo;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.CalcTableVSAssemblyInfo;
 import inetsoft.web.binding.controller.VSTableLayoutService;
+import inetsoft.web.binding.drm.DataRefModel;
 import inetsoft.web.binding.event.CopyCutCalcCellEvent;
 import inetsoft.web.binding.event.ModifyTableLayoutEvent;
 import inetsoft.web.binding.event.SetCellBindingEvent;
 import inetsoft.web.binding.model.table.CellBindingInfo;
+import inetsoft.web.binding.service.DataRefModelFactoryService;
 import inetsoft.web.wiz.viewsheet.ViewsheetSessionService;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -317,7 +325,8 @@ class CalcTableServiceTest {
 
    private record Harness(CalcTableService service, ViewsheetSessionService sessions,
                           VSTableLayoutService layoutService, Viewsheet viewsheet,
-                          CalcTableVSAssemblyInfo assemblyInfo) {}
+                          CalcTableVSAssemblyInfo assemblyInfo,
+                          DataRefModelFactoryService refModelService) {}
 
    private static Harness harness(int rows, int cols) {
       CalcTableVSAssembly assembly = mock(CalcTableVSAssembly.class);
@@ -345,10 +354,13 @@ class CalcTableServiceTest {
       ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
 
       try {
+         // A real CapturingCommandDispatcher, not a bare null: resolving a namedGroup against
+         // the repository-registered list dispatches GetPredefinedNamedGroupCommand the same
+         // way a read does, and needs somewhere real to land.
          doAnswer(invocation -> {
             ViewsheetSessionService.Mutation mutation = invocation.getArgument(2);
-            mutation.run(rvs, "rt1", null);
-            return null;
+            return CapturingCommandDispatcher.withCapturingDispatcher(
+               principal(), dispatcher -> { mutation.run(rvs, "rt1", dispatcher); return null; });
          }).when(sessions).mutate(anyString(), any(Principal.class), any());
          when(sessions.resolve(anyString(), any(Principal.class))).thenReturn(rvs);
 
@@ -366,8 +378,10 @@ class CalcTableServiceTest {
       }
 
       VSTableLayoutService layoutService = mock(VSTableLayoutService.class);
-      return new Harness(new CalcTableService(sessions, layoutService), sessions, layoutService,
-                         vs, info);
+      DataRefModelFactoryService refModelService = mock(DataRefModelFactoryService.class);
+      when(refModelService.createDataRefModel(any())).thenReturn(mock(DataRefModel.class));
+      return new Harness(new CalcTableService(sessions, layoutService, refModelService), sessions,
+                         layoutService, vs, info, refModelService);
    }
 
    private static Principal principal() {
@@ -460,6 +474,114 @@ class CalcTableServiceTest {
       @SuppressWarnings("unchecked")
       List<String> groups = (List<String>) read.get("namedGroups");
       assertTrue(groups.contains("Regions"), "expected worksheet-local group in: " + groups);
+   }
+
+   /**
+    * The confirmed silent-drop defect: {@code field.namedGroup} naming a worksheet-local group
+    * created via {@code add_named_group} must land on {@code CellBindingInfo.order} as an
+    * {@code EXPERT_NAMEDGROUP_INFO} built from that assembly's own per-group conditions, with
+    * {@code order.type == SORT_SPECIFIC} -- the bit {@code OrderInfo.isSpecific()} gates before
+    * a named group's conditions are ever folded into the actual grouping order.
+    */
+   @Test
+   void bindsAWorksheetLocalNamedGroupAsAnExpertOrder() throws Exception {
+      Harness h = harness(3, 3);
+      when(h.assemblyInfo().getSourceInfo())
+         .thenReturn(new SourceInfo(SourceInfo.ASSET, null, "Query1"));
+
+      Condition condition = mock(Condition.class);
+      when(condition.getOperation()).thenReturn(Condition.EQUAL_TO);
+      when(condition.getValues()).thenReturn(List.of("CA"));
+      ConditionList conditionList = new ConditionList();
+      conditionList.append(new ConditionItem(new AttributeRef(null, "REGION"), condition, 0));
+      NamedGroupInfo namedGroupInfo = new NamedGroupInfo();
+      namedGroupInfo.setGroupCondition("West", conditionList);
+
+      DefaultNamedGroupAssembly ngAssembly = mock(DefaultNamedGroupAssembly.class);
+      when(ngAssembly.getName()).thenReturn("Coastal");
+      when(ngAssembly.getAttachedType()).thenReturn(AttachedAssembly.COLUMN_ATTACHED);
+      when(ngAssembly.getAttachedSource())
+         .thenReturn(new SourceInfo(SourceInfo.ASSET, null, "Query1"));
+      when(ngAssembly.getAttachedAttribute()).thenReturn(new AttributeRef(null, "REGION"));
+      when(ngAssembly.getNamedGroupInfo()).thenReturn(namedGroupInfo);
+
+      Worksheet ws = mock(Worksheet.class);
+      when(ws.getAssemblies()).thenReturn(new Assembly[]{ ngAssembly });
+      when(h.viewsheet().getBaseWorksheet()).thenReturn(ws);
+
+      h.service.setCellBinding("tok", principal(), "Calc1", 0, 0,
+                               spec("content", "column", "grouping", "group", "expand", "vertical",
+                                    "field", Map.of("column", "REGION", "type", "dimension",
+                                                    "namedGroup", "Coastal")));
+
+      ArgumentCaptor<SetCellBindingEvent> captor =
+         ArgumentCaptor.forClass(SetCellBindingEvent.class);
+      verify(h.layoutService).setCellBinding(eq("rt1"), captor.capture(), any(Principal.class),
+                                             any());
+      inetsoft.web.binding.model.table.OrderModel order = captor.getValue().getBinding().getOrder();
+      assertEquals(XConstants.SORT_SPECIFIC, order.getType());
+      assertEquals(XNamedGroupInfo.EXPERT_NAMEDGROUP_INFO, order.getInfo().getType());
+      List<inetsoft.web.composer.model.condition.ConditionExpression> conds =
+         order.getInfo().getConditions();
+      assertEquals(1, conds.size());
+      assertEquals("West", conds.get(0).getName());
+      assertEquals(1, conds.get(0).getList().length);
+   }
+
+   /**
+    * A {@code namedGroup} that matches no worksheet-local assembly is treated as a genuine
+    * repository-registered predefined named group, exactly the shape the real Composer UI
+    * sends: {@code order.info = {name, type: ASSET_NAMEDGROUP_INFO}}, letting
+    * {@code VSTableLayoutService.setNamedGroupInfo}'s existing branch resolve it.
+    */
+   @Test
+   void bindsARegisteredPredefinedNamedGroupAsAnAssetReference() throws Exception {
+      Harness h = harness(3, 3);
+      GetPredefinedNamedGroupCommand command = new GetPredefinedNamedGroupCommand(
+         new AssetNamedGroupInfo[0]);
+      command.setNamedGroups(new String[]{ "Tiers" });
+      doAnswer(invocation -> {
+         CommandDispatcher dispatcher = invocation.getArgument(3);
+         dispatcher.sendCommand("Calc1", command);
+         return null;
+      }).when(h.layoutService).getNamedGroup(anyString(),
+                                             any(GetPredefinedNamedGroupEvent.class),
+                                             any(Principal.class), any());
+
+      h.service.setCellBinding("tok", principal(), "Calc1", 0, 0,
+                               spec("content", "column", "grouping", "group", "expand", "vertical",
+                                    "field", Map.of("column", "REGION", "type", "dimension",
+                                                    "namedGroup", "Tiers")));
+
+      ArgumentCaptor<SetCellBindingEvent> captor =
+         ArgumentCaptor.forClass(SetCellBindingEvent.class);
+      verify(h.layoutService).setCellBinding(eq("rt1"), captor.capture(), any(Principal.class),
+                                             any());
+      inetsoft.web.binding.model.table.OrderModel order = captor.getValue().getBinding().getOrder();
+      assertEquals(XConstants.SORT_SPECIFIC, order.getType());
+      assertEquals(XNamedGroupInfo.ASSET_NAMEDGROUP_INFO, order.getInfo().getType());
+      assertEquals("Tiers", order.getInfo().getName());
+   }
+
+   /**
+    * A {@code namedGroup} matching neither a worksheet-local assembly nor the repository-
+    * registered list must fail loud, naming the field/column -- rather than silently building a
+    * dangling {@code ASSET_NAMEDGROUP_INFO} reference that resolves to nothing at render time.
+    */
+   @Test
+   void refusesAnUnrecognizedNamedGroup() {
+      Harness h = harness(3, 3);
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> h.service.setCellBinding(
+            "tok", principal(), "Calc1", 0, 0,
+            spec("content", "column", "grouping", "group", "expand", "vertical",
+                 "field", Map.of("column", "REGION", "type", "dimension",
+                                 "namedGroup", "NoSuchGroup"))));
+
+      assertTrue(thrown.getMessage().contains("NoSuchGroup"));
+      assertTrue(thrown.getMessage().contains("REGION"));
    }
 
    @Test


### PR DESCRIPTION
## Summary

Follow-up to #4702's `namedGroups()` listing fix. That PR made worksheet-local named groups (created via `add_named_group`) show up in `list_named_groups`, but flagged an open question: whether such a group could actually be *bound* via `set_cell_binding`'s `field.namedGroup` parameter, or whether listing was cosmetic.

**Answer: it was a complete no-op, for any named group, not just worksheet-local ones.** `CalcTableService.toCellBindingInfo` never called `CellBindingInfo.setOrder(...)`, so `order` stayed at its Java default (`OrderModel` wrapping a `NamedGroupInfoModel` with `type=0`) — which satisfies neither branch of `VSTableLayoutService.setNamedGroupInfo`. A caller naming a named group got a cell that silently bound by column alone, with `{ok: true}` and no indication the name was dropped. Textbook CLAUDE.md "tool-misuse is a plugin gap" shape.

## Fix

`resolveNamedGroupOrder` (new, in `CalcTableService.java`) resolves a `namedGroup` name in two steps:
1. **Worksheet-local match** (a `DefaultNamedGroupAssembly` attached to the same table+column): converts its own per-group `ConditionList`s into an `EXPERT_NAMEDGROUP_INFO`-shaped order — the same shape a human drawing an ad-hoc group in the Composer produces.
2. **No local match**: treated as a genuine repository-registered predefined named group — builds an `ASSET_NAMEDGROUP_INFO` reference by name, exactly what the real Composer's `calc-group-option` UI sends, letting the existing (already-working) `VSTableLayoutService.setNamedGroupInfo` asset branch resolve it.
3. **Neither matches**: fails loud with an `IllegalArgumentException` naming the field/column, instead of silently building a dangling asset reference.

`order.type` is set to `XConstants.SORT_SPECIFIC` in both branches — confirmed (not just inferred by analogy) via `OrderInfo.isSpecific()`/`createSortOrder` that this bit gates whether the named-group conditions are ever folded into the actual `SortOrder` StyleBI groups by; without it the group is attached but inert.

Also updates `namedGroups()`'s response note (added by #4702), which previously hedged that bindability wasn't confirmed — that's now resolved.

**Explicitly out of scope, left alone:** the same silent-drop defect pattern exists on the chart/table binding path (`FieldRefFactory`, `TableBindingMutator` — neither reads `field.namedGroup()` either). That's a separate seam with its own call sites; flagging as a follow-up finding, not fixed here.

## Test plan

- [x] 3 new regression tests in `CalcTableServiceTest`: worksheet-local → `EXPERT_NAMEDGROUP_INFO` with correct converted conditions; registered-asset name → `ASSET_NAMEDGROUP_INFO` reference; unrecognized name → `IllegalArgumentException` naming the field/column
- [x] `./mvnw -pl core -Dtest=CalcTableServiceTest test` (from the worktree root) — 37/37 passing
- [x] Collateral: `RuntimeCalcTableLensTest,LayoutToolTest,CalcTableLensTest,CalcCellVocabularyTest` — all passing
- [x] Broad collateral: `-Dtest="inetsoft.web.wiz.**"` — 2113 tests / 185 classes, 0 failures
- [ ] Not verified against a live StyleBI server/browser — unit/Maven-level testing was the ceiling available in this environment

🤖 Generated with a multi-agent debugger/fixer pass (Claude Code)