### PR TITLE
Serve file targets from the wiz tabular table contract

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/WizTabularController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizTabularController.java
@@ -24,8 +24,12 @@ import inetsoft.uql.DataSourceListing;
 import inetsoft.uql.DataSourceListingService;
 import inetsoft.uql.XDataSource;
 import inetsoft.uql.XRepository;
+import inetsoft.uql.tabular.LayoutCreator;
 import inetsoft.uql.tabular.TabularDataSource;
+import inetsoft.uql.tabular.TabularEditor;
+import inetsoft.uql.tabular.TabularQuery;
 import inetsoft.uql.tabular.TabularUtil;
+import inetsoft.uql.tabular.TabularView;
 import inetsoft.util.Catalog;
 import inetsoft.util.MessageException;
 import inetsoft.web.portal.data.DataSourceDefinition;
@@ -33,11 +37,18 @@ import inetsoft.web.portal.data.DatasourcesService;
 import inetsoft.web.security.PermissionPath;
 import inetsoft.web.security.RequiredPermission;
 import inetsoft.web.security.Secured;
+import inetsoft.web.wiz.model.WizTabularBrowseResult;
 import inetsoft.web.wiz.model.WizTabularListing;
 import inetsoft.web.wiz.model.WizTabularListings;
 import inetsoft.web.wiz.model.WizTabularSaveResult;
+import inetsoft.web.wiz.model.WorksheetTableResponse;
+import inetsoft.web.wiz.request.WizTabularBrowseRequest;
 import inetsoft.web.wiz.request.WizTabularCreateRequest;
+import inetsoft.web.wiz.request.WizTabularProbeCloseRequest;
+import inetsoft.web.wiz.request.WizTabularProbeOpenRequest;
+import inetsoft.web.wiz.request.WizTabularProbeTableRequest;
 import inetsoft.web.wiz.service.UnsupportedDatasourceException;
+import inetsoft.web.wiz.service.WorksheetTableService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -45,6 +56,8 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.io.File;
+import java.nio.file.Files;
 import java.security.Principal;
 import java.util.*;
 
@@ -87,11 +100,13 @@ import java.util.*;
 public class WizTabularController {
    public WizTabularController(DatasourcesService datasourcesService,
                                SecurityEngine securityEngine,
-                               XRepository xrepository)
+                               XRepository xrepository,
+                               WorksheetTableService worksheetTableService)
    {
       this.datasourcesService = datasourcesService;
       this.securityEngine = securityEngine;
       this.xrepository = xrepository;
+      this.worksheetTableService = worksheetTableService;
    }
 
    /**
@@ -439,6 +454,331 @@ public class WizTabularController {
       return Map.of("duplicate", datasourcesService.checkDuplicate(name));
    }
 
+   // ─── Browsing a file-based connector, and probing what a target holds ─────────────────────
+
+   /**
+    * List one folder of a file-based connector.
+    *
+    * <p>The wiz twin of {@code TabularQueryDialogController.browse}, and deliberately a separate
+    * method rather than a call into it. What is shared is the mechanism — a query created with
+    * {@code TabularUtil.createQuery}, its layout, and the {@code relativeTo}/{@code foldersOnly}/
+    * {@code acceptTypes} editor properties the connector declares on its file property. What is not
+    * shared is the way in: {@code TabularQueryDialogController} extends {@code WorksheetController}
+    * and authorizes through a composer session, which a wiz caller carrying a bearer token does not
+    * have. So the gate here is the one every other method on this class uses.</p>
+    *
+    * <p>No {@code runtimeId}: the browse rules come off a freshly created query bean, which is why
+    * the composer's own version does not need one either.</p>
+    *
+    * <p>Sheets of a workbook are NOT expanded here. Listing them would mean opening every workbook
+    * in the tree just to answer "what is here", and the answer is needed only for the files that go
+    * on to be probed — {@code probe/table} names them when it needs them.</p>
+    *
+    * @param request   which data source, which folder, and how much of it.
+    * @param principal the current user.
+    *
+    * @return the folder's contents, with paths relative to the connector's root folder.
+    */
+   @PostMapping(value = "/tabular/browse", produces = MediaType.APPLICATION_JSON_VALUE)
+   public WizTabularBrowseResult browseTabularFiles(@RequestBody WizTabularBrowseRequest request,
+                                                    Principal principal)
+      throws Exception
+   {
+      String datasource = request == null ? null : emptyToNull(request.datasource());
+
+      if(datasource == null) {
+         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "datasource is required");
+      }
+
+      // READ, not WRITE: this reads what the data source points at, it does not reconfigure it.
+      // The same action buildTable checks before a tabular table may reach a connector at all.
+      requireDataSourcePermission(datasource, ResourceAction.READ, principal);
+      requireTabularDataSource(datasource);
+
+      String path = normalizeBrowsePath(request.path());
+
+      // callEditorMethods below runs the connector's own editor methods, which is exactly the reach
+      // refreshTabularView is bracketed for — TabularUtil.sessionId is a ThreadLocal nothing clears,
+      // so on a pooled thread "leave it alone" means "inherit the previous request's", possibly
+      // another user's.
+      beginConnectorSession(principal);
+
+      try {
+         return browse(datasource, path, request);
+      }
+      finally {
+         endConnectorSession();
+      }
+   }
+
+   /**
+    * Open a temporary worksheet to probe a data source's targets with.
+    *
+    * <p>One per annotation run, not one per file. The runtime never touches
+    * {@code AssetRepository} — nothing is persisted at any point — so the only thing it costs is a
+    * live session, and the only obligation it creates is {@code probe/close}.</p>
+    *
+    * @return a single-key object carrying the {@code runtimeId} to pass to the other two calls.
+    */
+   @PostMapping(value = "/tabular/probe/open", produces = MediaType.APPLICATION_JSON_VALUE)
+   public Map<String, String> openProbeWorksheet(
+      @RequestBody(required = false) WizTabularProbeOpenRequest request, Principal principal)
+      throws Exception
+   {
+      String datasource = request == null ? null : emptyToNull(request.datasource());
+
+      // Checked here rather than left to the first probe: a caller that may not read the data
+      // source should not get a runtime to try it with, and the probe's own gate would only say so
+      // after a session had been opened that the caller then has to remember to close.
+      if(datasource != null) {
+         requireDataSourcePermission(datasource, ResourceAction.READ, principal);
+      }
+
+      return Map.of("runtimeId", worksheetTableService.openProbeWorksheet(principal));
+   }
+
+   /**
+    * Build one target in the probe worksheet and report its columns and sample rows.
+    *
+    * <p>Answers in the same {@code WorksheetTableResponse} {@code POST /api/wiz/ws/table} does,
+    * including its {@code success}/{@code errorMessage} pair: a failure here is a 200 carrying the
+    * reason, not a 4xx, because the caller is a loop over a directory and one unreadable file must
+    * not end the walk. It is also how a multi-sheet workbook reports its sheets — the build refuses
+    * to guess which one was meant and lists them in the message.</p>
+    */
+   @PostMapping(value = "/tabular/probe/table", produces = MediaType.APPLICATION_JSON_VALUE)
+   public WorksheetTableResponse probeTable(@RequestBody WizTabularProbeTableRequest request,
+                                            Principal principal)
+      throws Exception
+   {
+      if(request == null || request.table() == null) {
+         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "table is required");
+      }
+
+      // The datasource READ gate itself lives in the service, on the same line createTables checks
+      // it, so the probe and the real build cannot come to different answers about who may reach a
+      // connector.
+      return worksheetTableService.probeTable(request.runtimeId(), request.table(), principal);
+   }
+
+   /** Release the probe runtime. Nothing was persisted, so nothing is left behind to clean up. */
+   @PostMapping("/tabular/probe/close")
+   @ResponseStatus(HttpStatus.NO_CONTENT)
+   public void closeProbeWorksheet(@RequestBody WizTabularProbeCloseRequest request,
+                                   Principal principal)
+      throws Exception
+   {
+      if(request == null) {
+         throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "runtimeId is required");
+      }
+
+      worksheetTableService.closeProbeWorksheet(request.runtimeId(), principal);
+   }
+
+   /**
+    * The browse itself, with the connector session already bound.
+    *
+    * <p>Reads the browse rules off the file property's editor the way the composer dialog does:
+    * {@code relativeTo} is the connector's root folder (a method on the query bean, which is why
+    * the layout has to be built and its editor methods run first), {@code foldersOnly} hides files,
+    * and {@code acceptTypes} is the connector's own extension whitelist — {@code .txt,.csv,.xls,
+    * .xlsx} for ServerFile. Reusing the connector's list rather than hard-coding one is what keeps
+    * this honest when a connector adds a format.</p>
+    */
+   private WizTabularBrowseResult browse(String datasource, String path,
+                                         WizTabularBrowseRequest request)
+   {
+      TabularQuery query = TabularUtil.createQuery(datasource);
+
+      if(query == null) {
+         throw new ResponseStatusException(
+            HttpStatus.UNPROCESSABLE_ENTITY, "Could not create a query for data source \"" +
+            datasource + "\" — its connector plugin may not be loaded.");
+      }
+
+      TabularView view = new LayoutCreator().createLayout(query);
+      TabularUtil.callEditorMethods(view.getViews(), query);
+
+      TabularView fileView = findFileView(view, request.property());
+
+      if(fileView == null) {
+         throw new ResponseStatusException(
+            HttpStatus.UNPROCESSABLE_ENTITY, "Data source \"" + datasource + "\" has no browsable " +
+            "file property" + (request.property() == null ? "" : " named \"" + request.property() +
+            "\"") + ", so there is nothing to browse. It is not a file-based connector.");
+      }
+
+      TabularEditor editor = fileView.getEditor();
+      String[] names = editor.getEditorPropertyNames();
+      String[] values = editor.getEditorPropertyValues();
+      String relativeTo = null;
+      boolean foldersOnly = false;
+      List<String> acceptTypes = new ArrayList<>();
+
+      if(names != null) {
+         for(int i = 0; i < names.length; i++) {
+            if("relativeTo".equals(names[i])) {
+               relativeTo = values[i] == null || values[i].isEmpty() ? null : values[i];
+            }
+            else if("foldersOnly".equals(names[i])) {
+               foldersOnly = Boolean.parseBoolean(values[i]);
+            }
+            else if("acceptTypes".equals(names[i]) && !request.all() && values[i] != null) {
+               acceptTypes.addAll(Arrays.asList(values[i].split(",")));
+            }
+         }
+      }
+
+      // Unlike the composer's version, a missing root is refused rather than answered with a listing
+      // of the server's drive roots. The dialog can do that because a human is configuring the
+      // source and has to find one; here the root IS the grant, and reading outside it is the one
+      // thing this endpoint must not do.
+      if(relativeTo == null) {
+         throw new ResponseStatusException(
+            HttpStatus.UNPROCESSABLE_ENTITY, "Data source \"" + datasource + "\" has no root " +
+            "folder configured, so there is nothing to browse.");
+      }
+
+      List<WizTabularBrowseResult.WizTabularBrowseEntry> entries = new ArrayList<>();
+      boolean truncated = collect(new File(relativeTo), path, foldersOnly, acceptTypes,
+                                  request.recursive(), entries);
+
+      // Folders first, then files, each alphabetical — a stable order, so re-browsing an unchanged
+      // directory produces an unchanged answer.
+      entries.sort(Comparator.comparing(
+            WizTabularBrowseResult.WizTabularBrowseEntry::folder, Comparator.reverseOrder())
+         .thenComparing(WizTabularBrowseResult.WizTabularBrowseEntry::path,
+                        String.CASE_INSENSITIVE_ORDER));
+
+      return new WizTabularBrowseResult(datasource, path, entries, truncated);
+   }
+
+   /**
+    * Collect one folder's entries, optionally walking into sub-folders.
+    *
+    * <p>Capped rather than unbounded. A recursive walk is what an annotation pass wants — the
+    * alternative is one request per directory — but a root pointed at a large tree would otherwise
+    * build a response nobody can use, so the walk stops and says it stopped.</p>
+    *
+    * @return true when the cap stopped the walk short.
+    */
+   private boolean collect(File root, String path, boolean foldersOnly, List<String> acceptTypes,
+                           boolean recursive,
+                           List<WizTabularBrowseResult.WizTabularBrowseEntry> entries)
+   {
+      File folder = path.isEmpty() ? root : new File(root, path);
+      File[] children = folder.listFiles();
+
+      if(children == null) {
+         return false;
+      }
+
+      for(File child : children) {
+         if(entries.size() >= MAX_BROWSE_ENTRIES) {
+            return true;
+         }
+
+         if(child.isHidden() || !Files.isReadable(child.toPath())) {
+            continue;
+         }
+
+         String childPath = path.isEmpty() ? child.getName() : path + "/" + child.getName();
+
+         if(child.isDirectory()) {
+            entries.add(new WizTabularBrowseResult.WizTabularBrowseEntry(
+               childPath, child.getName(), true));
+
+            if(recursive && collect(root, childPath, foldersOnly, acceptTypes, true, entries)) {
+               return true;
+            }
+         }
+         else if(!foldersOnly && accepts(acceptTypes, child.getName())) {
+            entries.add(new WizTabularBrowseResult.WizTabularBrowseEntry(
+               childPath, child.getName(), false));
+         }
+      }
+
+      return false;
+   }
+
+   /** Whether a file name matches the connector's own extension whitelist; empty accepts all. */
+   private static boolean accepts(List<String> acceptTypes, String name) {
+      if(acceptTypes.isEmpty()) {
+         return true;
+      }
+
+      for(String type : acceptTypes) {
+         if(!type.isBlank() && name.toLowerCase().endsWith(type.trim().toLowerCase())) {
+            return true;
+         }
+      }
+
+      return false;
+   }
+
+   /**
+    * The view of the named property, or — when none was named — the connector's file property.
+    *
+    * <p>Resolved by editor TYPE rather than by the name {@code "fileFolder"}, so a caller that does
+    * not know the connector does not have to guess one, and the next file-based connector needs no
+    * change here. {@code TabularUtil.getEditorType} keys {@code FILE} on a {@code java.io.File}
+    * property, which is the same signal {@code WorksheetTableService.fileTargetProperty} resolves
+    * the build target with — the two have to agree, or a file could be browsed under one property
+    * and bound through another.</p>
+    */
+   private static TabularView findFileView(TabularView view, String property) {
+      if(view.getEditor() != null && view.getValue() != null) {
+         boolean match = property == null || property.isEmpty()
+            ? view.getEditor().getType() == TabularEditor.Type.FILE
+            : property.equals(view.getValue());
+
+         if(match) {
+            return view;
+         }
+      }
+
+      for(TabularView child : view.getViews()) {
+         TabularView found = findFileView(child, property);
+
+         if(found != null) {
+            return found;
+         }
+      }
+
+      return null;
+   }
+
+   /**
+    * The folder to list, relative to the connector's root and provably inside it.
+    *
+    * <p>The same rule {@code WorksheetTableService.resolveTargetFile} applies to a build target, and
+    * for the same reason: the root folder is the whole of what a {@code ServerFileDataSource}
+    * grants, so an absolute path or a {@code ".."} segment is not a path to resolve leniently — it
+    * is a request to read outside the grant.</p>
+    */
+   private static String normalizeBrowsePath(String path) {
+      if(path == null || path.isEmpty() || "/".equals(path)) {
+         return "";
+      }
+
+      String normalized = path.replace('\\', '/').replaceAll("^/+", "").replaceAll("/+$", "");
+
+      if(new File(normalized).isAbsolute() || normalized.matches("^[A-Za-z]:.*")) {
+         throw new ResponseStatusException(
+            HttpStatus.BAD_REQUEST,
+            "path must be relative to the data source's root folder: \"" + path + "\"");
+      }
+
+      for(String segment : normalized.split("/")) {
+         if("..".equals(segment)) {
+            throw new ResponseStatusException(
+               HttpStatus.BAD_REQUEST, "path must not contain '..': \"" + path + "\"");
+         }
+      }
+
+      return normalized;
+   }
+
    /**
     * Maps a business failure onto a stable code.
     *
@@ -647,8 +987,16 @@ public class WizTabularController {
    /** Marks a connector session as this controller's, so it cannot collide with the portal's. */
    private static final String SESSION_PREFIX = "wiz:";
 
