### PR TITLE
fix(wiz): report unrecognized scriptable-property writes in execute_script

### DIFF
--- a/core/src/main/java/inetsoft/report/script/viewsheet/VSAScriptable.java
+++ b/core/src/main/java/inetsoft/report/script/viewsheet/VSAScriptable.java
@@ -61,6 +61,23 @@ public class VSAScriptable
    }
 
    /**
+    * Clear the names recorded by {@link #getUnrecognizedWrites()}, so a caller can scope
+    * tracking to a single script execution.
+    */
+   public void resetUnrecognizedWrites() {
+      unrecognizedWrites.clear();
+   }
+
+   /**
+    * Names passed to {@link #putMember(String, Object)} since the last {@link
+    * #resetUnrecognizedWrites()} that did not match a registered {@code propmap} property, and
+    * so fell back to the generic per-assembly expando map instead of actually being applied.
+    */
+   public List<String> getUnrecognizedWrites() {
+      return new ArrayList<>(unrecognizedWrites);
+   }
+
+   /**
     * Add properties.
     */
    private void init() {
@@ -172,6 +189,7 @@ public class VSAScriptable
             desc.set(element, value);
          }
          else {
+            unrecognizedWrites.add(name);
             getVarMap().put(name, value);
          }
       }
@@ -1109,6 +1127,9 @@ public class VSAScriptable
    private boolean includedAll = true;
    private Object element = null;
    private boolean inited = false;
+   // Names that missed propmap and fell back to the expando map in putMember(); see
+   // resetUnrecognizedWrites()/getUnrecognizedWrites().
+   private final List<String> unrecognizedWrites = Collections.synchronizedList(new ArrayList<>());
 
    private static final Logger LOG = LoggerFactory.getLogger(VSAScriptable.class);
 }

--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptExecuteService.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptExecuteService.java
@@ -19,7 +19,9 @@ package inetsoft.web.wiz.script;
 
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
+import inetsoft.report.script.viewsheet.VSAScriptable;
 import inetsoft.report.script.viewsheet.ViewsheetScope;
+import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.web.wiz.pairing.PairingException;
 import inetsoft.web.wiz.script.model.ScriptError;
 import inetsoft.web.wiz.script.model.ScriptExecResult;
@@ -75,7 +77,7 @@ public class ScriptExecuteService {
          return new ScriptExecResult(false, null, null, null, true,
             "Script references \"" + destructive + "\", which can change stored/live data. " +
             "Dry-run cannot safely preview this — call run_script_live with confirmed=true " +
-            "to execute it for real.", null);
+            "to execute it for real.", null, null);
       }
 
       return execute(rvs, target);
@@ -96,7 +98,7 @@ public class ScriptExecuteService {
       if(destructive != null && !confirmed) {
          return new ScriptExecResult(false, null, null, null, true,
             "Script references \"" + destructive + "\", which can change stored/live data. " +
-            "Call run_script_live again with confirmed=true to proceed.", null);
+            "Call run_script_live again with confirmed=true to proceed.", null, null);
       }
 
       return execute(rvs, target);
@@ -107,7 +109,7 @@ public class ScriptExecuteService {
 
       if(text == null || text.isEmpty()) {
          return new ScriptExecResult(true, null, null, List.of(), false, null,
-            "No script at " + target + " — nothing to execute.");
+            "No script at " + target + " — nothing to execute.", null);
       }
 
       ViewsheetSandbox box = rvs.getViewsheetSandbox().orElse(null);
@@ -136,13 +138,35 @@ public class ScriptExecuteService {
             "Use worksheet-chat's edit_expression/edit_condition tools on it instead.");
       };
 
+      VSAScriptable assemblyScriptable =
+         (target.location() == ScriptTarget.Location.ASSEMBLY ||
+          target.location() == ScriptTarget.Location.ASSEMBLY_ONCLICK)
+         ? scope.getVSAScriptable(assemblyName) : null;
+
+      if(assemblyScriptable != null) {
+         assemblyScriptable.resetUnrecognizedWrites();
+      }
+
       try {
          Object value = scope.execute(text, assemblyName);
-         return new ScriptExecResult(true, stringify(value), null, List.of(target.toString()),
-            false, null, "Executed " + target + ".");
+         List<String> unrecognized = assemblyScriptable != null ?
+            assemblyScriptable.getUnrecognizedWrites() : List.of();
+         List<String> changed = unrecognized.isEmpty() ? List.of(target.toString()) : List.of();
+         String summary = unrecognized.isEmpty() ? "Executed " + target + "." :
+            "Executed " + target + ", but assigned " + unrecognized +
+            " which " + (unrecognized.size() == 1 ? "is not a recognized scriptable property" :
+               "are not recognized scriptable properties") + " for this assembly type (" +
+            assemblyTypeName(rvs, assemblyName) + ") — the value " +
+            (unrecognized.size() == 1 ? "was" : "were") + " NOT applied; " +
+            (unrecognized.size() == 1 ? "it" : "they") + " only became an ad hoc script " +
+            "variable nothing else reads. Call get_script_context for " + assemblyName +
+            "'s real scriptable properties, or use get_assembly_properties/update_binding if " +
+            "you meant a different, non-scripted property.";
+         return new ScriptExecResult(true, stringify(value), null, changed, false, null, summary,
+            unrecognized.isEmpty() ? null : unrecognized);
       }
       catch(Exception ex) {
-         return new ScriptExecResult(false, null, toScriptError(ex), null, false, null, null);
+         return new ScriptExecResult(false, null, toScriptError(ex), null, false, null, null, null);
       }
    }
 
