### PR TITLE
Fix stale assertion in importCsvDetectTypeFalseMakesEveryColumnString

### DIFF
--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -914,9 +914,11 @@ class WorksheetAgentControllerTest {
       Worksheet ws = new Worksheet();
       WorksheetAgentController ctrl = importCtrl(ws, "TOK-DT");
 
-      // The same file twice, differing only in detectType. With detection on, "$499.99" cannot be
-      // coerced to a number; with it off the column is text and the value survives intact -- which
-      // is the answer L2 Finding 8 was missing.
+      // The same file twice, differing only in detectType. "299.99" and "$499.99" mix numeric
+      // sub-formats (plain vs. currency) that CSVLoader can't represent with the single cached
+      // Format it picks during type detection -- #4689 (Bug #76203) demotes a column like this to
+      // string rather than silently losing whichever values don't match that cached format, so
+      // detectType=true and detectType=false converge on the same string result here.
       ctrl.importCsv("TOK-DT", csvRequest("Typed", "price\n299.99\n$499.99",
                                           null, null, null, true, null, null, null, null),
                      TestPrincipals.user("alice", "host-org"));
@@ -929,8 +931,26 @@ class WorksheetAgentControllerTest {
 
       assertEquals(XSchema.STRING, ((ColumnRef) text.getAttribute(0)).getDataType(),
          "detectType=false must leave the column as string");
+      assertEquals(XSchema.STRING, ((ColumnRef) typed.getAttribute(0)).getDataType(),
+         "detectType=true demotes a mixed numeric sub-format column (plain + currency) to string");
+   }
+
+   @Test
+   void importCsvDetectTypeTrueDetectsANumericColumn() throws Exception {
+      Worksheet ws = new Worksheet();
+      WorksheetAgentController ctrl = importCtrl(ws, "TOK-DT2");
+
+      // Unlike the mixed plain/currency case above, both values here share the same currency
+      // sub-format, so CSVLoader's cached Format never changes between rows and the column is
+      // free to be detected as numeric.
+      ctrl.importCsv("TOK-DT2", csvRequest("Typed", "price\n$299.99\n$499.99",
+                                           null, null, null, true, null, null, null, null),
+                     TestPrincipals.user("alice", "host-org"));
+
+      ColumnSelection typed = importedTable(ws, "Typed").getColumnSelection(false);
+
       assertNotEquals(XSchema.STRING, ((ColumnRef) typed.getAttribute(0)).getDataType(),
-         "detectType=true must still detect a numeric column");
+         "detectType=true must still detect a numeric column when every value shares one format");
    }
 
    @Test


### PR DESCRIPTION
## Summary

**This unblocks CI on #4732, #4734, #4741, and likely every other in-flight PR** -- they've all been failing `WorksheetAgentControllerTest.importCsvDetectTypeFalseMakesEveryColumnString` for a reason completely unrelated to what each PR itself touches.

## Root cause

GitHub Actions' `pull_request`-triggered `Validation Build` workflow checks out `refs/pull/<PR>/merge` -- a synthetic merge of the PR branch with the *current* tip of the base branch -- not the raw PR branch. `stylebi-wiz-main-rebase` (and `main`) already has #4689 (Bug #76203, merged 2026-08-21) merged, which intentionally demotes a CSV column mixing numeric sub-formats (plain `299.99` + currency `$499.99`) to `string` under `detectType=true`, since `CSVLoader` can't represent both values with the single cached `Format` it picks during type detection -- keeping the raw text avoids silently losing whichever values don't match that format.

This test (`WorksheetAgentControllerTest.java:913-934`) predates #4689 and still asserted the *opposite*: `assertNotEquals(XSchema.STRING, ...)`, "detectType=true must still detect a numeric column". Since every `pull_request` CI run implicitly merges with the current base-branch tip, this test has been failing on **every single PR's CI**, deterministically, since #4689 merged -- regardless of what that PR touches. It was initially investigated as a locale/environment flake (see `docs/superpowers/plans/2026-08-22-csv-price-type-string-ci-flake-investigation.md`) before being traced to this stale assertion.

## Changes

- Flips the assertion in `importCsvDetectTypeFalseMakesEveryColumnString` to `assertEquals(XSchema.STRING, ...)`, matching #4689's now-intentional, already-shipped behavior, and updates the comment to describe why.
- Adds `importCsvDetectTypeTrueDetectsANumericColumn`, a companion test covering what the original assertion meant to protect: `detectType=true` still detects a numeric column when every value shares one sub-format (no format-cache conflict).

## Test plan

- [x] `WorksheetAgentControllerTest` -- 51/51 pass (`../mvnw -Dtest=WorksheetAgentControllerTest -Dgroups=core test`)
- [x] `CSVLoaderTest` -- 6/6 pass (`../mvnw -Dtest=CSVLoaderTest -Dgroups=core test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)