### PR TITLE
Bug #76171, gate Google Chat sharing on the webhook URL property value

### DIFF
--- a/core/src/main/java/inetsoft/web/share/ShareController.java
+++ b/core/src/main/java/inetsoft/web/share/ShareController.java
@@ -70,7 +70,8 @@ public class ShareController {
          boolean facebookEnabled = "true".equals(SreeEnv.getProperty("share.facebook.enabled")) &&
             checkPermission("facebook", user);
          boolean googleChatEnabled = "true".equals(SreeEnv.getProperty("share.googlechat.enabled")) &&
-            StringUtils.hasText("share.googlechat.url") && checkPermission("googlechat", user);
+            StringUtils.hasText(SreeEnv.getProperty("share.googlechat.url")) &&
+            checkPermission("googlechat", user);
          boolean linkedinEnabled = "true".equals(SreeEnv.getProperty("share.linkedin.enabled")) &&
             checkPermission("linkedin", user);
          boolean slackEnabled = "true".equals(SreeEnv.getProperty("share.slack.enabled")) &&


### PR DESCRIPTION
## Problem

`ShareController.getConfig` decides which entries of a dashboard's share menu are live. The Google Chat branch tested a string *literal* — the property's name — instead of reading the property:

```java
boolean googleChatEnabled = "true".equals(SreeEnv.getProperty("share.googlechat.enabled")) &&
   StringUtils.hasText("share.googlechat.url") && checkPermission("googlechat", user);
```

`StringUtils.hasText` of a non-empty literal is always `true`, so `share.googlechat.url` had no bearing on the result. The Slack branch five lines below is the same logic written correctly, which is what makes this a copy-paste slip rather than a design difference — `ShareSettingsService` reads and writes both channels' `enabled`/`url` pairs identically, and the Enterprise Manager form applies matching `urlRequired`/`invalidPrefix` validators to both.

## What an operator saw

With `share.googlechat.enabled` true and no webhook URL, the Google Hangouts Chat entry was live in the share menu. The failure arrived only on click: `sendGoogleChatMessage` re-reads `share.googlechat.url`, finds it blank, and throws `IllegalStateException("The Google Hangouts webhook URL is not set")`. Slack in the same state greys the entry and no user reaches the failure.

The Enterprise Manager Presentation form will not save the checkbox on with the URL field empty, so this state is not reachable from **Settings > Presentation**. It is reachable from **Settings > All Properties**, from `INETSOFTENV_SHARE_GOOGLECHAT_ENABLED` at first storage initialisation, and — most plausibly in practice — from an organization that enables Google Chat while inheriting the empty global URL from `defaults.properties`.

## Fix

Read the property, formatted to mirror the Slack branch:

```java
boolean googleChatEnabled = "true".equals(SreeEnv.getProperty("share.googlechat.enabled")) &&
   StringUtils.hasText(SreeEnv.getProperty("share.googlechat.url")) &&
   checkPermission("googlechat", user);
```

## Side effects

`getConfig` gates three callers: the `GET /api/share/config` endpoint, and both `sendGoogleChatMessage` and `sendSlackMessage` as their own precondition. The only behavior that changes is `googleChatEnabled` going from `true` to `false` in exactly the enabled-but-no-URL state. In that state the share attempt already failed — the exception moves from "The Google Hangouts webhook URL is not set" to "Sharing with Google Hangouts is not enabled", the same message Slack gives, and users no longer reach either because the entry is now inert. No install with a URL configured is affected.

## Note for the docs

`AllProperties.adoc` states that `share.googlechat.enabled` "Requires `share.googlechat.url` to also be set, otherwise the option remains hidden." This change makes the first half true. The "hidden" wording is still wrong, and wrong for the Slack entry too — `viewer-app.component.ts` maps both flags to `isShareHangoutsDisabled()`/`isShareSlackDisabled()`, so a disabled entry stays in the menu, greyed and inert. That correction belongs in the properties documentation, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
