### PR TITLE
Bug #76097, support datasource-scoped named groups and full condition operators in add_named_group

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
@@ -69,9 +69,16 @@ import java.util.Map;
  *   <li>{@code reorder_columns} — {@code table}, {@code columnOrder}</li>
  *   <li>{@code add_concat_subtable} — {@code table} (concat assembly), {@code name} (subtable to add)</li>
  *   <li>{@code remove_concat_subtable} — {@code table} (concat assembly), {@code name} (subtable to remove)</li>
- *   <li>{@code add_named_group} — {@code name}, {@code groupMappings}, {@code groupOthers}; either
- *       {@code table} + {@code column} (attach to a column) or {@code type} (standalone grouping,
- *       matched by data type; defaults to {@code "string"})</li>
+ *   <li>{@code add_named_group} — {@code name}, {@code groupMappings} (each mapping's
+ *       {@code operation} is any operator accepted by
+ *       {@link WorksheetMutationSupport#parseOperation}, e.g. {@code "STARTING_WITH"};
+ *       defaults to {@code EQUAL_TO} when omitted), {@code groupOthers}; exactly one of:
+ *       {@code table} + {@code column} (attach to a column on an existing worksheet table);
+ *       {@code datasource} + {@code sourceTable} + {@code attribute} (+ optional
+ *       {@code logicalModel}, or {@code schema}/{@code catalog} for a physical table) to scope
+ *       directly to a datasource/logical-model or physical-table path, matching what a human
+ *       produces via the Composer's own "Add Grouping" dialog; or {@code type} (standalone
+ *       grouping, matched by data type; defaults to {@code "string"})</li>
  *   <li>{@code set_column_description} — {@code table}, {@code column}, {@code description}</li>
  *   <li>{@code set_variable_values} — {@code variableValues} (map of variable name → value)</li>
  *   <li>{@code set_mirror_auto_update} — {@code table}, {@code visible} (true=auto-update on, false=off)</li>
@@ -82,7 +89,8 @@ import java.util.Map;
  *   <li>{@code edit_variable} — {@code name}, {@code type}, {@code label}, {@code defaultValue}</li>
  *   <li>{@code rename_variable} — {@code name}, {@code newName}</li>
  *   <li>{@code delete_variable} — {@code name}</li>
- *   <li>{@code edit_named_group} — {@code name}, {@code groupMappings}, {@code groupOthers}</li>
+ *   <li>{@code edit_named_group} — {@code name}, {@code groupMappings} (see {@code add_named_group}
+ *       for the {@code operation} field), {@code groupOthers}</li>
  *   <li>{@code edit_sql_query} — {@code table}, {@code expression} (new SQL string)</li>
  *   <li>{@code update_mirror} — {@code table}</li>
  *   <li>{@code set_table_mode} — {@code table}, {@code mode} ({@code "live"}, {@code "default"}, {@code "full"}, {@code "detail"}, {@code "edit"})</li>
@@ -208,5 +216,18 @@ public record EditRequest(
    /** True = insert before index, false = append after index (insert_column). */
    Boolean insert,
    /** New order of subtable names for reorder_concat_subtables. */
-   List<String> subtables
+   List<String> subtables,
+   /**
+    * Entity name (when {@code logicalModel} is given) or physical table name (otherwise) for
+    * add_named_group, when scoping the grouping directly to a datasource path — matching what a
+    * human produces via the Composer's own "Add Grouping" dialog ("Only For") — instead of
+    * attaching to a column on an existing worksheet table. Requires {@code datasource} and
+    * {@code attribute}; mutually exclusive with {@code table}/{@code column} and {@code type}.
+    */
+   String sourceTable,
+   /**
+    * Attribute/column name within {@code sourceTable} for add_named_group's datasource-scoped
+    * mode (see {@code sourceTable}).
+    */
+   String attribute
 ) {}

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -228,6 +228,33 @@ public class WorksheetAgentController {
          return;
       }
 