+   /**
+    * Ceiling on a single browse answer. A recursive walk of a root pointed at a large tree would
+    * otherwise build a response no caller can use; the walk stops and reports that it stopped, so
+    * the remainder stays reachable by browsing sub-folders individually.
+    */
+   private static final int MAX_BROWSE_ENTRIES = 2000;
+
    private final DatasourcesService datasourcesService;
    private final SecurityEngine securityEngine;
    private final XRepository xrepository;
+   private final WorksheetTableService worksheetTableService;
    private static final Logger LOG = LoggerFactory.getLogger(WizTabularController.class);
 }

--- a/core/src/main/java/inetsoft/web/wiz/model/WizTabularBrowseResult.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizTabularBrowseResult.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+import java.util.List;
+
+/**
+ * Answer to {@code POST /api/wiz/tabular/browse}: what one folder of a file-based connector holds.
+ *
+ * <p>PATHS ARE RELATIVE, and that is the point of not reusing the composer's {@code TreeNodeModel}.
+ * The dialog's node carries an {@code absolutePath} because a human is looking at a file picker on
+ * a machine they administer; this answer goes to an agent, and a server filesystem path is both
+ * something it must never send back ({@code tabularSource.target} is relative) and something it has
+ * no business learning. A {@code path} here is exactly what {@code target} takes.</p>
+ *
+ * @param datasource the connector instance that was browsed.
+ * @param path       the folder that was listed, relative to the connector's root; {@code ""} is it.
+ * @param entries    what the folder holds, folders first, each ordered by name.
+ * @param truncated  true when the walk hit its entry cap and stopped. Under truncation the absence
+ *                   of a file means "not reached", not "not there" — a caller that conflates the
+ *                   two will report a directory as smaller than it is. Browse the sub-folders
+ *                   individually to see the rest.
+ */
+public record WizTabularBrowseResult(String datasource, String path,
+                                     List<WizTabularBrowseEntry> entries, boolean truncated)
+{
+   /**
+    * One file or folder.
+    *
+    * @param path   path relative to the connector's ROOT folder — not to the folder being listed —
+    *               so it can be sent straight back as {@code tabularSource.target} with nothing to
+    *               re-join. This is also the identity the annotation stores for the table.
+    * @param name   the last segment, for display.
+    * @param folder true when this can be browsed into, false when it can be bound as a table.
+    */
+   public record WizTabularBrowseEntry(String path, String name, boolean folder) {
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/model/WorksheetTable.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WorksheetTable.java
@@ -176,7 +176,9 @@ public class WorksheetTable {
    @JsonIgnoreProperties(ignoreUnknown = true)
    public static class TabularSource {
       private String datasourcePath;
-      private String endpoint;
+      private String targetKind;
+      private String target;
+      private Map<String, String> params;
       private Map<String, String> parameters;
       private String jsonPath;
       private Boolean expanded;
@@ -189,12 +191,64 @@ public class WorksheetTable {
       public void setDatasourcePath(String datasourcePath) { this.datasourcePath = datasourcePath; }
 
       /**
-       * The connector's own name for the endpoint, e.g. "Charges". Matched exactly against the
-       * connector's endpoint map, which is keyed by that name and rejects duplicates
-       * ({@code EndpointJsonQuery.Endpoints.toMap}).
+       * Which KIND of thing {@link #getTarget()} names, and therefore which contract the rest of
+       * this object has to satisfy:
+       *
+       * <ul>
+       *   <li>{@code "endpoint"} — a SaaS/REST connector's endpoint. {@code target} is the endpoint
+       *       name and {@code parameters}/{@code jsonPath}/{@code expanded}/{@code expandedPath}
+       *       apply.</li>
+       *   <li>{@code "file"} — a path-addressed connector's file (ServerFile today). {@code target}
+       *       is the path RELATIVE to the connector's root folder, optionally suffixed
+       *       {@code "#<sheet>"} for a workbook, and {@code params} carries the parsing options.</li>
+       * </ul>
+       *
+       * <p>Omitted means {@code "endpoint"}. That is not a default chosen for convenience: endpoint
+       * was the only kind this object could express before {@code target} existed, so a request
+       * that does not mention a kind cannot mean anything else. Matched case-insensitively; an
+       * unrecognized value is refused by name rather than falling through to one of the two, which
+       * would build a table against a contract the caller did not ask for.</p>
        */
-      public String getEndpoint() { return endpoint; }
-      public void setEndpoint(String endpoint) { this.endpoint = endpoint; }
+      public String getTargetKind() { return targetKind; }
+      public void setTargetKind(String targetKind) { this.targetKind = targetKind; }
+
+      /**
+       * WHAT to bind, read according to {@link #getTargetKind()}.
+       *
+       * <p>For {@code "endpoint"}: the connector's own name for the endpoint, e.g. {@code "Charges"}.
+       * Matched exactly against the connector's endpoint map, which is keyed by that name and
+       * rejects duplicates ({@code EndpointJsonQuery.Endpoints.toMap}).</p>
+       *
+       * <p>For {@code "file"}: the path relative to the connector's root folder, e.g.
+       * {@code "2024/q1.csv"} — never absolute, and never containing {@code ".."}, because the root
+       * folder is the whole of what the data source grants access to. A workbook may name its sheet
+       * with a {@code "#"} suffix ({@code "2024/sales.xlsx#Q1"}), which is the same identity the
+       * annotation stores for the table, so the two cannot drift apart.</p>
+       *
+       * <p>{@code endpoint} is accepted as an alias so a caller written against the pre-generalized
+       * shape still binds — it named the same thing.</p>
+       */
+      @JsonAlias("endpoint")
+      public String getTarget() { return target; }
+      public void setTarget(String target) { this.target = target; }
+
+      /**
+       * Connector parsing options for {@code targetKind == "file"}, by the connector's own property
+       * name — {@code excelSheet}, {@code encoding}, {@code delimiter}, {@code tab},
+       * {@code headerColumnCount}, {@code firstRowHeader}, {@code removeQuotation},
+       * {@code unpivotData} for ServerFile. Omitted keys keep the connector's own default, which is
+       * a working default for a well-formed CSV.
+       *
+       * <p>Validated against the connector's declared properties rather than a fixed list, so a
+       * name the connector does not have is refused with the names it does have — the same stance
+       * {@code parameters} takes for an endpoint, and for the same reason: a dropped option parses
+       * the file DIFFERENTLY and still reports success.</p>
+       *
+       * <p>Distinct from {@link #getParameters()}, which carries URL-suffix values for an endpoint.
+       * The two are never both applicable, and supplying the wrong one for the kind is refused.</p>
+       */
+      public Map<String, String> getParams() { return params; }
+      public void setParams(Map<String, String> params) { this.params = params; }
 
       /**
        * Values by parameter NAME — the name part of a <code>{...}</code> token in the endpoint's URL

--- a/core/src/main/java/inetsoft/web/wiz/request/WizTabularBrowseRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/request/WizTabularBrowseRequest.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.request;
+
+/**
+ * Body of {@code POST /api/wiz/tabular/browse}.
+ *
+ * <p>The wiz counterpart of {@code /api/composer/ws/tabular-query-dialog/browse}. It reads the same
+ * connector metadata the composer dialog does — the file property's {@code relativeTo},
+ * {@code foldersOnly} and {@code acceptTypes} editor properties — but carries no
+ * {@code TabularView}: the dialog posts one back because a human has been editing it, whereas this
+ * caller has nothing to edit and only needs what a freshly created query already answers.</p>
+ *
+ * @param datasource full repository path of the connector instance.
+ * @param path       folder to list, RELATIVE to the connector's root; null or empty means the root.
+ *                   Never absolute and never containing {@code ".."} — the root folder is the whole
+ *                   of what the data source grants access to.
+ * @param property   the file property to read the browse rules from, e.g. {@code "fileFolder"}.
+ *                   Null resolves the connector's own file property, which is what a caller that
+ *                   does not know the connector should send.
+ * @param all        true ignores the property's {@code acceptTypes} filter and lists every file.
+ * @param recursive  true walks sub-folders in one call, which is what an annotation pass wants —
+ *                   the alternative is one request per directory. Bounded; see
+ *                   {@code WizTabularBrowseResult.truncated}.
+ */
+public record WizTabularBrowseRequest(String datasource, String path, String property,
+                                      boolean all, boolean recursive)
+{
+}

--- a/core/src/main/java/inetsoft/web/wiz/request/WizTabularProbeCloseRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/request/WizTabularProbeCloseRequest.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.request;
+
+/**
+ * Body of {@code POST /api/wiz/tabular/probe/close}.
+ *
+ * @param runtimeId the id {@code probe/open} returned.
+ */
+public record WizTabularProbeCloseRequest(String runtimeId) {
+}

--- a/core/src/main/java/inetsoft/web/wiz/request/WizTabularProbeOpenRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/request/WizTabularProbeOpenRequest.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.request;
+
+/**
+ * Body of {@code POST /api/wiz/tabular/probe/open}.
+ *
+ * @param datasource full repository path of the connector instance the probe run is for. The
+ *                   temporary worksheet itself is not bound to a data source — it is named here so
+ *                   the READ gate can run before a runtime is opened, rather than one probe later.
+ */
+public record WizTabularProbeOpenRequest(String datasource) {
+}

--- a/core/src/main/java/inetsoft/web/wiz/request/WizTabularProbeTableRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/request/WizTabularProbeTableRequest.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.request;
+
+import inetsoft.web.wiz.model.WorksheetTable;
+
+/**
+ * Body of {@code POST /api/wiz/tabular/probe/table}.
+ *
+ * @param runtimeId the id {@code probe/open} returned. One at a time: the runtime holds a single
+ *                  worksheet, which each probe mutates.
+ * @param table     the table to build, in the same shape {@code POST /api/wiz/ws/table} takes.
+ *                  {@code tableName} may be omitted — the assembly is removed again as soon as its
+ *                  columns have been read, so the name has no consequence.
+ */
+public record WizTabularProbeTableRequest(String runtimeId, WorksheetTable table) {
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -21,7 +21,9 @@ package inetsoft.web.wiz.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.report.TableLens;
+import inetsoft.report.composition.RuntimeWorksheet;
 import inetsoft.report.composition.execution.AssetQuerySandbox;
+import inetsoft.sree.SreeEnv;
 import inetsoft.sree.security.ResourceAction;
 import inetsoft.sree.security.ResourceType;
 import inetsoft.sree.security.SecurityEngine;
@@ -59,6 +61,9 @@ import inetsoft.web.wiz.model.osi.*;
 import inetsoft.web.wiz.request.GetDatabaseTableMetaRequest;
 import org.springframework.stereotype.Service;
 
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.security.Principal;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -194,6 +199,342 @@ public class WorksheetTableService {
       response.setWsId(worksheetEntry != null ? worksheetEntry.toIdentifier() : null);
       response.setTables(results);
       return response;
+   }
+
+   // ─── Probe: discover a tabular target's columns and sample rows, persisting nothing ───────
+
+   /**
+    * Open a throwaway worksheet runtime for a run of {@link #probeTable} calls.
+    *
+    * <p>{@code openTemporaryWorksheet} and {@code openWorksheet} are two different things:
+    * the latter opens a stored asset for editing, the former mints a pure runtime session that
+    * never touches {@code AssetRepository}. This path wants the second — an annotation pass reads
+    * a data source's files to describe them and must leave nothing behind, so there is no asset to
+    * create, no permission to delete one with, and no cleanup task to write.</p>
+    *
+    * <p>Opened once for a whole data source rather than per file, and CLOSED BY THE CALLER — a
+    * runtime session that is never closed is a leak, which is why {@link #closeProbeWorksheet}
+    * exists as its own call rather than being folded into the last probe.</p>
+    *
+    * <p>Sequential by construction: the returned runtime holds ONE {@code Worksheet}, which
+    * {@link #probeTable} mutates. Files of one data source must therefore be probed one at a time.
+    * That is a choice, not a limit — open a runtime per file to probe them in parallel, at the cost
+    * of that many live sessions.</p>
+    */
+   public String openProbeWorksheet(Principal user) throws Exception {
+      // The same action-level gate createTables applies, for the same reason: this opens a
+      // worksheet runtime, and the caller has to be allowed worksheets at all before it can.
+      checkWorksheetActionPermission(user);
+
+      return viewsheetService.openTemporaryWorksheet(user, null);
+   }
+
+   /**
+    * Build one table in the probe runtime, report what it holds, and take it back out.
+    *
+    * <p>WHY A WORKSHEET AT ALL, given a tabular query can answer its columns without one:
+    * {@code SelectableTabularQuery.getColumns()} needs no runtime, but SAMPLE ROWS do — only the
+    * runner that executes the query ever sees a row, and {@code buildTabularTable} is where
+    * {@code sampleRows} is wired onto the query. For a CSV that is not a nicety: a header row is
+    * often the entire column-name vocabulary a file has, so the values are most of what an
+    * annotation pass has to reason from. Replacing this with {@code createQuery + getColumns()}
+    * would look simpler and would halve what the annotation is written from.</p>
+    *
+    * <p>The assembly is removed on the way out. Each file is an independent question and none of
+    * them is being saved, so leaving them to pile up in the shared worksheet would only grow the
+    * runtime and slow every later probe's name resolution.</p>
+    *
+    * <p>A failure comes back as {@code success=false} with the reason, exactly as it does inside a
+    * {@code createTables} batch — the caller is an annotation loop walking a directory, and one
+    * unreadable file must not end the walk. It is also how a multi-sheet workbook reports its sheet
+    * names: {@code applyFileContract} refuses to guess and names them in the message.</p>
+    */
+   public WorksheetTableResponse probeTable(String runtimeId, WorksheetTable table, Principal user)
+      throws Exception
+   {
+      checkWorksheetActionPermission(user);
+
+      if(runtimeId == null || runtimeId.isBlank()) {
+         throw new IllegalArgumentException("runtimeId is required; open a probe worksheet first");
+      }
+
+      if(table == null) {
+         throw new IllegalArgumentException("table is required");
+      }
+
+      // Assigned rather than demanded. The name is an artifact of building an assembly and is
+      // discarded with it below, so making the caller invent one per file would be asking for a
+      // decision that has no consequence.
+      if(table.getTableName() == null || table.getTableName().isBlank()) {
+         table.setTableName("probe_" + PROBE_TABLE_SEQUENCE.incrementAndGet());
+      }
+
+      RuntimeWorksheet rws = viewsheetService.getWorksheet(runtimeId, user);
+      Worksheet worksheet = rws.getWorksheet();
+
+      try {
+         WorksheetTableResponse response = addOneTable(worksheet, table, user);
+         applySandboxSampleRows(worksheet, table, response, user);
+
+         return response;
+      }
+      catch(Exception e) {
+         return failure(table.getTableName(), rootMessage(e));
+      }
+      finally {
+         if(worksheet.getAssembly(table.getTableName()) != null) {
+            worksheet.removeAssembly(table.getTableName());
+         }
+      }
+   }
+
+   /**
+    * Sample a FILE target's rows by executing the table that was just built.
+    *
+    * <p>WHY THIS EXISTS AT ALL. The two target kinds discover their columns by opposite means, and
+    * the sampling mechanism was built for one of them. An endpoint has no column list until a
+    * request has been answered, so {@code EndpointJsonQueryRunner} — the only writer of
+    * {@code TabularQuery.setSampleRows} anywhere — takes the sample from that one unavoidable
+    * response. A file's columns come from {@code ServerFileQuery.loadColumns()} reading the header,
+    * which executes no query and involves no runner at all, so nothing ever fills the slot and
+    * {@link #applyResponseSampleRows} finds it empty every time. Left there, the probe worksheet
+    * would earn nothing: columns are obtainable with {@code createQuery + getColumns()} and no
+    * runtime whatever, and the sample was the entire reason for standing one up.</p>
+    *
+    * <p>WHY NOT IN THE CONNECTOR. The REST mechanism exists because a REST read is expensive —
+    * metered, paginated, one chance at it — so the sample has to ride along with the request that
+    * was already being paid for. A local file has no such constraint: executing the table once more
+    * after building it is cheap, and doing it HERE rather than in ServerFile means every future
+    * file-shaped connector (OneDrive) gets sampling with no connector code at all.</p>
+    *
+    * <p>WHY ONLY HERE, and not in {@code buildTabularTable}. This is the annotation probe, whose
+    * whole output is a description of the file. The user's own {@code createTables} must not run an
+    * extra query as a side effect of adding a table to a worksheet.</p>
+    *
+    * <p>A FAILURE IS NOT A FAILURE OF THE PROBE. The columns are already in hand and they are what
+    * the caller asked for; the values are the bonus. A corrupt row, a bad encoding, a timeout —
+    * each is logged and leaves the sample absent, and the probe still answers {@code success=true}
+    * with its column list.</p>
+    */
+   private void applySandboxSampleRows(Worksheet worksheet, WorksheetTable request,
+                                       WorksheetTableResponse response, Principal user)
+   {
+      // EVERY statement is inside the try, the deciding one included. This method is called from
+      // inside probeTable's own try, so anything that escaped here would be caught there and turn a
+      // successful probe into a failed one — throwing away the column list over a missing bonus.
+      // The inner catch is what makes that impossible, so nothing may sit outside it.
+      AssetQuerySandbox box = null;
+
+      try {
+         int limit = sandboxSampleLimit(request, response);
+
+         if(limit <= 0) {
+            return;
+         }
+
+         // One more than asked for, which is how "there was more" is learned: the extra row is the
+         // evidence, and it is dropped before the sample is reported. Without it a file of exactly
+         // "limit" rows and a file of ten thousand are indistinguishable in the answer.
+         int probe = limit + 1;
+
+         if(!(worksheet.getAssembly(request.getTableName()) instanceof TableAssembly table)) {
+            return;
+         }
+
+         // Bounds the CONNECTOR's read, not just what is copied out of the lens.
+         // TabularBoundQuery.merge pushes this onto the query as XQuery.rowlimit
+         // (PreAssetQuery.getDefinedMaxRows -> getMaxRows), and ServerFileRuntime's row loop tests
+         // exactly that: `while(node.next() && (maxRows <= 0 || getRowCount() <= maxRows))`. So a
+         // 200MB CSV stops after probe rows rather than being read to the end and then trimmed.
+         // Not restored: this assembly is removed in probeTable's finally and never persisted.
+         table.setMaxRows(probe);
+
+         // A FRESH sandbox, disposed here, rather than the runtime's own. getTableLens caches by
+         // (name, mode, aggregate, column-selection hash) and probeTable is a loop that reuses one
+         // table name across files — a directory of monthly exports with identical headers hashes
+         // identically, so the runtime's cache would answer February with January's rows. A private
+         // sandbox cannot have a stale entry. Mirrors probeExecutable, which builds its own for the
+         // same one-shot reason.
+         box = new AssetQuerySandbox(worksheet);
+         box.setBaseUser(user);
+
+         // RUNTIME_MODE, not the LIVE_MODE probeExecutable uses. LIVE samples input tables down to
+         // the sandbox's design-time cap (see WorksheetPreviewService), which is harmless when the
+         // only question is "did the query run" and wrong when the answer IS the values.
+         TableLens lens = box.getTableLens(request.getTableName(),
+                                           AssetQuerySandbox.RUNTIME_MODE);
+
+         if(lens == null) {
+            return;
+         }
+
+         List<Map<String, Object>> rows = readSampleRows(lens, probe);
+
+         if(rows.isEmpty()) {
+            return;
+         }
+
+         boolean truncated = rows.size() > limit;
+         response.setSampleRows(List.copyOf(truncated ? rows.subList(0, limit) : rows));
+
+         // Only when true, matching how the endpoint path reports it: a consumer reading values out
+         // of a sample has to tell "not in the file" from "not sampled".
+         if(truncated) {
+            response.setSampleRowsTruncated(true);
+         }
+      }
+      catch(Exception ex) {
+         LOG.warn("Could not sample rows for probe table '{}'; reporting its columns without them",
+                  request.getTableName(), ex);
+      }
+      finally {
+         // Caught separately because a finally block runs AFTER the catch above and would otherwise
+         // throw straight past it — the one way a sampling problem could still fail the probe.
+         if(box != null) {
+            try {
+               box.dispose();
+            }
+            catch(Exception ex) {
+               LOG.warn("Could not dispose the sampling sandbox for probe table '{}'",
+                        request.getTableName(), ex);
+            }
+         }
+      }
+   }
+
+   /**
+    * How many rows to sample for this probe, or 0 for none.
+    *
+    * <p>KEYED ON {@code targetKind == "file"}, which is what keeps the endpoint path untouched.
+    * Testing "the response has no sample yet" instead would look equivalent and is not: an endpoint
+    * whose first page came back empty also reports no sample, and re-executing to check would bill
+    * the customer a second time for a question already answered. The kind is the only signal that
+    * cannot be confused with an empty result.</p>
+    *
+    * <p>Opt-in, unchanged: {@code sampleRows} unset or 0 means none, so a caller that wanted only
+    * the column list runs exactly the work it ran before. {@code rest.sample.rows} is the
+    * deployment's ceiling on that decision and is honoured here too — it is the switch that stops
+    * sampled customer data leaving a tabular connector, and a deployment that set it to 0 must not
+    * be circumvented by a different kind of target reaching the same data. A value that is not a
+    * number yields no sample, which is the right way to be wrong about a knob governing customer
+    * data.</p>
+    */
+   static int sandboxSampleLimit(WorksheetTable request, WorksheetTableResponse response) {
+      if(request == null || response == null || !response.isSuccess() ||
+         response.getSampleRows() != null)
+      {
+         return 0;
+      }
+
+      WorksheetTable.TabularSource src = request.getTabularSource();
+
+      if(src == null || src.getSampleRows() == null || src.getSampleRows() <= 0) {
+         return 0;
+      }
+
+      String kind;
+
+      try {
+         kind = targetKindOf(src);
+      }
+      catch(RuntimeException ex) {
+         // A kind this build accepted cannot be invalid, but the predicate must be safe to ask
+         // about anything rather than throw out of a by-product step.
+         return 0;
+      }
+
+      if(!TARGET_KIND_FILE.equals(kind)) {
+         return 0;
+      }
+
+      int ceiling;
+
+      try {
+         ceiling = Integer.parseInt(SreeEnv.getProperty(
+            SAMPLE_ROWS_PROPERTY, Integer.toString(DEFAULT_SAMPLE_ROWS)));
+      }
+      catch(Exception ex) {
+         return 0;
+      }
+
+      return ceiling <= 0 ? 0 : Math.min(src.getSampleRows(), ceiling);
+   }
+
+   /**
+    * Copy at most {@code limit} data rows out of a lens, keyed by column name.
+    *
+    * <p>Row 0 is the header in StyleBI's {@code TableLens} convention, so data starts at 1. The read
+    * is bounded by {@code moreRows(row)} per row rather than by a row count taken up front: asking
+    * a lens how many rows it has forces the whole query to completion, which is the opposite of
+    * sampling.</p>
+    *
+    * <p>Keyed by name, and by the SAME name the {@code columns} list reports, so a consumer can pair
+    * the two without positional arithmetic. That also matches the endpoint path's rows, which are
+    * JSON objects keyed by the response's own field names.</p>
+    */
+   private static List<Map<String, Object>> readSampleRows(TableLens lens, int limit) {
+      int colCount = lens.getColCount();
+      String[] headers = new String[colCount];
+
+      for(int col = 0; col < colCount; col++) {
+         Object header = lens.getObject(0, col);
+         headers[col] = header != null ? header.toString() : "col" + col;
+      }
+
+      List<Map<String, Object>> rows = new ArrayList<>();
+
+      for(int row = 1; rows.size() < limit && lens.moreRows(row); row++) {
+         Map<String, Object> values = new LinkedHashMap<>();
+
+         for(int col = 0; col < colCount; col++) {
+            values.put(headers[col], toSampleCell(lens.getObject(row, col)));
+         }
+
+         rows.add(values);
+      }
+
+      return rows;
+   }
+
+   /**
+    * Reduce one cell to something Jackson can write and a consumer can read.
+    *
+    * <p>Deliberately identical to {@code WorksheetPreviewService.toJsonSafe}: both hand worksheet
+    * cell values to the same caller, and two rules for the same value would mean a date that is a
+    * string in one answer and an object in the other. Numbers, strings and booleans pass through as
+    * themselves; a date or {@code Temporal} becomes its {@code toString()} rather than a Jackson
+    * object graph or an epoch number nothing labels; {@code byte[]} becomes a marker because a
+    * base64 blob is never what a sample is read for.</p>
+    */
+   private static Object toSampleCell(Object value) {
+      if(value == null) {
+         return null;
+      }
+
+      if(value instanceof String || value instanceof Number || value instanceof Boolean) {
+         return value;
+      }
+
+      if(value instanceof java.util.Date || value instanceof java.time.temporal.Temporal) {
+         return value.toString();
+      }
+
+      if(value instanceof byte[]) {
+         return "(binary)";
+      }
+
+      return value.toString();
+   }
+
+   /** Release what {@link #openProbeWorksheet} opened. Nothing was persisted, so nothing is left. */
+   public void closeProbeWorksheet(String runtimeId, Principal user) throws Exception {
+      checkWorksheetActionPermission(user);
+
+      if(runtimeId == null || runtimeId.isBlank()) {
+         throw new IllegalArgumentException("runtimeId is required");
+      }
+
+      viewsheetService.closeWorksheet(runtimeId, user);
    }
 
    /**
@@ -1042,22 +1383,32 @@ public class WorksheetTableService {
    }
 
    /**
-    * Build a {@link TabularTableAssembly} bound to ONE endpoint of a SaaS/REST connector.
+    * Build a {@link TabularTableAssembly} bound to ONE target of a tabular connector — an endpoint
+    * of a SaaS/REST connector, or a file of a path-addressed one (ServerFile).
     *
     * <p>Follows the six steps {@code TabularQueryDialogService.setUpTable} takes, with the dialog's
     * {@code TabularView} round trip left out. The dialog needs a view because a human drives it; the
-    * two things a caller supplies here — which endpoint, and what its parameters are — are plain
+    * two things a caller supplies here — which target, and what its options are — are plain
     * annotated bean properties, so {@link TabularUtil#getPropertyMap} reaches them directly. That
     * also keeps {@code TabularUtil.callButtonMethods} out of the path, which is the only reader of
     * the {@code TabularUtil.sessionId} ThreadLocal — so unlike {@code WizTabularController}, this
     * path needs no connector session bound around it.</p>
     *
-    * <p>THIS METHOD SENDS A REAL REQUEST. {@code loadColumnSelection} is how the column list comes
+    * <p>THIS METHOD READS THE SOURCE. {@code loadColumnSelection} is how the column list comes
     * into existence — a tabular query has none until one response has been parsed
-    * ({@code TabularQuery.loadOutputColumns} runs it under {@code HINT_PREVIEW} at 100 rows). So the
-    * request is metered, and a failure there is a failure of the whole table. It is also why this
-    * type is left out of {@link #shouldProbe}: the probe would send a second request to answer a
-    * question the non-empty column check below already answers.</p>
+    * ({@code TabularQuery.loadOutputColumns} runs it under {@code HINT_PREVIEW} at 100 rows). On an
+    * endpoint that means a real, metered request; on a file it means opening and parsing the file's
+    * header. Either way a failure there is a failure of the whole table, which is why this type is
+    * left out of {@link #shouldProbe}: the probe would repeat the read to answer a question the
+    * non-empty column check below already answers.</p>
+    *
+    * <p>WHAT VARIES BY KIND is only the contract — which bean properties carry the target, which
+    * ones are required, and how a failure should be described. That is
+    * {@link #applyEndpointContract} / {@link #applyFileContract}; each returns a description of what
+    * it dialed, which is the one thing the shared half needs from it. Everything after that —
+    * the assembly, {@code setQuery}/{@code setSourceInfo}, {@code loadColumnSelection}, the
+    * empty-column check — is built on {@code TabularQuery}/{@code SelectableTabularQuery} and does
+    * not distinguish connectors at all.</p>
     */
    private AbstractTableAssembly buildTabularTable(Worksheet worksheet, WorksheetTable request)
       throws Exception
@@ -1069,8 +1420,14 @@ public class WorksheetTableService {
             "tabularSource.datasourcePath is required for tabular table");
       }
 
-      if(src.getEndpoint() == null || src.getEndpoint().isBlank()) {
-         throw new IllegalArgumentException("tabularSource.endpoint is required for tabular table");
+      String targetKind = targetKindOf(src);
+
+      if(src.getTarget() == null || src.getTarget().isBlank()) {
+         throw new IllegalArgumentException(
+            "tabularSource.target is required for tabular table — " +
+            (TARGET_KIND_FILE.equals(targetKind)
+               ? "the file path relative to the data source's root folder."
+               : "the connector's own name for the endpoint."));
       }
 
       // Meaningless in every direction: nothing on this path reads physicalSource, so a request
@@ -1144,9 +1501,18 @@ public class WorksheetTableService {
 
       Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(query.getClass());
 
-      // Fills endpoint + parameters + parsing options, and returns the fully built URL suffix as
-      // proof that all of it landed. Throws with every problem named; see the method.
-      String suffix = applyEndpointContract(query, pmap, src);
+      // The one branch. Each side fills the properties its kind of target needs and returns a
+      // description of what it is about to read — a built URL suffix for an endpoint, a resolved
+      // path (and sheet) for a file — as proof that all of it landed, and as the only thing the
+      // empty-column failure below can name. Throws with every problem named; see the methods.
+      String probeDesc = switch(targetKind) {
+         case TARGET_KIND_ENDPOINT -> applyEndpointContract(query, pmap, src);
+         case TARGET_KIND_FILE -> applyFileContract(query, pmap, src);
+         // Unreachable: targetKindOf refuses anything else. Present so a third kind added to the
+         // enum without a contract fails here rather than silently building an unconfigured query.
+         default -> throw new IllegalStateException(
+            "No tabular contract for targetKind \"" + targetKind + "\"");
+      };
 
       // Persisted on the query (XQuery.rowlimit, written as <maxrows>) rather than passed as a
       // HINT_MAX_ROWS hint: a hint bounds one execution, and what has to stay bounded is every
@@ -1155,8 +1521,11 @@ public class WorksheetTableService {
       if(src.getMaxRows() != null && src.getMaxRows() > 0) {
          query.setMaxRows(src.getMaxRows());
       }
-      else {
-         requireRowCapWhenPaged(query, src.getEndpoint(), dsName);
+      // Endpoints only. A local file is read whole in one pass — there are no pages to walk and no
+      // per-call bill — so demanding a row cap there would refuse a correct request for a cost that
+      // does not exist.
+      else if(TARGET_KIND_ENDPOINT.equals(targetKind)) {
+         requireRowCapWhenPaged(query, src.getTarget(), dsName);
       }
 
       // How many rows to report back, carried ON THE QUERY because the runner is the only place that
@@ -1191,11 +1560,19 @@ public class WorksheetTableService {
       ColumnSelection columns = table.getColumnSelection(false);
 
       if(columns == null || columns.getAttributeCount() == 0) {
-         throw new IllegalArgumentException(
-            "The request to endpoint '" + src.getEndpoint() + "' of '" + dsName +
-            "' returned no columns. URL suffix sent: " + suffix +
-            ". Check the parameter values and that the data source's credentials are valid; the " +
-            "underlying cause is in the server log for this request.");
+         // Worded per kind. The endpoint text names the URL suffix, which is the whole of what was
+         // sent and the first thing to check; repeating it for a file would hand whoever is
+         // debugging a URL that was never built and say nothing about the path, the sheet, or the
+         // delimiter — the three things that actually produce an empty parse.
+         throw new IllegalArgumentException(TARGET_KIND_FILE.equals(targetKind)
+            ? "Reading " + probeDesc + " of '" + dsName + "' produced no columns. Check that the " +
+              "file exists at that path, is not empty, and that the parsing options in " +
+              "tabularSource.params match it (sheet name, delimiter, encoding, first row as " +
+              "header); the underlying cause is in the server log for this request."
+            : "The request to endpoint '" + src.getTarget() + "' of '" + dsName +
+              "' returned no columns. URL suffix sent: " + probeDesc +
+              ". Check the parameter values and that the data source's credentials are valid; the " +
+              "underlying cause is in the server log for this request.");
       }
 
       worksheet.addAssembly(table);
@@ -1236,7 +1613,16 @@ public class WorksheetTableService {
             "that ship an endpoint catalogue can be used as a tabular table this way.");
       }
 
-      String endpoint = src.getEndpoint().trim();
+      // Refused rather than ignored, same rule as an unknown parameter name below: params is the
+      // file contract's option bag, nothing on this path reads it, and dropping it would parse the
+      // caller's request differently from how they wrote it and report success.
+      if(src.getParams() != null && !src.getParams().isEmpty()) {
+         throw new IllegalArgumentException(
+            "tabularSource.params applies to targetKind \"file\" only — an endpoint's values go in " +
+            "tabularSource.parameters, keyed by the endpoint's own parameter names.");
+      }
+
+      String endpoint = src.getTarget().trim();
       assertKnownEndpoint(query, endpoint, src.getDatasourcePath());
       endpointProp.setValue(query, endpoint);
 
@@ -1329,6 +1715,505 @@ public class WorksheetTableService {
       }
 
       return s;
+   }
+
+   /**
+    * The {@code targetKind} a tabular source asks for, normalized and checked.
+    *
+    * <p>Absent means {@code "endpoint"}, because before {@code target} existed this object could
+    * express nothing else — a caller that does not mention a kind is a caller written against that
+    * shape, and answering anything else for it would change the meaning of a request already in
+    * flight. Case and surrounding space are forgiven; an unrecognized value is refused by name
+    * rather than falling through to a default, which would build a table against a contract nobody
+    * asked for and report success.</p>
+    */
+   private static String targetKindOf(WorksheetTable.TabularSource src) {
+      String kind = src.getTargetKind();
+
+      if(kind == null || kind.isBlank()) {
+         return TARGET_KIND_ENDPOINT;
+      }
+
+      String normalized = kind.trim().toLowerCase();
+
+      if(!TARGET_KIND_ENDPOINT.equals(normalized) && !TARGET_KIND_FILE.equals(normalized)) {
+         throw new IllegalArgumentException(
+            "tabularSource.targetKind must be \"" + TARGET_KIND_ENDPOINT + "\" or \"" +
+            TARGET_KIND_FILE + "\", got \"" + kind + "\".");
+      }
+
+      return normalized;
+   }
+
+   /**
+    * Point a path-addressed tabular query at one file, apply its parsing options, and return a
+    * description of what it will read.
+    *
+    * <p>The counterpart of {@link #applyEndpointContract} — same job, different contract. What the
+    * two share is the mechanism underneath ({@link TabularUtil#getPropertyMap} plus
+    * {@link PropertyMeta}); what differs is which properties carry the target, which values are
+    * legal, and what a failure has to say. Nothing about a URL, a parameter template or pagination
+    * applies here, and nothing about a sheet name or a delimiter applies there.</p>
+    *
+    * <p>NOTHING HERE TRUSTS THAT A WRITE HAPPENED, for the same reason the endpoint contract does
+    * not: {@code PropertyMeta.setValue} reports a failed invocation with {@code LOG.error} and
+    * returns, so a mistyped option would silently leave the connector's default in place and parse
+    * the file differently from what was asked. The write methods are therefore invoked directly, so
+    * a reflection failure throws, and the file itself is read back afterwards.</p>
+    *
+    * @return a human description of the resolved target, e.g. {@code file '2024/q1.csv'} or
+    *         {@code file '2024/sales.xlsx' sheet 'Q1'}.
+    */
+   private String applyFileContract(TabularQuery query,
+                                    Map<String, PropertyMeta> pmap,
+                                    WorksheetTable.TabularSource src)
+      throws Exception
+   {
+      String dsName = src.getDatasourcePath();
+
+      // Refused rather than ignored, the mirror of the params rejection on the endpoint side. These
+      // four describe the shape of a JSON response; a file has no response and no row path, so
+      // accepting them would answer a request that cannot be honored.
+      if(src.getParameters() != null && !src.getParameters().isEmpty()) {
+         throw new IllegalArgumentException(
+            "tabularSource.parameters applies to targetKind \"" + TARGET_KIND_ENDPOINT + "\" only " +
+            "— a file's parsing options go in tabularSource.params.");
+      }
+
+      if(src.getJsonPath() != null || src.getExpanded() != null || src.getExpandedPath() != null) {
+         throw new IllegalArgumentException(
+            "tabularSource.jsonPath/expanded/expandedPath apply to targetKind \"" +
+            TARGET_KIND_ENDPOINT + "\" only — they describe a JSON response, and a file has none.");
+      }
+
+      PropertyMeta fileProp = fileTargetProperty(pmap, query, dsName);
+
+      // "path" or "path#sheet". Split on the LAST '#' so a file whose own name contains one still
+      // resolves; the sheet suffix is the same identity the annotation stores for the table, so
+      // accepting it here is what keeps the stored name and the bindable name the same string.
+      String rawTarget = src.getTarget().trim();
+      int hash = rawTarget.lastIndexOf('#');
+      String relativePath = hash < 0 ? rawTarget : rawTarget.substring(0, hash).trim();
+      String sheetFromTarget = hash < 0 ? null : rawTarget.substring(hash + 1).trim();
+
+      if(relativePath.isEmpty()) {
+         throw new IllegalArgumentException(
+            "tabularSource.target names no file: \"" + rawTarget + "\".");
+      }
+
+      File file = resolveTargetFile(query, relativePath, dsName);
+      invokeWriteMethod(fileProp, query, file);
+
+      // Read back, because the getter rebuilds the path from what the setter actually stored (the
+      // setter relativizes against the data source's root folder, so a failed or misresolved write
+      // shows up here and nowhere else). Everything below — the Excel test, the sheet list, the
+      // column read — derives from the file being set.
+      Object readBack = fileProp.getValue(query);
+
+      if(!(readBack instanceof File actual) ||
+         !actual.getCanonicalPath().equals(file.getCanonicalPath()))
+      {
+         throw new IllegalStateException(
+            "Failed to point '" + dsName + "' at file '" + relativePath + "' (resolved to " +
+            file.getPath() + ", read back as " + readBack + "); see the server log for the " +
+            "reflection failure.");
+      }
+
+      // Applied BEFORE the sheet is resolved: excelSheet is itself one of these, and the resolution
+      // below has to see whichever value the caller supplied.
+      applyFileParams(query, pmap, src, fileProp.getName(), dsName);
+
+      String sheet = resolveExcelSheet(query, pmap, src, sheetFromTarget, relativePath, dsName);
+
+      return "file '" + relativePath + "'" + (sheet == null ? "" : " sheet '" + sheet + "'");
+   }
+
+   /**
+    * The bean property that names the file, and the check that this connector has one at all.
+    *
+    * <p>Resolved by TYPE rather than hard-coded to ServerFile's {@code fileFolder}: a file target is
+    * a {@code java.io.File} property, which is exactly what {@code TabularUtil.getEditorType} keys
+    * its {@code FILE} editor on, so the next path-addressed connector needs no change here. The
+    * name is still preferred when present, so a connector carrying two File properties resolves the
+    * same way the composer dialog does rather than by declaration order.</p>
+    */
+   private PropertyMeta fileTargetProperty(Map<String, PropertyMeta> pmap, TabularQuery query,
+                                           String dsName)
+   {
+      List<PropertyMeta> fileProps = new ArrayList<>();
+
+      for(PropertyMeta prop : pmap.values()) {
+         if(isFileProperty(prop)) {
+            fileProps.add(prop);
+         }
+      }
+
+      if(fileProps.isEmpty()) {
+         throw new IllegalArgumentException(
+            "Data source '" + dsName + "' (type '" + query.getType() + "') is tabular but not " +
+            "file-based, so it has no file to select. Use targetKind \"" + TARGET_KIND_ENDPOINT +
+            "\" for a connector that ships an endpoint catalogue.");
+      }
+
+      for(PropertyMeta prop : fileProps) {
+         if(FILE_TARGET_PROPERTY.equals(prop.getName())) {
+            return prop;
+         }
+      }
+
+      if(fileProps.size() > 1) {
+         throw new IllegalStateException(
+            "Data source '" + dsName + "' (type '" + query.getType() + "') declares " +
+            fileProps.size() + " file properties and none named \"" + FILE_TARGET_PROPERTY +
+            "\", so which one tabularSource.target means is ambiguous.");
+      }
+
+      return fileProps.get(0);
+   }
+
+   private static boolean isFileProperty(PropertyMeta prop) {
+      Method setter = prop.getDescriptor().getWriteMethod();
+
+      return setter != null && setter.getParameterCount() == 1 &&
+         File.class.isAssignableFrom(setter.getParameterTypes()[0]);
+   }
+
+   /**
+    * Resolve {@code target} against the connector's root folder, refusing anything that leaves it.
+    *
+    * <p>The root folder IS the grant — a {@code ServerFileDataSource} authorizes one directory and
+    * nothing above it — so an absolute path or a {@code ".."} segment is not a path this method can
+    * resolve leniently; it is a request to read outside what the data source gives access to. Both
+    * are refused by shape, and the resolved path is then checked against the root canonically as
+    * well, because a symlink inside the root satisfies the shape check and still points out.</p>
+    *
+    * <p>{@code getRootFolder()} is reached by name for the same reason {@code getEndpoints} is: the
+    * class declaring it lives in the connector plugin and is not visible from core. A connector that
+    * does not answer it is left to resolve the path itself rather than blocked.</p>
+    */
+   private File resolveTargetFile(TabularQuery query, String relativePath, String dsName)
+      throws Exception
+   {
+      String normalized = relativePath.replace('\\', '/');
+
+      if(new File(normalized).isAbsolute() || normalized.startsWith("/") ||
+         normalized.matches("^[A-Za-z]:.*"))
+      {
+         throw new IllegalArgumentException(
+            "tabularSource.target must be relative to the data source's root folder, not an " +
+            "absolute path: '" + relativePath + "'.");
+      }
+
+      for(String segment : normalized.split("/")) {
+         if("..".equals(segment)) {
+            throw new IllegalArgumentException(
+               "tabularSource.target must not contain '..': '" + relativePath + "'. The data " +
+               "source's root folder is the whole of what it grants access to.");
+         }
+      }
+
+      String root = (String) callQueryMethod(query, "getRootFolder", dsName);
+      File file = root == null || root.isBlank()
+         ? new File(normalized) : new File(root, normalized);
+
+      if(root != null && !root.isBlank()) {
+         String rootPath = new File(root).getCanonicalPath();
+         String filePath = file.getCanonicalPath();
+
+         if(!filePath.equals(rootPath) && !filePath.startsWith(rootPath + File.separator)) {
+            throw new IllegalArgumentException(
+               "tabularSource.target resolves outside the data source's root folder: '" +
+               relativePath + "'.");
+         }
+      }
+
+      // Answered here rather than left to surface as "produced no columns", which is the same
+      // message an empty file and a bad delimiter produce and says nothing about which of the three
+      // it was.
+      if(!file.exists()) {
+         throw new IllegalArgumentException(
+            "Data source '" + dsName + "' has no file at '" + relativePath + "'. Browse the data " +
+            "source to see what it holds; the path is relative to its root folder.");
+      }
+
+      return file;
+   }
+
+   /**
+    * Write the caller's parsing options onto the query, refusing any the connector does not declare.
+    *
+    * <p>Validated against {@code pmap} rather than a fixed list of ServerFile's option names, so the
+    * next path-addressed connector's options work without a change here and its caller still gets
+    * told what it does accept. Unknown names are an error rather than something to drop, for the
+    * same reason an unknown endpoint parameter is: a dropped option parses the file DIFFERENTLY —
+    * a wrong delimiter yields one column, a wrong sheet yields another table's data — and reports
+    * success either way.</p>
+    */
+   private void applyFileParams(TabularQuery query, Map<String, PropertyMeta> pmap,
+                                WorksheetTable.TabularSource src, String targetPropertyName,
+                                String dsName)
+      throws Exception
+   {
+      Map<String, String> params = src.getParams();
+
+      if(params == null || params.isEmpty()) {
+         return;
+      }
+
+      for(Map.Entry<String, String> entry : params.entrySet()) {
+         String name = entry.getKey() == null ? null : entry.getKey().trim();
+         PropertyMeta prop = name == null ? null : pmap.get(name);
+
+         if(prop == null || isFileProperty(prop) || "columns".equals(name)) {
+            throw new IllegalArgumentException(
+               "Data source '" + dsName + "' has no parsing option named '" + entry.getKey() +
+               "'. Its options are: " + optionNames(pmap, targetPropertyName) +
+               ". The file itself goes in tabularSource.target, not here.");
+         }
+
+         invokeWriteMethod(prop, query, coerceParam(prop, name, entry.getValue()));
+      }
+   }
+
+   /** The option names a file-based connector accepts, target and column list excluded. */
+   private static String optionNames(Map<String, PropertyMeta> pmap, String targetPropertyName) {
+      return pmap.values().stream()
+         .map(PropertyMeta::getName)
+         .filter(name -> !name.equals(targetPropertyName) && !"columns".equals(name))
+         .sorted()
+         .collect(Collectors.joining(", "));
+   }
+
+   /**
+    * Convert one option's text to the type its setter takes.
+    *
+    * <p>Every value arrives as a string because {@code params} is a flat string map — the shape a
+    * caller can actually produce without knowing the connector's Java types. A value the setter's
+    * type cannot hold is refused with both the option name and what it expected, rather than
+    * silently becoming {@code 0} or {@code false}, which is what an unchecked conversion would
+    * write for "one" or "yes".</p>
+    */
+   private static Object coerceParam(PropertyMeta prop, String name, String raw) {
+      Class<?> type = prop.getDescriptor().getWriteMethod().getParameterTypes()[0];
+
+      if(raw == null) {
+         if(type.isPrimitive()) {
+            throw new IllegalArgumentException(
+               "Parsing option '" + name + "' has no value, and it cannot be cleared: it is a " +
+               type.getSimpleName() + ".");
+         }
+
+         return null;
+      }
+
+      String value = raw.trim();
+
+      try {
+         if(type == String.class) {
+            // Not trimmed: a delimiter of " " is a legitimate value, and it is the only option
+            // whose whole meaning can be whitespace.
+            return raw;
+         }
+         else if(type == boolean.class || type == Boolean.class) {
+            if(!"true".equalsIgnoreCase(value) && !"false".equalsIgnoreCase(value)) {
+               throw new NumberFormatException(value);
+            }
+
+            return Boolean.valueOf(value);
+         }
+         else if(type == int.class || type == Integer.class) {
+            return Integer.valueOf(value);
+         }
+         else if(type == long.class || type == Long.class) {
+            return Long.valueOf(value);
+         }
+         else if(type == short.class || type == Short.class) {
+            return Short.valueOf(value);
+         }
+         else if(type == double.class || type == Double.class) {
+            return Double.valueOf(value);
+         }
+         else if(type == float.class || type == Float.class) {
+            return Float.valueOf(value);
+         }
+         else if(type == char.class || type == Character.class) {
+            return value.isEmpty() ? ' ' : value.charAt(0);
+         }
+         else if(type.isEnum()) {
+            @SuppressWarnings({ "unchecked", "rawtypes" })
+            Object constant = Enum.valueOf((Class<Enum>) type, value);
+
+            return constant;
+         }
+      }
+      catch(IllegalArgumentException ex) {
+         throw new IllegalArgumentException(
+            "Parsing option '" + name + "' expects a " + type.getSimpleName() + ", got \"" + raw +
+            "\".");
+      }
+
+      throw new IllegalArgumentException(
+         "Parsing option '" + name + "' is a " + type.getSimpleName() +
+         ", which cannot be supplied as text in tabularSource.params.");
+   }
+
+   /**
+    * Settle which sheet of a workbook to read, and refuse to guess when the answer matters.
+    *
+    * <p>ServerFile's own default is the first sheet ({@code ServerFileUtil.getColumnDefinition}
+    * falls back to {@code getExcelSheetNames()[0]}), which is deterministic but silent — a
+    * three-sheet workbook builds a table from sheet one and reports success, and nothing in the
+    * result says the other two exist. That is the wrong answer for an annotation pass, whose whole
+    * job is to enumerate what can be bound. So an unqualified multi-sheet workbook FAILS, carrying
+    * the sheet names, which is the same "fail with what was missing, refill, retry" shape an
+    * endpoint's missing required parameter has.</p>
+    *
+    * <p>A single-sheet workbook is not ambiguous and is left to the connector's default: there is
+    * nothing for the caller to choose, and demanding a choice would refuse a correct request.</p>
+    *
+    * <p>{@code isExcel} and {@code getExcelSheetNames} are reached by name — the connector plugin is
+    * not visible from core. A connector answering neither is left alone rather than blocked; this
+    * exists to stop a silent wrong sheet, not to reject an unfamiliar connector.</p>
+    *
+    * @return the sheet that will be read, or {@code null} when the target is not a workbook.
+    */
+   private String resolveExcelSheet(TabularQuery query, Map<String, PropertyMeta> pmap,
+                                    WorksheetTable.TabularSource src, String sheetFromTarget,
+                                    String relativePath, String dsName)
+      throws Exception
+   {
+      PropertyMeta sheetProp = pmap.get(EXCEL_SHEET_PROPERTY);
+      Object excel = callQueryMethod(query, "isExcel", dsName);
+
+      if(sheetProp == null || !(excel instanceof Boolean isExcel)) {
+         if(sheetFromTarget != null) {
+            throw new IllegalArgumentException(
+               "Data source '" + dsName + "' has no sheet selection, so the \"#" + sheetFromTarget +
+               "\" suffix on tabularSource.target cannot be honored.");
+         }
+
+         return null;
+      }
+
+      // The '#' suffix and params.excelSheet name the same thing. Both is fine when they agree —
+      // a caller that echoes the stored identity into both is not making a mistake — and refused
+      // when they do not, because one of the two would have to be discarded silently.
+      String supplied = sheetFromTarget;
+      String fromParams = src.getParams() == null ? null : src.getParams().get(EXCEL_SHEET_PROPERTY);
+
+      if(fromParams != null && !fromParams.isBlank()) {
+         if(supplied != null && !supplied.isEmpty() && !supplied.equals(fromParams.trim())) {
+            throw new IllegalArgumentException(
+               "tabularSource.target names sheet '" + supplied + "' and tabularSource.params names " +
+               "sheet '" + fromParams.trim() + "'. Supply one of them.");
+         }
+
+         supplied = fromParams.trim();
+      }
+
+      if(!isExcel) {
+         if(supplied != null && !supplied.isEmpty()) {
+            throw new IllegalArgumentException(
+               "'" + relativePath + "' of '" + dsName + "' is not a workbook, so it has no sheet " +
+               "'" + supplied + "' to select.");
+         }
+
+         return null;
+      }
+
+      // Written through the property rather than left in params, so a sheet that arrived on the
+      // target suffix reaches the query the same way one supplied in params does.
+      if(supplied != null && !supplied.isEmpty()) {
+         invokeWriteMethod(sheetProp, query, supplied);
+      }
+
+      List<String> sheets = excelSheetNames(query, dsName);
+
+      if(sheets.isEmpty()) {
+         // The connector could not list them (an unreadable or malformed workbook). Not fatal here:
+         // the column read below fails with the real reason, and inventing one now would hide it.
+         return supplied;
+      }
+
+      if(supplied == null || supplied.isEmpty()) {
+         if(sheets.size() > 1) {
+            throw new IllegalArgumentException(
+               "'" + relativePath + "' of '" + dsName + "' has " + sheets.size() + " sheets, so " +
+               "one has to be named: " + String.join(", ", sheets) + ". Put it in " +
+               "tabularSource.params.excelSheet, or suffix tabularSource.target with \"#<sheet>\".");
+         }
+
+         // getExcelSheetNames() sets the query's sheet to the only one as a side effect, so the
+         // query is already pointed at it; reported back so the caller sees which one it was.
+         return sheets.get(0);
+      }
+
+      if(!sheets.contains(supplied)) {
+         throw new IllegalArgumentException(
+            "'" + relativePath + "' of '" + dsName + "' has no sheet named '" + supplied +
+            "'. Its sheets are: " + String.join(", ", sheets) + ".");
+      }
+
+      return supplied;
+   }
+
+   /** The workbook's sheet names, blanks dropped — the connector answers {@code [""]} for a miss. */
+   private List<String> excelSheetNames(TabularQuery query, String dsName) {
+      Object names = callQueryMethod(query, "getExcelSheetNames", dsName);
+      List<String> sheets = new ArrayList<>();
+
+      if(names instanceof String[] array) {
+         for(String name : array) {
+            if(name != null && !name.isBlank()) {
+               sheets.add(name);
+            }
+         }
+      }
+
+      return sheets;
+   }
+
+   /**
+    * Invoke a connector method core cannot see the declaring type of.
+    *
+    * <p>Same reflection {@link #assertKnownEndpoint} and {@link #requireRowCapWhenPaged} use, and
+    * the same stance on failure: a connector that does not answer is left alone rather than blocked,
+    * because these calls sharpen an error message or a default — none of them is the check that
+    * makes the build correct.</p>
+    */
+   private static Object callQueryMethod(TabularQuery query, String method, String dsName) {
+      try {
+         return query.getClass().getMethod(method).invoke(query);
+      }
+      catch(Exception ex) {
+         LOG.debug("Could not call {}() on the query for '{}'", method, dsName, ex);
+         return null;
+      }
+   }
+
+   /**
+    * Write a property through its setter directly, so a failed write throws.
+    *
+    * <p>{@code PropertyMeta.setValue} swallows the invocation failure with a {@code LOG.error},
+    * which on this path would leave the connector's default in place and parse the file differently
+    * from what was asked, reporting success. The endpoint contract answers that by reading the URL
+    * suffix back at the end; a file contract has no equivalent single readable summary, so the
+    * writes themselves are made loud instead.</p>
+    */
+   private static void invokeWriteMethod(PropertyMeta prop, Object bean, Object value)
+      throws Exception
+   {
+      try {
+         prop.getDescriptor().getWriteMethod().invoke(bean, value);
+      }
+      catch(InvocationTargetException ex) {
+         Throwable cause = ex.getCause() == null ? ex : ex.getCause();
+
+         throw new IllegalArgumentException(
+            "Setting '" + prop.getName() + "' to \"" + value + "\" failed: " +
+            (cause.getMessage() == null ? cause.getClass().getSimpleName() : cause.getMessage()),
+            cause);
+      }
    }
 
    /**
@@ -2864,6 +3749,28 @@ public class WorksheetTableService {
       int nl = msg.indexOf('\n');
       return nl > 0 ? msg.substring(0, nl) : msg;
    }
+
+   /** Names probe tables the caller did not name; the assembly is removed before the next one. */
+   private static final java.util.concurrent.atomic.AtomicLong PROBE_TABLE_SEQUENCE =
+      new java.util.concurrent.atomic.AtomicLong();
+
+   /**
+    * The deployment ceiling on sampled rows, shared with the endpoint path
+    * ({@code EndpointJsonQueryRunner}). Named for REST because that is where sampling started; it
+    * governs sampled customer data leaving ANY tabular connector, and 0 switches it off entirely.
+    */
+   private static final String SAMPLE_ROWS_PROPERTY = "rest.sample.rows";
+   /** What {@code rest.sample.rows} defaults to — {@code JsonRowSampler.DEFAULT_MAX_ROWS}. */
+   private static final int DEFAULT_SAMPLE_ROWS = 20;
+
+   /** {@code tabularSource.targetKind} for a SaaS/REST connector's endpoint. */
+   private static final String TARGET_KIND_ENDPOINT = "endpoint";
+   /** {@code tabularSource.targetKind} for a path-addressed connector's file. */
+   private static final String TARGET_KIND_FILE = "file";
+   /** ServerFile's name for the property that carries the file; preferred when a connector has it. */
+   private static final String FILE_TARGET_PROPERTY = "fileFolder";
+   /** The property a workbook's sheet is selected through. */
+   private static final String EXCEL_SHEET_PROPERTY = "excelSheet";
 
    private static final Logger LOG = LoggerFactory.getLogger(WorksheetTableService.class);
 }

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizTabularControllerSecurityTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizTabularControllerSecurityTest.java
@@ -29,6 +29,7 @@ import inetsoft.web.security.PermissionPath;
 import inetsoft.web.security.RequiredPermission;
 import inetsoft.web.security.Secured;
 import inetsoft.web.wiz.request.WizTabularCreateRequest;
+import inetsoft.web.wiz.service.WorksheetTableService;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -89,7 +90,11 @@ class WizTabularControllerSecurityTest {
                 "/api/wiz/tabular/refresh",
                 "/api/wiz/tabular/create",
                 "/api/wiz/tabular/update",
-                "/api/wiz/tabular/check-duplicate"),
+                "/api/wiz/tabular/check-duplicate",
+                "/api/wiz/tabular/browse",
+                "/api/wiz/tabular/probe/open",
+                "/api/wiz/tabular/probe/table",
+                "/api/wiz/tabular/probe/close"),
          new HashSet<>(mappedPaths()));
    }
 
@@ -357,12 +362,14 @@ class WizTabularControllerSecurityTest {
          // The update path refuses anything that is not tabular, so the stored source has to be one
          // for every test whose subject is something else.
          when(xrepository.getDataSource(anyString())).thenReturn(mock(TabularDataSource.class));
-         controller = new WizTabularController(datasourcesService, securityEngine, xrepository);
+         controller = new WizTabularController(datasourcesService, securityEngine, xrepository,
+                                               worksheetTableService);
       }
 
       final DatasourcesService datasourcesService = mock(DatasourcesService.class);
       final SecurityEngine securityEngine = mock(SecurityEngine.class);
       final XRepository xrepository = mock(XRepository.class);
+      final WorksheetTableService worksheetTableService = mock(WorksheetTableService.class);
       final Principal principal = mock(Principal.class);
       final WizTabularController controller;
    }

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizTabularControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizTabularControllerTest.java
@@ -34,6 +34,7 @@ import inetsoft.web.wiz.model.WizTabularListings;
 import inetsoft.web.wiz.model.WizTabularSaveResult;
 import inetsoft.web.wiz.request.WizTabularCreateRequest;
 import inetsoft.web.wiz.service.UnsupportedDatasourceException;
+import inetsoft.web.wiz.service.WorksheetTableService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -58,6 +59,7 @@ class WizTabularControllerTest {
    private DatasourcesService datasourcesService;
    private SecurityEngine securityEngine;
    private XRepository xrepository;
+   private WorksheetTableService worksheetTableService;
    private WizTabularController controller;
    private Principal principal;
 
@@ -66,7 +68,9 @@ class WizTabularControllerTest {
       datasourcesService = mock(DatasourcesService.class);
       securityEngine = mock(SecurityEngine.class);
       xrepository = mock(XRepository.class);
-      controller = new WizTabularController(datasourcesService, securityEngine, xrepository);
+      worksheetTableService = mock(WorksheetTableService.class);
+      controller = new WizTabularController(datasourcesService, securityEngine, xrepository,
+                                            worksheetTableService);
       principal = mock(Principal.class);
 
       when(securityEngine.checkPermission(any(), any(ResourceType.class), anyString(),

--- a/core/src/test/java/inetsoft/web/wiz/model/WorksheetTableRequestTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/model/WorksheetTableRequestTest.java
@@ -142,4 +142,62 @@ class WorksheetTableRequestTest {
       assertEquals("RANGE", output.at("/windowColumns/0/frame/mode").asText());
       assertEquals("day", output.at("/windowColumns/0/frame/offsetUnit").asText());
    }
+
+   // ─── tabularSource: the generalized target ────────────────────────────────
+
+   /**
+    * The field names are the contract with wiz-services, which builds this object. Bound here
+    * rather than left to the service tests because a rename that Jackson simply ignores produces a
+    * null target and an "is required" error, with nothing saying the caller spelled it differently.
+    */
+   @Test
+   void tabularFileTargetBinds() throws Exception {
+      ObjectMapper mapper = new ObjectMapper();
+
+      WorksheetTable t = mapper.readValue(
+         """
+         { "tableType": "tabular table",
+           "tabularSource": {
+             "datasourcePath": "Files/Sales",
+             "targetKind": "file",
+             "target": "2024/sales.xlsx#Q1",
+             "params": { "firstRowHeader": "true", "delimiter": ";" },
+             "sampleRows": 5
+           } }
+         """,
+         WorksheetTable.class);
+
+      WorksheetTable.TabularSource src = t.getTabularSource();
+      assertEquals("file", src.getTargetKind());
+      assertEquals("2024/sales.xlsx#Q1", src.getTarget());
+      assertEquals("true", src.getParams().get("firstRowHeader"));
+      assertEquals(";", src.getParams().get("delimiter"));
+      assertEquals(5, src.getSampleRows());
+   }
+
+   /**
+    * {@code endpoint} was this field's name before a file could be named through it, and it named
+    * the same thing. Kept as an alias so a caller written against that shape still binds rather
+    * than failing with "target is required" over a value it did supply.
+    */
+   @Test
+   void tabularEndpointBindsAsTargetUnderItsOldName() throws Exception {
+      ObjectMapper mapper = new ObjectMapper();
+
+      WorksheetTable t = mapper.readValue(
+         """
+         { "tableType": "tabular table",
+           "tabularSource": { "datasourcePath": "SaaS/Stripe", "endpoint": "Charges",
+                              "parameters": { "limit": "100" } } }
+         """,
+         WorksheetTable.class);
+
+      WorksheetTable.TabularSource src = t.getTabularSource();
+      assertEquals("Charges", src.getTarget());
+      // Absent, not defaulted on the model: buildTabularTable reads an absent kind as "endpoint",
+      // which is where that rule belongs — the model only reports what arrived.
+      assertNull(src.getTargetKind());
+      assertEquals("100", src.getParameters().get("limit"));
+      assertNull(src.getParams());
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServicePermissionTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServicePermissionTest.java
@@ -19,6 +19,8 @@ package inetsoft.web.wiz.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.report.composition.RuntimeWorksheet;
+import inetsoft.sree.SreeEnv;
 import inetsoft.sree.security.ResourceAction;
 import inetsoft.sree.security.ResourceType;
 import inetsoft.sree.security.SecurityEngine;
@@ -27,11 +29,13 @@ import inetsoft.test.BaseTestConfiguration;
 import inetsoft.test.ConfigurationContextInitializer;
 import inetsoft.test.SreeHome;
 import inetsoft.uql.XRepository;
+import inetsoft.uql.asset.Worksheet;
 import inetsoft.web.composer.ws.LayoutGraphService;
 import inetsoft.web.composer.ws.joins.InnerJoinService;
 import inetsoft.web.portal.controller.database.DataSourceService;
 import inetsoft.web.portal.controller.database.QueryManagerService;
 import inetsoft.web.wiz.model.DeleteWorksheetTablesRequest;
+import inetsoft.web.wiz.model.WorksheetTable;
 import inetsoft.web.wiz.model.WorksheetTableRequest;
 import inetsoft.web.wiz.model.WorksheetTableResponse;
 import inetsoft.web.wiz.model.WorksheetTablesResponse;
@@ -43,9 +47,13 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.security.Principal;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -383,6 +391,108 @@ class WorksheetTableServicePermissionTest {
 
       verifyNoInteractions(deps.xrepository);
    }
+
+   // ─── createTable -> buildTabularTable: which contract the target is read under ─────────────
+
+   /**
+    * The kind selects the contract — which properties carry the target, whether a row cap is
+    * demanded, how a failure is worded — so an unrecognized value cannot be resolved to either
+    * side. Refused by name rather than defaulted, which would build the table against a contract
+    * the caller did not ask for and report success.
+    *
+    * <p>Asserted before the data source is resolved, because the check has to precede everything
+    * the contract then does with it.</p>
+    */
+   @Test
+   void createTableTabularTableRejectsAnUnknownTargetKind() throws Exception {
+      Deps deps = new Deps();
+      when(deps.securityEngine.checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                               eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      when(deps.dataSourceService.checkPermission(anyString(), eq(ResourceAction.READ), eq(USER)))
+         .thenReturn(true);
+
+      WorksheetTableRequest request = batchOf("""
+         {
+           "tableName": "t1",
+           "tableType": "tabular table",
+           "tabularSource": { "datasourcePath": "myds", "targetKind": "table", "target": "q1.csv" }
+         }
+         """);
+
+      WorksheetTableResponse table = only(deps.service().createTables(request, USER));
+      assertFalse(table.isSuccess());
+      assertTrue(table.getErrorMessage().contains("targetKind"),
+                 "the error should name the field, got: " + table.getErrorMessage());
+
+      verifyNoInteractions(deps.xrepository);
+   }
+
+   /** Case and surrounding space are the caller's spelling, not a different request. */
+   @Test
+   void createTableTabularTableAcceptsATargetKindInAnyCase() throws Exception {
+      Deps deps = new Deps();
+      when(deps.securityEngine.checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                               eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      when(deps.dataSourceService.checkPermission(anyString(), eq(ResourceAction.READ), eq(USER)))
+         .thenReturn(true);
+
+      WorksheetTableRequest request = batchOf("""
+         {
+           "tableName": "t1",
+           "tableType": "tabular table",
+           "tabularSource": { "datasourcePath": "myds", "targetKind": " File ", "target": "q1.csv" }
+         }
+         """);
+
+      // Past the kind check and into the build, where the unstubbed repository ends it.
+      WorksheetTableResponse table = only(deps.service().createTables(request, USER));
+      assertFalse(table.isSuccess());
+      assertTrue(table.getErrorMessage().contains("Data source not found"),
+                 "should fail past the kind check, got: " + table.getErrorMessage());
+
+      verify(deps.xrepository).getDataSource(eq("myds"));
+   }
+
+   /**
+    * A target is required whichever kind it is, and the message has to say which THING is missing —
+    * an endpoint name and a file path are not the same thing to go and find.
+    */
+   @Test
+   void createTableTabularTableRequiresATargetAndSaysWhatKindOfOne() throws Exception {
+      Deps deps = new Deps();
+      when(deps.securityEngine.checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                               eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      when(deps.dataSourceService.checkPermission(anyString(), eq(ResourceAction.READ), eq(USER)))
+         .thenReturn(true);
+
+      WorksheetTableResponse asFile = only(deps.service().createTables(batchOf("""
+         {
+           "tableName": "t1",
+           "tableType": "tabular table",
+           "tabularSource": { "datasourcePath": "myds", "targetKind": "file" }
+         }
+         """), USER));
+      assertFalse(asFile.isSuccess());
+      assertTrue(asFile.getErrorMessage().contains("tabularSource.target is required") &&
+                    asFile.getErrorMessage().contains("file path"),
+                 "the file wording should name a path, got: " + asFile.getErrorMessage());
+
+      WorksheetTableResponse asEndpoint = only(deps.service().createTables(batchOf("""
+         {
+           "tableName": "t1",
+           "tableType": "tabular table",
+           "tabularSource": { "datasourcePath": "myds" }
+         }
+         """), USER));
+      assertFalse(asEndpoint.isSuccess());
+      assertTrue(asEndpoint.getErrorMessage().contains("tabularSource.target is required") &&
+                    asEndpoint.getErrorMessage().contains("endpoint"),
+                 "an absent kind is the endpoint one, got: " + asEndpoint.getErrorMessage());
+   }
+
    // ─── createTable -> buildTable: sql query table FREE_FORM_SQL gate ─────────
 
    @Test
@@ -447,5 +557,222 @@ class WorksheetTableServicePermissionTest {
       verify(deps.securityEngine).checkPermission(eq(USER), eq(ResourceType.FREE_FORM_SQL), eq("*"),
                                                   eq(ResourceAction.ACCESS));
       verify(deps.metadataApiService).getJDBCDatasource(eq("myds"));
+   }
+
+   // ─── probeTable: the annotation probe, and the sample it exists for ────────────────────────
+
+   @Test
+   void probeTableThrowsWhenWorksheetAccessDenied() throws Exception {
+      Deps deps = new Deps();
+      when(deps.securityEngine.checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                               eq(ResourceAction.ACCESS)))
+         .thenReturn(false);
+
+      WorksheetTable table = MAPPER.readValue(
+         "{ \"tableName\": \"t1\", \"tableType\": \"tabular table\" }", WorksheetTable.class);
+
+      assertThrows(SecurityException.class,
+                   () -> deps.service().probeTable("Worksheet-1", table, USER));
+
+      // Nothing is opened or looked up before the gate answers.
+      verifyNoInteractions(deps.viewsheetService);
+   }
+
+   /**
+    * A build failure comes back as a failed RESULT, not an exception. The caller is a loop over a
+    * directory and one unreadable file must not end the walk — the same contract a table inside a
+    * createTables batch has.
+    */
+   @Test
+   void probeTableReportsABuildFailureWithoutThrowingAndLeavesNoAssembly() throws Exception {
+      Deps deps = new Deps();
+      when(deps.securityEngine.checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                               eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      when(deps.dataSourceService.checkPermission(anyString(), eq(ResourceAction.READ), eq(USER)))
+         .thenReturn(true);
+
+      Worksheet worksheet = new Worksheet();
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(worksheet);
+      when(deps.viewsheetService.getWorksheet(eq("Worksheet-1"), eq(USER))).thenReturn(rws);
+
+      // xrepository is unstubbed, so the data source resolves to null and the build fails.
+      WorksheetTable table = MAPPER.readValue("""
+         { "tableName": "t1", "tableType": "tabular table",
+           "tabularSource": { "datasourcePath": "myds", "targetKind": "file",
+                              "target": "q1.csv", "sampleRows": 5 } }
+         """, WorksheetTable.class);
+
+      WorksheetTableResponse response = deps.service().probeTable("Worksheet-1", table, USER);
+
+      assertFalse(response.isSuccess());
+      assertTrue(response.getErrorMessage().contains("Data source not found"),
+                 "expected the build's own reason, got: " + response.getErrorMessage());
+
+      // Each file is an independent question; nothing may accumulate in the shared worksheet.
+      assertNull(worksheet.getAssembly("t1"),
+                 "the probe assembly must not survive the call that built it");
+   }
+
+   /** A caller that did not name the table gets one, because the name has no consequence. */
+   @Test
+   void probeTableNamesAnUnnamedTableRatherThanFailing() throws Exception {
+      Deps deps = new Deps();
+      when(deps.securityEngine.checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                               eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+
+      Worksheet worksheet = new Worksheet();
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(worksheet);
+      when(deps.viewsheetService.getWorksheet(eq("Worksheet-1"), eq(USER))).thenReturn(rws);
+
+      WorksheetTable table = MAPPER.readValue(
+         "{ \"tableType\": \"tabular table\" }", WorksheetTable.class);
+
+      WorksheetTableResponse response = deps.service().probeTable("Worksheet-1", table, USER);
+
+      assertNotNull(response.getTableName(), "an unnamed probe table must still be named");
+      assertFalse(response.isSuccess());
+   }
+
+   @Test
+   void probeTableRequiresARuntimeId() throws Exception {
+      Deps deps = new Deps();
+      when(deps.securityEngine.checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                               eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+
+      WorksheetTable table = MAPPER.readValue(
+         "{ \"tableName\": \"t1\", \"tableType\": \"tabular table\" }", WorksheetTable.class);
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> deps.service().probeTable("  ", table, USER));
+      assertTrue(ex.getMessage().contains("runtimeId"), ex.getMessage());
+   }
+
+   // ─── sandboxSampleLimit: the rule that keeps the endpoint path untouched ───────────────────
+
+   private static WorksheetTableResponse built() {
+      WorksheetTableResponse response = new WorksheetTableResponse();
+      response.setSuccess(true);
+      return response;
+   }
+
+   private static WorksheetTable tabular(String json) throws Exception {
+      return MAPPER.readValue(json, WorksheetTable.class);
+   }
+
+   /**
+    * THE assertion of this section. An endpoint's sample is taken by the runner from the one
+    * request it had to make; asking for it again here would send a second request to a metered API
+    * for data already accounted for. Keyed on the kind, not on "the response has no sample yet" —
+    * an endpoint whose first page came back empty also has none.
+    */
+   @Test
+   void sampleLimitIsZeroForAnEndpointEvenWhenRowsWereAskedForAndNoneCameBack() throws Exception {
+      WorksheetTable explicit = tabular("""
+         { "tableType": "tabular table",
+           "tabularSource": { "datasourcePath": "ds", "targetKind": "endpoint",
+                              "target": "Charges", "sampleRows": 10 } }
+         """);
+      assertEquals(0, WorksheetTableService.sandboxSampleLimit(explicit, built()));
+
+      // And with the kind omitted, which is how every pre-existing endpoint caller spells it.
+      WorksheetTable implied = tabular("""
+         { "tableType": "tabular table",
+           "tabularSource": { "datasourcePath": "ds", "endpoint": "Charges", "sampleRows": 10 } }
+         """);
+      assertEquals(0, WorksheetTableService.sandboxSampleLimit(implied, built()));
+   }
+
+   @Test
+   void sampleLimitIsTheRequestedCountForAFileTarget() throws Exception {
+      WorksheetTable table = tabular("""
+         { "tableType": "tabular table",
+           "tabularSource": { "datasourcePath": "ds", "targetKind": "file",
+                              "target": "q1.csv", "sampleRows": 7 } }
+         """);
+
+      assertEquals(7, WorksheetTableService.sandboxSampleLimit(table, built()));
+   }
+
+   /** Opt-in, unchanged: a caller that only wanted the column list runs no extra query. */
+   @Test
+   void sampleLimitIsZeroWhenNoRowsWereAskedFor() throws Exception {
+      WorksheetTable absent = tabular("""
+         { "tableType": "tabular table",
+           "tabularSource": { "datasourcePath": "ds", "targetKind": "file", "target": "q1.csv" } }
+         """);
+      assertEquals(0, WorksheetTableService.sandboxSampleLimit(absent, built()));
+
+      WorksheetTable zero = tabular("""
+         { "tableType": "tabular table",
+           "tabularSource": { "datasourcePath": "ds", "targetKind": "file",
+                              "target": "q1.csv", "sampleRows": 0 } }
+         """);
+      assertEquals(0, WorksheetTableService.sandboxSampleLimit(zero, built()));
+   }
+
+   /** A sample already on the response is never replaced, whatever produced it. */
+   @Test
+   void sampleLimitIsZeroWhenTheResponseAlreadyCarriesASample() throws Exception {
+      WorksheetTable table = tabular("""
+         { "tableType": "tabular table",
+           "tabularSource": { "datasourcePath": "ds", "targetKind": "file",
+                              "target": "q1.csv", "sampleRows": 7 } }
+         """);
+
+      WorksheetTableResponse response = built();
+      response.setSampleRows(List.of(Map.of("a", 1)));
+
+      assertEquals(0, WorksheetTableService.sandboxSampleLimit(table, response));
+   }
+
+   /** Nothing to sample from a table that was not built. */
+   @Test
+   void sampleLimitIsZeroForAFailedTable() throws Exception {
+      WorksheetTable table = tabular("""
+         { "tableType": "tabular table",
+           "tabularSource": { "datasourcePath": "ds", "targetKind": "file",
+                              "target": "q1.csv", "sampleRows": 7 } }
+         """);
+
+      WorksheetTableResponse failed = new WorksheetTableResponse();
+      failed.setSuccess(false);
+
+      assertEquals(0, WorksheetTableService.sandboxSampleLimit(table, failed));
+   }
+
+   /**
+    * {@code rest.sample.rows} is the deployment's ceiling on sampled customer data leaving a
+    * tabular connector, and 0 is the switch that stops it. A different KIND of target reaching the
+    * same data must not get around it.
+    */
+   @Test
+   void sampleLimitIsClampedByTheDeploymentCeilingAndSwitchedOffAtZero() throws Exception {
+      WorksheetTable table = tabular("""
+         { "tableType": "tabular table",
+           "tabularSource": { "datasourcePath": "ds", "targetKind": "file",
+                              "target": "q1.csv", "sampleRows": 50 } }
+         """);
+
+      String original = SreeEnv.getProperty("rest.sample.rows");
+
+      try {
+         SreeEnv.setProperty("rest.sample.rows", "3");
+         assertEquals(3, WorksheetTableService.sandboxSampleLimit(table, built()));
+
+         SreeEnv.setProperty("rest.sample.rows", "0");
+         assertEquals(0, WorksheetTableService.sandboxSampleLimit(table, built()));
+
+         // Not a number: no sample, rather than a guess about a knob governing customer data.
+         SreeEnv.setProperty("rest.sample.rows", "lots");
+         assertEquals(0, WorksheetTableService.sandboxSampleLimit(table, built()));
+      }
+      finally {
+         SreeEnv.setProperty("rest.sample.rows", original);
+      }
    }
 }


### PR DESCRIPTION
A tabular table could only name a REST endpoint. `tabularSource` now carries `targetKind` (`"endpoint"` | `"file"`), and `target` generalizes the former `endpoint` field: an endpoint name for one kind, a path relative to the connector root (optionally suffixed `"#<sheet>"`) for the other. `params` carries a file connector's own parsing options. `endpoint` stays readable as a Jackson alias, so a caller still sending it binds instead of being told `target` is missing.

## Build path

`buildTabularTable` splits into contract resolution plus a shared build. The endpoint half is unchanged. The file half fills the query's `File`-typed property and validates `params` against the connector's own `PropertyMeta` map, so an option a connector declares is accepted and one it does not is refused by name rather than dropped. `requireRowCapWhenPaged` stays endpoint-only: a local file has no pages to walk and no per-call bill, so demanding a cap there would refuse a correct request. `target` is resolved against the connector root and refused when absolute, containing `..`, resolving outside the root, or absent.

A multi-sheet workbook with no sheet named fails and names the sheets. `ServerFileUtil.getColumnDefinition` and `getExcelSheetNames` both default to `sheets[0]`, so a three-sheet workbook would otherwise have reported success having annotated one.

## Probe

Annotation needs a column list and sample rows without leaving an asset behind, so `openProbeWorksheet`/`probeTable`/`closeProbeWorksheet` read a target through a temporary worksheet that is never persisted, clearing the assembly between files.

Sampling cannot come from `setSampleRows`: only `EndpointJsonQueryRunner` fills it, and a file's columns are read without executing the query at all. `probeTable` executes the built assembly through its own `AssetQuerySandbox` instead — private because `getTableLens` caches on name plus column-selection hash, and a loop reusing one table name over files with identical headers would answer the second with the first one's rows. The row bound reaches the connector as `XQuery.rowlimit`, so reading stops at the limit rather than trimming afterwards, and one extra row is read as the evidence for `sampleRowsTruncated`. Sampling failure leaves the sample absent and the probe successful.

The ceiling stays `rest.sample.rows`: a deployment that set it to 0 to stop sampled data leaving a tabular connector must not be circumvented by a different kind of target reaching the same data.

## Routes

Four routes expose this to wiz under its own permission checks rather than a composer session: `/tabular/browse` and `/tabular/probe/{open,table,close}`. Browse reports each entry's path relative to the connector root, which is the same string a build takes back as `target`.

## Tests

Appended to existing files (`WorksheetTableRequestTest`, `WorksheetTableServicePermissionTest`, the two `WizTabularController*Test`), no new test files. `inetsoft.web.wiz.**`: 2204 tests, 0 failures.

Consumed by inetsoft-technology/stylebi-wiz#1785.

🤖 Generated with [Claude Code](https://claude.com/claude-code)