### PR TITLE
Bug #76189, add a real create-folder endpoint for the wiz Save dialog

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/WizVisualizationController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizVisualizationController.java
@@ -101,6 +101,9 @@ public class WizVisualizationController {
       catch(IllegalArgumentException e) {
          return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
       }
+      catch(SecurityException e) {
+         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Map.of("error", e.getMessage()));
+      }
       catch(Exception e) {
          LOG.error("Failed to create visualization folder", e);
          return ResponseEntity.internalServerError().body(Map.of("error", "An unexpected error occurred. Please try again."));

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizVisualizationController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizVisualizationController.java
@@ -22,10 +22,12 @@ import inetsoft.sree.security.SecurityException;
 import inetsoft.web.composer.model.TreeNodeModel;
 import inetsoft.web.wiz.model.WizDashboardEvent;
 import inetsoft.web.wiz.model.WizDashboardResult;
+import inetsoft.web.wiz.model.WizFolderSaveResult;
 import inetsoft.web.wiz.model.WizVisualizationRenderEvent;
 import inetsoft.web.wiz.model.WizVisualizationRenderResult;
 import inetsoft.web.wiz.model.WizVisualizationSaveEvent;
 import inetsoft.web.wiz.model.WizVisualizationSaveResult;
+import inetsoft.web.wiz.request.WizFolderCreateRequest;
 import inetsoft.web.wiz.service.RenderNotReadyException;
 import inetsoft.web.wiz.service.WizDashboardService;
 import inetsoft.web.wiz.service.WizVisualizationService;
@@ -76,6 +78,31 @@ public class WizVisualizationController {
       }
       catch(Exception e) {
          LOG.error("Failed to save visualization", e);
+         return ResponseEntity.internalServerError().body(Map.of("error", "An unexpected error occurred. Please try again."));
+      }
+   }
+
+   /**
+    * Creates a real folder under "Visualization Components" immediately, so the WIZ Save
+    * dialog's "New Folder" action behaves like a normal file manager: the folder exists on the
+    * server as soon as it is created, even if the dialog is closed before anything is ever saved
+    * into it. Unlike {@link #saveVisualization}, whose {@code targetFolderPath} only creates the
+    * folder as a side effect of writing a viewsheet there, this endpoint's only job is the
+    * folder itself.
+    */
+   @PostMapping(value = "/folders/create", produces = MediaType.APPLICATION_JSON_VALUE)
+   public ResponseEntity<?> createFolder(
+      @RequestBody WizFolderCreateRequest request, Principal principal)
+   {
+      try {
+         WizFolderSaveResult result = wizVisualizationService.createVisualizationFolder(request, principal);
+         return ResponseEntity.ok(result);
+      }
+      catch(IllegalArgumentException e) {
+         return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+      }
+      catch(Exception e) {
+         LOG.error("Failed to create visualization folder", e);
          return ResponseEntity.internalServerError().body(Map.of("error", "An unexpected error occurred. Please try again."));
       }
    }

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
@@ -31,6 +31,7 @@ import inetsoft.uql.asset.*;
 import inetsoft.uql.viewsheet.*;
 import inetsoft.uql.viewsheet.internal.WizUtil;
 import inetsoft.util.Catalog;
+import inetsoft.util.MessageException;
 import inetsoft.util.Tool;
 import inetsoft.web.composer.model.TreeNodeModel;
 import inetsoft.web.service.BinaryTransferService;
@@ -457,17 +458,33 @@ public class WizVisualizationService {
          throw new IllegalArgumentException("name must be a single path segment");
       }
 
-      String parentPath = Tool.isEmptyString(request.parentPath())
-         ? VISUALIZATION_COMPONENTS_FOLDER_PATH : request.parentPath();
+      // "/" means root too, matching the shared WizFolderCreateRequest.parentPath javadoc and
+      // WizDatabaseController#normalizePath's handling of the same convention.
+      String rawParentPath = request.parentPath();
+      String parentPath = (Tool.isEmptyString(rawParentPath) || "/".equals(rawParentPath))
+         ? VISUALIZATION_COMPONENTS_FOLDER_PATH : rawParentPath;
 
