### PR TITLE
Report a bounded sample of an endpoint's rows from the request the table build already made

### DIFF
--- a/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/EndpointJsonQueryRunner.java
+++ b/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/EndpointJsonQueryRunner.java
@@ -26,7 +26,9 @@ import inetsoft.uql.rest.json.RestDataIteratorStrategyFactory;
 import inetsoft.uql.rest.json.RestJsonQuery;
 import inetsoft.uql.rest.json.lookup.*;
 import inetsoft.uql.rest.json.lookup.LookupService;
+import inetsoft.sree.SreeEnv;
 import inetsoft.uql.util.BaseJsonTable;
+import inetsoft.uql.util.JsonRowSampler;
 import inetsoft.uql.util.JsonShapeDistiller;
 import inetsoft.uql.util.LookupList;
 import inetsoft.uql.util.LookupMap;
@@ -59,6 +61,7 @@ public class EndpointJsonQueryRunner extends RestJsonQueryRunner {
          strategy.setTouchTimestamp(getTouchTimestamp());
 
          boolean shaped = false;
+         boolean sampled = false;
 
          while(hasNext(strategy, table)) {
             final Object json = strategy.next();
@@ -92,6 +95,21 @@ public class EndpointJsonQueryRunner extends RestJsonQueryRunner {
             doLookups(query, json);
 
             final Object selectedData = selectData(json, query.getValidJsonPath(), transformer);
+
+            // Sample the ROWS, and note that every "before" in the comment above is an "after" here.
+            // The shape answers where the rows are; the sample answers what is in them, so it has to
+            // be taken from what jsonPath actually selected and after doLookups has grafted the
+            // lookup fields in -- otherwise it would report values the built table does not have.
+            //
+            // Still the FIRST page only, and for a different reason than the shape: later pages are
+            // more of the same data, and this is a sample rather than a read. Also before
+            // loadStreamed, because that flattens nested objects into columns (JsonTable.walkRecord)
+            // and the response's own structure cannot be recovered from the result.
+            if(!sampled) {
+               sampled = true;
+               sampleRows(selectedData);
+            }
+
             table.loadStreamed(selectedData);
          }
       }
@@ -121,6 +139,39 @@ public class EndpointJsonQueryRunner extends RestJsonQueryRunner {
          LOG.debug("Failed to distil the response shape for " + query.getClass().getSimpleName(), ex);
       }
    }
+
+   /**
+    * Record a bounded sample of the selected rows on the query, swallowing anything that goes wrong
+    * — a by-product, on the same terms as {@link #shapeResponse}.
+    *
+    * <p>{@code rest.sample.rows} is the row cap AND the switch: at {@code 0} nothing is sampled and
+    * no response values leave the connector. One property rather than a flag plus a size, because
+    * "how much customer data may travel" is a single decision, and it belongs to the deployment
+    * rather than to the caller — a caller-supplied opt-in would have to be known about in advance,
+    * which is exactly the extra round trip the sample exists to remove. A value that is not a
+    * number lands in the catch below and yields no sample, which is the right way to be wrong about
+    * a knob that governs customer data.</p>
+    */
+   private void sampleRows(Object selectedData) {
+      try {
+         int maxRows = Integer.parseInt(
+            SreeEnv.getProperty(SAMPLE_ROWS_PROPERTY,
+                                Integer.toString(JsonRowSampler.DEFAULT_MAX_ROWS)));
+
+         if(maxRows <= 0) {
+            return;
+         }
+
+         JsonRowSampler.Result result = JsonRowSampler.sample(selectedData, maxRows);
+         query.setSampleRows(result.getRows(), result.isTruncated());
+      }
+      catch(Exception ex) {
+         LOG.debug("Failed to sample rows for " + query.getClass().getSimpleName(), ex);
+      }
+   }
+
+   /** Rows to sample per build, and at 0 the switch that turns sampling off entirely. */
+   private static final String SAMPLE_ROWS_PROPERTY = "rest.sample.rows";
 
    private static final Logger LOG =
       LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());