+      // add_named_group with a datasource scopes "Only For" directly to a datasource/logical-model
+      // or physical-table path -- matching what a human produces via the Composer's own "Add
+      // Grouping" dialog -- rather than attaching to a column on an existing worksheet table.
+      // Needs the same permission checks + XLogicalModel/JDBC metadata lookups as add_table, so it
+      // is dispatched here rather than through the plain Editor.
+      if("add_named_group".equals(req.op()) && req.datasource() != null
+         && !req.datasource().isBlank())
+      {
+         if(req.table() != null || req.column() != null || req.type() != null) {
+            throw new PairingException(
+               "add_named_group: datasource is mutually exclusive with table/column and type.");
+         }
+
+         if(req.sourceTable() == null || req.sourceTable().isBlank()) {
+            throw new PairingException(
+               "sourceTable is required when datasource is specified for add_named_group.");
+         }
+
+         if(req.attribute() == null || req.attribute().isBlank()) {
+            throw new PairingException(
+               "attribute is required when datasource is specified for add_named_group.");
+         }
+
+         addDatasourceScopedNamedGroup(sessionToken, req, user);
+         return;
+      }
+
       // set_variable_values needs AssetQuerySandbox, not just Editor.
       if("set_variable_values".equals(req.op())) {
          setVariableValues(sessionToken, req, user);
@@ -477,6 +504,194 @@ public class WorksheetAgentController {
             SourceInfo.MODEL, datasourceName, logicalModelName);
          assembly.setSourceInfo(sinfo);
          assembly.setColumnSelection(columns);
+
+         int maxY = 0;
+
+         for(Assembly a : ws.getAssemblies()) {
+            if(!(a instanceof AbstractWSAssembly wa)) {
+               continue;
+            }
+
+            Point p = wa.getPixelOffset();
+            Dimension d = wa.getPixelSize();
+
+            if(p != null && d != null) {
+               maxY = Math.max(maxY, p.y + d.height);
+            }
+         }
+
+         assembly.setPixelOffset(new Point(25, maxY + 40));
+         ws.addAssembly(assembly);
+         return null;
+      });
+   }
+
+   /**
+    * Creates a {@link DefaultNamedGroupAssembly} scoped directly to a datasource/logical-model
+    * or physical-table attribute -- exactly what a human produces via the Composer's own "Add
+    * Grouping" dialog ("Only For" + "Attribute"), independent of any worksheet table. See
+    * {@code GroupingAssemblyDialogService#setGroupingAssemblyDialogProperties} for the
+    * human-driven equivalent this mirrors, and {@link #addLogicalModelTable}/{@link
+    * #addBoundTable} for the permission-check and metadata-lookup patterns reused here.
+    *
+    * <p>This is a different, orthogonal mode from the {@code table}+{@code column} attached
+    * grouping in {@code WorksheetEditService.Editor#addNamedGroup}: that mode intentionally
+    * records {@code attachedSource} as the worksheet table's own name -- a convention {@code
+    * CalcTableService}/{@code FieldRefFactory} rely on to resolve a chart/table/crosstab/
+    * calc-table's {@code field.namedGroup} binding -- so a grouping created here is not
+    * resolvable through that same binding-time matching, and is not attached to any worksheet
+    * table at all.</p>
+    */
+   private void addDatasourceScopedNamedGroup(String sessionToken, EditRequest req, Principal user)
+      throws Exception
+   {
+      String datasourceName = req.datasource();
+      String logicalModelName = req.logicalModel();
+      String sourceTableName = req.sourceTable();
+      String attributeName = req.attribute();
+      String name = req.name();
+
+      SourceInfo sinfo;
+      DataRef ref;
+
+      if(logicalModelName != null && !logicalModelName.isBlank()) {
+         // Mirrors addLogicalModelTable's permission checks and XLogicalModel/XEntity lookup.
+         if(!dataSourceService.checkPermission(datasourceName, ResourceAction.READ, user)) {
+            throw new PairingException(
+               "Access denied: no READ permission on datasource " + datasourceName);
+         }
+
+         XDataModel dataModel = dataSourceService.getDataModel(datasourceName);
+
+         if(dataModel == null) {
+            throw new PairingException("No data model found for datasource: " + datasourceName);
+         }
+
+         XLogicalModel lm = dataModel.getLogicalModel(logicalModelName);
+
+         if(lm == null) {
+            throw new PairingException("Logical model not found: " + logicalModelName
+               + " (datasource=" + datasourceName + ")");
+         }
+
+         AssetEntry modelEntry = new AssetEntry(AssetRepository.QUERY_SCOPE,
+            AssetEntry.Type.LOGIC_MODEL, datasourceName + "/" + logicalModelName, null);
+         modelEntry = dataSourceService.getModelAssetEntry(modelEntry);
+
+         if(modelEntry == null ||
+            !dataSourceService.checkPermission(modelEntry, ResourceAction.READ, user))
+         {
+            throw new PairingException("Access denied: no READ permission on logical model "
+               + logicalModelName + " (datasource=" + datasourceName + ")");
+         }
+
+         XEntity entity = lm.getEntity(sourceTableName);
+
+         if(entity == null) {
+            throw new PairingException("Entity not found: " + sourceTableName
+               + " (logicalModel=" + logicalModelName + ", datasource=" + datasourceName + ")");
+         }
+
+         XAttribute attr = entity.getAttribute(attributeName);
+
+         if(attr == null) {
+            throw new PairingException("Attribute not found: " + attributeName
+               + " (entity=" + sourceTableName + ", logicalModel=" + logicalModelName + ")");
+         }
+
+         sinfo = new SourceInfo(SourceInfo.MODEL, datasourceName, logicalModelName);
+         AttributeRef attributeRef = new AttributeRef(sourceTableName, attr.getName());
+         ColumnRef cref = new ColumnRef(attributeRef);
+
+         if(attr.getDataType() != null) {
+            cref.setDataType(attr.getDataType());
+         }
+
+         ref = cref;
+      }
+      else {
+         // Mirrors addBoundTable's permission checks and JDBC metadata lookup.
+         if(!securityEngine.checkPermission(user, ResourceType.PHYSICAL_TABLE, "*", ResourceAction.ACCESS)) {
+            throw new SecurityException(
+               Catalog.getCatalog().getString("composer.ws.boundPhysicalTableForbidden"));
+         }
+
+         if(!dataSourceService.checkPermission(datasourceName, ResourceAction.READ, user)) {
+            throw new PairingException(
+               "Access denied: no READ permission on datasource " + datasourceName);
+         }
+
+         JDBCDataSource jdbcDs = metadataApiService.getJDBCDatasource(datasourceName);
+         XNode tableMetaData = metadataApiService.getTableMetaData(
+            jdbcDs, req.catalog(), req.schema(), sourceTableName);
+
+         if(tableMetaData == null) {
+            throw new PairingException("Table not found: " + sourceTableName +
+               " (datasource=" + datasourceName +
+               ", schema=" + req.schema() +
+               ", catalog=" + req.catalog() + ")");
+         }
+
+         String qname = inetsoft.uql.jdbc.util.SQLTypes.getSQLTypes(jdbcDs)
+            .getQualifiedName(tableMetaData, jdbcDs);
+         String tableType = (String) tableMetaData.getAttribute("type");
+
+         inetsoft.web.wiz.model.DatabaseTableMeta tableMeta =
+            metadataApiService.getTableDetails(datasourceName, sourceTableName,
+               req.catalog(), req.schema(), user);
+
+         inetsoft.web.wiz.model.DatabaseTableMeta.ColumnMeta colMeta = null;
+
+         for(inetsoft.web.wiz.model.DatabaseTableMeta.ColumnMeta cm : tableMeta.getColumns()) {
+            if(attributeName.equals(cm.getName())) {
+               colMeta = cm;
+               break;
+            }
+         }
+
+         if(colMeta == null) {
+            throw new PairingException("Column not found: " + attributeName +
+               " (table=" + sourceTableName + ", datasource=" + datasourceName + ")");
+         }
+
+         SourceInfo physSinfo = new SourceInfo(SourceInfo.PHYSICAL_TABLE, datasourceName, qname);
+         physSinfo.setProperty(SourceInfo.SCHEMA, req.schema());
+         physSinfo.setProperty(SourceInfo.CATALOG, req.catalog());
+         physSinfo.setProperty(SourceInfo.TABLE_TYPE, tableType);
+         sinfo = physSinfo;
+
+         AttributeRef attributeRef = new AttributeRef(null, colMeta.getName());
+         ColumnRef cref = new ColumnRef(attributeRef);
+
+         if(colMeta.getType() != null) {
+            cref.setDataType(colMeta.getType());
+         }
+
+         ref = cref;
+      }
+
+      String conditionType = ref.getDataType() != null ? ref.getDataType() : XSchema.STRING;
+      List<WorksheetMutationSupport.GroupMapping> mappings = req.groupMappings();
+      boolean groupOthers = req.groupOthers() != null && req.groupOthers();
+
+      editService.applyOnRuntime(sessionToken, user, rws -> {
+         Worksheet ws = rws.getWorksheet();
+
+         NamedGroupInfo ngi = new NamedGroupInfo();
+         ngi.setOthers(groupOthers ? XConstants.GROUP_OTHERS : XConstants.LEAVE_OTHERS);
+
+         if(mappings != null) {
+            for(WorksheetMutationSupport.GroupMapping m : mappings) {
+               ngi.setGroupCondition(m.name(),
+                  WorksheetMutationSupport.buildGroupConditionList(conditionType, ref, m));
+            }
+         }
+
+         DefaultNamedGroupAssembly assembly = new DefaultNamedGroupAssembly(ws, name);
+         assembly.setNamedGroupInfo(ngi);
+         assembly.setAttachedType(AttachedAssembly.COLUMN_ATTACHED);
+         assembly.setAttachedSource(sinfo);
+         assembly.setAttachedAttribute(ref);
 
          int maxY = 0;
 

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -255,6 +255,20 @@ public class WorksheetAgentController {
          return;
       }
 
+      // add_named_group's datasource-scoped fields require 'datasource' -- without this guard,
+      // a caller that supplies sourceTable/attribute/logicalModel/schema/catalog but omits (or
+      // blanks) datasource would silently fall through to the plain Editor.addNamedGroup(table,
+      // column, type, ...) below with table/column/type all null, creating a standalone
+      // string-typed grouping and discarding what the caller actually asked for, with no error.
+      if("add_named_group".equals(req.op()) &&
+         (req.sourceTable() != null || req.attribute() != null || req.logicalModel() != null ||
+            req.schema() != null || req.catalog() != null))
+      {
+         throw new PairingException(
+            "add_named_group: sourceTable/attribute/logicalModel/schema/catalog require " +
+               "'datasource' to be set.");
+      }
+
       // set_variable_values needs AssetQuerySandbox, not just Editor.
       if("set_variable_values".equals(req.op())) {
          setVariableValues(sessionToken, req, user);
@@ -400,23 +414,7 @@ public class WorksheetAgentController {
          assembly.setSourceInfo(sinfo);
          assembly.setColumnSelection(columns);
 
-         // Position below existing assemblies.
-         int maxY = 0;
-
-         for(Assembly a : ws.getAssemblies()) {
-            if(!(a instanceof AbstractWSAssembly wa)) {
-               continue;
-            }
-
-            Point p = wa.getPixelOffset();
-            Dimension d = wa.getPixelSize();
-
-            if(p != null && d != null) {
-               maxY = Math.max(maxY, p.y + d.height);
-            }
-         }
-
-         assembly.setPixelOffset(new Point(25, maxY + 40));
+         positionBelowExisting(ws, assembly);
          ws.addAssembly(assembly);
          return null;
       });
@@ -505,22 +503,7 @@ public class WorksheetAgentController {
          assembly.setSourceInfo(sinfo);
          assembly.setColumnSelection(columns);
 
-         int maxY = 0;
-
-         for(Assembly a : ws.getAssemblies()) {
-            if(!(a instanceof AbstractWSAssembly wa)) {
-               continue;
-            }
-
-            Point p = wa.getPixelOffset();
-            Dimension d = wa.getPixelSize();
-
-            if(p != null && d != null) {
-               maxY = Math.max(maxY, p.y + d.height);
-            }
-         }
-
-         assembly.setPixelOffset(new Point(25, maxY + 40));
+         positionBelowExisting(ws, assembly);
          ws.addAssembly(assembly);
          return null;
       });
@@ -693,25 +676,36 @@ public class WorksheetAgentController {
          assembly.setAttachedSource(sinfo);
          assembly.setAttachedAttribute(ref);
 
-         int maxY = 0;
-
-         for(Assembly a : ws.getAssemblies()) {
-            if(!(a instanceof AbstractWSAssembly wa)) {
-               continue;
-            }
-
-            Point p = wa.getPixelOffset();
-            Dimension d = wa.getPixelSize();
-
-            if(p != null && d != null) {
-               maxY = Math.max(maxY, p.y + d.height);
-            }
-         }
-
-         assembly.setPixelOffset(new Point(25, maxY + 40));
+         positionBelowExisting(ws, assembly);
          ws.addAssembly(assembly);
          return null;
       });
+   }
+
+   /**
+    * Positions a newly-created assembly below every existing one on the canvas, left-aligned at
+    * the same column every other agent-created assembly starts at. Shared by every {@code add_*}
+    * op that builds its own assembly directly (rather than going through {@code Editor}, which
+    * has its own {@code placeAssembly}): {@link #addBoundTable}, {@link #addLogicalModelTable},
+    * {@link #addDatasourceScopedNamedGroup}, and {@code addSqlQuery}.
+    */
+   private static void positionBelowExisting(Worksheet ws, AbstractWSAssembly assembly) {
+      int maxY = 0;
+
+      for(Assembly a : ws.getAssemblies()) {
+         if(!(a instanceof AbstractWSAssembly wa)) {
+            continue;
+         }
+
+         Point p = wa.getPixelOffset();
+         Dimension d = wa.getPixelSize();
+
+         if(p != null && d != null) {
+            maxY = Math.max(maxY, p.y + d.height);
+         }
+      }
+
+      assembly.setPixelOffset(new Point(25, maxY + 40));
    }
 
    /**
@@ -2439,23 +2433,7 @@ public class WorksheetAgentController {
          info.setSourceInfo(new SourceInfo(
             SourceInfo.PHYSICAL_TABLE, body.datasource(), body.datasource()));
 
-         // Position below existing assemblies.
-         int maxY = 0;
-
-         for(Assembly a : ws.getAssemblies()) {
-            if(!(a instanceof AbstractWSAssembly wa)) {
-               continue;
-            }
-
-            Point p = wa.getPixelOffset();
-            Dimension d = wa.getPixelSize();
-
-            if(p != null && d != null) {
-               maxY = Math.max(maxY, p.y + d.height);
-            }
-         }
-
-         assembly.setPixelOffset(new Point(25, maxY + 40));
+         positionBelowExisting(ws, assembly);
          assembly.setSQLEdited(true);
 
          // Populate columns from the parsed SQL or by executing the query.

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -1809,25 +1809,10 @@ public class WorksheetEditService {
             ? XConstants.GROUP_OTHERS
             : XConstants.LEAVE_OTHERS);
 
-         // Build condition lists from simple value mappings.
-         // Each group maps to a ONE_OF condition on the column.
          if(mappings != null) {
             for(WorksheetMutationSupport.GroupMapping m : mappings) {
-               ConditionList conds = new ConditionList();
-
-               for(int i = 0; i < m.values().size(); i++) {
-                  if(i > 0) {
-                     JunctionOperator junc = new JunctionOperator(JunctionOperator.OR, 0);
-                     conds.append(junc);
-                  }
-
-                  Condition c = new Condition(conditionType);
-                  c.setOperation(XCondition.EQUAL_TO);
-                  c.addValue(m.values().get(i));
-                  conds.append(new ConditionItem(conditionRef, c, 0));
-               }
-
-               ngi.setGroupCondition(m.name(), conds);
+               ngi.setGroupCondition(m.name(),
+                  WorksheetMutationSupport.buildGroupConditionList(conditionType, conditionRef, m));
             }
          }
 
@@ -2130,21 +2115,8 @@ public class WorksheetEditService {
             DataRef conditionRef = namedGroupConditionRef(ref, conditionType);
 
             for(WorksheetMutationSupport.GroupMapping m : mappings) {
-               ConditionList conds = new ConditionList();
-
-               for(int i = 0; i < m.values().size(); i++) {
-                  if(i > 0) {
-                     JunctionOperator junc = new JunctionOperator(JunctionOperator.OR, 0);
-                     conds.append(junc);
-                  }
-
-                  Condition c = new Condition(conditionType);
-                  c.setOperation(XCondition.EQUAL_TO);
-                  c.addValue(m.values().get(i));
-                  conds.append(new ConditionItem(conditionRef, c, 0));
-               }
-
-               ngi.setGroupCondition(m.name(), conds);
+               ngi.setGroupCondition(m.name(),
+                  WorksheetMutationSupport.buildGroupConditionList(conditionType, conditionRef, m));
             }
          }
 

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -34,6 +34,7 @@ import inetsoft.uql.jdbc.UniformSQL;
 import inetsoft.uql.path.XSelection;
 import inetsoft.uql.schema.UserVariable;
 import inetsoft.uql.schema.XSchema;
+import inetsoft.web.wiz.pairing.PairingException;
 
 import java.util.*;
 
@@ -161,7 +162,7 @@ public final class WorksheetMutationSupport {
     * differs.</p>
     */
    static ConditionList buildGroupConditionList(
-      String conditionType, DataRef conditionRef, GroupMapping m)
+      String conditionType, DataRef conditionRef, GroupMapping m) throws PairingException
    {
       String operation = m.operation();
       int op = parseOperation(operation);
@@ -180,6 +181,16 @@ public final class WorksheetMutationSupport {
       boolean negatedEquality = op == XCondition.EQUAL_TO && negate;
 
       if(op == XCondition.ONE_OF || negatedEquality) {
+         // Condition.evaluate() for ONE_OF/BETWEEN reads the raw values list directly (no
+         // per-value OR'ing like the fallback branch below), so an empty or wrong-sized list here
+         // is not "no values matched" -- it is a silently wrong condition. An empty ONE_OF matches
+         // nothing; a NEGATED empty ONE_OF (e.g. "!=" with no values) matches EVERYTHING.
+         if(m.values() == null || m.values().isEmpty()) {
+            throw new PairingException(
+               "Group \"" + m.name() + "\": operation \"" + operation +
+                  "\" requires at least one value.");
+         }
+
          Condition c = new Condition(conditionType);
          c.setOperation(XCondition.ONE_OF);
          c.setNegated(negate);
@@ -193,6 +204,12 @@ public final class WorksheetMutationSupport {
       }
 
       if(op == XCondition.BETWEEN) {
+         if(m.values() == null || m.values().size() != 2) {
+            throw new PairingException(
+               "Group \"" + m.name() + "\": BETWEEN requires exactly two values (low, high), got " +
+                  (m.values() == null ? 0 : m.values().size()) + ".");
+         }
+
          Condition c = new Condition(conditionType);
          c.setOperation(op);
          c.setNegated(negate);

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -121,9 +121,112 @@ public final class WorksheetMutationSupport {
    }
 
    /**
-    * A named group mapping — group name to list of values that belong to that group.
+    * A named group mapping — group name to list of values that belong to that group, matched
+    * using {@code operation} (any operator accepted by {@link #parseOperation}, e.g.
+    * {@code "STARTING_WITH"}, {@code "!="}, {@code "ONE_OF"}; {@code null} defaults to
+    * {@code EQUAL_TO}, preserving the historical behavior of this record).
     */
-   public record GroupMapping(String name, java.util.List<String> values) {}
+   public record GroupMapping(String name, java.util.List<String> values, String operation) {
+      public GroupMapping(String name, java.util.List<String> values) {
+         this(name, values, null);
+      }
+   }
+
+   /**
+    * Builds the {@link ConditionList} for one named-group mapping, honoring the mapping's
+    * {@code operation} (any operator accepted by {@link #parseOperation}, defaulting to
+    * {@code EQUAL_TO} when omitted, matching this method's historical behavior).
+    *
+    * <p>{@code ONE_OF}/{@code NOT_ONE_OF} and {@code BETWEEN} test all of {@code m.values()}
+    * within a single {@link Condition}, matching how {@link Condition#evaluate} reads those
+    * operators — splitting them into OR'd single-value conditions the way the other operators
+    * below are handled would silently test only the first value. {@code NULL}/{@code NOT_NULL}
+    * take no value. Negated equality ({@code !=}/{@code NOT_EQUAL_TO}/{@code <>}) is routed
+    * through the same single-condition path as {@code NOT_ONE_OF} rather than per-value OR'd
+    * negation: {@code EQUAL_TO} only ever reads a condition's first value (see
+    * {@link Condition#evaluate}), so OR'ing several separately-negated single-value EQUAL_TO
+    * conditions together (e.g. {@code v != A OR v != B}) is a near-tautology — true for every
+    * {@code v} except one that somehow equals both {@code A} and {@code B} at once — instead of
+    * the intended "equal to none of these" ({@code NOT(v == A OR v == B)}, i.e. a negated
+    * {@code ONE_OF} over the same values). Every remaining operator (plain equality, comparisons,
+    * {@code STARTING_WITH}, {@code CONTAINS}, {@code LIKE}) only ever looks at its condition's
+    * first value, so each of {@code m.values()} becomes its own condition, OR'd together — e.g.
+    * {@code STARTING_WITH ["N", "S"]} means "starts with N or starts with S".</p>
+    *
+    * <p>Shared by {@code WorksheetEditService.Editor.addNamedGroup}/{@code editNamedGroup} (a
+    * grouping attached to a worksheet table's column) and
+    * {@code WorksheetAgentController.addDatasourceScopedNamedGroup} (a grouping scoped directly
+    * to a datasource/logical-model or physical-table attribute) — the condition-building logic is
+    * identical either way; only how {@code conditionRef}/{@code conditionType} were resolved
+    * differs.</p>
+    */
+   static ConditionList buildGroupConditionList(
+      String conditionType, DataRef conditionRef, GroupMapping m)
+   {
+      String operation = m.operation();
+      int op = parseOperation(operation);
+      boolean negate = isNegatedOperation(operation);
+      boolean equalInclusive = isEqualInclusive(operation);
+      ConditionList conds = new ConditionList();
+
+      if(op == XCondition.NULL) {
+         Condition c = new Condition(conditionType);
+         c.setOperation(op);
+         c.setNegated(negate);
+         conds.append(new ConditionItem(conditionRef, c, 0));
+         return conds;
+      }
+
+      boolean negatedEquality = op == XCondition.EQUAL_TO && negate;
+
+      if(op == XCondition.ONE_OF || negatedEquality) {
+         Condition c = new Condition(conditionType);
+         c.setOperation(XCondition.ONE_OF);
+         c.setNegated(negate);
+
+         for(String v : m.values()) {
+            c.addValue(v);
+         }
+
+         conds.append(new ConditionItem(conditionRef, c, 0));
+         return conds;
+      }
+
+      if(op == XCondition.BETWEEN) {
+         Condition c = new Condition(conditionType);
+         c.setOperation(op);
+         c.setNegated(negate);
+
+         for(String v : m.values()) {
+            c.addValue(v);
+         }
+
+         conds.append(new ConditionItem(conditionRef, c, 0));
+         return conds;
+      }
+
+      for(int i = 0; i < m.values().size(); i++) {
+         if(i > 0) {
+            conds.append(new JunctionOperator(JunctionOperator.OR, 0));
+         }
+
+         Condition c = new Condition(conditionType);
+         c.setOperation(op);
+
+         if(equalInclusive) {
+            c.setEqual(true);
+         }
+
+         if(negate) {
+            c.setNegated(true);
+         }
+
+         c.addValue(m.values().get(i));
+         conds.append(new ConditionItem(conditionRef, c, 0));
+      }
+
+      return conds;
+   }
 
    // =========================================================================
    // Filter helpers
@@ -1401,7 +1504,7 @@ public final class WorksheetMutationSupport {
     * or "greater-than-or-equal" comparison, which requires {@link Condition#setEqual(boolean)}
     * to be set to {@code true} in addition to the base LESS_THAN / GREATER_THAN operation.
     */
-   private static boolean isEqualInclusive(String operation) {
+   static boolean isEqualInclusive(String operation) {
       if(operation == null) {
          return false;
       }
@@ -1412,7 +1515,7 @@ public final class WorksheetMutationSupport {
       };
    }
 
-   private static boolean isNegatedOperation(String operation) {
+   static boolean isNegatedOperation(String operation) {
       if(operation == null) {
          return false;
       }

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
@@ -20,6 +20,7 @@ package inetsoft.web.wiz.worksheet;
 import inetsoft.report.composition.RuntimeWorksheet;
 import inetsoft.uql.*;
 import inetsoft.uql.asset.*;
+import inetsoft.uql.erm.AttributeRef;
 import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.erm.ExpressionRef;
 import inetsoft.uql.schema.UserVariable;
@@ -415,8 +416,40 @@ public class WorksheetReadService {
 
       DataRef attachedAttr = nga.getAttachedAttribute();
       SourceInfo attachedSource = nga.getAttachedSource();
-      String table = attachedSource != null ? attachedSource.getSource() : null;
-      String column = attachedAttr != null ? attachedAttr.getAttribute() : null;
+
+      // COLUMN_ATTACHED covers two different, mutually exclusive attachment kinds that share the
+      // same Java fields: a worksheet-table column (SourceInfo.ASSET, source = the worksheet
+      // assembly's own name) versus a datasource/logical-model or physical-table path (any other
+      // SourceInfo type). Reporting both under the same table/column fields would make a
+      // datasource-scoped group indistinguishable from a worksheet-table-attached one, even though
+      // no such worksheet table exists for it.
+      String table = null;
+      String column = null;
+      String datasource = null;
+      String logicalModel = null;
+      String sourceTable = null;
+      String attribute = null;
+
+      if(attachedSource != null && attachedSource.getType() == SourceInfo.ASSET) {
+         table = attachedSource.getSource();
+         column = attachedAttr != null ? attachedAttr.getAttribute() : null;
+      }
+      else if(attachedSource != null) {
+         datasource = attachedSource.getPrefix();
+
+         if(attachedSource.getType() == SourceInfo.MODEL) {
+            logicalModel = attachedSource.getSource();
+
+            if(attachedAttr instanceof ColumnRef cr && cr.getDataRef() instanceof AttributeRef ar) {
+               sourceTable = ar.getEntity();
+               attribute = ar.getAttribute();
+            }
+         }
+         else {
+            sourceTable = attachedSource.getSource();
+            attribute = attachedAttr != null ? attachedAttr.getAttribute() : null;
+         }
+      }
 
       NamedGroupInfo ngi = nga.getNamedGroupInfo();
       boolean groupOthers = ngi != null && ngi.getOthers() == XConstants.GROUP_OTHERS;
@@ -429,6 +462,7 @@ public class WorksheetReadService {
          for(String group : groups) {
             ConditionList conds = ngi.getGroupCondition(group);
             List<String> values = new ArrayList<>();
+            String operation = null;
 
             if(conds != null) {
                int size = conds.getConditionSize();
@@ -447,6 +481,10 @@ public class WorksheetReadService {
                   XCondition xc = item.getXCondition();
 
                   if(xc instanceof Condition c) {
+                     if(operation == null) {
+                        operation = groupMappingOperation(c);
+                     }
+
                      for(int v = 0; v < c.getValueCount(); v++) {
                         Object val = c.getValue(v);
                         values.add(val != null ? val.toString() : null);
@@ -455,11 +493,45 @@ public class WorksheetReadService {
                }
             }
 
-            mappings.add(new WorksheetModel.GroupMappingModel(group, values));
+            mappings.add(new WorksheetModel.GroupMappingModel(group, values, operation));
          }
       }
 
-      return new WorksheetModel.NamedGroupModel(name, table, column, mappings, groupOthers);
+      return new WorksheetModel.NamedGroupModel(
+         name, table, column, datasource, logicalModel, sourceTable, attribute, mappings,
+         groupOthers);
+   }
+
+   /**
+    * The inverse of {@link WorksheetMutationSupport#parseOperation}/{@code isNegatedOperation}/
+    * {@code isEqualInclusive} — recovers the {@code operation} string {@code add_named_group}
+    * would need to recreate this exact condition, so a group read back and then edited doesn't
+    * silently lose e.g. a {@code STARTING_WITH} match down to plain equality. Returns {@code null}
+    * (omitted on the wire) for an operation this vocabulary cannot express.
+    */
+   private String groupMappingOperation(Condition c) {
+      boolean negated = c.isNegated();
+
+      // Only EQUAL_TO/ONE_OF/NULL have a negated string in this vocabulary ("!=", "NOT_ONE_OF",
+      // "NOT_NULL"); the rest have no "NOT_..." counterpart add_named_group accepts. A negated
+      // LESS_THAN/GREATER_THAN/BETWEEN/STARTING_WITH/CONTAINS/LIKE is reachable here even though
+      // this tool never creates one -- a human can build one via the Composer's general condition
+      // editor (Condition.isNegatedChangeable() is unconditionally true) -- so reporting the
+      // positive string for a negated condition would silently flip its meaning if fed back into
+      // add_named_group/edit_named_group. Returning null (per this method's own contract) is
+      // correct there: it says "can't be expressed", not "not negated".
+      return switch(c.getOperation()) {
+         case XCondition.EQUAL_TO -> negated ? "NOT_EQUAL_TO" : "EQUAL_TO";
+         case XCondition.LESS_THAN -> negated ? null : c.isEqual() ? "LESS_THAN_OR_EQUAL" : "LESS_THAN";
+         case XCondition.GREATER_THAN -> negated ? null : c.isEqual() ? "GREATER_THAN_OR_EQUAL" : "GREATER_THAN";
+         case XCondition.BETWEEN -> negated ? null : "BETWEEN";
+         case XCondition.ONE_OF -> negated ? "NOT_ONE_OF" : "ONE_OF";
+         case XCondition.STARTING_WITH -> negated ? null : "STARTING_WITH";
+         case XCondition.CONTAINS -> negated ? null : "CONTAINS";
+         case XCondition.LIKE -> negated ? null : "LIKE";
+         case XCondition.NULL -> negated ? "NOT_NULL" : "NULL";
+         default -> null;
+      };
    }
 
    // -------------------------------------------------------------------------

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetScriptService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetScriptService.java
@@ -518,7 +518,8 @@ public class WorksheetScriptService {
          null, null, null, null,         // alias, description, maxRows, distinct
          null, null, null, null,         // columnOrder, groupMappings, groupOthers, variableValues
          null, null, null, null,         // x, y, label, defaultValue
-         null, null, null                // mode, insert, subtables
+         null, null, null,               // mode, insert, subtables
+         null, null                      // sourceTable, attribute
       );
    }
 
@@ -598,7 +599,8 @@ public class WorksheetScriptService {
          null, null, null, null,         // alias, description, maxRows, distinct
          null, null, null, null,         // columnOrder, groupMappings, groupOthers, variableValues
          null, null, null, null,         // x, y, label, defaultValue
-         null, null, null                // mode, insert, subtables
+         null, null, null,               // mode, insert, subtables
+         null, null                      // sourceTable, attribute
       );
    }
 
@@ -672,7 +674,8 @@ public class WorksheetScriptService {
          null, null, null, null,         // alias, description, maxRows, distinct
          null, null, null, null,         // columnOrder, groupMappings, groupOthers, variableValues
          null, null, null, null,         // x, y, label, defaultValue
-         null, null, null                // mode, insert, subtables
+         null, null, null,               // mode, insert, subtables
+         null, null                      // sourceTable, attribute
       );
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/model/WorksheetModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/model/WorksheetModel.java
@@ -257,17 +257,29 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
    /**
     * A named group assembly in the worksheet.
     *
-    * @param name          assembly name
-    * @param table         the source table the grouping is attached to
-    * @param column        the column the grouping is attached to
+    * @param name        assembly name
+    * @param table       worksheet table this group is attached to via {@code table}+{@code column}
+    *                    (mutually exclusive with {@code datasource} — never both non-null)
+    * @param column      column on {@code table} (see {@code table})
+    * @param datasource  datasource this group is scoped to via the datasource-scoped mode
+    *                    (mutually exclusive with {@code table} — never both non-null)
+    * @param logicalModel logical model name within {@code datasource}, when scoped to a logical-model
+    *                     entity attribute rather than a physical table column
+    * @param sourceTable entity name (when {@code logicalModel} is present) or physical table name,
+    *                    within {@code datasource}
+    * @param attribute   attribute/column name within {@code sourceTable}
     * @param groupMappings list of group name to values mappings
-    * @param groupOthers   {@code true} if unmapped values are grouped as "Others"
+    * @param groupOthers {@code true} if unmapped values are grouped as "Others"
     */
    @JsonInclude(JsonInclude.Include.NON_NULL)
    public record NamedGroupModel(
       String name,
       String table,
       String column,
+      String datasource,
+      String logicalModel,
+      String sourceTable,
+      String attribute,
       List<GroupMappingModel> groupMappings,
       boolean groupOthers
    ) {}
@@ -277,7 +289,10 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
     *
     * @param groupName the name of the group
     * @param values    the values assigned to this group
+    * @param operation how {@code values} is matched — any operator {@code add_named_group}'s
+    *                  {@code operation} accepts (e.g. {@code STARTING_WITH}), or {@code null} when
+    *                  it could not be determined from the underlying condition
     */
    @JsonInclude(JsonInclude.Include.NON_NULL)
-   public record GroupMappingModel(String groupName, List<String> values) {}
+   public record GroupMappingModel(String groupName, List<String> values, String operation) {}
 }

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -1549,6 +1549,54 @@ class WorksheetAgentControllerTest {
    }
 
    /**
+    * PR #4765 review follow-up: {@code sourceTable}/{@code attribute}/{@code logicalModel}/
+    * {@code schema}/{@code catalog} must require {@code datasource} server-side too, not only in
+    * the plugin's own client-side validation -- without this guard, omitting {@code datasource}
+    * (by mistake, or via any caller that bypasses the plugin) fell through to the legacy
+    * {@code Editor.addNamedGroup(table, column, type, ...)} path with everything null, silently
+    * creating a standalone string-typed grouping and discarding what the caller asked for.
+    */
+   @Test
+   void addNamedGroupRejectsSourceTableWithoutDatasource() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         mock(XRepository.class), mock(QueryManagerService.class));
+
+      EditRequest req = namedGroupDatasourceRequest(
+         "G", null, null, null, null, "Customer", "State", List.of(), false);
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-NGD9", req, agent));
+      assertTrue(ex.getMessage().contains("datasource"));
+      verifyNoInteractions(dataSourceService);
+      verifyNoInteractions(editSvc);
+   }
+
+   @Test
+   void addNamedGroupRejectsAttributeWithoutDatasource() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         mock(XRepository.class), mock(QueryManagerService.class));
+
+      EditRequest req = namedGroupDatasourceRequest(
+         "G", null, null, null, null, null, "State", List.of(), false);
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-NGD10", req, agent));
+      assertTrue(ex.getMessage().contains("datasource"));
+      verifyNoInteractions(dataSourceService);
+      verifyNoInteractions(editSvc);
+   }
+
+   /**
     * End-to-end regression for Bug #76097: {@code add_named_group} with {@code datasource} +
     * {@code logicalModel} + {@code sourceTable} (entity) + {@code attribute} must produce the
     * same kind of {@code attachedSource}/{@code attachedAttribute} a human creates via the

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -29,6 +29,12 @@ import inetsoft.uql.ColumnSelection;
 import inetsoft.uql.XRepository;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.asset.internal.SQLBoundTableAssemblyInfo;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.erm.XAttribute;
+import inetsoft.uql.erm.XDataModel;
+import inetsoft.uql.erm.XEntity;
+import inetsoft.uql.erm.XLogicalModel;
 import inetsoft.uql.jdbc.JDBCDataSource;
 import inetsoft.uql.jdbc.JDBCQuery;
 import inetsoft.uql.schema.XSchema;
@@ -136,6 +142,7 @@ class WorksheetAgentControllerTest {
          null, null, null, false, null, null, null, null, null, null, null, null, null, null,
          null, null, null, null, datasource, null, null, null, null, null, null, null, null,
          null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+         null, null,
          null, null
       );
    }
@@ -151,6 +158,7 @@ class WorksheetAgentControllerTest {
          null, null, null, false, null, null, null, null, null, null, null, null, null, null,
          null, null, null, null, null, null, null, null, null, null, null, null, null,
          null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+         null, null,
          null, null
       );
    }
@@ -162,6 +170,7 @@ class WorksheetAgentControllerTest {
          null, null, null, false, null, null, null, null, null, null, null, null, null, null,
          null, null, null, null, null, null, null, null, null, null, null, null, null,
          null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+         null, null,
          null, null
       );
    }
@@ -173,6 +182,7 @@ class WorksheetAgentControllerTest {
          null, null, expression, false, null, null, null, null, null, null, null, null, null, null,
          null, null, null, null, null, null, null, null, null, null, null, null, null,
          null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+         null, null,
          null, null
       );
    }
@@ -362,7 +372,8 @@ class WorksheetAgentControllerTest {
          null, null, null, null,
          null, null,
          null, null,
-         null, null, null);
+         null, null, null,
+         null, null);
 
       WorksheetAgentController ctrl = controller(featureOn(),
          mock(SheetJoinService.class), mock(SheetSessionService.class),
@@ -451,7 +462,8 @@ class WorksheetAgentControllerTest {
          null, null, null, null,
          null, null,
          null, null,
-         null, null, null);
+         null, null, null,
+         null, null);
 
       WorksheetAgentController ctrl = controller(featureOn(),
          mock(SheetJoinService.class), mock(SheetSessionService.class),
@@ -497,7 +509,8 @@ class WorksheetAgentControllerTest {
          null, null, null, null,
          null, null,
          null, null,
-         null, null, null);
+         null, null, null,
+         null, null);
 
       WorksheetAgentController ctrl = controller(featureOn(),
          mock(SheetJoinService.class), mock(SheetSessionService.class),
@@ -540,7 +553,8 @@ class WorksheetAgentControllerTest {
          null, null, null, null,
          null, null,
          null, null,
-         null, null, null);
+         null, null, null,
+         null, null);
 
       WorksheetAgentController ctrl = controller(featureOn(),
          mock(SheetJoinService.class), mock(SheetSessionService.class),
@@ -582,7 +596,8 @@ class WorksheetAgentControllerTest {
          null, null, null, null,
          null, null,
          null, null,
-         null, null, null);
+         null, null, null,
+         null, null);
 
       WorksheetAgentController ctrl = controller(featureOn(),
          mock(SheetJoinService.class), mock(SheetSessionService.class),
@@ -603,7 +618,8 @@ class WorksheetAgentControllerTest {
          null, null, null, null,
          null, null,
          null, null,
-         null, null, null
+         null, null, null,
+         null, null
       );
    }
 
@@ -687,6 +703,7 @@ class WorksheetAgentControllerTest {
          null, null, null, false, null, null, null, null, null, null, null, null, null, null,
          null, null, null, null, null, null, null, null, null, null, null, null, null,
          null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+         null, null,
          null, null
       );
    }
@@ -698,6 +715,7 @@ class WorksheetAgentControllerTest {
          null, null, null, false, null, null, null, null, null, null, null, null, null, null,
          null, null, null, null, null, null, null, null, null, null, null, null, null,
          null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+         null, null,
          null, null
       );
    }
@@ -1341,6 +1359,268 @@ class WorksheetAgentControllerTest {
 
       // The READ denial must short-circuit before any JDBC metadata probe.
       verifyNoInteractions(metadataApiService);
+   }
+
+   // ---------------------------------------------------------------------------
+   // add_named_group — datasource-scoped "Only For" mode (Bug #76097)
+   // ---------------------------------------------------------------------------
+
+   /**
+    * Builds an {@code add_named_group} EditRequest scoped to a datasource/logical-model or
+    * physical-table path, routing to {@code addDatasourceScopedNamedGroup()}.
+    */
+   private static EditRequest namedGroupDatasourceRequest(
+      String name, String datasource, String logicalModel, String schema, String catalog,
+      String sourceTable, String attribute,
+      List<WorksheetMutationSupport.GroupMapping> groupMappings, Boolean groupOthers)
+   {
+      return new EditRequest(
+         "add_named_group",   // op
+         null,                 // table
+         null,                 // column
+         name,                 // name
+         null,                 // type
+         null,                 // newName
+         null,                 // field
+         null,                 // operation
+         null,                 // values
+         null,                 // direction
+         null,                 // groups
+         null,                 // aggregates
+         null,                 // expression
+         false,                // sql
+         null,                 // leftTable
+         null,                 // leftKey
+         null,                 // rightTable
+         null,                 // rightKey
+         null,                 // joinType
+         null,                 // visible
+         null,                 // tables
+         null,                 // source
+         null,                 // concatType
+         null,                 // conditions
+         null,                 // ranking
+         null,                 // headerColumns
+         null,                 // dateOption
+         null,                 // boundaries
+         datasource,           // datasource
+         schema,               // schema
+         catalog,              // catalog
+         logicalModel,         // logicalModel
+         null,                 // leftKeys
+         null,                 // rightKeys
+         null,                 // row
+         null,                 // col
+         null,                 // value
+         null,                 // index
+         null,                 // alias
+         null,                 // description
+         null,                 // maxRows
+         null,                 // distinct
+         null,                 // columnOrder
+         groupMappings,        // groupMappings
+         groupOthers,          // groupOthers
+         null,                 // variableValues
+         null,                 // x
+         null,                 // y
+         null,                 // label
+         null,                 // defaultValue
+         null,                 // mode
+         null,                 // insert
+         null,                 // subtables
+         sourceTable,          // sourceTable
+         attribute             // attribute
+      );
+   }
+
+   @Test
+   void addNamedGroupRejectsDatasourceCombinedWithTable() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         mock(XRepository.class), mock(QueryManagerService.class));
+
+      EditRequest req = new EditRequest(
+         "add_named_group",   // op
+         "Customer1",          // table
+         "State",              // column
+         "G",                  // name
+         null,                 // type
+         null,                 // newName
+         null,                 // field
+         null,                 // operation
+         null,                 // values
+         null,                 // direction
+         null,                 // groups
+         null,                 // aggregates
+         null,                 // expression
+         false,                // sql
+         null,                 // leftTable
+         null,                 // leftKey
+         null,                 // rightTable
+         null,                 // rightKey
+         null,                 // joinType
+         null,                 // visible
+         null,                 // tables
+         null,                 // source
+         null,                 // concatType
+         null,                 // conditions
+         null,                 // ranking
+         null,                 // headerColumns
+         null,                 // dateOption
+         null,                 // boundaries
+         "Examples/Orders",    // datasource
+         null,                 // schema
+         null,                 // catalog
+         "Order Model",        // logicalModel
+         null,                 // leftKeys
+         null,                 // rightKeys
+         null,                 // row
+         null,                 // col
+         null,                 // value
+         null,                 // index
+         null,                 // alias
+         null,                 // description
+         null,                 // maxRows
+         null,                 // distinct
+         null,                 // columnOrder
+         List.<WorksheetMutationSupport.GroupMapping>of(), // groupMappings
+         false,                // groupOthers
+         null,                 // variableValues
+         null,                 // x
+         null,                 // y
+         null,                 // label
+         null,                 // defaultValue
+         null,                 // mode
+         null,                 // insert
+         null,                 // subtables
+         "Customer",           // sourceTable
+         "State"               // attribute
+      );
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-NGD1", req, agent));
+      assertTrue(ex.getMessage().contains("mutually exclusive"));
+      verifyNoInteractions(dataSourceService);
+      verifyNoInteractions(editSvc);
+   }
+
+   @Test
+   void addNamedGroupRequiresSourceTableWhenDatasourceGiven() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         mock(XRepository.class), mock(QueryManagerService.class));
+
+      EditRequest req = namedGroupDatasourceRequest(
+         "G", "Examples/Orders", "Order Model", null, null, null, "State", List.of(), false);
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-NGD2", req, agent));
+      assertTrue(ex.getMessage().contains("sourceTable"));
+      verifyNoInteractions(dataSourceService);
+      verifyNoInteractions(editSvc);
+   }
+
+   @Test
+   void addNamedGroupRequiresAttributeWhenDatasourceGiven() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         mock(XRepository.class), mock(QueryManagerService.class));
+
+      EditRequest req = namedGroupDatasourceRequest(
+         "G", "Examples/Orders", "Order Model", null, null, "Customer", null, List.of(), false);
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-NGD3", req, agent));
+      assertTrue(ex.getMessage().contains("attribute"));
+      verifyNoInteractions(dataSourceService);
+      verifyNoInteractions(editSvc);
+   }
+
+   /**
+    * End-to-end regression for Bug #76097: {@code add_named_group} with {@code datasource} +
+    * {@code logicalModel} + {@code sourceTable} (entity) + {@code attribute} must produce the
+    * same kind of {@code attachedSource}/{@code attachedAttribute} a human creates via the
+    * Composer's own "Add Grouping" dialog — {@code SourceInfo(MODEL, datasource, logicalModel)},
+    * and an {@code AttributeRef(entity, attribute)} — so "Only For" and "Attribute" resolve
+    * correctly, unlike the {@code table}+{@code column} worksheet-attached mode.
+    */
+   @Test
+   void addNamedGroupWithLogicalModelBuildsRealDatasourceSourceInfo() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      XAttribute stateAttr = new XAttribute("State", "SA.CUSTOMERS", "STATE", XSchema.STRING);
+      XEntity customerEntity = new XEntity("Customer");
+      customerEntity.addAttribute(stateAttr);
+      XLogicalModel orderModel = new XLogicalModel("Order Model");
+      orderModel.addEntity(customerEntity);
+
+      // XDataModel.addLogicalModel() reaches for a Spring-managed DataSourceRegistry bean
+      // (via XDataModel.getRegistry()) that isn't available outside a running application
+      // context, so the model is mocked and getLogicalModel() stubbed directly instead of
+      // actually registering orderModel on a real XDataModel.
+      XDataModel dataModel = mock(XDataModel.class);
+      when(dataModel.getLogicalModel("Order Model")).thenReturn(orderModel);
+
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      when(dataSourceService.checkPermission(eq("Examples/Orders"), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(true);
+      when(dataSourceService.getDataModel("Examples/Orders")).thenReturn(dataModel);
+      when(dataSourceService.getModelAssetEntry(any())).thenAnswer(inv -> inv.getArgument(0));
+      when(dataSourceService.checkPermission(any(AssetEntry.class), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(true);
+
+      Worksheet ws = new Worksheet();
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      when(editSvc.applyOnRuntime(eq("TOK-NGD4"), eq(agent), any())).thenAnswer(inv -> {
+         WorksheetEditService.ThrowingFunction<RuntimeWorksheet, ?> fn = inv.getArgument(2);
+         return fn.apply(rws);
+      });
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         mock(XRepository.class), mock(QueryManagerService.class));
+
+      List<WorksheetMutationSupport.GroupMapping> mappings = List.of(
+         new WorksheetMutationSupport.GroupMapping("N", List.of("NJ", "NY", "NV")));
+      EditRequest req = namedGroupDatasourceRequest(
+         "State N Group", "Examples/Orders", "Order Model", null, null,
+         "Customer", "State", mappings, true);
+
+      ctrl.edit("TOK-NGD4", req, agent);
+
+      DefaultNamedGroupAssembly nga = (DefaultNamedGroupAssembly) ws.getAssembly("State N Group");
+      assertNotNull(nga, "the datasource-scoped grouping must be created in the worksheet");
+
+      SourceInfo attached = nga.getAttachedSource();
+      assertEquals(SourceInfo.MODEL, attached.getType());
+      assertEquals("Examples/Orders", attached.getPrefix());
+      assertEquals("Order Model", attached.getSource());
+
+      DataRef ref = nga.getAttachedAttribute();
+      assertInstanceOf(AttributeRef.class, ((ColumnRef) ref).getDataRef());
+      AttributeRef attrRef = (AttributeRef) ((ColumnRef) ref).getDataRef();
+      assertEquals("Customer", attrRef.getEntity());
+      assertEquals("State", attrRef.getAttribute());
+      assertEquals(XSchema.STRING, ref.getDataType());
+
+      assertEquals(AttachedAssembly.COLUMN_ATTACHED, nga.getAttachedType());
+      assertNotNull(nga.getNamedGroupInfo().getGroupCondition("N"),
+         "group mappings must still be applied");
    }
 
    // ---------------------------------------------------------------------------

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceTest.java
@@ -20,7 +20,11 @@ package inetsoft.web.wiz.worksheet;
 import inetsoft.report.composition.RuntimeWorksheet;
 import inetsoft.sree.security.SecurityEngine;
 import inetsoft.uql.ColumnSelection;
+import inetsoft.uql.Condition;
+import inetsoft.uql.ConditionList;
+import inetsoft.uql.XCondition;
 import inetsoft.uql.asset.*;
+import inetsoft.uql.erm.AttributeRef;
 import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.web.wiz.pairing.*;
@@ -313,5 +317,140 @@ class WorksheetEditServiceTest {
       // object" and returning null) rather than propagating it, so this alone would not have
       // caught the regression — the assertions above on the condition ref are what matter here.
       assertDoesNotThrow(() -> ws.clone());
+   }
+
+   /**
+    * Guards the invariant {@code CalcTableService.worksheetNamedGroups}/{@code FieldRefFactory}
+    * depend on: a named group attached to a worksheet table column must carry
+    * {@code SourceInfo(ASSET, null, <worksheet table name>)} — the same convention
+    * {@code WizVsService}/{@code VSChartDndService} use for a chart/table/crosstab/calc-table's
+    * own bound-table {@code SourceInfo} — even when that table is itself bound to a real
+    * datasource/logical-model (a {@link BoundTableAssembly}). Reusing the table's own upstream
+    * {@code SourceInfo} here (attempted and reverted during Bug #76097) breaks that matching:
+    * those two classes look up a group by comparing the VS assembly's own worksheet-table-name
+    * {@code SourceInfo} against the group's {@code attachedSource}, so anything other than the
+    * worksheet table's name here makes a real, already-working named group silently stop
+    * resolving in chart/table/crosstab/calc-table bindings.
+    */
+   @Test
+   void addNamedGroupSourceInfoIsWorksheetTableNameEvenForBoundTable() throws Exception {
+      Worksheet ws = new Worksheet();
+      BoundTableAssembly t = new BoundTableAssembly(ws, "Customer1");
+      t.setSourceInfo(new SourceInfo(SourceInfo.MODEL, "Examples/Orders", "Order Model"));
+      ColumnSelection columns = new ColumnSelection();
+      ColumnRef stateRef = new ColumnRef(new AttributeRef("Customer", "State"));
+      stateRef.setDataType(XSchema.STRING);
+      columns.addAttribute(stateRef);
+      t.setColumnSelection(columns);
+      ws.addAssembly(t);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      JoinSession s = new JoinSession("TOK", "Worksheet/foo-7", "alice~;~host-org",
+                                     SheetType.WORKSHEET, 0L, Long.MAX_VALUE,
+                                     JoinSession.ConnectionMode.PAIRED, null, null, null);
+      when(sessions.resolve(eq("TOK"), any())).thenReturn(s);
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+
+      List<WorksheetMutationSupport.GroupMapping> mappings = List.of(
+         new WorksheetMutationSupport.GroupMapping("N", List.of("NJ", "NY", "NV")));
+
+      svc.apply("TOK", agent,
+                ed -> ed.addNamedGroup("StateNGroup", "Customer1", "State", null, mappings, true));
+
+      DefaultNamedGroupAssembly nga = (DefaultNamedGroupAssembly) ws.getAssembly("StateNGroup");
+      SourceInfo attached = nga.getAttachedSource();
+      assertNotNull(attached);
+      assertEquals(SourceInfo.ASSET, attached.getType());
+      assertEquals("Customer1", attached.getSource());
+   }
+
+   /**
+    * Regression for Bug #76097: a group mapping's negated-equality operation ("!=" /
+    * "NOT_EQUAL_TO") over more than one value must test "not equal to any of them" (a negated
+    * ONE_OF), not OR together separately-negated single-value EQUAL_TO conditions — the latter
+    * is a near-tautology (true for almost every input) since EQUAL_TO only ever reads a
+    * condition's first value.
+    */
+   @Test
+   void addNamedGroupNegatedEqualityExcludesAllListedValues() throws Exception {
+      Worksheet ws = new Worksheet();
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      JoinSession s = new JoinSession("TOK", "Worksheet/foo-7", "alice~;~host-org",
+                                     SheetType.WORKSHEET, 0L, Long.MAX_VALUE,
+                                     JoinSession.ConnectionMode.PAIRED, null, null, null);
+      when(sessions.resolve(eq("TOK"), any())).thenReturn(s);
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+
+      List<WorksheetMutationSupport.GroupMapping> mappings = List.of(
+         new WorksheetMutationSupport.GroupMapping("NotNYNJ", List.of("NY", "NJ"), "!="));
+
+      svc.apply("TOK", agent,
+                ed -> ed.addNamedGroup("StateNGroup", null, null, "string", mappings, true));
+
+      DefaultNamedGroupAssembly nga = (DefaultNamedGroupAssembly) ws.getAssembly("StateNGroup");
+      ConditionList conds = nga.getNamedGroupInfo().getGroupCondition("NotNYNJ");
+      assertEquals(1, conds.getSize(),
+         "negated equality over multiple values must be a single negated ONE_OF condition, " +
+            "not OR'd single-value conditions");
+      Condition c = conds.getConditionItem(0).getCondition();
+      assertEquals(XCondition.ONE_OF, c.getOperation());
+      assertTrue(c.isNegated());
+      assertEquals(2, c.getValueCount());
+      assertEquals("NY", c.getValue(0));
+      assertEquals("NJ", c.getValue(1));
+   }
+
+   /**
+    * Regression for Bug #76097: a group mapping's {@code operation} must be honored instead of
+    * always building an EQUAL_TO condition — "starts with N" should produce a single
+    * STARTING_WITH condition per value, not an enumerated equality list.
+    */
+   @Test
+   void addNamedGroupSupportsStartingWithOperator() throws Exception {
+      Worksheet ws = new Worksheet();
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      JoinSession s = new JoinSession("TOK", "Worksheet/foo-7", "alice~;~host-org",
+                                     SheetType.WORKSHEET, 0L, Long.MAX_VALUE,
+                                     JoinSession.ConnectionMode.PAIRED, null, null, null);
+      when(sessions.resolve(eq("TOK"), any())).thenReturn(s);
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+
+      List<WorksheetMutationSupport.GroupMapping> mappings = List.of(
+         new WorksheetMutationSupport.GroupMapping("N", List.of("N"), "STARTING_WITH"),
+         new WorksheetMutationSupport.GroupMapping("Others", List.of(), null));
+
+      svc.apply("TOK", agent,
+                ed -> ed.addNamedGroup("StateNGroup", null, null, "string", mappings, true));
+
+      DefaultNamedGroupAssembly nga = (DefaultNamedGroupAssembly) ws.getAssembly("StateNGroup");
+      Condition c = nga.getNamedGroupInfo().getGroupCondition("N")
+         .getConditionItem(0).getCondition();
+      assertEquals(XCondition.STARTING_WITH, c.getOperation());
+      assertEquals(1, c.getValueCount());
+      assertEquals("N", c.getValue(0));
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceTest.java
@@ -453,4 +453,73 @@ class WorksheetEditServiceTest {
       assertEquals(1, c.getValueCount());
       assertEquals("N", c.getValue(0));
    }
+
+   /**
+    * PR #4765 review follow-up: {@code BETWEEN} with any value count other than 2 is not "no
+    * matches" the way it silently was before -- {@link Condition#evaluate} only ever reads
+    * {@code values.get(0)}/{@code values.get(1)}, so a 1- or 3-value BETWEEN mapping is a
+    * malformed request that should fail loud, not be built into a condition that quietly never
+    * matches.
+    */
+   @Test
+   void addNamedGroupRejectsBetweenWithWrongValueCount() throws Exception {
+      Worksheet ws = new Worksheet();
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      JoinSession s = new JoinSession("TOK", "Worksheet/foo-7", "alice~;~host-org",
+                                     SheetType.WORKSHEET, 0L, Long.MAX_VALUE,
+                                     JoinSession.ConnectionMode.PAIRED, null, null, null);
+      when(sessions.resolve(eq("TOK"), any())).thenReturn(s);
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+
+      List<WorksheetMutationSupport.GroupMapping> mappings = List.of(
+         new WorksheetMutationSupport.GroupMapping("Mid", List.of("10"), "BETWEEN"));
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent,
+                         ed -> ed.addNamedGroup("G", null, null, "string", mappings, false)));
+      assertTrue(ex.getMessage().contains("BETWEEN"));
+      assertNull(ws.getAssembly("G"), "a rejected group must not be partially created");
+   }
+
+   /**
+    * PR #4765 review follow-up: an empty value list for {@code ONE_OF} matches nothing, but a
+    * NEGATED empty {@code ONE_OF} (e.g. {@code "!="} with no values) matches EVERYTHING -- both
+    * are almost certainly caller mistakes, not an intentional "match nothing"/"match everything"
+    * grouping, so they fail loud instead of silently building a useless or over-broad condition.
+    */
+   @Test
+   void addNamedGroupRejectsEmptyValuesForSetBasedOperation() throws Exception {
+      Worksheet ws = new Worksheet();
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      JoinSession s = new JoinSession("TOK", "Worksheet/foo-7", "alice~;~host-org",
+                                     SheetType.WORKSHEET, 0L, Long.MAX_VALUE,
+                                     JoinSession.ConnectionMode.PAIRED, null, null, null);
+      when(sessions.resolve(eq("TOK"), any())).thenReturn(s);
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+
+      List<WorksheetMutationSupport.GroupMapping> mappings = List.of(
+         new WorksheetMutationSupport.GroupMapping("NotAnything", List.of(), "!="));
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent,
+                         ed -> ed.addNamedGroup("G2", null, null, "string", mappings, false)));
+      assertTrue(ex.getMessage().contains("at least one value"));
+      assertNull(ws.getAssembly("G2"), "a rejected group must not be partially created");
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
@@ -18,8 +18,17 @@
 package inetsoft.web.wiz.worksheet;
 
 import inetsoft.report.composition.RuntimeWorksheet;
