### PR TITLE
Bind add_table to a REST/JSON endpoint + lookup chain (Java half)

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/model/WorksheetTable.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WorksheetTable.java
@@ -185,6 +185,9 @@ public class WorksheetTable {
       private String expandedPath;
       private Integer maxRows;
       private Integer sampleRows;
+      private List<String> lookup;
+      private Boolean lookupExpandArrays;
+      private Boolean lookupTopLevelOnly;
 
       /** Full repository path of the connector INSTANCE, e.g. "SaaS/Stripe Prod". */
       public String getDatasourcePath() { return datasourcePath; }
@@ -291,6 +294,36 @@ public class WorksheetTable {
        */
       public Integer getSampleRows() { return sampleRows; }
       public void setSampleRows(Integer sampleRows) { this.sampleRows = sampleRows; }
+
+      /**
+       * Ordered "Join With" lookup chain to graft onto the endpoint named by {@link #getTarget()}
+       * (only meaningful for {@code targetKind == "endpoint"}), one pre-built connector lookup
+       * name per nesting level, e.g. {@code ["Issue Event"]}, or
+       * {@code ["Repositories", "Contributors"]} for a two-level chain. Each name must be one of
+       * the CURRENT position's valid choices, which the connector's own endpoint catalogue
+       * declares. Max depth 5.
+       */
+      public List<String> getLookup() { return lookup; }
+      public void setLookup(List<String> lookup) { this.lookup = lookup; }
+
+      /**
+       * Only meaningful with {@link #getLookup()}: whether the LAST lookup's matched array
+       * expands into extra rows. Null keeps the connector's own default ({@code true}).
+       */
+      public Boolean getLookupExpandArrays() { return lookupExpandArrays; }
+      public void setLookupExpandArrays(Boolean lookupExpandArrays) {
+         this.lookupExpandArrays = lookupExpandArrays;
+      }
+
+      /**
+       * Only meaningful with {@link #getLookup()} and {@link #getLookupExpandArrays()}: whether
+       * only the top-level array is expanded. Null keeps the connector's own default
+       * ({@code true}).
+       */
+      public Boolean getLookupTopLevelOnly() { return lookupTopLevelOnly; }
+      public void setLookupTopLevelOnly(Boolean lookupTopLevelOnly) {
+         this.lookupTopLevelOnly = lookupTopLevelOnly;
+      }
    }
 
    // ─── Nested: column info ─────────────────────────────────────────────────

--- a/core/src/main/java/inetsoft/web/wiz/service/TabularEndpointBindingSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/TabularEndpointBindingSupport.java
@@ -1,0 +1,445 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.service;
+
+import inetsoft.uql.tabular.PropertyMeta;
+import inetsoft.uql.tabular.RestParameter;
+import inetsoft.uql.tabular.RestParameters;
+import inetsoft.uql.tabular.TabularQuery;
+import inetsoft.web.wiz.worksheet.WorksheetMutationSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Shared, connector-agnostic machinery for binding a {@link TabularQuery} to a REST/JSON
+ * endpoint (or a hand-authored suffix) and, optionally, a lookup chain -- extracted out of
+ * {@link WorksheetTableService} so {@code WorksheetAgentController}'s {@code add_table} op
+ * (the composer plugin's write path) can build the exact same {@code TabularTableAssembly}
+ * shape {@code WorksheetTableService.buildTabularTable} (the wiz-services {@code /ws/table}
+ * write path) already does, without maintaining two independently-drifting copies of "how to
+ * select an endpoint / lookup on a connector-agnostic query via reflection".
+ *
+ * <p>Every write here is read back before being trusted. Both
+ * {@code EndpointJsonQuery.setLookupEndpoint(String, int)} and {@code RestJsonQuery}'s per-level
+ * lookup setters SILENTLY NO-OP on bad input (an unknown lookup name, or an index past the
+ * 5-level cap) rather than throwing -- exactly the "tool accepted malformed input and produced a
+ * plausible-but-wrong result" failure mode this codebase's plugin testing principle calls out.
+ * Reading every write back, the same idiom {@link WorksheetTableService#applyEndpointContract}
+ * already established for {@code endpoint} itself, is what turns that silent failure into a
+ * loud one.</p>
+ */
+public final class TabularEndpointBindingSupport {
+
+   private TabularEndpointBindingSupport() {}
+
+   /**
+    * Set the endpoint and its parameter values on a NAMED CONNECTOR's tabular query (one whose
+    * query class exposes an {@code endpoint} property), and return the URL suffix that results.
+    *
+    * <p>ORDER IS NOT INTERCHANGEABLE. {@code getParameters()} derives the contract from the
+    * endpoint currently set on the bean, so setting the endpoint has to come first -- reversed,
+    * the contract comes back empty and every supplied value is reported as unknown. Setting the
+    * endpoint also runs the connector's {@code updatePagination}, which is what establishes the
+    * pagination spec, the request method and the content type.</p>
+    *
+    * @return the built URL suffix, with every parameter substituted.
+    */
+   public static String applyEndpointContract(TabularQuery query, Map<String, PropertyMeta> pmap,
+                                               String endpoint, Map<String, String> parameters,
+                                               String jsonPath, Boolean expanded,
+                                               String expandedPath, String dsName)
+      throws Exception
+   {
+      PropertyMeta endpointProp = pmap.get("endpoint");
+
+      if(endpointProp == null) {
+         throw new IllegalArgumentException(
+            "Data source '" + dsName + "' is tabular but not endpoint-based, so it has no " +
+            "endpoint to select. Only connectors that ship an endpoint catalogue can be used " +
+            "this way -- use suffix (+ optional customLookups) instead.");
+      }
+
+      String trimmedEndpoint = endpoint.trim();
+      assertKnownEndpoint(query, trimmedEndpoint, dsName);
+      endpointProp.setValue(query, trimmedEndpoint);
+
+      // Read back, because setValue swallows a failed invocation. Everything below derives from
+      // the endpoint being set, so an unnoticed failure here produces an empty contract and a
+      // null suffix, both of which are much harder to attribute than this line.
+      if(!trimmedEndpoint.equals(endpointProp.getValue(query))) {
+         throw new IllegalStateException(
+            "Failed to select endpoint '" + trimmedEndpoint + "' on the query for '" + dsName +
+            "'; see the server log for the reflection failure.");
+      }
+
+      // Read AFTER the endpoint is set, because that is when the connector's updatePagination has
+      // decided it. A POST endpoint is refused rather than attempted: the body it needs is carried
+      // on a private field of the connector's query and is only moved into the request body by a
+      // dialog BUTTON method this property-based path never runs.
+      PropertyMeta requestTypeProp = pmap.get("requestType");
+
+      if(requestTypeProp != null && "POST".equals(requestTypeProp.getValue(query))) {
+         throw new IllegalArgumentException(
+            "Endpoint '" + trimmedEndpoint + "' of '" + dsName + "' is a POST endpoint, which " +
+            "cannot be created this way yet: its request body comes from a template that only " +
+            "the connector's own dialog populates. Choose a GET endpoint.");
+      }
+
+      PropertyMeta paramProp = pmap.get("parameters");
+      Object contract = paramProp == null ? null : paramProp.getValue(query);
+
+      if(!(contract instanceof RestParameters params)) {
+         throw new IllegalStateException(
+            "Could not read the parameter contract for endpoint '" + trimmedEndpoint + "' of '" +
+            dsName + "'.");
+      }
+
+      Map<String, String> supplied = parameters == null
+         ? new LinkedHashMap<>() : new LinkedHashMap<>(parameters);
+      List<String> missing = new ArrayList<>();
+
+      for(RestParameter parameter : params.getParameters()) {
+         String value = supplied.remove(parameter.getName());
+
+         if(value != null && !value.isBlank()) {
+            parameter.setValue(value.trim());
+         }
+         else if(parameter.isRequired()) {
+            missing.add(parameter.getName());
+         }
+      }
+
+      // Every missing required name at once, rather than one round trip per name -- every round
+      // trip past this point is a metered request.
+      if(!missing.isEmpty()) {
+         throw new IllegalArgumentException(
+            "Endpoint '" + trimmedEndpoint + "' requires parameter(s) with no value supplied: " +
+            String.join(", ", missing) + ". Supply them; do not guess an identifier.");
+      }
+
+      // A name the endpoint does not declare is an error, not something to drop. Dropping it runs
+      // a DIFFERENT query than the one that was asked for and reports success -- and the likeliest
+      // cause is a caller using another endpoint's contract, which no later step can detect.
+      if(!supplied.isEmpty()) {
+         throw new IllegalArgumentException(
+            "Endpoint '" + trimmedEndpoint + "' has no parameter(s) named: " +
+            String.join(", ", supplied.keySet()) + ". Its parameters are: " +
+            params.getParameters().stream()
+               .map(p -> p.getName() + (p.isRequired() ? " (required)" : ""))
+               .collect(Collectors.joining(", ")) + ".");
+      }
+
+      paramProp.setValue(query, params);
+      setOptionalProperty(pmap, query, "jsonPath", jsonPath);
+      setOptionalProperty(pmap, query, "expanded", expanded);
+      setOptionalProperty(pmap, query, "expandedPath", expandedPath);
+
+      // The one end-to-end check, and the reason it is worth a line of its own: reading "suffix"
+      // back invokes the connector's getSuffix(), which rebuilds the URL from the endpoint
+      // template and the values just set. A null means one of the silent paths above fired after
+      // all -- the endpoint name resolved to no template, or a parameter never made it onto the
+      // bean.
+      PropertyMeta suffixProp = pmap.get("suffix");
+      Object suffix = suffixProp == null ? null : suffixProp.getValue(query);
+
+      if(!(suffix instanceof String s) || s.isBlank()) {
+         throw new IllegalStateException(
+            "Endpoint '" + trimmedEndpoint + "' of '" + dsName + "' produced no URL suffix " +
+            "after its parameters were set; see the server log.");
+      }
+
+      return s;
+   }
+
+   /**
+    * Set a directly-authored URL suffix + jsonPath on a GENERIC/CUSTOM REST-JSON query (no
+    * endpoint catalogue to select from). Read back for the same reason
+    * {@link #applyEndpointContract} reads back {@code endpoint}: a caller who mistakenly calls
+    * this on a named connector's query (whose {@code suffix} setter is a no-op derived from its
+    * {@code endpoint}) would otherwise see silent success while the table stayed bound to
+    * whatever {@code endpoint} happened to default to, rather than the suffix that was asked for.
+    */
+   public static String applyCustomSuffix(TabularQuery query, Map<String, PropertyMeta> pmap,
+                                          String suffix, String jsonPath, String dsName)
+   {
+      PropertyMeta suffixProp = pmap.get("suffix");
+
+      if(suffixProp == null) {
+         throw new IllegalStateException(
+            "'" + dsName + "' has no suffix property; see the server log.");
+      }
+
+      String trimmedSuffix = suffix.trim();
+      suffixProp.setValue(query, trimmedSuffix);
+
+      if(!trimmedSuffix.equals(suffixProp.getValue(query))) {
+         throw new IllegalStateException(
+            "Failed to set suffix '" + trimmedSuffix + "' on the query for '" + dsName + "' -- " +
+            "if this datasource is a named connector (has a predefined endpoint catalogue), use " +
+            "endpoint instead of suffix, since a named connector's suffix is derived from its " +
+            "endpoint and cannot be set directly.");
+      }
+
+      setOptionalProperty(pmap, query, "jsonPath", jsonPath);
+      return trimmedSuffix;
+   }
+
+   /**
+    * Set an ordered "Join With" lookup chain on a NAMED CONNECTOR's endpoint query, reading back
+    * every write because {@code EndpointJsonQuery.setLookupEndpoint} SILENTLY NO-OPS on an
+    * unknown name rather than throwing. Must run AFTER the base endpoint is set and verified:
+    * index 0's valid choices are read off THAT endpoint.
+    */
+   public static void applyLookupChain(TabularQuery query, Map<String, PropertyMeta> pmap,
+                                       List<String> lookup, Boolean expandArrays,
+                                       Boolean topLevelOnly, String baseEndpoint, String dsName)
+   {
+      if(lookup.size() > 5 /* EndpointJsonQuery.LOOKUP_QUERY_LIMIT -- core cannot import the
+                              connector-module constant, so this is a literal with a comment, same
+                              as this file already does for other connector-side facts */) {
+         throw new IllegalArgumentException(
+            "lookup has " + lookup.size() + " entries; a chain can be at most 5 levels deep.");
+      }
+
+      for(int i = 0; i < lookup.size(); i++) {
+         String name = lookup.get(i) == null ? null : lookup.get(i).trim();
+
+         if(name == null || name.isBlank()) {
+            throw new IllegalArgumentException("lookup[" + i + "] is blank.");
+         }
+
+         String[][] candidates = getLookupEndpointsAt(query, i);
+         boolean known = candidates != null &&
+            Arrays.stream(candidates).anyMatch(c -> c != null && c.length > 1 && name.equals(c[1]));
+
+         if(!known) {
+            String parent = i == 0 ? baseEndpoint : lookup.get(i - 1);
+            String available = candidates == null ? "(none)" :
+               Arrays.stream(candidates)
+                  .filter(c -> c != null && c.length > 1)
+                  .map(c -> c[1])
+                  .collect(Collectors.joining(", "));
+            throw new IllegalArgumentException(
+               "'" + parent + "' has no lookup named '" + name + "' (lookup[" + i + "] of '" +
+               dsName + "'). Available: " + available + ".");
+         }
+
+         PropertyMeta lookupProp = pmap.get("lookupEndpoint" + i);
+
+         if(lookupProp == null) {
+            throw new IllegalStateException(
+               "Connector for '" + dsName + "' does not expose a lookupEndpoint" + i +
+               " property; see the server log.");
+         }
+
+         lookupProp.setValue(query, name);
+
+         if(!name.equals(lookupProp.getValue(query))) {
+            throw new IllegalStateException(
+               "Failed to select lookup '" + name + "' at chain position " + i + " for '" +
+               dsName + "'; see the server log for the reflection failure.");
+         }
+      }
+
+      setOptionalProperty(pmap, query, "lookupExpanded", expandArrays);
+      setOptionalProperty(pmap, query, "lookupTopLevelOnly", topLevelOnly);
+   }
+
+   /**
+    * Set up to 5 hand-authored custom lookup levels on a GENERIC/CUSTOM REST-JSON query. Each
+    * level's four properties ({@code lookupUrl}/{@code lookupJsonPath}/{@code lookupKey}/
+    * {@code lookupIgnoreBaseUrl}{i}) silently no-op past index 4 -- read back every write for the
+    * same reason {@link #applyLookupChain} does for the named-connector case.
+    *
+    * <p>Within one level, {@code lookupUrl}{i} MUST be set before the other three: it is what
+    * grows the connector's backing lists to include index {@code i} at all (see
+    * {@code RestJsonQuery.setLookupURL}); the other three setters only take effect once that
+    * growth has already happened.</p>
+    *
+    * <p>Each level's {@code url} must contain the literal placeholder {@code {param<i+1>}}
+    * (1-indexed by position) -- {@code RestJsonQuery} auto-names each level's substitution
+    * parameter {@code "param" + (i + 1)} and substitutes into {@code url} by ordinary
+    * {@code {name}} template replacement, with NO validation of its own that the placeholder is
+    * actually present. An omitted placeholder is not caught by any read-back (the property is set
+    * to exactly what the caller wrote), so it is checked here instead, before anything is written,
+    * rather than silently accepting a URL guaranteed to request the same page for every row.</p>
+    */
+   public static void applyCustomLookupChain(TabularQuery query, Map<String, PropertyMeta> pmap,
+                                             List<WorksheetMutationSupport.CustomLookupSpec> customLookups,
+                                             String dsName)
+   {
+      if(customLookups.size() > 5) {
+         throw new IllegalArgumentException(
+            "customLookups has " + customLookups.size() +
+            " entries; a chain can be at most 5 levels deep.");
+      }
+
+      for(int i = 0; i < customLookups.size(); i++) {
+         WorksheetMutationSupport.CustomLookupSpec level = customLookups.get(i);
+
+         if(level.url() == null || level.url().isBlank()) {
+            throw new IllegalArgumentException("customLookups[" + i + "].url is required.");
+         }
+
+         String placeholder = "{param" + (i + 1) + "}";
+
+         if(!level.url().contains(placeholder)) {
+            throw new IllegalArgumentException(
+               "customLookups[" + i + "].url must contain the literal placeholder \"" +
+               placeholder + "\" so the id extracted via this level's jsonPath/key is " +
+               "substituted into the request -- got: \"" + level.url() + "\".");
+         }
+
+         setRequiredProperty(pmap, query, "lookupUrl" + i, level.url(), dsName, i);
+         setOptionalProperty(pmap, query, "lookupJsonPath" + i, level.jsonPath());
+         setOptionalProperty(pmap, query, "lookupKey" + i, level.key());
+         setOptionalProperty(pmap, query, "lookupIgnoreBaseUrl" + i,
+            level.ignoreBaseUrl() == null ? Boolean.FALSE : level.ignoreBaseUrl());
+      }
+   }
+
+   /**
+    * Reflection: {@code EndpointQuery#getLookupEndpoints(int)} is generic and not
+    * {@code @Property}-annotated, so it is unreachable through {@code pmap} -- the class
+    * declaring it lives in the connector plugin and is not visible from core, same reasoning as
+    * {@link #assertKnownEndpoint}'s {@code getEndpoints()}.
+    */
+   private static String[][] getLookupEndpointsAt(TabularQuery query, int index) {
+      try {
+         return (String[][]) query.getClass()
+            .getMethod("getLookupEndpoints", int.class).invoke(query, index);
+      }
+      catch(Exception ex) {
+         LOG.debug("Could not list lookup endpoints at depth {} for {}", index,
+                   query.getClass(), ex);
+         return null;
+      }
+   }
+
+   /**
+    * Refuse an unbounded row limit on an endpoint that paginates. {@code isPaged()} is public but
+    * not a {@code @Property}, so it is reached by name -- the same reflection
+    * {@link #assertKnownEndpoint} uses for {@code getEndpoints}. A connector that does not answer
+    * it is left alone rather than blocked: this check exists to stop a known-unbounded query, not
+    * to reject an unfamiliar one.
+    */
+   public static void requireRowCapWhenPaged(TabularQuery query, String endpoint, String dsName) {
+      boolean paged;
+
+      try {
+         paged = (Boolean) query.getClass().getMethod("isPaged").invoke(query);
+      }
+      catch(Exception ex) {
+         LOG.debug("Could not determine whether endpoint '{}' of '{}' paginates; not requiring " +
+                   "a row cap", endpoint, dsName, ex);
+         return;
+      }
+
+      if(paged) {
+         throw new IllegalArgumentException(
+            "Endpoint '" + endpoint + "' of '" + dsName + "' is paginated, so a row cap is " +
+            "required: without it every render of this table requests pages until the service " +
+            "runs out of data. Choose a row cap for the question being asked.");
+      }
+   }
+
+   /** Set a property only when a value was supplied, leaving the connector's default otherwise. */
+   public static void setOptionalProperty(Map<String, PropertyMeta> pmap, TabularQuery query,
+                                          String name, Object value)
+   {
+      PropertyMeta prop = value == null ? null : pmap.get(name);
+
+      if(prop != null) {
+         prop.setValue(query, value);
+      }
+   }
+
+   /**
+    * Like {@link #setOptionalProperty}, but for a value that must actually take -- read back and
+    * throw on the silent-no-op-past-depth-5 failure mode instead of leaving a half-built lookup
+    * chain.
+    */
+   private static void setRequiredProperty(Map<String, PropertyMeta> pmap, TabularQuery query,
+                                           String name, Object value, String dsName, int level)
+   {
+      PropertyMeta prop = pmap.get(name);
+
+      if(prop == null) {
+         throw new IllegalStateException(
+            "'" + dsName + "' has no " + name + " property; see the server log.");
+      }
+
+      prop.setValue(query, value);
+
+      if(!value.equals(prop.getValue(query))) {
+         throw new IllegalStateException(
+            "Failed to set customLookups[" + level + "] on '" + dsName + "'; see the server log " +
+            "for the reflection failure.");
+      }
+   }
+
+   /**
+    * Fail on an unknown endpoint name, listing what the connector does offer. Without this the
+    * name simply resolves to no suffix template and the failure surfaces as "produced no URL
+    * suffix", which does not say that the name was wrong. The tags method is reached by name
+    * because the interface declaring it lives in the connector plugin and is not visible from
+    * core; each row it returns is {@code {label, name}}.
+    */
+   public static void assertKnownEndpoint(TabularQuery query, String endpoint, String dsName) {
+      String[][] endpoints;
+
+      try {
+         endpoints = (String[][]) query.getClass().getMethod("getEndpoints").invoke(query);
+      }
+      catch(Exception ex) {
+         // Not fatal: a connector without this method still works, and applyEndpointContract's
+         // suffix check catches a bad name -- just with a vaguer message.
+         LOG.debug("Could not list endpoints for '{}'; skipping the name check", dsName, ex);
+         return;
+      }
+
+      if(endpoints == null) {
+         return;
+      }
+
+      List<String> names = new ArrayList<>();
+
+      for(String[] tag : endpoints) {
+         if(tag != null && tag.length > 1 && tag[1] != null) {
+            names.add(tag[1]);
+         }
+      }
+
+      if(!names.isEmpty() && !names.contains(endpoint)) {
+         List<String> sample = names.stream().sorted().limit(20).toList();
+         throw new IllegalArgumentException(
+            "Data source '" + dsName + "' has no endpoint named '" + endpoint + "'. It has " +
+            names.size() + " endpoint(s), for example: " + String.join(", ", sample) + ".");
+      }
+   }
+
+   private static final Logger LOG = LoggerFactory.getLogger(TabularEndpointBindingSupport.class);
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WorksheetTableService.java
@@ -43,8 +43,6 @@ import inetsoft.uql.schema.UserVariable;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.schema.XTypeNode;
 import inetsoft.uql.tabular.PropertyMeta;
-import inetsoft.uql.tabular.RestParameter;
-import inetsoft.uql.tabular.RestParameters;
 import inetsoft.uql.tabular.TabularDataSource;
 import inetsoft.uql.tabular.TabularQuery;
 import inetsoft.uql.tabular.TabularUtil;
@@ -1525,7 +1523,7 @@ public class WorksheetTableService {
       // per-call bill — so demanding a row cap there would refuse a correct request for a cost that
       // does not exist.
       else if(TARGET_KIND_ENDPOINT.equals(targetKind)) {
-         requireRowCapWhenPaged(query, src.getTarget(), dsName);
+         TabularEndpointBindingSupport.requireRowCapWhenPaged(query, src.getTarget(), dsName);
       }
 
       // How many rows to report back, carried ON THE QUERY because the runner is the only place that
@@ -1581,21 +1579,14 @@ public class WorksheetTableService {
 
    /**
     * Set the endpoint and its parameter values on a tabular query, and return the URL suffix that
-    * results.
+    * results. Also applies {@code src}'s lookup chain, if any, once the base endpoint is set.
     *
-    * <p>ORDER IS NOT INTERCHANGEABLE. {@code getParameters()} derives the contract from the endpoint
-    * currently set on the bean ({@code EndpointQueryDelegate.createParameters} scans that endpoint's
-    * suffix template with {@code RestParameter.fromToken}), so setting the endpoint has to come
-    * first — reversed, the contract comes back empty and every supplied value is reported as
-    * unknown. Setting the endpoint also does more than record a name: the connector's
-    * {@code updatePagination} runs from inside the setter and is what establishes the pagination
-    * spec, the request method and the content type.</p>
-    *
-    * <p>NOTHING HERE TRUSTS THAT A WRITE HAPPENED. {@code PropertyMeta.setValue} reports a failed
-    * invocation with {@code LOG.error} and returns, and {@code createParameters} skips a token its
-    * parser rejects with a {@code LOG.warn}. Both are silent to the caller, and the observable
-    * result of either is a request that goes out narrower than the one that was asked for. So every
-    * write is checked, by read-back where possible and by the suffix at the end.</p>
+    * <p>Delegates the connector-agnostic reflection machinery to
+    * {@link TabularEndpointBindingSupport#applyEndpointContract}, which
+    * {@code WorksheetAgentController.addTabularTable} (the composer plugin's write path) shares —
+    * this method's own job is just translating {@code src} into that shared contract's plain
+    * parameters, plus the one check ({@code params} is the FILE contract's option bag, not this
+    * one) that has no equivalent on the plugin path, which has no file target at all.</p>
     *
     * @return the built URL suffix, with every parameter substituted.
     */
@@ -1604,15 +1595,6 @@ public class WorksheetTableService {
                                         WorksheetTable.TabularSource src)
       throws Exception
    {
-      PropertyMeta endpointProp = pmap.get("endpoint");
-
-      if(endpointProp == null) {
-         throw new IllegalArgumentException(
-            "Data source '" + src.getDatasourcePath() + "' (type '" + query.getType() +
-            "') is tabular but not endpoint-based, so it has no endpoint to select. Only connectors " +
-            "that ship an endpoint catalogue can be used as a tabular table this way.");
-      }
-
       // Refused rather than ignored, same rule as an unknown parameter name below: params is the
       // file contract's option bag, nothing on this path reads it, and dropping it would parse the
       // caller's request differently from how they wrote it and report success.
@@ -1623,98 +1605,17 @@ public class WorksheetTableService {
       }
 
       String endpoint = src.getTarget().trim();
-      assertKnownEndpoint(query, endpoint, src.getDatasourcePath());
-      endpointProp.setValue(query, endpoint);
+      String suffix = TabularEndpointBindingSupport.applyEndpointContract(
+         query, pmap, endpoint, src.getParameters(), src.getJsonPath(), src.getExpanded(),
+         src.getExpandedPath(), src.getDatasourcePath());
 
-      // Read back, because setValue swallows a failed invocation. Everything below derives from the
-      // endpoint being set, so an unnoticed failure here produces an empty contract and a null
-      // suffix, both of which are much harder to attribute than this line.
-      if(!endpoint.equals(endpointProp.getValue(query))) {
-         throw new IllegalStateException(
-            "Failed to select endpoint '" + endpoint + "' on the query for '" +
-            src.getDatasourcePath() + "'; see the server log for the reflection failure.");
+      if(src.getLookup() != null && !src.getLookup().isEmpty()) {
+         TabularEndpointBindingSupport.applyLookupChain(query, pmap, src.getLookup(),
+            src.getLookupExpandArrays(), src.getLookupTopLevelOnly(), endpoint,
+            src.getDatasourcePath());
       }
 
-      // Read AFTER the endpoint is set, because that is when the connector's updatePagination has
-      // decided it. A POST endpoint is refused rather than attempted: the body it needs is carried
-      // on a private field of the connector's query and is only moved into the request body by
-      // populateRequestBodyTemplate, a dialog BUTTON method this property-based path never runs.
-      // Attempting one sends an empty body, which most APIs answer with a 400 and some with an
-      // unfiltered full result.
-      PropertyMeta requestTypeProp = pmap.get("requestType");
-
-      if(requestTypeProp != null && "POST".equals(requestTypeProp.getValue(query))) {
-         throw new IllegalArgumentException(
-            "Endpoint '" + endpoint + "' of '" + src.getDatasourcePath() + "' is a POST endpoint, " +
-            "which cannot be created this way yet: its request body comes from a template that only " +
-            "the connector's own dialog populates. Choose a GET endpoint.");
-      }
-
-      PropertyMeta paramProp = pmap.get("parameters");
-      Object contract = paramProp == null ? null : paramProp.getValue(query);
-
-      if(!(contract instanceof RestParameters params)) {
-         throw new IllegalStateException(
-            "Could not read the parameter contract for endpoint '" + endpoint + "' of '" +
-            src.getDatasourcePath() + "'.");
-      }
-
-      Map<String, String> supplied = src.getParameters() == null
-         ? new LinkedHashMap<>() : new LinkedHashMap<>(src.getParameters());
-      List<String> missing = new ArrayList<>();
-
-      for(RestParameter parameter : params.getParameters()) {
-         String value = supplied.remove(parameter.getName());
-
-         if(value != null && !value.isBlank()) {
-            parameter.setValue(value.trim());
-         }
-         else if(parameter.isRequired()) {
-            missing.add(parameter.getName());
-         }
-      }
-
-      // Every missing required name at once. SuffixTemplate.build() does raise a clear
-      // IllegalStateException for a missing required parameter, but only for the FIRST one it walks
-      // into, so a caller filling three of five would need three round trips to learn all of them —
-      // and every round trip past this point is a metered request.
-      if(!missing.isEmpty()) {
-         throw new IllegalArgumentException(
-            "Endpoint '" + endpoint + "' requires parameter(s) with no value supplied: " +
-            String.join(", ", missing) + ". Supply them; do not guess an identifier.");
-      }
-
-      // A name the endpoint does not declare is an error, not something to drop. Dropping it runs a
-      // DIFFERENT query than the one that was asked for and reports success — and the likeliest
-      // cause is a caller using another endpoint's contract, which no later step can detect.
-      if(!supplied.isEmpty()) {
-         throw new IllegalArgumentException(
-            "Endpoint '" + endpoint + "' has no parameter(s) named: " +
-            String.join(", ", supplied.keySet()) + ". Its parameters are: " +
-            params.getParameters().stream()
-               .map(p -> p.getName() + (p.isRequired() ? " (required)" : ""))
-               .collect(Collectors.joining(", ")) + ".");
-      }
-
-      paramProp.setValue(query, params);
-      setOptionalProperty(pmap, query, "jsonPath", src.getJsonPath());
-      setOptionalProperty(pmap, query, "expanded", src.getExpanded());
-      setOptionalProperty(pmap, query, "expandedPath", src.getExpandedPath());
-
-      // The one end-to-end check, and the reason it is worth a line of its own: reading "suffix"
-      // back invokes the connector's getSuffix(), which rebuilds the URL from the endpoint template
-      // and the values just set. A null means one of the silent paths above fired after all — the
-      // endpoint name resolved to no template, or a parameter never made it onto the bean.
-      PropertyMeta suffixProp = pmap.get("suffix");
-      Object suffix = suffixProp == null ? null : suffixProp.getValue(query);
-
-      if(!(suffix instanceof String s) || s.isBlank()) {
-         throw new IllegalStateException(
-            "Endpoint '" + endpoint + "' of '" + src.getDatasourcePath() + "' produced no URL " +
-            "suffix after its parameters were set; see the server log.");
-      }
-
-      return s;
+      return suffix;
    }
 
    /**
@@ -2213,96 +2114,6 @@ public class WorksheetTableService {
             "Setting '" + prop.getName() + "' to \"" + value + "\" failed: " +
             (cause.getMessage() == null ? cause.getClass().getSimpleName() : cause.getMessage()),
             cause);
-      }
-   }
-
-   /**
-    * Refuse an unbounded row limit on an endpoint that paginates.
-    *
-    * <p>{@code XQuery.rowlimit} defaults to 0, meaning unlimited, and on a paginated connector that
-    * is not "read a lot" — it is "keep requesting pages until the service runs out", on every render
-    * of the table, against an API that bills per call. Neither obvious remedy is right: requiring a
-    * cap unconditionally makes a caller invent a number for an endpoint like {@code /v1/balance} that
-    * issues one request and returns one object, and defaulting silently trades a slow answer for a
-    * wrong one — a table that quietly returns 100 of 5000 rows answers "how many are there"
-    * incorrectly, with nothing in the response saying so.</p>
-    *
-    * <p>So the condition checked is the one that actually matters, and it is accurate by now:
-    * {@code setEndpoint} ran the connector's {@code updatePagination}, which is what establishes the
-    * pagination spec. {@code isPaged()} is public but not a {@code @Property}, so it is reached by
-    * name — the same reflection {@link #assertKnownEndpoint} uses for {@code getEndpoints}. A
-    * connector that does not answer it is left alone rather than blocked: this check exists to stop a
-    * known-unbounded query, not to reject an unfamiliar one.</p>
-    */
-   private void requireRowCapWhenPaged(TabularQuery query, String endpoint, String dsName) {
-      boolean paged;
-
-      try {
-         paged = (Boolean) query.getClass().getMethod("isPaged").invoke(query);
-      }
-      catch(Exception ex) {
-         LOG.debug("Could not determine whether endpoint '{}' of '{}' paginates; not requiring a " +
-                   "row cap", endpoint, dsName, ex);
-         return;
-      }
-
-      if(paged) {
-         throw new IllegalArgumentException(
-            "Endpoint '" + endpoint + "' of '" + dsName + "' is paginated, so tabularSource.maxRows " +
-            "is required: without it every render of this table requests pages until the service runs " +
-            "out of data. Choose a row cap for the question being asked.");
-      }
-   }
-
-   /** Set a property only when a value was supplied, leaving the connector's default otherwise. */
-   private void setOptionalProperty(Map<String, PropertyMeta> pmap, TabularQuery query,
-                                    String name, Object value)
-   {
-      PropertyMeta prop = value == null ? null : pmap.get(name);
-
-      if(prop != null) {
-         prop.setValue(query, value);
-      }
-   }
-
-   /**
-    * Fail on an unknown endpoint name, listing what the connector does offer.
-    *
-    * <p>Without this the name simply resolves to no suffix template and the failure surfaces as
-    * "produced no URL suffix", which does not say that the name was wrong. The tags method is
-    * reached by name because the interface declaring it lives in the connector plugin and is not
-    * visible from core; each row it returns is {@code {label, name}}.</p>
-    */
-   private void assertKnownEndpoint(TabularQuery query, String endpoint, String dsName) {
-      String[][] endpoints;
-
-      try {
-         endpoints = (String[][]) query.getClass().getMethod("getEndpoints").invoke(query);
-      }
-      catch(Exception ex) {
-         // Not fatal: a connector without this method still works, and applyEndpointContract's
-         // suffix check catches a bad name — just with a vaguer message.
-         LOG.debug("Could not list endpoints for '{}'; skipping the name check", dsName, ex);
-         return;
-      }
-
-      if(endpoints == null) {
-         return;
-      }
-
-      List<String> names = new ArrayList<>();
-
-      for(String[] tag : endpoints) {
-         if(tag != null && tag.length > 1 && tag[1] != null) {
-            names.add(tag[1]);
-         }
-      }
-
-      if(!names.isEmpty() && !names.contains(endpoint)) {
-         List<String> sample = names.stream().sorted().limit(20).toList();
-         throw new IllegalArgumentException(
-            "Data source '" + dsName + "' has no endpoint named '" + endpoint + "'. It has " +
-            names.size() + " endpoint(s), for example: " + String.join(", ", sample) + ".");
       }
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
@@ -43,7 +43,7 @@ import java.util.Map;
  *   <li>{@code set_sort} — {@code table}, {@code field}, {@code direction} ("ASC" | "DESC")</li>
  *   <li>{@code add_join} — {@code name}, {@code leftTable}, {@code leftKey}, {@code rightTable}, {@code rightKey}, {@code joinType}; for multi-key joins use {@code leftKeys}/{@code rightKeys} instead of single key fields</li>
  *   <li>{@code remove_join} — {@code name}</li>
- *   <li>{@code add_table} — {@code table}, optional {@code datasource} (when provided, creates a bound table from the named datasource); optional {@code logicalModel} (when provided alongside datasource, {@code table} is an entity name within that logical model); optional {@code endpoint} (+ optional {@code lookup}/{@code lookupExpandArrays}/{@code lookupTopLevelOnly}) to bind a named REST/JSON connector's pre-built endpoint (and, optionally, one of its pre-built "Join With" lookup chains) instead of a physical table or logical model entity — {@code table} then names the NEW worksheet table rather than a physical path; optional {@code suffix} (+ optional {@code customLookups}) to bind a GENERIC/CUSTOM REST-JSON datasource's hand-authored URL suffix (and, optionally, up to 5 hand-authored custom lookup levels) instead — mutually exclusive with {@code endpoint}/{@code lookup}</li>
+ *   <li>{@code add_table} — {@code table}, optional {@code datasource} (when provided, creates a bound table from the named datasource); optional {@code logicalModel} (when provided alongside datasource, {@code table} is an entity name within that logical model); optional {@code endpoint} (+ optional {@code parameters}/{@code lookup}/{@code lookupExpandArrays}/{@code lookupTopLevelOnly}) to bind a named REST/JSON connector's pre-built endpoint (and, optionally, one of its pre-built "Join With" lookup chains) instead of a physical table or logical model entity — {@code table} then names the NEW worksheet table rather than a physical path; optional {@code suffix} (+ optional {@code customLookups}) to bind a GENERIC/CUSTOM REST-JSON datasource's hand-authored URL suffix (and, optionally, up to 5 hand-authored custom lookup levels) instead — mutually exclusive with {@code endpoint}/{@code parameters}/{@code lookup}</li>
  *   <li>{@code edit_condition} — {@code table}, {@code field}, {@code operation}, {@code values}</li>
  *   <li>{@code edit_expression} — {@code table}, {@code name}, {@code expression}, {@code type}, {@code sql}</li>
  *   <li>{@code edit_join} — {@code name}, {@code leftKey}, {@code rightKey}, {@code joinType}; for multi-key joins use {@code leftKeys}/{@code rightKeys}</li>
@@ -240,6 +240,15 @@ public record EditRequest(
     */
    String endpoint,
    /**
+    * Parameter values for {@code endpoint}, keyed by the endpoint's own parameter name (e.g.
+    * {@code {"owner": "inetsoft-technology", "repo": "stylebi"}} for GitHub's
+    * {@code Repository Issue Events}). Only meaningful with {@code endpoint} set; a name the
+    * endpoint does not declare is rejected rather than dropped, and a required parameter with no
+    * supplied value is rejected rather than guessed. Not yet supported on the generic/custom
+    * {@code suffix} path -- see {@code suffix}'s own doc comment.
+    */
+   Map<String, String> parameters,
+   /**
     * Ordered "Join With" lookup chain to graft onto {@code endpoint}, one pre-built connector
     * lookup name per nesting level (e.g. {@code ["Issue Event"]}, or
     * {@code ["Repositories", "Contributors"]} for a two-level chain). Each name must be one of
@@ -261,9 +270,10 @@ public record EditRequest(
    /**
     * URL suffix template for add_table on a GENERIC/CUSTOM REST-JSON datasource (one with no
     * predefined endpoint catalogue — see {@code list_endpoint_lookups}' {@code hasEndpointCatalog}
-    * flag). Mutually exclusive with {@code endpoint}; use exactly one of the two. Supports
-    * {@code {name}} placeholders filled from a future {@code parameters} field the same way a
-    * named connector's endpoint suffix does (not yet supported on this generic path).
+    * flag). Mutually exclusive with {@code endpoint}; use exactly one of the two. Unlike
+    * {@code endpoint}, this path has no declared parameter contract to validate against, so
+    * {@code parameters} does not apply here -- any {@code {name}} placeholder must already be
+    * filled in {@code suffix} itself.
     */
    String suffix,
    /**

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
@@ -43,7 +43,7 @@ import java.util.Map;
  *   <li>{@code set_sort} — {@code table}, {@code field}, {@code direction} ("ASC" | "DESC")</li>
  *   <li>{@code add_join} — {@code name}, {@code leftTable}, {@code leftKey}, {@code rightTable}, {@code rightKey}, {@code joinType}; for multi-key joins use {@code leftKeys}/{@code rightKeys} instead of single key fields</li>
  *   <li>{@code remove_join} — {@code name}</li>
- *   <li>{@code add_table} — {@code table}, optional {@code datasource} (when provided, creates a bound table from the named datasource); optional {@code logicalModel} (when provided alongside datasource, {@code table} is an entity name within that logical model)</li>
+ *   <li>{@code add_table} — {@code table}, optional {@code datasource} (when provided, creates a bound table from the named datasource); optional {@code logicalModel} (when provided alongside datasource, {@code table} is an entity name within that logical model); optional {@code endpoint} (+ optional {@code lookup}/{@code lookupExpandArrays}/{@code lookupTopLevelOnly}) to bind a named REST/JSON connector's pre-built endpoint (and, optionally, one of its pre-built "Join With" lookup chains) instead of a physical table or logical model entity — {@code table} then names the NEW worksheet table rather than a physical path; optional {@code suffix} (+ optional {@code customLookups}) to bind a GENERIC/CUSTOM REST-JSON datasource's hand-authored URL suffix (and, optionally, up to 5 hand-authored custom lookup levels) instead — mutually exclusive with {@code endpoint}/{@code lookup}</li>
  *   <li>{@code edit_condition} — {@code table}, {@code field}, {@code operation}, {@code values}</li>
  *   <li>{@code edit_expression} — {@code table}, {@code name}, {@code expression}, {@code type}, {@code sql}</li>
  *   <li>{@code edit_join} — {@code name}, {@code leftKey}, {@code rightKey}, {@code joinType}; for multi-key joins use {@code leftKeys}/{@code rightKeys}</li>
@@ -229,5 +229,53 @@ public record EditRequest(
     * Attribute/column name within {@code sourceTable} for add_named_group's datasource-scoped
     * mode (see {@code sourceTable}).
     */
-   String attribute
+   String attribute,
+   /**
+    * Endpoint name for add_table when binding a NAMED REST/JSON connector's pre-built endpoint
+    * catalogue (see {@code list_endpoint_lookups}) — a pre-built endpoint from that connector's
+    * own catalogue. When provided, {@code datasource} must name a tabular/REST datasource with
+    * an endpoint catalogue, {@code table} is used as the NEW worksheet table's name (not a
+    * physical table path — an endpoint has no physical path), and {@code schema}/{@code catalog}/
+    * {@code logicalModel}/{@code suffix} must be absent.
+    */
+   String endpoint,
+   /**
+    * Ordered "Join With" lookup chain to graft onto {@code endpoint}, one pre-built connector
+    * lookup name per nesting level (e.g. {@code ["Issue Event"]}, or
+    * {@code ["Repositories", "Contributors"]} for a two-level chain). Each name must be one of
+    * the CURRENT position's valid choices — {@code list_endpoint_lookups} reports them. Max
+    * depth 5. Only for add_table with {@code endpoint} set; authoring a brand-new lookup a
+    * connector does not already ship uses {@code customLookups} instead.
+    */
+   List<String> lookup,
+   /**
+    * Only meaningful with {@code lookup}: whether the LAST lookup's matched array expands into
+    * extra rows. Omit to keep the connector's own default ({@code true}).
+    */
+   Boolean lookupExpandArrays,
+   /**
+    * Only meaningful with {@code lookup} and {@code lookupExpandArrays}: whether only the
+    * top-level array is expanded. Omit to keep the connector's own default ({@code true}).
+    */
+   Boolean lookupTopLevelOnly,
+   /**
+    * URL suffix template for add_table on a GENERIC/CUSTOM REST-JSON datasource (one with no
+    * predefined endpoint catalogue — see {@code list_endpoint_lookups}' {@code hasEndpointCatalog}
+    * flag). Mutually exclusive with {@code endpoint}; use exactly one of the two. Supports
+    * {@code {name}} placeholders filled from a future {@code parameters} field the same way a
+    * named connector's endpoint suffix does (not yet supported on this generic path).
+    */
+   String suffix,
+   /**
+    * Ordered custom "Join With" lookup chain for a GENERIC/CUSTOM REST-JSON datasource's
+    * {@code suffix}-defined endpoint. Unlike {@code lookup} (named-connector chains, by name),
+    * each entry here hand-authors one level: {@code url} (must contain the literal placeholder
+    * {@code {param1}} for level 0, {@code {param2}} for level 1, etc. — 1-indexed by position —
+    * to receive the id extracted from the parent row), {@code jsonPath} (selects the parent
+    * row's array/entity to iterate), {@code key} (extracts each item's id from that
+    * {@code jsonPath}), {@code ignoreBaseUrl} (true if {@code url} is a full URL rather than a
+    * suffix appended to the datasource's base URL). Max 5 entries. Only valid together with
+    * {@code suffix}.
+    */
+   List<WorksheetMutationSupport.CustomLookupSpec> customLookups
 ) {}

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -38,6 +38,10 @@ import inetsoft.uql.jdbc.*;
 import inetsoft.uql.jdbc.util.JDBCUtil;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.schema.XTypeNode;
+import inetsoft.uql.tabular.PropertyMeta;
+import inetsoft.uql.tabular.TabularDataSource;
+import inetsoft.uql.tabular.TabularQuery;
+import inetsoft.uql.tabular.TabularUtil;
 import inetsoft.uql.text.TextOutput;
 import inetsoft.uql.util.DefaultMetaDataProvider;
 import inetsoft.uql.util.XEmbeddedTable;
@@ -54,6 +58,7 @@ import inetsoft.web.composer.ws.assembly.WorksheetEventUtil;
 import inetsoft.web.composer.ws.event.WSLayoutGraphEvent;
 import inetsoft.web.portal.controller.database.QueryManagerService;
 import inetsoft.web.wiz.pairing.*;
+import inetsoft.web.wiz.service.TabularEndpointBindingSupport;
 import inetsoft.web.wiz.script.PaneScopeService;
 import inetsoft.web.wiz.worksheet.model.WorksheetModel;
 import inetsoft.web.wiz.worksheet.model.WorksheetPropertiesModel;
@@ -205,6 +210,45 @@ public class WorksheetAgentController {
       throws Exception
    {
       requireEnabled();
+
+      // add_table with endpoint (named connector) or suffix (generic/custom REST-JSON) binds a
+      // TabularTableAssembly instead of a physical table or logical-model entity. Checked before
+      // every other add_table branch below so its own contradiction errors fire first -- in
+      // particular before the plain "add_table with a datasource" branch, which would otherwise
+      // route a request carrying both datasource and endpoint/suffix into addBoundTable.
+      if("add_table".equals(req.op()) &&
+         ((req.endpoint() != null && !req.endpoint().isBlank()) ||
+          (req.suffix() != null && !req.suffix().isBlank())))
+      {
+         boolean hasEndpoint = req.endpoint() != null && !req.endpoint().isBlank();
+         boolean hasSuffix = req.suffix() != null && !req.suffix().isBlank();
+
+         if(hasEndpoint && hasSuffix) {
+            throw new PairingException("add_table cannot carry both endpoint and suffix -- " +
+               "choose the named-connector form (endpoint) or the custom form (suffix), not both.");
+         }
+
+         if(req.datasource() == null || req.datasource().isBlank()) {
+            throw new PairingException(
+               "datasource is required when " + (hasEndpoint ? "endpoint" : "suffix") +
+               " is specified.");
+         }
+
+         if(req.logicalModel() != null && !req.logicalModel().isBlank()) {
+            throw new PairingException("add_table cannot carry both " +
+               (hasEndpoint ? "endpoint" : "suffix") + " and logicalModel -- choose one.");
+         }
+
+         if(req.schema() != null || req.catalog() != null) {
+            throw new PairingException("add_table cannot carry schema/catalog together with " +
+               (hasEndpoint ? "endpoint" : "suffix") + " -- those name a physical table; " +
+               (hasEndpoint ? "an endpoint" : "a custom REST-JSON suffix") +
+               " has no schema/catalog.");
+         }
+
+         addTabularTable(sessionToken, req, user);
+         return;
+      }
 
       // add_table with logicalModel requires datasource.
       if("add_table".equals(req.op()) && req.logicalModel() != null
@@ -505,6 +549,130 @@ public class WorksheetAgentController {
 
          positionBelowExisting(ws, assembly);
          ws.addAssembly(assembly);
+         return null;
+      });
+   }
+
+   /**
+    * Create a {@link TabularTableAssembly} bound either to a named REST/JSON connector's
+    * pre-built endpoint (+ optional pre-built lookup chain), or to a generic/custom REST-JSON
+    * datasource's hand-authored URL suffix (+ optional hand-authored custom lookup chain).
+    *
+    * <p>A datasource resolves to exactly one {@code TabularQuery} concrete class via
+    * {@link TabularUtil#createQuery}, never both shapes for the same datasource -- so which of
+    * the two this method builds is decided by which property the RESOLVED query class actually
+    * exposes ({@code pmap.get("endpoint")}), cross-checked against which field the CALLER
+    * supplied, rather than trusting the caller's field choice alone: setting {@code suffix}
+    * directly on a named connector's query is a silent no-op (its suffix is derived from
+    * {@code endpoint} instead), so a caller confusing the two forms is refused here rather than
+    * silently building a table against a contract nobody asked for.</p>
+    *
+    * <p>Shares {@link TabularEndpointBindingSupport} with
+    * {@link WorksheetTableService#buildTabularTable} (the wiz-services {@code /ws/table} write
+    * path), which already builds the same kind of {@code TabularTableAssembly} from its own
+    * {@code TabularSource} request shape.</p>
+    */
+   private void addTabularTable(String sessionToken, EditRequest req, Principal user)
+      throws Exception
+   {
+      String dsName = req.datasource();
+
+      if(!dataSourceService.checkPermission(dsName, ResourceAction.READ, user)) {
+         throw new PairingException("Access denied: no READ permission on datasource " + dsName);
+      }
+
+      XDataSource dataSource = xrepository.getDataSource(dsName);
+
+      if(dataSource == null) {
+         throw new PairingException("Data source not found: " + dsName);
+      }
+
+      if(!(dataSource instanceof TabularDataSource)) {
+         throw new PairingException("'" + dsName + "' is a " + dataSource.getType() +
+            " data source, not a tabular/REST one, so it has no endpoints to call. Use " +
+            "datasource+schema+table for a physical table, or datasource+logicalModel for a " +
+            "logical model entity.");
+      }
+
+      TabularQuery query = TabularUtil.createQuery(dsName);
+
+      if(query == null) {
+         throw new PairingException("Could not create a query for data source '" + dsName +
+            "' -- its connector plugin may not be loaded.");
+      }
+
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(query.getClass());
+      boolean namedConnector = pmap.get("endpoint") != null;
+      String suffix;
+
+      if(req.endpoint() != null && !req.endpoint().isBlank()) {
+         if(!namedConnector) {
+            throw new PairingException("'" + dsName + "' has no predefined endpoint catalogue " +
+               "-- use suffix (+ optional customLookups) instead of endpoint.");
+         }
+
+         suffix = TabularEndpointBindingSupport.applyEndpointContract(query, pmap, req.endpoint(),
+            null /* no parameters on this op yet -- see the design doc's flagged decision */,
+            null, null, null, dsName);
+         TabularEndpointBindingSupport.requireRowCapWhenPaged(query, req.endpoint(), dsName);
+
+         if(req.lookup() != null && !req.lookup().isEmpty()) {
+            TabularEndpointBindingSupport.applyLookupChain(query, pmap, req.lookup(),
+               req.lookupExpandArrays(), req.lookupTopLevelOnly(), req.endpoint(), dsName);
+         }
+      }
+      else {
+         if(namedConnector) {
+            throw new PairingException("'" + dsName + "' has a predefined endpoint catalogue -- " +
+               "use endpoint (+ optional lookup) instead of suffix; see list_endpoint_lookups.");
+         }
+
+         suffix = TabularEndpointBindingSupport.applyCustomSuffix(query, pmap, req.suffix(), null,
+            dsName);
+         TabularEndpointBindingSupport.requireRowCapWhenPaged(query, req.suffix(), dsName);
+
+         if(req.customLookups() != null && !req.customLookups().isEmpty()) {
+            TabularEndpointBindingSupport.applyCustomLookupChain(query, pmap, req.customLookups(),
+               dsName);
+         }
+      }
+
+      String tableName = req.table();
+
+      if(tableName == null || tableName.isBlank()) {
+         throw new PairingException("table (the desired worksheet table name) is required for " +
+            "add_table with endpoint/suffix.");
+      }
+
+      String target = namedConnector ? req.endpoint() : req.suffix();
+
+      editService.applyOnRuntime(sessionToken, user, rws -> {
+         Worksheet ws = rws.getWorksheet();
+         String assemblyName = AssetUtil.getNextName(ws, AssetUtil.normalizeTable(tableName));
+         TabularTableAssembly assembly = new TabularTableAssembly(ws, assemblyName);
+         TabularTableAssemblyInfo info = (TabularTableAssemblyInfo) assembly.getTableInfo();
+         info.setQuery(query);
+         info.setSourceInfo(new SourceInfo(SourceInfo.DATASOURCE, dsName, dsName));
+
+         positionBelowExisting(ws, assembly);
+         ws.addAssembly(assembly);
+
+         // The live HTTP call -- same call TabularQueryDialogService.setUpTable and
+         // WorksheetTableService.buildTabularTable both make; a tabular query has no columns
+         // until one response has been parsed.
+         assembly.loadColumnSelection(new VariableTable(), true, null);
+
+         ColumnSelection columns = assembly.getColumnSelection(false);
+
+         if(columns == null || columns.getAttributeCount() == 0) {
+            // Mirrors WorksheetTableService.buildTabularTable's empty-column check -- without this
+            // the assembly persists with zero columns and the agent is told "success" for a table
+            // nothing can bind to.
+            throw new PairingException("The request to '" + target + "' of '" + dsName +
+               "' returned no columns. URL suffix sent: " + suffix + ". Check the parameter " +
+               "values and datasource credentials -- see the server log for the cause.");
+         }
+
          return null;
       });
    }

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -612,8 +612,7 @@ public class WorksheetAgentController {
          }
 
          suffix = TabularEndpointBindingSupport.applyEndpointContract(query, pmap, req.endpoint(),
-            null /* no parameters on this op yet -- see the design doc's flagged decision */,
-            null, null, null, dsName);
+            req.parameters(), null, null, null, dsName);
          TabularEndpointBindingSupport.requireRowCapWhenPaged(query, req.endpoint(), dsName);
 
          if(req.lookup() != null && !req.lookup().isEmpty()) {

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -1369,6 +1369,25 @@ public final class WorksheetMutationSupport {
       t.setRankingConditionList(cl);
    }
 
+   /**
+    * Describes one hand-authored "Join With" lookup level for a GENERIC/CUSTOM REST-JSON
+    * datasource's {@code add_table} binding (see {@code TabularEndpointBindingSupport
+    * #applyCustomLookupChain}), as opposed to {@code lookup} (a named connector's pre-built
+    * lookup chain, selected by endpoint name only).
+    *
+    * @param url          URL template for this level. Must contain the literal placeholder
+    *                     {@code {paramN}} (1-indexed by this level's position in the chain,
+    *                     e.g. {@code {param1}} for the first level) so the id extracted via
+    *                     {@code jsonPath}/{@code key} from the PARENT level's row lands in the
+    *                     request StyleBI issues for this level.
+    * @param jsonPath     selects the parent row's array/entity to iterate for this level.
+    * @param key          extracts each item's id from that {@code jsonPath}.
+    * @param ignoreBaseUrl {@code true} if {@code url} is a full URL rather than a suffix
+    *                     appended to the datasource's base URL; omit/{@code null} for
+    *                     {@code false}.
+    */
+   public record CustomLookupSpec(String url, String jsonPath, String key, Boolean ignoreBaseUrl) {}
+
    // =========================================================================
    // Internal helpers
    // =========================================================================

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetScriptService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetScriptService.java
@@ -519,7 +519,9 @@ public class WorksheetScriptService {
          null, null, null, null,         // columnOrder, groupMappings, groupOthers, variableValues
          null, null, null, null,         // x, y, label, defaultValue
          null, null, null,               // mode, insert, subtables
-         null, null                      // sourceTable, attribute
+         null, null,                     // sourceTable, attribute
+         null, null, null, null, null, null  // endpoint, lookup, lookupExpandArrays,
+                                              // lookupTopLevelOnly, suffix, customLookups
       );
    }
 
@@ -600,7 +602,9 @@ public class WorksheetScriptService {
          null, null, null, null,         // columnOrder, groupMappings, groupOthers, variableValues
          null, null, null, null,         // x, y, label, defaultValue
          null, null, null,               // mode, insert, subtables
-         null, null                      // sourceTable, attribute
+         null, null,                     // sourceTable, attribute
+         null, null, null, null, null, null  // endpoint, lookup, lookupExpandArrays,
+                                              // lookupTopLevelOnly, suffix, customLookups
       );
    }
 
@@ -675,7 +679,9 @@ public class WorksheetScriptService {
          null, null, null, null,         // columnOrder, groupMappings, groupOthers, variableValues
          null, null, null, null,         // x, y, label, defaultValue
          null, null, null,               // mode, insert, subtables
-         null, null                      // sourceTable, attribute
+         null, null,                     // sourceTable, attribute
+         null, null, null, null, null, null  // endpoint, lookup, lookupExpandArrays,
+                                              // lookupTopLevelOnly, suffix, customLookups
       );
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetScriptService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetScriptService.java
@@ -520,7 +520,7 @@ public class WorksheetScriptService {
          null, null, null, null,         // x, y, label, defaultValue
          null, null, null,               // mode, insert, subtables
          null, null,                     // sourceTable, attribute
-         null, null, null, null, null, null  // endpoint, lookup, lookupExpandArrays,
+         null, null, null, null, null, null, null  // endpoint, parameters, lookup, lookupExpandArrays,
                                               // lookupTopLevelOnly, suffix, customLookups
       );
    }
@@ -603,7 +603,7 @@ public class WorksheetScriptService {
          null, null, null, null,         // x, y, label, defaultValue
          null, null, null,               // mode, insert, subtables
          null, null,                     // sourceTable, attribute
-         null, null, null, null, null, null  // endpoint, lookup, lookupExpandArrays,
+         null, null, null, null, null, null, null  // endpoint, parameters, lookup, lookupExpandArrays,
                                               // lookupTopLevelOnly, suffix, customLookups
       );
    }
@@ -680,7 +680,7 @@ public class WorksheetScriptService {
          null, null, null, null,         // x, y, label, defaultValue
          null, null, null,               // mode, insert, subtables
          null, null,                     // sourceTable, attribute
-         null, null, null, null, null, null  // endpoint, lookup, lookupExpandArrays,
+         null, null, null, null, null, null, null  // endpoint, parameters, lookup, lookupExpandArrays,
                                               // lookupTopLevelOnly, suffix, customLookups
       );
    }

--- a/core/src/test/java/inetsoft/web/wiz/service/FakeCustomRestQuery.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/FakeCustomRestQuery.java
@@ -1,0 +1,207 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.uql.tabular.Property;
+import inetsoft.uql.tabular.TabularQuery;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Minimal, REAL (non-mock) stand-in for a generic/custom REST-JSON query such as
+ * {@code RestJsonQuery} -- has a directly-settable {@code suffix} (unlike
+ * {@link FakeNamedConnectorQuery}'s no-op override) and NO {@code endpoint} property, which is
+ * exactly the signal {@code WorksheetAgentController.addTabularTable} uses to route between the
+ * named-connector and generic/custom paths.
+ *
+ * <p>Only two custom lookup levels are implemented (0 and 1) -- enough to exercise a two-level
+ * chain and the per-level ordering dependency ({@code lookupUrl}<i>i</i> must be set before
+ * {@code lookupJsonPath}<i>i</i>/{@code lookupKey}<i>i</i>/{@code lookupIgnoreBaseUrl}<i>i</i>,
+ * since it is what grows the backing lists to include index <i>i</i> at all, mirroring
+ * {@code RestJsonQuery.setLookupURL}/{@code addLookupQuery}). The "chain longer than 5" guard is
+ * checked by {@link TabularEndpointBindingSupport#applyCustomLookupChain} BEFORE any property
+ * write, so it needs no backing level to test.</p>
+ */
+public class FakeCustomRestQuery extends TabularQuery {
+   public FakeCustomRestQuery() {
+      super("FakeCustomRest");
+   }
+
+   @Property(label = "Suffix")
+   public String getSuffix() {
+      return suffix;
+   }
+
+   public void setSuffix(String suffix) {
+      this.suffix = suffix;
+   }
+
+   @Property(label = "Json Path")
+   public String getJsonPath() {
+      return jsonPath;
+   }
+
+   public void setJsonPath(String jsonPath) {
+      this.jsonPath = jsonPath;
+   }
+
+   @Property(label = "Lookup Url 0")
+   public String getLookupUrl0() {
+      return getLookupURL(0);
+   }
+
+   public void setLookupUrl0(String v) {
+      setLookupURL(0, v);
+   }
+
+   @Property(label = "Lookup Json Path 0")
+   public String getLookupJsonPath0() {
+      return getLookupJsonPath(0);
+   }
+
+   public void setLookupJsonPath0(String v) {
+      setLookupJsonPath(0, v);
+   }
+
+   @Property(label = "Lookup Key 0")
+   public String getLookupKey0() {
+      return getLookupKey(0);
+   }
+
+   public void setLookupKey0(String v) {
+      setLookupKey(0, v);
+   }
+
+   @Property(label = "Lookup Ignore Base Url 0")
+   public boolean getLookupIgnoreBaseUrl0() {
+      return getLookupIgnoreBaseUrl(0);
+   }
+
+   public void setLookupIgnoreBaseUrl0(boolean v) {
+      setLookupIgnoreBaseUrl(0, v);
+   }
+
+   @Property(label = "Lookup Url 1")
+   public String getLookupUrl1() {
+      return getLookupURL(1);
+   }
+
+   public void setLookupUrl1(String v) {
+      setLookupURL(1, v);
+   }
+
+   @Property(label = "Lookup Json Path 1")
+   public String getLookupJsonPath1() {
+      return getLookupJsonPath(1);
+   }
+
+   public void setLookupJsonPath1(String v) {
+      setLookupJsonPath(1, v);
+   }
+
+   @Property(label = "Lookup Key 1")
+   public String getLookupKey1() {
+      return getLookupKey(1);
+   }
+
+   public void setLookupKey1(String v) {
+      setLookupKey(1, v);
+   }
+
+   @Property(label = "Lookup Ignore Base Url 1")
+   public boolean getLookupIgnoreBaseUrl1() {
+      return getLookupIgnoreBaseUrl(1);
+   }
+
+   public void setLookupIgnoreBaseUrl1(boolean v) {
+      setLookupIgnoreBaseUrl(1, v);
+   }
+
+   // Non-@Property generic accessors, mirroring RestJsonQuery's own shape and its exact
+   // silent-no-op-past-the-limit behavior for each backing list.
+
+   public String getLookupURL(int i) {
+      return i < lookupUrls.size() ? lookupUrls.get(i) : null;
+   }
+
+   public void setLookupURL(int i, String url) {
+      if(url == null) {
+         return;
+      }
+
+      if(i >= lookupUrls.size()) {
+         if(i >= LIMIT) {
+            return;
+         }
+
+         while(lookupUrls.size() <= i) {
+            addLevel();
+         }
+      }
+
+      lookupUrls.set(i, url);
+   }
+
+   public String getLookupJsonPath(int i) {
+      return i < lookupJsonPaths.size() ? lookupJsonPaths.get(i) : null;
+   }
+
+   public void setLookupJsonPath(int i, String jsonPath) {
+      if(i < lookupJsonPaths.size()) {
+         lookupJsonPaths.set(i, jsonPath);
+      }
+      // else: silently no-op, same as RestJsonQuery -- this level's url must be set first.
+   }
+
+   public String getLookupKey(int i) {
+      return i < lookupKeys.size() ? lookupKeys.get(i) : null;
+   }
+
+   public void setLookupKey(int i, String key) {
+      if(i < lookupKeys.size()) {
+         lookupKeys.set(i, key);
+      }
+   }
+
+   public boolean getLookupIgnoreBaseUrl(int i) {
+      return i < lookupIgnoreBaseUrl.size() && lookupIgnoreBaseUrl.get(i);
+   }
+
+   public void setLookupIgnoreBaseUrl(int i, boolean ignoreBaseUrl) {
+      if(i < lookupIgnoreBaseUrl.size()) {
+         lookupIgnoreBaseUrl.set(i, ignoreBaseUrl);
+      }
+   }
+
+   /** Mirrors {@code RestJsonQuery.addLookupQuery} -- grows all four backing lists together. */
+   private void addLevel() {
+      lookupUrls.add("{param" + (lookupUrls.size() + 1) + "}");
+      lookupJsonPaths.add("");
+      lookupKeys.add("");
+      lookupIgnoreBaseUrl.add(false);
+   }
+
+   private static final int LIMIT = 2;
+   private String suffix;
+   private String jsonPath;
+   private final List<String> lookupUrls = new ArrayList<>();
+   private final List<String> lookupJsonPaths = new ArrayList<>();
+   private final List<String> lookupKeys = new ArrayList<>();
+   private final List<Boolean> lookupIgnoreBaseUrl = new ArrayList<>();
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/FakeNamedConnectorQuery.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/FakeNamedConnectorQuery.java
@@ -1,0 +1,227 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.uql.tabular.Property;
+import inetsoft.uql.tabular.RestParameter;
+import inetsoft.uql.tabular.RestParameters;
+import inetsoft.uql.tabular.TabularQuery;
+
+import java.util.*;
+
+/**
+ * Minimal, REAL (non-mock) stand-in for a named-connector {@code TabularQuery} such as
+ * {@code EndpointJsonQuery} -- reflects the exact {@code @Property}/{@code getEndpoints()}/
+ * {@code getLookupEndpoints(int)}/{@code isPaged()} shape
+ * {@link TabularEndpointBindingSupport} reaches by reflection, without depending on the
+ * {@code inetsoft-rest} connector module (core does not depend on it -- see
+ * {@code inetsoft.uql.rest.AbstractRestQuery}, the test-only stand-in for the same reason).
+ *
+ * <p>Endpoint graph, modeled on GitHub's real {@code endpoints.json} shape (one lookup per
+ * endpoint, chained): {@code Repos -> Issues -> Comments}. {@code Paged} and {@code PostEndpoint}
+ * exist only to exercise {@code requireRowCapWhenPaged}/the POST refusal.</p>
+ */
+public class FakeNamedConnectorQuery extends TabularQuery {
+   public FakeNamedConnectorQuery() {
+      super("FakeNamedConnector");
+   }
+
+   @Property(label = "Endpoint", required = true)
+   public String getEndpoint() {
+      return endpoint;
+   }
+
+   public void setEndpoint(String endpoint) {
+      this.endpoint = endpoint;
+      lookupEndpoints.clear();
+   }
+
+   @Property(label = "Parameters", required = true)
+   public RestParameters getParameters() {
+      return parameters;
+   }
+
+   public void setParameters(RestParameters parameters) {
+      this.parameters = parameters;
+   }
+
+   @Property(label = "Request Type")
+   public String getRequestType() {
+      return "PostEndpoint".equals(endpoint) ? "POST" : "GET";
+   }
+
+   /** Computed from {@code endpoint} + the parameter values -- the real class's shape. */
+   @Property(label = "Suffix")
+   public String getSuffix() {
+      if(endpoint == null) {
+         return null;
+      }
+
+      StringBuilder s = new StringBuilder("/").append(endpoint);
+
+      for(RestParameter p : parameters.getParameters()) {
+         if(p.getValue() != null) {
+            s.append('/').append(p.getValue());
+         }
+      }
+
+      return s.toString();
+   }
+
+   /** No-op, matching {@code EndpointJsonQuery.setSuffix} exactly -- the real silent-no-op case. */
+   public void setSuffix(String suffix) {
+   }
+
+   @Property(label = "Json Path")
+   public String getJsonPath() {
+      return jsonPath;
+   }
+
+   public void setJsonPath(String jsonPath) {
+      this.jsonPath = jsonPath;
+   }
+
+   @Property(label = "Expanded")
+   public Boolean getExpanded() {
+      return expanded;
+   }
+
+   public void setExpanded(Boolean expanded) {
+      this.expanded = expanded;
+   }
+
+   @Property(label = "Expanded Path")
+   public String getExpandedPath() {
+      return expandedPath;
+   }
+
+   public void setExpandedPath(String expandedPath) {
+      this.expandedPath = expandedPath;
+   }
+
+   @Property(label = "Lookup Expanded")
+   public boolean isLookupExpanded() {
+      return lookupExpanded;
+   }
+
+   public void setLookupExpanded(boolean lookupExpanded) {
+      this.lookupExpanded = lookupExpanded;
+   }
+
+   @Property(label = "Lookup Top Level Only")
+   public boolean isLookupTopLevelOnly() {
+      return lookupTopLevelOnly;
+   }
+
+   public void setLookupTopLevelOnly(boolean lookupTopLevelOnly) {
+      this.lookupTopLevelOnly = lookupTopLevelOnly;
+   }
+
+   @Property(label = "Lookup 0")
+   public String getLookupEndpoint0() {
+      return lookupEndpoints.size() > 0 ? lookupEndpoints.get(0) : null;
+   }
+
+   public void setLookupEndpoint0(String v) {
+      setLookupEndpoint(v, 0);
+   }
+
+   @Property(label = "Lookup 1")
+   public String getLookupEndpoint1() {
+      return lookupEndpoints.size() > 1 ? lookupEndpoints.get(1) : null;
+   }
+
+   public void setLookupEndpoint1(String v) {
+      setLookupEndpoint(v, 1);
+   }
+
+   // Non-@Property reflection surface, mirroring EndpointJsonQuery/RestJsonQuery exactly.
+
+   public boolean isPaged() {
+      return "Paged".equals(endpoint);
+   }
+
+   public String[][] getEndpoints() {
+      return ENDPOINT_MAP.keySet().stream()
+         .map(name -> new String[] { name, name })
+         .toArray(String[][]::new);
+   }
+
+   public String[][] getLookupEndpoints(int index) {
+      String parent = getParentEndpointOfLookupIndex(index);
+      List<String> lookups = parent == null
+         ? List.of() : ENDPOINT_MAP.getOrDefault(parent, List.of());
+      return lookups.stream().map(name -> new String[] { name, name }).toArray(String[][]::new);
+   }
+
+   /** Index 0's parent is the base endpoint; index i>0's parent is whatever was chosen at i-1. */
+   private String getParentEndpointOfLookupIndex(int index) {
+      if(index == 0) {
+         return endpoint;
+      }
+
+      return index <= lookupEndpoints.size() ? lookupEndpoints.get(index - 1) : null;
+   }
+
+   /**
+    * SILENTLY NO-OPS on an unknown name -- exactly {@code EndpointJsonQuery.setLookupEndpoint}'s
+    * real, documented behavior that {@link TabularEndpointBindingSupport#applyLookupChain}'s
+    * read-back exists to catch.
+    */
+   private void setLookupEndpoint(String name, int index) {
+      if(name == null) {
+         return;
+      }
+
+      String parent = getParentEndpointOfLookupIndex(index);
+      List<String> validNames = parent == null ? List.of() : ENDPOINT_MAP.getOrDefault(parent, List.of());
+
+      if(!validNames.contains(name)) {
+         return;
+      }
+
+      if(index >= lookupEndpoints.size()) {
+         if(index >= LOOKUP_LIMIT) {
+            return;
+         }
+
+         while(lookupEndpoints.size() <= index) {
+            lookupEndpoints.add(null);
+         }
+      }
+
+      lookupEndpoints.set(index, name);
+   }
+
+   private static final int LOOKUP_LIMIT = 5;
+   private static final Map<String, List<String>> ENDPOINT_MAP = Map.of(
+      "Repos", List.of("Issues"),
+      "Issues", List.of("Comments"),
+      "Comments", List.of(),
+      "Paged", List.of(),
+      "PostEndpoint", List.of());
+
+   private String endpoint;
+   private RestParameters parameters = new RestParameters();
+   private String jsonPath;
+   private Boolean expanded;
+   private String expandedPath;
+   private boolean lookupExpanded = true;
+   private boolean lookupTopLevelOnly = true;
+   private final List<String> lookupEndpoints = new ArrayList<>();
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/TabularEndpointBindingSupportTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/TabularEndpointBindingSupportTest.java
@@ -1,0 +1,377 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.uql.tabular.PropertyMeta;
+import inetsoft.uql.tabular.RestParameter;
+import inetsoft.uql.tabular.TabularUtil;
+import inetsoft.web.wiz.worksheet.WorksheetMutationSupport;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit coverage for {@link TabularEndpointBindingSupport}, the reflection-based helper shared by
+ * {@code WorksheetTableService.buildTabularTable} (wiz-services) and
+ * {@code WorksheetAgentController.addTabularTable} (composer plugin). Exercised against
+ * {@link FakeNamedConnectorQuery}/{@link FakeCustomRestQuery} -- real (non-mock) {@code TabularQuery}
+ * instances, since the class under test works entirely through {@code TabularUtil}'s bean-property
+ * reflection, which a mock cannot stand in for.
+ */
+@Tag("core")
+class TabularEndpointBindingSupportTest {
+
+   // ─── applyEndpointContract (named connector) ──────────────────────────────
+
+   @Test
+   void applyEndpointContractSetsEndpointAndBuildsSuffix() throws Exception {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(query.getClass());
+
+      String suffix = TabularEndpointBindingSupport.applyEndpointContract(
+         query, pmap, "Repos", null, null, null, null, "myds");
+
+      assertEquals("/Repos", suffix);
+      assertEquals("Repos", query.getEndpoint());
+   }
+
+   @Test
+   void applyEndpointContractSubstitutesSuppliedParameterValues() throws Exception {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+      RestParameter idParam = new RestParameter();
+      idParam.setName("id");
+      idParam.setRequired(true);
+      query.getParameters().getParameters().add(idParam);
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(query.getClass());
+
+      String suffix = TabularEndpointBindingSupport.applyEndpointContract(
+         query, pmap, "Repos", Map.of("id", "42"), null, null, null, "myds");
+
+      assertEquals("/Repos/42", suffix);
+   }
+
+   @Test
+   void applyEndpointContractRejectsMissingRequiredParameter() {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+      RestParameter idParam = new RestParameter();
+      idParam.setName("id");
+      idParam.setRequired(true);
+      query.getParameters().getParameters().add(idParam);
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(query.getClass());
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> TabularEndpointBindingSupport.applyEndpointContract(
+            query, pmap, "Repos", null, null, null, null, "myds"));
+      assertTrue(ex.getMessage().contains("id"), ex.getMessage());
+   }
+
+   @Test
+   void applyEndpointContractRejectsUnknownParameterName() {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+      RestParameter idParam = new RestParameter();
+      idParam.setName("id");
+      query.getParameters().getParameters().add(idParam);
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(query.getClass());
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> TabularEndpointBindingSupport.applyEndpointContract(
+            query, pmap, "Repos", Map.of("bogus", "1"), null, null, null, "myds"));
+      assertTrue(ex.getMessage().contains("bogus"), ex.getMessage());
+   }
+
+   @Test
+   void applyEndpointContractRejectsUnknownEndpointName() {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(query.getClass());
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> TabularEndpointBindingSupport.applyEndpointContract(
+            query, pmap, "Bogus", null, null, null, null, "myds"));
+      assertTrue(ex.getMessage().contains("Bogus"), ex.getMessage());
+   }
+
+   @Test
+   void applyEndpointContractRejectsPostEndpoint() {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(query.getClass());
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> TabularEndpointBindingSupport.applyEndpointContract(
+            query, pmap, "PostEndpoint", null, null, null, null, "myds"));
+      assertTrue(ex.getMessage().contains("POST endpoint"), ex.getMessage());
+   }
+
+   @Test
+   void requireRowCapWhenPagedThrowsForAPagedEndpoint() throws Exception {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(query.getClass());
+      TabularEndpointBindingSupport.applyEndpointContract(
+         query, pmap, "Paged", null, null, null, null, "myds");
+
+      assertThrows(IllegalArgumentException.class,
+         () -> TabularEndpointBindingSupport.requireRowCapWhenPaged(query, "Paged", "myds"));
+   }
+
+   @Test
+   void requireRowCapWhenPagedAllowsAnUnpagedEndpoint() throws Exception {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(query.getClass());
+      TabularEndpointBindingSupport.applyEndpointContract(
+         query, pmap, "Repos", null, null, null, null, "myds");
+
+      assertDoesNotThrow(
+         () -> TabularEndpointBindingSupport.requireRowCapWhenPaged(query, "Repos", "myds"));
+   }
+
+   // ─── applyLookupChain (named connector) ───────────────────────────────────
+
+   @Test
+   void applyLookupChainSetsSingleLevel() throws Exception {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(query.getClass());
+      TabularEndpointBindingSupport.applyEndpointContract(
+         query, pmap, "Repos", null, null, null, null, "myds");
+
+      TabularEndpointBindingSupport.applyLookupChain(
+         query, pmap, List.of("Issues"), null, null, "Repos", "myds");
+
+      assertEquals("Issues", query.getLookupEndpoint0());
+   }
+
+   @Test
+   void applyLookupChainSetsTwoLevelsInOrder() throws Exception {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(query.getClass());
+      TabularEndpointBindingSupport.applyEndpointContract(
+         query, pmap, "Repos", null, null, null, null, "myds");
+
+      TabularEndpointBindingSupport.applyLookupChain(
+         query, pmap, List.of("Issues", "Comments"), null, null, "Repos", "myds");
+
+      assertEquals("Issues", query.getLookupEndpoint0());
+      assertEquals("Comments", query.getLookupEndpoint1());
+   }
+
+   @Test
+   void applyLookupChainRejectsUnknownNameAtPositionZero() throws Exception {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(query.getClass());
+      TabularEndpointBindingSupport.applyEndpointContract(
+         query, pmap, "Repos", null, null, null, null, "myds");
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> TabularEndpointBindingSupport.applyLookupChain(
+            query, pmap, List.of("Bogus"), null, null, "Repos", "myds"));
+      assertTrue(ex.getMessage().contains("Issues"),
+         "should name Repos' actual lookup choices, got: " + ex.getMessage());
+   }
+
+   /**
+    * Proves the parent-endpoint chaining, not just single-level validation: an unknown name at
+    * position 1 must be checked against position 0's CHOSEN endpoint's ("Issues") own lookups
+    * ("Comments"), not position 0's parent ("Repos")'s.
+    */
+   @Test
+   void applyLookupChainRejectsUnknownNameAtPositionOneNamingPositionOnesChoices() throws Exception {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(query.getClass());
+      TabularEndpointBindingSupport.applyEndpointContract(
+         query, pmap, "Repos", null, null, null, null, "myds");
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> TabularEndpointBindingSupport.applyLookupChain(
+            query, pmap, List.of("Issues", "Bogus"), null, null, "Repos", "myds"));
+      assertTrue(ex.getMessage().contains("Comments"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("'Issues'"), ex.getMessage());
+   }
+
+   @Test
+   void applyLookupChainRejectsChainLongerThanFive() {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(query.getClass());
+
+      assertThrows(IllegalArgumentException.class,
+         () -> TabularEndpointBindingSupport.applyLookupChain(query, pmap,
+            List.of("a", "b", "c", "d", "e", "f"), null, null, "Repos", "myds"));
+   }
+
+   @Test
+   void applyLookupChainDefaultsLeaveConnectorDefaultsUntouched() throws Exception {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(query.getClass());
+      TabularEndpointBindingSupport.applyEndpointContract(
+         query, pmap, "Repos", null, null, null, null, "myds");
+
+      TabularEndpointBindingSupport.applyLookupChain(
+         query, pmap, List.of("Issues"), null, null, "Repos", "myds");
+
+      assertTrue(query.isLookupExpanded());
+      assertTrue(query.isLookupTopLevelOnly());
+   }
+
+   @Test
+   void applyLookupChainSuppliedFalseIsReadBack() throws Exception {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(query.getClass());
+      TabularEndpointBindingSupport.applyEndpointContract(
+         query, pmap, "Repos", null, null, null, null, "myds");
+
+      TabularEndpointBindingSupport.applyLookupChain(
+         query, pmap, List.of("Issues"), false, false, "Repos", "myds");
+
+      assertFalse(query.isLookupExpanded());
+      assertFalse(query.isLookupTopLevelOnly());
+   }
+
+   // ─── applyCustomSuffix (generic/custom) ───────────────────────────────────
+
+   @Test
+   void applyCustomSuffixSetsSuffixAndJsonPath() {
+      FakeCustomRestQuery query = new FakeCustomRestQuery();
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(query.getClass());
+
+      String suffix = TabularEndpointBindingSupport.applyCustomSuffix(
+         query, pmap, "/v1/widgets/{id}", "$.data[*]", "myds");
+
+      assertEquals("/v1/widgets/{id}", suffix);
+      assertEquals("$.data[*]", query.getJsonPath());
+   }
+
+   /**
+    * The one test that specifically exercises the cross-class silent-failure boundary: calling
+    * {@code applyCustomSuffix} against a named connector's query (whose {@code setSuffix} is a
+    * documented no-op) must be caught by the read-back, not silently "succeed" while leaving the
+    * table bound to whatever {@code endpoint} happens to default to.
+    */
+   @Test
+   void applyCustomSuffixRejectsSilentNoOpOnNamedConnectorQuery() {
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(query.getClass());
+
+      IllegalStateException ex = assertThrows(IllegalStateException.class,
+         () -> TabularEndpointBindingSupport.applyCustomSuffix(
+            query, pmap, "/v1/widgets/{id}", null, "myds"));
+      assertTrue(ex.getMessage().contains("endpoint"), ex.getMessage());
+   }
+
+   // ─── applyCustomLookupChain (generic/custom) ──────────────────────────────
+
+   @Test
+   void applyCustomLookupChainSetsFourFieldsPerLevel() {
+      FakeCustomRestQuery query = new FakeCustomRestQuery();
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(query.getClass());
+
+      TabularEndpointBindingSupport.applyCustomLookupChain(query, pmap, List.of(
+         new WorksheetMutationSupport.CustomLookupSpec(
+            "/v1/repos/{param1}/issues", "$.data[*]", "id", null),
+         new WorksheetMutationSupport.CustomLookupSpec(
+            "/v1/issues/{param2}/comments", "$.[*]", "id", true)
+      ), "myds");
+
+      assertEquals("/v1/repos/{param1}/issues", query.getLookupUrl0());
+      assertEquals("$.data[*]", query.getLookupJsonPath0());
+      assertEquals("id", query.getLookupKey0());
+      assertFalse(query.getLookupIgnoreBaseUrl0());
+
+      assertEquals("/v1/issues/{param2}/comments", query.getLookupUrl1());
+      assertEquals("$.[*]", query.getLookupJsonPath1());
+      assertEquals("id", query.getLookupKey1());
+      assertTrue(query.getLookupIgnoreBaseUrl1());
+   }
+
+   @Test
+   void applyCustomLookupChainDefaultsIgnoreBaseUrlToFalse() {
+      FakeCustomRestQuery query = new FakeCustomRestQuery();
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(query.getClass());
+
+      TabularEndpointBindingSupport.applyCustomLookupChain(query, pmap, List.of(
+         new WorksheetMutationSupport.CustomLookupSpec(
+            "/v1/repos/{param1}/issues", null, null, null)
+      ), "myds");
+
+      assertFalse(query.getLookupIgnoreBaseUrl0());
+   }
+
+   @Test
+   void applyCustomLookupChainRejectsBlankUrl() {
+      FakeCustomRestQuery query = new FakeCustomRestQuery();
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(query.getClass());
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> TabularEndpointBindingSupport.applyCustomLookupChain(query, pmap, List.of(
+            new WorksheetMutationSupport.CustomLookupSpec("  ", null, null, null)
+         ), "myds"));
+      assertTrue(ex.getMessage().contains("customLookups[0].url"), ex.getMessage());
+   }
+
+   /**
+    * The {@code {paramN}} convention is not enforced anywhere in the runtime substitution path
+    * (per the design doc's §8.8 flagged decision) -- so this validation exists ONLY here, before
+    * any property write, to refuse a URL guaranteed to malfunction rather than accept it silently.
+    */
+   @Test
+   void applyCustomLookupChainRejectsUrlMissingPlaceholder() {
+      FakeCustomRestQuery query = new FakeCustomRestQuery();
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(query.getClass());
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> TabularEndpointBindingSupport.applyCustomLookupChain(query, pmap, List.of(
+            new WorksheetMutationSupport.CustomLookupSpec(
+               "/v1/repos/issues", null, null, null)
+         ), "myds"));
+      assertTrue(ex.getMessage().contains("{param1}"), ex.getMessage());
+      assertNull(query.getLookupUrl0(), "must refuse before writing anything");
+   }
+
+   @Test
+   void applyCustomLookupChainRejectsPlaceholderAtWrongPosition() {
+      FakeCustomRestQuery query = new FakeCustomRestQuery();
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(query.getClass());
+
+      // Level 1 (0-indexed) must contain {param2}, not {param1}.
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> TabularEndpointBindingSupport.applyCustomLookupChain(query, pmap, List.of(
+            new WorksheetMutationSupport.CustomLookupSpec(
+               "/v1/repos/{param1}/issues", null, null, null),
+            new WorksheetMutationSupport.CustomLookupSpec(
+               "/v1/issues/{param1}/comments", null, null, null)
+         ), "myds"));
+      assertTrue(ex.getMessage().contains("{param2}"), ex.getMessage());
+   }
+
+   @Test
+   void applyCustomLookupChainRejectsChainLongerThanFive() {
+      FakeCustomRestQuery query = new FakeCustomRestQuery();
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(query.getClass());
+      List<WorksheetMutationSupport.CustomLookupSpec> tooMany = List.of(
+         new WorksheetMutationSupport.CustomLookupSpec("{param1}", null, null, null),
+         new WorksheetMutationSupport.CustomLookupSpec("{param2}", null, null, null),
+         new WorksheetMutationSupport.CustomLookupSpec("{param3}", null, null, null),
+         new WorksheetMutationSupport.CustomLookupSpec("{param4}", null, null, null),
+         new WorksheetMutationSupport.CustomLookupSpec("{param5}", null, null, null),
+         new WorksheetMutationSupport.CustomLookupSpec("{param6}", null, null, null));
+
+      assertThrows(IllegalArgumentException.class,
+         () -> TabularEndpointBindingSupport.applyCustomLookupChain(query, pmap, tooMany, "myds"));
+      assertNull(query.getLookupUrl0(), "must refuse before writing anything");
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceLookupWiringTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WorksheetTableServiceLookupWiringTest.java
@@ -1,0 +1,187 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.analytic.composition.ViewsheetService;
+import inetsoft.sree.security.ResourceAction;
+import inetsoft.sree.security.ResourceType;
+import inetsoft.sree.security.SecurityEngine;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.XRepository;
+import inetsoft.uql.tabular.TabularDataSource;
+import inetsoft.uql.tabular.TabularUtil;
+import inetsoft.web.composer.ws.LayoutGraphService;
+import inetsoft.web.composer.ws.joins.InnerJoinService;
+import inetsoft.web.portal.controller.database.DataSourceService;
+import inetsoft.web.portal.controller.database.QueryManagerService;
+import inetsoft.web.wiz.model.WorksheetTableRequest;
+import inetsoft.web.wiz.model.WorksheetTableResponse;
+import inetsoft.web.wiz.model.WorksheetTablesResponse;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Proves {@code WorksheetTableService.buildTabularTable} actually calls
+ * {@link TabularEndpointBindingSupport#applyLookupChain} when {@code tabularSource.lookup} is
+ * supplied -- not just that the helper itself is correct in isolation (already covered by
+ * {@link TabularEndpointBindingSupportTest}). A passing unit test that nothing production calls
+ * is worse than no test (see {@code 2026-08-19-tabular-table-creation.md} §5.2).
+ *
+ * <p>{@link FakeNamedConnectorQuery} stands in for a real connector's query class --
+ * {@code TabularUtil.createQuery} is mocked statically to return it (its normal path resolves a
+ * REGISTERED connector's query via a global {@code Config}/{@code XRepository.getRepository()}
+ * lookup, which no fake datasource can satisfy); every other static method on {@code TabularUtil}
+ * (notably {@code getPropertyMap}, the actual reflection under test) calls through to the real
+ * implementation.</p>
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WorksheetTableServiceLookupWiringTest {
+   private static final ObjectMapper MAPPER = new ObjectMapper();
+   private static final Principal USER = mock(Principal.class);
+
+   private static WorksheetTableRequest batchOf(String tableJson) throws Exception {
+      return MAPPER.readValue("{ \"tables\": [ " + tableJson + " ] }", WorksheetTableRequest.class);
+   }
+
+   private static WorksheetTableResponse only(WorksheetTablesResponse response) {
+      assertEquals(1, response.getTables().size(), "expected exactly one table result");
+      return response.getTables().get(0);
+   }
+
+   private WorksheetTableService service(XRepository xrepository,
+                                         DataSourceService dataSourceService,
+                                         SecurityEngine securityEngine)
+   {
+      return new WorksheetTableService(mock(ViewsheetService.class), mock(MetadataApiService.class),
+         mock(InnerJoinService.class), mock(LayoutGraphService.class),
+         mock(QueryManagerService.class), xrepository, new ObjectMapper(), dataSourceService,
+         securityEngine);
+   }
+
+   @Test
+   void buildTabularTableRefusesAnUnknownLookupNameViaTheSharedHelper() throws Exception {
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      when(securityEngine.checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                          eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      when(dataSourceService.checkPermission(eq("myds"), eq(ResourceAction.READ), eq(USER)))
+         .thenReturn(true);
+
+      TabularDataSource<?> ds = mock(TabularDataSource.class);
+      when(xrepository.getDataSource(eq("myds"))).thenReturn(ds);
+
+      WorksheetTableRequest request = batchOf("""
+         {
+           "tableName": "t1",
+           "tableType": "tabular table",
+           "tabularSource": {
+             "datasourcePath": "myds",
+             "endpoint": "Repos",
+             "lookup": ["Bogus"]
+           }
+         }
+         """);
+
+      try(MockedStatic<TabularUtil> tabularUtil =
+             mockStatic(TabularUtil.class, CALLS_REAL_METHODS))
+      {
+         tabularUtil.when(() -> TabularUtil.createQuery(eq("myds")))
+            .thenReturn(new FakeNamedConnectorQuery());
+
+         WorksheetTableResponse table =
+            only(service(xrepository, dataSourceService, securityEngine).createTables(request, USER));
+
+         assertFalse(table.isSuccess());
+         // "Issues" is Repos' one real lookup choice -- proves the request actually reached
+         // TabularEndpointBindingSupport.applyLookupChain (only that code path can name it),
+         // not just some other, unrelated failure.
+         assertTrue(table.getErrorMessage().contains("Issues"),
+            "expected the lookup-chain rejection naming Repos' real choices, got: " +
+               table.getErrorMessage());
+      }
+   }
+
+   @Test
+   void buildTabularTableAcceptsAKnownLookupNameViaTheSharedHelper() throws Exception {
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      when(securityEngine.checkPermission(eq(USER), eq(ResourceType.WORKSHEET), eq("*"),
+                                          eq(ResourceAction.ACCESS)))
+         .thenReturn(true);
+      when(dataSourceService.checkPermission(eq("myds"), eq(ResourceAction.READ), eq(USER)))
+         .thenReturn(true);
+
+      TabularDataSource<?> ds = mock(TabularDataSource.class);
+      when(xrepository.getDataSource(eq("myds"))).thenReturn(ds);
+
+      WorksheetTableRequest request = batchOf("""
+         {
+           "tableName": "t1",
+           "tableType": "tabular table",
+           "tabularSource": {
+             "datasourcePath": "myds",
+             "endpoint": "Repos",
+             "lookup": ["Issues"]
+           }
+         }
+         """);
+
+      try(MockedStatic<TabularUtil> tabularUtil =
+             mockStatic(TabularUtil.class, CALLS_REAL_METHODS))
+      {
+         tabularUtil.when(() -> TabularUtil.createQuery(eq("myds")))
+            .thenReturn(new FakeNamedConnectorQuery());
+
+         // A valid lookup name passes applyLookupChain and reaches loadColumnSelection, which
+         // fails for the unrelated reason that FakeNamedConnectorQuery has no real HTTP/data
+         // execution behind it -- proof the lookup validation itself did NOT reject this request.
+         WorksheetTableResponse table =
+            only(service(xrepository, dataSourceService, securityEngine).createTables(request, USER));
+
+         assertFalse(table.isSuccess());
+         assertFalse(table.getErrorMessage().contains("has no lookup named"),
+            "a known lookup name must not be rejected by applyLookupChain, got: " +
+               table.getErrorMessage());
+      }
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/EditRequestParametersDeserializationTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/EditRequestParametersDeserializationTest.java
@@ -1,0 +1,75 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.worksheet;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inetsoft.web.WebConfig;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies {@code add_table}'s {@code endpoint}+{@code parameters} shape round-trips through the
+ * real app {@link ObjectMapper} ({@link WebConfig#objectMapper()}, the same one Spring uses for
+ * every {@code @RequestBody EditRequest} controller method) -- {@code EditRequest} has no
+ * {@code @JsonIgnoreProperties(ignoreUnknown = true)}, so before {@code parameters} was added to
+ * the record, a real caller's {@code add_table} request supplying it (the common case: most
+ * real endpoints have required parameters) would 400 at deserialization before
+ * {@code addTabularTable} ever ran. See {@link GroupSpecDeserializationTest} for the sibling
+ * pattern this mirrors.
+ */
+@Tag("core")
+class EditRequestParametersDeserializationTest {
+
+   private final ObjectMapper mapper = new WebConfig().objectMapper();
+
+   @Test
+   void deserializesEndpointWithParameters() throws Exception {
+      EditRequest req = mapper.readValue("""
+         {
+           "op": "add_table",
+           "table": "issues",
+           "datasource": "SaaS/GitHub Prod",
+           "endpoint": "Repository Issue Events",
+           "parameters": {"owner": "inetsoft-technology", "repo": "stylebi"}
+         }
+         """, EditRequest.class);
+
+      assertEquals("Repository Issue Events", req.endpoint());
+      assertNotNull(req.parameters());
+      assertEquals(2, req.parameters().size());
+      assertEquals("inetsoft-technology", req.parameters().get("owner"));
+      assertEquals("stylebi", req.parameters().get("repo"));
+   }
+
+   @Test
+   void deserializesEndpointWithoutParameters() throws Exception {
+      EditRequest req = mapper.readValue("""
+         {
+           "op": "add_table",
+           "table": "issues",
+           "datasource": "SaaS/GitHub Prod",
+           "endpoint": "Repository Issue Events"
+         }
+         """, EditRequest.class);
+
+      assertEquals("Repository Issue Events", req.endpoint());
+      assertNull(req.parameters());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -38,10 +38,14 @@ import inetsoft.uql.erm.XLogicalModel;
 import inetsoft.uql.jdbc.JDBCDataSource;
 import inetsoft.uql.jdbc.JDBCQuery;
 import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.tabular.RestParameter;
+import inetsoft.uql.tabular.TabularDataSource;
+import inetsoft.uql.tabular.TabularUtil;
 import inetsoft.web.composer.ws.LayoutGraphService;
 import inetsoft.web.portal.controller.database.DataSourceService;
 import inetsoft.web.portal.controller.database.QueryManagerService;
 import inetsoft.web.wiz.pairing.*;
+import inetsoft.web.wiz.service.FakeNamedConnectorQuery;
 import inetsoft.web.wiz.service.MetadataApiService;
 import inetsoft.web.wiz.worksheet.model.WorksheetModel;
 import inetsoft.web.wiz.worksheet.model.WorksheetPropertiesModel;
@@ -144,7 +148,7 @@ class WorksheetAgentControllerTest {
          null, null, null, null, null, null, null, null, null, null, null, null, null, null,
          null, null,
          null, null,
-         null, null, null, null, null, null
+         null, null, null, null, null, null, null
       );
    }
 
@@ -157,8 +161,8 @@ class WorksheetAgentControllerTest {
     */
    private static EditRequest addTabularTableRequest(
       String table, String datasource, String logicalModel, String schema, String catalog,
-      String endpoint, List<String> lookup, Boolean lookupExpandArrays,
-      Boolean lookupTopLevelOnly, String suffix,
+      String endpoint, Map<String, String> parameters, List<String> lookup,
+      Boolean lookupExpandArrays, Boolean lookupTopLevelOnly, String suffix,
       List<WorksheetMutationSupport.CustomLookupSpec> customLookups)
    {
       return new EditRequest(
@@ -167,8 +171,8 @@ class WorksheetAgentControllerTest {
          null, null, null, null, null, null, null, null, datasource, schema,
          catalog, logicalModel, null, null, null, null, null, null, null, null,
          null, null, null, null, null, null, null, null, null, null,
-         null, null, null, null, null, endpoint, lookup, lookupExpandArrays, lookupTopLevelOnly,
-         suffix, customLookups
+         null, null, null, null, null, endpoint, parameters, lookup, lookupExpandArrays,
+         lookupTopLevelOnly, suffix, customLookups
       );
    }
 
@@ -185,7 +189,7 @@ class WorksheetAgentControllerTest {
          null, null, null, null, null, null, null, null, null, null, null, null, null, null,
          null, null,
          null, null,
-         null, null, null, null, null, null
+         null, null, null, null, null, null, null
       );
    }
 
@@ -198,7 +202,7 @@ class WorksheetAgentControllerTest {
          null, null, null, null, null, null, null, null, null, null, null, null, null, null,
          null, null,
          null, null,
-         null, null, null, null, null, null
+         null, null, null, null, null, null, null
       );
    }
 
@@ -211,7 +215,7 @@ class WorksheetAgentControllerTest {
          null, null, null, null, null, null, null, null, null, null, null, null, null, null,
          null, null,
          null, null,
-         null, null, null, null, null, null
+         null, null, null, null, null, null, null
       );
    }
 
@@ -402,7 +406,7 @@ class WorksheetAgentControllerTest {
          null, null,
          null, null, null,
          null, null,
-         null, null, null, null, null, null);
+         null, null, null, null, null, null, null);
 
       WorksheetAgentController ctrl = controller(featureOn(),
          mock(SheetJoinService.class), mock(SheetSessionService.class),
@@ -493,7 +497,7 @@ class WorksheetAgentControllerTest {
          null, null,
          null, null, null,
          null, null,
-         null, null, null, null, null, null);
+         null, null, null, null, null, null, null);
 
       WorksheetAgentController ctrl = controller(featureOn(),
          mock(SheetJoinService.class), mock(SheetSessionService.class),
@@ -541,7 +545,7 @@ class WorksheetAgentControllerTest {
          null, null,
          null, null, null,
          null, null,
-         null, null, null, null, null, null);
+         null, null, null, null, null, null, null);
 
       WorksheetAgentController ctrl = controller(featureOn(),
          mock(SheetJoinService.class), mock(SheetSessionService.class),
@@ -586,7 +590,7 @@ class WorksheetAgentControllerTest {
          null, null,
          null, null, null,
          null, null,
-         null, null, null, null, null, null);
+         null, null, null, null, null, null, null);
 
       WorksheetAgentController ctrl = controller(featureOn(),
          mock(SheetJoinService.class), mock(SheetSessionService.class),
@@ -630,7 +634,7 @@ class WorksheetAgentControllerTest {
          null, null,
          null, null, null,
          null, null,
-         null, null, null, null, null, null);
+         null, null, null, null, null, null, null);
 
       WorksheetAgentController ctrl = controller(featureOn(),
          mock(SheetJoinService.class), mock(SheetSessionService.class),
@@ -653,7 +657,7 @@ class WorksheetAgentControllerTest {
          null, null,
          null, null, null,
          null, null,
-         null, null, null, null, null, null
+         null, null, null, null, null, null, null
       );
    }
 
@@ -739,7 +743,7 @@ class WorksheetAgentControllerTest {
          null, null, null, null, null, null, null, null, null, null, null, null, null, null,
          null, null,
          null, null,
-         null, null, null, null, null, null
+         null, null, null, null, null, null, null
       );
    }
 
@@ -752,7 +756,7 @@ class WorksheetAgentControllerTest {
          null, null, null, null, null, null, null, null, null, null, null, null, null, null,
          null, null,
          null, null,
-         null, null, null, null, null, null
+         null, null, null, null, null, null, null
       );
    }
 
@@ -1412,7 +1416,7 @@ class WorksheetAgentControllerTest {
          mock(XRepository.class), mock(QueryManagerService.class));
 
       EditRequest req = addTabularTableRequest("t1", null, null, null, null,
-         "Charges", null, null, null, null, null);
+         "Charges", null, null, null, null, null, null);
 
       PairingException ex = assertThrows(PairingException.class,
          () -> ctrl.edit("TOK-TT1", req, agent));
@@ -1432,7 +1436,7 @@ class WorksheetAgentControllerTest {
          mock(XRepository.class), mock(QueryManagerService.class));
 
       EditRequest req = addTabularTableRequest("t1", "MyDatasource", "Order Model", null, null,
-         "Charges", null, null, null, null, null);
+         "Charges", null, null, null, null, null, null);
 
       PairingException ex = assertThrows(PairingException.class,
          () -> ctrl.edit("TOK-TT2", req, agent));
@@ -1452,7 +1456,7 @@ class WorksheetAgentControllerTest {
          mock(XRepository.class), mock(QueryManagerService.class));
 
       EditRequest req = addTabularTableRequest("t1", "MyDatasource", null, "dbo", null,
-         "Charges", null, null, null, null, null);
+         "Charges", null, null, null, null, null, null);
 
       PairingException ex = assertThrows(PairingException.class,
          () -> ctrl.edit("TOK-TT3", req, agent));
