### PR TITLE
fix(wiz): report a cleared date comparison as disabled, not enabled with defaults

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/DateComparisonDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/DateComparisonDialogService.java
@@ -100,6 +100,18 @@ public class DateComparisonDialogService {
       return model;
    }
 
+   @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
+   public Boolean isDateComparisonEnabled(@ClusterProxyKey String runtimeId, String objectId,
+                                          Principal principal) throws Exception
+   {
+      runtimeId = Tool.byteDecode(runtimeId);
+      RuntimeViewsheet rvs = viewsheetService.getViewsheet(runtimeId, principal);
+      Viewsheet vs = rvs.getViewsheet();
+      VSAssembly vsAssembly = vs.getAssembly(objectId);
+      VSAssemblyInfo info = vsAssembly == null ? null : vsAssembly.getVSAssemblyInfo();
+      return DateComparisonUtil.isDateComparisonDefined(info, false);
+   }
+
    @ClusterWriteMethod
    @ClusterProxyMethod(WorksheetEngine.CACHE_NAME)
    public Void clearDateComparison(@ClusterProxyKey String runtimeId, String assemblyName, String linkUri,

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
@@ -69,13 +69,20 @@ public class DateComparisonService {
    public Map<String, Object> read(String sessionToken, Principal user, String assemblyName)
       throws Exception
    {
-      DateComparisonPaneModel model = comparisonService.getDateComparison(
-         sessions.resolve(sessionToken, user).getID(), assemblyName, user);
+      String runtimeId = sessions.resolve(sessionToken, user).getID();
+      DateComparisonPaneModel model =
+         comparisonService.getDateComparison(runtimeId, assemblyName, user);
 
       Map<String, Object> out = new LinkedHashMap<>();
       out.put("assembly", assemblyName);
 
-      if(model == null) {
+      // getDateComparison() always returns a default-populated model for a DateCompareAble
+      // assembly, even when no comparison is actually set (e.g. after clear()), so "enabled"
+      // cannot be read from model == null.
+      boolean enabled = model != null &&
+         comparisonService.isDateComparisonEnabled(runtimeId, assemblyName, user);
+
+      if(!enabled) {
          out.put("enabled", false);
          return out;
       }

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
@@ -264,6 +264,22 @@ class DateComparisonServiceTest {
       assertEquals(false, read.get("enabled"));
    }
 
+   /**
+    * getDateComparison() always substitutes a default-populated model for a DateCompareAble
+    * assembly, even right after clear() — it never returns null in that case. Reading "enabled"
+    * from {@code model == null} would report a cleared comparison as still on.
+    */
+   @Test
+   void reportsAClearedComparisonAsDisabledDespiteTheDefaultModel() throws Exception {
+      Harness h = harness(model());
+      when(h.comparisons().isDateComparisonEnabled(anyString(), anyString(), any(Principal.class)))
+         .thenReturn(false);
+
+      Map<String, Object> read = h.service.read("tok", principal(), "Chart1");
+
+      assertEquals(false, read.get("enabled"));
+   }
+
    @Test
    void hidesTheEndDateWhenTheRangeAnchorsOnToday() throws Exception {
       Map<String, Object> read = harness(model()).service.read("tok", principal(), "Chart1");
@@ -296,6 +312,8 @@ class DateComparisonServiceTest {
          }).when(sessions).mutate(anyString(), any(Principal.class), any());
          when(comparisons.getDateComparison(anyString(), anyString(), any(Principal.class)))
             .thenReturn(model);
+         when(comparisons.isDateComparisonEnabled(anyString(), anyString(), any(Principal.class)))
+            .thenReturn(model != null);
       }
       catch(Exception e) {
          throw new IllegalStateException(e);


### PR DESCRIPTION
## Root cause

`DateComparisonDialogService.getDateComparison()` (core/src/main/java/inetsoft/web/composer/vs/dialog/DateComparisonDialogService.java) always substitutes a fresh, default-populated `DateComparisonPaneModel` for a `DateCompareAble` assembly, even when the real `DateComparisonInfo` is null — e.g. right after `clearDateComparison()`. That's correct for its two Composer-dialog callers (`DateComparisonDialogController` and `getShare()`), which need populated defaults to render an unconfigured dialog.

The wiz-agent read path, `DateComparisonService.read()` (core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java), broke on that same contract: it inferred `enabled` purely from `model == null`, which never happens for a `DateCompareAble` assembly. So `set_date_comparison` → `clear_date_comparison` → `get_date_comparison` kept reporting `enabled: true` with defaulted period values (`level: 5`/`periods: 2`, just `StandardPeriodPaneModel`'s untouched constructor defaults), even though the render correctly reverted — the render reads `assemblyInfo.getDateComparisonInfo()` directly, a different, correct signal.

There's already a well-tested predicate for exactly "is a comparison actually defined": `DateComparisonUtil.isDateComparisonDefined(info, false)`, already used by `getShare()`.

## Fix

1. Added `DateComparisonDialogService.isDateComparisonEnabled(runtimeId, objectId, principal)` — an additive method delegating to `DateComparisonUtil.isDateComparisonDefined(info, false)`. Doesn't change the contract of `getDateComparison()` or any of its 3 existing callers.
2. `DateComparisonService.read()` now sources `enabled` from `model != null && comparisonService.isDateComparisonEnabled(...)` instead of `model == null`.

## Tests

`DateComparisonServiceTest.java`:
- Updated the harness to stub `isDateComparisonEnabled(...)` to `model != null` by default, matching the existing tests' happy-path assumption.
- Added `reportsAClearedComparisonAsDisabledDespiteTheDefaultModel` — stubs `getDateComparison()` to return a non-null default-populated model (as it does after clear) while `isDateComparisonEnabled()` returns false, asserting `read()` reports `enabled: false`.

Verified the new test fails against the pre-fix code (`expected: <false> but was: <true>`) and all 19 tests in the class pass with the fix applied:

```
cd core && mvn test -Dtest=DateComparisonServiceTest
```

## Left alone

A dedicated `DateComparisonDialogServiceTest` exercising `isDateComparisonEnabled()` directly against a real assembly (set → clear → assert false) — it's a thin one-line delegation to the already-used `DateComparisonUtil.isDateComparisonDefined()` predicate, and the actual user-facing regression is fully covered by the `DateComparisonServiceTest` addition above, which is the only caller of the new method. Flagging in case the reviewer wants direct coverage anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)