### PR TITLE
fix(composer): set dialog.assemblyName in 17 action-handler directives

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/pairing/SheetPairingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/SheetPairingService.java
@@ -63,6 +63,15 @@ public class SheetPairingService {
       "viewsheetOnInit", "viewsheetOnLoad", "assemblyMain", "assemblyOnClick", "calcField",
       "worksheetExpression", "worksheetCondition");
 
+   /**
+    * The two assembly-scoped script kinds (as opposed to viewsheetOnInit/viewsheetOnLoad, which
+    * are legitimately whole-viewsheet and name no assembly) -- a blank {@code assembly} for
+    * either of these must be refused at mint time, not treated as if it were one of the two
+    * whole-viewsheet kinds.
+    */
+   private static final List<String> ASSEMBLY_REQUIRED_KINDS =
+      List.of("assemblyMain", "assemblyOnClick");
+
    private final ConcurrentHashMap<String, PairingGrant> grants;
    private final SecureRandom random = new SecureRandom();
    private final LongSupplier clock;
@@ -220,6 +229,16 @@ public class SheetPairingService {
       String assembly = ctx.assembly();
 
       if(isBlank(assembly)) {
+         if(ASSEMBLY_REQUIRED_KINDS.contains(ctx.kind())) {
+            // assemblyMain/assemblyOnClick name a specific assembly's script pane; a blank
+            // assembly here previously minted successfully and matched no pane-scoped target
+            // (the same false-success failure mode WORKSHEET_COLUMN_KINDS validation above
+            // exists to prevent) -- surface it here, at mint time, instead of degrading
+            // silently into a whole-sheet-shaped grant.
+            throw new PairingException(PairingException.Kind.INVALID_ARGUMENT,
+               "editorContext kind '" + ctx.kind() + "' requires 'assembly'");
+         }
+
          // Whole-viewsheet script kinds (viewsheetOnInit/viewsheetOnLoad) name no assembly.
          return;
       }

--- a/core/src/test/java/inetsoft/web/wiz/pairing/SheetPairingServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/pairing/SheetPairingServiceTest.java
@@ -55,6 +55,12 @@ import static org.mockito.Mockito.when;
  * [EditorContext: missing]   mint refuses an editorContext naming an assembly the runtime
  *                            does not have, at mint time
  * [EditorContext: kind]      mint refuses an editorContext with a blank kind
+ * [EditorContext: blank assembly] mint refuses assemblyMain/assemblyOnClick with a blank
+ *                            assembly rather than silently treating it as a whole-viewsheet
+ *                            kind (the server-side half of the missing dialog.assemblyName bug
+ *                            class -- see docs/superpowers/plans/2026-08-22-follow-focus-missing-assembly-name-fix-plan.md)
+ * [EditorContext: viewsheetOnInit] mint still accepts a genuinely assembly-less
+ *                            viewsheetOnInit/viewsheetOnLoad context
  * [EditorContext: calc ok]   mint accepts a calcField editorContext whose table+name exist
  *                            (table aliased from 'assembly', matching the real browser wiring)
  * [EditorContext: calc miss] mint refuses a calcField editorContext naming a field the
@@ -205,6 +211,36 @@ class SheetPairingServiceTest {
       when(vs.getAssembly("Chart1")).thenReturn(mock(VSAssembly.class));
       SheetPairingService svc = serviceWithViewsheetRuntime(rvs);
       EditorContext ctx = new EditorContext("assemblyMain", "Chart1", null, null);
+
+      String code = svc.mint("vs-1", "user", "sock-1", "user", SheetType.VIEWSHEET, ctx);
+
+      assertEquals(ctx, svc.peek(code).editorContext());
+   }
+
+   @Test
+   void refusesAnAssemblyOnClickEditorContextWithABlankAssembly() {
+      SheetPairingService svc = serviceAt(FIXED_NOW);
+      EditorContext ctx = new EditorContext("assemblyOnClick", null, null, null);
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.mint("vs-1", "user", "sock-1", "user", SheetType.VIEWSHEET, ctx));
+      assertEquals(PairingException.Kind.INVALID_ARGUMENT, ex.getKind());
+   }
+
+   @Test
+   void refusesAnAssemblyMainEditorContextWithABlankAssembly() {
+      SheetPairingService svc = serviceAt(FIXED_NOW);
+      EditorContext ctx = new EditorContext("assemblyMain", "  ", null, null);
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.mint("vs-1", "user", "sock-1", "user", SheetType.VIEWSHEET, ctx));
+      assertEquals(PairingException.Kind.INVALID_ARGUMENT, ex.getKind());
+   }
+
+   @Test
+   void mintsAViewsheetOnInitEditorContextWithNoAssembly() throws PairingException {
+      SheetPairingService svc = serviceAt(FIXED_NOW);
+      EditorContext ctx = new EditorContext("viewsheetOnInit", null, null, null);
 
       String code = svc.mint("vs-1", "user", "sock-1", "user", SheetType.VIEWSHEET, ctx);
 

--- a/web/projects/portal/src/app/composer/gui/vs/action/assembly-name-action-handlers.directive.spec.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/action/assembly-name-action-handlers.directive.spec.ts
@@ -1,0 +1,178 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { of as observableOf } from "rxjs";
+import { CalcTableActionHandlerDirective } from "./calc-table-action-handler.directive";
+import { CalendarActionHandlerDirective } from "./calendar-action-handler.directive";
+import { GroupContainerActionHandlerDirective } from "./group-container-action-handler.directive";
+import { LineActionHandlerDirective } from "./line-action-handler.directive";
+import { RectangleActionHandlerDirective } from "./rectangle-action-handler.directive";
+import { SelectionContainerActionHandlerDirective } from "./selection-container-action-handler.directive";
+import { SelectionListActionHandlerDirective } from "./selection-list-action-handler.directive";
+import { SelectionTreeActionHandlerDirective } from "./selection-tree-action-handler.directive";
+import { SliderActionHandlerDirective } from "./slider-action-handler.directive";
+import { SpinnerActionHandlerDirective } from "./spinner-action-handler.directive";
+import { TabActionHandlerDirective } from "./tab-action-handler.directive";
+import { TextInputActionHandlerDirective } from "./text-input-action-handler.directive";
+import { ViewsheetActionHandlerDirective } from "./viewsheet-action-handler.directive";
+import { VSCrosstabActionHandler } from "../../../../vsobjects/binding/vs-crosstab-action-handler";
+import { VSTableActionHandler } from "../../../../vsobjects/binding/vs-table-action-handler";
+
+/**
+ * Table-driven regression test for the assemblyName sweep documented in
+ * docs/superpowers/plans/2026-08-22-follow-focus-missing-assembly-name-fix-plan.md.
+ *
+ * 17 action-handler call sites imperatively instantiate a PropertyDialog (or
+ * equivalent) with a script pane but never assigned `dialog.assemblyName`,
+ * the Input that ClickableScriptPane/VSAssemblyScriptPane read to populate
+ * EditorContext.assembly for both Follow Focus's auto-push and G2's manual
+ * pane-scoped pairing. submit-action-handler (the reported case) and
+ * oval-action-handler (which already had a socketConnection regression test
+ * from the prior G2 Task 1 fix round) have their own dedicated spec files;
+ * this file covers the remaining 15 - the 12 "simple" directives that share
+ * an identical (modelService, modalService, context) constructor and a
+ * private showPropertyDialog(), plus calc-table-action-handler.directive.ts
+ * (constructor also takes an injector) and the two vsobjects/binding classes
+ * (VSCrosstabActionHandler / VSTableActionHandler), which are plain classes
+ * rather than directives and delegate to a nested AbstractActionHandler
+ * subclass's own showDialog() instead of calling it directly.
+ */
+
+function stubModelService(modelResponse: any = {}): any {
+   return { getModel: vi.fn(() => observableOf(modelResponse)) };
+}
+
+function stubModalService(componentInstance: any): any {
+   return {
+      open: vi.fn(() => ({
+         componentInstance,
+         result: new Promise(() => { /* never resolves - not exercised here */ })
+      }))
+   };
+}
+
+const context: any = { viewer: false, preview: false };
+
+describe("assembly-name wiring - simple (modelService, modalService, context) directives", () => {
+   const cases: Array<{
+      name: string;
+      Ctor: new (modelService: any, modalService: any, context: any) => any;
+      absoluteName: string;
+      modelResponse?: any;
+   }> = [
+      { name: "CalendarActionHandlerDirective", Ctor: CalendarActionHandlerDirective, absoluteName: "Calendar1" },
+      { name: "GroupContainerActionHandlerDirective", Ctor: GroupContainerActionHandlerDirective, absoluteName: "GroupContainer1" },
+      { name: "LineActionHandlerDirective", Ctor: LineActionHandlerDirective, absoluteName: "Line1" },
+      { name: "RectangleActionHandlerDirective", Ctor: RectangleActionHandlerDirective, absoluteName: "Rectangle1" },
+      { name: "SelectionContainerActionHandlerDirective", Ctor: SelectionContainerActionHandlerDirective, absoluteName: "SelectionContainer1" },
+      // SelectionListActionHandlerDirective additionally reaches into
+      // dialog.model.selectionGeneralPaneModel.generalPropPaneModel right after
+      // assignment, so the stubbed getModel response needs that shape present.
+      {
+         name: "SelectionListActionHandlerDirective", Ctor: SelectionListActionHandlerDirective,
+         absoluteName: "SelectionList1",
+         modelResponse: { selectionGeneralPaneModel: { generalPropPaneModel: { basicGeneralPaneModel: {} } } }
+      },
+      { name: "SelectionTreeActionHandlerDirective", Ctor: SelectionTreeActionHandlerDirective, absoluteName: "SelectionTree1" },
+      { name: "SliderActionHandlerDirective", Ctor: SliderActionHandlerDirective, absoluteName: "Slider1" },
+      { name: "SpinnerActionHandlerDirective", Ctor: SpinnerActionHandlerDirective, absoluteName: "Spinner1" },
+      { name: "TabActionHandlerDirective", Ctor: TabActionHandlerDirective, absoluteName: "Tab1" },
+      { name: "TextInputActionHandlerDirective", Ctor: TextInputActionHandlerDirective, absoluteName: "TextInput1" },
+      { name: "ViewsheetActionHandlerDirective", Ctor: ViewsheetActionHandlerDirective, absoluteName: "Viewsheet1" },
+   ];
+
+   it.each(cases)("$name sets dialog.assemblyName to the model's absoluteName", ({ Ctor, absoluteName, modelResponse }) => {
+      const vsInfo: any = {
+         runtimeId: "vs-123",
+         socketConnection: { sendEvent: vi.fn() },
+         vsObjects: []
+      };
+      const model: any = { absoluteName };
+      const componentInstance: any = {};
+      const modalService = stubModalService(componentInstance);
+
+      const directive = new Ctor(stubModelService(modelResponse ?? {}), modalService, context);
+      directive.model = model;
+      directive.vsInfo = vsInfo;
+
+      (directive as any).showPropertyDialog();
+
+      expect(modalService.open).toHaveBeenCalledTimes(1);
+      expect(componentInstance.assemblyName).toBe(absoluteName);
+   });
+});
+
+describe("CalcTableActionHandlerDirective - property dialog assemblyName wiring", () => {
+   it("gives the constructed CalcTablePropertyDialog an assemblyName matching the model's absoluteName", () => {
+      const vsInfo: any = {
+         runtimeId: "vs-calc-123",
+         socketConnection: { sendEvent: vi.fn() },
+         vsObjects: []
+      };
+      const model: any = { absoluteName: "CalcTable1" };
+      const componentInstance: any = {};
+      const modalService = stubModalService(componentInstance);
+      const injector: any = { get: vi.fn() };
+
+      const directive = new CalcTableActionHandlerDirective(
+         stubModelService(), modalService, injector, context);
+      directive.model = model;
+      directive.vsInfo = vsInfo;
+
+      (directive as any).showPropertyDialog();
+
+      expect(modalService.open).toHaveBeenCalledTimes(1);
+      expect(componentInstance.assemblyName).toBe("CalcTable1");
+   });
+});
+
+describe("VSCrosstabActionHandler - property dialog assemblyName wiring", () => {
+   it("gives the constructed CrosstabPropertyDialog an assemblyName matching the model's absoluteName", () => {
+      const viewsheetClient: any = { runtimeId: "vs-crosstab-123", sendEvent: vi.fn() };
+      const model: any = { absoluteName: "Crosstab1" };
+      const componentInstance: any = {};
+      const modalService = stubModalService(componentInstance);
+      const injector: any = { get: vi.fn() };
+
+      const handler = new VSCrosstabActionHandler(
+         stubModelService(), viewsheetClient, modalService, injector, context);
+
+      (handler as any).showCrosstabPropertiesDialog(model, []);
+
+      expect(modalService.open).toHaveBeenCalledTimes(1);
+      expect(componentInstance.assemblyName).toBe("Crosstab1");
+   });
+});
+
+describe("VSTableActionHandler - property dialog assemblyName wiring", () => {
+   it("gives the constructed TableViewPropertyDialog an assemblyName matching the model's absoluteName", () => {
+      const viewsheetClient: any = { runtimeId: "vs-table-123", sendEvent: vi.fn() };
+      const model: any = { absoluteName: "Table1" };
+      const componentInstance: any = {};
+      const modalService = stubModalService(componentInstance);
+      const injector: any = { get: vi.fn() };
+
+      const handler = new VSTableActionHandler(
+         stubModelService(), viewsheetClient, modalService, injector, context);
+
+      (handler as any).showTablePropertiesDialog(model, []);
+
+      expect(modalService.open).toHaveBeenCalledTimes(1);
+      expect(componentInstance.assemblyName).toBe("Table1");
+   });
+});

--- a/web/projects/portal/src/app/composer/gui/vs/action/calc-table-action-handler.directive.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/action/calc-table-action-handler.directive.ts
@@ -141,6 +141,7 @@ export class CalcTableActionHandlerDirective extends AbstractActionHandler imple
          dialog.model = data;
          dialog.runtimeId = this._viewsheet.runtimeId;
          dialog.socketConnection = this._viewsheet.socketConnection;
+         dialog.assemblyName = this.model.absoluteName;
          dialog.variableValues =
             VSUtil.getVariableList(this._viewsheet.vsObjects, this.model.absoluteName);
          dialog.openToScript = openToScript;

--- a/web/projects/portal/src/app/composer/gui/vs/action/calendar-action-handler.directive.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/action/calendar-action-handler.directive.ts
@@ -104,6 +104,7 @@ export class CalendarActionHandlerDirective extends AbstractActionHandler implem
          dialog.model = data;
          dialog.runtimeId = runtimeId;
          dialog.socketConnection = this.vsInfo.socketConnection;
+         dialog.assemblyName = this.model.absoluteName;
          dialog.variableValues =
             VSUtil.getVariableList(this.vsInfo.vsObjects, this.model.absoluteName);
          dialog.openToScript = openToScript;

--- a/web/projects/portal/src/app/composer/gui/vs/action/group-container-action-handler.directive.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/action/group-container-action-handler.directive.ts
@@ -110,6 +110,7 @@ export class GroupContainerActionHandlerDirective extends AbstractActionHandler 
             VSUtil.getVariableList(this.vsInfo.vsObjects, this.model.absoluteName);
          dialog.runtimeId = this.vsInfo.runtimeId;
          dialog.socketConnection = this.vsInfo.socketConnection;
+         dialog.assemblyName = this.model.absoluteName;
          dialog.openToScript = openToScript;
          dialog.scriptTreeModel = loadingScriptTreeModel;
          this.modelService.getModel(scriptUri, params).subscribe(res => dialog.scriptTreeModel = res);

--- a/web/projects/portal/src/app/composer/gui/vs/action/line-action-handler.directive.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/action/line-action-handler.directive.ts
@@ -116,6 +116,7 @@ export class LineActionHandlerDirective extends AbstractActionHandler implements
             VSUtil.getVariableList(this.vsInfo.vsObjects, this.model.absoluteName);
          dialog.runtimeId = this.vsInfo.runtimeId;
          dialog.socketConnection = this.vsInfo.socketConnection;
+         dialog.assemblyName = this.model.absoluteName;
          dialog.openToScript = openToScript;
          dialog.scriptTreeModel = loadingScriptTreeModel;
          this.modelService.getModel(scriptUri, params).subscribe(res => dialog.scriptTreeModel = res);

--- a/web/projects/portal/src/app/composer/gui/vs/action/oval-action-handler.directive.spec.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/action/oval-action-handler.directive.spec.ts
@@ -29,6 +29,12 @@ import { OvalActionHandlerDirective } from "./oval-action-handler.directive";
  * reviewer's own example) and asserts the constructed dialog instance comes
  * out with a live, non-null socketConnection - not just that the assignment
  * line exists in source.
+ *
+ * The same omission recurred for `dialog.assemblyName`: EditorContext-driven
+ * consumers (ClickableScriptPane / VSAssemblyScriptPane, and therefore Follow
+ * Focus / G2 pane-scoped pairing) read PropertyDialog.assemblyName, but it was
+ * never assigned by 17 of the 24 action-handler directives, including this
+ * one - see docs/superpowers/plans/2026-08-22-follow-focus-missing-assembly-name-fix-plan.md.
  */
 describe("OvalActionHandlerDirective - property dialog socket wiring", () => {
    it("gives the constructed OvalPropertyDialog a non-null socketConnection matching vsInfo's", () => {
@@ -65,5 +71,6 @@ describe("OvalActionHandlerDirective - property dialog socket wiring", () => {
       expect(componentInstance.runtimeId).toBe("vs-oval-123");
       expect(componentInstance.socketConnection).toBeTruthy();
       expect(componentInstance.socketConnection).toBe(socketConnectionStub);
+      expect(componentInstance.assemblyName).toBe("Oval1");
    });
 });

--- a/web/projects/portal/src/app/composer/gui/vs/action/oval-action-handler.directive.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/action/oval-action-handler.directive.ts
@@ -116,6 +116,7 @@ export class OvalActionHandlerDirective extends AbstractActionHandler implements
             VSUtil.getVariableList(this.vsInfo.vsObjects, this.model.absoluteName);
          dialog.runtimeId = this.vsInfo.runtimeId;
          dialog.socketConnection = this.vsInfo.socketConnection;
+         dialog.assemblyName = this.model.absoluteName;
          dialog.openToScript = openToScript;
          dialog.scriptTreeModel = loadingScriptTreeModel;
          this.modelService.getModel(scriptUri, params).subscribe(res => dialog.scriptTreeModel = res);

--- a/web/projects/portal/src/app/composer/gui/vs/action/rectangle-action-handler.directive.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/action/rectangle-action-handler.directive.ts
@@ -117,6 +117,7 @@ export class RectangleActionHandlerDirective extends AbstractActionHandler imple
             VSUtil.getVariableList(this.vsInfo.vsObjects, this.model.absoluteName);
          dialog.runtimeId = this.vsInfo.runtimeId;
          dialog.socketConnection = this.vsInfo.socketConnection;
+         dialog.assemblyName = this.model.absoluteName;
          dialog.openToScript = openToScript;
          dialog.scriptTreeModel = loadingScriptTreeModel;
          this.modelService.getModel(scriptUri, params).subscribe(res => dialog.scriptTreeModel = res);

--- a/web/projects/portal/src/app/composer/gui/vs/action/selection-container-action-handler.directive.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/action/selection-container-action-handler.directive.ts
@@ -104,6 +104,7 @@ export class SelectionContainerActionHandlerDirective extends AbstractActionHand
          dialog.model = data;
          dialog.runtimeId = this.vsInfo.runtimeId;
          dialog.socketConnection = this.vsInfo.socketConnection;
+         dialog.assemblyName = this.model.absoluteName;
          dialog.variableValues =
             VSUtil.getVariableList(this.vsInfo.vsObjects, this.model.absoluteName);
          dialog.openToScript = openToScript;

--- a/web/projects/portal/src/app/composer/gui/vs/action/selection-list-action-handler.directive.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/action/selection-list-action-handler.directive.ts
@@ -112,6 +112,7 @@ export class SelectionListActionHandlerDirective extends AbstractActionHandler i
             VSUtil.getVariableList(this.vsInfo.vsObjects, this.model.absoluteName);
          dialog.runtimeId = this.vsInfo.runtimeId;
          dialog.socketConnection = this.vsInfo.socketConnection;
+         dialog.assemblyName = this.model.absoluteName;
          dialog.openToScript = openToScript;
          dialog.scriptTreeModel = loadingScriptTreeModel;
          this.modelService.getModel(scriptUri, params).subscribe(res => dialog.scriptTreeModel = res);

--- a/web/projects/portal/src/app/composer/gui/vs/action/selection-tree-action-handler.directive.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/action/selection-tree-action-handler.directive.ts
@@ -106,6 +106,7 @@ export class SelectionTreeActionHandlerDirective extends AbstractActionHandler i
             VSUtil.getVariableList(this.vsInfo.vsObjects, this.model.absoluteName);
          dialog.runtimeId = this.vsInfo.runtimeId;
          dialog.socketConnection = this.vsInfo.socketConnection;
+         dialog.assemblyName = this.model.absoluteName;
          dialog.openToScript = openToScript;
          dialog.scriptTreeModel = loadingScriptTreeModel;
          this.modelService.getModel(scriptUri, params).subscribe(res => dialog.scriptTreeModel = res);

--- a/web/projects/portal/src/app/composer/gui/vs/action/slider-action-handler.directive.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/action/slider-action-handler.directive.ts
@@ -112,6 +112,7 @@ export class SliderActionHandlerDirective extends AbstractActionHandler implemen
             VSUtil.getVariableList(this.vsInfo.vsObjects, this.model.absoluteName);
          dialog.runtimeId = this.vsInfo.runtimeId;
          dialog.socketConnection = this.vsInfo.socketConnection;
+         dialog.assemblyName = this.model.absoluteName;
          dialog.openToScript = openToScript;
          dialog.scriptTreeModel = loadingScriptTreeModel;
          this.modelService.getModel(scriptUri, params).subscribe(res => dialog.scriptTreeModel = res);

--- a/web/projects/portal/src/app/composer/gui/vs/action/spinner-action-handler.directive.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/action/spinner-action-handler.directive.ts
@@ -111,6 +111,7 @@ export class SpinnerActionHandlerDirective extends AbstractActionHandler impleme
             VSUtil.getVariableList(this.vsInfo.vsObjects, this.model.absoluteName);
          dialog.runtimeId = this.vsInfo.runtimeId;
          dialog.socketConnection = this.vsInfo.socketConnection;
+         dialog.assemblyName = this.model.absoluteName;
          dialog.openToScript = openToScript;
          dialog.scriptTreeModel = loadingScriptTreeModel;
          this.modelService.getModel(scriptUri, params).subscribe(res => dialog.scriptTreeModel = res);

--- a/web/projects/portal/src/app/composer/gui/vs/action/submit-action-handler.directive.spec.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/action/submit-action-handler.directive.spec.ts
@@ -1,0 +1,63 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { of as observableOf } from "rxjs";
+import { SubmitActionHandlerDirective } from "./submit-action-handler.directive";
+
+/**
+ * l9-tester reported this exact case (Follow Focus L9 9.9/9.12): opening
+ * Submit1's Properties -> Script tab pushed an editorContext with assembly:
+ * null, because SubmitActionHandlerDirective never set `dialog.assemblyName`
+ * on the constructed SubmitPropertyDialog - the same missing-Input-assignment
+ * bug class as the G2 Task 1 socketConnection fix. See
+ * docs/superpowers/plans/2026-08-22-follow-focus-missing-assembly-name-fix-plan.md.
+ */
+describe("SubmitActionHandlerDirective - property dialog assemblyName wiring", () => {
+   it("gives the constructed SubmitPropertyDialog an assemblyName matching the model's absoluteName", () => {
+      const socketConnectionStub = { runtimeId: "vs-submit-123", sendEvent: vi.fn() };
+      const vsInfo: any = {
+         runtimeId: "vs-submit-123",
+         socketConnection: socketConnectionStub,
+         vsObjects: []
+      };
+      const model: any = { absoluteName: "Submit1" };
+
+      const modelService: any = {
+         getModel: vi.fn(() => observableOf({}))
+      };
+      const componentInstance: any = {};
+      const modalService: any = {
+         open: vi.fn(() => ({
+            componentInstance,
+            result: new Promise(() => { /* never resolves - not exercised here */ })
+         }))
+      };
+      const context: any = { viewer: false, preview: false };
+
+      const directive = new SubmitActionHandlerDirective(modelService, modalService, context);
+      directive.model = model;
+      directive.vsInfo = vsInfo;
+
+      // "properties" is private; invoke it the way the repo's other action-handler specs do.
+      (directive as any).showPropertyDialog();
+
+      expect(modalService.open).toHaveBeenCalledTimes(1);
+      expect(componentInstance.runtimeId).toBe("vs-submit-123");
+      expect(componentInstance.assemblyName).toBe("Submit1");
+   });
+});

--- a/web/projects/portal/src/app/composer/gui/vs/action/submit-action-handler.directive.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/action/submit-action-handler.directive.ts
@@ -109,6 +109,7 @@ export class SubmitActionHandlerDirective extends AbstractActionHandler implemen
          dialog.model = data;
          dialog.runtimeId = this.vsInfo.runtimeId;
          dialog.socketConnection = this.vsInfo.socketConnection;
+         dialog.assemblyName = this.model.absoluteName;
          dialog.variableValues =
             VSUtil.getVariableList(this.vsInfo.vsObjects, this.model.absoluteName);
          dialog.openToScript = openToScript;

--- a/web/projects/portal/src/app/composer/gui/vs/action/tab-action-handler.directive.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/action/tab-action-handler.directive.ts
@@ -108,6 +108,7 @@ export class TabActionHandlerDirective extends AbstractActionHandler implements 
          dialog.model = data;
          dialog.runtimeId = this.vsInfo.runtimeId;
          dialog.socketConnection = this.vsInfo.socketConnection;
+         dialog.assemblyName = this.model.absoluteName;
          dialog.variableValues =
             VSUtil.getVariableList(this.vsInfo.vsObjects, this.model.absoluteName);
          dialog.openToScript = openToScript;

--- a/web/projects/portal/src/app/composer/gui/vs/action/text-input-action-handler.directive.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/action/text-input-action-handler.directive.ts
@@ -111,6 +111,7 @@ export class TextInputActionHandlerDirective extends AbstractActionHandler imple
             VSUtil.getVariableList(this.vsInfo.vsObjects, this.model.absoluteName);
          dialog.runtimeId = this.vsInfo.runtimeId;
          dialog.socketConnection = this.vsInfo.socketConnection;
+         dialog.assemblyName = this.model.absoluteName;
          dialog.openToScript = openToScript;
          dialog.scriptTreeModel = loadingScriptTreeModel;
          this.modelService.getModel(scriptUri, params).subscribe(res => dialog.scriptTreeModel = res);

--- a/web/projects/portal/src/app/composer/gui/vs/action/viewsheet-action-handler.directive.ts
+++ b/web/projects/portal/src/app/composer/gui/vs/action/viewsheet-action-handler.directive.ts
@@ -104,6 +104,7 @@ export class ViewsheetActionHandlerDirective extends AbstractActionHandler imple
          dialog.model = data;
          dialog.runtimeId = this.vsInfo.runtimeId;
          dialog.socketConnection = this.vsInfo.socketConnection;
+         dialog.assemblyName = this.model.absoluteName;
          dialog.variableValues =
             VSUtil.getVariableList(this.vsInfo.vsObjects, this.model.absoluteName);
          dialog.openToScript = openToScript;

--- a/web/projects/portal/src/app/vsobjects/binding/vs-crosstab-action-handler.ts
+++ b/web/projects/portal/src/app/vsobjects/binding/vs-crosstab-action-handler.ts
@@ -102,6 +102,7 @@ export class VSCrosstabActionHandler extends AbstractActionHandler {
          dialog.openToScript = openToScript;
          dialog.runtimeId = this.viewsheetClient.runtimeId;
          dialog.socketConnection = this.viewsheetClient;
+         dialog.assemblyName = model.absoluteName;
          dialog.scriptTreeModel = loadingScriptTreeModel;
          this.modelService.getModel(scriptUri, params).subscribe(res => dialog.scriptTreeModel = res);
       });

--- a/web/projects/portal/src/app/vsobjects/binding/vs-table-action-handler.ts
+++ b/web/projects/portal/src/app/vsobjects/binding/vs-table-action-handler.ts
@@ -110,6 +110,7 @@ export class VSTableActionHandler extends AbstractActionHandler {
          dialog.openToScript = openToScript;
          dialog.runtimeId = this.viewsheetClient.runtimeId;
          dialog.socketConnection = this.viewsheetClient;
+         dialog.assemblyName = model.absoluteName;
          dialog.scriptTreeModel = loadingScriptTreeModel;
          this.modelService.getModel(scriptUri, params).subscribe(res => dialog.scriptTreeModel = res);
       });


### PR DESCRIPTION
## Summary

- 17 of the 24 `*-action-handler.directive.ts` files (composer/gui/vs/action and the two vsobjects/binding table/crosstab handlers) imperatively instantiate a script-pane-bearing PropertyDialog but never set `dialog.assemblyName`, alongside the existing `dialog.runtimeId`/`dialog.socketConnection` assignments. `ClickableScriptPane`/`VSAssemblyScriptPane` read that `@Input` to populate `EditorContext.assembly`, which both Follow Focus's server-pushed live indicator and G2's manual pane-scoped pairing depend on to resolve a target-less script tool call to a specific assembly.
- l9-tester hit this via `submit-action-handler.directive.ts` (Follow Focus L9 cases 9.9/9.12): opening Submit1's Properties → Script tab pushed an `editorContext` with `assembly: null`.
- This is the same bug class, in the same files, as a prior fix (G2 Task 1) that added the missing `dialog.socketConnection` assignment to these handlers — that sweep never got extended to `assemblyName`. 8 of 24 handlers (chart, check-box, combo-box, gauge, image, radio-button, range-slider, text) already set it correctly and were left untouched; two files flagged as possibly-affected in the original grep (`composer/gui/vs/action/crosstab-action-handler.directive.ts` and `table-action-handler.directive.ts`) were traced and confirmed to not instantiate a script-pane dialog at all, so they're correctly excluded.
- Also hardens `SheetPairingService.validateEditorContext` (server side): a blank `assembly` for `assemblyMain`/`assemblyOnClick` was previously treated identically to the two legitimately assembly-less whole-viewsheet kinds (`viewsheetOnInit`/`viewsheetOnLoad`) and minted successfully anyway. Now it's refused at mint time with a named error, closing the server-side half of the same silent-degradation gap (defense in depth alongside the Angular fix).

Full root-cause writeup: `docs/superpowers/plans/2026-08-22-follow-focus-missing-assembly-name-fix-plan.md` (stylebi-wiz repo).

## Test plan

- [x] `ng test portal --include="**/action/*action-handler.directive.spec.ts" --include="**/action/assembly-name-action-handlers.directive.spec.ts"` — 18/18 pass, including the extended `oval-action-handler.directive.spec.ts` (assemblyName assertion added to the existing socketConnection test), the new dedicated `submit-action-handler.directive.spec.ts` (the reported case), and a new table-driven `assembly-name-action-handlers.directive.spec.ts` covering the remaining 13 directives + `VSCrosstabActionHandler`/`VSTableActionHandler`.
- [x] Full portal suite (`ng test portal --watch=false`): 205 files / 1125 tests pass, no regressions.
- [x] `SheetPairingServiceTest` (Maven, offline, `-pl core`): 27/27 pass, including 3 new tests for the mint-time hardening (`assemblyOnClick`/`assemblyMain` blank-assembly refusal, and a positive `viewsheetOnInit` case confirming the legitimately assembly-less kinds still mint).
- [ ] Live re-verification of l9-tester's Submit1 repro (9.9/9.12) and a spot-check of one or two of the other 16 sites — not run in this pass (no live stack available); recommend l9-tester re-run before closing out the L9 finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)