### PR TITLE
Bug #76175: store the schedule task view as a per-user preference

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/schedule/EMScheduleTaskShowType.java
+++ b/core/src/main/java/inetsoft/web/admin/schedule/EMScheduleTaskShowType.java
@@ -18,11 +18,14 @@
 package inetsoft.web.admin.schedule;
 
 import inetsoft.sree.SreeEnv;
+import inetsoft.sree.UserEnv;
 import inetsoft.sree.security.ResourceAction;
 import inetsoft.sree.security.ResourceType;
 import inetsoft.web.security.RequiredPermission;
 import inetsoft.web.security.Secured;
 import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
 
 @RestController
 public class EMScheduleTaskShowType {
@@ -34,8 +37,8 @@ public class EMScheduleTaskShowType {
       )
    )
    @GetMapping("/api/em/schedule/change-show-type")
-   public boolean getScheduleTaskShowType() {
-      return SreeEnv.getBooleanProperty("schedule.show.tasks.as.list", "true");
+   public boolean getScheduleTaskShowType(Principal principal) {
+      return getShowTasksAsList(principal);
    }
 
    @Secured(
@@ -46,7 +49,37 @@ public class EMScheduleTaskShowType {
       )
    )
    @PutMapping("/api/em/schedule/change-show-type")
-   public void setConfiguration(@RequestParam("showTasksAsList") String showTasksAsList) {
-      SreeEnv.setProperty("schedule.show.tasks.as.list", showTasksAsList);
+   public void setConfiguration(@RequestParam("showTasksAsList") String showTasksAsList,
+                                Principal principal)
+   {
+      setShowTasksAsList(principal, showTasksAsList);
    }
+
+   /**
+    * Gets the list/folder view preference of the given user. The view is a per-user
+    * preference; the property is only the installation-wide default used until the
+    * user toggles the view themselves. That default is folder view, since
+    * getBooleanProperty() yields false for a property that is not set.
+    */
+   private boolean getShowTasksAsList(Principal principal) {
+      Object userSetting = UserEnv.getProperty(principal, SHOW_TYPE_USER_PROPERTY, null);
+
+      return userSetting != null ? Boolean.parseBoolean(String.valueOf(userSetting))
+         : SreeEnv.getBooleanProperty(SHOW_TYPE_PROPERTY);
+   }
+
+   /**
+    * Saves the list/folder view preference of the given user. Anonymous users only get a
+    * persisted preference if anonymous.userdata.save is enabled; otherwise UserEnv
+    * discards the write and the installation-wide default keeps applying.
+    */
+   private void setShowTasksAsList(Principal principal, String showTasksAsList) {
+      // normalize so that only "true"/"false" is stored, and so that an empty value is
+      // never passed to UserEnv.setProperty(), which treats it as a removal
+      UserEnv.setProperty(principal, SHOW_TYPE_USER_PROPERTY,
+                          Boolean.parseBoolean(showTasksAsList) + "");
+   }
+
+   private static final String SHOW_TYPE_PROPERTY = "schedule.show.tasks.as.list";
+   private static final String SHOW_TYPE_USER_PROPERTY = "em.schedule.showTasksAsList";
 }

--- a/core/src/main/java/inetsoft/web/portal/controller/ScheduleTaskShowType.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/ScheduleTaskShowType.java
@@ -18,11 +18,14 @@
 package inetsoft.web.portal.controller;
 
 import inetsoft.sree.SreeEnv;
+import inetsoft.sree.UserEnv;
 import inetsoft.sree.security.ResourceAction;
 import inetsoft.sree.security.ResourceType;
 import inetsoft.web.security.RequiredPermission;
 import inetsoft.web.security.Secured;
 import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
 
 @RestController
 public class ScheduleTaskShowType {
@@ -35,8 +38,8 @@ public class ScheduleTaskShowType {
       )
    })
    @GetMapping("/api/portal/schedule/change-show-type")
