### PR TITLE
Bug #76058, support crosstab mode in set_group_aggregate for the wiz agent

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
@@ -38,7 +38,14 @@ import java.util.Map;
  *   <li>{@code add_filter} — {@code table}, {@code field}, {@code operation}, {@code values}</li>
  *   <li>{@code remove_filter} — {@code table}, {@code field}</li>
  *   <li>{@code set_group_aggregate} — {@code table}, {@code groups} (each a column name or
- *       {@code {field, dateLevel}}), {@code aggregates}</li>
+ *       {@code {field, dateLevel}}), {@code aggregates}, optional {@code crosstab} (true =
+ *       display as a crosstab, matching the Group and Aggregate dialog's "Switch to
+ *       Crosstab" toggle; defaults to false). Per
+ *       {@link inetsoft.uql.asset.AggregateInfo#isCrosstab}, the
+ *       request is accepted either way but the crosstab actually takes effect only with at
+ *       least 2 {@code groups} and at least 1 {@code aggregates} entry — fewer than that and
+ *       the table silently reads back as a non-crosstab table on the next read, with no
+ *       error from this call.</li>
  *   <li>{@code add_expression_column} — {@code table}, {@code name}, {@code expression}, {@code type}, {@code sql}</li>
  *   <li>{@code set_sort} — {@code table}, {@code field}, {@code direction} ("ASC" | "DESC")</li>
  *   <li>{@code add_join} — {@code name}, {@code leftTable}, {@code leftKey}, {@code rightTable}, {@code rightKey}, {@code joinType}; for multi-key joins use {@code leftKeys}/{@code rightKeys} instead of single key fields</li>
@@ -297,5 +304,46 @@ public record EditRequest(
     * suffix appended to the datasource's base URL). Max 5 entries. Only valid together with
     * {@code suffix}.
     */
-   List<WorksheetMutationSupport.CustomLookupSpec> customLookups
-) {}
+   List<WorksheetMutationSupport.CustomLookupSpec> customLookups,
+   /**
+    * {@code true} to display set_group_aggregate's result as a crosstab (row/column
+    * headers) rather than a flat grouped table — the Composer's own Group and Aggregate
+    * dialog "Switch to Crosstab" toggle. Defaults to {@code false} when omitted. Takes visible
+    * effect only once {@code groups} has at least 2 entries and {@code aggregates} at least 1;
+    * with fewer, it is accepted but silently has no effect (same as the Composer dialog itself).
+    */
+   Boolean crosstab
+) {
+   /**
+    * Compatibility constructor for callers built before {@code crosstab} was added —
+    * defaults it to {@code null} (treated as {@code false}).
+    */
+   public EditRequest(
+      String op, String table, String column, String name, String type, String newName,
+      String field, String operation, List<String> values, String direction,
+      List<WorksheetMutationSupport.GroupSpec> groups,
+      List<WorksheetMutationSupport.AggregateSpec> aggregates, String expression, boolean sql,
+      String leftTable, String leftKey, String rightTable, String rightKey, String joinType,
+      Boolean visible, List<String> tables, String source, String concatType,
+      List<WorksheetMutationSupport.ConditionNode> conditions,
+      WorksheetMutationSupport.RankingSpec ranking, Integer headerColumns, String dateOption,
+      double[] boundaries, String datasource, String schema, String catalog, String logicalModel,
+      List<String> leftKeys, List<String> rightKeys, Integer row, Integer col, String value,
+      Integer index, String alias, String description, Integer maxRows, Boolean distinct,
+      List<String> columnOrder, List<WorksheetMutationSupport.GroupMapping> groupMappings,
+      Boolean groupOthers, Map<String, String> variableValues, Integer x, Integer y, String label,
+      String defaultValue, String mode, Boolean insert, List<String> subtables,
+      String sourceTable, String attribute, String endpoint, Map<String, String> parameters,
+      List<String> lookup, Boolean lookupExpandArrays, Boolean lookupTopLevelOnly, String suffix,
+      List<WorksheetMutationSupport.CustomLookupSpec> customLookups)
+   {
+      this(op, table, column, name, type, newName, field, operation, values, direction, groups,
+           aggregates, expression, sql, leftTable, leftKey, rightTable, rightKey, joinType,
+           visible, tables, source, concatType, conditions, ranking, headerColumns, dateOption,
+           boundaries, datasource, schema, catalog, logicalModel, leftKeys, rightKeys, row, col,
+           value, index, alias, description, maxRows, distinct, columnOrder, groupMappings,
+           groupOthers, variableValues, x, y, label, defaultValue, mode, insert, subtables,
+           sourceTable, attribute, endpoint, parameters, lookup, lookupExpandArrays,
+           lookupTopLevelOnly, suffix, customLookups, null);
+   }
+}

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -1595,7 +1595,8 @@ public class WorksheetAgentController {
                                             .map(a -> new WorksheetMutationSupport.AggregateSpec(
                                                 a.field(), a.formula(), a.alias()))
                                             .toList()
-                                        : List.of());
+                                        : List.of(),
+                                     Boolean.TRUE.equals(req.crosstab()));
          case "add_expression_column" -> {
             if(req.name() == null || req.name().isBlank()) {
                throw new PairingException("name is required for add_expression_column.");

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -487,7 +487,28 @@ public class WorksheetEditService {
                                     List<WorksheetMutationSupport.AggregateSpec> aggregates)
          throws PairingException
       {
-         WorksheetMutationSupport.applyAggregateInfo(requireTable(table), groups, aggregates);
+         setGroupAggregate(table, groups, aggregates, false);
+      }
+
+      /**
+       * Builds and sets a new {@link AggregateInfo} on the named table.
+       *
+       * @param table      the assembly name
+       * @param groups     group-by column specs (name, plus optional date grouping level)
+       * @param aggregates aggregate measures to apply
+       * @param crosstab   {@code true} to display the result as a crosstab (row/column
+       *                   headers) rather than a flat grouped table — the Composer's own
+       *                   Group and Aggregate dialog "Switch to Crosstab" toggle. Takes visible
+       *                   effect only once {@code groups} has at least 2 entries and
+       *                   {@code aggregates} at least 1 — see {@link AggregateInfo#isCrosstab}
+       * @throws PairingException if no {@link TableAssembly} with {@code table} exists
+       */
+      public void setGroupAggregate(String table, List<WorksheetMutationSupport.GroupSpec> groups,
+                                    List<WorksheetMutationSupport.AggregateSpec> aggregates,
+                                    boolean crosstab)
+         throws PairingException
+      {
+         WorksheetMutationSupport.applyAggregateInfo(requireTable(table), groups, aggregates, crosstab);
       }
 
       // -----------------------------------------------------------------------

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -400,6 +400,28 @@ public final class WorksheetMutationSupport {
                                          List<AggregateSpec> aggregates)
       throws inetsoft.web.wiz.pairing.PairingException
    {
+      applyAggregateInfo(t, groups, aggregates, false);
+   }
+
+   /**
+    * Builds and sets a new {@link AggregateInfo} on the table from the supplied
+    * group and aggregate specs, optionally in crosstab mode — the same "Switch to
+    * Crosstab" toggle as the Composer's own Group and Aggregate dialog.
+    *
+    * @param t          the table assembly to mutate
+    * @param groups     group-by column specs (name, plus optional date grouping level);
+    *                   {@code null} is treated as empty
+    * @param aggregates aggregate measures to apply; {@code null} is treated as empty
+    * @param crosstab   {@code true} to display the result as a crosstab (row/column
+    *                   headers) rather than a flat grouped table. {@link AggregateInfo#isCrosstab}
+    *                   only reports {@code true} back once the table has at least 2 groups and 1
+    *                   aggregate — with fewer, this is accepted but silently has no visible
+    *                   effect, matching the Composer dialog's own {@code setCrosstab} call
+    */
+   public static void applyAggregateInfo(TableAssembly t, List<GroupSpec> groups,
+                                         List<AggregateSpec> aggregates, boolean crosstab)
+      throws inetsoft.web.wiz.pairing.PairingException
+   {
       // Callers (e.g. WorksheetAgentController) may pass a null groups or aggregates
       // list when the request omits that key entirely; normalize before either the
       // emptiness check below or the per-spec loops run, so a null groups list paired
@@ -708,6 +730,7 @@ public final class WorksheetMutationSupport {
       // a rename_column alias on an aggregated column survives re-aggregation.
       t.setProperty(AGGREGATE_OUTPUT_ALIASES,
                     appliedAliases.isEmpty() ? "" : String.join("\n", appliedAliases));
+      ainfo.setCrosstab(crosstab);
       t.setAggregateInfo(ainfo);
       t.setAggregate(!ainfo.isEmpty());
    }

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
@@ -706,7 +706,7 @@ public class WorksheetReadService {
          aggregates.add(readAggregateRef(ar));
       }
 
-      return new WorksheetModel.AggregateModel(groups, aggregates);
+      return new WorksheetModel.AggregateModel(groups, aggregates, info.isCrosstab());
    }
 
    private WorksheetModel.AggregateModel.AggregateRefModel readAggregateRef(AggregateRef ar) {

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/model/WorksheetModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/model/WorksheetModel.java
@@ -207,9 +207,13 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
     *
     * @param groups     group-by dimensions
     * @param aggregates measure aggregate definitions
+    * @param crosstab   whether the table is displayed as a crosstab (row/column headers)
+    *                   rather than a flat grouped table — set via set_group_aggregate's
+    *                   {@code crosstab} option
     */
    @JsonInclude(JsonInclude.Include.NON_NULL)
-   public record AggregateModel(List<GroupModel> groups, List<AggregateRefModel> aggregates) {
+   public record AggregateModel(
+      List<GroupModel> groups, List<AggregateRefModel> aggregates, boolean crosstab) {
 
       /**
        * A single group-by dimension.

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -421,6 +421,114 @@ class WorksheetAgentControllerTest {
    }
 
    /**
+    * Confirms {@code crosstab} on a {@code set_group_aggregate} {@link EditRequest} reaches
+    * {@link AggregateInfo#isCrosstab} through the controller's dispatch switch, not just at the
+    * {@code WorksheetEditService.Editor} layer already covered by
+    * {@code WorksheetEditServiceMutatorsTest#setGroupAggregateCrosstabTogglesAggregateInfo}.
+    */
+   @Test
+   void editDispatchesSetGroupAggregateWithCrosstab() throws Exception {
+      Principal agent = TestPrincipals.user("alice", "host-org");
+
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "cust", "store", "amount");
+      ws.addAssembly(t);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      JoinSession s = session("TOK-XTAB");
+      when(sessions.resolve(eq("TOK-XTAB"), any())).thenReturn(s);
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+
+      List<WorksheetMutationSupport.GroupSpec> groups = List.of(
+         new WorksheetMutationSupport.GroupSpec("cust", null),
+         new WorksheetMutationSupport.GroupSpec("store", null));
+      List<WorksheetMutationSupport.AggregateSpec> aggregates = List.of(
+         new WorksheetMutationSupport.AggregateSpec("amount", "SUM", null));
+
+      EditRequest req = new EditRequest(
+         "set_group_aggregate", // op
+         "T",                   // table
+         null,                  // column
+         null,                  // name
+         null,                  // type
+         null,                  // newName
+         null,                  // field
+         null,                  // operation
+         null,                  // values
+         null,                  // direction
+         groups,                // groups
+         aggregates,            // aggregates
+         null,                  // expression
+         false,                 // sql
+         null,                  // leftTable
+         null,                  // leftKey
+         null,                  // rightTable
+         null,                  // rightKey
+         null,                  // joinType
+         null,                  // visible
+         null,                  // tables
+         null,                  // source
+         null,                  // concatType
+         null,                  // conditions
+         null,                  // ranking
+         null,                  // headerColumns
+         null,                  // dateOption
+         null,                  // boundaries
+         null,                  // datasource
+         null,                  // schema
+         null,                  // catalog
+         null,                  // logicalModel
+         null,                  // leftKeys
+         null,                  // rightKeys
+         null,                  // row
+         null,                  // col
+         null,                  // value
+         null,                  // index
+         null,                  // alias
+         null,                  // description
+         null,                  // maxRows
+         null,                  // distinct
+         null,                  // columnOrder
+         null,                  // groupMappings
+         null,                  // groupOthers
+         null,                  // variableValues
+         null,                  // x
+         null,                  // y
+         null,                  // label
+         null,                  // defaultValue
+         null,                  // mode
+         null,                  // insert
+         null,                  // subtables
+         null,                  // sourceTable
+         null,                  // attribute
+         null,                  // endpoint
+         null,                  // parameters
+         null,                  // lookup
+         null,                  // lookupExpandArrays
+         null,                  // lookupTopLevelOnly
+         null,                  // suffix
+         null,                  // customLookups
+         true                   // crosstab
+      );
+
+      WorksheetAgentController ctrl = controller(featureOn(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class));
+
+      ctrl.edit("TOK-XTAB", req, agent);
+
+      assertTrue(t.getAggregateInfo().isCrosstab(),
+                 "crosstab on the EditRequest should reach AggregateInfo through the controller");
+   }
+
+   /**
     * The snapshot guard for {@code insert_column}, pinned here rather than in
     * {@code WorksheetEditServiceMutatorsTest} because this op is the one that does not live in
     * the {@code Editor}: it manipulates {@link inetsoft.uql.util.XEmbeddedTable} directly from

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -322,6 +322,32 @@ class WorksheetEditServiceMutatorsTest {
    }
 
    @Test
+   void setGroupAggregateCrosstabTogglesAggregateInfo() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "cust", "store", "amount");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed ->
+         ed.setGroupAggregate("T", groups("cust", "store"),
+            List.of(new WorksheetMutationSupport.AggregateSpec("amount", "SUM", null)), true));
+      assertTrue(t.getAggregateInfo().isCrosstab());
+
+      // Switching back off must clear it again, matching the Composer dialog's own toggle.
+      svc.apply("TOK", agent, ed ->
+         ed.setGroupAggregate("T", groups("cust", "store"),
+            List.of(new WorksheetMutationSupport.AggregateSpec("amount", "SUM", null)), false));
+      assertFalse(t.getAggregateInfo().isCrosstab());
+
+      // The 3-arg overload (no explicit crosstab) must default to false.
+      svc.apply("TOK", agent, ed ->
+         ed.setGroupAggregate("T", groups("cust", "store"),
+            List.of(new WorksheetMutationSupport.AggregateSpec("amount", "SUM", null))));
+      assertFalse(t.getAggregateInfo().isCrosstab());
+   }
+
+   @Test
    void renameAliasSurvivesReAggregation() throws Exception {
       Worksheet ws = new Worksheet();
       EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "cust", "store", "amount");


### PR DESCRIPTION
## Summary

Worksheets support crosstab mode natively via `AggregateInfo.crosstab` (the Composer's Group and Aggregate dialog's own "Switch to Crosstab" toggle), but the wiz agent's `set_group_aggregate` operation never accepted or applied it anywhere in the stack. With no way to expose the feature, the AI agent told users worksheets have no crosstab concept at all (Redmine #76058) when asked to switch a Group-and-Aggregate table to one.

## Root Cause

`WorksheetMutationSupport.applyAggregateInfo` built a new `AggregateInfo` from the request's groups/aggregates but never called `setCrosstab(...)`, and the read-side model (`WorksheetReadService`/`WorksheetModel.AggregateModel`) never reported the current crosstab state either. The gap ran the whole way from the wire-level `EditRequest` down to the backing `AggregateInfo`.

## Fix

- `WorksheetMutationSupport.applyAggregateInfo` gained a new 4-arg overload accepting `boolean crosstab`, which calls `AggregateInfo.setCrosstab(crosstab)` before committing it to the table. The original 3-arg method now delegates to it with `false`, so its existing callers are unaffected.
- `WorksheetEditService.setGroupAggregate` gained the same 4-arg overload/delegation pattern.
- `WorksheetAgentController`'s `set_group_aggregate` dispatch now forwards `req.crosstab()` (treating `null` as `false`).
- `EditRequest` gained a `Boolean crosstab` field, appended as the record's last component (not inserted mid-list) plus a hand-written compatibility constructor, so the ~15 existing positional `new EditRequest(...)` call sites across tests/services don't need to change.
- `WorksheetModel.AggregateModel` gained a `boolean crosstab` field, populated from `AggregateInfo.isCrosstab()`, so `read_worksheet_model` reports the current state back.
- Documented that `crosstab: true` only takes visible effect once the table has at least 2 groups and 1 aggregate (matching `AggregateInfo.isCrosstab()`'s own definition and the Composer dialog's existing behavior) — fewer than that is accepted but silently has no effect.

## Test Plan

- [x] New unit test `setGroupAggregateCrosstabTogglesAggregateInfo` (`WorksheetEditServiceMutatorsTest`) covers crosstab true/false/default-omitted.
- [x] `WorksheetEditServiceMutatorsTest`, `WorksheetAgentControllerTest`, `WorksheetReadServiceTest`, `GroupSpecDeserializationTest` — 204 tests, all passing.
- [x] `mvnw compile -pl core` — clean build.
- [x] Independent code-reviewer agent pass — no blocking findings.
- [x] Live-verified end-to-end with the paired `stylebi-composer-chat` plugin against a rebuilt server (per user confirmation).

Companion PR in stylebi-wiz (plugin side): https://github.com/inetsoft-technology/stylebi-wiz/pull/new/bug-76058

Fixes Redmine #76058.