### PR TITLE
Bug #76176, pin portal.themes.file for the manager's lifetime

### DIFF
--- a/core/src/main/java/inetsoft/sree/portal/PortalThemesManager.java
+++ b/core/src/main/java/inetsoft/sree/portal/PortalThemesManager.java
@@ -564,7 +564,7 @@ public class PortalThemesManager implements XMLSerializable, AutoCloseable {
     * Must only be called by save(), which acquires the lock first.
     */
    private void saveUnderLock() {
-      String name = SreeEnv.getPath("portal.themes.file", "portalthemes.xml");
+      String name = getThemesFile();
       DataSpace space = dataSpace;
 
       try {
@@ -943,12 +943,32 @@ public class PortalThemesManager implements XMLSerializable, AutoCloseable {
    }
 
    /**
+    * Get the data space file that holds the portal themes. The name is resolved from the
+    * portal.themes.file property on first use and pinned for the lifetime of this manager.
+    * The load path, the save path and the change listener registration must all name the
+    * same file; if the property were re-read on each save, changing it on a running server
+    * would leave the loaded configuration coming from the old file while every subsequent
+    * save went to the new one, and would strand the change listener on the old file. A
+    * change to the property therefore takes effect on the next restart.
+    */
+   private String getThemesFile() {
+      String name = themesFile;
+
+      if(name == null) {
+         // a race here is benign, getPath() is deterministic
+         name = themesFile = SreeEnv.getPath("portal.themes.file", "portalthemes.xml");
+      }
+
+      return name;
+   }
+
+   /**
     * Build up the portal manager by parse a .xml file.
     */
    @PostConstruct
    public void loadThemes() {
       DataSpace space = dataSpace;
-      String name = SreeEnv.getPath("portal.themes.file", "portalthemes.xml");
+      String name = getThemesFile();
       boolean saveFile = false;
 
       try {
@@ -1068,6 +1088,7 @@ public class PortalThemesManager implements XMLSerializable, AutoCloseable {
    private PortalWelcomePage welcomePage;
    private List<PortalTab> portalTabs = new ArrayList<>();
    private String copyright;
+   private volatile String themesFile;
    private final DataChangeListenerManager dmgr = new DataChangeListenerManager();
 
    private static final Logger LOG = LoggerFactory.getLogger(PortalThemesManager.class);

--- a/core/src/test/java/inetsoft/sree/portal/PortalThemesManagerTest.java
+++ b/core/src/test/java/inetsoft/sree/portal/PortalThemesManagerTest.java
@@ -1,0 +1,149 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.sree.portal;
+
+import inetsoft.sree.SreeEnv;
+import inetsoft.sree.internal.cluster.Cluster;
+import inetsoft.util.DataChangeListener;
+import inetsoft.util.DataSpace;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.util.List;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * The name of the portal themes file must be resolved once and used by every path -- the
+ * load, the save and the change listener registration. Re-reading portal.themes.file on
+ * each save let a change to the property on a running server silently point the save path
+ * at a different file than the one the configuration was loaded from.
+ *
+ * Tier: [mockStatic] -- Mockito.mockStatic intercepts SreeEnv.getPath(), the manager's only
+ * static dependency on the property; no Spring application context required.
+ */
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class PortalThemesManagerTest {
+   @Mock private Cluster cluster;
+   @Mock private DataSpace dataSpace;
+   @Mock private DataSpace.Transaction transaction;
+
+   private MockedStatic<SreeEnv> sreeEnv;
+
+   @BeforeEach
+   void setUp() throws Exception {
+      sreeEnv = Mockito.mockStatic(SreeEnv.class);
+      setThemesFile(DEFAULT_THEMES_FILE);
+      when(cluster.getLock(anyString())).thenReturn(new ReentrantLock());
+      // serve the bundled configuration as the persisted file, so loadThemes() takes the
+      // normal path rather than the classpath fallback (which needs a Spring context)
+      when(dataSpace.getInputStream(any(), anyString()))
+         .thenAnswer(invocation -> bundledThemes());
+      when(dataSpace.beginTransaction()).thenReturn(transaction);
+      when(transaction.newStream(any(), anyString())).thenReturn(new ByteArrayOutputStream());
+   }
+
+   @AfterEach
+   void tearDown() {
+      sreeEnv.close();
+   }
+
+   @Test
+   void save_afterPropertyChanged_writesToTheFileThatWasLoaded() throws Exception {
+      setThemesFile("portalthemes-a.xml");
+      PortalThemesManager manager = new PortalThemesManager(cluster, dataSpace);
+      manager.loadThemes();
+
+      setThemesFile("portalthemes-b.xml");
+      manager.save();
+
+      List<String> written = capturedWrites();
+      assertFalse(written.isEmpty(), "expected at least one write");
+      assertTrue(written.stream().allMatch("portalthemes-a.xml"::equals),
+                 "save must keep writing the file the configuration was loaded from, but wrote " +
+                    written);
+   }
+
+   @Test
+   void save_afterPropertyChanged_unregistersTheListenerItRegistered() throws Exception {
+      setThemesFile("portalthemes-a.xml");
+      PortalThemesManager manager = new PortalThemesManager(cluster, dataSpace);
+      manager.loadThemes();
+
+      setThemesFile("portalthemes-b.xml");
+      manager.save();
+
+      // the remove/add pair around the write must target the same file, otherwise the
+      // listener on the old file is stranded and a second one is added on the new file
+      ArgumentCaptor<String> added = ArgumentCaptor.forClass(String.class);
+      ArgumentCaptor<String> removed = ArgumentCaptor.forClass(String.class);
+      verify(dataSpace, atLeastOnce())
+         .addChangeListener(isNull(), added.capture(), any(DataChangeListener.class));
+      verify(dataSpace, atLeastOnce())
+         .removeChangeListener(isNull(), removed.capture(), any(DataChangeListener.class));
+
+      assertTrue(added.getAllValues().stream().allMatch("portalthemes-a.xml"::equals),
+                 "listener registered on " + added.getAllValues());
+      assertTrue(removed.getAllValues().stream().allMatch("portalthemes-a.xml"::equals),
+                 "listener removed from " + removed.getAllValues());
+   }
+
+   @Test
+   void propertyUnset_usesTheDefaultFileName() throws Exception {
+      setThemesFile(DEFAULT_THEMES_FILE);
+      PortalThemesManager manager = new PortalThemesManager(cluster, dataSpace);
+      manager.loadThemes();
+      manager.save();
+
+      List<String> written = capturedWrites();
+      assertFalse(written.isEmpty(), "expected at least one write");
+      assertTrue(written.stream().allMatch("portalthemes.xml"::equals),
+                 "expected the default file name, but wrote " + written);
+   }
+
+   private InputStream bundledThemes() {
+      InputStream input =
+         getClass().getResourceAsStream("/inetsoft/sree/portal/portalthemes.xml");
+      assertNotNull(input, "bundled portalthemes.xml is missing from the classpath");
+
+      return input;
+   }
+
+   private List<String> capturedWrites() throws Exception {
+      ArgumentCaptor<String> file = ArgumentCaptor.forClass(String.class);
+      verify(transaction, atLeastOnce()).newStream(isNull(), file.capture());
+
+      return file.getAllValues();
+   }
+
+   private void setThemesFile(String value) {
+      sreeEnv.when(() -> SreeEnv.getPath(THEMES_FILE_PROPERTY, DEFAULT_THEMES_FILE))
+         .thenReturn(value);
+   }
+
+   private static final String THEMES_FILE_PROPERTY = "portal.themes.file";
+   private static final String DEFAULT_THEMES_FILE = "portalthemes.xml";
+}


### PR DESCRIPTION
## Problem

`PortalThemesManager` resolved `portal.themes.file` in two places with different lifetimes:

- `loadThemes()` — `@PostConstruct`, so once per bean
- `saveUnderLock()` — on every write

Nothing re-ran the load when the property changed. After an admin changed it on a running server, the manager kept serving the configuration loaded from the old file while every save went to the new one. The two diverged silently, and it was the old file that stayed in effect. A restart then switched to whatever the new file had accumulated, possibly a partial configuration written across several saves.

Two things that are easy to miss:

- **The property is reachable at runtime.** There is no dedicated UI field and the key is absent from `defaults.properties`, but the generic EM property editor (Settings → Properties, `PropertiesController`) lists and edits whatever `SreeEnv.getProperties()` returns, unfiltered.
- **The mismatch also stranded the change listener.** `DataChangeListenerManager` keys registrations on `(space, dir, file, listener)`, so `saveUnderLock()`'s `removeChangeListener` named a file that was never registered and matched nothing — leaving the old file's listener in place and adding a second one on the new file. The old file then kept driving `reset(); loadThemes();`.

The bundled fallback made it quieter still: when the named file is missing, `loadThemes()` falls back to the classpath copy and writes it out under the configured name, so pointing the property at an unwritten name produces a fresh default configuration rather than an error.

## Fix

Resolve the property once in `getThemesFile()` and use it from both the load and the save path, so those two and the change-listener registration can never name different files.

A change to the property now takes effect on the next restart — which is how the sibling `CustomThemesManager` already treats `custom.themes.file` (resolved in its constructor).

Live reload was considered and left out of scope. It would need a hook in `PropertiesController` for the local node *plus* a `PropertiesEngine.addPropertyChangeListener` for peers, because `PropertiesEngine.save()` deregisters its own KV-storage listener during the write, so the node making the change never fires its own property listener.

## Tests

New `PortalThemesManagerTest` (3 tests, `mockStatic(SreeEnv)`):

- `save_afterPropertyChanged_writesToTheFileThatWasLoaded`
- `save_afterPropertyChanged_unregistersTheListenerItRegistered`
- `propertyUnset_usesTheDefaultFileName`

Both regression tests were verified to fail against the unfixed code — the save test wrote `portalthemes-b.xml` instead of `-a.xml`, and the listener test caught the stranding.

`mvnw test -pl core -Dtest='*Theme*,*LookAndFeel*,*Presentation*,PermissionMatrixActionsS8Test,*Portal*'` → 151 tests, BUILD SUCCESS.

## Notes for the reviewer

Behavior is unchanged unless `portal.themes.file` is edited on a running server; with the property unset both paths resolve `portalthemes.xml` exactly as before. Every writer reaches the file only through `manager.save()` (`LookAndFeelService`, `PresentationLoginBannerSettingsService`, `PortalIntegrationViewSettingsService`, `WelcomePageService`), and none resolve the path themselves.

Three pre-existing weaknesses in this class were found while investigating and deliberately **not** touched, to keep the fix minimal:

- `clear()` is dead code (no callers) that reloads without `reset()` and without the distributed lock.
- `reset()` does not clear `cssEntries` / `faviconEntries` / `logoEntries` / `welcomePageEntries` / `userFontFaces`, so a remote change that *removes* an element leaves stale per-identity entries.
- The no-arg constructor passes `cluster = null`, so `save()` and the change listener NPE in any non-Spring instantiation that reaches them.

A companion enterprise PR updates `claude/theme.md` with the load/save/listener invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
