### PR TITLE
Bug #76174, apply the query cache settings without a restart

### DIFF
--- a/core/src/main/java/inetsoft/report/XSessionManager.java
+++ b/core/src/main/java/inetsoft/report/XSessionManager.java
@@ -96,26 +96,14 @@ public class XSessionManager {
     */
    @PostConstruct
    public void initAfterCreate() throws RemoteException {
-      String prop = SreeEnv.getProperty("query.cache.limit");
+      // registering applies query.cache.limit and query.cache.timeout, and keeps the
+      // cache in sync when they are changed later
+      QueryCacheSettings.register(dataCache);
 
-      if(prop != null) {
-         dataCache.setLimit(Integer.parseInt(prop));
-      }
-
-      prop = SreeEnv.getProperty("query.cache.timeout");
-
-      if(prop != null) {
-         dataCache.setTimeout(Long.parseLong(prop));
-      }
-
-      prop = SreeEnv.getProperty("query.cache.data");
+      String prop = SreeEnv.getProperty("query.cache.data");
 
       if(prop == null) {
-         setCacheData(true);
          dataCache.setTimeout(30000);
-      }
-      else {
-         setCacheData(prop.equalsIgnoreCase("true"));
       }
 
       dataSourceRegistry.addRefreshedListener(refreshedListener);
@@ -648,7 +636,7 @@ public class XSessionManager {
                                            XQuery query, Principal user)
          throws Exception
    {
-      boolean useCache = this.useCache;
+      boolean useCache = isCacheData();
       final Object cachedData = qvars.get(CACHED_DATA);
 
       // try fetching cached data option from variable table
@@ -741,6 +729,24 @@ public class XSessionManager {
     */
    public void setCacheData(boolean useCache) {
       this.useCache = useCache;
+   }
+
+   /**
+    * Check if query results should be cached. The query.cache.data property is read on
+    * every call so that a change to it takes effect without a restart. An explicit call
+    * to setCacheData() overrides the property.
+    *
+    * @return true to cache query results.
+    */
+   private boolean isCacheData() {
+      Boolean override = this.useCache;
+
+      if(override != null) {
+         return override;
+      }
+
+      String prop = SreeEnv.getProperty("query.cache.data");
+      return prop == null || prop.equalsIgnoreCase("true");
    }
 
    /**
@@ -928,7 +934,7 @@ public class XSessionManager {
    private Object session;
    private final Map<ReportSheet, String> executemap = new ConcurrentHashMap<>();
    private final DataCache<String, CEntry> dataCache = new DataCache<>();
-   private boolean useCache = false;
+   private volatile Boolean useCache = null; // explicit setCacheData() override
    private final XSessionService xSessionService;
    private final DataSourceRegistry dataSourceRegistry;
    private static final Set<QueryExecutionListener> queryExecutionListeners = new HashSet<>();

--- a/core/src/main/java/inetsoft/report/composition/execution/AssetDataCache.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetDataCache.java
@@ -734,17 +734,9 @@ public class AssetDataCache extends DataCache<DataKey, TableLens> {
    {
       this.dataSourceRegistry = dataSourceRegistry;
       this.distributedTableCacheStoreProvider = distributedTableCacheStoreProvider;
-      String prop = SreeEnv.getProperty("query.cache.limit", "100");
-
-      if(prop != null) {
-         setLimit(Integer.parseInt(prop));
-      }
-
-      prop = SreeEnv.getProperty("query.cache.timeout", "600000");
-
-      if(prop != null) {
-         setTimeout(Long.parseLong(prop));
-      }
+      // registering applies query.cache.limit and query.cache.timeout, and keeps this
+      // cache in sync when they are changed later
+      QueryCacheSettings.register(this);
 
       // default 6 threads per cpu for viewsheet might execute many queries
       pool = new ThreadPool(

--- a/core/src/main/java/inetsoft/sree/PropertiesEngine.java
+++ b/core/src/main/java/inetsoft/sree/PropertiesEngine.java
@@ -67,6 +67,14 @@ public class PropertiesEngine {
    @PostConstruct
    public void initEngine() {
       addPropertyChangeListener("string.compare.casesensitive", evt -> Tool.invalidateCaseSensitive());
+      // the new value is taken from the event rather than read back, because the
+      // in-memory properties are not reloaded until the change task is debounced
+      addPropertyChangeListener(
+         QueryCacheSettings.LIMIT_PROPERTY,
+         evt -> QueryCacheSettings.applyLimit((String) evt.getNewValue()));
+      addPropertyChangeListener(
+         QueryCacheSettings.TIMEOUT_PROPERTY,
+         evt -> QueryCacheSettings.applyTimeout((String) evt.getNewValue()));
       kvStorage = keyValueStorageManager.getStorage("sreeProperties");
    }
 
@@ -198,6 +206,10 @@ public class PropertiesEngine {
          getInternalProperties().remove(name);
          changedProps.add(name);
       }
+
+      // the log and SQL helper properties are deliberately not applied here, to keep the
+      // existing removal behavior
+      applyQueryCacheProperty(name);
    }
 
    /**
@@ -277,6 +289,22 @@ public class PropertiesEngine {
    private void applyProperty(String name) {
       applyLogProperty(name);
       applySqlHelperProperty(name);
+      applyQueryCacheProperty(name);
+   }
+
+   /**
+    * Push a changed query cache setting into the running caches, so that it takes effect
+    * without a restart. This handles the change on this node; the property change
+    * listener handles it on the other nodes of the cluster.
+    *
+    * @param name the property name.
+    */
+   private void applyQueryCacheProperty(String name) {
+      if(QueryCacheSettings.LIMIT_PROPERTY.equals(name) ||
+         QueryCacheSettings.TIMEOUT_PROPERTY.equals(name))
+      {
+         QueryCacheSettings.apply();
+      }
    }
 
    private void applySqlHelperProperty(String name) {

--- a/core/src/main/java/inetsoft/util/QueryCacheSettings.java
+++ b/core/src/main/java/inetsoft/util/QueryCacheSettings.java
@@ -1,0 +1,193 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.util;
+
+import inetsoft.sree.SreeEnv;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Central point of control for the query data cache settings,
+ * <tt>query.cache.limit</tt> and <tt>query.cache.timeout</tt>.
+ * <p>
+ * The caches that are sized from these two properties register themselves here. When
+ * either property is changed, the new value is pushed into every registered cache, so
+ * that a change made in the Enterprise Manager takes effect immediately instead of on
+ * the next restart.
+ *
+ * @version 15.0
+ * @author InetSoft Technology Corp
+ */
+public final class QueryCacheSettings {
+   /**
+    * Creates a new instance of QueryCacheSettings.
+    */
+   private QueryCacheSettings() {
+   }
+
+   /**
+    * Register a cache that is sized from the query cache properties. The current values
+    * are applied to the cache before this method returns. Only a weak reference to the
+    * cache is kept, so registration does not prevent it from being collected.
+    *
+    * @param cache the cache to register.
+    */
+   public static void register(DataCache<?, ?> cache) {
+      if(cache == null) {
+         return;
+      }
+
+      add(cache);
+      cache.setLimit(getLimit());
+      cache.setTimeout(getTimeout());
+   }
+
+   /**
+    * Add a cache to the registry without applying the current settings to it.
+    */
+   static void add(DataCache<?, ?> cache) {
+      synchronized(caches) {
+         caches.add(cache);
+      }
+   }
+
+   /**
+    * Get the configured maximum number of entries.
+    */
+   public static int getLimit() {
+      return parseLimit(SreeEnv.getProperty(LIMIT_PROPERTY));
+   }
+
+   /**
+    * Get the configured cache timeout, in milliseconds.
+    */
+   public static long getTimeout() {
+      return parseTimeout(SreeEnv.getProperty(TIMEOUT_PROPERTY));
+   }
+
+   /**
+    * Push the current property values into every registered cache.
+    */
+   public static void apply() {
+      int limit = getLimit();
+      long timeout = getTimeout();
+
+      for(DataCache<?, ?> cache : snapshot()) {
+         cache.setLimit(limit);
+         cache.setTimeout(timeout);
+      }
+   }
+
+   /**
+    * Push a new cache size into every registered cache.
+    * <p>
+    * This takes the raw property value rather than reading it back from {@link SreeEnv}
+    * because the property change notification is fired before the in-memory properties
+    * are reloaded, so a read here would see the previous value.
+    *
+    * @param value the new value of <tt>query.cache.limit</tt>, or <tt>null</tt> if the
+    *              property was removed.
+    */
+   public static void applyLimit(String value) {
+      int limit = parseLimit(value);
+
+      for(DataCache<?, ?> cache : snapshot()) {
+         cache.setLimit(limit);
+      }
+   }
+
+   /**
+    * Push a new cache timeout into every registered cache.
+    *
+    * @param value the new value of <tt>query.cache.timeout</tt>, or <tt>null</tt> if the
+    *              property was removed.
+    */
+   public static void applyTimeout(String value) {
+      long timeout = parseTimeout(value);
+
+      for(DataCache<?, ?> cache : snapshot()) {
+         cache.setTimeout(timeout);
+      }
+   }
+
+   /**
+    * Get the registered caches. A copy is taken so that the caches are not updated while
+    * holding the monitor.
+    */
+   private static DataCache<?, ?>[] snapshot() {
+      synchronized(caches) {
+         return caches.toArray(new DataCache<?, ?>[0]);
+      }
+   }
+
+   /**
+    * Parse a cache size. The value is bounded to the range of an int, since that is what
+    * the caches accept, so that an out-of-range value stored in the property does not
+    * fail the parse.
+    */
+   static int parseLimit(String value) {
+      if(value == null) {
+         return DEFAULT_LIMIT;
+      }
+
+      try {
+         return (int) Math.max(0, Math.min(Integer.MAX_VALUE, Long.parseLong(value.trim())));
+      }
+      catch(NumberFormatException ex) {
+         LOG.warn("Invalid value for {}, using {}: {}", LIMIT_PROPERTY, DEFAULT_LIMIT, value);
+         return DEFAULT_LIMIT;
+      }
+   }
+
+   /**
+    * Parse a cache timeout, in milliseconds.
+    */
+   static long parseTimeout(String value) {
+      if(value == null) {
+         return DEFAULT_TIMEOUT;
+      }
+
+      try {
+         return Math.max(0L, Long.parseLong(value.trim()));
+      }
+      catch(NumberFormatException ex) {
+         LOG.warn("Invalid value for {}, using {}: {}", TIMEOUT_PROPERTY, DEFAULT_TIMEOUT, value);
+         return DEFAULT_TIMEOUT;
+      }
+   }
+
+   /**
+    * The property that holds the maximum number of cache entries.
+    */
+   public static final String LIMIT_PROPERTY = "query.cache.limit";
+   /**
+    * The property that holds the cache timeout, in milliseconds.
+    */
+   public static final String TIMEOUT_PROPERTY = "query.cache.timeout";
+   /**
+    * The default cache size, matching defaults.properties.
+    */
+   public static final int DEFAULT_LIMIT = 100;
+   /**
+    * The default cache timeout, matching defaults.properties.
+    */
+   public static final long DEFAULT_TIMEOUT = 600000L;
+
+   private static final DataCache.CacheSet caches = new DataCache.CacheSet();
+   private static final Logger LOG = LoggerFactory.getLogger(QueryCacheSettings.class);
+}

--- a/core/src/main/java/inetsoft/web/admin/cache/CacheService.java
+++ b/core/src/main/java/inetsoft/web/admin/cache/CacheService.java
@@ -170,7 +170,7 @@ public class CacheService extends MonitorLevelService implements XSwappableMonit
     * @return the size of Data Cache Size.
     */
    public long getDataCacheSize() {
-      return Long.parseLong(SreeEnv.getProperty("query.cache.limit"));
+      return QueryCacheSettings.getLimit();
    }
 
    /**
@@ -234,7 +234,7 @@ public class CacheService extends MonitorLevelService implements XSwappableMonit
     * @return the timeout of Data Cache Timeout.
     */
    public long getDataCacheTimeout() {
-      return Long.parseLong(SreeEnv.getProperty("query.cache.timeout"));
+      return QueryCacheSettings.getTimeout();
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/admin/cache/CacheService.java
+++ b/core/src/main/java/inetsoft/web/admin/cache/CacheService.java
@@ -23,6 +23,7 @@ import inetsoft.sree.SreeEnv;
 import inetsoft.uql.table.XTableColumn;
 import inetsoft.uql.table.XTableFragment;
 import inetsoft.util.Catalog;
+import inetsoft.util.QueryCacheSettings;
 import inetsoft.util.swap.*;
 import inetsoft.web.admin.monitoring.*;
 import inetsoft.web.cluster.ServerClusterClient;
@@ -182,7 +183,7 @@ public class CacheService extends MonitorLevelService implements XSwappableMonit
             "cacheManager.invalidValue"));
       }
 
-      SreeEnv.setProperty("query.cache.limit", size + "");
+      SreeEnv.setProperty(QueryCacheSettings.LIMIT_PROPERTY, size + "");
 
       try {
          SreeEnv.save();
@@ -246,7 +247,7 @@ public class CacheService extends MonitorLevelService implements XSwappableMonit
             "cacheManager.invalidValue"));
       }
 
-      SreeEnv.setProperty("query.cache.timeout", timeout + "");
+      SreeEnv.setProperty(QueryCacheSettings.TIMEOUT_PROPERTY, timeout + "");
 
       try {
          SreeEnv.save();

--- a/core/src/main/java/inetsoft/web/admin/general/PerformanceSettingsService.java
+++ b/core/src/main/java/inetsoft/web/admin/general/PerformanceSettingsService.java
@@ -19,6 +19,7 @@ package inetsoft.web.admin.general;
 
 import inetsoft.report.composition.execution.AssetDataCache;
 import inetsoft.sree.SreeEnv;
+import inetsoft.util.QueryCacheSettings;
 import inetsoft.util.audit.ActionRecord;
 import inetsoft.web.admin.general.model.PerformanceSettingsModel;
 import inetsoft.web.viewsheet.AuditUser;
@@ -65,8 +66,8 @@ public class PerformanceSettingsService {
       flushAssetDataCache(oPreviewMaxRow, model.maxQueryPreviewRowCount());
 
       SreeEnv.setProperty("query.cache.data", model.dataSetCaching() + "");
-      SreeEnv.setProperty("query.cache.limit", model.dataCacheSize() + "");
-      SreeEnv.setProperty("query.cache.timeout", model.dataCacheTimeout() + "");
+      SreeEnv.setProperty(QueryCacheSettings.LIMIT_PROPERTY, model.dataCacheSize() + "");
+      SreeEnv.setProperty(QueryCacheSettings.TIMEOUT_PROPERTY, model.dataCacheTimeout() + "");
       SreeEnv.save();
    }
 

--- a/core/src/main/java/inetsoft/web/admin/general/PerformanceSettingsService.java
+++ b/core/src/main/java/inetsoft/web/admin/general/PerformanceSettingsService.java
@@ -42,8 +42,8 @@ public class PerformanceSettingsService {
          .maxQueryPreviewRowCount(Integer.parseInt(SreeEnv.getProperty("query.preview.maxrow")))
          .maxTableRowCount(Integer.parseInt(SreeEnv.getProperty("table.output.maxrow", "0")))
          .dataSetCaching(Boolean.valueOf(SreeEnv.getProperty("query.cache.data")))
-         .dataCacheSize(Long.parseLong(SreeEnv.getProperty("query.cache.limit")))
-         .dataCacheTimeout(Long.parseLong(SreeEnv.getProperty("query.cache.timeout")))
+         .dataCacheSize(QueryCacheSettings.getLimit())
+         .dataCacheTimeout(QueryCacheSettings.getTimeout())
          .build();
    }
 

--- a/core/src/test/java/inetsoft/util/QueryCacheSettingsTest.java
+++ b/core/src/test/java/inetsoft/util/QueryCacheSettingsTest.java
@@ -1,0 +1,117 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.util;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class QueryCacheSettingsTest {
+   @Test
+   void appliesNewLimitToRegisteredCache() {
+      DataCache<?, ?> cache = registerMock();
+
+      QueryCacheSettings.applyLimit("250");
+
+      verify(cache).setLimit(250);
+   }
+
+   @Test
+   void appliesNewTimeoutToRegisteredCache() {
+      DataCache<?, ?> cache = registerMock();
+
+      QueryCacheSettings.applyTimeout("900000");
+
+      verify(cache).setTimeout(900000L);
+   }
+
+   @Test
+   void removedLimitFallsBackToDefault() {
+      DataCache<?, ?> cache = registerMock();
+
+      QueryCacheSettings.applyLimit(null);
+
+      verify(cache).setLimit(QueryCacheSettings.DEFAULT_LIMIT);
+   }
+
+   @Test
+   void removedTimeoutFallsBackToDefault() {
+      DataCache<?, ?> cache = registerMock();
+
+      QueryCacheSettings.applyTimeout(null);
+
+      verify(cache).setTimeout(QueryCacheSettings.DEFAULT_TIMEOUT);
+   }
+
+   @Test
+   void appliesToEveryRegisteredCache() {
+      DataCache<?, ?> cache1 = registerMock();
+      DataCache<?, ?> cache2 = registerMock();
+
+      QueryCacheSettings.applyLimit("42");
+
+      verify(cache1).setLimit(42);
+      verify(cache2).setLimit(42);
+   }
+
+   @Test
+   void limitAboveIntRangeIsBounded() {
+      // the caches take an int, so a value larger than that stored in the property must
+      // not fail the parse the way Integer.parseInt() did
+      assertEquals(Integer.MAX_VALUE, QueryCacheSettings.parseLimit("9999999999"));
+   }
+
+   @Test
+   void negativeLimitIsBounded() {
+      assertEquals(0, QueryCacheSettings.parseLimit("-5"));
+   }
+
+   @Test
+   void negativeTimeoutIsBounded() {
+      assertEquals(0L, QueryCacheSettings.parseTimeout("-5"));
+   }
+
+   @Test
+   void unparsableLimitFallsBackToDefault() {
+      assertEquals(QueryCacheSettings.DEFAULT_LIMIT, QueryCacheSettings.parseLimit("abc"));
+   }
+
+   @Test
+   void unparsableTimeoutFallsBackToDefault() {
+      assertEquals(QueryCacheSettings.DEFAULT_TIMEOUT, QueryCacheSettings.parseTimeout("abc"));
+   }
+
+   @Test
+   void surroundingWhitespaceIsIgnored() {
+      assertEquals(250, QueryCacheSettings.parseLimit(" 250 "));
+      assertEquals(250L, QueryCacheSettings.parseTimeout(" 250 "));
+   }
+
+   /**
+    * Register a mock rather than a real cache, because the DataCache constructor
+    * registers with the sweeper, which needs the application context.
+    */
+   private DataCache<?, ?> registerMock() {
+      DataCache<?, ?> cache = mock(DataCache.class);
+      QueryCacheSettings.add(cache);
+      return cache;
+   }
+}

--- a/web/projects/em/src/app/settings/general/performance-settings-view/performance-settings-view.component.ts
+++ b/web/projects/em/src/app/settings/general/performance-settings-view/performance-settings-view.component.ts
@@ -73,7 +73,7 @@ export class PerformanceSettingsViewComponent {
          maxQueryPreviewRowCount: [this.model.maxQueryPreviewRowCount, Validators.min(0)],
          maxTableRowCount: [this.model.maxTableRowCount, FormValidators.positiveIntegerInRange],
          dataSetCaching: [this.model.dataSetCaching, Validators.min(0)],
-         dataCacheSize: [this.model.dataCacheSize, Validators.min(0)],
+         dataCacheSize: [this.model.dataCacheSize, FormValidators.positiveIntegerInRange],
          dataCacheTimeout: [this.model.dataCacheTimeout, Validators.min(0)],
       });
 


### PR DESCRIPTION
## Problem

`query.cache.limit` and `query.cache.timeout` were read once per process, so saving them in **Settings > General > Performance** changed the stored value and nothing else until the server was restarted. The page then redisplayed the new value, so it read as applied. `query.cache.data`, the third field of that group, did take effect immediately for `AssetDataCache`, which made the inconsistency hard to spot.

Three caches were sized from the two properties, and none of them re-read:

| Cache | Read once at |
|---|---|
| `XSessionManager.dataCache` | `initAfterCreate()` |
| `AssetDataCache` | constructor |
| `VpmUtil.vcache` (enterprise) | first VPM query |

## Fix

`QueryCacheSettings` becomes the single owner of the two properties. The three caches register themselves, and a change is pushed into every registered cache. Live application is safe: `limit` is only consulted at eviction time and `timeout` only at expiry checks, so nothing is sized at construction and no cache clear is needed.

Two propagation paths, because the local and remote cases differ:

- **Local node** — hooked into `PropertiesEngine.applyProperty()`, the mechanism already used for `mysql.server.timezone` and the log levels. This covers every write path at once: the Performance section, both `CacheService` setters, and the generic Properties page (`/api/admin/properties/edit`). `remove()` did not call that hook, so the query cache part is now called there too — deliberately not the log and SQL helper hooks, to leave removal behavior unchanged.
- **Other cluster nodes** — a `PropertyChangeListener` per key, alongside the existing `string.compare.casesensitive` listener. This is needed because `save()` removes the listener before writing and re-adds it after, so it never fires on the node that made the change.

The listener takes the new value from the event rather than reading it back, because `firePropertyChange` runs synchronously while the in-memory reload is debounced 500ms behind it — a read there returns the previous value.

## Also in this area

- `query.cache.data` was cached in an `XSessionManager` field at bean creation, so turning dataset caching off took effect for `AssetDataCache` but not for the query cache. It is now read per query; `setCacheData()` still overrides it.
- The cache size was parsed with `Integer.parseInt()` while the model and the EM field accept a `long`. A value above the int range did nothing until the next restart, which then threw out of `@PostConstruct`. Parsing now bounds the value, and the EM field uses the existing `positiveIntegerInRange` validator so it is rejected in the form rather than silently clamped.

## Testing

- 11 new unit tests in `QueryCacheSettingsTest` — push to registered caches, removal falls back to the default, int bounding, unparsable fallback. Mocks are used because the real `DataCache` constructor registers with the sweeper, which needs the application context.
- 2228 tests across `inetsoft.util.**`, `inetsoft.sree.**`, `inetsoft.web.admin.**` pass.
- 365 EM frontend tests pass.

## Related

The enterprise half of this change (`VpmUtil`) is in a separate PR, linked below once opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)