@@ -166,6 +190,17 @@ public class ScriptExecuteService {
       // Polyglot/host objects (e.g. GraalJS wrapper types) may not be Jackson-serializable —
       // fall back to a safe string representation rather than risking a 500 on the response.
       return String.valueOf(value);
+   }
+
+   /**
+    * Best-effort assembly type name (e.g. "SubmitVSAssembly") for the unrecognized-property
+    * message. Falls back to the assembly name itself if the assembly can't be resolved (should
+    * not happen for a target that just executed successfully, but this message is diagnostic
+    * text, not load-bearing behavior).
+    */
+   private static String assemblyTypeName(RuntimeViewsheet rvs, String assemblyName) {
+      VSAssembly assembly = rvs.getViewsheet().getAssembly(assemblyName);
+      return assembly != null ? assembly.getClass().getSimpleName() : assemblyName;
    }
 
    private static String firstDestructiveGlobal(String scriptText) {

--- a/core/src/main/java/inetsoft/web/wiz/script/model/ScriptExecResult.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/model/ScriptExecResult.java
@@ -22,4 +22,4 @@ import java.util.List;
 /** Mirrors wiz-services' {@code ScriptExecResult} TS interface exactly (field names matter for JSON). */
 public record ScriptExecResult(boolean ok, Object value, ScriptError error, List<String> changed,
                                boolean requiresConfirmation, String confirmationReason,
-                               String summary) {}
+                               String summary, List<String> unrecognizedProperties) {}

--- a/core/src/test/java/inetsoft/report/script/viewsheet/CalcTableVSAScriptableTest.java
+++ b/core/src/test/java/inetsoft/report/script/viewsheet/CalcTableVSAScriptableTest.java
@@ -101,4 +101,18 @@ public class CalcTableVSAScriptableTest {
       assertTrue(calcTableVSAScriptable.isCrosstabOrCalc());
       assertNull(calcTableVSAScriptable.getLayoutInfo());
    }
+
+   /**
+    * CalcTableVSAScriptable overrides getVarMap() (per-thread map) but not putMember() itself,
+    * so unrecognized-write tracking -- which fires in putMember()'s existing fallback branch --
+    * must still work through that override.
+    */
+   @Test
+   void testUnrecognizedWriteTrackedThroughGetVarMapOverride() {
+      calcTableVSAScriptable.putMember("notARealProperty", "x");
+
+      assertEquals(java.util.List.of("notARealProperty"),
+                   calcTableVSAScriptable.getUnrecognizedWrites());
+      assertEquals("x", calcTableVSAScriptable.getMember("notARealProperty"));
+   }
 }

--- a/core/src/test/java/inetsoft/report/script/viewsheet/SubmitVSAScriptableTest.java
+++ b/core/src/test/java/inetsoft/report/script/viewsheet/SubmitVSAScriptableTest.java
@@ -31,6 +31,8 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -85,5 +87,54 @@ public class SubmitVSAScriptableTest {
          assertFalse(submitVSAScriptable.isPublicProperty(property));
       }
       assertTrue(submitVSAScriptable.isPublicProperty("visible"));
