### PR TITLE
Feature #76073 - Add configurable shadow settings for rectangle and oval

### DIFF
--- a/core/src/main/java/inetsoft/report/gui/viewsheet/VSFaceUtil.java
+++ b/core/src/main/java/inetsoft/report/gui/viewsheet/VSFaceUtil.java
@@ -18,6 +18,7 @@
 package inetsoft.report.gui.viewsheet;
 
 import inetsoft.sree.portal.PortalThemesManager;
+import inetsoft.uql.viewsheet.ShapeShadow;
 import inetsoft.uql.viewsheet.internal.VSUtil;
 
 import java.awt.*;
@@ -121,6 +122,76 @@ public class VSFaceUtil {
       g.drawImage(shadow, 0, 0, null);
       g.drawImage(img, 0, 0, null);
       g.dispose();
+
+      return out;
+   }
+
+   /**
+    * Add a configurable drop shadow to the image.
+    *
+    * Unlike {@link #addShadow(BufferedImage, int)}, which always casts a fixed
+    * gray shadow down and to the right, this honours the shape's configured
+    * color, opacity, direction, distance and blur. The offset and the blur are
+    * independent here.
+    *
+    * @param img the shape image, at its natural size.
+    * @param shadow the shadow settings.
+    * @param insets how far the shadow extends past each side of the shape, as
+    *               returned by ShapeShadowUtil.getShadowInsets. The shape is
+    *               drawn at (insets.left, insets.top) in the returned image.
+    * @return a new image large enough to hold both the shape and its shadow.
+    */
+   public static BufferedImage addShadow(BufferedImage img, ShapeShadow shadow,
+                                         Insets insets)
+   {
+      if(shadow == null || insets == null) {
+         return img;
+      }
+
+      int w = img.getWidth();
+      int h = img.getHeight();
+      int outW = w + insets.left + insets.right;
+      int outH = h + insets.top + insets.bottom;
+
+      if(outW <= 0 || outH <= 0) {
+         return img;
+      }
+
+      // tint the shape's alpha channel with the shadow color, positioned where
+      // the shadow falls, then blur that layer on its own so the blur can
+      // spread into the margins without softening the shape itself
+      BufferedImage layer = new BufferedImage(outW, outH, BufferedImage.TYPE_INT_ARGB);
+      Graphics2D g2 = layer.createGraphics();
+
+      try {
+         g2.drawImage(img, insets.left + shadow.getOffsetX(),
+                      insets.top + shadow.getOffsetY(), null);
+         g2.setComposite(AlphaComposite.SrcIn);
+         g2.setColor(shadow.getShadowColor());
+         g2.fillRect(0, 0, outW, outH);
+      }
+      finally {
+         g2.dispose();
+      }
+
+      int blur = shadow.getBlurRadius();
+
+      // getGaussianBlurFilter requires a radius of at least 1
+      if(blur >= 1) {
+         layer = getGaussianBlurFilter(blur, true).filter(layer, null);
+         layer = getGaussianBlurFilter(blur, false).filter(layer, null);
+      }
+
+      BufferedImage out = new BufferedImage(outW, outH, BufferedImage.TYPE_INT_ARGB);
+      Graphics2D g3 = out.createGraphics();
+
+      try {
+         g3.drawImage(layer, 0, 0, null);
+         g3.drawImage(img, insets.left, insets.top, null);
+      }
+      finally {
+         g3.dispose();
+      }
 
       return out;
    }

--- a/core/src/main/java/inetsoft/report/gui/viewsheet/VSFloatable.java
+++ b/core/src/main/java/inetsoft/report/gui/viewsheet/VSFloatable.java
@@ -19,6 +19,7 @@ package inetsoft.report.gui.viewsheet;
 
 import inetsoft.report.internal.Graphics2DWrapper;
 import inetsoft.report.io.viewsheet.ExportUtil;
+import inetsoft.report.io.viewsheet.ShapeShadowUtil;
 import inetsoft.uql.viewsheet.VSCompositeFormat;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.uql.viewsheet.internal.*;
