### PR TITLE
75694, auto complete not working on unchained method calls.

### DIFF
--- a/build-tools/tern-annotations/src/main/java/com/inetsoft/build/tern/TernAnnotationProcessor.java
+++ b/build-tools/tern-annotations/src/main/java/com/inetsoft/build/tern/TernAnnotationProcessor.java
@@ -19,7 +19,7 @@ package com.inetsoft.build.tern;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.*;
 import com.google.auto.common.*;
 
 import javax.annotation.processing.*;
@@ -61,7 +61,6 @@ public class TernAnnotationProcessor extends AbstractProcessor {
 
    private void processAnnotations(RoundEnvironment roundEnv) {
       String baseUrl = processingEnv.getOptions().get("tern.baseUrl");
-      Map<String, Set<String>> superClasses = new HashMap<>();
 
       for(Element element : roundEnv.getElementsAnnotatedWith(TernClass.class)) {
          TypeElement classType = MoreElements.asType(element);
@@ -75,6 +74,7 @@ public class TernAnnotationProcessor extends AbstractProcessor {
 
          ClassDef classDef = new ClassDef(className, url.isEmpty() ? null : baseUrl + url);
          definitions.put(fullClassName, classDef);
+         ternClasses.add(fullClassName);
 
          TypeMirror superType = classType.getSuperclass();
 
@@ -125,7 +125,7 @@ public class TernAnnotationProcessor extends AbstractProcessor {
             classDef.addStaticMethod(methodDef);
          }
          else {
-            for(ClassDef classDef : getEnclosingClasses(element, superClasses)) {
+            for(ClassDef classDef : getEnclosingClasses(element)) {
                classDef.addMemberMethod(methodDef);
             }
          }
@@ -149,7 +149,7 @@ public class TernAnnotationProcessor extends AbstractProcessor {
             classDef.addStaticField(fieldDef);
          }
          else {
-            for(ClassDef classDef : getEnclosingClasses(element, superClasses)) {
+            for(ClassDef classDef : getEnclosingClasses(element)) {
                classDef.addMemberField(fieldDef);
             }
          }
@@ -178,10 +178,13 @@ public class TernAnnotationProcessor extends AbstractProcessor {
          // prior file and simply starts fresh. Trade-off: a class removed or renamed leaves a
          // stale entry in an incrementally-built file until the next clean build.
          ObjectNode definitionRoot = readExistingDefinitions(mapper, file);
+         Set<String> priorUnions = readUnionMarkers(definitionRoot);
 
          for(Map.Entry<String, ClassDef> e : definitions.entrySet()) {
             definitionRoot.set(e.getKey(), e.getValue().toJson(mapper));
          }
+
+         addUnionDefinitions(mapper, definitionRoot, priorUnions);
 
          try(OutputStream output = file.openOutputStream()) {
             mapper.writerWithDefaultPrettyPrinter().writeValue(output, definitionRoot);
@@ -211,6 +214,135 @@ public class TernAnnotationProcessor extends AbstractProcessor {
       }
 
       return mapper.createObjectNode();
+   }
+
+   /**
+    * Emit a synthetic definition for each unannotated base class that is referenced as a
+    * type, merging into it the members of every @TernClass subclass. Without this a method
+    * declared to return an abstract base - EGraph.getCoordinate(), RectCoord.getXScale() -
+    * is typed "?", so tern resolves nothing past it and auto-complete breaks for the whole
+    * chain (Bug #75694). Members that do not apply to the concrete instance are included by
+    * design: the alternative is offering nothing at all.
+    *
+    * This runs against the merged definition set (the previously generated definitions plus
+    * this round's) so an incremental compile cannot shrink a union down to only the
+    * subclasses that happened to be recompiled.
+    */
+   private void addUnionDefinitions(ObjectMapper mapper, ObjectNode definitionRoot,
+                                    Set<String> priorUnions)
+   {
+      Set<String> unions = new TreeSet<>(priorUnions);
+
+      for(String base : unionBases) {
+         // a real @TernClass definition always takes precedence over a synthetic union
+         if(isTernClass(base, definitionRoot, priorUnions)) {
+            continue;
+         }
+
+         Set<String> subclasses = superClasses.get(base);
+
+         if(subclasses == null) {
+            continue;
+         }
+
+         ObjectNode prototype = mapper.createObjectNode();
+
+         // sorted so that which subclass wins a name collision stays stable between builds
+         for(String subclass : new TreeSet<>(subclasses)) {
+            JsonNode subclassNode = definitionRoot.get(subclass);
+
+            if(subclassNode == null) {
+               continue;
+            }
+
+            JsonNode members = subclassNode.get("prototype");
+
+            if(!(members instanceof ObjectNode)) {
+               continue;
+            }
+
+            for(Iterator<Map.Entry<String, JsonNode>> it = members.fields(); it.hasNext(); ) {
+               Map.Entry<String, JsonNode> member = it.next();
+
+               if(!prototype.has(member.getKey())) {
+                  prototype.set(member.getKey(), member.getValue().deepCopy());
+               }
+            }
+         }
+
+         if(prototype.size() == 0) {
+            continue;
+         }
+
+         JsonNode existing = definitionRoot.get(base);
+         ObjectNode node;
+
+         if(existing instanceof ObjectNode) {
+            node = (ObjectNode) existing;
+         }
+         else {
+            node = mapper.createObjectNode();
+            node.put("!type", "fn()");
+            definitionRoot.set(base, node);
+         }
+
+         JsonNode declared = node.get("prototype");
+
+         // anything already declared on the base itself wins over a subclass member
+         if(declared instanceof ObjectNode) {
+            prototype.setAll((ObjectNode) declared);
+         }
+
+         node.set("prototype", prototype);
+         unions.add(base);
+      }
+
+      if(!unions.isEmpty()) {
+         ArrayNode marker = mapper.createArrayNode();
+         unions.forEach(marker::add);
+         definitionRoot.set(UNION_MARKER, marker);
+      }
+   }
+
+   /**
+    * Check whether a name belongs to a class declared with @TernClass, whose own definition
+    * must never be replaced by a synthetic union.
+    *
+    * @TernClass has SOURCE retention, so a base class whose source was not recompiled in this
+    * round cannot be tested for the annotation directly - it is not even in this round's
+    * definitions. A definition carried over from a previous build that this processor did not
+    * synthesize is therefore treated as a real @TernClass definition and left alone; without
+    * that check an incremental compile could overwrite, say, LinearScale with a union built
+    * from whichever of its subclasses happened to be recompiled.
+    */
+   private boolean isTernClass(String base, ObjectNode definitionRoot, Set<String> priorUnions) {
+      if(ternClasses.contains(base)) {
+         return true;
+      }
+
+      if(definitions.containsKey(base)) {
+         // known this round, and not annotated: the entry exists only because it was
+         // auto-created to carry static members (@TernField on an unannotated base)
+         return false;
+      }
+
+      return definitionRoot.has(base) && !priorUnions.contains(base);
+   }
+
+   /**
+    * Read back the names this processor previously emitted as synthetic unions. tern ignores
+    * the marker, which has to live in the definition file itself so that the distinction
+    * between a synthesized definition and a real @TernClass one survives across builds.
+    */
+   private Set<String> readUnionMarkers(ObjectNode definitionRoot) {
+      Set<String> markers = new TreeSet<>();
+      JsonNode marker = definitionRoot.get(UNION_MARKER);
+
+      if(marker != null && marker.isArray()) {
+         marker.forEach(name -> markers.add(name.asText()));
+      }
+
+      return markers;
    }
 
    private void logInfo(String message) {
@@ -266,7 +398,7 @@ public class TernAnnotationProcessor extends AbstractProcessor {
       return getClassName(element.getEnclosingElement());
    }
 
-   private Set<ClassDef> getEnclosingClasses(Element element, Map<String, Set<String>> superClasses) {
+   private Set<ClassDef> getEnclosingClasses(Element element) {
       Set<ClassDef> results = new HashSet<>();
 
       String className = getEnclosingClassName(element);
@@ -352,9 +484,42 @@ public class TernAnnotationProcessor extends AbstractProcessor {
       case "Double":
          return "number";
       default:
-         return definitions.containsKey(name) ? "+" + name : "?";
+         if(definitions.containsKey(name)) {
+            return "+" + name;
+         }
+
+         // The type has no @TernClass of its own - typically an abstract base such as
+         // Scale or Coordinate - so it would be emitted as "?", leaving tern unable to
+         // infer anything past it and killing auto-complete for the rest of the call
+         // chain (Bug #75694). If annotated classes extend it, record it here so a
+         // synthetic union definition carrying every subclass member is emitted for it,
+         // making it a real tern type.
+         if(!isPlatformType(mirror) && superClasses.containsKey(name)) {
+            unionBases.add(name);
+            return "+" + name;
+         }
+
+         return "?";
       }
    }
 
+   /**
+    * Check whether a type is a JDK type. Unioning the annotated subclasses of, say,
+    * java.lang.Object would produce a meaningless definition holding every annotated
+    * class in the project.
+    */
+   private boolean isPlatformType(TypeMirror mirror) {
+      String name = MoreTypes.asTypeElement(mirror).getQualifiedName().toString();
+      return name.startsWith("java.") || name.startsWith("javax.");
+   }
+
    private final Map<String, ClassDef> definitions = new TreeMap<>();
+   // supertype simple name -> full names of the @TernClass classes extending it
+   private final Map<String, Set<String>> superClasses = new HashMap<>();
+   // names declared with @TernClass, as opposed to entries auto-created for static members
+   private final Set<String> ternClasses = new HashSet<>();
+   // unannotated supertypes referenced as a type, emitted as synthetic union definitions
+   private final Set<String> unionBases = new TreeSet<>();
+
+   private static final String UNION_MARKER = "!unions";
 }

--- a/core/src/main/java/inetsoft/web/binding/VSScriptableService.java
+++ b/core/src/main/java/inetsoft/web/binding/VSScriptableService.java
@@ -816,6 +816,7 @@ public class VSScriptableService {
          ScriptPropertyTool.fixPropertyLink(scriptable, null, name, child);
          object.set("graph", child);
          createProperties0(mapper, library, child, scriptable, ids, "Chart.graph.");
+         bindToGeneratedType(library, child, "EGraph");
       }
       else if("highlighted".equals(name)) {
          createHighlightedDefinitions(mapper, library, object, scriptable);
@@ -1339,6 +1340,33 @@ public class VSScriptableService {
    }
 
 
+
+   /**
+    * Bind a definition node to a generated @TernClass definition so that tern can infer
+    * types through it. The scriptable member lists backing these nodes are plain name
+    * strings with no type information, so every call on them was typed "?" - which stopped
+    * tern resolving anything past the first assignment and broke auto-complete for chained
+    * graph API calls such as graph.getCoordinate().getXScale().getAxisSpec() (Bug #75694).
+    * The untyped duplicates are removed so they cannot shadow the generated members; names
+    * that exist only on the scriptable (bean-style aliases such as "coordinate") are kept.
+    */
+   private void bindToGeneratedType(ObjectNode library, ObjectNode node, String type) {
+      JsonNode definition = library.get(type);
+
+      if(!(definition instanceof ObjectNode)) {
+         return;
+      }
+
+      JsonNode members = definition.get("prototype");
+
+      if(members instanceof ObjectNode) {
+         List<String> names = new ArrayList<>();
+         members.fieldNames().forEachRemaining(names::add);
+         node.remove(names);
+      }
+
+      node.put("!type", "+" + type);
+   }
 
    private String getScriptType(ObjectMapper mapper, ObjectNode library, Object value) {
       if(value instanceof ScriptScope) {


### PR DESCRIPTION
  Root Cause:

  The AxisSpec definitions were not the problem - isLabelBetween, setLabelBetween,
  isGridBetween and setGridBetween were all present and correct in
  js-functions.generated.json. The earlier incremental-compile clobbering fix
  (PR #4280) was a real but different bug. What was broken is that nothing in the
  call chain leading to AxisSpec carried a type, in two independent places:

  1. "graph" was never bound to the generated EGraph definition. VSEGraphScriptable.getMemberKeys() returns a hardcoded list of bare member-name strings with no type information, which VSScriptableService turned into untyped nodes (the node itself was typed "+Object" via property-type.properties). So graph.getCoordinate() had no return type and the chain was already dead on the first line.

  2. Coordinate and Scale are abstract bases that carry @TernMethod members but have no @TernClass on the class itself, so they are not tern types. TernAnnotationProcessor therefore emitted "fn() -> ?" for EGraph.getCoordinate() and for RectCoord.getXScale()/getYScale().

  Why it looked inconsistent: when the object type is unknown, tern falls back to
  guessing - at query time it searches every known definition for a matching
  property. That is why

      scale.getAxisSpec().setG      <- did show a completion list
      var spec = scale.getAxisSpec(); spec.setG   <- showed nothing

  Guessed types are never written back into the inference graph, so assigning from an
  unresolvable call yields a null type and "spec." returns zero completions. Zero
  completions means no popup, and because script-pane sets hintDelay to 17000ms, no
  further completion attempt fires after the "." keystroke.

  Fix:

  1. TernAnnotationProcessor now emits a synthetic "union" definition for each unannotated base class that is referenced as a type, merging in the members of every @TernClass subclass, so the base becomes a real tern type and inference propagates through assignments. This intentionally offers members that may not apply to the concrete instance - the alternative is offering nothing at all. 12 unions are generated: Scale (56 members), Coordinate (66), GraphElement (107), VisualFrame (124), ColorFrame, ShapeFrame, SizeFrame, TextFrame, TextureFrame, LineFrame, GraphForm, SchemaPainter.

     - A real @TernClass definition is never replaced by a union. Since @TernClass has SOURCE retention, a base whose source was not recompiled cannot be tested for the annotation, so the synthesized names are recorded in a "!unions" key in the generated file (tern ignores unknown "!" keys) and that distinction survives across builds. Verified that LinearScale, RectCoord, LineElement, LabelForm, GShape and RGBCubeColorFrame keep their own definitions.
     - Unions are built after the merge-with-previous-file step from PR #4280 and are merged into any existing prototype, so an incremental compile can neither shrink a union nor overwrite a real definition. - java.*/javax.* types are excluded, so a method returning Object does not produce a union of every annotated class.

  2. VSScriptableService.bindToGeneratedType() binds the "graph" definition node to the generated EGraph definition ('"!type": "+EGraph"'), removing the untyped duplicates so they cannot shadow the generated members, and keeping the scriptable-only bean-style aliases (coordinate, legendLayout, legendPreferredSize, XTitleSpec, x2TitleSpec, YTitleSpec, y2TitleSpec).

  Result, verified against the regenerated definitions using the script from the report:

      coord -> Coordinate,  scale -> Scale,  spec -> AxisSpec
      spec. now offers 58 members, including setGridBetween, setLabelBetween,
      isGridBetween and isLabelBetween (previously 0)

  This also resolves #75681 (EGraph.getElement() was typed "?"): elem. now offers 107
  members.

  Files changed:
  - build-tools/tern-annotations/src/main/java/com/inetsoft/build/tern/TernAnnotationProcessor.java
  - core/src/main/java/inetsoft/web/binding/VSScriptableService.java

  Note: definitions are generated at compile time, so a clean build of core is needed to
  pick this up. One remaining incremental-build caveat: if a method returning a base type
  is processed in an annotation-processing round before any @TernClass subclass of that
  base has been seen, it keeps "-> ?" for that build. Clean builds are unaffected.