### PR TITLE
Route set_visual_frame to a bound field's own frame, not the top-level property

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticMutator.java
@@ -114,6 +114,18 @@ public final class ChartAestheticMutator {
    {
       String name = AestheticChannels.requireFrameChannel(channel, relationChart);
       VisualFrameModel frame = VisualFrameAliases.create(name, spec, relationChart);
+      AestheticInfo field = acceptsField(name) ? read(model, name) : null;
+
+      // A bound field carries its own frame (AestheticInfo.frame) -- that, not the top-level
+      // ChartBindingModel.xxxFrame property, is what the interactive Composer's own dialog writes
+      // (ColorFieldMc.changeColorFrame et al.) and what the render path
+      // (VSFrameVisitor.createVisualFrame -> AestheticRef.getVisualFrame) reads at paint time.
+      // Writing only the top-level property round-trips cleanly through get_chart_aesthetics/
+      // set_visual_frame -- both read and write the same wrong place -- but never reaches the chart.
+      if(field != null) {
+         field.setFrame(frame);
+         return;
+      }
 
       switch(name) {
          case "color" -> model.setColorFrame((ColorFrameModel) frame);
@@ -248,6 +260,12 @@ public final class ChartAestheticMutator {
    }
 
    private static VisualFrameModel frameOf(ChartBindingModel model, String channel) {
+      AestheticInfo field = acceptsField(channel) ? read(model, channel) : null;
+
+      if(field != null) {
+         return field.getFrame();
+      }
+
       return switch(channel) {
          case "color" -> model.getColorFrame();
          case "shape" -> model.getShapeFrame();

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticMutatorTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticMutatorTest.java
@@ -142,6 +142,39 @@ class ChartAestheticMutatorTest {
       assertInstanceOf(BluesColorModel.class, model.getColorFrame());
    }
 
+   /**
+    * The render path ({@code VSFrameVisitor.createVisualFrame} -> {@code AestheticRef.getVisualFrame})
+    * reads a bound field's own {@code frame} property, not {@code ChartBindingModel.colorFrame} —
+    * a frame written only to the top-level property never reaches the chart.
+    */
+   @Test
+   void aFrameSetOnABoundFieldLandsOnTheFieldNotTheTopLevelProperty() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setField(model, "color", measure("Sales", "Sum"));
+
+      ChartAestheticMutator.setFrame(
+         model, "color", spec("type", "gradient", "from", "#FFFF00", "to", "#8000FF"));
+
+      GradientColorModel onField =
+         assertInstanceOf(GradientColorModel.class, model.getColorField().getFrame());
+      assertEquals("#FFFF00", onField.getFromColor());
+      assertEquals("#8000FF", onField.getToColor());
+      assertNull(model.getColorFrame(), "the top-level property must stay untouched");
+   }
+
+   @Test
+   void aCategoricalFrameSetOnABoundDimensionLandsOnTheFieldNotTheTopLevelProperty() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setField(model, "color", dimension("Region"));
+
+      ChartAestheticMutator.setFrame(
+         model, "color", spec("type", "categorical", "colors", List.of("#FF0000", "#00FF00")));
+
+      CategoricalColorModel onField =
+         assertInstanceOf(CategoricalColorModel.class, model.getColorField().getFrame());
+      assertArrayEquals(new String[]{"#FF0000", "#00FF00"}, onField.getColors());
+   }
+
    // ── preservation, both ways ───────────────────────────────────────────────
 
    @Test


### PR DESCRIPTION
## Status: FIXED, UNVERIFIED (needs live confirm before merge)

Statically root-caused and fixed per docs/superpowers/plans/2026-08-23-color-frame-field-vs-toplevel-property-fix-plan.md. **Not yet confirmed against a live render** — do not merge until the tester repeats the gradient/palette (and categorical) `set_visual_frame` -> `get_viewsheet_image` repro from `infra/l3-tester-status.md` against a rebuilt container.

## Root cause

`ChartInfo` stores a channel's frame in two independent places: the bound field's own nested `AestheticInfo.frame`, and a separate top-level `ChartBindingModel.xxxFrame` property. The render path (`VSFrameVisitor.createVisualFrame()` -> `AestheticRef.getVisualFrame()`) and the real Angular Composer dialogs (`color-field-mc.component.ts`, `size-field-mc.component.ts`) both read/write the **nested** property whenever a field is bound to that channel.

`ChartAestheticMutator.setFrame()`/`frameOf()` always read/wrote only the **top-level** property, regardless of whether a field was bound. `get_chart_aesthetics`/`set_visual_frame` round-tripped cleanly with each other — both agree on the wrong place — so the desync was invisible to the tool pair itself, but the frame never reached the chart. This produced exactly the observed symptom: gradient/palette silently rendering with default colors whenever set on a field already bound to that channel (L3 Finding 5).

## Fix

`core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticMutator.java`

- `setFrame()`: if the channel has a bound field (`read(model, name)` non-null), write the frame onto that field's own `AestheticInfo.frame` instead of the top-level property. Unbound channels keep the unchanged top-level fallback.
- `frameOf()`: same preference on read, so `get_chart_aesthetics` reports whichever property is actually live.

Spot-checked `GraphGenerator`'s node-color/node-size render branches (relation charts) — they follow the identical nested-first/top-level-fallback pattern, so this fix also covers those channels; this was flagged as unverified in the debugger's plan and is now confirmed by direct source read.

## Effect on the categorical half (#4737)

stylebi#4737 fixed a real, separate defect (`useGlobal`/`shareColors` defaulting true) but only changed *what* gets written into the top-level property, not *where*. A categorical frame set on a dimension already bound to color goes through the same `setFrame()` call and hit the identical wrong-property bug. This fix should also resolve that case, but it needs its own live re-verification — recommend the tester re-check categorical alongside gradient/palette rather than assuming #4737 alone was sufficient.

## Tests

Two new regression tests in `ChartAestheticMutatorTest`:
- `aFrameSetOnABoundFieldLandsOnTheFieldNotTheTopLevelProperty` (gradient on a bound measure)
- `aCategoricalFrameSetOnABoundDimensionLandsOnTheFieldNotTheTopLevelProperty` (categorical on a bound dimension)

Confirmed locally:
- `./mvnw -o -pl core test -Dtest='ChartAestheticMutatorTest'` -> 28/28 pass
- `./mvnw -o -pl core test -Dtest='inetsoft.web.wiz.binding.**'` -> 318/318 pass, no regressions

## Out of scope / left alone

- `ChangeChartTypeProcessor` (#4743) still copies only the top-level `cFrame` when preserving frames across a chart-type change — once this fix lands, a field-bound frame that was never mirrored into `cFrame` could still be discarded on a chart-type change. Flagged in the plan as a follow-up live test (set gradient on bound measure, change chart type, confirm survival) — not fixed here, separate concern from the read/write-location bug this PR addresses.