@@ -1472,7 +1476,7 @@ class WorksheetAgentControllerTest {
          mock(XRepository.class), mock(QueryManagerService.class));
 
       EditRequest req = addTabularTableRequest("t1", "MyDatasource", null, null, null,
-         "Charges", null, null, null, "/v1/widgets/{id}", null);
+         "Charges", null, null, null, null, "/v1/widgets/{id}", null);
 
       PairingException ex = assertThrows(PairingException.class,
          () -> ctrl.edit("TOK-TT4", req, agent));
@@ -1496,7 +1500,7 @@ class WorksheetAgentControllerTest {
          xrepository, mock(QueryManagerService.class));
 
       EditRequest req = addTabularTableRequest("t1", "MyDatasource", null, null, null,
-         "Charges", null, null, null, null, null);
+         "Charges", null, null, null, null, null, null);
 
       PairingException ex = assertThrows(PairingException.class,
          () -> ctrl.edit("TOK-TT5", req, agent));
@@ -1523,7 +1527,7 @@ class WorksheetAgentControllerTest {
          xrepository, mock(QueryManagerService.class));
 
       EditRequest req = addTabularTableRequest("t1", "MyDatasource", null, null, null,
-         "Charges", null, null, null, null, null);
+         "Charges", null, null, null, null, null, null);
 
       // xrepository is an unstubbed mock, so getDataSource returns null and the request fails
       // with "Data source not found" -- proof execution proceeded past the permission gate into
