### PR TITLE
Address any tabular connector through its own declared parameters

### DIFF
--- a/core/src/main/java/inetsoft/uql/tabular/TabularQuerySchema.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularQuerySchema.java
@@ -1,0 +1,369 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.tabular;
+
+import java.util.*;
+
+/**
+ * A machine-readable description of the parameters needed to build a
+ * {@link TabularQuery}, produced by {@link TabularSchemaExtractor}.
+ *
+ * <p>This is the input contract a caller fills in; it is deliberately not the
+ * {@link TabularView} tree. A TabularView carries layout (row/col/span/padding/
+ * alignment) that a form renderer needs and a caller does not, and it is rebuilt
+ * on every round trip. This schema carries only what is needed to decide what to
+ * put in a parameter map.
+ *
+ * <p>Two things this schema does <em>not</em> cover, because they are not
+ * {@code @Property} state on the query bean:
+ * <ul>
+ *    <li>the data source itself — it selects <em>which</em> query class is used,
+ *        so it is chosen before a schema can be extracted at all;</li>
+ *    <li>per-column type/format overrides, which live in the query's own
+ *        {@code typemap}/{@code fmtmap} and are serialized separately.</li>
+ * </ul>
+ */
+public class TabularQuerySchema {
+   public String getDataSourceType() {
+      return dataSourceType;
+   }
+
+   public void setDataSourceType(String dataSourceType) {
+      this.dataSourceType = dataSourceType;
+   }
+
+   public String getQueryClass() {
+      return queryClass;
+   }
+
+   public void setQueryClass(String queryClass) {
+      this.queryClass = queryClass;
+   }
+
+   /**
+    * All parameters, in the order the layout presents them, with any that the
+    * {@code @View} annotation never references appended at the end.
+    */
+   public List<Param> getParams() {
+      return params;
+   }
+
+   public void setParams(List<Param> params) {
+      this.params = params;
+   }
+
+   /**
+    * Which parameters become relevant for each value of an enumerated parameter.
+    *
+    * <p>Keyed by the name of the enumerated ("axis") parameter, then by its value;
+    * the list holds the names of the parameters whose visibility that value turns
+    * on. Parameters visible under every value of an axis are omitted, since they
+    * do not actually depend on it.
+    *
+    * <p>Produced by probing, not by reading source: see
+    * {@link TabularSchemaExtractor#buildDependencyMatrix}.
+    */
+   public Map<String, Map<String, List<String>>> getDependencyMatrix() {
+      return dependencyMatrix;
+   }
+
+   public void setDependencyMatrix(Map<String, Map<String, List<String>>> dependencyMatrix) {
+      this.dependencyMatrix = dependencyMatrix;
+   }
+
+   /**
+    * Free-standing explanatory text from the {@code @View} layout that could not
+    * be attached to any one parameter.
+    */
+   public List<String> getNotes() {
+      return notes;
+   }
+
+   public void setNotes(List<String> notes) {
+      this.notes = notes;
+   }
+
+   /**
+    * Names of parameters that carry {@code @Property} but are never referenced by
+    * the {@code @View} annotation, and so have no editor, no group and no
+    * visibility condition. They remain settable.
+    */
+   public List<String> getUnreferencedParams() {
+      return unreferencedParams;
+   }
+
+   public void setUnreferencedParams(List<String> unreferencedParams) {
+      this.unreferencedParams = unreferencedParams;
+   }
+
+   public Param getParam(String name) {
+      return params.stream()
+         .filter(p -> Objects.equals(p.getName(), name))
+         .findFirst()
+         .orElse(null);
+   }
+
+   private String dataSourceType;
+   private String queryClass;
+   private List<Param> params = new ArrayList<>();
+   private Map<String, Map<String, List<String>>> dependencyMatrix = new LinkedHashMap<>();
+   private List<String> notes = new ArrayList<>();
+   private List<String> unreferencedParams = new ArrayList<>();
+
+   /**
+    * One settable parameter on the query bean.
+    */
+   public static class Param {
+      public String getName() {
+         return name;
+      }
+
+      public void setName(String name) {
+         this.name = name;
+      }
+
+      /**
+       * The parameter's description. Sourced from {@code @Property(label=...)},
+       * resolved through the connector's resource bundle, and falling back to the
+       * property name. This is the only description the framework carries —
+       * {@code @Property} has no separate documentation attribute.
+       */
+      public String getLabel() {
+         return label;
+      }
+
+      public void setLabel(String label) {
+         this.label = label;
+      }
+
+      /**
+       * Fully qualified name of the bean property type. This is the authoritative
+       * type: the editor type below is a rendering hint that silently degrades to
+       * TEXT for classes the core classloader cannot see.
+       */
+      public String getJavaType() {
+         return javaType;
+      }
+
+      public void setJavaType(String javaType) {
+         this.javaType = javaType;
+      }
+
+      public String getEditorType() {
+         return editorType;
+      }
+
+      public void setEditorType(String editorType) {
+         this.editorType = editorType;
+      }
+
+      public String getEditorSubtype() {
+         return editorSubtype;
+      }
+
+      public void setEditorSubtype(String editorSubtype) {
+         this.editorSubtype = editorSubtype;
+      }
+
+      /**
+       * Whether {@code @Property} declares the parameter required.
+       *
+       * <p>Read this as "required whenever it applies", not "always required". A
+       * parameter that only applies under one value of some other parameter is
+       * normally left unmarked here even though it is mandatory once that value is
+       * chosen, because the annotation has no way to say so. Use
+       * {@link TabularQuerySchema#getDependencyMatrix} to find what applies, and
+       * expect the connector's own runtime to enforce the rest.
+       */
+      public boolean isRequired() {
+         return required;
+      }
+
+      public void setRequired(boolean required) {
+         this.required = required;
+      }
+
+      public boolean isPassword() {
+         return password;
+      }
+
+      public void setPassword(boolean password) {
+         this.password = password;
+      }
+
+      public Double getMin() {
+         return min;
+      }
+
+      public void setMin(Double min) {
+         this.min = min;
+      }
+
+      public Double getMax() {
+         return max;
+      }
+
+      public void setMax(Double max) {
+         this.max = max;
+      }
+
+      public List<String> getPattern() {
+         return pattern;
+      }
+
+      public void setPattern(List<String> pattern) {
+         this.pattern = pattern;
+      }
+
+      /**
+       * The allowed values, when they are fixed. Empty when there is no fixed set
+       * or when the values are only known at runtime — see {@link #getTagsMethod}.
+       */
+      public List<String> getTags() {
+         return tags;
+      }
+
+      public void setTags(List<String> tags) {
+         this.tags = tags;
+      }
+
+      public List<String> getTagLabels() {
+         return tagLabels;
+      }
+
+      public void setTagLabels(List<String> tagLabels) {
+         this.tagLabels = tagLabels;
+      }
+
+      /**
+       * Non-empty when the allowed values are fetched at runtime (often over the
+       * network) rather than fixed. A schema extracted offline cannot list them;
+       * the query dialog's refreshView round trip can.
+       */
+      public String getTagsMethod() {
+         return tagsMethod;
+      }
+
+      public void setTagsMethod(String tagsMethod) {
+         this.tagsMethod = tagsMethod;
+      }
+
+      public List<String> getDependsOn() {
+         return dependsOn;
+      }
+
+      public void setDependsOn(List<String> dependsOn) {
+         this.dependsOn = dependsOn;
+      }
+
+      public String getEnabledMethod() {
+         return enabledMethod;
+      }
+
+      public void setEnabledMethod(String enabledMethod) {
+         this.enabledMethod = enabledMethod;
+      }
+
+      /**
+       * The bean method that decides whether this parameter applies, if any.
+       * The method name alone does not say under which values it returns true;
+       * {@link TabularQuerySchema#getDependencyMatrix} answers that.
+       */
+      public String getVisibleMethod() {
+         return visibleMethod;
+      }
+
+      public void setVisibleMethod(String visibleMethod) {
+         this.visibleMethod = visibleMethod;
+      }
+
+      /**
+       * True when this parameter, or a panel containing it, has a visibility
+       * condition — that is, when it does not always apply.
+       */
+      public boolean isConditional() {
+         return conditional;
+      }
+
+      public void setConditional(boolean conditional) {
+         this.conditional = conditional;
+      }
+
+      /**
+       * The {@code @View} panel this parameter sits in, if the layout groups it.
+       */
+      public String getGroup() {
+         return group;
+      }
+
+      public void setGroup(String group) {
+         this.group = group;
+      }
+
+      /**
+       * Explanatory text the layout places next to this parameter — usually a
+       * format example. These come from LABEL elements in {@code @View} and are
+       * not reachable by reflecting over {@code @Property} alone.
+       */
+      public List<String> getHints() {
+         return hints;
+      }
+
+      public void setHints(List<String> hints) {
+         this.hints = hints;
+      }
+
+      /**
+       * For a parameter whose value is a composite (or a list of composites), the
+       * parameters of that element type. Empty for scalars.
+       */
+      public List<Param> getElementParams() {
+         return elementParams;
+      }
+
+      public void setElementParams(List<Param> elementParams) {
+         this.elementParams = elementParams;
+      }
+
+      @Override
+      public String toString() {
+         return name + " (" + javaType + ")";
+      }
+
+      private String name;
+      private String label;
+      private String javaType;
+      private String editorType;
+      private String editorSubtype;
+      private boolean required;
+      private boolean password;
+      private Double min;
+      private Double max;
+      private List<String> pattern = new ArrayList<>();
+      private List<String> tags = new ArrayList<>();
+      private List<String> tagLabels = new ArrayList<>();
+      private String tagsMethod;
+      private List<String> dependsOn = new ArrayList<>();
+      private String enabledMethod;
+      private String visibleMethod;
+      private boolean conditional;
+      private String group;
+      private List<String> hints = new ArrayList<>();
+      private List<Param> elementParams = new ArrayList<>();
+   }
+}

