### PR TITLE
Bug #75992, write the font family, not the face name, on office export

### DIFF
--- a/core/src/main/java/inetsoft/report/io/viewsheet/VSFontHelper.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/VSFontHelper.java
@@ -21,6 +21,7 @@ import inetsoft.uql.viewsheet.internal.VSUtil;
 
 import java.awt.*;
 import java.util.Hashtable;
+import java.util.Locale;
 
 /**
  * Viewsheet font exporting helper.
@@ -35,6 +36,44 @@ public class VSFontHelper {
     */
    public static Font getDefaultFont() {
       return VSUtil.getDefaultFont();
+   }
+
+   /**
+    * Get the font family name to write out when exporting. The family (not the face)
+    * name is what office formats expect, since bold/italic are recorded separately -- a
+    * face name such as "Roboto Bold" cannot be resolved by the viewer, which then
+    * substitutes a font whose metrics differ from the ones used to lay the text out.
+    * See bug #75992.
+    * @param font the specified font.
+    * @return the font family to use when exporting.
+    */
+   public static String getExportFontFamily(Font font) {
+      if(font == null) {
+         return null;
+      }
+
+      String family = font.getFamily();
+
+      if(family == null || !exportFamilies.containsKey(key(family))) {
+         return family;
+      }
+
+      // the family collapsed to a java logical family, which means the server could not
+      // resolve the requested font. Write out the name that was actually asked for, so a
+      // client that does have it renders the same as the browser; only fall back to the
+      // mapping when the requested name is itself a logical name, since office cannot
+      // resolve those either.
+      String name = font.getName();
+
+      if(name != null && !exportFamilies.containsKey(key(name))) {
+         return name;
+      }
+
+      return exportFamilies.get(key(family));
+   }
+
+   private static String key(String family) {
+      return family.toLowerCase(Locale.ROOT);
    }
 
    /**
@@ -72,5 +111,18 @@ public class VSFontHelper {
    static {
       fontrates.put("dialog", DEFAULT_FONT_RATE);
       fontrates.put("comic sans ms", DEFAULT_FONT_RATE);
+   }
+
+   // java logical font family -> family that office applications can resolve. The
+   // pdf equivalent (FontManager) maps to the base-14 postscript names, which office
+   // does not have, so the values here are intentionally different.
+   private static final Hashtable<String, String> exportFamilies = new Hashtable<>();
+   static {
+      exportFamilies.put("dialog", "Arial");
+      exportFamilies.put("sansserif", "Arial");
+      exportFamilies.put("sans-serif", "Arial");
+      exportFamilies.put("serif", "Times New Roman");
+      exportFamilies.put("monospaced", "Courier New");
+      exportFamilies.put("dialoginput", "Courier New");
    }
 }

--- a/core/src/test/java/inetsoft/report/io/viewsheet/VSFontHelperTest.java
+++ b/core/src/test/java/inetsoft/report/io/viewsheet/VSFontHelperTest.java
@@ -1,0 +1,95 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.io.viewsheet;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.awt.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/*
+ * Bug #75992. The ppt/excel exporters write this family name into the document as the run's
+ * typeface. Office expects a family, not a face -- a face name such as "Roboto Bold" (what
+ * Font.getFontName() returns) cannot be resolved even when the family is installed, and the
+ * viewer then substitutes a font whose metrics differ from the ones the server measured with,
+ * re-wrapping text that fit. Java logical families are equally unresolvable and are mapped to
+ * families office actually has.
+ */
+@Tag("core")
+class VSFontHelperTest {
+   @Test
+   void nullFontYieldsNull() {
+      assertNull(VSFontHelper.getExportFontFamily(null));
+   }
+
+   @Test
+   void logicalFamiliesAreMappedToOfficeFamilies() {
+      assertEquals("Arial", VSFontHelper.getExportFontFamily(font("Dialog")));
+      assertEquals("Arial", VSFontHelper.getExportFontFamily(font("SansSerif")));
+      assertEquals("Times New Roman", VSFontHelper.getExportFontFamily(font("Serif")));
+      assertEquals("Courier New", VSFontHelper.getExportFontFamily(font("Monospaced")));
+      assertEquals("Courier New", VSFontHelper.getExportFontFamily(font("DialogInput")));
+   }
+
+   @Test
+   void mappingIsCaseInsensitive() {
+      assertEquals("Arial", VSFontHelper.getExportFontFamily(font("dialog")));
+      assertEquals("Times New Roman", VSFontHelper.getExportFontFamily(font("SERIF")));
+   }
+
+   /*
+    * The regression this guards: a styled font's face name carries the style suffix, so writing
+    * it out produced an unresolvable typeface. The style is written separately by the exporters.
+    */
+   @Test
+   void styledFontYieldsFamilyNotFaceName() {
+      Font bold = new Font("Dialog", Font.BOLD, 10);
+
+      assertEquals("Dialog.bold", bold.getFontName());
+      assertEquals("Arial", VSFontHelper.getExportFontFamily(bold));
+   }
+
+   /*
+    * A font the server cannot resolve has already collapsed to a logical family, but the name
+    * the user picked survives on the font. Keep it, so a client that does have the font renders
+    * like the browser does rather than being pinned to the logical-family fallback.
+    */
+   @Test
+   void unresolvedFontKeepsRequestedName() {
+      Font unresolved = new Font("No Such Font " + UNRESOLVED_SUFFIX, Font.PLAIN, 10);
+
+      assumeTrue(isLogicalFamily(unresolved),
+                 "font unexpectedly resolved on this platform");
+      assertEquals("No Such Font " + UNRESOLVED_SUFFIX,
+                   VSFontHelper.getExportFontFamily(unresolved));
+   }
+
+   private static boolean isLogicalFamily(Font font) {
+      return "Dialog".equalsIgnoreCase(font.getFamily())
+         || "DialogInput".equalsIgnoreCase(font.getFamily());
+   }
+
+   private static final String UNRESOLVED_SUFFIX = "Zzq";
+
+   private static Font font(String name) {
+      return new Font(name, Font.PLAIN, 10);
+   }
+}

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSUtil.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSUtil.java
@@ -178,7 +178,8 @@ public class PoiExcelVSUtil {
       }
 
       XSSFFont xfont = PoiExcelVSUtil.findFont(
-         book, txtFont.isBold(), color, (short) (size * 20), txtFont.getFamily(),
+         book, txtFont.isBold(), color, (short) (size * 20),
+         VSFontHelper.getExportFontFamily(txtFont),
          txtFont.isItalic(), bStrikeOut, ssstyle, hustyle);
 
       if(xfont == null) {
@@ -205,7 +206,7 @@ public class PoiExcelVSUtil {
          }
 
          xfont.setFontHeight((short) (size * 20));
-         xfont.setFontName(txtFont.getFamily());
+         xfont.setFontName(VSFontHelper.getExportFontFamily(txtFont));
          xfont.setItalic(txtFont.isItalic());
          xfont.setStrikeout(bStrikeOut);
          xfont.setTypeOffset(ssstyle);

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/ppt/PPTValueHelper.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/ppt/PPTValueHelper.java
@@ -294,8 +294,15 @@ public class PPTValueHelper {
          PPTVSUtil.getHorizontalAlign(format.getAlignment()));
 
       if(txtFont != null) {
-         if(txtFont.getFontName() != null) {
-            rtr.setFontFamily(txtFont.getFontName());
+         // bug #75992, write the font family, not the face name. getFontName()
+         // returns the face (e.g. "Roboto Bold"), which ppt cannot resolve as a
+         // typeface even when the family is installed, so it substitutes a font
+         // with different metrics and re-wraps the text. Bold/italic are written
+         // separately below. This matches writeRichTextContent and the excel export.
+         String family = VSFontHelper.getExportFontFamily(txtFont);
+
+         if(family != null) {
+            rtr.setFontFamily(family);
          }
 
          rtr.setFontSize((double) txtFont.getSize());
@@ -370,7 +377,7 @@ public class PPTValueHelper {
             rtr.setStrikethrough(((RichTextFont) rt.getFont()).isStrikethrough());
             rtr.setUnderlined(((RichTextFont) rt.getFont()).isUnderline());
             rtr.setFontColor(rt.getFgColor());
-            rtr.setFontFamily(rt.getFont().getFamily());
+            rtr.setFontFamily(VSFontHelper.getExportFontFamily(rt.getFont()));
             rtr.setFontSize((double) rt.getFont().getSize());
             rtr.setText(rt.getContent().replaceAll("%3Cbr%3E", ""));
             rtr.setCharacterSpacing(0);


### PR DESCRIPTION
## Summary

Follow-up to #4559. QA reported that the column still wraps in the exported PPTX and still does not match the portal preview.

The video shows the viewer reporting a **missing font** and rendering a substituted face, which explains why the margin fudge in #4559 could not work: `PPTValueHelper.writeContent()` wrote the run's typeface with `Font.getFontName()`, which returns the **face** name (`Roboto Bold`, `Dialog.bold`), not a family. OOXML's `a:latin/@typeface` expects a family, and bold/italic are already written separately a few lines below. So PowerPoint could not resolve the typeface even on a machine that has the family installed — it substituted a wider face and re-wrapped cell text that the server had measured as fitting. No fixed point margin can compensate for an unknown substitute font.

Every other exporter already got this right: Excel writes `getFamily()` (`PoiExcelVSUtil.java:181,208`) and PPT's own rich-text path writes `rt.getFont().getFamily()` (line 373). The single-run path was the outlier.

## Changes

- **`VSFontHelper.getExportFontFamily(Font)`** (new) — returns the font family. When the family has collapsed to a Java logical name (`Dialog`, `SansSerif`, …), the server could not resolve the requested font, so it prefers `Font.getName()` — the name that was actually asked for, which survives on the font — and only falls back to a mapping onto Office-resolvable families (`Arial`, `Times New Roman`, `Courier New`) when that name is itself logical. Office cannot resolve Java logical names any more than the server could. Note the PDF-side map in `FontManager.java:85-92` targets base-14 PostScript names, which Office lacks, so these values intentionally differ.
- **`PPTValueHelper`** — both the single-run path (line 298) and the rich-text path (line 380) go through the helper.
- **`PoiExcelVSUtil`** — the same helper at lines 181 and 208. Both had to change together: `findFont()`'s cache lookup compares on the name, so a mismatch would silently duplicate fonts in the workbook.

Unstyled runs of an installed font are byte-identical to before (`getFontName() == getFamily()`), and user fonts are unaffected — `StyleFont` returns `userFontName` from both accessors.

`PoiExcelVSExporter.java:2573` is deliberately left unmapped: it takes a CSS `font-family` from HTML rich text, not a `java.awt.Font`.

## Test plan

- [x] `mvnw install -pl core,utils/inetsoft-xml-formats` — BUILD SUCCESS
- [x] New `VSFontHelperTest` (5 tests) covers the logical-family mapping, case insensitivity, the face-name regression, and that an unresolvable font keeps its requested name
- [x] Existing `StyleFontDefaultFamilyTest` + `GopFontRatioTest` still pass (15 tests total, 0 skipped)
- [ ] Export the reported viewsheet to PowerPoint with **match layout**; the column no longer wraps and matches the portal preview
- [ ] Unzip the `.pptx` and check `ppt/slides/slide1.xml`: table `<a:rPr>` carries `<a:latin typeface="Roboto"/>`, never `typeface="Roboto Bold"`, with `b="1"` carrying the weight
- [ ] Regression: wrap-text-enabled columns still wrap; bold/italic/underline still render; crosstab and selection-list titles unchanged
- [ ] Export the same viewsheet to Excel and confirm font names are unchanged for resolved fonts

## Known residual

If the machine opening the deck has no Roboto at all, this does not fully close the gap — the PPTX embeds no fonts, and POI's XSLF exposes no API for a `p:embeddedFontLst` part. Today's remedies are setting `default.font.family` (`defaults.properties:56`) to an Office-safe family, or installing the font on client machines. Worth a separate enhancement if drift remains.

Separately worth its own ticket: `VSFontHelper.getFontSize()` scales font size by 0.85 while `PPTVSUtil.PIXEL_TO_POINT` scales geometry by 0.75, so PPT text always occupies ~13% more of its box than the preview. That is the pressure making these near-fit cases fragile in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