@@ -1557,12 +1561,60 @@ class WorksheetAgentControllerTest {
          xrepository, mock(QueryManagerService.class));
 
       EditRequest req = addTabularTableRequest("t1", "MyDatasource", null, null, null,
-         "Charges", null, null, null, null, null);
+         "Charges", null, null, null, null, null, null);
 
       PairingException ex = assertThrows(PairingException.class,
          () -> ctrl.edit("TOK-TT7", req, agent));
       assertTrue(ex.getMessage().contains("not a tabular/REST one"), ex.getMessage());
       verifyNoInteractions(editSvc);
+   }
+
+   /**
+    * Proves {@code req.parameters()} actually reaches
+    * {@code TabularEndpointBindingSupport.applyEndpointContract} through {@code addTabularTable}
+    * -- not just that the field exists on {@code EditRequest} and deserializes (see
+    * {@code EditRequestParametersDeserializationTest}). {@code Repos} is given a REQUIRED
+    * parameter ("id") with no value; supplying it via {@code req.parameters()} must satisfy
+    * that requirement and let execution reach {@code editService.applyOnRuntime} -- with the
+    * parameter hardcoded to {@code null} (the bug this test guards against), the same request
+    * would instead fail with "requires parameter(s) ... id" before ever reaching it.
+    */
+   @Test
+   void addTabularTableThreadsParametersIntoTheSharedHelper() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      when(dataSourceService.checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(true);
+
+      TabularDataSource<?> ds = mock(TabularDataSource.class);
+      when(xrepository.getDataSource(eq("MyDatasource"))).thenReturn(ds);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         xrepository, mock(QueryManagerService.class));
+
+      FakeNamedConnectorQuery query = new FakeNamedConnectorQuery();
+      RestParameter idParam = new RestParameter();
+      idParam.setName("id");
+      idParam.setRequired(true);
+      query.getParameters().getParameters().add(idParam);
+
+      EditRequest req = addTabularTableRequest("t1", "MyDatasource", null, null, null,
+         "Repos", Map.of("id", "42"), null, null, null, null, null);
+
+      try(MockedStatic<TabularUtil> tabularUtil = mockStatic(TabularUtil.class, CALLS_REAL_METHODS)) {
+         tabularUtil.when(() -> TabularUtil.createQuery(eq("MyDatasource"))).thenReturn(query);
+
+         assertDoesNotThrow(() -> ctrl.edit("TOK-TT8", req, agent),
+            "the supplied 'id' parameter must satisfy Repos' required contract");
+         // editService.applyOnRuntime is only reached AFTER applyEndpointContract succeeds --
+         // if 'id' had not been threaded through, a PairingException would have fired first and
+         // this mock would never have been touched.
+         verify(editSvc).applyOnRuntime(eq("TOK-TT8"), eq(agent), any());
+      }
    }
 
    // ---------------------------------------------------------------------------
