### PR TITLE
Bug #76236, guard chart binding tree against a disposed viewsheet

### DIFF
--- a/core/src/main/java/inetsoft/web/binding/handler/VSTreeHandler.java
+++ b/core/src/main/java/inetsoft/web/binding/handler/VSTreeHandler.java
@@ -64,9 +64,20 @@ public class VSTreeHandler {
       throws Exception
    {
       Viewsheet vs0 = rvs.getViewsheet();
+
+      // viewsheet may have been disposed/reset concurrently (e.g. user interacts with the
+      // binding tree before a heavy chart finishes loading), so vs0 can be null here.
+      if(vs0 == null) {
+         return null;
+      }
+
       String aname = info.getAbsoluteName2();
       aname = aname == null ? info.getAbsoluteName() : aname;
       ChartVSAssembly chart = (ChartVSAssembly) vs0.getAssembly(aname);
+
+      if(chart == null) {
+         return null;
+      }
 
       final Viewsheet vs = chart.getViewsheet();
       final String name = chart.getName();

--- a/core/src/main/java/inetsoft/web/binding/service/VSBindingTreeService.java
+++ b/core/src/main/java/inetsoft/web/binding/service/VSBindingTreeService.java
@@ -82,7 +82,7 @@ public class VSBindingTreeService {
                assetTreeModel = treeHandler.getChartTreeModel(
                   engine.getAssetRepository(), rvs, (ChartVSAssemblyInfo) info, false, principal);
 
-               if(appendComponentTree) {
+               if(assetTreeModel != null && appendComponentTree) {
                   treeHandler.appendVSAssemblyTree(rvs, assetTreeModel, principal, assembly);
                }
             }

--- a/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardBindingService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardBindingService.java
@@ -106,6 +106,11 @@ public class VSWizardBindingService {
          AssetTreeModel assetTreeModel = treeHandler.getChartTreeModel(
             viewsheetService.getAssetRepository(), rvs, temporaryInfo.getTempChart().getChartInfo(),
             true, principal);
+
+         if(assetTreeModel == null) {
+            return null;
+         }
+
          TreeNodeModel model = treeHandler.createTreeNodeModel(
             (AssetTreeModel.Node) assetTreeModel.getRoot(), principal);
          DataRefModel[] grayedOutFields = assemblyHandler.getGrayedOutFields(rvs);

--- a/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardObjectService.java
+++ b/core/src/main/java/inetsoft/web/vswizard/controller/VSWizardObjectService.java
@@ -209,6 +209,11 @@ public class VSWizardObjectService {
          AssetTreeModel assetTreeModel = treeHandler.getChartTreeModel(
             viewsheetService.getAssetRepository(), rvs,
             temporaryInfo.getTempChart().getChartInfo(), true, principal);
+
+         if(assetTreeModel == null) {
+            return null;
+         }
+
          TreeNodeModel model = treeHandler.createTreeNodeModel(
             (AssetTreeModel.Node) assetTreeModel.getRoot(), principal);
          DataRefModel[] grayedOutFields = assemblyHandler.getGrayedOutFields(rvs);


### PR DESCRIPTION
## Summary

Opening a heavy chart and quickly clicking "Binding Editor" or "Refresh Tree" before the viewsheet finishes loading could throw a `NullPointerException`:

```
java.lang.NullPointerException: Cannot invoke "inetsoft.uql.viewsheet.Viewsheet.getAssembly(String)" because "vs0" is null
        at inetsoft.web.binding.handler.VSTreeHandler.getChartTreeModel(VSTreeHandler.java:69)
```

## Root Cause

`RuntimeViewsheet.getViewsheet()` returns `null` once the `RuntimeViewsheet` has been disposed (`RuntimeViewsheet.dispose()` sets its `vs` field to `null`). `VSBindingTreeService.getBinding()` reads `rvs.getViewsheet()` once (non-null) to fetch the assembly info, then calls `VSTreeHandler.getChartTreeModel()`, which reads `rvs.getViewsheet()` a *second* time. Rapid user interaction with a still-loading, heavy chart can trigger a concurrent dispose/reset of the `RuntimeViewsheet` in the window between those two reads, so the second read returns `null` and `vs0.getAssembly(aname)` NPEs.

## Fix

- `VSTreeHandler.getChartTreeModel()` now returns `null` when the viewsheet (`vs0`) or the resolved chart assembly is unavailable, instead of dereferencing a possibly-null reference.
- Updated all three callers of `getChartTreeModel()` to tolerate a `null` result without introducing a new NPE further down the call chain:
  - `VSBindingTreeService.getBinding()` — guards the `appendVSAssemblyTree()` call.
  - `VSWizardBindingService` and `VSWizardObjectService` — guard the `assetTreeModel.getRoot()` dereference.

## Test Plan

- `./mvnw clean test-compile -pl core -am` — builds clean.
- `./mvnw test -pl core -am` — full core test suite: 4393 tests, 0 failures, 0 errors.
- Reviewed with the code-reviewer agent across two passes to confirm no regressions and that the null-return contract is honored by every caller.

Fixes Redmine #76236.