### PR TITLE
Bug #76022, keep fixed-height bottom-tab children flush in the scale-to-screen path

### DIFF
--- a/core/src/main/java/inetsoft/analytic/composition/event/VSEventUtil.java
+++ b/core/src/main/java/inetsoft/analytic/composition/event/VSEventUtil.java
@@ -1322,8 +1322,14 @@ public final class VSEventUtil {
             Dimension scaleSize = new Dimension();
 
             scaleSize.width = (int) Math.floor(size.width * sizeScale.x);
+            // the tab bar's height is not scaled, so its slack is absorbed by the
+            // children -- but only by children that scale vertically. A fixed-height
+            // child (input, submit, dropdown selection, nested tab) renders at its
+            // natural height, so adding the slack inflates its box and leaves the
+            // content detached from a bottom tab bar (Bug #76022).
+            double childRepairH = sizeScale.y == scaleRatio.y ? repairH : 0;
             scaleSize.height =
-               (int) Math.floor(size.height * sizeScale.y + repairH);
+               (int) Math.floor(size.height * sizeScale.y + childRepairH);
             scaleSize.height = Math.max(0, scaleSize.height);
 
             // top tabs: children below tab bar; bottom tabs: children above tab bar

--- a/core/src/test/java/inetsoft/analytic/composition/event/VSEventUtilTabScaleTest.java
+++ b/core/src/test/java/inetsoft/analytic/composition/event/VSEventUtilTabScaleTest.java
@@ -1,0 +1,149 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.analytic.composition.event;
+
+import inetsoft.report.composition.execution.ViewsheetSandbox;
+import inetsoft.test.*;
+import inetsoft.uql.viewsheet.*;
+import inetsoft.uql.viewsheet.internal.TabVSAssemblyInfo;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.awt.*;
+import java.awt.geom.Point2D;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for bottom-tab child geometry in the scale-to-screen path
+ * ({@code VSEventUtil.applyTabScale}).
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class },
+                      initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class VSEventUtilTabScaleTest {
+   /**
+    * Bug #76022: the tab bar's height is not scaled, so its slack is handed to the
+    * children. A radio button never scales vertically
+    * ({@code InputVSAssemblyInfo.getSizeScale} returns y=1), so adding the slack
+    * inflated its box and left the rendered content floating above the tab bar.
+    */
+   @Test
+   void fixedHeightChildKeepsNaturalHeightWhenScalingUp() throws Exception {
+      Viewsheet vs = createTabViewsheet("Gauge1");
+      applyScale(vs, 1.0, 1.5);
+
+      assertEquals(RADIO_HEIGHT, scaledSize(vs, "RadioButton1").height,
+                   "fixed-height child must not absorb the tab bar slack");
+      assertEquals(scaledTop(vs, "Tab1"),
+                   scaledTop(vs, "RadioButton1") + RADIO_HEIGHT,
+                   "radio button must end flush with the tab bar");
+   }
+
+   /**
+    * Mirror case: with a shrinking ratio the slack is negative, so the box used
+    * to be shorter than the content and the radios overlapped the tab bar.
+    */
+   @Test
+   void fixedHeightChildKeepsNaturalHeightWhenScalingDown() throws Exception {
+      Viewsheet vs = createTabViewsheet("Gauge1");
+      applyScale(vs, 1.0, 0.5);
+
+      assertEquals(RADIO_HEIGHT, scaledSize(vs, "RadioButton1").height,
+                   "fixed-height child must not absorb the tab bar slack");
+      assertEquals(scaledTop(vs, "Tab1"),
+                   scaledTop(vs, "RadioButton1") + RADIO_HEIGHT,
+                   "radio button must end flush with the tab bar");
+   }
+
+   /**
+    * A child that does scale vertically still absorbs the slack, so the tab
+    * group's total scaled extent is unchanged.
+    */
+   @Test
+   void scalingChildStillAbsorbsTabBarSlack() throws Exception {
+      Viewsheet vs = createTabViewsheet("RadioButton1");
+      applyScale(vs, 1.0, 1.5);
+
+      int expected = (int) Math.floor(GAUGE_HEIGHT * 1.5 + (TAB_HEIGHT * 1.5 - TAB_HEIGHT));
+      assertEquals(expected, scaledSize(vs, "Gauge1").height,
+                   "vertically scaling child keeps the tab bar slack");
+      assertEquals(scaledTop(vs, "Tab1"),
+                   scaledTop(vs, "Gauge1") + expected,
+                   "gauge must end flush with the tab bar");
+   }
+
+   private void applyScale(Viewsheet vs, double rx, double ry) throws Exception {
+      ViewsheetSandbox box = Mockito.mock(ViewsheetSandbox.class);
+      VSEventUtil.applyScale(vs, new Point2D.Double(rx, ry), true, null, 375, 667, box);
+   }
+
+   /**
+    * Geometry of the asset from the report: a bottom-tabs container with a gauge
+    * (140px, scales vertically) and a radio button (40px, fixed height), both
+    * design-time flush with the 24px tab bar.
+    *
+    * @param hidden the unselected tab child, invisible at runtime
+    */
+   private Viewsheet createTabViewsheet(String hidden) {
+      Viewsheet vs = new Viewsheet();
+      vs.getViewsheetInfo().setScaleToScreen(true);
+
+      GaugeVSAssembly gauge = new GaugeVSAssembly(vs, "Gauge1");
+      gauge.setPixelOffset(new Point(160, 204));
+      gauge.setPixelSize(new Dimension(140, GAUGE_HEIGHT));
+
+      RadioButtonVSAssembly radio = new RadioButtonVSAssembly(vs, "RadioButton1");
+      radio.setPixelOffset(new Point(160, 304));
+      radio.setPixelSize(new Dimension(200, RADIO_HEIGHT));
+
+      TabVSAssembly tab = new TabVSAssembly(vs, "Tab1");
+      tab.setPixelOffset(new Point(160, 344));
+      tab.setPixelSize(new Dimension(200, TAB_HEIGHT));
+      ((TabVSAssemblyInfo) tab.getInfo()).setBottomTabsValue(true);
+
+      vs.addAssembly(gauge);
+      vs.addAssembly(radio);
+      vs.addAssembly(tab);
+      tab.setAssemblies(new String[]{ "Gauge1", "RadioButton1" });
+      ((VSAssembly) vs.getAssembly(hidden)).getVSAssemblyInfo().setVisible("hide");
+
+      return vs;
+   }
+
+   private int scaledTop(Viewsheet vs, String name) {
+      return ((VSAssembly) vs.getAssembly(name)).getVSAssemblyInfo()
+         .getLayoutPosition(true).y;
+   }
+
+   private Dimension scaledSize(Viewsheet vs, String name) {
+      return ((VSAssembly) vs.getAssembly(name)).getVSAssemblyInfo().getLayoutSize(true);
+   }
+
+   private static final int TAB_HEIGHT = 24;
+   private static final int GAUGE_HEIGHT = 140;
+   private static final int RADIO_HEIGHT = 40;
+}