@@ -1635,6 +1687,7 @@ class WorksheetAgentControllerTest {
          sourceTable,          // sourceTable
          attribute,            // attribute
          null,                 // endpoint
+         null,                 // parameters
          null,                 // lookup
          null,                 // lookupExpandArrays
          null,                 // lookupTopLevelOnly
@@ -1710,6 +1763,7 @@ class WorksheetAgentControllerTest {
          "Customer",           // sourceTable
          "State",              // attribute
          null,                 // endpoint
+         null,                 // parameters
          null,                 // lookup
          null,                 // lookupExpandArrays
          null,                 // lookupTopLevelOnly

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -143,7 +143,32 @@ class WorksheetAgentControllerTest {
          null, null, null, null, datasource, null, null, null, null, null, null, null, null,
          null, null, null, null, null, null, null, null, null, null, null, null, null, null,
          null, null,
-         null, null
+         null, null,
+         null, null, null, null, null, null
+      );
+   }
+
+   /**
+    * Builds an {@code add_table} EditRequest that routes to {@code addTabularTable()} -- either
+    * the named-connector shape ({@code endpoint} + optional {@code lookup}) or the generic/custom
+    * shape ({@code suffix} + optional {@code customLookups}), or a deliberately-contradictory
+    * combination of these with {@code logicalModel}/{@code schema}/{@code catalog} for the
+    * dispatch-guard tests.
+    */
+   private static EditRequest addTabularTableRequest(
+      String table, String datasource, String logicalModel, String schema, String catalog,
+      String endpoint, List<String> lookup, Boolean lookupExpandArrays,
+      Boolean lookupTopLevelOnly, String suffix,
+      List<WorksheetMutationSupport.CustomLookupSpec> customLookups)
+   {
+      return new EditRequest(
+         "add_table", table, null, null, null, null, null, null, null, null,
+         null, null, null, false, null, null, null, null, null, null,
+         null, null, null, null, null, null, null, null, datasource, schema,
+         catalog, logicalModel, null, null, null, null, null, null, null, null,
+         null, null, null, null, null, null, null, null, null, null,
+         null, null, null, null, null, endpoint, lookup, lookupExpandArrays, lookupTopLevelOnly,
+         suffix, customLookups
       );
    }
 
@@ -159,7 +184,8 @@ class WorksheetAgentControllerTest {
          null, null, null, null, null, null, null, null, null, null, null, null, null,
          null, null, null, null, null, null, null, null, null, null, null, null, null, null,
          null, null,
-         null, null
+         null, null,
+         null, null, null, null, null, null
       );
    }
 
