### PR TITLE
Keep a filter's variable reference, refuse an unknown operator, and clear an aggregate's output alias

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -250,21 +250,18 @@ public final class WorksheetMutationSupport {
    // =========================================================================
 
    /**
-    * Builds a simple equality pre-condition and appends it (AND-joined) to the
-    * table's existing pre-condition list.
+    * Builds a pre-condition and appends it (AND-joined) to the table's existing
+    * pre-condition list.
     *
-    * <p>Only a single {@code operation} string is currently recognised:
-    * <ul>
-    *   <li>{@code "="} or {@code "EQUAL_TO"} — equality (default)</li>
-    *   <li>{@code "!="} or {@code "NOT_EQUAL_TO"} — not-equal</li>
-    *   <li>{@code "<"} or {@code "LESS_THAN"} — less-than</li>
-    *   <li>{@code ">"} or {@code "GREATER_THAN"} — greater-than</li>
-    * </ul>
-    * Unrecognised strings fall back to equality.</p>
+    * <p>{@link #parseOperation} owns the operator vocabulary and is the single place it is
+    * written down -- deliberately not restated here, since the copy that used to live in this
+    * javadoc listed four of the fifteen forms and said unrecognised strings fell back to
+    * equality, which is the defect parseOperation now refuses. An <i>absent</i> operator still
+    * means equality; a supplied one that is not recognised throws.</p>
     *
     * @param t         the table assembly to mutate
     * @param field     the column name to filter on
-    * @param operation the comparison operator (see above)
+    * @param operation the comparison operator; see {@link #parseOperation} for the accepted forms
     * @param values    one or more literal string values
     */
    public static void addFilter(TableAssembly t, String field,

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -1583,7 +1583,7 @@ public final class WorksheetMutationSupport {
          case "NOT_NULL"                 -> XCondition.NULL;    // negated via setNegated
          default -> throw new IllegalArgumentException(
             "'" + operation + "' is not a condition operator. Accepted: =, !=, <, <=, >, >=, " +
-            "BETWEEN, ONE_OF, NOT_ONE_OF, STARTING_WITH, CONTAINS, NULL, NOT_NULL. Omit the " +
+            "BETWEEN, ONE_OF, NOT_ONE_OF, STARTING_WITH, CONTAINS, LIKE, NULL, NOT_NULL. Omit the " +
             "operator entirely to mean equals -- an unrecognised one used to be applied as " +
             "equals, which quietly returns a different data set.");
       };

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -868,6 +868,17 @@ public final class WorksheetMutationSupport {
     * property (AggregateInfo of unknown provenance, e.g. set through the Composer UI)
     * every aggregate alias is cleared, preferring a loud unresolved-column failure over
     * a silently wrong chained aggregate.</p>
+    *
+    * <p>The alias is cleared on the column selection by name as well as on the
+    * AggregateInfo's own ref, because the two are only the same object until something
+    * clones the AggregateInfo and installs the copy. A preview does exactly that --
+    * {@code WorksheetPreviewService} snapshots and restores the AggregateInfo around
+    * RUNTIME_MODE execution, since {@code replaceVariables} rewrites it in place -- and
+    * {@link AggregateInfo#clone()} deep-clones every DataRef. Clearing only the
+    * AggregateInfo's ref then nulls an alias nothing reads, and the column the model
+    * reports keeps a name like {@code SUM_REVENUE} over un-aggregated rows for good.
+    * Live-confirmed 2026-08-25 (L2 Finding 20): the alias survived a clear only when a
+    * preview had run in between.</p>
     */
    private static void clearAggregateAliases(TableAssembly t) {
       AggregateInfo old = t.getAggregateInfo();
@@ -886,11 +897,40 @@ public final class WorksheetMutationSupport {
       Set<String> ownAliases = recorded == null ? null :
          new HashSet<>(Arrays.asList(recorded.split("\n", -1)));
 
+      ColumnSelection cs = t.getColumnSelection(false);
+
       for(int i = 0; i < old.getAggregateCount(); i++) {
          AggregateRef ar = old.getAggregate(i);
 
          if(ar.getDataRef() instanceof ColumnRef cr &&
             (ownAliases == null || ownAliases.contains(cr.getAlias())))
+         {
+            String alias = cr.getAlias();
+            cr.setAlias(null);
+            clearAliasInSelection(cs, cr, alias);
+         }
+      }
+   }
+
+   /**
+    * Clears {@code alias} from the column selection's own ref for the same base column.
+    *
+    * <p>A no-op in the ordinary case, where the column selection holds the very ref just
+    * cleared. It earns its place when the two have been separated by a clone -- matching
+    * on the base attribute AND the exact alias, so it cannot reach a different column
+    * that merely shares one of the two.</p>
+    */
+   private static void clearAliasInSelection(ColumnSelection cs, ColumnRef cleared,
+                                             String alias)
+   {
+      if(cs == null || alias == null || alias.isEmpty()) {
+         return;
+      }
+
+      for(int i = 0; i < cs.getAttributeCount(); i++) {
+         if(cs.getAttribute(i) instanceof ColumnRef cr && cr != cleared &&
+            alias.equals(cr.getAlias()) &&
+            Objects.equals(cr.getAttribute(), cleared.getAttribute()))
          {
             cr.setAlias(null);
          }

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -289,7 +289,7 @@ public final class WorksheetMutationSupport {
       }
 
       for(String v : values) {
-         c.addValue(v);
+         c.addValue(conditionValue(dtype, v));
       }
 
       ConditionItem item = new ConditionItem(ref, c, 0);
@@ -1493,12 +1493,43 @@ public final class WorksheetMutationSupport {
       return XSchema.STRING;
    }
 
+   /**
+    * Turns one condition value into what the engine stores: a {@link UserVariable} for a
+    * {@code $(name)} reference, otherwise the value coerced to the column's type.
+    *
+    * <p>Without the first case a variable reference is destroyed on the way in. The condition is
+    * typed from the resolved column, so on a numeric column {@code "$(Floor)"} does not parse and
+    * lands as {@code 0.0} -- not even the variable's default. The filter still reads as valid and
+    * still returns rows, so a parameterised filter silently becomes a constant one.
+    *
+    * <p>{@code AbstractCondition.getObject(type, value, true)} is what the engine itself uses, and
+    * {@code Condition.toString} renders such a value back as {@code $(name)}, so the round-trip is
+    * the same one the Composer's own condition dialog performs.
+    */
+   private static Object conditionValue(String dtype, String value) {
+      if(value != null && value.startsWith("$(") && value.endsWith(")") && value.length() > 3) {
+         return AbstractCondition.getObject(dtype, value.substring(2, value.length() - 1), true);
+      }
+
+      return value;
+   }
+   /**
+    * Maps an operator token to its XCondition constant.
+    *
+    * <p>An absent operator still means equals -- callers such as add_named_group leave it out on
+    * purpose. An operator that was <i>supplied</i> and is not recognised is refused instead,
+    * because defaulting it to equals silently returns a different data set: a filter written as
+    * greater-than becomes an equality test, the call answers ok, and nothing on screen marks it.
+    */
    static int parseOperation(String operation) {
-      if(operation == null) {
+      if(operation == null || operation.isBlank()) {
          return XCondition.EQUAL_TO;
       }
 
       return switch(operation.toUpperCase().replace(' ', '_')) {
+         // "=" had no case of its own -- it reached EQUAL_TO through the default branch, which is
+         // exactly why that branch could not simply be turned into a refusal.
+         case "=", "EQUAL_TO", "EQUALS" -> XCondition.EQUAL_TO;
          case "!=", "NOT_EQUAL_TO", "<>" -> XCondition.EQUAL_TO; // negated via setNegated
          case "<", "LESS_THAN"           -> XCondition.LESS_THAN;
          case ">", "GREATER_THAN"        -> XCondition.GREATER_THAN;
@@ -1512,7 +1543,11 @@ public final class WorksheetMutationSupport {
          case "LIKE"                     -> XCondition.LIKE;
          case "NULL", "IS_NULL"          -> XCondition.NULL;
          case "NOT_NULL"                 -> XCondition.NULL;    // negated via setNegated
-         default                         -> XCondition.EQUAL_TO;
+         default -> throw new IllegalArgumentException(
+            "'" + operation + "' is not a condition operator. Accepted: =, !=, <, <=, >, >=, " +
+            "BETWEEN, ONE_OF, NOT_ONE_OF, STARTING_WITH, CONTAINS, NULL, NOT_NULL. Omit the " +
+            "operator entirely to mean equals -- an unrecognised one used to be applied as " +
+            "equals, which quietly returns a different data set.");
       };
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -1313,13 +1313,12 @@ public final class WorksheetMutationSupport {
 
             if(spec.values() != null) {
                for(String v : spec.values()) {
-                  // $(varName) syntax maps to a UserVariable reference.
-                  if(v != null && v.startsWith("$(") && v.endsWith(")")) {
-                     c.addValue(new UserVariable(v.substring(2, v.length() - 1)));
-                  }
-                  else {
-                     c.addValue(v);
-                  }
+                  // Shared with addFilter rather than parsed a second time here. The local copy
+                  // had no lower bound on the name, so "$()" became a variable named "" -- one
+                  // nothing can ever resolve, reported as ok. Typing was NOT the difference: a
+                  // bare UserVariable still reaches the prompt with the condition's own type, so
+                  // both spellings already agreed there.
+                  c.addValue(conditionValue(dtype, v));
                }
             }
 

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -1315,9 +1315,11 @@ public final class WorksheetMutationSupport {
                for(String v : spec.values()) {
                   // Shared with addFilter rather than parsed a second time here. The local copy
                   // had no lower bound on the name, so "$()" became a variable named "" -- one
-                  // nothing can ever resolve, reported as ok. Typing was NOT the difference: a
-                  // bare UserVariable still reaches the prompt with the condition's own type, so
-                  // both spellings already agreed there.
+                  // nothing can ever resolve, reported as ok. Typing was NOT the difference,
+                  // though the bare constructor reads as though it would be: Condition.addValue
+                  // routes every value through convertType, whose UserVariable branch
+                  // (Condition:2129-2149) sets the type node from the condition's own type, so
+                  // the variable was typed from the column either way.
                   c.addValue(conditionValue(dtype, v));
                }
             }

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -1551,6 +1551,7 @@ public final class WorksheetMutationSupport {
 
       return value;
    }
+
    /**
     * Maps an operator token to its XCondition constant.
     *

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -350,6 +350,134 @@ class WorksheetEditServiceMutatorsTest {
          "a rename_column alias on an aggregated column must survive re-aggregation");
    }
 
+   /** Finds a column by its base attribute name, which an alias on it would otherwise shadow. */
+   private static ColumnRef columnByAttribute(TableAssembly t, String attribute) {
+      ColumnSelection cs = t.getColumnSelection(false);
+
+      for(int i = 0; i < cs.getAttributeCount(); i++) {
+         if(cs.getAttribute(i) instanceof ColumnRef cr && attribute.equals(cr.getAttribute())) {
+            return cr;
+         }
+      }
+
+      return null;
+   }
+
+   /**
+    * A preview between the aggregate and the clear used to strand the output alias for good.
+    *
+    * <p>clearAggregateAliases nulls the alias on the ColumnRef inside the OLD AggregateInfo, which
+    * is normally the very object the column selection holds. WorksheetPreviewService snapshots and
+    * restores the AggregateInfo around RUNTIME_MODE execution -- necessary, since
+    * AbstractTableAssembly.replaceVariables rewrites it in place -- and AggregateInfo.clone()
+    * deep-clones every DataRef. Afterwards the two are separate objects, so the clear nulled an
+    * alias nothing reads and the column the model reports kept a name like "total" over
+    * un-aggregated rows. Live-confirmed 2026-08-25 (L2 Finding 20): the alias survived a clear only
+    * when a preview had run in between. The clone here is that preview, reduced to the one step
+    * that matters.
+    */
+   @Test
+   void aggregateAliasIsClearedEvenAfterTheAggregateInfoHasBeenCloned() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "cust", "store", "amount");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed ->
+         ed.setGroupAggregate("T", groups("cust"),
+            List.of(new WorksheetMutationSupport.AggregateSpec("amount", "SUM", "total"))));
+      assertEquals("total", columnByAttribute(t, "amount").getAlias(),
+         "precondition: the aggregate labelled its output column");
+
+      // What a preview does: execute against a cloned AggregateInfo, then install the clone.
+      t.setAggregateInfo((AggregateInfo) t.getAggregateInfo().clone());
+
+      svc.apply("TOK", agent, ed -> ed.setGroupAggregate("T", List.of(), List.of()));
+
+      ColumnRef base = columnByAttribute(t, "amount");
+      assertNotNull(base, "the raw column must still be there after the clear");
+      assertNull(base.getAlias(),
+         "an aggregate output alias must not outlive the aggregate that created it");
+   }
+
+   /** Same separation, but the second call re-aggregates rather than clearing outright. */
+   @Test
+   void aggregateAliasIsClearedOnReAggregationAfterTheAggregateInfoHasBeenCloned()
+      throws Exception
+   {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "cust", "store", "amount");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed ->
+         ed.setGroupAggregate("T", groups("cust"),
+            List.of(new WorksheetMutationSupport.AggregateSpec("amount", "SUM", "total"))));
+      t.setAggregateInfo((AggregateInfo) t.getAggregateInfo().clone());
+
+      // Chaining on the prior output alias must still fail loud: that refusal is only correct
+      // because the alias is gone, and it was reachable again once a clone stranded it.
+      PairingException ex = assertThrows(PairingException.class, () ->
+         svc.apply("TOK", agent, ed ->
+            ed.setGroupAggregate("T", groups("store"),
+               List.of(new WorksheetMutationSupport.AggregateSpec("total", "AVG", "avg_total")))));
+      assertTrue(ex.getMessage().contains("total"));
+      assertNull(columnByAttribute(t, "amount").getAlias(),
+         "the prior output alias must be gone even though the AggregateInfo was cloned");
+   }
+
+   /** The negative control: the clear must not reach a deliberate rename_column alias. */
+   @Test
+   void renameAliasSurvivesAClearAfterTheAggregateInfoHasBeenCloned() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "cust", "store", "amount");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.renameColumn("T", "amount", "revenue"));
+      svc.apply("TOK", agent, ed ->
+         ed.setGroupAggregate("T", groups("cust"),
+            List.of(new WorksheetMutationSupport.AggregateSpec("amount", "SUM", null))));
+
+      t.setAggregateInfo((AggregateInfo) t.getAggregateInfo().clone());
+
+      svc.apply("TOK", agent, ed -> ed.setGroupAggregate("T", List.of(), List.of()));
+
+      assertEquals("revenue", columnByAttribute(t, "amount").getAlias(),
+         "a rename_column alias must survive a clear that follows a preview");
+   }
+
+   /**
+    * The clear now reaches into the column selection by name, so it has to be narrow: matching on
+    * the alias alone would strip an unrelated column that happens to carry the same one.
+    */
+   @Test
+   void clearingAnAggregateAliasLeavesAnotherColumnCarryingTheSameAliasAlone() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "cust", "store", "amount");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed ->
+         ed.setGroupAggregate("T", groups("cust"),
+            List.of(new WorksheetMutationSupport.AggregateSpec("amount", "SUM", "total"))));
+
+      // Set by hand rather than through renameColumn, which would refuse the collision -- the
+      // point is that the sweep is bounded by the base attribute, not that this state is reachable.
+      columnByAttribute(t, "store").setAlias("total");
+      t.setAggregateInfo((AggregateInfo) t.getAggregateInfo().clone());
+
+      svc.apply("TOK", agent, ed -> ed.setGroupAggregate("T", List.of(), List.of()));
+
+      assertNull(columnByAttribute(t, "amount").getAlias(), "the aggregated column loses its alias");
+      assertEquals("total", columnByAttribute(t, "store").getAlias(),
+         "a different column sharing the alias must be left alone");
+   }
+
    @Test
    void renameAliasSurvivesReAggregationAfterFailedIntermediateCall() throws Exception {
       Worksheet ws = new Worksheet();

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -2622,6 +2622,18 @@ class WorksheetEditServiceMutatorsTest {
       }
    }
 
