### PR TITLE
Fix set_chart_type migration bugs for treemap/mekko and size aesthetic gating

### DIFF
--- a/core/src/main/java/inetsoft/report/internal/graph/ChangeChartTypeProcessor.java
+++ b/core/src/main/java/inetsoft/report/internal/graph/ChangeChartTypeProcessor.java
@@ -1309,10 +1309,11 @@ public class ChangeChartTypeProcessor extends ChangeChartProcessor {
       }
    }
 
-   // if copyToTreemap() synthesized a size/color field from a measure, move it back to y
+   // if copyToTreemap() synthesized a size/color/shape field from a measure, move it back to y
    private void moveMeasureAestheticToY() {
       AestheticRef size = info.getSizeField();
       AestheticRef color = info.getColorField();
+      AestheticRef shape = info.getShapeField();
       DataRef dataRef = null;
 
       if(size != null && GraphUtil.isMeasure(size.getDataRef())) {
@@ -1322,6 +1323,10 @@ public class ChangeChartTypeProcessor extends ChangeChartProcessor {
       else if(color != null && GraphUtil.isMeasure(color.getDataRef())) {
          dataRef = color.getDataRef();
          info.setColorField(null);
+      }
+      else if(shape != null && GraphUtil.isMeasure(shape.getDataRef())) {
+         dataRef = shape.getDataRef();
+         info.setShapeField(null);
       }
 
       if(dataRef instanceof ChartRef) {

--- a/core/src/main/java/inetsoft/report/internal/graph/ChangeChartTypeProcessor.java
+++ b/core/src/main/java/inetsoft/report/internal/graph/ChangeChartTypeProcessor.java
@@ -92,8 +92,14 @@ public class ChangeChartTypeProcessor extends ChangeChartProcessor {
       if(!GraphTypes.isTreemap(oldType) && GraphTypes.isTreemap(newType)) {
          copyToTreemap();
       }
+      else if(GraphTypes.isTreemap(oldType) && !GraphTypes.isTreemap(newType)) {
+         copyFromTreemap();
+      }
       else if(!GraphTypes.isMekko(oldType) && GraphTypes.isMekko(newType)) {
          copyToMekko();
+      }
+      else if(GraphTypes.isMekko(oldType) && !GraphTypes.isMekko(newType)) {
+         copyFromMekko();
       }
       else if(!GraphTypes.isRelation(oldType) && GraphTypes.isRelation(newType)) {
          copyToRelation();
@@ -399,7 +405,7 @@ public class ChangeChartTypeProcessor extends ChangeChartProcessor {
       fixShapeField(newInfo, newInfo, getChartType(newInfo, ref));
       fixSizeField(newInfo, getChartType(newInfo, ref));
       fixSizeFrame(newInfo);
-      fixPieDimensions(info);
+      fixPieDimensions(newInfo);
       fixAggregateRefs(newInfo);
       fixMapDimensionRefs(newInfo);
       GraphDefault.setDefaultFormulas(info, newInfo);
@@ -1279,6 +1285,47 @@ public class ChangeChartTypeProcessor extends ChangeChartProcessor {
          AestheticRef aref = createAestheticRef(ref);
          aref.setVisualFrame(ref.isMeasure() ? new LinearSizeFrame() : new CategoricalSizeFrame());
          info.setSizeField(aref);
+      }
+   }
+
+   // copy the group dims (tree-dims) back to x, and a synthesized size/color measure back to y
+   private void copyFromTreemap() {
+      moveGroupFieldsToX();
+
+      if(info.getYFieldCount() == 0) {
+         moveMeasureAestheticToY();
+      }
+   }
+
+   // copy the group dim mekko may have added back to x; the y measure is already in place
+   private void copyFromMekko() {
+      moveGroupFieldsToX();
+   }
+
+   private void moveGroupFieldsToX() {
+      for(int i = info.getGroupFieldCount(); i > 0; i--) {
+         info.addXField(info.getGroupField(0));
+         info.removeGroupField(0);
+      }
+   }
+
+   // if copyToTreemap() synthesized a size/color field from a measure, move it back to y
+   private void moveMeasureAestheticToY() {
+      AestheticRef size = info.getSizeField();
+      AestheticRef color = info.getColorField();
+      DataRef dataRef = null;
+
+      if(size != null && GraphUtil.isMeasure(size.getDataRef())) {
+         dataRef = size.getDataRef();
+         info.setSizeField(null);
+      }
+      else if(color != null && GraphUtil.isMeasure(color.getDataRef())) {
+         dataRef = color.getDataRef();
+         info.setColorField(null);
+      }
+
+      if(dataRef instanceof ChartRef) {
+         info.addYField((ChartRef) dataRef);
       }
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/binding/AestheticChannels.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/AestheticChannels.java
@@ -58,7 +58,7 @@ public final class AestheticChannels {
    }
 
    public static String requireFieldChannel(String channel) {
-      return requireFieldChannel(channel, false);
+      return requireFieldChannel(channel, false, true);
    }
 
    /**
@@ -67,6 +67,19 @@ public final class AestheticChannels {
     *                      binding that this chart type never renders.
     */
    public static String requireFieldChannel(String channel, boolean relationChart) {
+      return requireFieldChannel(channel, relationChart, true);
+   }
+
+   /**
+    * @param relationChart see {@link #requireFieldChannel(String, boolean)}.
+    * @param sizeSupported whether the target chart type renders a {@code size} aesthetic (e.g.
+    *                      false for mekko/stock) — {@code GraphTypes.supportsSize(chartType)}.
+    *                      Accepting {@code size} on such a chart would store a binding that is
+    *                      silently never rendered.
+    */
+   public static String requireFieldChannel(String channel, boolean relationChart,
+                                            boolean sizeSupported)
+   {
       String name = normalize(channel);
 
       if(NODE_CHANNELS.contains(name)) {
@@ -77,6 +90,13 @@ public final class AestheticChannels {
          throw new IllegalArgumentException(
             "Channel '" + channel + "' only applies to relation charts (network, tree, chord) " +
             "— this chart is not one. Field channels: " + String.join(", ", FIELD_CHANNELS) + ".");
+      }
+
+      if("size".equals(name) && !sizeSupported) {
+         throw new IllegalArgumentException(
+            "Channel 'size' is not supported on this chart type — it accepts no size aesthetic " +
+            "and a binding here would never be rendered. Field channels: " +
+            String.join(", ", FIELD_CHANNELS) + ".");
       }
 
       if(FIELD_CHANNELS.contains(name)) {

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticAgentService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticAgentService.java
@@ -76,10 +76,9 @@ public class ChartAestheticAgentService {
       // open a checkpoint the caller then has to undo. This still needs the chart itself — node
       // channels are only valid on a relation chart, and size only on chart types that render
       // it — so it costs a resolve, not a mutate.
-      ChartVSAssembly chart = requireChart(sessions.resolve(sessionToken, user), assemblyName);
-      boolean relationChart = isRelationChart(chart);
-      String name = AestheticChannels.requireFieldChannel(
-         channel, relationChart, isSizeSupported(chart));
+      boolean relationChart = isRelationChart(sessionToken, user, assemblyName);
+      boolean sizeSupported = isSizeSupported(sessionToken, user, assemblyName);
+      String name = AestheticChannels.requireFieldChannel(channel, relationChart, sizeSupported);
 
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          ChartVSAssembly chart = requireChart(rvs, assemblyName);
@@ -99,10 +98,9 @@ public class ChartAestheticAgentService {
    public void clearField(String sessionToken, Principal user, String assemblyName,
                           String channel, String linkUri) throws Exception
    {
-      ChartVSAssembly chart = requireChart(sessions.resolve(sessionToken, user), assemblyName);
-      boolean relationChart = isRelationChart(chart);
-      String name = AestheticChannels.requireFieldChannel(
-         channel, relationChart, isSizeSupported(chart));
+      boolean relationChart = isRelationChart(sessionToken, user, assemblyName);
+      boolean sizeSupported = isSizeSupported(sessionToken, user, assemblyName);
+      String name = AestheticChannels.requireFieldChannel(channel, relationChart, sizeSupported);
 
       apply(sessionToken, user, assemblyName, name, linkUri,
             model -> ChartAestheticMutator.clearField(model, name, relationChart));
@@ -162,6 +160,13 @@ public class ChartAestheticAgentService {
    private static boolean isRelationChart(ChartVSAssembly chart) {
       VSChartInfo info = chart.getVSChartInfo();
       return info != null && GraphTypes.isRelation(info.getChartType());
+   }
+
+   private boolean isSizeSupported(String sessionToken, Principal user, String assemblyName)
+      throws Exception
+   {
+      RuntimeViewsheet rvs = sessions.resolve(sessionToken, user);
+      return isSizeSupported(requireChart(rvs, assemblyName));
    }
 
    /** No chart type yet (unbound chart) means no type is forbidding the size channel. */

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticAgentService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticAgentService.java
@@ -74,9 +74,12 @@ public class ChartAestheticAgentService {
    {
       // Validated before the runtime is touched, so a bad channel costs nothing and does not
       // open a checkpoint the caller then has to undo. This still needs the chart itself — node
-      // channels are only valid on a relation chart — so it costs a resolve, not a mutate.
-      boolean relationChart = isRelationChart(sessionToken, user, assemblyName);
-      String name = AestheticChannels.requireFieldChannel(channel, relationChart);
+      // channels are only valid on a relation chart, and size only on chart types that render
+      // it — so it costs a resolve, not a mutate.
+      ChartVSAssembly chart = requireChart(sessions.resolve(sessionToken, user), assemblyName);
+      boolean relationChart = isRelationChart(chart);
+      String name = AestheticChannels.requireFieldChannel(
+         channel, relationChart, isSizeSupported(chart));
 
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          ChartVSAssembly chart = requireChart(rvs, assemblyName);
@@ -96,8 +99,10 @@ public class ChartAestheticAgentService {
    public void clearField(String sessionToken, Principal user, String assemblyName,
                           String channel, String linkUri) throws Exception
    {
-      boolean relationChart = isRelationChart(sessionToken, user, assemblyName);
-      String name = AestheticChannels.requireFieldChannel(channel, relationChart);
+      ChartVSAssembly chart = requireChart(sessions.resolve(sessionToken, user), assemblyName);
+      boolean relationChart = isRelationChart(chart);
+      String name = AestheticChannels.requireFieldChannel(
+         channel, relationChart, isSizeSupported(chart));
 
       apply(sessionToken, user, assemblyName, name, linkUri,
             model -> ChartAestheticMutator.clearField(model, name, relationChart));
@@ -157,6 +162,12 @@ public class ChartAestheticAgentService {
    private static boolean isRelationChart(ChartVSAssembly chart) {
       VSChartInfo info = chart.getVSChartInfo();
       return info != null && GraphTypes.isRelation(info.getChartType());
+   }
+
+   /** No chart type yet (unbound chart) means no type is forbidding the size channel. */
+   private static boolean isSizeSupported(ChartVSAssembly chart) {
+      VSChartInfo info = chart.getVSChartInfo();
+      return info == null || GraphTypes.supportsSize(info.getChartType());
    }
 
    private void apply(String sessionToken, Principal user, String assemblyName, String channel,

--- a/core/src/test/java/inetsoft/report/internal/graph/ChangeChartTypeProcessorTest.java
+++ b/core/src/test/java/inetsoft/report/internal/graph/ChangeChartTypeProcessorTest.java
@@ -1,0 +1,92 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.internal.graph;
+
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.asset.AggregateFormula;
+import inetsoft.uql.viewsheet.graph.*;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class },
+                      initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class ChangeChartTypeProcessorTest {
+   @Test
+   void pieToTreemapMovesDimensionToGroup() {
+      ChartInfo info = new DefaultVSChartInfo();
+      info.addXField(dimension("Category"));
+      info.addYField(aggregate("Sales", AggregateFormula.SUM));
+
+      info = changeType(GraphTypes.CHART_BAR, GraphTypes.CHART_PIE, info);
+      info = changeType(GraphTypes.CHART_PIE, GraphTypes.CHART_TREEMAP, info);
+
+      assertEquals(1, info.getGroupFieldCount(),
+                   "the pie dimension must land on the treemap's group shelf, not stay " +
+                   "stranded on the aesthetic channel");
+      assertNull(info.getColorField(),
+                "the dimension must be moved off color, not left there and also duplicated " +
+                "onto group");
+   }
+
+   @Test
+   void treemapToBarMovesGroupDimensionToX() {
+      ChartInfo info = new DefaultVSChartInfo();
+      info.addXField(dimension("Category"));
+      info.addYField(aggregate("Sales", AggregateFormula.SUM));
+
+      info = changeType(GraphTypes.CHART_BAR, GraphTypes.CHART_TREEMAP, info);
+      assertEquals(1, info.getGroupFieldCount(), "sanity check on the treemap intermediate state");
+
+      info = changeType(GraphTypes.CHART_TREEMAP, GraphTypes.CHART_BAR, info);
+
+      assertEquals(1, info.getXFieldCount(),
+                   "the dimension must move back to x when leaving treemap");
+      assertEquals(0, info.getGroupFieldCount(),
+                   "the dimension must not be left stranded on the group shelf bar never reads");
+   }
+
+   private static ChartInfo changeType(int oldType, int newType, ChartInfo info) {
+      return new ChangeChartTypeProcessor(oldType, newType, null, info).process();
+   }
+
+   private static VSChartDimensionRef dimension(String field) {
+      VSChartDimensionRef dim = new VSChartDimensionRef();
+      dim.setGroupColumnValue(field);
+      return dim;
+   }
+
+   private static VSChartAggregateRef aggregate(String column, AggregateFormula formula) {
+      VSChartAggregateRef agg = new VSChartAggregateRef();
+      agg.setColumnValue(column);
+      agg.setFormula(formula);
+      agg.setAggregated(true);
+      return agg;
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticAgentServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticAgentServiceTest.java
@@ -193,6 +193,52 @@ class ChartAestheticAgentServiceTest {
                                           null, ""));
    }
 
+   // ── size gating on chart types that do not render it ───────────────────────
+
+   @Test
+   void setFieldRefusesSizeOnAChartTypeThatDoesNotSupportIt() {
+      ChartAestheticAgentService service = serviceWith(
+         sessionsFor(chartOfType(GraphTypes.CHART_MEKKO)), new ChartBindingModel(),
+         mock(ChangeChartAestheticService.class));
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> service.setField("tok", principal(), "Chart1", "size",
+                                new FieldRef("Sales", "measure", null, null, null), ""));
+      assertTrue(thrown.getMessage().contains("size"));
+   }
+
+   @Test
+   void setFieldRefusesSizeOnStockToo() {
+      ChartAestheticAgentService service = serviceWith(
+         sessionsFor(chartOfType(GraphTypes.CHART_STOCK)), new ChartBindingModel(),
+         mock(ChangeChartAestheticService.class));
+
+      assertThrows(Exception.class,
+                   () -> service.setField("tok", principal(), "Chart1", "size",
+                                          new FieldRef("Sales", "measure", null, null, null),
+                                          ""));
+   }
+
+   @Test
+   void setFieldAcceptsSizeOnAnOrdinaryChartType() throws Exception {
+      ChangeChartAestheticService aesthetics = mock(ChangeChartAestheticService.class);
+
+      harness(new ChartBindingModel(), aesthetics)
+         .setField("tok", principal(), "Chart1", "size",
+                  new FieldRef("Sales", "measure", null, null, null), "");
+
+      assertEquals("Sales", captureEvent(aesthetics).getModel().getSizeField().getFullName());
+   }
+
+   private static ChartVSAssembly chartOfType(int chartType) {
+      VSChartInfo info = mock(VSChartInfo.class);
+      when(info.getChartType()).thenReturn(chartType);
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      when(chart.getVSChartInfo()).thenReturn(info);
+      return chart;
+   }
+
    // ── node channels (spec 2c Phase 3) ───────────────────────────────────────
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticAgentServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticAgentServiceTest.java
@@ -204,7 +204,7 @@ class ChartAestheticAgentServiceTest {
       Exception thrown = assertThrows(
          Exception.class,
          () -> service.setField("tok", principal(), "Chart1", "size",
-                                new FieldRef("Sales", "measure", null, null, null), ""));
+                                new FieldRef("Sales", "measure", null, null, null), null, ""));
       assertTrue(thrown.getMessage().contains("size"));
    }
 
@@ -217,7 +217,7 @@ class ChartAestheticAgentServiceTest {
       assertThrows(Exception.class,
                    () -> service.setField("tok", principal(), "Chart1", "size",
                                           new FieldRef("Sales", "measure", null, null, null),
-                                          ""));
+                                          null, ""));
    }
 
    @Test
@@ -226,7 +226,7 @@ class ChartAestheticAgentServiceTest {
 
       harness(new ChartBindingModel(), aesthetics)
          .setField("tok", principal(), "Chart1", "size",
-                  new FieldRef("Sales", "measure", null, null, null), "");
+                  new FieldRef("Sales", "measure", null, null, null), null, "");
 
       assertEquals("Sales", captureEvent(aesthetics).getModel().getSizeField().getFullName());
    }


### PR DESCRIPTION
## Summary

Three related defects found live during test-plan verification of `set_chart_type`, all in `ChangeChartTypeProcessor`'s merged-type migration path or its neighboring aesthetic-channel validation.

- **Fix 1**: `fixChartInfo()`'s cross-merge-family branch (e.g. pie→treemap) built a fresh `newInfo` and correctly ran every post-step against it except `fixPieDimensions(info)` — called on the stale, discarded `info`. Pie's "move dimension back off the color channel" reversal never reached the returned chart, so the dimension stayed stranded on `colorField` and `copyToTreemap()`/`copyToMekko()` found nothing on x/y/group to harvest, rendering a blank plot. Fixed by calling `fixPieDimensions(newInfo)`.

- **Fix 2**: `copyToTreemap()`/`copyToMekko()` had no reverse halves (`copyFromRadar()`/`copyFromGantt()` exist for their families, but nothing mirrored these). Leaving treemap/mekko left the dimension stuck on the `group` shelf, since `copyFields()`'s group-copying loop unconditionally carries it forward and the target type's `supportsGroupFields()` doesn't refuse it. Added `copyFromTreemap()`/`copyFromMekko()` and wired them into `process()`'s dispatch.

- **Fix 3**: `GraphTypes.supportsSize()` is checked during type-change migration and drag-and-drop, but never on a direct aesthetic-channel write. `ChartAestheticAgentService.setField()`/`clearField()` validated the channel only via `AestheticChannels.requireFieldChannel()`, with no chart-type gate on `size` for mekko/stock — the binding was silently accepted and stored but never rendered. `requireFieldChannel()` now takes a `sizeSupported` parameter (same shape as the existing `relationChart` parameter) and refuses `size` by name when unsupported.

## Test plan

- [x] `ChangeChartTypeProcessorTest` (new): `pieToTreemapMovesDimensionToGroup`, `treemapToBarMovesGroupDimensionToX` — both pass
- [x] `ChartAestheticAgentServiceTest`: added `setFieldRefusesSizeOnAChartTypeThatDoesNotSupportIt` (mekko), `setFieldRefusesSizeOnStockToo`, `setFieldAcceptsSizeOnAnOrdinaryChartType` — all pass (17/17 in class)
- [x] `ChartAestheticMutatorTest` (existing, unaffected by the overload defaults) — 26/26 pass
- Ran narrowly via `./mvnw -pl core test -Dtest=ChangeChartTypeProcessorTest,ChartAestheticAgentServiceTest,ChartAestheticMutatorTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)