@@ -171,7 +197,8 @@ class WorksheetAgentControllerTest {
          null, null, null, null, null, null, null, null, null, null, null, null, null,
          null, null, null, null, null, null, null, null, null, null, null, null, null, null,
          null, null,
-         null, null
+         null, null,
+         null, null, null, null, null, null
       );
    }
 
@@ -183,7 +210,8 @@ class WorksheetAgentControllerTest {
          null, null, null, null, null, null, null, null, null, null, null, null, null,
          null, null, null, null, null, null, null, null, null, null, null, null, null, null,
          null, null,
-         null, null
+         null, null,
+         null, null, null, null, null, null
       );
    }
 
@@ -373,7 +401,8 @@ class WorksheetAgentControllerTest {
          null, null,
          null, null,
          null, null, null,
-         null, null);
+         null, null,
+         null, null, null, null, null, null);
 
       WorksheetAgentController ctrl = controller(featureOn(),
          mock(SheetJoinService.class), mock(SheetSessionService.class),
@@ -463,7 +492,8 @@ class WorksheetAgentControllerTest {
          null, null,
          null, null,
          null, null, null,
-         null, null);
+         null, null,
+         null, null, null, null, null, null);
 
       WorksheetAgentController ctrl = controller(featureOn(),
          mock(SheetJoinService.class), mock(SheetSessionService.class),
@@ -510,7 +540,8 @@ class WorksheetAgentControllerTest {
          null, null,
          null, null,
          null, null, null,
-         null, null);
+         null, null,
+         null, null, null, null, null, null);
 
       WorksheetAgentController ctrl = controller(featureOn(),
          mock(SheetJoinService.class), mock(SheetSessionService.class),
@@ -554,7 +585,8 @@ class WorksheetAgentControllerTest {
          null, null,
          null, null,
          null, null, null,
-         null, null);
+         null, null,
+         null, null, null, null, null, null);
 
       WorksheetAgentController ctrl = controller(featureOn(),
          mock(SheetJoinService.class), mock(SheetSessionService.class),
@@ -597,7 +629,8 @@ class WorksheetAgentControllerTest {
          null, null,
          null, null,
          null, null, null,
-         null, null);
+         null, null,
+         null, null, null, null, null, null);
 
       WorksheetAgentController ctrl = controller(featureOn(),
          mock(SheetJoinService.class), mock(SheetSessionService.class),
@@ -619,7 +652,8 @@ class WorksheetAgentControllerTest {
          null, null,
          null, null,
          null, null, null,
-         null, null
+         null, null,
+         null, null, null, null, null, null
       );
    }
 