-      if(!parentPath.startsWith(VISUALIZATION_COMPONENTS_FOLDER_PATH)) {
+      if(!parentPath.equals(VISUALIZATION_COMPONENTS_FOLDER_PATH) &&
+         !parentPath.startsWith(VISUALIZATION_COMPONENTS_FOLDER_PATH + "/"))
+      {
          throw new IllegalArgumentException(
             "parentPath must be under the visualization components folder");
       }
 
       AssetEntry parentEntry = new AssetEntry(
          AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.REPOSITORY_FOLDER, parentPath, null);
-      assetRepository.checkAssetPermission(principal, parentEntry, ResourceAction.WRITE);
+
+      // checkAssetPermission signals a WRITE denial via MessageException (see
+      // AbstractAssetEngine#checkAssetPermission0), not SecurityException — convert it so this
+      // reaches the controller's existing catch(SecurityException) branch (matching render/
+      // dashboard in the same controller) instead of falling into catch(Exception) as a
+      // misleading "unexpected error" 500.
+      try {
+         assetRepository.checkAssetPermission(principal, parentEntry, ResourceAction.WRITE);
+      }
+      catch(MessageException e) {
+         throw new SecurityException(e.getMessage());
+      }
 
       String path = parentPath + "/" + name;
       AssetEntry newEntry = new AssetEntry(

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
@@ -20,6 +20,7 @@ package inetsoft.web.wiz.service;
 
 import inetsoft.analytic.composition.ViewsheetService;
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.security.IdentityID;
 import inetsoft.sree.security.ResourceAction;
 import inetsoft.sree.security.ResourceType;
@@ -36,10 +37,12 @@ import inetsoft.web.service.BinaryTransferService;
 import inetsoft.web.viewsheet.controller.AssemblyImageService;
 import inetsoft.web.viewsheet.service.ExportResponse;
 import inetsoft.web.viewsheet.service.VSExportService;
+import inetsoft.web.wiz.model.WizFolderSaveResult;
 import inetsoft.web.wiz.model.WizVisualizationRenderEvent;
 import inetsoft.web.wiz.model.WizVisualizationRenderResult;
 import inetsoft.web.wiz.model.WizVisualizationSaveEvent;
 import inetsoft.web.wiz.model.WizVisualizationSaveResult;
+import inetsoft.web.wiz.request.WizFolderCreateRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -432,6 +435,52 @@ public class WizVisualizationService {
       }
 
       return result;
+   }
+
+   /**
+    * Creates a real folder under {@link #VISUALIZATION_COMPONENTS_FOLDER_PATH} immediately —
+    * unlike {@link #saveVisualization}'s {@code targetFolderPath}, which only creates the target
+    * folder as a side effect of writing a viewsheet into it, this is the folder's entire job.
+    * Mirrors {@code WizDatabaseController#createFolder}'s shape (advisory duplicate check, then
+    * create), reusing the same {@link WizFolderCreateRequest}/{@link WizFolderSaveResult} pair.
+    */
+   public WizFolderSaveResult createVisualizationFolder(WizFolderCreateRequest request, Principal principal)
+      throws Exception
+   {
+      if(request == null || Tool.isEmptyString(request.name())) {
+         throw new IllegalArgumentException("name is required");
+      }
+
+      String name = SUtil.removeControlChars(request.name().trim());
+
+      if(name.isEmpty() || name.contains("/") || ".".equals(name) || "..".equals(name)) {
+         throw new IllegalArgumentException("name must be a single path segment");
+      }
+
+      String parentPath = Tool.isEmptyString(request.parentPath())
+         ? VISUALIZATION_COMPONENTS_FOLDER_PATH : request.parentPath();
+
+      if(!parentPath.startsWith(VISUALIZATION_COMPONENTS_FOLDER_PATH)) {
+         throw new IllegalArgumentException(
+            "parentPath must be under the visualization components folder");
+      }
+
+      AssetEntry parentEntry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.REPOSITORY_FOLDER, parentPath, null);
+      assetRepository.checkAssetPermission(principal, parentEntry, ResourceAction.WRITE);
+
+      String path = parentPath + "/" + name;
+      AssetEntry newEntry = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.REPOSITORY_FOLDER, path, null);
+
+      // Advisory, not atomic with the addFolder call below — the same race every other wiz
+      // create-folder endpoint (e.g. WizDatabaseController#createFolder) already accepts.
+      if(assetRepository.containsEntry(newEntry)) {
+         return WizFolderSaveResult.failed(WizFolderSaveResult.DUPLICATE_NAME);
+      }
+
+      assetRepository.addFolder(newEntry, principal);
+      return WizFolderSaveResult.ok(path);
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVisualizationServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVisualizationServiceTest.java
@@ -34,9 +34,11 @@ import inetsoft.util.MessageException;
 import inetsoft.web.service.BinaryTransferService;
 import inetsoft.web.viewsheet.controller.AssemblyImageService;
 import inetsoft.web.viewsheet.service.VSExportService;