+import inetsoft.report.internal.binding.BaseField;
+import inetsoft.uql.Condition;
+import inetsoft.uql.ConditionItem;
+import inetsoft.uql.ConditionList;
+import inetsoft.uql.XCondition;
+import inetsoft.uql.XConstants;
 import inetsoft.uql.asset.*;
 import inetsoft.uql.asset.internal.*;
+import inetsoft.uql.erm.AttributeRef;
+import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.schema.XSchema;
 import inetsoft.web.wiz.pairing.TestWorksheets;
 import inetsoft.web.wiz.pairing.WizAgentTestSupport;
 import inetsoft.web.wiz.worksheet.model.WorksheetModel;
@@ -590,5 +599,152 @@ class WorksheetReadServiceTest {
 
       t.setVisibleTable(false);
       assertFalse(tableNamed(read(ws), "T").visibleInViewsheet());
+   }
+
+   // ---------------------------------------------------------------------------
+   // Named groups (Bug #76097 review follow-up)
+   // ---------------------------------------------------------------------------
+
+   private static DefaultNamedGroupAssembly namedGroup(
+      Worksheet ws, String name, SourceInfo attachedSource, DataRef attachedAttribute,
+      String groupName, WorksheetMutationSupport.GroupMapping mapping) throws Exception
+   {
+      NamedGroupInfo ngi = new NamedGroupInfo();
+      ngi.setOthers(XConstants.LEAVE_OTHERS);
+      DataRef conditionRef = attachedAttribute != null ? attachedAttribute
+         : new BaseField("this");
+      ngi.setGroupCondition(groupName,
+         WorksheetMutationSupport.buildGroupConditionList(XSchema.STRING, conditionRef, mapping));
+
+      DefaultNamedGroupAssembly assembly = new DefaultNamedGroupAssembly(ws, name);
+      assembly.setNamedGroupInfo(ngi);
+
+      if(attachedAttribute != null) {
+         assembly.setAttachedType(AttachedAssembly.COLUMN_ATTACHED);
+         assembly.setAttachedSource(attachedSource);
+         assembly.setAttachedAttribute(attachedAttribute);
+      }
+      else {
+         assembly.setAttachedType(AttachedAssembly.DATA_TYPE_ATTACHED);
+         assembly.setAttachedDataType(XSchema.STRING);
+      }
+
+      ws.addAssembly(assembly);
+      return assembly;
+   }
+
+   private static WorksheetModel.NamedGroupModel namedGroupNamed(WorksheetModel m, String name) {
+      return m.namedGroups().stream().filter(g -> name.equals(g.name())).findFirst().orElseThrow();
+   }
+
+   @Test
+   void readsWorksheetTableAttachedGroupAsTableColumnNotDatasourceScoped() throws Exception {
+      Worksheet ws = new Worksheet();
+      ColumnRef col = new ColumnRef(new AttributeRef(null, "State"));
+      col.setDataType(XSchema.STRING);
+      SourceInfo attachedSource = new SourceInfo(SourceInfo.ASSET, null, "Customer1");
+      namedGroup(ws, "StateNGroup", attachedSource, col, "N",
+         new WorksheetMutationSupport.GroupMapping("N", List.of("N"), "STARTING_WITH"));
+
+      WorksheetModel.NamedGroupModel ng = namedGroupNamed(read(ws), "StateNGroup");
+      assertEquals("Customer1", ng.table());
+      assertEquals("State", ng.column());
+      assertNull(ng.datasource());
+      assertNull(ng.logicalModel());
+      assertNull(ng.sourceTable());
+      assertNull(ng.attribute());
+      assertEquals("STARTING_WITH", ng.groupMappings().get(0).operation());
+   }
+
+   @Test
+   void readsLogicalModelScopedGroupAsDatasourceNotTableColumn() throws Exception {
+      Worksheet ws = new Worksheet();
+      ColumnRef col = new ColumnRef(new AttributeRef("Customer", "State"));
+      col.setDataType(XSchema.STRING);
+      SourceInfo attachedSource = new SourceInfo(SourceInfo.MODEL, "Examples/Orders", "Order Model");
+      namedGroup(ws, "State N Group", attachedSource, col, "N",
+         new WorksheetMutationSupport.GroupMapping("N", List.of("NJ", "NY", "NV")));
+
+      WorksheetModel.NamedGroupModel ng = namedGroupNamed(read(ws), "State N Group");
+      assertNull(ng.table());
+      assertNull(ng.column());
+      assertEquals("Examples/Orders", ng.datasource());
+      assertEquals("Order Model", ng.logicalModel());
+      assertEquals("Customer", ng.sourceTable());
+      assertEquals("State", ng.attribute());
+      // No operation given at creation -- must round-trip as explicit equality, not be silently
+      // omitted (which would look identical to "couldn't be determined").
+      assertEquals("EQUAL_TO", ng.groupMappings().get(0).operation());
+   }
+
+   @Test
+   void readsPhysicalTableScopedGroupAsDatasourceWithNoLogicalModel() throws Exception {
+      Worksheet ws = new Worksheet();
+      ColumnRef col = new ColumnRef(new AttributeRef(null, "STATE"));
+      col.setDataType(XSchema.STRING);
+      SourceInfo attachedSource = new SourceInfo(SourceInfo.PHYSICAL_TABLE, "MyDatasource", "SA.CUSTOMERS");
+      namedGroup(ws, "PhysGroup", attachedSource, col, "N",
+         new WorksheetMutationSupport.GroupMapping("N", List.of("N"), "STARTING_WITH"));
+
+      WorksheetModel.NamedGroupModel ng = namedGroupNamed(read(ws), "PhysGroup");
+      assertNull(ng.table());
+      assertNull(ng.column());
+      assertEquals("MyDatasource", ng.datasource());
+      assertNull(ng.logicalModel());
+      assertEquals("SA.CUSTOMERS", ng.sourceTable());
+      assertEquals("STATE", ng.attribute());
+   }
+
+   @Test
+   void readsNegatedEqualityOperationOnStandaloneGroup() throws Exception {
+      Worksheet ws = new Worksheet();
+      namedGroup(ws, "NotNYNJ", null, null, "NotNYNJ",
+         new WorksheetMutationSupport.GroupMapping("NotNYNJ", List.of("NY", "NJ"), "!="));
+
+      WorksheetModel.NamedGroupModel ng = namedGroupNamed(read(ws), "NotNYNJ");
+      assertNull(ng.table());
+      assertNull(ng.datasource());
+      assertEquals("NOT_ONE_OF", ng.groupMappings().get(0).operation());
+   }
+
+   /**
+    * PR #4765 review follow-up: {@code add_named_group}'s own vocabulary can never create a
+    * negated {@code STARTING_WITH}/{@code CONTAINS}/{@code LIKE}/{@code BETWEEN}/comparison (there
+    * is no {@code NOT_STARTING_WITH} etc.), but a human can, via the Composer's general condition
+    * editor ({@code Condition.isNegatedChangeable()} is unconditionally {@code true}) -- and
+    * {@code readNamedGroup} runs over every {@code DefaultNamedGroupAssembly} in the worksheet,
+    * not just wizard-created ones. Reporting the positive string for such a condition would
+    * silently flip its meaning if read back and fed into add_named_group/edit_named_group, so
+    * {@code operation} must come back {@code null} ("can't be expressed") rather than
+    * {@code "STARTING_WITH"}.
+    */
+   @Test
+   void readsNullOperationForNegatedStartingWithBeyondThisVocabulary() {
+      Worksheet ws = new Worksheet();
+      ColumnRef col = new ColumnRef(new AttributeRef(null, "State"));
+      col.setDataType(XSchema.STRING);
+
+      Condition c = new Condition(XSchema.STRING);
+      c.setOperation(XCondition.STARTING_WITH);
+      c.setNegated(true);
+      c.addValue("N");
+      ConditionList conds = new ConditionList();
+      conds.append(new ConditionItem(col, c, 0));
+
+      NamedGroupInfo ngi = new NamedGroupInfo();
+      ngi.setOthers(XConstants.LEAVE_OTHERS);
+      ngi.setGroupCondition("NotN", conds);
+
+      DefaultNamedGroupAssembly assembly = new DefaultNamedGroupAssembly(ws, "HumanMadeGroup");
+      assembly.setNamedGroupInfo(ngi);
+      assembly.setAttachedType(AttachedAssembly.COLUMN_ATTACHED);
+      assembly.setAttachedSource(new SourceInfo(SourceInfo.ASSET, null, "Customer1"));
+      assembly.setAttachedAttribute(col);
+      ws.addAssembly(assembly);
+
+      WorksheetModel.NamedGroupModel ng = namedGroupNamed(read(ws), "HumanMadeGroup");
+      assertNull(ng.groupMappings().get(0).operation(),
+         "a negated STARTING_WITH has no round-trippable operation string and must not be " +
+            "reported as the plain positive one");
    }
 }


