### PR TITLE
Bug #76293, fix the Save Viewsheet dialog and tidy the toolbar property plumbing

### DIFF
--- a/core/src/main/java/inetsoft/graph/internal/text/FreeHelper.java
+++ b/core/src/main/java/inetsoft/graph/internal/text/FreeHelper.java
@@ -32,6 +32,10 @@ public class FreeHelper extends LabelHelper {
    public FreeHelper(VLabel label, VGraph vgraph) {
       super(label, vgraph);
 
+      // GTool/GImpl only exposes a read that takes a call-site default, and
+      // DefaultProperties.getProperty(key, def) returns that default without consulting the
+      // defaults layer, so the graph.textlayout.maxstep line in defaults.properties is not
+      // reachable from here. Keep the two values in sync -- PropertyDefaultsTest pins them.
       String maxstep = GTool.getProperty("graph.textlayout.maxstep", "1000");
 
       if(maxstep != null) {

--- a/core/src/main/java/inetsoft/report/composition/graph/VGraphPair.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/VGraphPair.java
@@ -2616,8 +2616,12 @@ public class VGraphPair {
     */
    public boolean isChangedByScript() {
       // fix customer bug1365805534414
-      return isStructureChanged && !"true".equals(
-         SreeEnv.getProperty("graph.script.action.support", "false"));
+      // read without a call-site default so the graph.script.action.support line in
+      // defaults.properties is the single source of the shipped default. DefaultProperties
+      // .getProperty(key, def) returns the caller's default without consulting the defaults
+      // layer, so passing one here would make that declaration unreachable at runtime.
+      return isStructureChanged &&
+         !"true".equals(SreeEnv.getProperty("graph.script.action.support"));
    }
 
    /**

--- a/core/src/main/java/inetsoft/sree/internal/SUtil.java
+++ b/core/src/main/java/inetsoft/sree/internal/SUtil.java
@@ -388,22 +388,28 @@ public class SUtil {
     * @return the toolbar elements stored in a <code>List</code> instance.
     */
    public static List<ToolBarElement> getVSToolBarElements(boolean forceGlobal) {
-      List<ToolBarElement> elems = new ArrayList<>(ToolBarElement.VSTOOLBAR_ELEMENTS.length);
+      List<ToolBarElement> elems = new ArrayList<>(ToolBarElement.VSTOOLBAR_ELEMENTS.size());
 
-      for(int i = 0; i < ToolBarElement.VSTOOLBAR_ELEMENTS.length; i++) {
-         String name = ToolBarElement.VSTOOLBAR_ELEMENTS[i];
+      for(int i = 0; i < ToolBarElement.VSTOOLBAR_ELEMENTS.size(); i++) {
+         ToolBarElementDef def = ToolBarElement.VSTOOLBAR_ELEMENTS.get(i);
+         String name = def.property();
 
          if("vs.import.button".equals(name) && !LicenseManager.isComponentAvailable(LicenseManager.LicenseComponent.FORM)) {
             continue;
          }
 
+         // the "true" fallback, not the vs.import.button line in defaults.properties, is the
+         // effective default for these: forceGlobal routes this read through
+         // EarlyLoadedProperties, whose default layer is the JVM system properties rather than
+         // defaults.properties, so the declaration there is never consulted here. Keep the two
+         // in sync -- PropertyDefaultsTest pins them together.
          String visible = SreeEnv.getProperty(name, forceGlobal, "true");
          ToolBarElement elem = new ToolBarElement();
 
          elem.name = name;
          elem.visible = visible;
          elem.index = i;
-         elem.id = ToolBarElement.VSTOOLBAR_ELEMENT_ID[i];
+         elem.id = def.actionId();
 
          elems.add(elem);
       }
@@ -434,16 +440,50 @@ public class SUtil {
       public String visible = null;
       public int index = 0;
       public String id = null;
-      static final String[] VSTOOLBAR_ELEMENTS = {
-         "vs.previous.button", "vs.next.button", "vs.edit.button",
-         "vs.refresh.button", "vs.email.button", "vs.share.button", "vs.schedule.button",
-         "vs.export.button", "vs.import.button", "vs.print.button",
-         "vs.zoom", "vs.fullScreen.button", "vs.close.button",
-         "vs.bookmark.button"
-      };
-      static final String[] VSTOOLBAR_ELEMENT_ID = {
-         "Undo", "Redo", "Edit", "Refresh", "Email", "Social Sharing", "Schedule",
-         "Export", "Import", "Print", "Zoom", "Full Screen", "Close", "Bookmark"};
+      /**
+       * The dashboard toolbar buttons, in display order. Declaration order is significant:
+       * it becomes ToolBarElement.index, which compareTo() uses to keep Close last.
+       *
+       * Property names and action ids are paired here on purpose. They were previously two
+       * parallel arrays zipped by index, where inserting a button into one and not the other
+       * silently shifted every pairing below it.
+       *
+       * Two names do not match the button they control: vs.previous.button is Undo and
+       * vs.next.button is Redo. These names are shipped and are stored in operator settings,
+       * so they are deliberately left as they are -- renaming them would strand existing
+       * configuration. The Enterprise Manager toolbar page shows the action id's catalog label
+       * rather than the property name, so the mismatch is only visible to someone setting the
+       * property directly.
+       */
+      static final List<ToolBarElementDef> VSTOOLBAR_ELEMENTS = List.of(
+         new ToolBarElementDef("vs.previous.button", "Undo"),
+         new ToolBarElementDef("vs.next.button", "Redo"),
+         new ToolBarElementDef("vs.edit.button", "Edit"),
+         new ToolBarElementDef("vs.refresh.button", "Refresh"),
+         new ToolBarElementDef("vs.email.button", "Email"),
+         new ToolBarElementDef("vs.share.button", "Social Sharing"),
+         new ToolBarElementDef("vs.schedule.button", "Schedule"),
+         new ToolBarElementDef("vs.export.button", "Export"),
+         new ToolBarElementDef("vs.import.button", "Import"),
+         new ToolBarElementDef("vs.print.button", "Print"),
+         new ToolBarElementDef("vs.zoom", "Zoom"),
+         new ToolBarElementDef("vs.fullScreen.button", "Full Screen"),
+         new ToolBarElementDef("vs.close.button", "Close"),
+         // hiding Bookmark has a second, unrelated effect: AnnotationVSUtil.resetDataAnnotation
+         // reads this action's visibility and folds chart data annotations into the chart
+         // tooltip when it is hidden. Bookmark is the only entry here read outside the toolbar.
+         new ToolBarElementDef("vs.bookmark.button", "Bookmark"));
+   }
+
+   /**
+    * Pairs a dashboard toolbar button's server property name with the action id the toolbar and
+    * VSEventUtil.setActionVisible() use for it. The two used to be held in separate parallel
+    * arrays aligned only by convention.
+    *
+    * @param property the server property that controls the button's visibility.
+    * @param actionId the action id, also the catalog key for the button's label.
+    */
+   public record ToolBarElementDef(String property, String actionId) {
    }
 
    /**

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/AnnotationVSUtil.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/AnnotationVSUtil.java
@@ -1012,6 +1012,11 @@ public final class AnnotationVSUtil {
          "true".equals(UserEnv.getProperty(rvs.getUser(), "annotation", "true"));
       VSAssemblyInfo viewsheetInfo = vs.getVSAssemblyInfo();
 
+      // the Bookmark check reads a dashboard toolbar action: its visibility comes from the
+      // vs.bookmark.button server property, applied by VSEventUtil.setActionVisible(). Hiding
+      // that toolbar button therefore also folds chart data annotations into the tooltip here,
+      // the same result the user gets by turning annotations off. Bookmark is the only toolbar
+      // action id read outside the toolbar -- see SUtil.ToolBarElement.VSTOOLBAR_ELEMENTS.
       if((!showAnnotations || !viewsheetInfo.isActionVisible("Bookmark"))
          && !notesMap.isEmpty())
       {

--- a/core/src/main/java/inetsoft/uql/viewsheet/internal/CrosstabVSAssemblyInfo.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/internal/CrosstabVSAssemblyInfo.java
@@ -18,7 +18,6 @@
 package inetsoft.uql.viewsheet.internal;
 
 import inetsoft.report.TableDataPath;
-import inetsoft.sree.SreeEnv;
 import inetsoft.uql.*;
 import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.viewsheet.*;
@@ -156,19 +155,6 @@ public class CrosstabVSAssemblyInfo extends CrossBaseVSAssemblyInfo
 
       if(cubeType != null) {
          writer.print(" cubeType=\"" + cubeType + "\"");
-      }
-
-      // for web
-      if("true".equals(SreeEnv.getProperty("vs.crosstab.sortonheader"))) {
-         writer.print(" sortOnHeader=\"true\"");
-      }
-
-      if("true".equals(SreeEnv.getProperty("sort.crosstab.aggregate"))) {
-         writer.print(" sortAggregate=\"true\"");
-      }
-
-      if("true".equals(SreeEnv.getProperty("sort.crosstab.dimension"))) {
-         writer.print(" sortDimension=\"true\"");
       }
    }
 

--- a/core/src/main/java/inetsoft/web/composer/vs/dialog/SaveViewsheetDialogService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/dialog/SaveViewsheetDialogService.java
@@ -23,6 +23,7 @@ import inetsoft.cluster.*;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.WorksheetEngine;
 import inetsoft.report.composition.event.AssetEventUtil;
+import inetsoft.sree.SreeEnv;
 import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.security.IdentityID;
 import inetsoft.sree.security.ResourceAction;
@@ -104,11 +105,23 @@ public class SaveViewsheetDialogService {
       vsOptionsPaneModel.setMaxRowsWarning(info.isMaxRowsWarning());
       vsOptionsPaneModel.setHideNotifications(info.isHideNotifications());
       vsOptionsPaneModel.setCreateMv(info.isMVOnDemand());
+      // the shared pane hides the whole Create MV On-demand checkbox on !onDemandMvEnabled, so
+      // without this the createMv value populated above is unreachable from this dialog.
+      vsOptionsPaneModel.setOnDemandMvEnabled(!SUtil.isSharedDefaultOrgDashboard(rvs.getEntry()) &&
+                                                 "true".equals(SreeEnv.getProperty("mv.ondemand")));
       vsOptionsPaneModel.setAlias(viewsheet.getRuntimeEntry() == null ? null:
                                      viewsheet.getRuntimeEntry().getAlias());
       vsOptionsPaneModel.setDesc(info.getDescription());
       vsOptionsPaneModel.setServerSideUpdate(info.isUpdateEnabled());
       vsOptionsPaneModel.setTouchInterval(info.getTouchInterval());
+      // mirrors ViewsheetPropertyDialogService.getViewsheetInfo(): viewsheet-options-pane is shared
+      // by both dialogs and disables the Server-Side Update checkbox on !autoRefreshEnabled, so
+      // leaving this unset would leave the checkbox permanently greyed out in the Save dialog.
+      vsOptionsPaneModel.setAutoRefreshEnabled(
+         !"false".equals(SreeEnv.getProperty("vs.auto.refresh.enabled")));
+      // saveViewsheet() writes this back unconditionally, and VSOptionsPaneModel.snapGrid
+      // defaults to 20, so leaving it unpopulated resets any other snap grid to 20 on save.
+      vsOptionsPaneModel.setSnapGrid(info.getSnapGrid());
       vsOptionsPaneModel.setListOnPortalTree(info.isOnReport());
 
       //use worksheet data size if datasource is worksheet

--- a/core/src/test/java/inetsoft/sree/internal/PropertyDefaultsTest.java
+++ b/core/src/test/java/inetsoft/sree/internal/PropertyDefaultsTest.java
@@ -1,0 +1,127 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.sree.internal;
+
+import org.junit.jupiter.api.*;
+
+import java.io.*;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Pins shipped property defaults that a call site duplicates.
+ *
+ * {@code DefaultProperties.getProperty(key, def)} returns the caller's default without
+ * consulting the defaults layer, so a read that passes a default never sees the corresponding
+ * defaults.properties declaration. Where that read cannot be converted to the no-default
+ * overload, the two values have to agree by hand, and editing defaults.properties alone would
+ * silently change nothing. These tests fail when the pair drifts apart.
+ */
+@Tag("core")
+class PropertyDefaultsTest {
+   private static Properties defaults;
+
+   @BeforeAll
+   static void loadDefaults() throws IOException {
+      defaults = new Properties();
+
+      try(InputStream in = PropertyDefaultsTest.class.getResourceAsStream(
+         "/inetsoft/report/defaults.properties"))
+      {
+         assertNotNull(in, "defaults.properties is missing from the classpath");
+         defaults.load(in);
+      }
+   }
+
+   /**
+    * SUtil.getVSToolBarElements() reads each toolbar property through the early-loaded path,
+    * whose default layer is the JVM system properties, and supplies its own "true".
+    */
+   @Test
+   void vsImportButtonDefaultMatchesCallSite() {
+      assertEquals("true", defaults.getProperty("vs.import.button"),
+                   "vs.import.button in defaults.properties must match the \"true\" fallback " +
+                      "in SUtil.getVSToolBarElements()");
+   }
+
+   /**
+    * FreeHelper reads through GTool/GImpl, which only exposes an overload taking a default.
+    */
+   @Test
+   void textLayoutMaxStepDefaultMatchesCallSite() {
+      assertEquals("1000", defaults.getProperty("graph.textlayout.maxstep"),
+                   "graph.textlayout.maxstep in defaults.properties must match the \"1000\" " +
+                      "fallback in FreeHelper");
+   }
+
+   /**
+    * VGraphPair.isChangedByScript() reads this without a call-site default, so the declaration
+    * is the only source of the shipped value and must stay present.
+    */
+   @Test
+   void scriptActionSupportDefaultIsDeclared() {
+      assertEquals("false", defaults.getProperty("graph.script.action.support"),
+                   "VGraphPair.isChangedByScript() relies on this declaration for its default");
+   }
+
+   /**
+    * Two toolbar properties do not match the button they control. The names are shipped and
+    * appear in stored operator settings, so the mapping is frozen; this pins it so a reorder
+    * of VSTOOLBAR_ELEMENTS cannot quietly repoint them.
+    */
+   @Test
+   void undoAndRedoKeepTheirLegacyPropertyNames() {
+      assertEquals("Undo", actionIdFor("vs.previous.button"));
+      assertEquals("Redo", actionIdFor("vs.next.button"));
+   }
+
+   /**
+    * AnnotationVSUtil.resetDataAnnotation() reads the Bookmark action's visibility to decide
+    * whether to fold chart data annotations into the tooltip, so this pairing has a consumer
+    * outside the toolbar.
+    */
+   @Test
+   void bookmarkPairingIsStable() {
+      assertEquals("Bookmark", actionIdFor("vs.bookmark.button"));
+   }
+
+   @Test
+   void toolbarPropertiesAndActionIdsAreUnique() {
+      List<SUtil.ToolBarElementDef> defs = SUtil.ToolBarElement.VSTOOLBAR_ELEMENTS;
+      Set<String> properties = new HashSet<>();
+      Set<String> actionIds = new HashSet<>();
+
+      for(SUtil.ToolBarElementDef def : defs) {
+         assertTrue(properties.add(def.property()),
+                    "duplicate toolbar property: " + def.property());
+         assertTrue(actionIds.add(def.actionId()),
+                    "duplicate toolbar action id: " + def.actionId());
+      }
+
+      assertEquals(defs.size(), properties.size());
+   }
+
+   private static String actionIdFor(String property) {
+      return SUtil.ToolBarElement.VSTOOLBAR_ELEMENTS.stream()
+         .filter(def -> property.equals(def.property()))
+         .map(SUtil.ToolBarElementDef::actionId)
+         .findFirst()
+         .orElseThrow(() -> new AssertionError("no toolbar entry for " + property));
+   }
+}


### PR DESCRIPTION
Six findings were filed from documenting the `viewsheet.*` / `vs.*` properties. All six were re-verified against the working tree; one turned out to be partly mistaken and is handled differently from how it was filed (see below). A code review of the resulting diff surfaced two more defects of the same class as the first, which are also fixed here.

Everything is in `community`, so this is a community-only PR.

## The user-visible bug

`viewsheet-options-pane` is shared by the Viewsheet Property dialog and the Save Viewsheet dialog, but `SaveViewsheetDialogService.getSaveViewsheetInfo` populated only part of the model. Three fields were missing:

- **`autoRefreshEnabled`** — the pane disables the Server-Side Update checkbox on `!model.autoRefreshEnabled`, and only `ViewsheetPropertyDialogService.getViewsheetInfo` set it. The field is a primitive `boolean`, so it serialised as `false` and the checkbox was **permanently greyed out in the Save dialog** regardless of `vs.auto.refresh.enabled`, while staying operable in the Property dialog. This is the originally filed finding.
- **`snapGrid`** — `saveViewsheet()` writes this back unconditionally, and `VSOptionsPaneModel.snapGrid` defaults to `20`, so **Save As silently reset any other snap grid to 20**. Both defaults being 20 is why this went unnoticed; it only bites someone who changed the snap grid in the Property dialog first.
- **`onDemandMvEnabled`** — the pane gates the whole Create MV On-demand checkbox on it, so the `createMv` value populated two lines above was unreachable from this dialog. No data loss, but the control was invisible.

The last two were found by review, not in the filed issue. All three are the same populate-side omission, which suggests the two dialogs' populate blocks have drifted; a shared populate helper may be worth a follow-up, but that is out of scope here.

## Maintainability findings

**Toolbar property/action pairing.** `SUtil.ToolBarElement` held `VSTOOLBAR_ELEMENTS` (14 property names) and `VSTOOLBAR_ELEMENT_ID` (14 action ids) as separate arrays zipped by index in `getVSToolBarElements`. Nothing enforced equal length or matching order, and inserting a button into one and not the other would silently shift every pairing below it — surfacing as unrelated buttons responding to the wrong property. They are now one `List<ToolBarElementDef>` of `(property, actionId)` records.

Declaration order, `ToolBarElement.index`, the `compareTo` "Close last" rule, the public fields, `toString()`, and the `vs.import.button` FORM-licence skip are all preserved. Consumers (`PresentationToolbarSettingsService`, `VSEventUtil`) match by `id`/`name` and are untouched.

**Two names do not match their buttons.** `vs.previous.button` controls Undo and `vs.next.button` controls Redo. These are shipped names that appear in stored operator settings, so renaming them would strand existing configuration — they are documented in place instead. Note the EM toolbar page shows the action id's catalog label rather than the property name, so the mismatch is only visible to someone setting the property directly.

**Bookmark has a second consequence.** `AnnotationVSUtil.resetDataAnnotation` reads the Bookmark action's visibility and folds every chart data annotation into the chart tooltip when it is hidden — the behaviour a user gets by turning annotations off. Bookmark is the only one of the fourteen action ids read anywhere but the toolbar. Documented at both ends; no behaviour change.

**Write-only crosstab attributes.** `CrosstabVSAssemblyInfo.writeAttributes` emitted `sortOnHeader`, `sortAggregate` and `sortDimension` into stored crosstab XML. `parseAttributes` reads only `colCount` and `cubeType`, and nothing else in community or enterprise parses them; the viewer recomputes all three from their properties in `VSCrosstabModel` on every model construction. The writes are removed — they enlarged every saved crosstab and looked authoritative to anyone reading the stored XML. Existing assets carrying the attribute still load, ignored exactly as before.

## Correction to the "inert declarations" finding

The issue reported that `vs.import.button`, `graph.script.action.support` and `graph.textlayout.maxstep` are declared in `defaults.properties` but never consulted, and implied the declarations should go. That is not right — `defaults.properties` **is** read, by `SreeEnv.resetProperty` for global property resets and by `/api/admin/properties/defaults`, which is what EM's All Properties page displays as the shipped default. Deleting those lines would have been a regression.

The actual defect is narrower in cause and wider in reach: `DefaultProperties.getProperty(key, defaultValue)` reads only `mainProperties` and returns the caller's default, unlike the single-arg overload directly above it. **Every** read that passes a call-site default bypasses `defaults.properties` — repo-wide, not these three properties. Changing that is deliberately not attempted here: it would flip behaviour anywhere a call-site default differs from a declared one, with a blast radius that cannot be audited in this change.

Two of the three reads also cannot be cleanly converted:

- `SUtil` passes `forceGlobal` into the `earlyLoaded` slot, routing the read through `EarlyLoadedProperties`, whose default layer is the JVM system properties rather than `defaults.properties`. That path never sees the declaration under any overload — and dropping the `"true"` would resolve the other thirteen buttons to `null`, hiding every toolbar button.
- `FreeHelper` goes through `GTool.getProperty(String, String)`, the only overload on the `GImpl` SPI; converting it means widening the interface and both implementations.

So only `VGraphPair.isChangedByScript()` is converted, making `graph.script.action.support` genuinely sourced from its declaration. The other two are documented, and the new `PropertyDefaultsTest` pins each call-site default to its declared value — the real protection against the risk the issue names, which is editing `defaults.properties` while the call site keeps the old value.

## Testing

`PropertyDefaultsTest` (6 tests) pins the call-site defaults, the Undo/Redo mapping, and toolbar property/action-id uniqueness. It reads `defaults.properties` straight off the classpath, so it needs no server environment.

`core` compiles clean; `PropertyDefaultsTest`, `PresentationSettingsControllerTest`, `CrosstabVSAScriptableTest` and `VSCrosstabBindingScriptableTest` pass (18 tests).

Still wanted before merge, since they need a running server:

- Save a viewsheet via Save As and confirm the Server-Side Update checkbox is operable; set `vs.auto.refresh.enabled=false` and confirm it greys out in both dialogs.
- **Set a non-default snap grid, Save As, and confirm it survives** — this is the data-loss path.
- With `mv.ondemand=true`, confirm the Create MV On-demand checkbox now appears in the Save dialog.
- Save a crosstab and confirm no `sortOnHeader`/`sortAggregate`/`sortDimension` in the stored XML, that header sorting still works with `vs.crosstab.sortonheader=true`, and that a pre-existing crosstab asset still loads.
- Toggle all fourteen buttons in EM → Presentation → Toolbar Options, confirm each matches its button (Undo/Redo especially), exercise Reset, and confirm Close still sorts last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
