### PR TITLE
Bug #76297, resolve the Google client id secret on the signup page

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/controller/GoogleSignInSupport.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/GoogleSignInSupport.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.portal.controller;
+
+import inetsoft.sree.SreeEnv;
+import inetsoft.util.Tool;
+
+/**
+ * Reads the Google sign-in settings that are rendered onto the unauthenticated pages which
+ * offer the Google Identity Services button (login and signup). Both pages must resolve the
+ * settings the same way, so they share this class instead of reading the properties directly.
+ */
+final class GoogleSignInSupport {
+   /**
+    * Checks whether the Google sign-in button should be offered.
+    */
+   static boolean isEnabled() {
+      return SreeEnv.getBooleanProperty("security.googleSignIn.enabled");
+   }
+
+   /**
+    * Gets the Google OpenID client id to initialize the sign-in button with.
+    *
+    * The property may hold a reference to a secret kept in a cloud secrets manager rather than
+    * the client id itself, so it must be resolved before it is rendered onto a page. Do not
+    * drop the {@link Tool#getClientSecretRealValue(String, String)} call: it returns the value
+    * unchanged when the client id is stored literally, which is the only case where reading the
+    * property by itself happens to work.
+    */
+   static String getClientId() {
+      return Tool.getClientSecretRealValue(
+         SreeEnv.getProperty("styleBI.google.openid.client.id"), "client_id");
+   }
+
+   /**
+    * Gets the scopes requested from Google.
+    */
+   static String getScopes() {
+      return SreeEnv.getProperty("styleBI.google.openid.scopes", "openid email profile");
+   }
+
+   private GoogleSignInSupport() {
+   }
+}

--- a/core/src/main/java/inetsoft/web/portal/controller/LoginController.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/LoginController.java
@@ -137,12 +137,10 @@ public class LoginController {
                       LicenseManager.isEnterprise());
       model.addObject("isNotTenantServer", isNotTenantServer(request));
 
