### PR TITLE
Fix CSVLoader silently misparsing rows beyond the type-scan window

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/internal/AssetUtil.java
+++ b/core/src/main/java/inetsoft/uql/asset/internal/AssetUtil.java
@@ -2938,38 +2938,66 @@ public class AssetUtil {
       }
 
       if(XSchema.DOUBLE.equals(type)) {
-         NumberFormat fmt = NFMT;
          str = trimPlus(str);
+         NumberFormat fmt = numericFormatForShape(str);
 
-         if(str.endsWith("%")) {
-            fmt = PFMT;
-         }
-         else if(str.length() > 0 && str.charAt(0) == '$') {
-            fmt = CFMT;
-         }
-         else if(str.startsWith("-$")) {
-            fmt = CFMT;
-         }
-         else if(str.startsWith("($") && str.endsWith(")")) {
-            fmt = C2FMT;
-         }
-
-         try {
-            ParsePosition pos = new ParsePosition(0);
-            fmt.parseObject(str, pos);
-
-            if(pos.getIndex() != str.length()) {
-               throw new RuntimeException("failed: " + pos.getIndex());
-            }
-
+         if(fmt != null) {
             fmtMap.put((String) header, fmt);
          }
-         catch(Throwable ex) {
+         else {
             type = XSchema.STRING;
          }
       }
 
       return type;
+   }
+
+   /**
+    * Pick the numeric format matching a value's own shape (plain, percent, currency,
+    * or parenthesized negative currency) and confirm it consumes the entire string.
+    *
+    * @return the matching format, or null if none of the candidate formats fully parse it.
+    */
+   private static NumberFormat numericFormatForShape(String str) {
+      NumberFormat fmt = NFMT;
+
+      if(str.endsWith("%")) {
+         fmt = PFMT;
+      }
+      else if(str.length() > 0 && str.charAt(0) == '$') {
+         fmt = CFMT;
+      }
+      else if(str.startsWith("-$")) {
+         fmt = CFMT;
+      }
+      else if(str.startsWith("($") && str.endsWith(")")) {
+         fmt = C2FMT;
+      }
+
+      ParsePosition pos = new ParsePosition(0);
+      fmt.parseObject(str, pos);
+
+      return pos.getIndex() == str.length() ? fmt : null;
+   }
+
+   /**
+    * Re-derive and apply the numeric format matching a value's own shape. Used as a
+    * fallback when a column's cached format (picked from a sample of scanned rows)
+    * doesn't fully match a later row's own shape, e.g. a percent value beyond the
+    * type-detection scan window in an otherwise plain-number column.
+    *
+    * @return the parsed number, or null if no candidate format fully matches.
+    */
+   public static Number parseNumberByShape(String str) {
+      str = trimPlus(str);
+      NumberFormat fmt = numericFormatForShape(str);
+
+      if(fmt == null) {
+         return null;
+      }
+
+      Object result = fmt.parseObject(str, new ParsePosition(0));
+      return result instanceof Number ? (Number) result : null;
    }
 
    /**

--- a/core/src/main/java/inetsoft/uql/util/filereader/CSVLoader.java
+++ b/core/src/main/java/inetsoft/uql/util/filereader/CSVLoader.java
@@ -534,12 +534,29 @@ public final class CSVLoader {
             fmt = fmtMap.get(header[c]);
 
             if(fmt != null) {
-               Object nval = fmt.parseObject((String) val, new ParsePosition(0));
+               ParsePosition pos = new ParsePosition(0);
+               Object nval = fmt.parseObject((String) val, pos);
 
                // parseObject returns null instead of throwing when the value doesn't
-               // match the column format, don't discard the value in that case.
-               if(nval != null) {
+               // match the column format, and can also return a non-null result from
+               // only a partial match (e.g. the plain-number format matching just the
+               // digits of "50%" and silently dropping the percent scaling) -- require
+               // the format to consume the entire string before trusting the result.
+               if(nval != null && pos.getIndex() == ((String) val).length()) {
                   val = rdata[c] = nval;
+               }
+               else {
+                  // the cached format was picked from a sample of scanned rows and
+                  // doesn't fit this row's own shape (e.g. a currency/percent value
+                  // beyond the type-detection scan window) -- re-derive the format
+                  // from this value instead of leaving it to the plain
+                  // NumberParserWrapper fallback below, which doesn't understand
+                  // currency/percent notation.
+                  Number reshaped = AssetUtil.parseNumberByShape((String) val);
+
+                  if(reshaped != null) {
+                     val = rdata[c] = reshaped;
+                  }
                }
             }
 

--- a/core/src/test/java/inetsoft/uql/util/filereader/CSVLoaderTest.java
+++ b/core/src/test/java/inetsoft/uql/util/filereader/CSVLoaderTest.java
@@ -114,9 +114,35 @@ public class CSVLoaderTest {
    }
 
    /**
+    * Bug: a column's format/type is decided from only the sampled (typeRows) rows. A
+    * later row past that scan window that only partially matches the cached format
+    * (e.g. "50%" against the plain-number format cached for "100.5"/"200.5") was
+    * silently accepted as a wrong value (50.0) instead of falling through to the
+    * type-specific numeric fallback (0.5).
+    */
+   @Test
+   public void percentRowBeyondScanWindowNotSilentlyMisparsed() throws Exception {
+      List<String> types = new ArrayList<>();
+      XSwappableTable table = readColumn("rate",
+         new String[]{ "100.5", "200.5", "50%" }, types, 2);
+
+      Assertions.assertEquals(XSchema.DOUBLE, types.get(0));
+      Assertions.assertEquals(100.5, ((Number) table.getObject(1, 0)).doubleValue(), 0.001);
+      Assertions.assertEquals(200.5, ((Number) table.getObject(2, 0)).doubleValue(), 0.001);
+      Assertions.assertEquals(0.5, ((Number) table.getObject(3, 0)).doubleValue(), 0.001);
+   }
+
+   /**
     * Read a single column csv file, the returned table has the header in row 0.
     */
    private XSwappableTable readColumn(String header, String[] values, List<String> types)
+      throws Exception
+   {
+      return readColumn(header, values, types, 50000);
+   }
+
+   private XSwappableTable readColumn(String header, String[] values, List<String> types,
+                                       int typeRows)
       throws Exception
    {
       StringBuilder content = new StringBuilder(header).append('\n');
@@ -129,7 +155,7 @@ public class CSVLoaderTest {
                               content.toString().getBytes(StandardCharsets.UTF_8)).toFile();
 
       return CSVLoader.readCSV(file, "UTF-8", true, ",", true, false, new HashMap<>(), types,
-                               true, null, 50000, 0, -1, new DateParseInfo());
+                               true, null, typeRows, 0, -1, new DateParseInfo());
    }
 
    @TempDir


