### PR TITLE
Fix script writes not entering the undo/redo checkpoint stack

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptEditService.java
@@ -143,6 +143,12 @@ public class ScriptEditService {
 
       mutation.accept(rvs);
 
+      Viewsheet vs = rvs.getViewsheet();
+
+      if(vs != null) {
+         rvs.addCheckpoint(vs.prepareCheckpoint());
+      }
+
       // Write coordination: this is a direct live write, not routed through any
       // XxxPropertyDialogService, so it must bump the shared counter itself -- otherwise a
       // property dialog with an embedded script pane (Gauge, Chart, ... -- 15 of the 18

--- a/core/src/test/java/inetsoft/web/wiz/script/ScriptEditServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ScriptEditServiceTest.java
@@ -108,6 +108,38 @@ class ScriptEditServiceTest {
       verify(rvs).bumpWriteRevision();
    }
 
+   /**
+    * A script write is a real, persisted mutation, so it must enter the undo/redo checkpoint
+    * stack the same way composer edits do (see {@code ViewsheetSessionService#mutate} /
+    * {@code WorksheetEditService#apply}) -- otherwise undo/redo silently skip over script
+    * changes even though they took effect.
+    */
+   @Test
+   void applyAddsACheckpointSoUndoCoversTheScriptWrite() throws Exception {
+      Viewsheet vs = mock(Viewsheet.class);
+      Viewsheet checkpoint = mock(Viewsheet.class);
+      when(vs.prepareCheckpoint()).thenReturn(checkpoint);
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      SheetAgentBroadcastService broadcast = mock(SheetAgentBroadcastService.class);
+
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      JoinSession s = new JoinSession("TOK", "Viewsheet/foo-7", "alice~;~host-org",
+                                      SheetType.VIEWSHEET, 0L, Long.MAX_VALUE,
+                                      JoinSession.ConnectionMode.PAIRED, null, null, null);
+      when(sessions.resolve(eq("TOK"), any())).thenReturn(s);
+      when(runtimeAccess.getSheetForPairing(eq(SheetType.VIEWSHEET), eq("Viewsheet/foo-7"), eq(agent)))
+         .thenReturn(rvs);
+
+      ScriptEditService svc = new ScriptEditService(sessions, runtimeAccess, broadcast);
+      svc.apply("TOK", agent, r -> {});
+
+      verify(rvs).addCheckpoint(checkpoint);
+   }
+
    @Test
    void applyOnRuntimeIfChangedRejectsInvalidSession() {
       SheetSessionService sessions = mock(SheetSessionService.class);


### PR DESCRIPTION
## Summary
- `ScriptEditService.apply()` is the shared mutation path for `update_script` and `set_script_enabled` (called from `ViewsheetAgentController.writeScript`/`setEnabled`). It resolved the session, ran the mutation, bumped the write revision, and broadcast a refresh -- but never called `rvs.addCheckpoint(...)`, so script writes took real, persisted effect but never entered the undo/redo stack that `undo`/`redo`/`size()` read from.
- Fix: after `mutation.accept(rvs)` and before `rvs.bumpWriteRevision()`, add the same `rvs.addCheckpoint(vs.prepareCheckpoint())` call already used by the two sibling implementations (`ViewsheetSessionService.mutate()`, `WorksheetEditService.apply()`/`applyOnRuntime()`).
- Scope: only `ScriptEditService.apply()`'s two callers (`writeScript`, `setEnabled`) are affected -- verified no other callers exist. `applyOnRuntime`/`applyOnRuntimeIfChanged` (used by script execute/dry-run) are intentionally out of scope; whether running a script's side effects should be undoable is a separate, more debatable question.

## Test plan
- [x] Added `applyAddsACheckpointSoUndoCoversTheScriptWrite` to `ScriptEditServiceTest`, verifying `rvs.addCheckpoint(checkpoint)` is called with the result of `vs.prepareCheckpoint()`.
- [x] `./mvnw -pl core -am test -Dtest=ScriptEditServiceTest -o` — 7/7 tests pass (existing 6 + new regression test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)