### PR DESCRIPTION
Follow-up to #4635 — QA reported the gap is still visible in Chrome device emulation.

## Why #4635 didn't cover it

The reported asset's device layout `a` targets the "Small devices" device (**minWidth 768 / maxWidth 991**), so on a 375px phone `LayoutInfo.matchLayout` finds no match and **no device layout is applied**. The viewsheet has `scaleToScreen="true"`, so the geometry in the screenshot comes entirely from `CoreLifecycleService` → `VSEventUtil.applyScale` → `applyTabScale` — a path #4635 (layout space: `AbstractLayout.applyTab`, `VSLayoutService`) never touches. Pre-existing defect in the scaled path, not a regression.

## Root cause

`applyTabScale` gives the tab bar's unscaled slack to every child:

```java
double repairH = tabSize.height * scaleRatio.y - tabSize.height;   // 24 * (ry - 1)
scaleSize.height = (int) Math.floor(size.height * sizeScale.y + repairH);
int childY = bottomTabs ? tabPos.y - scaleSize.height : tabPos.y + tabSize.height;
```

That is right for a child that scales vertically — it keeps the tab group's total scaled extent correct while the bar stays 24px. But `InputVSAssemblyInfo.getSizeScale` returns `(rx, 1)`: a radio button never scales vertically. In the asset (`Gauge1` 140@204, `RadioButton1` 40@304, `Tab1` 24@344, `bottomTabs`, all design-time flush) at `ry ≈ 1.5`:

