### PR TITLE
Read and write a chart type at the level multiStyles decides

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
@@ -20,6 +20,7 @@ package inetsoft.web.wiz.binding;
 import inetsoft.uql.XPrincipal;
 import inetsoft.sree.security.IdentityID;
 import inetsoft.web.wiz.binding.model.AssemblyBinding;
+import inetsoft.web.wiz.binding.model.ChartTypeState;
 import inetsoft.web.wiz.binding.model.BindableTable;
 import inetsoft.web.wiz.binding.model.FieldRef;
 import inetsoft.web.wiz.pairing.*;
@@ -127,7 +128,7 @@ public class BindingAgentController {
    public record ShelfRequest(String assembly, String shelf, List<FieldRef> fields,
                               String table) {}
    public record ChartTypeRequest(String assembly, Integer type, Boolean multi,
-                                  Boolean stackMeasures, Boolean separate) {}
+                                  Boolean stackMeasures, Boolean separate, String field) {}
    public record SwapRequest(String assembly) {}
    public record SeparateStatusRequest(String assembly, Boolean separate) {}
 
@@ -180,6 +181,16 @@ public class BindingAgentController {
                                   request.field(), source, linkUri);
    }
 
+   @GetMapping("/api/wiz/v1/agent/binding/{sessionToken}/chart/type")
+   public ChartTypeState chartType(@PathVariable String sessionToken,
+                                   @RequestParam String assembly,
+                                   Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      return chartService.readChartType(sessionToken, user, assembly);
+   }
+
    @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/chart/type")
    public void setChartType(@PathVariable String sessionToken,
                             @RequestBody ChartTypeRequest request,
@@ -196,7 +207,7 @@ public class BindingAgentController {
 
       chartService.setChartType(sessionToken, user, request.assembly(), request.type(),
                                 request.multi(), request.stackMeasures(), request.separate(),
-                                linkUri);
+                                request.field(), linkUri);
    }
 
    @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/chart/swap-axes")

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingReadService.java
@@ -133,13 +133,29 @@ public class BindingReadService {
             FieldRef ref = FieldRefFactory.from(model);
 
             refs.add(withChartType && model instanceof ChartAestheticModel aesthetic
-                        ? new FieldRef(ref.column(), ref.type(), ref.aggregate(), ref.dateLevel(),
-                                       ref.namedGroup(), aesthetic.getChartType())
+                        ? withTypes(ref, aesthetic)
                         : ref);
          }
       }
 
       return refs;
+   }
+
+   /**
+    * Copies a measure's own chart type onto its ref, plus the runtime type when it differs.
+    *
+    * <p>Divergence-only, matching {@code ChartTypeState}: reported every time it would be noise,
+    * reported never and a measure left at {@code auto} would answer {@code auto} while drawing
+    * something else. The runtime value is the one that survives here — the assembly-level runtime
+    * type is maintained only on the separated branch of
+    * {@code AbstractChartInfo.updateChartType}, and merged is the multi-style case.
+    */
+   private static FieldRef withTypes(FieldRef ref, ChartAestheticModel aesthetic) {
+      int stored = aesthetic.getChartType();
+      int runtime = aesthetic.getRTChartType();
+
+      return new FieldRef(ref.column(), ref.type(), ref.aggregate(), ref.dateLevel(),
+                          ref.namedGroup(), stored, runtime == stored ? null : runtime);
    }
 
    private final VSBindingService binding;

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingReadService.java
@@ -24,6 +24,8 @@ import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.binding.drm.DataRefModel;
 import inetsoft.web.binding.model.BindingModel;
 import inetsoft.web.binding.model.ChartBindingModel;
+import inetsoft.web.binding.model.graph.ChartAestheticModel;
+import inetsoft.web.binding.model.graph.ChartRefModel;
 import inetsoft.web.binding.model.table.CrosstabBindingModel;
 import inetsoft.web.binding.model.table.TableBindingModel;
 import inetsoft.web.binding.service.VSBindingService;
