### PR TITLE
Let set_table_properties rename the table instead of dropping the name

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
@@ -63,7 +63,8 @@ import java.util.Map;
  *   <li>{@code edit_cell} — {@code table}, {@code row}, {@code col}, {@code value}</li>
  *   <li>{@code insert_row} — {@code table}, {@code index}</li>
  *   <li>{@code delete_row} — {@code table}, {@code index}</li>
- *   <li>{@code set_table_properties} — {@code table}, {@code alias}, {@code description}, {@code maxRows}, {@code distinct}</li>
+ *   <li>{@code set_table_properties} — {@code table}; any of {@code newName} (or {@code alias},
+ *       its accepted spelling), {@code description}, {@code maxRows}, {@code distinct}</li>
  *   <li>{@code add_cross_join} — {@code name}, {@code leftTable}, {@code rightTable}</li>
  *   <li>{@code add_merge_join} — {@code name}, {@code tables}</li>
  *   <li>{@code reorder_columns} — {@code table}, {@code columnOrder}</li>
@@ -116,7 +117,12 @@ public record EditRequest(
    String name,
    /** Data type string, e.g. {@code "string"}, {@code "integer"} (add_column, add_expression_column). */
    String type,
-   /** New alias for rename_column. */
+   /**
+    * The new name for a rename: the column's for {@code rename_column}, the table's for
+    * {@code set_table_properties} -- where it is a rename because a worksheet table has no display
+    * name of its own, the same shape as the Composer's table-properties dialog, whose model carries
+    * {@code newName}/{@code oldName} beside the other properties.
+    */
    String newName,
    /** Column name for filter / sort operations. */
    String field,
@@ -187,7 +193,11 @@ public record EditRequest(
    String value,
    /** Row index for insert_row / delete_row (0-based data row). */
    Integer index,
-   /** Table alias for set_table_properties. */
+   /**
+    * Accepted spelling of {@code newName} for {@code set_table_properties}, kept because callers
+    * reach for it. A worksheet table has no display name apart from its name, so setting an alias
+    * is a rename; {@code newName} wins when both are given.
+    */
    String alias,
    /** Table description for set_table_properties. */
    String description,

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -1511,6 +1511,13 @@ public class WorksheetAgentController {
             // 'alias' is accepted as a spelling of 'newName' rather than dropped: a worksheet table
             // has no display name apart from its name, so an alias request is a rename request. It
             // used to be discarded behind a comment while the call returned success.
+            //
+            // This looks redundant, because the only client of this endpoint is the composer plugin
+            // and that already normalises name/alias to newName before sending. It is here for the
+            // version it CANNOT normalise: a plugin bundle predating that change sends alias alone,
+            // and dist/bin.js ships inside the repo, so a server can outrun the bundle running
+            // against it. Drop this fallback and that pairing silently stops renaming again --
+            // which is the whole defect this op was fixed for.
             editor.setTableProperties(
                req.table(), req.newName() != null ? req.newName() : req.alias(),
                req.description(), req.maxRows(), req.distinct());

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -1508,8 +1508,12 @@ public class WorksheetAgentController {
             editor.deleteRow(req.table(), req.index());
          }
          case "set_table_properties" ->
+            // 'alias' is accepted as a spelling of 'newName' rather than dropped: a worksheet table
+            // has no display name apart from its name, so an alias request is a rename request. It
+            // used to be discarded behind a comment while the call returned success.
             editor.setTableProperties(
-               req.table(), req.alias(), req.description(), req.maxRows(), req.distinct());
+               req.table(), req.newName() != null ? req.newName() : req.alias(),
+               req.description(), req.maxRows(), req.distinct());
          case "add_cross_join" ->
             editor.addCrossJoin(req.name(), req.leftTable(), req.rightTable());
          case "add_merge_join" ->

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -1530,6 +1530,16 @@ public class WorksheetEditService {
          String name = table;
 
          if(newName != null && !newName.equals(table)) {
+            // Worksheet.renameAssembly checks only that the old name exists and the new one is
+            // free -- a blank name passes both and leaves a table nothing can address afterwards.
+            // Guarded here rather than only in the plugin, since this endpoint is reachable
+            // without it.
+            if(newName.trim().isEmpty()) {
+               throw new PairingException(
+                  "Cannot rename  + table +  to a blank name. Omit newName to leave the name " +
+                  "alone; a blank one would be accepted and leave the table unaddressable.");
+            }
+
             renameTable(table, newName);
             name = newName;
          }

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -1504,14 +1504,37 @@ public class WorksheetEditService {
        * @param distinct    distinct flag, or {@code null} to leave unchanged
        * @throws PairingException if the table is not found
        */
-      public void setTableProperties(String table, String alias, String description,
+      /**
+       * Applies the table properties, renaming the table when {@code newName} is given.
+       *
+       * <p>A worksheet table has no display name separate from its name -- the field exists on
+       * {@code AssetEntry}, {@code ColumnRef} and {@code WorksheetInfo}, on no {@code TableAssembly}
+       * -- so setting one is a rename. That is the shape the Composer's own table-properties dialog
+       * already has: {@code TablePropertyDialogModel} carries {@code newName}/{@code oldName} beside
+       * description, maxRows and distinct, and its service applies the properties and then renames
+       * through {@code refreshAssembly}. This used to accept an {@code alias} argument and drop it
+       * behind a comment, returning success while changing nothing.
+       *
+       * <p><b>The rename runs first, so a failure leaves everything untouched.</b> Renaming can fail
+       * on a name already in use, and applying the other properties before finding that out would
+       * half-write the patch -- the outcome this service refuses everywhere else. The remaining
+       * setters cannot fail, so ordering it this way makes the whole call all-or-nothing.
+       */
+      public void setTableProperties(String table, String newName, String description,
                                       Integer maxRows, Boolean distinct)
          throws PairingException
       {
-         TableAssembly t = requireTable(table);
+         // Resolved before the rename so an unknown table is reported against the name the caller
+         // passed, not against a name that does not exist yet.
+         requireTable(table);
+         String name = table;
 
-         // Table-level alias is not supported in the worksheet assembly model.
-         // Column-level aliases are set via rename_column instead.
+         if(newName != null && !newName.equals(table)) {
+            renameTable(table, newName);
+            name = newName;
+         }
+
+         TableAssembly t = requireTable(name);
 
          if(description != null) {
             t.setDescription(description);

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -2221,4 +2221,92 @@ class WorksheetEditServiceMutatorsTest {
 
       assertFalse(mirror.isAutoUpdate());
    }
+
+   // =========================================================================
+   // set_table_properties -- renaming is a table property
+   // =========================================================================
+
+   // A worksheet table has no display name apart from its name, so setting one is a rename. This
+   // used to take an "alias" argument and drop it behind a comment, returning success unchanged.
+
+   @Test
+   void setTablePropertiesRenamesTheTable() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly t = TestWorksheets.nonEmbeddedTableWithColumns(ws, "T", "a");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.setTableProperties("T", "Scores", null, null, null));
+
+      assertNotNull(ws.getAssembly("Scores"));
+      assertNull(ws.getAssembly("T"));
+   }
+
+   @Test
+   void setTablePropertiesAppliesTheOtherFieldsToTheRenamedTable() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly t = TestWorksheets.nonEmbeddedTableWithColumns(ws, "T", "a");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent,
+                ed -> ed.setTableProperties("T", "Scores", "the description", 25, true));
+
+      TableAssembly renamed = (TableAssembly) ws.getAssembly("Scores");
+      assertEquals("the description", renamed.getDescription());
+      assertEquals(25, renamed.getMaxRows());
+      assertTrue(renamed.isDistinct());
+   }
+
+   /**
+    * The rename runs first precisely so this holds: a name already in use fails the whole call and
+    * leaves the other fields alone, rather than half-writing the patch.
+    */
+   @Test
+   void aRenameOntoAnExistingNameChangesNothingAtAll() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly t = TestWorksheets.nonEmbeddedTableWithColumns(ws, "T", "a");
+      TableAssembly other = TestWorksheets.nonEmbeddedTableWithColumns(ws, "Taken", "a");
+      ws.addAssembly(t);
+      ws.addAssembly(other);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      assertThrows(Exception.class, () -> svc.apply(
+         "TOK", agent, ed -> ed.setTableProperties("T", "Taken", "should not land", 9, true)));
+
+      TableAssembly untouched = (TableAssembly) ws.getAssembly("T");
+      assertNotNull(untouched, "the table must keep its original name");
+      assertNull(untouched.getDescription(), "no property may be applied when the rename fails");
+   }
+
+   @Test
+   void omittingTheNameLeavesItAloneAndStillAppliesTheRest() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly t = TestWorksheets.nonEmbeddedTableWithColumns(ws, "T", "a");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.setTableProperties("T", null, "just a note", null, null));
+
+      assertNotNull(ws.getAssembly("T"));
+      assertEquals("just a note", ((TableAssembly) ws.getAssembly("T")).getDescription());
+   }
+
+   /** Passing the name it already has is a no-op rename, not a collision with itself. */
+   @Test
+   void passingTheSameNameIsNotTreatedAsACollision() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly t = TestWorksheets.nonEmbeddedTableWithColumns(ws, "T", "a");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.setTableProperties("T", "T", "kept", null, null));
+
+      assertEquals("kept", ((TableAssembly) ws.getAssembly("T")).getDescription());
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -2296,6 +2296,26 @@ class WorksheetEditServiceMutatorsTest {
       assertEquals("just a note", ((TableAssembly) ws.getAssembly("T")).getDescription());
    }
 
