### PR TITLE
Add catch-all exception handler to WizControllerErrorHandler

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/WizControllerErrorHandler.java
+++ b/core/src/main/java/inetsoft/web/wiz/WizControllerErrorHandler.java
@@ -227,5 +227,25 @@ public class WizControllerErrorHandler {
       return new ResponseEntity<>(payload, null, HttpStatus.CONFLICT);
    }
 
+   /**
+    * Maps any exception none of the handlers above recognize to a plain JSON 500.
+    *
+    * <p>Without this, an unanticipated exception (an NPE deep in a binding/viewsheet service, for
+    * example) fell through to Tomcat's own default HTML error page, which ignores the client's
+    * {@code Accept: application/json} header — leaking a raw, multi-KB HTML/stack-trace dump to
+    * the calling agent instead of a clean JSON error. Ordered last: Spring dispatches to the most
+    * specific matching handler, so this only catches what nothing else already does.
+    */
+   @ExceptionHandler(Exception.class)
+   public ResponseEntity<Map<String, String>> handleUnexpected(Exception e) {
+      LOG.error("Unexpected error in wiz agent request", e);
+
+      Map<String, String> payload = new HashMap<>();
+      payload.put("error",
+                  "An unexpected server error occurred while processing this request. This is a " +
+                  "StyleBI-side bug -- it has been logged; retrying will fail the same way.");
+      return new ResponseEntity<>(payload, null, HttpStatus.INTERNAL_SERVER_ERROR);
+   }
+
    private static final Logger LOG = LoggerFactory.getLogger(WizControllerErrorHandler.class);
 }

--- a/core/src/test/java/inetsoft/web/wiz/WizControllerErrorHandlerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/WizControllerErrorHandlerTest.java
@@ -175,6 +175,19 @@ class WizControllerErrorHandlerTest {
                  "every captured error must survive, got: [" + content + "]");
    }
 
+   /**
+    * Any exception none of the handlers above recognize — an NPE deep in a binding/viewsheet
+    * service, for example — must still come back as JSON 500, not fall through to Tomcat's own
+    * default HTML error page (which ignores the client's {@code Accept: application/json} header
+    * and leaks a raw, multi-KB stack-trace dump instead of a clean error).
+    */
+   @Test
+   void anUnrecognizedExceptionMapsToInternalServerErrorWithJsonBody() throws Exception {
+      mvc.perform(get("/wiz-test/throw").param("type", "unexpected"))
+         .andExpect(status().isInternalServerError())
+         .andExpect(content().string(containsString("unexpected server error")));
+   }
+
    @RestController
    private static class ThrowingController {
       @GetMapping("/wiz-test/throw")
@@ -217,6 +230,10 @@ class WizControllerErrorHandlerTest {
             throw new inetsoft.util.InvalidUserException(
                "Invalid user found: Principal[Client[admin@172.18.0.1@a2f160d8]] instead of " +
                "Principal[Client[admin@172.18.0.1@ab0096b3]]", () -> "admin");
+         }
+
+         if("unexpected".equals(type)) {
+            throw new NullPointerException("boom");
          }
 
          throw new java.lang.SecurityException("denied");


### PR DESCRIPTION
## Summary
- `WizControllerErrorHandler` (`@ControllerAdvice(basePackages = "inetsoft.web.wiz")`) only maps 7 specific exception types. Any other exception thrown by a wiz controller (viewsheet, script, worksheet, pairing, binding) fell through to Tomcat's own default HTML error page, which ignores the client's `Accept: application/json` header — leaking a raw, multi-KB HTML stack-trace dump to the calling MCP agent instead of a clean JSON error.
- Live-confirmed trigger: `get_binding`, `list_bindable_fields` (scoped and unscoped), and `set_table_source` all raw-500 on a crosstab assembly with no source bound yet. Also explains L4 Finding 5 (raw Tomcat 500 on an out-of-range legend index) and L6's raw `HttpRequestMethodNotSupportedException` note.
- Adds a last-resort `@ExceptionHandler(Exception.class)` that logs the exception and returns a plain JSON 500 (`{"error": "..."}`). Ordered last relative to the existing handlers — Spring dispatches to the most specific matching handler, so this only catches what nothing else already does.

## Test plan
- [x] `./mvnw test -pl core -Dtest=WizControllerErrorHandlerTest` — 9/9 pass, including the new `anUnrecognizedExceptionMapsToInternalServerErrorWithJsonBody` case (bare `NullPointerException` -> HTTP 500 JSON body containing "unexpected server error", not HTML)