@@ -56,7 +57,17 @@ public abstract class VSFloatable extends VSObject {
       int w = size.width;
       int h = size.height;
 
-      if(isShadow()) {
+      // a shape's shadow is configurable and can be cast in any direction, so
+      // grow the canvas on whichever sides it actually falls on. text, image
+      // and gauge shadows are still the fixed 6px down-and-right.
+      Insets shadowInsets = ShapeShadowUtil.isShapeShadow(getAssemblyInfo())
+         ? ShapeShadowUtil.getScaledShadowInsets(getAssemblyInfo()) : null;
+
+      if(shadowInsets != null) {
+         w += shadowInsets.left + shadowInsets.right;
+         h += shadowInsets.top + shadowInsets.bottom;
+      }
+      else if(isShadow()) {
          w += 6;
          h += 6;
       }
@@ -73,6 +84,13 @@ public abstract class VSFloatable extends VSObject {
 
       if(!isHighDPI() && isExport) {
          g.scale(2, 2);
+      }
+
+      // shift the origin so the shape keeps its own position while the shadow
+      // occupies the margin that was just added. everything paint() draws --
+      // background, content and borders -- moves together.
+      if(shadowInsets != null) {
+         g.translate(shadowInsets.left, shadowInsets.top);
       }
 
       VSFloatable.isExport.set(isExport);

--- a/core/src/main/java/inetsoft/report/gui/viewsheet/VSShape.java
+++ b/core/src/main/java/inetsoft/report/gui/viewsheet/VSShape.java
@@ -17,7 +17,9 @@
  */
 package inetsoft.report.gui.viewsheet;
 
+import inetsoft.report.io.viewsheet.ShapeShadowUtil;
 import inetsoft.uql.viewsheet.GradientColor;
+import inetsoft.uql.viewsheet.ShapeShadow;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.uql.viewsheet.internal.*;
 
@@ -50,10 +52,18 @@ public abstract class VSShape extends VSFloatable {
       g2.dispose();
 
       if(isShadow()) {
-         image = VSFaceUtil.addShadow(image, 6);
+         ShapeShadow shadow = getInfo().getShadowInfo();
+         // must match the insets getImage() grew the canvas by
+         Insets insets = ShapeShadowUtil.getScaledShadowInsets(getInfo());
+         image = VSFaceUtil.addShadow(image, shadow, insets);
+         // the shape sits at (left, top) inside the composite; draw it back by
+         // that much so the shape itself still lands on the origin, which is
+         // where getImage() has already translated to
+         g.drawImage(image, -insets.left, -insets.top, null);
       }
-
-      g.drawImage(image, 0, 0, null);
+      else {
+         g.drawImage(image, 0, 0, null);
+      }
    }
 
    /**

--- a/core/src/main/java/inetsoft/report/io/viewsheet/ShapeShadowUtil.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/ShapeShadowUtil.java
@@ -1,0 +1,149 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.io.viewsheet;
+
+import inetsoft.graph.internal.DimensionD;
+import inetsoft.uql.viewsheet.ShapeShadow;
+import inetsoft.uql.viewsheet.internal.*;
+
+import java.awt.*;
+import java.awt.geom.Rectangle2D;
+
+/**
+ * Helper for laying out the drop shadow of a shape assembly when exporting.
+ *
+ * A configurable shadow can be cast in any of eight directions, so the image
+ * canvas and the destination rectangle both have to grow on whichever sides
+ * the shadow actually falls on. Without this the shadow is clipped to (and
+ * squeezed into) the assembly's own bounds.
+ *
+ * @version 14.0
+ * @author InetSoft Technology Corp
+ */
+public final class ShapeShadowUtil {
+   private ShapeShadowUtil() {
+   }
+
+   /**
+    * Check whether the assembly is a shape drawing a configurable shadow.
+    */
+   public static boolean isShapeShadow(VSAssemblyInfo info) {
+      return info instanceof ShapeVSAssemblyInfo &&
+         ((ShapeVSAssemblyInfo) info).isShadow();
+   }
+
+   /**
+    * Get the amount, in pixels, that the shadow extends past each side of the
+    * shape. Returns zero insets for anything that is not a shape drawing a
+    * shadow, so callers can apply this unconditionally.
+    */
+   public static Insets getShadowInsets(VSAssemblyInfo info) {
+      if(!isShapeShadow(info)) {
+         return NO_SHADOW;
+      }
+
+      return getShadowInsets(((ShapeVSAssemblyInfo) info).getShadowInfo());
+   }
+
+   /**
+    * Get the amount, in pixels, that the shadow extends past each side of the
+    * shape.
+    */
+   public static Insets getShadowInsets(ShapeShadow shadow) {
+      if(shadow == null) {
+         return NO_SHADOW;
+      }
+
+      int offsetX = shadow.getOffsetX();
+      int offsetY = shadow.getOffsetY();
+      // twice the radius: the blur reaches about one radius past the shape,
+      // and the ConvolveOp leaves the outermost radius of the layer
+      // unconvolved (EDGE_NO_OP), so that band has to sit in empty space or
+      // the soft edge is cut off flat
+      int margin = 2 * shadow.getBlurRadius();
+
+      return new Insets(Math.max(0, -offsetY) + margin,   // top
+                        Math.max(0, -offsetX) + margin,   // left
+                        Math.max(0, offsetY) + margin,    // bottom
+                        Math.max(0, offsetX) + margin);   // right
+   }
+
+   /**
+    * Get the shadow insets in the shape image's own coordinate space, which is
+    * scaled by the assembly's scaling ratio (see VSShape.getImageSize). The
+    * destination rectangle is built from the unscaled size, so the image has
+    * to grow by the scaled insets for the shape to still map onto its own
+    * position.
+    */
+   public static Insets getScaledShadowInsets(VSAssemblyInfo info) {
+      Insets insets = getShadowInsets(info);
+
+      if(insets == NO_SHADOW) {
+         return insets;
+      }
+
+      DimensionD ratio = ((ShapeVSAssemblyInfo) info).getScalingRatio();
+
+      // annotation shapes are not scaled, matching VSShape.getImageSize
+      if(ratio == null || info instanceof AnnotationLineVSAssemblyInfo ||
+         info instanceof AnnotationRectangleVSAssemblyInfo)
+      {
+         return insets;
+      }
+
+      return new Insets((int) Math.round(insets.top * ratio.getHeight()),
+                        (int) Math.round(insets.left * ratio.getWidth()),
+                        (int) Math.round(insets.bottom * ratio.getHeight()),
+                        (int) Math.round(insets.right * ratio.getWidth()));
+   }
+
+   /**
+    * Grow a destination rectangle so the shadow of the assembly is not
+    * clipped. Returns the rectangle unchanged when there is no shadow.
+    *
+    * @param bounds the assembly's own bounds.
+    * @param info the assembly info.
+    * @param scale the coordinate scale applied to the bounds, so the insets
+    *              are expressed in the same units.
+    */
+   public static Rectangle2D expandForShadow(Rectangle2D bounds, VSAssemblyInfo info,
+                                             double scale)
+   {
+      if(bounds == null || !isShapeShadow(info)) {
+         return bounds;
+      }
+
+      Insets insets = getShadowInsets(info);
+
+      return new Rectangle2D.Double(
+         bounds.getX() - insets.left * scale,
+         bounds.getY() - insets.top * scale,
+         bounds.getWidth() + (insets.left + insets.right) * scale,
+         bounds.getHeight() + (insets.top + insets.bottom) * scale);
+   }
+
+   /**
+    * Grow a destination rectangle so the shadow of the assembly is not
+    * clipped, in unscaled pixel coordinates.
+    */
+   public static Rectangle2D expandForShadow(Rectangle2D bounds, VSAssemblyInfo info) {
+      return expandForShadow(bounds, info, 1);
+   }
+
+   private static final Insets NO_SHADOW = new Insets(0, 0, 0, 0);
+}

--- a/core/src/main/java/inetsoft/report/io/viewsheet/html/HTMLVSExporter.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/html/HTMLVSExporter.java
@@ -28,6 +28,7 @@ import inetsoft.report.internal.Common;
 import inetsoft.report.internal.table.TableFormat;
 import inetsoft.report.io.viewsheet.AbstractVSExporter;
 import inetsoft.report.io.viewsheet.ExportUtil;
+import inetsoft.report.io.viewsheet.ShapeShadowUtil;
 import inetsoft.uql.asset.Assembly;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.*;
@@ -241,7 +242,10 @@ public class HTMLVSExporter extends AbstractVSExporter {
       VSAssemblyInfo info = assembly.getVSAssemblyInfo();
 
       if(info != null) {
-         Rectangle2D bounds = helper.getBounds(info);
+         // a shape's shadow can fall outside the assembly's own bounds; a no-op
+         // for everything else
+         Rectangle2D bounds = ShapeShadowUtil.expandForShadow(
+            helper.getBounds(info), info, helper.getScale());
          BufferedImage img = getImage(assembly);
          boolean ignoreBackground = assembly instanceof ShapeVSAssembly ||
             assembly instanceof GaugeVSAssembly || assembly instanceof TabVSAssembly;

--- a/core/src/main/java/inetsoft/report/io/viewsheet/pdf/PDFVSExporter.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/pdf/PDFVSExporter.java
@@ -848,7 +848,11 @@ public class PDFVSExporter extends AbstractVSExporter {
       VSAssemblyInfo info = assembly.getVSAssemblyInfo();
 
       if(info != null) {
-         helper.drawImage(getImage(assembly), helper.getBounds(info));
+         // a shape's shadow can fall outside the assembly's own bounds; a
+         // no-op for everything else
+         Rectangle2D bounds = ShapeShadowUtil.expandForShadow(
+            helper.getBounds(info), info, helper.getScale());
+         helper.drawImage(getImage(assembly), bounds);
       }
    }
 

--- a/core/src/main/java/inetsoft/report/io/viewsheet/svg/SVGVSExporter.java
+++ b/core/src/main/java/inetsoft/report/io/viewsheet/svg/SVGVSExporter.java
@@ -516,6 +516,10 @@ public class SVGVSExporter extends AbstractVSExporter {
                bounds.getWidth() + 1, bounds.getHeight() + 1);
          }
 
+         // a shape's shadow can fall outside the assembly's own bounds; a
+         // no-op for everything else
+         bounds = ShapeShadowUtil.expandForShadow(bounds, info, helper.getScale());
+
          helper.drawImage(getImage(assembly), bounds);
       }
    }

--- a/core/src/main/java/inetsoft/report/script/viewsheet/ShapeVSAScriptable.java
+++ b/core/src/main/java/inetsoft/report/script/viewsheet/ShapeVSAScriptable.java
@@ -19,6 +19,7 @@ package inetsoft.report.script.viewsheet;
 
 import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.uql.viewsheet.GradientColor;
+import inetsoft.uql.viewsheet.ShapeShadow;
 import inetsoft.uql.viewsheet.internal.ShapeVSAssemblyInfo;
 
 /**
@@ -75,6 +76,8 @@ public class ShapeVSAScriptable extends VSAScriptable {
                      GradientColor.class, getClass(), this);
          addProperty("shadow", "isShadow", "setShadow",
                      boolean.class, info.getClass(), info);
+         addProperty("shadowInfo", "getShadowInfo", "setShadowInfo",
+                     ShapeShadow.class, info.getClass(), info);
       }
 
       addProperty("lineStyle", "getLineStyle", "setLineStyle",

--- a/core/src/main/java/inetsoft/uql/viewsheet/ShapeShadow.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/ShapeShadow.java
@@ -101,7 +101,7 @@ public class ShapeShadow implements Cloneable, Serializable {
     * Set the shadow opacity, 0-100.
     */
    public void setAlpha(int alpha) {
-      this.alpha = alpha;
+      this.alpha = Math.max(0, Math.min(100, alpha));
    }
 
    /**
@@ -127,10 +127,13 @@ public class ShapeShadow implements Cloneable, Serializable {
    }
 
    /**
-    * Set how far the shadow is offset, in pixels.
+    * Set how far the shadow is offset, in pixels. Clamped to the range the
+    * dialog allows: these values size the exported shadow image, so an
+    * out-of-range value arriving from a script or a raw dialog save must not
+    * be able to inflate the allocation.
     */
    public void setDistance(int distance) {
-      this.distance = distance;
+      this.distance = Math.max(0, Math.min(MAX_LENGTH, distance));
    }
 
    /**
@@ -141,10 +144,10 @@ public class ShapeShadow implements Cloneable, Serializable {
    }
 
    /**
-    * Set the blur radius, in pixels.
+    * Set the blur radius, in pixels. Clamped, see setDistance.
     */
    public void setBlur(int blur) {
-      this.blur = blur;
+      this.blur = Math.max(0, Math.min(MAX_LENGTH, blur));
    }
 
    /**
@@ -292,4 +295,9 @@ public class ShapeShadow implements Cloneable, Serializable {
    public static final int DEFAULT_ALPHA = 30;
    public static final int DEFAULT_DISTANCE = 5;
    public static final int DEFAULT_BLUR = 6;
+   /**
+    * The largest distance/blur the dialog allows, in pixels. Mirrors
+    * MAX_LENGTH in shadow-prop-pane.component.ts.
+    */
+   public static final int MAX_LENGTH = 50;
 }

--- a/core/src/main/java/inetsoft/uql/viewsheet/ShapeShadow.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/ShapeShadow.java
@@ -1,0 +1,295 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.viewsheet;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import inetsoft.report.composition.graph.GraphUtil;
+import inetsoft.util.Tool;
+
+import java.awt.*;
+import java.io.Serializable;
+
+/**
+ * Shadow settings for a shape assembly (rectangle/oval). The direction plus
+ * distance pair is the single source of truth for the shadow offset, so the
+ * browser, the export rasterizer and the export canvas insets cannot drift
+ * apart.
+ *
+ * @version 14.0
+ * @author InetSoft Technology Corp
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ShapeShadow implements Cloneable, Serializable {
+   /**
+    * North (shadow cast above the shape).
+    */
+   public static final String NORTH = "N";
+   /**
+    * North-east.
+    */
+   public static final String NORTH_EAST = "NE";
+   /**
+    * East.
+    */
+   public static final String EAST = "E";
+   /**
+    * South-east, the default.
+    */
+   public static final String SOUTH_EAST = "SE";
+   /**
+    * South.
+    */
+   public static final String SOUTH = "S";
+   /**
+    * South-west.
+    */
+   public static final String SOUTH_WEST = "SW";
+   /**
+    * West.
+    */
+   public static final String WEST = "W";
+   /**
+    * North-west.
+    */
+   public static final String NORTH_WEST = "NW";
+
+   /**
+    * The supported directions, in dialog order.
+    */
+   public static final String[] DIRECTIONS = {
+      NORTH, NORTH_EAST, EAST, SOUTH_EAST, SOUTH, SOUTH_WEST, WEST, NORTH_WEST
+   };
+
+   /**
+    * Get the shadow color, as a hex or integer string.
+    */
+   public String getColor() {
+      return color;
+   }
+
+   /**
+    * Set the shadow color, as a hex or integer string.
+    */
+   public void setColor(String color) {
+      this.color = color == null || color.isEmpty() ? DEFAULT_COLOR : color;
+   }
+
+   /**
+    * Get the shadow opacity, 0-100.
+    */
+   public int getAlpha() {
+      return alpha;
+   }
+
+   /**
+    * Set the shadow opacity, 0-100.
+    */
+   public void setAlpha(int alpha) {
+      this.alpha = alpha;
+   }
+
+   /**
+    * Get the direction the shadow is cast in, one of DIRECTIONS.
+    */
+   public String getDirection() {
+      return direction;
+   }
+
+   /**
+    * Set the direction the shadow is cast in, one of DIRECTIONS.
+    */
+   public void setDirection(String direction) {
+      this.direction = direction;
+   }
+
+   /**
+    * Get how far the shadow is offset, in pixels. For a diagonal direction
+    * this applies to both axes.
+    */
+   public int getDistance() {
+      return distance;
+   }
+
+   /**
+    * Set how far the shadow is offset, in pixels.
+    */
+   public void setDistance(int distance) {
+      this.distance = distance;
+   }
+
+   /**
+    * Get the blur radius, in pixels.
+    */
+   public int getBlur() {
+      return blur;
+   }
+
+   /**
+    * Set the blur radius, in pixels.
+    */
+   public void setBlur(int blur) {
+      this.blur = blur;
+   }
+
+   /**
+    * Get the horizontal shadow offset in pixels, positive to the right.
+    */
+   @JsonIgnore
+   public int getOffsetX() {
+      if(NORTH_EAST.equals(direction) || EAST.equals(direction) ||
+         SOUTH_EAST.equals(direction))
+      {
+         return distance;
+      }
+
+      if(NORTH_WEST.equals(direction) || WEST.equals(direction) ||
+         SOUTH_WEST.equals(direction))
+      {
+         return -distance;
+      }
+
+      return 0;
+   }
+
+   /**
+    * Get the vertical shadow offset in pixels, positive downwards.
+    */
+   @JsonIgnore
+   public int getOffsetY() {
+      if(SOUTH_EAST.equals(direction) || SOUTH.equals(direction) ||
+         SOUTH_WEST.equals(direction))
+      {
+         return distance;
+      }
+
+      if(NORTH_EAST.equals(direction) || NORTH.equals(direction) ||
+         NORTH_WEST.equals(direction))
+      {
+         return -distance;
+      }
+
+      return 0;
+   }
+
+   /**
+    * Get the gaussian blur radius to paint with on the server.
+    *
+    * VSFaceUtil's blur derives sigma as radius/3, while a css blur-radius of b
+    * corresponds to sigma b/2, so scale up to keep the exported shadow as soft
+    * as the one the browser draws.
+    */
+   @JsonIgnore
+   public int getBlurRadius() {
+      return blur <= 0 ? 0 : Math.max(1, Math.round(blur * 1.5f));
+   }
+
+   /**
+    * Get the shadow color with the opacity applied, for server side painting.
+    */
+   @JsonIgnore
+   public Color getShadowColor() {
+      Color clr = null;
+
+      if(color != null && !color.isEmpty()) {
+         try {
+            // returns null rather than throwing for "null" and other
+            // unparseable values
+            clr = GraphUtil.parseColor(color);
+         }
+         catch(Exception ex) {
+            clr = null;
+         }
+      }
+
+      if(clr == null) {
+         clr = Color.BLACK;
+      }
+
+      int a = Math.max(0, Math.min(100, alpha));
+
+      return new Color(clr.getRed(), clr.getGreen(), clr.getBlue(),
+                       Math.round(a * 255f / 100));
+   }
+
+   @Override
+   public Object clone() {
+      ShapeShadow clone = new ShapeShadow();
+      clone.color = this.color;
+      clone.alpha = this.alpha;
+      clone.direction = this.direction;
+      clone.distance = this.distance;
+      clone.blur = this.blur;
+
+      return clone;
+   }
+
+   @Override
+   public boolean equals(Object obj) {
+      if(!(obj instanceof ShapeShadow)) {
+         return false;
+      }
+
+      ShapeShadow shadow = (ShapeShadow) obj;
+
+      return Tool.equals(color, shadow.color) &&
+             alpha == shadow.alpha &&
+             Tool.equals(direction, shadow.direction) &&
+             distance == shadow.distance &&
+             blur == shadow.blur;
+   }
+
+   @Override
+   public int hashCode() {
+      int hash = alpha + distance * 31 + blur * 131;
+
+      if(color != null) {
+         hash += color.hashCode();
+      }
+
+      if(direction != null) {
+         hash += direction.hashCode();
+      }
+
+      return hash;
+   }
+
+   @Override
+   public String toString() {
+      return "ShapeShadow{" +
+         "color=" + color +
+         ", alpha=" + alpha +
+         ", direction=" + direction +
+         ", distance=" + distance +
+         ", blur=" + blur +
+         '}';
+   }
+
+   private String color = DEFAULT_COLOR;
+   private int alpha = DEFAULT_ALPHA;
+   private String direction = SOUTH_EAST;
+   private int distance = DEFAULT_DISTANCE;
+   private int blur = DEFAULT_BLUR;
+
+   // defaults chosen to approximate the shadow that was hardcoded before the
+   // settings existed: box-shadow: 5px 5px 3px 3px rgba(0,0,0,0.3)
+   public static final String DEFAULT_COLOR = "#000000";
+   public static final int DEFAULT_ALPHA = 30;
+   public static final int DEFAULT_DISTANCE = 5;
+   public static final int DEFAULT_BLUR = 6;
+}

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/ShapeVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/ShapeVSAssemblyInfo.java
@@ -22,6 +22,7 @@ import inetsoft.report.StyleConstants;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.viewsheet.DynamicValue;
 import inetsoft.uql.viewsheet.DynamicValue2;
