### PR TITLE
get_layout: add printSettings read-back for print layouts

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/LayoutReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/LayoutReadService.java
@@ -22,10 +22,13 @@ import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.uql.viewsheet.vslayout.*;
 import inetsoft.util.Catalog;
+import inetsoft.web.composer.model.vs.VSPrintLayoutDialogModel;
 import inetsoft.web.composer.vs.controller.VSLayoutService;
+import inetsoft.web.composer.vs.dialog.ViewsheetPropertyDialogService;
 import inetsoft.web.wiz.viewsheet.model.DeviceCatalogEntry;
 import inetsoft.web.wiz.viewsheet.model.LayoutModel;
 import inetsoft.web.wiz.viewsheet.model.LayoutObjectModel;
+import inetsoft.web.wiz.viewsheet.model.PrintLayoutSettingsModel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -62,12 +65,14 @@ public class LayoutReadService {
    public LayoutReadService(ViewsheetSessionService viewsheetSessions,
                              LayoutSessionService layoutSessions,
                              VSLayoutService vsLayoutService,
-                             DeviceRegistry deviceRegistry)
+                             DeviceRegistry deviceRegistry,
+                             ViewsheetPropertyDialogService dialogService)
    {
       this.viewsheetSessions = viewsheetSessions;
       this.layoutSessions = layoutSessions;
       this.vsLayoutService = vsLayoutService;
       this.deviceRegistry = deviceRegistry;
+      this.dialogService = dialogService;
    }
 
    /**
@@ -130,9 +135,45 @@ public class LayoutReadService {
       Boolean mobileOnly = print ? null : ((ViewsheetLayout) layout).isMobileOnly();
       List<String> selectedDevices = print ? null
          : Arrays.asList(((ViewsheetLayout) layout).getDeviceIds());
+      PrintLayoutSettingsModel printSettings = print ? readPrintSettings(sessionToken, agent)
+         : null;
 
       return new LayoutModel(layoutName, print ? "print" : "device", mobileOnly, selectedDevices,
-                              objects);
+                              printSettings, objects);
+   }
+
+   /**
+    * {@code null} when this viewsheet's print layout has never been configured -- {@code
+    * screensPane().getPrintLayout()} reads back {@code null} in that case, exactly as {@link
+    * PrintDeviceLayoutPropertyService#setPrintLayout} finds it before seeding a fresh one -- so a
+    * caller of {@code get_layout} can tell "unconfigured" apart from "configured with every field
+    * at its default" rather than seeing a zeroed-out {@link PrintLayoutSettingsModel} either way.
+    *
+    * <p>Goes through {@link ViewsheetSessionService#runtimeId}, not the raw {@code
+    * RuntimeViewsheet} {@link #get} already resolved -- {@link
+    * ViewsheetPropertyDialogService#getViewsheetInfo} is a composer service that re-resolves the
+    * sheet and enforces ownership against the agent's principal itself, the same seam {@link
+    * PrintDeviceLayoutPropertyService#setPrintLayout} calls through {@code sessions.mutate}'s
+    * {@code runtimeId} callback parameter; {@code runtimeId} grants the matching ownership bypass
+    * as a side effect (see its own doc).
+    */
+   private PrintLayoutSettingsModel readPrintSettings(String sessionToken, Principal agent)
+      throws Exception
+   {
+      String runtimeId = viewsheetSessions.runtimeId(sessionToken, agent);
+      VSPrintLayoutDialogModel printLayout =
+         dialogService.getViewsheetInfo(runtimeId, agent).screensPane().getPrintLayout();
+
+      if(printLayout == null) {
+         return null;
+      }
+
+      return new PrintLayoutSettingsModel(
+         printLayout.getPaperSize(), printLayout.getMarginTop(), printLayout.getMarginLeft(),
+         printLayout.getMarginBottom(), printLayout.getMarginRight(),
+         printLayout.getFooterFromEdge(), printLayout.getHeaderFromEdge(),
+         printLayout.isLandscape(), printLayout.getScaleFont(), printLayout.getNumberingStart(),
+         printLayout.getCustomWidth(), printLayout.getCustomHeight(), printLayout.getUnits());
    }
 
    private LayoutObjectModel toObjectModel(Viewsheet masterVs, VSAssemblyLayout assemblyLayout) {
@@ -186,4 +227,5 @@ public class LayoutReadService {
    private final LayoutSessionService layoutSessions;
    private final VSLayoutService vsLayoutService;
    private final DeviceRegistry deviceRegistry;
+   private final ViewsheetPropertyDialogService dialogService;
 }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/model/LayoutModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/model/LayoutModel.java
@@ -25,7 +25,14 @@ import java.util.List;
  * <p>{@code mobileOnly}/{@code selectedDevices} are {@code null} for a print layout ({@code type
  * == "print"}) — those fields exist only on a {@code ViewsheetLayout} (a device layout), never on
  * a {@code PrintLayout}.
+ *
+ * <p>{@code printSettings} is the opposite: populated only for a print layout, and only once one
+ * has actually been configured on the viewsheet -- {@code null} for a device layout, and also
+ * {@code null} for a print layout that has never had {@code set_print_layout} called on it (as
+ * opposed to a zeroed-out {@link PrintLayoutSettingsModel}, which would look like a real "every
+ * field at its default" configuration).
  */
 public record LayoutModel(String name, String type, Boolean mobileOnly,
-                           List<String> selectedDevices, List<LayoutObjectModel> objects) {
+                           List<String> selectedDevices, PrintLayoutSettingsModel printSettings,
+                           List<LayoutObjectModel> objects) {
 }

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/model/PrintLayoutSettingsModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/model/PrintLayoutSettingsModel.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.viewsheet.model;
+
+/**
+ * A print layout's paper/margin/scale settings, as {@code get_layout} reports them for a
+ * {@code type == "print"} layout -- the read-side mirror of the patch keys {@code
+ * set_print_layout} ({@code PrintDeviceLayoutPropertyService#applyPrintLayoutPatch}) accepts.
+ *
+ * <p>{@link LayoutModel#printSettings()} is {@code null} when the viewsheet's print layout has
+ * never been configured ({@code screensPane().getPrintLayout()} reads back {@code null}) --
+ * never a zeroed-out instance of this record -- so a caller can tell "unconfigured" apart from
+ * "configured with every field at its default".
+ */
+public record PrintLayoutSettingsModel(String paperSize, double marginTop, double marginLeft,
+                                        double marginBottom, double marginRight,
+                                        float footerFromEdge, float headerFromEdge,
+                                        boolean landscape, float scaleFont, int numberingStart,
+                                        double customWidth, double customHeight, String units) {
+}

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/LayoutReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/LayoutReadServiceTest.java
@@ -24,12 +24,17 @@ import inetsoft.uql.viewsheet.TextVSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.uql.viewsheet.vslayout.*;
 import inetsoft.util.Catalog;
+import inetsoft.web.composer.model.vs.ScreensPaneModel;
+import inetsoft.web.composer.model.vs.VSPrintLayoutDialogModel;
+import inetsoft.web.composer.model.vs.ViewsheetPropertyDialogModel;
 import inetsoft.web.composer.vs.controller.VSLayoutService;
+import inetsoft.web.composer.vs.dialog.ViewsheetPropertyDialogService;
 import inetsoft.web.wiz.pairing.TestPrincipals;
 import inetsoft.web.wiz.pairing.WizAgentTestSupport;
 import inetsoft.web.wiz.viewsheet.model.DeviceCatalogEntry;
 import inetsoft.web.wiz.viewsheet.model.LayoutModel;
 import inetsoft.web.wiz.viewsheet.model.LayoutObjectModel;
+import inetsoft.web.wiz.viewsheet.model.PrintLayoutSettingsModel;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
@@ -123,6 +128,8 @@ class LayoutReadServiceTest {
       assertEquals("print", model.type());
       assertNull(model.mobileOnly(), "a print layout has no mobileOnly flag");
       assertNull(model.selectedDevices(), "a print layout has no device selection");
+      assertNull(model.printSettings(),
+                 "installPrintLayout's LayoutInfo has no screensPane print settings configured");
       assertEquals(2, model.objects().size());
 
       LayoutObjectModel text = model.objects().stream()
@@ -147,6 +154,89 @@ class LayoutReadServiceTest {
       assertEquals(60, table.viewsheetY());
       assertTrue(table.supportsTableLayout(),
                  "a TableDataVSAssembly-backed object supports table layout");
+   }
+
+   @Test
+   void getPopulatesPrintSettingsWhenTheViewsheetsPrintLayoutIsConfigured() throws Exception {
+      Fixture fx = new Fixture();
+      fx.installPrintLayout();
+
+      VSPrintLayoutDialogModel configured = new VSPrintLayoutDialogModel();
+      configured.setPaperSize("Letter");
+      configured.setScaleFont(0.8f);
+      configured.setMarginTop(1.0);
+      configured.setLandscape(true);
+      ScreensPaneModel screensPane = new ScreensPaneModel();
+      screensPane.setPrintLayout(configured);
+      fx.withScreensPane(screensPane);
+
+      LayoutModel model = fx.service.get("tok1", AGENT, PRINT_LAYOUT);
+
+      PrintLayoutSettingsModel printSettings = model.printSettings();
+      assertNotNull(printSettings);
+      assertEquals("Letter", printSettings.paperSize());
+      assertEquals(0.8f, printSettings.scaleFont(), 0.0001f);
+      assertEquals(1.0, printSettings.marginTop(), 0.0001);
+      assertTrue(printSettings.landscape());
+   }
+
+   @Test
+   void getReturnsNullPrintSettingsRatherThanAZeroedOutRecordWhenNeverConfigured()
+      throws Exception
+   {
+      Fixture fx = new Fixture();
+      fx.installPrintLayout();
+      // Fixture's default screensPane has no print layout configured -- see its constructor.
+
+      LayoutModel model = fx.service.get("tok1", AGENT, PRINT_LAYOUT);
+
+      assertNull(model.printSettings());
+   }
+
+   @Test
+   void getRoundTripsWhatSetPrintLayoutActuallyWrote() throws Exception {
+      // The exact scenario live-caught during L11 testing: set_print_layout claims success but
+      // get_layout has no field to verify it against. Wires PrintDeviceLayoutPropertyService and
+      // LayoutReadService against the SAME ViewsheetPropertyDialogService mock, letting a
+      // setViewsheetInfo call feed back into the next getViewsheetInfo call, so this is a genuine
+      // write-then-read round trip rather than two independently-stubbed halves.
+      ViewsheetSessionService writeSessions = mock(ViewsheetSessionService.class);
+      ViewsheetPropertyDialogService dialogService = mock(ViewsheetPropertyDialogService.class);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      PrintDeviceLayoutPropertyService writeService = new PrintDeviceLayoutPropertyService(
+         writeSessions, dialogService, mock(DeviceRegistry.class));
+
+      ScreensPaneModel[] screensPaneHolder = { new ScreensPaneModel() };
+      when(dialogService.getViewsheetInfo(eq("rt1"), eq(AGENT))).thenAnswer(
+         invocation -> ViewsheetPropertyDialogModel.builder()
+            .screensPane(screensPaneHolder[0]).build());
+      doAnswer(invocation -> {
+         ViewsheetPropertyDialogModel written = invocation.getArgument(1);
+         screensPaneHolder[0] = written.screensPane();
+         return null;
+      }).when(dialogService).setViewsheetInfo(eq("rt1"), any(), eq(AGENT), any(), anyString(),
+                                              any());
+      doAnswer(invocation -> {
+         ViewsheetSessionService.Mutation mutation = invocation.getArgument(2);
+         mutation.run(rvs, "rt1", null);
+         return null;
+      }).when(writeSessions).mutate(anyString(), eq(AGENT), any());
+
+      writeService.setPrintLayout("tok1", AGENT, Map.of("paperSize", "Letter", "scaleFont", 0.8f),
+                                  "");
+
+      Fixture fx = new Fixture();
+      fx.installPrintLayout();
+      when(fx.viewsheetSessions.runtimeId(eq("tok1"), eq(AGENT))).thenReturn("rt1");
+      LayoutReadService readService = new LayoutReadService(fx.viewsheetSessions,
+         fx.layoutSessions, fx.vsLayoutService, fx.deviceRegistry, dialogService);
+
+      LayoutModel model = readService.get("tok1", AGENT, PRINT_LAYOUT);
+
+      PrintLayoutSettingsModel printSettings = model.printSettings();
+      assertNotNull(printSettings);
+      assertEquals("Letter", printSettings.paperSize());
+      assertEquals(0.8f, printSettings.scaleFont(), 0.0001f);
    }
 
    @Test
@@ -176,8 +266,10 @@ class LayoutReadServiceTest {
       final LayoutSessionService layoutSessions = mock(LayoutSessionService.class);
       final VSLayoutService vsLayoutService = new VSLayoutService();
       final DeviceRegistry deviceRegistry = mock(DeviceRegistry.class);
-      final LayoutReadService service =
-         new LayoutReadService(viewsheetSessions, layoutSessions, vsLayoutService, deviceRegistry);
+      final ViewsheetPropertyDialogService dialogService =
+         mock(ViewsheetPropertyDialogService.class);
+      final LayoutReadService service = new LayoutReadService(
+         viewsheetSessions, layoutSessions, vsLayoutService, deviceRegistry, dialogService);
 
       final Viewsheet masterVs = new Viewsheet();
       final RuntimeViewsheet masterRvs = mock(RuntimeViewsheet.class);
@@ -185,11 +277,15 @@ class LayoutReadServiceTest {
       Fixture() throws Exception {
          when(masterRvs.getViewsheet()).thenReturn(masterVs);
          when(viewsheetSessions.resolve(eq("tok1"), eq(AGENT))).thenReturn(masterRvs);
+         when(viewsheetSessions.runtimeId(eq("tok1"), eq(AGENT))).thenReturn("rt1");
          // resolveForRead's own clone content is never used by LayoutReadService -- both
          // coordinate-space readings come off the master directly (see the class doc) -- so a
          // bare mock standing in for "the layout name is known" is enough here.
          when(layoutSessions.resolveForRead(anyString(), eq(AGENT), anyString()))
             .thenReturn(mock(RuntimeViewsheet.class));
+         // No print layout configured by default -- individual tests override this via
+         // withPrintSettings below.
+         withScreensPane(new ScreensPaneModel());
 
          DeviceInfo mobile = new DeviceInfo();
          mobile.setId("wiz-mobile");
@@ -197,6 +293,13 @@ class LayoutReadServiceTest {
          mobile.setMinWidth(0);
          mobile.setMaxWidth(767);
          when(deviceRegistry.getDevices()).thenReturn(new DeviceInfo[] { mobile });
+      }
+
+      /** Stubs {@code dialogService.getViewsheetInfo} to read back {@code screensPane}. */
+      void withScreensPane(ScreensPaneModel screensPane) throws Exception {
+         ViewsheetPropertyDialogModel model =
+            ViewsheetPropertyDialogModel.builder().screensPane(screensPane).build();
+         when(dialogService.getViewsheetInfo(eq("rt1"), eq(AGENT))).thenReturn(model);
       }
 
       /**

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/LayoutUndoServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/LayoutUndoServiceTest.java
@@ -31,6 +31,7 @@ import inetsoft.uql.viewsheet.vslayout.VSAssemblyLayout;
 import inetsoft.uql.viewsheet.vslayout.ViewsheetLayout;
 import inetsoft.web.composer.vs.controller.VSLayoutControllerServiceProxy;
 import inetsoft.web.composer.vs.controller.VSLayoutService;
+import inetsoft.web.composer.vs.dialog.ViewsheetPropertyDialogService;
 import inetsoft.web.wiz.pairing.TestPrincipals;
 import inetsoft.web.wiz.pairing.WizAgentTestSupport;
 import org.junit.jupiter.api.Test;
@@ -187,12 +188,14 @@ class LayoutUndoServiceTest {
       final VSLayoutControllerServiceProxy vsLayoutControllerService =
          mock(VSLayoutControllerServiceProxy.class);
       final DeviceRegistry deviceRegistry = mock(DeviceRegistry.class);
+      final ViewsheetPropertyDialogService dialogService =
+         mock(ViewsheetPropertyDialogService.class);
       final LayoutSessionService layoutSessions =
          new LayoutSessionService(viewsheetSessions, viewsheetService, vsLayoutService);
       final LayoutMutationService mutationService = new LayoutMutationService(
          layoutSessions, viewsheetSessions, vsLayoutService, vsLayoutControllerService);
       final LayoutReadService readService = new LayoutReadService(
-         viewsheetSessions, layoutSessions, vsLayoutService, deviceRegistry);
+         viewsheetSessions, layoutSessions, vsLayoutService, deviceRegistry, dialogService);
       final LayoutUndoService undoService =
          new LayoutUndoService(layoutSessions, viewsheetSessions, vsLayoutService);
 

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentControllerTest.java
@@ -577,7 +577,8 @@ class ViewsheetAssemblyAgentControllerTest {
    @Test
    void getLayoutDelegatesToTheReadService() throws Exception {
       LayoutReadService readService = mock(LayoutReadService.class);
-      LayoutModel expected = new LayoutModel("Print Layout", "print", null, null, List.of());
+      LayoutModel expected =
+         new LayoutModel("Print Layout", "print", null, null, null, List.of());
       when(readService.get(eq("tok"), any(Principal.class), eq("Print Layout")))
          .thenReturn(expected);
 


### PR DESCRIPTION
## Summary
- `set_print_layout` (`PrintDeviceLayoutPropertyService.setPrintLayout`) writes a print layout's paperSize/margins/scaleFont/numbering/etc., but `get_layout` (`LayoutReadService.get` -> `LayoutModel`) had no field capable of reading any of it back -- a caller had zero way to verify what `set_print_layout` actually wrote beyond trusting its own `{ok:true}`.
- Adds `PrintLayoutSettingsModel` (mirrors `set_print_layout`'s patch keys / `VSPrintLayoutDialogModel`'s field types) and a new `LayoutModel.printSettings` field.
- `printSettings` is populated only for a print layout (`null` for device layouts), and is `null` when the viewsheet's print layout has never been configured (`screensPane().getPrintLayout()` reads back `null`) -- not a zeroed-out record -- so callers can tell "unconfigured" apart from "configured with every field at its default".
- `LayoutReadService` now injects `ViewsheetPropertyDialogService` and resolves the runtime id via `ViewsheetSessionService.runtimeId` (the same ownership-bypass seam `PrintDeviceLayoutPropertyService.setPrintLayout` uses through `sessions.mutate`'s callback parameter) to call `getViewsheetInfo`.

## Test plan
- [x] `LayoutReadServiceTest` -- new: `getPopulatesPrintSettingsWhenTheViewsheetsPrintLayoutIsConfigured`, `getReturnsNullPrintSettingsRatherThanAZeroedOutRecordWhenNeverConfigured`, `getRoundTripsWhatSetPrintLayoutActuallyWrote` (wires `PrintDeviceLayoutPropertyService.setPrintLayout` and `LayoutReadService.get` against the same mocked `ViewsheetPropertyDialogService` for a genuine write-then-read round trip -- the exact scenario live-caught during L11 testing).
- [x] Updated `LayoutUndoServiceTest`/`ViewsheetAssemblyAgentControllerTest` for the new `LayoutReadService`/`LayoutModel` constructor signatures.
- [x] `./mvnw -pl core clean test -Dtest=LayoutReadServiceTest,PrintDeviceLayoutPropertyServiceTest,ViewsheetAssemblyAgentControllerTest,LayoutUndoServiceTest` -- all green (7/4/10/28 passed, 0 failures).

A companion doc-only PR in `stylebi-wiz` updates `get_layout`'s tool description to document `printSettings` once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)