+   /**
+    * Worksheet.renameAssembly checks only that the old name exists and the new one is free, so a
+    * blank name passes both of its guards and leaves a table nothing can address afterwards.
+    */
+   @Test
+   void aBlankNameIsRefusedRatherThanLeavingTheTableUnaddressable() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly t = TestWorksheets.nonEmbeddedTableWithColumns(ws, "T", "a");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      assertThrows(Exception.class, () -> svc.apply(
+         "TOK", agent, ed -> ed.setTableProperties("T", "   ", "should not land", null, null)));
+
+      assertNotNull(ws.getAssembly("T"), "the table keeps its name");
+      assertNull(((TableAssembly) ws.getAssembly("T")).getDescription(),
+                 "nothing else in the patch may be applied either");
+   }
+
    /** Passing the name it already has is a no-op rename, not a collision with itself. */
    @Test
    void passingTheSameNameIsNotTreatedAsACollision() throws Exception {


### PR DESCRIPTION
`set_table_properties` took an `alias` argument, passed it to `WorksheetEditService`, and dropped it behind a comment while the call returned `{"ok":true}`:

```java
// Table-level alias is not supported in the worksheet assembly model.
// Column-level aliases are set via rename_column instead.
```

The caller got no rename and nothing said so.

## The comment was right about the field, wrong about the capability

There is no alias on a worksheet table — the field lives on `AssetEntry`, `ColumnRef` and `WorksheetInfo`, on no `TableAssembly`. But **a table's displayed name is its name**, so setting one is a rename, and renaming genuinely *is* a table property in this product: `TablePropertyDialogModel` carries `newName`/`oldName` beside description, maxRows and distinct, and its service applies the properties and then renames through `refreshAssembly`, which calls `renameAssembly` when the two names differ.

So this op was one line away from the capability it advertised.

## What changed

`newName` now performs the rename, and **`alias` is accepted as a spelling of it rather than discarded** — a caller that was silently failing starts working, instead of starting to 400.

**The rename runs first, so a failure leaves everything untouched.** Renaming can fail on a name already in use; applying description/maxRows/distinct before finding that out would half-write the patch, which this service refuses everywhere else. The remaining setters cannot fail, so ordering it this way makes the whole call all-or-nothing — there is a test for exactly that.

## One deliberate non-change

A review on the companion plugin PR suggested deleting the `alias` component outright. I kept it. `EditRequest` is a **53-component record constructed positionally in 15 places** — 3 in main, 12 in tests, the latter bare `null` lists with no positional comments. Removing a component means counting to position 48 in fifteen places, and the first attempt at it compiled clean only because incremental compilation had not rebuilt `WorksheetScriptService`; the breakage surfaced as a runtime `NoSuchMethodError`.

Keeping the component costs nothing once it means something, and the lie the review objected to is gone either way — `alias` now renames.

## Verification

5 tests, **verified non-vacuous**: reverting the rename logic fails three of them.

`inetsoft.web.wiz.worksheet.*Test` — **240 tests, all green**, on a branch rebased onto the current integration line (which has moved 19 commits since this work started, including #4765 touching three of the same files).

The plugin half is stylebi-wiz#1783, which sends both names and verifies the rename landed by reading the model back — so it stays honest against a server that predates this change rather than silently reporting success.