+import inetsoft.uql.viewsheet.ShapeShadow;
 import inetsoft.util.Tool;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -101,6 +102,25 @@ public class ShapeVSAssemblyInfo extends VSAssemblyInfo implements BaseAnnotatio
    }
 
    /**
+    * Get the drop shadow settings (color, opacity, direction, distance, blur).
+    * Never null; the shadow is only drawn when isShadow() is also true.
+    */
+   public ShapeShadow getShadowInfo() {
+      if(shadowInfo == null) {
+         shadowInfo = new ShapeShadow();
+      }
+
+      return shadowInfo;
+   }
+
+   /**
+    * Set the drop shadow settings.
+    */
+   public void setShadowInfo(ShapeShadow shadowInfo) {
+      this.shadowInfo = shadowInfo == null ? new ShapeShadow() : shadowInfo;
+   }
+
+   /**
     * Get the dynamic property values. Dynamic properties are properties that
     * can be a variable or a script.
     * @return the dynamic values.
@@ -145,6 +165,13 @@ public class ShapeVSAssemblyInfo extends VSAssemblyInfo implements BaseAnnotatio
    protected void writeContents(PrintWriter writer) {
       super.writeContents(writer);
 
+      ShapeShadow shadow0 = getShadowInfo();
+      writer.print("<shadowInfo color=\"" + Tool.escape(shadow0.getColor() + "") +
+                   "\" alpha=\"" + shadow0.getAlpha() +
+                   "\" direction=\"" + shadow0.getDirection() +
+                   "\" distance=\"" + shadow0.getDistance() +
+                   "\" blur=\"" + shadow0.getBlur() + "\"/>");
+
       if(annotations != null && !annotations.isEmpty()) {
          writer.print("<annotations>");
 
@@ -167,6 +194,20 @@ public class ShapeVSAssemblyInfo extends VSAssemblyInfo implements BaseAnnotatio
    protected void parseContents(Element elem, boolean isSiteAdminImport) throws Exception {
       super.parseContents(elem, isSiteAdminImport);
 
+      // absent for assets saved before shadow settings existed; keep defaults
+      Element snode = Tool.getChildNodeByTagName(elem, "shadowInfo");
+
+      if(snode != null) {
+         ShapeShadow shadow0 = new ShapeShadow();
+         shadow0.setColor(getShadowAttr(snode, "color", ShapeShadow.DEFAULT_COLOR));
+         shadow0.setDirection(getShadowAttr(snode, "direction", ShapeShadow.SOUTH_EAST));
+         shadow0.setAlpha(getShadowIntAttr(snode, "alpha", ShapeShadow.DEFAULT_ALPHA));
+         shadow0.setDistance(
+            getShadowIntAttr(snode, "distance", ShapeShadow.DEFAULT_DISTANCE));
+         shadow0.setBlur(getShadowIntAttr(snode, "blur", ShapeShadow.DEFAULT_BLUR));
+         shadowInfo = shadow0;
+      }
+
       Element anode = Tool.getChildNodeByTagName(elem, "annotations");
 
       if(anode != null) {
@@ -181,6 +222,21 @@ public class ShapeVSAssemblyInfo extends VSAssemblyInfo implements BaseAnnotatio
          }
       }
    }
+   private static String getShadowAttr(Element elem, String name, String def) {
+      String val = Tool.getAttribute(elem, name);
+      return val == null || val.isEmpty() ? def : val;
+   }
+
+   private static int getShadowIntAttr(Element elem, String name, int def) {
+      try {
+         String val = Tool.getAttribute(elem, name);
+         return val == null || val.isEmpty() ? def : Integer.parseInt(val);
+      }
+      catch(NumberFormatException ex) {
+         return def;
+      }
+   }
+
    /**
     * Copy the view part assembly info.
     * @param info the specified viewsheet assembly info.
@@ -193,6 +249,11 @@ public class ShapeVSAssemblyInfo extends VSAssemblyInfo implements BaseAnnotatio
 
       if(!Tool.equals(shadow, cinfo.shadow)) {
          shadow = cinfo.shadow;
+         result = true;
+      }
+
+      if(!Tool.equals(getShadowInfo(), cinfo.getShadowInfo())) {
+         shadowInfo = cinfo.getShadowInfo();
          result = true;
       }
 
@@ -228,6 +289,10 @@ public class ShapeVSAssemblyInfo extends VSAssemblyInfo implements BaseAnnotatio
 
          if(lineStyleValue != null) {
             sinfo.lineStyleValue = (DynamicValue2) lineStyleValue.clone();
+         }
+
+         if(shadowInfo != null) {
+            sinfo.shadowInfo = (ShapeShadow) shadowInfo.clone();
          }
 
          if(scalingRatio != null) {
@@ -326,6 +391,7 @@ public class ShapeVSAssemblyInfo extends VSAssemblyInfo implements BaseAnnotatio
    // view
    private Boolean islocked = false;
    private DynamicValue shadow = new DynamicValue("false", XSchema.BOOLEAN);
+   private ShapeShadow shadowInfo = new ShapeShadow();
    private DynamicValue2 lineStyleValue =
       new DynamicValue2(StyleConstants.THIN_LINE + "", XSchema.INTEGER);
    private DimensionD scalingRatio = new DimensionD(1.0, 1.0);

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/ShapeVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/ShapeVSAssemblyInfo.java
@@ -168,7 +168,7 @@ public class ShapeVSAssemblyInfo extends VSAssemblyInfo implements BaseAnnotatio
       ShapeShadow shadow0 = getShadowInfo();
       writer.print("<shadowInfo color=\"" + Tool.escape(shadow0.getColor() + "") +
                    "\" alpha=\"" + shadow0.getAlpha() +
-                   "\" direction=\"" + shadow0.getDirection() +
+                   "\" direction=\"" + Tool.escape(shadow0.getDirection() + "") +
                    "\" distance=\"" + shadow0.getDistance() +
                    "\" blur=\"" + shadow0.getBlur() + "\"/>");
 

--- a/core/src/main/java/inetsoft/web/composer/model/vs/OvalPropertyPaneModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/OvalPropertyPaneModel.java
@@ -51,14 +51,30 @@ public class OvalPropertyPaneModel implements Serializable {
       this.fillPropPaneModel = fillPropPaneModel;
    }
 
+   public ShadowPropPaneModel getShadowPropPaneModel() {
+      if(shadowPropPaneModel == null) {
+         shadowPropPaneModel = new ShadowPropPaneModel();
+      }
+
+      return shadowPropPaneModel;
+   }
+
+   public void setShadowPropPaneModel(
+      ShadowPropPaneModel shadowPropPaneModel)
+   {
+      this.shadowPropPaneModel = shadowPropPaneModel;
+   }
+
    @Override
    public String toString() {
       return "OvalPropertyPaneModel{" +
          "linePropPaneModel=" + linePropPaneModel +
          ", fillPropPaneModel=" + fillPropPaneModel +
+         ", shadowPropPaneModel=" + shadowPropPaneModel +
          '}';
    }
 
    private LinePropPaneModel linePropPaneModel;
    private FillPropPaneModel fillPropPaneModel;
+   private ShadowPropPaneModel shadowPropPaneModel;
 }

--- a/core/src/main/java/inetsoft/web/composer/model/vs/RectanglePropertyPaneModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/RectanglePropertyPaneModel.java
@@ -51,6 +51,20 @@ public class RectanglePropertyPaneModel implements Serializable {
       this.fillPropPaneModel = fillPropPaneModel;
    }
 
+   public ShadowPropPaneModel getShadowPropPaneModel() {
+      if(shadowPropPaneModel == null) {
+         shadowPropPaneModel = new ShadowPropPaneModel();
+      }
+
+      return shadowPropPaneModel;
+   }
+
+   public void setShadowPropPaneModel(
+      ShadowPropPaneModel shadowPropPaneModel)
+   {
+      this.shadowPropPaneModel = shadowPropPaneModel;
+   }
+
    public int getRadius() {
       return radius;
    }
@@ -65,10 +79,12 @@ public class RectanglePropertyPaneModel implements Serializable {
          "radius=" + radius +
          ", linePropPaneModel=" + linePropPaneModel +
          ", fillPropPaneModel=" + fillPropPaneModel +
+         ", shadowPropPaneModel=" + shadowPropPaneModel +
          '}';
    }
 
    private int radius;
    private LinePropPaneModel linePropPaneModel;
    private FillPropPaneModel fillPropPaneModel;
+   private ShadowPropPaneModel shadowPropPaneModel;
 }

--- a/core/src/main/java/inetsoft/web/composer/model/vs/ShadowPropPaneModel.java
+++ b/core/src/main/java/inetsoft/web/composer/model/vs/ShadowPropPaneModel.java
@@ -1,0 +1,93 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.composer.model.vs;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import inetsoft.uql.viewsheet.ShapeShadow;
+
+import java.io.Serializable;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ShadowPropPaneModel implements Serializable {
+   public boolean isApply() {
+      return apply;
+   }
+
+   public void setApply(boolean apply) {
+      this.apply = apply;
+   }
+
+   public String getColor() {
+      return color;
+   }
+
+   public void setColor(String color) {
+      this.color = color;
+   }
+
+   public int getAlpha() {
+      return alpha;
+   }
+
+   public void setAlpha(int alpha) {
+      this.alpha = alpha;
+   }
+
+   public String getDirection() {
+      return direction;
+   }
+
+   public void setDirection(String direction) {
+      this.direction = direction;
+   }
+
+   public int getDistance() {
+      return distance;
+   }
+
+   public void setDistance(int distance) {
+      this.distance = distance;
+   }
+
+   public int getBlur() {
+      return blur;
+   }
+
+   public void setBlur(int blur) {
+      this.blur = blur;
+   }
+
+   @Override
+   public String toString() {
+      return "ShadowPropPaneModel{" +
+         "apply=" + apply +
+         ", color='" + color + '\'' +
+         ", alpha=" + alpha +
+         ", direction='" + direction + '\'' +
+         ", distance=" + distance +
+         ", blur=" + blur +
+         '}';
+   }
+
+   private boolean apply;
+   private String color = ShapeShadow.DEFAULT_COLOR;
+   private int alpha = ShapeShadow.DEFAULT_ALPHA;
+   private String direction = ShapeShadow.SOUTH_EAST;
+   private int distance = ShapeShadow.DEFAULT_DISTANCE;
+   private int blur = ShapeShadow.DEFAULT_BLUR;
+}

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/OvalPropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/OvalPropertyDialogService.java
@@ -83,8 +83,7 @@ public class OvalPropertyDialogService {
       basicGeneralPaneModel.setName(ovalAssemblyInfo.getAbsoluteName());
       basicGeneralPaneModel.setVisible(ovalAssemblyInfo.getVisibleValue());
       basicGeneralPaneModel.setPrimary(ovalAssemblyInfo.isPrimary());
-      basicGeneralPaneModel.setShowShadowCheckbox(true);
-      basicGeneralPaneModel.setShadow(ovalAssemblyInfo.getShadowValue());
+      basicGeneralPaneModel.setShowShadowCheckbox(false);
       basicGeneralPaneModel.setObjectNames(this.vsObjectPropertyService.getObjectNames(
          vs, ovalAssemblyInfo.getAbsoluteName()));
 
@@ -131,6 +130,15 @@ public class OvalPropertyDialogService {
          fillPropPaneModel.setGradientColor(gradientColor);
       }
 
+      ShadowPropPaneModel shadowPropPaneModel = ovalPropertyPaneModel.getShadowPropPaneModel();
+      ShapeShadow shadow0 = ovalAssemblyInfo.getShadowInfo();
+      shadowPropPaneModel.setApply(ovalAssemblyInfo.getShadowValue());
+      shadowPropPaneModel.setColor(shadow0.getColor());
+      shadowPropPaneModel.setAlpha(shadow0.getAlpha());
+      shadowPropPaneModel.setDirection(shadow0.getDirection());
+      shadowPropPaneModel.setDistance(shadow0.getDistance());
+      shadowPropPaneModel.setBlur(shadow0.getBlur());
+
       vsAssemblyScriptPaneModel.scriptEnabled(ovalAssemblyInfo.isScriptEnabled());
       vsAssemblyScriptPaneModel.expression(ovalAssemblyInfo.getScript() == null ?
                                               "" : ovalAssemblyInfo.getScript());
@@ -170,7 +178,15 @@ public class OvalPropertyDialogService {
 
       ovalAssemblyInfo.setPrimary(basicGeneralPaneModel.isPrimary());
       ovalAssemblyInfo.setVisibleValue(basicGeneralPaneModel.getVisible());
-      ovalAssemblyInfo.setShadowValue(basicGeneralPaneModel.isShadow());
+      ShadowPropPaneModel shadowPropPaneModel = ovalPropertyPaneModel.getShadowPropPaneModel();
+      ovalAssemblyInfo.setShadowValue(shadowPropPaneModel.isApply());
+      ShapeShadow shadow0 = new ShapeShadow();
+      shadow0.setColor(shadowPropPaneModel.getColor());
+      shadow0.setAlpha(shadowPropPaneModel.getAlpha());
+      shadow0.setDirection(shadowPropPaneModel.getDirection());
+      shadow0.setDistance(shadowPropPaneModel.getDistance());
+      shadow0.setBlur(shadowPropPaneModel.getBlur());
+      ovalAssemblyInfo.setShadowInfo(shadow0);
 
       dialogService.setAssemblySize(ovalAssemblyInfo, sizePositionPaneModel);
       dialogService.setAssemblyPosition(ovalAssemblyInfo, sizePositionPaneModel);

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/RectanglePropertyDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/RectanglePropertyDialogService.java
@@ -79,8 +79,7 @@ public class RectanglePropertyDialogService {
       basicGeneralPaneModel.setName(rectangleAssemblyInfo.getAbsoluteName());
       basicGeneralPaneModel.setVisible(rectangleAssemblyInfo.getVisibleValue());
       basicGeneralPaneModel.setPrimary(rectangleAssemblyInfo.isPrimary());
-      basicGeneralPaneModel.setShowShadowCheckbox(true);
-      basicGeneralPaneModel.setShadow(rectangleAssemblyInfo.getShadowValue());
+      basicGeneralPaneModel.setShowShadowCheckbox(false);
       basicGeneralPaneModel.setObjectNames(this.vsObjectPropertyService.getObjectNames(vs, rectangleAssemblyInfo.getAbsoluteName()));
 
       Point pos = dialogService.getAssemblyPosition(rectangleAssemblyInfo, vs);
@@ -130,6 +129,15 @@ public class RectanglePropertyDialogService {
          fillPropPaneModel.setGradientColor(gradientColor);
       }
 
+      ShadowPropPaneModel shadowPropPaneModel = rectanglePropertyPaneModel.getShadowPropPaneModel();
+      ShapeShadow shadow0 = rectangleAssemblyInfo.getShadowInfo();
+      shadowPropPaneModel.setApply(rectangleAssemblyInfo.getShadowValue());
+      shadowPropPaneModel.setColor(shadow0.getColor());
+      shadowPropPaneModel.setAlpha(shadow0.getAlpha());
+      shadowPropPaneModel.setDirection(shadow0.getDirection());
+      shadowPropPaneModel.setDistance(shadow0.getDistance());
+      shadowPropPaneModel.setBlur(shadow0.getBlur());
+
       vsAssemblyScriptPaneModel.scriptEnabled(rectangleAssemblyInfo.isScriptEnabled());
       vsAssemblyScriptPaneModel.expression(rectangleAssemblyInfo.getScript() == null ?
                                               "" : rectangleAssemblyInfo.getScript());
@@ -169,7 +177,15 @@ public class RectanglePropertyDialogService {
 
       rectangleAssemblyInfo.setPrimary(basicGeneralPaneModel.isPrimary());
       rectangleAssemblyInfo.setVisibleValue(basicGeneralPaneModel.getVisible());
-      rectangleAssemblyInfo.setShadowValue(basicGeneralPaneModel.isShadow());
+      ShadowPropPaneModel shadowPropPaneModel = rectanglePropertyPaneModel.getShadowPropPaneModel();
+      rectangleAssemblyInfo.setShadowValue(shadowPropPaneModel.isApply());
+      ShapeShadow shadow0 = new ShapeShadow();
+      shadow0.setColor(shadowPropPaneModel.getColor());
+      shadow0.setAlpha(shadowPropPaneModel.getAlpha());
+      shadow0.setDirection(shadowPropPaneModel.getDirection());
+      shadow0.setDistance(shadowPropPaneModel.getDistance());
+      shadow0.setBlur(shadowPropPaneModel.getBlur());
+      rectangleAssemblyInfo.setShadowInfo(shadow0);
 
       dialogService.setAssemblySize(rectangleAssemblyInfo, sizePositionPaneModel);
       dialogService.setAssemblyPosition(rectangleAssemblyInfo, sizePositionPaneModel);

--- a/core/src/main/java/inetsoft/web/viewsheet/model/VSShapeModel.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/model/VSShapeModel.java
@@ -18,6 +18,7 @@
 package inetsoft.web.viewsheet.model;
 
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.viewsheet.ShapeShadow;
 import inetsoft.uql.viewsheet.ShapeVSAssembly;
 import inetsoft.uql.viewsheet.internal.ShapeVSAssemblyInfo;
 
@@ -29,6 +30,7 @@ public abstract class VSShapeModel<T extends ShapeVSAssembly> extends VSObjectMo
       locked = assemblyInfo.getLocked();
       lineStyle = assemblyInfo.getLineStyle();
       shadow = assemblyInfo.isShadow();
+      shadowInfo = (ShapeShadow) assemblyInfo.getShadowInfo().clone();
    }
 
    public boolean isLocked() {
@@ -43,7 +45,12 @@ public abstract class VSShapeModel<T extends ShapeVSAssembly> extends VSObjectMo
       return shadow;
    }
 
+   public ShapeShadow getShadowInfo() {
+      return shadowInfo;
+   }
+
    private boolean locked;
    private int lineStyle;
    private boolean shadow;
+   private ShapeShadow shadowInfo;
 }

--- a/core/src/main/resources/inetsoft/util/srinter.properties
+++ b/core/src/main/resources/inetsoft/util/srinter.properties
@@ -5601,3 +5601,15 @@ multi.switch=Multi
 multi.switchTip=Switch to multi-selection mode and select this item.
 vs.select.quickswitch.tooltip=Enable to allow users to quickly toggle between single and multi-selection.
 Allow\ toggle\ between\ single\ and\ multi-selection=Allow toggle between single and multi-selection
+! shape drop shadow settings
+Blur=Blur
+Direction=Direction
+Opacity=Opacity
+North=North
+Northeast=Northeast
+East=East
+Southeast=Southeast
+South=South
+Southwest=Southwest
+West=West
+Northwest=Northwest

--- a/core/src/test/java/inetsoft/report/gui/viewsheet/VSFaceUtilShadowTest.java
+++ b/core/src/test/java/inetsoft/report/gui/viewsheet/VSFaceUtilShadowTest.java
@@ -1,0 +1,205 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.report.gui.viewsheet;
+
+import inetsoft.report.io.viewsheet.ShapeShadowUtil;
+import inetsoft.uql.viewsheet.ShapeShadow;
+import inetsoft.test.*;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Geometry of the configurable shape drop shadow rasterizer.
+ *
+ * The shape must sit at (insets.left, insets.top) of the returned composite.
+ * VSShape.paintComponent relies on that to draw the composite back by the same
+ * amount so the shape still lands where the assembly actually is -- otherwise
+ * the background and borders, which paint() draws separately, end up offset
+ * from the shape.
+ */
+// VSFaceUtil has a static initializer that needs the server environment
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class },
+                      initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class VSFaceUtilShadowTest {
+   /** A fully opaque red square, so shadow pixels are easy to tell apart. */
+   private static BufferedImage square(int size) {
+      BufferedImage img = new BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB);
+      Graphics2D g = img.createGraphics();
+
+      try {
+         g.setColor(Color.RED);
+         g.fillRect(0, 0, size, size);
+      }
+      finally {
+         g.dispose();
+      }
+
+      return img;
+   }
+
+   private static ShapeShadow shadow(String direction, int distance, int blur) {
+      ShapeShadow shadow = new ShapeShadow();
+      shadow.setDirection(direction);
+      shadow.setDistance(distance);
+      shadow.setBlur(blur);
+      shadow.setColor("#000000");
+      shadow.setAlpha(100);
+
+      return shadow;
+   }
+
+   @Test
+   void compositeGrowsByTheInsetsOnEverySide() {
+      ShapeShadow shadow = shadow(ShapeShadow.SOUTH_EAST, 4, 0);
+      Insets insets = ShapeShadowUtil.getShadowInsets(shadow);
+
+      BufferedImage out = VSFaceUtil.addShadow(square(10), shadow, insets);
+
+      assertEquals(10 + insets.left + insets.right, out.getWidth());
+      assertEquals(10 + insets.top + insets.bottom, out.getHeight());
+   }
+
+   @Test
+   void shapeIsPlacedAtTheInsetOriginForADownRightShadow() {
+      ShapeShadow shadow = shadow(ShapeShadow.SOUTH_EAST, 4, 0);
+      Insets insets = ShapeShadowUtil.getShadowInsets(shadow);
+
+      BufferedImage out = VSFaceUtil.addShadow(square(10), shadow, insets);
+
+      // the shape's top-left corner must be exactly at (left, top)
+      assertEquals(Color.RED.getRGB(), out.getRGB(insets.left, insets.top),
+                   "shape should start at the inset origin");
+   }
+
+   @Test
+   void shapeIsPlacedAtTheInsetOriginForAnUpLeftShadow() {
+      // the case that did not exist before the shadow became configurable
+      ShapeShadow shadow = shadow(ShapeShadow.NORTH_WEST, 4, 0);
+      Insets insets = ShapeShadowUtil.getShadowInsets(shadow);
+
+      assertEquals(4, insets.left);
+      assertEquals(4, insets.top);
+
+      BufferedImage out = VSFaceUtil.addShadow(square(10), shadow, insets);
+
+      assertEquals(Color.RED.getRGB(), out.getRGB(insets.left, insets.top));
+      // and the shadow occupies the margin that was added above/left of it
+      assertTrue(alphaAt(out, 0, 0) > 0, "shadow should fill the top-left margin");
+   }
+
+   @Test
+   void shadowIsCastOnTheSideTheDirectionPointsAt() {
+      ShapeShadow shadow = shadow(ShapeShadow.SOUTH_EAST, 4, 0);
+      Insets insets = ShapeShadowUtil.getShadowInsets(shadow);
+
+      BufferedImage out = VSFaceUtil.addShadow(square(10), shadow, insets);
+
+      // the shadow reaches the bottom-right corner of the composite
+      assertTrue(alphaAt(out, out.getWidth() - 1, out.getHeight() - 1) > 0,
+                 "bottom-right should carry the shadow");
+      // the top-right corner is past the shape (10 wide) and above the
+      // shadow (offset down by 4), so nothing is drawn there
+      assertEquals(0, alphaAt(out, out.getWidth() - 1, 0),
+                   "top-right should be empty for a south-east shadow");
+   }
+
+   @Test
+   void shadowUsesTheConfiguredColor() {
+      ShapeShadow shadow = shadow(ShapeShadow.SOUTH_EAST, 4, 0);
+      shadow.setColor("#0000ff");
+      Insets insets = ShapeShadowUtil.getShadowInsets(shadow);
+
+      BufferedImage out = VSFaceUtil.addShadow(square(10), shadow, insets);
+      int rgb = out.getRGB(out.getWidth() - 1, out.getHeight() - 1);
+
+      assertEquals(0, (rgb >> 16) & 0xff, "no red in a blue shadow");
+      assertEquals(255, rgb & 0xff, "shadow should be blue");
+   }
+
+   @Test
+   void aZeroBlurSkipsTheConvolveAndStillProducesAShadow() {
+      // getGaussianBlurFilter rejects a radius below 1, so blur 0 must not blur
+      ShapeShadow shadow = shadow(ShapeShadow.EAST, 3, 0);
+      Insets insets = ShapeShadowUtil.getShadowInsets(shadow);
+
+      BufferedImage out = assertDoesNotThrow(
+         () -> VSFaceUtil.addShadow(square(8), shadow, insets));
+
+      assertEquals(8 + 3, out.getWidth());
+      assertEquals(8, out.getHeight());
+   }
+
+   @Test
+   void theBlurFadesOutInsteadOfBeingCutOffFlat() {
+      // regression: the insets used to allow only `blur` of margin, which put
+      // the ConvolveOp's unconvolved EDGE_NO_OP band right where the soft edge
+      // belonged, so the shadow ended in a hard step to fully transparent
+      ShapeShadow shadow = new ShapeShadow();   // SE, distance 5, blur 6
+      Insets insets = ShapeShadowUtil.getShadowInsets(shadow);
+
+      BufferedImage out = VSFaceUtil.addShadow(square(10), shadow, insets);
+
+      // walk right from inside the shadow to the edge of the composite, along a
+      // row that the shape itself does not cover
+      int y = insets.top + 9 + shadow.getOffsetY() / 2;
+      int previous = Integer.MAX_VALUE;
+      int steps = 0;
+
+      for(int x = insets.left + 10; x < out.getWidth(); x++) {
+         int alpha = alphaAt(out, x, y);
+         assertTrue(alpha <= previous, "alpha should only decrease outward");
+
+         if(alpha > 0 && alpha < 255) {
+            steps++;
+         }
+
+         previous = alpha;
+      }
+
+      // a genuine gradient, not a single step from opaque to nothing
+      assertTrue(steps >= 3,
+                 "expected a soft outward falloff, saw " + steps + " partial steps");
+      assertEquals(0, alphaAt(out, out.getWidth() - 1, y),
+                   "the shadow should have faded to nothing by the edge");
+   }
+
+   @Test
+   void aNullShadowReturnsTheImageUnchanged() {
+      BufferedImage img = square(6);
+
+      assertSame(img, VSFaceUtil.addShadow(img, null, new Insets(1, 1, 1, 1)));
+      assertSame(img, VSFaceUtil.addShadow(img, new ShapeShadow(), null));
+   }
+
+   private static int alphaAt(BufferedImage img, int x, int y) {
+      return (img.getRGB(x, y) >> 24) & 0xff;
+   }
+}

