### PR TITLE
Bug #76233, don't hold the sandbox lock across the asset data fetch

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/VSAQuery.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/VSAQuery.java
@@ -1058,9 +1058,7 @@ public abstract class VSAQuery {
       }
 
       try {
-         TableLens lens = AssetDataCache.getCache().getData(
-            box.getID(), table, wbox, ignored, mode,
-            limited, box.getTouchTimestamp(), qmgr);
+         TableLens lens = getDataWithoutSandboxLock(table, wbox, ignored, mode, limited, qmgr);
 
          List<Exception> exs = WorksheetService.ASSET_EXCEPTIONS.get();
 
@@ -1068,8 +1066,7 @@ public abstract class VSAQuery {
             tryIgnoring)
          {
             wbox.setIgnoreFiltering(true);
-            lens = AssetDataCache.getCache().getData(box.getID(), table, wbox, null, mode,
-                                          true, box.getTouchTimestamp(), qmgr);
+            lens = getDataWithoutSandboxLock(table, wbox, null, mode, true, qmgr);
             exs = WorksheetService.ASSET_EXCEPTIONS.get();
 
             if(exs != null) {
@@ -1099,6 +1096,40 @@ public abstract class VSAQuery {
       }
       finally {
          XUtil.VS_ASSEMBLY.set(null);
+      }
+   }
+
+   /**
+    * Fetch data from the asset data cache without holding a sandbox lock.
+    *
+    * <p>AssetDataCache.getData() blocks until the query has fully executed (it joins the
+    * processor thread) and, while computing the cache key, may fault swapped-out data back
+    * into memory by way of XSwapper.waitForMemory(), which can wait for as long as the
+    * memory state stays critical. Holding a sandbox read lock across that blocks every
+    * thread waiting for the write lock and -- because the sandbox lock is non-fair -- every
+    * reader queued behind those writers, which wedges the entire viewsheet and leaves the
+    * chart loading forever.
+    *
+    * <p>ViewsheetSandbox.doExecuteData() already releases all locks before calling
+    * query.getData() for exactly this reason (74001), but the VSAQuery subclasses re-acquire
+    * a read lock inside the fetch (ChartVSAQuery/TableVSAQuery/CrosstabVSAQuery
+    * getTableLens()), which defeats it. Releasing here restores that invariant regardless of
+    * which path reached the cache. The assembly mutations happen before this call and the
+    * fetch itself does not mutate assembly state, so it is safe to release.
+    */
+   private TableLens getDataWithoutSandboxLock(TableAssembly table, AssetQuerySandbox wbox,
+                                               Set ignored, int mode, boolean limited,
+                                               QueryManager qmgr)
+      throws Exception
+   {
+      box.unlockAll();
+
+      try {
+         return AssetDataCache.getCache().getData(
+            box.getID(), table, wbox, ignored, mode, limited, box.getTouchTimestamp(), qmgr);
+      }
+      finally {
+         box.restoreLocks();
       }
    }
 

--- a/core/src/main/java/inetsoft/util/swap/XSwapper.java
+++ b/core/src/main/java/inetsoft/util/swap/XSwapper.java
@@ -342,6 +342,19 @@ public final class XSwapper {
          criticalWait = true;
          criticalWaitCount.incrementAndGet();
 
+         // Cap the total time spent waiting here, measured from the moment the wait starts so
+         // that it also covers the uninterruptible waitLock.lock() below. The criticalNoSwap
+         // escape further down only fires when a swap sweep frees nothing at all; if the
+         // swapper keeps evicting something on every round but memory never recovers, the
+         // loop never terminates and the thread parks indefinitely -- together with any lock
+         // it already holds, which wedges the viewsheet (a sandbox read lock held here blocks
+         // every writer and, since that lock is non-fair, every reader queued behind them).
+         // Proceeding under critical memory is a risk, but a bounded risk beats hanging
+         // forever, and this generalizes the escape criticalNoSwap already provides.
+         final long maxWait = getMaxCriticalWait();
+         final long deadline = System.currentTimeMillis() + maxWait;
+         boolean timedOut = false;
+
          final Thread curr = Thread.currentThread();
          // waiting for memory in swapper thread, could deadlock
          boolean deadlock = curr instanceof XSwapperThread;
@@ -376,7 +389,12 @@ public final class XSwapper {
          try {
             // if critical mode and nothing to swap, let one thread to proceed
             // otherwise there is a 'deadlock' and the process would wait forever
-            while(getMemoryState() == CRITICAL_MEM && criticalNoSwap < 3) {
+            while(getMemoryState() == CRITICAL_MEM && criticalNoSwap.get() < 3) {
+               if(System.currentTimeMillis() >= deadline) {
+                  timedOut = true;
+                  break;
+               }
+
                synchronized(swapLock) {
                   swapLock.notifyAll();
                }
@@ -412,9 +430,14 @@ public final class XSwapper {
             }
          }
          finally {
-            if(criticalNoSwap > 0) {
+            if(criticalNoSwap.getAndSet(0) > 0) {
                doGC();
-               criticalNoSwap = 0;
+            }
+
+            if(timedOut) {
+               LOG.warn("Timed out after {}ms waiting for memory to be swapped out; " +
+                           "proceeding under critical memory. waiting={}, critical={}",
+                        maxWait, getWaitingThreadCount(), getCriticalWaitingThreadCount());
             }
 
             if(!deadlock) {
@@ -466,6 +489,37 @@ public final class XSwapper {
     */
    public void start() {
       stopped = false;
+   }
+
+   /**
+    * Get the maximum time, in milliseconds, that waitForMemory() may block a thread while
+    * the memory state stays critical.
+    */
+   long getMaxCriticalWait() {
+      // test override
+      if(maxCriticalWait >= 0) {
+         return maxCriticalWait;
+      }
+
+      // read every time so a property change takes effect without a restart. don't let a
+      // malformed value throw out of waitForMemory(), which runs in the middle of data fetches
+      try {
+         return Long.parseLong(
+            SreeEnv.getProperty("swapper.critical.max.wait",
+                                Long.toString(DEFAULT_CRITICAL_WAIT)));
+      }
+      catch(NumberFormatException ex) {
+         LOG.warn("Invalid swapper.critical.max.wait value, using {}ms",
+                  DEFAULT_CRITICAL_WAIT, ex);
+         return DEFAULT_CRITICAL_WAIT;
+      }
+   }
+
+   /**
+    * Set the maximum critical-memory wait. For tests.
+    */
+   void setMaxCriticalWait(long maxCriticalWait) {
+      this.maxCriticalWait = maxCriticalWait;
    }
 
    /**
@@ -694,7 +748,7 @@ public final class XSwapper {
                   swaplist.clear();
 
                   if(swapCnt == 0 && state == CRITICAL_MEM) {
-                     criticalNoSwap++;
+                     criticalNoSwap.incrementAndGet();
                   }
 
                   // get an acurate memory state after swapping
@@ -810,6 +864,8 @@ public final class XSwapper {
    private static final Logger LOG =
       LoggerFactory.getLogger(XSwapper.class);
 
+   // default cap on how long waitForMemory() blocks while the memory state stays critical
+   private static final long DEFAULT_CRITICAL_WAIT = 30000L;
    // swapping thresholds for [critical, bad, low, norm, good]
    private static final int[] PRIORITY = {1, 5, 20, 50, 200};
    // swapping percentage for [critical, bad, low, norm, good]
@@ -863,7 +919,8 @@ public final class XSwapper {
 
    private boolean stopped = false;
    private XSwapperThread[] threads = null;
-   private int criticalNoSwap = 0;
+   private final AtomicInteger criticalNoSwap = new AtomicInteger(0);
+   private volatile long maxCriticalWait = -1L;
    private int circle = 0;
    private int tcount = 0;
    private final long seed = Math.abs(System.currentTimeMillis());

--- a/core/src/main/resources/inetsoft/report/defaults.properties
+++ b/core/src/main/resources/inetsoft/report/defaults.properties
@@ -243,6 +243,7 @@ sree.properties=sree.properties
 string.compare.casesensitive=false
 stylereport.locale.resource=inetsoft/util/srinter
 swapper.count=1
+swapper.critical.max.wait=30000
 system.admin.address=
 table.cachedcell.threshold=20000
 table.export.cell.threshold.forcetocsv=

--- a/core/src/test/java/inetsoft/util/swap/XSwapperCriticalWaitTest.java
+++ b/core/src/test/java/inetsoft/util/swap/XSwapperCriticalWaitTest.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.util.swap;
+
+import inetsoft.test.*;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class, SwapperTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome()
+@Tag("core")
+class XSwapperCriticalWaitTest {
+   /**
+    * waitForMemory() must not block a caller indefinitely when the memory state never
+    * recovers. The existing criticalNoSwap escape only fires when a swap sweep frees
+    * nothing at all, so before the wall-clock cap a caller could park here forever --
+    * holding whatever locks it already had. In the reported chart hang that was a
+    * ViewsheetSandbox read lock, which blocked every writer and, because that lock is
+    * non-fair, every reader queued behind them, leaving the chart loading forever.
+    */
+   @Test
+   void waitForMemoryGivesUpWhenMemoryNeverRecovers() throws Exception {
+      final XSwapper swapper = spy(XSwapper.getSwapper());
+      // memory is critical and stays critical, and nothing is ever freed
+      doReturn(XSwapper.CRITICAL_MEM).when(swapper).getMemoryState();
+      swapper.setMaxCriticalWait(500L);
+
+      final long[] elapsed = new long[1];
+      // run on another thread so an unbounded wait fails the test instead of hanging the run
+      Thread caller = new Thread(() -> {
+         long start = System.currentTimeMillis();
+         swapper.waitForMemory();
+         elapsed[0] = System.currentTimeMillis() - start;
+      });
+
+      caller.setDaemon(true);
+      caller.start();
+      caller.join(30000L);
+
+      assertTrue(elapsed[0] > 0, "waitForMemory() did not return within 30s");
+      assertTrue(elapsed[0] >= 500L, "returned before the cap: " + elapsed[0] + "ms");
+      assertTrue(elapsed[0] < 15000L, "cap was not honored: " + elapsed[0] + "ms");
+   }
+}


### PR DESCRIPTION
## Problem

A chart stays in the loading state forever after the user interacts with it. Reported with `ThreadDump-10_8_0_11.txt`, which shows the whole viewsheet wedged — **no application thread is RUNNABLE**, only JVM/Ignite/Tomcat I/O selectors.

One thread holds the `ViewsheetSandbox` read lock (`ReentrantReadWriteLock$NonfairSync@3d3f53aa`) and is parked in `XSwapper.waitForMemory`:

```
clientInboundChannel-658   view:circular_network  assembly:Chart1
  VSChartAreasService:114              <- box.lockRead() at :111
   ViewsheetSandbox.getVGraphPair:6818
    VGraphPair.initGraph0:239
     ViewsheetSandbox.doExecuteData:6157   <- after thisLock.unlockAll() at :6148
      ChartVSAQuery.getTableLens:393       <- box.lockRead() at :358   *** re-acquired here ***
       VSAQuery.getTableLens:1061          <- AssetDataCache.getData(...)
        AssetDataCache.getCacheKey -> DataKey.createKey
         EmbeddedTableAssembly.printEmbeddedDataKey -> XEmbeddedTable.printKey:1617
          XSwappableTable.getObject -> XObjectColumn.access:563
           XSwapper.waitForMemory:403      <- parked
```

Queued behind it on the same lock: `OnDemand Thread4/5/19` and `clientInboundChannel-655` for the **write** lock (chart tile renders, plus the DnD `removeColumns` the user just did), and `OnDemand Thread3/20` and `clientInboundChannel-659` for the **read** lock. Four `http-nio-8080-exec-*` threads are parked in `GroupedThreadAspect.withGroupedThread` on those tile workers — those are the `getAssemblyImage` requests the browser never gets an answer to, i.e. the spinner.

## Root cause

Three things combine.

**1. A sandbox lock is held across the data fetch.** `ViewsheetSandbox.doExecuteData` deliberately calls `thisLock.unlockAll()` before `query.getData()` so the fetch holds no sandbox lock (comment cites 74001). The `VSAQuery` subclasses then re-acquire a read lock *inside* the fetch and hold it for the whole thing, defeating that mitigation — `ChartVSAQuery:358`, `TableVSAQuery:437`, `CrosstabVSAQuery:85`, `AbstractCrosstabVSAQuery:327`.

**2. The fetch can block forever.** Building the cache key hashes the first 50 rows of the embedded table (`XEmbeddedTable.printKey`); those rows had been swapped out, so reading them enters `waitForMemory()`:

```java
while(getMemoryState() == CRITICAL_MEM && criticalNoSwap < 3) { ... waitCondition.await(200ms); }
```

`criticalNoSwap` is only incremented when a swap sweep frees *nothing at all* (`XSwapper:697`) and is reset on every exit (`:417`). With memory critical but the swapper still evicting something each round, the counter never advances and the loop never terminates.

**3. The lock is non-fair.** `new ReentrantReadWriteLock(false)` lets a queued writer block subsequent readers, so one stuck reader plus one writer arrival stops every later reader too — even though the lock is only held in read mode. That is what turns a single parked thread into a dead dashboard.

## Changes

1. **`VSAQuery`** — the two `AssetDataCache.getCache().getData(...)` calls now go through `getDataWithoutSandboxLock(...)`, which wraps the fetch in `box.unlockAll()` / `box.restoreLocks()`. This restores the invariant `doExecuteData` already intended, and doing it at the shared chokepoint covers the chart, table, crosstab and calc-table paths in one place. `AssetDataCache.getData` blocks to completion (`processor.join()` at `AssetDataCache:857`), so this is exactly the kind of long blocking call the existing `unlockAll` pattern is for.

2. **`XSwapper.waitForMemory()`** — wall-clock cap on the critical-memory wait, new `swapper.critical.max.wait` property (default 30s, added to `defaults.properties`), with a warning logged on expiry. The deadline is taken before the uninterruptible `waitLock.lock()` so it bounds the whole call, not just the loop. This generalizes the escape `criticalNoSwap` already provides — from "nothing left to swap" to "swapping isn't helping" — and guarantees no thread parks there forever regardless of which lock it holds. Without it, change 1 removes this particular wedge but the next lock held across `waitForMemory` reproduces it.

3. **`criticalNoSwap` is now an `AtomicInteger`** — it is written by the swapper thread and read/reset in `waitForMemory` with no `volatile` or shared monitor (`waitLock` serializes the waiters, not the swapper). Not a cause of this hang, but this change touches that loop.

## Testing

- `mvnw compile -pl core`: clean.
- New `XSwapperCriticalWaitTest`: passes. Confirmed it is a real guard — with the deadline check short-circuited it hangs the full 30s and fails with `waitForMemory() did not return within 30s`.
- Targeted suites (`ChartVSAQueryTest`, `CrosstabVSAQueryTest`, `TableVSAQueryTest`, `EmbeddedQueryTest`, `AssetQueryTest`, `RealtimeTableMetaDataTest`, `XSwap*`): 17 tests, all pass.
- Full `core` suite: 4455 tests, failures only in `VSEventUtilTabScaleTest` (2) and `VSFontHelperTest` (5). Re-ran both with these changes stashed and got byte-identical failures, so they are pre-existing on `main`, not regressions.
- **Not** reproduced locally — the customer hang needs sustained critical memory with swapped-out embedded data. The diagnosis is pinned to an exact frame and lock by the dump, but the fix is verified by code reasoning and absence of regressions, not by observing the wedge clear. A fresh thread dump from the reporter would confirm; under this change no thread should sit in `XSwapper.waitForMemory` beneath `ChartVSAQuery.getTableLens`.

## Notes for reviewers

- Releasing the lock means assembly state can be mutated by a writer during the fetch, and `unlockAll()` also drops the *caller's* outer read lock (e.g. `VSChartAreasService:111`). That is the intent, and it is already true one frame up in `doExecuteData` — flagging it because it is the main judgement call here.
- Verified that `AssetDataCache.isProcessorThread()` is stable across the `unlockAll`/`restoreLocks` pair (the Processor always runs on a pool worker via `pool.add(...)`, never inline on the caller), so neither call can silently become a no-op while the other doesn't. `UpgradableReadWriteLock.restoreLocks()` also guards on an empty saved-state stack, so a mismatch would degrade to a no-op rather than corrupt the lock stack.
- **Residual, not addressed:** `ChartVSAQuery` still holds the read lock for ~30 lines after the fetch, over `data.moreRows(DOTPLOT_MAXROWS + 1)` (`:396-401`) and `getDcMergeDateTableLens`, which can re-enter `waitForMemory`. Narrowing that means reworking post-processing that genuinely reads assembly state; change 2 caps the worst case at 30s instead of forever. Same for `ViewsheetSandbox:7533` (`getTableMetaData`, the selection-list path), a second `AssetDataCache.getData` call site reached from callers holding sandbox locks.
- Proceeding under critical memory after the cap expires is a deliberate trade: a bounded OOM risk in place of an unbounded hang. Happy to raise the 30s default if that feels too aggressive.
- Related but distinct: #4715 (Bug #76085) fixed a different always-loading cause (dropped `maxSize` on pair regeneration, unbounded client `Retry-After` loop). That fix is present in the code this dump came from.
- Incidental in the same dump, unrelated to this hang: idle pooled `OnDemand Thread14/15/18` hold 4, 50 and 50 `GridCacheLockImpl$Sync` monitors, and the `XSwapperThread` holds one while idle in `swapLock.wait()`. Looks like leaked Ignite distributed locks; worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