@@ -70,9 +72,36 @@ public class BindingReadService {
       Map<String, List<FieldRef>> shelves = new LinkedHashMap<>();
 
       if(model instanceof ChartBindingModel chart) {
-         shelves.put("x", refs(chart.getXFields()));
-         shelves.put("y", refs(chart.getYFields()));
+         // Under Multi Style each measure renders with its own type, so x and y carry it per field.
+         // Gated on three things, not one: the shelf, because ChangeChartTypeProcessor's per-ref
+         // write searches getXFieldCount()/getYFieldCount() and nothing else, so an aggregate on
+         // `group` or on a single-field shelf has no such setting however willingly the model
+         // answers for it; the ref being a measure, since ChartDimensionRefModel has no chart type
+         // at all; and multi-style being on, because otherwise the value is inert and reporting it
+         // would describe something that cannot render — the shape of this lane's inert-frame
+         // finding.
+         boolean perField = chart.isMultiStyles();
+
+         shelves.put("x", refs(chart.getXFields(), perField));
+         shelves.put("y", refs(chart.getYFields(), perField));
          shelves.put("group", refs(chart.getGroupFields()));
+
+         // The ten single-field shelves. Left out of this read until now, so a
+         // set_chart_single_shelf write could not be read back at all: four OHLC shelves bound and
+         // visibly rendering while this reported x/y/group and nothing else.
+         //
+         // Reported only where something is bound, unlike x/y/group above. Those three are
+         // present-and-empty because they are meaningful on every chart; these ten are not, and
+         // listing `milestone` on a pie chart would advertise a shelf that chart cannot use — the
+         // same fabricated-capability shape as the phantom Dimensions column in
+         // BindableFieldsService.isColumn and the phantom y2 axis in ChartRegionResolver.
+         for(String shelf : ChartBindingMutator.SINGLE_SHELVES) {
+            ChartRefModel ref = ChartBindingMutator.readSingleShelf(chart, shelf);
+
+            if(ref != null) {
+               shelves.put(shelf, refs(List.of(ref)));
+            }
+         }
       }
       else if(model instanceof CrosstabBindingModel crosstab) {
          shelves.put("rows", refs(crosstab.getRows()));
@@ -93,11 +122,20 @@ public class BindingReadService {
    }
 
    private static List<FieldRef> refs(List<? extends DataRefModel> models) {
+      return refs(models, false);
+   }
+
+   private static List<FieldRef> refs(List<? extends DataRefModel> models, boolean withChartType) {
       List<FieldRef> refs = new ArrayList<>();
 
       if(models != null) {
          for(DataRefModel model : models) {
-            refs.add(FieldRefFactory.from(model));
+            FieldRef ref = FieldRefFactory.from(model);
+
+            refs.add(withChartType && model instanceof ChartAestheticModel aesthetic
+                        ? new FieldRef(ref.column(), ref.type(), ref.aggregate(), ref.dateLevel(),
+                                       ref.namedGroup(), aesthetic.getChartType())
+                        : ref);
          }
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingReadService.java
@@ -21,6 +21,7 @@ import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.viewsheet.CalcTableVSAssembly;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.graph.GraphTypes;
 import inetsoft.web.binding.drm.DataRefModel;
 import inetsoft.web.binding.model.BindingModel;
 import inetsoft.web.binding.model.ChartBindingModel;
@@ -142,20 +143,36 @@ public class BindingReadService {
    }
 
    /**
-    * Copies a measure's own chart type onto its ref, plus the runtime type when it differs.
+    * Copies a measure's own chart type onto its ref, plus the runtime type where that says
+    * something the stored one does not.
     *
-    * <p>Divergence-only, matching {@code ChartTypeState}: reported every time it would be noise,
-    * reported never and a measure left at {@code auto} would answer {@code auto} while drawing
-    * something else. The runtime value is the one that survives here — the assembly-level runtime
-    * type is maintained only on the separated branch of
-    * {@code AbstractChartInfo.updateChartType}, and merged is the multi-style case.
+    * <p>Divergence-only, matching {@code ChartTypeState}: reported on every field it would be
+    * noise, reported never and a measure left at {@code auto} would answer {@code auto} while
+    * drawing something else. These are the runtime types that survive where it matters —
+    * {@code AbstractChartInfo.updateChartType} maintains the assembly-level value only while
+    * multi-style is <em>off</em> and delegates to {@code updateFieldChartTypes} while it is on, so
+    * the per-measure ones are available exactly when per-measure types are what render. Its
+    * parameter is named {@code separated} and its javadoc describes it backwards; the call sites
+    * are what settle it, and {@link inetsoft.web.wiz.binding.model.ChartTypeState} records them so
+    * this does not have to be re-derived twice.
+    *
+    * <p>{@code CHART_AUTO} is withheld for the reason it is withheld at the assembly level: a
+    * render resolves to something concrete, so {@code auto} in the runtime slot is the unset
+    * default rather than an answer. It has to be excluded <em>here</em> as well, because
+    * {@code updateFieldChartTypes} does not reach every measure — it runs only when the last x or y
+    * field is a measure, walks only the trailing run of aggregates on that shelf (it {@code break}s
+    * at the first non-aggregate), and {@code updateChartType} returns early altogether when no
+    * runtime x/y fields are populated. A measure missed by any of those keeps {@code 0}, and
+    * reporting that against a stored {@code bar} would announce a render as {@code auto} that never
+    * happened — the stale-read shape this pair of records exists to close, one level down.
     */
    private static FieldRef withTypes(FieldRef ref, ChartAestheticModel aesthetic) {
       int stored = aesthetic.getChartType();
       int runtime = aesthetic.getRTChartType();
+      boolean resolved = runtime != stored && runtime != GraphTypes.CHART_AUTO;
 
       return new FieldRef(ref.column(), ref.type(), ref.aggregate(), ref.dateLevel(),
-                          ref.namedGroup(), stored, runtime == stored ? null : runtime);
+                          ref.namedGroup(), stored, resolved ? runtime : null);
    }
 
    private final VSBindingService binding;

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingReadService.java
@@ -165,6 +165,13 @@ public class BindingReadService {
     * runtime x/y fields are populated. A measure missed by any of those keeps {@code 0}, and
     * reporting that against a stored {@code bar} would announce a render as {@code auto} that never
     * happened — the stale-read shape this pair of records exists to close, one level down.
+    *
+    * <p>Nor is there a second source to fall back on, though the model-building code looks like
+    * there is: {@code ChartAestheticService.loadVisualFrames} sets the runtime type from
+    * {@code bindable.getRTChartType()} and then overrides it from {@code getAggregateRtType}, which
+    * returns an empty map unless the chart has an applied date comparison. Outside that case the
+    * design-time ref is the only maintainer of this value, so the guard above carries the whole
+    * weight rather than backing up a second opinion.
     */
    private static FieldRef withTypes(FieldRef ref, ChartAestheticModel aesthetic) {
       int stored = aesthetic.getChartType();

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingService.java
@@ -21,7 +21,11 @@ import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.viewsheet.ChartVSAssembly;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.graph.ChartAggregateRef;
+import inetsoft.uql.viewsheet.graph.ChartDescriptor;
+import inetsoft.uql.viewsheet.graph.ChartRef;
 import inetsoft.uql.viewsheet.graph.GraphTypes;
+import inetsoft.uql.viewsheet.graph.PlotDescriptor;
 import inetsoft.uql.viewsheet.graph.VSChartInfo;
 import inetsoft.web.binding.controller.ChangeChartRefService;
 import inetsoft.web.binding.controller.ChangeChartTypeService;
@@ -33,6 +37,8 @@ import inetsoft.web.binding.event.ChangeSeparateStatusEvent;
 import inetsoft.web.binding.model.ChartBindingModel;
 import inetsoft.web.binding.model.graph.ChartRefModel;
 import inetsoft.web.binding.service.VSBindingService;
+import inetsoft.web.viewsheet.service.CommandDispatcher;
+import inetsoft.web.wiz.binding.model.ChartTypeState;
 import inetsoft.web.wiz.binding.model.FieldRef;
 import inetsoft.web.wiz.viewsheet.ViewsheetSessionService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -240,20 +246,94 @@ public class ChartBindingService {
    }
 
    public void setChartType(String sessionToken, Principal user, String assemblyName, int type,
-                            Boolean multi, Boolean stackMeasures, Boolean separate,
+                            Boolean multi, Boolean stackMeasures, Boolean separate, String field,
                             String linkUri) throws Exception
    {
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
-         requireChart(rvs, assemblyName);
+         ChartVSAssembly chart = requireChart(rvs, assemblyName);
+         String ref = requireTypeableField(chart, assemblyName, field);
 
          ChangeChartTypeEvent event = new ChangeChartTypeEvent();
          event.setName(assemblyName);
          event.setType(type);
-         event.setMulti(Boolean.TRUE.equals(multi));
-         event.setStackMeasures(Boolean.TRUE.equals(stackMeasures));
-         event.setSeparate(!Boolean.FALSE.equals(separate));
+         event.setRef(ref);
+         // An omitted flag means "leave it alone", and the event has no way to say that: it carries
+         // three primitive booleans, and the obvious coercions -- TRUE.equals(null) for multi and
+         // stackMeasures, !FALSE.equals(null) for separate -- turn "unstated" into a concrete value
+         // the shared service then applies. Confirmed live on stackMeasures: a chart with it on,
+         // retyped once without mentioning it, read back with it off. So send what the chart
+         // already has, which leaves the shared service comparing a value to itself.
+         //
+         // multi has the same hole and escapes it only by accident, since its coerced value travels
+         // through the WebSocket path that drops it silently -- repairing that path would otherwise
+         // turn every plain retype into a multi-style teardown.
+         event.setMulti(multi == null ? isMultiStyles(chart) : multi);
+         event.setStackMeasures(
+            stackMeasures == null ? isStackMeasures(chart) : stackMeasures);
+         event.setSeparate(separate == null ? isSeparatedGraph(chart) : separate);
          typeService.changeChartType(runtimeId, event, user, dispatcher, linkUri);
+
+         applyMultiStyle(rvs, runtimeId, assemblyName, multi, separate, user, dispatcher, linkUri);
       });
+   }
+
+   /**
+    * Applies the requested multi-style state, which the chart-type change itself cannot.
+    *
+    * <p>{@code ChangeChartTypeService.handleMulti} is the only code that turns multiStyles on, and
+    * it routes through {@code ChangeSeparateStatusController} — a
+    * {@code @MessageMapping("/vs/chart/changeSeparateStatus")} handler that takes its runtime id
+    * from {@code runtimeViewsheetRef}, described in its own constructor as the runtime "associated
+    * with the WebSocket session", and returns silently when that id is null. An agent call is plain
+    * HTTP with a pairing token and has no such session, so {@code multi} was accepted, reported ok,
+    * and dropped — on every call, including the one case the shared path would otherwise have
+    * handled. It is also reached only when the type is unchanged, so asking for a new type and
+    * multi-style together lost the multi half twice over.
+    *
+    * <p>Repaired here rather than there. The shared path has no test coverage, and the defect is an
+    * absent WebSocket context rather than wrong logic, so no test at that layer would have caught
+    * it; meanwhile {@code setSeparateStatus} in this same class already makes exactly this call
+    * correctly, with the runtime id this method holds. Fixing the shared method is still worth
+    * doing for whatever calls it next — it is a trap for any non-WebSocket caller — but that is a
+    * change to Composer code with its own risk, not part of closing this gap for the agent.
+    *
+    * <p>The chart's info is re-read after the type change rather than captured before it, because
+    * {@code ChangeChartTypeService} replaces {@code VSChartInfo} outright for some transitions.
+    */
+   private void applyMultiStyle(RuntimeViewsheet rvs, String runtimeId, String assemblyName,
+                                Boolean multi, Boolean separate, Principal user,
+                                CommandDispatcher dispatcher, String linkUri) throws Exception
+   {
+      // An omitted multi is "not asked about", not "off" — the shared event builder coerces it to
+      // false, which is why a plain retype cannot leave the flag alone.
+      if(multi == null) {
+         return;
+      }
+
+      VSChartInfo info = requireChart(rvs, assemblyName).getVSChartInfo();
+
+      // Nothing to change, nothing to call. This is a second write with its own undo step, so
+      // firing it on a state that already matches would put a no-op into the Composer's history
+      // for every retype.
+      if(info == null || info.isMultiStyles() == multi) {
+         return;
+      }
+
+      // Separated travels with multi through this service — it sets both — so an unstated separate
+      // preserves what the chart has rather than pushing it either way.
+      boolean separated = separate == null ? info.isSeparatedGraph() : separate;
+      String forcedTypeName = separated ? null : forcedSeparateTypeName(info.getChartType());
+
+      if(forcedTypeName != null) {
+         throw new IllegalArgumentException(
+            "'" + assemblyName + "' is a " + forcedTypeName + " chart, which cannot be merged — " +
+            "StyleBI always renders it as separated graphs regardless of this setting. Call with " +
+            "separate: true, or leave it unset.");
+      }
+
+      ChangeSeparateStatusEvent event =
+         new ChangeSeparateStatusEvent(assemblyName, multi, separated);
+      separateStatusService.changeSeparateStatus(runtimeId, event, user, dispatcher, linkUri);
    }
 
    /**
@@ -339,6 +419,101 @@ public class ChartBindingService {
          event.setName(assemblyName);
          swapService.swapXYBinding(runtimeId, event, user, dispatcher, linkUri);
       });
+   }
+
+   /**
+    * Reads a chart's type and the flags that decide what it means, without opening a checkpoint.
+    *
+    * <p>{@code sessions.resolve} rather than {@code sessions.mutate}: a read that went through the
+    * mutating path would drop a no-op step into the user's Composer undo history for every look an
+    * agent takes.
+    */
+   public ChartTypeState readChartType(String sessionToken, Principal user, String assemblyName)
+      throws Exception
+   {
+      RuntimeViewsheet rvs = sessions.resolve(sessionToken, user);
+      ChartVSAssembly chart = requireChart(rvs, assemblyName);
+      ChartBindingModel model = (ChartBindingModel) binding.createModel(chart);
+
+      return new ChartTypeState(assemblyName, model.getChartType(), model.getRTChartType(),
+                                model.isMultiStyles(), model.isSeparated(),
+                                model.isStackMeasures());
+   }
+
+   /**
+    * The named measure, checked against the only two shelves a per-measure type can live on, or
+    * null when the caller asked about the whole chart.
+    *
+    * <p>Both refusals exist because the alternative is a write that reports ok and changes nothing.
+    * {@code ChangeChartTypeProcessor} looks for the ref by scanning {@code getXFieldCount()} and
+    * {@code getYFieldCount()}, and when it matches neither it sets no type at all — it does not fall
+    * back to the assembly, since it is inside the {@code ref != null} branch. So a misspelled
+    * column, or one that sits on {@code group} or a single-field shelf, is silently dropped. And a
+    * per-measure type on a chart that is not multi-style would be stored where nothing renders from
+    * it, which is the inert-write shape this lane already found on the visual frames.
+    */
+   private static String requireTypeableField(ChartVSAssembly chart, String assemblyName,
+                                              String field)
+   {
+      if(field == null || field.isBlank()) {
+         return null;
+      }
+
+      String name = field.trim();
+      VSChartInfo info = chart == null ? null : chart.getVSChartInfo();
+
+      if(info == null || !info.isMultiStyles()) {
+         throw new IllegalArgumentException(
+            "'" + assemblyName + "' is not a multi-style chart, so a per-measure type would be " +
+            "stored and never rendered. Call set_chart_type with multi: true first, then type the " +
+            "field.");
+      }
+
+      List<String> typeable = new ArrayList<>();
+
+      for(int i = 0; i < info.getXFieldCount(); i++) {
+         collectTypeable(info.getXField(i), typeable);
+      }
+
+      for(int i = 0; i < info.getYFieldCount(); i++) {
+         collectTypeable(info.getYField(i), typeable);
+      }
+
+      if(typeable.contains(name)) {
+         return name;
+      }
+
+      throw new IllegalArgumentException(
+         "'" + assemblyName + "' has no measure '" + name + "' on x or y, which are the only " +
+         "shelves a per-measure type applies to. " +
+         (typeable.isEmpty()
+             ? "It has no measures there at all — bind one first."
+             : "Measures that can be typed: " + String.join(", ", typeable) + ".") +
+         " get_binding reports what is bound where.");
+   }
+
+   private static void collectTypeable(ChartRef ref, List<String> names) {
+      if(ref instanceof ChartAggregateRef aggregate && aggregate.getFullName() != null) {
+         names.add(aggregate.getFullName());
+      }
+   }
+
+   private static boolean isMultiStyles(ChartVSAssembly chart) {
+      VSChartInfo info = chart == null ? null : chart.getVSChartInfo();
+      return info != null && info.isMultiStyles();
+   }
+
+   /** Defaults to separated, which is what the event's own null coercion did. */
+   private static boolean isSeparatedGraph(ChartVSAssembly chart) {
+      VSChartInfo info = chart == null ? null : chart.getVSChartInfo();
+      return info == null || info.isSeparatedGraph();
+   }
+
+   /** Lives on the plot descriptor rather than the chart info, unlike the other two flags. */
+   private static boolean isStackMeasures(ChartVSAssembly chart) {
+      ChartDescriptor descriptor = chart == null ? null : chart.getChartDescriptor();
+      PlotDescriptor plot = descriptor == null ? null : descriptor.getPlotDescriptor();
+      return plot != null && plot.isStackMeasures();
    }
 
    private static ChartVSAssembly requireChart(RuntimeViewsheet rvs, String assemblyName) {

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingService.java
@@ -258,6 +258,36 @@ public class ChartBindingService {
          ChartVSAssembly chart = requireChart(rvs, assemblyName);
          String ref = requireTypeableField(chart, assemblyName, field);
 
+         // requireTypeableField reads the chart's *current* multi-style state, so on a multi-style
+         // chart this pair sails through it: the per-measure type lands, then applyMultiStyle turns
+         // off the flag that renders it. Stored where nothing draws from it, reported as success —
+         // the shape that method exists to prevent, arriving through a door it cannot watch.
+         if(ref != null && Boolean.FALSE.equals(multi)) {
+            throw new IllegalArgumentException(
+               "'" + assemblyName + "': a per-measure type and multi: false cancel each other out. " +
+               "Only a multi-style chart renders per-measure types, so this would store one on '" +
+               field + "' and then switch off the mode that draws it. Drop 'field' to retype the " +
+               "whole chart, or drop 'multi' to leave multi-style on.");
+         }
+
+         // Hoisted above the retype, and narrowed to an explicit request. It used to run inside
+         // applyMultiStyle, after changeChartType had already landed, so asking to merge a treemap
+         // returned an error *and* left the chart retyped — a mutation followed by a refusal, which
+         // is the one failure shape this lane has spent its length removing. It needs only the
+         // requested type, so nothing forced it to sit downstream. Gating on FALSE rather than on
+         // the resolved value also stops it refusing a merge the caller never asked for: an omitted
+         // separate means "not asked about", and a forced-separate type is then simply obeyed.
+         if(Boolean.FALSE.equals(separate)) {
+            String forcedTypeName = forcedSeparateTypeName(type);
+
+            if(forcedTypeName != null) {
+               throw new IllegalArgumentException(
+                  "'" + assemblyName + "' is being set to a " + forcedTypeName + " chart, which " +
+                  "cannot be merged — StyleBI always renders it as separated graphs regardless of " +
+                  "this setting. Call with separate: true, or leave it unset.");
+            }
+         }
+
          ChangeChartTypeEvent event = new ChangeChartTypeEvent();
          event.setName(assemblyName);
          event.setType(type);
@@ -326,15 +356,11 @@ public class ChartBindingService {
 
       // Separated travels with multi through this service — it sets both — so an unstated separate
       // preserves what the chart has rather than pushing it either way.
+      //
+      // The forced-separate refusal that used to sit here now runs in setChartType, before the
+      // retype: raising it at this point meant the chart had already been retyped by the time the
+      // caller was told no.
       boolean separated = separate == null ? info.isSeparatedGraph() : separate;
-      String forcedTypeName = separated ? null : forcedSeparateTypeName(info.getChartType());
-
-      if(forcedTypeName != null) {
-         throw new IllegalArgumentException(
-            "'" + assemblyName + "' is a " + forcedTypeName + " chart, which cannot be merged — " +
-            "StyleBI always renders it as separated graphs regardless of this setting. Call with " +
-            "separate: true, or leave it unset.");
-      }
 
       ChangeSeparateStatusEvent event =
          new ChangeSeparateStatusEvent(assemblyName, multi, separated);
@@ -438,9 +464,28 @@ public class ChartBindingService {
    {
       RuntimeViewsheet rvs = sessions.resolve(sessionToken, user);
       ChartVSAssembly chart = requireChart(rvs, assemblyName);
-      ChartBindingModel model = (ChartBindingModel) binding.createModel(chart);
 
-      return new ChartTypeState(assemblyName, model.getChartType(), model.getRTChartType(),
+      // Pattern-matched rather than cast, the way BindingReadService.read does on the same call. A
+      // hard cast would surface a ClassCastException as a 500, where requireChart's own refusal for
+      // a non-chart assembly is a sentence the caller can act on — and losing that message on an
+      // assembly this method already checked would be a strange place to give it up.
+      if(!(binding.createModel(chart) instanceof ChartBindingModel model)) {
+         throw new IllegalArgumentException(
+            "'" + assemblyName + "' did not produce a chart binding, so it has no chart type. " +
+            "get_binding reports what an assembly is bound to.");
+      }
+
+      // Null unless the assembly-level runtime type is maintained: only the separated branch of
+      // AbstractChartInfo.updateChartType sets it, and CHART_AUTO is its unset default rather than
+      // a resolved answer. Reporting it regardless would hand the plugin — which treats a divergence
+      // as proof the renderer chose something else — a stale zero to draw that conclusion from, on
+      // merged charts, which is exactly the multi-style case. FieldRef.runtimeChartType carries the
+      // per-measure runtime type that *is* maintained there.
+      int runtime = model.getRTChartType();
+      Integer reportedRuntime =
+         model.isSeparated() && runtime != GraphTypes.CHART_AUTO ? runtime : null;
+
+      return new ChartTypeState(assemblyName, model.getChartType(), reportedRuntime,
                                 model.isMultiStyles(), model.isSeparated(),
                                 model.isStackMeasures());
    }
@@ -508,7 +553,16 @@ public class ChartBindingService {
       return info != null && info.isMultiStyles();
    }
 
-   /** Defaults to separated, which is what the event's own null coercion did. */
+   /**
+    * Defaults to separated, unlike the two flags either side of it, and deliberately.
+    *
+    * <p>All three answer "what does the chart have now" so that an omitted argument can be sent
+    * back unchanged. When there is no info to ask, the honest fallback is the product default, and
+    * StyleBI's is separated — a fresh chart reads {@code separated: true}. Answering false to match
+    * the other two would flip a default rather than preserve one, which is the opposite of what
+    * these helpers are for. (The null branch is close to unreachable: {@code requireChart} has
+    * already established the assembly is a chart.)
+    */
    private static boolean isSeparatedGraph(ChartVSAssembly chart) {
       VSChartInfo info = chart == null ? null : chart.getVSChartInfo();
       return info == null || info.isSeparatedGraph();

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartBindingService.java
@@ -475,15 +475,28 @@ public class ChartBindingService {
             "get_binding reports what an assembly is bound to.");
       }
 
-      // Null unless the assembly-level runtime type is maintained: only the separated branch of
-      // AbstractChartInfo.updateChartType sets it, and CHART_AUTO is its unset default rather than
-      // a resolved answer. Reporting it regardless would hand the plugin — which treats a divergence
-      // as proof the renderer chose something else — a stale zero to draw that conclusion from, on
-      // merged charts, which is exactly the multi-style case. FieldRef.runtimeChartType carries the
-      // per-measure runtime type that *is* maintained there.
+      // Null unless the assembly-level runtime type is maintained, and multiStyles is what decides
+      // that — not the chart's separated flag, which is an unrelated user-facing setting reported in
+      // the same response.
+      //
+      // AbstractChartInfo.updateChartType's parameter is *named* `separated`, and its javadoc
+      // describes it backwards, but the call sites settle it: 21 of 24 pass
+      // `!info.isMultiStyles()`, and VSChartDataHandler spells it out as
+      // `boolean sep = !info.isMultiStyles()`. So the branch that sets this assembly-level value
+      // runs when multi-style is off, and the branch that updates the per-measure types runs when
+      // it is on — FieldRef.runtimeChartType carries those.
+      //
+      // Gating on isSeparated() was wrong in both directions. A multi-style chart reads
+      // `separated: true` by default, so it reported an assembly-level value the per-measure branch
+      // had left stale — and a stale value is exactly what the `!= CHART_AUTO` guard cannot catch,
+      // since that only rejects never-set. A single-style merged chart went the other way and
+      // withheld a value that was being maintained.
+      //
+      // CHART_AUTO stays excluded: a render resolves to something concrete, so auto here is the
+      // unset default rather than an answer.
       int runtime = model.getRTChartType();
       Integer reportedRuntime =
-         model.isSeparated() && runtime != GraphTypes.CHART_AUTO ? runtime : null;
+         !model.isMultiStyles() && runtime != GraphTypes.CHART_AUTO ? runtime : null;
 
       return new ChartTypeState(assemblyName, model.getChartType(), reportedRuntime,
                                 model.isMultiStyles(), model.isSeparated(),

--- a/core/src/main/java/inetsoft/web/wiz/binding/FieldRefFactory.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/FieldRefFactory.java
@@ -243,5 +243,33 @@ public final class FieldRefFactory {
             String.join(" or ", TYPES) + ", got '" +
             (ref == null ? "null" : String.valueOf(ref.type())) + "'.");
       }
+
+      requireNoInboundChartType(ref);
+   }
+
+   /**
+    * Refuses a field that arrived carrying a chart type.
+    *
+    * <p>The chart read reports one per measure on a multi-style chart, which makes handing one of
+    * its field refs straight back to a write the obvious next move — and no write takes it. Writing
+    * a per-measure type is {@code set_chart_type}'s {@code field} argument.
+    *
+    * <p>Here rather than only in the plugin. The plugin refuses it too, but that is the outermost
+    * tier and the most bypassable one: wiz-services, a script, or any future client reaching
+    * {@code POST chart/shelf} directly would get the silent drop this whole surface is written
+    * against. Placed on {@code requireType} because every inbound ref passes through it — the chart
+    * path through {@code toChartRef}, the table and calc paths on their own — so one check covers
+    * all six writes instead of six checks drifting apart.
+    */
+   private static void requireNoInboundChartType(FieldRef ref) {
+      if(ref.chartType() == null && ref.runtimeChartType() == null) {
+         return;
+      }
+
+      throw new IllegalArgumentException(
+         "Field '" + ref.column() + "' carries a chart type, which no binding write can set — " +
+         "that is set_chart_type's 'field' argument, on a multi-style chart. The chart read " +
+         "reports it, so a ref read from there has to have it removed before it is written back; " +
+         "accepting it here would drop it silently and report success.");
    }
 }

--- a/core/src/main/java/inetsoft/web/wiz/binding/model/AssemblyBinding.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/model/AssemblyBinding.java
@@ -27,6 +27,13 @@ import java.util.Map;
  * {@code cols}, {@code aggregates}; table are {@code groups}, {@code details},
  * {@code aggregates}. Calc tables are not represented here — their binding lives in the cell
  * layout, per spec 2e.
+ *
+ * <p>A chart additionally carries whichever of the ten single-field shelves
+ * ({@code open}, {@code high}, {@code low}, {@code close}, {@code path}, {@code source},
+ * {@code target}, {@code start}, {@code end}, {@code milestone}) hold a field. Those keys are
+ * present only when bound, unlike the three list shelves above which are always present: they are
+ * meaningful on every chart, whereas {@code milestone} on a pie chart is not, and listing it would
+ * advertise a shelf that chart cannot use.
  */
 public record AssemblyBinding(String assembly, String objectType, String source,
                               Map<String, List<FieldRef>> shelves) {}

--- a/core/src/main/java/inetsoft/web/wiz/binding/model/ChartTypeState.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/model/ChartTypeState.java
@@ -36,8 +36,15 @@ package inetsoft.web.wiz.binding.model;
  *
  * <p>{@code runtimeChartType} is reported alongside {@code chartType} rather than instead of it. A
  * read that returns only the stored value is how a caller ends up shown what it wrote while the
- * renderer used something else — {@code ChangeChartTypeProcessor} clears runtime types on a
- * per-ref write for exactly that reason, so the two genuinely diverge.
+ * renderer used something else, and the two do genuinely diverge: {@code updateFieldChartTypes}
+ * derives the runtime type from the stored one through
+ * {@code getRTChartType(ctype, xref, measure, mcount)}, which coerces it — the polar, stacked and
+ * merged rules — so a stored {@code bar} can render as something else without anything having
+ * rewritten it. (Not to be confused with the loop in {@code ChangeChartTypeProcessor.fixChartInfo}
+ * commented "clear rt charttype": that calls {@code setChartType(0)} on the objects in
+ * {@code getRTFields()}, clearing the design-time type on the runtime refs rather than any runtime
+ * type, and this read is built from the design-time fields, so it is not the mechanism at work
+ * here.)
  *
  * <p><b>It is null unless the assembly-level runtime type is actually maintained, and
  * {@code multiStyles} is what decides that.</b> Not {@code separated} — that is an independent
@@ -61,8 +68,15 @@ package inetsoft.web.wiz.binding.model;
  * branch runs and this value is whatever it last held. Since {@code != CHART_AUTO} rejects only
  * never-set, the honest reading of this field is that it describes a render once the chart has
  * produced one; there is no in-band way to ask "has this rendered", and an open, executed viewsheet
- * — which is what an agent session holds — populates those fields. The per-measure types on
- * {@link FieldRef#runtimeChartType()} are bounded the same way, for the same reason.
+ * — which is what an agent session holds — populates those fields.
+ *
+ * <p>The per-measure types on {@link FieldRef#runtimeChartType()} are bounded the same way, and
+ * more tightly than they look. {@code ChartAestheticService.loadVisualFrames} appears to give them
+ * two sources — {@code bindable.getRTChartType()} and an override from
+ * {@code getAggregateRtType} — but that override returns an empty map unless the chart has an
+ * applied date comparison, so outside that case it never fires. The design-time ref's own runtime
+ * type is therefore the single maintainer of the per-measure value, with no fallback behind it,
+ * which is why its own {@code CHART_AUTO} guard is not belt-and-braces either.
  *
  * <p>The types are the raw {@code GraphTypes} codes. Naming them is the plugin's job: the
  * code↔name vocabulary already exists in three copies on this side

--- a/core/src/main/java/inetsoft/web/wiz/binding/model/ChartTypeState.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/model/ChartTypeState.java
@@ -39,17 +39,22 @@ package inetsoft.web.wiz.binding.model;
  * renderer used something else — {@code ChangeChartTypeProcessor} clears runtime types on a
  * per-ref write for exactly that reason, so the two genuinely diverge.
  *
- * <p><b>It is null unless the assembly-level runtime type is actually maintained</b>, which is
- * narrower than it looks. {@code AbstractChartInfo.updateChartType} sets it only on the
- * {@code separated} branch; the merged branch calls {@code updateFieldChartTypes} and leaves the
- * assembly-level value untouched, and the whole method returns early when no x/y refs are
- * populated. So on a merged chart, or one that has not rendered, the field would hold a stale or
- * never-set {@code 0} — and a caller told to read its presence as "the renderer resolved to
- * something else" would read that as an answer. Merged is the multi-style case, so this is the
- * common path rather than a corner; the runtime type that survives there is the per-measure one on
- * {@link FieldRef#runtimeChartType()}. {@code CHART_AUTO} is treated as unresolved for the same
- * reason: a render always resolves to a concrete type, so {@code auto} is the default rather than
- * an answer.
+ * <p><b>It is null unless the assembly-level runtime type is actually maintained, and
+ * {@code multiStyles} is what decides that.</b> Not {@code separated} — that is an independent
+ * user-facing setting this same response reports, and confusing the two is easy because
+ * {@code AbstractChartInfo.updateChartType} names its parameter {@code separated} and documents it
+ * backwards. The call sites are what settle it: 21 of 24 pass {@code !info.isMultiStyles()}, and
+ * {@code VSChartDataHandler} writes it out as {@code boolean sep = !info.isMultiStyles()}. So the
+ * branch that sets this value runs when multi-style is <em>off</em>, and the branch that updates the
+ * per-measure types runs when it is on.
+ *
+ * <p>The rule the caller needs is therefore one sentence, in terms of a field the response already
+ * carries: <b>this value is maintained exactly when {@code appliesTo} is {@code assembly}, and
+ * {@link FieldRef#runtimeChartType()} exactly when it is {@code measure}.</b> Reported outside that
+ * it would be a stale value a caller had been told to read as "the renderer resolved to something
+ * else". {@code CHART_AUTO} is excluded for a different reason — a render resolves to something
+ * concrete, so {@code auto} here is the unset default rather than an answer — and note it catches
+ * only never-set, never stale, which is why the gate above cannot be loosened.
  *
  * <p>The types are the raw {@code GraphTypes} codes. Naming them is the plugin's job: the
  * code↔name vocabulary already exists in three copies on this side

--- a/core/src/main/java/inetsoft/web/wiz/binding/model/ChartTypeState.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/model/ChartTypeState.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding.model;
+
+/**
+ * A chart's type and the three flags that decide what that type means.
+ *
+ * <p>Nothing in the agent surface reported any of this: not the binding read, not the aesthetics
+ * read, not the property tools, and not {@code get_assembly_properties(raw)} — the documented
+ * escape hatch for a property with no short name, whose dialog model carries no chart type at all.
+ * So {@code set_chart_type}'s own advice, to read the binding again afterwards because retyping
+ * changes which shelves are meaningful, could not be acted on.
+ *
+ * <p><b>{@code multiStyles} decides where the authoritative type lives.</b> With it off, the type
+ * is the assembly's — {@code chartType} here. With it on, StyleBI renders each measure with its own
+ * type, held on the {@code x} and {@code y} aggregates and reported by the binding read; the
+ * assembly-level value is then a default rather than what any measure necessarily draws as. The
+ * write side is the same split: {@code ChangeChartTypeEvent.ref} names one aggregate, and
+ * {@code ChangeChartTypeProcessor} sets that ref's type instead of the assembly's — searching x and
+ * y only, which is why a per-measure type exists on those two shelves and nowhere else.
+ *
+ * <p>{@code runtimeChartType} is reported alongside {@code chartType} rather than instead of it. A
+ * read that returns only the stored value is how a caller ends up shown what it wrote while the
+ * renderer used something else — {@code ChangeChartTypeProcessor} clears runtime types on a
+ * per-ref write for exactly that reason, so the two genuinely diverge.
+ *
+ * <p>The types are the raw {@code GraphTypes} codes. Naming them is the plugin's job: the
+ * code↔name vocabulary already exists in three copies on this side
+ * ({@code WizAutoBindingService} twice, {@code WizVsService} once) and a fourth would be one more
+ * to drift, while the plugin already owns the one facing the agent and already echoes names back
+ * from {@code set_chart_type}.
+ *
+ * @param assembly         the chart's name
+ * @param chartType        the assembly-level GraphTypes code
+ * @param runtimeChartType the code the last render resolved to
+ * @param multiStyles      whether each measure carries its own type
+ * @param separated        separated rather than merged graphs
+ * @param stackMeasures    whether measures are stacked
+ */
+public record ChartTypeState(String assembly, int chartType, int runtimeChartType,
+                             boolean multiStyles, boolean separated, boolean stackMeasures) {}

--- a/core/src/main/java/inetsoft/web/wiz/binding/model/ChartTypeState.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/model/ChartTypeState.java
@@ -56,6 +56,14 @@ package inetsoft.web.wiz.binding.model;
  * concrete, so {@code auto} here is the unset default rather than an answer — and note it catches
  * only never-set, never stale, which is why the gate above cannot be loosened.
  *
+ * <p>One residual, recorded rather than papered over: {@code updateChartType} returns early when no
+ * runtime x/y fields are populated, so on a chart that is bound but has not produced data neither
+ * branch runs and this value is whatever it last held. Since {@code != CHART_AUTO} rejects only
+ * never-set, the honest reading of this field is that it describes a render once the chart has
+ * produced one; there is no in-band way to ask "has this rendered", and an open, executed viewsheet
+ * — which is what an agent session holds — populates those fields. The per-measure types on
+ * {@link FieldRef#runtimeChartType()} are bounded the same way, for the same reason.
+ *
  * <p>The types are the raw {@code GraphTypes} codes. Naming them is the plugin's job: the
  * code↔name vocabulary already exists in three copies on this side
  * ({@code WizAutoBindingService} twice, {@code WizVsService} once) and a fourth would be one more

--- a/core/src/main/java/inetsoft/web/wiz/binding/model/ChartTypeState.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/model/ChartTypeState.java
@@ -39,6 +39,18 @@ package inetsoft.web.wiz.binding.model;
  * renderer used something else — {@code ChangeChartTypeProcessor} clears runtime types on a
  * per-ref write for exactly that reason, so the two genuinely diverge.
  *
+ * <p><b>It is null unless the assembly-level runtime type is actually maintained</b>, which is
+ * narrower than it looks. {@code AbstractChartInfo.updateChartType} sets it only on the
+ * {@code separated} branch; the merged branch calls {@code updateFieldChartTypes} and leaves the
+ * assembly-level value untouched, and the whole method returns early when no x/y refs are
+ * populated. So on a merged chart, or one that has not rendered, the field would hold a stale or
+ * never-set {@code 0} — and a caller told to read its presence as "the renderer resolved to
+ * something else" would read that as an answer. Merged is the multi-style case, so this is the
+ * common path rather than a corner; the runtime type that survives there is the per-measure one on
+ * {@link FieldRef#runtimeChartType()}. {@code CHART_AUTO} is treated as unresolved for the same
+ * reason: a render always resolves to a concrete type, so {@code auto} is the default rather than
+ * an answer.
+ *
  * <p>The types are the raw {@code GraphTypes} codes. Naming them is the plugin's job: the
  * code↔name vocabulary already exists in three copies on this side
  * ({@code WizAutoBindingService} twice, {@code WizVsService} once) and a fourth would be one more
@@ -47,10 +59,11 @@ package inetsoft.web.wiz.binding.model;
  *
  * @param assembly         the chart's name
  * @param chartType        the assembly-level GraphTypes code
- * @param runtimeChartType the code the last render resolved to
+ * @param runtimeChartType the code the last render resolved to, or null where the assembly-level
+ *                         value is not maintained
  * @param multiStyles      whether each measure carries its own type
  * @param separated        separated rather than merged graphs
  * @param stackMeasures    whether measures are stacked
  */
-public record ChartTypeState(String assembly, int chartType, int runtimeChartType,
+public record ChartTypeState(String assembly, int chartType, Integer runtimeChartType,
                              boolean multiStyles, boolean separated, boolean stackMeasures) {}

--- a/core/src/main/java/inetsoft/web/wiz/binding/model/FieldRef.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/model/FieldRef.java
@@ -37,11 +37,12 @@ package inetsoft.web.wiz.binding.model;
  * compare by hand. It matters most in the case a design-time-only read serves worst: a measure left
  * at {@code auto} reports {@code auto} forever, while the runtime value is the only thing that says
  * what appeared on screen. Reported per measure rather than left to
- * {@link ChartTypeState#runtimeChartType()} because the two are maintained in opposite branches —
- * {@code AbstractChartInfo.updateChartType} sets the assembly-level runtime type only when the
- * chart is separated, and delegates to {@code updateFieldChartTypes} when it is merged. Merged is
- * the multi-style case, so per-measure is the only runtime type available exactly where
- * per-measure types are what render.
+ * {@link ChartTypeState#runtimeChartType()} because the two are maintained in opposite branches of
+ * {@code AbstractChartInfo.updateChartType}, and <b>{@code multiStyles} is the flag that selects
+ * between them</b> — not the chart's {@code separated} setting, despite that being the name of the
+ * parameter. Its call sites pass {@code !info.isMultiStyles()}. So these per-measure values are
+ * maintained exactly while multi-style is on, which is exactly when they are what renders, and the
+ * assembly-level one is maintained exactly while it is off.
  *
  * @param column           the column name, as it appears in the binding tree
  * @param type             "dimension" or "measure"

--- a/core/src/main/java/inetsoft/web/wiz/binding/model/FieldRef.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/model/FieldRef.java
@@ -25,11 +25,28 @@ package inetsoft.web.wiz.binding.model;
  * A reference without it is exactly the input that gets coerced onto the wrong shelf and
  * renders plausibly wrong, so it is never defaulted.
  *
+ * <p>{@code chartType} is read-only and chart-only. Under Multi Style each measure renders with its
+ * own type, so that type belongs to the bound field rather than to the assembly — and it is
+ * reported only where it can render: on {@code x} and {@code y}, on a measure, and only while the
+ * chart is multi-style. Writing it goes through {@code set_chart_type}'s {@code field} argument,
+ * not through here, so an inbound value on this record is ignored.
+ *
  * @param column     the column name, as it appears in the binding tree
  * @param type       "dimension" or "measure"
  * @param aggregate  aggregate formula, measures only (e.g. "Sum", "Count")
  * @param dateLevel  date grouping level, dimensions only
  * @param namedGroup named-group name, dimensions only
+ * @param chartType  the measure's own GraphTypes code under Multi Style; null everywhere else
  */
 public record FieldRef(String column, String type, String aggregate, String dateLevel,
-                       String namedGroup) {}
+                       String namedGroup, Integer chartType) {
+   /**
+    * Every caller but the chart read builds a ref with no chart type. Kept so that adding the
+    * component did not touch forty-odd construction sites that have nothing to do with charts.
+    */
+   public FieldRef(String column, String type, String aggregate, String dateLevel,
+                   String namedGroup)
+   {
+      this(column, type, aggregate, dateLevel, namedGroup, null);
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/binding/model/FieldRef.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/model/FieldRef.java
@@ -28,25 +28,45 @@ package inetsoft.web.wiz.binding.model;
  * <p>{@code chartType} is read-only and chart-only. Under Multi Style each measure renders with its
  * own type, so that type belongs to the bound field rather than to the assembly — and it is
  * reported only where it can render: on {@code x} and {@code y}, on a measure, and only while the
- * chart is multi-style. Writing it goes through {@code set_chart_type}'s {@code field} argument,
- * not through here, so an inbound value on this record is ignored.
+ * chart is multi-style. Writing it is {@code set_chart_type}'s {@code field} argument, and an
+ * inbound value here is <em>refused</em> rather than ignored — see
+ * {@link inetsoft.web.wiz.binding.FieldRefFactory#requireType}.
  *
- * @param column     the column name, as it appears in the binding tree
- * @param type       "dimension" or "measure"
- * @param aggregate  aggregate formula, measures only (e.g. "Sum", "Count")
- * @param dateLevel  date grouping level, dimensions only
- * @param namedGroup named-group name, dimensions only
- * @param chartType  the measure's own GraphTypes code under Multi Style; null everywhere else
+ * <p>{@code runtimeChartType} is the code that measure actually draws as, and it is present only
+ * when it differs from {@code chartType} — its presence is the signal, so there is nothing to
+ * compare by hand. It matters most in the case a design-time-only read serves worst: a measure left
+ * at {@code auto} reports {@code auto} forever, while the runtime value is the only thing that says
+ * what appeared on screen. Reported per measure rather than left to
+ * {@link ChartTypeState#runtimeChartType()} because the two are maintained in opposite branches —
+ * {@code AbstractChartInfo.updateChartType} sets the assembly-level runtime type only when the
+ * chart is separated, and delegates to {@code updateFieldChartTypes} when it is merged. Merged is
+ * the multi-style case, so per-measure is the only runtime type available exactly where
+ * per-measure types are what render.
+ *
+ * @param column           the column name, as it appears in the binding tree
+ * @param type             "dimension" or "measure"
+ * @param aggregate        aggregate formula, measures only (e.g. "Sum", "Count")
+ * @param dateLevel        date grouping level, dimensions only
+ * @param namedGroup       named-group name, dimensions only
+ * @param chartType        the measure's own GraphTypes code under Multi Style; null everywhere else
+ * @param runtimeChartType what that measure resolved to, when it differs from {@code chartType}
  */
 public record FieldRef(String column, String type, String aggregate, String dateLevel,
-                       String namedGroup, Integer chartType) {
+                       String namedGroup, Integer chartType, Integer runtimeChartType) {
    /**
     * Every caller but the chart read builds a ref with no chart type. Kept so that adding the
-    * component did not touch forty-odd construction sites that have nothing to do with charts.
+    * components did not touch forty-odd construction sites that have nothing to do with charts.
     */
    public FieldRef(String column, String type, String aggregate, String dateLevel,
                    String namedGroup)
    {
-      this(column, type, aggregate, dateLevel, namedGroup, null);
+      this(column, type, aggregate, dateLevel, namedGroup, null, null);
+   }
+
+   /** A chart ref whose design-time type is all the read has to report. */
+   public FieldRef(String column, String type, String aggregate, String dateLevel,
+                   String namedGroup, Integer chartType)
+   {
+      this(column, type, aggregate, dateLevel, namedGroup, chartType, null);
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
@@ -232,7 +232,6 @@ class BindingAgentControllerTest {
       ChartTypeState state =
          new ChartTypeState("Chart1", 1, 5, true, true, false);
       ChartBindingService chartService = mock(ChartBindingService.class);
-      when(chartService.readChartType("tok", null, "Chart1")).thenReturn(state);
       when(chartService.readChartType(eq("tok"), any(), eq("Chart1"))).thenReturn(state);
 
       ChartTypeState read =

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindingAgentControllerTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
+import inetsoft.web.wiz.binding.model.ChartTypeState;
 
 @Tag("core")
 class BindingAgentControllerTest {
@@ -118,6 +119,20 @@ class BindingAgentControllerTest {
                                         mock(CalcTableService.class));
    }
 
+   private static BindingAgentController controllerWith(SheetAgentFeature feature,
+                                                        ChartBindingService chartService)
+   {
+      return new BindingAgentController(feature, mock(SheetJoinService.class),
+                                        mock(SheetSessionService.class),
+                                        mock(ViewsheetSessionService.class),
+                                        mock(BindableFieldsService.class),
+                                        mock(BindingReadService.class),
+                                        chartService,
+                                        mock(ChartAestheticAgentService.class),
+                                        mock(TableBindingService.class),
+                                        mock(CalcTableService.class));
+   }
+
    private static Principal principal() {
       return () -> "admin";
    }
@@ -193,4 +208,36 @@ class BindingAgentControllerTest {
                                          mock(SheetAgentBroadcastService.class));
    }
 
+   // ---------------------------------------------------------------------------
+   // GET chart/type. The mapping itself was untested while both downstream tiers
+   // got route tests, and the read is the half a caller reaches first.
+   // ---------------------------------------------------------------------------
+
+   @Test
+   void chartTypeRefusesWhenTheFeatureIsDisabled() throws Exception {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      when(feature.isEnabled()).thenReturn(false);
+      ChartBindingService chartService = mock(ChartBindingService.class);
+
+      assertThrows(ResponseStatusException.class,
+                   () -> controllerWith(feature, chartService).chartType("tok", "Chart1",
+                                                                        principal()));
+      verifyNoInteractions(chartService);
+   }
+
+   @Test
+   void chartTypeReturnsWhatTheServiceRead() throws Exception {
+      SheetAgentFeature feature = mock(SheetAgentFeature.class);
+      when(feature.isEnabled()).thenReturn(true);
+      ChartTypeState state =
+         new ChartTypeState("Chart1", 1, 5, true, true, false);
+      ChartBindingService chartService = mock(ChartBindingService.class);
+      when(chartService.readChartType("tok", null, "Chart1")).thenReturn(state);
+      when(chartService.readChartType(eq("tok"), any(), eq("Chart1"))).thenReturn(state);
+
+      ChartTypeState read =
+         controllerWith(feature, chartService).chartType("tok", "Chart1", principal());
+
+      assertSame(state, read, "the controller is a passthrough; it must not rebuild the state");
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindingReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindingReadServiceTest.java
@@ -23,10 +23,15 @@ import inetsoft.uql.viewsheet.ChartVSAssembly;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.web.binding.model.ChartBindingModel;
+import inetsoft.web.binding.model.graph.ChartAggregateRefModel;
+import inetsoft.web.binding.model.graph.ChartDimensionRefModel;
 import inetsoft.web.binding.service.VSBindingService;
 import inetsoft.web.wiz.binding.model.AssemblyBinding;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -46,6 +51,161 @@ class BindingReadServiceTest {
       assertTrue(result.shelves().containsKey("x"), "a chart exposes an x shelf");
       assertTrue(result.shelves().containsKey("y"));
       assertTrue(result.shelves().containsKey("group"));
+   }
+
+   /**
+    * The four candlestick shelves were bound and visibly rendering on a live chart while this read
+    * reported {@code {x, y, group}} and none of them, so a write could not be read back at all.
+    * {@link ChartBindingMutator#readSingleShelf} already answers this, and
+    * {@code ChartBindingService.requireNoBoundFields} already loops the whole list to name what a
+    * forced repoint would delete — the read simply never did the same loop.
+    */
+   @Test
+   void readsTheSingleValueShelvesAChartActuallyBinds() {
+      ChartBindingModel model = new ChartBindingModel();
+      model.setOpenField(aggregate("PAID", "Sum"));
+      model.setCloseField(aggregate("DISCOUNT", "Average"));
+
+      VSBindingService binding = mock(VSBindingService.class);
+      when(binding.createModel(any())).thenReturn(model);
+
+      AssemblyBinding result = new BindingReadService(binding)
+         .read(runtimeWith("Chart1", mock(ChartVSAssembly.class)), "Chart1");
+
+      assertTrue(result.shelves().containsKey("open"), "a bound open shelf must be reported");
+      assertEquals("PAID", result.shelves().get("open").get(0).column());
+      assertEquals("Sum", result.shelves().get("open").get(0).aggregate());
+      assertEquals("DISCOUNT", result.shelves().get("close").get(0).column());
+   }
+
+   /**
+    * One shelf from each of the four families, because the live run only exercised the OHLC four
+    * and a fix that special-cased those would have looked identical.
+    */
+   @Test
+   void coversEverySingleShelfFamilyRatherThanJustTheCandlestickFour() {
+      ChartBindingModel model = new ChartBindingModel();
+      model.setPathField(aggregate("ORDER_ID", "Count"));
+      model.setSourceField(aggregate("CUSTOMER_ID", "Count"));
+      model.setStartField(aggregate("QUANTITY", "Min"));
+      model.setMilestoneField(aggregate("PAID", "Max"));
+
+      VSBindingService binding = mock(VSBindingService.class);
+      when(binding.createModel(any())).thenReturn(model);
+
+      AssemblyBinding result = new BindingReadService(binding)
+         .read(runtimeWith("Chart1", mock(ChartVSAssembly.class)), "Chart1");
+
+      for(String shelf : List.of("path", "source", "start", "milestone")) {
+         assertTrue(result.shelves().containsKey(shelf), shelf + " must be reported when bound");
+      }
+   }
+
+   /**
+    * Only the shelves a chart actually binds are reported. Reporting all ten unconditionally would
+    * advertise {@code milestone} on a pie chart — the same fabricated-capability shape as the
+    * phantom {@code Dimensions} column and the phantom {@code y2} axis this plan already recorded.
+    *
+    * <p>Green on arrival: it drove nothing, and exists because the tempting symmetry with x/y/group
+    * — which are present-and-empty precisely because they are always meaningful — is the wrong
+    * precedent to copy here.
+    */
+   @Test
+   void doesNotAdvertiseSingleValueShelvesNothingIsBoundTo() {
+      VSBindingService binding = mock(VSBindingService.class);
+      when(binding.createModel(any())).thenReturn(new ChartBindingModel());
+
+      AssemblyBinding result = new BindingReadService(binding)
+         .read(runtimeWith("Chart1", mock(ChartVSAssembly.class)), "Chart1");
+
+      assertEquals(Set.of("x", "y", "group"), result.shelves().keySet(),
+                   "an unbound chart reports its three list shelves and nothing else");
+   }
+
+   /**
+    * Under Multi Style each measure renders with its own type, so that type is a property of the
+    * bound field rather than of the chart — {@code ChartAggregateRefModel} carries it, from the
+    * {@code ChartAestheticModel} interface, and {@code ChartDimensionRefModel} has no such property
+    * at all. Reported as the raw GraphTypes code; the plugin names it, since that vocabulary
+    * already exists in three copies on this side.
+    */
+   @Test
+   void reportsAPerMeasureChartTypeOnXAndYUnderMultiStyle() {
+      ChartBindingModel model = new ChartBindingModel();
+      model.setMultiStyles(true);
+      model.setXFields(List.of(withChartType(aggregate("PAID", "Sum"), 1)));
+      model.setYFields(List.of(withChartType(aggregate("DISCOUNT", "Sum"), 5)));
+
+      AssemblyBinding result = read(model);
+
+      assertEquals(Integer.valueOf(1), result.shelves().get("x").get(0).chartType());
+      assertEquals(Integer.valueOf(5), result.shelves().get("y").get(0).chartType());
+   }
+
+   /**
+    * With multi-style off the per-field value is inert — the chart draws as one type — so reporting
+    * it would hand back a setting that does not describe what renders. That is the shape of the
+    * inert-frame finding this lane already recorded against set_visual_frame.
+    */
+   @Test
+   void withholdsThePerMeasureTypeWhenTheChartIsNotMultiStyle() {
+      ChartBindingModel model = new ChartBindingModel();
+      model.setMultiStyles(false);
+      model.setXFields(List.of(withChartType(aggregate("PAID", "Sum"), 5)));
+
+      assertNull(read(model).shelves().get("x").get(0).chartType(),
+                 "a per-measure type that cannot render must not be reported");
+   }
+
+   /** A dimension has no chart type in the model, so claiming one would be fabricating it. */
+   @Test
+   void neverClaimsAPerMeasureTypeForADimension() {
+      ChartBindingModel model = new ChartBindingModel();
+      model.setMultiStyles(true);
+      model.setXFields(List.of(new ChartDimensionRefModel()));
+
+      assertNull(read(model).shelves().get("x").get(0).chartType());
+    }
+
+   /**
+    * The write side searches x and y only — {@code ChangeChartTypeProcessor} loops
+    * {@code getXFieldCount()}/{@code getYFieldCount()} and nothing else — so an aggregate sitting on
+    * `group`, or on one of the ten single-field shelves, has no per-measure type even though the
+    * model would happily answer for it. Reporting one there is the phantom-capability shape this
+    * plan has recorded three times.
+    */
+   @Test
+   void neverClaimsAPerMeasureTypeOffXAndY() {
+      ChartBindingModel model = new ChartBindingModel();
+      model.setMultiStyles(true);
+      model.setGroupFields(List.of(withChartType(aggregate("PAID", "Sum"), 5)));
+      model.setOpenField(withChartType(aggregate("DISCOUNT", "Max"), 5));
+
+      AssemblyBinding result = read(model);
+
+      assertNull(result.shelves().get("group").get(0).chartType(), "group carries no chart type");
+      assertNull(result.shelves().get("open").get(0).chartType(),
+                 "a single-field shelf carries no chart type");
+   }
+
+   private AssemblyBinding read(ChartBindingModel model) {
+      VSBindingService binding = mock(VSBindingService.class);
+      when(binding.createModel(any())).thenReturn(model);
+
+      return new BindingReadService(binding)
+         .read(runtimeWith("Chart1", mock(ChartVSAssembly.class)), "Chart1");
+   }
+
+   private static ChartAggregateRefModel withChartType(ChartAggregateRefModel ref, int type) {
+      ref.setChartType(type);
+      return ref;
+   }
+
+   private static ChartAggregateRefModel aggregate(String column, String formula) {
+      ChartAggregateRefModel ref = new ChartAggregateRefModel();
+      ref.setColumnValue(column);
+      ref.setFormula(formula);
+      return ref;
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindingReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindingReadServiceTest.java
@@ -36,6 +36,8 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
+import inetsoft.uql.viewsheet.graph.GraphTypes;
+import inetsoft.web.wiz.binding.model.FieldRef;
 
 @Tag("core")
 class BindingReadServiceTest {
@@ -143,6 +145,47 @@ class BindingReadServiceTest {
    }
 
    /**
+    * The case a design-time-only read serves worst: a measure left at {@code auto} answers
+    * {@code auto} forever, and the runtime type is the only thing that says what it drew. This is
+    * also the runtime type that survives on a merged chart, where the assembly-level one is not
+    * maintained — and merged is the multi-style case.
+    */
+   @Test
+   void reportsWhatAMeasureActuallyDrewWhenThatDiffersFromWhatWasStored() {
+      ChartBindingModel model = new ChartBindingModel();
+      model.setMultiStyles(true);
+      model.setYFields(List.of(
+         withTypes(aggregate("PAID", "Sum"), GraphTypes.CHART_AUTO, GraphTypes.CHART_BAR)));
+
+      FieldRef ref = read(model).shelves().get("y").get(0);
+
+      assertEquals(Integer.valueOf(GraphTypes.CHART_AUTO), ref.chartType());
+      assertEquals(Integer.valueOf(GraphTypes.CHART_BAR), ref.runtimeChartType());
+   }
+
+   /** Divergence-only: reported on every field it would be noise rather than a signal. */
+   @Test
+   void withholdsTheRuntimeTypeWhenItMatchesWhatWasStored() {
+      ChartBindingModel model = new ChartBindingModel();
+      model.setMultiStyles(true);
+      model.setYFields(List.of(withTypes(aggregate("PAID", "Sum"), 5, 5)));
+
+      assertNull(read(model).shelves().get("y").get(0).runtimeChartType());
+   }
+
+   @Test
+   void neverClaimsARuntimeTypeWhereItWithholdsTheStoredOne() {
+      ChartBindingModel model = new ChartBindingModel();
+      model.setMultiStyles(false);
+      model.setYFields(List.of(withTypes(aggregate("PAID", "Sum"), 1, 5)));
+
+      FieldRef ref = read(model).shelves().get("y").get(0);
+
+      assertNull(ref.chartType());
+      assertNull(ref.runtimeChartType());
+   }
+
+   /**
     * With multi-style off the per-field value is inert — the chart draws as one type — so reporting
     * it would hand back a setting that does not describe what renders. That is the shape of the
     * inert-frame finding this lane already recorded against set_visual_frame.
@@ -165,7 +208,7 @@ class BindingReadServiceTest {
       model.setXFields(List.of(new ChartDimensionRefModel()));
 
       assertNull(read(model).shelves().get("x").get(0).chartType());
-    }
+   }
 
    /**
     * The write side searches x and y only — {@code ChangeChartTypeProcessor} loops
@@ -198,6 +241,17 @@ class BindingReadServiceTest {
 
    private static ChartAggregateRefModel withChartType(ChartAggregateRefModel ref, int type) {
       ref.setChartType(type);
+      // Runtime mirrors design time unless a test says otherwise, so the divergence-only rule does
+      // not add a runtime type to every fixture that only cares about the stored one.
+      ref.setRTChartType(type);
+      return ref;
+   }
+
+   private static ChartAggregateRefModel withTypes(ChartAggregateRefModel ref, int type,
+                                                   int runtime)
+   {
+      ref.setChartType(type);
+      ref.setRTChartType(runtime);
       return ref;
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/binding/BindingReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/BindingReadServiceTest.java
@@ -147,8 +147,9 @@ class BindingReadServiceTest {
    /**
     * The case a design-time-only read serves worst: a measure left at {@code auto} answers
     * {@code auto} forever, and the runtime type is the only thing that says what it drew. This is
-    * also the runtime type that survives on a merged chart, where the assembly-level one is not
-    * maintained — and merged is the multi-style case.
+    * also the runtime type that survives while multi-style is on, which is exactly when the
+    * assembly-level one is not maintained — {@code multiStyles} selects between the two branches of
+    * {@code AbstractChartInfo.updateChartType}, not the chart's {@code separated} setting.
     */
    @Test
    void reportsWhatAMeasureActuallyDrewWhenThatDiffersFromWhatWasStored() {
@@ -171,6 +172,32 @@ class BindingReadServiceTest {
       model.setYFields(List.of(withTypes(aggregate("PAID", "Sum"), 5, 5)));
 
       assertNull(read(model).shelves().get("y").get(0).runtimeChartType());
+   }
+
+   /**
+    * The per-measure mirror of {@code withholdsTheRuntimeTypeWhenItIsStillTheUnresolvedDefault} on
+    * the assembly level, and the direction the two fixtures above leave uncovered: a stored
+    * {@code bar} with a runtime slot nothing ever assigned.
+    *
+    * <p>A real state rather than a hypothetical. {@code updateFieldChartTypes} does not reach every
+    * measure — it runs only when the last x or y field is a measure, and walks only the trailing
+    * run of aggregates on that shelf — and {@code updateChartType} returns early when no runtime
+    * x/y fields are populated. A measure missed by any of those keeps {@code CHART_AUTO}, and
+    * reporting it would tell a caller the measure drew as {@code auto} when no render said so.
+    */
+   @Test
+   void withholdsAPerMeasureRuntimeTypeThatIsStillTheUnresolvedDefault() {
+      ChartBindingModel model = new ChartBindingModel();
+      model.setMultiStyles(true);
+      model.setYFields(List.of(
+         withTypes(aggregate("PAID", "Sum"), GraphTypes.CHART_BAR, GraphTypes.CHART_AUTO)));
+
+      FieldRef ref = read(model).shelves().get("y").get(0);
+
+      assertEquals(Integer.valueOf(GraphTypes.CHART_BAR), ref.chartType(),
+                   "the stored type is still reported");
+      assertNull(ref.runtimeChartType(),
+                 "an unassigned runtime type must not be reported as what the measure drew");
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingServiceTest.java
@@ -53,6 +53,8 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import inetsoft.web.binding.model.table.TableBindingModel;
+import inetsoft.web.binding.model.BindingModel;
 
 @Tag("core")
 class ChartBindingServiceTest {
@@ -562,6 +564,88 @@ class ChartBindingServiceTest {
       verifyNoInteractions(types);
    }
 
+   /**
+    * requireTypeableField reads the chart's *current* multi-style state, so this pair passes it on
+    * a multi-style chart: the per-measure type lands, then applyMultiStyle switches off the flag
+    * that renders it. Stored where nothing draws it, reported as success — the very shape that
+    * method exists to prevent, reached through a door it cannot watch. Refused as a combination
+    * rather than by making requireTypeableField aware of the requested flag, because the two
+    * arguments are individually valid and it is only together that they cancel.
+    */
+   @Test
+   void refusesAPerMeasureTypeAskedForAlongsideTurningMultiStyleOff() {
+      ChangeChartTypeService types = mock(ChangeChartTypeService.class);
+      ChartBindingService service = multiStyleChart(types);
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> service.setChartType("tok", principal(), "Chart1", GraphTypes.CHART_LINE, false, null,
+                                    null, "Sum(PAID)", ""));
+
+      assertTrue(thrown.getMessage().contains("Sum(PAID)"), thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("multi"), thrown.getMessage());
+      verifyNoInteractions(types);
+   }
+
+   @Test
+   void stillAcceptsAPerMeasureTypeWhenMultiStyleIsLeftAlone() throws Exception {
+      ChangeChartTypeService types = mock(ChangeChartTypeService.class);
+
+      multiStyleChart(types)
+         .setChartType("tok", principal(), "Chart1", GraphTypes.CHART_LINE, null, null, null,
+                       "Sum(PAID)", "");
+
+      verify(types).changeChartType(any(), any(), any(), any(), any());
+   }
+
+   @Test
+   void stillAcceptsTurningMultiStyleOffForTheWholeChart() throws Exception {
+      ChangeChartTypeService types = mock(ChangeChartTypeService.class);
+
+      multiStyleChart(types)
+         .setChartType("tok", principal(), "Chart1", GraphTypes.CHART_LINE, false, null, null, null,
+                       "");
+
+      verify(types).changeChartType(any(), any(), any(), any(), any());
+   }
+
+   /**
+    * The forced-separate refusal used to live in applyMultiStyle, which runs *after*
+    * changeChartType, so asking to merge a treemap returned an error and left the chart retyped —
+    * a mutation followed by a refusal. It needs only the requested type, so nothing forced it
+    * downstream. This test is about the ordering, which is why it asserts on the type service
+    * having been left alone rather than only on the message.
+    */
+   @Test
+   void refusesAMergeOfAForcedSeparateTypeBeforeRetypingAnything() {
+      ChangeChartTypeService types = mock(ChangeChartTypeService.class);
+      ChartBindingService service = multiStyleChart(types);
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> service.setChartType("tok", principal(), "Chart1", GraphTypes.CHART_TREEMAP, true,
+                                    null, false, null, ""));
+
+      assertTrue(thrown.getMessage().contains("treemap"), thrown.getMessage());
+      verifyNoInteractions(types);
+   }
+
+   /**
+    * An omitted separate is "not asked about", so a forced-separate type is simply obeyed. The old
+    * check resolved the null against the chart's current state and could therefore refuse a merge
+    * nobody had requested.
+    */
+   @Test
+   void doesNotRefuseAForcedSeparateTypeWhenTheCallerSaidNothingAboutMerging() throws Exception {
+      ChangeChartTypeService types = mock(ChangeChartTypeService.class);
+
+      multiStyleChart(types)
+         .setChartType("tok", principal(), "Chart1", GraphTypes.CHART_TREEMAP, null, null, null,
+                       null, "");
+
+      verify(types).changeChartType(any(), any(), any(), any(), any());
+   }
+
    private static ChartBindingService multiStyleChart(ChangeChartTypeService types) {
       return chartWithFields(types, true);
    }
@@ -767,21 +851,79 @@ class ChartBindingServiceTest {
       // becomes a "stored but inert" mirror of what the renderer actually used.
       model.setRTChartType(5);
       model.setMultiStyles(true);
-      model.setSeparated(false);
+      model.setSeparated(true);
       model.setStackMeasures(true);
 
-      ChartTypeState state = harness(model, mock(ChangeChartRefService.class),
-                                     mock(ChangeChartTypeService.class),
-                                     mock(SwapXYBindingService.class),
-                                     mock(ChangeSeparateStatusService.class))
-         .readChartType("tok", principal(), "Chart1");
+      ChartTypeState state = readTypeOf(model);
 
       assertEquals("Chart1", state.assembly());
       assertEquals(1, state.chartType());
       assertEquals(5, state.runtimeChartType());
       assertTrue(state.multiStyles(), "multiStyles decides whether the type is per-measure");
-      assertFalse(state.separated());
+      assertTrue(state.separated());
       assertTrue(state.stackMeasures());
+   }
+
+   /**
+    * {@code AbstractChartInfo.updateChartType} sets the assembly-level runtime type only on its
+    * {@code separated} branch; the merged branch updates the per-measure types and leaves this one
+    * alone. So on a merged chart the field holds whatever it last held, and the plugin — which
+    * reads a divergence as proof the renderer chose something else — would draw that conclusion
+    * from a stale value. Merged is the multi-style case, so this is the common path.
+    */
+   @Test
+   void withholdsTheAssemblyRuntimeTypeOnAMergedChartWhereNothingMaintainsIt() throws Exception {
+      ChartBindingModel model = new ChartBindingModel();
+      model.setChartType(1);
+      model.setRTChartType(5);
+      model.setSeparated(false);
+
+      ChartTypeState state = readTypeOf(model);
+
+      assertEquals(1, state.chartType(), "the stored type is still reported");
+      assertNull(state.runtimeChartType(),
+                 "a merged chart's assembly-level runtime type is not maintained");
+   }
+
+   /**
+    * A render always resolves to a concrete type, so CHART_AUTO in this field is its unset default
+    * rather than an answer — and reporting it would make the plugin announce that the renderer
+    * resolved to "auto".
+    */
+   @Test
+   void withholdsTheRuntimeTypeWhenItIsStillTheUnresolvedDefault() throws Exception {
+      ChartBindingModel model = new ChartBindingModel();
+      model.setChartType(GraphTypes.CHART_BAR);
+      model.setRTChartType(GraphTypes.CHART_AUTO);
+      model.setSeparated(true);
+
+      assertNull(readTypeOf(model).runtimeChartType());
+   }
+
+   /**
+    * A hard cast would have surfaced as a ClassCastException and a 500, throwing away the sentence
+    * the sibling read produces for the same situation.
+    */
+   @Test
+   void refusesAnAssemblyWhoseModelIsNotAChartBinding() {
+      ChartBindingService service = harness(new TableBindingModel(),
+                                            mock(ChangeChartRefService.class),
+                                            mock(ChangeChartTypeService.class),
+                                            mock(SwapXYBindingService.class),
+                                            mock(ChangeSeparateStatusService.class));
+
+      Exception thrown = assertThrows(IllegalArgumentException.class,
+                                      () -> service.readChartType("tok", principal(), "Chart1"));
+
+      assertTrue(thrown.getMessage().contains("chart type"), thrown.getMessage());
+   }
+
+   private static ChartTypeState readTypeOf(ChartBindingModel model) throws Exception {
+      return harness(model, mock(ChangeChartRefService.class),
+                     mock(ChangeChartTypeService.class),
+                     mock(SwapXYBindingService.class),
+                     mock(ChangeSeparateStatusService.class))
+         .readChartType("tok", principal(), "Chart1");
    }
 
    /**
@@ -824,7 +966,7 @@ class ChartBindingServiceTest {
                  "must say it is not a chart, got: " + thrown.getMessage());
    }
 
-   private static ChartBindingService harness(ChartBindingModel model,
+   private static ChartBindingService harness(BindingModel model,
                                               ChangeChartRefService refs,
                                               ChangeChartTypeService types,
                                               SwapXYBindingService swap,
@@ -839,7 +981,7 @@ class ChartBindingServiceTest {
     * so these tests exercise the read-modify-write without a live runtime.
     */
    private static ChartBindingService harnessWithAssembly(VSAssembly assembly,
-                                                          ChartBindingModel model,
+                                                          BindingModel model,
                                                           ChangeChartRefService refs,
                                                           ChangeChartTypeService types,
                                                           SwapXYBindingService swap,

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingServiceTest.java
@@ -850,7 +850,9 @@ class ChartBindingServiceTest {
       // Deliberately different from chartType: reporting only the stored value is how a read
       // becomes a "stored but inert" mirror of what the renderer actually used.
       model.setRTChartType(5);
-      model.setMultiStyles(true);
+      // Single-style, because that is the state in which the assembly-level runtime type is the one
+      // being maintained. The multi-style case is covered below, where it is withheld.
+      model.setMultiStyles(false);
       model.setSeparated(true);
       model.setStackMeasures(true);
 
@@ -859,30 +861,49 @@ class ChartBindingServiceTest {
       assertEquals("Chart1", state.assembly());
       assertEquals(1, state.chartType());
       assertEquals(5, state.runtimeChartType());
-      assertTrue(state.multiStyles(), "multiStyles decides whether the type is per-measure");
+      assertFalse(state.multiStyles(), "multiStyles decides whether the type is per-measure");
       assertTrue(state.separated());
       assertTrue(state.stackMeasures());
    }
 
    /**
-    * {@code AbstractChartInfo.updateChartType} sets the assembly-level runtime type only on its
-    * {@code separated} branch; the merged branch updates the per-measure types and leaves this one
-    * alone. So on a merged chart the field holds whatever it last held, and the plugin — which
-    * reads a divergence as proof the renderer chose something else — would draw that conclusion
-    * from a stale value. Merged is the multi-style case, so this is the common path.
+    * multiStyles decides which level {@code AbstractChartInfo.updateChartType} maintains, despite
+    * its parameter being named {@code separated}: its call sites pass {@code !isMultiStyles()}. With
+    * multi-style on, the per-measure branch runs and this assembly-level value is left at whatever
+    * it last held — and the plugin reads a divergence as proof the renderer chose something else, so
+    * a stale value would be read as an answer. Note the {@code != CHART_AUTO} guard cannot help
+    * here: it rejects never-set, not stale, which is what makes the gate load-bearing.
     */
    @Test
-   void withholdsTheAssemblyRuntimeTypeOnAMergedChartWhereNothingMaintainsIt() throws Exception {
+   void withholdsTheAssemblyRuntimeTypeWhileMultiStyleIsOn() throws Exception {
       ChartBindingModel model = new ChartBindingModel();
       model.setChartType(1);
       model.setRTChartType(5);
-      model.setSeparated(false);
+      model.setMultiStyles(true);
+      // The state a freshly bound multi-style chart is actually in, and the one the earlier gate on
+      // isSeparated() reported a stale value from.
+      model.setSeparated(true);
 
       ChartTypeState state = readTypeOf(model);
 
       assertEquals(1, state.chartType(), "the stored type is still reported");
       assertNull(state.runtimeChartType(),
-                 "a merged chart's assembly-level runtime type is not maintained");
+                 "with multi-style on, nothing maintains the assembly-level runtime type");
+   }
+
+   /**
+    * The other direction the {@code isSeparated()} gate got wrong: a single-style merged chart is
+    * having this value maintained, and withholding it dropped real information.
+    */
+   @Test
+   void reportsTheAssemblyRuntimeTypeOnASingleStyleMergedChart() throws Exception {
+      ChartBindingModel model = new ChartBindingModel();
+      model.setChartType(1);
+      model.setRTChartType(5);
+      model.setMultiStyles(false);
+      model.setSeparated(false);
+
+      assertEquals(5, readTypeOf(model).runtimeChartType());
    }
 
    /**
@@ -895,7 +916,7 @@ class ChartBindingServiceTest {
       ChartBindingModel model = new ChartBindingModel();
       model.setChartType(GraphTypes.CHART_BAR);
       model.setRTChartType(GraphTypes.CHART_AUTO);
-      model.setSeparated(true);
+      model.setMultiStyles(false);
 
       assertNull(readTypeOf(model).runtimeChartType());
    }

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartBindingServiceTest.java
@@ -22,6 +22,11 @@ import inetsoft.uql.viewsheet.ChartVSAssembly;
 import inetsoft.uql.viewsheet.TextVSAssembly;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.uql.viewsheet.graph.ChartDescriptor;
+import inetsoft.uql.viewsheet.graph.GraphTypes;
+import inetsoft.uql.viewsheet.graph.PlotDescriptor;
+import inetsoft.uql.viewsheet.graph.VSChartAggregateRef;
+import inetsoft.uql.viewsheet.graph.VSChartInfo;
 import inetsoft.web.binding.controller.ChangeChartRefService;
 import inetsoft.web.binding.controller.ChangeChartTypeService;
 import inetsoft.web.binding.controller.ChangeSeparateStatusService;
@@ -33,6 +38,7 @@ import inetsoft.web.binding.model.ChartBindingModel;
 import inetsoft.web.binding.model.graph.ChartAggregateRefModel;
 import inetsoft.web.binding.model.graph.ChartDimensionRefModel;
 import inetsoft.web.binding.service.VSBindingService;
+import inetsoft.web.wiz.binding.model.ChartTypeState;
 import inetsoft.web.wiz.binding.model.FieldRef;
 import inetsoft.web.wiz.viewsheet.ViewsheetSessionService;
 import org.junit.jupiter.api.Tag;
@@ -98,7 +104,7 @@ class ChartBindingServiceTest {
 
       harness(new ChartBindingModel(), mock(ChangeChartRefService.class), types,
               mock(SwapXYBindingService.class), mock(ChangeSeparateStatusService.class))
-         .setChartType("tok", principal(), "Chart1", 3, null, null, null, "");
+         .setChartType("tok", principal(), "Chart1", 3, null, null, null, null, "");
 
       ArgumentCaptor<ChangeChartTypeEvent> captor =
          ArgumentCaptor.forClass(ChangeChartTypeEvent.class);
@@ -473,6 +479,350 @@ class ChartBindingServiceTest {
       return model;
    }
 
+   /**
+    * Multi Style's whole point is a per-measure type, and no tool could set one: set_chart_type was
+    * assembly-scoped, so `multi: true` switched on a mode with nothing behind it.
+    *
+    * <p>The backend already carries it — {@code ChangeChartTypeEvent.ref} names an aggregate and
+    * {@code ChangeChartTypeProcessor} sets that ref's type instead of the assembly's — and the agent
+    * path simply never filled the field in. Same shape as the single-shelf read: the capability
+    * exists and is exercised by the Composer, one tier just did not pass it along.
+    */
+   @Test
+   void namesOneMeasureWhenAskedToTypeJustThatField() throws Exception {
+      ChangeChartTypeService types = mock(ChangeChartTypeService.class);
+
+      multiStyleChart(types)
+         .setChartType("tok", principal(), "Chart1", GraphTypes.CHART_LINE, null, null, null,
+                       "Sum(DISCOUNT)", "");
+
+      ArgumentCaptor<ChangeChartTypeEvent> event =
+         ArgumentCaptor.forClass(ChangeChartTypeEvent.class);
+      verify(types).changeChartType(eq("rt1"), event.capture(), any(Principal.class), any(),
+                                    anyString());
+      assertEquals("Sum(DISCOUNT)", event.getValue().getRef(),
+                   "the field the caller named must reach the event");
+   }
+
+   /** No field named means the whole chart, exactly as before. */
+   @Test
+   void leavesTheRefEmptyWhenNoFieldWasNamed() throws Exception {
+      ChangeChartTypeService types = mock(ChangeChartTypeService.class);
+
+      multiStyleChart(types)
+         .setChartType("tok", principal(), "Chart1", GraphTypes.CHART_LINE, null, null, null, null,
+                       "");
+
+      ArgumentCaptor<ChangeChartTypeEvent> event =
+         ArgumentCaptor.forClass(ChangeChartTypeEvent.class);
+      verify(types).changeChartType(eq("rt1"), event.capture(), any(Principal.class), any(),
+                                    anyString());
+      assertNull(event.getValue().getRef());
+   }
+
+   /**
+    * {@code ChangeChartTypeProcessor} searches x and y for the named ref and, finding nothing, sets
+    * no type at all — it does not fall back to the assembly, because it is inside the
+    * {@code ref != null} branch. So a misspelled column, or one that sits on `group` or a
+    * single-field shelf, would report ok and change nothing. Refused by name instead, with the
+    * fields that would have worked.
+    */
+   @Test
+   void refusesAFieldThatIsNotOnXOrY() {
+      ChangeChartTypeService types = mock(ChangeChartTypeService.class);
+      ChartBindingService service = multiStyleChart(types);
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> service.setChartType("tok", principal(), "Chart1", GraphTypes.CHART_LINE, null, null,
+                                    null, "Sum(NOPE)", ""));
+
+      assertTrue(thrown.getMessage().contains("Sum(NOPE)"), thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("Sum(PAID)"),
+                 "must name the measures that would have worked, got: " + thrown.getMessage());
+      verifyNoInteractions(types);
+   }
+
+   /**
+    * A per-measure type only renders under Multi Style, so accepting one on a single-style chart
+    * would store a setting nothing draws from — and the caller would have no way to tell, since the
+    * write reports ok either way.
+    */
+   @Test
+   void refusesAPerFieldTypeOnAChartThatIsNotMultiStyle() {
+      ChangeChartTypeService types = mock(ChangeChartTypeService.class);
+      ChartBindingService service = singleStyleChart(types);
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> service.setChartType("tok", principal(), "Chart1", GraphTypes.CHART_LINE, null, null,
+                                    null, "Sum(PAID)", ""));
+
+      assertTrue(thrown.getMessage().contains("multi"), thrown.getMessage());
+      verifyNoInteractions(types);
+   }
+
+   private static ChartBindingService multiStyleChart(ChangeChartTypeService types) {
+      return chartWithFields(types, true);
+   }
+
+   private static ChartBindingService singleStyleChart(ChangeChartTypeService types) {
+      return chartWithFields(types, false);
+   }
+
+   private static ChartBindingService chartWithFields(ChangeChartTypeService types, boolean multi) {
+      // Mocked rather than built: getFullName() on a real ref depends on runtime state this test
+      // has no reason to stand up, and the name is the only thing the lookup cares about.
+      VSChartAggregateRef paid = mock(VSChartAggregateRef.class);
+      when(paid.getFullName()).thenReturn("Sum(PAID)");
+      VSChartAggregateRef discount = mock(VSChartAggregateRef.class);
+      when(discount.getFullName()).thenReturn("Sum(DISCOUNT)");
+
+      VSChartInfo info = mock(VSChartInfo.class);
+      when(info.isMultiStyles()).thenReturn(multi);
+      when(info.isSeparatedGraph()).thenReturn(true);
+      when(info.getChartType()).thenReturn(GraphTypes.CHART_BAR);
+      when(info.getXFieldCount()).thenReturn(1);
+      when(info.getXField(0)).thenReturn(paid);
+      when(info.getYFieldCount()).thenReturn(1);
+      when(info.getYField(0)).thenReturn(discount);
+
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      when(chart.getVSChartInfo()).thenReturn(info);
+
+      return harnessWithAssembly(chart, new ChartBindingModel(),
+                                 mock(ChangeChartRefService.class), types,
+                                 mock(SwapXYBindingService.class),
+                                 mock(ChangeSeparateStatusService.class));
+   }
+
+   /**
+    * An omitted flag means "leave it alone", and the shared event builder had no way to say that:
+    * {@code Boolean.TRUE.equals(stackMeasures)} turns a null into false, which is then applied.
+    *
+    * <p>Confirmed live before this test existed: on a chart with stackMeasures on, one
+    * {@code set_chart_type(bar)} that did not mention the flag read back with it **off**, same type
+    * and nothing else changed. {@code multi} has the same hole and only escapes it by accident —
+    * the coerced value travels through the WebSocket path that silently drops it — so repairing
+    * that path would turn every plain retype into a multi-style teardown.
+    */
+   @Test
+   void sendsTheChartsCurrentFlagsWhenTheCallerDidNotMentionThem() throws Exception {
+      ChangeChartTypeService types = mock(ChangeChartTypeService.class);
+      PlotDescriptor plot = mock(PlotDescriptor.class);
+      when(plot.isStackMeasures()).thenReturn(true);
+      ChartDescriptor descriptor = mock(ChartDescriptor.class);
+      when(descriptor.getPlotDescriptor()).thenReturn(plot);
+      VSChartInfo info = mock(VSChartInfo.class);
+      when(info.isMultiStyles()).thenReturn(true);
+      when(info.isSeparatedGraph()).thenReturn(false);
+      when(info.getChartType()).thenReturn(GraphTypes.CHART_BAR);
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      when(chart.getVSChartInfo()).thenReturn(info);
+      when(chart.getChartDescriptor()).thenReturn(descriptor);
+
+      harnessWithAssembly(chart, new ChartBindingModel(), mock(ChangeChartRefService.class),
+                          types, mock(SwapXYBindingService.class),
+                          mock(ChangeSeparateStatusService.class))
+         .setChartType("tok", principal(), "Chart1", GraphTypes.CHART_BAR, null, null, null, null, "");
+
+      ArgumentCaptor<ChangeChartTypeEvent> event =
+         ArgumentCaptor.forClass(ChangeChartTypeEvent.class);
+      verify(types).changeChartType(eq("rt1"), event.capture(), any(Principal.class), any(),
+                                    anyString());
+      assertTrue(event.getValue().isStackMeasures(),
+                 "an unmentioned stackMeasures must not be reported as off");
+      assertTrue(event.getValue().isMulti(), "an unmentioned multi must not be reported as off");
+      assertFalse(event.getValue().isSeparate(),
+                  "an unmentioned separate must carry the chart's own state, not a forced true");
+   }
+
+   /** What the caller does state still wins, so the preserving default cannot swallow a real ask. */
+   @Test
+   void stillSendsTheFlagsTheCallerDidState() throws Exception {
+      ChangeChartTypeService types = mock(ChangeChartTypeService.class);
+      PlotDescriptor plot = mock(PlotDescriptor.class);
+      when(plot.isStackMeasures()).thenReturn(true);
+      ChartDescriptor descriptor = mock(ChartDescriptor.class);
+      when(descriptor.getPlotDescriptor()).thenReturn(plot);
+      VSChartInfo info = mock(VSChartInfo.class);
+      when(info.isMultiStyles()).thenReturn(true);
+      when(info.isSeparatedGraph()).thenReturn(true);
+      when(info.getChartType()).thenReturn(GraphTypes.CHART_BAR);
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      when(chart.getVSChartInfo()).thenReturn(info);
+      when(chart.getChartDescriptor()).thenReturn(descriptor);
+
+      harnessWithAssembly(chart, new ChartBindingModel(), mock(ChangeChartRefService.class),
+                          types, mock(SwapXYBindingService.class),
+                          mock(ChangeSeparateStatusService.class))
+         .setChartType("tok", principal(), "Chart1", GraphTypes.CHART_BAR, false, false, null, null, "");
+
+      ArgumentCaptor<ChangeChartTypeEvent> event =
+         ArgumentCaptor.forClass(ChangeChartTypeEvent.class);
+      verify(types).changeChartType(eq("rt1"), event.capture(), any(Principal.class), any(),
+                                    anyString());
+      assertFalse(event.getValue().isStackMeasures(), "an explicit false must survive");
+      assertFalse(event.getValue().isMulti(), "an explicit false must survive");
+   }
+
+   /**
+    * set_chart_type's documented `multi` flag never reached the chart on this path.
+    *
+    * <p>{@code ChangeChartTypeService.handleMulti} — the only code that turns multiStyles on —
+    * routes through {@code ChangeSeparateStatusController}, a
+    * {@code @MessageMapping("/vs/chart/changeSeparateStatus")} handler that reads its runtime id
+    * from {@code runtimeViewsheetRef}, documented in its own constructor as the runtime "associated
+    * with the WebSocket session". An agent call is plain HTTP with a pairing token, so that id is
+    * null and the handler returns silently. Three live attempts reported ok with multiStyles still
+    * false, including the one that should have worked: type unchanged, two measures bound.
+    *
+    * <p>Applied here rather than repaired there, for two reasons: the shared path has no test
+    * coverage at all and the defect is a missing WebSocket context rather than wrong logic, so no
+    * mock test at that layer would have caught it; and this service already makes exactly this call
+    * correctly in {@code setSeparateStatus}, with the runtime id it holds.
+    */
+   @Test
+   void appliesMultiStyleItselfRatherThanLeavingItToTheWebSocketPath() throws Exception {
+      ChangeSeparateStatusService separateStatus = mock(ChangeSeparateStatusService.class);
+      VSChartInfo info = mock(VSChartInfo.class);
+      when(info.isMultiStyles()).thenReturn(false);
+      when(info.isSeparatedGraph()).thenReturn(true);
+      when(info.getChartType()).thenReturn(GraphTypes.CHART_BAR);
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      when(chart.getVSChartInfo()).thenReturn(info);
+
+      harnessWithAssembly(chart, new ChartBindingModel(), mock(ChangeChartRefService.class),
+                          mock(ChangeChartTypeService.class), mock(SwapXYBindingService.class),
+                          separateStatus)
+         .setChartType("tok", principal(), "Chart1", GraphTypes.CHART_BAR, true, null, null, null, "");
+
+      ArgumentCaptor<ChangeSeparateStatusEvent> event =
+         ArgumentCaptor.forClass(ChangeSeparateStatusEvent.class);
+      verify(separateStatus).changeSeparateStatus(eq("rt1"), event.capture(),
+                                                 any(Principal.class), any(), anyString());
+      assertTrue(event.getValue().isMulti(), "the multi the caller asked for must reach the chart");
+      assertTrue(event.getValue().isSeparate(),
+                 "separate was not given, so the chart's current separated state is preserved");
+   }
+
+   /**
+    * Nothing to change, nothing to call. The multi transition is a second write with its own
+    * undo step, so firing it when the state already matches would put a no-op into the user's
+    * Composer history for every retype.
+    */
+   @Test
+   void doesNotTouchMultiStyleWhenItAlreadyMatches() throws Exception {
+      ChangeSeparateStatusService separateStatus = mock(ChangeSeparateStatusService.class);
+      VSChartInfo info = mock(VSChartInfo.class);
+      when(info.isMultiStyles()).thenReturn(true);
+      when(info.getChartType()).thenReturn(GraphTypes.CHART_BAR);
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      when(chart.getVSChartInfo()).thenReturn(info);
+
+      harnessWithAssembly(chart, new ChartBindingModel(), mock(ChangeChartRefService.class),
+                          mock(ChangeChartTypeService.class), mock(SwapXYBindingService.class),
+                          separateStatus)
+         .setChartType("tok", principal(), "Chart1", GraphTypes.CHART_BAR, true, null, null, null, "");
+
+      verify(separateStatus, never()).changeSeparateStatus(anyString(), any(), any(), any(), any());
+   }
+
+   /**
+    * An omitted multi means "not asked for", not "off". Coercing it to false is what the shared
+    * event builder does, and it is why a plain retype cannot leave the flag alone.
+    */
+   @Test
+   void leavesMultiStyleAloneWhenTheCallerDidNotAskAboutIt() throws Exception {
+      ChangeSeparateStatusService separateStatus = mock(ChangeSeparateStatusService.class);
+      VSChartInfo info = mock(VSChartInfo.class);
+      when(info.isMultiStyles()).thenReturn(true);
+      when(info.getChartType()).thenReturn(GraphTypes.CHART_BAR);
+      ChartVSAssembly chart = mock(ChartVSAssembly.class);
+      when(chart.getVSChartInfo()).thenReturn(info);
+
+      harnessWithAssembly(chart, new ChartBindingModel(), mock(ChangeChartRefService.class),
+                          mock(ChangeChartTypeService.class), mock(SwapXYBindingService.class),
+                          separateStatus)
+         .setChartType("tok", principal(), "Chart1", GraphTypes.CHART_BAR, null, null, null, null, "");
+
+      verify(separateStatus, never()).changeSeparateStatus(anyString(), any(), any(), any(), any());
+   }
+
+   /**
+    * A chart's type had no reader anywhere in the agent surface — not get_binding, not
+    * get_chart_aesthetics, not the property tools, not even get_assembly_properties(raw), which is
+    * the documented escape hatch for a property with no short name. So set_chart_type's own advice
+    * to "read the binding again afterwards" could not be acted on.
+    *
+    * <p>Reports the codes, not names: the code↔name vocabulary already exists in three copies here
+    * (WizAutoBindingService twice, WizVsService once) plus the plugin's, and the plugin owns the
+    * one that faces the agent — set_chart_type already echoes names from it.
+    */
+   @Test
+   void readsTheAssemblyTypeAndTheThreeFlagsThatDecideWhatItMeans() throws Exception {
+      ChartBindingModel model = new ChartBindingModel();
+      model.setChartType(1);
+      // Deliberately different from chartType: reporting only the stored value is how a read
+      // becomes a "stored but inert" mirror of what the renderer actually used.
+      model.setRTChartType(5);
+      model.setMultiStyles(true);
+      model.setSeparated(false);
+      model.setStackMeasures(true);
+
+      ChartTypeState state = harness(model, mock(ChangeChartRefService.class),
+                                     mock(ChangeChartTypeService.class),
+                                     mock(SwapXYBindingService.class),
+                                     mock(ChangeSeparateStatusService.class))
+         .readChartType("tok", principal(), "Chart1");
+
+      assertEquals("Chart1", state.assembly());
+      assertEquals(1, state.chartType());
+      assertEquals(5, state.runtimeChartType());
+      assertTrue(state.multiStyles(), "multiStyles decides whether the type is per-measure");
+      assertFalse(state.separated());
+      assertTrue(state.stackMeasures());
+   }
+
+   /**
+    * A read must not open an undo checkpoint. The cheapest wrong implementation reuses
+    * {@code sessions.mutate}, which would put a no-op step into the user's Composer history for
+    * every read an agent makes.
+    */
+   @Test
+   void readsTheTypeWithoutOpeningACheckpoint() throws Exception {
+      ViewsheetSessionService sessions = mock(ViewsheetSessionService.class);
+      Viewsheet vs = mock(Viewsheet.class);
+      when(vs.getAssembly(anyString())).thenReturn(mock(ChartVSAssembly.class));
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      when(sessions.resolve(anyString(), any(Principal.class))).thenReturn(rvs);
+
+      VSBindingService binding = mock(VSBindingService.class);
+      when(binding.createModel(any())).thenReturn(new ChartBindingModel());
+
+      new ChartBindingService(sessions, binding, mock(ChangeChartRefService.class),
+                              mock(ChangeChartTypeService.class), mock(SwapXYBindingService.class),
+                              mock(ChangeSeparateStatusService.class))
+         .readChartType("tok", principal(), "Chart1");
+
+      verify(sessions, never()).mutate(anyString(), any(Principal.class), any());
+   }
+
+   @Test
+   void refusesToReadATypeOffSomethingThatIsNotAChart() {
+      ChartBindingService service = harnessWithAssembly(
+         mock(TextVSAssembly.class), new ChartBindingModel(),
+         mock(ChangeChartRefService.class), mock(ChangeChartTypeService.class),
+         mock(SwapXYBindingService.class), mock(ChangeSeparateStatusService.class));
+
+      Exception thrown = assertThrows(IllegalArgumentException.class,
+                                      () -> service.readChartType("tok", principal(), "Text1"));
+
+      assertTrue(thrown.getMessage().contains("not a chart"),
+                 "must say it is not a chart, got: " + thrown.getMessage());
+   }
+
    private static ChartBindingService harness(ChartBindingModel model,
                                               ChangeChartRefService refs,
                                               ChangeChartTypeService types,
@@ -507,6 +857,8 @@ class ChartBindingServiceTest {
             mutation.run(rvs, "rt1", null);
             return null;
          }).when(sessions).mutate(anyString(), any(Principal.class), any());
+         // Reads take this path instead — no checkpoint.
+         when(sessions.resolve(anyString(), any(Principal.class))).thenReturn(rvs);
       }
       catch(Exception e) {
          throw new IllegalStateException(e);

--- a/core/src/test/java/inetsoft/web/wiz/binding/FieldRefFactoryTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/FieldRefFactoryTest.java
@@ -310,4 +310,41 @@ class FieldRefFactoryTest {
          assertTrue(thrown.getMessage().contains("NoSuchGroup"));
       }
    }
+
+   /**
+    * The chart read reports a per-measure chart type, which makes handing one of its refs straight
+    * back to a write the obvious next move — and no write takes one. Refused here rather than only
+    * in the plugin: that is the outermost tier and the most bypassable one, and anything reaching
+    * these endpoints directly would otherwise get the silent drop this surface is written against.
+    */
+   @Test
+   void refusesAnInboundChartTypeRatherThanDroppingIt() {
+      FieldRef field = new FieldRef("PAID", "measure", "Sum", null, null, 5);
+
+      Exception thrown = assertThrows(IllegalArgumentException.class,
+                                      () -> FieldRefFactory.requireType(field));
+
+      assertTrue(thrown.getMessage().contains("PAID"), thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("set_chart_type"), thrown.getMessage());
+   }
+
+   @Test
+   void refusesAnInboundRuntimeChartTypeToo() {
+      FieldRef field = new FieldRef("PAID", "measure", "Sum", null, null, null, 1);
+
+      assertThrows(IllegalArgumentException.class, () -> FieldRefFactory.requireType(field));
+   }
+
+   /** The guard sits on requireType, so it covers the chart path through toChartRef as well. */
+   @Test
+   void refusesAnInboundChartTypeOnTheChartWritePathToo() {
+      FieldRef field = new FieldRef("PAID", "measure", "Sum", null, null, 5);
+
+      assertThrows(IllegalArgumentException.class, () -> FieldRefFactory.toChartRef(field));
+   }
+
+   @Test
+   void stillAcceptsARefThatCarriesNoChartType() {
+      FieldRefFactory.requireType(new FieldRef("PAID", "measure", "Sum", null, null));
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/binding/model/FieldRefBindingTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/model/FieldRefBindingTest.java
@@ -1,0 +1,110 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.binding.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Locks {@link FieldRef}'s wire contract as a <em>request</em> type.
+ *
+ * <p>It is easy to read it as a response shape — the chart and table reads return it — but it is
+ * also the body of every binding write: {@code ShelfRequest.fields}, {@code SingleShelfRequest},
+ * {@code AestheticFieldRequest}, {@code TableShelfRequest}, {@code TableFieldRequest}. It gained
+ * two components and two secondary constructors for the per-measure chart type, and records bind
+ * through the canonical constructor, so the reads a caller was already sending have to keep
+ * binding with those components absent. Nothing covered that, and the live verification for that
+ * change was about typing a measure rather than binding one.
+ */
+@Tag("core")
+class FieldRefBindingTest {
+   private final ObjectMapper mapper = new ObjectMapper();
+
+   @Test
+   void bindsTheShapeEveryCallerAlreadySends() throws Exception {
+      FieldRef ref = mapper.readValue(
+         """
+         { "column": "PAID", "type": "measure", "aggregate": "Sum" }
+         """, FieldRef.class);
+
+      assertEquals("PAID", ref.column());
+      assertEquals("measure", ref.type());
+      assertEquals("Sum", ref.aggregate());
+      assertNull(ref.dateLevel());
+      assertNull(ref.namedGroup());
+      assertNull(ref.chartType(), "absent means absent, not zero");
+      assertNull(ref.runtimeChartType());
+   }
+
+   @Test
+   void bindsADimensionWithItsDateLevel() throws Exception {
+      FieldRef ref = mapper.readValue(
+         """
+         { "column": "ORDER_DATE", "type": "dimension", "dateLevel": "Year" }
+         """, FieldRef.class);
+
+      assertEquals("dimension", ref.type());
+      assertEquals("Year", ref.dateLevel());
+      assertNull(ref.chartType());
+   }
+
+   /** The shape a shelf write actually arrives in, since `fields` is a list. */
+   @Test
+   void bindsAListOfRefsTheWayShelfRequestHoldsThem() throws Exception {
+      List<FieldRef> refs = mapper.readValue(
+         """
+         [ { "column": "PAID", "type": "measure", "aggregate": "Sum" },
+           { "column": "DISCOUNT", "type": "measure", "aggregate": "Sum" } ]
+         """, mapper.getTypeFactory().constructCollectionType(List.class, FieldRef.class));
+
+      assertEquals(2, refs.size());
+      assertEquals("DISCOUNT", refs.get(1).column());
+      assertNull(refs.get(0).chartType());
+   }
+
+   /**
+    * A ref read back from the chart read carries these, and handing it straight to a write is the
+    * obvious next move. Binding has to keep working — the refusal is
+    * {@code FieldRefFactory.requireType}'s job, and it can only refuse what reached it.
+    */
+   @Test
+   void bindsTheTwoReadOnlyComponentsSoTheWriteCanRefuseThem() throws Exception {
+      FieldRef ref = mapper.readValue(
+         """
+         { "column": "QUANTITY", "type": "measure", "aggregate": "Sum",
+           "chartType": 5, "runtimeChartType": 1 }
+         """, FieldRef.class);
+
+      assertEquals(Integer.valueOf(5), ref.chartType());
+      assertEquals(Integer.valueOf(1), ref.runtimeChartType());
+   }
+
+   @Test
+   void serialisesBackToTheSameShape() throws Exception {
+      String json = mapper.writeValueAsString(
+         new FieldRef("PAID", "measure", "Sum", null, null, 5, 1));
+
+      assertEquals(new FieldRef("PAID", "measure", "Sum", null, null, 5, 1),
+                   mapper.readValue(json, FieldRef.class));
+   }
+}


### PR DESCRIPTION
The server side of reading and writing a chart's type. Pairs with
`stylebi-wiz#1761` — the plugin tools call these endpoints.

`AbstractChartInfo` says it outright: `isMultiAesthetic()` returns
`isMultiStyles()`, *"check if aesthetics are stored in aggregates"*. One flag
decides whether the authoritative type lives on the assembly or on each measure,
on both the read and the write. Everything here follows from that.

- **`ChartTypeState` + `readChartType` + `GET chart/type`** — nothing reported a
  chart's type at all, so an agent could set one and not tell a write that landed
  from one the recommender had already overwritten. `multiStyles` is reported
  alongside rather than interpreted, since it is what tells a caller which level
  to trust. `runtimeChartType` sits next to the stored value rather than replacing
  it.
- **`FieldRef.chartType`, emitted by `BindingReadService`** — triple-gated: x or y
  shelf, the ref is a measure, and multi-style is on. Only x and y are searched by
  `ChangeChartTypeProcessor`'s per-ref write, dimensions have no such property, and
  on a single-style chart the value never renders. A five-argument constructor
  delegates, so the 44 existing construction sites are untouched.
- **`setChartType(field)`** — forwarded as `ChangeChartTypeEvent.ref`.
  `requireTypeableField` refuses a non-multi-style chart and refuses a field absent
  from x and y, naming the measures that would have worked; without it the write
  reported ok and changed nothing.
- **`setChartType` preserves the flags it was not given** — `multi`, `separate`
  and `stackMeasures` defaulted to false when omitted, so every retype silently
  cleared whatever the chart had.
- **`setChartType` applies a multi-style change** — the shared `handleMulti`
  no-ops unless the flag differs, and the separate-status side never ran from the
  agent path.
- **The ten single-field shelves on a chart read** — open/high/low/close/path/
  source/target/start/end/milestone, reported only where something is bound.

Confined to `inetsoft/web/wiz/binding` by design: the Composer's own chart-type
and aesthetic dialogs run unchanged code. Nothing deconstructs `FieldRef` as a
record pattern and nothing depends on its equality, so the added component changes
no behaviour anywhere.

Verified live against a running server with a two-measure multi-style chart: one
measure typed to `line` renders a bar and a line together, the other unchanged,
and both refusals leave the chart readable with no partial write.

`inetsoft.web.wiz.**` — 2166 tests, 1 failure, pre-existing and not from this
branch: `ScriptApiServiceTest.looksUpPrototypeMethodFromGeneratedCorpus` expects
`AreaElement.addDim`, which is absent from the committed `js-functions.json`; this
branch touches no script file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