+   /**
+    * "Absent" has to include whitespace, not just null. add_named_group omits the operator on
+    * purpose and the contract says an absent one means equals, so a blank string reaching the
+    * refusal would break a caller that had done nothing wrong.
+    */
+   @Test
+   void aBlankOperatorStillMeansEquals() {
+      assertEquals(XCondition.EQUAL_TO, WorksheetMutationSupport.parseOperation("   "));
+      assertEquals(XCondition.EQUAL_TO, WorksheetMutationSupport.parseOperation(""));
+      assertEquals(XCondition.EQUAL_TO, WorksheetMutationSupport.parseOperation(null));
+   }
+
    private static Object firstConditionOrNull(TableAssembly t) {
       ConditionListWrapper w = t.getPreConditionList();
       return w == null || w.isEmpty() ? null : firstCondition(t);

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -2579,7 +2579,9 @@ class WorksheetEditServiceMutatorsTest {
 
    /**
     * Defaulting an unrecognised operator to equals returns a different data set with nothing on
-    * screen marking it -- a greater-than quietly becomes an equality test.
+    * screen marking it -- "gt", a shape a caller reaches for when it does not know the vocabulary,
+    * used to become an equality test. Not spelled ">": that always had its own case and never
+    * reached the default branch, so it could not demonstrate this at all.
     */
    @Test
    void anUnrecognisedOperatorIsRefusedRatherThanAppliedAsEquals() throws Exception {
@@ -2590,13 +2592,34 @@ class WorksheetEditServiceMutatorsTest {
       WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
 
       Exception thrown = assertThrows(Exception.class, () -> svc.apply(
-         "TOK", agent, ed -> ed.addFilter("T", "a", "&gt;", "1")));
+         "TOK", agent, ed -> ed.addFilter("T", "a", "gt", "1")));
 
-      assertTrue(thrown.getMessage().contains("&gt;") ||
-                 thrown.getCause() != null && thrown.getCause().getMessage().contains("&gt;"),
+      assertTrue(thrown.getMessage().contains("gt") ||
+                 thrown.getCause() != null && thrown.getCause().getMessage().contains("gt"),
                  "the refusal must name the operator it rejected");
       assertNull(t.getPreConditionList() == null ? null : firstConditionOrNull(t),
                  "nothing may be written when the operator is refused");
+   }
+
+   /**
+    * The refusal exists so a caller can self-correct from it, which only works if it offers
+    * everything the parser takes. LIKE was accepted by the switch and absent from the message, and
+    * nothing caught it because nothing tied the two together -- this does, in both directions.
+    */
+   @Test
+   void everyAcceptedOperatorIsOfferedByTheRefusalMessage() {
+      String message = assertThrows(IllegalArgumentException.class,
+         () -> WorksheetMutationSupport.parseOperation("nonsense")).getMessage();
+
+      for(String op : List.of("=", "!=", "<", "<=", ">", ">=", "BETWEEN", "ONE_OF", "NOT_ONE_OF",
+                              "STARTING_WITH", "CONTAINS", "LIKE", "NULL", "NOT_NULL"))
+      {
+         assertDoesNotThrow(() -> WorksheetMutationSupport.parseOperation(op),
+                            op + " must be a recognised operator");
+         assertTrue(message.contains(op),
+                    "the refusal must offer " + op + " -- a caller reading it to self-correct "
+                    + "cannot discover an operator the message leaves out");
+      }
    }
 
    private static Object firstConditionOrNull(TableAssembly t) {

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -2520,9 +2520,14 @@ class WorksheetEditServiceMutatorsTest {
       assertInstanceOf(UserVariable.class, v, "a $(name) value must stay a variable");
       assertEquals("Floor", ((UserVariable) v).getName());
       // Passes on either side of the shared-helper change, and pinned for that reason: the
-      // refactor must not alter the type a variable arrives with. Typing was never the defect
-      // here -- UserVariable's type node defaults to StringType rather than null, and the
-      // condition's own type reaches the variable on both paths.
+      // refactor must not alter the type a variable arrives with. Typing was never the defect,
+      // and the reason is not the bare constructor -- which does leave the declaration-site
+      // StringType default (UserVariable:689) -- but Condition.addValue, which routes every value
+      // through convertType, whose `else if(val instanceof UserVariable)` branch
+      // (Condition:2129-2149) sets the type node from the condition's OWN type. The variable was
+      // therefore typed from the column by the time it was stored, whichever way it was built.
+      // Measured rather than reasoned: with this file's fix reverted and the sibling "$()" test
+      // failing as the canary that the revert had compiled, the type still read "double".
       assertEquals(XSchema.DOUBLE, ((UserVariable) v).getTypeNode().getType(),
          "the variable must carry the column's type, as it does through add_filter");
    }

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -23,6 +23,12 @@ import inetsoft.sree.security.ResourceType;
 import inetsoft.sree.security.SecurityEngine;
 import inetsoft.sree.security.SecurityException;
 import inetsoft.uql.ColumnSelection;
+import inetsoft.uql.ConditionListWrapper;
+import inetsoft.uql.XCondition;
+import inetsoft.uql.schema.UserVariable;
+import inetsoft.uql.schema.XSchema;
+import inetsoft.uql.Condition;
+import inetsoft.uql.ConditionItem;
 import inetsoft.uql.ConditionList;
 import inetsoft.uql.XConstants;
 import inetsoft.uql.asset.*;
@@ -2328,5 +2334,89 @@ class WorksheetEditServiceMutatorsTest {
       svc.apply("TOK", agent, ed -> ed.setTableProperties("T", "T", "kept", null, null));
 
       assertEquals("kept", ((TableAssembly) ws.getAssembly("T")).getDescription());
+   }
+
+   // =========================================================================
+   // Filter values and operators
+   // =========================================================================
+
+   private static Condition firstCondition(TableAssembly t) {
+      return (Condition) ((ConditionItem) t.getPreConditionList().getConditionList()
+         .getItem(0)).getXCondition();
+   }
+
+   /**
+    * The condition is typed from the resolved column, so on a numeric column a $(name) reference
+    * does not parse and used to land as 0.0 -- not even the variable's default. The filter still
+    * read as valid and still returned rows, so a parameterised filter silently became a constant.
+    */
+   @Test
+   void aVariableReferenceSurvivesAsAVariableNotAsZero() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly t = TestWorksheets.nonEmbeddedTableWithColumns(ws, "T", "a");
+      ((ColumnRef) t.getColumnSelection().getAttribute("a")).setDataType(XSchema.DOUBLE);
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.addFilter("T", "a", ">", "$(Floor)"));
+
+      Object v = firstCondition(t).getValue(0);
+      assertInstanceOf(UserVariable.class, v, "a $(name) value must stay a variable");
+      assertEquals("Floor", ((UserVariable) v).getName());
+   }
+
+   @Test
+   void anOrdinaryValueIsStillCoercedToTheColumnType() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly t = TestWorksheets.nonEmbeddedTableWithColumns(ws, "T", "a");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.addFilter("T", "a", "=", "hello"));
+
+      assertEquals("hello", firstCondition(t).getValue(0));
+   }
+
+   /**
+    * Defaulting an unrecognised operator to equals returns a different data set with nothing on
+    * screen marking it -- a greater-than quietly becomes an equality test.
+    */
+   @Test
+   void anUnrecognisedOperatorIsRefusedRatherThanAppliedAsEquals() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly t = TestWorksheets.nonEmbeddedTableWithColumns(ws, "T", "a");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      Exception thrown = assertThrows(Exception.class, () -> svc.apply(
+         "TOK", agent, ed -> ed.addFilter("T", "a", "&gt;", "1")));
+
+      assertTrue(thrown.getMessage().contains("&gt;") ||
+                 thrown.getCause() != null && thrown.getCause().getMessage().contains("&gt;"),
+                 "the refusal must name the operator it rejected");
+      assertNull(t.getPreConditionList() == null ? null : firstConditionOrNull(t),
+                 "nothing may be written when the operator is refused");
+   }
+
+   private static Object firstConditionOrNull(TableAssembly t) {
+      ConditionListWrapper w = t.getPreConditionList();
+      return w == null || w.isEmpty() ? null : firstCondition(t);
+   }
+
+   /** An omitted operator still means equals -- add_named_group leaves it out on purpose. */
+   @Test
+   void anOmittedOperatorStillMeansEquals() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly t = TestWorksheets.nonEmbeddedTableWithColumns(ws, "T", "a");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.addFilter("T", "a", null, "x"));
+
+      assertEquals(XCondition.EQUAL_TO, firstCondition(t).getOperation());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -2494,6 +2494,71 @@ class WorksheetEditServiceMutatorsTest {
       assertEquals("Floor", ((UserVariable) v).getName());
    }
 