+import inetsoft.web.wiz.model.WizFolderSaveResult;
 import inetsoft.web.wiz.model.WizVisualizationRenderEvent;
 import inetsoft.web.wiz.model.WizVisualizationSaveEvent;
 import inetsoft.web.wiz.model.WizVisualizationSaveResult;
+import inetsoft.web.wiz.request.WizFolderCreateRequest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -160,6 +162,102 @@ class WizVisualizationServiceTest {
          any(AssetEntry.class), eq(principal), eq(true), any(AssetContent.class));
       verify(viewsheetService).setViewsheet(
          any(Viewsheet.class), any(AssetEntry.class), eq(principal), eq(true), eq(true));
+   }
+
+   // ── createVisualizationFolder ─────────────────────────────────────────────────
+
+   @Test
+   void createFolderRejectsBlankName() throws Exception {
+      WizVisualizationService service = createService(mock(ViewsheetService.class), mock(AssetRepository.class));
+
+      assertThrows(IllegalArgumentException.class,
+                   () -> service.createVisualizationFolder(
+                      new WizFolderCreateRequest(null, "  "), mock(Principal.class)));
+   }
+
+   @Test
+   void createFolderRejectsNameWithPathSeparator() throws Exception {
+      WizVisualizationService service = createService(mock(ViewsheetService.class), mock(AssetRepository.class));
+
+      assertThrows(IllegalArgumentException.class,
+                   () -> service.createVisualizationFolder(
+                      new WizFolderCreateRequest(null, "a/b"), mock(Principal.class)));
+   }
+
+   @Test
+   void createFolderRejectsParentPathOutsideManagedFolder() throws Exception {
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      WizVisualizationService service = createService(mock(ViewsheetService.class), assetRepository);
+
+      assertThrows(IllegalArgumentException.class,
+                   () -> service.createVisualizationFolder(
+                      new WizFolderCreateRequest("some/unmanaged/folder", "Sales"), mock(Principal.class)));
+
+      // The folder-scope check must happen before any asset is touched.
+      verifyNoInteractions(assetRepository);
+   }
+
+   @Test
+   void createFolderDefaultsBlankParentPathToTheManagedRoot() throws Exception {
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      WizVisualizationService service = createService(mock(ViewsheetService.class), assetRepository);
+
+      when(assetRepository.containsEntry(any(AssetEntry.class))).thenReturn(false);
+
+      WizFolderSaveResult result = service.createVisualizationFolder(
+         new WizFolderCreateRequest(null, "Sales"), mock(Principal.class));
+
+      String expectedPath = WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/Sales";
+      assertTrue(result.ok());
+      assertEquals(expectedPath, result.path());
+      verify(assetRepository).addFolder(
+         argThat(e -> expectedPath.equals(e.getPath())), any(Principal.class));
+   }
+
+   @Test
+   void createFolderChecksWritePermissionOnTheParent() throws Exception {
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      WizVisualizationService service = createService(mock(ViewsheetService.class), assetRepository);
+
+      when(assetRepository.containsEntry(any(AssetEntry.class))).thenReturn(false);
+
+      String parentPath = WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/Region";
+      Principal principal = mock(Principal.class);
+      service.createVisualizationFolder(new WizFolderCreateRequest(parentPath, "Sales"), principal);
+
+      verify(assetRepository).checkAssetPermission(
+         eq(principal), argThat(e -> parentPath.equals(e.getPath())), eq(ResourceAction.WRITE));
+   }
+
+   @Test
+   void createFolderPropagatesPermissionDenial() throws Exception {
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      WizVisualizationService service = createService(mock(ViewsheetService.class), assetRepository);
+
+      doThrow(new MessageException("Write access denied"))
+         .when(assetRepository).checkAssetPermission(
+            any(Principal.class), any(AssetEntry.class), eq(ResourceAction.WRITE));
+
+      assertThrows(MessageException.class,
+                   () -> service.createVisualizationFolder(
+                      new WizFolderCreateRequest(null, "Sales"), mock(Principal.class)));
+
+      verify(assetRepository, never()).addFolder(any(AssetEntry.class), any(Principal.class));
+   }
+
+   @Test
+   void createFolderReturnsDuplicateNameWithoutCallingAddFolder() throws Exception {
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      WizVisualizationService service = createService(mock(ViewsheetService.class), assetRepository);
+
+      when(assetRepository.containsEntry(any(AssetEntry.class))).thenReturn(true);
+
+      WizFolderSaveResult result = service.createVisualizationFolder(
+         new WizFolderCreateRequest(null, "Sales"), mock(Principal.class));
+
+      assertFalse(result.ok());
+      assertEquals(WizFolderSaveResult.DUPLICATE_NAME, result.reason());
+      verify(assetRepository, never()).addFolder(any(AssetEntry.class), any(Principal.class));
    }
 
    // ── renderVisualization: guard + permission branches ─────────────────────────

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVisualizationServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVisualizationServiceTest.java
@@ -230,19 +230,57 @@ class WizVisualizationServiceTest {
    }
 
    @Test
