### PR TITLE
fix(wiz): use the ConditionValueModel.VALUE constant, not a lowercase literal

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ConditionVocabulary.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ConditionVocabulary.java
@@ -195,7 +195,7 @@ public final class ConditionVocabulary {
    private static ConditionValueModel value(Object raw) {
       ConditionValueModel value = new ConditionValueModel();
       value.setValue(raw);
-      value.setType("value");
+      value.setType(ConditionValueModel.VALUE);
       return value;
    }
 

--- a/core/src/test/java/inetsoft/web/composer/model/condition/ConditionUtilTest.java
+++ b/core/src/test/java/inetsoft/web/composer/model/condition/ConditionUtilTest.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.composer.model.condition;
+
+import inetsoft.test.*;
+import inetsoft.uql.ConditionList;
+import inetsoft.uql.asset.DateCondition;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.web.binding.drm.DataRefModel;
+import inetsoft.web.wiz.viewsheet.ConditionVocabulary;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.security.Principal;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * {@link ConditionVocabulary#toConditionList} builds each condition value with the same type
+ * discriminator that {@link ConditionUtil#fromModelToConditionList} switches on; if the two ever
+ * disagree, the DATE_IN branch below silently falls through instead of failing loud.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome()
+@Tag("core")
+class ConditionUtilTest {
+   @Test
+   void aNamedBuiltinDateRangeFromTheVocabularyBecomesARealDateCondition() throws Exception {
+      DataRefModel field = mock(DataRefModel.class);
+      when(field.getName()).thenReturn("OrderDate");
+      when(field.getDataType()).thenReturn(XSchema.DATE);
+
+      String builtinName = DateCondition.getBuiltinDateConditions()[0].getName();
+
+      Object[] model = ConditionVocabulary.toConditionList(
+         List.of(new ConditionVocabulary.Clause(
+            "OrderDate", "date_in", List.of(builtinName), null, false)),
+         new DataRefModel[]{ field });
+
+      Principal principal = () -> "admin";
+      ConditionList conditions =
+         ConditionUtil.fromModelToConditionList(model, null, null, principal);
+
+      assertInstanceOf(DateCondition.class, conditions.getXCondition(0),
+                        "a date_in value naming a builtin range must resolve to a real " +
+                        "DateCondition, not fall through to a plain value condition");
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ConditionVocabularyTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ConditionVocabularyTest.java
@@ -21,6 +21,7 @@ import inetsoft.uql.JunctionOperator;
 import inetsoft.uql.XCondition;
 import inetsoft.web.binding.drm.DataRefModel;
 import inetsoft.web.composer.model.condition.ConditionModel;
+import inetsoft.web.composer.model.condition.ConditionValueModel;
 import inetsoft.web.composer.model.condition.JunctionOperatorModel;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -57,6 +58,20 @@ class ConditionVocabularyTest {
       assertEquals(1, list.length);
       ConditionModel condition = assertInstanceOf(ConditionModel.class, list[0]);
       assertEquals(XCondition.EQUAL_TO, condition.getOperation());
+   }
+
+   /**
+    * ConditionUtil gates every value-model branch on {@code getType().equals(VALUE)}; a
+    * literal that doesn't match the constant (e.g. a lowercase "value") silently falls through
+    * to a generic fallback instead of the value's real type-specific handling.
+    */
+   @Test
+   void builtValuesCarryTheValueTypeConstant() {
+      Object[] list = ConditionVocabulary.toConditionList(
+         List.of(clause("Region", "equals", List.of("East"), null)), FIELDS);
+
+      ConditionModel condition = (ConditionModel) list[0];
+      assertEquals(ConditionValueModel.VALUE, condition.getValues()[0].getType());
    }
 
    @Test


### PR DESCRIPTION
## Root cause

`ConditionVocabulary.value()` (core/src/main/java/inetsoft/web/wiz/viewsheet/ConditionVocabulary.java:198) tagged every built condition value with the literal string `"value"` instead of the `ConditionValueModel.VALUE` constant (`"VALUE"`). Every downstream check in `ConditionUtil.fromModelToConditionList` (core/src/main/java/inetsoft/web/composer/model/condition/ConditionUtil.java) gates on an exact-case `equals()` against that constant, so all of them silently missed:

- Line 129-130: a `date_in` value naming a builtin or custom date range (e.g. "Last 96 months") never resolved to a real `DateCondition`.
- Line 224: the date-literal parsing branch was also skipped.

The value fell through to the generic per-value loop, where the fallback `Tool.getData(dataType, value)` can't parse a named range string and returns `null` — reproduced live via the viz-chat plugin: `set_condition` with `date_in` + a named range reports success, but `get_condition` reads the value back as `null` and the rendered crosstab collapses to a bogus single row.

Since `ConditionVocabulary` also backs highlight conditions (per its own doc comment), this fix applies to date-column `date_in` highlight conditions too, not just plain assembly conditions.

## Fix

One line: `value.setType(ConditionValueModel.VALUE)` instead of the hardcoded literal. Confirmed via grep this is the only place hardcoding the literal instead of the constant.

## Tests

- `ConditionVocabularyTest.builtValuesCarryTheValueTypeConstant` — asserts a built value's `getType()` equals `ConditionValueModel.VALUE`; this alone would have caught the typo.
- `ConditionUtilTest.aNamedBuiltinDateRangeFromTheVocabularyBecomesARealDateCondition` (new file) — builds a `date_in` clause naming a real builtin date range through `ConditionVocabulary.toConditionList()` → `ConditionUtil.fromModelToConditionList()`, asserting the resulting `XCondition` is a `DateCondition`, not a plain `AssetCondition`.

Both tests were verified to fail against the pre-fix code and pass with the fix applied.

```
cd core && mvn test -Dtest=ConditionVocabularyTest,ConditionUtilTest,AssemblyConditionServiceTest
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)