### PR TITLE
Stop advertising 'shadow' as a settable property for assembly types that never apply it

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/PropertyAliases.java
@@ -348,6 +348,12 @@ public final class PropertyAliases {
     */
    private static void outputGeneral(Map<String, String> aliases, String prefix) {
       basicGeneral(aliases, prefix + ".outputGeneralPaneModel.generalPropPaneModel");
+      // Only gauge/text/image (the outputGeneral() family) ever apply shadow back to the real
+      // assembly -- see VSFloatable.isShadow(), consulted only for OutputVSAssemblyInfo/
+      // ShapeVSAssemblyInfo. The dataGeneral() family (chart, table, submit, ...) inherits an
+      // unused field from the class hierarchy that no dialog service or renderer ever reads.
+      aliases.put("shadow",
+         prefix + ".outputGeneralPaneModel.generalPropPaneModel.basicGeneralPaneModel.shadow");
    }
 
    /**
@@ -382,7 +388,6 @@ public final class PropertyAliases {
       // wrote somewhere no one reads. The live switch is GeneralPropPaneModel.enabled, which
       // every property dialog service fills from VSAssemblyInfo.getEnabledValue().
       aliases.put("enabled", generalPrefix + ".enabled");
-      aliases.put("shadow", basic + ".shadow");
       aliases.put("primary", basic + ".primary");
       aliases.put("refresh", basic + ".refresh");
    }

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/AssemblyPropertyServiceTest.java
@@ -194,6 +194,24 @@ class AssemblyPropertyServiceTest {
                  "the valid key must not have been written before the bad one was found");
    }
 
+   /**
+    * The direct regression test for the reported defect: set_assembly_properties(Submit1,
+    * {shadow: true}) used to return a fake {@code {"ok":true}} and bump the write revision, but
+    * shadow was never applied -- SubmitPropertyDialogService never reads or writes it, so it
+    * always read back false. Now that PropertyAliases no longer registers shadow for submit,
+    * resolveForWrite's existing unknown-key refusal fires before anything is read or written.
+    */
+   @Test
+   void refusesShadowOnAnAssemblyTypeThatDoesNotApplyIt() {
+      AssemblyPropertyService service = serviceWith(mock(SubmitVSAssembly.class), null);
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> service.set("tok", principal(), "Submit1", Map.of("shadow", true), ""));
+
+      assertTrue(thrown.getMessage().contains("shadow"), "must name the refused key: " + thrown.getMessage());
+   }
+
    // ── harness ───────────────────────────────────────────────────────────────
 
    private static AssemblyPropertyService serviceWith(VSAssembly assembly, Object model) {

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyAliasesTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/PropertyAliasesTest.java
@@ -17,6 +17,9 @@
  */
 package inetsoft.web.wiz.viewsheet;
 
+import inetsoft.web.composer.model.vs.GaugePropertyDialogModel;
+import inetsoft.web.composer.model.vs.ImagePropertyDialogModel;
+import inetsoft.web.composer.model.vs.TextPropertyDialogModel;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -314,6 +317,44 @@ class PropertyAliasesTest {
    @Test
    void visibleStillResolvesOntoTheBasicGeneralPane() {
       assertTrue(PropertyAliases.resolve("chart", "visible").endsWith("basicGeneralPaneModel.visible"));
+   }
+
+   // ── 'shadow' is only real for the outputGeneral() family ──────────────────
+
+   /**
+    * shadow is only ever applied back to the real assembly by gauge/text/image's dialog services
+    * (VSFloatable.isShadow() is consulted only for OutputVSAssemblyInfo/ShapeVSAssemblyInfo). The
+    * dataGeneral() family (chart, table, crosstab, submit, the selection/input types, ...)
+    * inherits an unused field from the class hierarchy that no dialog service or renderer ever
+    * reads -- aliasing it there let set_assembly_properties(Submit1, {shadow: true}) return a
+    * fake {"ok":true} that always read back false.
+    */
+   @Test
+   void shadowIsOnlyAliasedForTheOutputAssemblyTypesThatApplyIt() {
+      for(String type : java.util.List.of("gauge", "text", "image")) {
+         assertTrue(PropertyAliases.forType(type).aliases().containsKey("shadow"),
+                    type + " should expose 'shadow'");
+      }
+
+      for(String type : java.util.List.of("submit", "chart", "table", "crosstab", "selectionlist")) {
+         assertFalse(PropertyAliases.forType(type).aliases().containsKey("shadow"),
+                     type + " should not expose 'shadow' -- it is never applied to the real assembly");
+      }
+   }
+
+   /** Guards against over-correcting: the 3 genuinely-working cases must not regress. */
+   @Test
+   void shadowRoundTripsOnEveryOutputAssembly() {
+      assertShadowRoundTrips("gauge", new GaugePropertyDialogModel());
+      assertShadowRoundTrips("text", new TextPropertyDialogModel());
+      assertShadowRoundTrips("image", ImagePropertyDialogModel.builder().build());
+   }
+
+   private static void assertShadowRoundTrips(String type, Object model) {
+      String path = PropertyAliases.resolve(type, "shadow");
+      model = PropertyPath.set(model, path, true);
+
+      assertEquals(true, PropertyPath.get(model, path), type + "'s shadow should round-trip");
    }
 
    // ── the chart line pane's read-only capability flags ──────────────────────


### PR DESCRIPTION
## Summary
- `PropertyAliases.basicGeneral()` unconditionally registered a `shadow` alias for ~17 assembly types, but only gauge/text/image (the `outputGeneral()` family) ever apply it back to the real assembly -- `VSFloatable.isShadow()` is only ever consulted for `OutputVSAssemblyInfo`/`ShapeVSAssemblyInfo`. The other 14 types (submit, chart, table, crosstab, selection/input types, ...) route through `dataGeneral()` and inherit an unused field from the class hierarchy that no dialog service or renderer ever reads.
- Symptom: `set_assembly_properties(Submit1, {shadow: true})` returned a fake `{"ok":true}` and bumped the write revision, but `shadow` always read back `false` via both `get_assembly_properties` and `list_assembly_properties`.
- Fix: remove `shadow` from `basicGeneral()`; register it explicitly only inside `outputGeneral()`, so gauge/text/image keep it via one shared line. Once the alias no longer exists for the other 14 types, `PropertyAliases.resolve()`'s existing unknown-key refusal (with nearest-match suggestion) fires loudly instead of a silent no-op success -- no new refusal-message code needed.
- Left out of scope (per the investigation, a separate defect class -- a missing alias, not a false one): `shapeGeneral()` (line/oval/rectangle) genuinely wires `shadow` in its dialog services but has no short-name alias for it at all today. Flagging for a follow-up if wanted, not bundled here.

## Test plan
- [x] `PropertyAliasesTest.shadowIsOnlyAliasedForTheOutputAssemblyTypesThatApplyIt` -- gauge/text/image expose `shadow`; submit/chart/table/crosstab/selectionlist don't.
- [x] `PropertyAliasesTest.shadowRoundTripsOnEveryOutputAssembly` -- guards against over-correcting; gauge/text/image (including the Immutables-backed image model) still round-trip `shadow` through `PropertyPath`.
- [x] `AssemblyPropertyServiceTest.refusesShadowOnAnAssemblyTypeThatDoesNotApplyIt` -- `service.set(..., "Submit1", {shadow: true}, ...)` now throws `IllegalArgumentException` naming `shadow`, at the same layer the original repro exercised through the MCP tool.
- [x] `./mvnw -pl core -am test -Dtest=PropertyAliasesTest,AssemblyPropertyServiceTest -o` -- 32/32 and 12/12 pass, 0 failures/errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)