### PR TITLE
Fix treemap/mekko-to-bar migration duplicating a dimension already on x and group

### DIFF
--- a/core/src/main/java/inetsoft/report/internal/graph/ChangeChartTypeProcessor.java
+++ b/core/src/main/java/inetsoft/report/internal/graph/ChangeChartTypeProcessor.java
@@ -1313,7 +1313,14 @@ public class ChangeChartTypeProcessor extends ChangeChartProcessor {
 
    private void moveGroupFieldsToX() {
       for(int i = info.getGroupFieldCount(); i > 0; i--) {
-         info.addXField(info.getGroupField(0));
+         ChartRef gfield = info.getGroupField(0);
+         boolean alreadyOnX = Arrays.stream(info.getXFields())
+            .anyMatch(xfield -> Tool.equals(xfield.getFullName(), gfield.getFullName()));
+
+         if(!alreadyOnX) {
+            info.addXField(gfield);
+         }
+
          info.removeGroupField(0);
       }
    }

--- a/core/src/test/java/inetsoft/report/internal/graph/ChangeChartTypeProcessorTest.java
+++ b/core/src/test/java/inetsoft/report/internal/graph/ChangeChartTypeProcessorTest.java
@@ -73,6 +73,41 @@ class ChangeChartTypeProcessorTest {
                    "the dimension must not be left stranded on the group shelf bar never reads");
    }
 
+   /**
+    * If a chart is already left with the same dimension on both {@code x} and {@code group}
+    * (e.g. from an earlier, separately-caused inconsistency) when it transitions out of
+    * treemap, {@code moveGroupFieldsToX} must not blindly append the group copy onto x --
+    * that would duplicate the dimension on x while still emptying group.
+    */
+   @Test
+   void treemapToBarDoesNotDuplicateADimensionAlreadyOnXAndGroup() {
+      ChartInfo info = new DefaultVSChartInfo();
+      info.addXField(dimension("Category"));
+      info.addGroupField(dimension("Category"));
+      info.addYField(aggregate("Sales", AggregateFormula.SUM));
+
+      info = changeType(GraphTypes.CHART_TREEMAP, GraphTypes.CHART_BAR, info);
+
+      assertEquals(1, info.getXFieldCount(),
+                   "must not duplicate a dimension already present on x");
+      assertEquals(0, info.getGroupFieldCount());
+   }
+
+   /** Same defect, same fix, the other merged type that shares {@code moveGroupFieldsToX}. */
+   @Test
+   void mekkoToBarDoesNotDuplicateADimensionAlreadyOnXAndGroup() {
+      ChartInfo info = new DefaultVSChartInfo();
+      info.addXField(dimension("Category"));
+      info.addGroupField(dimension("Category"));
+      info.addYField(aggregate("Sales", AggregateFormula.SUM));
+
+      info = changeType(GraphTypes.CHART_MEKKO, GraphTypes.CHART_BAR, info);
+
+      assertEquals(1, info.getXFieldCount(),
+                   "must not duplicate a dimension already present on x");
+      assertEquals(0, info.getGroupFieldCount());
+   }
+
    @Test
    void treemapToBarPreservesGradientColorFrame() {
       ChartInfo info = new DefaultVSChartInfo();


### PR DESCRIPTION
## Summary

L3 Finding 4 (reopened) — root-caused by debugger-l3-migration.

`#4738`'s `ChangeChartTypeProcessor.moveGroupFieldsToX()` unconditionally appends every
`group`-shelf field onto `x` with no dedup check. If a dimension is already present on both
`x` and `group` when a chart transitions out of treemap/mekko (e.g. `Submit1`'s Category
already on `x` from before entering treemap, plus the copy treemap put on `group`),
`moveGroupFieldsToX()` appends it a second time onto `x` while emptying `group` — leaving the
chart with a duplicated dimension on `x` and nothing on `group`.

## Fix

`moveGroupFieldsToX()` now checks each group field against every field already on `x` before
appending — reusing the exact `Tool.equals(..., getFullName())` idiom this file's own
`isRefEquals` (line ~225) already uses for the identical "is this ref already represented"
question. `group` is still unconditionally emptied either way, matching the existing
contract. No new imports needed — `Tool`/`Arrays` are both already covered by this file's
existing wildcard imports.

`copyFromMekko()` shares `moveGroupFieldsToX()`, so it's fixed for free too — added a
regression test for that path as well.

**Out of scope, left alone per the debugger's own audit** (separate/unconfirmed, not
requested):
- `fixPieDimensions()`'s pie-conversion branch unconditionally overwriting an existing
  measure-typed aesthetic (a different defect).
- The incidental `set_visual_frame` false-error-on-success lead in
  `ChangeChartAestheticService` (only a lead, not root-caused).

## Test plan
- [x] Added `treemapToBarDoesNotDuplicateADimensionAlreadyOnXAndGroup` and
      `mekkoToBarDoesNotDuplicateADimensionAlreadyOnXAndGroup` to
      `ChangeChartTypeProcessorTest`, matching the file's existing `changeType`/`dimension`
      helper shapes.
- [x] Verified the new tests actually catch the bug: reverted just the source fix via
      `git stash`, reran — both failed with `expected: <1> but was: <2>` (the exact reported
      duplication). Restored the fix and reran — green.
- [x] `./mvnw -o test -pl core -Dtest=ChangeChartTypeProcessorTest` — 8/8 pass (6 existing + 2
      new, existing ones unmodified)
- [x] Full `core` module suite (`./mvnw -o test -pl core`) — 6990 tests, 0 failures, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)