### PR TITLE
Add curated response schema carrier to endpoint catalog

### DIFF
--- a/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/json/AbstractEndpoint.java
+++ b/connectors/inetsoft-rest/src/main/java/inetsoft/uql/rest/json/AbstractEndpoint.java
@@ -77,9 +77,37 @@ public class AbstractEndpoint implements EndpointJsonQuery.Endpoint {
    }
 
    /**
-    * {@code description} is deliberately excluded here and from {@link #hashCode()}: rewording an
-    * endpoint does not make it a different endpoint, and folding it in would make identity depend
-    * on prose that is expected to be revised.
+    * The structure this endpoint's response has, as declared here rather than derived from a live
+    * response. Optional, and absent from most {@code endpoints.json} files.
+    *
+    * <p>Declared as a bare {@code Object} on purpose, and NOT as a {@code Map}. Nothing in this
+    * connector reads it: the field exists so that the loader's mapper, which rejects unknown
+    * properties and whose failure {@code Endpoints.load} turns into an EMPTY endpoint map, can bind
+    * a file that carries the key. The consumer is the wiz catalogue (see
+    * {@code WizEndpointCatalogEntry}), which parses the tree itself.</p>
+    *
+    * <p>A {@code Map} would not do. The representation allows an array at the root -- an API whose
+    * response body IS a bare array -- and binding that to a {@code Map} is a type mismatch on a
+    * KNOWN property, which no ignore-unknown setting excuses. {@code Object} binds any JSON and
+    * serializes back verbatim, so the representation can evolve without touching Java.</p>
+    *
+    * <p>Deliberately excluded from {@link #equals} and {@link #hashCode()}, for the same reason
+    * {@code description} is: restating what an endpoint returns does not make it a different
+    * endpoint.</p>
+    */
+   public Object getResponseSchema() {
+      return responseSchema;
+   }
+
+   public void setResponseSchema(Object responseSchema) {
+      this.responseSchema = responseSchema;
+   }
+
+   /**
+    * {@code description} and {@code responseSchema} are deliberately excluded here and from
+    * {@link #hashCode()}: rewording an endpoint, or declaring what it returns, does not make it a
+    * different endpoint, and folding either in would make identity depend on prose or a structure
+    * that is expected to be revised.
     */
    @Override
    public boolean equals(Object o) {
@@ -102,4 +130,5 @@ public class AbstractEndpoint implements EndpointJsonQuery.Endpoint {
    private String suffix;
    private boolean paged;
    private List<JsonLookupEndpoint> lookups = Collections.emptyList();
+   private Object responseSchema;
 }

--- a/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/stripe/endpoints.json
+++ b/connectors/inetsoft-rest/src/main/resources/inetsoft/uql/rest/datasource/stripe/endpoints.json
@@ -4,31 +4,710 @@
       "name": "Balance",
       "description": "The current account balance as a single record, not a list. Shows available and pending amounts per currency. Answers \"how much do I have right now\"; historical movement of money lives in Balance Transactions instead.",
       "paged": false,
-      "suffix": "/v1/balance"
+      "suffix": "/v1/balance",
+      "responseSchema": {
+        "available": [
+          {
+            "amount": "double",
+            "currency": "string",
+            "source_types": {
+              "bank_account": "double",
+              "card": "double",
+              "fpx": "double"
+            }
+          }
+        ],
+        "connect_reserved": [
+          {
+            "amount": "double",
+            "currency": "string",
+            "source_types": {
+              "bank_account": "double",
+              "card": "double",
+              "fpx": "double"
+            }
+          }
+        ],
+        "instant_available": [
+          {
+            "amount": "double",
+            "currency": "string",
+            "source_types": {
+              "bank_account": "double",
+              "card": "double",
+              "fpx": "double"
+            }
+          }
+        ],
+        "issuing": {
+          "available": [
+            {
+              "amount": "double",
+              "currency": "string",
+              "source_types": {
+                "bank_account": "double",
+                "card": "double",
+                "fpx": "double"
+              }
+            }
+          ]
+        },
+        "livemode": "boolean",
+        "object": "string",
+        "pending": [
+          {
+            "amount": "double",
+            "currency": "string",
+            "source_types": {
+              "bank_account": "double",
+              "card": "double",
+              "fpx": "double"
+            }
+          }
+        ]
+      }
     },
     {
       "name": "Balance Transaction",
       "description": "A single balance transaction by its id. Same fields as Balance Transactions; use it when the id is already known rather than to scan or aggregate.",
       "paged": false,
-      "suffix": "/v1/balance_transactions/{Balance Transactions ID}"
+      "suffix": "/v1/balance_transactions/{Balance Transactions ID}",
+      "responseSchema": {
+        "amount": "double",
+        "available_on": "double",
+        "created": "double",
+        "currency": "string",
+        "description": "string",
+        "exchange_rate": "double",
+        "fee": "double",
+        "fee_details": [
+          {
+            "amount": "double",
+            "application": "string",
+            "currency": "string",
+            "description": "string",
+            "type": "string"
+          }
+        ],
+        "id": "string",
+        "net": "double",
+        "object": "string",
+        "reporting_category": "string",
+        "source": "string",
+        "status": "string",
+        "type": "string"
+      }
     },
     {
       "name": "Balance Transactions",
       "description": "Every movement of money through the Stripe balance -- charges, refunds, payouts, fees and adjustments alike. Carries gross amount, fee and net separately, currency and exchange_rate, the date funds become available_on, and a reporting_category and type naming what caused the movement. The right table for net revenue and fee analysis, because it is the only one where fees are broken out from gross.",
       "paged": true,
-      "suffix": "/v1/balance_transactions?payout={Payout ID?}&type={Type?:charge|refund|...}&available_on={Available On?:Unix timestamp}&Created={Created?:Unix timestamp}&currency={Currency?:ISO currency code}&source={Source ID?}"
+      "suffix": "/v1/balance_transactions?payout={Payout ID?}&type={Type?:charge|refund|...}&available_on={Available On?:Unix timestamp}&Created={Created?:Unix timestamp}&currency={Currency?:ISO currency code}&source={Source ID?}",
+      "responseSchema": {
+        "data": [
+          {
+            "amount": "double",
+            "available_on": "double",
+            "created": "double",
+            "currency": "string",
+            "description": "string",
+            "exchange_rate": "double",
+            "fee": "double",
+            "fee_details": [
+              {
+                "amount": "double",
+                "application": "string",
+                "currency": "string",
+                "description": "string",
+                "type": "string"
+              }
+            ],
+            "id": "string",
+            "net": "double",
+            "object": "string",
+            "reporting_category": "string",
+            "source": "string",
+            "status": "string",
+            "type": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Charge",
       "description": "A single charge by its id. Same fields as Charges; use it when the charge id is already known rather than to scan or aggregate.",
       "paged": false,
-      "suffix": "/v1/charges/{Charge ID}"
+      "suffix": "/v1/charges/{Charge ID}",
+      "responseSchema": {
+        "amount": "double",
+        "amount_captured": "double",
+        "amount_refunded": "double",
+        "application": "string",
+        "application_fee": "string",
+        "application_fee_amount": "double",
+        "balance_transaction": "string",
+        "billing_details": {
+          "address": {
+            "city": "string",
+            "country": "string",
+            "line1": "string",
+            "line2": "string",
+            "postal_code": "string",
+            "state": "string"
+          },
+          "email": "string",
+          "name": "string",
+          "phone": "string"
+        },
+        "calculated_statement_descriptor": "string",
+        "captured": "boolean",
+        "created": "double",
+        "currency": "string",
+        "customer": "string",
+        "description": "string",
+        "disputed": "boolean",
+        "failure_code": "string",
+        "failure_message": "string",
+        "fraud_details": {
+          "stripe_report": "string",
+          "user_report": "string"
+        },
+        "id": "string",
+        "livemode": "boolean",
+        "metadata": {
+          "*": "string"
+        },
+        "object": "string",
+        "on_behalf_of": "string",
+        "outcome": {
+          "network_status": "string",
+          "reason": "string",
+          "risk_level": "string",
+          "risk_score": "double",
+          "rule": "string",
+          "seller_message": "string",
+          "type": "string"
+        },
+        "paid": "boolean",
+        "payment_intent": "string",
+        "payment_method": "string",
+        "payment_method_details": {
+          "ach_credit_transfer": {
+            "account_number": "string",
+            "bank_name": "string",
+            "routing_number": "string",
+            "swift_code": "string"
+          },
+          "ach_debit": {
+            "account_holder_type": "string",
+            "bank_name": "string",
+            "country": "string",
+            "fingerprint": "string",
+            "last4": "string",
+            "routing_number": "string"
+          },
+          "alipay": {
+            "fingerprint": "string",
+            "transaction_id": "string"
+          },
+          "au_becs_debit": {
+            "bsb_number": "string",
+            "fingerprint": "string",
+            "last4": "string",
+            "mandate": "string"
+          },
+          "bacs_debit": {
+            "fingerprint": "string",
+            "last4": "string",
+            "mandate": "string",
+            "sort_code": "string"
+          },
+          "bancontact": {
+            "bank_code": "string",
+            "bank_name": "string",
+            "bic": "string",
+            "iban_last4": "string",
+            "preferred_language": "string",
+            "verified_name": "string"
+          },
+          "card": {
+            "brand": "string",
+            "checks": {
+              "address_line1_check": "string",
+              "address_postal_code_check": "string",
+              "cvc_check": "string"
+            },
+            "country": "string",
+            "exp_month": "double",
+            "exp_year": "double",
+            "fingerprint": "string",
+            "funding": "string",
+            "installments": {
+              "plan": {
+                "count": "double",
+                "interval": "string",
+                "type": "string"
+              }
+            },
+            "last4": "string",
+            "network": "string",
+            "three_d_secure": {
+              "authentication_flow": "string",
+              "result": "string",
+              "result_reason": "string",
+              "version": "string"
+            },
+            "wallet": {
+              "dynamic_last4": "string",
+              "masterpass": {
+                "billing_address": {
+                  "city": "string",
+                  "country": "string",
+                  "line1": "string",
+                  "line2": "string",
+                  "postal_code": "string",
+                  "state": "string"
+                },
+                "email": "string",
+                "name": "string",
+                "shipping_address": {
+                  "city": "string",
+                  "country": "string",
+                  "line1": "string",
+                  "line2": "string",
+                  "postal_code": "string",
+                  "state": "string"
+                }
+              },
+              "type": "string",
+              "visa_checkout": {
+                "billing_address": {
+                  "city": "string",
+                  "country": "string",
+                  "line1": "string",
+                  "line2": "string",
+                  "postal_code": "string",
+                  "state": "string"
+                },
+                "email": "string",
+                "name": "string",
+                "shipping_address": {
+                  "city": "string",
+                  "country": "string",
+                  "line1": "string",
+                  "line2": "string",
+                  "postal_code": "string",
+                  "state": "string"
+                }
+              }
+            }
+          },
+          "card_present": {
+            "brand": "string",
+            "cardholder_name": "string",
+            "country": "string",
+            "emv_auth_data": "string",
+            "exp_month": "double",
+            "exp_year": "double",
+            "fingerprint": "string",
+            "funding": "string",
+            "generated_card": "string",
+            "last4": "string",
+            "network": "string",
+            "read_method": "string",
+            "receipt": {
+              "account_type": "string",
+              "application_cryptogram": "string",
+              "application_preferred_name": "string",
+              "authorization_code": "string",
+              "authorization_response_code": "string",
+              "cardholder_verification_method": "string",
+              "dedicated_file_name": "string",
+              "terminal_verification_results": "string",
+              "transaction_status_information": "string"
+            }
+          },
+          "eps": {
+            "verified_name": "string"
+          },
+          "fpx": {
+            "bank": "string",
+            "transaction_id": "string"
+          },
+          "giropay": {
+            "bank_code": "string",
+            "bank_name": "string",
+            "bic": "string",
+            "verified_name": "string"
+          },
+          "ideal": {
+            "bank": "string",
+            "bic": "string",
+            "iban_last4": "string",
+            "verified_name": "string"
+          },
+          "interac_present": {
+            "brand": "string",
+            "cardholder_name": "string",
+            "country": "string",
+            "emv_auth_data": "string",
+            "exp_month": "double",
+            "exp_year": "double",
+            "fingerprint": "string",
+            "funding": "string",
+            "generated_card": "string",
+            "last4": "string",
+            "network": "string",
+            "read_method": "string",
+            "receipt": {
+              "account_type": "string",
+              "application_cryptogram": "string",
+              "application_preferred_name": "string",
+              "authorization_code": "string",
+              "authorization_response_code": "string",
+              "cardholder_verification_method": "string",
+              "dedicated_file_name": "string",
+              "terminal_verification_results": "string",
+              "transaction_status_information": "string"
+            }
+          },
+          "multibanco": {
+            "entity": "string",
+            "reference": "string"
+          },
+          "oxxo": {
+            "number": "string"
+          },
+          "p24": {
+            "reference": "string",
+            "verified_name": "string"
+          },
+          "sepa_debit": {
+            "bank_code": "string",
+            "branch_code": "string",
+            "country": "string",
+            "fingerprint": "string",
+            "last4": "string",
+            "mandate": "string"
+          },
+          "sofort": {
+            "bank_code": "string",
+            "bank_name": "string",
+            "bic": "string",
+            "country": "string",
+            "iban_last4": "string",
+            "preferred_language": "string",
+            "verified_name": "string"
+          },
+          "type": "string"
+        },
+        "receipt_email": "string",
+        "receipt_number": "string",
+        "receipt_url": "string",
+        "refunded": "boolean",
+        "review": "string",
+        "shipping": {
+          "address": {
+            "city": "string",
+            "country": "string",
+            "line1": "string",
+            "line2": "string",
+            "postal_code": "string",
+            "state": "string"
+          },
+          "carrier": "string",
+          "name": "string",
+          "phone": "string",
+          "tracking_number": "string"
+        },
+        "source_transfer": "string",
+        "statement_descriptor": "string",
+        "statement_descriptor_suffix": "string",
+        "status": "string",
+        "transfer": "string",
+        "transfer_data": {
+          "amount": "double",
+          "destination": "string"
+        },
+        "transfer_group": "string"
+      }
     },
     {
       "name": "Charges",
       "description": "Payment attempts against a card or other payment method, one row each. Carries amount, amount_captured and amount_refunded, currency, whether it was captured, refunded or disputed, the failure_code and failure_message when declined, and links to the customer and payment method. The usual table for revenue, transaction volume, and decline or dispute rates.",
       "paged": true,
       "suffix": "/v1/charges?created={Created?:Unix timestamp}&payment_intent={Payment Intent ID?}&transfer_group={Transfer Group?}",
+      "responseSchema": {
+        "data": [
+          {
+            "amount": "double",
+            "amount_captured": "double",
+            "amount_refunded": "double",
+            "application": "string",
+            "application_fee": "string",
+            "application_fee_amount": "double",
+            "balance_transaction": "string",
+            "billing_details": {
+              "address": {
+                "city": "string",
+                "country": "string",
+                "line1": "string",
+                "line2": "string",
+                "postal_code": "string",
+                "state": "string"
+              },
+              "email": "string",
+              "name": "string",
+              "phone": "string"
+            },
+            "calculated_statement_descriptor": "string",
+            "captured": "boolean",
+            "created": "double",
+            "currency": "string",
+            "customer": "string",
+            "description": "string",
+            "disputed": "boolean",
+            "failure_code": "string",
+            "failure_message": "string",
+            "fraud_details": {
+              "stripe_report": "string",
+              "user_report": "string"
+            },
+            "id": "string",
+            "livemode": "boolean",
+            "metadata": {
+              "*": "string"
+            },
+            "object": "string",
+            "on_behalf_of": "string",
+            "outcome": {
+              "network_status": "string",
+              "reason": "string",
+              "risk_level": "string",
+              "risk_score": "double",
+              "rule": "string",
+              "seller_message": "string",
+              "type": "string"
+            },
+            "paid": "boolean",
+            "payment_intent": "string",
+            "payment_method": "string",
+            "payment_method_details": {
+              "ach_credit_transfer": {
+                "account_number": "string",
+                "bank_name": "string",
+                "routing_number": "string",
+                "swift_code": "string"
+              },
+              "ach_debit": {
+                "account_holder_type": "string",
+                "bank_name": "string",
+                "country": "string",
+                "fingerprint": "string",
+                "last4": "string",
+                "routing_number": "string"
+              },
+              "alipay": {
+                "fingerprint": "string",
+                "transaction_id": "string"
+              },
+              "au_becs_debit": {
+                "bsb_number": "string",
+                "fingerprint": "string",
+                "last4": "string",
+                "mandate": "string"
+              },
+              "bacs_debit": {
+                "fingerprint": "string",
+                "last4": "string",
+                "mandate": "string",
+                "sort_code": "string"
+              },
+              "bancontact": {
+                "bank_code": "string",
+                "bank_name": "string",
+                "bic": "string",
+                "iban_last4": "string",
+                "preferred_language": "string",
+                "verified_name": "string"
+              },
+              "card": {
+                "brand": "string",
+                "checks": {
+                  "address_line1_check": "string",
+                  "address_postal_code_check": "string",
+                  "cvc_check": "string"
+                },
+                "country": "string",
+                "exp_month": "double",
+                "exp_year": "double",
+                "fingerprint": "string",
+                "funding": "string",
+                "installments": {
+                  "plan": {
+                    "count": "double",
+                    "interval": "string",
+                    "type": "string"
+                  }
+                },
+                "last4": "string",
+                "network": "string",
+                "three_d_secure": {
+                  "authentication_flow": "string",
+                  "result": "string",
+                  "result_reason": "string",
+                  "version": "string"
+                },
+                "wallet": {
+                  "dynamic_last4": "string",
+                  "masterpass": {
+                    "email": "string",
+                    "name": "string"
+                  },
+                  "type": "string",
+                  "visa_checkout": {
+                    "email": "string",
+                    "name": "string"
+                  }
+                }
+              },
+              "card_present": {
+                "brand": "string",
+                "cardholder_name": "string",
+                "country": "string",
+                "emv_auth_data": "string",
+                "exp_month": "double",
+                "exp_year": "double",
+                "fingerprint": "string",
+                "funding": "string",
+                "generated_card": "string",
+                "last4": "string",
+                "network": "string",
+                "read_method": "string",
+                "receipt": {
+                  "account_type": "string",
+                  "application_cryptogram": "string",
+                  "application_preferred_name": "string",
+                  "authorization_code": "string",
+                  "authorization_response_code": "string",
+                  "cardholder_verification_method": "string",
+                  "dedicated_file_name": "string",
+                  "terminal_verification_results": "string",
+                  "transaction_status_information": "string"
+                }
+              },
+              "eps": {
+                "verified_name": "string"
+              },
+              "fpx": {
+                "bank": "string",
+                "transaction_id": "string"
+              },
+              "giropay": {
+                "bank_code": "string",
+                "bank_name": "string",
+                "bic": "string",
+                "verified_name": "string"
+              },
+              "ideal": {
+                "bank": "string",
+                "bic": "string",
+                "iban_last4": "string",
+                "verified_name": "string"
+              },
+              "interac_present": {
+                "brand": "string",
+                "cardholder_name": "string",
+                "country": "string",
+                "emv_auth_data": "string",
+                "exp_month": "double",
+                "exp_year": "double",
+                "fingerprint": "string",
+                "funding": "string",
+                "generated_card": "string",
+                "last4": "string",
+                "network": "string",
+                "read_method": "string",
+                "receipt": {
+                  "account_type": "string",
+                  "application_cryptogram": "string",
+                  "application_preferred_name": "string",
+                  "authorization_code": "string",
+                  "authorization_response_code": "string",
+                  "cardholder_verification_method": "string",
+                  "dedicated_file_name": "string",
+                  "terminal_verification_results": "string",
+                  "transaction_status_information": "string"
+                }
+              },
+              "multibanco": {
+                "entity": "string",
+                "reference": "string"
+              },
+              "oxxo": {
+                "number": "string"
+              },
+              "p24": {
+                "reference": "string",
+                "verified_name": "string"
+              },
+              "sepa_debit": {
+                "bank_code": "string",
+                "branch_code": "string",
+                "country": "string",
+                "fingerprint": "string",
+                "last4": "string",
+                "mandate": "string"
+              },
+              "sofort": {
+                "bank_code": "string",
+                "bank_name": "string",
+                "bic": "string",
+                "country": "string",
+                "iban_last4": "string",
+                "preferred_language": "string",
+                "verified_name": "string"
+              },
+              "type": "string"
+            },
+            "receipt_email": "string",
+            "receipt_number": "string",
+            "receipt_url": "string",
+            "refunded": "boolean",
+            "review": "string",
+            "shipping": {
+              "address": {
+                "city": "string",
+                "country": "string",
+                "line1": "string",
+                "line2": "string",
+                "postal_code": "string",
+                "state": "string"
+              },
+              "carrier": "string",
+              "name": "string",
+              "phone": "string",
+              "tracking_number": "string"
+            },
+            "source_transfer": "string",
+            "statement_descriptor": "string",
+            "statement_descriptor_suffix": "string",
+            "status": "string",
+            "transfer": "string",
+            "transfer_data": {
+              "amount": "double",
+              "destination": "string"
+            },
+            "transfer_group": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      },
       "lookups": [
         {
           "endpoints": [
@@ -47,13 +726,154 @@
       "name": "Customer",
       "description": "A single customer by its id. Same fields as Customers; use it when the customer id is already known rather than to scan or aggregate.",
       "paged": false,
-      "suffix": "/v1/customers/{Customer ID}"
+      "suffix": "/v1/customers/{Customer ID}",
+      "responseSchema": {
+        "address": {
+          "city": "string",
+          "country": "string",
+          "line1": "string",
+          "line2": "string",
+          "postal_code": "string",
+          "state": "string"
+        },
+        "balance": "double",
+        "created": "double",
+        "currency": "string",
+        "default_source": "string",
+        "delinquent": "boolean",
+        "description": "string",
+        "discount": {
+          "checkout_session": "string",
+          "customer": "string",
+          "end": "double",
+          "id": "string",
+          "invoice": "string",
+          "invoice_item": "string",
+          "object": "string",
+          "promotion_code": "string",
+          "start": "double",
+          "subscription": "string"
+        },
+        "email": "string",
+        "id": "string",
+        "invoice_prefix": "string",
+        "invoice_settings": {
+          "custom_fields": [
+            {
+              "name": "string",
+              "value": "string"
+            }
+          ],
+          "default_payment_method": "string",
+          "footer": "string"
+        },
+        "livemode": "boolean",
+        "metadata": {
+          "*": "string"
+        },
+        "name": "string",
+        "next_invoice_sequence": "double",
+        "object": "string",
+        "phone": "string",
+        "preferred_locales": [
+          "string"
+        ],
+        "shipping": {
+          "address": {
+            "city": "string",
+            "country": "string",
+            "line1": "string",
+            "line2": "string",
+            "postal_code": "string",
+            "state": "string"
+          },
+          "carrier": "string",
+          "name": "string",
+          "phone": "string",
+          "tracking_number": "string"
+        },
+        "tax_exempt": "string"
+      }
     },
     {
       "name": "Customers",
       "description": "The customer records, one row each. Carries name, email, address, account balance, currency, whether the customer is delinquent, any active discount, and invoice settings. Use for customer counts, signup dates, and for joining payments back to who made them.",
       "paged": true,
       "suffix": "/v1/customers?email={Email?}&created={Created?:Unix timestamp}",
+      "responseSchema": {
+        "data": [
+          {
+            "address": {
+              "city": "string",
+              "country": "string",
+              "line1": "string",
+              "line2": "string",
+              "postal_code": "string",
+              "state": "string"
+            },
+            "balance": "double",
+            "created": "double",
+            "currency": "string",
+            "default_source": "string",
+            "delinquent": "boolean",
+            "description": "string",
+            "discount": {
+              "checkout_session": "string",
+              "customer": "string",
+              "end": "double",
+              "id": "string",
+              "invoice": "string",
+              "invoice_item": "string",
+              "object": "string",
+              "promotion_code": "string",
+              "start": "double",
+              "subscription": "string"
+            },
+            "email": "string",
+            "id": "string",
+            "invoice_prefix": "string",
+            "invoice_settings": {
+              "custom_fields": [
+                {
+                  "name": "string",
+                  "value": "string"
+                }
+              ],
+              "default_payment_method": "string",
+              "footer": "string"
+            },
+            "livemode": "boolean",
+            "metadata": {
+              "*": "string"
+            },
+            "name": "string",
+            "next_invoice_sequence": "double",
+            "object": "string",
+            "phone": "string",
+            "preferred_locales": [
+              "string"
+            ],
+            "shipping": {
+              "address": {
+                "city": "string",
+                "country": "string",
+                "line1": "string",
+                "line2": "string",
+                "postal_code": "string",
+                "state": "string"
+              },
+              "carrier": "string",
+              "name": "string",
+              "phone": "string",
+              "tracking_number": "string"
+            },
+            "tax_exempt": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      },
       "lookups": [
         {
           "endpoints": [
@@ -75,67 +895,847 @@
       "name": "Dispute",
       "description": "A single dispute by its id. Same fields as Disputes; use it when the dispute id is already known rather than to scan or aggregate.",
       "paged": false,
-      "suffix": "/v1/disputes/{Dispute ID}"
+      "suffix": "/v1/disputes/{Dispute ID}",
+      "responseSchema": {
+        "amount": "double",
+        "balance_transactions": [
+          {
+            "amount": "double",
+            "available_on": "double",
+            "created": "double",
+            "currency": "string",
+            "description": "string",
+            "exchange_rate": "double",
+            "fee": "double",
+            "fee_details": [
+              {
+                "amount": "double",
+                "application": "string",
+                "currency": "string",
+                "description": "string",
+                "type": "string"
+              }
+            ],
+            "id": "string",
+            "net": "double",
+            "object": "string",
+            "reporting_category": "string",
+            "source": "string",
+            "status": "string",
+            "type": "string"
+          }
+        ],
+        "charge": "string",
+        "created": "double",
+        "currency": "string",
+        "evidence": {
+          "access_activity_log": "string",
+          "billing_address": "string",
+          "cancellation_policy": "string",
+          "cancellation_policy_disclosure": "string",
+          "cancellation_rebuttal": "string",
+          "customer_communication": "string",
+          "customer_email_address": "string",
+          "customer_name": "string",
+          "customer_purchase_ip": "string",
+          "customer_signature": "string",
+          "duplicate_charge_documentation": "string",
+          "duplicate_charge_explanation": "string",
+          "duplicate_charge_id": "string",
+          "product_description": "string",
+          "receipt": "string",
+          "refund_policy": "string",
+          "refund_policy_disclosure": "string",
+          "refund_refusal_explanation": "string",
+          "service_date": "string",
+          "service_documentation": "string",
+          "shipping_address": "string",
+          "shipping_carrier": "string",
+          "shipping_date": "string",
+          "shipping_documentation": "string",
+          "shipping_tracking_number": "string",
+          "uncategorized_file": "string",
+          "uncategorized_text": "string"
+        },
+        "evidence_details": {
+          "due_by": "double",
+          "has_evidence": "boolean",
+          "past_due": "boolean",
+          "submission_count": "double"
+        },
+        "id": "string",
+        "is_charge_refundable": "boolean",
+        "livemode": "boolean",
+        "metadata": {
+          "*": "string"
+        },
+        "object": "string",
+        "payment_intent": "string",
+        "reason": "string",
+        "status": "string"
+      }
     },
     {
       "name": "Disputes",
       "description": "Chargebacks raised by cardholders, one row each. Carries amount, currency, the reason given, status, the evidence submitted and its deadline, and links to the disputed charge and payment_intent. Use for dispute rate and dispute outcomes.",
       "paged": true,
-      "suffix": "/v1/disputes?charge={Charge ID?}&payment_intent={Payment Intent ID?}&created={Created?:Unix timestamp}"
+      "suffix": "/v1/disputes?charge={Charge ID?}&payment_intent={Payment Intent ID?}&created={Created?:Unix timestamp}",
+      "responseSchema": {
+        "data": [
+          {
+            "amount": "double",
+            "balance_transactions": [
+              {
+                "amount": "double",
+                "available_on": "double",
+                "created": "double",
+                "currency": "string",
+                "description": "string",
+                "exchange_rate": "double",
+                "fee": "double",
+                "fee_details": [
+                  {
+                    "amount": "double",
+                    "application": "string",
+                    "currency": "string",
+                    "description": "string",
+                    "type": "string"
+                  }
+                ],
+                "id": "string",
+                "net": "double",
+                "object": "string",
+                "reporting_category": "string",
+                "source": "string",
+                "status": "string",
+                "type": "string"
+              }
+            ],
+            "charge": "string",
+            "created": "double",
+            "currency": "string",
+            "evidence": {
+              "access_activity_log": "string",
+              "billing_address": "string",
+              "cancellation_policy": "string",
+              "cancellation_policy_disclosure": "string",
+              "cancellation_rebuttal": "string",
+              "customer_communication": "string",
+              "customer_email_address": "string",
+              "customer_name": "string",
+              "customer_purchase_ip": "string",
+              "customer_signature": "string",
+              "duplicate_charge_documentation": "string",
+              "duplicate_charge_explanation": "string",
+              "duplicate_charge_id": "string",
+              "product_description": "string",
+              "receipt": "string",
+              "refund_policy": "string",
+              "refund_policy_disclosure": "string",
+              "refund_refusal_explanation": "string",
+              "service_date": "string",
+              "service_documentation": "string",
+              "shipping_address": "string",
+              "shipping_carrier": "string",
+              "shipping_date": "string",
+              "shipping_documentation": "string",
+              "shipping_tracking_number": "string",
+              "uncategorized_file": "string",
+              "uncategorized_text": "string"
+            },
+            "evidence_details": {
+              "due_by": "double",
+              "has_evidence": "boolean",
+              "past_due": "boolean",
+              "submission_count": "double"
+            },
+            "id": "string",
+            "is_charge_refundable": "boolean",
+            "livemode": "boolean",
+            "metadata": {
+              "*": "string"
+            },
+            "object": "string",
+            "payment_intent": "string",
+            "reason": "string",
+            "status": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Event",
       "description": "A single event by its id. Same fields as Events; use it when the event id is already known rather than to scan or aggregate.",
       "paged": false,
-      "suffix": "/v1/events/{Event ID}"
+      "suffix": "/v1/events/{Event ID}",
+      "responseSchema": {
+        "account": "string",
+        "api_version": "string",
+        "created": "double",
+        "id": "string",
+        "livemode": "boolean",
+        "object": "string",
+        "pending_webhooks": "double",
+        "request": {
+          "id": "string",
+          "idempotency_key": "string"
+        },
+        "type": "string"
+      }
     },
     {
       "name": "Events",
       "description": "The audit trail of everything that happened in the account: objects created or updated, payments succeeding or failing, and so on. Each row names the event type, when it occurred, and carries the affected object. Use for activity timelines and for auditing what changed, not as a substitute for querying the objects themselves.",
       "paged": true,
-      "suffix": "/v1/events?created={Created?:Unix timestamp}&delivery_success={Delivery Success?:true|false}&type={Event Type?}"
+      "suffix": "/v1/events?created={Created?:Unix timestamp}&delivery_success={Delivery Success?:true|false}&type={Event Type?}",
+      "responseSchema": {
+        "data": [
+          {
+            "account": "string",
+            "api_version": "string",
+            "created": "double",
+            "id": "string",
+            "livemode": "boolean",
+            "object": "string",
+            "pending_webhooks": "double",
+            "request": {
+              "id": "string",
+              "idempotency_key": "string"
+            },
+            "type": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "File",
       "description": "A single file by its id. Same fields as Files; use it when the file id is already known.",
       "paged": false,
-      "suffix": "/v1/files/{File ID}"
+      "suffix": "/v1/files/{File ID}",
+      "responseSchema": {
+        "created": "double",
+        "expires_at": "double",
+        "filename": "string",
+        "id": "string",
+        "links": {
+          "data": [
+            {
+              "created": "double",
+              "expired": "boolean",
+              "expires_at": "double",
+              "file": "string",
+              "id": "string",
+              "livemode": "boolean",
+              "metadata": {
+                "*": "string"
+              },
+              "object": "string",
+              "url": "string"
+            }
+          ],
+          "has_more": "boolean",
+          "object": "string",
+          "url": "string"
+        },
+        "object": "string",
+        "purpose": "string",
+        "size": "double",
+        "title": "string",
+        "type": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Files",
       "description": "Files uploaded to Stripe -- dispute evidence, identity documents, exported reports. Carries filename, size, type, purpose naming why it was uploaded, and expires_at. Use for auditing what has been uploaded, not for the business data inside the files.",
       "paged": true,
-      "suffix": "/v1/files?purpose={Purpose?}&created={Created?:Unix timestamp}"
+      "suffix": "/v1/files?purpose={Purpose?}&created={Created?:Unix timestamp}",
+      "responseSchema": {
+        "data": [
+          {
+            "created": "double",
+            "expires_at": "double",
+            "filename": "string",
+            "id": "string",
+            "links": {
+              "data": [
+                {
+                  "created": "double",
+                  "expired": "boolean",
+                  "expires_at": "double",
+                  "file": "string",
+                  "id": "string",
+                  "livemode": "boolean",
+                  "metadata": {
+                    "*": "string"
+                  },
+                  "object": "string",
+                  "url": "string"
+                }
+              ],
+              "has_more": "boolean",
+              "object": "string",
+              "url": "string"
+            },
+            "object": "string",
+            "purpose": "string",
+            "size": "double",
+            "title": "string",
+            "type": "string",
+            "url": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "File Link",
       "description": "A single file link by its id. Same fields as File Links; use it when the link id is already known.",
       "paged": false,
-      "suffix": "/v1/file_links/{File Link ID}"
+      "suffix": "/v1/file_links/{File Link ID}",
+      "responseSchema": {
+        "created": "double",
+        "expired": "boolean",
+        "expires_at": "double",
+        "file": "string",
+        "id": "string",
+        "livemode": "boolean",
+        "metadata": {
+          "*": "string"
+        },
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "File Links",
       "description": "Shareable public URLs pointing at uploaded files. Carries the target file, its url, whether it has expired, and expires_at. Use for finding which files were shared and whether those links are still live.",
       "paged": true,
-      "suffix": "/v1/file_links?created={Created?:Unix timestamp}&expired={Expired?:true|false}&file={File ID?}"
+      "suffix": "/v1/file_links?created={Created?:Unix timestamp}&expired={Expired?:true|false}&file={File ID?}",
+      "responseSchema": {
+        "data": [
+          {
+            "created": "double",
+            "expired": "boolean",
+            "expires_at": "double",
+            "file": "string",
+            "id": "string",
+            "livemode": "boolean",
+            "metadata": {
+              "*": "string"
+            },
+            "object": "string",
+            "url": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Mandate",
       "description": "The customer's recorded authorization to be charged by a given payment method, for direct debit and similar schemes. Carries status, type, single_use or multi_use, and the acceptance record. Reached by id from a payment; there is no list endpoint.",
       "paged": false,
-      "suffix": "/v1/mandates/{Mandate ID}"
+      "suffix": "/v1/mandates/{Mandate ID}",
+      "responseSchema": {
+        "customer_acceptance": {
+          "accepted_at": "double",
+          "online": {
+            "ip_address": "string",
+            "user_agent": "string"
+          },
+          "type": "string"
+        },
+        "id": "string",
+        "livemode": "boolean",
+        "object": "string",
+        "payment_method": "string",
+        "payment_method_details": {
+          "au_becs_debit": {
+            "url": "string"
+          },
+          "bacs_debit": {
+            "network_status": "string",
+            "reference": "string",
+            "url": "string"
+          },
+          "sepa_debit": {
+            "reference": "string",
+            "url": "string"
+          },
+          "type": "string"
+        },
+        "single_use": {
+          "amount": "double",
+          "currency": "string"
+        },
+        "status": "string",
+        "type": "string"
+      }
     },
     {
       "name": "Payment Intent",
       "description": "A single payment intent by its id. Same fields as Payment Intents; use it when the id is already known rather than to scan or aggregate.",
       "paged": false,
-      "suffix": "/v1/payment_intents/{Payment Intent ID}?client_secret={Client Secret}"
+      "suffix": "/v1/payment_intents/{Payment Intent ID}?client_secret={Client Secret}",
+      "responseSchema": {
+        "amount": "double",
+        "amount_capturable": "double",
+        "amount_received": "double",
+        "application": "string",
+        "application_fee_amount": "double",
+        "canceled_at": "double",
+        "cancellation_reason": "string",
+        "capture_method": "string",
+        "client_secret": "string",
+        "confirmation_method": "string",
+        "created": "double",
+        "currency": "string",
+        "customer": "string",
+        "description": "string",
+        "id": "string",
+        "last_payment_error": {
+          "charge": "string",
+          "code": "string",
+          "decline_code": "string",
+          "doc_url": "string",
+          "message": "string",
+          "param": "string",
+          "payment_method": {
+            "au_becs_debit": {
+              "bsb_number": "string",
+              "fingerprint": "string",
+              "last4": "string"
+            },
+            "bacs_debit": {
+              "fingerprint": "string",
+              "last4": "string",
+              "sort_code": "string"
+            },
+            "billing_details": {
+              "address": {
+                "city": "string",
+                "country": "string",
+                "line1": "string",
+                "line2": "string",
+                "postal_code": "string",
+                "state": "string"
+              },
+              "email": "string",
+              "name": "string",
+              "phone": "string"
+            },
+            "card": {
+              "brand": "string",
+              "checks": {
+                "address_line1_check": "string",
+                "address_postal_code_check": "string",
+                "cvc_check": "string"
+              },
+              "country": "string",
+              "exp_month": "double",
+              "exp_year": "double",
+              "fingerprint": "string",
+              "funding": "string",
+              "generated_from": {
+                "charge": "string",
+                "payment_method_details": {
+                  "card_present": {
+                    "brand": "string",
+                    "cardholder_name": "string",
+                    "country": "string",
+                    "emv_auth_data": "string",
+                    "exp_month": "double",
+                    "exp_year": "double",
+                    "fingerprint": "string",
+                    "funding": "string",
+                    "generated_card": "string",
+                    "last4": "string",
+                    "network": "string",
+                    "read_method": "string"
+                  },
+                  "type": "string"
+                }
+              },
+              "last4": "string",
+              "networks": {
+                "available": [
+                  "string"
+                ],
+                "preferred": "string"
+              },
+              "three_d_secure_usage": {
+                "supported": "boolean"
+              },
+              "wallet": {
+                "dynamic_last4": "string",
+                "masterpass": {
+                  "billing_address": {
+                    "city": "string",
+                    "country": "string",
+                    "line1": "string",
+                    "line2": "string",
+                    "postal_code": "string",
+                    "state": "string"
+                  },
+                  "email": "string",
+                  "name": "string",
+                  "shipping_address": {
+                    "city": "string",
+                    "country": "string",
+                    "line1": "string",
+                    "line2": "string",
+                    "postal_code": "string",
+                    "state": "string"
+                  }
+                },
+                "type": "string",
+                "visa_checkout": {
+                  "billing_address": {
+                    "city": "string",
+                    "country": "string",
+                    "line1": "string",
+                    "line2": "string",
+                    "postal_code": "string",
+                    "state": "string"
+                  },
+                  "email": "string",
+                  "name": "string",
+                  "shipping_address": {
+                    "city": "string",
+                    "country": "string",
+                    "line1": "string",
+                    "line2": "string",
+                    "postal_code": "string",
+                    "state": "string"
+                  }
+                }
+              }
+            },
+            "created": "double",
+            "customer": "string",
+            "fpx": {
+              "bank": "string"
+            },
+            "id": "string",
+            "ideal": {
+              "bank": "string",
+              "bic": "string"
+            },
+            "livemode": "boolean",
+            "metadata": {
+              "*": "string"
+            },
+            "object": "string",
+            "sepa_debit": {
+              "bank_code": "string",
+              "branch_code": "string",
+              "country": "string",
+              "fingerprint": "string",
+              "last4": "string"
+            },
+            "sofort": {
+              "country": "string"
+            },
+            "type": "string"
+          },
+          "setup_intent": {
+            "application": "string",
+            "cancellation_reason": "string",
+            "client_secret": "string",
+            "created": "double",
+            "customer": "string",
+            "description": "string",
+            "id": "string",
+            "latest_attempt": "string",
+            "livemode": "boolean",
+            "mandate": "string",
+            "metadata": {
+              "*": "string"
+            },
+            "next_action": {
+              "redirect_to_url": {
+                "return_url": "string",
+                "url": "string"
+              },
+              "type": "string"
+            },
+            "object": "string",
+            "on_behalf_of": "string",
+            "payment_method": "string",
+            "payment_method_types": [
+              "string"
+            ],
+            "single_use_mandate": "string",
+            "status": "string",
+            "usage": "string"
+          },
+          "type": "string"
+        },
+        "livemode": "boolean",
+        "metadata": {
+          "*": "string"
+        },
+        "next_action": {
+          "alipay_handle_redirect": {
+            "native_data": "string",
+            "native_url": "string",
+            "return_url": "string",
+            "url": "string"
+          },
+          "oxxo_display_details": {
+            "expires_after": "double",
+            "hosted_voucher_url": "string",
+            "number": "string"
+          },
+          "redirect_to_url": {
+            "return_url": "string",
+            "url": "string"
+          },
+          "type": "string"
+        },
+        "object": "string",
+        "on_behalf_of": "string",
+        "payment_method": "string",
+        "payment_method_types": [
+          "string"
+        ],
+        "receipt_email": "string",
+        "review": "string",
+        "setup_future_usage": "string",
+        "shipping": {
+          "address": {
+            "city": "string",
+            "country": "string",
+            "line1": "string",
+            "line2": "string",
+            "postal_code": "string",
+            "state": "string"
+          },
+          "carrier": "string",
+          "name": "string",
+          "phone": "string",
+          "tracking_number": "string"
+        },
+        "statement_descriptor": "string",
+        "statement_descriptor_suffix": "string",
+        "status": "string",
+        "transfer_data": {
+          "amount": "double",
+          "destination": "string"
+        },
+        "transfer_group": "string"
+      }
     },
     {
       "name": "Payment Intents",
       "description": "The full lifecycle of collecting a payment, including attempts that never became a charge. Carries amount, amount_received and amount_capturable, status, capture_method, cancellation_reason and last_payment_error, plus links to customer and payment method. Prefer this over Charges when the question involves abandoned or failed attempts, since a charge only comes into existence once an attempt succeeds.",
       "paged": true,
       "suffix": "/v1/payment_intents?customer={Customer ID?}&created={Created?:Unix timestamp}",
+      "responseSchema": {
+        "data": [
+          {
+            "amount": "double",
+            "amount_capturable": "double",
+            "amount_received": "double",
+            "application": "string",
+            "application_fee_amount": "double",
+            "canceled_at": "double",
+            "cancellation_reason": "string",
+            "capture_method": "string",
+            "client_secret": "string",
+            "confirmation_method": "string",
+            "created": "double",
+            "currency": "string",
+            "customer": "string",
+            "description": "string",
+            "id": "string",
+            "last_payment_error": {
+              "charge": "string",
+              "code": "string",
+              "decline_code": "string",
+              "doc_url": "string",
+              "message": "string",
+              "param": "string",
+              "payment_method": {
+                "au_becs_debit": {
+                  "bsb_number": "string",
+                  "fingerprint": "string",
+                  "last4": "string"
+                },
+                "bacs_debit": {
+                  "fingerprint": "string",
+                  "last4": "string",
+                  "sort_code": "string"
+                },
+                "billing_details": {
+                  "address": {
+                    "city": "string",
+                    "country": "string",
+                    "line1": "string",
+                    "line2": "string",
+                    "postal_code": "string",
+                    "state": "string"
+                  },
+                  "email": "string",
+                  "name": "string",
+                  "phone": "string"
+                },
+                "card": {
+                  "brand": "string",
+                  "checks": {
+                    "address_line1_check": "string",
+                    "address_postal_code_check": "string",
+                    "cvc_check": "string"
+                  },
+                  "country": "string",
+                  "exp_month": "double",
+                  "exp_year": "double",
+                  "fingerprint": "string",
+                  "funding": "string",
+                  "generated_from": {
+                    "charge": "string"
+                  },
+                  "last4": "string",
+                  "networks": {
+                    "preferred": "string"
+                  },
+                  "three_d_secure_usage": {
+                    "supported": "boolean"
+                  },
+                  "wallet": {
+                    "dynamic_last4": "string",
+                    "type": "string"
+                  }
+                },
+                "created": "double",
+                "customer": "string",
+                "fpx": {
+                  "bank": "string"
+                },
+                "id": "string",
+                "ideal": {
+                  "bank": "string",
+                  "bic": "string"
+                },
+                "livemode": "boolean",
+                "metadata": {
+                  "*": "string"
+                },
+                "object": "string",
+                "sepa_debit": {
+                  "bank_code": "string",
+                  "branch_code": "string",
+                  "country": "string",
+                  "fingerprint": "string",
+                  "last4": "string"
+                },
+                "sofort": {
+                  "country": "string"
+                },
+                "type": "string"
+              },
+              "setup_intent": {
+                "application": "string",
+                "cancellation_reason": "string",
+                "client_secret": "string",
+                "created": "double",
+                "customer": "string",
+                "description": "string",
+                "id": "string",
+                "latest_attempt": "string",
+                "livemode": "boolean",
+                "mandate": "string",
+                "metadata": {
+                  "*": "string"
+                },
+                "next_action": {
+                  "redirect_to_url": {
+                    "return_url": "string",
+                    "url": "string"
+                  },
+                  "type": "string"
+                },
+                "object": "string",
+                "on_behalf_of": "string",
+                "payment_method": "string",
+                "payment_method_types": [
+                  "string"
+                ],
+                "single_use_mandate": "string",
+                "status": "string",
+                "usage": "string"
+              },
+              "type": "string"
+            },
+            "livemode": "boolean",
+            "metadata": {
+              "*": "string"
+            },
+            "next_action": {
+              "alipay_handle_redirect": {
+                "native_data": "string",
+                "native_url": "string",
+                "return_url": "string",
+                "url": "string"
+              },
+              "oxxo_display_details": {
+                "expires_after": "double",
+                "hosted_voucher_url": "string",
+                "number": "string"
+              },
+              "redirect_to_url": {
+                "return_url": "string",
+                "url": "string"
+              },
+              "type": "string"
+            },
+            "object": "string",
+            "on_behalf_of": "string",
+            "payment_method": "string",
+            "payment_method_types": [
+              "string"
+            ],
+            "receipt_email": "string",
+            "review": "string",
+            "setup_future_usage": "string",
+            "shipping": {
+              "address": {
+                "city": "string",
+                "country": "string",
+                "line1": "string",
+                "line2": "string",
+                "postal_code": "string",
+                "state": "string"
+              },
+              "carrier": "string",
+              "name": "string",
+              "phone": "string",
+              "tracking_number": "string"
+            },
+            "statement_descriptor": "string",
+            "statement_descriptor_suffix": "string",
+            "status": "string",
+            "transfer_data": {
+              "amount": "double",
+              "destination": "string"
+            },
+            "transfer_group": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      },
       "lookups": [
         {
           "endpoint": "Payment Method",
@@ -149,13 +1749,456 @@
       "name": "Setup Intent",
       "description": "A single setup intent by its id. Same fields as Setup Intents; use it when the id is already known.",
       "paged": false,
-      "suffix": "/v1/setup_intents/{Setup Intent ID}?client_secret={Client Secret}"
+      "suffix": "/v1/setup_intents/{Setup Intent ID}?client_secret={Client Secret}",
+      "responseSchema": {
+        "application": "string",
+        "cancellation_reason": "string",
+        "client_secret": "string",
+        "created": "double",
+        "customer": "string",
+        "description": "string",
+        "id": "string",
+        "last_setup_error": {
+          "charge": "string",
+          "code": "string",
+          "decline_code": "string",
+          "doc_url": "string",
+          "message": "string",
+          "param": "string",
+          "payment_intent": {
+            "amount": "double",
+            "amount_capturable": "double",
+            "amount_received": "double",
+            "application": "string",
+            "application_fee_amount": "double",
+            "canceled_at": "double",
+            "cancellation_reason": "string",
+            "capture_method": "string",
+            "client_secret": "string",
+            "confirmation_method": "string",
+            "created": "double",
+            "currency": "string",
+            "customer": "string",
+            "description": "string",
+            "id": "string",
+            "livemode": "boolean",
+            "metadata": {
+              "*": "string"
+            },
+            "next_action": {
+              "alipay_handle_redirect": {
+                "native_data": "string",
+                "native_url": "string",
+                "return_url": "string",
+                "url": "string"
+              },
+              "oxxo_display_details": {
+                "expires_after": "double",
+                "hosted_voucher_url": "string",
+                "number": "string"
+              },
+              "redirect_to_url": {
+                "return_url": "string",
+                "url": "string"
+              },
+              "type": "string"
+            },
+            "object": "string",
+            "on_behalf_of": "string",
+            "payment_method": "string",
+            "payment_method_types": [
+              "string"
+            ],
+            "receipt_email": "string",
+            "review": "string",
+            "setup_future_usage": "string",
+            "shipping": {
+              "address": {
+                "city": "string",
+                "country": "string",
+                "line1": "string",
+                "line2": "string",
+                "postal_code": "string",
+                "state": "string"
+              },
+              "carrier": "string",
+              "name": "string",
+              "phone": "string",
+              "tracking_number": "string"
+            },
+            "statement_descriptor": "string",
+            "statement_descriptor_suffix": "string",
+            "status": "string",
+            "transfer_data": {
+              "amount": "double",
+              "destination": "string"
+            },
+            "transfer_group": "string"
+          },
+          "payment_method": {
+            "au_becs_debit": {
+              "bsb_number": "string",
+              "fingerprint": "string",
+              "last4": "string"
+            },
+            "bacs_debit": {
+              "fingerprint": "string",
+              "last4": "string",
+              "sort_code": "string"
+            },
+            "billing_details": {
+              "address": {
+                "city": "string",
+                "country": "string",
+                "line1": "string",
+                "line2": "string",
+                "postal_code": "string",
+                "state": "string"
+              },
+              "email": "string",
+              "name": "string",
+              "phone": "string"
+            },
+            "card": {
+              "brand": "string",
+              "checks": {
+                "address_line1_check": "string",
+                "address_postal_code_check": "string",
+                "cvc_check": "string"
+              },
+              "country": "string",
+              "exp_month": "double",
+              "exp_year": "double",
+              "fingerprint": "string",
+              "funding": "string",
+              "generated_from": {
+                "charge": "string",
+                "payment_method_details": {
+                  "card_present": {
+                    "brand": "string",
+                    "cardholder_name": "string",
+                    "country": "string",
+                    "emv_auth_data": "string",
+                    "exp_month": "double",
+                    "exp_year": "double",
+                    "fingerprint": "string",
+                    "funding": "string",
+                    "generated_card": "string",
+                    "last4": "string",
+                    "network": "string",
+                    "read_method": "string"
+                  },
+                  "type": "string"
+                }
+              },
+              "last4": "string",
+              "networks": {
+                "available": [
+                  "string"
+                ],
+                "preferred": "string"
+              },
+              "three_d_secure_usage": {
+                "supported": "boolean"
+              },
+              "wallet": {
+                "dynamic_last4": "string",
+                "masterpass": {
+                  "billing_address": {
+                    "city": "string",
+                    "country": "string",
+                    "line1": "string",
+                    "line2": "string",
+                    "postal_code": "string",
+                    "state": "string"
+                  },
+                  "email": "string",
+                  "name": "string",
+                  "shipping_address": {
+                    "city": "string",
+                    "country": "string",
+                    "line1": "string",
+                    "line2": "string",
+                    "postal_code": "string",
+                    "state": "string"
+                  }
+                },
+                "type": "string",
+                "visa_checkout": {
+                  "billing_address": {
+                    "city": "string",
+                    "country": "string",
+                    "line1": "string",
+                    "line2": "string",
+                    "postal_code": "string",
+                    "state": "string"
+                  },
+                  "email": "string",
+                  "name": "string",
+                  "shipping_address": {
+                    "city": "string",
+                    "country": "string",
+                    "line1": "string",
+                    "line2": "string",
+                    "postal_code": "string",
+                    "state": "string"
+                  }
+                }
+              }
+            },
+            "created": "double",
+            "customer": "string",
+            "fpx": {
+              "bank": "string"
+            },
+            "id": "string",
+            "ideal": {
+              "bank": "string",
+              "bic": "string"
+            },
+            "livemode": "boolean",
+            "metadata": {
+              "*": "string"
+            },
+            "object": "string",
+            "sepa_debit": {
+              "bank_code": "string",
+              "branch_code": "string",
+              "country": "string",
+              "fingerprint": "string",
+              "last4": "string"
+            },
+            "sofort": {
+              "country": "string"
+            },
+            "type": "string"
+          },
+          "type": "string"
+        },
+        "latest_attempt": "string",
+        "livemode": "boolean",
+        "mandate": "string",
+        "metadata": {
+          "*": "string"
+        },
+        "next_action": {
+          "redirect_to_url": {
+            "return_url": "string",
+            "url": "string"
+          },
+          "type": "string"
+        },
+        "object": "string",
+        "on_behalf_of": "string",
+        "payment_method": "string",
+        "payment_method_types": [
+          "string"
+        ],
+        "single_use_mandate": "string",
+        "status": "string",
+        "usage": "string"
+      }
     },
     {
       "name": "Setup Intents",
       "description": "Attempts to save a payment method for later use without charging it -- card-on-file setup, mandate collection. Carries status, usage, cancellation_reason, last_setup_error, and links to customer and payment method. Use for onboarding and saved-card success rates; actual payments are in Payment Intents.",
       "paged": true,
       "suffix": "/v1/setup_intents?customer={Customer ID?}&payment_method={Payment Method?}&created={Created?:Unix timestamp}",
+      "responseSchema": {
+        "data": [
+          {
+            "application": "string",
+            "cancellation_reason": "string",
+            "client_secret": "string",
+            "created": "double",
+            "customer": "string",
+            "description": "string",
+            "id": "string",
+            "last_setup_error": {
+              "charge": "string",
+              "code": "string",
+              "decline_code": "string",
+              "doc_url": "string",
+              "message": "string",
+              "param": "string",
+              "payment_intent": {
+                "amount": "double",
+                "amount_capturable": "double",
+                "amount_received": "double",
+                "application": "string",
+                "application_fee_amount": "double",
+                "canceled_at": "double",
+                "cancellation_reason": "string",
+                "capture_method": "string",
+                "client_secret": "string",
+                "confirmation_method": "string",
+                "created": "double",
+                "currency": "string",
+                "customer": "string",
+                "description": "string",
+                "id": "string",
+                "livemode": "boolean",
+                "metadata": {
+                  "*": "string"
+                },
+                "next_action": {
+                  "alipay_handle_redirect": {
+                    "native_data": "string",
+                    "native_url": "string",
+                    "return_url": "string",
+                    "url": "string"
+                  },
+                  "oxxo_display_details": {
+                    "expires_after": "double",
+                    "hosted_voucher_url": "string",
+                    "number": "string"
+                  },
+                  "redirect_to_url": {
+                    "return_url": "string",
+                    "url": "string"
+                  },
+                  "type": "string"
+                },
+                "object": "string",
+                "on_behalf_of": "string",
+                "payment_method": "string",
+                "payment_method_types": [
+                  "string"
+                ],
+                "receipt_email": "string",
+                "review": "string",
+                "setup_future_usage": "string",
+                "shipping": {
+                  "address": {
+                    "city": "string",
+                    "country": "string",
+                    "line1": "string",
+                    "line2": "string",
+                    "postal_code": "string",
+                    "state": "string"
+                  },
+                  "carrier": "string",
+                  "name": "string",
+                  "phone": "string",
+                  "tracking_number": "string"
+                },
+                "statement_descriptor": "string",
+                "statement_descriptor_suffix": "string",
+                "status": "string",
+                "transfer_data": {
+                  "amount": "double",
+                  "destination": "string"
+                },
+                "transfer_group": "string"
+              },
+              "payment_method": {
+                "au_becs_debit": {
+                  "bsb_number": "string",
+                  "fingerprint": "string",
+                  "last4": "string"
+                },
+                "bacs_debit": {
+                  "fingerprint": "string",
+                  "last4": "string",
+                  "sort_code": "string"
+                },
+                "billing_details": {
+                  "address": {
+                    "city": "string",
+                    "country": "string",
+                    "line1": "string",
+                    "line2": "string",
+                    "postal_code": "string",
+                    "state": "string"
+                  },
+                  "email": "string",
+                  "name": "string",
+                  "phone": "string"
+                },
+                "card": {
+                  "brand": "string",
+                  "checks": {
+                    "address_line1_check": "string",
+                    "address_postal_code_check": "string",
+                    "cvc_check": "string"
+                  },
+                  "country": "string",
+                  "exp_month": "double",
+                  "exp_year": "double",
+                  "fingerprint": "string",
+                  "funding": "string",
+                  "generated_from": {
+                    "charge": "string"
+                  },
+                  "last4": "string",
+                  "networks": {
+                    "preferred": "string"
+                  },
+                  "three_d_secure_usage": {
+                    "supported": "boolean"
+                  },
+                  "wallet": {
+                    "dynamic_last4": "string",
+                    "type": "string"
+                  }
+                },
+                "created": "double",
+                "customer": "string",
+                "fpx": {
+                  "bank": "string"
+                },
+                "id": "string",
+                "ideal": {
+                  "bank": "string",
+                  "bic": "string"
+                },
+                "livemode": "boolean",
+                "metadata": {
+                  "*": "string"
+                },
+                "object": "string",
+                "sepa_debit": {
+                  "bank_code": "string",
+                  "branch_code": "string",
+                  "country": "string",
+                  "fingerprint": "string",
+                  "last4": "string"
+                },
+                "sofort": {
+                  "country": "string"
+                },
+                "type": "string"
+              },
+              "type": "string"
+            },
+            "latest_attempt": "string",
+            "livemode": "boolean",
+            "mandate": "string",
+            "metadata": {
+              "*": "string"
+            },
+            "next_action": {
+              "redirect_to_url": {
+                "return_url": "string",
+                "url": "string"
+              },
+              "type": "string"
+            },
+            "object": "string",
+            "on_behalf_of": "string",
+            "payment_method": "string",
+            "payment_method_types": [
+              "string"
+            ],
+            "single_use_mandate": "string",
+            "status": "string",
+            "usage": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      },
       "lookups": [
         {
           "endpoint": "Mandate",
@@ -169,121 +2212,1358 @@
       "name": "Payout",
       "description": "A single payout by its id. Same fields as Payouts; use it when the payout id is already known.",
       "paged": false,
-      "suffix": "/v1/payouts/{Payout ID}"
+      "suffix": "/v1/payouts/{Payout ID}",
+      "responseSchema": {
+        "amount": "double",
+        "arrival_date": "double",
+        "automatic": "boolean",
+        "balance_transaction": "string",
+        "created": "double",
+        "currency": "string",
+        "description": "string",
+        "destination": "string",
+        "failure_balance_transaction": "string",
+        "failure_code": "string",
+        "failure_message": "string",
+        "id": "string",
+        "livemode": "boolean",
+        "metadata": {
+          "*": "string"
+        },
+        "method": "string",
+        "object": "string",
+        "source_type": "string",
+        "statement_descriptor": "string",
+        "status": "string",
+        "type": "string"
+      }
     },
     {
       "name": "Payouts",
       "description": "Transfers of your Stripe balance to your own bank account. Carries amount, currency, arrival_date, whether the payout was automatic, its method and status, and failure_code and failure_message when it did not land. Use for settlement timing and failed payouts -- customer-facing revenue is in Charges, not here.",
       "paged": true,
-      "suffix": "/v1/payouts?status={Status?:pending|paid|failed|canceled}&arrival_date={Arrival Date?:Unix timestamp}&created={Created?:Unix timestamp}&destination={Destination?}"
+      "suffix": "/v1/payouts?status={Status?:pending|paid|failed|canceled}&arrival_date={Arrival Date?:Unix timestamp}&created={Created?:Unix timestamp}&destination={Destination?}",
+      "responseSchema": {
+        "data": [
+          {
+            "amount": "double",
+            "arrival_date": "double",
+            "automatic": "boolean",
+            "balance_transaction": "string",
+            "created": "double",
+            "currency": "string",
+            "description": "string",
+            "destination": "string",
+            "failure_balance_transaction": "string",
+            "failure_code": "string",
+            "failure_message": "string",
+            "id": "string",
+            "livemode": "boolean",
+            "metadata": {
+              "*": "string"
+            },
+            "method": "string",
+            "object": "string",
+            "source_type": "string",
+            "statement_descriptor": "string",
+            "status": "string",
+            "type": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Product",
       "description": "A single product by its id. Same fields as Products; use it when the product id is already known.",
       "paged": false,
-      "suffix": "/v1/products/{Product ID}"
+      "suffix": "/v1/products/{Product ID}",
+      "responseSchema": {
+        "active": "boolean",
+        "created": "double",
+        "description": "string",
+        "id": "string",
+        "images": [
+          "string"
+        ],
+        "livemode": "boolean",
+        "metadata": {
+          "*": "string"
+        },
+        "name": "string",
+        "object": "string",
+        "package_dimensions": {
+          "height": "double",
+          "length": "double",
+          "weight": "double",
+          "width": "double"
+        },
+        "shippable": "boolean",
+        "statement_descriptor": "string",
+        "unit_label": "string",
+        "updated": "double",
+        "url": "string"
+      }
     },
     {
       "name": "Products",
       "description": "The goods or services being sold, one row each. Carries name, description, whether it is active, images, its default_price, and shipping attributes. Use for catalogue questions and to give revenue a product dimension; the amounts themselves live in Prices, Invoices and Charges.",
       "paged": true,
-      "suffix": "/v1/products?active={Active?:true|false}&created={Created?:Unix timestamp}&ids={IDs?:id1,id2,...}&shippable={Shippable?:true|false}&type={Product Type?}&url={Product URL?}"
+      "suffix": "/v1/products?active={Active?:true|false}&created={Created?:Unix timestamp}&ids={IDs?:id1,id2,...}&shippable={Shippable?:true|false}&type={Product Type?}&url={Product URL?}",
+      "responseSchema": {
+        "data": [
+          {
+            "active": "boolean",
+            "created": "double",
+            "description": "string",
+            "id": "string",
+            "images": [
+              "string"
+            ],
+            "livemode": "boolean",
+            "metadata": {
+              "*": "string"
+            },
+            "name": "string",
+            "object": "string",
+            "package_dimensions": {
+              "height": "double",
+              "length": "double",
+              "weight": "double",
+              "width": "double"
+            },
+            "shippable": "boolean",
+            "statement_descriptor": "string",
+            "unit_label": "string",
+            "updated": "double",
+            "url": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Refund",
       "description": "A single refund by its id. Same fields as Refunds; use it when the refund id is already known.",
       "paged": false,
-      "suffix": "/v1/refunds/{Refund ID}"
+      "suffix": "/v1/refunds/{Refund ID}",
+      "responseSchema": {
+        "amount": "double",
+        "balance_transaction": "string",
+        "charge": "string",
+        "created": "double",
+        "currency": "string",
+        "description": "string",
+        "failure_balance_transaction": "string",
+        "failure_reason": "string",
+        "id": "string",
+        "metadata": {
+          "*": "string"
+        },
+        "object": "string",
+        "payment_intent": "string",
+        "reason": "string",
+        "receipt_number": "string",
+        "source_transfer_reversal": "string",
+        "status": "string",
+        "transfer_reversal": "string"
+      }
     },
     {
       "name": "Refunds",
       "description": "Money returned to customers, one row per refund. Carries amount, currency, the reason given, status, and failure_reason when the refund itself failed, plus links back to the charge and payment_intent it reverses. Use for refund totals, refund rate, and refund reasons.",
       "paged": true,
-      "suffix": "/v1/refunds?charge={Charge ID?}&payment_intent={Payment Intent ID?}&created={Created?:Unix timestamp}"
+      "suffix": "/v1/refunds?charge={Charge ID?}&payment_intent={Payment Intent ID?}&created={Created?:Unix timestamp}",
+      "responseSchema": {
+        "data": [
+          {
+            "amount": "double",
+            "balance_transaction": "string",
+            "charge": "string",
+            "created": "double",
+            "currency": "string",
+            "description": "string",
+            "failure_balance_transaction": "string",
+            "failure_reason": "string",
+            "id": "string",
+            "metadata": {
+              "*": "string"
+            },
+            "object": "string",
+            "payment_intent": "string",
+            "reason": "string",
+            "receipt_number": "string",
+            "source_transfer_reversal": "string",
+            "status": "string",
+            "transfer_reversal": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Token",
       "description": "A one-time token representing card or bank details, by its id. Carries the type, the card or bank_account it stands for, and whether it has been used. Created by client-side integrations and consumed immediately -- rarely useful for analysis.",
       "paged": false,
-      "suffix": "/v1/tokens/{Token ID}"
+      "suffix": "/v1/tokens/{Token ID}",
+      "responseSchema": {
+        "bank_account": {
+          "account": "string",
+          "account_holder_name": "string",
+          "account_holder_type": "string",
+          "available_payout_methods": [
+            "string"
+          ],
+          "bank_name": "string",
+          "country": "string",
+          "currency": "string",
+          "customer": "string",
+          "default_for_currency": "boolean",
+          "fingerprint": "string",
+          "id": "string",
+          "last4": "string",
+          "metadata": {
+            "*": "string"
+          },
+          "object": "string",
+          "routing_number": "string",
+          "status": "string"
+        },
+        "card": {
+          "account": "string",
+          "address_city": "string",
+          "address_country": "string",
+          "address_line1": "string",
+          "address_line1_check": "string",
+          "address_line2": "string",
+          "address_state": "string",
+          "address_zip": "string",
+          "address_zip_check": "string",
+          "available_payout_methods": [
+            "string"
+          ],
+          "brand": "string",
+          "country": "string",
+          "currency": "string",
+          "customer": "string",
+          "cvc_check": "string",
+          "default_for_currency": "boolean",
+          "dynamic_last4": "string",
+          "exp_month": "double",
+          "exp_year": "double",
+          "fingerprint": "string",
+          "funding": "string",
+          "id": "string",
+          "last4": "string",
+          "metadata": {
+            "*": "string"
+          },
+          "name": "string",
+          "object": "string",
+          "tokenization_method": "string"
+        },
+        "client_ip": "string",
+        "created": "double",
+        "id": "string",
+        "livemode": "boolean",
+        "object": "string",
+        "type": "string",
+        "used": "boolean"
+      }
     },
     {
       "name": "Payment Method",
       "description": "A single payment method by its id. Same fields as Payment Methods; use it when the id is already known.",
       "paged": false,
-      "suffix": "/v1/payment_methods/{Payment Method ID}"
+      "suffix": "/v1/payment_methods/{Payment Method ID}",
+      "responseSchema": {
+        "au_becs_debit": {
+          "bsb_number": "string",
+          "fingerprint": "string",
+          "last4": "string"
+        },
+        "bacs_debit": {
+          "fingerprint": "string",
+          "last4": "string",
+          "sort_code": "string"
+        },
+        "billing_details": {
+          "address": {
+            "city": "string",
+            "country": "string",
+            "line1": "string",
+            "line2": "string",
+            "postal_code": "string",
+            "state": "string"
+          },
+          "email": "string",
+          "name": "string",
+          "phone": "string"
+        },
+        "card": {
+          "brand": "string",
+          "checks": {
+            "address_line1_check": "string",
+            "address_postal_code_check": "string",
+            "cvc_check": "string"
+          },
+          "country": "string",
+          "exp_month": "double",
+          "exp_year": "double",
+          "fingerprint": "string",
+          "funding": "string",
+          "generated_from": {
+            "charge": "string",
+            "payment_method_details": {
+              "card_present": {
+                "brand": "string",
+                "cardholder_name": "string",
+                "country": "string",
+                "emv_auth_data": "string",
+                "exp_month": "double",
+                "exp_year": "double",
+                "fingerprint": "string",
+                "funding": "string",
+                "generated_card": "string",
+                "last4": "string",
+                "network": "string",
+                "read_method": "string",
+                "receipt": {
+                  "account_type": "string",
+                  "application_cryptogram": "string",
+                  "application_preferred_name": "string",
+                  "authorization_code": "string",
+                  "authorization_response_code": "string",
+                  "cardholder_verification_method": "string",
+                  "dedicated_file_name": "string",
+                  "terminal_verification_results": "string",
+                  "transaction_status_information": "string"
+                }
+              },
+              "type": "string"
+            }
+          },
+          "last4": "string",
+          "networks": {
+            "available": [
+              "string"
+            ],
+            "preferred": "string"
+          },
+          "three_d_secure_usage": {
+            "supported": "boolean"
+          },
+          "wallet": {
+            "dynamic_last4": "string",
+            "masterpass": {
+              "billing_address": {
+                "city": "string",
+                "country": "string",
+                "line1": "string",
+                "line2": "string",
+                "postal_code": "string",
+                "state": "string"
+              },
+              "email": "string",
+              "name": "string",
+              "shipping_address": {
+                "city": "string",
+                "country": "string",
+                "line1": "string",
+                "line2": "string",
+                "postal_code": "string",
+                "state": "string"
+              }
+            },
+            "type": "string",
+            "visa_checkout": {
+              "billing_address": {
+                "city": "string",
+                "country": "string",
+                "line1": "string",
+                "line2": "string",
+                "postal_code": "string",
+                "state": "string"
+              },
+              "email": "string",
+              "name": "string",
+              "shipping_address": {
+                "city": "string",
+                "country": "string",
+                "line1": "string",
+                "line2": "string",
+                "postal_code": "string",
+                "state": "string"
+              }
+            }
+          }
+        },
+        "created": "double",
+        "customer": "string",
+        "fpx": {
+          "bank": "string"
+        },
+        "id": "string",
+        "ideal": {
+          "bank": "string",
+          "bic": "string"
+        },
+        "livemode": "boolean",
+        "metadata": {
+          "*": "string"
+        },
+        "object": "string",
+        "sepa_debit": {
+          "bank_code": "string",
+          "branch_code": "string",
+          "country": "string",
+          "fingerprint": "string",
+          "last4": "string"
+        },
+        "sofort": {
+          "country": "string"
+        },
+        "type": "string"
+      }
     },
     {
       "name": "Payment Methods",
       "description": "Payment instruments attached to customers -- cards, bank debits, wallets. Carries the method type and its per-type details, billing_details, and the owning customer. Filtered by type and customer. Use for payment-mix questions; individual attempts are in Charges and Payment Intents.",
       "paged": true,
-      "suffix": "/v1/payment_methods?customer={Customer ID}&type={Payment Method Type:card|ideal|sepa_debit}"
+      "suffix": "/v1/payment_methods?customer={Customer ID}&type={Payment Method Type:card|ideal|sepa_debit}",
+      "responseSchema": {
+        "data": [
+          {
+            "au_becs_debit": {
+              "bsb_number": "string",
+              "fingerprint": "string",
+              "last4": "string"
+            },
+            "bacs_debit": {
+              "fingerprint": "string",
+              "last4": "string",
+              "sort_code": "string"
+            },
+            "billing_details": {
+              "address": {
+                "city": "string",
+                "country": "string",
+                "line1": "string",
+                "line2": "string",
+                "postal_code": "string",
+                "state": "string"
+              },
+              "email": "string",
+              "name": "string",
+              "phone": "string"
+            },
+            "card": {
+              "brand": "string",
+              "checks": {
+                "address_line1_check": "string",
+                "address_postal_code_check": "string",
+                "cvc_check": "string"
+              },
+              "country": "string",
+              "exp_month": "double",
+              "exp_year": "double",
+              "fingerprint": "string",
+              "funding": "string",
+              "generated_from": {
+                "charge": "string",
+                "payment_method_details": {
+                  "card_present": {
+                    "brand": "string",
+                    "cardholder_name": "string",
+                    "country": "string",
+                    "emv_auth_data": "string",
+                    "exp_month": "double",
+                    "exp_year": "double",
+                    "fingerprint": "string",
+                    "funding": "string",
+                    "generated_card": "string",
+                    "last4": "string",
+                    "network": "string",
+                    "read_method": "string"
+                  },
+                  "type": "string"
+                }
+              },
+              "last4": "string",
+              "networks": {
+                "available": [
+                  "string"
+                ],
+                "preferred": "string"
+              },
+              "three_d_secure_usage": {
+                "supported": "boolean"
+              },
+              "wallet": {
+                "dynamic_last4": "string",
+                "masterpass": {
+                  "billing_address": {
+                    "city": "string",
+                    "country": "string",
+                    "line1": "string",
+                    "line2": "string",
+                    "postal_code": "string",
+                    "state": "string"
+                  },
+                  "email": "string",
+                  "name": "string",
+                  "shipping_address": {
+                    "city": "string",
+                    "country": "string",
+                    "line1": "string",
+                    "line2": "string",
+                    "postal_code": "string",
+                    "state": "string"
+                  }
+                },
+                "type": "string",
+                "visa_checkout": {
+                  "billing_address": {
+                    "city": "string",
+                    "country": "string",
+                    "line1": "string",
+                    "line2": "string",
+                    "postal_code": "string",
+                    "state": "string"
+                  },
+                  "email": "string",
+                  "name": "string",
+                  "shipping_address": {
+                    "city": "string",
+                    "country": "string",
+                    "line1": "string",
+                    "line2": "string",
+                    "postal_code": "string",
+                    "state": "string"
+                  }
+                }
+              }
+            },
+            "created": "double",
+            "customer": "string",
+            "fpx": {
+              "bank": "string"
+            },
+            "id": "string",
+            "ideal": {
+              "bank": "string",
+              "bic": "string"
+            },
+            "livemode": "boolean",
+            "metadata": {
+              "*": "string"
+            },
+            "object": "string",
+            "sepa_debit": {
+              "bank_code": "string",
+              "branch_code": "string",
+              "country": "string",
+              "fingerprint": "string",
+              "last4": "string"
+            },
+            "sofort": {
+              "country": "string"
+            },
+            "type": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Bank Account",
       "description": "A single saved bank account by its id. Requires the customer id as well. Same fields as Bank Accounts.",
       "paged": false,
-      "suffix": "v1/customers/{Customer ID}/sources/{Bank Account ID}"
+      "suffix": "v1/customers/{Customer ID}/sources/{Bank Account ID}",
+      "responseSchema": {
+        "account": "string",
+        "account_holder_name": "string",
+        "account_holder_type": "string",
+        "available_payout_methods": [
+          "string"
+        ],
+        "bank_name": "string",
+        "country": "string",
+        "currency": "string",
+        "customer": "string",
+        "default_for_currency": "boolean",
+        "fingerprint": "string",
+        "id": "string",
+        "last4": "string",
+        "metadata": {
+          "*": "string"
+        },
+        "object": "string",
+        "routing_number": "string",
+        "status": "string"
+      }
     },
     {
       "name": "Bank Accounts",
       "description": "Bank accounts saved against one customer as a payment source. Requires a customer id; the object=bank_account filter is already applied by this endpoint. Legacy sources API -- newer integrations keep bank debits in Payment Methods instead.",
       "paged": true,
-      "suffix": "v1/customers/{Customer ID}/sources/?object=bank_account"
+      "suffix": "v1/customers/{Customer ID}/sources/?object=bank_account",
+      "responseSchema": {
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Card",
       "description": "A single saved card by its id. Requires the customer id as well. Same fields as Cards.",
       "paged": false,
-      "suffix": "/v1/customers/{Customer ID}/sources/{Card ID}"
+      "suffix": "/v1/customers/{Customer ID}/sources/{Card ID}",
+      "responseSchema": {
+        "account": "string",
+        "address_city": "string",
+        "address_country": "string",
+        "address_line1": "string",
+        "address_line1_check": "string",
+        "address_line2": "string",
+        "address_state": "string",
+        "address_zip": "string",
+        "address_zip_check": "string",
+        "available_payout_methods": [
+          "string"
+        ],
+        "brand": "string",
+        "country": "string",
+        "currency": "string",
+        "customer": "string",
+        "cvc_check": "string",
+        "default_for_currency": "boolean",
+        "dynamic_last4": "string",
+        "exp_month": "double",
+        "exp_year": "double",
+        "fingerprint": "string",
+        "funding": "string",
+        "id": "string",
+        "last4": "string",
+        "metadata": {
+          "*": "string"
+        },
+        "name": "string",
+        "object": "string",
+        "tokenization_method": "string"
+      }
     },
     {
       "name": "Cards",
       "description": "Cards saved against one customer as a payment source. Requires a customer id; the object=card filter is already applied by this endpoint. Legacy sources API -- newer integrations keep cards in Payment Methods instead.",
       "paged": true,
-      "suffix": "v1/customers/{Customer ID}/sources/?object=card"
+      "suffix": "v1/customers/{Customer ID}/sources/?object=card",
+      "responseSchema": {
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Source",
       "description": "A payment source by its id, from the legacy sources API. Carries the source type and its details, status, and owning customer. Superseded by Payment Methods for new integrations.",
       "paged": false,
-      "suffix": "/v1/sources/{Source ID}?client_secret={Client Secret?}"
+      "suffix": "/v1/sources/{Source ID}?client_secret={Client Secret?}",
+      "responseSchema": {
+        "ach_credit_transfer": {
+          "account_number": "string",
+          "bank_name": "string",
+          "fingerprint": "string",
+          "refund_account_holder_name": "string",
+          "refund_account_holder_type": "string",
+          "refund_routing_number": "string",
+          "routing_number": "string",
+          "swift_code": "string"
+        },
+        "ach_debit": {
+          "bank_name": "string",
+          "country": "string",
+          "fingerprint": "string",
+          "last4": "string",
+          "routing_number": "string",
+          "type": "string"
+        },
+        "alipay": {
+          "data_string": "string",
+          "native_url": "string",
+          "statement_descriptor": "string"
+        },
+        "amount": "double",
+        "au_becs_debit": {
+          "bsb_number": "string",
+          "fingerprint": "string",
+          "last4": "string"
+        },
+        "bancontact": {
+          "bank_code": "string",
+          "bank_name": "string",
+          "bic": "string",
+          "iban_last4": "string",
+          "preferred_language": "string",
+          "statement_descriptor": "string"
+        },
+        "card": {
+          "address_line1_check": "string",
+          "address_zip_check": "string",
+          "brand": "string",
+          "country": "string",
+          "cvc_check": "string",
+          "dynamic_last4": "string",
+          "exp_month": "double",
+          "exp_year": "double",
+          "fingerprint": "string",
+          "funding": "string",
+          "last4": "string",
+          "name": "string",
+          "three_d_secure": "string",
+          "tokenization_method": "string"
+        },
+        "card_present": {
+          "application_cryptogram": "string",
+          "application_preferred_name": "string",
+          "authorization_code": "string",
+          "authorization_response_code": "string",
+          "brand": "string",
+          "country": "string",
+          "cvm_type": "string",
+          "data_type": "string",
+          "dedicated_file_name": "string",
+          "emv_auth_data": "string",
+          "evidence_customer_signature": "string",
+          "evidence_transaction_certificate": "string",
+          "exp_month": "double",
+          "exp_year": "double",
+          "fingerprint": "string",
+          "funding": "string",
+          "last4": "string",
+          "pos_device_id": "string",
+          "pos_entry_mode": "string",
+          "read_method": "string",
+          "reader": "string",
+          "terminal_verification_results": "string",
+          "transaction_status_information": "string"
+        },
+        "client_secret": "string",
+        "code_verification": {
+          "attempts_remaining": "double",
+          "status": "string"
+        },
+        "created": "double",
+        "currency": "string",
+        "customer": "string",
+        "eps": {
+          "reference": "string",
+          "statement_descriptor": "string"
+        },
+        "flow": "string",
+        "giropay": {
+          "bank_code": "string",
+          "bank_name": "string",
+          "bic": "string",
+          "statement_descriptor": "string"
+        },
+        "id": "string",
+        "ideal": {
+          "bank": "string",
+          "bic": "string",
+          "iban_last4": "string",
+          "statement_descriptor": "string"
+        },
+        "klarna": {
+          "background_image_url": "string",
+          "client_token": "string",
+          "first_name": "string",
+          "last_name": "string",
+          "locale": "string",
+          "logo_url": "string",
+          "page_title": "string",
+          "pay_later_asset_urls_descriptive": "string",
+          "pay_later_asset_urls_standard": "string",
+          "pay_later_name": "string",
+          "pay_later_redirect_url": "string",
+          "pay_now_asset_urls_descriptive": "string",
+          "pay_now_asset_urls_standard": "string",
+          "pay_now_name": "string",
+          "pay_now_redirect_url": "string",
+          "pay_over_time_asset_urls_descriptive": "string",
+          "pay_over_time_asset_urls_standard": "string",
+          "pay_over_time_name": "string",
+          "pay_over_time_redirect_url": "string",
+          "payment_method_categories": "string",
+          "purchase_country": "string",
+          "purchase_type": "string",
+          "redirect_url": "string",
+          "shipping_delay": "double",
+          "shipping_first_name": "string",
+          "shipping_last_name": "string"
+        },
+        "livemode": "boolean",
+        "metadata": {
+          "*": "string"
+        },
+        "multibanco": {
+          "entity": "string",
+          "reference": "string",
+          "refund_account_holder_address_city": "string",
+          "refund_account_holder_address_country": "string",
+          "refund_account_holder_address_line1": "string",
+          "refund_account_holder_address_line2": "string",
+          "refund_account_holder_address_postal_code": "string",
+          "refund_account_holder_address_state": "string",
+          "refund_account_holder_name": "string",
+          "refund_iban": "string"
+        },
+        "object": "string",
+        "owner": {
+          "address": {
+            "city": "string",
+            "country": "string",
+            "line1": "string",
+            "line2": "string",
+            "postal_code": "string",
+            "state": "string"
+          },
+          "email": "string",
+          "name": "string",
+          "phone": "string",
+          "verified_address": {
+            "city": "string",
+            "country": "string",
+            "line1": "string",
+            "line2": "string",
+            "postal_code": "string",
+            "state": "string"
+          },
+          "verified_email": "string",
+          "verified_name": "string",
+          "verified_phone": "string"
+        },
+        "p24": {
+          "reference": "string"
+        },
+        "receiver": {
+          "address": "string",
+          "amount_charged": "double",
+          "amount_received": "double",
+          "amount_returned": "double",
+          "refund_attributes_method": "string",
+          "refund_attributes_status": "string"
+        },
+        "redirect": {
+          "failure_reason": "string",
+          "return_url": "string",
+          "status": "string",
+          "url": "string"
+        },
+        "sepa_debit": {
+          "bank_code": "string",
+          "branch_code": "string",
+          "country": "string",
+          "fingerprint": "string",
+          "last4": "string",
+          "mandate_reference": "string",
+          "mandate_url": "string"
+        },
+        "sofort": {
+          "bank_code": "string",
+          "bank_name": "string",
+          "bic": "string",
+          "country": "string",
+          "iban_last4": "string",
+          "preferred_language": "string",
+          "statement_descriptor": "string"
+        },
+        "source_order": {
+          "amount": "double",
+          "currency": "string",
+          "email": "string",
+          "items": [
+            {
+              "amount": "double",
+              "currency": "string",
+              "description": "string",
+              "parent": "string",
+              "quantity": "double",
+              "type": "string"
+            }
+          ],
+          "shipping": {
+            "address": {
+              "city": "string",
+              "country": "string",
+              "line1": "string",
+              "line2": "string",
+              "postal_code": "string",
+              "state": "string"
+            },
+            "carrier": "string",
+            "name": "string",
+            "phone": "string",
+            "tracking_number": "string"
+          }
+        },
+        "statement_descriptor": "string",
+        "status": "string",
+        "three_d_secure": {
+          "address_line1_check": "string",
+          "address_zip_check": "string",
+          "authenticated": "boolean",
+          "brand": "string",
+          "card": "string",
+          "country": "string",
+          "customer": "string",
+          "cvc_check": "string",
+          "dynamic_last4": "string",
+          "exp_month": "double",
+          "exp_year": "double",
+          "fingerprint": "string",
+          "funding": "string",
+          "last4": "string",
+          "name": "string",
+          "three_d_secure": "string",
+          "tokenization_method": "string"
+        },
+        "type": "string",
+        "usage": "string",
+        "wechat": {
+          "prepay_id": "string",
+          "qr_code_url": "string",
+          "statement_descriptor": "string"
+        }
+      }
     },
     {
       "name": "Session",
       "description": "A Stripe Checkout session by its id: one attempt by a customer to pay through Stripe's hosted page. Carries amount_total and amount_subtotal, currency, payment_status and status, the line items, and links to customer and payment intent. Use for hosted-checkout conversion questions.",
       "paged": false,
-      "suffix": "/v1/checkout/sessions/{Session ID}"
+      "suffix": "/v1/checkout/sessions/{Session ID}",
+      "responseSchema": {
+        "allow_promotion_codes": "boolean",
+        "amount_subtotal": "double",
+        "amount_total": "double",
+        "billing_address_collection": "string",
+        "cancel_url": "string",
+        "client_reference_id": "string",
+        "currency": "string",
+        "customer": "string",
+        "customer_email": "string",
+        "id": "string",
+        "line_items": {
+          "data": [
+            {
+              "amount_subtotal": "double",
+              "amount_total": "double",
+              "currency": "string",
+              "description": "string",
+              "discounts": [
+                {
+                  "amount": "double",
+                  "discount": {
+                    "checkout_session": "string",
+                    "customer": "string",
+                    "end": "double",
+                    "id": "string",
+                    "invoice": "string",
+                    "invoice_item": "string",
+                    "object": "string",
+                    "promotion_code": "string",
+                    "start": "double",
+                    "subscription": "string"
+                  }
+                }
+              ],
+              "id": "string",
+              "object": "string",
+              "price": {
+                "active": "boolean",
+                "billing_scheme": "string",
+                "created": "double",
+                "currency": "string",
+                "id": "string",
+                "livemode": "boolean",
+                "lookup_key": "string",
+                "metadata": {
+                  "*": "string"
+                },
+                "nickname": "string",
+                "object": "string",
+                "product": "string",
+                "recurring": {
+                  "interval": "string",
+                  "interval_count": "double",
+                  "usage_type": "string"
+                },
+                "tiers_mode": "string",
+                "transform_quantity": {
+                  "divide_by": "double",
+                  "round": "string"
+                },
+                "type": "string",
+                "unit_amount": "double",
+                "unit_amount_decimal": "string"
+              },
+              "quantity": "double",
+              "taxes": [
+                {
+                  "amount": "double",
+                  "rate": {
+                    "active": "boolean",
+                    "created": "double",
+                    "description": "string",
+                    "display_name": "string",
+                    "id": "string",
+                    "inclusive": "boolean",
+                    "jurisdiction": "string",
+                    "livemode": "boolean",
+                    "object": "string",
+                    "percentage": "double"
+                  }
+                }
+              ]
+            }
+          ],
+          "has_more": "boolean",
+          "object": "string",
+          "url": "string"
+        },
+        "livemode": "boolean",
+        "locale": "string",
+        "metadata": {
+          "*": "string"
+        },
+        "mode": "string",
+        "object": "string",
+        "payment_intent": "string",
+        "payment_method_types": [
+          "string"
+        ],
+        "payment_status": "string",
+        "setup_intent": "string",
+        "shipping_address_collection": {
+          "allowed_countries": [
+            "string"
+          ]
+        },
+        "submit_type": "string",
+        "subscription": "string",
+        "success_url": "string",
+        "total_details": {
+          "amount_discount": "double",
+          "amount_tax": "double",
+          "breakdown": {
+            "discounts": [
+              {
+                "amount": "double",
+                "discount": {
+                  "checkout_session": "string",
+                  "customer": "string",
+                  "end": "double",
+                  "id": "string",
+                  "invoice": "string",
+                  "invoice_item": "string",
+                  "object": "string",
+                  "promotion_code": "string",
+                  "start": "double",
+                  "subscription": "string"
+                }
+              }
+            ],
+            "taxes": [
+              {
+                "amount": "double",
+                "rate": {
+                  "active": "boolean",
+                  "created": "double",
+                  "description": "string",
+                  "display_name": "string",
+                  "id": "string",
+                  "inclusive": "boolean",
+                  "jurisdiction": "string",
+                  "livemode": "boolean",
+                  "metadata": {
+                    "*": "string"
+                  },
+                  "object": "string",
+                  "percentage": "double"
+                }
+              }
+            ]
+          }
+        }
+      }
     },
     {
       "name": "Coupon",
       "description": "A single coupon by its id. Same fields as Coupons; use it when the coupon id is already known.",
       "paged": false,
-      "suffix": "/v1/coupons/{Coupon ID}"
+      "suffix": "/v1/coupons/{Coupon ID}",
+      "responseSchema": {
+        "amount_off": "double",
+        "applies_to": {
+          "products": [
+            "string"
+          ]
+        },
+        "created": "double",
+        "currency": "string",
+        "duration": "string",
+        "duration_in_months": "double",
+        "id": "string",
+        "livemode": "boolean",
+        "max_redemptions": "double",
+        "metadata": {
+          "*": "string"
+        },
+        "name": "string",
+        "object": "string",
+        "percent_off": "double",
+        "redeem_by": "double",
+        "times_redeemed": "double",
+        "valid": "boolean"
+      }
     },
     {
       "name": "Coupons",
       "description": "Discounts that can be applied to invoices and subscriptions. Carries amount_off or percent_off, duration and duration_in_months, max_redemptions and times_redeemed, and whether the coupon is still valid. Use for discount programme analysis and redemption rates.",
       "paged": true,
-      "suffix": "/v1/coupons?created={Created?:Unix timestamp}"
+      "suffix": "/v1/coupons?created={Created?:Unix timestamp}",
+      "responseSchema": {
+        "data": [
+          {
+            "amount_off": "double",
+            "applies_to": {
+              "products": [
+                "string"
+              ]
+            },
+            "created": "double",
+            "currency": "string",
+            "duration": "string",
+            "duration_in_months": "double",
+            "id": "string",
+            "livemode": "boolean",
+            "max_redemptions": "double",
+            "metadata": {
+              "*": "string"
+            },
+            "name": "string",
+            "object": "string",
+            "percent_off": "double",
+            "redeem_by": "double",
+            "times_redeemed": "double",
+            "valid": "boolean"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Credit Note",
       "description": "A single credit note by its id. Same fields as Credit Notes; use it when the id is already known.",
       "paged": false,
-      "suffix": "/v1/credit_notes/{Credit Note ID}"
+      "suffix": "/v1/credit_notes/{Credit Note ID}",
+      "responseSchema": {
+        "amount": "double",
+        "created": "double",
+        "currency": "string",
+        "customer": "string",
+        "customer_balance_transaction": "string",
+        "discount_amount": "double",
+        "discount_amounts": [
+          {
+            "amount": "double",
+            "discount": "string"
+          }
+        ],
+        "id": "string",
+        "invoice": "string",
+        "lines": {
+          "data": [
+            {
+              "amount": "double",
+              "description": "string",
+              "discount_amount": "double",
+              "discount_amounts": [
+                {
+                  "amount": "double",
+                  "discount": "string"
+                }
+              ],
+              "id": "string",
+              "invoice_line_item": "string",
+              "livemode": "boolean",
+              "object": "string",
+              "quantity": "double",
+              "tax_rates": [
+                {
+                  "active": "boolean",
+                  "created": "double",
+                  "description": "string",
+                  "display_name": "string",
+                  "id": "string",
+                  "inclusive": "boolean",
+                  "jurisdiction": "string",
+                  "livemode": "boolean",
+                  "metadata": {
+                    "*": "string"
+                  },
+                  "object": "string",
+                  "percentage": "double"
+                }
+              ],
+              "type": "string",
+              "unit_amount": "double",
+              "unit_amount_decimal": "string"
+            }
+          ],
+          "has_more": "boolean",
+          "object": "string",
+          "url": "string"
+        },
+        "livemode": "boolean",
+        "memo": "string",
+        "metadata": {
+          "*": "string"
+        },
+        "number": "string",
+        "object": "string",
+        "out_of_band_amount": "double",
+        "pdf": "string",
+        "reason": "string",
+        "status": "string",
+        "subtotal": "double",
+        "total": "double",
+        "type": "string",
+        "voided_at": "double"
+      }
     },
     {
       "name": "Credit Note Line Items",
       "description": "The individual lines of one credit note, each carrying its own amount, quantity, description, tax and discount amounts. Requires a credit note id; use it to break a credit down by what was credited.",
       "paged": true,
-      "suffix": "/v1/credit_notes/{Credit Note ID}/lines"
+      "suffix": "/v1/credit_notes/{Credit Note ID}/lines",
+      "responseSchema": {
+        "data": [
+          {
+            "amount": "double",
+            "description": "string",
+            "discount_amount": "double",
+            "discount_amounts": [
+              {
+                "amount": "double",
+                "discount": "string"
+              }
+            ],
+            "id": "string",
+            "invoice_line_item": "string",
+            "livemode": "boolean",
+            "object": "string",
+            "quantity": "double",
+            "tax_rates": [
+              {
+                "active": "boolean",
+                "created": "double",
+                "description": "string",
+                "display_name": "string",
+                "id": "string",
+                "inclusive": "boolean",
+                "jurisdiction": "string",
+                "livemode": "boolean",
+                "metadata": {
+                  "*": "string"
+                },
+                "object": "string",
+                "percentage": "double"
+              }
+            ],
+            "type": "string",
+            "unit_amount": "double",
+            "unit_amount_decimal": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Credit Notes",
       "description": "Documents that reduce an already-issued invoice, for a refund or a write-off. Carries amount, currency, the reason, status, and links to the invoice and customer. Use for credited or written-off revenue -- this is the adjustment side of billing, which Invoices alone does not show.",
       "paged": true,
       "suffix": "/v1/credit_notes?invoice={Invoice ID}&customer={Customer ID?}",
+      "responseSchema": {
+        "data": [
+          {
+            "amount": "double",
+            "created": "double",
+            "currency": "string",
+            "customer": "string",
+            "customer_balance_transaction": "string",
+            "discount_amount": "double",
+            "discount_amounts": [
+              {
+                "amount": "double",
+                "discount": "string"
+              }
+            ],
+            "id": "string",
+            "invoice": "string",
+            "lines": {
+              "data": [
+                {
+                  "amount": "double",
+                  "description": "string",
+                  "discount_amount": "double",
+                  "id": "string",
+                  "invoice_line_item": "string",
+                  "livemode": "boolean",
+                  "object": "string",
+                  "quantity": "double",
+                  "type": "string",
+                  "unit_amount": "double",
+                  "unit_amount_decimal": "string"
+                }
+              ],
+              "has_more": "boolean",
+              "object": "string",
+              "url": "string"
+            },
+            "livemode": "boolean",
+            "memo": "string",
+            "metadata": {
+              "*": "string"
+            },
+            "number": "string",
+            "object": "string",
+            "out_of_band_amount": "double",
+            "pdf": "string",
+            "reason": "string",
+            "status": "string",
+            "subtotal": "double",
+            "total": "double",
+            "type": "string",
+            "voided_at": "double"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      },
       "lookups": [
         {
           "endpoint": "Credit Note Line Items",
@@ -297,37 +3577,306 @@
       "name": "Customer Balance Transaction",
       "description": "A single customer balance transaction by its id. Requires the customer id as well. Same fields as Customer Balance Transactions.",
       "paged": false,
-      "suffix": "/v1/customers/{Customer ID}/balance_transactions/{Customer Balance Transaction ID}"
+      "suffix": "/v1/customers/{Customer ID}/balance_transactions/{Customer Balance Transaction ID}",
+      "responseSchema": {
+        "amount": "double",
+        "created": "double",
+        "credit_note": "string",
+        "currency": "string",
+        "customer": "string",
+        "description": "string",
+        "ending_balance": "double",
+        "id": "string",
+        "invoice": "string",
+        "livemode": "boolean",
+        "metadata": {
+          "*": "string"
+        },
+        "object": "string",
+        "type": "string"
+      }
     },
     {
       "name": "Customer Balance Transactions",
       "description": "Movements of one customer's account credit -- the balance Stripe applies to their future invoices. Carries amount, ending_balance, currency, type, and links to the invoice or credit note that caused it. Requires a customer id. Not to be confused with Balance Transactions, which is your own account's money.",
       "paged": true,
-      "suffix": "/v1/customers/{Customer ID}/balance_transactions"
+      "suffix": "/v1/customers/{Customer ID}/balance_transactions",
+      "responseSchema": {
+        "data": [
+          {
+            "amount": "double",
+            "created": "double",
+            "credit_note": "string",
+            "currency": "string",
+            "customer": "string",
+            "description": "string",
+            "ending_balance": "double",
+            "id": "string",
+            "invoice": "string",
+            "livemode": "boolean",
+            "metadata": {
+              "*": "string"
+            },
+            "object": "string",
+            "type": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Tax ID",
       "description": "A single customer tax ID by its id. Requires the customer id as well. Same fields as Tax IDs.",
       "paged": false,
-      "suffix": "/v1/customers/{Customer ID}/tax_ids/{Tax ID}"
+      "suffix": "/v1/customers/{Customer ID}/tax_ids/{Tax ID}",
+      "responseSchema": {
+        "country": "string",
+        "created": "double",
+        "customer": "string",
+        "id": "string",
+        "livemode": "boolean",
+        "object": "string",
+        "type": "string",
+        "value": "string",
+        "verification": {
+          "status": "string",
+          "verified_address": "string",
+          "verified_name": "string"
+        }
+      }
     },
     {
       "name": "Tax IDs",
       "description": "Tax registration numbers recorded against one customer, such as a VAT or GST number. Carries the type, value, country and verification status. Requires a customer id. Use for tax compliance and B2B customer questions.",
       "paged": true,
-      "suffix": "/v1/customers/{Customer ID}/tax_ids"
+      "suffix": "/v1/customers/{Customer ID}/tax_ids",
+      "responseSchema": {
+        "data": [
+          {
+            "country": "string",
+            "created": "double",
+            "customer": "string",
+            "id": "string",
+            "livemode": "boolean",
+            "object": "string",
+            "type": "string",
+            "value": "string",
+            "verification": {
+              "status": "string",
+              "verified_address": "string",
+              "verified_name": "string"
+            }
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Invoice",
       "description": "A single invoice by its id. Same fields as Invoices; use it when the invoice id is already known.",
       "paged": false,
-      "suffix": "/v1/invoices/{Invoice ID}"
+      "suffix": "/v1/invoices/{Invoice ID}",
+      "responseSchema": {
+        "account_country": "string",
+        "account_name": "string",
+        "amount_due": "double",
+        "amount_paid": "double",
+        "amount_remaining": "double",
+        "attempt_count": "double",
+        "attempted": "boolean",
+        "auto_advance": "boolean",
+        "billing_reason": "string",
+        "collection_method": "string",
+        "created": "double",
+        "currency": "string",
+        "custom_fields": [
+          {
+            "name": "string",
+            "value": "string"
+          }
+        ],
+        "customer": "string",
+        "customer_address": {
+          "city": "string",
+          "country": "string",
+          "line1": "string",
+          "line2": "string",
+          "postal_code": "string",
+          "state": "string"
+        },
+        "customer_email": "string",
+        "customer_name": "string",
+        "customer_phone": "string",
+        "customer_shipping": {
+          "address": {
+            "city": "string",
+            "country": "string",
+            "line1": "string",
+            "line2": "string",
+            "postal_code": "string",
+            "state": "string"
+          },
+          "carrier": "string",
+          "name": "string",
+          "phone": "string",
+          "tracking_number": "string"
+        },
+        "customer_tax_exempt": "string",
+        "customer_tax_ids": [
+          {
+            "type": "string",
+            "value": "string"
+          }
+        ],
+        "default_payment_method": "string",
+        "default_source": "string",
+        "default_tax_rates": [
+          {
+            "active": "boolean",
+            "created": "double",
+            "description": "string",
+            "display_name": "string",
+            "id": "string",
+            "inclusive": "boolean",
+            "jurisdiction": "string",
+            "livemode": "boolean",
+            "metadata": {
+              "*": "string"
+            },
+            "object": "string",
+            "percentage": "double"
+          }
+        ],
+        "description": "string",
+        "discounts": [
+          "string"
+        ],
+        "due_date": "double",
+        "ending_balance": "double",
+        "footer": "string",
+        "hosted_invoice_url": "string",
+        "id": "string",
+        "invoice_pdf": "string",
+        "lines": {
+          "data": [
+            {
+              "amount": "double",
+              "currency": "string",
+              "description": "string",
+              "discount_amounts": [
+                {
+                  "amount": "double",
+                  "discount": "string"
+                }
+              ],
+              "discountable": "boolean",
+              "discounts": [
+                "string"
+              ],
+              "id": "string",
+              "livemode": "boolean",
+              "metadata": {
+                "*": "string"
+              },
+              "object": "string",
+              "period": {
+                "end": "double",
+                "start": "double"
+              },
+              "quantity": "double",
+              "subscription": "string"
+            }
+          ],
+          "has_more": "boolean",
+          "object": "string",
+          "url": "string"
+        },
+        "livemode": "boolean",
+        "metadata": {
+          "*": "string"
+        },
+        "next_payment_attempt": "double",
+        "number": "string",
+        "object": "string",
+        "period_end": "double",
+        "period_start": "double",
+        "post_payment_credit_notes_amount": "double",
+        "pre_payment_credit_notes_amount": "double",
+        "receipt_number": "string",
+        "starting_balance": "double",
+        "statement_descriptor": "string",
+        "status": "string",
+        "status_transitions": {
+          "finalized_at": "double",
+          "marked_uncollectible_at": "double",
+          "paid_at": "double",
+          "voided_at": "double"
+        },
+        "subtotal": "double",
+        "threshold_reason": {
+          "amount_gte": "double",
+          "item_reasons": [
+            {
+              "line_item_ids": [
+                "string"
+              ],
+              "usage_gte": "double"
+            }
+          ]
+        },
+        "total": "double",
+        "total_discount_amounts": [
+          {
+            "amount": "double",
+            "discount": "string"
+          }
+        ],
+        "webhooks_delivered_at": "double"
+      }
     },
     {
       "name": "Invoice Line Items",
       "description": "The individual lines of one invoice, each with amount, currency, quantity, the period it covers, its price and any discounts. Requires an invoice id. Use it when the question is about what an invoice was made of rather than its total.",
       "paged": true,
-      "suffix": "/v1/invoices/{Invoice ID}/lines"
+      "suffix": "/v1/invoices/{Invoice ID}/lines",
+      "responseSchema": {
+        "data": [
+          {
+            "amount": "double",
+            "currency": "string",
+            "description": "string",
+            "discount_amounts": [
+              {
+                "amount": "double",
+                "discount": "string"
+              }
+            ],
+            "discountable": "boolean",
+            "discounts": [
+              "string"
+            ],
+            "id": "string",
+            "livemode": "boolean",
+            "metadata": {
+              "*": "string"
+            },
+            "object": "string",
+            "period": {
+              "end": "double",
+              "start": "double"
+            },
+            "quantity": "double",
+            "subscription": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Upcoming Invoice",
@@ -346,6 +3895,164 @@
       "description": "Billing documents, one row each. Carries amount_due, amount_paid and amount_remaining, currency, status and billing_reason, collection_method, the period covered, and links to customer and subscription. Use for billed versus collected revenue, overdue balances, and invoice-level breakdowns.",
       "paged": true,
       "suffix": "/v1/invoices?customer={Customer ID?}&status={Status?:draft|open|paid|uncollectible|void}&subscription={Subscription?}&collection_method={Collection Method?:charge_automatically|send_invoice}&created={Created?:Unix timestamp}&due_date={Due Date?:Unix timestamp}",
+      "responseSchema": {
+        "data": [
+          {
+            "account_country": "string",
+            "account_name": "string",
+            "amount_due": "double",
+            "amount_paid": "double",
+            "amount_remaining": "double",
+            "attempt_count": "double",
+            "attempted": "boolean",
+            "auto_advance": "boolean",
+            "billing_reason": "string",
+            "collection_method": "string",
+            "created": "double",
+            "currency": "string",
+            "custom_fields": [
+              {
+                "name": "string",
+                "value": "string"
+              }
+            ],
+            "customer": "string",
+            "customer_address": {
+              "city": "string",
+              "country": "string",
+              "line1": "string",
+              "line2": "string",
+              "postal_code": "string",
+              "state": "string"
+            },
+            "customer_email": "string",
+            "customer_name": "string",
+            "customer_phone": "string",
+            "customer_shipping": {
+              "address": {
+                "city": "string",
+                "country": "string",
+                "line1": "string",
+                "line2": "string",
+                "postal_code": "string",
+                "state": "string"
+              },
+              "carrier": "string",
+              "name": "string",
+              "phone": "string",
+              "tracking_number": "string"
+            },
+            "customer_tax_exempt": "string",
+            "customer_tax_ids": [
+              {
+                "type": "string",
+                "value": "string"
+              }
+            ],
+            "default_payment_method": "string",
+            "default_source": "string",
+            "default_tax_rates": [
+              {
+                "active": "boolean",
+                "created": "double",
+                "description": "string",
+                "display_name": "string",
+                "id": "string",
+                "inclusive": "boolean",
+                "jurisdiction": "string",
+                "livemode": "boolean",
+                "metadata": {
+                  "*": "string"
+                },
+                "object": "string",
+                "percentage": "double"
+              }
+            ],
+            "description": "string",
+            "discounts": [
+              "string"
+            ],
+            "due_date": "double",
+            "ending_balance": "double",
+            "footer": "string",
+            "hosted_invoice_url": "string",
+            "id": "string",
+            "invoice_pdf": "string",
+            "lines": {
+              "data": [
+                {
+                  "amount": "double",
+                  "currency": "string",
+                  "description": "string",
+                  "discountable": "boolean",
+                  "discounts": [
+                    "string"
+                  ],
+                  "id": "string",
+                  "livemode": "boolean",
+                  "metadata": {
+                    "*": "string"
+                  },
+                  "object": "string",
+                  "period": {
+                    "end": "double",
+                    "start": "double"
+                  },
+                  "quantity": "double",
+                  "subscription": "string"
+                }
+              ],
+              "has_more": "boolean",
+              "object": "string",
+              "url": "string"
+            },
+            "livemode": "boolean",
+            "metadata": {
+              "*": "string"
+            },
+            "next_payment_attempt": "double",
+            "number": "string",
+            "object": "string",
+            "period_end": "double",
+            "period_start": "double",
+            "post_payment_credit_notes_amount": "double",
+            "pre_payment_credit_notes_amount": "double",
+            "receipt_number": "string",
+            "starting_balance": "double",
+            "statement_descriptor": "string",
+            "status": "string",
+            "status_transitions": {
+              "finalized_at": "double",
+              "marked_uncollectible_at": "double",
+              "paid_at": "double",
+              "voided_at": "double"
+            },
+            "subtotal": "double",
+            "threshold_reason": {
+              "amount_gte": "double",
+              "item_reasons": [
+                {
+                  "line_item_ids": [
+                    "string"
+                  ],
+                  "usage_gte": "double"
+                }
+              ]
+            },
+            "total": "double",
+            "total_discount_amounts": [
+              {
+                "amount": "double",
+                "discount": "string"
+              }
+            ],
+            "webhooks_delivered_at": "double"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      },
       "lookups": [
         {
           "endpoint": "Invoice Line Items",
@@ -359,43 +4066,788 @@
       "name": "Invoice Item",
       "description": "A single invoice item by its id. Same fields as Invoice Items; use it when the id is already known.",
       "paged": false,
-      "suffix": "/v1/invoiceitems/{Invoice Item ID}"
+      "suffix": "/v1/invoiceitems/{Invoice Item ID}",
+      "responseSchema": {
+        "amount": "double",
+        "currency": "string",
+        "customer": "string",
+        "date": "double",
+        "description": "string",
+        "discountable": "boolean",
+        "discounts": [
+          "string"
+        ],
+        "id": "string",
+        "invoice": "string",
+        "livemode": "boolean",
+        "metadata": {
+          "*": "string"
+        },
+        "object": "string",
+        "period": {
+          "end": "double",
+          "start": "double"
+        },
+        "proration": "boolean",
+        "quantity": "double",
+        "tax_rates": [
+          {
+            "active": "boolean",
+            "created": "double",
+            "description": "string",
+            "display_name": "string",
+            "id": "string",
+            "inclusive": "boolean",
+            "jurisdiction": "string",
+            "livemode": "boolean",
+            "metadata": {
+              "*": "string"
+            },
+            "object": "string",
+            "percentage": "double"
+          }
+        ]
+      }
     },
     {
       "name": "Invoice Items",
       "description": "Charges staged onto a customer's next invoice before it is issued -- one-off fees, prorations, adjustments. Carries amount, currency, description, the customer and the invoice it will land on. Use for pending charges not yet billed; issued totals are in Invoices.",
       "paged": true,
-      "suffix": "/v1/invoiceitems?created={Created?:Unix timestamp}&invoice={Invoice ID?}&pending={Pending?:true|false}"
+      "suffix": "/v1/invoiceitems?created={Created?:Unix timestamp}&invoice={Invoice ID?}&pending={Pending?:true|false}",
+      "responseSchema": {
+        "data": [
+          {
+            "amount": "double",
+            "currency": "string",
+            "customer": "string",
+            "date": "double",
+            "description": "string",
+            "discountable": "boolean",
+            "discounts": [
+              "string"
+            ],
+            "id": "string",
+            "invoice": "string",
+            "livemode": "boolean",
+            "metadata": {
+              "*": "string"
+            },
+            "object": "string",
+            "period": {
+              "end": "double",
+              "start": "double"
+            },
+            "proration": "boolean",
+            "quantity": "double",
+            "tax_rates": [
+              {
+                "active": "boolean",
+                "created": "double",
+                "description": "string",
+                "display_name": "string",
+                "id": "string",
+                "inclusive": "boolean",
+                "jurisdiction": "string",
+                "livemode": "boolean",
+                "metadata": {
+                  "*": "string"
+                },
+                "object": "string",
+                "percentage": "double"
+              }
+            ]
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Plan",
       "description": "A single plan by its id. Same fields as Plans; use it when the plan id is already known.",
       "paged": false,
-      "suffix": "/v1/plans/{Plan ID}"
+      "suffix": "/v1/plans/{Plan ID}",
+      "responseSchema": {
+        "active": "boolean",
+        "amount": "double",
+        "amount_decimal": "string",
+        "billing_scheme": "string",
+        "created": "double",
+        "currency": "string",
+        "id": "string",
+        "interval": "string",
+        "interval_count": "double",
+        "livemode": "boolean",
+        "metadata": {
+          "*": "string"
+        },
+        "nickname": "string",
+        "object": "string",
+        "product": "string",
+        "tiers_mode": "string",
+        "transform_usage": {
+          "divide_by": "double",
+          "round": "string"
+        },
+        "trial_period_days": "double",
+        "usage_type": "string"
+      }
     },
     {
       "name": "Plans",
       "description": "The older recurring pricing model: amount, currency, billing interval and interval_count, billing_scheme, and whether the plan is active. Superseded by Prices for new integrations, but still populated for accounts that predate it. Check both when analysing subscription pricing.",
       "paged": true,
-      "suffix": "/v1/plans?active={Active?:true|false}&product={Product ID?}&created={Created?:Unix timestamp}"
+      "suffix": "/v1/plans?active={Active?:true|false}&product={Product ID?}&created={Created?:Unix timestamp}",
+      "responseSchema": {
+        "data": [
+          {
+            "active": "boolean",
+            "amount": "double",
+            "amount_decimal": "string",
+            "billing_scheme": "string",
+            "created": "double",
+            "currency": "string",
+            "id": "string",
+            "interval": "string",
+            "interval_count": "double",
+            "livemode": "boolean",
+            "metadata": {
+              "*": "string"
+            },
+            "nickname": "string",
+            "object": "string",
+            "product": "string",
+            "tiers_mode": "string",
+            "transform_usage": {
+              "divide_by": "double",
+              "round": "string"
+            },
+            "trial_period_days": "double",
+            "usage_type": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Account",
       "description": "One connected account by its id, in a Stripe Connect platform. Carries the business profile, country, default_currency, what it is allowed to do (capabilities, charges_enabled, payouts_enabled) and any outstanding verification requirements. Use for platform and marketplace questions.",
       "paged": false,
-      "suffix": "/v1/accounts/{Account ID}"
+      "suffix": "/v1/accounts/{Account ID}",
+      "responseSchema": {
+        "business_profile": {
+          "mcc": "string",
+          "name": "string",
+          "product_description": "string",
+          "support_address": {
+            "city": "string",
+            "country": "string",
+            "line1": "string",
+            "line2": "string",
+            "postal_code": "string",
+            "state": "string"
+          },
+          "support_email": "string",
+          "support_phone": "string",
+          "support_url": "string",
+          "url": "string"
+        },
+        "business_type": "string",
+        "capabilities": {
+          "au_becs_debit_payments": "string",
+          "bacs_debit_payments": "string",
+          "card_issuing": "string",
+          "card_payments": "string",
+          "cartes_bancaires_payments": "string",
+          "fpx_payments": "string",
+          "jcb_payments": "string",
+          "legacy_payments": "string",
+          "oxxo_payments": "string",
+          "tax_reporting_us_1099_k": "string",
+          "tax_reporting_us_1099_misc": "string",
+          "transfers": "string"
+        },
+        "charges_enabled": "boolean",
+        "company": {
+          "address": {
+            "city": "string",
+            "country": "string",
+            "line1": "string",
+            "line2": "string",
+            "postal_code": "string",
+            "state": "string"
+          },
+          "address_kana": {
+            "city": "string",
+            "country": "string",
+            "line1": "string",
+            "line2": "string",
+            "postal_code": "string",
+            "state": "string",
+            "town": "string"
+          },
+          "address_kanji": {
+            "city": "string",
+            "country": "string",
+            "line1": "string",
+            "line2": "string",
+            "postal_code": "string",
+            "state": "string",
+            "town": "string"
+          },
+          "directors_provided": "boolean",
+          "executives_provided": "boolean",
+          "name": "string",
+          "name_kana": "string",
+          "name_kanji": "string",
+          "owners_provided": "boolean",
+          "phone": "string",
+          "structure": "string",
+          "tax_id_provided": "boolean",
+          "tax_id_registrar": "string",
+          "vat_id_provided": "boolean",
+          "verification": {
+            "document": {
+              "back": "string",
+              "details": "string",
+              "details_code": "string",
+              "front": "string"
+            }
+          }
+        },
+        "country": "string",
+        "created": "double",
+        "default_currency": "string",
+        "details_submitted": "boolean",
+        "email": "string",
+        "external_accounts": {
+          "has_more": "boolean",
+          "object": "string",
+          "url": "string"
+        },
+        "id": "string",
+        "individual": {
+          "account": "string",
+          "address": {
+            "city": "string",
+            "country": "string",
+            "line1": "string",
+            "line2": "string",
+            "postal_code": "string",
+            "state": "string"
+          },
+          "address_kana": {
+            "city": "string",
+            "country": "string",
+            "line1": "string",
+            "line2": "string",
+            "postal_code": "string",
+            "state": "string",
+            "town": "string"
+          },
+          "address_kanji": {
+            "city": "string",
+            "country": "string",
+            "line1": "string",
+            "line2": "string",
+            "postal_code": "string",
+            "state": "string",
+            "town": "string"
+          },
+          "created": "double",
+          "dob": {
+            "day": "double",
+            "month": "double",
+            "year": "double"
+          },
+          "email": "string",
+          "first_name": "string",
+          "first_name_kana": "string",
+          "first_name_kanji": "string",
+          "gender": "string",
+          "id": "string",
+          "id_number_provided": "boolean",
+          "last_name": "string",
+          "last_name_kana": "string",
+          "last_name_kanji": "string",
+          "maiden_name": "string",
+          "metadata": {
+            "*": "string"
+          },
+          "object": "string",
+          "phone": "string",
+          "political_exposure": "string",
+          "relationship": {
+            "director": "boolean",
+            "executive": "boolean",
+            "owner": "boolean",
+            "percent_ownership": "double",
+            "representative": "boolean",
+            "title": "string"
+          },
+          "requirements": {
+            "currently_due": [
+              "string"
+            ],
+            "errors": [
+              {
+                "code": "string",
+                "reason": "string",
+                "requirement": "string"
+              }
+            ],
+            "eventually_due": [
+              "string"
+            ],
+            "past_due": [
+              "string"
+            ],
+            "pending_verification": [
+              "string"
+            ]
+          },
+          "ssn_last_4_provided": "boolean",
+          "verification": {
+            "additional_document": {
+              "back": "string",
+              "details": "string",
+              "details_code": "string",
+              "front": "string"
+            },
+            "details": "string",
+            "details_code": "string",
+            "document": {
+              "back": "string",
+              "details": "string",
+              "details_code": "string",
+              "front": "string"
+            },
+            "status": "string"
+          }
+        },
+        "metadata": {
+          "*": "string"
+        },
+        "object": "string",
+        "payouts_enabled": "boolean",
+        "requirements": {
+          "current_deadline": "double",
+          "currently_due": [
+            "string"
+          ],
+          "disabled_reason": "string",
+          "errors": [
+            {
+              "code": "string",
+              "reason": "string",
+              "requirement": "string"
+            }
+          ],
+          "eventually_due": [
+            "string"
+          ],
+          "past_due": [
+            "string"
+          ],
+          "pending_verification": [
+            "string"
+          ]
+        },
+        "settings": {
+          "bacs_debit_payments": {
+            "display_name": "string"
+          },
+          "branding": {
+            "icon": "string",
+            "logo": "string",
+            "primary_color": "string",
+            "secondary_color": "string"
+          },
+          "card_payments": {
+            "decline_on": {
+              "avs_failure": "boolean",
+              "cvc_failure": "boolean"
+            },
+            "statement_descriptor_prefix": "string"
+          },
+          "dashboard": {
+            "display_name": "string",
+            "timezone": "string"
+          },
+          "payments": {
+            "statement_descriptor": "string",
+            "statement_descriptor_kana": "string",
+            "statement_descriptor_kanji": "string"
+          },
+          "payouts": {
+            "debit_negative_balances": "boolean",
+            "schedule": {
+              "delay_days": "double",
+              "interval": "string",
+              "monthly_anchor": "double",
+              "weekly_anchor": "string"
+            },
+            "statement_descriptor": "string"
+          },
+          "sepa_debit_payments": {
+            "creditor_id": "string"
+          }
+        },
+        "tos_acceptance": {
+          "date": "double",
+          "ip": "string",
+          "user_agent": "string"
+        },
+        "type": "string"
+      }
     },
     {
       "name": "Subscription",
       "description": "A single subscription by its id. Same fields as Subscriptions; use it when the subscription id is already known.",
       "paged": false,
-      "suffix": "/v1/subscriptions/{Subscription ID}"
+      "suffix": "/v1/subscriptions/{Subscription ID}",
+      "responseSchema": {
+        "application_fee_percent": "double",
+        "billing_cycle_anchor": "double",
+        "billing_thresholds": {
+          "amount_gte": "double",
+          "reset_billing_cycle_anchor": "boolean"
+        },
+        "cancel_at": "double",
+        "cancel_at_period_end": "boolean",
+        "canceled_at": "double",
+        "collection_method": "string",
+        "created": "double",
+        "customer": "string",
+        "days_until_due": "double",
+        "default_payment_method": "string",
+        "default_source": "string",
+        "default_tax_rates": [
+          {
+            "active": "boolean",
+            "created": "double",
+            "description": "string",
+            "display_name": "string",
+            "id": "string",
+            "inclusive": "boolean",
+            "jurisdiction": "string",
+            "livemode": "boolean",
+            "metadata": {
+              "*": "string"
+            },
+            "object": "string",
+            "percentage": "double"
+          }
+        ],
+        "ended_at": "double",
+        "id": "string",
+        "items": {
+          "data": [
+            {
+              "billing_thresholds": {
+                "usage_gte": "double"
+              },
+              "created": "double",
+              "id": "string",
+              "metadata": {
+                "*": "string"
+              },
+              "object": "string",
+              "price": {
+                "active": "boolean",
+                "billing_scheme": "string",
+                "created": "double",
+                "currency": "string",
+                "id": "string",
+                "livemode": "boolean",
+                "lookup_key": "string",
+                "metadata": {
+                  "*": "string"
+                },
+                "nickname": "string",
+                "object": "string",
+                "product": "string",
+                "recurring": {
+                  "interval": "string",
+                  "interval_count": "double",
+                  "usage_type": "string"
+                },
+                "tiers_mode": "string",
+                "transform_quantity": {
+                  "divide_by": "double",
+                  "round": "string"
+                },
+                "type": "string",
+                "unit_amount": "double",
+                "unit_amount_decimal": "string"
+              },
+              "quantity": "double",
+              "subscription": "string",
+              "tax_rates": [
+                {
+                  "active": "boolean",
+                  "created": "double",
+                  "description": "string",
+                  "display_name": "string",
+                  "id": "string",
+                  "inclusive": "boolean",
+                  "jurisdiction": "string",
+                  "livemode": "boolean",
+                  "metadata": {
+                    "*": "string"
+                  },
+                  "object": "string",
+                  "percentage": "double"
+                }
+              ]
+            }
+          ],
+          "has_more": "boolean",
+          "object": "string",
+          "url": "string"
+        },
+        "latest_invoice": "string",
+        "livemode": "boolean",
+        "metadata": {
+          "*": "string"
+        },
+        "next_pending_invoice_item_invoice": "double",
+        "object": "string",
+        "pause_collection": {
+          "behavior": "string",
+          "resumes_at": "double"
+        },
+        "pending_invoice_item_interval": {
+          "interval": "string",
+          "interval_count": "double"
+        },
+        "pending_setup_intent": "string",
+        "pending_update": {
+          "billing_cycle_anchor": "double",
+          "expires_at": "double",
+          "subscription_items": [
+            {
+              "billing_thresholds": {
+                "usage_gte": "double"
+              },
+              "created": "double",
+              "id": "string",
+              "metadata": {
+                "*": "string"
+              },
+              "object": "string",
+              "price": {
+                "active": "boolean",
+                "billing_scheme": "string",
+                "created": "double",
+                "currency": "string",
+                "id": "string",
+                "livemode": "boolean",
+                "lookup_key": "string",
+                "metadata": {
+                  "*": "string"
+                },
+                "nickname": "string",
+                "object": "string",
+                "product": "string",
+                "recurring": {
+                  "interval": "string",
+                  "interval_count": "double",
+                  "usage_type": "string"
+                },
+                "tiers_mode": "string",
+                "transform_quantity": {
+                  "divide_by": "double",
+                  "round": "string"
+                },
+                "type": "string",
+                "unit_amount": "double",
+                "unit_amount_decimal": "string"
+              },
+              "quantity": "double",
+              "subscription": "string",
+              "tax_rates": [
+                {
+                  "active": "boolean",
+                  "created": "double",
+                  "description": "string",
+                  "display_name": "string",
+                  "id": "string",
+                  "inclusive": "boolean",
+                  "jurisdiction": "string",
+                  "livemode": "boolean",
+                  "metadata": {
+                    "*": "string"
+                  },
+                  "object": "string",
+                  "percentage": "double"
+                }
+              ]
+            }
+          ],
+          "trial_end": "double",
+          "trial_from_plan": "boolean"
+        },
+        "schedule": "string",
+        "start_date": "double",
+        "status": "string",
+        "transfer_data": {
+          "amount_percent": "double",
+          "destination": "string"
+        },
+        "trial_end": "double",
+        "trial_start": "double"
+      }
     },
     {
       "name": "Subscriptions",
       "description": "Recurring billing agreements, one row each. Carries status, the current billing period, created and canceled_at, cancel_at_period_end, collection_method, currency, and links to the customer and the prices being billed. Use for MRR, churn, active subscriber counts, and cancellation analysis.",
       "paged": true,
       "suffix": "/v1/subscriptions?customer={Customer ID?}&plan={Plan ID?}&status={Status?:incomplete|trialing|...}&collection_method={Collection Method?}&created={Created?:Unix timestamp}&current_period_end={Current Period End?:Unix timestamp}&current_period_start={Current Period Start?:Unix timestamp}",
+      "responseSchema": {
+        "data": [
+          {
+            "application_fee_percent": "double",
+            "billing_cycle_anchor": "double",
+            "billing_thresholds": {
+              "amount_gte": "double",
+              "reset_billing_cycle_anchor": "boolean"
+            },
+            "cancel_at": "double",
+            "cancel_at_period_end": "boolean",
+            "canceled_at": "double",
+            "collection_method": "string",
+            "created": "double",
+            "customer": "string",
+            "days_until_due": "double",
+            "default_payment_method": "string",
+            "default_source": "string",
+            "default_tax_rates": [
+              {
+                "active": "boolean",
+                "created": "double",
+                "description": "string",
+                "display_name": "string",
+                "id": "string",
+                "inclusive": "boolean",
+                "jurisdiction": "string",
+                "livemode": "boolean",
+                "metadata": {
+                  "*": "string"
+                },
+                "object": "string",
+                "percentage": "double"
+              }
+            ],
+            "ended_at": "double",
+            "id": "string",
+            "items": {
+              "data": [
+                {
+                  "billing_thresholds": {
+                    "usage_gte": "double"
+                  },
+                  "created": "double",
+                  "id": "string",
+                  "metadata": {
+                    "*": "string"
+                  },
+                  "object": "string",
+                  "price": {
+                    "active": "boolean",
+                    "billing_scheme": "string",
+                    "created": "double",
+                    "currency": "string",
+                    "id": "string",
+                    "livemode": "boolean",
+                    "lookup_key": "string",
+                    "nickname": "string",
+                    "object": "string",
+                    "product": "string",
+                    "tiers_mode": "string",
+                    "type": "string",
+                    "unit_amount": "double",
+                    "unit_amount_decimal": "string"
+                  },
+                  "quantity": "double",
+                  "subscription": "string"
+                }
+              ],
+              "has_more": "boolean",
+              "object": "string",
+              "url": "string"
+            },
+            "latest_invoice": "string",
+            "livemode": "boolean",
+            "metadata": {
+              "*": "string"
+            },
+            "next_pending_invoice_item_invoice": "double",
+            "object": "string",
+            "pause_collection": {
+              "behavior": "string",
+              "resumes_at": "double"
+            },
+            "pending_invoice_item_interval": {
+              "interval": "string",
+              "interval_count": "double"
+            },
+            "pending_setup_intent": "string",
+            "pending_update": {
+              "billing_cycle_anchor": "double",
+              "expires_at": "double",
+              "subscription_items": [
+                {
+                  "billing_thresholds": {
+                    "usage_gte": "double"
+                  },
+                  "created": "double",
+                  "id": "string",
+                  "metadata": {
+                    "*": "string"
+                  },
+                  "object": "string",
+                  "price": {
+                    "active": "boolean",
+                    "billing_scheme": "string",
+                    "created": "double",
+                    "currency": "string",
+                    "id": "string",
+                    "livemode": "boolean",
+                    "lookup_key": "string",
+                    "nickname": "string",
+                    "object": "string",
+                    "product": "string",
+                    "tiers_mode": "string",
+                    "type": "string",
+                    "unit_amount": "double",
+                    "unit_amount_decimal": "string"
+                  },
+                  "quantity": "double",
+                  "subscription": "string"
+                }
+              ],
+              "trial_end": "double",
+              "trial_from_plan": "boolean"
+            },
+            "schedule": "string",
+            "start_date": "double",
+            "status": "string",
+            "transfer_data": {
+              "amount_percent": "double",
+              "destination": "string"
+            },
+            "trial_end": "double",
+            "trial_start": "double"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      },
       "lookups": [
         {
           "endpoint": "Subscription Items",
@@ -409,13 +4861,136 @@
       "name": "Subscription Item",
       "description": "A single subscription item by its id. Same fields as Subscription Items; use it when the id is already known.",
       "paged": false,
-      "suffix": "/v1/subscription_items/{Subscription Item ID}"
+      "suffix": "/v1/subscription_items/{Subscription Item ID}",
+      "responseSchema": {
+        "billing_thresholds": {
+          "usage_gte": "double"
+        },
+        "created": "double",
+        "id": "string",
+        "metadata": {
+          "*": "string"
+        },
+        "object": "string",
+        "price": {
+          "active": "boolean",
+          "billing_scheme": "string",
+          "created": "double",
+          "currency": "string",
+          "id": "string",
+          "livemode": "boolean",
+          "lookup_key": "string",
+          "metadata": {
+            "*": "string"
+          },
+          "nickname": "string",
+          "object": "string",
+          "product": "string",
+          "recurring": {
+            "interval": "string",
+            "interval_count": "double",
+            "usage_type": "string"
+          },
+          "tiers_mode": "string",
+          "transform_quantity": {
+            "divide_by": "double",
+            "round": "string"
+          },
+          "type": "string",
+          "unit_amount": "double",
+          "unit_amount_decimal": "string"
+        },
+        "quantity": "double",
+        "subscription": "string",
+        "tax_rates": [
+          {
+            "active": "boolean",
+            "created": "double",
+            "description": "string",
+            "display_name": "string",
+            "id": "string",
+            "inclusive": "boolean",
+            "jurisdiction": "string",
+            "livemode": "boolean",
+            "metadata": {
+              "*": "string"
+            },
+            "object": "string",
+            "percentage": "double"
+          }
+        ]
+      }
     },
     {
       "name": "Subscription Items",
       "description": "The individual priced components of subscriptions -- a subscription billing three products has three items. Carries quantity, the price being billed, the current period, and the parent subscription. Use it when per-product subscription revenue is needed rather than per-subscription totals.",
       "paged": true,
       "suffix": "/v1/subscription_items?subscription={Subscription ID}",
+      "responseSchema": {
+        "data": [
+          {
+            "billing_thresholds": {
+              "usage_gte": "double"
+            },
+            "created": "double",
+            "id": "string",
+            "metadata": {
+              "*": "string"
+            },
+            "object": "string",
+            "price": {
+              "active": "boolean",
+              "billing_scheme": "string",
+              "created": "double",
+              "currency": "string",
+              "id": "string",
+              "livemode": "boolean",
+              "lookup_key": "string",
+              "metadata": {
+                "*": "string"
+              },
+              "nickname": "string",
+              "object": "string",
+              "product": "string",
+              "recurring": {
+                "interval": "string",
+                "interval_count": "double",
+                "usage_type": "string"
+              },
+              "tiers_mode": "string",
+              "transform_quantity": {
+                "divide_by": "double",
+                "round": "string"
+              },
+              "type": "string",
+              "unit_amount": "double",
+              "unit_amount_decimal": "string"
+            },
+            "quantity": "double",
+            "subscription": "string",
+            "tax_rates": [
+              {
+                "active": "boolean",
+                "created": "double",
+                "description": "string",
+                "display_name": "string",
+                "id": "string",
+                "inclusive": "boolean",
+                "jurisdiction": "string",
+                "livemode": "boolean",
+                "metadata": {
+                  "*": "string"
+                },
+                "object": "string",
+                "percentage": "double"
+              }
+            ]
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      },
       "lookups": [
         {
           "endpoint": "Subscription Item Period Summaries",
@@ -429,25 +5004,261 @@
       "name": "Schedule",
       "description": "A single subscription schedule by its id. Same fields as Schedules; use it when the id is already known.",
       "paged": false,
-      "suffix": "/v1/subscription_schedules/{Subscription Schedule ID}"
+      "suffix": "/v1/subscription_schedules/{Subscription Schedule ID}",
+      "responseSchema": {
+        "canceled_at": "double",
+        "completed_at": "double",
+        "created": "double",
+        "current_phase": {
+          "end_date": "double",
+          "start_date": "double"
+        },
+        "customer": "string",
+        "default_settings": {
+          "billing_cycle_anchor": "string",
+          "billing_thresholds": {
+            "amount_gte": "double",
+            "reset_billing_cycle_anchor": "boolean"
+          },
+          "collection_method": "string",
+          "default_payment_method": "string",
+          "invoice_settings": {
+            "days_until_due": "double"
+          },
+          "transfer_data": {
+            "amount_percent": "double",
+            "destination": "string"
+          }
+        },
+        "end_behavior": "string",
+        "id": "string",
+        "livemode": "boolean",
+        "metadata": {
+          "*": "string"
+        },
+        "object": "string",
+        "phases": [
+          {
+            "add_invoice_items": [
+              {
+                "price": "string",
+                "quantity": "double"
+              }
+            ],
+            "application_fee_percent": "double",
+            "billing_cycle_anchor": "string",
+            "billing_thresholds": {
+              "amount_gte": "double",
+              "reset_billing_cycle_anchor": "boolean"
+            },
+            "collection_method": "string",
+            "default_payment_method": "string",
+            "default_tax_rates": [
+              {
+                "active": "boolean",
+                "created": "double",
+                "description": "string",
+                "display_name": "string",
+                "id": "string",
+                "inclusive": "boolean",
+                "jurisdiction": "string",
+                "livemode": "boolean",
+                "metadata": {
+                  "*": "string"
+                },
+                "object": "string",
+                "percentage": "double"
+              }
+            ],
+            "end_date": "double",
+            "invoice_settings": {
+              "days_until_due": "double"
+            },
+            "items": [
+              {
+                "billing_thresholds": {
+                  "usage_gte": "double"
+                },
+                "price": "string",
+                "quantity": "double",
+                "tax_rates": [
+                  {
+                    "active": "boolean",
+                    "created": "double",
+                    "description": "string",
+                    "display_name": "string",
+                    "id": "string",
+                    "inclusive": "boolean",
+                    "jurisdiction": "string",
+                    "livemode": "boolean",
+                    "object": "string",
+                    "percentage": "double"
+                  }
+                ]
+              }
+            ],
+            "proration_behavior": "string",
+            "start_date": "double",
+            "transfer_data": {
+              "amount_percent": "double",
+              "destination": "string"
+            },
+            "trial_end": "double"
+          }
+        ],
+        "released_at": "double",
+        "released_subscription": "string",
+        "status": "string",
+        "subscription": "string"
+      }
     },
     {
       "name": "Schedules",
       "description": "Planned future changes to subscriptions -- phased pricing, scheduled upgrades, planned cancellation. Carries the phases, current_phase, end_behavior, and status. Use for what is going to happen to billing; what is billing now is in Subscriptions.",
       "paged": true,
-      "suffix": "/v1/subscription_schedules?customer={Customer ID?}&canceled_at={Canceled At?:Unix timestamp}&completed_at={Completed At?:Unix timestamp}&created={Created?:Unix timestamp}&released_at={Released At?}&scheduled={Scheduled?:true|false}"
+      "suffix": "/v1/subscription_schedules?customer={Customer ID?}&canceled_at={Canceled At?:Unix timestamp}&completed_at={Completed At?:Unix timestamp}&created={Created?:Unix timestamp}&released_at={Released At?}&scheduled={Scheduled?:true|false}",
+      "responseSchema": {
+        "data": [
+          {
+            "canceled_at": "double",
+            "completed_at": "double",
+            "created": "double",
+            "current_phase": {
+              "end_date": "double",
+              "start_date": "double"
+            },
+            "customer": "string",
+            "default_settings": {
+              "billing_cycle_anchor": "string",
+              "billing_thresholds": {
+                "amount_gte": "double",
+                "reset_billing_cycle_anchor": "boolean"
+              },
+              "collection_method": "string",
+              "default_payment_method": "string",
+              "invoice_settings": {
+                "days_until_due": "double"
+              },
+              "transfer_data": {
+                "amount_percent": "double",
+                "destination": "string"
+              }
+            },
+            "end_behavior": "string",
+            "id": "string",
+            "livemode": "boolean",
+            "metadata": {
+              "*": "string"
+            },
+            "object": "string",
+            "phases": [
+              {
+                "add_invoice_items": [
+                  {
+                    "price": "string",
+                    "quantity": "double"
+                  }
+                ],
+                "application_fee_percent": "double",
+                "billing_cycle_anchor": "string",
+                "billing_thresholds": {
+                  "amount_gte": "double",
+                  "reset_billing_cycle_anchor": "boolean"
+                },
+                "collection_method": "string",
+                "default_payment_method": "string",
+                "default_tax_rates": [
+                  {
+                    "active": "boolean",
+                    "created": "double",
+                    "description": "string",
+                    "display_name": "string",
+                    "id": "string",
+                    "inclusive": "boolean",
+                    "jurisdiction": "string",
+                    "livemode": "boolean",
+                    "object": "string",
+                    "percentage": "double"
+                  }
+                ],
+                "end_date": "double",
+                "invoice_settings": {
+                  "days_until_due": "double"
+                },
+                "items": [
+                  {
+                    "price": "string",
+                    "quantity": "double"
+                  }
+                ],
+                "proration_behavior": "string",
+                "start_date": "double",
+                "transfer_data": {
+                  "amount_percent": "double",
+                  "destination": "string"
+                },
+                "trial_end": "double"
+              }
+            ],
+            "released_at": "double",
+            "released_subscription": "string",
+            "status": "string",
+            "subscription": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Tax Rate",
       "description": "A single tax rate by its id. Same fields as Tax Rates.",
       "paged": false,
-      "suffix": "/v1/tax_rates/{Tax Rate ID}"
+      "suffix": "/v1/tax_rates/{Tax Rate ID}",
+      "responseSchema": {
+        "active": "boolean",
+        "created": "double",
+        "description": "string",
+        "display_name": "string",
+        "id": "string",
+        "inclusive": "boolean",
+        "jurisdiction": "string",
+        "livemode": "boolean",
+        "metadata": {
+          "*": "string"
+        },
+        "object": "string",
+        "percentage": "double"
+      }
     },
     {
       "name": "Tax Rates",
       "description": "The tax rates available to apply to invoices and subscriptions. Carries display_name, percentage, jurisdiction, country, whether it is inclusive, and whether it is still active. Use for tax breakdowns and for finding which rates are in use.",
       "paged": true,
-      "suffix": "/v1/tax_rates?active={Active?:true|false}&created={Created?:Unix timestamp}&inclusive={Inclusive?:true|false}"
+      "suffix": "/v1/tax_rates?active={Active?:true|false}&created={Created?:Unix timestamp}&inclusive={Inclusive?:true|false}",
+      "responseSchema": {
+        "data": [
+          {
+            "active": "boolean",
+            "created": "double",
+            "description": "string",
+            "display_name": "string",
+            "id": "string",
+            "inclusive": "boolean",
+            "jurisdiction": "string",
+            "livemode": "boolean",
+            "metadata": {
+              "*": "string"
+            },
+            "object": "string",
+            "percentage": "double"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Subscription Item Period Summaries",
@@ -459,25 +5270,369 @@
       "name": "Billing Meters",
       "paged": true,
       "suffix": "/v1/billing/meters?status={Status?:active|inactive}&limit={Limit?}",
-      "description": "The billing meters defined on the account -- the named usage events a metered price is billed against, each with its event name, the aggregation applied (sum or count), its status, and how events map to a customer. The replacement for the retired usage records model. A meter is the definition; what was actually consumed is in its event summaries."
+      "description": "The billing meters defined on the account -- the named usage events a metered price is billed against, each with its event name, the aggregation applied (sum or count), its status, and how events map to a customer. The replacement for the retired usage records model. A meter is the definition; what was actually consumed is in its event summaries.",
+      "responseSchema": {
+        "data": [
+          {
+            "created": "double",
+            "customer_mapping": {
+              "event_payload_key": "string",
+              "type": "string"
+            },
+            "default_aggregation": {
+              "formula": "string"
+            },
+            "display_name": "string",
+            "event_name": "string",
+            "event_time_window": "string",
+            "id": "string",
+            "livemode": "boolean",
+            "object": "string",
+            "status": "string",
+            "status_transitions": {
+              "deactivated_at": "double"
+            },
+            "updated": "double",
+            "value_settings": {
+              "event_payload_key": "string"
+            }
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Billing Meter",
       "paged": false,
       "suffix": "/v1/billing/meters/{Meter ID}",
-      "description": "One billing meter by id, with its aggregation and event mapping."
+      "description": "One billing meter by id, with its aggregation and event mapping.",
+      "responseSchema": {
+        "created": "double",
+        "customer_mapping": {
+          "event_payload_key": "string",
+          "type": "string"
+        },
+        "default_aggregation": {
+          "formula": "string"
+        },
+        "display_name": "string",
+        "event_name": "string",
+        "event_time_window": "string",
+        "id": "string",
+        "livemode": "boolean",
+        "object": "string",
+        "status": "string",
+        "status_transitions": {
+          "deactivated_at": "double"
+        },
+        "updated": "double",
+        "value_settings": {
+          "event_payload_key": "string"
+        }
+      }
     },
     {
       "name": "Billing Meter Event Summaries",
       "paged": true,
       "suffix": "/v1/billing/meters/{Meter ID}/event_summaries?customer={Customer ID}&start_time={Start Time:unix timestamp}&end_time={End Time:unix timestamp}&value_grouping_window={Grouping Window?:hour|day}&limit={Limit?}",
-      "description": "Aggregated usage for ONE CUSTOMER against one meter over a time range, optionally bucketed by hour or day. Requires the meter id, a customer, and both a start and end time -- none of them optional, so this cannot be swept across an account in a single call: usage analysis costs one request per customer per meter. The value is what will be billed, so it is the bridge between what a customer did and what they are charged."
+      "description": "Aggregated usage for ONE CUSTOMER against one meter over a time range, optionally bucketed by hour or day. Requires the meter id, a customer, and both a start and end time -- none of them optional, so this cannot be swept across an account in a single call: usage analysis costs one request per customer per meter. The value is what will be billed, so it is the bridge between what a customer did and what they are charged.",
+      "responseSchema": {
+        "data": [
+          {
+            "aggregated_value": "double",
+            "end_time": "double",
+            "id": "string",
+            "livemode": "boolean",
+            "meter": "string",
+            "object": "string",
+            "start_time": "double"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Connected Accounts",
       "description": "Every account connected to this Stripe Connect platform, one row each. Carries business profile, country, default_currency, capabilities, charges_enabled and payouts_enabled, and outstanding requirements. Use for seller or partner counts, onboarding completion, and which accounts are blocked from charging or being paid out.",
       "paged": true,
       "suffix": "/v1/accounts?created={Created?:Unix timestamp}",
+      "responseSchema": {
+        "data": [
+          {
+            "business_profile": {
+              "mcc": "string",
+              "name": "string",
+              "product_description": "string",
+              "support_address": {
+                "city": "string",
+                "country": "string",
+                "line1": "string",
+                "line2": "string",
+                "postal_code": "string",
+                "state": "string"
+              },
+              "support_email": "string",
+              "support_phone": "string",
+              "support_url": "string",
+              "url": "string"
+            },
+            "business_type": "string",
+            "capabilities": {
+              "au_becs_debit_payments": "string",
+              "bacs_debit_payments": "string",
+              "card_issuing": "string",
+              "card_payments": "string",
+              "cartes_bancaires_payments": "string",
+              "fpx_payments": "string",
+              "jcb_payments": "string",
+              "legacy_payments": "string",
+              "oxxo_payments": "string",
+              "tax_reporting_us_1099_k": "string",
+              "tax_reporting_us_1099_misc": "string",
+              "transfers": "string"
+            },
+            "charges_enabled": "boolean",
+            "company": {
+              "address": {
+                "city": "string",
+                "country": "string",
+                "line1": "string",
+                "line2": "string",
+                "postal_code": "string",
+                "state": "string"
+              },
+              "address_kana": {
+                "city": "string",
+                "country": "string",
+                "line1": "string",
+                "line2": "string",
+                "postal_code": "string",
+                "state": "string",
+                "town": "string"
+              },
+              "address_kanji": {
+                "city": "string",
+                "country": "string",
+                "line1": "string",
+                "line2": "string",
+                "postal_code": "string",
+                "state": "string",
+                "town": "string"
+              },
+              "directors_provided": "boolean",
+              "executives_provided": "boolean",
+              "name": "string",
+              "name_kana": "string",
+              "name_kanji": "string",
+              "owners_provided": "boolean",
+              "phone": "string",
+              "structure": "string",
+              "tax_id_provided": "boolean",
+              "tax_id_registrar": "string",
+              "vat_id_provided": "boolean",
+              "verification": {
+                "document": {
+                  "back": "string",
+                  "details": "string",
+                  "details_code": "string",
+                  "front": "string"
+                }
+              }
+            },
+            "country": "string",
+            "created": "double",
+            "default_currency": "string",
+            "details_submitted": "boolean",
+            "email": "string",
+            "external_accounts": {
+              "has_more": "boolean",
+              "object": "string",
+              "url": "string"
+            },
+            "id": "string",
+            "individual": {
+              "account": "string",
+              "address": {
+                "city": "string",
+                "country": "string",
+                "line1": "string",
+                "line2": "string",
+                "postal_code": "string",
+                "state": "string"
+              },
+              "address_kana": {
+                "city": "string",
+                "country": "string",
+                "line1": "string",
+                "line2": "string",
+                "postal_code": "string",
+                "state": "string",
+                "town": "string"
+              },
+              "address_kanji": {
+                "city": "string",
+                "country": "string",
+                "line1": "string",
+                "line2": "string",
+                "postal_code": "string",
+                "state": "string",
+                "town": "string"
+              },
+              "created": "double",
+              "dob": {
+                "day": "double",
+                "month": "double",
+                "year": "double"
+              },
+              "email": "string",
+              "first_name": "string",
+              "first_name_kana": "string",
+              "first_name_kanji": "string",
+              "gender": "string",
+              "id": "string",
+              "id_number_provided": "boolean",
+              "last_name": "string",
+              "last_name_kana": "string",
+              "last_name_kanji": "string",
+              "maiden_name": "string",
+              "metadata": {
+                "*": "string"
+              },
+              "object": "string",
+              "phone": "string",
+              "political_exposure": "string",
+              "relationship": {
+                "director": "boolean",
+                "executive": "boolean",
+                "owner": "boolean",
+                "percent_ownership": "double",
+                "representative": "boolean",
+                "title": "string"
+              },
+              "requirements": {
+                "currently_due": [
+                  "string"
+                ],
+                "errors": [
+                  {
+                    "code": "string",
+                    "reason": "string",
+                    "requirement": "string"
+                  }
+                ],
+                "eventually_due": [
+                  "string"
+                ],
+                "past_due": [
+                  "string"
+                ],
+                "pending_verification": [
+                  "string"
+                ]
+              },
+              "ssn_last_4_provided": "boolean",
+              "verification": {
+                "additional_document": {
+                  "back": "string",
+                  "details": "string",
+                  "details_code": "string",
+                  "front": "string"
+                },
+                "details": "string",
+                "details_code": "string",
+                "document": {
+                  "back": "string",
+                  "details": "string",
+                  "details_code": "string",
+                  "front": "string"
+                },
+                "status": "string"
+              }
+            },
+            "metadata": {
+              "*": "string"
+            },
+            "object": "string",
+            "payouts_enabled": "boolean",
+            "requirements": {
+              "current_deadline": "double",
+              "currently_due": [
+                "string"
+              ],
+              "disabled_reason": "string",
+              "errors": [
+                {
+                  "code": "string",
+                  "reason": "string",
+                  "requirement": "string"
+                }
+              ],
+              "eventually_due": [
+                "string"
+              ],
+              "past_due": [
+                "string"
+              ],
+              "pending_verification": [
+                "string"
+              ]
+            },
+            "settings": {
+              "bacs_debit_payments": {
+                "display_name": "string"
+              },
+              "branding": {
+                "icon": "string",
+                "logo": "string",
+                "primary_color": "string",
+                "secondary_color": "string"
+              },
+              "card_payments": {
+                "decline_on": {
+                  "avs_failure": "boolean",
+                  "cvc_failure": "boolean"
+                },
+                "statement_descriptor_prefix": "string"
+              },
+              "dashboard": {
+                "display_name": "string",
+                "timezone": "string"
+              },
+              "payments": {
+                "statement_descriptor": "string",
+                "statement_descriptor_kana": "string",
+                "statement_descriptor_kanji": "string"
+              },
+              "payouts": {
+                "debit_negative_balances": "boolean",
+                "schedule": {
+                  "delay_days": "double",
+                  "interval": "string",
+                  "monthly_anchor": "double",
+                  "weekly_anchor": "string"
+                },
+                "statement_descriptor": "string"
+              },
+              "sepa_debit_payments": {
+                "creditor_id": "string"
+              }
+            },
+            "tos_acceptance": {
+              "date": "double",
+              "ip": "string",
+              "user_agent": "string"
+            },
+            "type": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      },
       "lookups": [
         {
           "endpoints": [
@@ -496,13 +5651,88 @@
       "name": "Application Fee",
       "description": "A single application fee by its id. Same fields as Application Fees.",
       "paged": false,
-      "suffix": "/v1/application_fees/{Application Fee ID}"
+      "suffix": "/v1/application_fees/{Application Fee ID}",
+      "responseSchema": {
+        "account": "string",
+        "amount": "double",
+        "amount_refunded": "double",
+        "application": "string",
+        "balance_transaction": "string",
+        "charge": "string",
+        "created": "double",
+        "currency": "string",
+        "id": "string",
+        "livemode": "boolean",
+        "object": "string",
+        "originating_transaction": "string",
+        "refunded": "boolean",
+        "refunds": {
+          "data": [
+            {
+              "amount": "double",
+              "balance_transaction": "string",
+              "created": "double",
+              "currency": "string",
+              "fee": "string",
+              "id": "string",
+              "metadata": {
+                "*": "string"
+              },
+              "object": "string"
+            }
+          ],
+          "has_more": "boolean",
+          "object": "string",
+          "url": "string"
+        }
+      }
     },
     {
       "name": "Application Fees",
       "description": "Fees your platform collected from connected accounts' charges. Carries amount, amount_refunded, currency, and links to the charge and the account it was taken from. Use for platform revenue -- this is what the platform earned, as distinct from what the connected account earned.",
       "paged": true,
       "suffix": "/v1/application_fees?charge={Charge ID?}&created={Created?:Unix timestamp}",
+      "responseSchema": {
+        "data": [
+          {
+            "account": "string",
+            "amount": "double",
+            "amount_refunded": "double",
+            "application": "string",
+            "balance_transaction": "string",
+            "charge": "string",
+            "created": "double",
+            "currency": "string",
+            "id": "string",
+            "livemode": "boolean",
+            "object": "string",
+            "originating_transaction": "string",
+            "refunded": "boolean",
+            "refunds": {
+              "data": [
+                {
+                  "amount": "double",
+                  "balance_transaction": "string",
+                  "created": "double",
+                  "currency": "string",
+                  "fee": "string",
+                  "id": "string",
+                  "metadata": {
+                    "*": "string"
+                  },
+                  "object": "string"
+                }
+              ],
+              "has_more": "boolean",
+              "object": "string",
+              "url": "string"
+            }
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      },
       "lookups": [
         {
           "endpoint": "Application Fee Refunds",
@@ -516,97 +5746,1216 @@
       "name": "Application Fee Refund",
       "description": "A single application fee refund by its id. Requires the fee id as well. Same fields as Application Fee Refunds.",
       "paged": false,
-      "suffix": "/v1/application_fees/{Application Fee ID}/refunds/{Refund ID}"
+      "suffix": "/v1/application_fees/{Application Fee ID}/refunds/{Refund ID}",
+      "responseSchema": {
+        "amount": "double",
+        "balance_transaction": "string",
+        "created": "double",
+        "currency": "string",
+        "fee": "string",
+        "id": "string",
+        "metadata": {
+          "*": "string"
+        },
+        "object": "string"
+      }
     },
     {
       "name": "Application Fee Refunds",
       "description": "Refunds of application fees back to connected accounts. Carries amount, currency and the fee being reversed. Requires an application fee id.",
       "paged": true,
-      "suffix": "/v1/application_fees/{Application Fee ID}/refunds"
+      "suffix": "/v1/application_fees/{Application Fee ID}/refunds",
+      "responseSchema": {
+        "data": [
+          {
+            "amount": "double",
+            "balance_transaction": "string",
+            "created": "double",
+            "currency": "string",
+            "fee": "string",
+            "id": "string",
+            "metadata": {
+              "*": "string"
+            },
+            "object": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Account Capability",
       "description": "A single capability of one connected account. Requires the account id as well. Same fields as Account Capabilities.",
       "paged": false,
-      "suffix": "/v1/accounts/{Account ID}/capabilities/{Capability ID}"
+      "suffix": "/v1/accounts/{Account ID}/capabilities/{Capability ID}",
+      "responseSchema": {
+        "account": "string",
+        "id": "string",
+        "object": "string",
+        "requested": "boolean",
+        "requested_at": "double",
+        "requirements": {
+          "current_deadline": "double",
+          "currently_due": [
+            "string"
+          ],
+          "disabled_reason": "string",
+          "errors": [
+            {
+              "code": "string",
+              "reason": "string",
+              "requirement": "string"
+            }
+          ],
+          "eventually_due": [
+            "string"
+          ],
+          "past_due": [
+            "string"
+          ],
+          "pending_verification": [
+            "string"
+          ]
+        },
+        "status": "string"
+      }
     },
     {
       "name": "Account Capabilities",
       "description": "What one connected account is permitted to do -- card payments, transfers, and so on -- one row per capability. Carries status and the requirements still outstanding. Requires an account id. Use for onboarding blockers.",
       "paged": false,
-      "suffix": "/v1/accounts/{Account ID}/capabilities"
+      "suffix": "/v1/accounts/{Account ID}/capabilities",
+      "responseSchema": {
+        "data": [
+          {
+            "account": "string",
+            "id": "string",
+            "object": "string",
+            "requested": "boolean",
+            "requested_at": "double",
+            "requirements": {
+              "current_deadline": "double",
+              "currently_due": [
+                "string"
+              ],
+              "disabled_reason": "string",
+              "errors": [
+                {
+                  "code": "string",
+                  "reason": "string",
+                  "requirement": "string"
+                }
+              ],
+              "eventually_due": [
+                "string"
+              ],
+              "past_due": [
+                "string"
+              ],
+              "pending_verification": [
+                "string"
+              ]
+            },
+            "status": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Country",
       "description": "The Stripe capabilities of every supported country, one row each. Despite the singular name this is the LIST endpoint. Carries default_currency, supported payment methods and currencies, and the verification fields required there. Use for what Stripe supports where, not for your own transactions.",
       "paged": true,
-      "suffix": "/v1/country_specs"
+      "suffix": "/v1/country_specs",
+      "responseSchema": {
+        "data": [
+          {
+            "default_currency": "string",
+            "id": "string",
+            "object": "string",
+            "supported_bank_account_currencies": {
+              "*": [
+                "string"
+              ]
+            },
+            "supported_payment_currencies": [
+              "string"
+            ],
+            "supported_payment_methods": [
+              "string"
+            ],
+            "supported_transfer_countries": [
+              "string"
+            ],
+            "verification_fields": {
+              "company": {
+                "additional": [
+                  "string"
+                ],
+                "minimum": [
+                  "string"
+                ]
+              },
+              "individual": {
+                "additional": [
+                  "string"
+                ],
+                "minimum": [
+                  "string"
+                ]
+              }
+            }
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Countries",
       "description": "The Stripe capabilities of ONE country, by its country code. Despite the plural name this takes a single id -- the naming is the reverse of what it looks like. Same fields as Country.",
       "paged": false,
-      "suffix": "/v1/country_specs/{Country ID}"
+      "suffix": "/v1/country_specs/{Country ID}",
+      "responseSchema": {
+        "default_currency": "string",
+        "id": "string",
+        "object": "string",
+        "supported_bank_account_currencies": {
+          "*": [
+            "string"
+          ]
+        },
+        "supported_payment_currencies": [
+          "string"
+        ],
+        "supported_payment_methods": [
+          "string"
+        ],
+        "supported_transfer_countries": [
+          "string"
+        ],
+        "verification_fields": {
+          "company": {
+            "additional": [
+              "string"
+            ],
+            "minimum": [
+              "string"
+            ]
+          },
+          "individual": {
+            "additional": [
+              "string"
+            ],
+            "minimum": [
+              "string"
+            ]
+          }
+        }
+      }
     },
     {
       "name": "Account Bank Account",
       "description": "A single external account of one connected account, by its id. Requires the account id as well. Carries the bank name, last4, currency, country and whether it is the default for that currency.",
       "paged": false,
-      "suffix": "/v1/accounts/{Account ID}/external_accounts/{Bank Account ID}"
+      "suffix": "/v1/accounts/{Account ID}/external_accounts/{Bank Account ID}",
+      "responseSchema": {
+        "account": "string",
+        "account_holder_name": "string",
+        "account_holder_type": "string",
+        "available_payout_methods": [
+          "string"
+        ],
+        "bank_name": "string",
+        "country": "string",
+        "currency": "string",
+        "customer": "string",
+        "default_for_currency": "boolean",
+        "fingerprint": "string",
+        "id": "string",
+        "last4": "string",
+        "metadata": {
+          "*": "string"
+        },
+        "object": "string",
+        "routing_number": "string",
+        "status": "string"
+      }
     },
     {
       "name": "Account Bank Accounts",
       "description": "The bank accounts attached to one connected account for payouts, with the bank name, last four digits, currency, country and status. Requires an account id. NOTE THE FILTER: external_accounts holds bank accounts and debit cards together, and object=bank_account is what separates them -- without it the endpoint returns both kinds mixed, which is how the same list can appear under two names.",
       "paged": true,
-      "suffix": "/v1/accounts/{Account ID}/external_accounts?object=bank_account"
+      "suffix": "/v1/accounts/{Account ID}/external_accounts?object=bank_account",
+      "responseSchema": {
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Account Card",
       "description": "A single external account of one connected account, by its id. Requires the account id as well. Carries last4, brand, currency, country and whether it is the default for that currency.",
       "paged": false,
-      "suffix": "/v1/accounts/{Account ID}/external_accounts/{Card ID}"
+      "suffix": "/v1/accounts/{Account ID}/external_accounts/{Card ID}",
+      "responseSchema": {
+        "account": "string",
+        "address_city": "string",
+        "address_country": "string",
+        "address_line1": "string",
+        "address_line1_check": "string",
+        "address_line2": "string",
+        "address_state": "string",
+        "address_zip": "string",
+        "address_zip_check": "string",
+        "available_payout_methods": [
+          "string"
+        ],
+        "brand": "string",
+        "country": "string",
+        "currency": "string",
+        "customer": "string",
+        "cvc_check": "string",
+        "default_for_currency": "boolean",
+        "dynamic_last4": "string",
+        "exp_month": "double",
+        "exp_year": "double",
+        "fingerprint": "string",
+        "funding": "string",
+        "id": "string",
+        "last4": "string",
+        "metadata": {
+          "*": "string"
+        },
+        "name": "string",
+        "object": "string",
+        "tokenization_method": "string"
+      }
     },
     {
       "name": "Account Cards",
       "description": "The debit cards attached to one connected account for payouts, with brand, last four digits, expiry and country. Requires an account id. The object=card filter is what distinguishes this from Account Bank Accounts; the underlying endpoint is the same and returns both kinds unfiltered.",
       "paged": true,
-      "suffix": "/v1/accounts/{Account ID}/external_accounts?object=card"
+      "suffix": "/v1/accounts/{Account ID}/external_accounts?object=card",
+      "responseSchema": {
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Person",
       "description": "A single person on one connected account, by its id. Requires the account id as well. Same fields as People.",
       "paged": false,
-      "suffix": "/v1/accounts/{Account ID}/persons/{Person ID}"
+      "suffix": "/v1/accounts/{Account ID}/persons/{Person ID}",
+      "responseSchema": {
+        "account": "string",
+        "address": {
+          "city": "string",
+          "country": "string",
+          "line1": "string",
+          "line2": "string",
+          "postal_code": "string",
+          "state": "string"
+        },
+        "address_kana": {
+          "city": "string",
+          "country": "string",
+          "line1": "string",
+          "line2": "string",
+          "postal_code": "string",
+          "state": "string",
+          "town": "string"
+        },
+        "address_kanji": {
+          "city": "string",
+          "country": "string",
+          "line1": "string",
+          "line2": "string",
+          "postal_code": "string",
+          "state": "string",
+          "town": "string"
+        },
+        "created": "double",
+        "dob": {
+          "day": "double",
+          "month": "double",
+          "year": "double"
+        },
+        "email": "string",
+        "first_name": "string",
+        "first_name_kana": "string",
+        "first_name_kanji": "string",
+        "gender": "string",
+        "id": "string",
+        "id_number_provided": "boolean",
+        "last_name": "string",
+        "last_name_kana": "string",
+        "last_name_kanji": "string",
+        "maiden_name": "string",
+        "metadata": {
+          "*": "string"
+        },
+        "object": "string",
+        "phone": "string",
+        "political_exposure": "string",
+        "relationship": {
+          "director": "boolean",
+          "executive": "boolean",
+          "owner": "boolean",
+          "percent_ownership": "double",
+          "representative": "boolean",
+          "title": "string"
+        },
+        "requirements": {
+          "currently_due": [
+            "string"
+          ],
+          "errors": [
+            {
+              "code": "string",
+              "reason": "string",
+              "requirement": "string"
+            }
+          ],
+          "eventually_due": [
+            "string"
+          ],
+          "past_due": [
+            "string"
+          ],
+          "pending_verification": [
+            "string"
+          ]
+        },
+        "ssn_last_4_provided": "boolean",
+        "verification": {
+          "additional_document": {
+            "back": "string",
+            "details": "string",
+            "details_code": "string",
+            "front": "string"
+          },
+          "details": "string",
+          "details_code": "string",
+          "document": {
+            "back": "string",
+            "details": "string",
+            "details_code": "string",
+            "front": "string"
+          },
+          "status": "string"
+        }
+      }
     },
     {
       "name": "People",
       "description": "The individuals associated with one connected account -- owners, directors, representatives -- as required for identity verification. Carries names, dob, address, relationship to the business, and verification status. Requires an account id.",
       "paged": true,
-      "suffix": "/v1/accounts/{Account ID}/persons?relationship={Relationship?}"
+      "suffix": "/v1/accounts/{Account ID}/persons?relationship={Relationship?}",
+      "responseSchema": {
+        "data": [
+          {
+            "account": "string",
+            "address": {
+              "city": "string",
+              "country": "string",
+              "line1": "string",
+              "line2": "string",
+              "postal_code": "string",
+              "state": "string"
+            },
+            "address_kana": {
+              "city": "string",
+              "country": "string",
+              "line1": "string",
+              "line2": "string",
+              "postal_code": "string",
+              "state": "string",
+              "town": "string"
+            },
+            "address_kanji": {
+              "city": "string",
+              "country": "string",
+              "line1": "string",
+              "line2": "string",
+              "postal_code": "string",
+              "state": "string",
+              "town": "string"
+            },
+            "created": "double",
+            "dob": {
+              "day": "double",
+              "month": "double",
+              "year": "double"
+            },
+            "email": "string",
+            "first_name": "string",
+            "first_name_kana": "string",
+            "first_name_kanji": "string",
+            "gender": "string",
+            "id": "string",
+            "id_number_provided": "boolean",
+            "last_name": "string",
+            "last_name_kana": "string",
+            "last_name_kanji": "string",
+            "maiden_name": "string",
+            "metadata": {
+              "*": "string"
+            },
+            "object": "string",
+            "phone": "string",
+            "political_exposure": "string",
+            "relationship": {
+              "director": "boolean",
+              "executive": "boolean",
+              "owner": "boolean",
+              "percent_ownership": "double",
+              "representative": "boolean",
+              "title": "string"
+            },
+            "requirements": {
+              "currently_due": [
+                "string"
+              ],
+              "errors": [
+                {
+                  "code": "string",
+                  "reason": "string",
+                  "requirement": "string"
+                }
+              ],
+              "eventually_due": [
+                "string"
+              ],
+              "past_due": [
+                "string"
+              ],
+              "pending_verification": [
+                "string"
+              ]
+            },
+            "ssn_last_4_provided": "boolean",
+            "verification": {
+              "additional_document": {
+                "back": "string",
+                "details": "string",
+                "details_code": "string",
+                "front": "string"
+              },
+              "details": "string",
+              "details_code": "string",
+              "document": {
+                "back": "string",
+                "details": "string",
+                "details_code": "string",
+                "front": "string"
+              },
+              "status": "string"
+            }
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Top-Up",
       "description": "A single top-up by its id. Same fields as Top-Ups.",
       "paged": false,
-      "suffix": "/v1/topups/{Top-up ID}"
+      "suffix": "/v1/topups/{Top-up ID}",
+      "responseSchema": {
+        "amount": "double",
+        "balance_transaction": "string",
+        "created": "double",
+        "currency": "string",
+        "description": "string",
+        "expected_availability_date": "double",
+        "failure_code": "string",
+        "failure_message": "string",
+        "id": "string",
+        "livemode": "boolean",
+        "metadata": {
+          "*": "string"
+        },
+        "object": "string",
+        "source": {
+          "ach_credit_transfer": {
+            "account_number": "string",
+            "bank_name": "string",
+            "fingerprint": "string",
+            "refund_account_holder_name": "string",
+            "refund_account_holder_type": "string",
+            "refund_routing_number": "string",
+            "routing_number": "string",
+            "swift_code": "string"
+          },
+          "ach_debit": {
+            "bank_name": "string",
+            "country": "string",
+            "fingerprint": "string",
+            "last4": "string",
+            "routing_number": "string",
+            "type": "string"
+          },
+          "alipay": {
+            "data_string": "string",
+            "native_url": "string",
+            "statement_descriptor": "string"
+          },
+          "amount": "double",
+          "au_becs_debit": {
+            "bsb_number": "string",
+            "fingerprint": "string",
+            "last4": "string"
+          },
+          "bancontact": {
+            "bank_code": "string",
+            "bank_name": "string",
+            "bic": "string",
+            "iban_last4": "string",
+            "preferred_language": "string",
+            "statement_descriptor": "string"
+          },
+          "card": {
+            "address_line1_check": "string",
+            "address_zip_check": "string",
+            "brand": "string",
+            "country": "string",
+            "cvc_check": "string",
+            "dynamic_last4": "string",
+            "exp_month": "double",
+            "exp_year": "double",
+            "fingerprint": "string",
+            "funding": "string",
+            "last4": "string",
+            "name": "string",
+            "three_d_secure": "string",
+            "tokenization_method": "string"
+          },
+          "card_present": {
+            "application_cryptogram": "string",
+            "application_preferred_name": "string",
+            "authorization_code": "string",
+            "authorization_response_code": "string",
+            "brand": "string",
+            "country": "string",
+            "cvm_type": "string",
+            "data_type": "string",
+            "dedicated_file_name": "string",
+            "emv_auth_data": "string",
+            "evidence_customer_signature": "string",
+            "evidence_transaction_certificate": "string",
+            "exp_month": "double",
+            "exp_year": "double",
+            "fingerprint": "string",
+            "funding": "string",
+            "last4": "string",
+            "pos_device_id": "string",
+            "pos_entry_mode": "string",
+            "read_method": "string",
+            "reader": "string",
+            "terminal_verification_results": "string",
+            "transaction_status_information": "string"
+          },
+          "client_secret": "string",
+          "code_verification": {
+            "attempts_remaining": "double",
+            "status": "string"
+          },
+          "created": "double",
+          "currency": "string",
+          "customer": "string",
+          "eps": {
+            "reference": "string",
+            "statement_descriptor": "string"
+          },
+          "flow": "string",
+          "giropay": {
+            "bank_code": "string",
+            "bank_name": "string",
+            "bic": "string",
+            "statement_descriptor": "string"
+          },
+          "id": "string",
+          "ideal": {
+            "bank": "string",
+            "bic": "string",
+            "iban_last4": "string",
+            "statement_descriptor": "string"
+          },
+          "klarna": {
+            "background_image_url": "string",
+            "client_token": "string",
+            "first_name": "string",
+            "last_name": "string",
+            "locale": "string",
+            "logo_url": "string",
+            "page_title": "string",
+            "pay_later_asset_urls_descriptive": "string",
+            "pay_later_asset_urls_standard": "string",
+            "pay_later_name": "string",
+            "pay_later_redirect_url": "string",
+            "pay_now_asset_urls_descriptive": "string",
+            "pay_now_asset_urls_standard": "string",
+            "pay_now_name": "string",
+            "pay_now_redirect_url": "string",
+            "pay_over_time_asset_urls_descriptive": "string",
+            "pay_over_time_asset_urls_standard": "string",
+            "pay_over_time_name": "string",
+            "pay_over_time_redirect_url": "string",
+            "payment_method_categories": "string",
+            "purchase_country": "string",
+            "purchase_type": "string",
+            "redirect_url": "string",
+            "shipping_delay": "double",
+            "shipping_first_name": "string",
+            "shipping_last_name": "string"
+          },
+          "livemode": "boolean",
+          "metadata": {
+            "*": "string"
+          },
+          "multibanco": {
+            "entity": "string",
+            "reference": "string",
+            "refund_account_holder_address_city": "string",
+            "refund_account_holder_address_country": "string",
+            "refund_account_holder_address_line1": "string",
+            "refund_account_holder_address_line2": "string",
+            "refund_account_holder_address_postal_code": "string",
+            "refund_account_holder_address_state": "string",
+            "refund_account_holder_name": "string",
+            "refund_iban": "string"
+          },
+          "object": "string",
+          "owner": {
+            "address": {
+              "city": "string",
+              "country": "string",
+              "line1": "string",
+              "line2": "string",
+              "postal_code": "string",
+              "state": "string"
+            },
+            "email": "string",
+            "name": "string",
+            "phone": "string",
+            "verified_address": {
+              "city": "string",
+              "country": "string",
+              "line1": "string",
+              "line2": "string",
+              "postal_code": "string",
+              "state": "string"
+            },
+            "verified_email": "string",
+            "verified_name": "string",
+            "verified_phone": "string"
+          },
+          "p24": {
+            "reference": "string"
+          },
+          "receiver": {
+            "address": "string",
+            "amount_charged": "double",
+            "amount_received": "double",
+            "amount_returned": "double",
+            "refund_attributes_method": "string",
+            "refund_attributes_status": "string"
+          },
+          "redirect": {
+            "failure_reason": "string",
+            "return_url": "string",
+            "status": "string",
+            "url": "string"
+          },
+          "sepa_debit": {
+            "bank_code": "string",
+            "branch_code": "string",
+            "country": "string",
+            "fingerprint": "string",
+            "last4": "string",
+            "mandate_reference": "string",
+            "mandate_url": "string"
+          },
+          "sofort": {
+            "bank_code": "string",
+            "bank_name": "string",
+            "bic": "string",
+            "country": "string",
+            "iban_last4": "string",
+            "preferred_language": "string",
+            "statement_descriptor": "string"
+          },
+          "source_order": {
+            "amount": "double",
+            "currency": "string",
+            "email": "string",
+            "items": [
+              {
+                "amount": "double",
+                "currency": "string",
+                "description": "string",
+                "parent": "string",
+                "quantity": "double",
+                "type": "string"
+              }
+            ],
+            "shipping": {
+              "address": {
+                "city": "string",
+                "country": "string",
+                "line1": "string",
+                "line2": "string",
+                "postal_code": "string",
+                "state": "string"
+              },
+              "carrier": "string",
+              "name": "string",
+              "phone": "string",
+              "tracking_number": "string"
+            }
+          },
+          "statement_descriptor": "string",
+          "status": "string",
+          "three_d_secure": {
+            "address_line1_check": "string",
+            "address_zip_check": "string",
+            "authenticated": "boolean",
+            "brand": "string",
+            "card": "string",
+            "country": "string",
+            "customer": "string",
+            "cvc_check": "string",
+            "dynamic_last4": "string",
+            "exp_month": "double",
+            "exp_year": "double",
+            "fingerprint": "string",
+            "funding": "string",
+            "last4": "string",
+            "name": "string",
+            "three_d_secure": "string",
+            "tokenization_method": "string"
+          },
+          "type": "string",
+          "usage": "string",
+          "wechat": {
+            "prepay_id": "string",
+            "qr_code_url": "string",
+            "statement_descriptor": "string"
+          }
+        },
+        "statement_descriptor": "string",
+        "status": "string",
+        "transfer_group": "string"
+      }
     },
     {
       "name": "Top-Ups",
       "description": "Money you added to your own Stripe balance from an external bank account, typically to fund payouts. Carries amount, currency, status, expected_availability_date, and failure_code when it did not clear. Not customer revenue.",
       "paged": true,
-      "suffix": "/v1/topups?amount={Amount?}&created={Created?:Unix timestamp}"
+      "suffix": "/v1/topups?amount={Amount?}&created={Created?:Unix timestamp}",
+      "responseSchema": {
+        "data": [
+          {
+            "amount": "double",
+            "balance_transaction": "string",
+            "created": "double",
+            "currency": "string",
+            "description": "string",
+            "expected_availability_date": "double",
+            "failure_code": "string",
+            "failure_message": "string",
+            "id": "string",
+            "livemode": "boolean",
+            "metadata": {
+              "*": "string"
+            },
+            "object": "string",
+            "source": {
+              "ach_credit_transfer": {
+                "account_number": "string",
+                "bank_name": "string",
+                "fingerprint": "string",
+                "refund_account_holder_name": "string",
+                "refund_account_holder_type": "string",
+                "refund_routing_number": "string",
+                "routing_number": "string",
+                "swift_code": "string"
+              },
+              "ach_debit": {
+                "bank_name": "string",
+                "country": "string",
+                "fingerprint": "string",
+                "last4": "string",
+                "routing_number": "string",
+                "type": "string"
+              },
+              "alipay": {
+                "data_string": "string",
+                "native_url": "string",
+                "statement_descriptor": "string"
+              },
+              "amount": "double",
+              "au_becs_debit": {
+                "bsb_number": "string",
+                "fingerprint": "string",
+                "last4": "string"
+              },
+              "bancontact": {
+                "bank_code": "string",
+                "bank_name": "string",
+                "bic": "string",
+                "iban_last4": "string",
+                "preferred_language": "string",
+                "statement_descriptor": "string"
+              },
+              "card": {
+                "address_line1_check": "string",
+                "address_zip_check": "string",
+                "brand": "string",
+                "country": "string",
+                "cvc_check": "string",
+                "dynamic_last4": "string",
+                "exp_month": "double",
+                "exp_year": "double",
+                "fingerprint": "string",
+                "funding": "string",
+                "last4": "string",
+                "name": "string",
+                "three_d_secure": "string",
+                "tokenization_method": "string"
+              },
+              "card_present": {
+                "application_cryptogram": "string",
+                "application_preferred_name": "string",
+                "authorization_code": "string",
+                "authorization_response_code": "string",
+                "brand": "string",
+                "country": "string",
+                "cvm_type": "string",
+                "data_type": "string",
+                "dedicated_file_name": "string",
+                "emv_auth_data": "string",
+                "evidence_customer_signature": "string",
+                "evidence_transaction_certificate": "string",
+                "exp_month": "double",
+                "exp_year": "double",
+                "fingerprint": "string",
+                "funding": "string",
+                "last4": "string",
+                "pos_device_id": "string",
+                "pos_entry_mode": "string",
+                "read_method": "string",
+                "reader": "string",
+                "terminal_verification_results": "string",
+                "transaction_status_information": "string"
+              },
+              "client_secret": "string",
+              "code_verification": {
+                "attempts_remaining": "double",
+                "status": "string"
+              },
+              "created": "double",
+              "currency": "string",
+              "customer": "string",
+              "eps": {
+                "reference": "string",
+                "statement_descriptor": "string"
+              },
+              "flow": "string",
+              "giropay": {
+                "bank_code": "string",
+                "bank_name": "string",
+                "bic": "string",
+                "statement_descriptor": "string"
+              },
+              "id": "string",
+              "ideal": {
+                "bank": "string",
+                "bic": "string",
+                "iban_last4": "string",
+                "statement_descriptor": "string"
+              },
+              "klarna": {
+                "background_image_url": "string",
+                "client_token": "string",
+                "first_name": "string",
+                "last_name": "string",
+                "locale": "string",
+                "logo_url": "string",
+                "page_title": "string",
+                "pay_later_asset_urls_descriptive": "string",
+                "pay_later_asset_urls_standard": "string",
+                "pay_later_name": "string",
+                "pay_later_redirect_url": "string",
+                "pay_now_asset_urls_descriptive": "string",
+                "pay_now_asset_urls_standard": "string",
+                "pay_now_name": "string",
+                "pay_now_redirect_url": "string",
+                "pay_over_time_asset_urls_descriptive": "string",
+                "pay_over_time_asset_urls_standard": "string",
+                "pay_over_time_name": "string",
+                "pay_over_time_redirect_url": "string",
+                "payment_method_categories": "string",
+                "purchase_country": "string",
+                "purchase_type": "string",
+                "redirect_url": "string",
+                "shipping_delay": "double",
+                "shipping_first_name": "string",
+                "shipping_last_name": "string"
+              },
+              "livemode": "boolean",
+              "metadata": {
+                "*": "string"
+              },
+              "multibanco": {
+                "entity": "string",
+                "reference": "string",
+                "refund_account_holder_address_city": "string",
+                "refund_account_holder_address_country": "string",
+                "refund_account_holder_address_line1": "string",
+                "refund_account_holder_address_line2": "string",
+                "refund_account_holder_address_postal_code": "string",
+                "refund_account_holder_address_state": "string",
+                "refund_account_holder_name": "string",
+                "refund_iban": "string"
+              },
+              "object": "string",
+              "owner": {
+                "address": {
+                  "city": "string",
+                  "country": "string",
+                  "line1": "string",
+                  "line2": "string",
+                  "postal_code": "string",
+                  "state": "string"
+                },
+                "email": "string",
+                "name": "string",
+                "phone": "string",
+                "verified_address": {
+                  "city": "string",
+                  "country": "string",
+                  "line1": "string",
+                  "line2": "string",
+                  "postal_code": "string",
+                  "state": "string"
+                },
+                "verified_email": "string",
+                "verified_name": "string",
+                "verified_phone": "string"
+              },
+              "p24": {
+                "reference": "string"
+              },
+              "receiver": {
+                "address": "string",
+                "amount_charged": "double",
+                "amount_received": "double",
+                "amount_returned": "double",
+                "refund_attributes_method": "string",
+                "refund_attributes_status": "string"
+              },
+              "redirect": {
+                "failure_reason": "string",
+                "return_url": "string",
+                "status": "string",
+                "url": "string"
+              },
+              "sepa_debit": {
+                "bank_code": "string",
+                "branch_code": "string",
+                "country": "string",
+                "fingerprint": "string",
+                "last4": "string",
+                "mandate_reference": "string",
+                "mandate_url": "string"
+              },
+              "sofort": {
+                "bank_code": "string",
+                "bank_name": "string",
+                "bic": "string",
+                "country": "string",
+                "iban_last4": "string",
+                "preferred_language": "string",
+                "statement_descriptor": "string"
+              },
+              "source_order": {
+                "amount": "double",
+                "currency": "string",
+                "email": "string",
+                "items": [
+                  {
+                    "amount": "double",
+                    "currency": "string",
+                    "description": "string",
+                    "parent": "string",
+                    "quantity": "double",
+                    "type": "string"
+                  }
+                ],
+                "shipping": {
+                  "address": {
+                    "city": "string",
+                    "country": "string",
+                    "line1": "string",
+                    "line2": "string",
+                    "postal_code": "string",
+                    "state": "string"
+                  },
+                  "carrier": "string",
+                  "name": "string",
+                  "phone": "string",
+                  "tracking_number": "string"
+                }
+              },
+              "statement_descriptor": "string",
+              "status": "string",
+              "three_d_secure": {
+                "address_line1_check": "string",
+                "address_zip_check": "string",
+                "authenticated": "boolean",
+                "brand": "string",
+                "card": "string",
+                "country": "string",
+                "customer": "string",
+                "cvc_check": "string",
+                "dynamic_last4": "string",
+                "exp_month": "double",
+                "exp_year": "double",
+                "fingerprint": "string",
+                "funding": "string",
+                "last4": "string",
+                "name": "string",
+                "three_d_secure": "string",
+                "tokenization_method": "string"
+              },
+              "type": "string",
+              "usage": "string",
+              "wechat": {
+                "prepay_id": "string",
+                "qr_code_url": "string",
+                "statement_descriptor": "string"
+              }
+            },
+            "statement_descriptor": "string",
+            "status": "string",
+            "transfer_group": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Transfer",
       "description": "A single transfer by its id. Same fields as Transfers.",
       "paged": false,
-      "suffix": "/v1/transfers/{Transfer ID}"
+      "suffix": "/v1/transfers/{Transfer ID}",
+      "responseSchema": {
+        "amount": "double",
+        "amount_reversed": "double",
+        "balance_transaction": "string",
+        "created": "double",
+        "currency": "string",
+        "description": "string",
+        "destination": "string",
+        "destination_payment": "string",
+        "id": "string",
+        "livemode": "boolean",
+        "metadata": {
+          "*": "string"
+        },
+        "object": "string",
+        "reversals": {
+          "data": [
+            {
+              "amount": "double",
+              "balance_transaction": "string",
+              "created": "double",
+              "currency": "string",
+              "destination_payment_refund": "string",
+              "id": "string",
+              "metadata": {
+                "*": "string"
+              },
+              "object": "string",
+              "source_refund": "string",
+              "transfer": "string"
+            }
+          ],
+          "has_more": "boolean",
+          "object": "string",
+          "url": "string"
+        },
+        "reversed": "boolean",
+        "source_transaction": "string",
+        "source_type": "string",
+        "transfer_group": "string"
+      }
     },
     {
       "name": "Transfers",
       "description": "Money moved from your Stripe balance to a connected account. Carries amount, amount_reversed, currency, the destination account, and the charge it originated from. Use for what was paid out to sellers or partners; payouts to your own bank are in Payouts.",
       "paged": true,
       "suffix": "/v1/transfers?destination={Destination?}created={Created?:Unix timestamp}&transfer_group={Transfer Group}",
+      "responseSchema": {
+        "data": [
+          {
+            "amount": "double",
+            "amount_reversed": "double",
+            "balance_transaction": "string",
+            "created": "double",
+            "currency": "string",
+            "description": "string",
+            "destination": "string",
+            "destination_payment": "string",
+            "id": "string",
+            "livemode": "boolean",
+            "metadata": {
+              "*": "string"
+            },
+            "object": "string",
+            "reversals": {
+              "data": [
+                {
+                  "amount": "double",
+                  "balance_transaction": "string",
+                  "created": "double",
+                  "currency": "string",
+                  "destination_payment_refund": "string",
+                  "id": "string",
+                  "metadata": {
+                    "*": "string"
+                  },
+                  "object": "string",
+                  "source_refund": "string",
+                  "transfer": "string"
+                }
+              ],
+              "has_more": "boolean",
+              "object": "string",
+              "url": "string"
+            },
+            "reversed": "boolean",
+            "source_transaction": "string",
+            "source_type": "string",
+            "transfer_group": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      },
       "lookups": [
         {
           "endpoint": "Reversals",
@@ -620,49 +6969,235 @@
       "name": "Reversal",
       "description": "A single transfer reversal by its id. Requires the transfer id as well. Same fields as Reversals.",
       "paged": false,
-      "suffix": "/v1/transfers/{Transfer ID}/reversals/{Reversal ID}"
+      "suffix": "/v1/transfers/{Transfer ID}/reversals/{Reversal ID}",
+      "responseSchema": {
+        "amount": "double",
+        "balance_transaction": "string",
+        "created": "double",
+        "currency": "string",
+        "destination_payment_refund": "string",
+        "id": "string",
+        "metadata": {
+          "*": "string"
+        },
+        "object": "string",
+        "source_refund": "string",
+        "transfer": "string"
+      }
     },
     {
       "name": "Reversals",
       "description": "Transfers that were pulled back from a connected account. Carries amount, currency and the transfer being reversed. Requires a transfer id.",
       "paged": true,
-      "suffix": "/v1/transfers/{Transfer ID}/reversals"
+      "suffix": "/v1/transfers/{Transfer ID}/reversals",
+      "responseSchema": {
+        "data": [
+          {
+            "amount": "double",
+            "balance_transaction": "string",
+            "created": "double",
+            "currency": "string",
+            "destination_payment_refund": "string",
+            "id": "string",
+            "metadata": {
+              "*": "string"
+            },
+            "object": "string",
+            "source_refund": "string",
+            "transfer": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Early Fraud Warning",
       "description": "A single early fraud warning by its id. Same fields as Early Fraud Warnings.",
       "paged": false,
-      "suffix": "/v1/radar/early_fraud_warnings/{Early Fraud Warning ID}"
+      "suffix": "/v1/radar/early_fraud_warnings/{Early Fraud Warning ID}",
+      "responseSchema": {
+        "actionable": "boolean",
+        "charge": "string",
+        "created": "double",
+        "fraud_type": "string",
+        "id": "string",
+        "livemode": "boolean",
+        "object": "string"
+      }
     },
     {
       "name": "Early Fraud Warnings",
       "description": "Notices from the card networks that a charge is likely fraudulent, usually arriving before a dispute does. Carries fraud_type, whether it is actionable, and links to the charge and payment intent. Use as a leading indicator of disputes.",
       "paged": true,
-      "suffix": "/v1/radar/early_fraud_warnings?charge={Charge ID}"
+      "suffix": "/v1/radar/early_fraud_warnings?charge={Charge ID}",
+      "responseSchema": {
+        "data": [
+          {
+            "actionable": "boolean",
+            "charge": "string",
+            "created": "double",
+            "fraud_type": "string",
+            "id": "string",
+            "livemode": "boolean",
+            "object": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Review",
       "description": "A single fraud review by its id. Same fields as Open Reviews.",
       "paged": false,
-      "suffix": "/v1/reviews/{Review ID}"
+      "suffix": "/v1/reviews/{Review ID}",
+      "responseSchema": {
+        "billing_zip": "string",
+        "charge": "string",
+        "closed_reason": "string",
+        "created": "double",
+        "id": "string",
+        "ip_address": "string",
+        "ip_address_location": {
+          "city": "string",
+          "country": "string",
+          "latitude": "double",
+          "longitude": "double",
+          "region": "string"
+        },
+        "livemode": "boolean",
+        "object": "string",
+        "open": "boolean",
+        "opened_reason": "string",
+        "payment_intent": "string",
+        "reason": "string",
+        "session": {
+          "browser": "string",
+          "device": "string",
+          "platform": "string",
+          "version": "string"
+        }
+      }
     },
     {
       "name": "Open Reviews",
       "description": "Payments held for manual fraud review. Carries the reason it was opened, whether it is still open, closed_reason once decided, ip_address and its location, and links to the charge and payment intent. Named for open reviews but the underlying list returns closed ones too -- filter on the open field.",
       "paged": true,
-      "suffix": "/v1/reviews?created={Created?:Unix timestamp}"
+      "suffix": "/v1/reviews?created={Created?:Unix timestamp}",
+      "responseSchema": {
+        "data": [
+          {
+            "billing_zip": "string",
+            "charge": "string",
+            "closed_reason": "string",
+            "created": "double",
+            "id": "string",
+            "ip_address": "string",
+            "ip_address_location": {
+              "city": "string",
+              "country": "string",
+              "latitude": "double",
+              "longitude": "double",
+              "region": "string"
+            },
+            "livemode": "boolean",
+            "object": "string",
+            "open": "boolean",
+            "opened_reason": "string",
+            "payment_intent": "string",
+            "reason": "string",
+            "session": {
+              "browser": "string",
+              "device": "string",
+              "platform": "string",
+              "version": "string"
+            }
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Value List",
       "description": "A single Radar value list by its id. Same fields as Value Lists.",
       "paged": false,
-      "suffix": "/v1/radar/value_lists/{Value List ID}"
+      "suffix": "/v1/radar/value_lists/{Value List ID}",
+      "responseSchema": {
+        "alias": "string",
+        "created": "double",
+        "created_by": "string",
+        "id": "string",
+        "item_type": "string",
+        "list_items": {
+          "data": [
+            {
+              "created": "double",
+              "created_by": "string",
+              "id": "string",
+              "livemode": "boolean",
+              "object": "string",
+              "value": "string",
+              "value_list": "string"
+            }
+          ],
+          "has_more": "boolean",
+          "object": "string",
+          "url": "string"
+        },
+        "livemode": "boolean",
+        "metadata": {
+          "*": "string"
+        },
+        "name": "string",
+        "object": "string"
+      }
     },
     {
       "name": "Value Lists",
       "description": "Named lists used by Stripe Radar fraud rules -- blocked cards, allowed countries, and so on. Carries the list name, alias, and the type of item it holds. Use for auditing what the fraud rules are matching against.",
       "paged": true,
       "suffix": "/v1/radar/value_lists?alias={Alias?}&contains={Contains?:value1,value2,...}&created={Created?:Unix timestamp}",
+      "responseSchema": {
+        "data": [
+          {
+            "alias": "string",
+            "created": "double",
+            "created_by": "string",
+            "id": "string",
+            "item_type": "string",
+            "list_items": {
+              "data": [
+                {
+                  "created": "double",
+                  "created_by": "string",
+                  "id": "string",
+                  "livemode": "boolean",
+                  "object": "string",
+                  "value": "string",
+                  "value_list": "string"
+                }
+              ],
+              "has_more": "boolean",
+              "object": "string",
+              "url": "string"
+            },
+            "livemode": "boolean",
+            "metadata": {
+              "*": "string"
+            },
+            "name": "string",
+            "object": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      },
       "lookups": [
         {
           "endpoint": "Value List Items",
@@ -676,37 +7211,140 @@
       "name": "Value List Item",
       "description": "A single Radar value list item by its id. Same fields as Value List Items.",
       "paged": false,
-      "suffix": "/v1/radar/value_list_items/{Value List Item ID}"
+      "suffix": "/v1/radar/value_list_items/{Value List Item ID}",
+      "responseSchema": {
+        "created": "double",
+        "created_by": "string",
+        "id": "string",
+        "livemode": "boolean",
+        "object": "string",
+        "value": "string",
+        "value_list": "string"
+      }
     },
     {
       "name": "Value List Items",
       "description": "The entries inside Radar value lists. Carries the value, who created it, and which list it belongs to. Filtered by value list.",
       "paged": true,
-      "suffix": "/v1/radar/value_list_items?value_list={Value List ID}&value={Value?}&created={Created?:Unix timestamp}"
+      "suffix": "/v1/radar/value_list_items?value_list={Value List ID}&value={Value?}&created={Created?:Unix timestamp}",
+      "responseSchema": {
+        "data": [
+          {
+            "created": "double",
+            "created_by": "string",
+            "id": "string",
+            "livemode": "boolean",
+            "object": "string",
+            "value": "string",
+            "value_list": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Location",
       "description": "A single Terminal location by its id. Same fields as Locations.",
       "paged": false,
-      "suffix": "/v1/terminal/locations/{Location ID}"
+      "suffix": "/v1/terminal/locations/{Location ID}",
+      "responseSchema": {
+        "address": {
+          "city": "string",
+          "country": "string",
+          "line1": "string",
+          "line2": "string",
+          "postal_code": "string",
+          "state": "string"
+        },
+        "display_name": "string",
+        "id": "string",
+        "livemode": "boolean",
+        "metadata": {
+          "*": "string"
+        },
+        "object": "string"
+      }
     },
     {
       "name": "Locations",
       "description": "Physical places where Stripe Terminal card readers are deployed. Carries display_name and address. Use to give in-person payments a location dimension.",
       "paged": true,
-      "suffix": "/v1/terminal/locations"
+      "suffix": "/v1/terminal/locations",
+      "responseSchema": {
+        "data": [
+          {
+            "address": {
+              "city": "string",
+              "country": "string",
+              "line1": "string",
+              "line2": "string",
+              "postal_code": "string",
+              "state": "string"
+            },
+            "display_name": "string",
+            "id": "string",
+            "livemode": "boolean",
+            "metadata": {
+              "*": "string"
+            },
+            "object": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Reader",
       "description": "A single Terminal reader by its id. Same fields as Readers.",
       "paged": false,
-      "suffix": "v1/terminal/readers/{Reader ID}"
+      "suffix": "v1/terminal/readers/{Reader ID}",
+      "responseSchema": {
+        "device_sw_version": "string",
+        "device_type": "string",
+        "id": "string",
+        "ip_address": "string",
+        "label": "string",
+        "livemode": "boolean",
+        "location": "string",
+        "metadata": {
+          "*": "string"
+        },
+        "object": "string",
+        "serial_number": "string",
+        "status": "string"
+      }
     },
     {
       "name": "Readers",
       "description": "Stripe Terminal card readers. Carries label, device_type, serial_number, status, ip_address, last_seen_at and the location it belongs to. Use for fleet health and for tying in-person payments to a device.",
       "paged": true,
-      "suffix": "/v1/terminal/readers?device_type={Device Type?:bbpos_chipper2x|verifone_P400}&location={Location ID?}&status={Status?:offline|online}"
+      "suffix": "/v1/terminal/readers?device_type={Device Type?:bbpos_chipper2x|verifone_P400}&location={Location ID?}&status={Status?:offline|online}",
+      "responseSchema": {
+        "data": [
+          {
+            "device_sw_version": "string",
+            "device_type": "string",
+            "id": "string",
+            "ip_address": "string",
+            "label": "string",
+            "livemode": "boolean",
+            "location": "string",
+            "metadata": {
+              "*": "string"
+            },
+            "object": "string",
+            "serial_number": "string",
+            "status": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Order",
@@ -756,49 +7394,331 @@
       "name": "Scheduled Query Run",
       "description": "A single scheduled query run by its id. Same fields as Scheduled Query Runs.",
       "paged": false,
-      "suffix": "/v1/sigma/scheduled_query_runs/{Scheduled Query Run ID}"
+      "suffix": "/v1/sigma/scheduled_query_runs/{Scheduled Query Run ID}",
+      "responseSchema": {
+        "created": "double",
+        "data_load_time": "double",
+        "error": {
+          "message": "string"
+        },
+        "file": {
+          "created": "double",
+          "expires_at": "double",
+          "filename": "string",
+          "id": "string",
+          "links": {
+            "data": [
+              {
+                "created": "double",
+                "expired": "boolean",
+                "expires_at": "double",
+                "file": "string",
+                "id": "string",
+                "livemode": "boolean",
+                "metadata": {
+                  "*": "string"
+                },
+                "object": "string",
+                "url": "string"
+              }
+            ],
+            "has_more": "boolean",
+            "object": "string",
+            "url": "string"
+          },
+          "object": "string",
+          "purpose": "string",
+          "size": "double",
+          "title": "string",
+          "type": "string",
+          "url": "string"
+        },
+        "id": "string",
+        "livemode": "boolean",
+        "object": "string",
+        "result_available_until": "double",
+        "sql": "string",
+        "status": "string",
+        "title": "string"
+      }
     },
     {
       "name": "Scheduled Query Runs",
       "description": "Executions of saved Sigma SQL queries. Carries the sql that ran, status, data_load_time, error when it failed, and a link to the result file. Use for auditing scheduled analytics jobs.",
       "paged": true,
-      "suffix": "/v1/sigma/scheduled_query_runs"
+      "suffix": "/v1/sigma/scheduled_query_runs",
+      "responseSchema": {
+        "data": [
+          {
+            "created": "double",
+            "data_load_time": "double",
+            "error": {
+              "message": "string"
+            },
+            "file": {
+              "created": "double",
+              "expires_at": "double",
+              "filename": "string",
+              "id": "string",
+              "links": {
+                "data": [
+                  {
+                    "created": "double",
+                    "expired": "boolean",
+                    "expires_at": "double",
+                    "file": "string",
+                    "id": "string",
+                    "livemode": "boolean",
+                    "object": "string",
+                    "url": "string"
+                  }
+                ],
+                "has_more": "boolean",
+                "object": "string",
+                "url": "string"
+              },
+              "object": "string",
+              "purpose": "string",
+              "size": "double",
+              "title": "string",
+              "type": "string",
+              "url": "string"
+            },
+            "id": "string",
+            "livemode": "boolean",
+            "object": "string",
+            "result_available_until": "double",
+            "sql": "string",
+            "status": "string",
+            "title": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Report Run",
       "description": "A single report run by its id. Same fields as Report Runs.",
       "paged": false,
-      "suffix": "/v1/reporting/report_runs/{Report Run ID}"
+      "suffix": "/v1/reporting/report_runs/{Report Run ID}",
+      "responseSchema": {
+        "created": "double",
+        "error": "string",
+        "id": "string",
+        "livemode": "boolean",
+        "object": "string",
+        "parameters": {
+          "columns": [
+            "string"
+          ],
+          "connected_account": "string",
+          "currency": "string",
+          "interval_end": "double",
+          "interval_start": "double",
+          "payout": "string",
+          "reporting_category": "string",
+          "timezone": "string"
+        },
+        "report_type": "string",
+        "result": {
+          "created": "double",
+          "expires_at": "double",
+          "filename": "string",
+          "id": "string",
+          "links": {
+            "data": [
+              {
+                "created": "double",
+                "expired": "boolean",
+                "expires_at": "double",
+                "file": "string",
+                "id": "string",
+                "livemode": "boolean",
+                "metadata": {
+                  "*": "string"
+                },
+                "object": "string",
+                "url": "string"
+              }
+            ],
+            "has_more": "boolean",
+            "object": "string",
+            "url": "string"
+          },
+          "object": "string",
+          "purpose": "string",
+          "size": "double",
+          "title": "string",
+          "type": "string",
+          "url": "string"
+        },
+        "status": "string",
+        "succeeded_at": "double"
+      }
     },
     {
       "name": "Report Runs",
       "description": "Executions of Stripe's prebuilt financial reports. Carries the report_type, the parameters it ran with, status, succeeded_at, and a link to the resulting file. Use for auditing which reports were produced; the report contents are in the linked file, not here.",
       "paged": true,
-      "suffix": "/v1/reporting/report_runs?created={Created?:Unix timestamp}"
+      "suffix": "/v1/reporting/report_runs?created={Created?:Unix timestamp}",
+      "responseSchema": {
+        "data": [
+          {
+            "created": "double",
+            "error": "string",
+            "id": "string",
+            "livemode": "boolean",
+            "object": "string",
+            "parameters": {
+              "columns": [
+                "string"
+              ],
+              "connected_account": "string",
+              "currency": "string",
+              "interval_end": "double",
+              "interval_start": "double",
+              "payout": "string",
+              "reporting_category": "string",
+              "timezone": "string"
+            },
+            "report_type": "string",
+            "result": {
+              "created": "double",
+              "expires_at": "double",
+              "filename": "string",
+              "id": "string",
+              "links": {
+                "data": [
+                  {
+                    "created": "double",
+                    "expired": "boolean",
+                    "expires_at": "double",
+                    "file": "string",
+                    "id": "string",
+                    "livemode": "boolean",
+                    "object": "string",
+                    "url": "string"
+                  }
+                ],
+                "has_more": "boolean",
+                "object": "string",
+                "url": "string"
+              },
+              "object": "string",
+              "purpose": "string",
+              "size": "double",
+              "title": "string",
+              "type": "string",
+              "url": "string"
+            },
+            "status": "string",
+            "succeeded_at": "double"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Report Type",
       "description": "A single report type by its id. Same fields as Report Types.",
       "paged": false,
-      "suffix": "/v1/reporting/report_types/{Report Type ID}"
+      "suffix": "/v1/reporting/report_types/{Report Type ID}",
+      "responseSchema": {
+        "data_available_end": "double",
+        "data_available_start": "double",
+        "default_columns": [
+          "string"
+        ],
+        "id": "string",
+        "name": "string",
+        "object": "string",
+        "updated": "double",
+        "version": "double"
+      }
     },
     {
       "name": "Report Types",
       "description": "The prebuilt financial reports Stripe offers, one row each. Carries the report name, its default_columns, and the date range of data available. Use to discover what can be reported on before running one.",
       "paged": false,
-      "suffix": "/v1/reporting/report_types"
+      "suffix": "/v1/reporting/report_types",
+      "responseSchema": {
+        "data": [
+          {
+            "data_available_end": "double",
+            "data_available_start": "double",
+            "default_columns": [
+              "string"
+            ],
+            "id": "string",
+            "name": "string",
+            "object": "string",
+            "updated": "double",
+            "version": "double"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Webhook Endpoint",
       "description": "A single webhook endpoint by its id. Same fields as Webhook Endpoints.",
       "paged": false,
-      "suffix": "/v1/webhook_endpoints/{Webhook Endpoint ID}"
+      "suffix": "/v1/webhook_endpoints/{Webhook Endpoint ID}",
+      "responseSchema": {
+        "api_version": "string",
+        "application": "string",
+        "created": "double",
+        "description": "string",
+        "enabled_events": [
+          "string"
+        ],
+        "id": "string",
+        "livemode": "boolean",
+        "metadata": {
+          "*": "string"
+        },
+        "object": "string",
+        "secret": "string",
+        "status": "string",
+        "url": "string"
+      }
     },
     {
       "name": "Webhook Endpoints",
       "description": "The URLs Stripe sends event notifications to. Carries the url, which enabled_events it subscribes to, status, and api_version. Use for auditing integration wiring; the events themselves are in Events.",
       "paged": true,
-      "suffix": "/v1/webhook_endpoints"
+      "suffix": "/v1/webhook_endpoints",
+      "responseSchema": {
+        "data": [
+          {
+            "api_version": "string",
+            "application": "string",
+            "created": "double",
+            "description": "string",
+            "enabled_events": [
+              "string"
+            ],
+            "id": "string",
+            "livemode": "boolean",
+            "metadata": {
+              "*": "string"
+            },
+            "object": "string",
+            "secret": "string",
+            "status": "string",
+            "url": "string"
+          }
+        ],
+        "has_more": "boolean",
+        "object": "string",
+        "url": "string"
+      }
     }
   ]
 }

--- a/connectors/inetsoft-rest/src/test/java/inetsoft/uql/rest/json/EndpointsJsonLoadableTest.java
+++ b/connectors/inetsoft-rest/src/test/java/inetsoft/uql/rest/json/EndpointsJsonLoadableTest.java
@@ -161,6 +161,11 @@ class EndpointsJsonLoadableTest {
       int declaredResponseSchemas = 0;
       int boundResponseSchemas = 0;
 
+      // The counts above compare the corpus against itself, so they stay green if every curated tree
+      // is deleted at once -- which is exactly what a regenerated endpoints.json would do. Stripe is
+      // the connector those trees were written for, so its count standing at zero means they are gone.
+      int stripeResponseSchemas = 0;
+
       for(Path file : files) {
          String connector = file.getParent().getFileName().toString();
 
@@ -172,7 +177,12 @@ class EndpointsJsonLoadableTest {
                continue;
             }
 
-            declaredResponseSchemas += countDeclaredResponseSchemas(file);
+            int declaredHere = countDeclaredResponseSchemas(file);
+            declaredResponseSchemas += declaredHere;
+
+            if("stripe".equals(connector)) {
+               stripeResponseSchemas = declaredHere;
+            }
 
             boolean hasSuffix = false;
             boolean hasDescription = false;
@@ -249,6 +259,10 @@ class EndpointsJsonLoadableTest {
          failures.add("responseSchema: " + declaredResponseSchemas + " declared across the corpus but "
                          + boundResponseSchemas + " bound to a non-null "
                          + "WizEndpointCatalogEntry.responseSchema()");
+      }
+
+      if(stripeResponseSchemas == 0) {
+         failures.add("stripe: no entry declares a responseSchema");
       }
 
       assertTrue(failures.isEmpty(),

--- a/connectors/inetsoft-rest/src/test/java/inetsoft/uql/rest/json/EndpointsJsonLoadableTest.java
+++ b/connectors/inetsoft-rest/src/test/java/inetsoft/uql/rest/json/EndpointsJsonLoadableTest.java
@@ -61,6 +61,11 @@ class EndpointsJsonLoadableTest {
       ObjectMapper mapper = EndpointJsonQuery.Endpoints.createObjectMapper();
       List<String> failures = new ArrayList<>();
 
+      // Guards the same silent failure as the field-level checks below, but for responseSchema
+      // specifically: a renamed or misspelled JSON key would leave AbstractEndpoint.responseSchema
+      // null for every stripe entry while every other assertion here stayed green.
+      boolean sawStripeResponseSchema = false;
+
       for(Path file : files) {
          Path dir = file.getParent();
          String connector = dir.getFileName().toString();
@@ -87,10 +92,24 @@ class EndpointsJsonLoadableTest {
             if(list == null || list.isEmpty()) {
                failures.add(connector + ": parsed but declares no endpoints");
             }
+
+            if("stripe".equals(connector) && list != null) {
+               for(Object endpoint : list) {
+                  if(endpoint instanceof AbstractEndpoint
+                     && ((AbstractEndpoint) endpoint).getResponseSchema() != null)
+                  {
+                     sawStripeResponseSchema = true;
+                  }
+               }
+            }
          }
          catch(Exception e) {
             failures.add(connector + ": " + e.getMessage());
          }
+      }
+
+      if(!sawStripeResponseSchema) {
+         failures.add("stripe: no entry bound a non-null responseSchema");
       }
 
       assertTrue(failures.isEmpty(),
@@ -124,6 +143,11 @@ class EndpointsJsonLoadableTest {
       boolean sawStripeLookupWithEndpointsArray = false;
       boolean sawGithubLookupWithSingularEndpoint = false;
 
+      // Guards the silent-drop failure mode described in the class javadoc, specific to
+      // responseSchema: WizEndpointCatalogEntry ignores unknown properties, so a renamed or
+      // misspelled key would leave every entry's responseSchema() null with no error anywhere.
+      boolean sawStripeResponseSchema = false;
+
       for(Path file : files) {
          String connector = file.getParent().getFileName().toString();
 
@@ -152,6 +176,10 @@ class EndpointsJsonLoadableTest {
 
                if(entry.description() != null && !entry.description().isBlank()) {
                   hasDescription = true;
+               }
+
+               if("stripe".equals(connector) && entry.responseSchema() != null) {
+                  sawStripeResponseSchema = true;
                }
 
                if(entry.lookups() != null) {
@@ -200,6 +228,10 @@ class EndpointsJsonLoadableTest {
 
       if(!sawGithubLookupWithSingularEndpoint) {
          failures.add("github: no lookup bound a non-blank singular \"endpoint\"");
+      }
+
+      if(!sawStripeResponseSchema) {
+         failures.add("stripe: no entry's responseSchema() was non-null");
       }
 
       assertTrue(failures.isEmpty(),

--- a/connectors/inetsoft-rest/src/test/java/inetsoft/uql/rest/json/EndpointsJsonLoadableTest.java
+++ b/connectors/inetsoft-rest/src/test/java/inetsoft/uql/rest/json/EndpointsJsonLoadableTest.java
@@ -92,8 +92,13 @@ class EndpointsJsonLoadableTest {
          // method reads SreeEnv, which needs a Spring context this test has no reason to stand up,
          // and it converts the very failure being hunted here into an empty map. Reading directly
          // lets the exception surface with the offending property named.
-         try(InputStream input = Files.newInputStream(file)) {
-            Object parsed = mapper.readValue(input, endpointsClass);
+         try {
+            // Read once and bound twice from the same bytes: the strict binding below and the raw
+            // count share the file, but not the parse -- they target different types, and routing the
+            // strict one through a JsonNode would change the very input path this test exists to
+            // exercise.
+            byte[] source = Files.readAllBytes(file);
+            Object parsed = mapper.readValue(source, endpointsClass);
             @SuppressWarnings("rawtypes")
             List list = ((EndpointJsonQuery.Endpoints) parsed).getEndpoints();
 
@@ -101,7 +106,7 @@ class EndpointsJsonLoadableTest {
                failures.add(connector + ": parsed but declares no endpoints");
             }
 
-            declaredResponseSchemas += countDeclaredResponseSchemas(file);
+            declaredResponseSchemas += countDeclaredResponseSchemas(mapper, source);
 
             if(list != null) {
                for(Object endpoint : list) {
@@ -169,15 +174,16 @@ class EndpointsJsonLoadableTest {
       for(Path file : files) {
          String connector = file.getParent().getFileName().toString();
 
-         try(InputStream input = Files.newInputStream(file)) {
-            WizEndpointCatalog catalog = mapper.readValue(input, WizEndpointCatalog.class);
+         try {
+            byte[] source = Files.readAllBytes(file);
+            WizEndpointCatalog catalog = mapper.readValue(source, WizEndpointCatalog.class);
 
             if(catalog.endpoints() == null || catalog.endpoints().isEmpty()) {
                failures.add(connector + ": parsed but declares no endpoints");
                continue;
             }
 
-            int declaredHere = countDeclaredResponseSchemas(file);
+            int declaredHere = countDeclaredResponseSchemas(mapper, source);
             declaredResponseSchemas += declaredHere;
 
             if("stripe".equals(connector)) {
@@ -302,9 +308,14 @@ class EndpointsJsonLoadableTest {
     * <p>Read straight off the JSON tree rather than off either bound model, because it is the
     * baseline both bindings are checked against: a count taken from a bound object could only ever
     * agree with itself.</p>
+    *
+    * <p>Takes the caller's mapper and the already-read bytes rather than opening the file again with
+    * a mapper of its own. {@code readTree} does no bean binding, so the strictness that separates the
+    * two callers' mappers cannot affect this count — which is what makes a third mapper here pure
+    * duplication.</p>
     */
-   private int countDeclaredResponseSchemas(Path file) throws IOException {
-      JsonNode root = RAW_MAPPER.readTree(file.toFile());
+   private int countDeclaredResponseSchemas(ObjectMapper mapper, byte[] source) throws IOException {
+      JsonNode root = mapper.readTree(source);
       JsonNode endpoints = root.path("endpoints");
       int declared = 0;
 
@@ -362,7 +373,5 @@ class EndpointsJsonLoadableTest {
       return null;
    }
 
-   /** Plain mapper used only to count declarations off the raw JSON. */
-   private static final ObjectMapper RAW_MAPPER = new ObjectMapper();
    private static final String DATASOURCE_PACKAGE = "/inetsoft/uql/rest/datasource";
 }

--- a/connectors/inetsoft-rest/src/test/java/inetsoft/uql/rest/json/EndpointsJsonLoadableTest.java
+++ b/connectors/inetsoft-rest/src/test/java/inetsoft/uql/rest/json/EndpointsJsonLoadableTest.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.uql.rest.json;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import inetsoft.web.wiz.model.WizEndpointCatalog;
 import inetsoft.web.wiz.model.WizEndpointCatalogEntry;
@@ -62,9 +63,16 @@ class EndpointsJsonLoadableTest {
       List<String> failures = new ArrayList<>();
 
       // Guards the same silent failure as the field-level checks below, but for responseSchema
-      // specifically: a renamed or misspelled JSON key would leave AbstractEndpoint.responseSchema
-      // null for every stripe entry while every other assertion here stayed green.
-      boolean sawStripeResponseSchema = false;
+      // specifically: a renamed field or getter would leave AbstractEndpoint.responseSchema null for
+      // every entry that declares one, while every other assertion here stayed green.
+      //
+      // Stated as "every declaration binds" rather than "at least one exists", because the two guard
+      // different things and only one of them belongs in this file. Whether the CORPUS carries any
+      // curated tree is a property of endpoints.json, asserted where those trees are written; whether
+      // a declared tree REACHES the bean is a property of this binding, which is what this test is
+      // for. Written the other way round, this file would have to fail until the corpus caught up.
+      int declaredResponseSchemas = 0;
+      int boundResponseSchemas = 0;
 
       for(Path file : files) {
          Path dir = file.getParent();
@@ -93,12 +101,14 @@ class EndpointsJsonLoadableTest {
                failures.add(connector + ": parsed but declares no endpoints");
             }
 
-            if("stripe".equals(connector) && list != null) {
+            declaredResponseSchemas += countDeclaredResponseSchemas(file);
+
+            if(list != null) {
                for(Object endpoint : list) {
                   if(endpoint instanceof AbstractEndpoint
                      && ((AbstractEndpoint) endpoint).getResponseSchema() != null)
                   {
-                     sawStripeResponseSchema = true;
+                     boundResponseSchemas++;
                   }
                }
             }
@@ -108,8 +118,9 @@ class EndpointsJsonLoadableTest {
          }
       }
 
-      if(!sawStripeResponseSchema) {
-         failures.add("stripe: no entry bound a non-null responseSchema");
+      if(boundResponseSchemas != declaredResponseSchemas) {
+         failures.add("responseSchema: " + declaredResponseSchemas + " declared across the corpus but "
+                         + boundResponseSchemas + " bound to a non-null AbstractEndpoint.responseSchema");
       }
 
       assertTrue(failures.isEmpty(),
@@ -144,9 +155,11 @@ class EndpointsJsonLoadableTest {
       boolean sawGithubLookupWithSingularEndpoint = false;
 
       // Guards the silent-drop failure mode described in the class javadoc, specific to
-      // responseSchema: WizEndpointCatalogEntry ignores unknown properties, so a renamed or
-      // misspelled key would leave every entry's responseSchema() null with no error anywhere.
-      boolean sawStripeResponseSchema = false;
+      // responseSchema: WizEndpointCatalogEntry ignores unknown properties, so a renamed record
+      // component would leave every declared tree's responseSchema() null with no error anywhere.
+      // Counted rather than sampled, for the reason given on the same pair in the test above.
+      int declaredResponseSchemas = 0;
+      int boundResponseSchemas = 0;
 
       for(Path file : files) {
          String connector = file.getParent().getFileName().toString();
@@ -158,6 +171,8 @@ class EndpointsJsonLoadableTest {
                failures.add(connector + ": parsed but declares no endpoints");
                continue;
             }
+
+            declaredResponseSchemas += countDeclaredResponseSchemas(file);
 
             boolean hasSuffix = false;
             boolean hasDescription = false;
@@ -178,8 +193,8 @@ class EndpointsJsonLoadableTest {
                   hasDescription = true;
                }
 
-               if("stripe".equals(connector) && entry.responseSchema() != null) {
-                  sawStripeResponseSchema = true;
+               if(entry.responseSchema() != null) {
+                  boundResponseSchemas++;
                }
 
                if(entry.lookups() != null) {
@@ -230,8 +245,10 @@ class EndpointsJsonLoadableTest {
          failures.add("github: no lookup bound a non-blank singular \"endpoint\"");
       }
 
-      if(!sawStripeResponseSchema) {
-         failures.add("stripe: no entry's responseSchema() was non-null");
+      if(boundResponseSchemas != declaredResponseSchemas) {
+         failures.add("responseSchema: " + declaredResponseSchemas + " declared across the corpus but "
+                         + boundResponseSchemas + " bound to a non-null "
+                         + "WizEndpointCatalogEntry.responseSchema()");
       }
 
       assertTrue(failures.isEmpty(),
@@ -263,6 +280,29 @@ class EndpointsJsonLoadableTest {
 
       assertFalse(roots.isEmpty(), "resource package not on the classpath: " + DATASOURCE_PACKAGE);
       return roots;
+   }
+
+   /**
+    * How many entries in one file carry a {@code responseSchema} key with a non-null value.
+    *
+    * <p>Read straight off the JSON tree rather than off either bound model, because it is the
+    * baseline both bindings are checked against: a count taken from a bound object could only ever
+    * agree with itself.</p>
+    */
+   private int countDeclaredResponseSchemas(Path file) throws IOException {
+      JsonNode root = RAW_MAPPER.readTree(file.toFile());
+      JsonNode endpoints = root.path("endpoints");
+      int declared = 0;
+
+      for(JsonNode endpoint : endpoints) {
+         JsonNode schema = endpoint.get("responseSchema");
+
+         if(schema != null && !schema.isNull()) {
+            declared++;
+         }
+      }
+
+      return declared;
    }
 
    private List<Path> findEndpointFiles(List<Path> roots) throws Exception {
@@ -308,5 +348,7 @@ class EndpointsJsonLoadableTest {
       return null;
    }
 
+   /** Plain mapper used only to count declarations off the raw JSON. */
+   private static final ObjectMapper RAW_MAPPER = new ObjectMapper();
    private static final String DATASOURCE_PACKAGE = "/inetsoft/uql/rest/datasource";
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/WizEndpointCatalogEntry.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizEndpointCatalogEntry.java
@@ -37,6 +37,18 @@ import java.util.List;
  *
  * @param description what the endpoint is for. Null for the entries nobody has described yet, and
  *                    for the ones deliberately left blank because the vendor has withdrawn them.
+ * @param responseSchema the response structure the connector's maintainer declared for this
+ *                       endpoint, straight out of {@code endpoints.json}. Null means the endpoint
+ *                       has not been curated, which is equivalent to not having declared one.
+ *                       This record is the ONLY channel this value has into wiz.
+ *
+ *                       <p>Typed as {@code Object} rather than {@code Map<String, Object>} for the
+ *                       same reason as {@code AbstractEndpoint.getResponseSchema}: the
+ *                       representation allows an array at the root, and binding that to a
+ *                       {@code Map} would be a type mismatch on a known property that
+ *                       {@code ignoreUnknown} cannot excuse, which
+ *                       {@link inetsoft.web.wiz.service.EndpointCatalogReader} would surface as an
+ *                       {@code IOException} for the whole connector.</p>
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record WizEndpointCatalogEntry(
@@ -44,6 +56,7 @@ public record WizEndpointCatalogEntry(
    String description,
    String suffix,
    Boolean paged,
-   List<WizEndpointLookup> lookups)
+   List<WizEndpointLookup> lookups,
+   Object responseSchema)
 {
 }

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizDatabaseControllerSecurityTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizDatabaseControllerSecurityTest.java
@@ -476,11 +476,11 @@ class WizDatabaseControllerSecurityTest {
       doReturn(String.class).when(fixture.uqlConfig).getClass("Rest.Stripe", "plugin.StripeQuery");
       when(fixture.endpointCatalogReader.read(String.class)).thenReturn(new WizEndpointCatalog(
          List.of(new WizEndpointCatalogEntry("Charges", "Payment attempts.", "/v1/charges",
-                                             Boolean.TRUE, List.of()),
-                 new WizEndpointCatalogEntry("SKUs", null, "/v1/skus", null, List.of()),
+                                             Boolean.TRUE, List.of(), null),
+                 new WizEndpointCatalogEntry("SKUs", null, "/v1/skus", null, List.of(), null),
                  // Whitespace is not a description: nothing can be retrieved by it, so counting it
                  // as described would promise the ingest more than it can index.
-                 new WizEndpointCatalogEntry("Plans", "   ", "/v1/plans", null, List.of()))));
+                 new WizEndpointCatalogEntry("Plans", "   ", "/v1/plans", null, List.of(), null))));
 
       List<WizEndpointCatalogType> types = fixture.controller.getEndpointCatalogTypes();
 


### PR DESCRIPTION
## Summary
- `AbstractEndpoint` gains an optional `Object responseSchema` pass-through field, excluded from `equals`/`hashCode`, so the strict query-path mapper can bind an `endpoints.json` that carries a declared response structure. `Object` rather than `Map` because the representation allows an array at the root, and binding that to a `Map` would be a type mismatch on a known property that `ignoreUnknown` cannot excuse.
- `WizEndpointCatalogEntry` gains the matching sixth record component `Object responseSchema` — the only channel this value has into the wiz catalogue.
- `EndpointsJsonLoadableTest` gets a counting assertion added to each of its two existing test cases: every entry that declares a `responseSchema` in the raw JSON must bind to a non-null value. That guards the key being silently dropped (catalog path, which ignores unknown properties) or the field being renamed (query path, which throws on unknown properties and gets swallowed to an empty endpoint map by `Endpoints.load`).
- `WizDatabaseControllerSecurityTest` updated for the new record arity (mechanical compile fix, no behavior change).

## Notes
The counting assertions are vacuously true on this branch (nothing declares a `responseSchema` yet) and become live the moment the companion PR lands its curated trees. Stated this way on purpose: whether a declared tree REACHES the model is a property of this binding, which is what this file is for; whether the corpus declares any tree at all is a property of `endpoints.json`, asserted in #4752 where those trees are written. Asserted the other way round, this file would have had to fail until the corpus caught up.

This PR must still merge first: adding the key to `endpoints.json` before `AbstractEndpoint` can bind it empties the connector's whole endpoint map. #4752 is stacked on this branch, so its base retargets automatically on merge.

## Test plan
- [x] `mvn -pl core,connectors/inetsoft-rest -am -DskipTests install` — compiles
- [x] `mvn -pl core -Dtest=WizDatabaseControllerSecurityTest test` — passes
- [x] `mvn -pl connectors/inetsoft-rest -Dtest='!EndpointsJsonLoadableTest,!*endpoints*' test` — 118 tests pass, 0 failures
- [x] `mvn -pl connectors/inetsoft-rest -Dtest=EndpointsJsonLoadableTest test` — 2 tests, 0 failures on this branch, and 2 tests, 0 failures again with #4752's 104 curated trees present (104 declared, 104 bound on both mappers)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>