--- a/core/src/test/java/inetsoft/uql/viewsheet/ShapeShadowTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/ShapeShadowTest.java
@@ -1,0 +1,270 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.viewsheet;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.report.io.viewsheet.ShapeShadowUtil;
+import inetsoft.uql.viewsheet.internal.ShapeVSAssemblyInfo;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mockito;
+
+import java.awt.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("core")
+class ShapeShadowTest {
+   @Test
+   void defaultsApproximateTheLegacyHardcodedShadow() {
+      ShapeShadow shadow = new ShapeShadow();
+
+      // the shadow that used to be hardcoded fell 5px down and to the right
+      assertEquals(ShapeShadow.SOUTH_EAST, shadow.getDirection());
+      assertEquals(5, shadow.getOffsetX());
+      assertEquals(5, shadow.getOffsetY());
+      assertEquals(30, shadow.getAlpha());
+      assertEquals(6, shadow.getBlur());
+   }
+
+   @ParameterizedTest
+   @CsvSource({
+      "N,   0, -7",
+      "NE,  7, -7",
+      "E,   7,  0",
+      "SE,  7,  7",
+      "S,   0,  7",
+      "SW, -7,  7",
+      "W,  -7,  0",
+      "NW, -7, -7"
+   })
+   void directionMapsToSignedOffsets(String direction, int expectedX, int expectedY) {
+      ShapeShadow shadow = new ShapeShadow();
+      shadow.setDirection(direction);
+      shadow.setDistance(7);
+
+      assertEquals(expectedX, shadow.getOffsetX(), "offsetX for " + direction);
+      assertEquals(expectedY, shadow.getOffsetY(), "offsetY for " + direction);
+   }
+
+   @Test
+   void unknownDirectionCastsNoOffset() {
+      ShapeShadow shadow = new ShapeShadow();
+      shadow.setDirection("bogus");
+      shadow.setDistance(9);
+
+      assertEquals(0, shadow.getOffsetX());
+      assertEquals(0, shadow.getOffsetY());
+   }
+
+   @Test
+   void shadowColorAppliesOpacity() {
+      ShapeShadow shadow = new ShapeShadow();
+      shadow.setColor("#ff0000");
+      shadow.setAlpha(50);
+
+      Color color = shadow.getShadowColor();
+      assertEquals(255, color.getRed());
+      assertEquals(0, color.getGreen());
+      assertEquals(0, color.getBlue());
+      assertEquals(128, color.getAlpha());
+   }
+
+   @Test
+   void shadowColorFallsBackToBlackForAnUnparseableColor() {
+      ShapeShadow shadow = new ShapeShadow();
+      shadow.setColor("not-a-color");
+      shadow.setAlpha(100);
+
+      Color color = shadow.getShadowColor();
+      assertEquals(Color.BLACK.getRGB(), color.getRGB());
+   }
+
+   @Test
+   void alphaIsClampedToTheValidRange() {
+      ShapeShadow shadow = new ShapeShadow();
+      shadow.setAlpha(500);
+      assertEquals(255, shadow.getShadowColor().getAlpha());
+
+      shadow.setAlpha(-20);
+      assertEquals(0, shadow.getShadowColor().getAlpha());
+   }
+
+   @Test
+   void cloneAndEqualsCoverEveryField() {
+      ShapeShadow shadow = new ShapeShadow();
+      shadow.setColor("#123456");
+      shadow.setAlpha(42);
+      shadow.setDirection(ShapeShadow.NORTH_WEST);
+      shadow.setDistance(11);
+      shadow.setBlur(3);
+
+      ShapeShadow clone = (ShapeShadow) shadow.clone();
+      assertEquals(shadow, clone);
+      assertEquals(shadow.hashCode(), clone.hashCode());
+
+      clone.setBlur(4);
+      assertNotEquals(shadow, clone);
+   }
+
+   @Test
+   void onlyTheFieldsTheClientNeedsAreSerialized() throws Exception {
+      // regression: getShadowColor() is a bean property, so jackson walked
+      // java.awt.Color -> ColorSpace -> ICC profile and emitted ~9kb of base64
+      // for every shape on every model refresh
+      String json = new ObjectMapper().writeValueAsString(new ShapeShadow());
+
+      assertFalse(json.contains("shadowColor"), json);
+      assertFalse(json.contains("colorSpace"), json);
+      assertFalse(json.contains("offsetX"), json);
+      assertFalse(json.contains("blurRadius"), json);
+      assertTrue(json.contains("\"direction\""), json);
+      assertTrue(json.length() < 200, "unexpectedly large payload: " + json.length());
+   }
+
+   // ---- insets, which is what keeps the export from clipping the shadow ----
+
+   @Test
+   void insetsGrowOnlyTheSidesTheShadowFallsOn() {
+      ShapeShadow shadow = new ShapeShadow();
+      shadow.setDirection(ShapeShadow.SOUTH_EAST);
+      shadow.setDistance(5);
+      shadow.setBlur(0);   // no blur, so the insets are the offset alone
+
+      Insets insets = ShapeShadowUtil.getShadowInsets(shadow);
+      assertEquals(0, insets.top);
+      assertEquals(0, insets.left);
+      assertEquals(5, insets.bottom);
+      assertEquals(5, insets.right);
+   }
+
+   @Test
+   void insetsGrowUpAndLeftForANorthWestShadow() {
+      ShapeShadow shadow = new ShapeShadow();
+      shadow.setDirection(ShapeShadow.NORTH_WEST);
+      shadow.setDistance(5);
+      shadow.setBlur(0);
+
+      Insets insets = ShapeShadowUtil.getShadowInsets(shadow);
+      assertEquals(5, insets.top);
+      assertEquals(5, insets.left);
+      assertEquals(0, insets.bottom);
+      assertEquals(0, insets.right);
+   }
+
+   @Test
+   void blurGrowsEverySide() {
+      ShapeShadow shadow = new ShapeShadow();
+      shadow.setDirection(ShapeShadow.EAST);
+      shadow.setDistance(4);
+      shadow.setBlur(3);
+
+      // the margin is twice the blur radius so the ConvolveOp's unconvolved
+      // edge band lands in empty space instead of clipping the soft edge
+      int margin = 2 * shadow.getBlurRadius();
+      assertEquals(10, margin);   // radius = round(3 * 1.5) = 5
+
+      Insets insets = ShapeShadowUtil.getShadowInsets(shadow);
+      assertEquals(margin, insets.top);
+      assertEquals(margin, insets.left);
+      assertEquals(margin, insets.bottom);
+      assertEquals(margin + 4, insets.right);
+   }
+
+   @Test
+   void blurRadiusScalesUpToMatchTheCssBlur() {
+      ShapeShadow shadow = new ShapeShadow();
+
+      // VSFaceUtil derives sigma as radius/3; css blur-radius b is sigma b/2
+      shadow.setBlur(6);
+      assertEquals(9, shadow.getBlurRadius());
+
+      shadow.setBlur(0);
+      assertEquals(0, shadow.getBlurRadius(), "no blur means no convolve");
+
+      shadow.setBlur(1);
+      assertEquals(2, shadow.getBlurRadius());
+   }
+
+   @Test
+   void aNullColorFallsBackToTheDefaultRatherThanPersistingNull() {
+      ShapeShadow shadow = new ShapeShadow();
+      shadow.setColor(null);
+
+      assertEquals(ShapeShadow.DEFAULT_COLOR, shadow.getColor());
+
+      // black, carrying the default 30% opacity rather than being opaque
+      Color color = shadow.getShadowColor();
+      assertEquals(0, color.getRed());
+      assertEquals(0, color.getGreen());
+      assertEquals(0, color.getBlue());
+      assertEquals(Math.round(30 * 255f / 100), color.getAlpha());
+   }
+
+   @Test
+   void theLiteralNullColorDoesNotBlowUp() {
+      // Tool.getColorFromHexString returns null for "null" without throwing,
+      // so the exception path alone is not enough of a guard
+      ShapeShadow shadow = new ShapeShadow();
+      shadow.setColor("null");
+      shadow.setAlpha(100);
+
+      assertEquals(Color.BLACK.getRGB(), shadow.getShadowColor().getRGB());
+   }
+
+   @Test
+   void insetsAreZeroWhenTheShadowIsOff() {
+      ShapeVSAssemblyInfo info = Mockito.mock(ShapeVSAssemblyInfo.class);
+      Mockito.when(info.isShadow()).thenReturn(false);
+
+      assertFalse(ShapeShadowUtil.isShapeShadow(info));
+      assertNoInsets(ShapeShadowUtil.getShadowInsets(info));
+   }
+
+   @Test
+   void insetsAreZeroForANullShadow() {
+      assertNoInsets(ShapeShadowUtil.getShadowInsets((ShapeShadow) null));
+   }
+
+   @Test
+   void insetsAreAppliedWhenTheShadowIsOn() {
+      ShapeShadow shadow = new ShapeShadow();
+      shadow.setDirection(ShapeShadow.SOUTH);
+      shadow.setDistance(4);
+      shadow.setBlur(0);
+
+      ShapeVSAssemblyInfo info = Mockito.mock(ShapeVSAssemblyInfo.class);
+      Mockito.when(info.isShadow()).thenReturn(true);
+      Mockito.when(info.getShadowInfo()).thenReturn(shadow);
+
+      assertTrue(ShapeShadowUtil.isShapeShadow(info));
+
+      Insets insets = ShapeShadowUtil.getShadowInsets(info);
+      assertEquals(0, insets.top);
+      assertEquals(4, insets.bottom);
+   }
+
+   private static void assertNoInsets(Insets insets) {
+      assertEquals(0, insets.top);
+      assertEquals(0, insets.left);
+      assertEquals(0, insets.bottom);
+      assertEquals(0, insets.right);
+   }
+}