- `Gauge1`: `140*1.5 + 12 = 222` — box grows with the content, bottom edge on the strip. Correct.
- `RadioButton1`: `40*1 + 12 = 52` — box inflated by 12px while the rendered content is still 40px (title 20 + one 20px row) and top-aligned inside it. The box bottom meets the strip; the visible radios stop 12px short of it. That is the reported gap, and it explains why only the radio looks wrong.

Same class of assembly affected wherever `getSizeScale().y != scaleRatio.y`: `SubmitVSAssemblyInfo`, `TimeSliderVSAssemblyInfo`, dropdown `SelectionList`/`Calendar`, non-vertical-scaling `TextVSAssemblyInfo`, nested `TabVSAssemblyInfo`. It only *looks* broken for bottom tabs, because there the strip sits directly under the child; with top tabs the slack lands below the content where nothing anchors it.

## Fix

Only hand the slack to children that actually scale vertically:

```java
double childRepairH = sizeScale.y == scaleRatio.y ? repairH : 0;
```

- `scaleRatio.y == 1` → `repairH` is already 0, so nothing changes there.
- Bottom tabs: `childY = tabPos.y - scaleSize.height` still anchors to the bar, now with the correct height, so the *content* is flush too. Also fixes the `ry < 1` mirror case, where the box shrank below the content and the radios overlapped the strip.
- Top tabs: positions unchanged (`tabPos.y + tabSize.height`); fixed-height children just stop reporting a padded height.
- The embedded-viewsheet branch further down the loop reuses `scaleSize`; `ViewsheetVSAssemblyInfo` has no `getSizeScale` override, so it keeps `repairH` and is unaffected.

## Tests

New `VSEventUtilTabScaleTest` rebuilds the reported asset's geometry and drives the real `VSEventUtil.applyScale`. Confirmed failing without the fix:

```
fixedHeightChildKeepsNaturalHeightWhenScalingUp   expected: <40> but was: <52>
fixedHeightChildKeepsNaturalHeightWhenScalingDown expected: <40> but was: <28>
```

The third test pins the unchanged behavior (a vertically scaling gauge still absorbs the slack and stays flush).

Regression run, all green: `VSEventUtilTabScaleTest, AbstractLayoutTest, VSLayoutServiceTest, TabVSAScriptableTest, TabVSAssemblyTest, TabPropertyDialogServiceTest, SelectionTreePropertyDialogServiceTest, ComposerObjectServiceTest`.

Not yet verified in a running server; reporter will check iPhone SE (375px, the pure scale-to-screen case from the report) and ~800px (where layout `a` matches, exercising layout + scale together).

## Known adjacent issues, deliberately left alone

- `applyTabScale` anchors the bar from `TabVSAssemblyInfo.getBottomTabChildHeight` (label-**inclusive**) but places children from the declared height (label-**exclusive**). That bites a bottom-tab input child with a top/bottom label — not this asset (no `labelInfo`), and the client already offsets dropdown selections/calendars itself, so changing it risks double-shifting.
- `handleOverlapping` runs after `applyTabScale` and, for a *visible* overlapping `ListInputVSAssembly`, re-runs `applyAssemblyScale`, discarding the tab anchoring. It does not fire here (the unselected tab child is invisible) but it is latent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
