### PR TITLE
L6 follow-ups: missing i18n key + named-group discovery for chart/crosstab/table

### DIFF
--- a/core/src/main/java/inetsoft/web/binding/controller/VSTableLayoutService.java
+++ b/core/src/main/java/inetsoft/web/binding/controller/VSTableLayoutService.java
@@ -316,13 +316,17 @@ public class VSTableLayoutService {
    public Void getNamedGroup(@ClusterProxyKey String id, GetPredefinedNamedGroupEvent event,
                              Principal principal, CommandDispatcher dispatcher) throws Exception
    {
-      if(!quickCheckForCalc(id, event.getName(), principal)) {
-         return null;
-      }
-
       String name = event.getName();
       ViewsheetService engine = viewsheetService;
       RuntimeViewsheet rvs = engine.getViewsheet(id, principal);
+
+      // Unlike the calc-cell operations above, a predefined named group is a property of the
+      // assembly's bound source/column, not of calc-table cells -- any DataVSAssembly (chart,
+      // crosstab, table, calc table) resolves one the same way.
+      if(!(rvs.getViewsheet().getAssembly(name) instanceof DataVSAssembly)) {
+         return null;
+      }
+
       AssetNamedGroupInfo[] infos = getPredefinedNamedGroup(rvs, name, event.getColumn());
 
       if(infos == null) {
@@ -531,11 +535,15 @@ public class VSTableLayoutService {
    private AssetNamedGroupInfo[] getPredefinedNamedGroup(RuntimeViewsheet rvs,
                                                          String name, String colName) throws Exception
    {
-      CalcTableVSAssembly assembly = getCalcTableVSAssembly(rvs, name);
-      CalcTableVSAssemblyInfo info = (CalcTableVSAssemblyInfo) assembly.getInfo();
-      SourceInfo sinfo = info.getSourceInfo();
+      VSAssembly assembly = rvs.getViewsheet().getAssembly(name);
 
-      if(info == null || sinfo == null) {
+      if(!(assembly instanceof DataVSAssembly dataAssembly)) {
+         return null;
+      }
+
+      SourceInfo sinfo = dataAssembly.getSourceInfo();
+
+      if(sinfo == null) {
          return null;
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/binding/CalcTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/CalcTableService.java
@@ -30,6 +30,7 @@ import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.util.XNamedGroupInfo;
 import inetsoft.uql.viewsheet.CalcTableVSAssembly;
+import inetsoft.uql.viewsheet.DataVSAssembly;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.uql.viewsheet.internal.CalcTableVSAssemblyInfo;
@@ -194,6 +195,10 @@ public class CalcTableService {
    /**
     * The predefined named groups a column offers, for a cell's {@code namedGroup}.
     *
+    * <p>Works for any {@code DataVSAssembly} -- chart, crosstab, table, or calc table -- not
+    * just calc tables. Named groups are a property of the assembly's bound source/column, so
+    * discovery isn't limited to the assembly kind that happens to consume them by cell.
+    *
     * <p>Same command-dispatch shape as {@link #cellScript}: {@code getNamedGroup} answers by
     * dispatching a {@code GetPredefinedNamedGroupCommand}.
     */
@@ -208,7 +213,7 @@ public class CalcTableService {
       }
 
       return sessions.read(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
-         CalcTableVSAssembly assembly = requireCalcTable(rvs, assemblyName);
+         DataVSAssembly assembly = requireDataAssembly(rvs, assemblyName);
 
          // The command carries the group NAMES only — its constructor takes
          // AssetNamedGroupInfo[] but keeps just getName() from each. The members are not on
@@ -316,16 +321,17 @@ public class CalcTableService {
 
    /**
     * The worksheet-local {@code DefaultNamedGroupAssembly}(s) {@code add_named_group} created
-    * on this column, attached to the calc table's own source -- a different kind from the
+    * on this column, attached to the assembly's own source -- a different kind from the
     * repository-registered "predefined named group" assets {@link #predefinedNamedGroupNames}
-    * sees.
+    * sees. Takes any {@code DataVSAssembly} (chart, crosstab, table, calc table), not just a
+    * calc table -- named groups are a property of the bound source/column, not of calc cells.
     */
    private List<DefaultNamedGroupAssembly> worksheetNamedGroups(RuntimeViewsheet rvs,
-                                                                CalcTableVSAssembly assembly,
+                                                                DataVSAssembly assembly,
                                                                 String column)
    {
       List<DefaultNamedGroupAssembly> matches = new ArrayList<>();
-      SourceInfo sinfo = ((CalcTableVSAssemblyInfo) assembly.getInfo()).getSourceInfo();
+      SourceInfo sinfo = assembly.getSourceInfo();
       Worksheet ws = rvs.getViewsheet() == null ? null : rvs.getViewsheet().getBaseWorksheet();
 
       if(sinfo == null || sinfo.getSource() == null || ws == null) {
@@ -715,6 +721,23 @@ public class CalcTableService {
             layout.getRowCount() + " row(s) by " + layout.getColCount() + " column(s). " +
             "Coordinates read before a layout change are stale — re-read the layout.");
       }
+   }
+
+   private static DataVSAssembly requireDataAssembly(RuntimeViewsheet rvs, String assemblyName) {
+      Viewsheet vs = rvs == null ? null : rvs.getViewsheet();
+      VSAssembly assembly = vs == null ? null : vs.getAssembly(assemblyName);
+
+      if(assembly == null) {
+         throw new IllegalArgumentException("Unknown assembly '" + assemblyName + "'.");
+      }
+
+      if(!(assembly instanceof DataVSAssembly data)) {
+         throw new IllegalArgumentException(
+            "'" + assemblyName + "' is a " + assembly.getClass().getSimpleName() +
+            ", which has no bound source/column to look up named groups on.");
+      }
+
+      return data;
    }
 
    private static CalcTableVSAssembly requireCalcTable(RuntimeViewsheet rvs,

--- a/core/src/main/resources/inetsoft/util/srinter.properties
+++ b/core/src/main/resources/inetsoft/util/srinter.properties
@@ -3613,6 +3613,7 @@ composer.vs.datasource.convertToWorksheet.prompt=A Data Worksheet will be create
 composer.vs.dragData=Drag in a data field from the Data Source folder
 composer.vs.dragVisual=Drag in a component from the Toolbox folder
 compose.vs.entry.contains.caret=Data source cannot contain special character ^
+composer.vs.group.namedGroupNotSupported=Named groups are not supported for this column type.
 composer.vs.options.refreshIntervalValid=The refresh interval must be between 1 and 86400.
 composer.vs.options.snapGrid=Snap grid must be an integer greater than 0 and multiple of 5.
 composer.vs.parameters=When opening a Dashboard, enabled parameters will be ordered according to their position in the list

--- a/core/src/test/java/inetsoft/web/composer/vs/objects/controller/ComposerGroupColumnsServiceTest.java
+++ b/core/src/test/java/inetsoft/web/composer/vs/objects/controller/ComposerGroupColumnsServiceTest.java
@@ -100,5 +100,8 @@ class ComposerGroupColumnsServiceTest {
       Exception thrown = assertThrows(MessageException.class,
          () -> service.group("runtime1", groupEvent(), "/", null, null));
       assertNotNull(thrown.getMessage());
+      // The message must resolve to real prose from the catalog, not fall back to the raw
+      // resource key (which happens silently when a key has no entry in srinter.properties).
+      assertNotEquals("composer.vs.group.namedGroupNotSupported", thrown.getMessage());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/binding/CalcTableServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/CalcTableServiceTest.java
@@ -336,6 +336,10 @@ class CalcTableServiceTest {
       when(layout.getColCount()).thenReturn(cols);
       when(info.getTableLayout()).thenReturn(layout);
       when(assembly.getInfo()).thenReturn(info);
+      // Real DataVSAssembly#getSourceInfo() delegates to getInfo().getSourceInfo() -- keep this
+      // mock consistent with that so stubbing info.getSourceInfo() (as the named-group tests do)
+      // is reflected on the generalized assembly.getSourceInfo() path too.
+      when(assembly.getSourceInfo()).thenAnswer(invocation -> info.getSourceInfo());
       return harnessFor(assembly, info, rows, cols);
    }
 
@@ -470,6 +474,64 @@ class CalcTableServiceTest {
       when(h.viewsheet().getBaseWorksheet()).thenReturn(ws);
 
       Map<String, Object> read = h.service.namedGroups("tok", principal(), "Calc1", "REGION");
+
+      @SuppressWarnings("unchecked")
+      List<String> groups = (List<String>) read.get("namedGroups");
+      assertTrue(groups.contains("Regions"), "expected worksheet-local group in: " + groups);
+   }
+
+   /**
+    * Fix: {@code namedGroups()} previously required a {@code CalcTableVSAssembly}
+    * ({@code requireCalcTable} rejected anything else, pointing the caller at
+    * get_table_binding/get_binding -- which report current bindings, not the catalog of
+    * available named groups). Named groups are a property of the assembly's bound
+    * source/column, so a chart/crosstab/table dimension must be discoverable the same way.
+    */
+   @Test
+   void namedGroupsWorksForANonCalcDataAssemblyLikeACrosstab() throws Exception {
+      Harness h = harnessFor(mock(CrosstabVSAssembly.class), 0, 0);
+      GetPredefinedNamedGroupCommand command = new GetPredefinedNamedGroupCommand(
+         new AssetNamedGroupInfo[0]);
+      command.setNamedGroups(new String[]{ "Regions" });
+      doAnswer(invocation -> {
+         CommandDispatcher dispatcher = invocation.getArgument(3);
+         dispatcher.sendCommand("Crosstab1", command);
+         return null;
+      }).when(h.layoutService).getNamedGroup(anyString(),
+                                             any(GetPredefinedNamedGroupEvent.class),
+                                             any(Principal.class), any());
+
+      Map<String, Object> read =
+         h.service.namedGroups("tok", principal(), "Crosstab1", "REGION");
+
+      assertEquals(List.of("Regions"), read.get("namedGroups"));
+   }
+
+   /**
+    * Same generalization for the worksheet-local ({@code add_named_group}) discovery path,
+    * which now resolves the assembly's {@code SourceInfo} directly via
+    * {@code DataVSAssembly#getSourceInfo()} rather than casting to
+    * {@code CalcTableVSAssemblyInfo}.
+    */
+   @Test
+   void namedGroupsIncludesWorksheetLocalGroupsForANonCalcDataAssembly() throws Exception {
+      CrosstabVSAssembly assembly = mock(CrosstabVSAssembly.class);
+      when(assembly.getSourceInfo()).thenReturn(new SourceInfo(SourceInfo.ASSET, null, "Query1"));
+      Harness h = harnessFor(assembly, 0, 0);
+
+      DefaultNamedGroupAssembly ngAssembly = mock(DefaultNamedGroupAssembly.class);
+      when(ngAssembly.getName()).thenReturn("Regions");
+      when(ngAssembly.getAttachedType()).thenReturn(AttachedAssembly.COLUMN_ATTACHED);
+      when(ngAssembly.getAttachedSource())
+         .thenReturn(new SourceInfo(SourceInfo.ASSET, null, "Query1"));
+      when(ngAssembly.getAttachedAttribute()).thenReturn(new AttributeRef(null, "REGION"));
+
+      Worksheet ws = mock(Worksheet.class);
+      when(ws.getAssemblies()).thenReturn(new Assembly[]{ ngAssembly });
+      when(h.viewsheet().getBaseWorksheet()).thenReturn(ws);
+
+      Map<String, Object> read =
+         h.service.namedGroups("tok", principal(), "Crosstab1", "REGION");
 
       @SuppressWarnings("unchecked")
       List<String> groups = (List<String>) read.get("namedGroups");


### PR DESCRIPTION
## Summary

Two small follow-ups from a debugger audit of #4731 (chart/table named-group binding
redesign).

**1. Missing i18n key.** `ComposerGroupColumnsService.group()` throws a `MessageException`
keyed by `composer.vs.group.namedGroupNotSupported` (the loud refusal to regroup-by-literal-
value a dimension already bound to an Expert/Asset named group -- the fix #4731 added).
`srinter.properties` had no entry for that key. `Catalog.getString0()` silently falls back to
the raw key string when a key is missing, so the user-facing message was the literal id
instead of English prose. Added the key.

**2. `list_named_groups` had no discovery path outside calc tables.**
`CalcTableService.namedGroups()` -- the backend behind the `list_named_groups` MCP tool -- was
hard-gated to `CalcTableVSAssembly` via `requireCalcTable`, which throws for anything else and
points the caller at `get_table_binding`/`get_binding` instead. Those report *current*
bindings, not the *catalog* of available named groups, so there was no way to discover what
named groups exist for a chart/crosstab/table dimension at all -- even though #4731 already
lets those dimensions *consume* a named group by name (`FieldRefFactory.resolveNamedGroupInfo`).

Named groups are a property of the assembly's bound source/column, not of calc-table cells, so:
- `CalcTableService.namedGroups()` now resolves via a new `requireDataAssembly` (any
  `DataVSAssembly`) instead of `requireCalcTable`, and its private `worksheetNamedGroups()`
  helper reads `SourceInfo` straight off the assembly (`DataVSAssembly#getSourceInfo()`) rather
  than casting to `CalcTableVSAssemblyInfo` -- mirroring the same generalization
  `FieldRefFactory.resolveNamedGroupInfo`/`worksheetNamedGroups` already does for the write
  path.
- `VSTableLayoutService.getNamedGroup`/`getPredefinedNamedGroup` (which `namedGroups()`
  dispatches to for the repository-registered "predefined named group" half of the lookup) had
  the same `CalcTableVSAssembly`-only gate (`quickCheckForCalc`, a cast to
  `CalcTableVSAssemblyInfo`) and are generalized the same way. The other calc-cell-specific
  handlers in that service (layout/cell read-write, copy/cut) are untouched -- they are
  genuinely calc-table-only operations.

The endpoint these dispatch through (`GET .../calc/named-groups`) and the `list_named_groups`
MCP tool that calls it were already assembly-name-agnostic (no calc-specific routing), so this
generalization is reachable immediately, not dead code. A companion PR
(inetsoft-technology/stylebi-wiz#1760) updates that tool's stale "the calc table's name"
docs/error messages to match.

## Test plan
- [x] `./mvnw -o test -pl core -Dtest=ComposerGroupColumnsServiceTest` -- strengthened the
      existing test to assert the thrown message is real prose, not the raw key; passes
- [x] `./mvnw -o test -pl core -Dtest=CalcTableServiceTest` -- 39 tests pass, including two new
      regression tests: `namedGroupsWorksForANonCalcDataAssemblyLikeACrosstab` and
      `namedGroupsIncludesWorksheetLocalGroupsForANonCalcDataAssembly`
- [x] Broader regression pass: `./mvnw -o test -pl core -Dtest='inetsoft.web.wiz.binding.**,inetsoft.web.binding.**,inetsoft.web.composer.vs.objects.controller.**'` -- 357 tests pass
- [x] Full `core` module test suite (`./mvnw -o test -pl core`) -- 7000 tests, 1 failure + 3
      errors, all in unrelated packages (`JavaScriptEngineTest`, `ImageVSAScriptableTest`,
      `ViewsheetScopeTest` -- image loading over a URL, no network in this sandbox;
      `OrganizationContextHolderThreadingTest` -- a pre-existing Spring-context-shutdown timing
      flake). None touch the files this PR changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)