### PR TITLE
Bug #76082, refuse reorder_columns on a crosstab worksheet table

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -1604,12 +1604,21 @@ public class WorksheetEditService {
        * @param table       the assembly name
        * @param columnOrder ordered list of column names defining the new order.
        *                    Columns not mentioned are appended at the end.
-       * @throws PairingException if the table is not found
+       * @throws PairingException if the table is not found, or if the table is a crosstab
+       *                    (column order there is controlled by the row/column groups, not
+       *                    the column selection — this mirrors the Composer UI, which disables
+       *                    "Reorder Table Columns" for crosstab tables)
        */
       public void reorderColumns(String table, List<String> columnOrder)
          throws PairingException
       {
          TableAssembly t = requireTable(table);
+         AggregateInfo aggInfo = t.getAggregateInfo();
+
+         if(aggInfo != null && aggInfo.isCrosstab()) {
+            throw new PairingException("Cannot reorder columns on a crosstab table: " + table);
+         }
+
          ColumnSelection cs = t.getColumnSelection(false);
 
          // Bare attribute names that occur more than once (e.g. "ID" from both a

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -1831,6 +1831,32 @@ class WorksheetEditServiceMutatorsTest {
       assertTrue(reordered.containsAttribute(orderId), "Orders.ID must survive reordering");
    }
 
+   @Test
+   void reorderColumnsRefusedOnCrosstabTable() throws Exception {
+      // Bug #76082: the Composer UI disables "Reorder Table Columns" for a crosstab
+      // table (ws-details-pane.component.ts#isSupportChangeColumnOrder), because column
+      // layout there is driven by the row/column groups, not the column selection order.
+      // reorderColumns() had no equivalent guard, so it silently dropped names that don't
+      // match a static column (e.g. a pivoted value like "2024") and returned success.
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t =
+         TestWorksheets.tableWithColumns(ws, "T", "orderDate", "employee", "total");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed ->
+         ed.setGroupAggregate("T",
+            groups("orderDate", "employee"),
+            List.of(new WorksheetMutationSupport.AggregateSpec("total", "SUM", null))));
+      t.getAggregateInfo().setCrosstab(true);
+
+      PairingException ex = assertThrows(PairingException.class, () ->
+         svc.apply("TOK", agent, ed -> ed.reorderColumns("T", List.of("2024", "employee"))));
+      assertTrue(ex.getMessage().contains("crosstab"), "Unexpected message: " + ex.getMessage());
+      assertTrue(ex.getMessage().contains("T"), "Unexpected message: " + ex.getMessage());
+   }
+
    // =========================================================================
    // Cell/row edits: snapshot write protection
    // =========================================================================


### PR DESCRIPTION
## Summary

The AI Wiz plugin's `reorder_columns` tool silently succeeded when called on a worksheet table in crosstab mode, even though the Composer UI disables "Reorder Table Columns" for crosstab tables entirely. Any requested column name that didn't match the table's static column selection (e.g. a pivoted value like "2024", which isn't a real design-time column) was silently dropped instead of erroring, so the agent reported the reorder as applied when nothing meaningful happened.

## Root Cause

`WorksheetEditService.reorderColumns()` had no guard for crosstab tables. In crosstab mode, column layout is driven by the row/column group configuration (`AggregateInfo`), not by the table's `ColumnSelection` order — this is exactly why the Composer UI's `isSupportChangeColumnOrder()` (`ws-details-pane.component.ts`) disables the reorder button when `aggregateInfo.crosstab` is true. The backend method never mirrored that rule, and its unmatched-name lookup (`Map.remove()` returning `null`) was silently ignored rather than surfaced, so a bad or crosstab-inapplicable request still returned success.

## Fix

Added a guard at the top of `reorderColumns()`: if the table's `AggregateInfo.isCrosstab()` is true, throw a `PairingException` ("Cannot reorder columns on a crosstab table: <table>") instead of proceeding — mirroring the Composer UI's own rule and matching the file's existing validation-error conventions (`PairingException`'s single-arg constructor → HTTP 400).

## Test Plan

- Added `reorderColumnsRefusedOnCrosstabTable` to `WorksheetEditServiceMutatorsTest`, verifying the guard throws for a crosstab table.
- `WorksheetEditServiceMutatorsTest` passes in full (86/86), including the pre-existing `reorderColumns*` tests (bare-name matching, ambiguous-name handling) — unaffected since none use a crosstab table.
- Verified live: reproduced the Redmine repro (group by Order Date-Year + Employee, Sum(Total), switch to crosstab, then `reorder_columns(["2024", "Employee"])`) against a running server built from this branch — now fails loudly with `Cannot reorder columns on a crosstab table: All Sales` instead of returning `{ "ok": true }`.

Fixes Redmine #76082.