### PR TITLE
Bug #76292, guard the graph.*.maxcount parse and always report chart truncation

### DIFF
--- a/core/src/main/java/inetsoft/graph/element/GraphElement.java
+++ b/core/src/main/java/inetsoft/graph/element/GraphElement.java
@@ -772,16 +772,16 @@ public abstract class GraphElement extends Graphable {
             String msg = GTool.getString("viewer.viewsheet.chart.shapeCountMax", mcount) +
                ": " + Arrays.toString(elem.getDims()) + "," + Arrays.toString(elem.getVars());
 
-            // showing a warning to end user is more distractive than
-            // helpful. if max is very large, when the max is reached, the graph
-            // is generally so over crowed that any truncation is unlikely
-            // noticeable or significant
-            if(mcount > 100000) {
-               LOG.debug(msg);
-            }
-            else {
-               CoreTool.addUserMessage(msg);
-            }
+            // truncation is always reported. this used to be suppressed above a fixed
+            // threshold of 100000, on the reasoning that a graph that crowded is past the
+            // point where truncation is noticeable. but the shipped graph.point.maxcount
+            // (10000000) sits above that threshold, so the suppression hid row loss at a
+            // shipped default, on the one chart type most likely to be plotting a large row
+            // count -- a reader could not tell whether they were seeing all their data.
+            // CoreTool.addUserMessage de-duplicates, so the repeated calls made while
+            // building geometry still raise a single message.
+            LOG.debug(msg);
+            CoreTool.addUserMessage(msg);
 
             rcount = mcount;
          }

--- a/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
@@ -3114,7 +3114,10 @@ public abstract class GraphGenerator {
 
       alls = createElement0(chartType, names, xname, false, alls);
 
-      // set geometry max count
+      // set geometry max count. resolved once instead of per element: it only depends on
+      // chartType, and a misconfigured graph.*.maxcount warns on each call.
+      int mcount = GraphTypes.getGeomMaxCount(chartType);
+
       for(int i = 0; i < alls.size(); i++) {
          GraphElement elem = (GraphElement) alls.get(i);
 
@@ -3122,7 +3125,6 @@ public abstract class GraphGenerator {
             continue;
          }
 
-         int mcount = GraphTypes.getGeomMaxCount(chartType);
          elem.setHint(GraphElement.HINT_MAX_COUNT, mcount);
       }
    }

--- a/core/src/main/java/inetsoft/uql/viewsheet/graph/GraphTypes.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/graph/GraphTypes.java
@@ -21,6 +21,8 @@ import inetsoft.report.composition.graph.GraphUtil;
 import inetsoft.report.composition.region.ChartConstants;
 import inetsoft.sree.SreeEnv;
 import inetsoft.util.Catalog;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