@@ -704,7 +738,8 @@ class WorksheetAgentControllerTest {
          null, null, null, null, null, null, null, null, null, null, null, null, null,
          null, null, null, null, null, null, null, null, null, null, null, null, null, null,
          null, null,
-         null, null
+         null, null,
+         null, null, null, null, null, null
       );
    }
 
@@ -716,7 +751,8 @@ class WorksheetAgentControllerTest {
          null, null, null, null, null, null, null, null, null, null, null, null, null,
          null, null, null, null, null, null, null, null, null, null, null, null, null, null,
          null, null,
-         null, null
+         null, null,
+         null, null, null, null, null, null
       );
    }
 
@@ -1362,6 +1398,174 @@ class WorksheetAgentControllerTest {
    }
 
    // ---------------------------------------------------------------------------
+   // add_table with endpoint/suffix — dispatch guards + permission gate for addTabularTable()
+   // ---------------------------------------------------------------------------
+
+   @Test
+   void addTabularTableRequiresDatasource() {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         mock(XRepository.class), mock(QueryManagerService.class));
+
+      EditRequest req = addTabularTableRequest("t1", null, null, null, null,
+         "Charges", null, null, null, null, null);
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-TT1", req, agent));
+      assertTrue(ex.getMessage().contains("datasource is required"));
+      verifyNoInteractions(dataSourceService);
+      verifyNoInteractions(editSvc);
+   }
+
+   @Test
+   void addTabularTableRejectsLogicalModelTogetherWithEndpoint() {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         mock(XRepository.class), mock(QueryManagerService.class));
+
+      EditRequest req = addTabularTableRequest("t1", "MyDatasource", "Order Model", null, null,
+         "Charges", null, null, null, null, null);
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-TT2", req, agent));
+      assertTrue(ex.getMessage().contains("logicalModel"));
+      verifyNoInteractions(dataSourceService);
+      verifyNoInteractions(editSvc);
+   }
+
+   @Test
+   void addTabularTableRejectsSchemaCatalogTogetherWithEndpoint() {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         mock(XRepository.class), mock(QueryManagerService.class));
+
+      EditRequest req = addTabularTableRequest("t1", "MyDatasource", null, "dbo", null,
+         "Charges", null, null, null, null, null);
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-TT3", req, agent));
+      assertTrue(ex.getMessage().contains("schema/catalog"));
+      verifyNoInteractions(dataSourceService);
+      verifyNoInteractions(editSvc);
+   }
+
+   @Test
+   void addTabularTableRejectsBothEndpointAndSuffix() {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         mock(XRepository.class), mock(QueryManagerService.class));
+
+      EditRequest req = addTabularTableRequest("t1", "MyDatasource", null, null, null,
+         "Charges", null, null, null, "/v1/widgets/{id}", null);
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-TT4", req, agent));
+      assertTrue(ex.getMessage().contains("both endpoint and suffix"));
+      verifyNoInteractions(dataSourceService);
+      verifyNoInteractions(editSvc);
+   }
+
+   @Test
+   void addTabularTableDeniedByDatasourceReadThrowsPairingException() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      when(dataSourceService.checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(false);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         xrepository, mock(QueryManagerService.class));
+
+      EditRequest req = addTabularTableRequest("t1", "MyDatasource", null, null, null,
+         "Charges", null, null, null, null, null);
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-TT5", req, agent));
+      assertTrue(ex.getMessage().contains("no READ permission on datasource MyDatasource"));
+
+      // The READ denial must short-circuit before the data source (and its connector) is
+      // resolved at all -- the next step dials a real, metered endpoint.
+      verifyNoInteractions(xrepository);
+      verifyNoInteractions(editSvc);
+   }
+
+   @Test
+   void addTabularTableProceedsPastPermissionGateWhenReadGranted() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      when(dataSourceService.checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(true);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         xrepository, mock(QueryManagerService.class));
+
+      EditRequest req = addTabularTableRequest("t1", "MyDatasource", null, null, null,
+         "Charges", null, null, null, null, null);
+
+      // xrepository is an unstubbed mock, so getDataSource returns null and the request fails
+      // with "Data source not found" -- proof execution proceeded past the permission gate into
+      // addTabularTable's own datasource resolution, exactly the shape
+      // createTableTabularTableProceedsWhenDatasourceReadGranted already asserts on the
+      // wiz-services side.
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-TT6", req, agent));
+      assertTrue(ex.getMessage().contains("Data source not found"), ex.getMessage());
+      verify(xrepository).getDataSource(eq("MyDatasource"));
+      verifyNoInteractions(editSvc);
+   }
+
+   @Test
+   void addTabularTableRejectsNonTabularDatasource() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService editSvc = mock(WorksheetEditService.class);
+      DataSourceService dataSourceService = mock(DataSourceService.class);
+      XRepository xrepository = mock(XRepository.class);
+
+      when(dataSourceService.checkPermission(eq("MyDatasource"), eq(ResourceAction.READ), eq(agent)))
+         .thenReturn(true);
+
+      // A JDBC datasource is an XDataSource that is NOT a TabularDataSource.
+      JDBCDataSource jdbcDs = mock(JDBCDataSource.class);
+      when(jdbcDs.getType()).thenReturn("JDBC");
+      when(xrepository.getDataSource(eq("MyDatasource"))).thenReturn(jdbcDs);
+
+      WorksheetAgentController ctrl = securityController(editSvc,
+         dataSourceService, mock(SecurityEngine.class), mock(MetadataApiService.class),
+         xrepository, mock(QueryManagerService.class));
+
+      EditRequest req = addTabularTableRequest("t1", "MyDatasource", null, null, null,
+         "Charges", null, null, null, null, null);
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> ctrl.edit("TOK-TT7", req, agent));
+      assertTrue(ex.getMessage().contains("not a tabular/REST one"), ex.getMessage());
+      verifyNoInteractions(editSvc);
+   }
+
+   // ---------------------------------------------------------------------------
    // add_named_group — datasource-scoped "Only For" mode (Bug #76097)
    // ---------------------------------------------------------------------------
 
