### PR TITLE
Bug #76063, fix illegible active tab text/underline in EM dark theme

### DIFF
--- a/web/projects/em/src/theme-dark.scss
+++ b/web/projects/em/src/theme-dark.scss
@@ -54,6 +54,19 @@ body {
   color: var(--inet-em-light-primary-text);
 }
 
+// The active tab label and its underline otherwise take the primary palette
+// color, which is a dark gray that is illegible against the dark theme's
+// dark background
+.mat-mdc-tab-nav-bar,
+.mat-mdc-tab-group {
+  --mat-tab-active-label-text-color: var(--inet-em-light-primary-text);
+  --mat-tab-active-focus-label-text-color: var(--inet-em-light-primary-text);
+  --mat-tab-active-hover-label-text-color: var(--inet-em-light-primary-text);
+  --mat-tab-active-indicator-color: var(--inet-em-light-primary-text);
+  --mat-tab-active-focus-indicator-color: var(--inet-em-light-primary-text);
+  --mat-tab-active-hover-indicator-color: var(--inet-em-light-primary-text);
+}
+
 .mat-mdc-progress-bar .mdc-linear-progress__buffer-bar {
     background-color: dimgray;
 }


### PR DESCRIPTION
## Summary

When a custom Enterprise Manager theme is flagged as dark (imports a theme JAR whose CSS sets `--inet-em-dark`), the currently-selected tab's label text and underline render illegibly dark against the dark background — e.g. the "Themes" tab in Presentation settings.

## Root Cause

Angular Material's M2 tab theming sets the *inactive* tab label color from the theme's dark-aware foreground palette, but sets the *active* tab's label and indicator colors to the theme's raw primary palette color, which resolves to `--inet-em-primary-500`. That variable is hardcoded to `#424242` (dark gray) in `_variables.scss` identically for both the light and dark compiled bundles, so it isn't dark-mode aware. Against a dark background this renders illegibly.

## Fix

Added an override in `web/projects/em/src/theme-dark.scss` (compiled only into `theme-dark.css`, which the backend links only when the active theme is flagged dark) forcing the active tab's label and indicator colors to the light text color, matching the existing pattern already used in this same file for the snack bar label and selected dropdown option.

## Test Plan

- [x] `npm run build` succeeds
- [x] `npm run test:em` — 365/365 tests pass
- [x] `npm run lint` — no new errors
- [x] Manually verified: imported a custom dark theme JAR, set it as default, confirmed the selected tab's text and underline are now legible

Fixes Redmine #76063.