### PR TITLE
Track unrecognized scriptable-property writes for VS_INIT/VS_LOAD too

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptExecuteService.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptExecuteService.java
@@ -21,6 +21,7 @@ import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.report.script.viewsheet.VSAScriptable;
 import inetsoft.report.script.viewsheet.ViewsheetScope;
+import inetsoft.uql.asset.Assembly;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.web.wiz.pairing.PairingException;
 import inetsoft.web.wiz.script.model.ScriptError;
@@ -28,7 +29,10 @@ import inetsoft.web.wiz.script.model.ScriptExecResult;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -138,29 +142,43 @@ public class ScriptExecuteService {
             "Use worksheet-chat's edit_expression/edit_condition tools on it instead.");
       };
 
-      VSAScriptable assemblyScriptable =
-         (target.location() == ScriptTarget.Location.ASSEMBLY ||
-          target.location() == ScriptTarget.Location.ASSEMBLY_ONCLICK)
-         ? scope.getVSAScriptable(assemblyName) : null;
+      // ASSEMBLY/ASSEMBLY_ONCLICK touch exactly the one named assembly. VS_INIT/VS_LOAD run with
+      // assemblyName == null and can write to any assembly in the sheet by name, so every
+      // assembly's scriptable is tracked -- each was already eagerly created and cached in the
+      // scope's own propmap when the sandbox initialized (ViewsheetScope#addProperties0), so
+      // this is a lookup, not a fresh instantiation with its own side effects.
+      Map<String, VSAScriptable> trackedScriptables = trackedScriptables(target, assemblyName, rvs, scope);
 
