### PR TITLE
Bug #76085, fix chart image request storm and always-loading chart

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartAreasService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/chart/VSChartAreasService.java
@@ -131,7 +131,11 @@ public class VSChartAreasService {
 
          if(pair != null && !pair.isCompleted()) {
             box.clearGraph(absoluteName);
-            pair = box.getVGraphPair(absoluteName);
+            // pass maxSize so the regenerated pair is laid out at the same content size
+            // used by the chart image requests (AssemblyImageService uses info.getMaxSize()).
+            // otherwise the two paths keep cancelling each other's graph, which makes the
+            // image requests return Retry-After forever and the chart always loading.
+            pair = box.getVGraphPair(absoluteName, true, maxSize);
          }
 
          if(pair != null) {

--- a/web/projects/portal/src/app/graph/objects/chart-image.directive.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-image.directive.ts
@@ -30,10 +30,17 @@ export class ChartImageDirective implements OnDestroy {
    set chartImage(value: string | SafeValue) {
       if(value !== this._chartImage) {
          this._chartImage = value;
+         this.resetRetry();
 
          if(this._loadTimer !== null) {
             clearTimeout(this._loadTimer);
             this._loadTimer = null;
+         }
+
+         // a retry armed for the previous address must not fire after the address changed.
+         if(this.retryTimer !== null) {
+            clearTimeout(this.retryTimer);
+            this.retryTimer = null;
          }
 
          if(!!value) {
@@ -56,6 +63,14 @@ export class ChartImageDirective implements OnDestroy {
    private currentBlobUrl: string = null;
    private loadSubscription: Subscription = null;
    private retryTimer: ReturnType<typeof setTimeout> | null = null;
+   private retryCount = 0;
+   private retryStart = 0;
+   // the server answers with Retry-After while the chart graph is still being generated.
+   // give up only after a generous wall-clock budget: a large/slow graph (big dataset, mv
+   // build, web map) may legitimately take a long time, and the facet/legend/title areas
+   // don't listen to onError, so giving up early leaves those tiles permanently blank.
+   private readonly MAX_RETRY_TIME = 300000;
+   private readonly MAX_RETRY_INTERVAL = 5000;
 
    constructor(private element: ElementRef, private http: HttpClient, private renderer: Renderer2) {
    }
@@ -80,6 +95,11 @@ export class ChartImageDirective implements OnDestroy {
       }
    }
 
+   private resetRetry(): void {
+      this.retryCount = 0;
+      this.retryStart = 0;
+   }
+
    private loadImage(reloading = false): void {
       if(this.retryTimer != null) {
          clearTimeout(this.retryTimer);
@@ -99,14 +119,43 @@ export class ChartImageDirective implements OnDestroy {
          this.loadSubscription = this.http.get(this.chartImage as string, { observe: "response", responseType: "blob" }).subscribe(
             response => {
                if(response.headers?.has("Retry-After")) {
-                  const interval = parseInt(response.headers.get("Retry-After"), 10) * 1000;
+                  // ignore a late response for an address we no longer want, so it doesn't
+                  // consume the current address's retry budget or reload the wrong image.
+                  if(requestedImage != this.chartImage) {
+                     return;
+                  }
+
+                  const now = Date.now();
+
+                  if(this.retryCount == 0) {
+                     this.retryStart = now;
+                  }
+                  else if(now - this.retryStart >= this.MAX_RETRY_TIME) {
+                     console.warn("Giving up loading image after " + this.retryCount +
+                                  " retries " + this.chartImage);
+                     this.resetRetry();
+                     this.onError.emit();
+                     return;
+                  }
+
+                  this.retryCount++;
+                  const seconds = parseInt(response.headers.get("Retry-After"), 10);
+                  // a missing/malformed header must not turn the retry into a busy loop.
+                  const interval = isNaN(seconds) ? 1000 : Math.max(seconds, 1) * 1000;
+                  // escalate up to MAX_RETRY_INTERVAL, but never poll faster than the
+                  // server asked for.
+                  const delay = Math.max(
+                     interval, Math.min(interval * this.retryCount, this.MAX_RETRY_INTERVAL));
+
                   this.retryTimer = setTimeout(() => {
                      this.retryTimer = null;
                      this.loadImage(true);
-                  }, interval);
+                  }, delay);
                }
                else if(requestedImage == this.chartImage) {
                   // Do not set if image address changed before the request returned
+                  this.resetRetry();
+
                   if(this.currentBlobUrl) {
                      URL.revokeObjectURL(this.currentBlobUrl);
                   }

--- a/web/projects/portal/src/app/graph/objects/chart-object-area-base.ts
+++ b/web/projects/portal/src/app/graph/objects/chart-object-area-base.ts
@@ -18,6 +18,7 @@
 import { AfterViewInit, Directive, ElementRef, HostBinding, inject, Input, NgZone, OnDestroy, ViewChild } from "@angular/core";
 import { SafeStyle } from "@angular/platform-browser";
 import { fromEvent, Subscription } from "rxjs";
+import { Dimension } from "../../common/data/dimension";
 import { GuiTool } from "../../common/util/gui-tool";
 import { ScaleService } from "../../widget/services/scale/scale-service";
 import { ChartAreaName } from "../model/chart-area-name";
@@ -54,6 +55,14 @@ export abstract class ChartObjectAreaBase<T extends ChartObject>
    protected _model: ChartModel;
    private _scrollTop = 0;
    private _scrollLeft = 0;
+   // max-mode size cached per generation. measuring the DOM inside getSrc() (which the
+   // template calls for every tile on every change detection pass) is both a forced layout
+   // read and a source of spurious url changes: a scrollbar appearing/disappearing changes
+   // the url by a few pixels and makes every tile reload, even though the server ignores
+   // these values when the assembly has a max size. (see AssemblyImageService)
+   private maxModeSize: Dimension = null;
+   private maxModeSizeGenTime: number = null;
+   private maxModeSizeContainer: any = null;
 
    @Input() public set scrollLeft(scroll: number) {
       this._scrollLeft = scroll;
@@ -127,7 +136,11 @@ export abstract class ChartObjectAreaBase<T extends ChartObject>
 
       inject(NgZone).runOutsideAngular(() => {
          this.addSubscription(fromEvent(window, "resize")
-            .subscribe(() => this.drawSelectedRegions())
+            .subscribe(() => {
+               // the cached max-mode size is measured from the DOM, so re-measure on resize.
+               this.maxModeSize = null;
+               this.drawSelectedRegions();
+            })
          );
       });
    }
@@ -210,7 +223,7 @@ export abstract class ChartObjectAreaBase<T extends ChartObject>
       let maxHeight = 0;
 
       if(this.maxMode) {
-         let viewSize = GuiTool.getChartMaxModeSize(container);
+         const viewSize = this.getMaxModeSize(container);
          maxWidth = viewSize.width;
          maxHeight = viewSize.height;
       }
@@ -227,6 +240,21 @@ export abstract class ChartObjectAreaBase<T extends ChartObject>
          "/" + this.genTime +
          "/" + true +
          "?" + NetTool.xsrfToken();
+   }
+
+   // measure the max-mode size once per graph generation instead of on every call. genTime
+   // changes whenever the server regenerates the chart areas, which is exactly when the
+   // measurement may have changed.
+   private getMaxModeSize(container: any): Dimension {
+      if(this.maxModeSize == null || this.maxModeSizeGenTime !== this.genTime ||
+         this.maxModeSizeContainer !== container)
+      {
+         this.maxModeSize = GuiTool.getChartMaxModeSize(container);
+         this.maxModeSizeGenTime = this.genTime;
+         this.maxModeSizeContainer = container;
+      }
+
+      return this.maxModeSize;
    }
 
    isTileVisible(tile: ChartTile): boolean {


### PR DESCRIPTION
## Problem

Reported repro: import `ST_interval1`, open the viewsheet in composer, click the edit icon to reach the binding pane, then *Show Enlarged* → *Show Actual Size*. The chart sometimes stays in the loading state forever, a burst of `getAssemblyImage` XHRs is issued, and the browser UI goes sluggish.

The attached HAR looked like duplicate requests, but it isn't: the 25 entries are the 9 distinct chart areas (`plot_area`, both x axes, both y axes, both titles, legend title/content) re-requested across **three full re-render cycles** (`genTime` 194876 → 205009 → 205229). The last two are 220 ms apart at the *same* requested size (444×495) but a *different* layout (legend width 83→50, plot width 327→304) — the server was re-laying-out the chart repeatedly. The truncated DevTools "Name" column only showed the shared `true?_csrf=…` tail, which made them look identical.

## Root cause

`VSChartAreasService` dropped the max-mode size when it regenerated an incomplete `VGraphPair`:

```java
pair = box.getVGraphPair(absoluteName, true, maxSize);   // correct size
...
if(pair != null && !pair.isCompleted()) {
   box.clearGraph(absoluteName);
   pair = box.getVGraphPair(absoluteName);               // maxSize lost -> maxsize = null
}
```

The tile endpoint uses the other size — `AssemblyImageService` prefers `info.getMaxSize()` and only falls back to the URL's `maxWidth/maxHeight` when it is null. `ViewsheetSandbox.getVGraphPair` cancels and rebuilds any pair whose `getContentSize()` differs from the requested one, so the two paths kept cancelling each other's graph. A cancelled/incomplete pair makes the image endpoint return `Retry-After: 1` with an empty body and the areas response `completed=false`, both of which the client re-requests — hence the burst, the stuck spinner, and the main-thread load. The existing comment in `AssemblyImageService` describes exactly this failure mode.

## Changes

1. **`VSChartAreasService`** — pass the in-scope `maxSize` when regenerating the pair, so the areas path and the image path agree on the content size. This is the actual fix.

2. **`ChartImageDirective`** — the `Retry-After` loop had no limit, no backoff, and emitted neither `onLoaded` nor `onError`, so nothing ever cleared the tile's loading state. Now bounded by a 5-minute wall-clock budget (deliberately generous: a large graph can legitimately take a while, and the facet/legend/title templates bind none of the load outputs, so giving up early would leave those tiles permanently blank), with escalating delay that never polls faster than the server asked, a guard so a late response for a superseded address can't consume the current address's budget, and `retryTimer` cleared when the address changes.

3. **`ChartObjectAreaBase.getSrc()`** — measured the DOM via `GuiTool.getChartMaxModeSize()` for every tile on every change-detection pass, so a scrollbar appearing shifted the URL by a few pixels and reloaded every tile, and each call forced a layout. The measurement is now cached per `genTime` (invalidated on window resize and on a container change). Safe because `maxMode` is only true when `info.getMaxSize() != null`, and the server ignores the URL's `maxWidth/maxHeight` in exactly that case.

## Testing

- `tsc --noEmit` on the portal app: clean.
- `mvnw compile -pl core`: clean.
- The 17 TL spec files covering `graph/objects`, `vs-binding-pane` and `vs-object-container`: 590 tests pass.
- Manual verification of the reported repro is pending with the reporter's data.

## Notes for reviewers

- `RegionPropertyDialogService.java:336-338` has the identical drop-the-`maxSize` pattern in the chart region properties dialog. Left alone here to keep the fix scoped; worth a follow-up.
- Pre-existing and not addressed: the second `getVGraphPair` call runs outside `box.lockRead()` and `maxSize` is captured before the lock, so a concurrent max-mode resize can still regenerate at a stale size. This change narrows that race considerably but does not close it.
- Also pre-existing, and the likely reason the burst *feels* like a freeze rather than just slow: `Tool.clone(this.model)` (lodash `cloneDeep` of the whole chart model including every region) on every `SetChartAreasCommand`, and the per-tile synchronous `canvas.toDataURL()` PNG encode in `captureChartSnapshot()`. Deliberately out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
