### PR TITLE
Fix set_chart_type silently discarding a custom color frame

### DIFF
--- a/core/src/main/java/inetsoft/report/internal/graph/ChangeChartTypeProcessor.java
+++ b/core/src/main/java/inetsoft/report/internal/graph/ChangeChartTypeProcessor.java
@@ -172,7 +172,10 @@ public class ChangeChartTypeProcessor extends ChangeChartProcessor {
             info.setColorFrame(new BluesColorFrame());
          }
       }
-      else if(!(info.getColorFrame() instanceof StaticColorFrame)) {
+      else if(GraphTypes.isContour(oldType) && info.getColorFrame() instanceof LinearColorFrame) {
+         // Linear/Blues frames only make sense for contour; migrating away from contour with
+         // one still set needs to fall back to something ordinary charts can render. Any other
+         // frame the user explicitly set is valid on non-contour types and must not be touched.
          info.setColorFrame(new StaticColorFrame());
       }
    }
@@ -556,6 +559,12 @@ public class ChangeChartTypeProcessor extends ChangeChartProcessor {
       ninfo.setMeasureMapType(oinfo.getMapType());
       ninfo.setAxisDescriptor(info.getAxisDescriptor());
       ninfo.setAxisDescriptor2(info.getAxisDescriptor2());
+
+      ninfo.setColorFrameWrapper(oinfo.getColorFrameWrapper());
+      ninfo.setShapeFrameWrapper(oinfo.getShapeFrameWrapper());
+      ninfo.setSizeFrameWrapper(oinfo.getSizeFrameWrapper());
+      ninfo.setLineFrameWrapper(oinfo.getLineFrameWrapper());
+      ninfo.setTextureFrameWrapper(oinfo.getTextureFrameWrapper());
    }
 
    /**

--- a/core/src/test/java/inetsoft/report/internal/graph/ChangeChartTypeProcessorTest.java
+++ b/core/src/test/java/inetsoft/report/internal/graph/ChangeChartTypeProcessorTest.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.report.internal.graph;
 
+import inetsoft.graph.aesthetic.*;
 import inetsoft.test.BaseTestConfiguration;
 import inetsoft.test.ConfigurationContextInitializer;
 import inetsoft.test.SreeHome;
@@ -70,6 +71,61 @@ class ChangeChartTypeProcessorTest {
                    "the dimension must move back to x when leaving treemap");
       assertEquals(0, info.getGroupFieldCount(),
                    "the dimension must not be left stranded on the group shelf bar never reads");
+   }
+
+   @Test
+   void treemapToBarPreservesGradientColorFrame() {
+      ChartInfo info = new DefaultVSChartInfo();
+      info.addXField(dimension("Category"));
+      info.addYField(aggregate("Sales", AggregateFormula.SUM));
+      info.setColorFrame(new GradientColorFrame());
+
+      info = changeType(GraphTypes.CHART_TREEMAP, GraphTypes.CHART_BAR, info);
+
+      assertInstanceOf(GradientColorFrame.class, info.getColorFrame(),
+                        "a gradient color frame explicitly set by the user must survive a " +
+                        "type change that crosses the merged/non-merged boundary");
+   }
+
+   @Test
+   void barToBarStackPreservesCategoricalColorFrame() {
+      ChartInfo info = new DefaultVSChartInfo();
+      info.addXField(dimension("Category"));
+      info.addYField(aggregate("Sales", AggregateFormula.SUM));
+      info.setColorFrame(new CategoricalColorFrame());
+
+      info = changeType(GraphTypes.CHART_BAR, GraphTypes.CHART_BAR_STACK, info);
+
+      assertInstanceOf(CategoricalColorFrame.class, info.getColorFrame(),
+                        "a categorical color frame must survive a same-family type change " +
+                        "that reuses the same ChartInfo object");
+   }
+
+   @Test
+   void barToScatterContourStillSwitchesToBluesColorFrame() {
+      ChartInfo info = new DefaultVSChartInfo();
+      info.addXField(dimension("Category"));
+      info.addYField(aggregate("Sales", AggregateFormula.SUM));
+      info.setColorFrame(new StaticColorFrame());
+
+      info = changeType(GraphTypes.CHART_BAR, GraphTypes.CHART_SCATTER_CONTOUR, info);
+
+      assertInstanceOf(BluesColorFrame.class, info.getColorFrame(),
+                        "entering contour must still switch to a Blues color frame");
+   }
+
+   @Test
+   void scatterContourToBarStillResetsToStaticColorFrame() {
+      ChartInfo info = new DefaultVSChartInfo();
+      info.addXField(dimension("Category"));
+      info.addYField(aggregate("Sales", AggregateFormula.SUM));
+      info.setColorFrame(new BluesColorFrame());
+
+      info = changeType(GraphTypes.CHART_SCATTER_CONTOUR, GraphTypes.CHART_BAR, info);
+
+      assertInstanceOf(StaticColorFrame.class, info.getColorFrame(),
+                        "leaving contour with a Linear/Blues frame still attached must reset " +
+                        "to a static color frame");
    }
 
    private static ChartInfo changeType(int oldType, int newType, ChartInfo info) {


### PR DESCRIPTION
## Summary
- `ChangeChartTypeProcessor.fixColorFrame()` reset any non-`StaticColorFrame` color frame to a generic default `StaticColorFrame` (`#518db9`) on every non-contour type change, regardless of the old type or whether the current frame was actually incompatible with the new type. This destroyed gradient/categorical/palette color frames the user had explicitly set via `set_visual_frame`, even when switching to a type (e.g. `bar`) that fully supports them. Fix: only reset when actually leaving contour with a Linear/Blues frame still attached — the one case where a fallback is warranted.
- Separately, `copyGeneralValues()` rebuilds a brand-new `ChartInfo` when a type change crosses the merged/non-merged boundary (e.g. treemap -> bar), but never copied the frame wrappers from the old object, so a gradient frame never survived even before `fixColorFrame` ran. Fix: copy all five frame wrappers (color/shape/size/line/texture) across in `copyGeneralValues()`.
- Both root causes had to be fixed together: same-family transitions (bar -> bar_stack) only needed fix 1; cross-family transitions (treemap -> bar) needed both.

## Test plan
- [x] Added 4 regression tests to the existing `ChangeChartTypeProcessorTest` (from #4738):
  - `treemapToBarPreservesGradientColorFrame` — exercises both root causes together
  - `barToBarStackPreservesCategoricalColorFrame` — isolates root cause 1 (same object survives)
  - `barToScatterContourStillSwitchesToBluesColorFrame` — confirms legitimate contour-entry behavior unchanged
  - `scatterContourToBarStillResetsToStaticColorFrame` — confirms the one case where reset-on-leaving-contour is still correct
- [x] `./mvnw.cmd -pl core -Dtest=ChangeChartTypeProcessorTest -Dsurefire.failIfNoSpecifiedTests=false test` — all 6 tests pass (2 existing + 4 new)
- [x] Verified `copyToContour()` re-derives its own decision independently from `info`/`oinfo`, so carrying frame wrappers over in `copyGeneralValues()` does not change its later behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)