+   /** One condition through set_conditions, so the $(name) handling can be compared to addFilter's. */
+   private static void setOneCondition(WorksheetEditService svc, Principal agent, String value)
+      throws Exception
+   {
+      svc.apply("TOK", agent, ed -> ed.setConditions("T", List.of(
+         new WorksheetMutationSupport.ConditionNode(
+            new WorksheetMutationSupport.ConditionSpec(
+               "a", ">", List.of(value), false, null), null, 0))));
+   }
+
+   /** A $(name) through set_conditions must stay a variable, typed from its column. */
+   @Test
+   void aVariableThroughSetConditionsCarriesItsColumnType() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly t = TestWorksheets.nonEmbeddedTableWithColumns(ws, "T", "a");
+      ((ColumnRef) t.getColumnSelection().getAttribute("a")).setDataType(XSchema.DOUBLE);
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      setOneCondition(svc, agent, "$(Floor)");
+
+      Object v = firstCondition(t).getValue(0);
+      assertInstanceOf(UserVariable.class, v, "a $(name) value must stay a variable");
+      assertEquals("Floor", ((UserVariable) v).getName());
+      // Passes on either side of the shared-helper change, and pinned for that reason: the
+      // refactor must not alter the type a variable arrives with. Typing was never the defect
+      // here -- UserVariable's type node defaults to StringType rather than null, and the
+      // condition's own type reaches the variable on both paths.
+      assertEquals(XSchema.DOUBLE, ((UserVariable) v).getTypeNode().getType(),
+         "the variable must carry the column's type, as it does through add_filter");
+   }
+
+   /**
+    * The real difference between the two paths: set_conditions had no lower bound on the name, so
+    * "$()" became a variable named "" -- one nothing can ever resolve, accepted without complaint.
+    */
+   @Test
+   void anEmptyVariableNameIsNotTreatedAsAVariableThroughSetConditions() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly t = TestWorksheets.nonEmbeddedTableWithColumns(ws, "T", "a");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      setOneCondition(svc, agent, "$()");
+
+      assertEquals("$()", firstCondition(t).getValue(0),
+         "an empty name is a literal, not a variable nothing can ever resolve");
+   }
+
+   /** The non-variable path must be untouched: a plain value still arrives as itself. */
+   @Test
+   void anOrdinaryValueThroughSetConditionsIsUnchanged() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly t = TestWorksheets.nonEmbeddedTableWithColumns(ws, "T", "a");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      setOneCondition(svc, agent, "hello");
+
+      assertEquals("hello", firstCondition(t).getValue(0));
+   }
+
    @Test
    void anOrdinaryValueIsStillCoercedToTheColumnType() throws Exception {
       Worksheet ws = new Worksheet();


### PR DESCRIPTION
Four defects found live while re-running L2 — two in worksheet filters (case 2.9, which the original pass could not have hit because it never wrote a filter containing a variable), one in the aggregate clear path, and one raised in review of this PR.

## A `$(variable)` reference was destroyed by type coercion

`addFilter` types the condition from the resolved column and added each value verbatim, so on a `double` column `$(DiscountFloor)` did not parse and landed as **`0.0`** — not even the variable's default of `0.1`:

```
written:  Discount > $(DiscountFloor)
stored:   Discount > 0.0
```

A parameterised filter silently became a constant one, which makes variables unusable in worksheet filters — the subject that lane exists to cover.

Values now route through `AbstractCondition.getObject(type, value, true)` for a `$(name)`, which is what the engine itself stores and what `Condition.toString` renders back as `$(name)`. That is the same round-trip the Composer's own condition dialog performs, so nothing new is invented.

## An unrecognised operator was applied as `=`

`parseOperation` ended `default -> XCondition.EQUAL_TO`, so a supplied operator it did not know became equals and the call answered `{"ok":true}` with a plausible disclosure. **A greater-than quietly becoming an equality test returns a different data set with nothing on screen marking it** — the shape of L7 Finding 2, where `trendLineType: "LINEAR"` became `NONE`.

Now refused, naming the token and listing the legal ones. An **absent** operator still means equals, because `add_named_group` omits it on purpose — the null branch was already separate, so that path is untouched.

## An aggregate output alias outlived the aggregate

`clearAggregateAliases` undoes an aggregate's output label by nulling the alias on the `ColumnRef` inside the old `AggregateInfo` — normally the very object the column selection holds. **A preview separates them:** `WorksheetPreviewService` snapshots and restores the `AggregateInfo` around `RUNTIME_MODE` execution (necessary — `replaceVariables` rewrites it in place) and `AggregateInfo.clone()` deep-clones every `DataRef`. The clear then nulled an alias nothing reads:

```
set_group_aggregate  Revenue -> SUM_REVENUE
preview                                        <- clones, installs the copy
set_group_aggregate  [] []                     <- clears the copy's alias
read model           Revenue (alias SUM_REVENUE)   forever
```

A detail table showed a column labelled as a sum holding raw per-row values. **Worse than a wrong label:** the stranded alias let a chained aggregate resolve back to the raw column, reopening the silently-wrong flat-aggregate-over-un-aggregated-rows hole `86fbc7262` closed.

Fixed on the clear side, not in the preview whose snapshot is required: the alias is also cleared on the column selection's own ref, matched on base attribute **and** exact alias so the sweep cannot reach a different column sharing one of the two.

## One parser for `$(name)`, not two

Review follow-up. `setConditions` parsed `$(name)` itself with no lower bound on the name, so **`"$()"` became a variable named `""`** — one nothing can ever resolve, accepted without complaint. It now calls the same `conditionValue` helper `addFilter` uses.

The review also reported that copy leaving the `UserVariable`'s type node null. **That is not so, and it is worth correcting rather than quietly fixing:** `UserVariable.xtype` defaults to `new StringType()`, not null, and printing the type on both sides of this change gives `double` either way — both spellings already agreed on typing. The test for it is kept as a guard that the refactor does not change the type a variable arrives with, labelled as a guard rather than as a bug.

## One thing worth flagging to a reviewer

**`"="` had no case of its own.** Plain equals reached `EQUAL_TO` through the very default branch being replaced, so turning that branch into a refusal broke six existing tests until an explicit `case "=", "EQUAL_TO", "EQUALS"` was added. The default was load-bearing, not dead — a comment now says so, since the next person to read that switch will wonder why equals is spelled out when nothing else obviously needed it.

## Verification

11 tests, each **verified non-vacuous by reverting its own fix**:

| fix | tests | fail without it |
|---|---|---|
| `$(variable)` coercion | 2 | 2 |
| unrecognised operator | 2 | 1 (one pins that an *omitted* operator still means equals) |
| aggregate alias | 4 | 3 (the fourth is the negative control: a deliberate `rename_column` alias must survive) |
| one `$(name)` parser | 3 | 1 (two are typing guards, true on both sides — see above) |

**2292 tests green**, `BUILD SUCCESS`.

The aggregate-alias fix was also **confirmed live** against a running Composer in both directions: the output alias is cleared after aggregate → preview → clear, and a `rename_column` alias on an aggregated column still survives the same sequence. A fix that cleared everything would look identical in the first half alone.

Finding 18 from the same run — `list_condition_operators` requiring a viewsheet session while `add_filter` is a worksheet tool, so the operators could not be looked up before writing — is fixed plugin-side in stylebi-wiz. That gap fed this PR's second defect directly: a caller could not check, guessed, and the guess was accepted.

