### PR TITLE
Fix categorical color frame useGlobal/shareColors defaulting-on defect

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/binding/VisualFrameAliases.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/VisualFrameAliases.java
@@ -558,16 +558,19 @@ public final class VisualFrameAliases {
    /**
     * A categorical colour frame, optionally with per-value colour mapping.
     *
-    * <p><b>The {@code useGlobal} footgun lives here.</b> {@code CategoricalColorModel} defaults
-    * {@code useGlobal} and {@code shareColors} to {@code true}, and while {@code useGlobal} is set
-    * the automatic palette wins: an explicit per-value colour is accepted, stored, and never
-    * rendered. That is a recorded defect, and it is invisible — the model round-trips perfectly
-    * and the chart shows something else.
+    * <p><b>The {@code useGlobal}/{@code shareColors} footgun lives here.</b>
+    * {@code CategoricalColorModel} defaults both {@code useGlobal} and {@code shareColors} to
+    * {@code true}. While {@code useGlobal} is set the automatic palette wins at render time; and
+    * independently, while {@code shareColors} is set the whole frame is replaced by a cached
+    * shared frame for the same column before per-value colours are even applied. Either flag
+    * alone is enough to make an explicit per-value colour accepted, stored, and never rendered.
+    * That is a recorded defect, and it is invisible — the model round-trips perfectly and the
+    * chart shows something else.
     *
-    * <p>So supplying a mapping clears {@code useGlobal}, because supplying one <i>is</i> the
-    * intent to override the automatic palette. Asking for {@code useGlobal: true} alongside a
-    * mapping is refused rather than honoured, since that combination cannot render what was
-    * asked for.
+    * <p>So supplying {@code colors} and/or a {@code mapping} clears both flags, because supplying
+    * either <i>is</i> the intent to override the automatic/shared palette. Asking for
+    * {@code useGlobal: true} alongside a mapping is refused rather than honoured, since that
+    * combination cannot render what was asked for.
     */
    private static VisualFrameModel categoricalColor(Map<String, Object> spec) {
       List<String> colors = strList(spec, "colors");
@@ -607,13 +610,16 @@ public final class VisualFrameAliases {
          }
 
          model.setColorMaps(maps.toArray(new ColorMapModel[0]));
-         // Supplying a mapping IS the intent to override the automatic palette.
-         model.setUseGlobal(false);
-         model.setShareColors(false);
       }
-      else if(useGlobal != null) {
-         model.setUseGlobal(useGlobal);
-      }
+
+      // Supplying colours and/or a mapping is the intent to override the automatic/shared
+      // palette. useGlobal and shareColors both default to true on a fresh CategoricalColorModel;
+      // leaving either set is what makes an explicit frame round-trip perfectly and never render.
+      // Default both false; honour an explicit useGlobal: true if the caller actually wants to
+      // keep sharing.
+      boolean share = Boolean.TRUE.equals(useGlobal);
+      model.setUseGlobal(share);
+      model.setShareColors(share);
 
       return model;
    }

--- a/core/src/test/java/inetsoft/web/wiz/binding/VisualFrameAliasesTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/VisualFrameAliasesTest.java
@@ -368,6 +368,26 @@ class VisualFrameAliasesTest {
       assertEquals("#4E79A7", frame.getColorMaps()[0].getColor());
    }
 
+   /**
+    * The same defect, hit through the tool's own primary documented example: a plain
+    * {@code colors} list with no mapping and no explicit {@code useGlobal}. Both flags default
+    * to {@code true} and neither was previously cleared for this shape, so the colours were
+    * accepted, stored, and never rendered.
+    */
+   @Test
+   void aPlainColoursListClearsUseGlobalAndShareColorsSoItActuallyRenders() {
+      CategoricalColorModel frame = assertInstanceOf(
+         CategoricalColorModel.class,
+         VisualFrameAliases.create("color", spec("type", "categorical",
+            "colors", java.util.List.of("#FF0000", "#00FF00", "#0000FF", "#FFFF00"))));
+
+      assertFalse(frame.isUseGlobal(),
+                  "leaving useGlobal set is what made the explicit colours never render");
+      assertFalse(frame.isShareColors(),
+                  "shareColors independently pulls in another chart's cached frame for the " +
+                  "same column even when useGlobal is cleared");
+   }
+
    @Test
    void refusesUseGlobalTogetherWithAMapping() {
       Exception thrown = assertThrows(


### PR DESCRIPTION
## Summary
- \`set_visual_frame\` with a \`categorical\` frame type round-tripped correctly via \`get_chart_aesthetics\` but silently had zero effect on the render — colors stayed at the workspace default.
- Root cause: \`CategoricalColorModel\` defaults both \`useGlobal\` and \`shareColors\` to \`true\`. Either flag alone lets the automatic/shared palette win at render time over an explicit per-value color, even though the model itself round-trips the explicit colors perfectly.
- Only the \`mapping\` code path previously cleared these two flags. The tool's own primary documented example — a plain \`colors\` list with no \`mapping\` and no explicit \`useGlobal\` — left both flags at their default `true`, so the write was inert at render.
- Fix: `VisualFrameAliases.categoricalColor()` now clears both `useGlobal` and `shareColors` whenever `colors` and/or `mapping` is supplied (either is unambiguous override intent), while still honoring an explicit `useGlobal: true` if the caller wants to opt back into cross-chart sharing.
- Only the categorical half of this finding is addressed here; the gradient/palette half is a separate, not-yet-root-caused defect and is intentionally out of scope.
- Verified via grep that `categoricalColor()` has exactly one caller (`VisualFrameAliases.create()`'s own dispatch) — this method is not shared with the human Composer's binding controllers, so blast radius is limited to the agent-facing `set_visual_frame` tool.

## Test plan
- [x] Added `aPlainColoursListClearsUseGlobalAndShareColorsSoItActuallyRenders` to `VisualFrameAliasesTest`, covering the previously-broken "colors, no mapping, no useGlobal" shape.
- [x] `./mvnw.cmd -pl core -o test -Dtest=VisualFrameAliasesTest` — all 43 tests pass (0 failures, 0 errors), including the existing `aColourMappingClearsUseGlobalSoItActuallyRenders`, `refusesUseGlobalTogetherWithAMapping`, and `acceptsUseGlobalOnItsOwn`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)