### PR TITLE
Add live primary-key columns to getDatabaseTables response

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/model/DatabaseTableInfo.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/DatabaseTableInfo.java
@@ -20,6 +20,8 @@ package inetsoft.web.wiz.model;
 
 import inetsoft.uql.asset.AssetEntry;
 
+import java.util.List;
+
 public class DatabaseTableInfo {
    public String getType() {
       return type;
@@ -69,10 +71,19 @@ public class DatabaseTableInfo {
       this.assetData = assetData;
    }
 
+   public List<String> getPrimaryKeyColumns() {
+      return primaryKeyColumns;
+   }
+
+   public void setPrimaryKeyColumns(List<String> primaryKeyColumns) {
+      this.primaryKeyColumns = primaryKeyColumns;
+   }
+
    private String type;
    private String database;
    private String catalog;
    private String schema;
    private String table;
    private AssetEntry assetData;
+   private List<String> primaryKeyColumns;
 }

--- a/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/MetadataApiService.java
@@ -1265,6 +1265,7 @@ public class MetadataApiService {
       }
 
       List<OsiRelationship> relationships = buildRelationships(metaDataProvider, tables);
+      populatePrimaryKeys(metaDataProvider, tables);
 
       DatasourceTablesResponse response = new DatasourceTablesResponse();
       response.setTables(tables);
@@ -1687,6 +1688,62 @@ public class MetadataApiService {
       }
 
       return new ArrayList<>(relMap.values());
+   }
+
+   /**
+    * Populate each table's primary key columns, one JDBC catalog round trip per table -- same
+    * cost class as the per-table KEYRELATION query buildRelationships already issues.
+    */
+   static void populatePrimaryKeys(DefaultMetaDataProvider metaDataProvider,
+                                    List<DatabaseTableInfo> tables)
+   {
+      for(DatabaseTableInfo table : tables) {
+         XNode query = new XNode(table.getTable());
+
+         if(table.getCatalog() != null) {
+            query.setAttribute("catalog", table.getCatalog());
+         }
+
+         if(table.getSchema() != null) {
+            query.setAttribute("schema", table.getSchema());
+         }
+
+         List<String> primaryKeyColumns = new ArrayList<>();
+
+         try {
+            XNode pkResult = metaDataProvider.getPrimaryKeys(query);
+            collectPrimaryKeyColumnNames(pkResult, primaryKeyColumns);
+         }
+         catch(Exception e) {
+            log.warn("Failed to get primary keys for table '{}'", table.getTable(), e);
+         }
+
+         table.setPrimaryKeyColumns(primaryKeyColumns);
+      }
+   }
+
+   /**
+    * JDBCHandler.getPrimaryKeys builds one unnamed XNode per key-column row, so for a composite
+    * (2+ column) primary key, XNode.addChild's own duplicate-name detection (every unnamed node
+    * defaults to the same name) merges them into a single XSequenceNode child instead of leaving
+    * them as separate top-level children -- the same quirk XUtil.isPrimaryKey already works
+    * around. Unwrap one level so every key column is collected regardless of key width.
+    */
+   private static void collectPrimaryKeyColumnNames(XNode pkResult, List<String> out) {
+      for(int i = 0; i < pkResult.getChildCount(); i++) {
+         XNode keyNode = pkResult.getChild(i);
+
+         if(keyNode instanceof XSequenceNode) {
+            collectPrimaryKeyColumnNames(keyNode, out);
+            continue;
+         }
+
+         String pkColumnName = (String) keyNode.getAttribute("pkColumnName");
+
+         if(!Tool.isEmptyString(pkColumnName)) {
+            out.add(pkColumnName);
+         }
+      }
    }
 
    private void collectLeafNodes(XNode node, List<XNode> leaves) {

--- a/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServicePrimaryKeyColumnsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/MetadataApiServicePrimaryKeyColumnsTest.java
@@ -1,0 +1,138 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.uql.XNode;
+import inetsoft.uql.util.DefaultMetaDataProvider;
+import inetsoft.web.wiz.model.DatabaseTableInfo;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression tests for {@code getDatabaseTables}'s primary-key enrichment: each returned
+ * {@link DatabaseTableInfo} should carry {@code primaryKeyColumns}, read the same way
+ * {@code buildRelationships} already reads FK columns -- one {@code PRIMARYKEY} metadata query
+ * per table via {@link DefaultMetaDataProvider#getPrimaryKeys}.
+ */
+@Tag("core")
+class MetadataApiServicePrimaryKeyColumnsTest {
+
+   private static DatabaseTableInfo table(String catalog, String schema, String name) {
+      DatabaseTableInfo info = new DatabaseTableInfo();
+      info.setCatalog(catalog);
+      info.setSchema(schema);
+      info.setTable(name);
+      return info;
+   }
+
+   private static XNode pkResult(String... pkColumnNames) {
+      XNode root = new XNode();
+
+      for(String col : pkColumnNames) {
+         XNode child = new XNode();
+         child.setAttribute("pkColumnName", col);
+         root.addChild(child);
+      }
+
+      return root;
+   }
+
+   @Test
+   void populatesPrimaryKeyColumnsForDeclaredSingleColumnKey() throws Exception {
+      DatabaseTableInfo orders = table(null, "dbo", "Orders");
+      DefaultMetaDataProvider provider = mock(DefaultMetaDataProvider.class);
+      when(provider.getPrimaryKeys(any(XNode.class))).thenReturn(pkResult("OrderID"));
+
+      MetadataApiService.populatePrimaryKeys(provider, List.of(orders));
+
+      assertEquals(List.of("OrderID"), orders.getPrimaryKeyColumns());
+   }
+
+   @Test
+   void populatesCompositePrimaryKeyColumnsInResultOrder() throws Exception {
+      DatabaseTableInfo lineItems = table(null, "dbo", "OrderLineItems");
+      DefaultMetaDataProvider provider = mock(DefaultMetaDataProvider.class);
+      when(provider.getPrimaryKeys(any(XNode.class)))
+         .thenReturn(pkResult("OrderID", "LineNumber"));
+
+      MetadataApiService.populatePrimaryKeys(provider, List.of(lineItems));
+
+      assertEquals(List.of("OrderID", "LineNumber"), lineItems.getPrimaryKeyColumns());
+   }
+
+   @Test
+   void queriesEachTableWithItsOwnCatalogAndSchema() throws Exception {
+      DatabaseTableInfo orders = table("mydb", "dbo", "Orders");
+      DefaultMetaDataProvider provider = mock(DefaultMetaDataProvider.class);
+      when(provider.getPrimaryKeys(any(XNode.class))).thenReturn(pkResult("OrderID"));
+
+      MetadataApiService.populatePrimaryKeys(provider, List.of(orders));
+
+      org.mockito.ArgumentCaptor<XNode> captor = org.mockito.ArgumentCaptor.forClass(XNode.class);
+      verify(provider).getPrimaryKeys(captor.capture());
+      XNode query = captor.getValue();
+      assertEquals("Orders", query.getName());
+      assertEquals("mydb", query.getAttribute("catalog"));
+      assertEquals("dbo", query.getAttribute("schema"));
+   }
+
+   @Test
+   void tableWithNoDeclaredPrimaryKeyGetsEmptyList() throws Exception {
+      DatabaseTableInfo noKeyTable = table(null, "dbo", "AuditLog");
+      DefaultMetaDataProvider provider = mock(DefaultMetaDataProvider.class);
+      when(provider.getPrimaryKeys(any(XNode.class))).thenReturn(pkResult());
+
+      MetadataApiService.populatePrimaryKeys(provider, List.of(noKeyTable));
+
+      assertTrue(noKeyTable.getPrimaryKeyColumns().isEmpty());
+   }
+
+   @Test
+   void failedPrimaryKeyLookupLeavesEmptyListRatherThanThrowing() throws Exception {
+      DatabaseTableInfo orders = table(null, "dbo", "Orders");
+      DefaultMetaDataProvider provider = mock(DefaultMetaDataProvider.class);
+      when(provider.getPrimaryKeys(any(XNode.class))).thenThrow(new RuntimeException("boom"));
+
+      MetadataApiService.populatePrimaryKeys(provider, List.of(orders));
+
+      assertTrue(orders.getPrimaryKeyColumns().isEmpty());
+   }
+
+   @Test
+   void eachTableInTheListIsQueriedIndependently() throws Exception {
+      DatabaseTableInfo orders = table(null, "dbo", "Orders");
+      DatabaseTableInfo customers = table(null, "dbo", "Customers");
+      DefaultMetaDataProvider provider = mock(DefaultMetaDataProvider.class);
+      when(provider.getPrimaryKeys(any(XNode.class)))
+         .thenReturn(pkResult("OrderID"), pkResult("CustomerID"));
+
+      MetadataApiService.populatePrimaryKeys(provider, List.of(orders, customers));
+
+      assertEquals(List.of("OrderID"), orders.getPrimaryKeyColumns());
+      assertEquals(List.of("CustomerID"), customers.getPrimaryKeyColumns());
+   }
+}


### PR DESCRIPTION
## Summary
- `MetadataApiService.getDatabaseTables()` already returns every table in a datasource plus a live FK relationship graph (`buildRelationships`), computed straight from JDBC catalog metadata. It did not return each table's primary-key columns, even though the sibling infrastructure to fetch that (`DefaultMetaDataProvider.getPrimaryKeys(XNode)`, the `PRIMARYKEY` query type) already existed and was unused for this purpose.
- Adds an additive `primaryKeyColumns: List<String>` field to `DatabaseTableInfo` and a new `populatePrimaryKeys` loop in `MetadataApiService`, mirroring the existing per-table `buildRelationships` FK loop (one extra JDBC catalog round trip per table, server-side, inside the same existing HTTP call).
- Along the way, found and fixed a real bug this change would otherwise have silently inherited: `JDBCHandler.getPrimaryKeys` builds one anonymous (`new XNode()`, default name `"node"`) child per key-column row, so for any table with a composite (2+ column) primary key, `XNode.addChild`'s own duplicate-name merge collapses those rows into a single `XSequenceNode` instead of leaving them as separate top-level children — the same quirk `XUtil.isPrimaryKey` already special-cases (and gives up on, rather than fully unwrapping). Rather than changing the shared `JDBCHandler`/`XNode` behavior (which several other unrelated callers depend on today), the new `populatePrimaryKeys` code unwraps `XSequenceNode` locally so every composite key column is collected correctly.

This is the Java half of a two-repo feature; the wiz-services/composer plugin half (a new `get_datasource_relationships` MCP tool) is a separate PR in `stylebi-wiz` from a parallel effort. Design doc: `stylebi-wiz/docs/superpowers/specs/2026-08-24-physical-model-pk-fk-tool-design.md`.

## Test plan
- [x] New `MetadataApiServicePrimaryKeyColumnsTest` (6 cases): single-column PK, composite PK (exercises the `XSequenceNode` unwrap), per-table catalog/schema query construction, no-declared-PK table, failed lookup doesn't throw, multiple tables queried independently.
- [x] `./mvnw -pl core test -Dtest="MetadataApiService*,JDBCHandlerKeyRelationshipTest"` — 86 tests, 0 failures.
- [ ] No live server / JDBC datasource verification (unit-level only, per the design doc's own §8 caveat).