@@ -820,64 +822,127 @@ public class GraphTypes {
     * Get geometry max count.
     */
    public static int getGeomMaxCount(int type) {
-      String mstr = null;
+      String prop = null;
 
+      // is3DBar must be tested before isBar: isBar() returns true for CHART_3D_BAR and
+      // CHART_3D_BAR_STACK too, so reordering these two branches -- or inserting a new one
+      // between them -- would silently retire graph.3dbar.maxcount and move 3D bars onto
+      // graph.bar.maxcount. GraphTypesTest locks this.
       if(GraphTypes.is3DBar(type)) {
-         mstr = SreeEnv.getProperty("graph.3dbar.maxcount");
+         prop = "graph.3dbar.maxcount";
       }
       else if(GraphTypes.isBar(type)) {
-         mstr = SreeEnv.getProperty("graph.bar.maxcount");
+         prop = "graph.bar.maxcount";
       }
       else if(type == GraphTypes.CHART_PIE || type == GraphTypes.CHART_DONUT) {
-         mstr = SreeEnv.getProperty("graph.pie.maxcount");
+         prop = "graph.pie.maxcount";
       }
       else if(type == GraphTypes.CHART_SUNBURST) {
-         mstr = SreeEnv.getProperty("graph.pie.maxcount");
+         prop = "graph.pie.maxcount";
       }
       else if(type == GraphTypes.CHART_TREEMAP) {
-         mstr = SreeEnv.getProperty("graph.pie.maxcount");
+         prop = "graph.pie.maxcount";
       }
       else if(type == GraphTypes.CHART_CIRCLE_PACKING) {
-         mstr = SreeEnv.getProperty("graph.pie.maxcount");
+         prop = "graph.pie.maxcount";
       }
       else if(type == GraphTypes.CHART_ICICLE) {
-         mstr = SreeEnv.getProperty("graph.pie.maxcount");
+         prop = "graph.pie.maxcount";
       }
       else if(type == GraphTypes.CHART_3D_PIE) {
-         mstr = SreeEnv.getProperty("graph.3dpie.maxcount");
+         prop = "graph.3dpie.maxcount";
       }
       else if(GraphTypes.isArea(type)) {
-         mstr = SreeEnv.getProperty("graph.area.maxcount");
+         prop = "graph.area.maxcount";
       }
       else if(GraphTypes.isLine(type)) {
-         mstr = SreeEnv.getProperty("graph.line.maxcount");
+         prop = "graph.line.maxcount";
       }
       else if(GraphTypes.isPoint(type)) {
-         mstr = SreeEnv.getProperty("graph.point.maxcount");
+         prop = "graph.point.maxcount";
       }
       else if(GraphTypes.isRadar(type)) {
-         mstr = SreeEnv.getProperty("graph.radar.maxcount");
+         prop = "graph.radar.maxcount";
       }
       else if(GraphTypes.isCandle(type)) {
-         mstr = SreeEnv.getProperty("graph.candle.maxcount");
+         prop = "graph.candle.maxcount";
       }
       else if(GraphTypes.isStock(type)) {
-         mstr = SreeEnv.getProperty("graph.stock.maxcount");
+         prop = "graph.stock.maxcount";
       }
       else if(GraphTypes.isWaterfall(type)) {
-         mstr = SreeEnv.getProperty("graph.waterfall.maxcount");
+         prop = "graph.waterfall.maxcount";
       }
       else if(GraphTypes.isPareto(type)) {
-         mstr = SreeEnv.getProperty("graph.pareto.maxcount");
+         prop = "graph.pareto.maxcount";
       }
 
-      if(mstr != null) {
-         return Integer.parseInt(mstr);
+      if(prop != null) {
+         return getMaxCount(prop);
       }
 
       return -1;
    }
 
+   /**
+    * Gets a graph.*.maxcount property. A non-numeric value logs a warning naming the
+    * property and falls back to the value shipped in defaults.properties, so an admin typo
+    * degrades the limit instead of failing chart generation with an opaque
+    * NumberFormatException out of GraphGenerator.createElement.
+    *
+    * <p>The fallback is the shipped default rather than any site-wide value: when an
+    * org-scoped override (inetsoft.org.&lt;id&gt;.graph.*.maxcount) is the value that fails to
+    * parse, the limit drops to what defaults.properties ships, not to a site-wide setting in
+    * sree.properties. That keeps the fallback predictable, and the warning names the property
+    * so the bad override can be corrected.
+    *
+    * <p>A null value means the property is not configured at all, which is not an admin
+    * error and so is not warned about. In practice it does not arise for these properties:
+    * PropertiesEngine chains internalProperties to defaults.properties, and all of the
+    * graph.*.maxcount names ship a default there.
+    *
+    * <p>A negative value is returned as configured; -1 is the "no limit" sentinel this
+    * method already returns for a chart type that matches no property.
+    *
+    * @param name the property name.
+    *
+    * @return the configured max count, or -1 for no limit.
+    */
+   private static int getMaxCount(String name) {
+      String value = SreeEnv.getProperty(name);
+      Integer count = parseCount(value);
+
+      if(count != null) {
+         return count;
+      }
+
+      Properties defaults = SreeEnv.getDefaultProperties();
+      Integer def = defaults != null ? parseCount(defaults.getProperty(name)) : null;
+      int applied = def != null ? def : -1;
+
+      if(value != null) {
+         LOG.warn("Invalid {} value \"{}\", using {}", name, value,
+                  applied < 0 ? "no limit" : applied);
+      }
+
+      return applied;
+   }
+
+   /**
+    * Parses a max count property value.
+    *
+    * @return the parsed value, or null if it is missing or not a number.
+    */
+   private static Integer parseCount(String value) {
+      try {
+         return Integer.parseInt(value);
+      }
+      catch(NumberFormatException e) {
+         return null;
+      }
+   }
+
    private static final HashMap map = new LinkedHashMap();
    private static final HashMap chartTypes = new LinkedHashMap();
+   private static final Logger LOG = LoggerFactory.getLogger(GraphTypes.class);
 }

--- a/core/src/test/java/inetsoft/graph/element/GraphElementTruncationMessageTest.java
+++ b/core/src/test/java/inetsoft/graph/element/GraphElementTruncationMessageTest.java
@@ -1,0 +1,127 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.graph.element;
+
+import inetsoft.graph.data.DefaultDataSet;
+import inetsoft.util.CoreTool;
+import inetsoft.util.UserMessage;
+import inetsoft.web.viewsheet.command.MessageCommand.Type;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests that GraphElement.getEndRow() reports row truncation to the end user.
+ *
+ * <p>The report used to be suppressed above a fixed limit of 100000, which meant a chart
+ * using the shipped graph.point.maxcount (10000000) dropped rows silently. These pin the
+ * message to both sides of that former threshold.
+ */
+@Tag("core")
+class GraphElementTruncationMessageTest {
+   @BeforeEach
+   @AfterEach
+   void clearUserMessages() {
+      CoreTool.clearUserMessage();
+   }
+
+   /**
+    * 100001 is one above the threshold that used to demote this message to LOG.debug; 500 is
+    * well below it and was always reported. Both must now reach the user.
+    */
+   @ParameterizedTest(name = "a limit of {0} reports the truncation to the user")
+   @ValueSource(ints = { 500, 100001 })
+   void getEndRowReportsTruncationRegardlessOfTheLimit(int maxCount) {
+      DefaultDataSet data = dataSet(maxCount + 2);
+      PointElement elem = new PointElement("Cat", "m1");
+      elem.setHint(GraphElement.HINT_MAX_COUNT, maxCount);
+
+      int endRow = GraphElement.getEndRow(data, 0, -1, elem);
+
+      assertEquals(maxCount, endRow, "the data must still be truncated to the limit");
+
+      UserMessage message = CoreTool.getUserMessage();
+      assertNotNull(message,
+                    "truncating rows must be reported to the user: without it a reader " +
+                    "cannot tell whether they are seeing all their data");
+      // the catalog formats the limit with grouping separators (100,001), so compare digits
+      assertTrue(message.getMessage().replace(",", "").contains(String.valueOf(maxCount)),
+                 "the message must name the limit that was applied, but was: " +
+                 message.getMessage());
+   }
+
+   @Test
+   void getEndRowIsSilentWhenNothingIsTruncated() {
+      DefaultDataSet data = dataSet(10);
+      PointElement elem = new PointElement("Cat", "m1");
+      elem.setHint(GraphElement.HINT_MAX_COUNT, 100);
+
+      assertEquals(10, GraphElement.getEndRow(data, 0, -1, elem),
+                   "a limit above the row count must not truncate");
+      assertNull(CoreTool.getUserMessage(),
+                 "a chart that fits under its limit must not warn about truncation");
+   }
+
+   @Test
+   void getEndRowReportsTruncationOnceForRepeatedCalls() {
+      // getEndRow is called repeatedly while geometry is built, so the message would be
+      // noisy if CoreTool.addUserMessage did not de-duplicate. asserted through
+      // getUserMessages() rather than getUserMessage(): the latter reduces with
+      // UserMessage.merge(), which drops text already contained in the accumulation, so it
+      // would collapse duplicates on its own and the assertion could never fail. The
+      // getUserMessages() merge concatenates unconditionally for messages with no assembly
+      // name, so one stored message means one line.
+      DefaultDataSet data = dataSet(600);
+      PointElement elem = new PointElement("Cat", "m1");
+      elem.setHint(GraphElement.HINT_MAX_COUNT, 500);
+
+      for(int i = 0; i < 4; i++) {
+         GraphElement.getEndRow(data, 0, -1, elem);
+      }
+
+      List<UserMessage> messages = CoreTool.getUserMessages(Type.INFO);
+
+      assertEquals(1, messages.size(), "the truncation must be stored as a single message");
+      assertEquals(0, countLineBreaks(messages.get(0).getMessage()),
+                   "four truncating calls must leave one message, not one per call, but was: " +
+                   messages.get(0).getMessage());
+   }
+
+   private static int countLineBreaks(String message) {
+      return message.split("\n", -1).length - 1;
+   }
+
+   private static DefaultDataSet dataSet(int rows) {
+      Object[][] values = new Object[rows + 1][2];
+      values[0] = new Object[]{ "Cat", "m1" };
+
+      for(int i = 0; i < rows; i++) {
+         values[i + 1] = new Object[]{ "c" + i, (double) i };
+      }
+
+      return new DefaultDataSet(values);
+   }
+}

--- a/core/src/test/java/inetsoft/uql/viewsheet/graph/GraphTypesTest.java
+++ b/core/src/test/java/inetsoft/uql/viewsheet/graph/GraphTypesTest.java
@@ -1,0 +1,171 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.uql.viewsheet.graph;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import inetsoft.sree.SreeEnv;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
+import org.slf4j.LoggerFactory;
+
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests GraphTypes.getGeomMaxCount(), which resolves the graph.*.maxcount limit that
+ * GraphGenerator.createElement stores on each element to cap how many rows a chart draws
+ * shapes for.
+ */
+@Tag("core")
+class GraphTypesTest {
+   @Test
+   void getGeomMaxCountReturnsConfiguredValue() {
+      try(MockedStatic<SreeEnv> sreeEnv = mockStatic(SreeEnv.class)) {
+         sreeEnv.when(() -> SreeEnv.getProperty("graph.bar.maxcount")).thenReturn("1500");
+
+         assertEquals(1500, GraphTypes.getGeomMaxCount(GraphTypes.CHART_BAR),
+                      "A numeric graph.bar.maxcount must be used as-is");
+      }
+   }
+
+   @Test
+   void getGeomMaxCountReturnsNegativeValueAsConfigured() {
+      try(MockedStatic<SreeEnv> sreeEnv = mockStatic(SreeEnv.class)) {
+         sreeEnv.when(() -> SreeEnv.getProperty("graph.bar.maxcount")).thenReturn("-1");
+
+         assertEquals(-1, GraphTypes.getGeomMaxCount(GraphTypes.CHART_BAR),
+                      "A negative graph.bar.maxcount is a deliberate no-limit setting and " +
+                      "must be returned unchanged, not treated as a bad value");
+      }
+   }
+
+   @ParameterizedTest(name = "graph.bar.maxcount [{0}] falls back to the shipped default")
+   @NullSource
+   @ValueSource(strings = { "abc", "", " ", "100,000", "1e5", "100000px" })
+   void getGeomMaxCountFallsBackWhenValueIsNotANumber(String propertyValue) {
+      // the parse used to be a bare Integer.parseInt outside any try, so an admin typo threw
+      // NumberFormatException out of GraphGenerator.createElement -- at chart generation
+      // time, not when the value was stored -- and the chart failed to render
+      try(MockedStatic<SreeEnv> sreeEnv = mockStatic(SreeEnv.class)) {
+         sreeEnv.when(() -> SreeEnv.getProperty("graph.bar.maxcount")).thenReturn(propertyValue);
+         sreeEnv.when(SreeEnv::getDefaultProperties)
+            .thenReturn(defaults("graph.bar.maxcount", "100000"));
+
+         assertEquals(100000, GraphTypes.getGeomMaxCount(GraphTypes.CHART_BAR),
+                      "A missing or non-numeric graph.bar.maxcount must fall back to the " +
+                      "value shipped in defaults.properties instead of throwing");
+      }
+   }
+
+   @Test
+   void getGeomMaxCountFallsBackToNoLimitWhenTheDefaultIsAlsoUnusable() {
+      try(MockedStatic<SreeEnv> sreeEnv = mockStatic(SreeEnv.class)) {
+         sreeEnv.when(() -> SreeEnv.getProperty("graph.bar.maxcount")).thenReturn("abc");
+         sreeEnv.when(SreeEnv::getDefaultProperties).thenReturn(new Properties());
+
+         assertEquals(-1, GraphTypes.getGeomMaxCount(GraphTypes.CHART_BAR),
+                      "With no usable default the limit must degrade to -1 (no limit), the " +
+                      "same value returned for a chart type that matches no property");
+      }
+   }
+
+   @Test
+   void getGeomMaxCountWarnsNamingThePropertyAndTheOffendingValue() {
+      // the warning is half the fix: without it the fallback is silent and an admin has no
+      // way to attribute a chart drawing on the default limit to the value they mistyped
+      Logger logger = (Logger) LoggerFactory.getLogger(GraphTypes.class);
+      ListAppender<ILoggingEvent> appender = new ListAppender<>();
+      appender.start();
+      logger.addAppender(appender);
+
+      try {
+         try(MockedStatic<SreeEnv> sreeEnv = mockStatic(SreeEnv.class)) {
+            sreeEnv.when(() -> SreeEnv.getProperty("graph.bar.maxcount")).thenReturn("100,000");
+            sreeEnv.when(SreeEnv::getDefaultProperties)
+               .thenReturn(defaults("graph.bar.maxcount", "100000"));
+
+            GraphTypes.getGeomMaxCount(GraphTypes.CHART_BAR);
+         }
+
+         assertEquals(1, appender.list.size(), "the fallback must report itself exactly once");
+
+         ILoggingEvent event = appender.list.get(0);
+         assertEquals(Level.WARN, event.getLevel(), "the fallback must be reported at WARN");
+
+         String message = event.getFormattedMessage();
+         assertTrue(message.contains("graph.bar.maxcount"),
+                    "the warning must name the property so it can be corrected, but was: " +
+                    message);
+         assertTrue(message.contains("100,000"),
+                    "the warning must quote the offending value, but was: " + message);
+      }
+      finally {
+         logger.detachAppender(appender);
+      }
+   }
+
+   /**
+    * isBar() returns true for the 3D bar types as well as the flat ones, so getGeomMaxCount
+    * relies on testing is3DBar first. Reordering those two branches -- or inserting a new one
+    * between them -- would silently retire graph.3dbar.maxcount and move 3D bars onto
+    * graph.bar.maxcount. This pins the property to the type.
+    */
+   @ParameterizedTest(name = "3D bar type {0} resolves graph.3dbar.maxcount")
+   @ValueSource(ints = { GraphTypes.CHART_3D_BAR, GraphTypes.CHART_3D_BAR_STACK })
+   void getGeomMaxCountPrefers3dBarPropertyOverBarProperty(int type) {
+      assertTrue(GraphTypes.isBar(type),
+                 "precondition: isBar() is a superset of is3DBar(), which is why the branch " +
+                 "order in getGeomMaxCount is load-bearing");
+
+      try(MockedStatic<SreeEnv> sreeEnv = mockStatic(SreeEnv.class)) {
+         sreeEnv.when(() -> SreeEnv.getProperty("graph.3dbar.maxcount")).thenReturn("111");
+         sreeEnv.when(() -> SreeEnv.getProperty("graph.bar.maxcount")).thenReturn("222");
+
+         assertEquals(111, GraphTypes.getGeomMaxCount(type),
+                      "a 3D bar must draw its limit from graph.3dbar.maxcount, not from " +
+                      "graph.bar.maxcount");
+      }
+   }
+
+   @Test
+   void getGeomMaxCountUsesBarPropertyForFlatBars() {
+      try(MockedStatic<SreeEnv> sreeEnv = mockStatic(SreeEnv.class)) {
+         sreeEnv.when(() -> SreeEnv.getProperty("graph.3dbar.maxcount")).thenReturn("111");
+         sreeEnv.when(() -> SreeEnv.getProperty("graph.bar.maxcount")).thenReturn("222");
+
+         assertEquals(222, GraphTypes.getGeomMaxCount(GraphTypes.CHART_BAR),
+                      "a flat bar must draw its limit from graph.bar.maxcount");
+      }
+   }
+
+   private static Properties defaults(String name, String value) {
+      Properties properties = new Properties();
+      properties.setProperty(name, value);
+      return properties;
+   }
+}


### PR DESCRIPTION
## Summary

Three related defects in the `graph.*.maxcount` family, which caps how many data rows a chart draws shapes for.

### 1. Twelve properties shared one unguarded parse

`GraphTypes.getGeomMaxCount` ended in a bare `Integer.parseInt(mstr)` outside any `try`. A non-numeric value in any of the twelve `graph.*.maxcount` properties threw `NumberFormatException` during *chart generation*, not when the value was stored. It escaped `GraphGenerator.createElement` through `VGraphPair.initGraph`, so the chart failed to render with an opaque `For input string: "100,000"` that did not name the property responsible.

The property is now resolved through a guarded accessor modelled on `ScheduleTask.getTaskTimeout` (added for #76177): a bad value logs one WARN naming the property and the offending value, then falls back to the value shipped in `defaults.properties`. No new default constants were invented — `SreeEnv.getDefaultProperties()` already exposes the shipped values.

Notes on the fallback, both captured in the javadoc:
- It goes to the shipped default rather than a site-wide `sree.properties` value, which matters when a bad *org-scoped* override is what failed to parse. A predictable fallback plus a WARN naming the property is the better trade.
- A value that is simply not configured is not an admin error and is not warned about. In practice it cannot arise here: `PropertiesEngine` chains `internalProperties` to `defaults.properties`, and all twelve names ship a default.

A deliberately negative value still parses and still means "no limit".

### 2. The truncation warning was suppressed at exactly the default that needed it

`GraphElement.getEndRow` raised the user-facing `Truncating shapes to {0}. To display in full, please reduce the number of data rows.` only when the limit was `100000` or less. The shipped defaults are:

| property | default |
|---|---|
| `graph.point.maxcount` | `10000000` |
| `graph.bar.maxcount` / `graph.line.maxcount` / `graph.3dbar.maxcount` | `100000` |

Because the test was strictly greater-than, bar/line/3dbar landed on the reporting side while a **Point chart dropped rows silently at its shipped default** — and Point is the type most likely to be plotting a large row count. A reader could not tell whether they were seeing all their data.

The truncation is now always reported. `CoreTool.addUserMessage` de-duplicates via `existUserMessage`, so the repeated calls made while building geometry still raise a single message. `LOG.debug` is kept alongside so the server log records it unconditionally.

The only shipped limit above the removed threshold is `graph.point.maxcount`, so the behaviour change is confined to the intended case.

### 3. `graph.3dbar.maxcount` was alive only by branch order

`isBar` returns true for `CHART_3D_BAR`/`CHART_3D_BAR_STACK` as well as the flat types, so a 3D bar matches both the `is3DBar` branch and the `isBar` branch. Only the ordering kept `graph.3dbar.maxcount` from being dead, and nothing tested it. Reordering those branches — or inserting one between them — would have silently retired the property and moved 3D bars onto `graph.bar.maxcount`.

The ordering is left as-is (it is correct today), now documented as load-bearing and pinned by a test.

### Also

`getGeomMaxCount(chartType)` is resolved once in `GraphGenerator.createElement` instead of once per element. It depends only on `chartType`, and leaving it in the loop would emit one warning per element.

## Tests

Two new files, 18 tests.

`GraphTypesTest` (new package directory — there was no test for this class):
- a numeric value is used as-is, and a negative value is preserved
- six non-numeric forms (`abc`, `` , ` `, `100,000`, `1e5`, `100000px`) plus null fall back instead of throwing
- exactly one WARN, at WARN level, naming both the property and the offending value
- no usable default degrades to `-1` (no limit)
- both 3D bar types resolve `graph.3dbar.maxcount` while flat bars resolve `graph.bar.maxcount` — the regression lock for finding 3

`GraphElementTruncationMessageTest`:
- truncation is reported at both `500` and `100001` (the latter fails against the old code)
- no message when nothing is truncated
- repeated calls raise a single message, asserted through `getUserMessages()` rather than `getUserMessage()` — the latter reduces with `UserMessage.merge`, which drops text already contained in the accumulation and would collapse duplicates on its own, making the assertion unfalsifiable

Verified with `./mvnw test -pl core` over `inetsoft.graph.**`, `inetsoft.report.composition.graph.**` and `inetsoft.uql.viewsheet.graph.**`: 126 tests, 0 failures (the single skip is pre-existing in `GraphRenderTest`).

## Out of scope

Most other `graph.*` properties parse unguarded the same way — `graph.subgraph.maxcount` (`RectCoord`), `graph.legend.maxcount` (`Legend`), `graph.axislabel.maxcount` (`CategoricalScale`, `TimeScale`), `graph.textlayout.maxcount` (`TextLayoutManager`), `graph.textlayout.maxstep` (`FreeHelper`), `graph.maxarea` (`VGraph`), `graph.pie.min.ratio` (`PolarCoord`), `graph.max.nodes` (`RelationElement`). `EGraph` is the one already-guarded site.

Deliberately not included here to keep the change scoped. `FreeHelper` is the one worth prioritising in a follow-up: its parse is in a static initialiser, so a bad value yields `ExceptionInInitializerError` rather than a render failure. A shared numeric accessor on `GTool` would fold all of them plus `GraphTypes` into one place; none exists today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