### PR DESCRIPTION
## Summary

`add_named_group`/`edit_named_group` (the AI-assistant worksheet tool backing StyleBI's Composer chat plugin) only supported enumerated equality values for group mappings, and had no way to scope a grouping directly to a datasource/logical-model or physical-table path the way a human does via the Composer's own "Add Grouping" dialog ("Only For" + "Attribute").

## Root Cause

- Group mapping conditions were always built as `EQUAL_TO`, hardcoded — there was no way to express "starts with N" or any other operator.
- The tool only supported attaching to an existing worksheet table's column (`table`+`column`) or a fully standalone, type-only grouping. Neither corresponds to a datasource/logical-model-scoped grouping the way the native Composer dialog creates one.

## Fix

- Added an `operation` field to each group mapping (`WorksheetMutationSupport.GroupMapping`), honored by a new shared `WorksheetMutationSupport.buildGroupConditionList`, supporting the full condition-operator vocabulary already used elsewhere in this tool surface (`=`, `!=`, `<`, `>`, `<=`, `>=`, `BETWEEN`, `ONE_OF`/`NOT_ONE_OF`, `STARTING_WITH`, `CONTAINS`, `LIKE`, `NULL`/`NOT_NULL`). Negated equality is routed through the same set-based logic as `NOT_ONE_OF` rather than per-value OR'd negation, since `EQUAL_TO` only ever reads a condition's first value (per-value negation would otherwise produce a near-tautological always-true condition for a multi-value exclusion).
- Added a new `WorksheetAgentController.addDatasourceScopedNamedGroup`, dispatched from `add_named_group` when `datasource` is given: it resolves a logical-model entity attribute (mirroring `addLogicalModelTable`'s permission checks and lookups) or a physical-table column (mirroring `addBoundTable`'s), and builds the same kind of `SourceInfo`/attribute a human's "Add Grouping" dialog would — independent of any worksheet table.
- The existing `table`+`column` attached mode is intentionally unchanged: its `SourceInfo(ASSET, null, table)` convention is relied on by `CalcTableService.worksheetNamedGroups()`/`FieldRefFactory` to resolve a chart/table/crosstab/calc-table's `namedGroup` binding, so changing it would have silently broken that binding-resolution path for any grouping attached this way.

## Test Plan

- `./mvnw -pl core test -Dtest="inetsoft.web.wiz.worksheet.*Test,CalcTableServiceTest,FieldRefFactoryTest"` — all pass, including new regression tests for the operator support, the datasource-scoped mode, and a guard that the `table`+`column` mode's `SourceInfo` convention stays intact even when the underlying table is a real `BoundTableAssembly`.
- Live-verified via the `stylebi-composer-chat` plugin against a running server: created a named group scoped to `Examples/Orders` → `Order Model` → `Customer:State`, with an `N` group built via `STARTING_WITH`.

Fixes Redmine #76097.