### PR TITLE
Report the table properties the worksheet write tools set

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
@@ -28,6 +28,7 @@ import inetsoft.web.wiz.worksheet.model.WorksheetModel;
 import inetsoft.web.wiz.worksheet.model.WorksheetPropertiesModel;
 import org.springframework.stereotype.Service;
 
+import java.awt.Point;
 import java.util.*;
 
 /**
@@ -117,7 +118,7 @@ public class WorksheetReadService {
       WorksheetModel.AggregateModel aggregates = readAggregates(t);
       List<WorksheetModel.SortModel> sorts = readSorts(t);
 
-      java.awt.Point offset = t.getPixelOffset();
+      Point offset = t.getPixelOffset();
       int maxRows = t.getMaxRows();
 
       return new WorksheetModel.TableModel(
@@ -126,8 +127,9 @@ public class WorksheetReadService {
          preConditions, postConditions, rankingConditions,
          aggregates, sorts, primary,
          t.getDescription(),
-         // -1 is how the assembly stores "unlimited". Reporting it as-is would be read back as a
-         // real limit of -1, and reporting 0 would collide with a genuine limit of zero rows.
+         // Anything <= 0 is "no limit" -- the engine applies one only when it is positive -- so
+         // -1 and 0 both report null rather than reading back as a limit of -1 or of zero rows.
+         // Note this is the effective limit, capped by query.runtime.maxrow; see TableModel.
          maxRows <= 0 ? null : maxRows,
          t.isDistinct(), t.isVisibleTable(), tableMode(t),
          offset == null ? null : offset.x, offset == null ? null : offset.y);
@@ -274,7 +276,9 @@ public class WorksheetReadService {
    }
 
    /**
-    * The table's display mode, as the vocabulary {@code set_table_mode} accepts.
+    * The table's display mode, in four of the five words {@code set_table_mode} accepts --
+    * {@code live}, {@code full}, {@code detail} and {@code edit}. The fifth, {@code default},
+    * is not a state and never appears here; see the note below.
     *
     * <p>No field stores it: the mode is a combination of {@code liveData}, {@code runtime} and
     * {@code editMode}, and {@code set_table_mode} writes all three per mode. Deriving it here is

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
@@ -117,11 +117,20 @@ public class WorksheetReadService {
       WorksheetModel.AggregateModel aggregates = readAggregates(t);
       List<WorksheetModel.SortModel> sorts = readSorts(t);
 
+      java.awt.Point offset = t.getPixelOffset();
+      int maxRows = t.getMaxRows();
+
       return new WorksheetModel.TableModel(
          name, type, columns, joins,
          readSources(t), readConcatType(t), readConcatCompatible(t), readAutoUpdate(t),
          preConditions, postConditions, rankingConditions,
-         aggregates, sorts, primary);
+         aggregates, sorts, primary,
+         t.getDescription(),
+         // -1 is how the assembly stores "unlimited". Reporting it as-is would be read back as a
+         // real limit of -1, and reporting 0 would collide with a genuine limit of zero rows.
+         maxRows <= 0 ? null : maxRows,
+         t.isDistinct(), t.isVisibleTable(), tableMode(t),
+         offset == null ? null : offset.x, offset == null ? null : offset.y);
    }
 
    // -------------------------------------------------------------------------
@@ -262,6 +271,39 @@ public class WorksheetReadService {
     */
    private Boolean readAutoUpdate(TableAssembly t) {
       return t instanceof MirrorTableAssembly mirror ? mirror.isAutoUpdate() : null;
+   }
+
+   /**
+    * The table's display mode, as the vocabulary {@code set_table_mode} accepts.
+    *
+    * <p>No field stores it: the mode is a combination of {@code liveData}, {@code runtime} and
+    * {@code editMode}, and {@code set_table_mode} writes all three per mode. Deriving it here is
+    * what lets a caller read back what it just set — without this, the write is verifiable only by
+    * its side effects, which is what left case 1.19 unable to round-trip.
+    *
+    * <p>Checked in the order the writer distinguishes them: {@code edit} owns editMode, and among
+    * the live modes only {@code live} sets runtime, so live-without-runtime reads as
+    * {@code detail}.
+    *
+    * <p><b>This reports the resulting state, not the word that was written, and the two can
+    * differ.</b> {@code set_table_mode("live")} sets runtime from {@code isRuntimeSelected()},
+    * so on a table whose runtime selection is off it lands in the same state as
+    * {@code "detail"} and reads back as {@code detail}. Likewise {@code "default"} is not a
+    * state of its own — the writer resolves it to live for an embedded table and metadata for a
+    * bound one — so it reads back as {@code detail} or {@code full}. Neither is a lost write;
+    * both are the mode the table is actually in. A caller wanting to confirm a specific word was
+    * honoured should compare states, not strings.
+    */
+   private String tableMode(TableAssembly t) {
+      if(t.isEditMode()) {
+         return "edit";
+      }
+
+      if(t.isLiveData()) {
+         return t.isRuntime() ? "live" : "detail";
+      }
+
+      return "full";
    }
 
    private String tableType(TableAssembly t) {

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/model/WorksheetModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/model/WorksheetModel.java
@@ -90,17 +90,28 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
     * @param sorts              sort directives; empty when none
     * @param primary            {@code true} if this is the worksheet's primary assembly
     * @param description        the table's own description; {@code null} when unset
-    * @param maxRows            the table's row limit, or {@code null} when unlimited. Stored as
-    *                           {@code -1} for unlimited and reported as {@code null} so that an
-    *                           unset limit is not confused with a limit of zero rows.
+    * @param maxRows            the row limit in effect, or {@code null} when there is none. This
+    *                           is the <em>effective</em> limit, not the stored one: the assembly
+    *                           folds {@code query.runtime.maxrow} and the organization row limit
+    *                           into it, so on a capped server this can be smaller than the number
+    *                           written, and a table stored as unlimited reports the cap. It is the
+    *                           same value the Composer's table-properties dialog shows. Anything
+    *                           {@code <= 0} is no limit at all — the engine applies one only when
+    *                           it is positive — and all of those report {@code null}, so {@code 0}
+    *                           is not a limit of zero rows.
     * @param distinct           whether the table returns only distinct rows
     * @param visibleInViewsheet whether the table is exposed to viewsheets bound to this sheet
     * @param mode               the table's display mode — {@code live}, {@code full},
-    *                           {@code detail}, {@code edit} or {@code default} — derived from the
-    *                           same three flags {@code set_table_mode} writes, since no single
-    *                           field stores it
-    * @param x                  the assembly's pixel offset on the worksheet canvas
-    * @param y                  the assembly's pixel offset on the worksheet canvas
+    *                           {@code detail} or {@code edit} — derived from the same three flags
+    *                           {@code set_table_mode} writes, since no single field stores it.
+    *                           {@code set_table_mode} also accepts {@code default}, which is not
+    *                           a state of its own and so never appears here: the writer resolves
+    *                           it to live for an embedded table and metadata for a bound one, and
+    *                           it reads back as {@code detail} or {@code full} accordingly
+    * @param x                  the assembly's horizontal pixel offset on the worksheet canvas;
+    *                           {@code null} only if the assembly carries no offset at all
+    * @param y                  the assembly's vertical pixel offset on the worksheet canvas;
+    *                           {@code null} only if the assembly carries no offset at all
     */
    @JsonInclude(JsonInclude.Include.NON_NULL)
    public record TableModel(

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/model/WorksheetModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/model/WorksheetModel.java
@@ -89,6 +89,18 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
     * @param aggregates         group-by / aggregate info; {@code null} when none is set
     * @param sorts              sort directives; empty when none
     * @param primary            {@code true} if this is the worksheet's primary assembly
+    * @param description        the table's own description; {@code null} when unset
+    * @param maxRows            the table's row limit, or {@code null} when unlimited. Stored as
+    *                           {@code -1} for unlimited and reported as {@code null} so that an
+    *                           unset limit is not confused with a limit of zero rows.
+    * @param distinct           whether the table returns only distinct rows
+    * @param visibleInViewsheet whether the table is exposed to viewsheets bound to this sheet
+    * @param mode               the table's display mode — {@code live}, {@code full},
+    *                           {@code detail}, {@code edit} or {@code default} — derived from the
+    *                           same three flags {@code set_table_mode} writes, since no single
+    *                           field stores it
+    * @param x                  the assembly's pixel offset on the worksheet canvas
+    * @param y                  the assembly's pixel offset on the worksheet canvas
     */
    @JsonInclude(JsonInclude.Include.NON_NULL)
    public record TableModel(
@@ -105,7 +117,14 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
       List<FilterModel> rankingConditions,
       AggregateModel aggregates,
       List<SortModel> sorts,
-      boolean primary
+      boolean primary,
+      String description,
+      Integer maxRows,
+      boolean distinct,
+      boolean visibleInViewsheet,
+      String mode,
+      Integer x,
+      Integer y
    ) {}
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
@@ -494,4 +494,91 @@ class WorksheetReadServiceTest {
       assertEquals("entry description", p.description());
       assertFalse(p.dataSource());
    }
+
+   // The write tools set description, maxRows, distinct, mode and position, and none of them came
+   // back in the model -- so a caller could not tell a working write from a dropped one. That is
+   // what left L1 case 1.19 unable to round-trip and 1.16 unable to verify a position at all.
+
+   @Test
+   void reportsTheTablePropertiesTheWriteToolsSet() {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "col");
+      t.setDescription("what this table is for");
+      t.setMaxRows(25);
+      t.setDistinct(true);
+      ws.addAssembly(t);
+
+      WorksheetModel.TableModel m = tableNamed(read(ws), "T");
+
+      assertEquals("what this table is for", m.description());
+      assertEquals(Integer.valueOf(25), m.maxRows());
+      assertTrue(m.distinct());
+   }
+
+   /**
+    * -1 is how the assembly stores "unlimited". Reporting it verbatim would read back as a real
+    * limit of -1, and reporting 0 would collide with a genuine limit of zero rows.
+    */
+   @Test
+   void anUnlimitedRowLimitIsReportedAsNullRatherThanMinusOne() {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "col");
+      t.setMaxRows(-1);
+      ws.addAssembly(t);
+
+      assertNull(tableNamed(read(ws), "T").maxRows());
+   }
+
+   @Test
+   void reportsThePixelOffsetSoAPositionWriteCanBeVerified() {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "col");
+      t.setPixelOffset(new java.awt.Point(120, 340));
+      ws.addAssembly(t);
+
+      WorksheetModel.TableModel m = tableNamed(read(ws), "T");
+
+      assertEquals(Integer.valueOf(120), m.x());
+      assertEquals(Integer.valueOf(340), m.y());
+   }
+
+   /**
+    * Mode has no field of its own -- set_table_mode writes liveData, runtime and editMode per mode,
+    * so the read derives it from the same three. It reports the state the table is in, which is not
+    * always the word that was written: see tableMode's own note.
+    */
+   @Test
+   void derivesTheDisplayModeFromTheFlagsSetTableModeWrites() {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "col");
+      ws.addAssembly(t);
+
+      t.setEditMode(true);
+      assertEquals("edit", tableNamed(read(ws), "T").mode());
+
+      t.setEditMode(false);
+      t.setLiveData(true);
+      t.setRuntime(true);
+      assertEquals("live", tableNamed(read(ws), "T").mode());
+
+      t.setRuntime(false);
+      assertEquals("detail", tableNamed(read(ws), "T").mode());
+
+      t.setLiveData(false);
+      assertEquals("full", tableNamed(read(ws), "T").mode());
+   }
+
+   /** Both directions, since a one-sided assertion would pass against a hardcoded {@code false}. */
+   @Test
+   void reportsWhetherTheTableIsExposedToViewsheets() {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "col");
+      ws.addAssembly(t);
+
+      t.setVisibleTable(true);
+      assertTrue(tableNamed(read(ws), "T").visibleInViewsheet());
+
+      t.setVisibleTable(false);
+      assertFalse(tableNamed(read(ws), "T").visibleInViewsheet());
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
@@ -26,6 +26,7 @@ import inetsoft.web.wiz.worksheet.model.WorksheetModel;
 import inetsoft.web.wiz.worksheet.model.WorksheetPropertiesModel;
 import org.junit.jupiter.api.*;
 
