### PR TITLE
fix(wiz): merge js-functions.json into ScriptApiService lookup

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptApiService.java
@@ -19,12 +19,15 @@ package inetsoft.web.wiz.script;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import inetsoft.web.wiz.script.model.FunctionSignature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.io.InputStream;
+import java.util.Iterator;
+import java.util.Map;
 
 /**
  * Best-effort "Layer A" static metadata lookup (the generated Tern {@code js-functions} JSON the
@@ -36,7 +39,8 @@ import java.io.InputStream;
 @Service
 public class ScriptApiService {
    private static final Logger LOG = LoggerFactory.getLogger(ScriptApiService.class);
-   private static final String RESOURCE = "/inetsoft/web/binding/js-functions.generated.json";
+   private static final String RESOURCE_FUNCTIONS = "/inetsoft/web/binding/js-functions.json";
+   private static final String RESOURCE_GENERATED = "/inetsoft/web/binding/js-functions.generated.json";
 
    /**
     * Looks up a top-level function ({@code "dateAdd"}) or a prototype method
@@ -80,17 +84,31 @@ public class ScriptApiService {
    }
 
    private JsonNode load() {
-      try(InputStream in = getClass().getResourceAsStream(RESOURCE)) {
-         if(in == null) {
-            LOG.warn("Script API metadata resource not found: {}", RESOURCE);
-            return MAPPER.createObjectNode();
+      try {
+         ObjectNode functions = (ObjectNode) readResource(RESOURCE_FUNCTIONS);
+         ObjectNode generated = (ObjectNode) readResource(RESOURCE_GENERATED);
+
+         for(Iterator<Map.Entry<String, JsonNode>> it = generated.fields(); it.hasNext();) {
+            Map.Entry<String, JsonNode> e = it.next();
+            functions.set(e.getKey(), e.getValue());
          }
 
-         return MAPPER.readTree(in);
+         return functions;
       }
       catch(Exception e) {
          LOG.warn("Failed to load script API metadata", e);
          return MAPPER.createObjectNode();
+      }
+   }
+
+   private JsonNode readResource(String path) throws Exception {
+      try(InputStream in = getClass().getResourceAsStream(path)) {
+         if(in == null) {
+            LOG.warn("Script API metadata resource not found: {}", path);
+            return MAPPER.createObjectNode();
+         }
+
+         return MAPPER.readTree(in);
       }
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/script/ScriptApiServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ScriptApiServiceTest.java
@@ -1,0 +1,60 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.script;
+
+import inetsoft.web.wiz.script.model.FunctionSignature;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+class ScriptApiServiceTest {
+   private final ScriptApiService service = new ScriptApiService();
+
+   @Test
+   void looksUpTopLevelGlobalFromHandAuthoredCorpus() {
+      FunctionSignature runQuery = service.lookup("runQuery");
+      assertTrue(runQuery.found());
+      assertNotNull(runQuery.type());
+      assertNotNull(runQuery.url());
+
+      FunctionSignature alert = service.lookup("alert");
+      assertTrue(alert.found());
+      assertNotNull(alert.type());
+
+      FunctionSignature setCellValue = service.lookup("setCellValue");
+      assertTrue(setCellValue.found());
+      assertNotNull(setCellValue.type());
+   }
+
+   @Test
+   void looksUpPrototypeMethodFromGeneratedCorpus() {
+      FunctionSignature signature = service.lookup("AreaElement.addDim");
+      assertTrue(signature.found());
+      assertNotNull(signature.type());
+   }
+
+   @Test
+   void returnsNotFoundForUnknownName() {
+      FunctionSignature signature = service.lookup("doesNotExist");
+      assertFalse(signature.found());
+      assertNull(signature.type());
+      assertNull(signature.url());
+   }
+}


### PR DESCRIPTION
## Summary
- `get_function_signature` (Composer plugin tool -> `ScriptApiService.lookup`) returned `found:false` for every input, including its own documented examples (`runQuery`, `alert`, `setCellValue`).
- Root cause: `ScriptApiService` only loaded `/inetsoft/web/binding/js-functions.generated.json` (a Tern-generated file covering ~81 internal `inetsoft.graph.*` chart-primitive classes only -- no global functions at all). The actual function/global corpus (`runQuery`, `alert`, `setCellValue`, etc.) lives in the separate, hand-authored `js-functions.json`, which `ScriptApiService` never loaded.
- Fixed by merging both resources the same way `VSScriptableService` (`core/src/main/java/inetsoft/web/binding/VSScriptableService.java:330-338`) and `ScriptService` (`core/src/main/java/inetsoft/web/composer/script/service/ScriptService.java:180-182`) already do: read `js-functions.json` as the base `ObjectNode`, overlay every field from `js-functions.generated.json` on top.
- `lookup()`'s `Type.method` / bare-name dot-splitting logic was already correct and is unchanged -- it just needed the merged data.

## Test plan
- [x] Added `core/src/test/java/inetsoft/web/wiz/script/ScriptApiServiceTest.java`: asserts `runQuery`/`alert`/`setCellValue` are found with real `type`/`url` (hand-authored corpus), `AreaElement.addDim` is still found (generated corpus, confirms merge didn't regress graph-class lookups), and `doesNotExist` cleanly returns not-found.
- [x] `mvn -pl core -o test -Dtest=ScriptApiServiceTest` -- 3/3 passed
- [x] `mvn -pl core -o test -Dtest="inetsoft.web.wiz.script.*Test"` -- full package regression, 128/128 passed
- [ ] Live re-verification against a running Composer/StyleBI stack -- intentionally deferred. A rebuild/restart right now would kill the `l9-tester` agent's in-progress live-test session (see `docs/superpowers/plans/2026-08-17-consolidated-composer-plugin-test-plan.md` concurrency notes). Matches this plan's FIXED-UNVERIFIED convention until the current L9 lane finishes.

Companion doc-only fix: `stylebi-wiz` plugin/composer PR (separate repo) corrects `get_function_signature`'s tool-description example, which cited a nonexistent key (`ChartElement.setColor`) unrelated to this bug but which would still confuse callers after this fix lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)