### PR TITLE
Thread rvs/source/refModelService through TableBindingMutator addField/removeField/moveField

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/binding/TableBindingMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/TableBindingMutator.java
@@ -151,6 +151,29 @@ public final class TableBindingMutator {
    public static void addField(BaseTableBindingModel model, String shelf, FieldRef field,
                                Integer position)
    {
+      try {
+         addField(model, shelf, field, position, null, null, null);
+      }
+      catch(RuntimeException e) {
+         throw e; // preserve e.g. requireShelf/requireCompatible's IllegalArgumentException as-is
+      }
+      catch(Exception e) {
+         throw new RuntimeException(e);
+      }
+   }
+
+   /**
+    * @param rvs            the runtime viewsheet, so a field already on the shelf (or the one
+    *                       being added) carrying {@code namedGroup} can be resolved against a
+    *                       worksheet-local named group, the same as {@link #setShelf} below.
+    * @param sourceInfo     the crosstab's or table's own {@code SourceInfo}.
+    * @param refModelService needed to resolve a worksheet-local named group's conditions.
+    */
+   public static void addField(BaseTableBindingModel model, String shelf, FieldRef field,
+                               Integer position, RuntimeViewsheet rvs, SourceInfo sourceInfo,
+                               DataRefModelFactoryService refModelService)
+      throws Exception
+   {
       String name = requireShelf(model, shelf);
       requireCompatible(name, field);
       List<FieldRef> current = new ArrayList<>(read(model, name));
@@ -163,10 +186,27 @@ public final class TableBindingMutator {
       }
 
       current.add(index, field);
-      setShelf(model, name, current);
+      setShelf(model, name, current, rvs, sourceInfo, refModelService);
    }
 
    public static void removeField(BaseTableBindingModel model, String shelf, String column) {
+      try {
+         removeField(model, shelf, column, null, null, null);
+      }
+      catch(RuntimeException e) {
+         throw e; // preserve e.g. requireShelf's IllegalArgumentException as-is
+      }
+      catch(Exception e) {
+         throw new RuntimeException(e);
+      }
+   }
+
+   /** @see #addField(BaseTableBindingModel, String, FieldRef, Integer, RuntimeViewsheet, SourceInfo, DataRefModelFactoryService) */
+   public static void removeField(BaseTableBindingModel model, String shelf, String column,
+                                  RuntimeViewsheet rvs, SourceInfo sourceInfo,
+                                  DataRefModelFactoryService refModelService)
+      throws Exception
+   {
       String name = requireShelf(model, shelf);
       List<FieldRef> current = new ArrayList<>(read(model, name));
       boolean removed = current.removeIf(
@@ -178,7 +218,7 @@ public final class TableBindingMutator {
             (current.isEmpty() ? "(nothing)" : columns(current)) + ".");
       }
 
-      setShelf(model, name, current);
+      setShelf(model, name, current, rvs, sourceInfo, refModelService);
    }
 
    /**
@@ -191,6 +231,23 @@ public final class TableBindingMutator {
     */
    public static void moveField(BaseTableBindingModel model, String fromShelf, String toShelf,
                                 String column, Integer position)
+   {
+      try {
+         moveField(model, fromShelf, toShelf, column, position, null, null, null);
+      }
+      catch(RuntimeException e) {
+         throw e; // preserve e.g. requireShelf/requireCompatible's IllegalArgumentException as-is
+      }
+      catch(Exception e) {
+         throw new RuntimeException(e);
+      }
+   }
+
+   /** @see #addField(BaseTableBindingModel, String, FieldRef, Integer, RuntimeViewsheet, SourceInfo, DataRefModelFactoryService) */
+   public static void moveField(BaseTableBindingModel model, String fromShelf, String toShelf,
+                                String column, Integer position, RuntimeViewsheet rvs,
+                                SourceInfo sourceInfo, DataRefModelFactoryService refModelService)
+      throws Exception
    {
       String from = requireShelf(model, fromShelf);
       String to = requireShelf(model, toShelf);
@@ -214,8 +271,8 @@ public final class TableBindingMutator {
       }
 
       target.add(index, field);
-      setShelf(model, from, source);
-      setShelf(model, to, target);
+      setShelf(model, from, source, rvs, sourceInfo, refModelService);
+      setShelf(model, to, target, rvs, sourceInfo, refModelService);
    }
 
    /** What a shelf currently holds, in the shared vocabulary. */

--- a/core/src/main/java/inetsoft/web/wiz/binding/TableBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/TableBindingService.java
@@ -190,23 +190,28 @@ public class TableBindingService {
    public void addField(String sessionToken, Principal user, String assemblyName, String shelf,
                         FieldRef field, Integer position) throws Exception
    {
-      apply(sessionToken, user, assemblyName,
-            model -> TableBindingMutator.addField(model, shelf, field, position));
+      applyWithContext(sessionToken, user, assemblyName,
+         (model, rvs, source) ->
+            TableBindingMutator.addField(model, shelf, field, position, rvs, source,
+                                         refModelService));
    }
 
    public void removeField(String sessionToken, Principal user, String assemblyName,
                            String shelf, String column) throws Exception
    {
-      apply(sessionToken, user, assemblyName,
-            model -> TableBindingMutator.removeField(model, shelf, column));
+      applyWithContext(sessionToken, user, assemblyName,
+         (model, rvs, source) ->
+            TableBindingMutator.removeField(model, shelf, column, rvs, source, refModelService));
    }
 
    public void moveField(String sessionToken, Principal user, String assemblyName,
                          String fromShelf, String toShelf, String column, Integer position)
       throws Exception
    {
-      apply(sessionToken, user, assemblyName,
-            model -> TableBindingMutator.moveField(model, fromShelf, toShelf, column, position));
+      applyWithContext(sessionToken, user, assemblyName,
+         (model, rvs, source) ->
+            TableBindingMutator.moveField(model, fromShelf, toShelf, column, position, rvs,
+                                          source, refModelService));
    }
 
    public void setSort(String sessionToken, Principal user, String assemblyName, String shelf,
@@ -318,6 +323,35 @@ public class TableBindingService {
                       Consumer<BaseTableBindingModel> mutation) throws Exception
    {
       apply(sessionToken, user, assemblyName, mutation, false);
+   }
+
+   /**
+    * A shelf mutation that also needs the runtime context {@link TableBindingMutator#setShelf}
+    * threads through to resolve a field's {@code namedGroup} -- unlike the plain {@link Consumer}
+    * overload above, which reapplies a shelf with no context and so silently drops an
+    * already-resolved {@code namedGroup} on any field the mutation doesn't itself touch.
+    */
+   @FunctionalInterface
+   private interface ContextualShelfMutation {
+      void accept(BaseTableBindingModel model, RuntimeViewsheet rvs,
+                  inetsoft.uql.asset.SourceInfo source) throws Exception;
+   }
+
+   private void applyWithContext(String sessionToken, Principal user, String assemblyName,
+                                 ContextualShelfMutation mutation) throws Exception
+   {
+      sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         BaseTableBindingModel model = requireTableBinding(rvs, assemblyName);
+         VSAssembly assembly = rvs.getViewsheet().getAssembly(assemblyName);
+         inetsoft.uql.asset.SourceInfo source = assembly instanceof DataVSAssembly data
+            ? data.getSourceInfo() : null;
+         mutation.accept(model, rvs, source);
+
+         ApplyVSAssemblyInfoEvent event = new ApplyVSAssemblyInfoEvent();
+         event.setName(assemblyName);
+         event.setBinding(model);
+         bindingModelService.setBinding(runtimeId, event, user, dispatcher);
+      });
    }
 
    private void apply(String sessionToken, Principal user, String assemblyName,

--- a/core/src/test/java/inetsoft/web/wiz/binding/TableBindingMutatorTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/TableBindingMutatorTest.java
@@ -18,10 +18,13 @@
 package inetsoft.web.wiz.binding;
 
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.report.internal.binding.AssetNamedGroupInfo;
+import inetsoft.report.internal.binding.SummaryAttr;
 import inetsoft.uql.Condition;
 import inetsoft.uql.ConditionItem;
 import inetsoft.uql.ConditionList;
 import inetsoft.uql.XConstants;
+import inetsoft.uql.asset.AssetRepository;
 import inetsoft.uql.asset.AttachedAssembly;
 import inetsoft.uql.asset.DefaultNamedGroupAssembly;
 import inetsoft.uql.asset.NamedGroupInfo;
@@ -730,6 +733,12 @@ class TableBindingMutatorTest {
     * TableBindingMutator#moveField} to reapply a whole shelf has no runtime context, so a field
     * carrying {@code namedGroup} through that path is left unresolved rather than throwing --
     * the same, pre-existing gap as before this class learned to resolve named groups at all.
+    *
+    * <p>This is about calling the plain, no-context {@code setShelf} directly (still a real,
+    * documented gap for a caller that has no context to give it) -- not the defect the
+    * addField/removeField/moveField tests below cover, which is that those three ALREADY HAVE
+    * {@code rvs}/{@code source}/{@code refModelService} in scope (via
+    * {@code TableBindingService}) but were routing through this no-context overload anyway.
     */
    @Test
    void theThreeArgSetShelfLeavesANamedGroupUnresolved() {
@@ -739,5 +748,125 @@ class TableBindingMutatorTest {
                                    List.of(dimWithNamedGroup("REGION", "Coastal")));
 
       assertNull(model.getRows().get(0).getNamedGroupInfo());
+   }
+
+   // ── addField/removeField/moveField must not drop an unrelated field's resolved
+   // ── named group when they reapply the whole shelf (L6 reopened) ──────────────
+   //
+   // Uses the repository-registered ("predefined") named group shape, not the worksheet-local
+   // Expert one setShelfResolvesAWorksheetLocalNamedGroupAndForcesSortSpecific above uses:
+   // FieldRefFactory.resolveNamedGroupInfo's EXPERT_NAMEDGROUP_INFO branch never calls
+   // NamedGroupInfoModel.setName(...), so a re-read of the model after the FIRST setShelf
+   // reconstructs a FieldRef with namedGroup()==null regardless of rvs -- a separate,
+   // pre-existing round-trip gap, not the addField/removeField/moveField defect these tests
+   // target. The ASSET_NAMEDGROUP_INFO_REF branch does set the name, so it round-trips and
+   // isolates the one thing under test here: whether rvs/source/refModelService actually reach
+   // setShelf on a second call.
+
+   private record NamedGroupFixture(CrosstabBindingModel model, RuntimeViewsheet rvs,
+                                    DataRefModelFactoryService refModelService) {}
+
+   /**
+    * A crosstab with "REGION" already bound to a repository-registered "Tiers" named group on
+    * rows, plus an unrelated second field, "Category", also on rows. Must run inside the
+    * caller's {@code MockedStatic<AssetUtil>}/{@code MockedStatic<SummaryAttr>} scope.
+    */
+   private static NamedGroupFixture crosstabWithRegionBoundToARegisteredNamedGroupAndCategory(
+      MockedStatic<AssetUtil> assetUtil, MockedStatic<SummaryAttr> summaryAttr) throws Exception
+   {
+      AssetRepository rep = mock(AssetRepository.class);
+      assetUtil.when(() -> AssetUtil.getAssetRepository(false)).thenReturn(rep);
+
+      AssetNamedGroupInfo tiers = mock(AssetNamedGroupInfo.class);
+      when(tiers.getName()).thenReturn("Tiers");
+      summaryAttr.when(() -> SummaryAttr.getAssetNamedGroupInfos(any(), eq(rep), isNull()))
+         .thenReturn(new AssetNamedGroupInfo[]{ tiers });
+
+      Worksheet ws = mock(Worksheet.class);
+      when(ws.getAssemblies()).thenReturn(new inetsoft.uql.asset.Assembly[0]);
+      RuntimeViewsheet rvs = rvsWithWorksheet(ws);
+      DataRefModelFactoryService refModelService = refModelService();
+
+      CrosstabBindingModel model = new CrosstabBindingModel();
+      TableBindingMutator.setShelf(model, "rows",
+         List.of(dimWithNamedGroup("REGION", "Tiers"), dim("Category")),
+         rvs, QUERY1_SOURCE, refModelService);
+
+      return new NamedGroupFixture(model, rvs, refModelService);
+   }
+
+   private static BDimensionRefModel regionOn(CrosstabBindingModel model) {
+      return model.getRows().stream()
+         .filter(r -> "REGION".equals(r.getColumnValue()))
+         .findFirst()
+         .orElseThrow();
+   }
+
+   @Test
+   void addFieldPreservesAnAlreadyResolvedNamedGroupOnAnotherFieldOnTheSameShelf()
+      throws Exception
+   {
+      try(MockedStatic<AssetUtil> assetUtil = mockStatic(AssetUtil.class);
+          MockedStatic<SummaryAttr> summaryAttr = mockStatic(SummaryAttr.class))
+      {
+         NamedGroupFixture fx =
+            crosstabWithRegionBoundToARegisteredNamedGroupAndCategory(assetUtil, summaryAttr);
+
+         TableBindingMutator.addField(fx.model(), "rows", dim("Year"), null,
+                                      fx.rvs(), QUERY1_SOURCE, fx.refModelService());
+
+         BDimensionRefModel region = regionOn(fx.model());
+         assertEquals(XConstants.SORT_SPECIFIC, region.getOrder());
+         assertNotNull(region.getNamedGroupInfo(),
+            "an unrelated addField on the same shelf must not drop REGION's resolved named " +
+            "group");
+         assertEquals("Tiers", region.getNamedGroupInfo().getName());
+      }
+   }
+
+   @Test
+   void removeFieldPreservesAnAlreadyResolvedNamedGroupOnAnotherFieldOnTheSameShelf()
+      throws Exception
+   {
+      try(MockedStatic<AssetUtil> assetUtil = mockStatic(AssetUtil.class);
+          MockedStatic<SummaryAttr> summaryAttr = mockStatic(SummaryAttr.class))
+      {
+         NamedGroupFixture fx =
+            crosstabWithRegionBoundToARegisteredNamedGroupAndCategory(assetUtil, summaryAttr);
+
+         TableBindingMutator.removeField(fx.model(), "rows", "Category",
+                                         fx.rvs(), QUERY1_SOURCE, fx.refModelService());
+
+         assertEquals(1, fx.model().getRows().size());
+         BDimensionRefModel region = regionOn(fx.model());
+         assertEquals(XConstants.SORT_SPECIFIC, region.getOrder());
+         assertNotNull(region.getNamedGroupInfo(),
+            "an unrelated removeField on the same shelf must not drop REGION's resolved " +
+            "named group");
+         assertEquals("Tiers", region.getNamedGroupInfo().getName());
+      }
+   }
+
+   @Test
+   void moveFieldPreservesAnAlreadyResolvedNamedGroupOnAnotherFieldOnTheSameShelf()
+      throws Exception
+   {
+      try(MockedStatic<AssetUtil> assetUtil = mockStatic(AssetUtil.class);
+          MockedStatic<SummaryAttr> summaryAttr = mockStatic(SummaryAttr.class))
+      {
+         NamedGroupFixture fx =
+            crosstabWithRegionBoundToARegisteredNamedGroupAndCategory(assetUtil, summaryAttr);
+
+         TableBindingMutator.moveField(fx.model(), "rows", "cols", "Category", null,
+                                       fx.rvs(), QUERY1_SOURCE, fx.refModelService());
+
+         assertEquals(1, fx.model().getRows().size(), "only REGION should remain on rows");
+         BDimensionRefModel region = regionOn(fx.model());
+         assertEquals(XConstants.SORT_SPECIFIC, region.getOrder());
+         assertNotNull(region.getNamedGroupInfo(),
+            "moving an unrelated field off the same shelf must not drop REGION's resolved " +
+            "named group");
+         assertEquals("Tiers", region.getNamedGroupInfo().getName());
+      }
    }
 }


### PR DESCRIPTION
## Summary

L6 reopened — confirmed, already-located defect from debugger-l6's investigation (found
alongside, but independent of, a separate render-layer crosstab named-group issue tracked
elsewhere).

`TableBindingMutator.addField`/`removeField`/`moveField` — backing the `add_table_field`/
`remove_table_field`/`move_table_field` MCP tools — all reapply a shelf's **entire** field
list through the 3-arg `setShelf(model, shelf, fields)` overload, which calls
`dimensions(fields, null, null, null)`. Because `rvs` is always `null` through that path,
**any field already on the shelf that carries a `namedGroup` has it silently dropped** the
next time one of those three tools touches that shelf — not just the field actually being
added/removed/moved, since the whole shelf's field list is rebuilt from scratch each call.
This gap was already flagged in the shipped code's own `@implNote` on the no-context
`dimensions(fields)` overload — a known, deliberately unclosed gap, not an oversight.

## Fix

Mechanical, per the debugger's own scoping — the 6-arg `setShelf` overload and
`FieldRefFactory.resolveNamedGroupInfo` already exist and are already proven correct by
#4731's own tests; no new resolution logic needed:

- `TableBindingMutator.addField`/`removeField`/`moveField` each get a new overload taking
  `RuntimeViewsheet`/`SourceInfo`/`DataRefModelFactoryService` and calling the existing 6-arg
  `setShelf` instead of the 3-arg one. The old no-context overloads now delegate to the new
  ones with nulls, so every existing caller/test (including direct `TableBindingMutatorTest`
  calls) is unaffected.
- `TableBindingService.addField`/`removeField`/`moveField` thread their already-in-scope
  `rvs`/`source` down via a new `applyWithContext` helper, mirroring `TableBindingService
  .setShelf`'s own existing `SourceInfo`-resolution pattern (`assembly instanceof
  DataVSAssembly`) exactly — the same precedent the debugger pointed at.

## A note on the regression test shape

The debugger's proposed test used the worksheet-local ("Expert") named-group shape. While
writing it, I found that shape can't round-trip through a second shelf rebuild **regardless
of this fix** — `FieldRefFactory.resolveNamedGroupInfo`'s `EXPERT_NAMEDGROUP_INFO` branch
never calls `NamedGroupInfoModel.setName(...)`, so a re-read of the model afterward recovers
`namedGroup()` as `null` on its own. That's a separate, pre-existing round-trip gap, not part
of this fix's scope (flagging it, not fixing it here). The regression tests instead use the
repository-registered (`ASSET_NAMEDGROUP_INFO_REF`) shape, which does set the name and so
round-trips correctly, cleanly isolating the actual defect under test: whether `rvs`/`source`
reach `setShelf` on a second call.

## Test plan
- [x] Added `addField`/`removeField`/`moveFieldPreservesAnAlreadyResolvedNamedGroupOn
      AnotherFieldOnTheSameShelf` to `TableBindingMutatorTest`
- [x] Verified all three genuinely catch the bug: temporarily made the new overloads call the
      3-arg `setShelf` instead of the 6-arg one (simulating the pre-fix behavior) — all three
      failed with the exact reported symptom (`order` reverting from `SORT_SPECIFIC`,
      `namedGroupInfo` becoming `null`). Restored the fix, reran — green.
- [x] `./mvnw -o test -pl core -Dtest=TableBindingMutatorTest,TableBindingServiceTest` —
      64/64 pass, existing tests unmodified
- [x] Broader sweep `-Dtest='inetsoft.web.wiz.binding.**,inetsoft.web.binding.**'` —
      329/329 pass
- [x] Full `core` module suite (`./mvnw -o test -pl core`) — 6991 tests, 0 failures, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)