### PR TITLE
fix(wiz): refuse applyRow highlights on assemblies that cannot store them

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightService.java
@@ -144,6 +144,7 @@ public class AssemblyHighlightService {
 
          // Before the shared condition vocabulary gets a chance to blame the field name.
          requireHighlightableRegion(model, assemblyName, region);
+         requireRowApplicable(model, assemblyName, highlight);
 
          List<HighlightModel> highlights = new ArrayList<>();
          boolean found = false;
@@ -339,6 +340,28 @@ public class AssemblyHighlightService {
          ". For a crosstab or table this usually means a header cell: highlights attach to DATA " +
          "cells, so pass 'row' and 'col' of one (row 1, col 1 is the first). Call list_highlights " +
          "with that region to see the fields it exposes.");
+   }
+
+   /**
+    * Refuses {@code applyRow:true} on an assembly whose dialog model does not support it (a
+    * Crosstab, whose {@code TableDataVSAssemblyInfo} sibling class never wires up row highlights).
+    *
+    * <p>Without this the highlight was silently dropped: {@code HighlightDialogService} only
+    * stores a row-level highlight for a {@code TableVSAssemblyInfo}, so an {@code applyRow:true}
+    * highlight on a Crosstab is excluded from the per-cell store AND never reaches the row store —
+    * stored nowhere, with the call still reporting success.
+    */
+   private static void requireRowApplicable(HighlightDialogModel model, String assemblyName,
+                                            Highlight highlight)
+   {
+      if(!highlight.applyRow() || model.isShowRow()) {
+         return;
+      }
+
+      throw new IllegalArgumentException(
+         "'" + assemblyName + "' does not support 'applyRow' — apply-to-row highlights are only " +
+         "available on assemblies whose dialog model shows the row option (e.g. a plain table), " +
+         "not this one. Drop 'applyRow' to highlight the cell instead.");
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightServiceTest.java
@@ -65,6 +65,13 @@ class AssemblyHighlightServiceTest {
          false);
    }
 
+   private static AssemblyHighlightService.Highlight highlightApplyRow(String name) {
+      return new AssemblyHighlightService.Highlight(
+         name, null, "#ff0000",
+         List.of(new ConditionVocabulary.Clause("Revenue", ">", List.of(1000), null, false)),
+         true);
+   }
+
    @Test
    void addsAHighlightWithItsConditionBuiltByTheSharedVocabulary() throws Exception {
       Harness h = harness(model());
@@ -295,6 +302,32 @@ class AssemblyHighlightServiceTest {
       assertTrue(thrown.getMessage().contains("DATA"), thrown.getMessage());
       assertFalse(thrown.getMessage().contains("cannot filter on"),
                   "must not blame the field: " + thrown.getMessage());
+   }
+
+   /**
+    * {@code CrosstabVSAssemblyInfo} is a sibling of {@code TableVSAssemblyInfo}, not a subtype, so
+    * {@code HighlightDialogService} never wires up row-level highlights for it: the real
+    * {@code getHighlightDialogModel} leaves {@code showRow} false for a Crosstab. An
+    * {@code applyRow:true} highlight there was excluded from the per-cell store (because applyRow
+    * is true) AND never reached the row store (because it isn't a TableVSAssemblyInfo) — stored
+    * nowhere, with the call still reporting success. This must be refused instead.
+    */
+   @Test
+   void refusesApplyRowOnAnAssemblyWhoseModelDoesNotSupportIt() throws Exception {
+      HighlightDialogModel crosstabModel = model();
+      crosstabModel.setShowRow(false);
+      Harness h = harness(crosstabModel);
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> h.service.set("tok", principal(), "Crosstab1", null,
+                             highlightApplyRow("RowHighlight"), false, ""));
+
+      assertTrue(thrown.getMessage().contains("Crosstab1"), thrown.getMessage());
+      assertTrue(thrown.getMessage().toLowerCase().contains("applyrow"), thrown.getMessage());
+      verify(h.highlights, never()).setHighlightDialogModel(anyString(), anyString(), any(),
+                                                             anyString(), any(Principal.class),
+                                                             any());
    }
 
    // ── read ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Root cause

