### PR TITLE
Bug #76040, stop the mobile sandwich menu from being covered by the paging control

### DIFF
--- a/web/projects/portal/src/app/vsobjects/objects/viewer-mobile-toolbar/viewer-mobile-toolbar.component.tl.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/viewer-mobile-toolbar/viewer-mobile-toolbar.component.tl.spec.ts
@@ -23,11 +23,19 @@
  *   Group 1 [Risk 2] — hasMenuAction: correct boolean logic; wrong result hides the
  *                       sandwich menu button or shows it when it should not exist
  *   Group 2 [Risk 2] — showMobileSandwichDropdown: open/close toggle; wrong branch leaves
- *                       the overlay permanently open or permanently closed
+ *                       the overlay permanently open or permanently closed. Also pins down
+ *                       the fix for the unresponsive mobile sandwich menu: the options must
+ *                       not pin a z-index, or the menu sits below the paging control
  *   Group 3 [Risk 1] — allowedActionsNum: defaultButtons increments by 1 when hasMenuAction
  *                       is true; arithmetic error shows too many or too few toolbar actions
  *
- * Confirmed bugs: none
+ * Confirmed bugs: pinned zIndex 1000 put the menu below the mobile paging control (fixed)
+ *
+ * Known, not fixed here: sandwichMenuOpen is never reset when the dropdown closes on its
+ *   own, so the first tap on the sandwich button after an external close is a no-op. The
+ *   flag cannot simply be reset -- FixedDropdownComponent emits onClose from its own
+ *   document mousedown/click listeners before the button's (click) runs, so an accurate
+ *   flag makes the button reopen the menu instead of dismissing it.
  *
  * Out of scope:
  *   actions setter — trivially assigns _actions; no logic to contract-test
@@ -67,6 +75,17 @@ beforeEach(() => {
    DROPDOWN_SERVICE_MOCK.open.mockClear();
    dropdownRefMock.close.mockClear();
 });
+
+function openSandwich(comp: ViewerMobileToolbarComponent): void {
+   comp.mobileSandwichElement = {
+      nativeElement: {
+         getBoundingClientRect: () => ({ left: 10, top: 20 }),
+         offsetHeight: 50,
+      },
+   } as ElementRef;
+
+   comp.showMobileSandwichDropdown({});
+}
 
 async function renderComp(actions: Partial<AbstractVSActions<any>> = makeActions()) {
    const { fixture } = await render(ViewerMobileToolbarComponent, {
@@ -145,6 +164,19 @@ describe("ViewerMobileToolbarComponent — showMobileSandwichDropdown", () => {
       expect(dropdownRefMock.close).toHaveBeenCalledTimes(1);
       expect(comp.sandwichMenuOpen).toBe(false);
       expect(DROPDOWN_SERVICE_MOCK.open).not.toHaveBeenCalled();
+   });
+
+   // 🔁 Regression-sensitive: a pinned zIndex becomes an inline style on the dropdown host
+   // and overrides the .fixed-dropdown stylesheet value (999900). The old value of 1000 put
+   // this menu below the mobile paging control (z-index 9999, pointer-events: all) that the
+   // viewer plants at the tapped cell, so taps on overlapping menu items hit-tested to the
+   // control and were silently swallowed.
+   it("should not pin a z-index on the dropdown options", async () => {
+      const { comp } = await renderComp();
+      openSandwich(comp);
+
+      const options = DROPDOWN_SERVICE_MOCK.open.mock.calls[0][1] as any;
+      expect(options.zIndex).toBeUndefined();
    });
 });
 

--- a/web/projects/portal/src/app/vsobjects/objects/viewer-mobile-toolbar/viewer-mobile-toolbar.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/viewer-mobile-toolbar/viewer-mobile-toolbar.component.ts
@@ -73,8 +73,12 @@ export class ViewerMobileToolbarComponent {
             },
             contextmenu: true,
             autoClose: true,
-            closeOnOutsideClick: true,
-            zIndex: 1000
+            closeOnOutsideClick: true
+            // don't pin a z-index: an inline style overrides the .fixed-dropdown
+            // stylesheet value (999900) and the pinned 1000 put this menu *below* the
+            // mobile paging control (z-index 9999, pointer-events: all), which the
+            // viewer plants at the tapped cell. Taps on menu items that overlapped it
+            // hit-tested to the control instead and were silently swallowed.
          } as DropdownOptions;
          this.mobileSandwichRef = this.dropdownService.open(component, options);
          this.sandwichMenuOpen = true;


### PR DESCRIPTION
## Problem

On mobile, tapping a crosstab cell raises a tip view, and then tapping an action such as **Hide Column** does nothing — *sometimes*.

