### PR TITLE
Bug #76238, guard against a null assembly lookup in ChartVSAQuery.getAssembly()

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/ChartVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/ChartVSAQuery.java
@@ -71,7 +71,8 @@ public class ChartVSAQuery extends CubeVSAQuery implements BindableVSAQuery {
          return assembly;
       }
 
-      return assembly = (VSAssembly) super.getAssembly().clone();
+      VSAssembly base = super.getAssembly();
+      return assembly = base == null ? null : (VSAssembly) base.clone();
    }
 
    /**


### PR DESCRIPTION
## Summary

`ChartVSAQuery.getAssembly()` threw an intermittent NullPointerException in the Visualization Wizard when switching chart types (repro is unstable/timing-dependent), logged as:

```
java.lang.NullPointerException: Cannot invoke "inetsoft.uql.viewsheet.VSAssembly.clone()" because the return value of "inetsoft.report.composition.execution.CubeVSAQuery.getAssembly()" is null
    at inetsoft.report.composition.execution.ChartVSAQuery.getAssembly(ChartVSAQuery.java:74)
    at inetsoft.report.composition.execution.ChartVSAQuery.getTableAssembly(ChartVSAQuery.java:595)
    at inetsoft.report.composition.execution.ChartVSAQuery.getTableLens(ChartVSAQuery.java:360)
    at inetsoft.report.composition.execution.ChartVSAQuery.getData(ChartVSAQuery.java:104)
    ...
    at inetsoft.web.vswizard.handler.VSWizardBindingHandler.changeFormat(VSWizardBindingHandler.java:2168)
```

## Root Cause

`ChartVSAQuery.getAssembly()` calls `super.getAssembly().clone()` unconditionally. The base implementation (`VSAQuery.getAssembly()`, inherited unchanged through `CubeVSAQuery`/`DataVSAQuery`) is `getViewsheet().getAssembly(vname)`, which legitimately returns `null` when the named assembly is transiently absent from the viewsheet — exactly the case during the wizard's rapid chart-type-switch flow, where the temp chart assembly bound to the query's `vname` can momentarily not be present. Sibling methods in the same class (`getData()` and `getTableAssembly()`) already null-check `getAssembly()`'s result, confirming `null` is an expected, designed return value that this override alone failed to honor by dereferencing it with `.clone()` before the null check could ever run.

## Fix

`ChartVSAQuery.getAssembly()` now null-checks the base assembly before cloning it, returning `null` instead of throwing, consistent with how the rest of the class already treats a missing assembly.

## Test Plan

- `./mvnw clean install -pl core -am -DskipTests` — build succeeds
- `./mvnw test -pl core -Dtest=ChartVSAQueryTest` — 2/2 existing tests pass
- Manual repro: open a chart in the wizard and rapidly switch chart types; previously intermittently logged the NPE above via `VSWizardBindingHandler.changeFormat`, now returns `null` gracefully with no error logged.

Fixes Redmine #76238.