--- a/core/src/test/java/inetsoft/uql/viewsheet/internal/ShapeVSAssemblyInfoShadowTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/internal/ShapeVSAssemblyInfoShadowTest.java
@@ -1,0 +1,174 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.viewsheet.internal;
+
+import inetsoft.test.*;
+import inetsoft.uql.viewsheet.ShapeShadow;
+import inetsoft.util.Tool;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import java.io.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * The shadow settings persist as a <shadowInfo> child element of the shape
+ * assembly, so the round trip is what guarantees a dashboard reopens looking
+ * the way it was saved -- and that an asset written before the settings
+ * existed still parses.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class, SwapperTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class ShapeVSAssemblyInfoShadowTest {
+   @Test
+   void shadowSettingsSurviveAnXmlRoundTrip() throws Exception {
+      RectangleVSAssemblyInfo info = new RectangleVSAssemblyInfo();
+      info.setShadowValue(true);
+      ShapeShadow shadow = new ShapeShadow();
+      shadow.setColor("#336699");
+      shadow.setAlpha(65);
+      shadow.setDirection(ShapeShadow.NORTH_WEST);
+      shadow.setDistance(12);
+      shadow.setBlur(4);
+      info.setShadowInfo(shadow);
+
+      RectangleVSAssemblyInfo parsed = roundTrip(info);
+
+      assertTrue(parsed.getShadowValue());
+      assertEquals(shadow, parsed.getShadowInfo());
+   }
+
+   @Test
+   void anAssetSavedBeforeTheSettingsExistedParsesBackToTheDefaults()
+      throws Exception
+   {
+      // the <shadowInfo> element simply is not there in an older asset
+      RectangleVSAssemblyInfo info = new RectangleVSAssemblyInfo();
+      info.setShadowValue(true);
+
+      String xml = write(info).replaceAll("<shadowInfo[^>]*/>", "");
+      assertFalse(xml.contains("shadowInfo"), xml);
+
+      RectangleVSAssemblyInfo parsed = new RectangleVSAssemblyInfo();
+      parsed.parseXML(parse(xml));
+
+      assertTrue(parsed.getShadowValue());
+      assertEquals(new ShapeShadow(), parsed.getShadowInfo(),
+                   "an absent element must fall back to the defaults that " +
+                   "approximate the previously hardcoded shadow");
+   }
+
+   /**
+    * The direction is not restricted to DIRECTIONS by its setter (an unknown
+    * value simply casts no offset), and the script API exposes shadowInfo as a
+    * writable bean property, so a quote reaching the attribute must not be
+    * able to break the assembly's own xml.
+    */
+   @Test
+   void aDirectionContainingXmlSyntaxDoesNotCorruptTheAssembly()
+      throws Exception
+   {
+      RectangleVSAssemblyInfo info = new RectangleVSAssemblyInfo();
+      info.setShadowValue(true);
+      ShapeShadow shadow = new ShapeShadow();
+      shadow.setDirection("\"><evil attr=\"");
+      info.setShadowInfo(shadow);
+
+      // would throw on the malformed document if the attribute were raw
+      RectangleVSAssemblyInfo parsed = roundTrip(info);
+
+      assertEquals("\"><evil attr=\"", parsed.getShadowInfo().getDirection());
+      assertEquals(0, parsed.getShadowInfo().getOffsetX());
+      assertEquals(0, parsed.getShadowInfo().getOffsetY());
+   }
+
+   @Test
+   void anOutOfRangeDistanceOrBlurIsClampedRatherThanPersisted()
+      throws Exception
+   {
+      // these size the exported shadow image, so a value bypassing the
+      // dialog's own clamp must not reach the rasterizer
+      RectangleVSAssemblyInfo info = new RectangleVSAssemblyInfo();
+      info.setShadowValue(true);
+      ShapeShadow shadow = new ShapeShadow();
+      shadow.setDistance(100000);
+      shadow.setBlur(100000);
+      info.setShadowInfo(shadow);
+
+      assertEquals(ShapeShadow.MAX_LENGTH, shadow.getDistance());
+      assertEquals(ShapeShadow.MAX_LENGTH, shadow.getBlur());
+
+      RectangleVSAssemblyInfo parsed = roundTrip(info);
+
+      assertEquals(ShapeShadow.MAX_LENGTH, parsed.getShadowInfo().getDistance());
+      assertEquals(ShapeShadow.MAX_LENGTH, parsed.getShadowInfo().getBlur());
+   }
+
+   @Test
+   void anOutOfRangeDistanceOrBlurInAnEditedAssetIsClampedOnParse()
+      throws Exception
+   {
+      RectangleVSAssemblyInfo info = new RectangleVSAssemblyInfo();
+      info.setShadowValue(true);
+
+      String xml = write(info)
+         .replaceAll("distance=\"[0-9]+\"", "distance=\"100000\"")
+         .replaceAll("blur=\"[0-9]+\"", "blur=\"100000\"");
+
+      RectangleVSAssemblyInfo parsed = new RectangleVSAssemblyInfo();
+      parsed.parseXML(parse(xml));
+
+      assertEquals(ShapeShadow.MAX_LENGTH, parsed.getShadowInfo().getDistance());
+      assertEquals(ShapeShadow.MAX_LENGTH, parsed.getShadowInfo().getBlur());
+   }
+
+   private static RectangleVSAssemblyInfo roundTrip(RectangleVSAssemblyInfo info)
+      throws Exception
+   {
+      RectangleVSAssemblyInfo parsed = new RectangleVSAssemblyInfo();
+      parsed.parseXML(parse(write(info)));
+
+      return parsed;
+   }
+
+   private static String write(RectangleVSAssemblyInfo info) {
+      StringWriter buffer = new StringWriter();
+
+      try(PrintWriter writer = new PrintWriter(buffer)) {
+         info.writeXML(writer);
+      }
+
+      return buffer.toString();
+   }
+
+   private static Element parse(String xml) throws Exception {
+      Document doc = Tool.parseXML(new StringReader(xml));
+
+      return doc.getDocumentElement();
+   }
+}

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/excel/PoiExcelVSExporter.java
@@ -1994,6 +1994,21 @@ public class PoiExcelVSExporter extends ExcelVSExporter {
          size = (Dimension) newInfo[1];
       }
 