-      if(assemblyScriptable != null) {
-         assemblyScriptable.resetUnrecognizedWrites();
+      for(VSAScriptable scriptable : trackedScriptables.values()) {
+         scriptable.resetUnrecognizedWrites();
       }
 
       try {
          Object value = scope.execute(text, assemblyName);
-         List<String> unrecognized = assemblyScriptable != null ?
-            assemblyScriptable.getUnrecognizedWrites() : List.of();
+         List<String> unrecognized = new ArrayList<>();
+
+         for(Map.Entry<String, VSAScriptable> entry : trackedScriptables.entrySet()) {
+            for(String name : entry.getValue().getUnrecognizedWrites()) {
+               // ASSEMBLY/ASSEMBLY_ONCLICK already name the one assembly in the message below,
+               // so the bare property name is unambiguous there. VS_INIT/VS_LOAD can touch
+               // several different assemblies, so qualify with which one to avoid conflating
+               // e.g. two different assemblies' own unrecognized "label".
+               unrecognized.add(assemblyName != null ? name : entry.getKey() + "." + name);
+            }
+         }
+
          List<String> changed = unrecognized.isEmpty() ? List.of(target.toString()) : List.of();
          String summary = unrecognized.isEmpty() ? "Executed " + target + "." :
             "Executed " + target + ", but assigned " + unrecognized +
             " which " + (unrecognized.size() == 1 ? "is not a recognized scriptable property" :
-               "are not recognized scriptable properties") + " for this assembly type (" +
-            assemblyTypeName(rvs, assemblyName) + ") — the value " +
+               "are not recognized scriptable properties") +
+            (assemblyName != null ? " for this assembly type (" +
+               assemblyTypeName(rvs, assemblyName) + ")" : "") + " — the value " +
             (unrecognized.size() == 1 ? "was" : "were") + " NOT applied; " +
             (unrecognized.size() == 1 ? "it" : "they") + " only became an ad hoc script " +
-            "variable nothing else reads. Call get_script_context for " + assemblyName +
-            "'s real scriptable properties, or use get_assembly_properties/update_binding if " +
+            "variable nothing else reads. Call get_script_context for " +
+            (assemblyName != null ? assemblyName + "'s" : "the named assembly's") +
+            " real scriptable properties, or use get_assembly_properties/update_binding if " +
             "you meant a different, non-scripted property.";
          return new ScriptExecResult(true, stringify(value), null, changed, false, null, summary,
             unrecognized.isEmpty() ? null : unrecognized);
@@ -168,6 +186,40 @@ public class ScriptExecuteService {
       catch(Exception ex) {
          return new ScriptExecResult(false, null, toScriptError(ex), null, false, null, null, null);
       }
+   }
+
+   /**
+    * Which {@code VSAScriptable}(s) to reset/check {@code getUnrecognizedWrites()} on around
+    * this execution. Empty for a location with no per-assembly scriptable to instrument
+    * (e.g. an already-thrown location never reaches here).
+    */
+   private static Map<String, VSAScriptable> trackedScriptables(
+      ScriptTarget target, String assemblyName, RuntimeViewsheet rvs, ViewsheetScope scope)
+   {
+      if(target.location() == ScriptTarget.Location.ASSEMBLY ||
+         target.location() == ScriptTarget.Location.ASSEMBLY_ONCLICK)
+      {
+         VSAScriptable scriptable = scope.getVSAScriptable(assemblyName);
+         return scriptable != null ? Map.of(assemblyName, scriptable) : Map.of();
+      }
+
+      if(target.location() == ScriptTarget.Location.VS_INIT ||
+         target.location() == ScriptTarget.Location.VS_LOAD)
+      {
+         Map<String, VSAScriptable> tracked = new LinkedHashMap<>();
+
+         for(Assembly assembly : rvs.getViewsheet().getAssemblies()) {
+            VSAScriptable scriptable = scope.getVSAScriptable(assembly.getName());
+
+            if(scriptable != null) {
+               tracked.put(assembly.getName(), scriptable);
+            }
+         }
+
+         return tracked;
+      }
+
+      return Map.of();
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/script/ScriptExecuteServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ScriptExecuteServiceTest.java
@@ -30,7 +30,9 @@ import inetsoft.web.wiz.script.model.ScriptExecResult;
 import inetsoft.web.wiz.script.model.ScriptInfo;
 import org.junit.jupiter.api.Test;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -127,6 +129,154 @@ class ScriptExecuteServiceTest {
       assertEquals(List.of(target.toString()), result.changed());
       assertNull(result.unrecognizedProperties());
       verify(scriptable).resetUnrecognizedWrites();
+   }
+
+   /**
+    * Builds a RuntimeViewsheet with a real onInit (or onLoad) script and one real
+    * {@code SubmitVSAssembly} per entry in {@code scriptablesByAssembly}, each wired to the
+    * given mock scriptable via {@code scope.getVSAScriptable(name)} -- for exercising the
+    * VS_INIT/VS_LOAD-location unrecognized-write reporting, which (unlike
+    * ASSEMBLY/ASSEMBLY_ONCLICK) runs with {@code assemblyName == null} and can write to any
+    * assembly in the sheet by name, not just a single "current" one.
+    */
+   private RuntimeViewsheet viewsheetWithVsScript(boolean onLoad, String script,
+                                                   ViewsheetScope scope,
+                                                   Map<String, VSAScriptable> scriptablesByAssembly)
+   {
+      Viewsheet vs = new Viewsheet();
+
+      if(onLoad) {
+         vs.getViewsheetInfo().setOnLoad(script);
+      }
+      else {
+         vs.getViewsheetInfo().setOnInit(script);
+      }
+
+      vs.getViewsheetInfo().setScriptEnabled(true);
+
+      for(String name : scriptablesByAssembly.keySet()) {
+         SubmitVSAssembly submit = new SubmitVSAssembly();
+         ((SubmitVSAssemblyInfo) submit.getVSAssemblyInfo()).setName(name);
+         vs.addAssembly(submit);
+      }
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      ViewsheetSandbox box = mock(ViewsheetSandbox.class);
+      when(box.getScope()).thenReturn(scope);
+      when(rvs.getViewsheetSandbox()).thenReturn(Optional.of(box));
+
+      for(Map.Entry<String, VSAScriptable> entry : scriptablesByAssembly.entrySet()) {
+         when(scope.getVSAScriptable(entry.getKey())).thenReturn(entry.getValue());
+      }
+
+      return rvs;
+   }
+
+   @Test
+   void executeQualifiesAndReportsAnUnrecognizedWriteFromAnAssemblyTouchedByVsInit()
+      throws Exception
+   {
+      String script = "Submit1.label = 'ClauseTest42';";
+      ViewsheetScope scope = mock(ViewsheetScope.class);
+      when(scope.execute(eq(script), nullable(String.class))).thenReturn(null);
+
+      VSAScriptable submit1 = mock(VSAScriptable.class);
+      when(submit1.getUnrecognizedWrites()).thenReturn(List.of("label"));
+
+      RuntimeViewsheet rvs =
+         viewsheetWithVsScript(false, script, scope, Map.of("Submit1", submit1));
+      ScriptExecuteService svc = new ScriptExecuteService(new ScriptReadService());
+
+      ScriptExecResult result = svc.runLive(rvs, ScriptTarget.parse("vs-init"), false);
+
+      assertTrue(result.ok());
+      assertEquals(List.of(), result.changed());
+      // Qualified with the assembly name, unlike the single-assembly ASSEMBLY/ASSEMBLY_ONCLICK
+      // path -- VS_INIT/VS_LOAD have no single "the assembly" the message can name.
+      assertEquals(List.of("Submit1.label"), result.unrecognizedProperties());
+      assertTrue(result.summary().contains("Submit1.label"), result.summary());
+      verify(submit1).resetUnrecognizedWrites();
+   }
+
+   /**
+    * VS_INIT can touch several assemblies; each one's scriptable must be reset/checked, but
+    * only the one that actually wrote an unrecognized name should show up in the result -- an
+    * untouched assembly's scriptable reporting an empty list must not leak into the aggregate.
+    */
+   @Test
+   void executeOnlyReportsUnrecognizedWritesFromTheAssembliesActuallyTouchedByVsInit()
+      throws Exception
+   {
+      String script = "Submit2.label = 'ClauseTest42';";
+      ViewsheetScope scope = mock(ViewsheetScope.class);
+      when(scope.execute(eq(script), nullable(String.class))).thenReturn(null);
+
+      VSAScriptable submit1 = mock(VSAScriptable.class);
+      when(submit1.getUnrecognizedWrites()).thenReturn(List.of());
+      VSAScriptable submit2 = mock(VSAScriptable.class);
+      when(submit2.getUnrecognizedWrites()).thenReturn(List.of("label"));
+
+      Map<String, VSAScriptable> scriptables = new LinkedHashMap<>();
+      scriptables.put("Submit1", submit1);
+      scriptables.put("Submit2", submit2);
+      RuntimeViewsheet rvs = viewsheetWithVsScript(false, script, scope, scriptables);
+      ScriptExecuteService svc = new ScriptExecuteService(new ScriptReadService());
+
+      ScriptExecResult result = svc.runLive(rvs, ScriptTarget.parse("vs-init"), false);
+
+      assertTrue(result.ok());
+      assertEquals(List.of(), result.changed());
+      assertEquals(List.of("Submit2.label"), result.unrecognizedProperties());
+      verify(submit1).resetUnrecognizedWrites();
+      verify(submit2).resetUnrecognizedWrites();
+   }
+
+   @Test
+   void executeReportsARealPropertyWriteFromVsInitNormallyWithNoUnrecognizedProperties()
+      throws Exception
+   {
+      String script = "Submit1.enabled = false;";
+      ViewsheetScope scope = mock(ViewsheetScope.class);
+      when(scope.execute(eq(script), nullable(String.class))).thenReturn(false);
+
+      VSAScriptable submit1 = mock(VSAScriptable.class);
+      when(submit1.getUnrecognizedWrites()).thenReturn(List.of());
+
+      RuntimeViewsheet rvs =
+         viewsheetWithVsScript(false, script, scope, Map.of("Submit1", submit1));
+      ScriptTarget target = ScriptTarget.parse("vs-init");
+      ScriptExecuteService svc = new ScriptExecuteService(new ScriptReadService());
+
+      ScriptExecResult result = svc.runLive(rvs, target, false);
+
+      assertTrue(result.ok());
+      assertEquals(List.of(target.toString()), result.changed());
+      assertNull(result.unrecognizedProperties());
+      verify(submit1).resetUnrecognizedWrites();
+   }
+
+   /** Same mechanism, the other location that runs with {@code assemblyName == null}. */
+   @Test
+   void executeTracksUnrecognizedWritesForVsLoadTheSameWayAsVsInit() throws Exception {
+      String script = "Submit1.label = 'ClauseTest42';";
+      ViewsheetScope scope = mock(ViewsheetScope.class);
+      when(scope.execute(eq(script), nullable(String.class))).thenReturn(null);
+
+      VSAScriptable submit1 = mock(VSAScriptable.class);
+      when(submit1.getUnrecognizedWrites()).thenReturn(List.of("label"));
+
+      RuntimeViewsheet rvs =
+         viewsheetWithVsScript(true, script, scope, Map.of("Submit1", submit1));
+      ScriptExecuteService svc = new ScriptExecuteService(new ScriptReadService());
+
+      ScriptExecResult result = svc.runLive(rvs, ScriptTarget.parse("vs-load"), false);
+
+      assertTrue(result.ok());
+      assertEquals(List.of(), result.changed());
+      assertEquals(List.of("Submit1.label"), result.unrecognizedProperties());
+      verify(submit1).resetUnrecognizedWrites();
    }
 
    @Test


### PR DESCRIPTION
## Summary

Follow-up to `#4733` (fix(wiz): report unrecognized scriptable-property writes in
execute_script), closing a known-remaining gap flagged by the reviewer during that PR.

`#4733` added `VSAScriptable#resetUnrecognizedWrites()`/`getUnrecognizedWrites()` and wired it
into `ScriptExecuteService.execute()` — but only for `ASSEMBLY`/`ASSEMBLY_ONCLICK` targets,
tracking the single named assembly's scriptable. `VS_INIT`/`VS_LOAD` scripts run with
`assemblyName == null` (they have no single "current" assembly) and can write to *any*
assembly in the sheet by name — e.g. `Submit1.label = "X";` inside an `onInit` script. The
identical silent-absorption bug (an unrecognized property assignment landing in the per-
assembly expando map instead of erroring, reported as a plausible success) was still fully
reachable from those two locations.

### Fix

`ScriptExecuteService.execute()` now resolves a `Map<String, VSAScriptable>` of assemblies to
track via a new `trackedScriptables()` helper:
- `ASSEMBLY`/`ASSEMBLY_ONCLICK`: unchanged — the single named assembly's scriptable.
- `VS_INIT`/`VS_LOAD`: every assembly in the sheet's own `VSAScriptable`, resolved via
  `scope.getVSAScriptable(name)`. This is a lookup, not new instantiation:
  `ViewsheetScope#addProperties0` already eagerly creates and caches every assembly's
  scriptable in the scope's own `propmap` at sandbox init, well before any script runs.

All tracked scriptables are reset before `scope.execute(...)` and checked after. Unrecognized
names are aggregated across every tracked assembly; when the target is `VS_INIT`/`VS_LOAD`
(no single assembly to name), each is qualified `"AssemblyName.property"` to disambiguate two
different assemblies' own unrecognized same-named write. The `ASSEMBLY`/`ASSEMBLY_ONCLICK`
message/behavior is byte-for-byte unchanged (bare property name, no qualification) — the
existing 9 `ScriptExecuteServiceTest` tests pass without modification.

No shape change to `ScriptExecResult`/`unrecognizedProperties` — it was already a plain
`List<String>`. A companion PR (`inetsoft-technology/stylebi-wiz`) documents the new qualified
form in the MCP tool description and adds pass-through regression tests.

## Test plan
- [x] `./mvnw -o test -pl core -Dtest=ScriptExecuteServiceTest` — 13/13 pass (9 existing +
      4 new: unrecognized write on one VS_INIT-touched assembly, correct isolation when only
      one of two touched assemblies has an unrecognized write, real-property-write regression
      guard for VS_INIT, and VS_LOAD parity)
- [x] Broader sweep `-Dtest='inetsoft.web.wiz.script.**,inetsoft.report.script.viewsheet.**'`
      — 388/388 pass
- [x] Full `core` module suite (`./mvnw -o test -pl core`) — 6992 tests, 0 failures, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)