### PR TITLE
fix(wiz): verify the runtime, not just the pairing record, in session()

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/script/ViewsheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ViewsheetAgentController.java
@@ -133,12 +133,19 @@ public class ViewsheetAgentController {
     * RIGHT NOW" and get a live answer, independent of whatever it minted or cached at connect
     * time. Requires no pane-scope check of its own: a session is always entitled to know its own
     * scope, whole-sheet or pane-scoped alike.
+    *
+    * <p>Also verifies the runtime the pairing names still exists (mirrors {@link #targets}) --
+    * {@link #resolveSession} alone only checks the in-memory pairing record, not whether the
+    * {@link RuntimeViewsheet} it points at has since been evicted independently. Without this, a
+    * pairing that outlives its runtime read back as {@code valid} here while every other endpoint
+    * on this controller correctly reported the session as expired.
     */
    @GetMapping("/api/wiz/v1/agent/script/{sessionToken}/session")
    public SessionInfo session(@PathVariable String sessionToken, Principal user)
       throws PairingException
    {
       requireEnabled();
+      editService.resolve(sessionToken, user);
       JoinSession session = resolveSession(sessionToken, user);
       return new SessionInfo(session.runtimeId(), session.sheetType().name().toLowerCase(),
                              session.editorContext(), session.followFocusEnabled());

--- a/core/src/test/java/inetsoft/web/wiz/script/ViewsheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ViewsheetAgentControllerTest.java
@@ -292,6 +292,42 @@ class ViewsheetAgentControllerTest {
       assertEquals(PANE_RUNTIME_ID, after.runtimeId());
    }
 
+   /**
+    * A pairing record can stay valid (present, unexpired, owned) in {@code SheetSessionService}
+    * long after the {@link RuntimeViewsheet} its {@code runtimeId} names has been evicted
+    * independently -- {@link #resolveSession} only checks the pairing record. {@code session()}
+    * must also dereference the runtime (via {@link ScriptEditService#resolve}, same as
+    * {@link #targets}) and report the pairing as expired when it is gone, not report {@code
+    * valid} while every other endpoint on this controller already reports expired.
+    */
+   @Test
+   void sessionRefusesAPairingRecordWhoseRuntimeIsGone() throws PairingException {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      when(feature.isEnabled()).thenReturn(true);
+
+      SheetSessionService sessionService = mock(SheetSessionService.class);
+      when(sessionService.resolve(eq(PANE_TOKEN), eq("admin"))).thenReturn(wholeSheetSession());
+
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(runtimeAccess.getSheetForPairing(eq(SheetType.VIEWSHEET), eq(PANE_RUNTIME_ID), any()))
+         .thenThrow(new PairingException(PairingException.Kind.SESSION_EXPIRED,
+            "Viewsheet runtime not found or expired: " + PANE_RUNTIME_ID));
+
+      ScriptEditService editService = new ScriptEditService(sessionService, runtimeAccess,
+         mock(SheetAgentBroadcastService.class));
+
+      ViewsheetAgentController controller = new ViewsheetAgentController(feature,
+         mock(SheetJoinService.class), sessionService, editService, mock(ScriptReadService.class),
+         mock(ScriptExecuteService.class), mock(ScriptContextService.class),
+         mock(ScriptApiService.class), mock(ScriptImageService.class), mock(ViewsheetService.class),
+         mock(SheetAgentBroadcastService.class));
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> controller.session(PANE_TOKEN, principal()));
+      assertEquals(PairingException.Kind.SESSION_EXPIRED, ex.getKind());
+      assertTrue(ex.getMessage().contains("runtime not found or expired"), ex.getMessage());
+   }
+
    @Test
    void imageRefusesACalcFieldFromAWholeSheetSession() throws Exception {
       ViewsheetAgentController controller = wholeSheetController();


### PR DESCRIPTION
## Summary
- `ViewsheetAgentController.session()` (`GET /api/wiz/v1/agent/script/{token}/session`) resolved only the in-memory `JoinSession` pairing record via `resolveSession()`, never dereferencing the `RuntimeViewsheet` its `runtimeId` names. A pairing record can stay valid (present, unexpired, owned) long after the runtime it points at has been evicted independently, so this status probe reported the session `valid` while every other endpoint on this controller (`targets`, `readScript`, etc., via `ScriptEditService.resolve`) already reported it expired.
- Live-confirmed impact: right after an MCP server reconnect, `status` reported a session as `valid:true` while the very next call against the same session immediately failed with "runtime not found or expired".
- Fix reuses the existing `editService.resolve(sessionToken, user)` call — the same pattern `targets()` already follows two methods below — so `session()` now also verifies the runtime through `SheetRuntimeAccess.getSheetForPairing`, surfacing a 404 `SESSION_EXPIRED` once the runtime is gone instead of a stale 200. No new bean injection needed since `ScriptEditService` was already a constructor dependency of this controller.
- Scoped to `session()` only — `resolveSession()`'s pairing-only contract is left untouched, since other callers (`requirePaneScope`, `targets`) rely on it and separately dereference the runtime elsewhere already.
- No `stylebi-wiz` (plugin) change needed — the plugin's existing 404→"expired" classification in `classifyProbeError()` already handles this correctly once the backend returns 404.

## Test plan
- [x] Added `sessionRefusesAPairingRecordWhoseRuntimeIsGone` to `ViewsheetAgentControllerTest`, covering a live pairing record whose `runtimeId` no longer resolves to a real runtime.
- [x] `./mvnw -pl core -Dtest=ViewsheetAgentControllerTest test -o` — 12/12 pass (11 pre-existing + 1 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)