-   void createFolderPropagatesPermissionDenial() throws Exception {
+   void createFolderConvertsPermissionDenialToSecurityException() throws Exception {
       AssetRepository assetRepository = mock(AssetRepository.class);
       WizVisualizationService service = createService(mock(ViewsheetService.class), assetRepository);
 
+      // checkAssetPermission signals a WRITE denial via MessageException (see
+      // AbstractAssetEngine#checkAssetPermission0) — the service must convert this to
+      // SecurityException so it reaches WizVisualizationController#createFolder's
+      // catch(SecurityException) branch (a real 403) instead of falling into catch(Exception)
+      // as a misleading "unexpected error" 500.
       doThrow(new MessageException("Write access denied"))
          .when(assetRepository).checkAssetPermission(
             any(Principal.class), any(AssetEntry.class), eq(ResourceAction.WRITE));
 
-      assertThrows(MessageException.class,
+      assertThrows(inetsoft.sree.security.SecurityException.class,
                    () -> service.createVisualizationFolder(
                       new WizFolderCreateRequest(null, "Sales"), mock(Principal.class)));
 
       verify(assetRepository, never()).addFolder(any(AssetEntry.class), any(Principal.class));
+   }
+
+   @Test
+   void createFolderTreatsSlashParentPathAsRoot() throws Exception {
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      WizVisualizationService service = createService(mock(ViewsheetService.class), assetRepository);
+
+      when(assetRepository.containsEntry(any(AssetEntry.class))).thenReturn(false);
+
+      // WizFolderCreateRequest.parentPath's javadoc documents "/" as meaning root, same as
+      // null/empty — matching WizDatabaseController#normalizePath's handling of the same input.
+      WizFolderSaveResult result = service.createVisualizationFolder(
+         new WizFolderCreateRequest("/", "Sales"), mock(Principal.class));
+
+      String expectedPath = WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/Sales";
+      assertTrue(result.ok());
+      assertEquals(expectedPath, result.path());
+   }
+
+   @Test
+   void createFolderRejectsASiblingPathSharingOnlyAPrefix() throws Exception {
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      WizVisualizationService service = createService(mock(ViewsheetService.class), assetRepository);
+
+      // A path that merely starts with the same characters as the managed root (but is not
+      // actually under it) must not pass the "under the visualization components folder" guard.
+      String siblingPath = WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "-evil";
+
+      assertThrows(IllegalArgumentException.class,
+                   () -> service.createVisualizationFolder(
+                      new WizFolderCreateRequest(siblingPath, "Sales"), mock(Principal.class)));
+
+      verifyNoInteractions(assetRepository);
    }
 
    @Test


### PR DESCRIPTION
## Summary
- The wiz Save dialog's "New Folder" action had no dedicated create-folder endpoint: a folder only ever became real as a side effect of `WizVisualizationService#saveVisualization` writing a viewsheet into it via `ensureFolder()`. Closing the dialog before saving meant the folder was never persisted, so reopening the dialog never showed it.
- Adds `POST /api/wiz/visualization/folders/create` to `WizVisualizationController`, backed by `WizVisualizationService#createVisualizationFolder`.
- Mirrors the existing wiz create-folder convention (`WizDatabaseController#createFolder`) by reusing `WizFolderCreateRequest`/`WizFolderSaveResult` instead of minting new request/response types.
- Validates the target path stays under `VISUALIZATION_COMPONENTS_FOLDER_PATH`, checks WRITE permission on the parent folder, and reports `DUPLICATE_NAME` as a normal `{ok:false}` result (not an exception) — same shape the datasource-folder endpoint already uses.

## Test plan
- [x] 7 new unit tests in `WizVisualizationServiceTest` (blank/invalid name, path-outside-managed-folder guard, permission check, permission denial propagation, duplicate-name short-circuit, default-to-root path resolution) — all 12 tests in the class pass
- [x] `mvn -pl community/core -am compile` verified clean
- [x] Verified live: paired wiz-services/portal change (branch `bug-76189` in `stylebi-wiz`) creates a folder via this endpoint, closes the dialog without saving, reopens it — folder persists

Paired with `stylebi-wiz` PR #1798, which is the only caller of this endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)