### PR TITLE
Bug #76194, enforce the destination folder before mutating a renamed asset

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/AbstractAssetEngine.java
+++ b/core/src/main/java/inetsoft/uql/asset/AbstractAssetEngine.java
@@ -3077,6 +3077,22 @@ public abstract class AbstractAssetEngine implements AssetRepository, AutoClosea
          return;
       }
 
+      // Bug #76194: resolve and validate the destination parent folder up front,
+      // before any mutation of the source entry. Previously this was fetched (and
+      // left unchecked for null) only after the source had already been removed
+      // from its folder and deleted from storage, so any failure past that point
+      // permanently destroyed the source sheet without ever creating the renamed copy.
+      AssetEntry npentry = nentry.getParent();
+      AssetFolder npfolder = getParentFolder(nentry, nstorage);
+      String npidentifier = npentry.toIdentifier();
+
+      if(npfolder == null) {
+         MessageException ex = new MessageException(
+            catalog.getString("common.pfolderNotFound") + ": " + npentry);
+         ex.setKeywords("FOLDER_REQUIRED");
+         throw ex;
+      }
+
       DependencyHandler dependencyHandler = DependencyHandler.getInstance();
 
       if(oentry.isWorksheet()) {
@@ -3121,9 +3137,6 @@ public abstract class AbstractAssetEngine implements AssetRepository, AutoClosea
          }
       }
 
-      AssetEntry npentry = nentry.getParent();
-      AssetFolder npfolder = getParentFolder(nentry, nstorage);
-      String npidentifier = npentry.toIdentifier();
       opfolder = getParentFolder(oentry, ostorage);
 
       if(npentry.equals(opentry)) {
@@ -3140,16 +3153,6 @@ public abstract class AbstractAssetEngine implements AssetRepository, AutoClosea
       }
 
       opfolder.removeEntry(oentry);
-
-      if(!Objects.equals(opidentifier, npidentifier) || !Objects.equals(opfolder, npfolder)) {
-         ostorage.putXMLSerializable(opidentifier, opfolder);
-      }
-
-      if(!Objects.equals(oidentifier, nidentifier)) {
-         ostorage.remove(oidentifier);
-         EmbeddedDataCacheHandler.clearWSCache(oidentifier);
-      }
-
       npfolder.addEntry(nentry);
 
       if(nentry.getAlias() != null && oentry.getAlias() != null &&
@@ -3167,9 +3170,17 @@ public abstract class AbstractAssetEngine implements AssetRepository, AutoClosea
          renameVSBookmark(oentry, nentry);
       }
 
+      // Only overwrite/remove the source's storage entries after the destination
+      // has been fully created; a failure above now leaves the source sheet
+      // untouched instead of destroying it (Bug #76194).
+      if(!Objects.equals(opidentifier, npidentifier) || !Objects.equals(opfolder, npfolder)) {
+         ostorage.putXMLSerializable(opidentifier, opfolder);
+      }
+
       //remove oidentifier last, otherwise dependencies might rewrite it
       if(!Objects.equals(oidentifier, nidentifier)) {
          ostorage.remove(oidentifier);
+         EmbeddedDataCacheHandler.clearWSCache(oidentifier);
       }
 
       clearCache(oentry);


### PR DESCRIPTION
## Summary

`POST /api/public/viewsheets/rename` (and any other caller of `AssetRepository.changeSheet()`) could permanently destroy the source asset without ever creating the renamed copy, when the rename/move failed partway through.

## Root Cause

In `AbstractAssetEngine.changeSheet0()`, the source entry was removed from its old parent folder, that folder change was persisted, and the source's storage record was deleted — all *before* the destination parent folder was validated, before the destination entry was added to its folder, and before the new sheet was written to storage. Any failure in that window (most commonly: the destination's parent folder doesn't exist yet, causing `getParentFolder()` to return `null` and a subsequent NPE on `npfolder.addEntry(nentry)`) left the source deleted and the destination never created. The client only saw a generic HTTP 500 with no indication of the data loss.

There were also two separate `ostorage.remove(oidentifier)` calls in the method — one premature (right after removing the entry from the old folder) and one at the very end, guarded by a comment indicating removal should happen last so dependency rewriting isn't disrupted. The early one appears to be a leftover duplicate that defeated that intent.

## Fix

- Resolve and validate the destination's parent folder up front, before any mutation of the source entry; throw a clear `MessageException` instead of proceeding into an NPE.
- Remove the premature deletion of the source's old folder listing and storage record.
- Defer that removal/overwrite to the very end of the method, after the destination entry has been added to its folder and the new sheet has been written to storage, and after dependent-sheet and bookmark updates have completed successfully.

This preserves the existing behavior for all currently-succeeding renames; it only changes what happens when the rename would otherwise fail — the source is now left untouched instead of being destroyed.

## Test Plan

- Reproduced the original defect: renaming/moving a private viewsheet into a `GLOBAL_SCOPE` folder path that doesn't exist returned HTTP 500 and permanently deleted the source viewsheet with nothing created at the destination.
- Verified with this fix that the same request now fails cleanly and the source viewsheet remains intact and unchanged.
- `./mvnw -pl core -am compile` and `test-compile` both succeed under Java 21.
- Independent code review confirmed the reordering preserves correct behavior for cross-folder moves, same-folder renames, alias-only renames within the same folder (a subtly different `AssetEntry.equals()`/`hashCode()` edge case), and both worksheet and viewsheet paths, with no regression risk to the two existing call sites of `changeSheet0`.

Fixes Redmine #76194.