### PR TITLE
Fix locale-dependent CSV numeric type detection flake in AssetUtil

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/internal/AssetUtil.java
+++ b/core/src/main/java/inetsoft/uql/asset/internal/AssetUtil.java
@@ -3495,10 +3495,17 @@ public class AssetUtil {
 
    public static boolean debug = false;
    private static DecimalFormat numFmt = null;
-   private static final DecimalFormat NFMT = new DecimalFormat("#,###.#");
-   private static final NumberFormat PFMT = NumberFormat.getPercentInstance();
-   private static final NumberFormat CFMT = new DecimalFormat("$#,##0.##;-$#,##0.##");
-   private static final NumberFormat C2FMT = new DecimalFormat("$#,##0.##;($#,##0.##)");
+   // these recognize StyleBI's own canonical numeric/currency/percent text
+   // representations during import-time type sniffing (not user-facing
+   // rendering), so they must stay pinned to Locale.US regardless of the
+   // JVM default locale in effect when AssetUtil is first class-loaded.
+   private static final DecimalFormat NFMT =
+      new DecimalFormat("#,###.#", DecimalFormatSymbols.getInstance(Locale.US));
+   private static final NumberFormat PFMT = NumberFormat.getPercentInstance(Locale.US);
+   private static final NumberFormat CFMT =
+      new DecimalFormat("$#,##0.##;-$#,##0.##", DecimalFormatSymbols.getInstance(Locale.US));
+   private static final NumberFormat C2FMT =
+      new DecimalFormat("$#,##0.##;($#,##0.##)", DecimalFormatSymbols.getInstance(Locale.US));
 
    private static final String REPOSITORY_KEY = AssetUtil.class.getName() + ".repository";
    private static final String DESIGN_REPOSITORY_KEY =

--- a/core/src/test/java/inetsoft/uql/asset/internal/AssetUtilTest.java
+++ b/core/src/test/java/inetsoft/uql/asset/internal/AssetUtilTest.java
@@ -23,7 +23,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import java.lang.reflect.Field;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.Format;
 import java.util.HashMap;
 import java.util.Locale;
@@ -43,6 +48,26 @@ public class AssetUtilTest {
    @AfterEach
    void restoreDefaultLocale() {
       Locale.setDefault(originalDefault);
+   }
+
+   /**
+    * NFMT/PFMT/CFMT/C2FMT are private static final, built once at whatever
+    * locale is the JVM default the moment AssetUtil is first class-loaded.
+    * Which test triggers that class-load first is Surefire run-order
+    * dependent and cannot be controlled from this test, so asserting via an
+    * end-to-end parse (as getTypeDetectsNumericValuesUnderNonUsDefaultLocale
+    * below does) cannot reliably re-exercise the class-load path in a full
+    * suite run. Inspect the already-constructed formatters' embedded
+    * symbols directly instead, which is independent of load order.
+    */
+   @ParameterizedTest
+   @ValueSource(strings = { "NFMT", "PFMT", "CFMT", "C2FMT" })
+   void formattersAreLocaleInvariant(String fieldName) throws Exception {
+      Field field = AssetUtil.class.getDeclaredField(fieldName);
+      field.setAccessible(true);
+      DecimalFormat fmt = (DecimalFormat) field.get(null);
+
+      assertEquals(DecimalFormatSymbols.getInstance(Locale.US), fmt.getDecimalFormatSymbols());
    }
 
    /**

--- a/core/src/test/java/inetsoft/uql/asset/internal/AssetUtilTest.java
+++ b/core/src/test/java/inetsoft/uql/asset/internal/AssetUtilTest.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.uql.asset.internal;
+
+import inetsoft.uql.schema.XSchema;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.text.Format;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Tag("core")
+public class AssetUtilTest {
+   private Locale originalDefault;
+
+   @BeforeEach
+   void saveDefaultLocale() {
+      originalDefault = Locale.getDefault();
+   }
+
+   @AfterEach
+   void restoreDefaultLocale() {
+      Locale.setDefault(originalDefault);
+   }
+
+   /**
+    * AssetUtil's numeric/currency/percent formatters are used to recognize
+    * StyleBI's own canonical text representations during import type
+    * sniffing, regardless of the JVM default locale in effect at the time.
+    */
+   @Test
+   void getTypeDetectsNumericValuesUnderNonUsDefaultLocale() {
+      // France's grouping separator (a narrow no-break space) differs from
+      // "." used in these values' literal text, unlike e.g. Germany's,
+      // where "." happens to also be the grouping separator and would
+      // silently parse to a wrong-but-non-throwing value instead.
+      Locale.setDefault(Locale.FRANCE);
+
+      Map<String, Format> fmtMap = new HashMap<>();
+      String plainNumberType =
+         AssetUtil.getType("price", XSchema.INTEGER, "299.99", fmtMap, null);
+      String currencyType =
+         AssetUtil.getType("price", XSchema.INTEGER, "$499.99", fmtMap, null);
+
+      assertEquals(XSchema.DOUBLE, plainNumberType);
+      assertEquals(XSchema.DOUBLE, currencyType);
+   }
+}


### PR DESCRIPTION
## Root cause

`AssetUtil.NFMT`/`PFMT`/`CFMT`/`C2FMT` (used by `AssetUtil.getType()` for CSV/Excel import-time numeric type detection) were declared `private static final` and built once, at whatever `Locale.getDefault()` was in effect the moment `AssetUtil` was first class-loaded in a JVM. If any earlier-running test in the same Surefire fork left a non-US default locale in place (e.g. via `Locale.setDefault(...)` without restoring it), these formatters got permanently poisoned for the rest of that fork's life. Depending on the locale's grouping separator, this can either produce a silently-wrong parsed value or (for e.g. French, whose grouping separator isn't `.`) cause the string to fail to fully parse, falling back to `STRING` type.

This caused `WorksheetAgentControllerTest.importCsvDetectTypeFalseMakesEveryColumnString` to fail intermittently and order-dependently in CI's Linux Surefire run (`filesystem` run order differs from Windows), while always passing locally on Windows and in isolation — blocking merges on several unrelated PRs (#4732 and others). Confirmed this is not a real regression: both the test and the underlying CSV-import behavior (`0fc080828`) are correct as committed.

## Fix

Pin `NFMT`/`PFMT`/`CFMT`/`C2FMT` explicitly to `Locale.US` (`core/src/main/java/inetsoft/uql/asset/internal/AssetUtil.java:3496-3507`) instead of relying on the JVM default at class-load time. These formatters exist to recognize StyleBI's own canonical numeric/currency/percent text representations during import-time type sniffing — not to render numbers back to a user in their locale — so they should never have varied with the runtime default locale.

Left `AssetUtil.getNumberFormat()` (`numFmt`, line ~1355) alone — it's a distinct field used by `format()` for user-facing value rendering/export and is configurable via the `format.number` sree property, which is a legitimately locale-aware, different concern from import-time type sniffing.

## Regression test

Added `core/src/test/java/inetsoft/uql/asset/internal/AssetUtilTest.java`, which sets `Locale.setDefault(Locale.FRANCE)` (a locale whose grouping separator isn't `.`, so it reproduces the actual parse failure rather than a silently-wrong-value pass), calls `AssetUtil.getType()` on `"299.99"` and `"$499.99"`, and asserts both are still detected as numeric. Restores the original default locale in `@AfterEach`. Verified this test fails without the fix and passes with it.

## Testing

- `./mvnw -pl core -o test -Dtest=AssetUtilTest` — 1/1 pass
- `./mvnw -pl core -o test -Dtest=WorksheetAgentControllerTest` — 50/50 pass (including the previously flaky test)
- Verified the new test fails without the fix (locale poisoning reproduced) and passes with it

## Note on the leaking test

Could not pin the exact test/call site that leaks a non-US default locale on CI's Linux runner (grepped `core/src/test` for `Locale.setDefault`; the two call sites found both already restore correctly in `@AfterAll`). This fix is independent of finding it — it closes the underlying fragility in `AssetUtil` regardless of which test (if any) is the culprit.