+      // a shape's shadow can fall outside the assembly's own bounds. this runs
+      // after the line branch above, which replaces position/size outright.
+      // excel anchors to the cell grid, so the offset lands on the nearest
+      // column or row boundary rather than exactly.
+      if(ShapeShadowUtil.isShapeShadow(info)) {
+         Insets insets = ShapeShadowUtil.getShadowInsets(info);
+         // clamp at the sheet edge without stretching the anchor: whatever the
+         // shift cannot take off the position comes off the size instead
+         int left = Math.min(insets.left, Math.max(0, position.x));
+         int top0 = Math.min(insets.top, Math.max(0, position.y));
+         position = new Point(position.x - left, position.y - top0);
+         size = new Dimension(size.width + left + insets.right,
+                              size.height + top0 + insets.bottom);
+      }
+
       Point top = new Point();
       Point bottom = new Point();
       position.y = Math.max(position.y, 0);

--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/ppt/PPTVSExporter.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/report/io/viewsheet/ppt/PPTVSExporter.java
@@ -1149,7 +1149,10 @@ public class PPTVSExporter extends AbstractVSExporter {
          return;
       }
 
-      Rectangle2D bounds = coordinator.getBounds(info);
+      // the shadow can fall outside the assembly's own bounds, so grow the
+      // destination or it would be clipped and squeezed
+      Rectangle2D bounds = ShapeShadowUtil.expandForShadow(
+         coordinator.getBounds(info), info, coordinator.getScale());
 
       try {
          writePicture(getImage(assembly), bounds);

--- a/web/projects/portal/src/app/common/data/base-format-model.ts
+++ b/web/projects/portal/src/app/common/data/base-format-model.ts
@@ -46,6 +46,18 @@ export interface GradientColor {
    colors: ColorStop[];
 }
 
+/**
+ * Drop shadow settings for a shape assembly (rectangle/oval). Mirrors the
+ * java inetsoft.uql.viewsheet.ShapeShadow.
+ */
+export interface ShapeShadow {
+   color: string;
+   alpha: number;
+   direction: string;
+   distance: number;
+   blur: number;
+}
+
 export interface ColorStop {
    color: string;
    offset: number;

--- a/web/projects/portal/src/app/common/test/test-utils.ts
+++ b/web/projects/portal/src/app/common/test/test-utils.ts
@@ -1109,7 +1109,8 @@ export namespace TestUtils {
          color: "#55555",
          lineStyle: StyleConstants.THIN_LINE,
          locked: false,
-         shadow: false
+         shadow: false,
+         shadowInfo: { color: "#000000", alpha: 30, direction: "SE", distance: 5, blur: 6 }
       }, createMockVSObjectModel("VSLine", name));
    }
 
@@ -1121,7 +1122,8 @@ export namespace TestUtils {
          roundCornerValue: 0,
          locked: false,
          lineStyle: StyleConstants.THIN_LINE,
-         shadow: false
+         shadow: false,
+         shadowInfo: { color: "#000000", alpha: 30, direction: "SE", distance: 5, blur: 6 }
       }, createMockVSObjectModel("VSRectangle", name));
    }
 
@@ -1132,7 +1134,8 @@ export namespace TestUtils {
       return Object.assign({
          locked: false,
          lineStyle: StyleConstants.THIN_LINE,
-         shadow: false
+         shadow: false,
+         shadowInfo: { color: "#000000", alpha: 30, direction: "SE", distance: 5, blur: 6 }
       }, createMockVSObjectModel("VSOval", name));
    }
 

--- a/web/projects/portal/src/app/common/util/shape-shadow-util.ts
+++ b/web/projects/portal/src/app/common/util/shape-shadow-util.ts
@@ -1,0 +1,131 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import type { ShapeShadow } from "../data/base-format-model";
+
+/**
+ * Direction/distance to offset conversion for shape drop shadows. Mirrors
+ * inetsoft.uql.viewsheet.ShapeShadow so the browser and the server side
+ * exports agree on where the shadow falls.
+ */
+export namespace ShapeShadowUtil {
+   export const DIRECTIONS: string[] =
+      ["N", "NE", "E", "SE", "S", "SW", "W", "NW"];
+
+   export const DEFAULT_SHADOW: ShapeShadow = {
+      color: "#000000",
+      alpha: 30,
+      direction: "SE",
+      distance: 5,
+      blur: 6
+   };
+
+   /**
+    * Get the horizontal offset in pixels, positive to the right.
+    */
+   export function getOffsetX(shadow: ShapeShadow): number {
+      if(!shadow) {
+         return 0;
+      }
+
+      if(shadow.direction == "NE" || shadow.direction == "E" ||
+         shadow.direction == "SE")
+      {
+         return shadow.distance;
+      }
+
+      if(shadow.direction == "NW" || shadow.direction == "W" ||
+         shadow.direction == "SW")
+      {
+         return -shadow.distance;
+      }
+
+      return 0;
+   }
+
+   /**
+    * Get the vertical offset in pixels, positive downwards.
+    */
+   export function getOffsetY(shadow: ShapeShadow): number {
+      if(!shadow) {
+         return 0;
+      }
+
+      if(shadow.direction == "SE" || shadow.direction == "S" ||
+         shadow.direction == "SW")
+      {
+         return shadow.distance;
+      }
+
+      if(shadow.direction == "NE" || shadow.direction == "N" ||
+         shadow.direction == "NW")
+      {
+         return -shadow.distance;
+      }
+
+      return 0;
+   }
+
+   /**
+    * Get the shadow color as an rgba() string, with the opacity applied.
+    */
+   export function getRgba(shadow: ShapeShadow): string {
+      const alpha = Math.max(0, Math.min(100, shadow ? shadow.alpha : 0)) / 100;
+      const rgb = toRgb(shadow ? shadow.color : null);
+
+      return `rgba(${rgb[0]}, ${rgb[1]}, ${rgb[2]}, ${alpha})`;
+   }
+
+   /**
+    * Get a CSS box-shadow value for the settings, or null when there is none.
+    */
+   export function getBoxShadow(shadow: ShapeShadow): string {
+      if(!shadow) {
+         return null;
+      }
+
+      const blur = Math.max(0, shadow.blur);
+
+      return `${getOffsetX(shadow)}px ${getOffsetY(shadow)}px ${blur}px ` +
+         getRgba(shadow);
+   }
+
+   function toRgb(color: string): [number, number, number] {
+      if(!color) {
+         return [0, 0, 0];
+      }
+
+      let hex = color.trim();
+
+      if(hex.startsWith("#")) {
+         hex = hex.substring(1);
+      }
+
+      // expand the #rgb shorthand
+      if(hex.length == 3) {
+         hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
+      }
+
+      const num = parseInt(hex, 16);
+
+      if(hex.length != 6 || isNaN(num)) {
+         return [0, 0, 0];
+      }
+
+      return [(num >> 16) & 0xff, (num >> 8) & 0xff, num & 0xff];
+   }
+}

--- a/web/projects/portal/src/app/composer/data/vs/rectangle-property-pane-model.ts
+++ b/web/projects/portal/src/app/composer/data/vs/rectangle-property-pane-model.ts
@@ -17,9 +17,11 @@
  */
 import { LinePropPaneModel } from "./line-prop-pane-model";
 import { FillPropPaneModel } from "./fill-prop-pane-model";
+import { ShadowPropPaneModel } from "./shadow-prop-pane-model";
 
 export interface RectanglePropertyPaneModel {
    linePropPaneModel: LinePropPaneModel;
    fillPropPaneModel: FillPropPaneModel;
+   shadowPropPaneModel: ShadowPropPaneModel;
    radius: number;
 }

--- a/web/projects/portal/src/app/composer/data/vs/shadow-prop-pane-model.ts
+++ b/web/projects/portal/src/app/composer/data/vs/shadow-prop-pane-model.ts
@@ -15,12 +15,11 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { LinePropPaneModel } from "./line-prop-pane-model";
-import { FillPropPaneModel } from "./fill-prop-pane-model";
-import { ShadowPropPaneModel } from "./shadow-prop-pane-model";
-
-export interface OvalPropertyPaneModel {
-   linePropPaneModel: LinePropPaneModel;
-   fillPropPaneModel: FillPropPaneModel;
-   shadowPropPaneModel: ShadowPropPaneModel;
+export interface ShadowPropPaneModel {
+   apply: boolean;
+   color: string;
+   alpha: number;
+   direction: string;
+   distance: number;
+   blur: number;
 }

--- a/web/projects/portal/src/app/composer/dialog/vs/oval-property-pane.component.html
+++ b/web/projects/portal/src/app/composer/dialog/vs/oval-property-pane.component.html
@@ -17,3 +17,4 @@
   -->
 <line-prop-pane [model]="model.linePropPaneModel" [variables]="variableValues" [vsId]="vsId"></line-prop-pane>
 <fill-prop-pane [model]="model.fillPropPaneModel" [variables]="variableValues" [vsId]="vsId"></fill-prop-pane>
+<shadow-prop-pane [model]="model.shadowPropPaneModel"></shadow-prop-pane>

--- a/web/projects/portal/src/app/composer/dialog/vs/oval-property-pane.component.ts
+++ b/web/projects/portal/src/app/composer/dialog/vs/oval-property-pane.component.ts
@@ -18,12 +18,13 @@
 import { Component, Input } from "@angular/core";
 import { LinePropPane } from "./line-prop-pane.component";
 import { FillPropPane } from "./fill-prop-pane.component";
+import { ShadowPropPane } from "./shadow-prop-pane.component";
 import { OvalPropertyPaneModel } from "../../data/vs/oval-property-pane-model";
 
 @Component({
     selector: "oval-property-pane",
     templateUrl: "oval-property-pane.component.html",
-    imports: [LinePropPane, FillPropPane]
+    imports: [LinePropPane, FillPropPane, ShadowPropPane]
 })
 export class OvalPropertyPane {
    @Input() model: OvalPropertyPaneModel;

--- a/web/projects/portal/src/app/composer/dialog/vs/rectangle-property-pane.component.html
+++ b/web/projects/portal/src/app/composer/dialog/vs/rectangle-property-pane.component.html
@@ -17,6 +17,7 @@
   -->
 <line-prop-pane [model]="model.linePropPaneModel" [variables]="variableValues" [vsId]="vsId"></line-prop-pane>
 <fill-prop-pane [model]="model.fillPropPaneModel" [variables]="variableValues" [vsId]="vsId"></fill-prop-pane>
+<shadow-prop-pane [model]="model.shadowPropPaneModel"></shadow-prop-pane>
 <form ngNoForm (submit)="$event.preventDefault()" class="form-horizontal container-fluid">
   <fieldset>
     <legend>_#(Shape)</legend>

--- a/web/projects/portal/src/app/composer/dialog/vs/rectangle-property-pane.component.ts
+++ b/web/projects/portal/src/app/composer/dialog/vs/rectangle-property-pane.component.ts
@@ -19,6 +19,7 @@ import { Component, Input } from "@angular/core";
 import { UntypedFormGroup } from "@angular/forms";
 import { LinePropPane } from "./line-prop-pane.component";
 import { FillPropPane } from "./fill-prop-pane.component";
+import { ShadowPropPane } from "./shadow-prop-pane.component";
 import { RadiusDropdown } from "../../../widget/format/radius-dropdown.component";
 import { RectanglePropertyPaneModel } from "../../data/vs/rectangle-property-pane-model";
 
@@ -28,6 +29,7 @@ import { RectanglePropertyPaneModel } from "../../data/vs/rectangle-property-pan
     imports: [
         LinePropPane,
         FillPropPane,
+        ShadowPropPane,
         RadiusDropdown,
     ]
 })

