### PR TITLE
Named-group consumer redesign: chart/crosstab/table dimensions support Expert/Asset named groups

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/VSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/VSAQuery.java
@@ -37,6 +37,7 @@ import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.graph.GraphTypes;
 import inetsoft.uql.viewsheet.graph.VSChartInfo;
 import inetsoft.uql.viewsheet.internal.DateComparisonUtil;
+import inetsoft.uql.viewsheet.internal.NamedGroupConditionUtil;
 import inetsoft.uql.viewsheet.internal.VSUtil;
 import inetsoft.util.*;
 import inetsoft.util.log.LogLevel;
@@ -722,7 +723,7 @@ public abstract class VSAQuery {
          ConditionList gconds = null;
          boolean grouped = false;
          VSDimensionRef dim = null;
-         SNamedGroupInfo groups = null;
+         XNamedGroupInfo groups = null;
 
          for(DataRef ref : arr) {
             if(!(ref instanceof VSDimensionRef)) {
@@ -739,7 +740,7 @@ public abstract class VSAQuery {
 
             if(dim.isNameGroup()) {
                grouped = true;
-               groups = (SNamedGroupInfo) dim.getNamedGroupInfo();
+               groups = dim.getNamedGroupInfo();
                break;
             }
          }
@@ -757,7 +758,11 @@ public abstract class VSAQuery {
 
          if(grouped && cexpr.getOperation() == XCondition.ONE_OF) {
             HashSet values = new HashSet<>();
-            String dtype = groups.getDataRef().getDataType();
+            // dim.getDataRef() is the actual column being grouped, already in scope from the
+            // loop above -- the more correct source for this dtype regardless of groups' own
+            // concrete type (groups' own embedded DataRef, where it exists at all, is a
+            // separate, occasionally-stale copy of the same information).
+            String dtype = dim.getDataRef().getDataType();
 
             for(int j = 0; j < cexpr.getValueCount(); j++) {
                Object val = cexpr.getValue(j);
@@ -765,6 +770,12 @@ public abstract class VSAQuery {
                ConditionList agconds = groups.getGroupCondition(nval);
 
                if(agconds != null && agconds.getSize() != 0) {
+                  if(NamedGroupConditionUtil.needsColumnResolution(groups)) {
+                     agconds = (ConditionList) agconds.clone();
+                     NamedGroupConditionUtil.resolveConditionColumn(
+                        agconds, dim.getDataRef().getAttribute());
+                  }
+
                   if(negated) {
                      agconds = (ConditionList) agconds.clone();
                      agconds.negate();
@@ -826,6 +837,11 @@ public abstract class VSAQuery {
          String nval = getGroupName(cexpr.getValue(0));
          gconds = grouped && !isNull ? groups.getGroupCondition(nval) : null;
 
+         if(gconds != null && !gconds.isEmpty() && NamedGroupConditionUtil.needsColumnResolution(groups)) {
+            gconds = (ConditionList) gconds.clone();
+            NamedGroupConditionUtil.resolveConditionColumn(gconds, dim.getDataRef().getAttribute());
+         }
+
          if(gconds != null && !gconds.isEmpty() && negated) {
             gconds = (ConditionList) gconds.clone();
             gconds.negate();
@@ -836,7 +852,9 @@ public abstract class VSAQuery {
                citem.setAttribute(cref);
 
                if(!isNull) {
-                  String dtype = groups.getDataRef().getDataType();
+                  // dim.getDataRef() is the actual column being grouped -- see the ONE_OF
+                  // branch's identical note above.
+                  String dtype = dim.getDataRef().getDataType();
 
                   if(!XSchema.STRING.equals(dtype)) {
                      cexpr.setType(dtype);
@@ -875,7 +893,17 @@ public abstract class VSAQuery {
 
                if(gitem instanceof ConditionItem) {
                   ConditionItem gcond = (ConditionItem) gitem;
-                  gcond.setAttribute(cref);
+
+                  // Only SNamedGroupInfo's own per-group conditions are single-value, always
+                  // against the grouped column itself -- forcing every item onto cref is safe
+                  // for it. An Expert group's conditions may genuinely reference other columns
+                  // (e.g. group by revenue tier using a different column's value), already
+                  // correctly attributed by the time they get here -- forcing them onto cref
+                  // would corrupt a compound, multi-column condition.
+                  if(groups instanceof SNamedGroupInfo) {
+                     gcond.setAttribute(cref);
+                  }
+
                   gcond.setLevel(item.getLevel());
 
                   ConditionItem gcond0 = (ConditionItem) gcond.clone();
@@ -896,7 +924,11 @@ public abstract class VSAQuery {
 
                if(gitem instanceof ConditionItem) {
                   ConditionItem gcond = (ConditionItem) gitem;
-                  gcond.setAttribute(cref);
+
+                  // See the drillThrough branch's identical note above.
+                  if(groups instanceof SNamedGroupInfo) {
+                     gcond.setAttribute(cref);
+                  }
                }
 
                gitem.setLevel(gitem.getLevel() + citem.getLevel() + 1);

--- a/core/src/main/java/inetsoft/report/internal/binding/AssetNamedGroupInfo.java
+++ b/core/src/main/java/inetsoft/report/internal/binding/AssetNamedGroupInfo.java
@@ -265,7 +265,7 @@ public class AssetNamedGroupInfo implements XNamedGroupInfo, XMLSerializable, Co
     */
    @Override
    public void writeXML(PrintWriter writer) {
-      writer.print("<namedgroups type=\"" + getType() + "\"");
+      writer.print("<namedgroups class=\"" + getClass().getName() + "\" type=\"" + getType() + "\"");
       writer.print(" source=\"" + Tool.escape(entry.toIdentifier()) + "\"");
       writer.println(">");
 

--- a/core/src/main/java/inetsoft/report/internal/binding/ExpertNamedGroupInfo.java
+++ b/core/src/main/java/inetsoft/report/internal/binding/ExpertNamedGroupInfo.java
@@ -253,7 +253,8 @@ public class ExpertNamedGroupInfo implements XNamedGroupInfo, XMLSerializable {
       String[] names = getGroups(false);
 
       if(names.length > 0) {
-         writer.println("<namedgroups type=\"" + getType() + "\">");
+         writer.println("<namedgroups class=\"" + getClass().getName() + "\" type=\"" +
+            getType() + "\">");
 
          for(int i = 0; i < names.length; i++) {
             writer.print("<namedGroup><![CDATA[" +

--- a/core/src/main/java/inetsoft/uql/viewsheet/CrosstabVSAssembly.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/CrosstabVSAssembly.java
@@ -27,6 +27,7 @@ import inetsoft.report.internal.table.TableHyperlinkAttr;
 import inetsoft.uql.*;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.asset.internal.AssetUtil;
+import inetsoft.uql.util.XNamedGroupInfo;
 import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.util.XSourceInfo;
 import inetsoft.uql.viewsheet.internal.*;
@@ -282,8 +283,8 @@ public class CrosstabVSAssembly extends CrossBaseVSAssembly implements
 
       VSDimensionRef nvref = (VSDimensionRef) nref;
       VSDimensionRef ovref = (VSDimensionRef) oref;
-      SNamedGroupInfo ngroupInfo = (SNamedGroupInfo) nvref.getNamedGroupInfo();
-      SNamedGroupInfo ogroupInfo = (SNamedGroupInfo) ovref.getNamedGroupInfo();
+      XNamedGroupInfo ngroupInfo = nvref.getNamedGroupInfo();
+      XNamedGroupInfo ogroupInfo = ovref.getNamedGroupInfo();
 
       boolean ungroup = ngroupInfo == null &&
          ogroupInfo != null && !ogroupInfo.isEmpty();

--- a/core/src/main/java/inetsoft/uql/viewsheet/VSDimensionRef.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/VSDimensionRef.java
@@ -237,12 +237,7 @@ public class VSDimensionRef extends AbstractDataRef implements ContentObject, XD
     */
    @Override
    public void setNamedGroupInfo(XNamedGroupInfo info) {
-      if(info == null || info instanceof SNamedGroupInfo) {
-         this.groupInfo = (SNamedGroupInfo) info;
-      }
-      else {
-         throw new IllegalArgumentException("Please set SNamedGroupInfo for VSDimensionRef.");
-      }
+      this.groupInfo = info;
    }
 
    /**
@@ -319,18 +314,26 @@ public class VSDimensionRef extends AbstractDataRef implements ContentObject, XD
       ref0.setDataType(XSchema.STRING);
       ref0.setRefType(getRefType());
 
-      // backward compatibility
-      if((getRefType() & DataRef.CUBE) == DataRef.CUBE) {
-         processGroupInfo(getRefType(), groupInfo);
+      // backward compatibility -- CUBE display-value translation only applies to the literal
+      // value-list carrier; Expert/Asset conditions are already fully-typed Condition values,
+      // nothing to translate.
+      if((getRefType() & DataRef.CUBE) == DataRef.CUBE && groupInfo instanceof SNamedGroupInfo) {
+         processGroupInfo(getRefType(), (SNamedGroupInfo) groupInfo);
       }
 
       ref0.setNamedGroupInfo(groupInfo);
       ColumnRef column = new ColumnRef(ref0);
       column.setDataType(XSchema.STRING);
-      DataRef nref = groupInfo.getDataRef();
 
-      if(nref instanceof AttributeRef) {
-         ((AttributeRef) nref).setDataType(dtype);
+      // Only SNamedGroupInfo carries its own embedded DataRef needing a backfilled data type
+      // (used later by SNamedGroupInfo.getGroupCondition's own value-typing). Expert/Asset
+      // conditions carry pre-typed Condition values and have no equivalent embedded ref.
+      if(groupInfo instanceof SNamedGroupInfo) {
+         DataRef nref = ((SNamedGroupInfo) groupInfo).getDataRef();
+
+         if(nref instanceof AttributeRef) {
+            ((AttributeRef) nref).setDataType(dtype);
+         }
       }
 
       GroupRef groupRef = new GroupRef(column);
@@ -1089,9 +1092,9 @@ public class VSDimensionRef extends AbstractDataRef implements ContentObject, XD
 
       if(node != null) {
          String cls = Tool.getAttribute(node, "class");
-         groupInfo = cls != null ? (SNamedGroupInfo) Class.forName(cls).newInstance() :
+         groupInfo = cls != null ? (XNamedGroupInfo) Class.forName(cls).newInstance() :
             new SNamedGroupInfo();
-         groupInfo.parseXML(node);
+         ((XMLSerializable) groupInfo).parseXML(node);
       }
 
       String comboTypeString = Tool.getChildValueByTagName(elem, "comboType");
@@ -1266,7 +1269,7 @@ public class VSDimensionRef extends AbstractDataRef implements ContentObject, XD
       }
 
       if(groupInfo != null) {
-         groupInfo.writeXML(writer);
+         ((XMLSerializable) groupInfo).writeXML(writer);
       }
 
       if(comboType != null) {
@@ -1746,7 +1749,7 @@ public class VSDimensionRef extends AbstractDataRef implements ContentObject, XD
       }
 
       if(groupInfo != null) {
-         dim.groupInfo = (SNamedGroupInfo) groupInfo.clone();
+         dim.groupInfo = (XNamedGroupInfo) groupInfo.clone();
       }
 
       return dim;
@@ -1941,7 +1944,7 @@ public class VSDimensionRef extends AbstractDataRef implements ContentObject, XD
    private DataRef group;
    private RankingCondition ranking;
    private String[] dates;
-   private SNamedGroupInfo groupInfo;
+   private XNamedGroupInfo groupInfo;
    private int runtimeID = (byte) -1;
    private ComboMode comboType = ComboMode.VALUE;
    private Integer oldRuntimeDateLevel; // old runtime date level value

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/NamedGroupConditionUtil.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/NamedGroupConditionUtil.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.viewsheet.internal;
+
+import inetsoft.uql.ConditionItem;
+import inetsoft.uql.ConditionList;
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.util.XNamedGroupInfo;
+import inetsoft.util.Catalog;
+
+/**
+ * Shared support for splicing an {@link XNamedGroupInfo} group's own {@link ConditionList} into
+ * a filter/selection condition against a real bound column.
+ *
+ * <p>Extracted from the near-identical {@code TableConditionUtil.syncConditionList} and
+ * {@code BaseTableShowDetailsService.syncConditionList}, which resolve the same
+ * {@code "this"}-placeholder convention for calc-table cells; chart/crosstab/table dimensions
+ * need the identical resolution wherever an Asset-typed group's conditions are spliced into a
+ * query-time or interactive filter.
+ */
+public final class NamedGroupConditionUtil {
+   private NamedGroupConditionUtil() {
+   }
+
+   /**
+    * Resolves an Asset-typed named group's condition list against a real bound column, replacing
+    * the {@code "this"} placeholder attribute a repository-registered (data-type-attached) named
+    * group asset's conditions carry when authored unattached to any specific column.
+    */
+   public static void resolveConditionColumn(ConditionList list, String columnName) {
+      for(int i = 0; i < list.getConditionSize(); i += 2) {
+         ConditionItem item = list.getConditionItem(i);
+
+         if(item == null) {
+            continue;
+         }
+
+         DataRef ref = item.getAttribute();
+         String attr = ref == null ? null : ref.getAttribute().trim();
+
+         if(Catalog.getCatalog().getString("this").equals(attr) || "this".equals(attr)) {
+            item.setAttribute(new ColumnRef(new AttributeRef(columnName)));
+         }
+      }
+   }
+
+   /** True only for the two asset-backed shapes whose conditions may carry the "this" placeholder. */
+   public static boolean needsColumnResolution(XNamedGroupInfo info) {
+      return info != null && (info.getType() == XNamedGroupInfo.ASSET_NAMEDGROUP_INFO_REF ||
+         info.getType() == XNamedGroupInfo.ASSET_NAMEDGROUP_INFO);
+   }
+}

--- a/core/src/main/java/inetsoft/web/binding/model/BDimensionRefModel.java
+++ b/core/src/main/java/inetsoft/web/binding/model/BDimensionRefModel.java
@@ -420,8 +420,33 @@ public class BDimensionRefModel extends AbstractBDRefModel {
          dim.setDataRef(refMode.createDataRef());
       }
 
-      if(this.getOrder() == XConstants.SORT_SPECIFIC && (ngInfoModel == null ||
-         ngInfoModel.getGroups() == null || ngInfoModel.getGroups().isEmpty()) &&
+      // Turns a resolved model-side named group into a live one on the real ref.
+      if(ngInfoModel != null) {
+         if((dim.getRefType() & DataRef.CUBE) != 0) {
+            throw new IllegalArgumentException("Named-group binding to a predefined or " +
+               "worksheet-local named group is not supported for OLAP cube data sources; only " +
+               "manual value grouping is available for cube dimensions.");
+         }
+
+         try {
+            dim.setNamedGroupInfo(ngInfoModel.createNamedGroupInfo(dim.getDataRef()));
+         }
+         catch(RuntimeException e) {
+            throw e;
+         }
+         catch(Exception e) {
+            throw new RuntimeException(e); // createDataRef() itself declares no checked exception
+         }
+      }
+
+      // A namedGroup binding has no getGroups() content of its own for the EXPERT/ASSET_REF
+      // shapes (their data lives in getConditions()/getName(), not getGroups()) -- checking
+      // "has no named-group content of any kind" (type 0, the field's own declared default)
+      // rather than "has no content of the SIMPLE/manual-value kind specifically" avoids
+      // silently stripping SORT_SPECIFIC -- and the grouping it gates -- right back off for
+      // those two shapes.
+      if(this.getOrder() == XConstants.SORT_SPECIFIC &&
+         (ngInfoModel == null || ngInfoModel.getType() == 0) &&
          (this.getManualOrder() == null || this.getManualOrder().isEmpty()))
       {
          dim.setOrder(getOrder() & ~XConstants.SORT_SPECIFIC);

--- a/core/src/main/java/inetsoft/web/binding/service/graph/ChartDimensionInfoFactory.java
+++ b/core/src/main/java/inetsoft/web/binding/service/graph/ChartDimensionInfoFactory.java
@@ -83,6 +83,28 @@ public abstract class ChartDimensionInfoFactory<M extends ChartDimensionRef>
       if(model.getDataRefModel() != null) {
          ref.setDataRef(model.getDataRefModel().createDataRef());
       }
+
+      // Turns a resolved model-side named group into a live one on the real ref. Must run
+      // after setDataRef above -- createNamedGroupInfo's ASSET_NAMEDGROUP_INFO_REF branch
+      // resolves against ref.getDataRef(), which is stale (from before this paste) until that
+      // call lands.
+      if(model.getOrder() != XConstants.SORT_NONE && model.getNamedGroupInfo() != null) {
+         if((ref.getRefType() & DataRef.CUBE) != 0) {
+            throw new IllegalArgumentException("Named-group binding to a predefined or " +
+               "worksheet-local named group is not supported for OLAP cube data sources; only " +
+               "manual value grouping is available for cube dimensions.");
+         }
+
+         try {
+            ref.setNamedGroupInfo(model.getNamedGroupInfo().createNamedGroupInfo(ref.getDataRef()));
+         }
+         catch(RuntimeException e) {
+            throw e;
+         }
+         catch(Exception e) {
+            throw new RuntimeException(e);
+         }
+      }
    }
 
    private final DataRefModelFactoryService refModelService;

--- a/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerGroupColumnsService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/objects/controller/ComposerGroupColumnsService.java
@@ -34,6 +34,8 @@ import inetsoft.uql.util.XSourceInfo;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.graph.*;
 import inetsoft.uql.viewsheet.internal.*;
+import inetsoft.util.Catalog;
+import inetsoft.util.MessageException;
 import inetsoft.util.Tool;
 import inetsoft.web.binding.command.SetVSBindingModelCommand;
 import inetsoft.web.binding.handler.VSChartHandler;
@@ -158,6 +160,16 @@ public class ComposerGroupColumnsService {
 
       if(refs.stream().anyMatch(dim -> dim.getNamedGroupInfo() instanceof DCNamedGroupInfo)) {
          return null;
+      }
+
+      // Every operation below is a mutation on a literal value-to-group-name mapping
+      // (SNamedGroupInfo), which an Expert/Asset-typed group has no equivalent of -- refuse
+      // loudly rather than let the casts below throw an unexplained ClassCastException.
+      if(refs.stream().anyMatch(dim ->
+         dim.getNamedGroupInfo() != null && !(dim.getNamedGroupInfo() instanceof SNamedGroupInfo)))
+      {
+         throw new MessageException(Catalog.getCatalog().getString(
+            "composer.vs.group.namedGroupNotSupported"));
       }
 
       for(VSDimensionRef ref : refs) {

--- a/core/src/main/java/inetsoft/web/graph/GraphBuilder.java
+++ b/core/src/main/java/inetsoft/web/graph/GraphBuilder.java
@@ -43,6 +43,7 @@ import inetsoft.uql.XCube;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.asset.internal.AssetUtil;
 import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.util.XNamedGroupInfo;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.graph.*;
 import inetsoft.uql.viewsheet.internal.*;
@@ -1294,22 +1295,24 @@ public class GraphBuilder {
 
          if(ref instanceof VSChartDimensionRef) {
             VSChartDimensionRef dimRef = (VSChartDimensionRef) ref;
-            SNamedGroupInfo groupInfo = (SNamedGroupInfo)
-               dimRef.getNamedGroupInfo();
+            XNamedGroupInfo groupInfo = dimRef.getNamedGroupInfo();
             String label = (childArea instanceof DimensionLabelArea)
                ? ((DimensionLabelArea) childArea).getValue() : null;
+            // getGroups() membership is the type-agnostic equivalent of SNamedGroupInfo's own
+            // getGroupValue(label) != null check -- provably equivalent for SNamedGroupInfo too,
+            // since addGroupName/values.put happen together in setGroupValue.
             grouped = groupInfo != null && !(groupInfo instanceof DCNamedGroupInfo) &&
-               label != null && groupInfo.getGroupValue(label) != null;
+               label != null && Arrays.asList(groupInfo.getGroups()).contains(label);
             isPeriod = dimRef.getDates() != null && dimRef.getDates().length >= 2;
          }
          else if(ref instanceof AestheticRef) {
             DataRef dataRef =((AestheticRef) ref).getDataRef();
 
             if(dataRef instanceof VSChartDimensionRef) {
-               SNamedGroupInfo groupInfo =
-                  (SNamedGroupInfo) ((VSChartDimensionRef) dataRef).getNamedGroupInfo();
+               XNamedGroupInfo groupInfo = ((VSChartDimensionRef) dataRef).getNamedGroupInfo();
+               String label = ((LegendItemArea) childArea).getValue();
                grouped = groupInfo != null && !(groupInfo instanceof DCNamedGroupInfo) &&
-                  groupInfo.getGroupValue(((LegendItemArea) childArea).getValue()) != null;
+                  label != null && Arrays.asList(groupInfo.getGroups()).contains(label);
             }
          }
 

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/table/BaseTableService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/table/BaseTableService.java
@@ -33,6 +33,7 @@ import inetsoft.uql.VariableTable;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.asset.internal.AssetUtil;
 import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.util.XNamedGroupInfo;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.graph.Calculator;
 import inetsoft.uql.viewsheet.internal.*;
@@ -860,12 +861,17 @@ public abstract class BaseTableService<T extends BaseTableEvent> {
                      VSDimensionRef dim = (VSDimensionRef) ref;
                      cell.setDrillLevel(VSUtil.getDrillLevel(dim, crosstabInfo.getXCube()));
 
-                     // setGrouped
-                     SNamedGroupInfo groupInfo = (SNamedGroupInfo) dim.getNamedGroupInfo();
+                     // setGrouped -- membership was already decided once, at query time, by
+                     // the SQL/script expression that produced this row's value (NamedRangeRef),
+                     // so this is a String membership test, not a per-cell condition evaluation.
+                     XNamedGroupInfo groupInfo = dim.getNamedGroupInfo();
                      boolean grouped = false;
 
-                     if(cell.getCellData() != null && groupInfo != null) {
-                        grouped = groupInfo.getGroupValue(cell.getCellData() + "") != null;
+                     if(cell.getCellData() != null && groupInfo != null &&
+                        !(groupInfo instanceof DCNamedGroupInfo))
+                     {
+                        Set<String> groupNames = new HashSet<>(Arrays.asList(groupInfo.getGroups()));
+                        grouped = groupNames.contains(cell.getCellData() + "");
                      }
 
                      cell.setGrouped(grouped);
@@ -924,12 +930,20 @@ public abstract class BaseTableService<T extends BaseTableEvent> {
                      VSDimensionRef dim = (VSDimensionRef) ref;
                      cell.setDrillLevel(VSUtil.getDrillLevel(dim, crosstabInfo.getXCube()));
                      cell.setPeriod(dim.getDates() != null && dim.getDates().length >= 2);
-                     // grouped
-                     SNamedGroupInfo groupInfo = (SNamedGroupInfo)
-                        ((VSDimensionRef) ref).getNamedGroupInfo();
+                     // grouped -- membership was already decided once, at query time, by the
+                     // SQL/script expression that produced this row's value (NamedRangeRef), so
+                     // this is a String membership test, not a per-cell condition evaluation.
+                     XNamedGroupInfo groupInfo = ((VSDimensionRef) ref).getNamedGroupInfo();
                      final String cellString = getCellString(cell.getCellData());
-                     boolean grouped = groupInfo != null && !(groupInfo instanceof DCNamedGroupInfo)
-                        && cellString != null && groupInfo.getGroupValue(cellString) != null;
+                     boolean grouped = false;
+
+                     if(groupInfo != null && !(groupInfo instanceof DCNamedGroupInfo) &&
+                        cellString != null)
+                     {
+                        Set<String> groupNames = new HashSet<>(Arrays.asList(groupInfo.getGroups()));
+                        grouped = groupNames.contains(cellString);
+                     }
+
                      cell.setGrouped(grouped);
                   }
                }

--- a/core/src/main/java/inetsoft/web/viewsheet/controller/table/BaseTableService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/table/BaseTableService.java
@@ -789,6 +789,10 @@ public abstract class BaseTableService<T extends BaseTableEvent> {
       Arrays.fill(spanRow, start);
       CrossTabFilter filter = Util.getCrosstab(lens);
       Map<BaseTableCellModel.FullHashObjWrapper, VSFormatModel> formatModelCache = new HashMap<>();
+      // Keyed by groupInfo identity -- the same dimension's groupInfo instance is shared by
+      // every cell in its column/row across this whole render, so this computes the group-name
+      // set once per dimension rather than once per cell.
+      Map<XNamedGroupInfo, Set<String>> groupNamesCache = new HashMap<>();
 
       for(int i = start; i < end; i++) {
          for(int j = 0; j < colCount; j++) {
@@ -870,7 +874,8 @@ public abstract class BaseTableService<T extends BaseTableEvent> {
                      if(cell.getCellData() != null && groupInfo != null &&
                         !(groupInfo instanceof DCNamedGroupInfo))
                      {
-                        Set<String> groupNames = new HashSet<>(Arrays.asList(groupInfo.getGroups()));
+                        Set<String> groupNames = groupNamesCache.computeIfAbsent(
+                           groupInfo, g -> new HashSet<>(Arrays.asList(g.getGroups())));
                         grouped = groupNames.contains(cell.getCellData() + "");
                      }
 
@@ -940,7 +945,8 @@ public abstract class BaseTableService<T extends BaseTableEvent> {
                      if(groupInfo != null && !(groupInfo instanceof DCNamedGroupInfo) &&
                         cellString != null)
                      {
-                        Set<String> groupNames = new HashSet<>(Arrays.asList(groupInfo.getGroups()));
+                        Set<String> groupNames = groupNamesCache.computeIfAbsent(
+                           groupInfo, g -> new HashSet<>(Arrays.asList(g.getGroups())));
                         grouped = groupNames.contains(cellString);
                      }
 

--- a/core/src/main/java/inetsoft/web/viewsheet/handler/crosstab/CrosstabDrillHandler.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/handler/crosstab/CrosstabDrillHandler.java
@@ -367,12 +367,30 @@ public class CrosstabDrillHandler
    public static ConditionList getGroupCondition(XNamedGroupInfo groupInfo, ColumnRef columnRef,
                                                  String name)
    {
-      ConditionList conditionList = new ConditionList();
-
-      if(!(groupInfo instanceof SNamedGroupInfo)) {
-         return conditionList;
+      if(groupInfo == null) {
+         return new ConditionList();
       }
 
+      if(!(groupInfo instanceof SNamedGroupInfo)) {
+         // Expert/Asset conditions are already fully-typed Condition values -- splice the
+         // group's own condition list directly rather than reconstructing one from a literal
+         // value list (which only SNamedGroupInfo has).
+         ConditionList conds = groupInfo.getGroupCondition(name);
+
+         if(conds == null || conds.isEmpty()) {
+            return new ConditionList();
+         }
+
+         conds = (ConditionList) conds.clone();
+
+         if(NamedGroupConditionUtil.needsColumnResolution(groupInfo)) {
+            NamedGroupConditionUtil.resolveConditionColumn(conds, columnRef.getAttribute());
+         }
+
+         return conds;
+      }
+
+      ConditionList conditionList = new ConditionList();
       SNamedGroupInfo info = (SNamedGroupInfo) groupInfo;
       List<?> value = info.getGroupValue(name);
 

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticAgentService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticAgentService.java
@@ -26,6 +26,7 @@ import inetsoft.uql.viewsheet.graph.VSChartInfo;
 import inetsoft.web.binding.controller.ChangeChartAestheticService;
 import inetsoft.web.binding.event.ChangeChartRefEvent;
 import inetsoft.web.binding.model.ChartBindingModel;
+import inetsoft.web.binding.service.DataRefModelFactoryService;
 import inetsoft.web.binding.service.VSBindingService;
 import inetsoft.web.wiz.binding.model.FieldRef;
 import inetsoft.web.wiz.viewsheet.ViewsheetSessionService;
@@ -53,11 +54,13 @@ public class ChartAestheticAgentService {
    @Autowired
    public ChartAestheticAgentService(ViewsheetSessionService sessions,
                                 VSBindingService binding,
-                                ChangeChartAestheticService aestheticService)
+                                ChangeChartAestheticService aestheticService,
+                                DataRefModelFactoryService refModelService)
    {
       this.sessions = sessions;
       this.binding = binding;
       this.aestheticService = aestheticService;
+      this.refModelService = refModelService;
    }
 
    /**
@@ -75,9 +78,18 @@ public class ChartAestheticAgentService {
       boolean relationChart = isRelationChart(sessionToken, user, assemblyName);
       String name = AestheticChannels.requireFieldChannel(channel, relationChart);
 
-      apply(sessionToken, user, assemblyName, name, linkUri, model -> {
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         ChartVSAssembly chart = requireChart(rvs, assemblyName);
+         ChartBindingModel model = (ChartBindingModel) binding.createModel(chart);
          ChartBindingService.applySource(model, sourceTable);
-         ChartAestheticMutator.setField(model, name, field, relationChart);
+         ChartAestheticMutator.setField(
+            model, name, field, relationChart, rvs, chart.getSourceInfo(), refModelService);
+
+         ChangeChartRefEvent event = new ChangeChartRefEvent();
+         event.setName(assemblyName);
+         event.setFieldType(name);
+         event.setModel(model);
+         aestheticService.changeChartAesthetic(runtimeId, event, user, dispatcher, linkUri);
       });
    }
 
@@ -184,4 +196,5 @@ public class ChartAestheticAgentService {
    private final ViewsheetSessionService sessions;
    private final VSBindingService binding;
    private final ChangeChartAestheticService aestheticService;
+   private final DataRefModelFactoryService refModelService;
 }

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticMutator.java
@@ -17,10 +17,13 @@
  */
 package inetsoft.web.wiz.binding;
 
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.asset.SourceInfo;
 import inetsoft.web.binding.model.BindingRefModel;
 import inetsoft.web.binding.model.ChartBindingModel;
 import inetsoft.web.binding.model.graph.AestheticInfo;
 import inetsoft.web.binding.model.graph.aesthetic.*;
+import inetsoft.web.binding.service.DataRefModelFactoryService;
 import inetsoft.web.wiz.binding.model.FieldRef;
 
 import java.util.ArrayList;
@@ -51,6 +54,28 @@ public final class ChartAestheticMutator {
    public static void setField(ChartBindingModel model, String channel, FieldRef field,
                                boolean relationChart)
    {
+      try {
+         setField(model, channel, field, relationChart, null, null, null);
+      }
+      catch(RuntimeException e) {
+         throw e; // preserve e.g. requireFieldChannel's IllegalArgumentException as-is
+      }
+      catch(Exception e) {
+         throw new RuntimeException(e);
+      }
+   }
+
+   /**
+    * @param rvs            the runtime viewsheet, so a field's {@code namedGroup} can be
+    *                       resolved against a worksheet-local named group.
+    * @param source         the chart's own {@code SourceInfo}.
+    * @param refModelService needed to resolve a worksheet-local named group's conditions.
+    */
+   public static void setField(ChartBindingModel model, String channel, FieldRef field,
+                               boolean relationChart, RuntimeViewsheet rvs, SourceInfo source,
+                               DataRefModelFactoryService refModelService)
+      throws Exception
+   {
       String name = AestheticChannels.requireFieldChannel(channel, relationChart);
 
       if(field == null) {
@@ -62,7 +87,7 @@ public final class ChartAestheticMutator {
 
       AestheticInfo info = new AestheticInfo();
       info.setFullName(field.column());
-      info.setDataInfo(FieldRefFactory.toChartRef(field));
+      info.setDataInfo(FieldRefFactory.toChartRef(field, rvs, source, refModelService));
       assign(model, name, info);
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingMutator.java
@@ -17,10 +17,13 @@
  */
 package inetsoft.web.wiz.binding;
 
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.asset.SourceInfo;
 import inetsoft.web.binding.model.ChartBindingModel;
 import inetsoft.web.binding.model.graph.ChartAggregateRefModel;
 import inetsoft.web.binding.model.graph.ChartDimensionRefModel;
 import inetsoft.web.binding.model.graph.ChartRefModel;
+import inetsoft.web.binding.service.DataRefModelFactoryService;
 import inetsoft.web.wiz.binding.model.FieldRef;
 
 import java.util.ArrayList;
@@ -43,6 +46,28 @@ public final class ChartBindingMutator {
    }
 
    public static void setShelf(ChartBindingModel model, String shelf, List<FieldRef> fields) {
+      try {
+         setShelf(model, shelf, fields, null, null, null);
+      }
+      catch(RuntimeException e) {
+         throw e; // preserve e.g. requireType's IllegalArgumentException as-is
+      }
+      catch(Exception e) {
+         throw new RuntimeException(e);
+      }
+   }
+
+   /**
+    * @param rvs            the runtime viewsheet, so a field's {@code namedGroup} can be
+    *                       resolved against a worksheet-local named group.
+    * @param source         the chart's own {@code SourceInfo}.
+    * @param refModelService needed to resolve a worksheet-local named group's conditions.
+    */
+   public static void setShelf(ChartBindingModel model, String shelf, List<FieldRef> fields,
+                               RuntimeViewsheet rvs, SourceInfo source,
+                               DataRefModelFactoryService refModelService)
+      throws Exception
+   {
       String name = shelf == null ? "" : shelf.trim().toLowerCase();
 
       if(SINGLE_SHELVES.contains(name)) {
@@ -62,7 +87,7 @@ public final class ChartBindingMutator {
       List<ChartRefModel> refs = new ArrayList<>();
 
       for(FieldRef field : fields == null ? List.<FieldRef>of() : fields) {
-         refs.add(FieldRefFactory.toChartRef(field));
+         refs.add(FieldRefFactory.toChartRef(field, rvs, source, refModelService));
       }
 
       switch(name) {
@@ -92,8 +117,26 @@ public final class ChartBindingMutator {
     * why {@code set_chart_type} and these belong in the same conversation.
     */
    public static void setSingleShelf(ChartBindingModel model, String shelf, FieldRef field) {
+      try {
+         setSingleShelf(model, shelf, field, null, null, null);
+      }
+      catch(RuntimeException e) {
+         throw e; // preserve e.g. requireSingleShelf's IllegalArgumentException as-is
+      }
+      catch(Exception e) {
+         throw new RuntimeException(e);
+      }
+   }
+
+   /** @see #setShelf(ChartBindingModel, String, List, RuntimeViewsheet, SourceInfo, DataRefModelFactoryService) */
+   public static void setSingleShelf(ChartBindingModel model, String shelf, FieldRef field,
+                                     RuntimeViewsheet rvs, SourceInfo source,
+                                     DataRefModelFactoryService refModelService)
+      throws Exception
+   {
       String name = requireSingleShelf(shelf);
-      ChartRefModel ref = field == null ? null : FieldRefFactory.toChartRef(field);
+      ChartRefModel ref = field == null
+         ? null : FieldRefFactory.toChartRef(field, rvs, source, refModelService);
 
       switch(name) {
       case "open" -> model.setOpenField(ref);

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingService.java
@@ -32,6 +32,7 @@ import inetsoft.web.binding.event.ChangeChartTypeEvent;
 import inetsoft.web.binding.event.ChangeSeparateStatusEvent;
 import inetsoft.web.binding.model.ChartBindingModel;
 import inetsoft.web.binding.model.graph.ChartRefModel;
+import inetsoft.web.binding.service.DataRefModelFactoryService;
 import inetsoft.web.binding.service.VSBindingService;
 import inetsoft.web.wiz.binding.model.FieldRef;
 import inetsoft.web.wiz.viewsheet.ViewsheetSessionService;
@@ -61,7 +62,8 @@ public class ChartBindingService {
                               ChangeChartRefService refService,
                               ChangeChartTypeService typeService,
                               SwapXYBindingService swapService,
-                              ChangeSeparateStatusService separateStatusService)
+                              ChangeSeparateStatusService separateStatusService,
+                              DataRefModelFactoryService refModelService)
    {
       this.sessions = sessions;
       this.binding = binding;
@@ -69,6 +71,7 @@ public class ChartBindingService {
       this.typeService = typeService;
       this.swapService = swapService;
       this.separateStatusService = separateStatusService;
+      this.refModelService = refModelService;
    }
 
    /**
@@ -84,7 +87,8 @@ public class ChartBindingService {
          ChartVSAssembly chart = requireChart(rvs, assemblyName);
          ChartBindingModel model = (ChartBindingModel) binding.createModel(chart);
          applySource(model, sourceTable);
-         ChartBindingMutator.setShelf(model, shelf, fields);
+         ChartBindingMutator.setShelf(
+            model, shelf, fields, rvs, chart.getSourceInfo(), refModelService);
 
          ChangeChartRefEvent event = new ChangeChartRefEvent();
          event.setName(assemblyName);
@@ -229,7 +233,8 @@ public class ChartBindingService {
          ChartVSAssembly chart = requireChart(rvs, assemblyName);
          ChartBindingModel model = (ChartBindingModel) binding.createModel(chart);
          applySource(model, sourceTable);
-         ChartBindingMutator.setSingleShelf(model, shelf, field);
+         ChartBindingMutator.setSingleShelf(
+            model, shelf, field, rvs, chart.getSourceInfo(), refModelService);
 
          ChangeChartRefEvent event = new ChangeChartRefEvent();
          event.setName(assemblyName);
@@ -364,4 +369,5 @@ public class ChartBindingService {
    private final ChangeChartTypeService typeService;
    private final SwapXYBindingService swapService;
    private final ChangeSeparateStatusService separateStatusService;
+   private final DataRefModelFactoryService refModelService;
 }

--- a/core/src/main/java/inetsoft/web/wiz/binding/FieldRefFactory.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/FieldRefFactory.java
@@ -17,14 +17,33 @@
  */
 package inetsoft.web.wiz.binding;
 
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.internal.binding.AssetNamedGroupInfo;
+import inetsoft.report.internal.binding.SummaryAttr;
+import inetsoft.uql.XConstants;
+import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.asset.AttachedAssembly;
+import inetsoft.uql.asset.DefaultNamedGroupAssembly;
+import inetsoft.uql.asset.SourceInfo;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.asset.internal.AssetUtil;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.util.XNamedGroupInfo;
 import inetsoft.web.binding.drm.DataRefModel;
 import inetsoft.web.binding.model.BAggregateRefModel;
 import inetsoft.web.binding.model.BDimensionRefModel;
+import inetsoft.web.binding.model.NamedGroupInfoModel;
 import inetsoft.web.binding.model.graph.ChartAggregateRefModel;
 import inetsoft.web.binding.model.graph.ChartDimensionRefModel;
 import inetsoft.web.binding.model.graph.ChartRefModel;
+import inetsoft.web.binding.service.DataRefModelFactoryService;
+import inetsoft.web.composer.model.condition.ConditionExpression;
+import inetsoft.web.composer.model.condition.ConditionUtil;
 import inetsoft.web.wiz.binding.model.FieldRef;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /** Converts between StyleBI's ref models and the agent-facing {@link FieldRef}. */
@@ -45,6 +64,31 @@ public final class FieldRefFactory {
     * learned about a new field attribute.
     */
    public static ChartRefModel toChartRef(FieldRef field) {
+      try {
+         return toChartRef(field, null, null, null);
+      }
+      catch(RuntimeException e) {
+         throw e; // preserve e.g. requireType's IllegalArgumentException as-is
+      }
+      catch(Exception e) {
+         throw new RuntimeException(e);
+      }
+   }
+
+   /**
+    * Builds the chart-side ref model a {@link FieldRef} describes, resolving {@code namedGroup}
+    * into a live {@link NamedGroupInfoModel} when the field carries one.
+    *
+    * @param rvs            the runtime viewsheet, for a worksheet-local named group lookup.
+    * @param source         the chart's own {@code SourceInfo}, so a worksheet-local name is
+    *                       matched against groups attached to the same source.
+    * @param refModelService needed to convert a worksheet-local group's conditions into the
+    *                        model shape {@link NamedGroupInfoModel#createNamedGroupInfo} expects.
+    */
+   public static ChartRefModel toChartRef(FieldRef field, RuntimeViewsheet rvs, SourceInfo source,
+                                          DataRefModelFactoryService refModelService)
+      throws Exception
+   {
       requireType(field);
 
       if(MEASURE.equalsIgnoreCase(field.type())) {
@@ -67,7 +111,106 @@ public final class FieldRefFactory {
          ref.setDateLevel(DateLevels.normalize(field.dateLevel()));
       }
 
+      if(field.namedGroup() != null) {
+         ref.setNamedGroupInfo(resolveNamedGroupInfo(
+            field.namedGroup(), rvs, source, field.column(), refModelService));
+         ref.setOrder(XConstants.SORT_SPECIFIC);
+      }
+
       return ref;
+   }
+
+   /**
+    * Resolves a field's {@code namedGroup} name into a fully-formed, already-validated
+    * {@link NamedGroupInfoModel} -- worksheet-local first (an {@code EXPERT_NAMEDGROUP_INFO}
+    * built from the {@code DefaultNamedGroupAssembly}'s own per-group conditions, mirroring
+    * {@code CalcTableService#worksheetLocalOrder}), then a repository-registered predefined
+    * named group (an {@code ASSET_NAMEDGROUP_INFO_REF} by name, left for
+    * {@code NamedGroupInfoModel#createNamedGroupInfo} to resolve against the field's own
+    * {@code DataRef} at apply time). Neither matching throws, naming the field/column -- a name
+    * that resolves to nothing would otherwise silently bind with no grouping at all.
+    */
+   public static NamedGroupInfoModel resolveNamedGroupInfo(
+      String namedGroup, RuntimeViewsheet rvs, SourceInfo source, String column,
+      DataRefModelFactoryService refModelService) throws Exception
+   {
+      for(DefaultNamedGroupAssembly ngAssembly : worksheetNamedGroups(rvs, source, column)) {
+         if(namedGroup.equals(ngAssembly.getName())) {
+            NamedGroupInfoModel model = new NamedGroupInfoModel();
+            model.setType(XNamedGroupInfo.EXPERT_NAMEDGROUP_INFO);
+
+            for(String group : ngAssembly.getNamedGroupInfo().getGroups(false)) {
+               Object[] conditions = ConditionUtil.fromConditionListToModel(
+                  ngAssembly.getNamedGroupInfo().getGroupCondition(group), refModelService);
+               ConditionExpression conditionExpression = new ConditionExpression();
+               conditionExpression.setName(group);
+               conditionExpression.setList(conditions);
+               model.addCondition(conditionExpression);
+            }
+
+            return model;
+         }
+      }
+
+      AssetRepository rep = AssetUtil.getAssetRepository(false);
+
+      if(rep != null) {
+         DataRef fld = new AttributeRef(column);
+         AssetNamedGroupInfo[] infos = SummaryAttr.getAssetNamedGroupInfos(fld, rep, null);
+
+         for(AssetNamedGroupInfo info : infos) {
+            if(namedGroup.equals(info.getName())) {
+               NamedGroupInfoModel model = new NamedGroupInfoModel();
+               model.setType(XNamedGroupInfo.ASSET_NAMEDGROUP_INFO_REF);
+               model.setName(namedGroup);
+               return model;
+            }
+         }
+      }
+
+      throw new IllegalArgumentException(
+         "'" + namedGroup + "' is not a named group on column '" + column + "' -- it matches " +
+         "neither a worksheet-local group created by add_named_group nor a repository-" +
+         "registered predefined named group. list_named_groups reports what is available.");
+   }
+
+   /**
+    * The worksheet-local {@code DefaultNamedGroupAssembly}(s) attached to this column of this
+    * source -- mirrors {@code CalcTableService#worksheetNamedGroups}, generalized to any
+    * {@code SourceInfo} rather than one calc table's own.
+    */
+   private static List<DefaultNamedGroupAssembly> worksheetNamedGroups(
+      RuntimeViewsheet rvs, SourceInfo source, String column)
+   {
+      List<DefaultNamedGroupAssembly> matches = new ArrayList<>();
+      Worksheet ws = rvs == null || rvs.getViewsheet() == null
+         ? null : rvs.getViewsheet().getBaseWorksheet();
+
+      if(source == null || source.getSource() == null || ws == null) {
+         return matches;
+      }
+
+      for(Assembly wsAssembly : ws.getAssemblies()) {
+         if(!(wsAssembly instanceof DefaultNamedGroupAssembly ngAssembly) ||
+            ngAssembly.getAttachedType() != AttachedAssembly.COLUMN_ATTACHED)
+         {
+            continue;
+         }
+
+         SourceInfo attachedSource = ngAssembly.getAttachedSource();
+         DataRef attr = ngAssembly.getAttachedAttribute();
+
+         if(attachedSource == null || attr == null ||
+            !source.getSource().equals(attachedSource.getSource()) ||
+            !column.equals(attr.getAttribute()))
+         {
+            continue;
+         }
+
+         matches.add(ngAssembly);
+      }
+
+      return matches;
    }
 
    public static FieldRef from(DataRefModel ref) {

--- a/core/src/main/java/inetsoft/web/wiz/binding/TableBindingMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/TableBindingMutator.java
@@ -17,6 +17,8 @@
  */
 package inetsoft.web.wiz.binding;
 
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.asset.SourceInfo;
 import inetsoft.web.binding.drm.AttributeRefModel;
 import inetsoft.web.binding.drm.ColumnRefModel;
 import inetsoft.web.binding.drm.DataRefModel;
@@ -27,6 +29,7 @@ import inetsoft.web.binding.model.table.BaseTableBindingModel;
 import inetsoft.web.binding.model.table.CrosstabOptionInfo;
 import inetsoft.web.binding.model.table.CrosstabBindingModel;
 import inetsoft.web.binding.model.table.TableBindingModel;
+import inetsoft.web.binding.service.DataRefModelFactoryService;
 import inetsoft.web.wiz.binding.model.FieldRef;
 
 import java.util.*;
@@ -102,6 +105,28 @@ public final class TableBindingMutator {
    }
 
    public static void setShelf(BaseTableBindingModel model, String shelf, List<FieldRef> fields) {
+      try {
+         setShelf(model, shelf, fields, null, null, null);
+      }
+      catch(RuntimeException e) {
+         throw e; // preserve e.g. requireShelf/requireCompatible's IllegalArgumentException as-is
+      }
+      catch(Exception e) {
+         throw new RuntimeException(e);
+      }
+   }
+
+   /**
+    * @param rvs            the runtime viewsheet, so a dimension's {@code namedGroup} can be
+    *                       resolved against a worksheet-local named group.
+    * @param source         the crosstab's or table's own {@code SourceInfo}.
+    * @param refModelService needed to resolve a worksheet-local named group's conditions.
+    */
+   public static void setShelf(BaseTableBindingModel model, String shelf, List<FieldRef> fields,
+                               RuntimeViewsheet rvs, SourceInfo source,
+                               DataRefModelFactoryService refModelService)
+      throws Exception
+   {
       String name = requireShelf(model, shelf);
       List<FieldRef> refs = fields == null ? List.of() : fields;
 
@@ -110,9 +135,12 @@ public final class TableBindingMutator {
       }
 
       switch(name) {
-         case "rows" -> ((CrosstabBindingModel) model).setRows(dimensions(refs));
-         case "cols" -> ((CrosstabBindingModel) model).setCols(dimensions(refs));
-         case "groups" -> ((TableBindingModel) model).setGroups(dimensions(refs));
+         case "rows" -> ((CrosstabBindingModel) model).setRows(
+            dimensions(refs, rvs, source, refModelService));
+         case "cols" -> ((CrosstabBindingModel) model).setCols(
+            dimensions(refs, rvs, source, refModelService));
+         case "groups" -> ((TableBindingModel) model).setGroups(
+            dimensions(refs, rvs, source, refModelService));
          case "details" -> ((TableBindingModel) model).setDetails(details(refs));
          default -> model.setAggregates(aggregates(refs));
       }
@@ -247,7 +275,19 @@ public final class TableBindingMutator {
 
    // ── conversions ───────────────────────────────────────────────────────────
 
+   /**
+    * @implNote {@link #addField}/{@link #moveField} reapply a shelf through this overload with
+    * no runtime context -- a field carrying {@code namedGroup} through that path is left
+    * unresolved, same as before this method learned to resolve it at all.
+    */
    private static List<BDimensionRefModel> dimensions(List<FieldRef> fields) {
+      return dimensions(fields, null, null, null);
+   }
+
+   private static List<BDimensionRefModel> dimensions(List<FieldRef> fields, RuntimeViewsheet rvs,
+                                                       SourceInfo source,
+                                                       DataRefModelFactoryService refModelService)
+   {
       List<BDimensionRefModel> out = new ArrayList<>();
 
       for(FieldRef field : fields) {
@@ -257,6 +297,21 @@ public final class TableBindingMutator {
 
          if(field.dateLevel() != null) {
             ref.setDateLevel(DateLevels.normalize(field.dateLevel()));
+         }
+
+         if(field.namedGroup() != null && rvs != null) {
+            try {
+               ref.setNamedGroupInfo(FieldRefFactory.resolveNamedGroupInfo(
+                  field.namedGroup(), rvs, source, field.column(), refModelService));
+            }
+            catch(RuntimeException e) {
+               throw e; // preserve IllegalArgumentException's loud, field-named message as-is
+            }
+            catch(Exception e) {
+               throw new RuntimeException(e);
+            }
+
+            ref.setOrder(XConstants.SORT_SPECIFIC);
          }
 
          out.add(ref);

--- a/core/src/main/java/inetsoft/web/wiz/binding/TableBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/TableBindingService.java
@@ -27,6 +27,7 @@ import inetsoft.web.binding.model.table.BaseTableBindingModel;
 import inetsoft.web.binding.model.table.CalcTableBindingModel;
 import inetsoft.web.binding.model.table.CrosstabBindingModel;
 import inetsoft.web.binding.model.table.TableBindingModel;
+import inetsoft.web.binding.service.DataRefModelFactoryService;
 import inetsoft.web.binding.service.VSBindingService;
 import inetsoft.web.wiz.binding.model.FieldRef;
 import inetsoft.web.wiz.viewsheet.ViewsheetSessionService;
@@ -55,18 +56,31 @@ public class TableBindingService {
    @Autowired
    public TableBindingService(ViewsheetSessionService sessions,
                               VSBindingService binding,
-                              VSBindingModelService bindingModelService)
+                              VSBindingModelService bindingModelService,
+                              DataRefModelFactoryService refModelService)
    {
       this.sessions = sessions;
       this.binding = binding;
       this.bindingModelService = bindingModelService;
+      this.refModelService = refModelService;
    }
 
    public void setShelf(String sessionToken, Principal user, String assemblyName, String shelf,
                         List<FieldRef> fields) throws Exception
    {
-      apply(sessionToken, user, assemblyName,
-            model -> TableBindingMutator.setShelf(model, shelf, fields));
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         BaseTableBindingModel model = requireTableBinding(rvs, assemblyName);
+         Viewsheet vs = rvs.getViewsheet();
+         VSAssembly assembly = vs.getAssembly(assemblyName);
+         inetsoft.uql.asset.SourceInfo source = assembly instanceof DataVSAssembly data
+            ? data.getSourceInfo() : null;
+         TableBindingMutator.setShelf(model, shelf, fields, rvs, source, refModelService);
+
+         ApplyVSAssemblyInfoEvent event = new ApplyVSAssemblyInfoEvent();
+         event.setName(assemblyName);
+         event.setBinding(model);
+         bindingModelService.setBinding(runtimeId, event, user, dispatcher);
+      });
    }
 
    /**
@@ -376,4 +390,5 @@ public class TableBindingService {
    private final ViewsheetSessionService sessions;
    private final VSBindingService binding;
    private final VSBindingModelService bindingModelService;
+   private final DataRefModelFactoryService refModelService;
 }

--- a/core/src/test/java/inetsoft/report/composition/execution/CrosstabNamedGroupEndToEndTest.java
+++ b/core/src/test/java/inetsoft/report/composition/execution/CrosstabNamedGroupEndToEndTest.java
@@ -1,0 +1,226 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.composition.execution;
+
+import inetsoft.report.TableLens;
+import inetsoft.report.internal.binding.AssetNamedGroupInfo;
+import inetsoft.report.internal.binding.ExpertNamedGroupInfo;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.IntegrationTestConfiguration;
+import inetsoft.test.SreeHome;
+import inetsoft.test.SwapperTestConfiguration;
+import inetsoft.uql.Condition;
+import inetsoft.uql.ConditionItem;
+import inetsoft.uql.ConditionList;
+import inetsoft.uql.ColumnSelection;
+import inetsoft.uql.JunctionOperator;
+import inetsoft.uql.VariableTable;
+import inetsoft.uql.XCondition;
+import inetsoft.uql.XConstants;
+import inetsoft.uql.asset.AbstractSheet;
+import inetsoft.uql.asset.AggregateFormula;
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.asset.EmbeddedTableAssembly;
+import inetsoft.uql.asset.SourceInfo;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.util.XEmbeddedTable;
+import inetsoft.uql.util.XNamedGroupInfo;
+import inetsoft.uql.viewsheet.CrosstabVSAssembly;
+import inetsoft.uql.viewsheet.VSAggregateRef;
+import inetsoft.uql.viewsheet.VSCrosstabInfo;
+import inetsoft.uql.viewsheet.VSDimensionRef;
+import inetsoft.uql.viewsheet.Viewsheet;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.*;
+
+/**
+ * The full-stack proof per this program's own "{"ok":true} is not evidence" standard: a real
+ * {@link CrosstabVSAQuery} execution, against a real in-memory {@link TableLens}, with an
+ * Expert or Asset-typed {@link XNamedGroupInfo} on an ordinary crosstab row dimension --
+ * mirroring {@code CrosstabSortByValueEntityQualifiedNameTest}'s fixture shape. Confirms the
+ * grouping this whole redesign exists to unblock actually changes the rendered data, not just
+ * the model.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class, SwapperTestConfiguration.class, IntegrationTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class CrosstabNamedGroupEndToEndTest {
+   /** Builds a one-row-dimension, one-aggregate crosstab grouping STATE by {@code groupInfo}. */
+   private TableLens run(XNamedGroupInfo groupInfo) throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly table = new EmbeddedTableAssembly(ws, "Query1");
+      ColumnSelection cs = new ColumnSelection();
+      cs.addAttribute(new ColumnRef(new AttributeRef("STATE")));
+      cs.addAttribute(new ColumnRef(new AttributeRef("CUSTOMER_ID")));
+      table.setColumnSelection(cs, false);
+
+      Object[][] rows = new Object[][]{
+         {"STATE", "CUSTOMER_ID"},
+         {"NJ", "C1"}, {"NJ", "C2"}, {"NJ", "C3"}, {"NJ", "C4"}, {"NJ", "C5"}, {"NJ", "C6"},
+         {"CA", "C7"}, {"CA", "C8"}, {"CA", "C9"}, {"CA", "C10"},
+         {"MA", "C11"}, {"MA", "C12"}, {"MA", "C13"}, {"MA", "C14"},
+      };
+      table.setEmbeddedData(new XEmbeddedTable(new String[]{ "string", "string" }, rows));
+      ws.addAssembly(table);
+
+      Viewsheet vs = new Viewsheet();
+      CrosstabVSAssembly crosstab = new CrosstabVSAssembly(vs, "Crosstab1");
+      crosstab.setSourceInfo(new SourceInfo(SourceInfo.ASSET, null, "Query1"));
+      vs.addAssembly(crosstab);
+
+      VSDimensionRef stateDim = new VSDimensionRef();
+      stateDim.setDataRef(new AttributeRef("STATE"));
+      stateDim.setGroupColumnValue("STATE");
+      stateDim.setDataType(XSchema.STRING);
+      // The Part 2/Part 3 wiring this test proves: an ordinary dimension carrying a resolved
+      // Expert/Asset XNamedGroupInfo, forced to SORT_SPECIFIC exactly as
+      // FieldRefFactory.resolveNamedGroupInfo/ChartDimensionInfoFactory.pasteChartRef/
+      // BDimensionRefModel.createDataRef do at the wiz binding-apply layer.
+      stateDim.setNamedGroupInfo(groupInfo);
+      stateDim.setOrder(XConstants.SORT_SPECIFIC);
+
+      VSAggregateRef countAgg = new VSAggregateRef();
+      countAgg.setDataRef(new AttributeRef("CUSTOMER_ID"));
+      countAgg.setColumnValue("CUSTOMER_ID");
+      countAgg.setFormulaValue(AggregateFormula.COUNT_ALL.getFormulaName());
+
+      VSCrosstabInfo cinfo = new VSCrosstabInfo();
+      cinfo.setDesignRowHeaders(new VSDimensionRef[]{ stateDim });
+      cinfo.setDesignColHeaders(new VSDimensionRef[0]);
+      cinfo.setDesignAggregates(new VSAggregateRef[]{ countAgg });
+      crosstab.setVSCrosstabInfo(cinfo);
+
+      // No AssetEntry/asset-repository is available in a from-scratch unit test, so the base
+      // worksheet and query sandbox are wired in directly rather than through the normal
+      // asset-repository-backed constructors.
+      Method setBaseWorksheet = Viewsheet.class.getDeclaredMethod("setBaseWorksheet", Worksheet.class);
+      setBaseWorksheet.setAccessible(true);
+      setBaseWorksheet.invoke(vs, ws);
+
+      ViewsheetSandbox box = new ViewsheetSandbox(vs, AbstractSheet.SHEET_RUNTIME_MODE, null, false, null);
+      AssetQuerySandbox wbox = new AssetQuerySandbox(ws, null, new VariableTable());
+      Field wboxField = ViewsheetSandbox.class.getDeclaredField("wbox");
+      wboxField.setAccessible(true);
+      wboxField.set(box, wbox);
+
+      cinfo.update(vs, cs, null, false, "Query1", null);
+
+      TableLens lens = new CrosstabVSAQuery(box, "Crosstab1", false).getTableLens();
+      lens.moreRows(TableLens.EOT);
+      return lens;
+   }
+
+   /** All row labels (column 0) actually present in the rendered crosstab, skipping the header. */
+   private static Set<String> rowLabels(TableLens lens) {
+      Set<String> labels = new HashSet<>();
+
+      for(int r = 1; r < lens.getRowCount(); r++) {
+         labels.add(String.valueOf(lens.getObject(r, 0)));
+      }
+
+      return labels;
+   }
+
+   private static int countFor(TableLens lens, String label) {
+      for(int r = 1; r < lens.getRowCount(); r++) {
+         if(label.equals(String.valueOf(lens.getObject(r, 0)))) {
+            return ((Number) lens.getObject(r, 1)).intValue();
+         }
+      }
+
+      throw new AssertionError("no row for '" + label + "' in: " + rowLabels(lens));
+   }
+
+   /** {@code STATE = 'NJ' OR STATE = 'CA'} -- two OR-joined equality items, the shape
+    *  {@code add_named_group} actually produces, and the only shape
+    *  {@code NamedRangeRef.getScriptExpression()} knows how to translate (it switches on
+    *  {@code EQUAL_TO}/{@code LESS_THAN}/{@code GREATER_THAN} per item; a single multi-value
+    *  {@code ONE_OF} condition falls through unhandled there). */
+   private static ConditionList coastalCondition() {
+      ConditionList conds = new ConditionList();
+      Condition nj = new Condition(XSchema.STRING);
+      nj.setOperation(XCondition.EQUAL_TO);
+      nj.addValue("NJ");
+      conds.append(new ConditionItem(new AttributeRef("STATE"), nj, 0));
+      conds.append(new JunctionOperator(JunctionOperator.OR, 0));
+      Condition ca = new Condition(XSchema.STRING);
+      ca.setOperation(XCondition.EQUAL_TO);
+      ca.addValue("CA");
+      conds.append(new ConditionItem(new AttributeRef("STATE"), ca, 0));
+      return conds;
+   }
+
+   @Test
+   void groupsByAWorksheetLocalExpertNamedGroup() throws Exception {
+      ExpertNamedGroupInfo info = new ExpertNamedGroupInfo();
+      info.setGroupCondition("Coastal", coastalCondition());
+
+      TableLens lens = run(info);
+
+      assertEquals(Set.of("Coastal", "MA"), rowLabels(lens),
+         "NJ and CA must collapse into the named group; MA is ungrouped and passes through");
+      assertEquals(10, countFor(lens, "Coastal"), "NJ (6) + CA (4)");
+      assertEquals(4, countFor(lens, "MA"));
+      assertFalse(rowLabels(lens).contains("NJ"), "NJ must not survive ungrouped");
+      assertFalse(rowLabels(lens).contains("CA"), "CA must not survive ungrouped");
+   }
+
+   /**
+    * Confirms the same query-engine path is exercised identically for a repository-registered
+    * ("predefined") named group -- by the time an {@link AssetNamedGroupInfo} reaches
+    * {@code VSDimensionRef.createGroupRef()}, the asset lookup has already resolved (Part 1/3),
+    * so a mocked {@code getGroups()}/{@code getGroupCondition()} pair is a faithful stand-in for
+    * one without needing a live {@code AssetRepository} in this test.
+    */
+   @Test
+   void groupsByARepositoryRegisteredAssetNamedGroup() throws Exception {
+      AssetNamedGroupInfo info = mock(AssetNamedGroupInfo.class);
+      when(info.getType()).thenReturn(XNamedGroupInfo.ASSET_NAMEDGROUP_INFO_REF);
+      when(info.isEmpty()).thenReturn(false);
+      when(info.getGroups()).thenReturn(new String[]{ "Coastal" });
+      when(info.getGroupCondition("Coastal")).thenReturn(coastalCondition());
+      // VSDimensionRef.clone() -- exercised somewhere along cinfo.update()'s runtime-ref
+      // preparation -- calls groupInfo.clone(); an unstubbed Mockito mock returns null there,
+      // silently discarding the named group before the query ever runs.
+      when(info.clone()).thenReturn(info);
+
+      TableLens lens = run(info);
+
+      assertEquals(Set.of("Coastal", "MA"), rowLabels(lens));
+      assertEquals(10, countFor(lens, "Coastal"), "NJ (6) + CA (4)");
+      assertEquals(4, countFor(lens, "MA"));
+   }
+}

--- a/core/src/test/java/inetsoft/report/composition/execution/VSAQueryTest.java
+++ b/core/src/test/java/inetsoft/report/composition/execution/VSAQueryTest.java
@@ -1,0 +1,147 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.composition.execution;
+
+import inetsoft.report.internal.binding.AssetNamedGroupInfo;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.Condition;
+import inetsoft.uql.ConditionItem;
+import inetsoft.uql.ConditionList;
+import inetsoft.uql.XCondition;
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.viewsheet.CrosstabVSAssembly;
+import inetsoft.uql.viewsheet.VSCrosstabInfo;
+import inetsoft.uql.viewsheet.VSDimensionRef;
+import inetsoft.report.internal.binding.ExpertNamedGroupInfo;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * {@code replaceGroupValues} splices a named group's own stored condition list in place of a
+ * "filter by group name" condition. It widens from a hard {@code SNamedGroupInfo} cast to
+ * {@code XNamedGroupInfo}, sources {@code dtype} from the dimension's own {@code DataRef} rather
+ * than the group's (type-specific, occasionally-stale) embedded copy, and resolves an Asset
+ * group's {@code "this"}-placeholder conditions before splicing (worksheet-local Expert groups
+ * never carry the placeholder -- their conditions already reference the real column).
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class VSAQueryTest {
+   private static VSDimensionRef regionRow() {
+      VSDimensionRef ref = new VSDimensionRef();
+      ref.setDataRef(new ColumnRef(new AttributeRef("REGION")));
+      ref.setDataType(XSchema.STRING);
+      return ref;
+   }
+
+   private static CrosstabVSAssembly crosstabWithRow(VSDimensionRef row) {
+      CrosstabVSAssembly crosstab =
+         new CrosstabVSAssembly(new inetsoft.uql.viewsheet.Viewsheet(), "Crosstab1");
+      VSCrosstabInfo cinfo = new VSCrosstabInfo();
+      cinfo.setRuntimeRowHeaders(new VSDimensionRef[]{ row });
+      cinfo.setRuntimeColHeaders(new VSDimensionRef[0]);
+      crosstab.setVSCrosstabInfo(cinfo);
+      return crosstab;
+   }
+
+   private static ConditionList filterByGroupName(String groupName) {
+      Condition cond = new Condition(XSchema.STRING);
+      cond.setOperation(XCondition.EQUAL_TO);
+      cond.addValue(groupName);
+      ConditionList conds = new ConditionList();
+      conds.append(new ConditionItem(new AttributeRef("REGION"), cond, 0));
+      return conds;
+   }
+
+   @Test
+   void splicesAnExpertNamedGroupsOwnConditionInPlaceOfTheGroupNameFilter() {
+      VSDimensionRef row = regionRow();
+      ExpertNamedGroupInfo info = new ExpertNamedGroupInfo();
+      Condition groupCond = new Condition(XSchema.STRING);
+      groupCond.setOperation(XCondition.EQUAL_TO);
+      groupCond.addValue("CA");
+      ConditionList groupConds = new ConditionList();
+      // Expert groups' conditions already reference the real column -- no "this" placeholder.
+      groupConds.append(new ConditionItem(new AttributeRef("REGION"), groupCond, 0));
+      info.setGroupCondition("West", groupConds);
+      row.setNamedGroupInfo(info);
+
+      ConditionList result = VSAQuery.replaceGroupValues(
+         filterByGroupName("West"), crosstabWithRow(row), false);
+
+      assertEquals(1, result.getConditionSize());
+      ConditionItem item = result.getConditionItem(0);
+      assertEquals("REGION", item.getAttribute().getAttribute());
+      assertEquals("CA", item.getCondition().getValue(0));
+   }
+
+   @Test
+   void resolvesTheThisPlaceholderInAnAssetNamedGroupBeforeSplicing() {
+      VSDimensionRef row = regionRow();
+      AssetNamedGroupInfo info = mock(AssetNamedGroupInfo.class);
+      when(info.getType()).thenReturn(inetsoft.uql.util.XNamedGroupInfo.ASSET_NAMEDGROUP_INFO_REF);
+      when(info.isEmpty()).thenReturn(false);
+      when(info.getGroups()).thenReturn(new String[]{ "West" });
+
+      Condition placeholderCond = new Condition(XSchema.STRING);
+      placeholderCond.setOperation(XCondition.EQUAL_TO);
+      placeholderCond.addValue("CA");
+      ConditionList placeholderConds = new ConditionList();
+      // A repository-registered named group authored unattached to any column carries a "this"
+      // placeholder in place of a real column reference.
+      placeholderConds.append(new ConditionItem(new ColumnRef(new AttributeRef("this")),
+                                                placeholderCond, 0));
+      when(info.getGroupCondition("West")).thenReturn(placeholderConds);
+      row.setNamedGroupInfo(info);
+
+      ConditionList result = VSAQuery.replaceGroupValues(
+         filterByGroupName("West"), crosstabWithRow(row), false);
+
+      assertEquals(1, result.getConditionSize());
+      ConditionItem item = result.getConditionItem(0);
+      assertEquals("REGION", item.getAttribute().getAttribute(),
+         "the \"this\" placeholder must be resolved to the real bound column before splicing");
+      assertEquals("CA", item.getCondition().getValue(0));
+   }
+
+   @Test
+   void leavesAnUngroupedFilterUnchanged() {
+      VSDimensionRef row = regionRow();
+
+      ConditionList result = VSAQuery.replaceGroupValues(
+         filterByGroupName("Anything"), crosstabWithRow(row), false);
+
+      assertEquals(1, result.getConditionSize());
+      assertEquals("REGION", result.getConditionItem(0).getAttribute().getAttribute());
+      assertEquals("Anything", result.getConditionItem(0).getCondition().getValue(0));
+   }
+}

--- a/core/src/test/java/inetsoft/uql/viewsheet/CrosstabVSAssemblyTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/CrosstabVSAssemblyTest.java
@@ -1,0 +1,135 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.viewsheet;
+
+import inetsoft.report.internal.binding.ExpertNamedGroupInfo;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.viewsheet.internal.CrosstabTree;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * {@code updateGroupExpandPath}'s two casts to {@code SNamedGroupInfo} widen to
+ * {@code XNamedGroupInfo} -- a pure widen, since the method only ever calls {@code isEmpty()}/
+ * {@code equals()}, both already interface-generic. Invoked via reflection since the method
+ * itself is private and its public entry point ({@code setVSAssemblyInfo}) needs a full
+ * cube/aggregate-change scenario unrelated to what this method actually does.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class CrosstabVSAssemblyTest {
+   private static VSDimensionRef regionRef() {
+      VSDimensionRef ref = new VSDimensionRef();
+      ref.setDataRef(new ColumnRef(new AttributeRef("REGION")));
+      ref.setDataType(XSchema.STRING);
+      return ref;
+   }
+
+   private static void markDrilled(CrosstabVSAssembly assembly, String field) throws Exception {
+      Field expandedField = CrosstabTree.class.getDeclaredField("expanded");
+      expandedField.setAccessible(true);
+      @SuppressWarnings("unchecked")
+      Map<String, Set<String>> expanded =
+         (Map<String, Set<String>>) expandedField.get(assembly.getCrosstabTree());
+      expanded.put(field, new HashSet<>(Set.of("some-drilled-value")));
+   }
+
+   private static void invokeUpdateGroupExpandPath(CrosstabVSAssembly assembly,
+                                                    VSDimensionRef nref, VSDimensionRef oref)
+      throws Exception
+   {
+      Method method = CrosstabVSAssembly.class.getDeclaredMethod(
+         "updateGroupExpandPath", inetsoft.uql.erm.DataRef.class, inetsoft.uql.erm.DataRef.class);
+      method.setAccessible(true);
+      method.invoke(assembly, nref, oref);
+   }
+
+   @Test
+   void removesTheDrillWhenAnExpertNamedGroupIsAddedToAPreviouslyUngroupedDimension() throws Exception {
+      CrosstabVSAssembly assembly = new CrosstabVSAssembly();
+      VSDimensionRef oref = regionRef();
+      markDrilled(assembly, oref.getFullName());
+
+      VSDimensionRef nref = regionRef();
+      nref.setNamedGroupInfo(new ExpertNamedGroupInfo());
+      ExpertNamedGroupInfo info = (ExpertNamedGroupInfo) nref.getNamedGroupInfo();
+      info.setGroupCondition("West", new inetsoft.uql.ConditionList());
+
+      assertDoesNotThrow(() -> invokeUpdateGroupExpandPath(assembly, nref, oref));
+      assertFalse(assembly.getCrosstabTree().isDrilled(oref.getFullName()),
+         "grouping a previously-ungrouped dimension should invalidate its drill path");
+   }
+
+   @Test
+   void removesTheDrillWhenAnExpertNamedGroupIsChanged() throws Exception {
+      CrosstabVSAssembly assembly = new CrosstabVSAssembly();
+
+      VSDimensionRef oref = regionRef();
+      ExpertNamedGroupInfo oldInfo = new ExpertNamedGroupInfo();
+      oldInfo.setGroupCondition("West", new inetsoft.uql.ConditionList());
+      oref.setNamedGroupInfo(oldInfo);
+      markDrilled(assembly, oref.getFullName());
+
+      VSDimensionRef nref = regionRef();
+      ExpertNamedGroupInfo newInfo = new ExpertNamedGroupInfo();
+      newInfo.setGroupCondition("East", new inetsoft.uql.ConditionList());
+      nref.setNamedGroupInfo(newInfo);
+
+      assertDoesNotThrow(() -> invokeUpdateGroupExpandPath(assembly, nref, oref));
+      assertFalse(assembly.getCrosstabTree().isDrilled(oref.getFullName()),
+         "changing an Expert named group's conditions should invalidate the drill path");
+   }
+
+   @Test
+   void leavesTheDrillAloneWhenTheExpertNamedGroupIsUnchanged() throws Exception {
+      CrosstabVSAssembly assembly = new CrosstabVSAssembly();
+
+      VSDimensionRef oref = regionRef();
+      ExpertNamedGroupInfo info = new ExpertNamedGroupInfo();
+      info.setGroupCondition("West", new inetsoft.uql.ConditionList());
+      oref.setNamedGroupInfo(info);
+      markDrilled(assembly, oref.getFullName());
+
+      VSDimensionRef nref = regionRef();
+      nref.setNamedGroupInfo((ExpertNamedGroupInfo) info.clone());
+
+      assertDoesNotThrow(() -> invokeUpdateGroupExpandPath(assembly, nref, oref));
+      assertTrue(assembly.getCrosstabTree().isDrilled(oref.getFullName()),
+         "an unchanged Expert named group must not disturb an existing drill path");
+   }
+}

--- a/core/src/test/java/inetsoft/uql/viewsheet/VSDimensionRefTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/VSDimensionRefTest.java
@@ -1,0 +1,195 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.viewsheet;
+
+import inetsoft.report.internal.binding.ExpertNamedGroupInfo;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.Condition;
+import inetsoft.uql.ConditionItem;
+import inetsoft.uql.ConditionList;
+import inetsoft.uql.XCondition;
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.asset.GroupRef;
+import inetsoft.uql.asset.NamedRangeRef;
+import inetsoft.uql.asset.SNamedGroupInfo;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.schema.XSchema;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.ByteArrayInputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * {@code groupInfo} widened from {@code SNamedGroupInfo} to {@code XNamedGroupInfo}
+ * (chart/table/crosstab dimension named-group consumer redesign, Phase 0). Confirms the existing
+ * {@code SNamedGroupInfo} path round-trips unchanged, then exercises the newly-reachable
+ * {@code ExpertNamedGroupInfo} shape directly (Part 2 wiring, Phase 3, is what will eventually
+ * construct a ref this way through the wiz layer -- this test bypasses it, matching Phase 0's own
+ * "not exercised by any live path yet" scope).
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class VSDimensionRefTest {
+   private static VSDimensionRef regionRef() {
+      VSDimensionRef ref = new VSDimensionRef();
+      ref.setDataRef(new ColumnRef(new AttributeRef("REGION")));
+      ref.setDataType(XSchema.STRING);
+      return ref;
+   }
+
+   private static ExpertNamedGroupInfo westGroup() {
+      ExpertNamedGroupInfo info = new ExpertNamedGroupInfo();
+      Condition cond = new Condition(XSchema.STRING);
+      cond.setOperation(XCondition.EQUAL_TO);
+      cond.addValue("CA");
+      ConditionList conds = new ConditionList();
+      conds.append(new ConditionItem(new AttributeRef("REGION"), cond, 0));
+      info.setGroupCondition("West", conds);
+      return info;
+   }
+
+   // ── SNamedGroupInfo round-trip safety (pure refactor-safety bar) ────────────
+
+   @Test
+   void simpleNamedGroupInfoStillRoundTripsThroughCreateGroupRef() {
+      VSDimensionRef ref = regionRef();
+      SNamedGroupInfo info = new SNamedGroupInfo();
+      info.setDataRef(new AttributeRef("REGION"));
+      info.setGroupValue("West", List.of("CA", "OR"));
+      ref.setNamedGroupInfo(info);
+
+      GroupRef groupRef = ref.createGroupRef(null);
+
+      assertNotNull(groupRef);
+      DataRef inner = ((ColumnRef) groupRef.getDataRef()).getDataRef();
+      assertInstanceOf(NamedRangeRef.class, inner);
+      String expr = ((NamedRangeRef) inner).getExpression();
+      assertTrue(expr.contains("West"), "SNamedGroupInfo grouping expression: " + expr);
+   }
+
+   @Test
+   void simpleNamedGroupInfoStillRoundTripsThroughXmlAndClone() throws Exception {
+      VSDimensionRef ref = regionRef();
+      SNamedGroupInfo info = new SNamedGroupInfo();
+      info.setDataRef(new AttributeRef("REGION"));
+      info.setGroupValue("West", List.of("CA", "OR"));
+      ref.setNamedGroupInfo(info);
+
+      VSDimensionRef restored = xmlRoundTrip(ref);
+      assertInstanceOf(SNamedGroupInfo.class, restored.getNamedGroupInfo());
+      assertEquals(List.of("West"), List.of(restored.getNamedGroupInfo().getGroups()));
+
+      VSDimensionRef cloned = (VSDimensionRef) ref.clone();
+      assertInstanceOf(SNamedGroupInfo.class, cloned.getNamedGroupInfo());
+      assertNotSame(info, cloned.getNamedGroupInfo(), "clone must be a deep copy");
+   }
+
+   // ── new behavior: ExpertNamedGroupInfo, direct construction (Phase 0) ───────
+
+   @Test
+   void setNamedGroupInfoAcceptsAnExpertNamedGroupInfo() {
+      VSDimensionRef ref = regionRef();
+      assertDoesNotThrow(() -> ref.setNamedGroupInfo(westGroup()));
+      assertInstanceOf(ExpertNamedGroupInfo.class, ref.getNamedGroupInfo());
+   }
+
+   @Test
+   void createGroupRefBuildsANamedRangeRefFromAnExpertNamedGroupInfo() {
+      VSDimensionRef ref = regionRef();
+      ref.setNamedGroupInfo(westGroup());
+
+      GroupRef groupRef = ref.createGroupRef(null);
+
+      assertNotNull(groupRef);
+      DataRef inner = ((ColumnRef) groupRef.getDataRef()).getDataRef();
+      assertInstanceOf(NamedRangeRef.class, inner);
+
+      NamedRangeRef namedRange = (NamedRangeRef) inner;
+      String sqlExpr = namedRange.getExpression();
+      String scriptExpr = namedRange.getScriptExpression();
+
+      assertTrue(sqlExpr.contains("West"), "SQL CASE expression: " + sqlExpr);
+      assertTrue(sqlExpr.contains("'CA'"), "SQL CASE expression: " + sqlExpr);
+      assertTrue(scriptExpr.contains("West"), "script expression: " + scriptExpr);
+   }
+
+   @Test
+   void xmlRoundTripPreservesAnExpertNamedGroupInfoAndItsConditions() throws Exception {
+      VSDimensionRef ref = regionRef();
+      ref.setNamedGroupInfo(westGroup());
+
+      VSDimensionRef restored = xmlRoundTrip(ref);
+
+      assertInstanceOf(ExpertNamedGroupInfo.class, restored.getNamedGroupInfo(),
+         "the missing class= attribute gap (Decision 5) would deserialize this as a plain " +
+         "SNamedGroupInfo instead, or throw, depending on the reflective lookup's fallback");
+      assertEquals(List.of("West"), List.of(restored.getNamedGroupInfo().getGroups()));
+      ConditionList restoredConds = restored.getNamedGroupInfo().getGroupCondition("West");
+      assertEquals(1, restoredConds.getConditionSize());
+   }
+
+   @Test
+   void cloneDeepCopiesAnExpertNamedGroupInfo() {
+      VSDimensionRef ref = regionRef();
+      ExpertNamedGroupInfo info = westGroup();
+      ref.setNamedGroupInfo(info);
+
+      VSDimensionRef cloned = (VSDimensionRef) ref.clone();
+
+      assertInstanceOf(ExpertNamedGroupInfo.class, cloned.getNamedGroupInfo());
+      assertNotSame(info, cloned.getNamedGroupInfo(), "clone must be a deep copy");
+      assertEquals(info, cloned.getNamedGroupInfo());
+   }
+
+   private static VSDimensionRef xmlRoundTrip(VSDimensionRef ref) throws Exception {
+      StringWriter sw = new StringWriter();
+      PrintWriter pw = new PrintWriter(sw);
+      ref.writeXML(pw);
+      pw.flush();
+
+      DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+      factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+      factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+      Document doc = factory.newDocumentBuilder()
+         .parse(new ByteArrayInputStream(sw.toString().getBytes()));
+      Element elem = doc.getDocumentElement();
+
+      VSDimensionRef restored = new VSDimensionRef();
+      restored.parseXML(elem);
+      return restored;
+   }
+}

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/NamedGroupConditionUtilTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/NamedGroupConditionUtilTest.java
@@ -1,0 +1,94 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.viewsheet.internal;
+
+import inetsoft.report.internal.binding.AssetNamedGroupInfo;
+import inetsoft.report.internal.binding.ExpertNamedGroupInfo;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.Condition;
+import inetsoft.uql.ConditionItem;
+import inetsoft.uql.ConditionList;
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.asset.SNamedGroupInfo;
+import inetsoft.uql.erm.AttributeRef;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Extracted from the near-identical {@code TableConditionUtil.syncConditionList} /
+ * {@code BaseTableShowDetailsService.syncConditionList} so chart/crosstab/table dimensions can
+ * share the same "this"-placeholder resolution those two calc-table paths already rely on.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class NamedGroupConditionUtilTest {
+   @Test
+   void needsColumnResolutionIsTrueOnlyForTheTwoAssetBackedShapes() {
+      assertTrue(NamedGroupConditionUtil.needsColumnResolution(new AssetNamedGroupInfo()));
+      assertFalse(NamedGroupConditionUtil.needsColumnResolution(new ExpertNamedGroupInfo()));
+      assertFalse(NamedGroupConditionUtil.needsColumnResolution(new SNamedGroupInfo()));
+      assertFalse(NamedGroupConditionUtil.needsColumnResolution(null));
+   }
+
+   @Test
+   void replacesTheThisPlaceholderWithTheRealColumn() {
+      Condition cond = new Condition();
+      cond.setOperation(Condition.EQUAL_TO);
+      cond.addValue("CA");
+      ConditionList list = new ConditionList();
+      list.append(new ConditionItem(new ColumnRef(new AttributeRef("this")), cond, 0));
+
+      NamedGroupConditionUtil.resolveConditionColumn(list, "REGION");
+
+      assertEquals("REGION", list.getConditionItem(0).getAttribute().getAttribute());
+   }
+
+   @Test
+   void leavesARealColumnAttributeAlone() {
+      Condition cond = new Condition();
+      cond.setOperation(Condition.EQUAL_TO);
+      cond.addValue("CA");
+      ConditionList list = new ConditionList();
+      list.append(new ConditionItem(new ColumnRef(new AttributeRef("STATE")), cond, 0));
+
+      NamedGroupConditionUtil.resolveConditionColumn(list, "REGION");
+
+      assertEquals("STATE", list.getConditionItem(0).getAttribute().getAttribute());
+   }
+
+   @Test
+   void toleratesAConditionItemWithNoAttribute() {
+      Condition cond = new Condition();
+      cond.setOperation(Condition.EQUAL_TO);
+      ConditionList list = new ConditionList();
+      list.append(new ConditionItem(null, cond, 0));
+
+      assertDoesNotThrow(() -> NamedGroupConditionUtil.resolveConditionColumn(list, "REGION"));
+   }
+}

--- a/core/src/test/java/inetsoft/web/binding/model/BDimensionRefModelTest.java
+++ b/core/src/test/java/inetsoft/web/binding/model/BDimensionRefModelTest.java
@@ -1,0 +1,185 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.binding.model;
+
+import inetsoft.report.internal.binding.AssetNamedGroupInfo;
+import inetsoft.report.internal.binding.ExpertNamedGroupInfo;
+import inetsoft.report.internal.binding.SummaryAttr;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.Condition;
+import inetsoft.uql.ConditionItem;
+import inetsoft.uql.ConditionList;
+import inetsoft.uql.XCondition;
+import inetsoft.uql.XConstants;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.asset.internal.AssetUtil;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.util.XNamedGroupInfo;
+import inetsoft.uql.viewsheet.VSDimensionRef;
+import inetsoft.web.binding.drm.AttributeRefModel;
+import inetsoft.web.binding.drm.ColumnRefModel;
+import inetsoft.web.binding.drm.DataRefModel;
+import inetsoft.web.binding.service.DataRefModelFactoryService;
+import inetsoft.web.composer.model.condition.ConditionExpression;
+import inetsoft.web.composer.model.condition.ConditionUtil;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * {@code createDataRef()}'s Part 2 wiring (mirrors {@code ChartDimensionInfoFactoryTest}) plus
+ * the {@code SORT_SPECIFIC}-stripping guard fix: the original guard checked {@code
+ * getGroups().isEmpty()}, which is only populated by the manual-value ({@code
+ * SIMPLE_NAMEDGROUP_INFO}) shape -- an Expert or Asset-ref model has its content in {@code
+ * getConditions()}/{@code getName()} instead, so the old guard silently stripped
+ * {@code SORT_SPECIFIC} right back off for those two shapes, undoing the wiring in the same call.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class BDimensionRefModelTest {
+   private static ColumnRefModel regionColumnModel() {
+      ColumnRefModel column = new ColumnRefModel();
+      column.setAttribute("REGION");
+      AttributeRefModel attr = new AttributeRefModel();
+      attr.setAttribute("REGION");
+      column.setDataRefModel(attr);
+      return column;
+   }
+
+   private static NamedGroupInfoModel expertModel(String groupName, String value) {
+      Condition cond = new Condition(XSchema.STRING);
+      cond.setOperation(XCondition.EQUAL_TO);
+      cond.addValue(value);
+      ConditionList conds = new ConditionList();
+      conds.append(new ConditionItem(new AttributeRef("REGION"), cond, 0));
+
+      DataRefModelFactoryService refModelService = mock(DataRefModelFactoryService.class);
+      when(refModelService.createDataRefModel(any())).thenReturn(mock(DataRefModel.class));
+      Object[] list = ConditionUtil.fromConditionListToModel(conds, refModelService);
+
+      ConditionExpression expr = new ConditionExpression();
+      expr.setName(groupName);
+      expr.setList(list);
+
+      NamedGroupInfoModel model = new NamedGroupInfoModel();
+      model.setType(XNamedGroupInfo.EXPERT_NAMEDGROUP_INFO);
+      model.addCondition(expr);
+      return model;
+   }
+
+   @Test
+   void wiresAnExpertNamedGroupModelIntoALiveRef() {
+      BDimensionRefModel model = new BDimensionRefModel();
+      model.setOrder(XConstants.SORT_SPECIFIC);
+      model.setDataRefModel(regionColumnModel());
+      model.setNamedGroupInfo(expertModel("West", "CA"));
+
+      DataRef dim = model.createDataRef();
+
+      assertInstanceOf(VSDimensionRef.class, dim);
+      XNamedGroupInfo info = ((VSDimensionRef) dim).getNamedGroupInfo();
+      assertInstanceOf(ExpertNamedGroupInfo.class, info);
+      assertEquals(List.of("West"), List.of(info.getGroups()));
+      assertEquals(XConstants.SORT_SPECIFIC, ((VSDimensionRef) dim).getOrder(),
+         "the guard fix must not strip SORT_SPECIFIC off an Expert-typed named group");
+   }
+
+   @Test
+   void wiresAnAssetNamedGroupModelIntoALiveRef() {
+      NamedGroupInfoModel ngModel = new NamedGroupInfoModel();
+      ngModel.setType(XNamedGroupInfo.ASSET_NAMEDGROUP_INFO_REF);
+      ngModel.setName("Tiers");
+
+      BDimensionRefModel model = new BDimensionRefModel();
+      model.setOrder(XConstants.SORT_SPECIFIC);
+      model.setDataRefModel(regionColumnModel());
+      model.setNamedGroupInfo(ngModel);
+
+      try(MockedStatic<AssetUtil> assetUtil = mockStatic(AssetUtil.class);
+          MockedStatic<SummaryAttr> summaryAttr = mockStatic(SummaryAttr.class))
+      {
+         AssetRepository rep = mock(AssetRepository.class);
+         assetUtil.when(() -> AssetUtil.getAssetRepository(false)).thenReturn(rep);
+
+         AssetNamedGroupInfo info = mock(AssetNamedGroupInfo.class);
+         when(info.getName()).thenReturn("Tiers");
+         summaryAttr.when(() -> SummaryAttr.getAssetNamedGroupInfos(any(), eq(rep), isNull()))
+            .thenReturn(new AssetNamedGroupInfo[]{ info });
+
+         DataRef dim = model.createDataRef();
+
+         assertSame(AssetNamedGroupInfo.class, ((VSDimensionRef) dim).getNamedGroupInfo().getClass());
+         assertEquals(XConstants.SORT_SPECIFIC, ((VSDimensionRef) dim).getOrder(),
+            "the guard fix must not strip SORT_SPECIFIC off an Asset-ref named group");
+      }
+   }
+
+   @Test
+   void refusesANamedGroupOnACubeSourcedDimension() {
+      // No DataRefModel -- createDataRef() builds a fresh VSDimensionRef with no data ref set at
+      // all by default, so pre-set one with the CUBE bit already on it is not applicable here;
+      // instead confirm the guard fires against the ref's own resolved refType by giving it a
+      // cube-tagged attribute directly through the model's DataRefModel.
+      ColumnRefModel column = regionColumnModel();
+      ((AttributeRefModel) column.getDataRefModel()).setRefType(DataRef.CUBE);
+
+      BDimensionRefModel model = new BDimensionRefModel();
+      model.setOrder(XConstants.SORT_SPECIFIC);
+      model.setDataRefModel(column);
+      model.setNamedGroupInfo(expertModel("West", "CA"));
+
+      IllegalArgumentException thrown =
+         assertThrows(IllegalArgumentException.class, model::createDataRef);
+      assertTrue(thrown.getMessage().toLowerCase().contains("cube"));
+   }
+
+   /**
+    * The pre-existing case the original guard protected: a {@code SORT_SPECIFIC} order with no
+    * named-group content of any kind and no manual order must still have {@code SORT_SPECIFIC}
+    * stripped -- confirming the fix widens the guard rather than removing its original purpose.
+    */
+   @Test
+   void stillStripsSortSpecificWhenThereIsNoNamedGroupContentAtAll() {
+      BDimensionRefModel model = new BDimensionRefModel();
+      model.setOrder(XConstants.SORT_SPECIFIC);
+      model.setDataRefModel(regionColumnModel());
+
+      DataRef dim = model.createDataRef();
+
+      assertEquals(0, ((VSDimensionRef) dim).getOrder() & XConstants.SORT_SPECIFIC,
+         "an order with no named group and no manual order must still have SORT_SPECIFIC stripped");
+   }
+}

--- a/core/src/test/java/inetsoft/web/binding/service/graph/ChartDimensionInfoFactoryTest.java
+++ b/core/src/test/java/inetsoft/web/binding/service/graph/ChartDimensionInfoFactoryTest.java
@@ -1,0 +1,188 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.binding.service.graph;
+
+import inetsoft.report.internal.binding.AssetNamedGroupInfo;
+import inetsoft.report.internal.binding.ExpertNamedGroupInfo;
+import inetsoft.report.internal.binding.SummaryAttr;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.Condition;
+import inetsoft.uql.ConditionItem;
+import inetsoft.uql.ConditionList;
+import inetsoft.uql.XCondition;
+import inetsoft.uql.XConstants;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.asset.internal.AssetUtil;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.util.XNamedGroupInfo;
+import inetsoft.uql.viewsheet.graph.VSChartDimensionRef;
+import inetsoft.web.binding.drm.ColumnRefModel;
+import inetsoft.web.binding.model.NamedGroupInfoModel;
+import inetsoft.web.binding.model.graph.ChartDimensionRefModel;
+import inetsoft.web.binding.service.DataRefModelFactoryService;
+import inetsoft.web.composer.model.condition.ConditionExpression;
+import inetsoft.web.composer.model.condition.ConditionUtil;
+import inetsoft.web.binding.drm.DataRefModel;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * {@code pasteChartRef}'s Part 2 wiring: a resolved {@code NamedGroupInfoModel} (built by the
+ * wiz layer's {@code FieldRefFactory.resolveNamedGroupInfo}) turns into a live
+ * {@code XNamedGroupInfo} on the real ref -- the capability {@code VSDimensionRef.setNamedGroupInfo}
+ * used to refuse outright (see the design doc's superseded "Feasibility update").
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class ChartDimensionInfoFactoryTest {
+   private final ChartDimensionInfoFactory.VSChartDimensionInfoFactory factory =
+      new ChartDimensionInfoFactory.VSChartDimensionInfoFactory(
+         new DataRefModelFactoryService(List.of()));
+
+   private static ColumnRefModel regionColumnModel() {
+      ColumnRefModel column = new ColumnRefModel();
+      column.setAttribute("REGION");
+      inetsoft.web.binding.drm.AttributeRefModel attr = new inetsoft.web.binding.drm.AttributeRefModel();
+      attr.setAttribute("REGION");
+      column.setDataRefModel(attr);
+      return column;
+   }
+
+   private static NamedGroupInfoModel expertModel(String groupName, String value) {
+      Condition cond = new Condition(XSchema.STRING);
+      cond.setOperation(XCondition.EQUAL_TO);
+      cond.addValue(value);
+      ConditionList conds = new ConditionList();
+      conds.append(new ConditionItem(new AttributeRef("REGION"), cond, 0));
+
+      DataRefModelFactoryService refModelService = mock(DataRefModelFactoryService.class);
+      when(refModelService.createDataRefModel(any())).thenReturn(mock(DataRefModel.class));
+      Object[] list = ConditionUtil.fromConditionListToModel(conds, refModelService);
+
+      ConditionExpression expr = new ConditionExpression();
+      expr.setName(groupName);
+      expr.setList(list);
+
+      NamedGroupInfoModel model = new NamedGroupInfoModel();
+      model.setType(XNamedGroupInfo.EXPERT_NAMEDGROUP_INFO);
+      model.addCondition(expr);
+      return model;
+   }
+
+   @Test
+   void wiresAnExpertNamedGroupModelIntoALiveRef() {
+      ChartDimensionRefModel model = new ChartDimensionRefModel();
+      model.setOrder(XConstants.SORT_SPECIFIC);
+      model.setDataRefModel(regionColumnModel());
+      model.setNamedGroupInfo(expertModel("West", "CA"));
+
+      VSChartDimensionRef ref = new VSChartDimensionRef();
+      factory.pasteChartRef(null, model, ref);
+
+      assertInstanceOf(ExpertNamedGroupInfo.class, ref.getNamedGroupInfo());
+      assertEquals(List.of("West"), List.of(ref.getNamedGroupInfo().getGroups()));
+   }
+
+   @Test
+   void wiresAnAssetNamedGroupModelIntoALiveRef() {
+      NamedGroupInfoModel model2 = new NamedGroupInfoModel();
+      model2.setType(XNamedGroupInfo.ASSET_NAMEDGROUP_INFO_REF);
+      model2.setName("Tiers");
+
+      ChartDimensionRefModel model = new ChartDimensionRefModel();
+      model.setOrder(XConstants.SORT_SPECIFIC);
+      model.setDataRefModel(regionColumnModel());
+      model.setNamedGroupInfo(model2);
+
+      VSChartDimensionRef ref = new VSChartDimensionRef();
+
+      try(MockedStatic<AssetUtil> assetUtil = mockStatic(AssetUtil.class);
+          MockedStatic<SummaryAttr> summaryAttr = mockStatic(SummaryAttr.class))
+      {
+         AssetRepository rep = mock(AssetRepository.class);
+         assetUtil.when(() -> AssetUtil.getAssetRepository(false)).thenReturn(rep);
+
+         AssetNamedGroupInfo info = mock(AssetNamedGroupInfo.class);
+         when(info.getName()).thenReturn("Tiers");
+         summaryAttr.when(() -> SummaryAttr.getAssetNamedGroupInfos(any(), eq(rep), isNull()))
+            .thenReturn(new AssetNamedGroupInfo[]{ info });
+
+         factory.pasteChartRef(null, model, ref);
+      }
+
+      assertSame(ref.getNamedGroupInfo().getClass(), AssetNamedGroupInfo.class);
+   }
+
+   @Test
+   void refusesANamedGroupOnACubeSourcedDimension() {
+      ChartDimensionRefModel model = new ChartDimensionRefModel();
+      model.setOrder(XConstants.SORT_SPECIFIC);
+      // No DataRefModel on the model -- pasteChartRef must not overwrite the ref's own
+      // already-cube-tagged DataRef, which is what carries the refType getRefType() reads.
+      model.setNamedGroupInfo(expertModel("West", "CA"));
+
+      VSChartDimensionRef ref = new VSChartDimensionRef();
+      AttributeRef cubeAttr = new AttributeRef("REGION");
+      cubeAttr.setRefType(DataRef.CUBE);
+      ref.setDataRef(new ColumnRef(cubeAttr));
+
+      IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+         () -> factory.pasteChartRef(null, model, ref));
+      assertTrue(thrown.getMessage().toLowerCase().contains("cube"));
+      assertNull(ref.getNamedGroupInfo(), "a refused binding must not leave partial state");
+   }
+
+   /**
+    * {@code order == SORT_NONE} clears an existing named group unconditionally -- the wiz layer
+    * (Part 1) always forces {@code order = SORT_SPECIFIC} whenever it resolves a {@code
+    * namedGroup}, so this path only fires for a caller explicitly clearing one, or a stale model
+    * that still carries a {@code namedGroupInfo} despite an unspecific order.
+    */
+   @Test
+   void sortNoneClearsAnExistingNamedGroupEvenIfTheModelStillCarriesOne() {
+      ChartDimensionRefModel model = new ChartDimensionRefModel();
+      model.setOrder(XConstants.SORT_NONE);
+      model.setDataRefModel(regionColumnModel());
+      model.setNamedGroupInfo(expertModel("West", "CA"));
+
+      VSChartDimensionRef ref = new VSChartDimensionRef();
+      ref.setNamedGroupInfo(new ExpertNamedGroupInfo());
+      factory.pasteChartRef(null, model, ref);
+
+      assertNull(ref.getNamedGroupInfo());
+   }
+}

--- a/core/src/test/java/inetsoft/web/composer/vs/objects/controller/ComposerGroupColumnsServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/objects/controller/ComposerGroupColumnsServiceTest.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.composer.vs.objects.controller;
+
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.internal.binding.ExpertNamedGroupInfo;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.graph.VSChartDimensionRef;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
+import inetsoft.util.MessageException;
+import inetsoft.web.binding.service.VSBindingService;
+import inetsoft.web.composer.vs.objects.event.GroupFieldsEvent;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * {@code group()} ("right-click a column -> Group columns") hand-picks specific literal cell
+ * values into ad-hoc groups -- an operation with no sensible generalization to an Expert or
+ * Asset-typed named group's own conditions. Before this fix, a dimension bound to one crashed
+ * with an unexplained {@link ClassCastException} the moment this dialog touched it (four
+ * unconditional {@code SNamedGroupInfo} casts); now it is refused loudly instead.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class ComposerGroupColumnsServiceTest {
+   private static ChartVSAssembly chartWithExpertGroupedXField(Viewsheet vs) {
+      VSChartDimensionRef ref = new VSChartDimensionRef();
+      ref.setDataRef(new ColumnRef(new AttributeRef("REGION")));
+      ref.setDataType(XSchema.STRING);
+      ExpertNamedGroupInfo info = new ExpertNamedGroupInfo();
+      info.setGroupCondition("West", new inetsoft.uql.ConditionList());
+      ref.setNamedGroupInfo(info);
+
+      VSChartInfo chartInfo = new VSChartInfo();
+      chartInfo.addXField(ref);
+
+      ChartVSAssembly assembly = new ChartVSAssembly(vs, "Chart1");
+      assembly.setVSChartInfo(chartInfo);
+      vs.addAssembly(assembly);
+      return assembly;
+   }
+
+   private static GroupFieldsEvent groupEvent() {
+      GroupFieldsEvent event = new GroupFieldsEvent();
+      event.setName("Chart1");
+      event.setColumnName("REGION");
+      event.setGroupName("NewGroup");
+      event.setLabels(new String[]{ "West" });
+      return event;
+   }
+
+   @Test
+   void refusesGroupingAColumnBoundToAnExpertNamedGroup() throws Exception {
+      Viewsheet vs = new Viewsheet();
+      chartWithExpertGroupedXField(vs);
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      ViewsheetService viewsheetService = mock(ViewsheetService.class);
+      when(viewsheetService.getViewsheet(anyString(), any())).thenReturn(rvs);
+
+      ComposerGroupColumnsService service = new ComposerGroupColumnsService(
+         viewsheetService, mock(VSBindingService.class), mock(VSObjectPropertyService.class));
+
+      Exception thrown = assertThrows(MessageException.class,
+         () -> service.group("runtime1", groupEvent(), "/", null, null));
+      assertNotNull(thrown.getMessage());
+   }
+}

--- a/core/src/test/java/inetsoft/web/graph/GraphBuilderTest.java
+++ b/core/src/test/java/inetsoft/web/graph/GraphBuilderTest.java
@@ -1,0 +1,142 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.graph;
+
+import inetsoft.report.composition.region.DimensionLabelArea;
+import inetsoft.report.internal.Region;
+import inetsoft.report.internal.binding.ExpertNamedGroupInfo;
+import inetsoft.report.internal.binding.AssetNamedGroupInfo;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.viewsheet.graph.ChartDescriptor;
+import inetsoft.uql.viewsheet.graph.ChartInfo;
+import inetsoft.uql.viewsheet.graph.VSChartDimensionRef;
+import inetsoft.web.graph.model.ChartModel;
+import inetsoft.web.graph.model.ChartRegion;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * {@code createChartRegion}'s two {@code SNamedGroupInfo} casts (dimension-axis labels and
+ * legend items) widen to {@code XNamedGroupInfo}, and the "is this label a group name" check
+ * switches from {@code SNamedGroupInfo}'s own {@code getGroupValue(label) != null} to the
+ * type-agnostic {@code getGroups()} membership test every {@code XNamedGroupInfo} implementation
+ * supports. By the time this runs, the label is already the group name the query engine computed
+ * (see {@code VSDimensionRefTest} for the {@code NamedRangeRef} expression that produces it) --
+ * this test only exercises the membership check itself, not query execution.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class GraphBuilderTest {
+   private static VSChartDimensionRef regionRef() {
+      VSChartDimensionRef ref = new VSChartDimensionRef();
+      ref.setDataRef(new ColumnRef(new AttributeRef("REGION")));
+      ref.setDataType(XSchema.STRING);
+      return ref;
+   }
+
+   /** Sets up a GraphBuilder + mocked DimensionLabelArea just far enough to reach the
+    *  dimension-axis-label grouped-flag check, and returns the resulting region. */
+   private static ChartRegion buildRegionFor(VSChartDimensionRef dimRef, String label)
+      throws Exception
+   {
+      ChartInfo cinfo = mock(ChartInfo.class);
+      when(cinfo.getFieldByName(anyString(), anyBoolean())).thenReturn(dimRef);
+
+      ChartModel model = mock(ChartModel.class);
+      when(model.getStringDictionary()).thenReturn(new ArrayList<>());
+
+      DimensionLabelArea area = mock(DimensionLabelArea.class);
+      when(area.getValue()).thenReturn(label);
+      when(area.getDimensionName()).thenReturn("REGION");
+      when(area.getParentValues()).thenReturn(List.of());
+      when(area.getHyperlinks()).thenReturn(new inetsoft.report.Hyperlink.Ref[0]);
+
+      GraphBuilder builder = new GraphBuilder(null, cinfo, null, new ChartDescriptor(), model);
+
+      Method method = GraphBuilder.class.getDeclaredMethod("createChartRegion",
+         inetsoft.report.composition.region.DefaultArea.class, Region[].class, String.class,
+         int.class, short[][].class);
+      method.setAccessible(true);
+      return (ChartRegion) method.invoke(builder, area, new Region[0], null, -1, null);
+   }
+
+   @Test
+   void marksAnExpertNamedGroupLabelAsGrouped() throws Exception {
+      VSChartDimensionRef ref = regionRef();
+      ExpertNamedGroupInfo info = new ExpertNamedGroupInfo();
+      info.setGroupCondition("West", new inetsoft.uql.ConditionList());
+      ref.setNamedGroupInfo(info);
+
+      ChartRegion region = buildRegionFor(ref, "West");
+
+      assertEquals(Boolean.TRUE, region.grouped());
+   }
+
+   @Test
+   void doesNotMarkAnUnrelatedLabelAsGrouped() throws Exception {
+      VSChartDimensionRef ref = regionRef();
+      ExpertNamedGroupInfo info = new ExpertNamedGroupInfo();
+      info.setGroupCondition("West", new inetsoft.uql.ConditionList());
+      ref.setNamedGroupInfo(info);
+
+      ChartRegion region = buildRegionFor(ref, "California");
+
+      assertNull(region.grouped());
+   }
+
+   @Test
+   void marksAnAssetNamedGroupLabelAsGrouped() throws Exception {
+      VSChartDimensionRef ref = regionRef();
+      AssetNamedGroupInfo info = mock(AssetNamedGroupInfo.class);
+      when(info.getGroups()).thenReturn(new String[]{ "Tier1" });
+      ref.setNamedGroupInfo(info);
+
+      ChartRegion region = buildRegionFor(ref, "Tier1");
+
+      assertEquals(Boolean.TRUE, region.grouped());
+   }
+
+   @Test
+   void ungroupedDimensionIsNeverMarkedGrouped() throws Exception {
+      VSChartDimensionRef ref = regionRef();
+
+      ChartRegion region = buildRegionFor(ref, "California");
+
+      assertNull(region.grouped());
+   }
+}

--- a/core/src/test/java/inetsoft/web/viewsheet/controller/table/BaseTableServiceTest.java
+++ b/core/src/test/java/inetsoft/web/viewsheet/controller/table/BaseTableServiceTest.java
@@ -1,0 +1,141 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.viewsheet.controller.table;
+
+import inetsoft.report.composition.VSTableLens;
+import inetsoft.report.internal.binding.ExpertNamedGroupInfo;
+import inetsoft.report.internal.table.SpanMap;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.report.TableDataPath;
+import inetsoft.uql.viewsheet.VSDimensionRef;
+import inetsoft.uql.viewsheet.VSFormat;
+import inetsoft.uql.viewsheet.internal.CrosstabVSAssemblyInfo;
+import inetsoft.web.composer.vs.objects.controller.VSTableService;
+import inetsoft.web.viewsheet.model.table.BaseTableCellModel;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.awt.*;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * The two per-cell "is this cell's value a named group name" checks (span-cell creation and
+ * plain-cell creation, respectively) widen from {@code SNamedGroupInfo}'s own
+ * {@code getGroupValue(value) != null} to the type-agnostic {@code getGroups()} membership test.
+ * By the time this runs the cell's value is already the group name the query engine computed
+ * (see {@code VSDimensionRefTest}) -- this is a String membership test, not a per-cell condition
+ * evaluation (the operator's stated performance concern).
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class BaseTableServiceTest {
+   private static VSDimensionRef regionRef(String namedGroup) {
+      VSDimensionRef ref = new VSDimensionRef();
+      ref.setDataRef(new ColumnRef(new AttributeRef("REGION")));
+      ref.setDataType(XSchema.STRING);
+
+      if(namedGroup != null) {
+         ExpertNamedGroupInfo info = new ExpertNamedGroupInfo();
+         info.setGroupCondition(namedGroup, new inetsoft.uql.ConditionList());
+         ref.setNamedGroupInfo(info);
+      }
+
+      return ref;
+   }
+
+   /**
+    * @param spanned when true, the cell hits the span-cell-creation branch (~line 867); when
+    *                false, it hits the plain-cell-creation branch (~line 936).
+    */
+   private static BaseTableCellModel[][] getTableCellsFor(VSDimensionRef dim, Object cellValue,
+                                                           boolean spanned) throws Exception
+   {
+      CrosstabVSAssemblyInfo info = new CrosstabVSAssemblyInfo();
+
+      VSTableLens lens = mock(VSTableLens.class);
+      when(lens.getColCount()).thenReturn(1);
+      when(lens.getObject(anyInt(), anyInt())).thenReturn(cellValue);
+      when(lens.getFormat(anyInt(), anyInt(), anyInt())).thenReturn(new VSFormat());
+      when(lens.getTableDataPath(anyInt(), anyInt()))
+         .thenReturn(new TableDataPath(-1, TableDataPath.SUMMARY));
+
+      SpanMap spanMap = mock(SpanMap.class);
+      when(spanMap.get(anyInt(), anyInt()))
+         .thenReturn(spanned ? new Rectangle(0, 0, 1, 1) : null);
+      when(lens.getSpanMap(anyInt(), anyInt())).thenReturn(spanMap);
+
+      try(MockedStatic<VSTableService> vsTableService = mockStatic(VSTableService.class)) {
+         vsTableService.when(() -> VSTableService.getCrosstabCellDataRef(
+               any(), any(), anyInt(), anyInt(), anyBoolean()))
+            .thenReturn(dim);
+
+         Method method = BaseTableService.class.getDeclaredMethod("getTableCells",
+            inetsoft.uql.viewsheet.internal.VSAssemblyInfo.class, VSTableLens.class, int.class,
+            int.class, inetsoft.report.composition.FormTableLens.class, boolean.class);
+         method.setAccessible(true);
+         return (BaseTableCellModel[][]) method.invoke(null, info, lens, 0, 1, null, false);
+      }
+   }
+
+   @Test
+   void spanCellIsMarkedGroupedWhenTheCellValueIsAnExpertGroupName() throws Exception {
+      BaseTableCellModel[][] cells = getTableCellsFor(regionRef("West"), "West", true);
+      assertEquals(Boolean.TRUE, cells[0][0].isGrouped());
+   }
+
+   @Test
+   void spanCellIsNotMarkedGroupedForAnUnrelatedValue() throws Exception {
+      BaseTableCellModel[][] cells = getTableCellsFor(regionRef("West"), "California", true);
+      assertNull(cells[0][0].isGrouped());
+   }
+
+   @Test
+   void plainCellIsMarkedGroupedWhenTheCellValueIsAnExpertGroupName() throws Exception {
+      BaseTableCellModel[][] cells = getTableCellsFor(regionRef("West"), "West", false);
+      assertEquals(Boolean.TRUE, cells[0][0].isGrouped());
+   }
+
+   @Test
+   void plainCellIsNotMarkedGroupedForAnUnrelatedValue() throws Exception {
+      BaseTableCellModel[][] cells = getTableCellsFor(regionRef("West"), "California", false);
+      assertNull(cells[0][0].isGrouped());
+   }
+
+   @Test
+   void ungroupedDimensionIsNeverMarkedGrouped() throws Exception {
+      BaseTableCellModel[][] cells = getTableCellsFor(regionRef(null), "California", false);
+      assertNull(cells[0][0].isGrouped());
+   }
+}

--- a/core/src/test/java/inetsoft/web/viewsheet/handler/crosstab/CrosstabDrillHandlerTest.java
+++ b/core/src/test/java/inetsoft/web/viewsheet/handler/crosstab/CrosstabDrillHandlerTest.java
@@ -1,0 +1,109 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.viewsheet.handler.crosstab;
+
+import inetsoft.report.internal.binding.AssetNamedGroupInfo;
+import inetsoft.report.internal.binding.ExpertNamedGroupInfo;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.Condition;
+import inetsoft.uql.ConditionItem;
+import inetsoft.uql.ConditionList;
+import inetsoft.uql.XCondition;
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.util.XNamedGroupInfo;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * {@code getGroupCondition} has no live callers today (Decision 4) but was the codebase's own
+ * cited example of a graceful defensive guard against non-{@code SNamedGroupInfo} types --
+ * confirmed to be a stub that returned an empty condition list for Expert/Asset groups rather
+ * than something that actually worked for them. Widened to splice the group's own condition list
+ * (with "this"-placeholder resolution for Asset groups), matching Site 2's shared utility.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class CrosstabDrillHandlerTest {
+   private static ColumnRef regionColumn() {
+      ColumnRef ref = new ColumnRef(new AttributeRef("REGION"));
+      ref.setDataType(XSchema.STRING);
+      return ref;
+   }
+
+   @Test
+   void returnsAnEmptyConditionListForANullGroupInfo() {
+      ConditionList result = CrosstabDrillHandler.getGroupCondition(null, regionColumn(), "West");
+      assertTrue(result.isEmpty());
+   }
+
+   @Test
+   void splicesAnExpertNamedGroupsOwnCondition() {
+      ExpertNamedGroupInfo info = new ExpertNamedGroupInfo();
+      Condition cond = new Condition(XSchema.STRING);
+      cond.setOperation(XCondition.EQUAL_TO);
+      cond.addValue("CA");
+      ConditionList groupConds = new ConditionList();
+      groupConds.append(new ConditionItem(new AttributeRef("REGION"), cond, 0));
+      info.setGroupCondition("West", groupConds);
+
+      ConditionList result = CrosstabDrillHandler.getGroupCondition(info, regionColumn(), "West");
+
+      assertEquals(1, result.getConditionSize());
+      assertEquals("CA", result.getConditionItem(0).getCondition().getValue(0));
+   }
+
+   @Test
+   void resolvesTheThisPlaceholderForAnAssetNamedGroup() {
+      AssetNamedGroupInfo info = mock(AssetNamedGroupInfo.class);
+      when(info.getType()).thenReturn(XNamedGroupInfo.ASSET_NAMEDGROUP_INFO_REF);
+
+      Condition cond = new Condition(XSchema.STRING);
+      cond.setOperation(XCondition.EQUAL_TO);
+      cond.addValue("CA");
+      ConditionList placeholderConds = new ConditionList();
+      placeholderConds.append(
+         new ConditionItem(new ColumnRef(new AttributeRef("this")), cond, 0));
+      when(info.getGroupCondition("West")).thenReturn(placeholderConds);
+
+      ConditionList result = CrosstabDrillHandler.getGroupCondition(info, regionColumn(), "West");
+
+      assertEquals(1, result.getConditionSize());
+      assertEquals("REGION", result.getConditionItem(0).getAttribute().getAttribute());
+   }
+
+   @Test
+   void returnsAnEmptyConditionListWhenTheGroupNameHasNoCondition() {
+      ExpertNamedGroupInfo info = new ExpertNamedGroupInfo();
+      ConditionList result = CrosstabDrillHandler.getGroupCondition(info, regionColumn(), "NoSuch");
+      assertTrue(result.isEmpty());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticAgentServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticAgentServiceTest.java
@@ -306,7 +306,8 @@ class ChartAestheticAgentServiceTest {
    {
       VSBindingService binding = mock(VSBindingService.class);
       when(binding.createModel(any())).thenReturn(model);
-      return new ChartAestheticAgentService(sessions, binding, aesthetics);
+      return new ChartAestheticAgentService(sessions, binding, aesthetics,
+                                            mock(inetsoft.web.binding.service.DataRefModelFactoryService.class));
    }
 
    private static Principal principal() {

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingServiceTest.java
@@ -515,7 +515,8 @@ class ChartBindingServiceTest {
       VSBindingService binding = mock(VSBindingService.class);
       when(binding.createModel(any())).thenReturn(model);
 
-      return new ChartBindingService(sessions, binding, refs, types, swap, separateStatus);
+      return new ChartBindingService(sessions, binding, refs, types, swap, separateStatus,
+                                     mock(inetsoft.web.binding.service.DataRefModelFactoryService.class));
    }
 
    private static Principal principal() {

--- a/core/src/test/java/inetsoft/web/wiz/binding/FieldRefFactoryTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/FieldRefFactoryTest.java
@@ -17,13 +17,38 @@
  */
 package inetsoft.web.wiz.binding;
 
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.internal.binding.AssetNamedGroupInfo;
+import inetsoft.report.internal.binding.SummaryAttr;
+import inetsoft.uql.XConstants;
+import inetsoft.uql.Condition;
+import inetsoft.uql.ConditionItem;
+import inetsoft.uql.ConditionList;
+import inetsoft.uql.asset.AssetRepository;
+import inetsoft.uql.asset.AttachedAssembly;
+import inetsoft.uql.asset.DefaultNamedGroupAssembly;
+import inetsoft.uql.asset.NamedGroupInfo;
+import inetsoft.uql.asset.SourceInfo;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.asset.internal.AssetUtil;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.util.XNamedGroupInfo;
+import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.binding.drm.DataRefModel;
 import inetsoft.web.binding.model.BAggregateRefModel;
 import inetsoft.web.binding.model.BDimensionRefModel;
+import inetsoft.web.binding.model.NamedGroupInfoModel;
+import inetsoft.web.binding.model.graph.ChartDimensionRefModel;
+import inetsoft.web.binding.model.graph.ChartRefModel;
+import inetsoft.web.binding.service.DataRefModelFactoryService;
 import inetsoft.web.wiz.binding.model.FieldRef;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 /**
  * Guards the shared field-reference vocabulary. Specs 2b–2e inherit it and spec #4's
@@ -137,5 +162,152 @@ class FieldRefFactoryTest {
    void requireTypeAcceptsBothValidDiscriminatorsCaseInsensitively() {
       FieldRefFactory.requireType(new FieldRef("A", "DIMENSION", null, null, null));
       FieldRefFactory.requireType(new FieldRef("B", "measure", null, null, null));
+   }
+
+   // ── namedGroup resolution ─────────────────────────────────────────────────
+
+   private static final SourceInfo QUERY1_SOURCE =
+      new SourceInfo(SourceInfo.ASSET, null, "Query1");
+
+   private static RuntimeViewsheet rvsWithWorksheet(Worksheet ws) {
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getBaseWorksheet()).thenReturn(ws);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      return rvs;
+   }
+
+   private static DataRefModelFactoryService refModelService() {
+      DataRefModelFactoryService service = mock(DataRefModelFactoryService.class);
+      when(service.createDataRefModel(any())).thenReturn(mock(DataRefModel.class));
+      return service;
+   }
+
+   /**
+    * {@code createNamedGroupInfo}'s {@code ASSET_NAMEDGROUP_INFO_REF} branch -- constant {@code
+    * 4}, confirmed by {@code AssetNamedGroupInfo.getType()} itself -- is what this must produce
+    * for a registered-name match. {@code ASSET_NAMEDGROUP_INFO} (constant {@code 3}, #4707's own
+    * calc-table-specific sentinel) has no branch in that method and would silently resolve to
+    * {@code null} at apply time.
+    */
+   @Test
+   void resolveNamedGroupInfoBuildsAnExpertNamedGroupFromAWorksheetLocalAssembly() throws Exception {
+      Condition condition = mock(Condition.class);
+      when(condition.getOperation()).thenReturn(Condition.EQUAL_TO);
+      when(condition.getValues()).thenReturn(java.util.List.of("CA"));
+      ConditionList conditionList = new ConditionList();
+      conditionList.append(new ConditionItem(new AttributeRef(null, "REGION"), condition, 0));
+      NamedGroupInfo namedGroupInfo = new NamedGroupInfo();
+      namedGroupInfo.setGroupCondition("West", conditionList);
+
+      DefaultNamedGroupAssembly ngAssembly = mock(DefaultNamedGroupAssembly.class);
+      when(ngAssembly.getName()).thenReturn("Coastal");
+      when(ngAssembly.getAttachedType()).thenReturn(AttachedAssembly.COLUMN_ATTACHED);
+      when(ngAssembly.getAttachedSource()).thenReturn(QUERY1_SOURCE);
+      when(ngAssembly.getAttachedAttribute()).thenReturn(new AttributeRef(null, "REGION"));
+      when(ngAssembly.getNamedGroupInfo()).thenReturn(namedGroupInfo);
+
+      Worksheet ws = mock(Worksheet.class);
+      when(ws.getAssemblies()).thenReturn(new inetsoft.uql.asset.Assembly[]{ ngAssembly });
+
+      NamedGroupInfoModel model = FieldRefFactory.resolveNamedGroupInfo(
+         "Coastal", rvsWithWorksheet(ws), QUERY1_SOURCE, "REGION", refModelService());
+
+      assertEquals(XNamedGroupInfo.EXPERT_NAMEDGROUP_INFO, model.getType());
+      assertEquals(1, model.getConditions().size());
+      assertEquals("West", model.getConditions().get(0).getName());
+      assertEquals(1, model.getConditions().get(0).getList().length);
+   }
+
+   @Test
+   void resolveNamedGroupInfoBuildsAnAssetReferenceForARegisteredNameUsingTheRefConstant()
+      throws Exception
+   {
+      Worksheet ws = mock(Worksheet.class);
+      when(ws.getAssemblies()).thenReturn(new inetsoft.uql.asset.Assembly[0]);
+
+      try(MockedStatic<AssetUtil> assetUtil = mockStatic(AssetUtil.class);
+          MockedStatic<SummaryAttr> summaryAttr = mockStatic(SummaryAttr.class))
+      {
+         AssetRepository rep = mock(AssetRepository.class);
+         assetUtil.when(() -> AssetUtil.getAssetRepository(false)).thenReturn(rep);
+
+         AssetNamedGroupInfo info = mock(AssetNamedGroupInfo.class);
+         when(info.getName()).thenReturn("Tiers");
+         summaryAttr.when(() -> SummaryAttr.getAssetNamedGroupInfos(any(), eq(rep), isNull()))
+            .thenReturn(new AssetNamedGroupInfo[]{ info });
+
+         NamedGroupInfoModel model = FieldRefFactory.resolveNamedGroupInfo(
+            "Tiers", rvsWithWorksheet(ws), QUERY1_SOURCE, "REGION", refModelService());
+
+         // The crux of stylebi's own designer-found bug: type 3 (ASSET_NAMEDGROUP_INFO,
+         // #4707's calc-table sentinel) has no branch in createNamedGroupInfo and silently
+         // resolves to null. Type 4 (ASSET_NAMEDGROUP_INFO_REF) is the one it actually handles.
+         assertEquals(4, XNamedGroupInfo.ASSET_NAMEDGROUP_INFO_REF);
+         assertEquals(XNamedGroupInfo.ASSET_NAMEDGROUP_INFO_REF, model.getType());
+         assertNotEquals(XNamedGroupInfo.ASSET_NAMEDGROUP_INFO, model.getType());
+         assertEquals("Tiers", model.getName());
+      }
+   }
+
+   @Test
+   void resolveNamedGroupInfoRefusesAnUnrecognizedNameNamingTheFieldAndColumn() {
+      Worksheet ws = mock(Worksheet.class);
+      when(ws.getAssemblies()).thenReturn(new inetsoft.uql.asset.Assembly[0]);
+
+      try(MockedStatic<AssetUtil> assetUtil = mockStatic(AssetUtil.class)) {
+         assetUtil.when(() -> AssetUtil.getAssetRepository(false)).thenReturn(null);
+
+         Exception thrown = assertThrows(IllegalArgumentException.class,
+            () -> FieldRefFactory.resolveNamedGroupInfo(
+               "NoSuchGroup", rvsWithWorksheet(ws), QUERY1_SOURCE, "REGION", refModelService()));
+
+         assertTrue(thrown.getMessage().contains("NoSuchGroup"));
+         assertTrue(thrown.getMessage().contains("REGION"));
+      }
+   }
+
+   /**
+    * {@code toChartRef} must force {@code order = SORT_SPECIFIC} when a {@code namedGroup}
+    * resolves -- {@code OrderInfo.isSpecific()} gates whether the named group's conditions are
+    * ever folded into the actual grouping, so a resolved-but-unspecific order silently renders
+    * without any grouping at all.
+    */
+   @Test
+   void toChartRefForcesSortSpecificWhenANamedGroupResolves() throws Exception {
+      DefaultNamedGroupAssembly ngAssembly = mock(DefaultNamedGroupAssembly.class);
+      when(ngAssembly.getName()).thenReturn("Coastal");
+      when(ngAssembly.getAttachedType()).thenReturn(AttachedAssembly.COLUMN_ATTACHED);
+      when(ngAssembly.getAttachedSource()).thenReturn(QUERY1_SOURCE);
+      when(ngAssembly.getAttachedAttribute()).thenReturn(new AttributeRef(null, "REGION"));
+      when(ngAssembly.getNamedGroupInfo()).thenReturn(new NamedGroupInfo());
+
+      Worksheet ws = mock(Worksheet.class);
+      when(ws.getAssemblies()).thenReturn(new inetsoft.uql.asset.Assembly[]{ ngAssembly });
+
+      FieldRef field = new FieldRef("REGION", "dimension", null, null, "Coastal");
+      ChartRefModel ref = FieldRefFactory.toChartRef(
+         field, rvsWithWorksheet(ws), QUERY1_SOURCE, refModelService());
+
+      assertInstanceOf(ChartDimensionRefModel.class, ref);
+      assertEquals(XConstants.SORT_SPECIFIC, ((ChartDimensionRefModel) ref).getOrder());
+      assertNotNull(((ChartDimensionRefModel) ref).getNamedGroupInfo());
+   }
+
+   @Test
+   void toChartRefRefusesAnUnrecognizedNamedGroup() {
+      Worksheet ws = mock(Worksheet.class);
+      when(ws.getAssemblies()).thenReturn(new inetsoft.uql.asset.Assembly[0]);
+
+      try(MockedStatic<AssetUtil> assetUtil = mockStatic(AssetUtil.class)) {
+         assetUtil.when(() -> AssetUtil.getAssetRepository(false)).thenReturn(null);
+         FieldRef field = new FieldRef("REGION", "dimension", null, null, "NoSuchGroup");
+
+         Exception thrown = assertThrows(IllegalArgumentException.class,
+            () -> FieldRefFactory.toChartRef(
+               field, rvsWithWorksheet(ws), QUERY1_SOURCE, refModelService()));
+
+         assertTrue(thrown.getMessage().contains("NoSuchGroup"));
+      }
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/binding/TableBindingMutatorTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/TableBindingMutatorTest.java
@@ -17,17 +17,37 @@
  */
 package inetsoft.web.wiz.binding;
 
+import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.Condition;
+import inetsoft.uql.ConditionItem;
+import inetsoft.uql.ConditionList;
+import inetsoft.uql.XConstants;
+import inetsoft.uql.asset.AttachedAssembly;
+import inetsoft.uql.asset.DefaultNamedGroupAssembly;
+import inetsoft.uql.asset.NamedGroupInfo;
+import inetsoft.uql.asset.SourceInfo;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.asset.internal.AssetUtil;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.util.XNamedGroupInfo;
+import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.binding.drm.ColumnRefModel;
+import inetsoft.web.binding.drm.DataRefModel;
+import inetsoft.web.binding.model.BDimensionRefModel;
 import inetsoft.web.binding.model.table.CrosstabBindingModel;
 import inetsoft.web.binding.model.table.TableBindingModel;
+import inetsoft.web.binding.service.DataRefModelFactoryService;
 import inetsoft.web.wiz.binding.model.FieldRef;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 @Tag("core")
 class TableBindingMutatorTest {
@@ -630,5 +650,94 @@ class TableBindingMutatorTest {
       assertTrue(String.valueOf(vocabulary.get("crosstab")).contains("rowTotals"));
       assertEquals(List.of(), vocabulary.get("table"),
                    "a table has no options this write path can actually apply");
+   }
+
+   // ── namedGroup resolution (rvs-aware setShelf) ────────────────────────────
+
+   private static final SourceInfo QUERY1_SOURCE =
+      new SourceInfo(SourceInfo.ASSET, null, "Query1");
+
+   private static FieldRef dimWithNamedGroup(String column, String namedGroup) {
+      return new FieldRef(column, "dimension", null, null, namedGroup);
+   }
+
+   private static RuntimeViewsheet rvsWithWorksheet(Worksheet ws) {
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getBaseWorksheet()).thenReturn(ws);
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      return rvs;
+   }
+
+   private static DataRefModelFactoryService refModelService() {
+      DataRefModelFactoryService service = mock(DataRefModelFactoryService.class);
+      when(service.createDataRefModel(any())).thenReturn(mock(DataRefModel.class));
+      return service;
+   }
+
+   @Test
+   void setShelfResolvesAWorksheetLocalNamedGroupAndForcesSortSpecific() throws Exception {
+      Condition condition = mock(Condition.class);
+      when(condition.getOperation()).thenReturn(Condition.EQUAL_TO);
+      when(condition.getValues()).thenReturn(List.of("CA"));
+      ConditionList conditionList = new ConditionList();
+      conditionList.append(new ConditionItem(new AttributeRef(null, "REGION"), condition, 0));
+      NamedGroupInfo namedGroupInfo = new NamedGroupInfo();
+      namedGroupInfo.setGroupCondition("West", conditionList);
+
+      DefaultNamedGroupAssembly ngAssembly = mock(DefaultNamedGroupAssembly.class);
+      when(ngAssembly.getName()).thenReturn("Coastal");
+      when(ngAssembly.getAttachedType()).thenReturn(AttachedAssembly.COLUMN_ATTACHED);
+      when(ngAssembly.getAttachedSource()).thenReturn(QUERY1_SOURCE);
+      when(ngAssembly.getAttachedAttribute()).thenReturn(new AttributeRef(null, "REGION"));
+      when(ngAssembly.getNamedGroupInfo()).thenReturn(namedGroupInfo);
+
+      Worksheet ws = mock(Worksheet.class);
+      when(ws.getAssemblies()).thenReturn(new inetsoft.uql.asset.Assembly[]{ ngAssembly });
+
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows", List.of(dimWithNamedGroup("REGION", "Coastal")),
+                                   rvsWithWorksheet(ws), QUERY1_SOURCE, refModelService());
+
+      BDimensionRefModel dim = model.getRows().get(0);
+      assertEquals(XConstants.SORT_SPECIFIC, dim.getOrder());
+      assertEquals(XNamedGroupInfo.EXPERT_NAMEDGROUP_INFO, dim.getNamedGroupInfo().getType());
+      assertEquals(1, dim.getNamedGroupInfo().getConditions().size());
+      assertEquals("West", dim.getNamedGroupInfo().getConditions().get(0).getName());
+   }
+
+   @Test
+   void setShelfRefusesAnUnrecognizedNamedGroupNamingTheFieldAndColumn() {
+      Worksheet ws = mock(Worksheet.class);
+      when(ws.getAssemblies()).thenReturn(new inetsoft.uql.asset.Assembly[0]);
+      CrosstabBindingModel model = new CrosstabBindingModel();
+
+      try(MockedStatic<AssetUtil> assetUtil = mockStatic(AssetUtil.class)) {
+         assetUtil.when(() -> AssetUtil.getAssetRepository(false)).thenReturn(null);
+
+         Exception thrown = assertThrows(IllegalArgumentException.class,
+            () -> TableBindingMutator.setShelf(
+               model, "rows", List.of(dimWithNamedGroup("REGION", "NoSuchGroup")),
+               rvsWithWorksheet(ws), QUERY1_SOURCE, refModelService()));
+
+         assertTrue(thrown.getMessage().contains("NoSuchGroup"));
+         assertTrue(thrown.getMessage().contains("REGION"));
+      }
+   }
+
+   /**
+    * The 3-arg {@code setShelf} used by {@link TableBindingMutator#addField}/{@link
+    * TableBindingMutator#moveField} to reapply a whole shelf has no runtime context, so a field
+    * carrying {@code namedGroup} through that path is left unresolved rather than throwing --
+    * the same, pre-existing gap as before this class learned to resolve named groups at all.
+    */
+   @Test
+   void theThreeArgSetShelfLeavesANamedGroupUnresolved() {
+      CrosstabBindingModel model = new CrosstabBindingModel();
+
+      TableBindingMutator.setShelf(model, "rows",
+                                   List.of(dimWithNamedGroup("REGION", "Coastal")));
+
+      assertNull(model.getRows().get(0).getNamedGroupInfo());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/binding/TableBindingServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/TableBindingServiceTest.java
@@ -313,7 +313,8 @@ class TableBindingServiceTest {
    {
       VSBindingService binding = mock(VSBindingService.class);
       when(binding.createModel(any())).thenReturn(model);
-      return new TableBindingService(sessions, binding, bindings);
+      return new TableBindingService(sessions, binding, bindings,
+                                     mock(inetsoft.web.binding.service.DataRefModelFactoryService.class));
    }
 
    private static Principal principal() {


### PR DESCRIPTION
## Summary

Un-defers Part 2 of the named-group binding work (Part 1, wiz-layer resolution, already merged on this branch). A deeper trace found the query-time grouping mechanism (`NamedRangeRef`'s CASE/script expression) was already `XNamedGroupInfo`-generic; the actual wall was six unconditional `(SNamedGroupInfo)` casts scattered across query filtering, chart rendering, crosstab/table rendering, drill tracking, and the Composer's own "Group columns" dialog — not the query engine itself. Widens all of them so an ordinary chart/crosstab/table dimension can now be bound to a worksheet-local (Expert) or repository-registered (Asset) named group, not just the manual-value (`SNamedGroupInfo`) kind.

Design docs (in the `stylebi-wiz` repo):
- `docs/superpowers/plans/2026-08-21-chart-table-namedgroup-consumer-redesign.md` (this plan)
- `docs/superpowers/plans/2026-08-21-chart-table-namedgroup-binding-design.md` (Part 1 + the superseded "Feasibility update")
- `docs/superpowers/plans/2026-08-21-chart-table-namedgroup-silent-drop-fix-plan.md` (original diagnosis)

## What changed, by phase

**Phase 0 (foundation, zero behavior change):**
- New `NamedGroupConditionUtil.resolveConditionColumn`/`needsColumnResolution`, extracted from the near-identical `TableConditionUtil`/`BaseTableShowDetailsService` helpers (calc-table's own "this"-placeholder resolution for repository-registered named groups authored unattached to a column).
- `VSDimensionRef.groupInfo` widens `SNamedGroupInfo` → `XNamedGroupInfo`; `setNamedGroupInfo` drops its type guard; `createGroupRef()` narrows to `instanceof SNamedGroupInfo` only where genuinely `SNamedGroupInfo`-specific (CUBE display-value translation, embedded `DataRef` data-type backfill).
- XML round-trip gap: `ExpertNamedGroupInfo`/`AssetNamedGroupInfo.writeXML` now emit a `class=` attribute matching `SNamedGroupInfo`'s own convention, so `VSDimensionRef.parseXML`'s existing reflective instantiation round-trips them. (`OrderInfo`'s sibling convention dispatches on `type=` instead, but that can't distinguish `DCNamedGroupInfo` from its `SNamedGroupInfo` parent — mirrored the `class=` approach instead of introducing a second, lossier one.)

**Phase 1 (read/render sites):**
- `GraphBuilder`, `BaseTableService`: widen the casts; "is this label/cell value a group name" switches from `getGroupValue(v) != null` to the type-agnostic `getGroups()` membership test (a `Set` lookup, not a per-cell condition evaluation).
- `CrosstabVSAssembly.updateGroupExpandPath`: pure widen (`isEmpty()`/`equals()` are already interface-generic).

**Phase 2 (filter/condition sites + CUBE exclusion):**
- `VSAQuery.replaceGroupValues`: drops the cast, sources `dtype` from the dimension's own `DataRef`, resolves an Asset group's `"this"`-placeholder before splicing. Narrows a pre-existing blanket "rewrite every spliced condition's attribute" behavior to `SNamedGroupInfo` only, since an Expert group's conditions may reference other columns and already carry the correct one.
- `CrosstabDrillHandler.getGroupCondition` (no live callers today, but the codebase's own cited "safe defensive pattern" example): widened to actually splice Expert/Asset conditions instead of unconditionally returning empty.

**Phase 3 (the binding-apply wiring Part 1 was blocked on):**
- `ChartDimensionInfoFactory.pasteChartRef` / `BDimensionRefModel.createDataRef`: wire `NamedGroupInfoModel.createNamedGroupInfo`'s result into the now-generic `setNamedGroupInfo`, refusing loudly for a CUBE-sourced dimension (OLAP/MDX generation is untouched by design — no Expert/Asset equivalent exists there).
- `BDimensionRefModel`'s `SORT_SPECIFIC`-stripping guard now checks "no named-group content of any kind" instead of "no manual-value groups specifically" — the old guard silently stripped the bit right back off for Expert/Asset-typed models.
- `ComposerGroupColumnsService`: refuses (`MessageException`) instead of crashing (`ClassCastException`) when "Group columns" targets an Expert/Asset-grouped column.

**Phase 4 (end-to-end proof):** a real `ViewsheetSandbox`/`CrosstabVSAQuery` execution (mirrors `CrosstabSortByValueEntityQualifiedNameTest`'s fixture) confirms the *rendered* crosstab actually groups rows, not just the model.

## Test plan
- [x] `NamedGroupConditionUtilTest`, `VSDimensionRefTest`, `CrosstabVSAssemblyTest`, `GraphBuilderTest`, `BaseTableServiceTest`, `VSAQueryTest`, `CrosstabDrillHandlerTest`, `ChartDimensionInfoFactoryTest`, `BDimensionRefModelTest`, `ComposerGroupColumnsServiceTest`, `CrosstabNamedGroupEndToEndTest` — all new, all confirmed to fail against the pre-fix code and pass against this branch (verified per-file via `git stash`/`git checkout <old-sha> --`).
- [x] Full existing suites green: `inetsoft.web.wiz.**` (2124 tests, 1 pre-existing unrelated failure — `WorksheetAgentControllerTest#importCsvDetectTypeFalseMakesEveryColumnString`, a CSV type-detection test, confirmed failing identically on the pre-Part-2 baseline), `inetsoft.uql.viewsheet.**`, `inetsoft.web.graph.**`, `inetsoft.web.viewsheet.controller.table.**`, `inetsoft.web.composer.vs.objects.controller.**`, `inetsoft.web.binding.**`, `inetsoft.report.composition.execution.**` — all 0 failures.
- [ ] Live verification (Composer session) not run as part of this PR — no live stack was available; noted as an open item in the design doc's own Task 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)