-      boolean googleSignInEnabled = SreeEnv.getBooleanProperty("security.googleSignIn.enabled");
-
-      if(googleSignInEnabled) {
-         model.addObject("gClientId", getGoogleClientId());
+      if(GoogleSignInSupport.isEnabled()) {
+         model.addObject("gClientId", GoogleSignInSupport.getClientId());
          model.addObject("gLoginUri", linkUri + "login/googleSSO");
-         model.addObject("gScopes", getGoogleScopes());
+         model.addObject("gScopes", GoogleSignInSupport.getScopes());
 
          try {
             String encodedUrl = requestedUrl == null ? null :
@@ -225,15 +223,6 @@ public class LoginController {
          .map(Cookie::getValue).findFirst().orElse(null);
 
       return orgId != null ? orgId : SUtil.getLoginOrganization(request);
-   }
-
-   private String getGoogleClientId() {
-      return Tool.getClientSecretRealValue(
-         SreeEnv.getProperty("styleBI.google.openid.client.id"), "client_id");
-   }
-
-   private String getGoogleScopes() {
-      return SreeEnv.getProperty("styleBI.google.openid.scopes", "openid email profile");
    }
 
    private final SecurityEngine securityEngine;

--- a/core/src/main/java/inetsoft/web/portal/controller/SignupController.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/SignupController.java
@@ -17,7 +17,6 @@
  */
 package inetsoft.web.portal.controller;
 
-import inetsoft.sree.SreeEnv;
 import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.portal.CustomThemesManager;
 import inetsoft.sree.portal.PortalThemesManager;
@@ -66,13 +65,10 @@ public class SignupController {
                               !"default".equals(customThemesManager.getSelectedTheme());
       model.addObject("customTheme", isCustomTheme);
 
-      boolean googleSignInEnabled = SreeEnv.getBooleanProperty("security.googleSignIn.enabled");
-
-      if(googleSignInEnabled) {
-         model.addObject("gClientId", SreeEnv.getProperty("styleBI.google.openid.client.id"));
+      if(GoogleSignInSupport.isEnabled()) {
+         model.addObject("gClientId", GoogleSignInSupport.getClientId());
          model.addObject("gLoginUri", linkUri + "login/googleSSO");
-         model.addObject("gScopes",
-            SreeEnv.getProperty("styleBI.google.openid.scopes", "openid email profile"));
+         model.addObject("gScopes", GoogleSignInSupport.getScopes());
       }
 
       String header = CacheControl.noCache()

--- a/core/src/test/java/inetsoft/web/portal/controller/GoogleSignInSupportTest.java
+++ b/core/src/test/java/inetsoft/web/portal/controller/GoogleSignInSupportTest.java
@@ -1,0 +1,103 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.portal.controller;
+
+import inetsoft.sree.SreeEnv;
+import inetsoft.util.Tool;
+import org.junit.jupiter.api.*;
+import org.mockito.MockedStatic;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class GoogleSignInSupportTest {
+   private static final String CLIENT_ID_PROPERTY = "styleBI.google.openid.client.id";
+   private static final String SCOPES_PROPERTY = "styleBI.google.openid.scopes";
+   private static final String DEFAULT_SCOPES = "openid email profile";
+
+   private MockedStatic<SreeEnv> sreeEnvStatic;
+   private MockedStatic<Tool> toolStatic;
+
+   @BeforeEach
+   void setUp() {
+      sreeEnvStatic = mockStatic(SreeEnv.class, withSettings().lenient());
+      toolStatic = mockStatic(Tool.class, withSettings().lenient());
+   }
+
+   @AfterEach
+   void tearDown() {
+      toolStatic.close();
+      sreeEnvStatic.close();
+   }
+
+   // the client id property may hold a reference to a secret kept in a cloud secrets manager,
+   // so the page must be given the resolved client id, not the stored reference
+   @Test
+   void clientIdIsResolvedThroughSecretsManager() {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty(CLIENT_ID_PROPERTY)).thenReturn("secret-ref");
+      toolStatic.when(() -> Tool.getClientSecretRealValue("secret-ref", "client_id"))
+         .thenReturn("real-id.apps.googleusercontent.com");
+
+      assertEquals("real-id.apps.googleusercontent.com", GoogleSignInSupport.getClientId());
+   }
+
+   // the stored value and the "client_id" key of the secret are what identify the client id
+   // within the secret, so both must reach the resolver
+   @Test
+   void clientIdPassesPropertyValueAndSecretKeyToResolver() {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty(CLIENT_ID_PROPERTY)).thenReturn("secret-ref");
+
+      GoogleSignInSupport.getClientId();
+
+      toolStatic.verify(() -> Tool.getClientSecretRealValue("secret-ref", "client_id"));
+   }
+
+   // an unset client id must stay unset so the pages leave the google button out entirely
+   @Test
+   void clientIdIsNullWhenPropertyNotConfigured() {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty(CLIENT_ID_PROPERTY)).thenReturn(null);
+      toolStatic.when(() -> Tool.getClientSecretRealValue(null, "client_id")).thenReturn(null);
+
+      assertNull(GoogleSignInSupport.getClientId());
+   }
+
+   @Test
+   void scopesFallBackToDefaultWhenNotConfigured() {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty(SCOPES_PROPERTY, DEFAULT_SCOPES))
+         .thenReturn(DEFAULT_SCOPES);
+
+      assertEquals(DEFAULT_SCOPES, GoogleSignInSupport.getScopes());
+   }
+
+   @Test
+   void scopesUseConfiguredValue() {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty(SCOPES_PROPERTY, DEFAULT_SCOPES))
+         .thenReturn("openid email");
+
+      assertEquals("openid email", GoogleSignInSupport.getScopes());
+   }
+
+   @Test
+   void enabledFollowsProperty() {
+      sreeEnvStatic.when(() -> SreeEnv.getBooleanProperty("security.googleSignIn.enabled"))
+         .thenReturn(true);
+
+      assertTrue(GoogleSignInSupport.isEnabled());
+   }
+}


### PR DESCRIPTION
## Problem

`styleBI.google.openid.client.id` may hold either a literal Google OpenID client id or, on an install configured with a cloud secrets manager, a reference to a secret that must be resolved through `Tool.getClientSecretRealValue(value, "client_id")`.

Two controllers put that value on a page model as `gClientId`, which the templates render into `data-client_id` for the Google Identity Services button:

- `LoginController` resolved it. Correct.
- `SignupController` read the property directly. **Bug.**

So on an install using cloud secrets, Google sign-in works and Google sign-up initializes its button with the secret reference and fails, with no error naming a property. It also put the reference text into the signup page source. `showSignUpDetailPage` delegates to `showSignUpPage`, so it inherited the same defect.

## Fix

Moved the three Google sign-in property reads into a new package-private `GoogleSignInSupport`, and pointed both controllers at it, so the pages cannot drift apart again. `LoginController`'s private `getGoogleClientId`/`getGoogleScopes` are gone; its login-only `gState` block is untouched.

No behavior change where the client id is stored literally: `Tool.getClientSecretRealValue` returns its argument unchanged outside cloud-secrets mode, passes null/empty through, and returns the original value if a reference cannot be resolved.

## Testing

- New `GoogleSignInSupportTest` — 6 tests, 0 failures. The pinning assertion verifies that both the property value and the `client_id` secret key reach the resolver. `SignupControllerTest` defers the `showSignUpPage` cases because they need the `SreeEnv`/`OrganizationManager` statics mocked, so the helper is tested directly with `mockStatic`.
- `SignupControllerTest` — 17 tests, 0 failures.

Not run: the manual browser checks against a live server with a configured client id, and against a non-`local` secrets backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