--- a/web/projects/portal/src/app/composer/dialog/vs/shadow-prop-pane.component.html
+++ b/web/projects/portal/src/app/composer/dialog/vs/shadow-prop-pane.component.html
@@ -1,0 +1,81 @@
+<!--
+  ~ This file is part of StyleBI.
+  ~ Copyright (C) 2024  InetSoft Technology
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+<form ngNoForm (submit)="$event.preventDefault()" class="form-horizontal container-fluid">
+  <fieldset>
+    <legend>_#(Shadow)</legend>
+    <div class="form-row-float-label row">
+      <div class="col-auto">
+        <label class="form-check-label">
+          <input type="checkbox" class="form-check-input" data-test="shadowApply"
+                 [(ngModel)]="model.apply"/>
+          _#(Apply)
+        </label>
+      </div>
+      <div class="col-auto ps-1" [class.disable-actions-fade]="!enabled">
+        <color-editor data-test="shadowColorPicker"
+                      [color]="model.color" (colorChange)="changeColor($event)"
+                      [enabled]="enabled"
+                      [palette]="shadowColors"></color-editor>
+      </div>
+    </div>
+    <div class="form-row-float-label row" [class.disable-actions-fade]="!enabled">
+      <div class="col">
+        <div class="form-floating">
+          <alpha-dropdown [(alpha)]="model.alpha" [disabled]="!enabled"
+                          (alphaInvalid)="changeAlphaWarning($event)">
+          </alpha-dropdown>
+          <label>_#(Opacity)</label>
+        </div>
+      </div>
+      <div class="col">
+        <div class="form-floating">
+          <select class="form-control" data-test="shadowDirection"
+                  [(ngModel)]="model.direction" [disabled]="!enabled">
+            @for (dir of directions; track dir.value) {
+              <option [value]="dir.value">{{dir.label}}</option>
+            }
+          </select>
+          <label>_#(Direction)</label>
+        </div>
+      </div>
+    </div>
+    <div class="form-row-float-label row" [class.disable-actions-fade]="!enabled">
+      <div class="col">
+        <div class="form-floating">
+          <input type="number" class="form-control" data-test="shadowDistance"
+                 min="0" max="50" [ngModel]="model.distance" [disabled]="!enabled"
+                 (ngModelChange)="clamp('distance', $event)"/>
+          <label>_#(Distance)</label>
+        </div>
+      </div>
+      <div class="col">
+        <div class="form-floating">
+          <input type="number" class="form-control" data-test="shadowBlur"
+                 min="0" max="50" [ngModel]="model.blur" [disabled]="!enabled"
+                 (ngModelChange)="clamp('blur', $event)"/>
+          <label>_#(Blur)</label>
+        </div>
+      </div>
+    </div>
+    @if (alphaInvalid) {
+      <div class="alert alert-danger">
+        _#(viewer.flash.format.invalidTransparencyError)
+      </div>
+    }
+  </fieldset>
+</form>

--- a/web/projects/portal/src/app/composer/dialog/vs/shadow-prop-pane.component.ts
+++ b/web/projects/portal/src/app/composer/dialog/vs/shadow-prop-pane.component.ts
@@ -1,0 +1,82 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { Component, Input, OnInit } from "@angular/core";
+import { FormsModule } from "@angular/forms";
+import { ShadowPropPaneModel } from "../../data/vs/shadow-prop-pane-model";
+import { ShapeShadowUtil } from "../../../common/util/shape-shadow-util";
+import { DefaultPalette } from "../../../widget/color-picker/default-palette";
+import { ColorEditor } from "../../../widget/color-picker/color-editor.component";
+import { AlphaDropdown } from "../../../widget/format/alpha-dropdown.component";
+
+/** Upper bound for the distance and blur fields, in pixels. */
+const MAX_LENGTH = 50;
+
+@Component({
+    selector: "shadow-prop-pane",
+    templateUrl: "shadow-prop-pane.component.html",
+    imports: [
+        FormsModule,
+        ColorEditor,
+        AlphaDropdown,
+    ]
+})
+export class ShadowPropPane implements OnInit {
+   @Input() model: ShadowPropPaneModel;
+   shadowColors = DefaultPalette.chart;
+   alphaInvalid: boolean = false;
+
+   readonly directions: {value: string, label: string}[] = [
+      { value: "N", label: "_#(js:North)" },
+      { value: "NE", label: "_#(js:Northeast)" },
+      { value: "E", label: "_#(js:East)" },
+      { value: "SE", label: "_#(js:Southeast)" },
+      { value: "S", label: "_#(js:South)" },
+      { value: "SW", label: "_#(js:Southwest)" },
+      { value: "W", label: "_#(js:West)" },
+      { value: "NW", label: "_#(js:Northwest)" }
+   ];
+
+   ngOnInit() {
+      // guard against a model persisted before these settings existed
+      if(!this.model.color) {
+         this.model.color = ShapeShadowUtil.DEFAULT_SHADOW.color;
+      }
+
+      if(!this.model.direction) {
+         this.model.direction = ShapeShadowUtil.DEFAULT_SHADOW.direction;
+      }
+   }
+
+   get enabled(): boolean {
+      return !!this.model.apply;
+   }
+
+   changeColor(color: string): void {
+      this.model.color = color;
+   }
+
+   changeAlphaWarning(invalid: boolean): void {
+      this.alphaInvalid = invalid;
+   }
+
+   /** Keep a cleared or out-of-range entry from reaching the server. */
+   clamp(field: "distance" | "blur", value: any): void {
+      const num = parseInt(value, 10);
+      this.model[field] = isNaN(num) ? 0 : Math.max(0, Math.min(MAX_LENGTH, num));
+   }
+}

--- a/web/projects/portal/src/app/vsobjects/model/vs-shape-model.ts
+++ b/web/projects/portal/src/app/vsobjects/model/vs-shape-model.ts
@@ -15,10 +15,12 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+import type { ShapeShadow } from "../../common/data/base-format-model";
 import { VSObjectModel } from "./vs-object-model";
 
 export interface VSShapeModel extends VSObjectModel {
    locked: boolean;
    lineStyle: number;
    shadow: boolean;
+   shadowInfo: ShapeShadow;
 }

--- a/web/projects/portal/src/app/vsobjects/objects/shape/vs-oval.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/shape/vs-oval.component.html
@@ -35,18 +35,23 @@
       [attr.width]="model.objectFormat.width"
       [attr.height]="model.objectFormat.height">
       <defs>
-        <filter [attr.id]="ovalFilterId">
-          <feGaussianBlur in="SourceAlpha" stdDeviation="3" ></feGaussianBlur>
-          <feOffset dx="2" dy="4"></feOffset>
+        <filter [attr.id]="ovalFilterId" filterUnits="userSpaceOnUse"
+          [attr.x]="-shadowMargin" [attr.y]="-shadowMargin"
+          [attr.width]="model.objectFormat.width + shadowMargin * 2"
+          [attr.height]="model.objectFormat.height + shadowMargin * 2">
+          <feGaussianBlur in="SourceAlpha" [attr.stdDeviation]="shadowStdDeviation"></feGaussianBlur>
+          <feOffset [attr.dx]="shadowOffsetX" [attr.dy]="shadowOffsetY" result="offsetBlur"></feOffset>
+          <feFlood [attr.flood-color]="shadowColor" [attr.flood-opacity]="shadowOpacity"></feFlood>
+          <feComposite in2="offsetBlur" operator="in"></feComposite>
           <feMerge>
             <feMergeNode></feMergeNode>
             <feMergeNode in="SourceGraphic"></feMergeNode>
           </feMerge>
         </filter>
         <mask [attr.id]="ovalMaskId">
-          <rect x="-16" y="-16"
-            [attr.width]="model.objectFormat.width + 32"
-            [attr.height]="model.objectFormat.height + 32"
+          <rect [attr.x]="-shadowMargin" [attr.y]="-shadowMargin"
+            [attr.width]="model.objectFormat.width + shadowMargin * 2"
+            [attr.height]="model.objectFormat.height + shadowMargin * 2"
             fill="white">
           </rect>
           <ellipse fill="black"
@@ -89,7 +94,6 @@
         <ellipse
           [attr.filter]="'url(#' + ovalFilterId + ')'"
           [attr.mask]="'url(#' + ovalMaskId + ')'"
-          [attr.opacity]="model.objectFormat.alpha"
           [attr.cx]="model.objectFormat.width / 2"
           [attr.cy]="model.objectFormat.height / 2"
           [attr.rx]="model.objectFormat.width / 2"

--- a/web/projects/portal/src/app/vsobjects/objects/shape/vs-oval.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/shape/vs-oval.component.ts
@@ -19,6 +19,7 @@ import { Component, Input, NgZone, OnChanges, SimpleChanges } from "@angular/cor
 import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
 import { ViewsheetClientService } from "../../../common/viewsheet-client";
 import { ContextProvider } from "../../context-provider.service";
+import { ShapeShadowUtil } from "../../../common/util/shape-shadow-util";
 import { VSOvalModel } from "../../model/vs-oval-model";
 import { VSShape } from "./vs-shape";
 import { DataTipService } from "../data-tip/data-tip.service";