### PR DESCRIPTION
## Summary

The originally-assigned bug (a column mixing plain and currency numbers within the *scanned* rows getting a wrong single cached format applied to every row, silently nulling out mismatched values) was **already fixed** by #4689, merged before this investigation, with regression tests (`mixedNumberAndCurrencyKeptAsString`, `mixedCurrencyAndNumberKeptAsString` in `CSVLoaderTest`). All 7 tests in `CSVLoaderTest` pass on this branch confirming that fix still holds.

While verifying the original root cause against current source, I found a **related but distinct, still-live defect**: `CSVLoader.readCSV` only samples the first `typeRows` lines to decide a numeric column's format (`fmtMap`). `parseRow()`'s second, full-data pass applies that single cached format to *every* row, but only checked `parseObject() != null` (from #4689), not whether the format consumed the *whole* string. A row beyond the scan window whose shape doesn't match the cached format (e.g. `"50%"` in a column typed from `"100.5"`/`"200.5"`) got silently accepted as a **wrong, non-null value** (`50.0` instead of `0.5`) -- worse than a dropped value, since nothing signals the corruption.

## Fix

- `CSVLoader.parseRow()`: require the cached format's `ParsePosition` to reach the end of the string before trusting the parsed result.
- When it doesn't, fall back to re-deriving the correct format from that row's own shape via a new `AssetUtil.parseNumberByShape()` (extracted from the existing scan-time format-selection logic in `AssetUtil.getType()`), instead of the plain `NumberParserWrapper` fallback, which doesn't understand currency/percent notation.

## Test plan

- [x] `CSVLoaderTest` (7 tests, including new `percentRowBeyondScanWindowNotSilentlyMisparsed`) -- `mvnw -pl core -am -o test -Dtest=CSVLoaderTest`, all pass
- [x] Reproduced the bug live before the fix (assertion failure: expected `0.5`, got `50.0`) and confirmed the fix resolves it

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>