### PR TITLE
Bug #76051, encrypt the Fluentd password and pin the credential round trip

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/logviewer/LogSettingService.java
+++ b/core/src/main/java/inetsoft/web/admin/logviewer/LogSettingService.java
@@ -269,7 +269,7 @@ public class LogSettingService {
             "log.fluentd.security.userAuthenticationEnabled",
             Boolean.toString(model.userAuthenticationEnabled()));
          SreeEnv.setProperty("log.fluentd.security.username", sanitizeProperty(model.username()));
-         SreeEnv.setProperty("log.fluentd.security.password", sanitizeProperty(model.password()));
+         SreeEnv.setProperty("log.fluentd.security.password", toPassword(model.password()));
          SreeEnv.setProperty("log.fluentd.tlsEnabled", Boolean.toString(model.tlsEnabled()));
          SreeEnv.setProperty(
             "log.fluentd.tls.caCertificateFile", sanitizeProperty(model.caCertificateFile()));

--- a/core/src/test/java/inetsoft/web/admin/logviewer/LogSettingServiceCryptoTest.java
+++ b/core/src/test/java/inetsoft/web/admin/logviewer/LogSettingServiceCryptoTest.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.logviewer;
+
+/*
+ * Test strategy
+ *
+ * LogSettingServiceTest stubs Tool.encryptPassword and Tool.decryptPassword so its
+ * assertions do not depend on a master key, which means it pins which method is called but
+ * not that the two are actually inverses. That is the invariant the Fluentd shared key bug
+ * turned on: the value this service stores has to be recoverable by whatever reads it, and
+ * the reader that configures the collector connection (ForwardService.getSecret, in the
+ * enterprise module) calls Tool.decryptPassword. This test runs the real encryption once,
+ * under the Spring/SreeHome harness the crypto needs, to hold the two halves together.
+ *
+ * Behavioral guarantees covered:
+ *
+ * [G7] What toPassword stores is not the clear text, and Tool.decryptPassword recovers it
+ *      exactly. If the write side moves to an encryption whose inverse is no longer
+ *      Tool.decryptPassword, the digest the collector is asked to match goes wrong again
+ *      and this fails, where the stubbed suites would stay green.
+ */
+
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.test.*;
+import inetsoft.util.Tool;
+import inetsoft.util.log.LogManager;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(
+   classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome()
+@Tag("core")
+class LogSettingServiceCryptoTest {
+   // [G7] the stored form is encrypted at rest and the runtime reader recovers it
+   @Test
+   void storedCredentialIsRecoverableByTheRuntimeReader() {
+      LogSettingService service =
+         new LogSettingService(mock(SecurityEngine.class), mock(LogManager.class));
+
+      // toPassword is what setFluentdSettings stores for both the shared key and the
+      // password; the surrounding whitespace also checks the trim survives the round trip
+      String stored = ReflectionTestUtils.invokeMethod(service, "toPassword", "  secret-key  ");
+
+      assertNotNull(stored);
+      assertNotEquals("secret-key", stored, "the credential must not be stored in clear text");
+      assertEquals("secret-key", Tool.decryptPassword(stored));
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/logviewer/LogSettingServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/logviewer/LogSettingServiceTest.java
@@ -35,8 +35,15 @@ package inetsoft.web.admin.logviewer;
  * [G3] A shared key with no surrounding whitespace is stored unchanged, so the trim
  *      cannot damage a key that was already correct.
  * [G4] A blank shared key clears the property rather than storing an encrypted blank.
- * [G5] The shared key is the only Fluentd field that is encrypted; its neighbours are
- *      trimmed but stored as plain text.
+ * [G5] Both credentials are encrypted; the non-secret fields are trimmed but stored as
+ *      plain text. The password used to be stored in clear text even though the read
+ *      already ran it through decryptPassword, which left it readable on the enterprise
+ *      Settings > Properties page (PropertiesController only filters the log.fluentd.*
+ *      family on community builds).
+ * [G6] The read decrypts both credentials, so the write and the Logging page agree. The
+ *      runtime read in ForwardService.getClient has to decrypt the same way; it used to
+ *      call plain SreeEnv.getProperty and digest the ciphertext, which no Logging-page
+ *      input could make authenticate (see enterprise ForwardServiceTest).
  */
 
 import inetsoft.sree.SreeEnv;
@@ -53,12 +60,14 @@ import org.mockito.MockedStatic;
 
 import java.security.Principal;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @Tag("core")
 class LogSettingServiceTest {
    private static final String SHARED_KEY_PROPERTY = "log.fluentd.security.sharedKey";
+   private static final String PASSWORD_PROPERTY = "log.fluentd.security.password";
 
    private LogSettingService service;
    private Principal principal;
@@ -136,20 +145,52 @@ class LogSettingServiceTest {
       saveSharedKey("   ");
 
       sreeEnvStatic.verify(() -> SreeEnv.setProperty(SHARED_KEY_PROPERTY, null));
-      toolStatic.verify(() -> Tool.encryptPassword(anyString()), never());
+      // scoped to the blank value: the password on the same model is a non-blank
+      // credential and is legitimately encrypted
+      toolStatic.verify(
+         () -> Tool.encryptPassword(argThat(value -> value == null || value.isBlank())),
+         never());
    }
 
-   // [G5] the neighbouring fields are trimmed but not encrypted
+   // [G5] both credentials are encrypted; the non-secret fields are only trimmed
    @Test
-   void otherFluentdFieldsAreTrimmedAndNotEncrypted() {
+   void credentialsAreEncryptedAndOtherFieldsAreOnlyTrimmed() {
       service.setConfiguration(model(fluentdSettings("secret-key")), principal);
 
+      sreeEnvStatic.verify(
+         () -> SreeEnv.setProperty("log.fluentd.security.password", "ENC:logger-pw"));
       sreeEnvStatic.verify(() -> SreeEnv.setProperty("log.fluentd.host", "fluentd.example.com"));
       sreeEnvStatic.verify(() -> SreeEnv.setProperty("log.fluentd.security.username", "logger"));
-      sreeEnvStatic.verify(() -> SreeEnv.setProperty("log.fluentd.security.password", "logger-pw"));
       sreeEnvStatic.verify(
          () -> SreeEnv.setProperty("log.fluentd.tls.caCertificateFile", "/certs/ca.pem"));
-      toolStatic.verify(() -> Tool.encryptPassword(anyString()), times(1));
+      toolStatic.verify(() -> Tool.encryptPassword(anyString()), times(2));
+   }
+
+   // [G6] the Logging page shows the decrypted credentials, so the write and this read
+   // agree; ForwardService must decrypt the same way (see enterprise ForwardServiceTest)
+   @Test
+   void credentialsAreDecryptedWhenRead() {
+      toolStatic.when(() -> Tool.decryptPassword(anyString()))
+         .thenAnswer(invocation -> {
+            String stored = invocation.getArgument(0);
+            return stored.startsWith("ENC:") ? stored.substring(4) : stored;
+         });
+      sreeEnvStatic.when(() -> SreeEnv.getProperty(anyString(), anyString()))
+         .thenAnswer(invocation -> invocation.getArgument(1));
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("log.provider")).thenReturn("fluentd");
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("log.detail.level")).thenReturn("INFO");
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("report.log.max")).thenReturn("1000000");
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("report.log.count")).thenReturn("1");
+      sreeEnvStatic.when(() -> SreeEnv.getProperty(SHARED_KEY_PROPERTY))
+         .thenReturn("ENC:secret-key");
+      sreeEnvStatic.when(() -> SreeEnv.getProperty(PASSWORD_PROPERTY))
+         .thenReturn("ENC:logger-pw");
+
+      LogSettingsModel model = service.getConfiguration();
+
+      assertNotNull(model);
+      assertEquals("secret-key", model.fluentdSettings().sharedKey());
+      assertEquals("logger-pw", model.fluentdSettings().password());
    }
 
    private void saveSharedKey(String sharedKey) {


### PR DESCRIPTION
## Problem

A Fluentd shared key saved from **Settings > Logging** can never authenticate. It is stored encrypted (`setFluentdSettings` → `toPassword` → `Tool.encryptPassword`), but `ForwardService.getClient` in the enterprise module read it with a plain `SreeEnv.getProperty` and handed the ciphertext to `ForwardClient` — which **digests** the key rather than sending it. StyleBI's digest was computed over the ciphertext, the collector computed its own over the operator's real key, and `readPong` threw `Authentication failed: ...`. No combination of Logging-page inputs made it succeed.

The read-side fix lives in the enterprise module. **This PR is the community half.**

## What this PR changes

`log.fluentd.security.password` — the neighbouring field, which showed what correct looked like — was written through `sanitizeProperty` with no encryption and read back the same way, so that half authenticated end to end. It was also stored in **clear text**, and since `PropertiesController` only filters the `log.fluentd.*` family on community builds (`PropertiesController.java:140`), it was readable on the enterprise **Settings > Properties** page and returned by `GET /api/admin/properties`.

It now goes through the same `toPassword` helper as the shared key:

```java
SreeEnv.setProperty("log.fluentd.security.password", toPassword(model.password()));
```

The read side needed no change — `getFluentdSettings` already ran the password through `Tool.decryptPassword` (`LogSettingService.java:117-119`). That call was the no-op that hid the gap, working only because `LocalPasswordEncryption.decryptPassword` returns unprefixed input verbatim.

## Backward compatibility

No migration. That same clear-text tolerance means existing stored passwords keep authenticating until the next save re-encrypts them.

## Tests

| Guarantee | Change |
|---|---|
| [G4] | Rescoped. It asserted `encryptPassword` was *never* called for a blank shared key — true only while the password was clear text. Now asserts no **blank** value is ever encrypted, which is what [G4] is about. |
| [G5] | Now expects both credentials encrypted and the non-secret fields only trimmed. |
| [G6] | New — the read returns both credentials decrypted. |
| [G7] | New class `LogSettingServiceCryptoTest`. The stubbed suites cannot prove `Tool.encryptPassword` and `Tool.decryptPassword` are inverses, which is exactly the invariant this bug turned on, so this runs the real encryption once under the `@SreeHome` harness. |

`LogSettingServiceTest` 6/6, `LogSettingServiceCryptoTest` 1/1, `PropertiesControllerTest` 14/14 (adjacent, unchanged).

## Note for release

Once the password is stored encrypted, a node still running the **pre-fix** `ForwardService` will send the ciphertext as the password. The community and enterprise changes need to ship together; merge this first.

Also pre-existing, now affecting a second field: if `INETSOFT_MASTER_PASSWORD` or `password.encryption.key` changes, decryption returns the ciphertext verbatim and the Logging page renders it in a populated-looking field. Saving that page re-encrypts it, producing a doubly-encrypted value.

## Not stale-checked twice

The report filed alongside this also flagged #76048 (`toPassword` encrypting the untrimmed value). That is **already fixed** — `toPassword` calls `sanitizeProperty` first, and [G1]–[G3] pin it. No change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
