### PR TITLE
Add ScriptTarget.Kind exhaustiveness guard to SheetPairingService

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/pairing/SheetPairingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/SheetPairingService.java
@@ -59,7 +59,7 @@ public class SheetPairingService {
     * packages depend on each other in both directions. An unrecognized kind is refused here, at
     * mint time, rather than left to surface later at {@code ScriptTarget.Kind.fromWire}.
     */
-   private static final List<String> RECOGNIZED_KINDS = List.of(
+   static final List<String> RECOGNIZED_KINDS = List.of(
       "viewsheetOnInit", "viewsheetOnLoad", "assemblyMain", "assemblyOnClick", "calcField",
       "worksheetExpression", "worksheetCondition", "worksheetConditionValue");
 
@@ -255,10 +255,10 @@ public class SheetPairingService {
    }
 
    /**
-    * The two worksheet kinds addressed by (table, field) rather than by assembly alone --
+    * The worksheet kinds addressed by (table, field) rather than by assembly alone --
     * exactly like {@code calcField}, and validated the same way (whole-branch review finding 3).
     *
-    * <p>Before this, both fell through to the generic "does the assembly exist" branch, which
+    * <p>Before this, these fell through to the generic "does the assembly exist" branch, which
     * neither requires nor verifies {@code name}. "New expression column" opens the formula editor
     * with no {@code formulaName}, so the mint carried no name; the mint SUCCEEDED, {@code status}
     * reported a healthy pane-scoped session, and then {@code PaneScopeService.matchesGrant}
@@ -271,15 +271,15 @@ public class SheetPairingService {
       List.of("worksheetExpression", "worksheetCondition", "worksheetConditionValue");
 
    /**
-    * Verifies a {@code worksheetExpression}/{@code worksheetCondition} context names a column
-    * that actually exists, mirroring the {@code calcField} branch against the
-    * {@link TableAssembly}'s own column selection.
+    * Verifies a {@code worksheetExpression}/{@code worksheetCondition}/
+    * {@code worksheetConditionValue} context names a column that actually exists, mirroring the
+    * {@code calcField} branch against the {@link TableAssembly}'s own column selection.
     *
     * <p>{@code worksheetExpression} is checked against EXPRESSION columns specifically, matching
     * on the same {@code ExpressionRef} name/attribute pair {@code WorksheetScriptService} reads
     * and writes through, so a grant cannot be minted for a location that service would then
-    * refuse. {@code worksheetCondition} is checked against any column, since adding a condition
-    * to a field that has none yet is legitimate.
+    * refuse. {@code worksheetCondition} and {@code worksheetConditionValue} are checked against
+    * any column, since adding a condition to a field that has none yet is legitimate.
     */
    private static void validateWorksheetColumnContext(RuntimeSheet rs, EditorContext ctx)
       throws PairingException

--- a/core/src/test/java/inetsoft/web/wiz/pairing/SheetPairingServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/pairing/SheetPairingServiceTest.java
@@ -31,6 +31,7 @@ import inetsoft.uql.asset.Worksheet;
 import inetsoft.uql.viewsheet.CalculateRef;
 import inetsoft.uql.viewsheet.VSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
+import inetsoft.web.wiz.script.ScriptTarget;
 import org.junit.jupiter.api.Test;
 
 import java.security.Principal;
@@ -75,6 +76,14 @@ import static org.mockito.Mockito.when;
  * [EditorContext: IDOR]      mint against a runtimeId the caller does not own fails identically
  *                            whether or not the named assembly exists -- the failure must never
  *                            become an oracle for what exists on someone else's open sheet
+ * [EditorContext: conditionValue ok]   mint accepts a worksheetConditionValue editorContext
+ *                            naming a column the worksheet runtime has
+ * [EditorContext: conditionValue no name] mint refuses a worksheetConditionValue context that
+ *                            carries no name
+ * [EditorContext: conditionValue no column] mint refuses a worksheetConditionValue context
+ *                            naming a column the table does not have
+ * [Kinds: exhaustive]        every ScriptTarget.Kind wire name is in RECOGNIZED_KINDS -- catches
+ *                            a new Kind added there but never wired into this hand-maintained list
  */
 /*
  * @WizAgentTestSupport (which itself carries @Tag("core")) replaces a bare @Tag: the
@@ -464,6 +473,20 @@ class SheetPairingServiceTest {
       assertEquals(PairingException.Kind.INVALID_ARGUMENT, ex.getKind());
       assertTrue(ex.getMessage().contains("NoSuchColumn"),
                  "message must name what was asked for: " + ex.getMessage());
+   }
+
+   /**
+    * Would have caught stylebi's worksheetConditionValue regression the moment
+    * {@code ScriptTarget.Kind.WORKSHEET_CONDITION_VALUE} was added but never wired into
+    * {@code RECOGNIZED_KINDS} -- mirrors {@code PaneScopeServiceTest#everyKindIsClassifiedByExactlyOneGuard}.
+    */
+   @Test
+   void everyScriptTargetKindIsRecognized() {
+      for(ScriptTarget.Kind k : ScriptTarget.Kind.values()) {
+         assertTrue(SheetPairingService.RECOGNIZED_KINDS.contains(k.wireName()),
+            "ScriptTarget.Kind '" + k.wireName() + "' is missing from " +
+            "SheetPairingService.RECOGNIZED_KINDS -- mint would refuse it as an unknown kind.");
+      }
    }
 
    /**


### PR DESCRIPTION
## Summary

This PR originally fixed `SheetPairingService` rejecting `worksheetConditionValue` pairing mints. That production fix (adding `"worksheetConditionValue"` to `RECOGNIZED_KINDS`/`WORKSHEET_COLUMN_KINDS`) already landed on `main` independently via #4789, along with the same three mirror tests this PR added -- so this branch has been rebased to drop everything that's now redundant and keep only what #4789 did not add:

- **`everyScriptTargetKindIsRecognized`**: an exhaustiveness test iterating `ScriptTarget.Kind.values()` against `RECOGNIZED_KINDS`, catching a new `Kind` added but never wired into this hand-maintained list -- this is the most valuable part of the original PR and #4789 did not add it. Required widening `RECOGNIZED_KINDS`'s visibility from `private` to package-private for the same-package test to reference it.
- **`SheetPairingService` javadoc corrections**: #4789 updated the two wire-kind lists but left the surrounding prose stale (still said "the two worksheet kinds..." after a third kind was added). Fixed the wording on `WORKSHEET_COLUMN_KINDS` and `validateWorksheetColumnContext`.
- **Header docblock index catch-up**: #4789 added its three tests without adding class-level index entries for them. Added the three `conditionValue` entries plus `[Kinds: exhaustive]`.

Retitled from "Fix worksheetConditionValue pairing mint rejection" since the fix itself is no longer part of this diff.

## Test plan
- [x] `SheetPairingServiceTest`: 31/31 passing (`mvnw -pl core test -Dtest=SheetPairingServiceTest -o`).
- [x] Rebased cleanly onto `stylebi-wiz-main-rebase`; `SheetPairingService.java` merges with zero conflicts (both sides made the same list additions independently); the only conflict was in the test file, where the now-duplicate mirror tests were dropped in favor of #4789's existing versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