Two earlier fixes ([#4646](https://github.com/inetsoft-technology/stylebi/pull/4646), Bug #76042; [#4643](https://github.com/inetsoft-technology/stylebi/pull/4643), Bug #76036) addressed an orphaned `onAssemblyActionEvent` emitter — the action fired but nothing was subscribed. That cause is genuinely handled by `ViewerAppComponent.resyncSelectedActions()`, which is why this repro survived both: **the tap never reaches the action's `(click)` handler at all.**

## Root cause

On mobile the per-assembly mini-toolbar renders no buttons (`mini-toolbar.component.html` guards the row with `@if (!mobileDevice)`); actions appear in the top `viewer-mobile-toolbar`. **"Hide Column" is a *menu* action** — `CrosstabActions` puts it in `createMenuActions()`, not `createToolbarActions()` — so on mobile it is only reachable through the sandwich dropdown.

`showMobileSandwichDropdown()` pinned `zIndex: 1000`. `FixedDropdownService` applies that as an **inline** style on the dropdown host, overriding the app-wide `.fixed-dropdown` value of **999900** (`set-z-index-selector` in `scss/internal/_directives.scss`). It was the only dropdown in the portal with such an override — the `moreActions` dropdown in the same template uses `[fixedDropdown]` with no override and so runs at 999900, which is why toolbar actions always worked and only the sandwich menu failed.

Meanwhile selecting a crosstab cell plants the mobile paging control **at the tap point**:

- `selectAssembly()` → `showScrollButton(event)` sets `pageControlStartX/Y` from the event's `clientX/clientY`.
- `isPageControlVisible()` is true for a selected `VSCrosstab` (`usePagingControl` covers `VSChart / VSTable / VSCrosstab / VSCalcTable`).
- `<paging-control>` is a top-level sibling **outside** `.viewer-root`, so it shares a stacking context with the body-appended dropdown. Its `.scroll-controls` is `position: fixed; z-index: 9999`, becomes `pointer-events: all` when enabled, and swallows what lands on it via `(click)="$event.stopPropagation()"`.

9999 beats 1000, so taps on menu items overlapping that 80×80 control hit-tested to the control and were silently discarded.

This accounts for every facet of the report: crosstab/table/chart-specific (`usePagingControl`), requiring the exact gesture that also raises a tip view (tapping a data cell is what positions the control), and intermittent because it is purely positional. The existing `hasDropdownOrTooltip ? y -= buttonSize` shift in `showScrollButton` is a pre-existing band-aid for the same collision.

## Fix

Drop the `zIndex` pin so the `.fixed-dropdown` stylesheet value applies, matching every other dropdown in the app. One property removed; no new code path.

## Side effects

Mobile-only; desktop is untouched. The sandwich menu now paints above the paging control (9999), the notification toasts (`10000`) and the row-limit message (`1001`) — correct for a menu overlay. Nested-dropdown stacking is decided by `DropdownStackService.isCurrent` (DOM/stack order), not z-index, so it is unaffected. Nothing in the codebase intentionally covers this menu.

## A trap for the next person

I first also made `sandwichMenuOpen` accurate by subscribing to `mobileSandwichRef.closeEvent`, to fix a separate dead tap (the first tap on the sandwich button after the menu closes by itself is a no-op). **Code review caught that this regresses the button's dismiss gesture, so it was reverted.**

`DropdownRef.closeEvent` *is* `FixedDropdownComponent.onClose`, and that component emits it from its own document listeners — `documentMousedown0` for any outside mousedown, `documentClick` for *any* click while the dropdown is current, plus `FixedDropdownContextmenuComponent`'s document `touchstart` — all of which run **before** the button's own `(click)`. The stale flag is precisely what absorbs that double handling; resetting it makes the second tap reopen the menu instead of closing it.

That dead tap is real but cannot be fixed from this component — it needs `FixedDropdownComponent`/`DropdownRef` to distinguish "closed by this very tap" from "closed earlier". The spec header records the constraint.

## Testing

`viewer-mobile-toolbar.component.tl.spec.ts` gains a regression test asserting the options carry no pinned `zIndex`. 8/8 pass; I confirmed the new test fails against the pre-fix source. ESLint clean.

```
npx ng run portal:test-tl --include="**/viewer-mobile-toolbar.component.tl.spec.ts"
```

**Not yet verified on a device.** Suggested manual check (Chrome DevTools device toolbar with touch emulation — mobile detection is UA-based and memoized in `GuiTool.isMobileDevice()`):

1. Open a viewsheet whose crosstab has a tip view bound; tap a data cell. The tip view, the top mobile toolbar and the round 80×80 paging control should all appear.
2. Tap the sandwich button. **Before:** `getComputedStyle(document.querySelector('.fixed-dropdown')).zIndex` → `1000`, and for the "Hide Column" anchor, `document.elementFromPoint(...)` at its centre returns `.scroll-controls` or one of its arrow buttons. **After:** `999900`, and `elementFromPoint` returns the `<a class="dropdown-item">`.
3. Tap "Hide Column" — the column hides and a `/events/composer/viewsheet/table/showHideColumns` frame goes out.
4. Repeat tapping cells in several regions (upper-right, mid, lower-right) and confirm every menu item responds.
5. Regression check: open the sandwich menu, tap the sandwich button again — it must **dismiss** the menu, not reopen it.

## Related, not fixed here

Each of these would also present as "no response" and is worth a follow-up if the tester still sees issues:

1. `VSDataTipDirective.isMouseInDataTip()` exempts `mini-toolbar`, `.mobile-toolbar` and `.page-control-container` but **not** `.fixed-dropdown`, while the desktop `onLeave()` path does. On mobile every tap on a sandwich item therefore tears the tip view down at `touchstart`, including a synchronous `detectChanges()` inside the touch handler.
2. `FixedDropdownContextmenuComponent` leaks a document `touchstart` listener on every open: added with `{passive: false}` (capture `false`) but removed with `true`, so `removeEventListener` never matches.
3. `VSCrosstab.hideColumn()` reads `this.loadedRows.start` and `model.cells[rowNumber][value].colSpan` unguarded. `loadedRows` has no initializer, and `selectedHeaders` keys are absolute rows pruned only against the total row count (`refreshHeaderSelection`), not against the loaded window — a throw there would abort before `sendEvent`. The `Math.max(0, key - start)` clamp also silently reads the wrong row for a column-header cell when scrolled.
4. `ComposerVSTableService.hideColumns()` still runs a full refresh when `columns` is empty, which is indistinguishable from "no response".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
