### PR TITLE
Bug #76295, fix three Presentation and share settings defects

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/presentation/PresentationFontMappingSettingsService.java
+++ b/core/src/main/java/inetsoft/web/admin/presentation/PresentationFontMappingSettingsService.java
@@ -76,7 +76,7 @@ public class PresentationFontMappingSettingsService {
       objectType = ActionRecord.OBJECT_TYPE_EMPROPERTY
    )
    public void resetSettings() throws Exception {
-      SreeEnv.setProperty("pdf.font.mapping", "");
+      SreeEnv.resetProperty("pdf.font.mapping", false);
       SreeEnv.save();
    }
 }

--- a/core/src/main/java/inetsoft/web/composer/vs/controller/ExportController.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/ExportController.java
@@ -223,7 +223,8 @@ public class ExportController {
          bookmarks, onlyDataComponents, exportAllTabbedTables, csvConfig, principal);
 
       VSExportService.setResponseHeader(
-         new ExportResponse(response), result.getSuffix(), "attachment", result.getFileName(), result.getMime());
+         new ExportResponse(response), result.getSuffix(), result.getDisposition(),
+         result.getFileName(), result.getMime());
 
       BinaryTransfer data = result.getData();
       binaryTransferService.writeData(data, response.getOutputStream());

--- a/core/src/main/java/inetsoft/web/composer/vs/controller/ExportControllerService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/ExportControllerService.java
@@ -109,6 +109,10 @@ public class ExportControllerService {
 
       boolean embedded = "embed".equalsIgnoreCase(SreeEnv.getProperty("pdf.output.attachment"))
          && !matchesAssetIdFormat;
+      // same rule as VSExportService.writeViewsheetExport() so the two export paths agree
+      String disposition = !rvs.isPreview() &&
+         FileFormatInfo.EXPORT_TYPE_PDF == format &&
+         embedded || print ? "inline" : "attachment";
 
       String key = "/" + ExportControllerService.class.getName() + "_" + runtimeId + "_" + format;
       BinaryTransfer data = binaryTransferService.createBinaryTransfer(key);
@@ -124,7 +128,7 @@ public class ExportControllerService {
       String mime = VSExportService.getMime(format);
 
       try {
-         return new ViewsheetExportResult(data, fileName, mime, suffix);
+         return new ViewsheetExportResult(data, fileName, mime, suffix, disposition);
       }
       catch(Exception ex) {
          LOG.warn("Unable to complete export for {}", runtimeId);
@@ -344,17 +348,26 @@ public class ExportControllerService {
       private final String fileName;
       private final String mime;
       private final String suffix;
+      private final String disposition;
 
       public ViewsheetExportResult(BinaryTransfer data, String fileName, String mime, String suffix) {
+         this(data, fileName, mime, suffix, "attachment");
+      }
+
+      public ViewsheetExportResult(BinaryTransfer data, String fileName, String mime, String suffix,
+                                   String disposition)
+      {
          this.data = data;
          this.fileName = fileName;
          this.mime = mime;
          this.suffix = suffix;
+         this.disposition = disposition;
       }
 
       public BinaryTransfer getData() { return data; }
       public String getFileName() { return fileName; }
       public String getMime() { return mime; }
       public String getSuffix() { return suffix; }
+      public String getDisposition() { return disposition; }
    }
 }

--- a/core/src/main/java/inetsoft/web/composer/vs/controller/ExportControllerService.java
+++ b/core/src/main/java/inetsoft/web/composer/vs/controller/ExportControllerService.java
@@ -109,10 +109,9 @@ public class ExportControllerService {
 
       boolean embedded = "embed".equalsIgnoreCase(SreeEnv.getProperty("pdf.output.attachment"))
          && !matchesAssetIdFormat;
-      // same rule as VSExportService.writeViewsheetExport() so the two export paths agree
-      String disposition = !rvs.isPreview() &&
-         FileFormatInfo.EXPORT_TYPE_PDF == format &&
-         embedded || print ? "inline" : "attachment";
+      // shared with VSExportService so the two export paths cannot disagree
+      String disposition =
+         VSExportService.getContentDisposition(format, rvs.isPreview(), embedded, print);
 
       String key = "/" + ExportControllerService.class.getName() + "_" + runtimeId + "_" + format;
       BinaryTransfer data = binaryTransferService.createBinaryTransfer(key);

--- a/core/src/main/java/inetsoft/web/viewsheet/service/VSExportService.java
+++ b/core/src/main/java/inetsoft/web/viewsheet/service/VSExportService.java
@@ -592,6 +592,26 @@ public class VSExportService {
       }
    }
 
+   /**
+    * Gets the Content-disposition value for an export. Shared with
+    * ExportControllerService.exportViewsheet() so the viewer and Composer export paths
+    * cannot disagree about whether a PDF opens in the browser or downloads.
+    *
+    * @param format   the export format, one of the FileFormatInfo.EXPORT_TYPE_* constants.
+    * @param preview  <tt>true</tt> if the viewsheet is being previewed.
+    * @param embedded <tt>true</tt> if the "pdf.output.attachment" property is "embed" and the
+    *                 export is not addressed by asset ID.
+    * @param print    <tt>true</tt> if this export feeds the print flow.
+    *
+    * @return "inline" or "attachment".
+    */
+   public static String getContentDisposition(int format, boolean preview, boolean embedded,
+                                              boolean print)
+   {
+      return !preview && FileFormatInfo.EXPORT_TYPE_PDF == format &&
+         embedded || print ? "inline" : "attachment";
+   }
+
    private void writeViewsheetExport(RuntimeViewsheet rvs, ExportResponse response,
                                      Principal principal, int format, boolean previewPrintLayout,
                                      boolean print, boolean match, boolean expandSelections,
@@ -602,9 +622,7 @@ public class VSExportService {
       throws Exception
    {
       String name = getViewsheetFileName(rvs.getEntry());
-      String disposition = !rvs.isPreview() &&
-         FileFormatInfo.EXPORT_TYPE_PDF == format &&
-         embedded || print ? "inline" : "attachment";
+      String disposition = getContentDisposition(format, rvs.isPreview(), embedded, print);
 
       if(!print) {
          setResponseHeader(response, suffix, disposition, name, mime);

--- a/core/src/test/java/inetsoft/web/admin/presentation/PresentationFontMappingSettingsServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/presentation/PresentationFontMappingSettingsServiceTest.java
@@ -34,6 +34,10 @@ package inetsoft.web.admin.presentation;
  * [G1] A well-formed list parses into one model per entry, split at the first colon.
  * [G2] An entry with no colon is skipped instead of throwing.
  * [G3] Null or empty property yields an empty list.
+ * [G4] resetSettings() resets the property rather than storing an empty string. Every other
+ *      resetSettings() on the Presentation page goes through SreeEnv.resetProperty(); storing
+ *      "" left a value behind that the one-argument and two-argument accessors read
+ *      differently, so it was neither the shipped default nor absent.
  */
 
 import inetsoft.sree.SreeEnv;
@@ -99,5 +103,14 @@ class PresentationFontMappingSettingsServiceTest {
    void nullOrEmptyPropertyYieldsEmptyList() {
       assertTrue(parse(null).isEmpty());
       assertTrue(parse("").isEmpty());
+   }
+
+   @Test
+   void resetSettingsResetsPropertyInsteadOfStoringEmptyString() {
+      assertDoesNotThrow(() -> service.resetSettings());
+
+      sreeEnvStatic.verify(() -> SreeEnv.resetProperty("pdf.font.mapping", false));
+      sreeEnvStatic.verify(() -> SreeEnv.setProperty(eq("pdf.font.mapping"), anyString()), never());
+      sreeEnvStatic.verify(SreeEnv::save);
    }
 }

--- a/core/src/test/java/inetsoft/web/admin/presentation/PresentationPdfGenerationSettingsServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/presentation/PresentationPdfGenerationSettingsServiceTest.java
@@ -36,6 +36,9 @@ package inetsoft.web.admin.presentation;
  * [G4] pdf.output.attachment resolves "embed" case-insensitively. It is not a boolean, but the
  *      card renders it as a checkbox and both enforcement sites (ExportControllerService and
  *      VSExportService) compare with equalsIgnoreCase, so the same split applied to it.
+ *      ExportControllerService previously computed the comparison and discarded it, leaving
+ *      the Composer export path always "attachment" while the viewer path honoured the
+ *      setting; it now carries the disposition out on ViewsheetExportResult.
  */
 
 import inetsoft.sree.SreeEnv;

--- a/core/src/test/java/inetsoft/web/viewsheet/service/VSExportServiceTest.java
+++ b/core/src/test/java/inetsoft/web/viewsheet/service/VSExportServiceTest.java
@@ -102,6 +102,53 @@ class VSExportServiceTest {
          "non-VSO export formats must be redirected to the real host-org entry, not denied");
    }
 
+   // -- getContentDisposition(): shared by the viewer (VSExportService) and Composer
+   // (ExportControllerService.exportViewsheet) export paths. Before the two were unified, the
+   // Composer path hardcoded "attachment" and ignored "pdf.output.attachment" entirely, so the
+   // same viewsheet downloaded from Composer but opened in-browser from the viewer.
+   //
+   // The rule parses as ((!preview && PDF == format && embedded) || print), so "print" forces
+   // "inline" on its own and every other case needs all three of the first three terms.
+
+   @Test
+   void getContentDisposition_pdfEmbeddedNotPreview_isInline() {
+      assertEquals("inline", VSExportService.getContentDisposition(
+                      FileFormatInfo.EXPORT_TYPE_PDF, false, true, false),
+                   "a non-preview PDF export with pdf.output.attachment=embed must open in " +
+                   "the browser -- this is the ordinary Composer export that used to download");
+   }
+
+   @Test
+   void getContentDisposition_pdfNotEmbedded_isAttachment() {
+      assertEquals("attachment", VSExportService.getContentDisposition(
+                      FileFormatInfo.EXPORT_TYPE_PDF, false, false, false),
+                   "the default pdf.output.attachment setting must still download");
+   }
+
+   @Test
+   void getContentDisposition_pdfEmbeddedButPreview_isAttachment() {
+      assertEquals("attachment", VSExportService.getContentDisposition(
+                      FileFormatInfo.EXPORT_TYPE_PDF, true, true, false),
+                   "a preview export must not go inline even when embedding is enabled");
+   }
+
+   @ParameterizedTest
+   @ValueSource(ints = {FileFormatInfo.EXPORT_TYPE_EXCEL, FileFormatInfo.EXPORT_TYPE_CSV,
+                        FileFormatInfo.EXPORT_TYPE_POWERPOINT, FileFormatInfo.EXPORT_TYPE_HTML,
+                        FileFormatInfo.EXPORT_TYPE_PNG, FileFormatInfo.EXPORT_TYPE_SNAPSHOT})
+   void getContentDisposition_nonPdfFormats_areAttachmentEvenWhenEmbedded(int format) {
+      assertEquals("attachment", VSExportService.getContentDisposition(format, false, true, false),
+                   "pdf.output.attachment=embed must not affect non-PDF formats");
+   }
+
+   @ParameterizedTest
+   @ValueSource(ints = {FileFormatInfo.EXPORT_TYPE_PDF, FileFormatInfo.EXPORT_TYPE_EXCEL,
+                        FileFormatInfo.EXPORT_TYPE_CSV})
+   void getContentDisposition_print_isInlineRegardlessOfEverythingElse(int format) {
+      assertEquals("inline", VSExportService.getContentDisposition(format, true, false, true),
+                   "print forces inline on its own, independent of format/preview/embedded");
+   }
+
    private VSExportService newServiceWithResolvableSharedEntries() throws Exception {
       OrganizationContextHolder.setCurrentOrgId(VIEWER_ORG);
 

--- a/web/projects/portal/src/index.html
+++ b/web/projects/portal/src/index.html
@@ -56,7 +56,7 @@
         <polygon class="ls-el" points="162.618,31.907 126.508,38.319 126.508,80.167 155.929,80.167 162.618,76.305"/>
       </svg>
     </div>
-    <span data-th-if="${#strings.isEmpty(customLoadingLogo)}" data-th-text="#{app.loading}">Loading...</span>
+    <span data-th-if="${#strings.isEmpty(customLoadingText)}" data-th-text="#{app.loading}">Loading...</span>
     <span data-th-if="${not #strings.isEmpty(customLoadingText)}" data-th-text="${customLoadingText}"></span>
   </div>
   <app-root></app-root>


### PR DESCRIPTION
Three of four findings from a server-property audit of the Presentation page. All four were re-verified against the current `main` before filing — the original report was written against `935c85a58`, a merge commit that is not an ancestor of `main`.

## 1. Font mapping reset wrote an empty string

`PresentationFontMappingSettingsService.resetSettings()` wrote `""`; every other `resetSettings()` on the page goes through `SreeEnv.resetProperty()`. An empty stored value is not an unset one — the one-argument accessor sees an empty string where it expected a default, the two-argument form treats it as absent, and neither is "reset".

`pdf.font.mapping` has no entry in `defaults.properties`, so `resetProperty` resolves a `null` default and removes the property.

Impact is limited to stored state: both readers (`PDF3Generator:58` and this service's own `getModel()`) null-and-empty check before parsing, so no output changes today.

## 2. The Composer export path ignored `pdf.output.attachment`

`ExportControllerService` computed the `"embed"` comparison and then discarded it, and `ExportController` hardcoded `"attachment"`. `VSExportService` honours the setting. The two export paths disagreed about user-visible behaviour.

The audit was unsure whether the read was vestigial or a lost branch — it was a lost branch, and it affects the **common** case rather than an edge case: `embedded` requires `!matchesAssetIdFormat`, which is set false exactly when no asset entry resolves, i.e. the ordinary Composer runtime-id export.

The disposition is now computed where `rvs` is in scope, reusing `VSExportService`'s rule with its operator precedence preserved verbatim so the two paths cannot drift again, and carried out on `ViewsheetExportResult`.

**No enterprise change needed.** The four-argument `ViewsheetExportResult` constructor is retained, delegating with `"attachment"`, so `ViewsheetApiService` compiles unchanged and the public download API keeps returning `attachment`. Making a download API return `inline` would be a separate, unrequested behaviour change.

Non-PDF formats still get `attachment` via the rule's `PDF == format` term; `print` still forces `inline` on both paths; `setResponseHeader` normalizes the string, so no new header-injection surface.

## 3. A custom loading logo removed the loading message

`index.html` gated the built-in `app.loading` span on `portal.customLoadingLogo` being empty, so adding a logo silently removed the message unless the operator also set `portal.customLoadingText`. It is now gated on `customLoadingText`: a logo no longer suppresses the text, and a custom text still replaces the built-in one. The logo continues to replace the animated indicator.

One correction to the report, which said neither property's Enterprise Manager control mentions the coupling: `portal.customLoadingLogo` has **no** EM control at all — only `customLoadingText` does. The docs half is filed separately as #76181.

## 4. Open Graph — not fixed here, and the reported mechanism is wrong

The defect is real: `share.opengraph.*` is written organization-scoped but read unscoped in `HomePageController`. An organization sets its own values, sees them in Enterprise Manager, and a social network never shows them.

The report attributes this to "no principal, so `useAvailableOrgProperty` cannot substitute an org-scoped name". That path exists but is usually **not** the one taken. `AnonymousUserFilter` gives an unauthenticated request an anonymous principal, and the org comes from `getCookieRecordedOrgID`, which falls back to `Organization.getDefaultOrganizationID()` when the request carries no cookies. A crawler carries none — so the resolved org is the *default* organization, not the owning one. Both routes reach the same outcome, so the conclusion stands, but the reason should be recorded correctly.

Left for a follow-up because the fix is a product decision, not a bug fix: the Open Graph branch keys off `/app/viewer/view/<assetId>`, and the asset-ID formats built there carry no organization, so resolving it would need host-to-org resolution or a new org segment in shared links.

One thing noted so it is not re-reported: `getOpenGraphImage`'s `cachedImage` is process-wide but keyed on the resolved image URL and recomputes on mismatch, so it is a size-lookup cache and does not leak one org's image to another.

## Testing

`PresentationFontMappingSettingsServiceTest` + `PresentationPdfGenerationSettingsServiceTest` — 22 tests pass. The new reset test verifies `resetProperty` was called *and* that no `setProperty` for that key was, so it fails against the old code rather than passing vacuously. `community/core` and `enterprise` both compile.

Not yet run: end-to-end verification of #2 against a live server (tick the browser-embed option, export from Composer, confirm `Content-disposition: inline`, then confirm Excel/CSV stay `attachment` and the viewer path is unregressed). Worth doing before merge, since #2 is the change with real user-visible behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