@@ -1429,7 +1633,13 @@ class WorksheetAgentControllerTest {
          null,                 // insert
          null,                 // subtables
          sourceTable,          // sourceTable
-         attribute             // attribute
+         attribute,            // attribute
+         null,                 // endpoint
+         null,                 // lookup
+         null,                 // lookupExpandArrays
+         null,                 // lookupTopLevelOnly
+         null,                 // suffix
+         null                  // customLookups
       );
    }
 
@@ -1498,7 +1708,13 @@ class WorksheetAgentControllerTest {
          null,                 // insert
          null,                 // subtables
          "Customer",           // sourceTable
-         "State"               // attribute
+         "State",              // attribute
+         null,                 // endpoint
+         null,                 // lookup
+         null,                 // lookupExpandArrays
+         null,                 // lookupTopLevelOnly
+         null,                 // suffix
+         null                  // customLookups
       );
 
       PairingException ex = assertThrows(PairingException.class,


### PR DESCRIPTION
## Summary

Java half of a two-repo feature; the TS/plugin half is a separate PR from `implementer-jsonlookup` in `stylebi-wiz`. Design doc: `stylebi-wiz` `docs/superpowers/specs/2026-08-24-json-endpoint-lookup-worksheet-binding-design.md`.

Composer's `add_table` op had no way to bind a worksheet table to a REST/JSON tabular datasource's endpoint (only `wiz-services`' own `/ws/table` path could, via `WorksheetTableService.buildTabularTable`/`applyEndpointContract`), and neither path supported selecting a pre-built "Join With" lookup chain, or authoring a custom endpoint/lookup chain against a generic REST-JSON datasource.

- **New shared class** `TabularEndpointBindingSupport` (`core/src/main/java/inetsoft/web/wiz/service/`) — extracted from `WorksheetTableService`'s existing `applyEndpointContract`/`assertKnownEndpoint`/`requireRowCapWhenPaged`/`setOptionalProperty` (pure move, no behavior change — its own test suite passes unchanged), plus new `applyLookupChain`/`applyCustomSuffix`/`applyCustomLookupChain` methods for the named-connector and generic/custom paths.
- **New `WorksheetAgentController.addTabularTable`** — new `add_table` dispatch branch (`endpoint`+optional `lookup`, or `suffix`+optional `customLookups`), routing between the two based on which properties the resolved `TabularQuery` class actually exposes (`pmap.get("endpoint")`), never trusting the caller's field choice alone — mirrors the read-back discipline the shared helper already uses to catch `EndpointJsonQuery`/`RestJsonQuery`'s documented silent-no-op setters.
- **`EditRequest`** gains `endpoint`, `lookup`, `lookupExpandArrays`, `lookupTopLevelOnly`, `suffix`, `customLookups` fields (+ new `WorksheetMutationSupport.CustomLookupSpec` record).
- **`WorksheetTableService.buildTabularTable`** now also applies a named-connector lookup chain when `tabularSource.lookup` is supplied (new `WorksheetTable.TabularSource` fields `lookup`/`lookupExpandArrays`/`lookupTopLevelOnly`) — the "for free" lookup support on the wiz-services path the design calls for.
- Validates each custom lookup level's `url` contains the literal `{paramN}` placeholder its position requires (1-indexed) — nothing in the runtime substitution path itself (`LookupService`) catches an omitted one, so a URL missing it would otherwise silently request the same page for every row.

## Deviations from the design doc

- The outer repo's remote tip had moved past the design's snapshot (`958ac7c9f` vs. the doc's `1f6345f8e`) by the time I started — verified `1f6345f8e` is an ancestor and branched fresh from the current tip.
- `WorksheetTableService`/`WorksheetTable.TabularSource` have gained a `targetKind`/file-target shape since the design's research pass that wasn't in scope there; the extraction only touches the endpoint-contract code path and leaves the file-target path untouched.
- `applyEndpointContract`'s shared signature takes plain parameters (`endpoint`, `parameters` map, `jsonPath`, etc.) rather than the design's sketch of passing `WorksheetTable.TabularSource` directly, since the controller's `EditRequest` has no equivalent object to hand it — `WorksheetTableService` now has a thin wrapper that unpacks its own `TabularSource`.
- Per the assigned scope, did **not** extend `WorksheetTableService`/`TabularSource` with `suffix`/`customLookups` for the generic/custom path (design §8.6 flags this as optional/recommended, not required) — `wiz-services` still can't bind a generic REST-JSON custom endpoint; only the plugin path (`WorksheetAgentController`) can. Flagging as a follow-up if parity is wanted.
- `parameters` support is threaded into `addTabularTable`'s named-connector path at the `TabularEndpointBindingSupport` layer, but `EditRequest`/`addTabularTable` itself doesn't yet accept a `parameters` field from the plugin — coordinate with `implementer-jsonlookup` on whether the TS side needs this added.

## Test plan

- [x] `TabularEndpointBindingSupportTest` (new) — 23 cases against real (non-mock) `TabularQuery` fixtures (`FakeNamedConnectorQuery`/`FakeCustomRestQuery`) covering `applyEndpointContract`, `applyLookupChain`, `applyCustomSuffix`, `applyCustomLookupChain`, including the cross-class silent-no-op boundary and the `{paramN}` placeholder validation.
- [x] `WorksheetAgentControllerTest` (extended) — 7 new `addTabularTable` dispatch-guard/permission-gate cases.
- [x] `WorksheetTableServiceLookupWiringTest` (new) — 2 cases proving `buildTabularTable` actually calls the shared `applyLookupChain`, not just that the helper is correct in isolation.
- [x] Full `inetsoft.web.wiz.**` package: 2307 tests, 0 failures (confirms the `WorksheetTableService` extraction is behavior-preserving).

```
./mvnw -o -pl core test -Dtest='inetsoft.web.wiz.**'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)