-   public boolean getScheduleTaskShowType() {
-      return SreeEnv.getBooleanProperty("schedule.show.tasks.as.list", "true");
+   public boolean getScheduleTaskShowType(Principal principal) {
+      return getShowTasksAsList(principal);
    }
 
    @Secured({
@@ -48,7 +51,37 @@ public class ScheduleTaskShowType {
       )
    })
    @PutMapping("/api/portal/schedule/change-show-type")
-   public void setConfiguration(@RequestParam("showTasksAsList") String showTasksAsList) {
-      SreeEnv.setProperty("schedule.show.tasks.as.list", showTasksAsList);
+   public void setConfiguration(@RequestParam("showTasksAsList") String showTasksAsList,
+                                Principal principal)
+   {
+      setShowTasksAsList(principal, showTasksAsList);
    }
+
+   /**
+    * Gets the list/folder view preference of the given user. The view is a per-user
+    * preference; the property is only the installation-wide default used until the
+    * user toggles the view themselves. That default is folder view, since
+    * getBooleanProperty() yields false for a property that is not set.
+    */
+   private boolean getShowTasksAsList(Principal principal) {
+      Object userSetting = UserEnv.getProperty(principal, SHOW_TYPE_USER_PROPERTY, null);
+
+      return userSetting != null ? Boolean.parseBoolean(String.valueOf(userSetting))
+         : SreeEnv.getBooleanProperty(SHOW_TYPE_PROPERTY);
+   }
+
+   /**
+    * Saves the list/folder view preference of the given user. Anonymous users only get a
+    * persisted preference if anonymous.userdata.save is enabled; otherwise UserEnv
+    * discards the write and the installation-wide default keeps applying.
+    */
+   private void setShowTasksAsList(Principal principal, String showTasksAsList) {
+      // normalize so that only "true"/"false" is stored, and so that an empty value is
+      // never passed to UserEnv.setProperty(), which treats it as a removal
+      UserEnv.setProperty(principal, SHOW_TYPE_USER_PROPERTY,
+                          Boolean.parseBoolean(showTasksAsList) + "");
+   }
+
+   private static final String SHOW_TYPE_PROPERTY = "schedule.show.tasks.as.list";
+   private static final String SHOW_TYPE_USER_PROPERTY = "portal.schedule.showTasksAsList";
 }

--- a/core/src/test/java/inetsoft/web/admin/schedule/EMScheduleTaskShowTypeTest.java
+++ b/core/src/test/java/inetsoft/web/admin/schedule/EMScheduleTaskShowTypeTest.java
@@ -1,0 +1,156 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.schedule;
+
+import inetsoft.sree.SreeEnv;
+import inetsoft.sree.UserEnv;
+import org.junit.jupiter.api.*;
+import org.mockito.MockedStatic;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Verifies that the Enterprise Manager task list/folder view is stored as a persisted
+ * per-user preference, under a key of its own so that it does not track the portal.
+ */
+@Tag("core")
+class EMScheduleTaskShowTypeTest {
+   private static final String PROPERTY = "schedule.show.tasks.as.list";
+   private static final String USER_PROPERTY = "em.schedule.showTasksAsList";
+   private static final String PORTAL_USER_PROPERTY = "portal.schedule.showTasksAsList";
+
+   private EMScheduleTaskShowType controller;
+   private Principal alice;
+   private Principal bob;
+
+   @BeforeEach
+   void before() {
+      controller = new EMScheduleTaskShowType();
+      alice = mock(Principal.class);
+      bob = mock(Principal.class);
+   }
+
+   @Test
+   void get_noStoredPreference_usesPropertyDefault() {
+      try(MockedStatic<UserEnv> ue = mockStatic(UserEnv.class);
+          MockedStatic<SreeEnv> se = mockStatic(SreeEnv.class))
+      {
+         ue.when(() -> UserEnv.getProperty(alice, USER_PROPERTY, null)).thenReturn(null);
+         se.when(() -> SreeEnv.getBooleanProperty(PROPERTY)).thenReturn(false);
+
+         assertFalse(controller.getScheduleTaskShowType(alice));
+      }
+   }
+
+   @Test
+   void get_storedFalse_isNotTreatedAsUnset() {
+      try(MockedStatic<UserEnv> ue = mockStatic(UserEnv.class);
+          MockedStatic<SreeEnv> se = mockStatic(SreeEnv.class))
+      {
+         ue.when(() -> UserEnv.getProperty(alice, USER_PROPERTY, null)).thenReturn("false");
+         se.when(() -> SreeEnv.getBooleanProperty(PROPERTY)).thenReturn(true);
+
+         assertFalse(controller.getScheduleTaskShowType(alice));
+         se.verifyNoInteractions();
+      }
+   }
+
+   @Test
+   void get_preferenceIsNotSharedBetweenUsers() {
+      try(MockedStatic<UserEnv> ue = mockStatic(UserEnv.class);
+          MockedStatic<SreeEnv> se = mockStatic(SreeEnv.class))
+      {
+         ue.when(() -> UserEnv.getProperty(alice, USER_PROPERTY, null)).thenReturn("false");
+         ue.when(() -> UserEnv.getProperty(bob, USER_PROPERTY, null)).thenReturn(null);
+         se.when(() -> SreeEnv.getBooleanProperty(PROPERTY)).thenReturn(true);
+
+         assertFalse(controller.getScheduleTaskShowType(alice));
+         assertTrue(controller.getScheduleTaskShowType(bob));
+      }
+   }
+
+   /**
+    * Enterprise Manager and the portal are separate surfaces, so toggling one must not
+    * rearrange the other.
+    */
+   @Test
+   void get_doesNotReadThePortalPreference() {
+      try(MockedStatic<UserEnv> ue = mockStatic(UserEnv.class);
+          MockedStatic<SreeEnv> se = mockStatic(SreeEnv.class))
+      {
+         ue.when(() -> UserEnv.getProperty(alice, PORTAL_USER_PROPERTY, null)).thenReturn("false");
+         ue.when(() -> UserEnv.getProperty(alice, USER_PROPERTY, null)).thenReturn(null);
+         se.when(() -> SreeEnv.getBooleanProperty(PROPERTY)).thenReturn(true);
+
+         assertTrue(controller.getScheduleTaskShowType(alice));
+      }
+   }
+
+   @Test
+   void put_storesUnderTheEmKeyOnly() throws Exception {
+      try(MockedStatic<UserEnv> ue = mockStatic(UserEnv.class);
+          MockedStatic<SreeEnv> se = mockStatic(SreeEnv.class))
+      {
+
+         controller.setConfiguration("false", alice);
+
+         ue.verify(() -> UserEnv.setProperty(alice, USER_PROPERTY, "false"));
+         ue.verify(() -> UserEnv.setProperty(any(), eq(PORTAL_USER_PROPERTY), any()), never());
+         se.verifyNoInteractions();
+      }
+   }
+
+   /**
+    * The installation-wide default must be read with the varargs-free overload.
+    * getBooleanProperty(name, "true") reads as "default to true" but actually means
+    * "true only when the value equals 'true'", which is a different thing.
+    */
+   @Test
+   void get_defaultIsReadWithoutTrueValues() {
+      try(MockedStatic<UserEnv> ue = mockStatic(UserEnv.class);
+          MockedStatic<SreeEnv> se = mockStatic(SreeEnv.class))
+      {
+         ue.when(() -> UserEnv.getProperty(alice, USER_PROPERTY, null)).thenReturn(null);
+
+         controller.getScheduleTaskShowType(alice);
+
+         se.verify(() -> SreeEnv.getBooleanProperty(PROPERTY));
+      }
+   }
+
+   /**
+    * Anonymous preferences are UserEnv's business: it drops the write unless
+    * anonymous.userdata.save is enabled. The controller must not write installation-wide
+    * configuration on its behalf.
+    */
+   @Test
+   void put_neverWritesTheGlobalProperty() {
+      try(MockedStatic<UserEnv> ue = mockStatic(UserEnv.class);
+          MockedStatic<SreeEnv> se = mockStatic(SreeEnv.class))
+      {
+         controller.setConfiguration("false", null);
+
+         ue.verify(() -> UserEnv.setProperty(null, USER_PROPERTY, "false"));
+         se.verifyNoInteractions();
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/web/portal/controller/ScheduleTaskShowTypeTest.java
+++ b/core/src/test/java/inetsoft/web/portal/controller/ScheduleTaskShowTypeTest.java
@@ -1,0 +1,168 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.portal.controller;
+
+import inetsoft.sree.SreeEnv;
+import inetsoft.sree.UserEnv;
+import org.junit.jupiter.api.*;
+import org.mockito.MockedStatic;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Verifies that the portal task list/folder view is stored as a persisted per-user
+ * preference, with the property acting only as the installation-wide default.
+ */
+@Tag("core")
+class ScheduleTaskShowTypeTest {
+   private static final String PROPERTY = "schedule.show.tasks.as.list";
+   private static final String USER_PROPERTY = "portal.schedule.showTasksAsList";
+
+   private ScheduleTaskShowType controller;
+   private Principal alice;
+   private Principal bob;
+
+   @BeforeEach
+   void before() {
+      controller = new ScheduleTaskShowType();
+      alice = mock(Principal.class);
+      bob = mock(Principal.class);
+   }
+
+   @Test
+   void get_noStoredPreference_usesPropertyDefault() {
+      try(MockedStatic<UserEnv> ue = mockStatic(UserEnv.class);
+          MockedStatic<SreeEnv> se = mockStatic(SreeEnv.class))
+      {
+         ue.when(() -> UserEnv.getProperty(alice, USER_PROPERTY, null)).thenReturn(null);
+         se.when(() -> SreeEnv.getBooleanProperty(PROPERTY)).thenReturn(false);
+
+         assertFalse(controller.getScheduleTaskShowType(alice));
+      }
+   }
+
+   @Test
+   void get_storedFalse_isNotTreatedAsUnset() {
+      try(MockedStatic<UserEnv> ue = mockStatic(UserEnv.class);
+          MockedStatic<SreeEnv> se = mockStatic(SreeEnv.class))
+      {
+         ue.when(() -> UserEnv.getProperty(alice, USER_PROPERTY, null)).thenReturn("false");
+         // the installation default is the opposite of the user's choice
+         se.when(() -> SreeEnv.getBooleanProperty(PROPERTY)).thenReturn(true);
+
+         assertFalse(controller.getScheduleTaskShowType(alice));
+         // the user has chosen, so the default must not be consulted at all
+         se.verifyNoInteractions();
+      }
+   }
+
+   @Test
+   void get_storedPreferenceOverridesPropertyDefault() {
+      try(MockedStatic<UserEnv> ue = mockStatic(UserEnv.class);
+          MockedStatic<SreeEnv> se = mockStatic(SreeEnv.class))
+      {
+         ue.when(() -> UserEnv.getProperty(alice, USER_PROPERTY, null)).thenReturn("true");
+         se.when(() -> SreeEnv.getBooleanProperty(PROPERTY)).thenReturn(false);
+
+         assertTrue(controller.getScheduleTaskShowType(alice));
+      }
+   }
+
+   /**
+    * The regression this change is about: one user's toggle must not change what any
+    * other user sees.
+    */
+   @Test
+   void get_preferenceIsNotSharedBetweenUsers() {
+      try(MockedStatic<UserEnv> ue = mockStatic(UserEnv.class);
+          MockedStatic<SreeEnv> se = mockStatic(SreeEnv.class))
+      {
+         ue.when(() -> UserEnv.getProperty(alice, USER_PROPERTY, null)).thenReturn("false");
+         ue.when(() -> UserEnv.getProperty(bob, USER_PROPERTY, null)).thenReturn(null);
+         se.when(() -> SreeEnv.getBooleanProperty(PROPERTY)).thenReturn(true);
+
+         assertFalse(controller.getScheduleTaskShowType(alice));
+         assertTrue(controller.getScheduleTaskShowType(bob));
+      }
+   }
+
+   @Test
+   void put_storesPerUserAndDoesNotWriteTheGlobalProperty() throws Exception {
+      try(MockedStatic<UserEnv> ue = mockStatic(UserEnv.class);
+          MockedStatic<SreeEnv> se = mockStatic(SreeEnv.class))
+      {
+
+         controller.setConfiguration("false", alice);
+
+         ue.verify(() -> UserEnv.setProperty(alice, USER_PROPERTY, "false"));
+         // the installation-wide property is a default only; it must stay untouched
+         se.verifyNoInteractions();
+      }
+   }
+
+   @Test
+   void put_normalizesTheStoredValue() throws Exception {
+      try(MockedStatic<UserEnv> ue = mockStatic(UserEnv.class);
+          MockedStatic<SreeEnv> se = mockStatic(SreeEnv.class))
+      {
+
+         // an empty value would otherwise be a removal in UserEnv.setProperty()
+         controller.setConfiguration("", alice);
+
+         ue.verify(() -> UserEnv.setProperty(alice, USER_PROPERTY, "false"));
+      }
+   }
+
+   /**
+    * The installation-wide default must be read with the varargs-free overload.
+    * getBooleanProperty(name, "true") reads as "default to true" but actually means
+    * "true only when the value equals 'true'", which is a different thing.
+    */
+   @Test
+   void get_defaultIsReadWithoutTrueValues() {
+      try(MockedStatic<UserEnv> ue = mockStatic(UserEnv.class);
+          MockedStatic<SreeEnv> se = mockStatic(SreeEnv.class))
+      {
+         ue.when(() -> UserEnv.getProperty(alice, USER_PROPERTY, null)).thenReturn(null);
+
+         controller.getScheduleTaskShowType(alice);
+
+         se.verify(() -> SreeEnv.getBooleanProperty(PROPERTY));
+      }
+   }
+
+   /**
+    * Anonymous preferences are UserEnv's business: it drops the write unless
+    * anonymous.userdata.save is enabled. The controller must not write installation-wide
+    * configuration on its behalf.
+    */
+   @Test
+   void put_neverWritesTheGlobalProperty() {
+      try(MockedStatic<UserEnv> ue = mockStatic(UserEnv.class);
+          MockedStatic<SreeEnv> se = mockStatic(SreeEnv.class))
+      {
+         controller.setConfiguration("false", null);
+
+         ue.verify(() -> UserEnv.setProperty(null, USER_PROPERTY, "false"));
+         se.verifyNoInteractions();
+      }
+   }
+}

--- a/web/projects/em/src/app/settings/schedule/schedule-task-list/schedule-task-list.component.ts
+++ b/web/projects/em/src/app/settings/schedule/schedule-task-list/schedule-task-list.component.ts
@@ -273,8 +273,10 @@ export class ScheduleTaskListComponent implements OnInit, AfterViewInit, OnDestr
          },
          (error) => {
             this.dialog.open(MessageDialog, this.setConfigs(`_#(js:Error)`,
-               "Failed to load tasks: " + error.error ? error.error.message : "",
+               "Failed to load tasks: " + (error.error?.message || ""),
                MessageDialogType.ERROR));
+            // fall back to the default view so that the task list still loads
+            this.loadTasks();
          },
          () => {
             this.loading = false;
@@ -1070,10 +1072,23 @@ export class ScheduleTaskListComponent implements OnInit, AfterViewInit, OnDestr
    }
 
    showAllTasks(showAll: boolean): void {
+      const oldValue = this.showTasksAsList;
       this.showTasksAsList = showAll;
       let params = new HttpParams().set("showTasksAsList", showAll + "");
-      this.http.put(CHANGE_SHOW_TYPE_URI, null, {params}).subscribe(() => {
-         this.loadTasks();
+      this.http.put(CHANGE_SHOW_TYPE_URI, null, {params}).subscribe({
+         next: () => this.loadTasks(),
+         error: (error) => {
+            // the request never reached the preference, so don't leave the view showing
+            // a state that was not stored. Ignore a stale failure that a later toggle
+            // has already superseded.
+            if(this.showTasksAsList === showAll) {
+               this.showTasksAsList = oldValue;
+            }
+
+            this.dialog.open(MessageDialog, this.setConfigs(`_#(js:Error)`,
+               "Failed to change the schedule task view: " + (error.error?.message || ""),
+               MessageDialogType.ERROR));
+         }
       });
    }
 

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-list/schedule-task-list.component.risk.tl.spec.ts
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-list/schedule-task-list.component.risk.tl.spec.ts
@@ -380,5 +380,32 @@ describe("ScheduleTaskListComponent — risk tests", () => {
             spy.mockRestore();
          }
       });
+
+      // The preference is stored server-side, so a failed PUT must not leave the view
+      // showing something that was never saved.
+      it("reverts showTasksAsList when the PUT fails", async () => {
+         const { comp, fixture } = await renderScheduleTaskList();
+         server.use(
+            http.put("*/api/portal/schedule/change-show-type", () => {
+               return new HttpResponse(null, { status: 500 });
+            }),
+         );
+         const spy = vi.spyOn(comp, "loadTasks").mockImplementation(() => {});
+
+         try {
+            expect(comp.showTasksAsList).toBe(true);
+            comp.changeShowType(false);
+            // optimistic local change is applied first
+            expect(comp.showTasksAsList).toBe(false);
+
+            await waitFor(() => expect(comp.showTasksAsList).toBe(true));
+            expect(comp.INIT_TREE_PANE_SIZE).toBe(0);
+            expect(spy).not.toHaveBeenCalled();
+            await fixture.whenStable();
+         }
+         finally {
+            spy.mockRestore();
+         }
+      });
    });
 });

