### PR TITLE
fix(wiz): resolve bare sortByField column names for aliased crosstab aggregates

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/AbstractCrosstabVSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AbstractCrosstabVSAQuery.java
@@ -1057,6 +1057,33 @@ public abstract class AbstractCrosstabVSAQuery extends CubeVSAQuery
          if(colname.equals(aggrs[i].getAttribute())) {
             return i;
          }
+
+         // getAttribute() above still isn't enough for a normal (non-cube) crosstab: its
+         // aggregates go through VSAggregateRef#update() with aalias=true (CrossBaseVSAssemblyInfo
+         // only ever passes false for a cube other than SQL Server Analysis Services), which --
+         // whenever the aggregate's full name differs from its bare column, i.e. any aggregate
+         // with a real formula -- wraps the resolved column in an AliasDataRef named after that
+         // full name (e.g. "Count(ORDER_ID)"). AbstractCrosstabVSAQuery#createAggregates() then
+         // rebuilds the runtime aggregate again for pivot-cell re-aggregation (aggregate-on-
+         // aggregate) and carries that same alias-wrapping ref forward as its data ref, while
+         // overwriting the new ref's own design-time column value with the query's computed
+         // column name too -- so neither getAttribute()/getName() (the alias) nor getColumnValue()
+         // (now also the alias, post-rebuild) ever reflect the bare source column. The alias'
+         // wrapped base ref is the only place that original bare name still lives.
+         DataRef aggDataRef = aggrs[i] instanceof VSAggregateRef ?
+            ((VSAggregateRef) aggrs[i]).getDataRef() : null;
+
+         if(aggDataRef instanceof ColumnRef) {
+            aggDataRef = ((ColumnRef) aggDataRef).getDataRef();
+         }
+
+         if(aggDataRef instanceof AliasDataRef) {
+            DataRef base = ((AliasDataRef) aggDataRef).getDataRef();
+
+            if(base != null && colname.equals(base.getAttribute())) {
+               return i;
+            }
+         }
       }
 
       return -1;

