### PR TITLE
Bug #76027, keep the annotation rectangle's scaled position in sync with its pixel offset

### DIFF
--- a/core/src/main/java/inetsoft/web/viewsheet/controller/annotation/VSAnnotationAddService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/controller/annotation/VSAnnotationAddService.java
@@ -194,10 +194,9 @@ public class VSAnnotationAddService {
       // Set annotation properties
       annotation.setPixelOffset(annotationPosition);
       ainfo.setScaledPosition(new Point(x, y));
-      boolean isViewsheet = assemblyType == AnnotationVSAssemblyInfo.VIEWSHEET;
       Point point = annotationService.getAdjustedPoint(event, rvs, psize, assemblyType);
       annotationRectangle.setPixelOffset(point);
-      src = new Point2D.Double(isViewsheet ? x : point.x, point.y);
+      src = new Point2D.Double(point.x, point.y);
       dst = new Point2D.Double();
       tx.transform(src, dst);
       rinfo.setScaledPosition(new Point((int) Math.floor(dst.getX()),


### PR DESCRIPTION
## Summary

Viewsheet-level annotations (added via right-click canvas > Add Annotation) rendered ~70px too far left immediately after being added, then appeared to "jump" to the right after the viewsheet was reloaded.

## Root Cause

In `VSAnnotationAddService.addAnnotation()`, the annotation rectangle's `pixelOffset` and `scaledPosition` were set to two different values for viewsheet-type annotations:

- `pixelOffset` was set from `point`, the result of `getAdjustedPoint()`, which always adds a 70px offset meant to leave room for the connecting line used by assembly/data-type annotations.
- `scaledPosition` was derived from `isViewsheet ? x : point.x` — for viewsheet-type annotations this used the raw, unadjusted click `x`, missing the same 70px offset.

`VSAssemblyInfo.getLayoutPosition()` prefers the transient `scaledPosition` field over `pixelOffset` when it's non-null, so the freshly-added annotation rendered using the wrong (un-offset) position. `scaledPosition` is not persisted and resets to `null` on a fresh load, so reopening the viewsheet fell back to the correctly-persisted `pixelOffset`, which looked like the annotation had moved.

## Fix

Always derive `scaledPosition` from the same adjusted `point` used for `pixelOffset`, removing the `isViewsheet` special case that caused the two fields to diverge.

## Test Plan

- [x] `VSAnnotationAddServiceTest` passes (`addViewsheetAnnotation`, `addAssemblyAnnotation`)
- [x] `community/core` compiles
- [ ] Manual: enable security, open a viewsheet, right-click empty canvas > Add Annotation, confirm it appears in the correct position immediately (no shift after reload)

Fixes Redmine #76027.