--- a/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/EndpointJsonQueryRunner.java
+++ b/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/EndpointJsonQueryRunner.java
@@ -144,25 +144,36 @@ public class EndpointJsonQueryRunner extends RestJsonQueryRunner {
     * Record a bounded sample of the selected rows on the query, swallowing anything that goes wrong
     * — a by-product, on the same terms as {@link #shapeResponse}.
     *
-    * <p>{@code rest.sample.rows} is the row cap AND the switch: at {@code 0} nothing is sampled and
-    * no response values leave the connector. One property rather than a flag plus a size, because
-    * "how much customer data may travel" is a single decision, and it belongs to the deployment
-    * rather than to the caller — a caller-supplied opt-in would have to be known about in advance,
-    * which is exactly the extra round trip the sample exists to remove. A value that is not a
-    * number lands in the catch below and yields no sample, which is the right way to be wrong about
-    * a knob that governs customer data.</p>
+    * <p>NOTHING IS SAMPLED UNLESS THE CALLER ASKED. {@code TabularQuery.getSampleRowLimit} is 0 by
+    * default, so every path that does not set it — the composer dialog, every later render, any
+    * caller that only wanted columns — runs exactly the request it ran before and pays for exactly
+    * the response it did before. Rows are returned to whoever asked for them and are spent tokens
+    * in that answer, which makes the count the caller's decision rather than a default.</p>
+    *
+    * <p>{@code rest.sample.rows} is the CEILING on that decision, and at {@code 0} the switch that
+    * stops any response value leaving the connector no matter what is requested. So the deployment
+    * bounds the exposure and the caller bounds the cost; neither can override the other. A value
+    * that is not a number lands in the catch below and yields no sample, which is the right way to
+    * be wrong about a knob that governs customer data.</p>
     */
    private void sampleRows(Object selectedData) {
       try {
-         int maxRows = Integer.parseInt(
-            SreeEnv.getProperty(SAMPLE_ROWS_PROPERTY,
-                                Integer.toString(JsonRowSampler.DEFAULT_MAX_ROWS)));
+         int requested = query.getSampleRowLimit();
 
-         if(maxRows <= 0) {
+         if(requested <= 0) {
             return;
          }
 
-         JsonRowSampler.Result result = JsonRowSampler.sample(selectedData, maxRows);
+         int ceiling = Integer.parseInt(
+            SreeEnv.getProperty(SAMPLE_ROWS_PROPERTY,
+                                Integer.toString(JsonRowSampler.DEFAULT_MAX_ROWS)));
+
+         if(ceiling <= 0) {
+            return;
+         }
+
+         JsonRowSampler.Result result =
+            JsonRowSampler.sample(selectedData, Math.min(requested, ceiling));
          query.setSampleRows(result.getRows(), result.isTruncated());
       }
       catch(Exception ex) {
@@ -170,7 +181,10 @@ public class EndpointJsonQueryRunner extends RestJsonQueryRunner {
       }
    }
 
-   /** Rows to sample per build, and at 0 the switch that turns sampling off entirely. */
+   /**
+    * The most rows a caller may have reported back, and at 0 the switch that turns sampling off
+    * entirely. A ceiling, not a default: a caller that asks for nothing gets nothing.
+    */
    private static final String SAMPLE_ROWS_PROPERTY = "rest.sample.rows";
 
    private static final Logger LOG =

--- a/connectors/inetsoft-tabular-util/src/main/java/inetsoft/uql/util/JsonRowSampler.java
+++ b/connectors/inetsoft-tabular-util/src/main/java/inetsoft/uql/util/JsonRowSampler.java
@@ -1,0 +1,262 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.util;
+
+import java.util.*;
+
+/**
+ * Take a bounded sample of the rows a JSON response actually carried, in the response's own
+ * structure.
+ *
+ * <p>The counterpart of {@link JsonShapeDistiller}, and deliberately its opposite: that one reports
+ * which paths exist and drops every value, this one reports values. So the two answer different
+ * questions — where the rows are and what they are called, versus what is in them — and neither
+ * replaces the other.</p>
+ *
+ * <p>CARRYING VALUES IS THE WHOLE POINT AND ALSO THE WHOLE RISK. These are customer data, not a
+ * property of the connector: unlike a shape, a sample must never be recorded once and reused for
+ * everyone, and the amount of it that travels has to be bounded at the source. Hence the budget
+ * below, and hence the caller-side kill switch that decides whether to ask for a sample at all
+ * ({@code EndpointJsonQueryRunner}).</p>
+ *
+ * <p>THE BUDGET HAS FOUR LIMITS, and they are not interchangeable:</p>
+ * <ul>
+ *   <li>rows — how many rows a caller needs to read a set of parameter values off;</li>
+ *   <li>nodes — the total size of the sample, which rows alone do not bound: one row of a payments
+ *       API can carry a hundred fields;</li>
+ *   <li>depth — how far into a nested object the sample goes;</li>
+ *   <li>string length — the one limit that a row count cannot approximate at all, since a single
+ *       description, HTML body or base64 blob outweighs every other field in the response.</li>
+ * </ul>
+ *
+ * <p>WHOLE ROWS ONLY. When the node budget runs out mid-row the row is dropped rather than
+ * half-copied, because a half row reads as a row whose remaining fields the response did not have.
+ * The same reasoning drives the markers: an over-long value is REPLACED by
+ * {@code "<omitted: N chars>"} and never truncated in place, because a truncated id is a wrong
+ * value that looks entirely valid and will be sent back as a parameter, whereas a marker cannot be
+ * mistaken for data. Any limit firing sets {@link Result#isTruncated()}: "this path is absent from
+ * the sample" then means "not sampled", not "not in the response".</p>
+ */
+public final class JsonRowSampler {
+   /** Rows per sample. Enough to read a set of parameter values off, not enough to be a data feed. */
+   public static final int DEFAULT_MAX_ROWS = 20;
+
+   /** Total nodes across all rows. Beyond this, whole rows are dropped. */
+   public static final int DEFAULT_MAX_NODES = 2000;
+
+   /** Nesting depth beyond which a subtree is replaced by {@link #OMITTED_DEPTH}. */
+   public static final int DEFAULT_MAX_DEPTH = 8;
+
+   /**
+    * String values longer than this are replaced by a marker. Ids, dates, emails and gids — the
+    * values a caller samples for — are far shorter; bodies and blobs are far longer.
+    */
+   public static final int DEFAULT_MAX_STRING = 200;
+
+   /** Stands in for a subtree that the depth cap cut off. Never a value from the response. */
+   public static final String OMITTED_DEPTH = "<omitted: depth>";
+
+   private JsonRowSampler() {
+   }
+
+   /** The sampled rows, plus whether any limit cut the sample short. */
+   public static final class Result {
+      private final List<?> rows;
+      private final boolean truncated;
+
+      Result(List<?> rows, boolean truncated) {
+         this.rows = rows;
+         this.truncated = truncated;
+      }
+
+      /**
+       * The rows, in the response's own structure — nested objects stay nested, and NOT flattened
+       * the way {@link JsonTable#loadStreamed} flattens them into columns. Never null; empty when
+       * the selection held no rows.
+       *
+       * <p>UNMODIFIABLE, recursively. It is held by a query, shared with every clone of that query
+       * and with the response that reports it, so in-place mutation anywhere would corrupt state
+       * shared across query instances.</p>
+       */
+      public List<?> getRows() {
+         return rows;
+      }
+
+      /**
+       * True when the sample is not a faithful copy of the rows it was taken from: rows were left
+       * out, or a value was replaced by a marker. A caller extracting parameter values has to
+       * treat this as "I have not necessarily seen every distinct value".
+       */
+      public boolean isTruncated() {
+         return truncated;
+      }
+   }
+
+   public static Result sample(Object selectedData, int maxRows) {
+      return sample(selectedData, maxRows, DEFAULT_MAX_NODES, DEFAULT_MAX_DEPTH, DEFAULT_MAX_STRING);
+   }
+
+   /**
+    * @param selectedData what the row path selected — a list of rows to sample from. Anything else
+    *                     (a single object, a scalar, null) yields no rows, which is not an error:
+    *                     it is a response this sample has nothing to say about.
+    * @param maxRows      rows to keep; zero or less yields no rows.
+    */
+   public static Result sample(Object selectedData, int maxRows, int maxNodes, int maxDepth,
+                               int maxString)
+   {
+      if(!(selectedData instanceof List) || maxRows <= 0) {
+         return new Result(List.of(), false);
+      }
+
+      List<?> selected = (List<?>) selectedData;
+      List<Object> rows = new ArrayList<>();
+      Budget budget = new Budget(maxNodes, maxDepth, maxString);
+      boolean dropped = false;
+
+      for(int i = 0; i < selected.size(); i++) {
+         // Reached here with an element still in hand, so there IS something the sample leaves out.
+         if(rows.size() >= maxRows) {
+            dropped = true;
+            break;
+         }
+
+         Object row = copyOf(selected.get(i), budget, 0);
+
+         if(budget.exhausted) {
+            dropped = true;
+            break;
+         }
+
+         rows.add(row);
+      }
+
+      return new Result(Collections.unmodifiableList(rows), dropped || budget.trimmed);
+   }
+
+   /**
+    * Copy one value, spending budget as it goes.
+    *
+    * <p>The copy is built fresh rather than sharing the response's own maps: the response object is
+    * still being consumed by {@code loadStreamed} and by lookups after this returns, and a sample
+    * that aliased it would report whatever those did next. Each container is wrapped unmodifiable
+    * as it is finished, so the tree is immutable on the way out with no second pass.</p>
+    *
+    * @return the copy, or an incomplete value once {@link Budget#exhausted} is set — the caller
+    *         discards the whole row in that case, so what is returned no longer matters.
+    */
+   private static Object copyOf(Object value, Budget budget, int depth) {
+      if(!budget.spend()) {
+         return null;
+      }
+
+      // Only containers are cut by depth. A scalar at the cut is already bounded by maxString, and
+      // dropping it would cost the caller a value it could have used for nothing.
+      if((value instanceof Map || value instanceof List) && depth >= budget.maxDepth) {
+         budget.trimmed = true;
+         return OMITTED_DEPTH;
+      }
+
+      if(value instanceof Map) {
+         Map<String, Object> copy = new LinkedHashMap<>();
+
+         for(Map.Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
+            if(!(entry.getKey() instanceof String)) {
+               continue;
+            }
+
+            Object child = copyOf(entry.getValue(), budget, depth + 1);
+
+            if(budget.exhausted) {
+               return null;
+            }
+
+            copy.put((String) entry.getKey(), child);
+         }
+
+         return Collections.unmodifiableMap(copy);
+      }
+
+      if(value instanceof List) {
+         List<Object> copy = new ArrayList<>();
+
+         for(Object element : (List<?>) value) {
+            Object child = copyOf(element, budget, depth + 1);
+
+            if(budget.exhausted) {
+               return null;
+            }
+
+            copy.add(child);
+         }
+
+         return Collections.unmodifiableList(copy);
+      }
+
+      return leaf(value, budget);
+   }
+
+   /**
+    * A leaf value, converted through the same function the table uses
+    * ({@link JsonTable#getJavaValue}) so a sampled value and the built table's value agree, and so
+    * the JSON-P and Jackson object models arrive as Java values rather than as wrapper objects a
+    * caller could not use.
+    */
+   private static Object leaf(Object value, Budget budget) {
+      Object plain = JsonTable.getJavaValue(value);
+
+      if(plain instanceof String && ((String) plain).length() > budget.maxString) {
+         budget.trimmed = true;
+         return "<omitted: " + ((String) plain).length() + " chars>";
+      }
+
+      return plain;
+   }
+
+   /**
+    * The four limits, carried through the walk so one place records that a limit fired.
+    *
+    * <p>{@code exhausted} and {@code trimmed} are separate because they have different remedies:
+    * the node cap means the row being copied cannot be kept at all, while a marker means the row is
+    * kept and one value in it is not what the response held.</p>
+    */
+   private static final class Budget {
+      private final int maxNodes;
+      private final int maxDepth;
+      private final int maxString;
+      private int nodes;
+      private boolean exhausted;
+      private boolean trimmed;
+
+      Budget(int maxNodes, int maxDepth, int maxString) {
+         this.maxNodes = maxNodes;
+         this.maxDepth = maxDepth;
+         this.maxString = maxString;
+      }
+
+      boolean spend() {
+         if(nodes >= maxNodes) {
+            exhausted = true;
+            return false;
+         }
+
+         nodes++;
+         return true;
+      }
+   }
+}

--- a/connectors/inetsoft-tabular-util/src/test/java/inetsoft/uql/util/JsonRowSamplerTest.java
+++ b/connectors/inetsoft-tabular-util/src/test/java/inetsoft/uql/util/JsonRowSamplerTest.java
@@ -1,0 +1,196 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.util;
+
+import org.junit.jupiter.api.Test;
+
+import javax.json.Json;
+import java.io.StringReader;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * No Spring context here, same as {@link JsonShapeDistillerTest}: the sampler is a pure function
+ * over a parsed JSON value and stands up nothing.
+ *
+ * <p>Most cases are driven through hand-built maps, because that is what {@code selectData} hands
+ * the sampler once JSONPath has run. The JSON-P object model is covered separately
+ * ({@link #convertsJsonPValuesToPlainJava()}), since it is the model whose leaves are wrapper
+ * objects rather than Java values.</p>
+ */
+public class JsonRowSamplerTest {
+   private static Map<String, Object> map(Object... keysAndValues) {
+      Map<String, Object> map = new LinkedHashMap<>();
+
+      for(int i = 0; i < keysAndValues.length; i += 2) {
+         map.put((String) keysAndValues[i], keysAndValues[i + 1]);
+      }
+
+      return map;
+   }
+
+   private static Object parse(String json) {
+      try(javax.json.JsonReader reader = Json.createReader(new StringReader(json))) {
+         return reader.read();
+      }
+   }
+
+   @SuppressWarnings("unchecked")
+   private static Map<String, Object> row(List<?> rows, int index) {
+      return (Map<String, Object>) assertInstanceOf(Map.class, rows.get(index));
+   }
+
+   @Test
+   public void keepsRowsAsRawNestedObjects() {
+      // NOT flattened: JsonTable.walkRecord would report this row as columns id / dispute.status,
+      // and the whole point of sampling before loadStreamed is that the caller sees the response's
+      // own shape. A nested object stays a nested object.
+      List<?> rows = JsonRowSampler.sample(
+         List.of(map("id", "ch_1", "dispute", map("status", "won"))), 20).getRows();
+
+      assertEquals(1, rows.size());
+      Map<String, Object> row = row(rows, 0);
+      assertEquals("ch_1", row.get("id"));
+      assertNull(row.get("dispute.status"));
+
+      Map<?, ?> dispute = assertInstanceOf(Map.class, row.get("dispute"));
+      assertEquals("won", dispute.get("status"));
+   }
+
+   @Test
+   public void capsRowCountAndReportsTruncated() {
+      JsonRowSampler.Result result = JsonRowSampler.sample(
+         List.of(map("gid", "1"), map("gid", "2"), map("gid", "3")), 2);
+
+      assertEquals(2, result.getRows().size());
+      assertEquals("1", row(result.getRows(), 0).get("gid"));
+      assertEquals("2", row(result.getRows(), 1).get("gid"));
+      // The caller has NOT seen every distinct value, which is the whole reason this flag exists.
+      assertTrue(result.isTruncated());
+   }
+
+   @Test
+   public void reportsNoTruncationWhenEverythingFits() {
+      JsonRowSampler.Result result = JsonRowSampler.sample(
+         List.of(map("gid", "1"), map("gid", "2")), 20);
+
+      assertEquals(2, result.getRows().size());
+      assertFalse(result.isTruncated());
+   }
+
+   @Test
+   public void yieldsNoRowsWhenTheSelectionIsNotAList() {
+      // A jsonPath that selected a single object, a scalar, or nothing. Not an error: the caller
+      // simply gets no sample.
+      for(Object selected : new Object[] { map("id", "ch_1"), "scalar", null }) {
+         JsonRowSampler.Result result = JsonRowSampler.sample(selected, 20);
+
+         assertTrue(result.getRows().isEmpty(), "expected no rows for " + selected);
+         assertFalse(result.isTruncated(), "expected no truncation for " + selected);
+      }
+   }
+
+   @Test
+   public void keepsScalarRows() {
+      // A bare array of scalars is a legitimate response, and skipping non-object elements would
+      // silently make "20 rows" mean fewer than 20.
+      List<?> rows = JsonRowSampler.sample(List.of("a", "b"), 20).getRows();
+
+      assertEquals(List.of("a", "b"), rows);
+   }
+
+   @Test
+   public void replacesAnOverlongStringWithAMarkerRatherThanTruncatingIt() {
+      String long300 = "x".repeat(300);
+      JsonRowSampler.Result result = JsonRowSampler.sample(
+         List.of(map("gid", "1234567890", "description", long300)), 20,
+         JsonRowSampler.DEFAULT_MAX_NODES, JsonRowSampler.DEFAULT_MAX_DEPTH, 200);
+
+      Map<String, Object> row = row(result.getRows(), 0);
+      // A truncated id would be a wrong value that looks entirely valid, and would be sent as a
+      // parameter. The marker cannot be mistaken for data.
+      assertEquals("<omitted: 300 chars>", row.get("description"));
+      assertEquals("1234567890", row.get("gid"));
+      assertTrue(result.isTruncated());
+   }
+
+   @Test
+   public void replacesASubtreeBeyondTheDepthCapWithAMarker() {
+      JsonRowSampler.Result result = JsonRowSampler.sample(
+         List.of(map("a", map("b", map("c", "deep")))), 20,
+         JsonRowSampler.DEFAULT_MAX_NODES, 2, JsonRowSampler.DEFAULT_MAX_STRING);
+
+      Map<String, Object> row = row(result.getRows(), 0);
+      Map<?, ?> a = assertInstanceOf(Map.class, row.get("a"));
+      assertEquals(JsonRowSampler.OMITTED_DEPTH, a.get("b"));
+      assertTrue(result.isTruncated());
+   }
+
+   @Test
+   public void dropsAWholeRowWhenTheNodeBudgetRunsOut() {
+      // Three nodes per row (the object plus two leaves), so the second row does not fit in four.
+      JsonRowSampler.Result result = JsonRowSampler.sample(
+         List.of(map("a", "1", "b", "2"), map("a", "3", "b", "4")), 20, 4,
+         JsonRowSampler.DEFAULT_MAX_DEPTH, JsonRowSampler.DEFAULT_MAX_STRING);
+
+      // A half row is a lie: it reads as a row whose fields are absent from the response.
+      assertEquals(1, result.getRows().size());
+      Map<String, Object> row = row(result.getRows(), 0);
+      assertEquals("1", row.get("a"));
+      assertEquals("2", row.get("b"));
+      assertTrue(result.isTruncated());
+   }
+
+   @Test
+   public void returnsRowsThatAreUnmodifiableAllTheWayDown() {
+      // Held by the query, shared with every clone of it and with the response that reports them,
+      // so an in-place mutation anywhere would corrupt state shared across query instances.
+      List<?> rows = JsonRowSampler.sample(
+         List.of(map("id", "ch_1", "dispute", map("status", "won"))), 20).getRows();
+
+      Map<String, Object> row = row(rows, 0);
+      Map<?, ?> nested = assertInstanceOf(Map.class, row.get("dispute"));
+
+      assertThrows(UnsupportedOperationException.class, () -> ((List<Object>) rows).add(map()));
+      assertThrows(UnsupportedOperationException.class, () -> row.put("id", "other"));
+      assertThrows(UnsupportedOperationException.class,
+                   () -> ((Map<String, Object>) nested).put("status", "lost"));
+   }
+
+   @Test
+   public void convertsJsonPValuesToPlainJava() {
+      // JSON-P leaves are wrapper objects (JsonString, JsonNumber, JsonValue.NULL). Left as they
+      // are, the response would serialize the wrappers rather than the values, and a caller could
+      // not use one as a parameter. Converted through the same function the table uses, so a
+      // sampled value and the built table's value agree.
+      List<?> rows = JsonRowSampler.sample(
+         parse("[{\"id\":\"ch_1\",\"amount\":2000,\"live\":true,\"note\":null,"
+                  + "\"tags\":[\"a\"],\"dispute\":{\"status\":\"won\"}}]"), 20).getRows();
+
+      Map<String, Object> row = row(rows, 0);
+      assertEquals("ch_1", row.get("id"));
+      assertEquals(2000.0, row.get("amount"));
+      assertEquals(Boolean.TRUE, row.get("live"));
+      assertNull(row.get("note"));
+      assertEquals(List.of("a"), row.get("tags"));
+
+      Map<?, ?> dispute = assertInstanceOf(Map.class, row.get("dispute"));
+      assertEquals("won", dispute.get("status"));
+   }
+}

--- a/core/src/main/java/inetsoft/uql/tabular/TabularQuery.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularQuery.java
@@ -367,6 +367,44 @@ public abstract class TabularQuery extends XQuery {
    }
 
    /**
+    * A bounded sample of the rows this query's last execution actually read.
+    *
+    * <p>The same kind of slot as {@link #getResponseShape}, on the same terms — core defines it and
+    * never fills it, only the connector sees a response, absent is the normal state — and it
+    * describes ONE EXECUTION too, so it is likewise cleared by {@link #clone()} and never written
+    * to XML.</p>
+    *
+    * <p>What differs is what it carries: a shape is a property of the connector, these rows are
+    * CUSTOMER DATA. So this one must not be recorded and reused for anyone else, and the connector
+    * that fills it bounds it at the source ({@code JsonRowSampler}, and the
+    * {@code rest.sample.rows} property that can switch sampling off entirely).</p>
+    *
+    * <p>A list, but core never looks inside an element: rows are the connector's response format.
+    * Unmodifiable, recursively — see the field comment for why that matters.</p>
+    */
+   public List<?> getSampleRows() {
+      return sampleRows;
+   }
+
+   /**
+    * @param rows      the sampled rows, or null to report none.
+    * @param truncated whether a limit cut the sample short (rows left out, or a value replaced by a
+    *                  marker) — a consumer extracting parameter values has to tell "this value is
+    *                  not in the response" from "this value was not sampled".
+    */
+   public void setSampleRows(List<?> rows, boolean truncated) {
+      this.sampleRows = rows;
+      this.sampleRowsTruncated = truncated;
+   }
+
+   /**
+    * Whether {@link #getSampleRows} left something out rather than copying every row faithfully.
+    */
+   public boolean isSampleRowsTruncated() {
+      return sampleRowsTruncated;
+   }
+
+   /**
     * Copy query properties from an existing query.
     */
    public void copyInfo(TabularQuery query) {
@@ -399,6 +437,11 @@ public abstract class TabularQuery extends XQuery {
       copy.responseShape = null;
       copy.responseShapeTruncated = false;
 
+      // Cleared for the same reason, and the reason applies harder here: these are rows of customer
+      // data, so a clone inheriting them would report one execution's data as another's.
+      copy.sampleRows = null;
+      copy.sampleRowsTruncated = false;
+
       return copy;
    }
 
@@ -413,6 +456,13 @@ public abstract class TabularQuery extends XQuery {
     */
    private Object responseShape;
    private boolean responseShapeTruncated;
+   /**
+    * See {@link #getSampleRows}. Cleared by {@link #clone()}, same as {@code responseShape}, and
+    * shared by reference once set in the same way — so it must not be mutated in place. Enforced at
+    * the producing end: {@code JsonRowSampler} returns a recursively unmodifiable structure.
+    */
+   private List<?> sampleRows;
+   private boolean sampleRowsTruncated;
    private Map<String, String> typemap = new HashMap<>();
    private Map<String, String> fmtmap = new HashMap<>();
    private Map<String, String> extentmap = new HashMap<>();

--- a/core/src/main/java/inetsoft/uql/tabular/TabularQuery.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularQuery.java
@@ -405,6 +405,25 @@ public abstract class TabularQuery extends XQuery {
    }
 
    /**
+    * How many rows the caller asked to have reported back. 0, the default, means none — sampling is
+    * OPT-IN, because rows are of no use to a caller that only wanted the column list and are paid
+    * for in that caller's response.
+    *
+    * <p>An INPUT, and that makes it the mirror image of {@link #getSampleRows} in two ways. It is
+    * NOT cleared by {@link #clone()}: the clone is the object that executes, so a limit the caller
+    * set has to reach it or nothing is ever sampled. And it is not written to XML deliberately
+    * rather than incidentally — a saved query that carried it would sample again on every later
+    * render, holding rows of customer data on a query nobody is reading them from.</p>
+    */
+   public int getSampleRowLimit() {
+      return sampleRowLimit;
+   }
+
+   public void setSampleRowLimit(int sampleRowLimit) {
+      this.sampleRowLimit = sampleRowLimit;
+   }
+
+   /**
     * Copy query properties from an existing query.
     */
    public void copyInfo(TabularQuery query) {
@@ -463,6 +482,11 @@ public abstract class TabularQuery extends XQuery {
     */
    private List<?> sampleRows;
    private boolean sampleRowsTruncated;
+   /**
+    * See {@link #getSampleRowLimit}. Deliberately NOT cleared by {@link #clone()} — it is the
+    * caller's request rather than an execution's result, and the clone is what executes.
+    */
+   private int sampleRowLimit;
    private Map<String, String> typemap = new HashMap<>();
    private Map<String, String> fmtmap = new HashMap<>();
    private Map<String, String> extentmap = new HashMap<>();

--- a/core/src/main/java/inetsoft/uql/tabular/impl/TabularHandler.java
+++ b/core/src/main/java/inetsoft/uql/tabular/impl/TabularHandler.java
@@ -103,6 +103,12 @@ public class TabularHandler extends XHandler {
       oquery.setResponseShape(((TabularQuery) query).getResponseShape(),
                               ((TabularQuery) query).isResponseShapeTruncated());
 
+      // Same clone boundary, same unconditional copy, same dependence on clone() clearing the field
+      // -- see above. Kept as a second call rather than folded into one: a sample is rows of customer
+      // data and a shape is not, so the two are switched, bounded and consumed separately.
+      oquery.setSampleRows(((TabularQuery) query).getSampleRows(),
+                           ((TabularQuery) query).isSampleRowsTruncated());
+
       if(tbl != null && tbl.getColCount() > 0) {
          int max = TabularUtil.getMaxRows(query, params);
 

--- a/core/src/main/java/inetsoft/web/wiz/model/WorksheetTable.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WorksheetTable.java
@@ -182,6 +182,7 @@ public class WorksheetTable {
       private Boolean expanded;
       private String expandedPath;
       private Integer maxRows;
+      private Integer sampleRows;
 
       /** Full repository path of the connector INSTANCE, e.g. "SaaS/Stripe Prod". */
       public String getDatasourcePath() { return datasourcePath; }
@@ -221,6 +222,21 @@ public class WorksheetTable {
        */
       public Integer getMaxRows() { return maxRows; }
       public void setMaxRows(Integer maxRows) { this.maxRows = maxRows; }
+
+      /**
+       * How many rows of DATA to report back in {@code WorksheetTableResponse.sampleRows}. Null or
+       * 0 reports none, which is the default: the rows are of no use to a caller that only needed
+       * the column list, and they are paid for in that caller's response.
+       *
+       * <p>NOT a row cap and unrelated to {@link #getMaxRows}. This bounds what is REPORTED from the
+       * one request the build already makes; maxRows bounds what every later render FETCHES.</p>
+       *
+       * <p>Capped by {@code rest.sample.rows}, so a request larger than the deployment allows is
+       * clamped rather than refused, and a deployment that sets it to 0 returns no rows whatever is
+       * asked for here.</p>
+       */
+      public Integer getSampleRows() { return sampleRows; }
+      public void setSampleRows(Integer sampleRows) { this.sampleRows = sampleRows; }
    }
 
    // ─── Nested: column info ─────────────────────────────────────────────────

--- a/core/src/main/java/inetsoft/web/wiz/model/WorksheetTableResponse.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WorksheetTableResponse.java
@@ -69,6 +69,31 @@ public class WorksheetTableResponse {
     */
    private boolean responseSchemaTruncated;
 
+   /**
+    * Rows from the endpoint's first page, as the row path selected them — the VALUES, where
+    * {@code responseSchema} carries only the structure. Present only for a {@code tabular table},
+    * only when the connector reported some, and never when {@code rest.sample.rows} is 0.
+    *
+    * <p>A caller reads these to resolve a parameter whose legal values live in another endpoint's
+    * data: {@code Section Tasks} needs a section, and the sections are rows of
+    * {@code Project Sections}. Without them that costs a viewsheet, which is a chart runtime built
+    * to read four ids out of.</p>
+    *
+    * <p>RAW RESPONSE KEYS, NOT the flattened names in {@code columns}. {@code JsonTable.walkRecord}
+    * joins nested keys with "." to build the column list, so {@code {a:{b:1}}} is column
+    * {@code a.b} there and a nested object here. Take a column name from {@code columns}; take a
+    * value from these.</p>
+    */
+   private List<?> sampleRows;
+
+   /**
+    * True when {@code sampleRows} is not a faithful copy of the first page's rows: rows were left
+    * out, or a value was replaced by an {@code "<omitted: ...>"} marker (too long, or too deep).
+    * A consumer extracting parameter values must not read the sample as the full set of values —
+    * under truncation, a value's absence means "not sampled", not "not in the response".
+    */
+   private boolean sampleRowsTruncated;
+
    private boolean success;
    private String errorMessage;
 
@@ -93,6 +118,15 @@ public class WorksheetTableResponse {
 
    public void setResponseSchemaTruncated(boolean responseSchemaTruncated) {
       this.responseSchemaTruncated = responseSchemaTruncated;
+   }
+
+   public List<?> getSampleRows() { return sampleRows; }
+   public void setSampleRows(List<?> sampleRows) { this.sampleRows = sampleRows; }
+
+   public boolean isSampleRowsTruncated() { return sampleRowsTruncated; }
+
+   public void setSampleRowsTruncated(boolean sampleRowsTruncated) {
+      this.sampleRowsTruncated = sampleRowsTruncated;
    }
 
    public boolean isSuccess() { return success; }

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -1159,6 +1159,12 @@ public class WorksheetTableService {
          requireRowCapWhenPaged(query, src.getEndpoint(), dsName);
       }
 
+      // How many rows to report back, carried ON THE QUERY because the runner is the only place that
+      // sees a response and it is the only thing that can sample one. Zero when the caller did not
+      // ask, which is the default: sampling is opt-in, so a table built without this field runs
+      // exactly the request it ran before and reports exactly the columns.
+      query.setSampleRowLimit(src.getSampleRows() == null ? 0 : Math.max(0, src.getSampleRows()));
+
       TabularTableAssembly table = new TabularTableAssembly(worksheet, request.getTableName());
       TabularTableAssemblyInfo info = (TabularTableAssemblyInfo) table.getTableInfo();
       info.setQuery(query);

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -299,6 +299,7 @@ public class WorksheetTableService {
       response.setTableName(table.getName());
       response.setColumns(columns);
       applyResponseShape(response, table);
+      applyResponseSampleRows(response, table);
 
       if(request.isAsPrimaryTable()) {
          String dbTableOverride = request.getPhysicalSource() != null
@@ -355,6 +356,44 @@ public class WorksheetTableService {
       // the only thing that carries the difference.
       if(query.isResponseShapeTruncated()) {
          response.setResponseSchemaTruncated(true);
+      }
+   }
+
+   /**
+    * Report a sample of the rows the endpoint returned, when this table came from one.
+    *
+    * <p>Same by-product as the shape and from the same single request — see
+    * {@link #applyResponseShape}. What it adds is the VALUES, which is what a caller needs when the
+    * legal values of one endpoint's parameter are rows of another's data; the shape can only say
+    * that the field exists.</p>
+    *
+    * <p>Kept separate from {@code applyResponseShape} rather than folded in, because the two carry
+    * different things: a shape is a property of the connector, and a sample is customer data that
+    * a deployment can switch off ({@code rest.sample.rows}). They are consumed, bounded and
+    * governed separately, so they are read separately.</p>
+    *
+    * <p>Absent is normal: a non-tabular table has no response, sampling may be off, and an empty
+    * page yields no rows.</p>
+    */
+   private void applyResponseSampleRows(WorksheetTableResponse response,
+                                        AbstractTableAssembly table)
+   {
+      if(!(table.getTableInfo() instanceof TabularTableAssemblyInfo info)) {
+         return;
+      }
+
+      TabularQuery query = info.getQuery();
+
+      if(query == null || query.getSampleRows() == null || query.getSampleRows().isEmpty()) {
+         return;
+      }
+
+      response.setSampleRows(query.getSampleRows());
+
+      // Only set when true, same as the shape's flag: a caller extracting parameter values has to be
+      // able to tell "the response has no such value" from "the sample stopped before it".
+      if(query.isSampleRowsTruncated()) {
+         response.setSampleRowsTruncated(true);
       }
    }
 


### PR DESCRIPTION
Creating a tabular table sends a request and reports the structure of what came back. It cannot report what was IN it, and that is what a caller needs when one endpoint's required parameter takes its legal values from another endpoint's data — Asana's `Section Tasks` needs a section, and the sections are rows of `Project Sections`. Reading those ids costs a viewsheet today, which stands up a chart runtime to answer a question the build already had the data for.

`/ws/table` now returns `sampleRows` for a tabular table, when the caller asks for them, taken from the page the build already fetched.

## The sample

`JsonRowSampler` is the counterpart of `JsonShapeDistiller` and deliberately its opposite: the shape answers where the rows are and what the fields are called, the sample answers what is in them. So the two are taken at different points of the same page — the shape before `jsonPath` narrows it and before `doLookups` grafts lookup responses in, the sample after both, because a sample has to be of the rows the built table actually has. Both are first page only, and both cost no extra request.

Carrying values is the point and also the risk, so the sample is bounded four ways rather than by a row count alone: rows, total nodes, nesting depth, and string length. The last is the one a row count cannot approximate, since a single description or base64 blob outweighs every other field in the response.

- A row that does not fit the node budget is **dropped rather than half-copied** — a half row reads as a row whose remaining fields the response did not have.
- An over-long value is **replaced by `"<omitted: N chars>"`, never truncated in place** — a truncated id is a wrong value that looks entirely valid and will be sent straight back as a parameter.
- Anything left out sets `sampleRowsTruncated`, without which "this value is absent" and "this value was not sampled" are the same answer.

Leaf values go through `JsonTable.getJavaValue`, the same conversion the table uses. Without it the JSON-P and Jackson object models — both of which reach this runner — would serialize their wrapper objects instead of the values, and a caller could not use one as a parameter.

## Who decides what

`tabularSource.sampleRows` is the request field, and its default of 0 means no rows. Every path that does not set it — the composer dialog, every later render, every caller that wanted columns — runs the same request and pays for the same response as before. The rows are returned to whoever asked and are spent tokens in that answer, so the count is the caller's decision.

`rest.sample.rows` is the ceiling on that decision, default 20, and at 0 the switch that stops any response value leaving the connector. The deployment bounds how much customer data may ever travel; the caller bounds what one answer costs. A request above the ceiling is clamped rather than refused — the caller asked for a sample, and a smaller sample is still one.

## The clone boundary

The result slot mirrors `responseShape`, including the two halves that only work together: `clone()` clears it and `TabularHandler.execute` copies it back unconditionally. The reason applies harder here — a clone inheriting the field would report one execution's customer data as another's. It is likewise never written to worksheet XML.

The requested LIMIT is the mirror image, being an input rather than a result: `clone()` must NOT clear it, because the clone is the object that executes, and it is left out of the XML deliberately rather than incidentally — a saved query carrying it would sample again on every render and leave rows of customer data on a query nobody is reading them from.

## Tests

`JsonRowSamplerTest` (10 cases): raw nesting preserved, row cap and truncation, the whole-row boundary of the node budget, depth and long-string markers, non-Map elements, non-List input, recursive immutability, JSON-P value conversion.

Ran green: `inetsoft-tabular-util` 42, and `TabularTableAssemblyTest` + `WorksheetTableService*Test` in core, 92.

Design: `docs/superpowers/specs/2026-08-20-tabular-build-sample-rows-design.md` in stylebi-wiz (companion PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