+   }
+
+   /**
+    * "label" is not a wired scriptable property for Submit (SubmitVSAScriptable's
+    * addOutputProperties() is a no-op), so the write falls back to the expando map in
+    * putMember() and must be recorded as unrecognized instead of persisting.
+    */
+   @Test
+   void testPutMemberOnUnregisteredPropertyRecordedAsUnrecognizedAndNotApplied() {
+      submitVSAScriptable.putMember("label", "ClauseTest42");
+
+      assertEquals(List.of("label"), submitVSAScriptable.getUnrecognizedWrites());
+      assertEquals("Submit", submitVSAssemblyInfo.getLabelName());
+   }
+
+   @Test
+   void testPutMemberOnRegisteredPropertyNotRecordedAsUnrecognizedAndIsApplied() {
+      assertTrue(submitVSAssemblyInfo.isEnabled());
+
+      submitVSAScriptable.putMember("enabled", false);
+
+      assertEquals(List.of(), submitVSAScriptable.getUnrecognizedWrites());
+      assertFalse(submitVSAssemblyInfo.isEnabled());
+   }
+
+   /**
+    * resetUnrecognizedWrites() must scope tracking to a single execution, not accumulate
+    * across calls.
+    */
+   @Test
+   void testResetUnrecognizedWritesClearsPriorTracking() {
+      submitVSAScriptable.putMember("label", "ClauseTest42");
+      assertEquals(List.of("label"), submitVSAScriptable.getUnrecognizedWrites());
+
+      submitVSAScriptable.resetUnrecognizedWrites();
+      assertEquals(List.of(), submitVSAScriptable.getUnrecognizedWrites());
+   }
+
+   /**
+    * A genuinely ad hoc scratch var (not shadowing any real property) must still execute
+    * cleanly via the same expando fallback -- this instrumentation is additive only and must
+    * not turn legitimate expando usage into an error.
+    */
+   @Test
+   void testPutMemberOnAdHocScratchVarStillSucceeds() {
+      assertDoesNotThrow(() -> submitVSAScriptable.putMember("myScratchFlag", true));
+
+      assertEquals(List.of("myScratchFlag"), submitVSAScriptable.getUnrecognizedWrites());
+      assertEquals(true, submitVSAScriptable.getMember("myScratchFlag"));
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/script/ScriptExecuteServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ScriptExecuteServiceTest.java
@@ -19,14 +19,18 @@ package inetsoft.web.wiz.script;
 
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
+import inetsoft.report.script.viewsheet.VSAScriptable;
 import inetsoft.report.script.viewsheet.ViewsheetScope;
+import inetsoft.uql.viewsheet.SubmitVSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.internal.SubmitVSAssemblyInfo;
 import inetsoft.web.wiz.pairing.PairingException;
 import inetsoft.web.wiz.pairing.WizAgentTestSupport;
 import inetsoft.web.wiz.script.model.ScriptExecResult;
 import inetsoft.web.wiz.script.model.ScriptInfo;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -53,6 +57,76 @@ class ScriptExecuteServiceTest {
       when(rvs.getViewsheetSandbox()).thenReturn(Optional.of(box));
 
       return rvs;
+   }
+
+   /**
+    * Builds a RuntimeViewsheet with a real Submit1 assembly (so {@code getViewsheet().getAssembly}
+    * resolves) and a mocked scope/scriptable, for exercising the ASSEMBLY-location
+    * unrecognized-write reporting in {@code execute()}.
+    */
+   private RuntimeViewsheet viewsheetWithAssemblyScript(String script, ViewsheetScope scope,
+                                                        VSAScriptable scriptable)
+   {
+      Viewsheet vs = new Viewsheet();
+      SubmitVSAssembly submit = new SubmitVSAssembly();
+      SubmitVSAssemblyInfo info = (SubmitVSAssemblyInfo) submit.getVSAssemblyInfo();
+      info.setName("Submit1");
+      info.setScript(script);
+      info.setScriptEnabled(true);
+      vs.addAssembly(submit);
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      ViewsheetSandbox box = mock(ViewsheetSandbox.class);
+      when(box.getScope()).thenReturn(scope);
+      when(rvs.getViewsheetSandbox()).thenReturn(Optional.of(box));
+      when(scope.getVSAScriptable("Submit1")).thenReturn(scriptable);
+
+      return rvs;
+   }
+
+   @Test
+   void executeExcludesTargetFromChangedAndReportsUnrecognizedPropertyWrite() throws Exception {
+      String script = "Submit1.label = 'ClauseTest42';";
+      ViewsheetScope scope = mock(ViewsheetScope.class);
+      when(scope.execute(eq(script), eq("Submit1"))).thenReturn("ClauseTest42");
+
+      VSAScriptable scriptable = mock(VSAScriptable.class);
+      when(scriptable.getUnrecognizedWrites()).thenReturn(List.of("label"));
+
+      RuntimeViewsheet rvs = viewsheetWithAssemblyScript(script, scope, scriptable);
+      ScriptExecuteService svc = new ScriptExecuteService(new ScriptReadService());
+
+      ScriptExecResult result = svc.runLive(rvs, ScriptTarget.of(ScriptTarget.Kind.ASSEMBLY_MAIN, "Submit1"), false);
+
+      assertTrue(result.ok());
+      assertEquals(List.of(), result.changed());
+      assertEquals(List.of("label"), result.unrecognizedProperties());
+      assertTrue(result.summary().contains("label"), result.summary());
+      assertTrue(result.summary().contains("SubmitVSAssembly"), result.summary());
+      verify(scriptable).resetUnrecognizedWrites();
+   }
+
+   @Test
+   void executeReportsRealPropertyWriteNormallyWithNoUnrecognizedProperties() throws Exception {
+      String script = "Submit1.enabled = false;";
+      ViewsheetScope scope = mock(ViewsheetScope.class);
+      when(scope.execute(eq(script), eq("Submit1"))).thenReturn(false);
+
+      VSAScriptable scriptable = mock(VSAScriptable.class);
+      when(scriptable.getUnrecognizedWrites()).thenReturn(List.of());
+
+      RuntimeViewsheet rvs = viewsheetWithAssemblyScript(script, scope, scriptable);
+      ScriptTarget target = ScriptTarget.of(ScriptTarget.Kind.ASSEMBLY_MAIN, "Submit1");
+      ScriptExecuteService svc = new ScriptExecuteService(new ScriptReadService());
+
+      ScriptExecResult result = svc.runLive(rvs, target, false);
+
+      assertTrue(result.ok());
+      assertEquals(List.of(target.toString()), result.changed());
+      assertNull(result.unrecognizedProperties());
+      verify(scriptable).resetUnrecognizedWrites();
    }
 
    @Test


### PR DESCRIPTION
## Root cause

`execute_script`/`run_script_live` reported a clean, plausible success for scripts that assign to a property that isn't wired into an assembly's scriptable `propmap` (e.g. `Submit1.label = "X";`), because two things compounded:

1. `VSAScriptable.putMember` (`core/src/main/java/inetsoft/report/script/viewsheet/VSAScriptable.java:163-184`) silently falls back to a generic per-assembly expando map when a name isn't in `propmap`, instead of erroring. This fallback is itself an intentional, real StyleBI scripting feature (ad hoc per-assembly scratch vars) — it must not be made to throw.
2. `ScriptExecuteService.execute()` (`core/src/main/java/inetsoft/web/wiz/script/ScriptExecuteService.java:105-147`) always reported `ok:true` with the target in `changed` on any non-throwing run, with no way to distinguish a real property write from one absorbed into the expando map.

The real backing field (e.g. `SubmitVSAssemblyInfo.labelName`) never actually changed — only `get_assembly_properties` and the live UI showed the truth; the script tool itself was silently, plausibly wrong.

## Fix

- `VSAScriptable`: added per-instance tracking (`resetUnrecognizedWrites()` / `getUnrecognizedWrites()`), recording the property name in `putMember`'s existing silent-fallback branch. Purely additive — no change to the assignment behavior itself.
- `ScriptExecuteService.execute()`: for `ASSEMBLY`/`ASSEMBLY_ONCLICK` targets, resets tracking on the target's `VSAScriptable` before `scope.execute(...)` and reads it after. If any unrecognized writes occurred: the target is excluded from `changed`, and the new `unrecognizedProperties` field + a `summary` message name the properties, the assembly type, and point the caller at `get_script_context`/`get_assembly_properties`/`update_binding` instead.
- `ok` stays `true` on this path (decision made with the team, not revisited here) — a script can legitimately mix one real property write with an intentional scratch var, and the two can't yet be told apart with certainty; the new field/message is what fixes the silent-plausible-success problem.
- `ScriptExecResult` record gained `List<String> unrecognizedProperties`; a matching field is being added in `stylebi-wiz`'s TS mirrors (`scriptAgentService.ts`, `scriptTools.ts`) in a companion PR.

## Regression tests

- `SubmitVSAScriptableTest`: unregistered write (`label`) is tracked and NOT applied; registered write (`enabled`) is applied and NOT tracked; `resetUnrecognizedWrites()` scopes tracking to one execution; a genuine ad hoc scratch var still executes cleanly (no error) via the same fallback.
- `CalcTableVSAScriptableTest`: confirms tracking still fires correctly through `CalcTableVSAScriptable`'s `getVarMap()` override (that override only changes where the expando value is stored, not `putMember`'s branch where tracking happens).
- `ScriptExecuteServiceTest`: an ASSEMBLY-location script with an unrecognized write excludes the target from `changed`, reports it in `unrecognizedProperties`, and includes it (plus the assembly type) in `summary`; a script with a real property write reports normally with `unrecognizedProperties` absent.

## Test plan

- `./mvnw -pl core test -Dtest=ScriptExecuteServiceTest,SubmitVSAScriptableTest,CalcTableVSAScriptableTest` — all pass (9, 6, 4 tests respectively).
- Live re-verification against a running Composer/StyleBI stack is intentionally deferred — other agents are actively using the live stack for a separate lane right now. Follows this test plan's own "FIXED, UNVERIFIED" convention.

Companion PR (shape-only mirror in `stylebi-wiz`): TBD, linked separately.