--- a/core/src/test/java/inetsoft/report/composition/execution/CrosstabSortByValueAliasedAggregateNameTest.java
+++ b/core/src/test/java/inetsoft/report/composition/execution/CrosstabSortByValueAliasedAggregateNameTest.java
@@ -1,0 +1,158 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.composition.execution;
+
+import inetsoft.report.TableLens;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.IntegrationTestConfiguration;
+import inetsoft.test.SreeHome;
+import inetsoft.test.SwapperTestConfiguration;
+import inetsoft.uql.ColumnSelection;
+import inetsoft.uql.VariableTable;
+import inetsoft.uql.XConstants;
+import inetsoft.uql.asset.AbstractSheet;
+import inetsoft.uql.asset.AggregateFormula;
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.asset.EmbeddedTableAssembly;
+import inetsoft.uql.asset.SourceInfo;
+import inetsoft.uql.asset.Worksheet;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.util.XEmbeddedTable;
+import inetsoft.uql.viewsheet.CrosstabVSAssembly;
+import inetsoft.uql.viewsheet.VSAggregateRef;
+import inetsoft.uql.viewsheet.VSCrosstabInfo;
+import inetsoft.uql.viewsheet.VSDimensionRef;
+import inetsoft.uql.viewsheet.Viewsheet;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression test for a "value_desc"/"value_asc" crosstab sort silently falling back to a
+ * label sort when the aggregate goes through the real (non-cube) production update path,
+ * which -- unlike {@link CrosstabSortByValueEntityQualifiedNameTest}'s {@code aalias=false} --
+ * always aliases an aggregate whose full name differs from its bare column (i.e. any aggregate
+ * with a real formula). {@code CrossBaseVSAssemblyInfo#update()} computes {@code aalias = true}
+ * for every non-cube source ({@code aalias} is only ever {@code false} for a cube other than
+ * SQL Server Analysis Services), so this is the path every real crosstab actually takes.
+ *
+ * <p>When {@code aalias} is true, {@code VSAggregateRef#update()} wraps the resolved column in
+ * a {@code ColumnRef} over an {@code AliasDataRef} named after the aggregate's full name (e.g.
+ * {@code "Count(CUSTOMER_ID)"}). {@code AliasDataRef#getAttribute()} and {@code #getName()} both
+ * return that alias, never the bare source column -- so {@code AbstractCrosstabVSAQuery#findCol}'s
+ * {@code getAttribute()} check (added for {@link CrosstabSortByValueEntityQualifiedNameTest}'s
+ * fix) can never match a bare {@code sortByField} for an ordinarily-aliased real aggregate, even
+ * though it does match in that test's own {@code aalias=false} fixture. {@code
+ * VSAggregateRef#getColumnValue()} -- the aggregate's untouched design-time column string --
+ * survives the aliasing untouched and is what {@code findCol} now falls back to.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class, SwapperTestConfiguration.class, IntegrationTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class CrosstabSortByValueAliasedAggregateNameTest {
+   private static final String ENTITY = "CUSTOMERS";
+
+   /** Builds a one-row-dimension, one-aggregate crosstab, updated through the real aalias=true path. */
+   private TableLens run(String sortByField) throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly table = new EmbeddedTableAssembly(ws, "Query1");
+      ColumnSelection cs = new ColumnSelection();
+      cs.addAttribute(new ColumnRef(new AttributeRef(ENTITY, "STATE")));
+      cs.addAttribute(new ColumnRef(new AttributeRef(ENTITY, "CUSTOMER_ID")));
+      table.setColumnSelection(cs, false);
+
+      Object[][] rows = new Object[][]{
+         {"STATE", "CUSTOMER_ID"},
+         {"NJ", "C1"}, {"NJ", "C2"}, {"NJ", "C3"}, {"NJ", "C4"}, {"NJ", "C5"}, {"NJ", "C6"},
+         {"CA", "C7"}, {"CA", "C8"}, {"CA", "C9"}, {"CA", "C10"},
+         {"MA", "C11"}, {"MA", "C12"}, {"MA", "C13"}, {"MA", "C14"},
+      };
+      table.setEmbeddedData(new XEmbeddedTable(new String[]{ "string", "string" }, rows));
+      ws.addAssembly(table);
+
+      Viewsheet vs = new Viewsheet();
+      CrosstabVSAssembly crosstab = new CrosstabVSAssembly(vs, "Crosstab1");
+      crosstab.setSourceInfo(new SourceInfo(SourceInfo.ASSET, null, "Query1"));
+      vs.addAssembly(crosstab);
+
+      VSDimensionRef stateDim = new VSDimensionRef();
+      stateDim.setDataRef(new AttributeRef(ENTITY, "STATE"));
+      stateDim.setGroupColumnValue("STATE");
+      stateDim.setOrder(XConstants.SORT_VALUE_DESC);
+      stateDim.setSortByColValue(sortByField);
+
+      VSAggregateRef countAgg = new VSAggregateRef();
+      countAgg.setDataRef(new AttributeRef(ENTITY, "CUSTOMER_ID"));
+      countAgg.setColumnValue("CUSTOMER_ID");
+      countAgg.setFormulaValue(AggregateFormula.COUNT_ALL.getFormulaName());
+
+      VSCrosstabInfo cinfo = new VSCrosstabInfo();
+      cinfo.setDesignRowHeaders(new VSDimensionRef[]{ stateDim });
+      cinfo.setDesignColHeaders(new VSDimensionRef[0]);
+      cinfo.setDesignAggregates(new VSAggregateRef[]{ countAgg });
+      crosstab.setVSCrosstabInfo(cinfo);
+
+      // No AssetEntry/asset-repository is available in a from-scratch unit test, so the base
+      // worksheet and query sandbox are wired in directly rather than through the normal
+      // asset-repository-backed constructors.
+      Method setBaseWorksheet = Viewsheet.class.getDeclaredMethod("setBaseWorksheet", Worksheet.class);
+      setBaseWorksheet.setAccessible(true);
+      setBaseWorksheet.invoke(vs, ws);
+
+      ViewsheetSandbox box = new ViewsheetSandbox(vs, AbstractSheet.SHEET_RUNTIME_MODE, null, false, null);
+      AssetQuerySandbox wbox = new AssetQuerySandbox(ws, null, new VariableTable());
+      Field wboxField = ViewsheetSandbox.class.getDeclaredField("wbox");
+      wboxField.setAccessible(true);
+      wboxField.set(box, wbox);
+
+      // aalias=true -- what CrossBaseVSAssemblyInfo#update() actually passes for every
+      // non-cube source, unlike CrosstabSortByValueEntityQualifiedNameTest's aalias=false.
+      cinfo.update(vs, cs, null, true, "Query1", null);
+
+      return new CrosstabVSAQuery(box, "Crosstab1", false).getTableLens();
+   }
+
+   private static void assertSortedByCountDescending(TableLens table) {
+      table.moreRows(TableLens.EOT);
+
+      assertEquals("NJ", table.getObject(1, 0), "highest count (6) must sort first");
+      assertEquals("CA", table.getObject(2, 0), "tied count (4) -- either tied row may come next");
+      assertEquals("MA", table.getObject(3, 0), "tied count (4)");
+   }
+
+   @Test
+   void sortsByValueWhenSortByFieldIsTheBareColumnName() throws Exception {
+      assertSortedByCountDescending(run("CUSTOMER_ID"));
+   }
+
+   @Test
+   void sortsByValueWhenSortByFieldIsTheFullyQualifiedAggregateName() throws Exception {
+      assertSortedByCountDescending(run("Count(CUSTOMER_ID)"));
+   }
+}

--- a/core/src/test/java/inetsoft/report/composition/execution/CrosstabSortByValueAliasedAggregateNameTest.java
+++ b/core/src/test/java/inetsoft/report/composition/execution/CrosstabSortByValueAliasedAggregateNameTest.java
@@ -67,8 +67,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * {@code getAttribute()} check (added for {@link CrosstabSortByValueEntityQualifiedNameTest}'s
  * fix) can never match a bare {@code sortByField} for an ordinarily-aliased real aggregate, even
  * though it does match in that test's own {@code aalias=false} fixture. {@code
- * VSAggregateRef#getColumnValue()} -- the aggregate's untouched design-time column string --
- * survives the aliasing untouched and is what {@code findCol} now falls back to.
+ * VSAggregateRef#getColumnValue()} is no help either -- {@code
+ * AbstractCrosstabVSAQuery#createAggregates()}'s pivot-cell re-aggregation rebuild overwrites it
+ * with the same full/aliased name too. The bare source column only survives inside the
+ * {@code AliasDataRef}'s own wrapped base ref, which is what {@code findCol} now falls back to
+ * (unwrapping {@code ColumnRef} -> {@code AliasDataRef} -> base ref and checking
+ * {@code base.getAttribute()}).
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { BaseTestConfiguration.class, SwapperTestConfiguration.class, IntegrationTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)


### PR DESCRIPTION
## Summary

Composer plugin test-plan L5, Finding 3: `set_field_sort`'s `sortByField` doesn't resolve a bare column name (e.g. `"ORDER_ID"`) for a `value_desc`/`value_asc` crosstab sort. It silently falls back to a label/chronological sort instead of throwing or working — indistinguishable from success until the actual rendered values are checked. `#4697` claimed to fix a related issue but this symptom persisted.

## Root cause

`AbstractCrosstabVSAQuery#findCol` only matched the sort's target column against an aggregate's `getAttribute()`. For any non-cube crosstab (i.e. every real crosstab — `CrossBaseVSAssemblyInfo#update()` only ever passes `aalias=false` for a cube other than SQL Server Analysis Services), `VSAggregateRef#update()` wraps the resolved column in an `AliasDataRef` named after the aggregate's full computed name (e.g. `"Count(ORDER_ID)"`) whenever that full name differs from the bare column. `createAggregates()`'s pivot-cell re-aggregation rebuild then carries that same alias forward and also overwrites the rebuilt ref's `getColumnValue()` with the query-level full name — so by the time `findCol` runs, neither `getAttribute()`/`getName()` nor `getColumnValue()` on the runtime aggregate ref reflects the original bare source column. The only place the true bare name survives is the alias's own wrapped base ref.

## Fix

Added a fallback in `findCol`: unwrap the aggregate's `ColumnRef` → `AliasDataRef` → base ref chain and compare `colname` against that base ref's `getAttribute()`.

## Tests

- New regression test `CrosstabSortByValueAliasedAggregateNameTest`, modeled on the existing `CrosstabSortByValueEntityQualifiedNameTest` (`#4697`) but with `aalias=true` — the aliasing path every real (non-cube) crosstab actually takes, which the `#4697` test never exercised. Covers both a bare column name and a fully-qualified name.
- `mvnw -o test -pl core -Dtest=CrosstabSortByValueAliasedAggregateNameTest,CrosstabSortByValueEntityQualifiedNameTest` → `Tests run: 4, Failures: 0, Errors: 0`
- `mvnw -o test -pl core -Dtest="inetsoft.report.composition.execution.*Test"` (whole package) → `Tests run: 70, Failures: 0, Errors: 0`, no regressions

Local tests pass (4/4 targeted + 70/70 package); live visual confirmation against the deployed container is in progress separately and will be added as a PR comment once done.

## Test plan

- [x] Targeted regression tests pass locally
- [x] Full `execution` package test suite passes locally (no regressions)
- [ ] Live visual confirmation against deployed stack (crosstab rows sort by `Count(ORDER_ID)` desc rather than chronologically) — in progress, will follow up as a PR comment