@@ -38,6 +39,13 @@ export class VSOval extends VSShape<VSOvalModel> implements OnChanges {
    @Input() selected: boolean = false;
    public ovalFilterId: string;
    public ovalMaskId: string;
+   public shadowOffsetX: number = 0;
+   public shadowOffsetY: number = 0;
+   public shadowStdDeviation: number = 0;
+   public shadowColor: string;
+   public shadowOpacity: number = 0;
+   // how far the shadow reaches past the ellipse, used to size the mask
+   public shadowMargin: number = 0;
 
    constructor(protected viewsheetClient: ViewsheetClientService,
                protected modalService: NgbModal,
@@ -55,7 +63,24 @@ export class VSOval extends VSShape<VSOvalModel> implements OnChanges {
             this.viewsheetClient.runtimeId + this.getAssemblyName());
          this.ovalMaskId = "ovalmask" + this.validateID(
             this.viewsheetClient.runtimeId + this.getAssemblyName());
+         this.updateShadow();
       }
+   }
+
+   private updateShadow(): void {
+      const shadow = this.model.shadowInfo;
+      this.shadowOffsetX = ShapeShadowUtil.getOffsetX(shadow);
+      this.shadowOffsetY = ShapeShadowUtil.getOffsetY(shadow);
+      const blur = shadow ? Math.max(0, shadow.blur) : 0;
+      // feGaussianBlur takes a standard deviation, not a css blur radius
+      this.shadowStdDeviation = blur / 2;
+      this.shadowColor = shadow ? shadow.color : "#000000";
+      this.shadowOpacity =
+         Math.max(0, Math.min(100, shadow ? shadow.alpha : 0)) / 100;
+      // the mask has to clear the blur as well as the offset, or the shadow
+      // gets clipped at larger settings
+      this.shadowMargin = blur * 3 +
+         Math.max(Math.abs(this.shadowOffsetX), Math.abs(this.shadowOffsetY));
    }
 
    validateID(id: string): string {

--- a/web/projects/portal/src/app/vsobjects/objects/shape/vs-rectangle.component.html
+++ b/web/projects/portal/src/app/vsobjects/objects/shape/vs-rectangle.component.html
@@ -30,8 +30,7 @@
     [style.position]="viewer || embeddedVS ? 'absolute' : 'relative'"
     [style.width.px]="model.objectFormat.width"
     [style.height.px]="model.objectFormat.height"
-    [style.z-index]="viewer ? model.objectFormat.zIndex : null"
-    [class.vs-rectangle--shadow]="model.shadow">
+    [style.z-index]="viewer ? model.objectFormat.zIndex : null">
     <svg class="vs-rectangle__svg"
       [attr.shape-rendering]="roundCornerValue ? 'auto' : 'crispEdges'"
       [attr.width]="model.objectFormat.width"
@@ -97,7 +96,7 @@
       [style.width.px]="model.objectFormat.width"
       [style.height.px]="model.objectFormat.height"
       [style.border-radius.px]="roundCornerValue"
-      [style.opacity]="model.objectFormat.alpha">
+      [style.box-shadow]="shadowCss">
     </div>
     @if (viewer) {
       <div class="annotation-hidden-container">

--- a/web/projects/portal/src/app/vsobjects/objects/shape/vs-rectangle.component.scss
+++ b/web/projects/portal/src/app/vsobjects/objects/shape/vs-rectangle.component.scss
@@ -25,7 +25,3 @@
   top: 0;
   left: 0;
 }
-
-.vs-rectangle--shadow > .vs-rectangle__box-shadow {
-  box-shadow: 5px 5px 3px 3px rgba(0,0,0,0.3);
-}

--- a/web/projects/portal/src/app/vsobjects/objects/shape/vs-rectangle.component.spec.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/shape/vs-rectangle.component.spec.ts
@@ -1,0 +1,138 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+/**
+ * VSRectangle - configurable drop shadow.
+ *
+ * Risk-first coverage:
+ *   Group 1 - ngOnChanges: the derived css box-shadow for the configured settings
+ *   Group 2 - round corner clamping (pre-existing behavior, guarded against regression)
+ *
+ * The shadow used to be a hardcoded scss rule; it is now computed from
+ * model.shadowInfo, so the defaults must still approximate the old look.
+ *
+ * Mocking strategy:
+ *   - direct class instantiation with lightweight service stubs; no DOM or HTTP
+ *     interception is needed, so this is a plain spec rather than a .tl one
+ */
+import { NgZone } from "@angular/core";
+
+import { TestUtils } from "../../../common/test/test-utils";
+import { ShapeShadowUtil } from "../../../common/util/shape-shadow-util";
+import { VSRectangleModel } from "../../model/vs-rectangle-model";
+import { VSRectangle } from "./vs-rectangle.component";
+
+function createComponent(modelOverrides: Partial<VSRectangleModel> = {}) {
+   const viewsheetClient = { runtimeId: "runtime-1", sendEvent: vi.fn() };
+   const comp = new VSRectangle(
+      viewsheetClient as any,
+      {} as any,
+      new NgZone({}),
+      { viewer: false, preview: false, composer: false, binding: false } as any,
+      { isDataTip: vi.fn().mockReturnValue(false) } as any
+   );
+   const model = TestUtils.createMockVSRectangleModel("Rectangle1");
+   model.objectFormat.width = 200;
+   model.objectFormat.height = 100;
+   comp.model = { ...model, ...modelOverrides };
+   return { comp };
+}
+
+describe("VSRectangle - Group 1: shadow css", () => {
+   it("should not set a box-shadow when the shadow is off", () => {
+      const { comp } = createComponent({ shadow: false });
+
+      comp.ngOnChanges({ model: {} as any });
+
+      expect(comp.shadowCss).toBeNull();
+   });
+
+   it("should approximate the previously hardcoded shadow with the defaults", () => {
+      const { comp } = createComponent({ shadow: true });
+
+      comp.ngOnChanges({ model: {} as any });
+
+      // was scss: box-shadow: 5px 5px 3px 3px rgba(0,0,0,0.3)
+      expect(comp.shadowCss).toBe("5px 5px 6px rgba(0, 0, 0, 0.3)");
+   });
+
+   it("should honor the configured color, opacity, distance and blur", () => {
+      const { comp } = createComponent({
+         shadow: true,
+         shadowInfo: {
+            color: "#ff8800", alpha: 50, direction: "E", distance: 10, blur: 2
+         }
+      });
+
+      comp.ngOnChanges({ model: {} as any });
+
+      expect(comp.shadowCss).toBe("10px 0px 2px rgba(255, 136, 0, 0.5)");
+   });
+
+   it("should cast the shadow up and to the left for a northwest direction", () => {
+      const { comp } = createComponent({
+         shadow: true,
+         shadowInfo: {
+            color: "#000000", alpha: 100, direction: "NW", distance: 4, blur: 0
+         }
+      });
+
+      comp.ngOnChanges({ model: {} as any });
+
+      expect(comp.shadowCss).toBe("-4px -4px 0px rgba(0, 0, 0, 1)");
+   });
+});
+
+describe("ShapeShadowUtil", () => {
+   it("should map every direction to the expected signed offsets", () => {
+      const expected: {[dir: string]: [number, number]} = {
+         N: [0, -3], NE: [3, -3], E: [3, 0], SE: [3, 3],
+         S: [0, 3], SW: [-3, 3], W: [-3, 0], NW: [-3, -3]
+      };
+
+      for(const dir of ShapeShadowUtil.DIRECTIONS) {
+         const shadow = { color: "#000000", alpha: 100, direction: dir,
+                          distance: 3, blur: 0 };
+         expect([ShapeShadowUtil.getOffsetX(shadow),
+                 ShapeShadowUtil.getOffsetY(shadow)]).toEqual(expected[dir]);
+      }
+   });
+
+   it("should fall back to black for a malformed color", () => {
+      const shadow = { color: "nonsense", alpha: 100, direction: "SE",
+                       distance: 1, blur: 0 };
+      expect(ShapeShadowUtil.getRgba(shadow)).toBe("rgba(0, 0, 0, 1)");
+   });
+
+   it("should expand the #rgb shorthand", () => {
+      const shadow = { color: "#f00", alpha: 100, direction: "SE",
+                       distance: 1, blur: 0 };
+      expect(ShapeShadowUtil.getRgba(shadow)).toBe("rgba(255, 0, 0, 1)");
+   });
+});
+
+describe("VSRectangle - Group 2: round corner", () => {
+   it("should clamp the round corner to the smaller of width and height", () => {
+      const { comp } = createComponent({ roundCornerValue: 500 });
+      comp.model.objectFormat.width = 200;
+      comp.model.objectFormat.height = 60;
+
+      comp.ngOnChanges({ model: {} as any });
+
+      expect(comp.roundCornerValue).toBe(60);
+   });
+});

--- a/web/projects/portal/src/app/vsobjects/objects/shape/vs-rectangle.component.ts
+++ b/web/projects/portal/src/app/vsobjects/objects/shape/vs-rectangle.component.ts
@@ -19,6 +19,7 @@ import { Component, Input, NgZone, OnChanges, SimpleChanges } from "@angular/cor
 import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
 import { ViewsheetClientService } from "../../../common/viewsheet-client";
 import { ContextProvider } from "../../context-provider.service";
+import { ShapeShadowUtil } from "../../../common/util/shape-shadow-util";
 import { VSRectangleModel } from "../../model/vs-rectangle-model";
 import { VSShape } from "./vs-shape";
 import { DataTipService } from "../data-tip/data-tip.service";
@@ -42,6 +43,7 @@ import { VSDataTipDirective } from "../data-tip/vs-data-tip.directive";
 export class VSRectangle extends VSShape<VSRectangleModel> implements OnChanges {
    @Input() selected: boolean = false;
    roundCornerValue: number;
+   shadowCss: string;
 
    constructor(protected viewsheetClientService: ViewsheetClientService,
                protected modalService: NgbModal,
@@ -57,6 +59,8 @@ export class VSRectangle extends VSShape<VSRectangleModel> implements OnChanges 
          this.updateLineStyle();
          this.roundCornerValue = Math.min(this.model.roundCornerValue,
             this.model.objectFormat.width, this.model.objectFormat.height);
+         this.shadowCss = this.model.shadow
+            ? ShapeShadowUtil.getBoxShadow(this.model.shadowInfo) : null;
       }
    }
 }


### PR DESCRIPTION
## Problem

You could switch a Shadow on for a Rectangle from the property dialog, but there were no settings to control it. Reported ask: the usual direction, opacity, colour and width controls.

The single boolean was also rendered three different, mutually inconsistent ways:

| Path | What it drew |
|---|---|
| Rectangle, browser | css `box-shadow: 5px 5px 3px 3px rgba(0,0,0,0.3)` |
| Oval, browser | svg filter, `stdDeviation=3`, `dx=2 dy=4`, always black |
| All exports | `VSFaceUtil.addShadow(image, 6)` — fixed grey gaussian blur |

So a dashboard already looked different on screen than in an exported PDF.

## What this does

Adds **Colour, Opacity, Direction (8 compass points), Distance and Blur** to the Shape tab of the Rectangle and Oval property dialogs, stored in a new `ShapeShadow` value object on `ShapeVSAssemblyInfo` and honoured identically by the browser and by every export format.

`ShapeShadow` is modelled on the existing `GradientColor` — same package, same `Cloneable`/`Serializable` shape, same child-element persistence. The direction-to-offset maths lives in exactly one place per language (`ShapeShadow` / `shape-shadow-util.ts`) so the render paths cannot drift, and all three now blur with the same sigma.

The on/off checkbox moves out of the General tab into the new Shadow group beside the settings it controls, for Rectangle and Oval only. Text, Image and Gauge keep their General-tab checkbox and their existing fixed shadow — `VSFaceUtil.addShadow(img, int)` is untouched and still used by `VSImageable` and the gauges.

## Two existing defects fixed along the way

Both had to be fixed for the feature to work at all:

1. **Exports clipped and squeezed the shadow.** The image was generated 6px larger, but every exporter drew it into the assembly's *unexpanded* rectangle (`PDFCoordinateHelper.drawImage` even clips to it). The destination rectangle now grows along with the image. This is why export shadows never matched the screen.

2. **The blur tail was cut off flat.** `ConvolveOp` with `EDGE_NO_OP` leaves the outermost `radius` band unconvolved, and the insets allowed exactly `blur` of margin — so the whole outward falloff landed in that dead band. Measured before the fix, alpha stepped `41 → 0` with no gradient. The margin is now twice the blur radius.

## Compatibility

- An asset saved without a `<shadowInfo>` element parses back to the defaults (black, 30%, south-east, distance 5, blur 6), which approximate the previously hardcoded look.
- The `shadow` boolean is unchanged — still the on/off switch, still persisted, still public script API. A new `shadowInfo` script property is exposed alongside it.

**Deliberate appearance changes**, worth a release note:
- Oval adopts the rectangle's geometry instead of its own `dx=2 dy=4`.
- Exports gain the browser's geometry and a black-at-30% shadow instead of grey, and no longer clip.
- Rectangle on screen shifts very slightly (a 6px blur replacing 3px blur + 3px spread).
- The shadow layer no longer multiplies by the object's Fill alpha, so the Opacity field means what it says.

## Testing

- New `ShapeShadowTest` (24) and `VSFaceUtilShadowTest` (8) — all 8 directions incl. negative offsets, XML round-trip with and without the element, colour fallbacks, inset geometry, and the blur falloff.
- `vs-rectangle.component.spec.ts` (8) — the derived css string, and that the defaults still reproduce the legacy look.
- Portal 959 pass, EM 365 pass, production build and ESLint clean.
- Verified live in the composer and against real exported files.

## Notes for the reviewer

- Three sites must agree or shapes render offset: the canvas growth plus `g.translate` in `VSFloatable.getImage`, the `-insets.left/-insets.top` draw in `VSShape.paintComponent`, and `ShapeShadowUtil.expandForShadow`. There are comments at each.
- Excel anchors to the cell grid, so the offset lands on the nearest column/row boundary rather than exactly — accepted rather than reworking Excel anchoring.
- `getShadowColor()`/`getOffsetX()`/`getOffsetY()` are `@JsonIgnore`d deliberately: as bean properties Jackson walked `java.awt.Color → ColorSpace → ICC profile` and emitted ~9.7 KB per shape on every model refresh. There is a test pinning the payload size.

## Out of scope

Line shadow is inconsistent independently of this change: `LineVSAssemblyInfo` inherits the flag and `VSShape` paints it, but the dialog hides the checkbox, the script property is disabled, and the Angular component ignores it — so a line with `shadowValue="true"` shows a shadow in PDF/Excel/PPT but not in the browser. Left alone here; worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