+import java.awt.Point;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -516,8 +517,17 @@ class WorksheetReadServiceTest {
    }
 
    /**
-    * -1 is how the assembly stores "unlimited". Reporting it verbatim would read back as a real
-    * limit of -1, and reporting 0 would collide with a genuine limit of zero rows.
+    * -1 is how the assembly stores "unlimited", and reporting it verbatim would read back as a
+    * real limit of -1. 0 is the same unlimited, not a limit of zero rows -- the engine applies a
+    * limit only when it is positive -- so everything {@code <= 0} reports null.
+    *
+    * <p>What this asserts holds only with no global cap configured, which is this suite's state:
+    * getMaxRows() runs the stored value through Util.getQueryLocalRuntimeMaxrow, so with
+    * query.runtime.maxrow or an organization row limit set, a table stored as unlimited reports
+    * that cap instead of null. The read is deliberately the effective limit -- the Composer's own
+    * dialog shows the same number -- so this is the documented behaviour, not a gap. Asserting the
+    * capped case would mean mutating global state from a unit test; it is verifiable on a
+    * configured server.
     */
    @Test
    void anUnlimitedRowLimitIsReportedAsNullRatherThanMinusOne() {
@@ -533,7 +543,7 @@ class WorksheetReadServiceTest {
    void reportsThePixelOffsetSoAPositionWriteCanBeVerified() {
       Worksheet ws = new Worksheet();
       EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "col");
-      t.setPixelOffset(new java.awt.Point(120, 340));
+      t.setPixelOffset(new Point(120, 340));
       ws.addAssembly(t);
 
       WorksheetModel.TableModel m = tableNamed(read(ws), "T");


### PR DESCRIPTION
`set_table_properties`, `set_table_mode` and `set_assembly_position` all wrote fields that `read_worksheet_model` never reported back. A caller could not distinguish a working write from a dropped one — which is exactly what left L1 case **1.19** unable to round-trip and **1.16** unable to verify a position at all.

## Nothing new is computed

`TableAssembly` already exposes every one of these, and `TablePropertyDialogService:64-77` reads the same getters to fill the Composer's own table-properties dialog. This surfaces them through `TableModel`:

| Field | Source |
|---|---|
| `description` | `getDescription()` |
| `maxRows` | `getMaxRows()` |
| `distinct` | `isDistinct()` |
| `visibleInViewsheet` | `isVisibleTable()` |
| `mode` | derived from `isLiveData()` / `isRuntime()` / `isEditMode()` |
| `x` / `y` | `getPixelOffset()` |

## Two judgement calls worth reviewing

**`maxRows` reports `null` for unlimited**, not the stored `-1` — which would read back as a real limit of −1 — and not `0`, which would collide with a genuine limit of zero rows.

**`mode` reports the state, not the word that was written, and the javadoc says so** rather than implying a perfect round-trip. No field stores the mode; `set_table_mode` writes three flags per mode, and two of its five words do not map to distinct states: `"live"` sets runtime from `isRuntimeSelected()`, so on a table whose runtime selection is off it lands in the same state as `"detail"`; and `"default"` is resolved by the writer to live for an embedded table and metadata for a bound one. Neither is a lost write — both report the mode the table is actually in — but a caller wanting to confirm a specific word was honoured should compare states, not strings.

## Verification

5 tests, and **non-vacuity checked with two separate mutations** rather than assumed: stubbing the new fields empty fails three of them, and reporting `maxRows` verbatim fails the `-1` case. The visibility test asserts both directions, since a one-sided assertion would pass against a hardcoded `false`.

`inetsoft.web.wiz.worksheet.*Test` — **219 tests, all green**. `TableModel` has exactly one construction site, so no caller was left behind by the record change.

## What this does not do

It does not unblock **1.10**, which needs row counts. `rowCount` exists in the dialog model but only for `EmbeddedTableAssembly` (`getRowCount() - 1`), and 1.10's concatenation sources come from a datasource — so that case needs a different oracle.

Live verification of 1.16 and 1.19 is still owed and needs a rebuilt stack.