`set_highlight` on a Crosstab with `applyRow: true` returns `{ok:true}` but the highlight is never stored — absent from a subsequent `list_highlights`, not rendered by `get_viewsheet_image`. Reproduced live.

`HighlightDialogService.updateHighlights` (core/src/main/java/inetsoft/web/composer/vs/dialog/HighlightDialogService.java:463-491), the `TableDataVSAssemblyInfo` branch:

```java
for(HighlightModel highlightModel : highlights) {
   if(!highlightModel.isApplyRow()) {                    // excludes applyRow=true from the per-cell store
      cells.addHighlight(highlightModel.getName(), ...);
   }
}
tableHighlightAttr.setHighlight(dataPath, cells);

if(assemblyInfo instanceof TableVSAssemblyInfo) {          // FALSE for Crosstab
   highlightService.applyToRowHighlight(tableHighlightAttr, dataPath, highlights, principal);
}
```

`CrosstabVSAssemblyInfo extends CrossBaseVSAssemblyInfo extends TableDataVSAssemblyInfo` — a **sibling** of `TableVSAssemblyInfo`, not a subtype. So on a Crosstab with `applyRow:true`: the per-cell store excludes it (because applyRow is true), and the row store never runs (wrong type check) — stored nowhere.

`ViewsheetAssemblyAgentController.setHighlight` has no return value/validation, so the caller gets an unconditional success.

Symmetric on read: `getHighlightDialogModel` only sets `model.setShowRow(true)` and calls `getRowHighlight(...)` inside `instanceof TableVSAssemblyInfo` — matches the observed `appliesToRow: false` on a Crosstab.

This was never caught through the UI because the Composer's own highlight dialog only shows the "apply to row" checkbox `@if (model.showRow)` — a human can never construct this combination for a Crosstab. Only the wiz agent's raw, type-unchecked `applyRow` boolean can.

Whether to extend real Crosstab row-highlight support is a separate product/feature decision — `applyToRowHighlight`/`getRowHighlight` are already generic over `TableHighlightAttr`/`TableDataPath` (shared by both `TableVSAssemblyInfo` and `CrosstabVSAssemblyInfo`), so the mechanism itself has nothing Table-specific; it's just never been wired up for Crosstab. This PR fails loud instead, matching this repo's philosophy for tool-misuse.

## Fix

`AssemblyHighlightService.set()` (core/src/main/java/inetsoft/web/wiz/viewsheet/AssemblyHighlightService.java), alongside the existing `requireHighlightableRegion` guard: added `requireRowApplicable(model, assemblyName, highlight)`, which throws `IllegalArgumentException` naming the assembly when `highlight.applyRow()` is true but the resolved dialog model's `isShowRow()` is false.

## Tests

`AssemblyHighlightServiceTest.java` — added `refusesApplyRowOnAnAssemblyWhoseModelDoesNotSupportIt`: builds a Crosstab-shaped model (`showRow=false`, as the real `getHighlightDialogModel` produces for a Crosstab) and calls `set(...)` with `applyRow: true`, asserting it throws naming the assembly and never reaches `setHighlightDialogModel`, rather than silently succeeding.

Verified the test fails against the pre-fix code (`Expected java.lang.Exception to be thrown, but nothing was thrown`) and all 23 tests in the class pass with the fix applied. Also ran `ViewsheetAssemblyAgentControllerTest` (the only other caller, which mocks `AssemblyHighlightService` at the boundary) to confirm no collateral breakage.

```
cd core && mvn test -Dtest=AssemblyHighlightServiceTest,ViewsheetAssemblyAgentControllerTest
```

## Left alone

`delete_highlight` shares `read()`/`updateHighlights` — it will correctly report "no highlight named X" for an applyRow-true Crosstab highlight, since it was never stored. Not a separate bug, no change made there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)