--- a/core/src/main/java/inetsoft/uql/tabular/TabularSchemaExtractor.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularSchemaExtractor.java
@@ -270,7 +270,24 @@ public class TabularSchemaExtractor {
       axes.forEach(axis -> byName.put(axis.name, axis));
 
       for(Map.Entry<String, Map<String, List<String>>> outer : firstPass.entrySet()) {
+         Axis outerAxis = byName.get(outer.getKey());
+
+         if(outerAxis == null) {
+            continue;
+         }
+
          for(Map.Entry<String, List<String>> row : outer.getValue().entrySet()) {
+            // The matrix is keyed by the value's TEXT, because it is published as JSON. Setting a
+            // property needs the value itself: handed "true" for a boolean setter, the reflective
+            // invocation fails, PropertyMeta.setValue swallows it, and the probe runs with the
+            // outer axis still at its default -- so every gate under a boolean outer axis would be
+            // missed, silently and while looking like there was nothing to find.
+            Object outerValue = valueFor(outerAxis, row.getKey());
+
+            if(outerValue == null) {
+               continue;
+            }
+
             for(String gatedName : row.getValue()) {
                Axis inner = byName.get(gatedName);
 
@@ -282,7 +299,7 @@ public class TabularSchemaExtractor {
 
                for(Object value : inner.values) {
                   Map<String, Object> combo = new LinkedHashMap<>();
-                  combo.put(outer.getKey(), row.getKey());
+                  combo.put(outer.getKey(), outerValue);
                   combo.put(inner.name, value);
                   Probe result = probe(cls, dataSource, combo);
 
@@ -307,6 +324,25 @@ public class TabularSchemaExtractor {
             }
          }
       }
+   }
+
+   /**
+    * The axis value whose text is the given matrix key.
+    *
+    * <p>Matched by text rather than carried alongside because the matrix is what gets published,
+    * and giving its rows a second, object-valued shadow copy purely to re-probe them would be one
+    * more thing to keep in step.
+    *
+    * @return the value, or {@code null} if no value of this axis has that text.
+    */
+   private Object valueFor(Axis axis, String text) {
+      for(Object value : axis.values) {
+         if(String.valueOf(value).equals(text)) {
+            return value;
+         }
+      }
+
+      return null;
    }
 
    /**

--- a/core/src/main/java/inetsoft/uql/tabular/TabularSchemaExtractor.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularSchemaExtractor.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.uql.tabular;
 
+import inetsoft.uql.XDataSource;
 import inetsoft.uql.util.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -116,9 +117,53 @@ public class TabularSchemaExtractor {
       }
 
       schema.setParams(params);
-      schema.setDependencyMatrix(buildDependencyMatrix(cls, params));
+      schema.setDependencyMatrix(buildDependencyMatrix(cls, prototype.getDataSource(), params));
 
       return schema;
+   }
+
+   /**
+    * Of the named parameters, those that do not apply to the query as it currently stands.
+    *
+    * <p>The counterpart of the dependency matrix, asked of one configured query rather than of a
+    * class: it answers "given what is already set, is this parameter read?". Setting one that is
+    * not is the failure mode a caller cannot see — the value is stored on the bean and never looked
+    * at, so the request goes out as though it had never been given and the result is a plausible
+    * wrong answer rather than an error.
+    *
+    * <p>A name this class does not recognize is not reported here. Whether a parameter exists is a
+    * different question from whether it applies, and the caller checks it against the schema.
+    */
+   public Set<String> findInapplicable(TabularQuery query, Collection<String> names) {
+      Set<String> inapplicable = new LinkedHashSet<>();
+
+      if(names == null || names.isEmpty()) {
+         return inapplicable;
+      }
+
+      try {
+         TabularView root = new LayoutCreator().createLayout(query);
+         TabularUtil.callViewMethods(root.getViews(), query);
+
+         Probe visible = new Probe();
+         collectVisible(root.getViews(), true, false, visible);
+
+         for(String name : names) {
+            // Only parameters the layout actually places can be judged. One the @View annotation
+            // never references has no visibility condition to evaluate, so there is no ground to
+            // call it inapplicable.
+            if(visible.known.contains(name) && !visible.allVisible.contains(name)) {
+               inapplicable.add(name);
+            }
+         }
+      }
+      catch(Exception ex) {
+         // Reporting nothing is the safe direction: this check exists to warn, and a check that
+         // could not run must not turn into a claim that every parameter is wrong.
+         LOG.debug("Failed to evaluate parameter applicability for " + query.getClass(), ex);
+      }
+
+      return inapplicable;
    }
 
    /**
@@ -144,11 +189,11 @@ public class TabularSchemaExtractor {
     * that axis: they are not gated on it.
     */
    Map<String, Map<String, List<String>>> buildDependencyMatrix(
-      Class<?> cls, List<TabularQuerySchema.Param> params)
+      Class<?> cls, XDataSource dataSource, List<TabularQuerySchema.Param> params)
    {
       Map<String, Map<String, List<String>>> matrix = new LinkedHashMap<>();
       List<Axis> axes = findAxes(params);
-      Probe baseline = probe(cls, Collections.emptyMap());
+      Probe baseline = probe(cls, dataSource, Collections.emptyMap());
 
       if(axes.isEmpty() || baseline == null) {
          return matrix;
@@ -160,7 +205,7 @@ public class TabularSchemaExtractor {
          Map<String, Set<String>> raw = new LinkedHashMap<>();
 
          for(Object value : axis.values) {
-            Probe result = probe(cls, Collections.singletonMap(axis.name, value));
+            Probe result = probe(cls, dataSource, Collections.singletonMap(axis.name, value));
 
             if(result == null || isSelfGating(axis.name, baseline, result)) {
                raw = null;
@@ -178,7 +223,7 @@ public class TabularSchemaExtractor {
       }
 
       matrix.putAll(firstPass);
-      addCombinationGates(cls, params, axes, firstPass, matrix);
+      addCombinationGates(cls, dataSource, params, axes, firstPass, matrix);
 
       return matrix;
    }
@@ -201,8 +246,8 @@ public class TabularSchemaExtractor {
     * and the condition is not described here" rather than claiming it never
     * applies.
     */
-   private void addCombinationGates(Class<?> cls, List<TabularQuerySchema.Param> params,
-                                    List<Axis> axes,
+   private void addCombinationGates(Class<?> cls, XDataSource dataSource,
+                                    List<TabularQuerySchema.Param> params, List<Axis> axes,
                                     Map<String, Map<String, List<String>>> firstPass,
                                     Map<String, Map<String, List<String>>> matrix)
    {
@@ -239,7 +284,7 @@ public class TabularSchemaExtractor {
                   Map<String, Object> combo = new LinkedHashMap<>();
                   combo.put(outer.getKey(), row.getKey());
                   combo.put(inner.name, value);
-                  Probe result = probe(cls, combo);
+                  Probe result = probe(cls, dataSource, combo);
 
                   if(result == null) {
                      continue;
@@ -284,9 +329,17 @@ public class TabularSchemaExtractor {
     * @return what is visible under those values, or {@code null} if the probe could
     *         not be run
     */
-   private Probe probe(Class<?> cls, Map<String, Object> values) {
+   private Probe probe(Class<?> cls, XDataSource dataSource, Map<String, Object> values) {
       try {
          Object probe = cls.getDeclaredConstructor().newInstance();
+
+         // The probe has to stand where the real query stands. A visibility condition may read the
+         // data source -- a connector varies what it offers by which account it is pointed at --
+         // and a probe built without one would answer for a query nobody is going to run.
+         if(dataSource != null && probe instanceof TabularQuery) {
+            ((TabularQuery) probe).setDataSource(dataSource);
+         }
+
          Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(cls);
 
          for(Map.Entry<String, Object> e : values.entrySet()) {
@@ -332,13 +385,17 @@ public class TabularSchemaExtractor {
          boolean conditional = ancestorConditional || method != null && !method.isEmpty();
          boolean visible = ancestorVisible && view.isVisible();
 
-         if(visible && view.getEditor() != null && view.getValue() != null) {
-            out.allVisible.add(view.getValue());
+         if(view.getEditor() != null && view.getValue() != null) {
+            out.known.add(view.getValue());
 
-            // a parameter with no condition anywhere above it applies regardless, so
-            // listing it under every value of an axis would say nothing
-            if(conditional) {
-               out.conditionalVisible.add(view.getValue());
+            if(visible) {
+               out.allVisible.add(view.getValue());
+
+               // a parameter with no condition anywhere above it applies regardless, so
+               // listing it under every value of an axis would say nothing
+               if(conditional) {
+                  out.conditionalVisible.add(view.getValue());
+               }
             }
          }
 
@@ -570,6 +627,8 @@ public class TabularSchemaExtractor {
     * What one probe saw.
     */
    private static final class Probe {
+      /** every parameter the layout places, whether or not it is currently shown */
+      private final Set<String> known = new LinkedHashSet<>();
       private final Set<String> allVisible = new LinkedHashSet<>();
       private final Set<String> conditionalVisible = new LinkedHashSet<>();
    }

--- a/core/src/main/java/inetsoft/uql/tabular/TabularSchemaExtractor.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularSchemaExtractor.java
@@ -1,0 +1,580 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.tabular;
+
+import inetsoft.uql.util.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.*;
+
+/**
+ * Derives a {@link TabularQuerySchema} — the parameters needed to build a query,
+ * their types, their descriptions, and which of them apply when — from a
+ * connector's query class.
+ *
+ * <p>Nothing here is connector-specific. Everything comes from three sources the
+ * connector already provides:
+ *
+ * <ol>
+ *    <li>reflection over {@code @Property}, which gives the authoritative set of
+ *        settable parameters along with their types and validation;</li>
+ *    <li>the {@code @View} layout, which gives descriptions resolved through the
+ *        connector's resource bundle, grouping, and the format examples that sit
+ *        beside a field as LABEL elements;</li>
+ *    <li>probing, which gives the dependency matrix — see
+ *        {@link #buildDependencyMatrix}.</li>
+ * </ol>
+ *
+ * <p>Reflection and layout are combined rather than one being preferred: a class
+ * that declares {@code @View} gets a tree covering only the properties that
+ * annotation references, but any other {@code @Property} is still settable, so the
+ * reflected set is the one that decides membership and the tree only enriches it.
+ */
+public class TabularSchemaExtractor {
+   /**
+    * Extracts the schema for a data source type, resolving the query class through
+    * the connector's own classloader.
+    *
+    * @param dataSourceType the registered type key, e.g. {@code "Rest.GitHub"}
+    *
+    * @return the schema, or {@code null} if the type is not registered or its
+    *         query class cannot be instantiated
+    */
+   public TabularQuerySchema extract(String dataSourceType) {
+      try {
+         Config config = Config.getConfig();
+         String queryClass = config.getQueryClass(dataSourceType);
+
+         if(queryClass == null) {
+            LOG.debug("No query class registered for tabular type: {}", dataSourceType);
+            return null;
+         }
+
+         // through the connector's classloader -- Class.forName would not find it
+         Class<?> cls = config.getClass(dataSourceType, queryClass);
+         TabularQuery prototype = (TabularQuery) cls.getDeclaredConstructor().newInstance();
+
+         return extract(prototype, dataSourceType);
+      }
+      catch(Exception ex) {
+         LOG.warn("Failed to extract tabular query schema for type: " + dataSourceType, ex);
+         return null;
+      }
+   }
+
+   /**
+    * Extracts the schema from a query instance. The instance is read, and copies of
+    * its class are created for probing, but the instance itself is not modified.
+    */
+   public TabularQuerySchema extract(TabularQuery prototype, String dataSourceType) {
+      Class<?> cls = prototype.getClass();
+      TabularQuerySchema schema = new TabularQuerySchema();
+      schema.setDataSourceType(dataSourceType != null ? dataSourceType : prototype.getType());
+      schema.setQueryClass(cls.getName());
+
+      // reflection decides membership
+      Map<String, TabularQuerySchema.Param> byName = new LinkedHashMap<>();
+
+      for(PropertyMeta prop : TabularUtil.findProperties(cls)) {
+         byName.put(prop.getName(), createParam(prop, new HashSet<>(), 0));
+      }
+
+      // the layout enriches, and gives the presentation order
+      List<String> ordered = new ArrayList<>();
+      TabularView root = new LayoutCreator().createLayout(prototype);
+      enrich(root.getViews(), byName, ordered, schema.getNotes(), null, false);
+
+      List<TabularQuerySchema.Param> params = new ArrayList<>();
+
+      for(String name : ordered) {
+         params.add(byName.get(name));
+      }
+
+      // properties the @View annotation never mentions are still settable
+      for(Map.Entry<String, TabularQuerySchema.Param> e : byName.entrySet()) {
+         if(!ordered.contains(e.getKey())) {
+            params.add(e.getValue());
+            schema.getUnreferencedParams().add(e.getKey());
+         }
+      }
+
+      schema.setParams(params);
+      schema.setDependencyMatrix(buildDependencyMatrix(cls, params));
+
+      return schema;
+   }
+
+   /**
+    * Builds the map from an enumerated parameter's value to the parameters that
+    * value turns on.
+    *
+    * <p>This is done by probing rather than by reading the connector's source. For
+    * each candidate value, a throwaway query is created, the value is set, a layout
+    * is built, and {@link TabularUtil#callViewMethods} is asked to evaluate the
+    * visibility conditions. That call only invokes {@code visibleMethod} and
+    * {@code enabledMethod}, so probing stays local: it does not fetch dropdown
+    * contents and does not reach the network.
+    *
+    * <p>Probing beats parsing the condition methods because it reports what those
+    * methods actually return. A condition that ORs two cases, or that reads a
+    * second parameter as well, needs no special handling here — it simply produces
+    * the answer it produces.
+    *
+    * <p>Two passes. The first varies one parameter at a time. Any parameter that is
+    * conditional but never appeared in that pass is gated on a combination rather
+    * than a single value, so a second pass varies pairs, looking only for those.
+    * Parameters that stay visible across every value of an axis are dropped from
+    * that axis: they are not gated on it.
+    */
+   Map<String, Map<String, List<String>>> buildDependencyMatrix(
+      Class<?> cls, List<TabularQuerySchema.Param> params)
+   {
+      Map<String, Map<String, List<String>>> matrix = new LinkedHashMap<>();
+      List<Axis> axes = findAxes(params);
+      Probe baseline = probe(cls, Collections.emptyMap());
+
+      if(axes.isEmpty() || baseline == null) {
+         return matrix;
+      }
+
+      Map<String, Map<String, List<String>>> firstPass = new LinkedHashMap<>();
+
+      for(Axis axis : axes) {
+         Map<String, Set<String>> raw = new LinkedHashMap<>();
+
+         for(Object value : axis.values) {
+            Probe result = probe(cls, Collections.singletonMap(axis.name, value));
+
+            if(result == null || isSelfGating(axis.name, baseline, result)) {
+               raw = null;
+               break;
+            }
+
+            raw.put(String.valueOf(value), result.conditionalVisible);
+         }
+
+         Map<String, List<String>> gated = dropUngated(raw);
+
+         if(!gated.isEmpty()) {
+            firstPass.put(axis.name, gated);
+         }
+      }
+
+      matrix.putAll(firstPass);
+      addCombinationGates(cls, params, axes, firstPass, matrix);
+
+      return matrix;
+   }
+
+   /**
+    * Second probing pass, for parameters gated on two values at once.
+    *
+    * <p>Rather than trying every pair of parameters, this follows the shape such a
+    * gate actually has: the second parameter is itself only relevant under the
+    * first. A link relation matters only for a link-header link parameter, and a
+    * link parameter matters only under link pagination — so the pairs worth trying
+    * are exactly those the first pass already found, paired with the enumerated
+    * parameters that same value turns on. That keeps this to a few dozen probes
+    * instead of a combinatorial sweep, and it looks precisely where a second-level
+    * gate can be.
+    *
+    * <p>A parameter gated on three conditions at once, or on two unrelated ones,
+    * is still missed. It then appears in the schema as conditional, with a
+    * visibility method and no matrix entry — which says "this applies sometimes,
+    * and the condition is not described here" rather than claiming it never
+    * applies.
+    */
+   private void addCombinationGates(Class<?> cls, List<TabularQuerySchema.Param> params,
+                                    List<Axis> axes,
+                                    Map<String, Map<String, List<String>>> firstPass,
+                                    Map<String, Map<String, List<String>>> matrix)
+   {
+      Set<String> reached = new HashSet<>();
+      firstPass.values().forEach(rows -> rows.values().forEach(reached::addAll));
+
+      Set<String> unreached = new LinkedHashSet<>();
+
+      for(TabularQuerySchema.Param param : params) {
+         if(param.isConditional() && !reached.contains(param.getName())) {
+            unreached.add(param.getName());
+         }
+      }
+
+      if(unreached.isEmpty()) {
+         return;
+      }
+
+      Map<String, Axis> byName = new HashMap<>();
+      axes.forEach(axis -> byName.put(axis.name, axis));
+
+      for(Map.Entry<String, Map<String, List<String>>> outer : firstPass.entrySet()) {
+         for(Map.Entry<String, List<String>> row : outer.getValue().entrySet()) {
+            for(String gatedName : row.getValue()) {
+               Axis inner = byName.get(gatedName);
+
+               if(inner == null || unreached.isEmpty()) {
+                  continue;
+               }
+
+               Map<String, List<String>> found = new LinkedHashMap<>();
+
+               for(Object value : inner.values) {
+                  Map<String, Object> combo = new LinkedHashMap<>();
+                  combo.put(outer.getKey(), row.getKey());
+                  combo.put(inner.name, value);
+                  Probe result = probe(cls, combo);
+
+                  if(result == null) {
+                     continue;
+                  }
+
+                  Set<String> visible = result.conditionalVisible;
+                  visible.retainAll(unreached);
+
+                  if(!visible.isEmpty()) {
+                     found.put(outer.getKey() + "=" + row.getKey() + " & " +
+                                  inner.name + "=" + value,
+                               new ArrayList<>(visible));
+                  }
+               }
+
+               if(!found.isEmpty()) {
+                  matrix.put(outer.getKey() + " & " + inner.name, found);
+                  found.values().forEach(unreached::removeAll);
+               }
+            }
+         }
+      }
+   }
+
+   /**
+    * Whether setting a parameter is what makes that parameter itself appear.
+    *
+    * <p>Some setters have side effects beyond the property — growing the list a
+    * panel's visibility is computed from, for instance. Probing such a parameter
+    * reports its own panel turning on, along with every sibling in it, and reads as
+    * "this parameter gates its neighbours" when nothing of the sort is true: the
+    * real gate is elsewhere, usually a button. Comparing against the baseline
+    * catches it, and the axis is dropped rather than described wrongly.
+    */
+   private boolean isSelfGating(String axis, Probe baseline, Probe result) {
+      return !baseline.allVisible.contains(axis) && result.allVisible.contains(axis);
+   }
+
+   /**
+    * Sets the given values on a fresh query and evaluates the visibility conditions.
+    *
+    * @return what is visible under those values, or {@code null} if the probe could
+    *         not be run
+    */
+   private Probe probe(Class<?> cls, Map<String, Object> values) {
+      try {
+         Object probe = cls.getDeclaredConstructor().newInstance();
+         Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(cls);
+
+         for(Map.Entry<String, Object> e : values.entrySet()) {
+            PropertyMeta prop = pmap.get(e.getKey());
+
+            if(prop == null) {
+               return null;
+            }
+
+            prop.setValue(probe, e.getValue());
+         }
+
+         TabularView root = new LayoutCreator().createLayout(probe);
+         TabularUtil.callViewMethods(root.getViews(), probe);
+
+         Probe result = new Probe();
+         collectVisible(root.getViews(), true, false, result);
+         values.keySet().forEach(result.conditionalVisible::remove);
+
+         return result;
+      }
+      catch(Exception ex) {
+         LOG.debug("Failed to probe visibility for {} with {}", cls.getName(), values, ex);
+         return null;
+      }
+   }
+
+   /**
+    * A view is only really shown when every panel containing it is shown too, so
+    * visibility is carried down rather than read off each node. The same applies to
+    * being conditional: a field with no condition of its own inside a conditional
+    * panel is still conditional.
+    */
+   private void collectVisible(TabularView[] views, boolean ancestorVisible,
+                               boolean ancestorConditional, Probe out)
+   {
+      if(views == null) {
+         return;
+      }
+
+      for(TabularView view : views) {
+         String method = view.getVisibleMethod();
+         boolean conditional = ancestorConditional || method != null && !method.isEmpty();
+         boolean visible = ancestorVisible && view.isVisible();
+
+         if(visible && view.getEditor() != null && view.getValue() != null) {
+            out.allVisible.add(view.getValue());
+
+            // a parameter with no condition anywhere above it applies regardless, so
+            // listing it under every value of an axis would say nothing
+            if(conditional) {
+               out.conditionalVisible.add(view.getValue());
+            }
+         }
+
+         collectVisible(view.getViews(), visible, conditional, out);
+      }
+   }
+
+   /**
+    * Keeps only the parameters an axis actually gates. One that is visible for
+    * every value of the axis is visible for reasons of its own, and saying it
+    * depends on the axis would be wrong.
+    */
+   private Map<String, List<String>> dropUngated(Map<String, Set<String>> raw) {
+      Map<String, List<String>> gated = new LinkedHashMap<>();
+
+      if(raw == null || raw.isEmpty()) {
+         return gated;
+      }
+
+      Set<String> everywhere = null;
+
+      for(Set<String> visible : raw.values()) {
+         if(everywhere == null) {
+            everywhere = new HashSet<>(visible);
+         }
+         else {
+            everywhere.retainAll(visible);
+         }
+      }
+
+      for(Map.Entry<String, Set<String>> e : raw.entrySet()) {
+         List<String> names = new ArrayList<>(e.getValue());
+         names.removeAll(everywhere);
+         gated.put(e.getKey(), names);
+      }
+
+      boolean any = gated.values().stream().anyMatch(names -> !names.isEmpty());
+
+      return any ? gated : new LinkedHashMap<>();
+   }
+
+   /**
+    * The parameters worth varying: those with a fixed set of values. Booleans count
+    * — they gate as often as enumerations do. Values fetched at runtime do not,
+    * since they are not known here.
+    */
+   private List<Axis> findAxes(List<TabularQuerySchema.Param> params) {
+      List<Axis> axes = new ArrayList<>();
+
+      for(TabularQuerySchema.Param param : params) {
+         boolean runtimeTags = param.getTagsMethod() != null && !param.getTagsMethod().isEmpty();
+
+         if(!param.getTags().isEmpty() && !runtimeTags) {
+            axes.add(new Axis(param.getName(), new ArrayList<Object>(param.getTags())));
+         }
+         else if("boolean".equals(param.getJavaType()) ||
+                 Boolean.class.getName().equals(param.getJavaType()))
+         {
+            axes.add(new Axis(param.getName(), Arrays.<Object>asList(Boolean.TRUE, Boolean.FALSE)));
+         }
+      }
+
+      return axes;
+   }
+
+   private TabularQuerySchema.Param createParam(PropertyMeta prop, Set<Class<?>> seen, int depth) {
+      TabularQuerySchema.Param param = new TabularQuerySchema.Param();
+      param.setName(prop.getName());
+      param.setLabel(prop.getDisplayLabel());
+
+      Class<?> type = prop.getDescriptor().getPropertyType();
+      param.setJavaType(type == null ? null : type.getName());
+
+      Property property = prop.getProperty();
+
+      if(property != null) {
+         param.setRequired(property.required());
+         param.setPassword(property.password());
+         param.setMin(Double.isNaN(property.min()) ? null : property.min());
+         param.setMax(Double.isNaN(property.max()) ? null : property.max());
+         param.setPattern(Arrays.asList(property.pattern()));
+      }
+
+      PropertyEditor editor = prop.getEditor();
+
+      if(editor != null) {
+         param.setTags(Arrays.asList(editor.tags()));
+         param.setTagLabels(Arrays.asList(editor.labels()));
+         param.setTagsMethod(emptyToNull(editor.tagsMethod()));
+         param.setDependsOn(Arrays.asList(editor.dependsOn()));
+         param.setEnabledMethod(emptyToNull(editor.enabledMethod()));
+      }
+
+      param.setElementParams(extractElementParams(type, seen, depth));
+
+      return param;
+   }
+
+   /**
+    * A parameter can hold a composite, or a list of them — an HTTP parameter, a
+    * query parameter, a column definition. Filling one in means filling in its own
+    * parameters, so they are described here too.
+    */
+   private List<TabularQuerySchema.Param> extractElementParams(Class<?> type, Set<Class<?>> seen,
+                                                               int depth)
+   {
+      List<TabularQuerySchema.Param> elements = new ArrayList<>();
+
+      if(type == null || depth >= MAX_NESTING) {
+         return elements;
+      }
+
+      Class<?> element = type.isArray() ? type.getComponentType() : type;
+
+      if(isScalar(element) || !seen.add(element)) {
+         return elements;
+      }
+
+      try {
+         for(PropertyMeta prop : TabularUtil.findProperties(element)) {
+            elements.add(createParam(prop, seen, depth + 1));
+         }
+      }
+      catch(Exception ex) {
+         LOG.debug("Failed to describe element type: " + element.getName(), ex);
+      }
+
+      return elements;
+   }
+
+   /**
+    * Walks the layout to attach what only the layout knows: the bundle-resolved
+    * description, the panel a parameter sits in, its visibility condition, and the
+    * examples placed beside it.
+    *
+    * <p>A LABEL is attached to the field it follows, which is where it is rendered
+    * and what it is written to explain. One that follows no field is kept as a note
+    * on the schema instead of being dropped.
+    */
+   private void enrich(TabularView[] views, Map<String, TabularQuerySchema.Param> byName,
+                       List<String> ordered, List<String> notes, String group,
+                       boolean ancestorConditional)
+   {
+      if(views == null) {
+         return;
+      }
+
+      TabularQuerySchema.Param previous = null;
+
+      for(TabularView view : views) {
+         String method = view.getVisibleMethod();
+         boolean conditional = ancestorConditional || method != null && !method.isEmpty();
+
+         if(view.getType() == ViewType.LABEL) {
+            String text = view.getDisplayLabel() != null ? view.getDisplayLabel() : view.getText();
+
+            if(text != null && !text.isEmpty()) {
+               if(previous != null) {
+                  previous.getHints().add(text);
+               }
+               else {
+                  notes.add(text);
+               }
+            }
+
+            continue;
+         }
+
+         String name = view.getValue();
+         TabularQuerySchema.Param param = name == null ? null : byName.get(name);
+
+         if(param != null && view.getEditor() != null) {
+            if(!ordered.contains(name)) {
+               ordered.add(name);
+            }
+
+            if(view.getDisplayLabel() != null && !view.getDisplayLabel().isEmpty()) {
+               param.setLabel(view.getDisplayLabel());
+            }
+
+            param.setGroup(group);
+            param.setVisibleMethod(emptyToNull(method));
+            param.setConditional(conditional);
+            param.setRequired(param.isRequired() || view.isRequired());
+            param.setEditorType(name(view.getEditor().getType()));
+            param.setEditorSubtype(name(view.getEditor().getSubtype()));
+            previous = param;
+         }
+
+         String childGroup = group;
+
+         if(view.getType() == ViewType.PANEL) {
+            String text = view.getDisplayLabel() != null ? view.getDisplayLabel() : view.getText();
+            childGroup = text != null && !text.isEmpty() ? text : group;
+         }
+
+         enrich(view.getViews(), byName, ordered, notes, childGroup, conditional);
+      }
+   }
+
+   private boolean isScalar(Class<?> cls) {
+      return cls == null || cls.isPrimitive() || cls.isEnum() || cls == String.class ||
+         Number.class.isAssignableFrom(cls) || cls == Boolean.class || cls == Character.class ||
+         cls == File.class || Date.class.isAssignableFrom(cls) || cls.getName().startsWith("java.");
+   }
+
+   private String name(Enum<?> value) {
+      return value == null ? null : value.name();
+   }
+
+   private String emptyToNull(String value) {
+      return value == null || value.isEmpty() ? null : value;
+   }
+
+   /**
+    * One parameter to vary while probing, and the values to try.
+    */
+   private static final class Axis {
+      Axis(String name, List<Object> values) {
+         this.name = name;
+         this.values = values;
+      }
+
+      private final String name;
+      private final List<Object> values;
+   }
+
+   /**
+    * What one probe saw.
+    */
+   private static final class Probe {
+      private final Set<String> allVisible = new LinkedHashSet<>();
+      private final Set<String> conditionalVisible = new LinkedHashSet<>();
+   }
+
+   private static final int MAX_NESTING = 2;
+
+   private static final Logger LOG = LoggerFactory.getLogger(TabularSchemaExtractor.class);
+}

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizTabularController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizTabularController.java
@@ -287,15 +287,12 @@ public class WizTabularController {
          }
 
          XDataSource dataSource = xrepository.getDataSource(path);
-         TabularQuerySchema schema =
-            new TabularSchemaExtractor().extract(query, dataSource == null ? null : dataSource.getType());
 
-         if(schema == null) {
-            throw new ResponseStatusException(
-               HttpStatus.BAD_REQUEST, "No query parameter contract is available for '" + path + "'.");
-         }
-
-         return schema;
+         // Not null-checked: this overload describes the instance it is handed and always answers.
+         // Only the one that resolves the query class itself can fail to produce a query, and that
+         // case is the guard above.
+         return new TabularSchemaExtractor()
+            .extract(query, dataSource == null ? null : dataSource.getType());
       }
       finally {
          endConnectorSession();

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizTabularController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizTabularController.java
@@ -28,6 +28,8 @@ import inetsoft.uql.tabular.LayoutCreator;
 import inetsoft.uql.tabular.TabularDataSource;
 import inetsoft.uql.tabular.TabularEditor;
 import inetsoft.uql.tabular.TabularQuery;
+import inetsoft.uql.tabular.TabularQuerySchema;
+import inetsoft.uql.tabular.TabularSchemaExtractor;
 import inetsoft.uql.tabular.TabularUtil;
 import inetsoft.uql.tabular.TabularView;
 import inetsoft.util.Catalog;
@@ -224,6 +226,82 @@ public class WizTabularController {
     *                                        a JDBC database has no form here and would render as an
     *                                        empty one.
     */
+   /**
+    * The parameters a data source's query takes, what each one means, and which of them apply when.
+    *
+    * <p>WHAT THIS ANSWERS THAT NOTHING ELSE DOES. A caller building a tabular table has to decide
+    * what to put in {@code tabularSource.queryParams}, and until now there was nowhere to learn it.
+    * {@code /tabular/definition} describes the DATA SOURCE's form — the connection — not the
+    * query's. And the structure that does describe a query, {@code TabularView}, is a form layout:
+    * two thirds of every node is row, column, span and padding, and nothing in it says that an
+    * offset parameter is read under one pagination strategy and ignored under another.</p>
+    *
+    * <p>THE DEPENDENCY MATRIX IS THE PART WORTH READING. Most of a connector's parameters are
+    * conditional, and a parameter that does not apply is not refused — it is stored on the query
+    * and never looked at, so the request goes out as though it had never been given. The matrix
+    * says which choice turns on which parameters, so that can be got right before the call rather
+    * than diagnosed after it.</p>
+    *
+    * <p>DERIVED, NEVER STORED. Every field comes from the connector's own {@code @Property} and
+    * {@code @View} declarations, so a connector that adds a parameter is described correctly with
+    * no change here. Two things it does not carry: what each value of an enumerated parameter
+    * actually does, which lives in the runner rather than in any annotation, and which parameters a
+    * given choice makes mandatory, which the annotations have no way to express.</p>
+    *
+    * <p>Gated on READ, unlike {@code /tabular/definition} next to it. That one returns stored
+    * credentials and so demands WRITE; this returns a description of the connector's shape and no
+    * value the user configured.</p>
+    *
+    * @param path      the data source's full repository path.
+    * @param principal the current user.
+    *
+    * @return the parameter contract for that data source's query.
+    */
+   @GetMapping(value = "/tabular/query-schema", produces = MediaType.APPLICATION_JSON_VALUE)
+   @Secured({
+      @RequiredPermission(
+         resourceType = ResourceType.DATA_SOURCE, actions = ResourceAction.READ
+      )
+   })
+   public TabularQuerySchema getQuerySchema(
+      @PermissionPath @RequestParam("path") String path, Principal principal) throws Exception
+   {
+      requireTabularDataSource(path);
+
+      // Extraction runs the connector's own visibility methods, which is the same capability
+      // /tabular/refresh gates on. Those methods are the connector's code and this decides how many
+      // times they are invoked, so the session is bound the way every other such call binds it.
+      beginConnectorSession(principal);
+
+      try {
+         // Built through createQuery rather than from the type alone, so the query carries the data
+         // source it will actually run against. A visibility condition is free to read it — a
+         // connector can offer different parameters for different accounts — and a schema extracted
+         // from a datasource-less query would then describe a query nobody is going to run.
+         TabularQuery query = TabularUtil.createQuery(path);
+
+         if(query == null) {
+            throw new ResponseStatusException(
+               HttpStatus.BAD_REQUEST,
+               "Could not create a query for '" + path + "' — its connector plugin may not be loaded.");
+         }
+
+         XDataSource dataSource = xrepository.getDataSource(path);
+         TabularQuerySchema schema =
+            new TabularSchemaExtractor().extract(query, dataSource == null ? null : dataSource.getType());
+
+         if(schema == null) {
+            throw new ResponseStatusException(
+               HttpStatus.BAD_REQUEST, "No query parameter contract is available for '" + path + "'.");
+         }
+
+         return schema;
+      }
+      finally {
+         endConnectorSession();
+      }
+   }
+
    @GetMapping(value = "/tabular/definition", produces = MediaType.APPLICATION_JSON_VALUE)
    @Secured({
       @RequiredPermission(

--- a/core/src/main/java/inetsoft/web/wiz/model/WorksheetTable.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WorksheetTable.java
@@ -180,6 +180,7 @@ public class WorksheetTable {
       private String target;
       private Map<String, String> params;
       private Map<String, String> parameters;
+      private Map<String, Object> queryParams;
       private String jsonPath;
       private Boolean expanded;
       private String expandedPath;
@@ -261,6 +262,29 @@ public class WorksheetTable {
        */
       public Map<String, String> getParameters() { return parameters; }
       public void setParameters(Map<String, String> parameters) { this.parameters = parameters; }
+
+      /**
+       * The whole query, by the connector's own property names, for {@code targetKind == "query"}.
+       *
+       * <p>Where {@link #getParams()} and {@link #getParameters()} each carry one slice of one kind
+       * of connector, this carries all of any connector: the names and the values come from the
+       * parameter contract {@code GET /api/wiz/tabular/query-schema} publishes for this data source,
+       * which is derived from the connector's own {@code @Property} declarations. That is what lets
+       * a connector with neither endpoints nor files — a document store, a cloud analytics API, a
+       * search index — be bound at all, and it is where the two older kinds are headed. Until they
+       * move they are untouched and keep their own contracts.</p>
+       *
+       * <p>TYPED, unlike the two older maps. A parameter can be a number, a flag, or one of a fixed
+       * set of names, and the schema says which. Declaring everything a string would put the
+       * conversion in the caller and, worse, make a wrong guess indistinguishable from a value the
+       * connector chose to ignore.</p>
+       *
+       * <p>Three things are checked before the query runs, because each of them otherwise fails
+       * quietly: a name the connector does not declare, a value that does not reach the bean, and a
+       * parameter that does not apply to the rest of what was sent.</p>
+       */
+      public Map<String, Object> getQueryParams() { return queryParams; }
+      public void setQueryParams(Map<String, Object> queryParams) { this.queryParams = queryParams; }
 
       /** JSON path to the row array, e.g. "$.data[*]". Null keeps the connector's default. */
       public String getJsonPath() { return jsonPath; }

--- a/core/src/main/java/inetsoft/web/wiz/service/TabularEndpointBindingSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/TabularEndpointBindingSupport.java
@@ -340,29 +340,38 @@ public final class TabularEndpointBindingSupport {
    }
 
    /**
-    * Refuse an unbounded row limit on an endpoint that paginates. {@code isPaged()} is public but
+    * Refuse an unbounded row limit on a query that paginates. {@code isPaged()} is public but
     * not a {@code @Property}, so it is reached by name -- the same reflection
     * {@link #assertKnownEndpoint} uses for {@code getEndpoints}. A connector that does not answer
     * it is left alone rather than blocked: this check exists to stop a known-unbounded query, not
     * to reject an unfamiliar one.
+    *
+    * <p>Not only endpoints. Pagination is an ordinary property -- {@code setPaginationType} writes
+    * the spec that {@code isPaged()} reads, with nothing in between -- so a target kind addressed
+    * by its parameters rather than by an endpoint name can paginate just as readily. Which kinds
+    * are asked is {@code WorksheetTableService.rowCapRequiredFor}; what this needs to know is that
+    * {@code target} may be absent, since such a kind has no endpoint to name.</p>
     */
-   public static void requireRowCapWhenPaged(TabularQuery query, String endpoint, String dsName) {
+   public static void requireRowCapWhenPaged(TabularQuery query, String target, String dsName) {
+      // Built first so the message reads correctly for a kind that has no target: there is no
+      // endpoint to blame, and the data source is the whole of what can be pointed at.
+      String subject = target == null || target.isBlank()
+         ? "The query on '" + dsName + "'" : "Endpoint '" + target + "' of '" + dsName + "'";
       boolean paged;
 
       try {
          paged = (Boolean) query.getClass().getMethod("isPaged").invoke(query);
       }
       catch(Exception ex) {
-         LOG.debug("Could not determine whether endpoint '{}' of '{}' paginates; not requiring " +
-                   "a row cap", endpoint, dsName, ex);
+         LOG.debug("Could not determine whether {} paginates; not requiring a row cap", subject, ex);
          return;
       }
 
       if(paged) {
          throw new IllegalArgumentException(
-            "Endpoint '" + endpoint + "' of '" + dsName + "' is paginated, so a row cap is " +
-            "required: without it every render of this table requests pages until the service " +
-            "runs out of data. Choose a row cap for the question being asked.");
+            subject + " is paginated, so a row cap is required: without it every render of this " +
+            "table requests pages until the service runs out of data. Choose a row cap for the " +
+            "question being asked.");
       }
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -2341,7 +2341,6 @@ public class WorksheetTableService {
    }
 
    /**
-   /**
     * Whether a target kind has to justify building a table with no row cap.
     *
     * <p>Everything but a file. A local file is read whole in one pass — no pages to walk, no

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -1624,6 +1624,8 @@ public class WorksheetTableService {
             "tabularSource.parameters, keyed by the endpoint's own parameter names.");
       }
 
+      rejectQueryParams(src, TARGET_KIND_ENDPOINT, "tabularSource.parameters");
+
       String endpoint = src.getTarget().trim();
       String suffix = TabularEndpointBindingSupport.applyEndpointContract(
          query, pmap, endpoint, src.getParameters(), src.getJsonPath(), src.getExpanded(),
@@ -1752,7 +1754,8 @@ public class WorksheetTableService {
     * carry two answers for one parameter and silently keep whichever ran last. Refused rather than
     * merged, in the same spirit as the endpoint/file contracts refusing each other's fields.
     */
-   private void rejectForeignFields(WorksheetTable.TabularSource src) {
+   // Package-private so the test that pins the rejections can call it, the way shouldProbe is.
+   void rejectForeignFields(WorksheetTable.TabularSource src) {
       if(src.getParameters() != null && !src.getParameters().isEmpty()) {
          throw new IllegalArgumentException(
             "tabularSource.parameters applies to targetKind \"" + TARGET_KIND_ENDPOINT +
@@ -1776,11 +1779,43 @@ public class WorksheetTableService {
             "\", set those properties by name in queryParams.");
       }
 
+      // The lookup chain is addressed by endpoint NAME at each level, which is the one thing this
+      // kind does not have -- it is why a query request has no target either. A connector that
+      // chains lookups through properties sets them like any other property, in queryParams.
+      if(src.getLookup() != null && !src.getLookup().isEmpty() ||
+         src.getLookupExpandArrays() != null || src.getLookupTopLevelOnly() != null)
+      {
+         throw new IllegalArgumentException(
+            "tabularSource.lookup/lookupExpandArrays/lookupTopLevelOnly apply to targetKind \"" +
+            TARGET_KIND_ENDPOINT + "\" only — each level names an endpoint, and \"" +
+            TARGET_KIND_QUERY + "\" addresses the data by parameter instead.");
+      }
+
       // Nothing on this path reads it, so a target here names something that will not be used.
       if(src.getTarget() != null && !src.getTarget().isBlank()) {
          throw new IllegalArgumentException(
             "tabularSource.target does not apply to targetKind \"" + TARGET_KIND_QUERY +
             "\" — queryParams is what addresses the data.");
+      }
+   }
+
+   /**
+    * Refuse a query-kind parameter map on a request that is not query-kind.
+    *
+    * <p>The mirror of {@link #rejectForeignFields}, and the half that field points at. Only
+    * {@code applyQueryContract} reads {@code queryParams}, so on either older kind the whole map
+    * would be dropped and the table would build and report success having ignored everything the
+    * caller put in it -- a request half-migrated between kinds, or one that named the wrong kind,
+    * looking exactly like a request that worked.</p>
+    *
+    * @param instead the field this kind expects the values in, named so the message says where to
+    *                move them rather than only what is wrong.
+    */
+   void rejectQueryParams(WorksheetTable.TabularSource src, String kind, String instead) {
+      if(src.getQueryParams() != null && !src.getQueryParams().isEmpty()) {
+         throw new IllegalArgumentException(
+            "tabularSource.queryParams applies to targetKind \"" + TARGET_KIND_QUERY +
+            "\" only — for \"" + kind + "\", put the values in " + instead + ".");
       }
    }
 
@@ -1886,6 +1921,8 @@ public class WorksheetTableService {
             "tabularSource.jsonPath/expanded/expandedPath apply to targetKind \"" +
             TARGET_KIND_ENDPOINT + "\" only — they describe a JSON response, and a file has none.");
       }
+
+      rejectQueryParams(src, TARGET_KIND_FILE, "tabularSource.params");
 
       PropertyMeta fileProp = fileTargetProperty(pmap, query, dsName);
 

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -45,6 +45,7 @@ import inetsoft.uql.schema.XTypeNode;
 import inetsoft.uql.tabular.PropertyMeta;
 import inetsoft.uql.tabular.TabularDataSource;
 import inetsoft.uql.tabular.TabularQuery;
+import inetsoft.uql.tabular.TabularSchemaExtractor;
 import inetsoft.uql.tabular.TabularUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -441,6 +442,11 @@ public class WorksheetTableService {
          return 0;
       }
 
+      // File only, and the query kind is deliberately not added to it. Sampling here means running
+      // the table a second time, which is free for a local file and is a second metered call for
+      // anything else; the query kind addresses any connector at all, so it cannot be assumed to be
+      // the free case. A connector whose runner samples its own response still reports rows through
+      // that path, exactly as an endpoint does.
       if(!TARGET_KIND_FILE.equals(kind)) {
          return 0;
       }
@@ -1420,7 +1426,12 @@ public class WorksheetTableService {
 
       String targetKind = targetKindOf(src);
 
-      if(src.getTarget() == null || src.getTarget().isBlank()) {
+      // Not asked of the query kind, which has no separate target to name: there, the parameters
+      // ARE what is being addressed, and demanding a target as well would mean inventing a value
+      // for a field that nothing on that path reads.
+      if(!TARGET_KIND_QUERY.equals(targetKind) &&
+         (src.getTarget() == null || src.getTarget().isBlank()))
+      {
          throw new IllegalArgumentException(
             "tabularSource.target is required for tabular table — " +
             (TARGET_KIND_FILE.equals(targetKind)
@@ -1506,6 +1517,7 @@ public class WorksheetTableService {
       String probeDesc = switch(targetKind) {
          case TARGET_KIND_ENDPOINT -> applyEndpointContract(query, pmap, src);
          case TARGET_KIND_FILE -> applyFileContract(query, pmap, src);
+         case TARGET_KIND_QUERY -> applyQueryContract(query, pmap, src);
          // Unreachable: targetKindOf refuses anything else. Present so a third kind added to the
          // enum without a contract fails here rather than silently building an unconfigured query.
          default -> throw new IllegalStateException(
@@ -1562,6 +1574,17 @@ public class WorksheetTableService {
          // sent and the first thing to check; repeating it for a file would hand whoever is
          // debugging a URL that was never built and say nothing about the path, the sheet, or the
          // delimiter — the three things that actually produce an empty parse.
+         if(TARGET_KIND_QUERY.equals(targetKind)) {
+            // Neither of the other two texts fits: there is no URL to re-read and no file to
+            // check. What was sent is the parameter set, so that is what is named back.
+            throw new IllegalArgumentException(
+               "The query on '" + dsName + "' returned no columns. Parameters sent: " + probeDesc +
+               ". Check them against GET /api/wiz/tabular/query-schema — in particular that each " +
+               "one applies to the others, since one that does not is stored and never read — and " +
+               "that the data source's credentials are valid; the underlying cause is in the " +
+               "server log for this request.");
+         }
+
          throw new IllegalArgumentException(TARGET_KIND_FILE.equals(targetKind)
             ? "Reading " + probeDesc + " of '" + dsName + "' produced no columns. Check that the " +
               "file exists at that path, is not empty, and that the parsing options in " +
@@ -1637,13 +1660,225 @@ public class WorksheetTableService {
 
       String normalized = kind.trim().toLowerCase();
 
-      if(!TARGET_KIND_ENDPOINT.equals(normalized) && !TARGET_KIND_FILE.equals(normalized)) {
+      if(!TARGET_KIND_ENDPOINT.equals(normalized) && !TARGET_KIND_FILE.equals(normalized) &&
+         !TARGET_KIND_QUERY.equals(normalized))
+      {
          throw new IllegalArgumentException(
-            "tabularSource.targetKind must be \"" + TARGET_KIND_ENDPOINT + "\" or \"" +
-            TARGET_KIND_FILE + "\", got \"" + kind + "\".");
+            "tabularSource.targetKind must be \"" + TARGET_KIND_ENDPOINT + "\", \"" +
+            TARGET_KIND_FILE + "\" or \"" + TARGET_KIND_QUERY + "\", got \"" + kind + "\".");
       }
 
       return normalized;
+   }
+
+   /**
+    * Configure a tabular query from the connector's own declared parameters, and return a
+    * description of what it will run.
+    *
+    * <p>THE GENERAL CONTRACT, where {@link #applyEndpointContract} and {@link #applyFileContract}
+    * are two special ones. Those two know in advance which properties matter — an endpoint name and
+    * its URL tokens, a file path and its parsing options — which is what makes them short, and also
+    * what makes them apply to two kinds of connector out of the many StyleBI ships. A document
+    * store, a cloud analytics API and a search index have neither an endpoint nor a file, and no
+    * amount of either contract binds one. This one takes the names from the connector instead, so
+    * it fits whatever the connector declares. The two older kinds are untouched and keep their own
+    * contracts; this is where they are headed, not something they now go through.</p>
+    *
+    * <p>THREE CHECKS, and each exists because the failure it catches is invisible. A name the
+    * connector does not declare would be dropped, and the query would run without whatever it was
+    * meant to say. A value the bean refuses would leave the connector's default in place, because
+    * {@code PropertyMeta.setValue} reports a failed invocation with {@code LOG.error} and returns
+    * normally. And a parameter that does not apply to the rest of what was sent is stored and never
+    * read — an offset written under link-following pagination changes nothing, and the answer comes
+    * back looking like the first page of a correct result.</p>
+    *
+    * <p>THE THIRD IS A WARNING, NOT A REFUSAL. Applicability is decided by running the connector's
+    * own visibility methods, and those answer for the form, which is a narrower question than
+    * whether the runner reads the property. A connector is free to read something its form hides.
+    * Refusing on that basis would block correct requests, so the request proceeds and the finding
+    * is logged.</p>
+    *
+    * @return a description of the parameters that were set.
+    */
+   private String applyQueryContract(TabularQuery query,
+                                     Map<String, PropertyMeta> pmap,
+                                     WorksheetTable.TabularSource src)
+   {
+      Map<String, Object> requested = src.getQueryParams();
+
+      if(requested == null || requested.isEmpty()) {
+         throw new IllegalArgumentException(
+            "tabularSource.queryParams is required for targetKind \"" + TARGET_KIND_QUERY +
+            "\" — it is the whole of what addresses the data. Ask " +
+            "GET /api/wiz/tabular/query-schema for the names this data source accepts.");
+      }
+
+      rejectForeignFields(src);
+
+      List<String> applied = new ArrayList<>();
+
+      for(Map.Entry<String, Object> entry : requested.entrySet()) {
+         String name = entry.getKey();
+         PropertyMeta prop = pmap.get(name);
+
+         if(prop == null) {
+            // Named rather than counted, and answered with the alternatives: the caller is working
+            // from a schema, and the useful reply to a name that is not in it is the set that is.
+            throw new IllegalArgumentException(
+               "'" + name + "' is not a parameter of data source '" + src.getDatasourcePath() +
+               "'. It accepts: " + String.join(", ", new TreeSet<>(pmap.keySet())) + ".");
+         }
+
+         Object value = coerce(prop, name, entry.getValue());
+         prop.setValue(query, value);
+
+         // setValue swallows a failed invocation, so the write is confirmed by reading it back
+         // rather than assumed. A setter that normalizes — trimming, or resolving an alias — is
+         // expected and allowed; what is not is the value never arriving at all.
+         Object stored = prop.getValue(query);
+
+         if(value != null && stored == null) {
+            throw new IllegalArgumentException(
+               "Setting '" + name + "' to " + describe(entry.getValue()) + " did not take effect " +
+               "on data source '" + src.getDatasourcePath() + "'. The server log for this request " +
+               "carries the reason.");
+         }
+
+         applied.add(name + "=" + describe(stored));
+      }
+
+      warnInapplicable(query, requested.keySet(), src);
+
+      return String.join(", ", applied);
+   }
+
+   /**
+    * Refuse the older kinds' fields on a query-kind request.
+    *
+    * <p>They address the same properties by other names, so accepting both would let one request
+    * carry two answers for one parameter and silently keep whichever ran last. Refused rather than
+    * merged, in the same spirit as the endpoint/file contracts refusing each other's fields.
+    */
+   private void rejectForeignFields(WorksheetTable.TabularSource src) {
+      if(src.getParameters() != null && !src.getParameters().isEmpty()) {
+         throw new IllegalArgumentException(
+            "tabularSource.parameters applies to targetKind \"" + TARGET_KIND_ENDPOINT +
+            "\" only — for \"" + TARGET_KIND_QUERY + "\", put every value in queryParams.");
+      }
+
+      if(src.getParams() != null && !src.getParams().isEmpty()) {
+         throw new IllegalArgumentException(
+            "tabularSource.params applies to targetKind \"" + TARGET_KIND_FILE +
+            "\" only — for \"" + TARGET_KIND_QUERY + "\", put every value in queryParams.");
+      }
+   }
+
+   /**
+    * Log the parameters that were set but do not apply to the rest of the request.
+    *
+    * <p>Kept out of the response deliberately. {@code WorksheetTableResponse} reports success and a
+    * column list, and a table that built correctly must not come back looking like it failed; the
+    * caller that wants to know beforehand asks the schema, whose dependency matrix says which
+    * parameters each choice turns on.</p>
+    */
+   private void warnInapplicable(TabularQuery query, Set<String> names,
+                                 WorksheetTable.TabularSource src)
+   {
+      Set<String> inapplicable = new TabularSchemaExtractor().findInapplicable(query, names);
+
+      if(!inapplicable.isEmpty()) {
+         LOG.warn("Tabular query on '{}' was given parameters that do not apply to the rest of " +
+                     "the request and will not be read: {}. See the dependency matrix in " +
+                     "GET /api/wiz/tabular/query-schema for what each choice turns on.",
+                  src.getDatasourcePath(), String.join(", ", inapplicable));
+      }
+   }
+
+   /**
+    * Convert a JSON value to what the bean property takes.
+    *
+    * <p>WHY THIS IS NEEDED AT ALL: {@code PropertyMeta.setValue} converts a string to an enum and
+    * fills a primitive for null, but does nothing for the case that actually arrives here — JSON
+    * carries {@code 100} as an {@code Integer} and {@code "100"} as a {@code String}, and a
+    * property that takes {@code int} accepts neither reliably. Handed the wrong one, the reflective
+    * invocation fails, {@code setValue} logs it, and the connector's default survives into a query
+    * that reports success.</p>
+    *
+    * <p>Only scalars are converted. A composite parameter — a list of HTTP headers, a set of column
+    * definitions — is refused by name rather than half-built from a map, because a partially
+    * populated composite is exactly the silent wrong answer this contract exists to prevent.</p>
+    */
+   private Object coerce(PropertyMeta prop, String name, Object value) {
+      Class<?> type = prop.getDescriptor().getPropertyType();
+
+      if(value == null || type == null || type.isInstance(value)) {
+         return value;
+      }
+
+      // left to setValue, which resolves the constant and reports an unknown one
+      if(type.isEnum() || type == String.class) {
+         return value;
+      }
+
+      String text = String.valueOf(value).trim();
+
+      try {
+         if(type == boolean.class || type == Boolean.class) {
+            if(value instanceof Boolean) {
+               return value;
+            }
+
+            // Boolean.parseBoolean would read "yes" and "1" as false, quietly turning a flag the
+            // caller meant to set into one it did not.
+            if("true".equalsIgnoreCase(text) || "false".equalsIgnoreCase(text)) {
+               return Boolean.valueOf(text);
+            }
+
+            throw new NumberFormatException(text);
+         }
+
+         if(type == int.class || type == Integer.class) {
+            return value instanceof Number ? ((Number) value).intValue() : Integer.valueOf(text);
+         }
+
+         if(type == long.class || type == Long.class) {
+            return value instanceof Number ? ((Number) value).longValue() : Long.valueOf(text);
+         }
+
+         if(type == short.class || type == Short.class) {
+            return value instanceof Number ? ((Number) value).shortValue() : Short.valueOf(text);
+         }
+
+         if(type == byte.class || type == Byte.class) {
+            return value instanceof Number ? ((Number) value).byteValue() : Byte.valueOf(text);
+         }
+
+         if(type == double.class || type == Double.class) {
+            return value instanceof Number ? ((Number) value).doubleValue() : Double.valueOf(text);
+         }
+
+         if(type == float.class || type == Float.class) {
+            return value instanceof Number ? ((Number) value).floatValue() : Float.valueOf(text);
+         }
+      }
+      catch(NumberFormatException ex) {
+         throw new IllegalArgumentException(
+            "'" + name + "' takes " + type.getSimpleName() + ", and " + describe(value) +
+            " is not one.");
+      }
+
+      throw new IllegalArgumentException(
+         "'" + name + "' takes " + type.getSimpleName() + ", which this contract cannot build from " +
+         "a JSON value. Composite parameters are set through the connector's own editor, not here.");
+   }
+
+   /** A value as it should appear in a message: quoted if text, bare otherwise, and never null. */
+   private String describe(Object value) {
+      if(value == null) {
+         return "null";
+      }
+
+      return value instanceof String ? "'" + value + "'" : String.valueOf(value);
    }
 
    /**
@@ -3578,6 +3813,11 @@ public class WorksheetTableService {
    private static final String TARGET_KIND_ENDPOINT = "endpoint";
    /** {@code tabularSource.targetKind} for a path-addressed connector's file. */
    private static final String TARGET_KIND_FILE = "file";
+   /**
+    * {@code tabularSource.targetKind} for any connector, addressed through its own declared
+    * parameters rather than through a target the two older kinds recognize.
+    */
+   private static final String TARGET_KIND_QUERY = "query";
    /** ServerFile's name for the property that carries the file; preferred when a connector has it. */
    private static final String FILE_TARGET_PROPERTY = "fileFolder";
    /** The property a workbook's sheet is selected through. */

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -1686,11 +1686,12 @@ public class WorksheetTableService {
     *
     * <p>THREE CHECKS, and each exists because the failure it catches is invisible. A name the
     * connector does not declare would be dropped, and the query would run without whatever it was
-    * meant to say. A value the bean refuses would leave the connector's default in place, because
-    * {@code PropertyMeta.setValue} reports a failed invocation with {@code LOG.error} and returns
-    * normally. And a parameter that does not apply to the rest of what was sent is stored and never
-    * read — an offset written under link-following pagination changes nothing, and the answer comes
-    * back looking like the first page of a correct result.</p>
+    * meant to say. A value the bean refuses would leave the connector's DEFAULT in place — not
+    * null, the previous value — because {@code PropertyMeta.setValue} reports a failed invocation
+    * with {@code LOG.error} and returns normally; that is why the setter is invoked directly here
+    * instead, so the failure is one. And a parameter that does not apply to the rest of what was
+    * sent is stored and never read — an offset written under link-following pagination changes
+    * nothing, and the answer comes back looking like the first page of a correct result.</p>
     *
     * <p>THE THIRD IS A WARNING, NOT A REFUSAL. Applicability is decided by running the connector's
     * own visibility methods, and those answer for the form, which is a narrower question than
@@ -1703,6 +1704,7 @@ public class WorksheetTableService {
    private String applyQueryContract(TabularQuery query,
                                      Map<String, PropertyMeta> pmap,
                                      WorksheetTable.TabularSource src)
+      throws Exception
    {
       Map<String, Object> requested = src.getQueryParams();
 
@@ -1729,22 +1731,16 @@ public class WorksheetTableService {
                "'. It accepts: " + String.join(", ", new TreeSet<>(pmap.keySet())) + ".");
          }
 
-         Object value = coerce(prop, name, entry.getValue());
-         prop.setValue(query, value);
+         // NOT PropertyMeta.setValue. That swallows a failed invocation with LOG.error and
+         // returns, leaving the PREVIOUS value in place -- so a rejected value is indistinguishable
+         // from an accepted one for any property with a non-null default, which is most of them.
+         // Reading the property back afterwards does not close that gap either: the old value comes
+         // back non-null and looks like a successful write. Invoking the setter directly is what
+         // makes a failure a failure, and it is what the file contract above does for the same
+         // reason.
+         invokeWriteMethod(prop, query, coerceParam(prop, name, text(entry.getValue()), "Parameter"));
 
-         // setValue swallows a failed invocation, so the write is confirmed by reading it back
-         // rather than assumed. A setter that normalizes — trimming, or resolving an alias — is
-         // expected and allowed; what is not is the value never arriving at all.
-         Object stored = prop.getValue(query);
-
-         if(value != null && stored == null) {
-            throw new IllegalArgumentException(
-               "Setting '" + name + "' to " + describe(entry.getValue()) + " did not take effect " +
-               "on data source '" + src.getDatasourcePath() + "'. The server log for this request " +
-               "carries the reason.");
-         }
-
-         applied.add(name + "=" + describe(stored));
+         applied.add(name + "=" + describe(prop, prop.getValue(query)));
       }
 
       warnInapplicable(query, requested.keySet(), src);
@@ -1771,6 +1767,24 @@ public class WorksheetTableService {
             "tabularSource.params applies to targetKind \"" + TARGET_KIND_FILE +
             "\" only — for \"" + TARGET_KIND_QUERY + "\", put every value in queryParams.");
       }
+
+      // These three are endpoint-kind shorthands for properties this contract addresses by their
+      // own names. Only applyEndpointContract reads them, so on a query request they would be
+      // accepted and then ignored -- and if the caller ALSO named them in queryParams, one request
+      // would carry two answers for one property with no way to tell which won.
+      if(src.getJsonPath() != null || src.getExpanded() != null || src.getExpandedPath() != null) {
+         throw new IllegalArgumentException(
+            "tabularSource.jsonPath/expanded/expandedPath apply to targetKind \"" +
+            TARGET_KIND_ENDPOINT + "\" only — for \"" + TARGET_KIND_QUERY +
+            "\", set those properties by name in queryParams.");
+      }
+
+      // Nothing on this path reads it, so a target here names something that will not be used.
+      if(src.getTarget() != null && !src.getTarget().isBlank()) {
+         throw new IllegalArgumentException(
+            "tabularSource.target does not apply to targetKind \"" + TARGET_KIND_QUERY +
+            "\" — queryParams is what addresses the data.");
+      }
    }
 
    /**
@@ -1795,85 +1809,39 @@ public class WorksheetTableService {
    }
 
    /**
-    * Convert a JSON value to what the bean property takes.
+    * A JSON value as the text {@link #coerceParam} converts.
     *
-    * <p>WHY THIS IS NEEDED AT ALL: {@code PropertyMeta.setValue} converts a string to an enum and
-    * fills a primitive for null, but does nothing for the case that actually arrives here — JSON
-    * carries {@code 100} as an {@code Integer} and {@code "100"} as a {@code String}, and a
-    * property that takes {@code int} accepts neither reliably. Handed the wrong one, the reflective
-    * invocation fails, {@code setValue} logs it, and the connector's default survives into a query
-    * that reports success.</p>
+    * <p>Jackson hands back an {@code Integer} for {@code 100} and a {@code String} for
+    * {@code "100"}, and the property behind either may be an {@code int}, an enum or a string. Going
+    * through text is what lets one conversion serve all of those, and it is the conversion the file
+    * contract already uses; the alternative is a second one that has to agree with it forever.</p>
     *
-    * <p>Only scalars are converted. A composite parameter — a list of HTTP headers, a set of column
-    * definitions — is refused by name rather than half-built from a map, because a partially
-    * populated composite is exactly the silent wrong answer this contract exists to prevent.</p>
+    * <p>A composite arrives as a list or a map and is passed through as its own text, which
+    * {@code coerceParam} then refuses by name. That is deliberate: a composite half-built from a
+    * map is exactly the silent wrong answer this contract exists to prevent, so it is refused
+    * rather than approximated.</p>
     */
-   private Object coerce(PropertyMeta prop, String name, Object value) {
-      Class<?> type = prop.getDescriptor().getPropertyType();
-
-      if(value == null || type == null || type.isInstance(value)) {
-         return value;
-      }
-
-      // left to setValue, which resolves the constant and reports an unknown one
-      if(type.isEnum() || type == String.class) {
-         return value;
-      }
-
-      String text = String.valueOf(value).trim();
-
-      try {
-         if(type == boolean.class || type == Boolean.class) {
-            if(value instanceof Boolean) {
-               return value;
-            }
-
-            // Boolean.parseBoolean would read "yes" and "1" as false, quietly turning a flag the
-            // caller meant to set into one it did not.
-            if("true".equalsIgnoreCase(text) || "false".equalsIgnoreCase(text)) {
-               return Boolean.valueOf(text);
-            }
-
-            throw new NumberFormatException(text);
-         }
-
-         if(type == int.class || type == Integer.class) {
-            return value instanceof Number ? ((Number) value).intValue() : Integer.valueOf(text);
-         }
-
-         if(type == long.class || type == Long.class) {
-            return value instanceof Number ? ((Number) value).longValue() : Long.valueOf(text);
-         }
-
-         if(type == short.class || type == Short.class) {
-            return value instanceof Number ? ((Number) value).shortValue() : Short.valueOf(text);
-         }
-
-         if(type == byte.class || type == Byte.class) {
-            return value instanceof Number ? ((Number) value).byteValue() : Byte.valueOf(text);
-         }
-
-         if(type == double.class || type == Double.class) {
-            return value instanceof Number ? ((Number) value).doubleValue() : Double.valueOf(text);
-         }
-
-         if(type == float.class || type == Float.class) {
-            return value instanceof Number ? ((Number) value).floatValue() : Float.valueOf(text);
-         }
-      }
-      catch(NumberFormatException ex) {
-         throw new IllegalArgumentException(
-            "'" + name + "' takes " + type.getSimpleName() + ", and " + describe(value) +
-            " is not one.");
-      }
-
-      throw new IllegalArgumentException(
-         "'" + name + "' takes " + type.getSimpleName() + ", which this contract cannot build from " +
-         "a JSON value. Composite parameters are set through the connector's own editor, not here.");
+   private static String text(Object value) {
+      return value == null ? null : String.valueOf(value);
    }
 
-   /** A value as it should appear in a message: quoted if text, bare otherwise, and never null. */
-   private String describe(Object value) {
+   /**
+    * A value as it should appear in a message — and never a secret.
+    *
+    * <p>What is built here is joined into {@code probeDesc}, which is embedded verbatim in the
+    * exception thrown when a query returns no columns. Zero columns is an ordinary failure — wrong
+    * filter, expired credential — and {@code WizControllerErrorHandler} turns the exception into a
+    * response, so a connector declaring an API key as a query parameter would have it printed to
+    * the caller and into the log. The two sibling contracts cannot leak this way because neither
+    * returns raw property values: the endpoint one returns a URL suffix and the file one a path.</p>
+    */
+   private static String describe(PropertyMeta prop, Object value) {
+      if(prop != null && prop.getProperty() != null && prop.getProperty().password()) {
+         // Reported as set rather than omitted: whether a secret was supplied at all is exactly
+         // what someone reading this message needs to know.
+         return value == null ? "null" : "***";
+      }
+
       if(value == null) {
          return "null";
       }
@@ -2130,12 +2098,24 @@ public class WorksheetTableService {
     * write for "one" or "yes".</p>
     */
    private static Object coerceParam(PropertyMeta prop, String name, String raw) {
+      return coerceParam(prop, name, raw, "Parsing option");
+   }
+
+   /**
+    * The same conversion for a caller that is not supplying parsing options.
+    *
+    * <p>Only the noun in the messages differs. The query contract sends a whole query rather than a
+    * file's parsing options, so "Parsing option 'suffix'" would name the wrong thing; which
+    * conversions are legal is identical, and duplicating the method to change one word is how the
+    * two would drift apart.</p>
+    */
+   private static Object coerceParam(PropertyMeta prop, String name, String raw, String noun) {
       Class<?> type = prop.getDescriptor().getWriteMethod().getParameterTypes()[0];
 
       if(raw == null) {
          if(type.isPrimitive()) {
             throw new IllegalArgumentException(
-               "Parsing option '" + name + "' has no value, and it cannot be cleared: it is a " +
+               noun + " '" + name + "' has no value, and it cannot be cleared: it is a " +
                type.getSimpleName() + ".");
          }
 
@@ -2183,14 +2163,19 @@ public class WorksheetTableService {
          }
       }
       catch(IllegalArgumentException ex) {
+         // Enum.valueOf throws this for a constant that does not exist, and it is worth naming the
+         // ones that do: a caller working from the schema has the list, and one that guessed does
+         // not.
+         String expected = type.isEnum()
+            ? "one of " + Arrays.toString(type.getEnumConstants()) : "a " + type.getSimpleName();
+
          throw new IllegalArgumentException(
-            "Parsing option '" + name + "' expects a " + type.getSimpleName() + ", got \"" + raw +
-            "\".");
+            noun + " '" + name + "' expects " + expected + ", got \"" + raw + "\".");
       }
 
       throw new IllegalArgumentException(
-         "Parsing option '" + name + "' is a " + type.getSimpleName() +
-         ", which cannot be supplied as text in tabularSource.params.");
+         noun + " '" + name + "' is a " + type.getSimpleName() +
+         ", which cannot be supplied as text.");
    }
 
    /**
@@ -2345,8 +2330,14 @@ public class WorksheetTableService {
       catch(InvocationTargetException ex) {
          Throwable cause = ex.getCause() == null ? ex : ex.getCause();
 
+         // The value is redacted when the property is a secret. This message reaches the caller
+         // through WizControllerErrorHandler, and a setter that rejects a password would otherwise
+         // print it on the way out.
+         String shown = prop.getProperty() != null && prop.getProperty().password()
+            ? "***" : String.valueOf(value);
+
          throw new IllegalArgumentException(
-            "Setting '" + prop.getName() + "' to \"" + value + "\" failed: " +
+            "Setting '" + prop.getName() + "' to \"" + shown + "\" failed: " +
             (cause.getMessage() == null ? cause.getClass().getSimpleName() : cause.getMessage()),
             cause);
       }

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -1531,10 +1531,7 @@ public class WorksheetTableService {
       if(src.getMaxRows() != null && src.getMaxRows() > 0) {
          query.setMaxRows(src.getMaxRows());
       }
-      // Endpoints only. A local file is read whole in one pass — there are no pages to walk and no
-      // per-call bill — so demanding a row cap there would refuse a correct request for a cost that
-      // does not exist.
-      else if(TARGET_KIND_ENDPOINT.equals(targetKind)) {
+      else if(rowCapRequiredFor(targetKind)) {
          TabularEndpointBindingSupport.requireRowCapWhenPaged(query, src.getTarget(), dsName);
       }
 
@@ -2341,6 +2338,27 @@ public class WorksheetTableService {
             (cause.getMessage() == null ? cause.getClass().getSimpleName() : cause.getMessage()),
             cause);
       }
+   }
+
+   /**
+   /**
+    * Whether a target kind has to justify building a table with no row cap.
+    *
+    * <p>Everything but a file. A local file is read whole in one pass — no pages to walk, no
+    * per-call bill — so demanding a cap there would refuse a correct request for a cost that does
+    * not exist. Every other kind can paginate, the query kind included: it addresses any connector
+    * at all, and pagination is set through a property like any other, reaching
+    * {@code paginationSpec} directly without passing through the endpoint machinery. A paginated
+    * query built without a cap pages to exhaustion on every render, which is the bill
+    * {@link TabularEndpointBindingSupport#requireRowCapWhenPaged} refuses to run up.</p>
+    *
+    * <p>Written as an exemption rather than a list on purpose. A kind added later is covered unless
+    * someone deliberately excuses it, and the two mistakes are not the same size: a wrong exemption
+    * is a metered API walked to the end on every render, a wrong inclusion is one clear message
+    * asking for a number.</p>
+    */
+   static boolean rowCapRequiredFor(String targetKind) {
+      return !TARGET_KIND_FILE.equals(targetKind);
    }
 
    /**

--- a/core/src/test/java/inetsoft/uql/tabular/TabularSchemaExtractorTest.java
+++ b/core/src/test/java/inetsoft/uql/tabular/TabularSchemaExtractorTest.java
@@ -1,0 +1,335 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.tabular;
+
+import inetsoft.uql.util.Config;
+import inetsoft.util.ConfigurationContext;
+import org.junit.jupiter.api.*;
+import org.springframework.context.ApplicationContext;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Behaviour of {@link TabularSchemaExtractor}, against a fixture connector rather than a real one.
+ *
+ * <p>A fixture is used deliberately. Every real tabular query class lives in a connector plugin and
+ * is not on core's classpath, so testing against one would mean testing whatever connector happened
+ * to be built — and the cases worth pinning here are structural, not connector-specific: a gate on
+ * one value, a gate needing two, and a setter whose side effects make it look like a gate when it
+ * is not. The fixture states each of those in a few lines, where finding a real connector that
+ * exhibits all three would not.</p>
+ */
+@Tag("core")
+class TabularSchemaExtractorTest {
+   /**
+    * {@code LayoutCreator} resolves labels through the connector's resource bundle, which it reaches
+    * via {@code Config.getConfig()} — a Spring bean. There is no context in a plain unit test, so a
+    * stub is installed that answers no bundle; the raw {@code @Property} label is then used, which
+    * is what these assertions are about anyway.
+    */
+   @BeforeAll
+   static void installContext() {
+      previous = ConfigurationContext.getContext();
+      Config config = mock(Config.class);
+      when(config.getResourceBundle(org.mockito.ArgumentMatchers.any())).thenReturn(null);
+
+      ApplicationContext context = mock(ApplicationContext.class);
+      when(context.getBean(Config.class)).thenReturn(config);
+      ConfigurationContext.getContext().setApplicationContext(context);
+   }
+
+   @AfterAll
+   static void clearContext() {
+      if(previous != null) {
+         previous.setApplicationContext(null);
+      }
+   }
+
+   @Test
+   void everyAnnotatedPropertyIsReported() {
+      TabularQuerySchema schema = extract();
+      Set<String> names = new HashSet<>();
+      schema.getParams().forEach(p -> names.add(p.getName()));
+
+      assertTrue(names.containsAll(Set.of("mode", "pageSize", "cursorField", "linkField",
+                                          "linkStyle", "relation", "detailed", "note", "hidden")),
+                 "expected every @Property to be reported, got " + names);
+   }
+
+   /**
+    * A property the {@code @View} annotation never mentions is still settable, so leaving it out of
+    * the contract would describe the query as narrower than it is.
+    */
+   @Test
+   void aPropertyOutsideTheViewIsStillReported() {
+      TabularQuerySchema schema = extract();
+
+      assertNotNull(schema.getParam("hidden"), "a @Property outside @View is still settable");
+      assertTrue(schema.getUnreferencedParams().contains("hidden"),
+                 "it should be marked as one the layout does not place");
+   }
+
+   @Test
+   void theLabelIsTheDescription() {
+      assertEquals("Page Size", extract().getParam("pageSize").getLabel());
+   }
+
+   /**
+    * A LABEL element carries the format example, and it is attached to the field it follows — which
+    * is where it renders and what it is written to explain. Reflection over {@code @Property} alone
+    * never sees it.
+    */
+   @Test
+   void aLabelElementBecomesAHintOnTheFieldItFollows() {
+      assertEquals(List.of("Example: id,name"), extract().getParam("cursorField").getHints());
+   }
+
+   @Test
+   void theJavaTypeIsReportedRatherThanTheEditorType() {
+      assertEquals("int", extract().getParam("pageSize").getJavaType());
+      assertEquals(Mode.class.getName(), extract().getParam("mode").getJavaType());
+   }
+
+   @Test
+   void aGateOnOneValueIsFound() {
+      Map<String, List<String>> byMode = extract().getDependencyMatrix().get("mode");
+
+      assertNotNull(byMode, "mode gates other parameters, so it should be an axis");
+      assertEquals(List.of("cursorField"), byMode.get("CURSOR"));
+      assertEquals(List.of("linkField", "linkStyle"), byMode.get("LINK"));
+      assertEquals(List.of(), byMode.get("NONE"));
+   }
+
+   /**
+    * A parameter visible under every value of an axis is visible for reasons of its own. Saying it
+    * depends on the axis would be wrong, and it would bury the ones that do.
+    */
+   @Test
+   void aParameterVisibleUnderEveryValueIsNotReportedAsGated() {
+      extract().getDependencyMatrix().getOrDefault("mode", Map.of()).forEach(
+         (value, names) -> assertFalse(names.contains("pageSize"),
+                                       "pageSize applies to every mode and is not gated on " + value));
+   }
+
+   /**
+    * The case a single-value sweep cannot reach: {@code relation} needs LINK mode AND a HEADER link
+    * style. The second parameter is itself only relevant under the first, which is the shape the
+    * pair pass looks for.
+    */
+   @Test
+   void aGateNeedingTwoValuesIsFound() {
+      Map<String, List<String>> pair =
+         extract().getDependencyMatrix().get("mode & linkStyle");
+
+      assertNotNull(pair, "a gate needing two values should be reported under the pair");
+      assertEquals(List.of("relation"), pair.get("mode=LINK & linkStyle=HEADER"));
+   }
+
+   /**
+    * {@code detailed}'s setter grows the list its own panel's visibility is computed from, so
+    * probing it reports the panel turning on and reads as though it gated {@code note}. It does not
+    * — the real gate is elsewhere — so the axis is dropped rather than described wrongly.
+    */
+   @Test
+   void anAxisThatTurnsItselfOnIsNotReportedAsAGate() {
+      assertNull(extract().getDependencyMatrix().get("detailed"),
+                 "a parameter whose setter is what makes it visible is not a gate");
+   }
+
+   @Test
+   void aParameterThatDoesNotApplyIsNamed() {
+      FixtureQuery query = new FixtureQuery();
+      query.setMode(Mode.LINK);
+
+      assertEquals(Set.of("cursorField"),
+                   new TabularSchemaExtractor().findInapplicable(
+                      query, List.of("pageSize", "linkField", "cursorField")));
+   }
+
+   @Test
+   void anApplicableParameterIsNotNamed() {
+      FixtureQuery query = new FixtureQuery();
+      query.setMode(Mode.CURSOR);
+
+      assertTrue(new TabularSchemaExtractor().findInapplicable(
+         query, List.of("pageSize", "cursorField")).isEmpty());
+   }
+
+   /**
+    * A name the layout never places has no condition to evaluate, so there is no ground to call it
+    * inapplicable — that question belongs to the schema, which says whether it exists at all.
+    */
+   @Test
+   void aParameterOutsideTheLayoutIsNotCalledInapplicable() {
+      assertTrue(new TabularSchemaExtractor().findInapplicable(
+         new FixtureQuery(), List.of("hidden")).isEmpty());
+   }
+
+   private TabularQuerySchema extract() {
+      return new TabularSchemaExtractor().extract(new FixtureQuery(), FixtureQuery.TYPE);
+   }
+
+   private static ConfigurationContext previous;
+
+   public enum Mode { NONE, CURSOR, LINK }
+
+   public enum LinkStyle { BODY, HEADER }
+
+   /**
+    * A connector reduced to the structures under test.
+    */
+   @View(vertical = true, value = {
+      @View1(vertical = true, type = ViewType.PANEL, elements = {
+         @View2("mode"),
+         @View2("pageSize"),
+         @View2(value = "cursorField", visibleMethod = "isCursorMode"),
+         @View2(type = ViewType.LABEL, text = "Example: id,name"),
+         @View2(value = "linkField", visibleMethod = "isLinkMode"),
+         @View2(value = "linkStyle", visibleMethod = "isLinkMode"),
+         @View2(value = "relation", visibleMethod = "isHeaderLink"),
+      }),
+      @View1(value = "detailed"),
+      @View1(vertical = true, type = ViewType.PANEL, visibleMethod = "isDetailVisible", elements = {
+         @View2("note"),
+      }),
+   })
+   public static class FixtureQuery extends TabularQuery {
+      public FixtureQuery() {
+         super(TYPE);
+      }
+
+      @Property(label = "Mode")
+      @PropertyEditor(tags = { "NONE", "CURSOR", "LINK" })
+      public Mode getMode() {
+         return mode;
+      }
+
+      public void setMode(Mode mode) {
+         this.mode = mode;
+      }
+
+      @Property(label = "Page Size")
+      public int getPageSize() {
+         return pageSize;
+      }
+
+      public void setPageSize(int pageSize) {
+         this.pageSize = pageSize;
+      }
+
+      @Property(label = "Cursor Field")
+      public String getCursorField() {
+         return cursorField;
+      }
+
+      public void setCursorField(String cursorField) {
+         this.cursorField = cursorField;
+      }
+
+      @Property(label = "Link Field")
+      public String getLinkField() {
+         return linkField;
+      }
+
+      public void setLinkField(String linkField) {
+         this.linkField = linkField;
+      }
+
+      @Property(label = "Link Style")
+      @PropertyEditor(tags = { "BODY", "HEADER" })
+      public LinkStyle getLinkStyle() {
+         return linkStyle;
+      }
+
+      public void setLinkStyle(LinkStyle linkStyle) {
+         this.linkStyle = linkStyle;
+      }
+
+      @Property(label = "Relation")
+      public String getRelation() {
+         return relation;
+      }
+
+      public void setRelation(String relation) {
+         this.relation = relation;
+      }
+
+      /** Its setter is what makes its own panel appear -- see the test that pins this. */
+      @Property(label = "Detailed")
+      public boolean isDetailed() {
+         return detailed;
+      }
+
+      public void setDetailed(boolean detailed) {
+         this.detailed = detailed;
+         this.notes.add("note");
+      }
+
+      @Property(label = "Note")
+      public String getNote() {
+         return note;
+      }
+
+      public void setNote(String note) {
+         this.note = note;
+      }
+
+      /** Annotated but never placed by {@code @View}. */
+      @Property(label = "Hidden")
+      public String getHidden() {
+         return hidden;
+      }
+
+      public void setHidden(String hidden) {
+         this.hidden = hidden;
+      }
+
+      public boolean isCursorMode() {
+         return mode == Mode.CURSOR;
+      }
+
+      public boolean isLinkMode() {
+         return mode == Mode.LINK;
+      }
+
+      public boolean isHeaderLink() {
+         return isLinkMode() && linkStyle == LinkStyle.HEADER;
+      }
+
+      public boolean isDetailVisible() {
+         return !notes.isEmpty();
+      }
+
+      static final String TYPE = "Test.Fixture";
+
+      private Mode mode = Mode.NONE;
+      private int pageSize = 100;
+      private String cursorField;
+      private String linkField;
+      private LinkStyle linkStyle = LinkStyle.BODY;
+      private String relation;
+      private boolean detailed;
+      private String note;
+      private String hidden;
+      private final List<String> notes = new ArrayList<>();
+   }
+}

--- a/core/src/test/java/inetsoft/uql/tabular/TabularSchemaExtractorTest.java
+++ b/core/src/test/java/inetsoft/uql/tabular/TabularSchemaExtractorTest.java
@@ -71,7 +71,8 @@ class TabularSchemaExtractorTest {
       schema.getParams().forEach(p -> names.add(p.getName()));
 
       assertTrue(names.containsAll(Set.of("mode", "pageSize", "cursorField", "linkField",
-                                          "linkStyle", "relation", "detailed", "note", "hidden")),
+                                          "linkStyle", "relation", "scoped", "scope", "scopeName",
+                                          "detailed", "note", "hidden")),
                  "expected every @Property to be reported, got " + names);
    }
 
@@ -155,6 +156,21 @@ class TabularSchemaExtractorTest {
                  "a parameter whose setter is what makes it visible is not a gate");
    }
 
+   /**
+    * The outer half of a pair can be a boolean, and the matrix is keyed by the value's TEXT because
+    * it is published as JSON. Re-probing from that text has to recover the value itself: handed
+    * "true", a boolean setter's reflective invocation fails, {@code PropertyMeta.setValue} swallows
+    * it, and the probe would run with the outer axis still false — finding nothing, and looking
+    * exactly like there was nothing to find.
+    */
+   @Test
+   void aGateNeedingTwoValuesIsFoundWhenTheOuterOneIsABoolean() {
+      Map<String, List<String>> pair = extract().getDependencyMatrix().get("scoped & scope");
+
+      assertNotNull(pair, "scopeName is gated on scoped=true AND scope=NAMED");
+      assertEquals(List.of("scopeName"), pair.get("scoped=true & scope=NAMED"));
+   }
+
    @Test
    void aParameterThatDoesNotApplyIsNamed() {
       FixtureQuery query = new FixtureQuery();
@@ -194,6 +210,8 @@ class TabularSchemaExtractorTest {
 
    public enum LinkStyle { BODY, HEADER }
 
+   public enum Scope { ALL, NAMED }
+
    /**
     * A connector reduced to the structures under test.
     */
@@ -206,7 +224,10 @@ class TabularSchemaExtractorTest {
          @View2(value = "linkField", visibleMethod = "isLinkMode"),
          @View2(value = "linkStyle", visibleMethod = "isLinkMode"),
          @View2(value = "relation", visibleMethod = "isHeaderLink"),
+         @View2(value = "scope", visibleMethod = "isScoped"),
+         @View2(value = "scopeName", visibleMethod = "isNamedScope"),
       }),
+      @View1(value = "scoped"),
       @View1(value = "detailed"),
       @View1(vertical = true, type = ViewType.PANEL, visibleMethod = "isDetailVisible", elements = {
          @View2("note"),
@@ -273,6 +294,34 @@ class TabularSchemaExtractorTest {
          this.relation = relation;
       }
 
+      @Property(label = "Scoped")
+      public boolean isScoped() {
+         return scoped;
+      }
+
+      public void setScoped(boolean scoped) {
+         this.scoped = scoped;
+      }
+
+      @Property(label = "Scope")
+      @PropertyEditor(tags = { "ALL", "NAMED" })
+      public Scope getScope() {
+         return scope;
+      }
+
+      public void setScope(Scope scope) {
+         this.scope = scope;
+      }
+
+      @Property(label = "Scope Name")
+      public String getScopeName() {
+         return scopeName;
+      }
+
+      public void setScopeName(String scopeName) {
+         this.scopeName = scopeName;
+      }
+
       /** Its setter is what makes its own panel appear -- see the test that pins this. */
       @Property(label = "Detailed")
       public boolean isDetailed() {
@@ -315,6 +364,10 @@ class TabularSchemaExtractorTest {
          return isLinkMode() && linkStyle == LinkStyle.HEADER;
       }
 
+      public boolean isNamedScope() {
+         return scoped && scope == Scope.NAMED;
+      }
+
       public boolean isDetailVisible() {
          return !notes.isEmpty();
       }
@@ -327,6 +380,9 @@ class TabularSchemaExtractorTest {
       private String linkField;
       private LinkStyle linkStyle = LinkStyle.BODY;
       private String relation;
+      private boolean scoped;
+      private Scope scope = Scope.ALL;
+      private String scopeName;
       private boolean detailed;
       private String note;
       private String hidden;

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizTabularControllerSecurityTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizTabularControllerSecurityTest.java
@@ -94,8 +94,30 @@ class WizTabularControllerSecurityTest {
                 "/api/wiz/tabular/browse",
                 "/api/wiz/tabular/probe/open",
                 "/api/wiz/tabular/probe/table",
-                "/api/wiz/tabular/probe/close"),
+                "/api/wiz/tabular/probe/close",
+                "/api/wiz/tabular/query-schema"),
          new HashSet<>(mappedPaths()));
+   }
+
+   /**
+    * The one endpoint here gated on READ rather than WRITE, and the gate has to be checked for the
+    * same reason the others are: it is an annotation, so no behavioural test in this package
+    * exercises it.
+    *
+    * <p>READ is the right level and the difference from {@code /tabular/definition} next to it is
+    * deliberate. That one returns the stored definition, credentials included, so it demands the
+    * permission that could already overwrite them. This returns the connector's SHAPE — parameter
+    * names, types, labels, which parameters apply when — and no value the user configured, so
+    * demanding WRITE would refuse a caller who may legitimately read the data source. Weakening it
+    * further, to no gate at all, would expose which data sources exist to anyone who can guess a
+    * path.</p>
+    */
+   @Test
+   void tabularQuerySchemaIsGatedOnReadWithAWiredPermissionPath() throws Exception {
+      Method method = WizTabularController.class.getDeclaredMethod(
+         "getQuerySchema", String.class, Principal.class);
+
+      assertGateOnPathParameter(method, ResourceAction.READ);
    }
 
    @Test
@@ -277,6 +299,15 @@ class WizTabularControllerSecurityTest {
     * looks correct in a diff, but {@code SecuredAspect} then has no resource to check.
     */
    private static void assertWriteGateOnPathParameter(Method method) {
+      assertGateOnPathParameter(method, ResourceAction.WRITE);
+   }
+
+   /**
+    * The same assertion for a handler gated on something other than WRITE. Which action is right is
+    * the handler's own question — see the test that calls this — but the wiring is not, and it is
+    * the wiring this catches.
+    */
+   private static void assertGateOnPathParameter(Method method, ResourceAction action) {
       Secured secured = method.getAnnotation(Secured.class);
       assertNotNull(secured, method.getName() + " must carry @Secured");
       assertEquals(1, secured.value().length,
@@ -285,10 +316,11 @@ class WizTabularControllerSecurityTest {
       RequiredPermission permission = secured.value()[0];
       assertEquals(ResourceType.DATA_SOURCE, permission.resourceType(),
                    method.getName() + " must be gated on the data source, not another resource");
-      assertArrayEquals(new ResourceAction[]{ ResourceAction.WRITE }, permission.actions(),
-                        method.getName() + " must require WRITE: a tabular definition carries the " +
-                           "connector's own credentials, which is the editor's business and not a " +
-                           "data reader's");
+      assertArrayEquals(new ResourceAction[]{ action }, permission.actions(),
+                        method.getName() + " must require " + action + ": a handler that returns " +
+                           "the connector's credentials is the editor's business and not a data " +
+                           "reader's, and one that returns only its shape must not demand the " +
+                           "permission that could overwrite it");
       assertEquals("", permission.resource(),
                    method.getName() + " must resolve its resource from the request path, not a " +
                       "fixed resource name");

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceKindFieldsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceKindFieldsTest.java
@@ -1,0 +1,173 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.web.wiz.model.WorksheetTable;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * A field belonging to one target kind, sent with another, is refused rather than ignored.
+ *
+ * <p>Every one of these fields is read on exactly one path. Sent with a different kind it is not
+ * rejected by anything downstream — it is simply never looked at, and the table builds and reports
+ * success having ignored whatever the caller put in it. A request half-migrated between kinds, or
+ * one that named the wrong kind, then looks exactly like a request that worked.
+ *
+ * <p>The rejections have to run in both directions to be worth anything, which is what these pin:
+ * an older kind's field on a query request, and the new {@code queryParams} on an older one.
+ */
+@Tag("core")
+class WorksheetTableServiceKindFieldsTest {
+   @Test
+   void aQueryRequestRefusesTheEndpointsParameterMap() {
+      WorksheetTable.TabularSource src = source();
+      src.setParameters(Map.of("since", "2024-01-01"));
+
+      assertMessage(assertThrows(IllegalArgumentException.class,
+                                 () -> service().rejectForeignFields(src)),
+                    "tabularSource.parameters");
+   }
+
+   @Test
+   void aQueryRequestRefusesTheFilesOptionBag() {
+      WorksheetTable.TabularSource src = source();
+      src.setParams(Map.of("delimiter", ","));
+
+      assertMessage(assertThrows(IllegalArgumentException.class,
+                                 () -> service().rejectForeignFields(src)),
+                    "tabularSource.params");
+   }
+
+   @Test
+   void aQueryRequestRefusesTheEndpointsResponseShapeFields() {
+      WorksheetTable.TabularSource src = source();
+      src.setJsonPath("$.data[*]");
+
+      assertMessage(assertThrows(IllegalArgumentException.class,
+                                 () -> service().rejectForeignFields(src)),
+                    "jsonPath");
+   }
+
+   /**
+    * A lookup level names an endpoint, which is the one thing this kind does not have — it is why a
+    * query request has no target either.
+    */
+   @Test
+   void aQueryRequestRefusesTheLookupChain() {
+      WorksheetTable.TabularSource src = source();
+      src.setLookup(List.of("Charge Refunds"));
+
+      assertMessage(assertThrows(IllegalArgumentException.class,
+                                 () -> service().rejectForeignFields(src)),
+                    "tabularSource.lookup");
+   }
+
+   /**
+    * The two flags only mean anything alongside a lookup chain, so they are refused on their own
+    * too: accepting one silently would drop the setting the caller actually cared about.
+    */
+   @Test
+   void aQueryRequestRefusesALookupFlagOnItsOwn() {
+      WorksheetTable.TabularSource src = source();
+      src.setLookupExpandArrays(Boolean.TRUE);
+
+      assertThrows(IllegalArgumentException.class, () -> service().rejectForeignFields(src));
+   }
+
+   @Test
+   void aQueryRequestRefusesATargetItWouldNotRead() {
+      WorksheetTable.TabularSource src = source();
+      src.setTarget("Charges");
+
+      assertMessage(assertThrows(IllegalArgumentException.class,
+                                 () -> service().rejectForeignFields(src)),
+                    "tabularSource.target");
+   }
+
+   @Test
+   void aQueryRequestCarryingOnlyItsOwnFieldsIsAccepted() {
+      assertDoesNotThrow(() -> service().rejectForeignFields(source()));
+   }
+
+   /**
+    * The other direction, and the one the new field points at: nothing on the endpoint or file path
+    * reads {@code queryParams}, so it would be dropped whole.
+    */
+   @Test
+   void anEndpointRequestRefusesQueryParams() {
+      WorksheetTable.TabularSource src = new WorksheetTable.TabularSource();
+      src.setQueryParams(Map.of("suffix", "/v1/charges"));
+
+      IllegalArgumentException ex = assertThrows(
+         IllegalArgumentException.class,
+         () -> service().rejectQueryParams(src, "endpoint", "tabularSource.parameters"));
+
+      assertMessage(ex, "tabularSource.queryParams");
+      assertMessage(ex, "tabularSource.parameters");
+   }
+
+   @Test
+   void aFileRequestRefusesQueryParams() {
+      WorksheetTable.TabularSource src = new WorksheetTable.TabularSource();
+      src.setQueryParams(Map.of("excelSheet", "Q1"));
+
+      assertMessage(assertThrows(
+                       IllegalArgumentException.class,
+                       () -> service().rejectQueryParams(src, "file", "tabularSource.params")),
+                    "tabularSource.params");
+   }
+
+   @Test
+   void anEmptyQueryParamsMapIsNotARequestToUseIt() {
+      WorksheetTable.TabularSource src = new WorksheetTable.TabularSource();
+      src.setQueryParams(Map.of());
+
+      assertDoesNotThrow(() -> service().rejectQueryParams(src, "endpoint", "tabularSource.parameters"));
+   }
+
+   /** A query-kind source carrying nothing but what its own contract reads. */
+   private static WorksheetTable.TabularSource source() {
+      WorksheetTable.TabularSource src = new WorksheetTable.TabularSource();
+      src.setDatasourcePath("SaaS/Example");
+      src.setTargetKind("query");
+      src.setQueryParams(Map.of("suffix", "/v1/charges"));
+
+      return src;
+   }
+
+   /**
+    * The message has to name the field, since it is the whole of what tells the caller which of the
+    * several things they sent has to move.
+    */
+   private static void assertMessage(Exception ex, String expected) {
+      assertTrue(ex.getMessage() != null && ex.getMessage().contains(expected),
+                 "expected the message to name '" + expected + "', got: " + ex.getMessage());
+   }
+
+   private static WorksheetTableService service() {
+      // Both rejections read only their arguments, never instance state, so null wiring is safe --
+      // the same shape WorksheetTableServiceShouldProbeTest uses.
+      return new WorksheetTableService(null, null, null, null, null, null, null, null, null);
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceRowCapTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceRowCapTest.java
@@ -1,0 +1,74 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Which target kinds have to justify a table built with no row cap.
+ *
+ * <p>The check exists because a paginated table with no cap requests pages until the service runs
+ * out of data, on every render — and {@code createTables} builds wiz analytics with an unlimited
+ * design row count, so "every render" is the normal case rather than the edge one.
+ *
+ * <p>It was reachable only for an endpoint, which was right while an endpoint was the only kind
+ * that could paginate. The query kind addresses any connector, and pagination there is set through
+ * a property like any other: {@code RestJsonQuery.setPaginationType} writes the pagination spec
+ * directly, and {@code AbstractRestQuery.isPaged()} reads that spec, so neither goes anywhere near
+ * the endpoint machinery. A query-kind request that set a pagination type and no cap would have
+ * been built uncapped and silently.
+ */
+@Tag("core")
+class WorksheetTableServiceRowCapTest {
+   @Test
+   void anEndpointHasToJustifyAnUncappedTable() {
+      assertTrue(WorksheetTableService.rowCapRequiredFor("endpoint"));
+   }
+
+   /**
+    * The gap this pins. A query-kind request can set a pagination type through its parameters, so
+    * it can page, so it has to answer the same question an endpoint does.
+    */
+   @Test
+   void aQueryHasToJustifyAnUncappedTable() {
+      assertTrue(WorksheetTableService.rowCapRequiredFor("query"));
+   }
+
+   /**
+    * A local file is read whole in one pass. There are no pages and no per-call bill, so demanding
+    * a cap would refuse a correct request for a cost that does not exist.
+    */
+   @Test
+   void aFileDoesNot() {
+      assertFalse(WorksheetTableService.rowCapRequiredFor("file"));
+   }
+
+   /**
+    * The exemption is a list of one, not a whitelist of the kinds that existed when it was written.
+    * A kind added later is covered until someone decides otherwise, which is the safe direction: a
+    * wrong exemption is a metered API walked to the end on every render, a wrong inclusion is one
+    * message asking for a number.
+    */
+   @Test
+   void aKindNobodyHasWrittenYetIsCoveredByDefault() {
+      assertTrue(WorksheetTableService.rowCapRequiredFor("some-future-kind"));
+   }
+}


### PR DESCRIPTION
## What

Two things a caller building a tabular table could not previously get:

1. **`GET /api/wiz/tabular/query-schema?path=X`** — what parameters a data source's query takes, what each means, and which of them apply when.
2. **`targetKind: "query"`** — a third `buildTabularTable` contract that addresses any connector through its own declared parameters.

`endpoint` and `file` are untouched and keep their own contracts. This is where they are headed, not something they now go through.

## Why

`buildTabularTable` knows two kinds of target, and both are short because both know in advance which properties matter. That is also why they reach two kinds of connector out of the many StyleBI ships: a document store, a cloud analytics API and a search index have neither an endpoint nor a file, and no amount of either contract binds one.

And nothing described a query's parameters at all. `@Property` has no documentation attribute; `/tabular/definition` describes the data source's form, not the query's; and `TabularView` — the one structure that does describe a query — is a form layout, two thirds row/column/span/padding, with nothing in it saying that an offset parameter is read under one pagination strategy and ignored under another.

## How the schema is derived

Everything comes from what connectors already declare, so a connector that adds a parameter is described correctly with no change here:

- **reflection over `@Property`** — which parameters exist, their types, their validation
- **the `@View` layout** — descriptions resolved through the connector's bundle, grouping, and the format examples that sit beside a field as LABEL elements
- **probing** — the dependency matrix

Probing runs `TabularUtil.callViewMethods` against throwaway queries. That call only invokes `visibleMethod`/`enabledMethod`, so it stays local and never reaches the network. It reports what those methods actually return, so a condition that ORs two cases needs no special handling.

## Validation

Against `RestJsonQuery` — 52 parameters, nothing unreferenced. All six pagination rows reproduce the hand-derived expectation exactly:

| paginationType | parameters turned on |
|---|---|
| `NONE` | — |
| `PAGE_COUNT` | totalPagesParamValue/Type, pageNumberParamToWriteValue/Type, zeroBasedPageIndex |
| `TOTAL_COUNT_AND_OFFSET` | totalCountParamValue/Type, offsetParamValue/Type, maxResultsPerPage |
| `TOTAL_COUNT_AND_PAGE` | totalCountParamValue/Type, pageNumberParamToWriteValue/Type, zeroBasedPageIndex, maxResultsPerPage |
| `ITERATION` | hasNextParamValue/Type, pageOffsetParamToReadValue/Type, pageOffsetParamToWriteValue/Type, incrementOffset |
| `LINK_ITERATION` | linkParamValue/Type |
| `paginationType & linkParamType` | `LINK_ITERATION & LINK_HEADER` → linkRelation |

Including the two non-obvious ones: `totalCountParam` shared by two strategies, and `linkRelation` gated on a pair rather than a single value.

## Three checks, because each failure is otherwise invisible

| | check | result |
|---|---|---|
| 1 | a name the connector does not declare | refused, with the names that do exist |
| 2 | a value that does not reach the bean | refused (converted, then confirmed by read-back) |
| 3 | a parameter that does not apply to the rest of the request | **warned, not refused** |

**Check 2 is a measured silent failure.** `PropertyMeta.setValue` resolves an enum constant and fills a primitive for null, but does nothing for what arrives over JSON. Handed `"45"` for an `int` property it fails the reflective invocation, logs it, and returns normally — leaving the connector's default in a query that reports success. Measured on `RestJsonQuery`, that loses the write for `timeout`, `maxResultsPerPage` and `expanded` alike. Hence `queryParams` is `Map<String, Object>`, not `Map<String, String>`: sending everything as a string would put the conversion in the caller and make a wrong guess indistinguishable from a value the connector ignored.

**Check 3 warns rather than refuses** because applicability is decided by the connector's own visibility methods, and those answer for the form — a narrower question than whether the runner reads the property. A connector is free to read something its form hides, so refusing on that basis would block correct requests. Measured: a `LINK_ITERATION` query given `offsetParamValue` and `maxResultsPerPage` has both correctly named as dead — they are stored and never read, and the answer comes back looking like a correct first page.

## Two things probing has to be careful about

Both found against `RestJsonQuery`:

**A gate can need two values at once.** Sweeping every pair is combinatorial and mostly wasted — ~18 candidate axes means 153 pairs, and `linkRelation`'s is late in that order, so the budget runs out first. The second pass follows the shape such a gate has instead: the second parameter is itself only relevant under the first, so the pairs worth trying are the ones the first pass already found. A few dozen probes instead of hundreds.

**A setter can have side effects beyond its property.** Setting one of the lookup flags grows the list the lookup panels' visibility is computed from, so probing it reports its own panel turning on together with every sibling in it — which reads as "this parameter gates its neighbours" when the real gate is the Add Lookup Query button. A baseline probe catches a parameter that is what makes itself appear, and the axis is dropped rather than described wrongly. Those parameters then show as conditional with no matrix entry: the condition is not described here, rather than a claim that they never apply.

## Notes

- Extraction runs against a live context — `LayoutCreator` resolves labels through `Config.getConfig()`, a Spring bean — so this is a server-side facility, not an offline dump tool.
- `/tabular/query-schema` is gated on READ, not the WRITE `/tabular/definition` beside it demands: it returns the connector's shape and no configured value.
- Sandbox sampling stays file-only. Sampling means running the table a second time — free for a local file, a second metered call for anything else — and the query kind cannot be assumed to be the free case.
- Composite parameters (`LIST`/`HTTP_PARAMETER`/`COLUMN`/…) are refused by name rather than half-built from a map. The schema still describes their `elementParams`.
- **Not yet covered:** what each value of an enumerated parameter actually *does* (that lives in the runner, not in any annotation), and which parameters a given choice makes *mandatory* (the annotations have no way to say). Both are planned as an opt-in per-connector supplement.

## Testing

Narrow `javac` compile of the five changed files, plus two harnesses run against `RestJsonQuery` producing the matrix and the check results above. No Maven build or test suite was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)