### PR TITLE
Bug #75930, drop the round corner corner-masks in Excel/PPT table export

### DIFF
--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
@@ -1168,9 +1168,8 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
          color = bcolors == null ? null : bcolors.bottomColor;
       }
       else {
-         // No border configured at all: there's no outline to compensate the mask with a
-         // curve, so skip masking too rather than leaving an unrounded white square with
-         // no border and no explanation.
+         // No border configured at all: the rounded outline shape is the only thing drawn
+         // here, so there is nothing to round.
          return;
       }
 
@@ -1179,13 +1178,6 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
       if(lineStyle == ExcelVSUtil.EXCEL_NO_BORDER) {
          return;
       }
-
-      // Mask the square cell background/content that would otherwise stick out past the
-      // curve at each corner (e.g. a shaded title-row fill, or the corner-most cell's
-      // text) with a plain white square, the same way the viewer's overflow:hidden clips
-      // it. This must happen before the border outline below so the outline's curve is
-      // drawn on top of the mask, not under it.
-      maskTableCorners(pixelBounds, radius);
 
       XSSFSimpleShape shape = patriarch.createSimpleShape(
          (XSSFClientAnchor) getAnchorFromPixelRect(pixelBounds));
@@ -1202,29 +1194,6 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
       else {
          shape.setLineStyleColor(0, 0, 0);
       }
-   }
-
-   /**
-    * Paint over the four radius x radius corners of the given bounds with a plain white
-    * square, hiding whatever square cell content is underneath so it reads as clipped by
-    * the rounded corner instead of poking out past it.
-    */
-   private void maskTableCorners(Rectangle2D pixelBounds, int radius) {
-      double x = pixelBounds.getX();
-      double y = pixelBounds.getY();
-      double w = pixelBounds.getWidth();
-      double h = pixelBounds.getHeight();
-
-      maskCorner(x, y, radius);
-      maskCorner(x + w - radius, y, radius);
-      maskCorner(x, y + h - radius, radius);
-      maskCorner(x + w - radius, y + h - radius, radius);
-   }
-
-   private void maskCorner(double x, double y, double size) {
-      XSSFSimpleShape mask = patriarch.createSimpleShape((XSSFClientAnchor)
-         getAnchorFromPixelRect(new Rectangle2D.Double(x, y, size, size)));
-      mask.setFillColor(255, 255, 255);
    }
 
    private void fixAlignment(XSSFTextBox tb, int align) {

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/ppt/PPTValueHelper.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/ppt/PPTValueHelper.java
@@ -459,14 +459,6 @@ public class PPTValueHelper {
          }
 
          if(type != 0 && PPTVSUtil.getBorderWidth(type) != 0) {
-            // Table/crosstab cells are written as individual shapes with their own
-            // (non-rounded) borders, so the single rounded outline drawn on top doesn't
-            // automatically hide the square cell content that sticks out past the curve
-            // near each corner (PPT has no Graphics2D-style clip to lean on, unlike
-            // PDF/SVG). Mask it with a plain white square first, mirroring
-            // PoiExcelVSExporter's corner mask for the same underlying limitation.
-            maskTableCorners(x, y, width, height, format.getRoundCorner());
-
             XSLFAutoShape roundBorder = slide.createAutoShape();
             roundBorder.setAnchor(new Rectangle(x, y, width, height));
             PPTVSUtil.applyRoundCorner(roundBorder, format.getRoundCorner(), bounds);
@@ -539,31 +531,6 @@ public class PPTValueHelper {
             }
          }
       }
-   }
-
-   /**
-    * Paint over the four radius x radius corners with a plain white square, hiding
-    * whatever square cell content is underneath so it reads as clipped by the rounded
-    * corner instead of poking out past it.
-    */
-   private void maskTableCorners(int x, int y, int width, int height, int roundCorner) {
-      int r = (int) Math.min(roundCorner * PPTVSUtil.PIXEL_TO_POINT,
-                             Math.min(width, height) / 2d);
-
-      if(r <= 0) {
-         return;
-      }
-
-      maskCorner(x, y, r);
-      maskCorner(x + width - r, y, r);
-      maskCorner(x, y + height - r, r);
-      maskCorner(x + width - r, y + height - r, r);
-   }
-
-   private void maskCorner(int x, int y, int size) {
-      XSLFAutoShape mask = slide.createAutoShape();
-      mask.setAnchor(new Rectangle(x, y, size, size));
-      mask.setFillColor(Color.WHITE);
    }
 
    private Rectangle2D bounds = null;


### PR DESCRIPTION
## Summary
Follow-up to #4557. Testing of the merged build reported that on Excel and PPT export of a round-corner Table, *"some styles are missing on round corner"* — white notches at the corners where the outer border stroke, the title-row background fill, and the left edge of the title text were wiped out.

Root cause is the corner-masking hack #4516/#4557 added for the two formats that cannot clip:

- `PoiExcelVSExporter.maskTableCorners()`/`maskCorner()` — four opaque white `radius x radius` `XSSFSimpleShape` squares at the object's corners.
- `PPTValueHelper.maskTableCorners()`/`maskCorner()` — the same with `XSLFAutoShape`s, and with no radius cap (unlike Excel's `MAX_TABLE_ROUND_RADIUS = 8`), so the damage there scales with the configured round corner.

The region that should be hidden is the corner square **minus** the quarter-disc inside the arc. A full square also erases everything that legitimately belongs *inside* the rounded shape — hence the missing border/fill/text.

PDF/SVG/PNG are unaffected: they use a real `Graphics2D` `RoundRectangle2D` clip (`beginRoundCornerClip`/`endRoundCornerClip` in `VSTableDataHelper`), which is correct.

Excel and PPT have no equivalent clip, so this drops the masking in both and keeps only the rounded-rectangle outline overlay. Remaining accepted tradeoff: a small square sliver of cell fill/border can show just outside the arc at each corner — bounded by the 8px cap in Excel, and far less objectionable than erasing styles. (The exact-fidelity alternative — custom-geometry `arcTo` corner wedges filled with the resolved background color — is a bigger change and can follow if that sliver proves visible in practice.)

Everything else from #4557 is unchanged: the `setRoundCorner` copies in the six Table/Crosstab helpers, the PPT `setCellType(0)` reset, the PDF/SVG/PNG clips, and the HTML `getRoundCorner()`/`overflow:hidden` fix.

## Test plan
- [ ] Export a Table/Crosstab with round corner + a full border and a shaded title row to Excel and PPT; confirm no white corner notches, the outer border runs continuously into the curve, and the title fill/text are intact.
- [ ] Repeat with round corner set but no border configured; confirm no stray shapes (unchanged early return).
- [ ] Repeat with a partial border (top only); confirm the documented uniform-outline tradeoff still looks reasonable.
- [ ] Regression: non-rounded Table/Crosstab to Excel/PPT unchanged, and the same rounded viewsheet to PDF/PNG/HTML still renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)