--- a/web/projects/portal/src/app/portal/schedule/schedule-task-list/schedule-task-list.component.ts
+++ b/web/projects/portal/src/app/portal/schedule/schedule-task-list/schedule-task-list.component.ts
@@ -160,16 +160,13 @@ export class ScheduleTaskListComponent implements OnInit, OnDestroy, AfterConten
          this.scheduleChangeService.onFolderChange.subscribe(() => this.loadTaskFolderTree())
       );
 
-      this.http.get(CHANGE_SHOW_TYPE_URI).subscribe((showTasksAsList) => {
-         this.showTasksAsList = <boolean> showTasksAsList;
-
-         if(!this.showTasksAsList) {
-            this.INIT_TREE_PANE_SIZE = 20;
-            this.loadTaskFolderTree();
-         }
-         else {
-            this.loadTasks();
-         }
+      this.http.get(CHANGE_SHOW_TYPE_URI).subscribe({
+         next: (showTasksAsList) => {
+            this.showTasksAsList = <boolean> showTasksAsList;
+            this.applyShowType();
+         },
+         // fall back to the default view so that the task list still loads
+         error: () => this.applyShowType()
       });
 
       this.http.get(CHECK_ROOT_PERMISSION_URI).subscribe((rootPermission: boolean) => {
@@ -265,12 +262,39 @@ export class ScheduleTaskListComponent implements OnInit, OnDestroy, AfterConten
    }
 
    changeShowType(value: boolean): void {
+      const oldValue = this.showTasksAsList;
       this.showTasksAsList = value;
       this.INIT_TREE_PANE_SIZE = this.showTasksAsList ? 0 : 20;
       let params = new HttpParams().set("showTasksAsList", this.showTasksAsList + "");
-      this.http.put(CHANGE_SHOW_TYPE_URI, null, {params}).subscribe(() => {
-         this.loadTasks();
+      this.http.put(CHANGE_SHOW_TYPE_URI, null, {params}).subscribe({
+         next: () => this.loadTasks(),
+         error: (error) => {
+            // the request never reached the preference, so don't leave the view showing
+            // a state that was not stored. Ignore a stale failure that a later toggle
+            // has already superseded.
+            if(this.showTasksAsList === value) {
+               this.showTasksAsList = oldValue;
+               this.INIT_TREE_PANE_SIZE = this.showTasksAsList ? 0 : 20;
+            }
+
+            ComponentTool.showHttpError(
+               "Failed to change the schedule task view", error, this.modal);
+         }
       });
+   }
+
+   /**
+    * Loads the tree and/or the task list for the current view.
+    */
+   private applyShowType(): void {
+      if(!this.showTasksAsList) {
+         this.INIT_TREE_PANE_SIZE = 20;
+         this.loadTaskFolderTree();
+      }
+      else {
+         this.INIT_TREE_PANE_SIZE = 0;
+         this.loadTasks();
+      }
    }
 
    initTaskList(list: ScheduleTaskList) {


### PR DESCRIPTION
## Problem

The schedule task list/folder view toggle in Enterprise Manager and the portal wrote `schedule.show.tasks.as.list` and stopped there. Filed for review rather than with a proposed fix, because two things were wrong and they did not have the same answer.

**The write never reached storage.** `PropertiesEngine.setProperty` updates the in-memory properties and records the name in `changedProps`; `save()` is what drains that set. Neither controller called `SreeEnv.save()`, unlike the ~25 admin settings services that all end with it. So the toggle survived a restart only if an administrator happened to visit some unrelated settings page afterwards, which flushed it as a side effect. Worse, `save()` *clears* `changedProps`, so an unrelated page saving first discarded the pending toggle outright. Persistence is also what drives `KeyValueStorage` listener propagation, so the value never reached other cluster nodes.

**The state was stored at the wrong granularity.** One global property backed a per-user toolbar gesture, so any user's toggle changed the view for every other user, across both surfaces. The writes used the two-argument `setProperty`, which writes an unprefixed global key, while reads go through the org-scoped path (`useAvailableOrgProperty`) and fall back to that same key — so the value leaked **across organizations** too, not only across users.

## Approach

The view is a per-user preference. `UserEnv` is the established mechanism and is what `PreferencesDialogController` already uses for `historyBarEnable`, so both controllers store the toggle there:

| Concern | Where it lives |
| --- | --- |
| Per-user state, portal | `UserEnv` key `portal.schedule.showTasksAsList` |
| Per-user state, EM | `UserEnv` key `em.schedule.showTasksAsList` |
| Installation default | `SreeEnv` property `schedule.show.tasks.as.list` (read-only) |

`UserEnv.setProperty` persists on write and rolls the in-memory value back if the write throws, so **both defects are fixed at once** and no `SreeEnv.save()` is needed — these controllers no longer write `SreeEnv` at all. Separate keys per surface stop a portal toggle from rearranging the EM task screen; the two components already called separate endpoints.

The endpoint contract is deliberately unchanged — same URLs, same parameter, same boolean response — so no frontend service or test mock needed updating.

### A trap worth flagging to reviewers

Both reads now use the varargs-free `getBooleanProperty(name)` overload. The previous `getBooleanProperty(name, "true")` *reads* as "default to true", but the second parameter is `String... trueValues`, so it actually means "true only when the value equals `'true'`" and returns **false** for an unset property. `schedule.show.tasks.as.list` is declared nowhere in the repo, so the effective default was already folder view. The call is now written so it cannot be misread, and a test pins the overload so the trap is not reintroduced. (#4692 documents the same `getBooleanProperty` semantics across thirteen other properties.)

### Anonymous users

They get a persisted preference only when `anonymous.userdata.save` is enabled — exactly what that property governs. The controllers delegate that decision to `UserEnv` rather than writing installation-wide configuration on a guest's behalf; these endpoints are gated on schedule access, not admin rights.

## Client-side

Both toggle handlers set local state before the PUT with no error callback, so a rejected request left the view showing a state that was never stored. Both now revert — and only when their own optimistic value is still current, so a stale failure cannot clobber a newer saved state.

The portal's initial GET had no error branch at all, leaving neither the tree nor the task list loaded on failure; EM's showed a dialog but never called `loadTasks()`, stranding an empty list. Both now fall back to the default view and still load. EM's error text also had a precedence bug (`"…" + error.error ? … : …`) that made the conditional always truthy, appending a literal `undefined` for a non-JSON body.

## Testing

- **New JUnit tests, 15 passing** (8 portal, 7 EM). The core regression guard is that two principals do not see each other's value; also covered are a stored `false` not being mistaken for "never chose", EM not reading the portal key, the varargs-free overload being used, and the controller never writing the global property.
- **Frontend:** all 24 schedule TL suites pass (schedule-task-list 53 + 20, including a new revert-on-PUT-failure test); full EM TL suite green (70 files); ESLint clean.
- Unrelated pre-existing failures in the portal TL run (viewsheet/composer/wizard, `VSTable is not a constructor`) drifted 31 → 26 → 23 files across runs with this code unchanged.

## Not addressed

`UserEnv.setProperty` catches persistence failures internally and returns normally, so the PUT answers 200 even when nothing was saved. Surfacing that would mean changing `UserEnv`'s contract and every caller, well outside this fix. The client revert still earns its place for transport and auth failures, and its comment claims only that. Worth a separate issue if save failures should propagate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
