### PR TITLE
Bug #76288, surface MV dimension overflow at query time

### DIFF
--- a/core/src/main/java/inetsoft/mv/MVAssetQuery.java
+++ b/core/src/main/java/inetsoft/mv/MVAssetQuery.java
@@ -18,7 +18,10 @@
 package inetsoft.mv;
 
 import inetsoft.uql.erm.vpm.VpmProcessor;
+import inetsoft.mv.data.MV;
 import inetsoft.mv.data.MVQueryBuilder;
+import inetsoft.mv.data.MVStorage;
+import inetsoft.sree.internal.SUtil;
 import inetsoft.report.TableLens;
 import inetsoft.report.composition.QueryTreeModel.QueryNode;
 import inetsoft.report.composition.execution.*;
@@ -639,6 +642,66 @@ public class MVAssetQuery extends AssetQuery {
                LOG.warn(msg);
                Tool.addUserMessage(msg);
             }
+         }
+      }
+
+      // grouping on a dimension whose dictionary overflowed mv.dim.max.size returns
+      // incomplete results, since XDimDictionary.indexOf then returns the row
+      // position rather than a value index. detail queries are unaffected -- the
+      // raw values are retained for them -- so only warn for grouping queries.
+      if(!empty && ainfo.getGroupCount() > 0 && mvname != null) {
+         try {
+            String mvfile = MVStorage.getFile(mvname);
+            String mvorg = SUtil.getOrgIDFromMVPath(mvname);
+            MV mv = MVStorage.getInstance().get(mvfile, mvorg);
+            MVDef mvdef = mv == null ? null : mv.getDef(false, mvorg);
+            // rinfo may be null on the mv.name property path, so take this from the
+            // def rather than from rinfo, as MVQueryBuilder.transform does
+            boolean mvWS = mvdef != null && mvdef.isWSMV();
+
+            // mirrors the detail determination in MVQueryBuilder.transform: a WSMV
+            // non-crosstab query without aggregate.down runs as a detail query even
+            // though its aggregate info is not empty -- unless it is distinct, which
+            // transform() flips back to a grouping query
+            boolean mvDetail = mvWS && !ainfo.isCrosstab() &&
+               !"true".equals(table.getProperty("aggregate.down")) && !table.isDistinct();
+
+            if(mv != null && !mvDetail) {
+               List<GroupRef> checked = new ArrayList<>();
+
+               // resolve the groups the way MVQueryBuilder.transform does, so the
+               // headers line up with the mv. done on copies -- the refs are shared
+               // with the assembly and must not be rewritten here.
+               for(GroupRef gref : ainfo.getGroups()) {
+                  // dropped before the mv query is built, so never grouped on
+                  if(AssetUtil.isNullExpression(gref)) {
+                     continue;
+                  }
+
+                  DataRef cref = gref.getDataRef();
+
+                  // a ws mv keys an aliased column by its alias
+                  if(mvWS && cref instanceof ColumnRef && ((ColumnRef) cref).getAlias() != null) {
+                     checked.add(new GroupRef(VSUtil.getVSColumnRef((ColumnRef) cref)));
+                  }
+                  else {
+                     checked.add(gref);
+                  }
+               }
+
+               for(String col : mv.getOverflowedGroups(checked.toArray(new GroupRef[0]))) {
+                  String msg = "Dimension column \"" + col + "\" has too many distinct " +
+                     "values in the materialized view. Grouping on it may return " +
+                     "incomplete results. Increase the mv.dim.max.size parameter and " +
+                     "regenerate the materialized view.";
+                  LOG.warn(msg);
+                  Tool.addUserMessage(msg);
+               }
+            }
+         }
+         catch(Exception ex) {
+            // the overflow check is advisory, never fail the query for it
+            LOG.debug("Failed to check MV dimension overflow: " + mvname, ex);
          }
       }
 

--- a/core/src/main/java/inetsoft/mv/data/MV.java
+++ b/core/src/main/java/inetsoft/mv/data/MV.java
@@ -38,6 +38,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.*;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Materialized view, it stores dimension dictionaries at server node. When
@@ -91,6 +92,7 @@ public final class MV implements Cloneable {
     * Create palette.
     */
    private void createPalette(int size) {
+      this.overflowed.clear();
       this.palette = new DictionaryPalette[size];
 
       for(int i = 0; i < size; i++) {
@@ -239,6 +241,7 @@ public final class MV implements Cloneable {
     */
    public XDimDictionaryIndex getDictionaryIndex(int column, XDimDictionary dict) {
       loadContent();
+      overflowed.clear();
       return palette[column].getDictionary(dict);
    }
 
@@ -255,6 +258,7 @@ public final class MV implements Cloneable {
     */
    public void setDictionary(int column, int index, XDimDictionary dict) {
       loadContent();
+      overflowed.clear();
       palette[column].setDictionary(index, dict);
    }
 
@@ -510,6 +514,7 @@ public final class MV implements Cloneable {
 
       //read block dictionarys.
       int ccnt = dcnt + mcnt;
+      overflowed.clear();
       palette = new DictionaryPalette[ccnt];
 
       for(int i = 0; i < ccnt; i++) {
@@ -815,31 +820,60 @@ public final class MV implements Cloneable {
    }
 
    /**
-    * Check if the columns are valid dimensions.
+    * Get the names of the group columns whose dimension dictionary overflowed
+    * mv.dim.max.size. Grouping on such a column produces incomplete results,
+    * since the dictionary no longer maps values to unique indexes (see
+    * XDimDictionary.indexOf, which returns the row position when overflown).
+    *
+    * @return the overflowed column names, empty if none.
     */
-   public void checkValidity(GroupRef[] groups) {
+   public List<String> getOverflowedGroups(GroupRef[] groups) {
       loadContent();
+      List<String> overflowed = new ArrayList<>();
 
-      // check whether one dimension is overflow
       for(GroupRef group : groups) {
          DataRef dref = group.getDataRef();
          String attrName = MVDef.getMVHeader(dref);
-         int idx = indexOfHeader(attrName, 0);
-         List<XDimDictionary> dicts = palette[idx].getDicts();
 
-         for(XDimDictionary dict : dicts) {
-            if(idx >= 0 && idx < palette.length &&
-               dict != null && dict.isOverflow())
-            {
-               String msg = "Dimension column \"" + attrName +
-                  "\" has too many distinct values. " +
-                  "It can't be used for grouping and filtering! " +
-                  "If grouping or filtering of \"" + attrName + "\" is " +
-                  "needed, increase the mv.dim.max.size parameter.";
-               throw new RuntimeException(msg);
+         if(attrName != null && isColumnOverflowed(attrName)) {
+            overflowed.add(attrName);
+         }
+      }
+
+      return overflowed;
+   }
+
+   /**
+    * Check whether any block's dictionary for the column overflowed.
+    *
+    * <p>Answering this reads each of the column's dictionaries off storage
+    * (XDimDictionary.read is a delayed read that leaves the flag unset), so the result is
+    * memoized -- otherwise every query grouping on the column would pay for it again, and the
+    * healthy case, where nothing overflowed, is the one that reads them all.
+    */
+   private boolean isColumnOverflowed(String header) {
+      Boolean cached = overflowed.get(header);
+
+      if(cached != null) {
+         return cached;
+      }
+
+      int idx = indexOfHeader(header, 0);
+      boolean over = false;
+
+      // not an mv dimension column, nothing to check
+      if(idx >= 0 && idx < palette.length) {
+         for(XDimDictionary dict : palette[idx].getDicts()) {
+            if(dict != null && dict.checkOverflow()) {
+               over = true;
+               // one report per column, not once per block
+               break;
             }
          }
       }
+
+      overflowed.put(header, over);
+      return over;
    }
 
    /**
@@ -1023,6 +1057,7 @@ public final class MV implements Cloneable {
 
       try {
          MV mv = (MV) super.clone();
+         mv.overflowed = new ConcurrentHashMap<>();
          mv.palette = new DictionaryPalette[palette.length];
          mv.blockInfos = new ArrayList<>();
 
@@ -1059,6 +1094,8 @@ public final class MV implements Cloneable {
    private List<MVBlockInfo> blockInfos = new ArrayList<>();
    private final List<Integer> blockBaseRows = new ArrayList<>();
    private DictionaryPalette[] palette;
+   // memoized per-column overflow, keyed by mv header; cleared when the palette changes
+   private Map<String, Boolean> overflowed = new ConcurrentHashMap<>();
    int dcnt;
    int mcnt;
    String[] headers;

--- a/core/src/main/java/inetsoft/mv/data/MVBuilder.java
+++ b/core/src/main/java/inetsoft/mv/data/MVBuilder.java
@@ -601,9 +601,10 @@ public final class MVBuilder {
                int lookahead = nextb;
                String maxStr = SreeEnv.getProperty("mv.max.block");
                int maxBlock = maxStr != null ? Integer.parseInt(maxStr) : preferred * 10;
+               int maxRow = getMaxBreakRow(r, size, maxBlock);
                boolean found = false;
 
-               for(; lens.moreRows(nextb) && nextb <= maxBlock; nextb++) {
+               for(; lens.moreRows(nextb) && nextb <= maxRow; nextb++) {
                   // optimization, look at 100 rows and if eq, skip to the next row.
                   // this is based on the assumption the breakcol is sorted.
                   if(lookahead == nextb) {
@@ -628,10 +629,12 @@ public final class MVBuilder {
 
                size = nextb - r;
 
-               if(!found) {
-                  LOG.warn("Distinct count defined on " + lens.getObject(0, breakcol) +
+               // only warn if the block was actually cut short by the size cap.
+               // running out of rows is the normal end of the last block.
+               if(!found && lens.moreRows(nextb)) {
+                  LOG.warn("Distinct count defined on " + XUtil.getHeader(lens, breakcol) +
                      " caused MV block to exceed maximum size (" + maxBlock +
-                              "). As a result, the disinct count may not be accurate. " +
+                              "). As a result, the distinct count may not be accurate. " +
                      "Modify the dashboard to remove the distinct count, or increase " +
                      "maximum block size by defining mv.max.block property.");
                }
@@ -874,6 +877,25 @@ public final class MVBuilder {
    private boolean isDesktop() {
       boolean desktop = FSService.getConfig().isDesktop();
       return desktop;
+   }
+
+   /**
+    * Get the last source row a block may extend to while looking for a break
+    * boundary. mv.max.block is a block *length*, so the bound is relative to the
+    * start of the block (r) -- comparing an absolute row index against it would
+    * shrink the allowance as the build advances, and disable the distinct-count
+    * protection entirely once r passed the limit. The bound can never be less
+    * than the block already accumulated.
+    *
+    * @param r        the source row this block starts at.
+    * @param size     the rows already accumulated for this block.
+    * @param maxBlock the mv.max.block limit, as a row count.
+    */
+   static int getMaxBreakRow(int r, int size, int maxBlock) {
+      // saturate instead of overflowing: a wrapped negative bound would silently
+      // switch the protection back off, which is the bug this guards against.
+      long maxRow = (long) r + Math.max(maxBlock, size);
+      return maxRow > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) maxRow;
    }
 
    /**

--- a/core/src/main/java/inetsoft/mv/data/XDimDictionary.java
+++ b/core/src/main/java/inetsoft/mv/data/XDimDictionary.java
@@ -116,6 +116,21 @@ public class XDimDictionary extends XSwappable implements Cloneable {
    }
 
    /**
+    * Check if the dimension value overflows, forcing the delayed read first.
+    *
+    * <p>{@link #read} defers everything but size/hashCode/dataType, and the overflow flag is
+    * only assigned by {@code read0()}. {@link #isOverflow()} therefore reports a stale
+    * {@code false} for a dictionary that has been loaded from storage but not yet accessed.
+    * Callers that must get a truthful answer on a cold dictionary use this instead; it costs a
+    * full read of the dictionary, so it is not for hot paths. Dictionaries built in memory are
+    * already valid, making this a no-op for them.
+    */
+   public boolean checkOverflow() {
+      validate();
+      return overflow;
+   }
+
+   /**
     * Mark this dictionary as overflow.
     */
    public void setOverflow(boolean overflow) {

--- a/core/src/test/java/inetsoft/mv/data/MVBuilderMaxBlockTest.java
+++ b/core/src/test/java/inetsoft/mv/data/MVBuilderMaxBlockTest.java
@@ -1,0 +1,94 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.mv.data;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies {@link MVBuilder#getMaxBreakRow}, the bound on how far a block may extend while
+ * looking for a distinct-count break boundary.
+ *
+ * <p>{@code mv.max.block} is a block <em>length</em>, but the loop used to compare it against
+ * {@code nextb} -- an absolute index into the source table. The allowance therefore shrank as the
+ * build advanced, and once the row cursor passed {@code mv.max.block} the loop body stopped
+ * running altogether: the protection silently switched off for the rest of the table, and the
+ * "caused MV block to exceed maximum size" warning fired for every remaining block.
+ */
+@Tag("core")
+class MVBuilderMaxBlockTest {
+   private static final int MAX_BLOCK = 10_000_000;
+   private static final int PREFERRED = 1_000_000;
+
+   /**
+    * The reported bug: at a row cursor past mv.max.block the old comparison
+    * ({@code nextb <= maxBlock}) was already false, so no rows were scanned for a break boundary.
+    */
+   @Test
+   void allowsFullBlockLengthWellPastMaxBlock() {
+      int r = 20_000_000;
+      int maxRow = MVBuilder.getMaxBreakRow(r, PREFERRED, MAX_BLOCK);
+
+      assertTrue(maxRow > r + PREFERRED,
+                 "a block starting past mv.max.block must still be allowed to look ahead");
+      assertEquals(r + MAX_BLOCK, maxRow, "every block gets the same allowance");
+   }
+
+   /** Every block gets the same allowance, regardless of how far into the table it starts. */
+   @Test
+   void allowanceIsIndependentOfBlockPosition() {
+      int first = MVBuilder.getMaxBreakRow(0, PREFERRED, MAX_BLOCK);
+      int later = MVBuilder.getMaxBreakRow(50_000_000, PREFERRED, MAX_BLOCK);
+
+      assertEquals(first - 0, later - 50_000_000);
+   }
+
+   /**
+    * A mv.max.block smaller than the block already accumulated must not produce a bound behind
+    * the cursor -- that would make size negative, and hasNext() treats size <= 0 as end of data,
+    * silently truncating the MV.
+    */
+   @Test
+   void neverBoundsBelowTheBlockAlreadyAccumulated() {
+      int r = 5_000;
+      int size = PREFERRED;
+      int maxRow = MVBuilder.getMaxBreakRow(r, size, 100);
+
+      assertEquals(r + size, maxRow);
+      assertTrue(maxRow - r > 0, "block size must stay positive");
+   }
+
+   /**
+    * A large configured mv.max.block near the end of a big table must not wrap to a negative
+    * bound -- that would silently switch the protection back off, the very bug being fixed.
+    */
+   @Test
+   void saturatesInsteadOfOverflowing() {
+      int maxRow = MVBuilder.getMaxBreakRow(Integer.MAX_VALUE - 10, PREFERRED, MAX_BLOCK);
+
+      assertEquals(Integer.MAX_VALUE, maxRow);
+      assertTrue(maxRow > 0, "bound must never wrap negative");
+   }
+
+   @Test
+   void honorsAnExplicitlyConfiguredLimit() {
+      assertEquals(1_000 + 250_000, MVBuilder.getMaxBreakRow(1_000, 1_000, 250_000));
+   }
+}

--- a/core/src/test/java/inetsoft/mv/data/MVOverflowedGroupsTest.java
+++ b/core/src/test/java/inetsoft/mv/data/MVOverflowedGroupsTest.java
@@ -1,0 +1,182 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.mv.data;
+
+import inetsoft.test.*;
+import inetsoft.uql.asset.ColumnRef;
+import inetsoft.uql.asset.GroupRef;
+import inetsoft.uql.erm.AttributeRef;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies {@link MV#getOverflowedGroups}, which reports the group columns whose dimension
+ * dictionary overflowed {@code mv.dim.max.size}. Grouping on such a column silently returns
+ * incomplete results, because {@code XDimDictionary.indexOf} then returns the row position
+ * rather than a value index -- so every row becomes its own group.
+ *
+ * <p>This replaced the never-called {@code MV.checkValidity(GroupRef[])}, which additionally
+ * dereferenced {@code palette[idx]} before bounds-checking {@code idx}, so it would have thrown
+ * {@link ArrayIndexOutOfBoundsException} on any group column absent from the MV headers.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class, SwapperTestConfiguration.class },
+                      initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class MVOverflowedGroupsTest {
+   @Test
+   void reportsOverflowedDimensionColumn() {
+      MV mv = createMV();
+      overflow(mv, 0);
+
+      assertEquals(List.of("City"), mv.getOverflowedGroups(groups("City")));
+   }
+
+   @Test
+   void ignoresColumnThatDidNotOverflow() {
+      MV mv = createMV();
+      // "State" has a dictionary, but it is within mv.dim.max.size
+      mv.getDictionaryIndex(1, new XDimDictionary());
+
+      assertTrue(mv.getOverflowedGroups(groups("State")).isEmpty());
+   }
+
+   /**
+    * A column overflowed across several blocks holds one overflowed dictionary per block in its
+    * palette. The operator should be told about the column once, not once per block.
+    */
+   @Test
+   void reportsColumnOnceEvenWhenSeveralBlocksOverflowed() {
+      MV mv = createMV();
+      // distinct state per dictionary: XDimDictionary.equals compares overflow,
+      // size, hashCode, cnull and cls, so identical dicts would be deduped by
+      // DictionaryPalette and the test would not exercise the per-block loop.
+      // the ascending palette indexes prove three separate dictionaries were stored,
+      // so the per-block loop really is exercised
+      assertEquals(0, overflow(mv, 0, "a").getIndex());
+      assertEquals(1, overflow(mv, 0, "b").getIndex());
+      assertEquals(2, overflow(mv, 0, "c").getIndex());
+
+      assertEquals(List.of("City"), mv.getOverflowedGroups(groups("City")));
+   }
+
+   @Test
+   void reportsEveryOverflowedColumn() {
+      MV mv = createMV();
+      overflow(mv, 0);
+      overflow(mv, 1);
+
+      assertEquals(List.of("City", "State"), mv.getOverflowedGroups(groups("City", "State")));
+   }
+
+   /**
+    * Regression guard for the bounds-check ordering bug in the method this replaced: a group on a
+    * column that is not an MV header makes {@code indexOfHeader} return -1, which used to index
+    * the palette array before the guard ran.
+    */
+   @Test
+   void skipsGroupColumnMissingFromTheMV() {
+      MV mv = createMV();
+      overflow(mv, 0);
+
+      assertDoesNotThrow(() -> mv.getOverflowedGroups(groups("NotAnMVColumn")));
+      assertTrue(mv.getOverflowedGroups(groups("NotAnMVColumn")).isEmpty());
+   }
+
+   /**
+    * The per-column result is memoized so that repeated queries do not re-read every block's
+    * dictionary off storage. That memo must not outlive a change to the palette.
+    */
+   @Test
+   void memoizedResultIsInvalidatedWhenThePaletteChanges() {
+      MV mv = createMV();
+
+      // prime the memo with a negative answer
+      assertTrue(mv.getOverflowedGroups(groups("City")).isEmpty());
+
+      overflow(mv, 0, "a");
+
+      assertEquals(List.of("City"), mv.getOverflowedGroups(groups("City")),
+                   "a dictionary added after the first check must still be seen");
+   }
+
+   /** Repeated checks are stable, and the memo returns the same answer. */
+   @Test
+   void repeatedChecksAreStable() {
+      MV mv = createMV();
+      overflow(mv, 0);
+
+      assertEquals(List.of("City"), mv.getOverflowedGroups(groups("City")));
+      assertEquals(List.of("City"), mv.getOverflowedGroups(groups("City")));
+      assertEquals(List.of("City"), mv.getOverflowedGroups(groups("City")));
+   }
+
+   @Test
+   void returnsEmptyForNoGroups() {
+      assertTrue(createMV().getOverflowedGroups(new GroupRef[0]).isEmpty());
+   }
+
+   /**
+    * An in-memory MV with two dimensions ("City", "State") and one measure ("Total").
+    * {@code contentPos} defaults to -1, so {@code loadContent()} is a no-op here.
+    */
+   private static MV createMV() {
+      return new MV(2, 1, new String[]{ "City", "State", "Total" }, new String[3],
+                    new Class[3], null, null);
+   }
+
+   /** Add an overflowed dictionary to the given column's palette. */
+   private static void overflow(MV mv, int column) {
+      overflow(mv, column, null);
+   }
+
+   /**
+    * Add an overflowed dictionary carrying {@code value}, which distinguishes it from other
+    * overflowed dictionaries -- an overflown dict folds each added value into its hashCode.
+    */
+   private static XDimDictionaryIndex overflow(MV mv, int column, Object value) {
+      XDimDictionary dict = new XDimDictionary();
+      dict.setOverflow(true);
+
+      if(value != null) {
+         dict.addValue(value);
+      }
+
+      return mv.getDictionaryIndex(column, dict);
+   }
+
+   private static GroupRef[] groups(String... names) {
+      GroupRef[] groups = new GroupRef[names.length];
+
+      for(int i = 0; i < names.length; i++) {
+         groups[i] = new GroupRef(new ColumnRef(new AttributeRef(null, names[i])));
+      }
+
+      return groups;
+   }
+}

--- a/core/src/test/java/inetsoft/mv/data/XDimDictionaryOverflowReadTest.java
+++ b/core/src/test/java/inetsoft/mv/data/XDimDictionaryOverflowReadTest.java
@@ -1,0 +1,108 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.mv.data;
+
+import inetsoft.test.*;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.File;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * {@link XDimDictionary#read} is a <em>delayed</em> read: it takes only size, hashCode and
+ * dataType off the channel, marks the dictionary invalid and returns. The {@code overflow} flag
+ * is assigned by {@code read0()}, which does not run until {@code validate()} is triggered.
+ *
+ * <p>{@link XDimDictionary#checkOverflow()} forces that read, so it reports truthfully on a cold
+ * dictionary. {@link XDimDictionary#isOverflow()} deliberately does not -- it is read on the
+ * MV build/incremental paths where the extra deserialization would be too costly, and where
+ * changing the answer would alter the on-disk index layout of appended blocks.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class, SwapperTestConfiguration.class },
+                      initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class XDimDictionaryOverflowReadTest {
+   @Test
+   void reportsOverflowOnAFreshlyReadDictionary(@TempDir Path dir) throws Exception {
+      XDimDictionary read = roundTrip(dir, true);
+
+      // the failure this guards: read() leaves overflow unassigned, so without
+      // validating this is false and the MV overflow warning never fires
+      assertTrue(read.checkOverflow(),
+                 "overflow must survive a delayed read without an explicit access first");
+   }
+
+   @Test
+   void doesNotReportOverflowForANormalDictionary(@TempDir Path dir) throws Exception {
+      assertFalse(roundTrip(dir, false).checkOverflow());
+   }
+
+   /**
+    * isOverflow() must stay a plain field read. Making it validate would silently re-activate
+    * the overflow branch in MVBuilder.hasNext() that has never run for storage-loaded
+    * dictionaries, changing the index layout of incrementally appended blocks.
+    */
+   @Test
+   void isOverflowStaysCheapAndDoesNotForceTheRead(@TempDir Path dir) throws Exception {
+      XDimDictionary read = roundTrip(dir, true);
+
+      assertFalse(read.isOverflow(), "isOverflow() must not trigger the delayed read");
+      // and once validated, both agree
+      assertTrue(read.checkOverflow());
+      assertTrue(read.isOverflow());
+   }
+
+   /** Write a dictionary out and read it back through the delayed-read path. */
+   private static XDimDictionary roundTrip(Path dir, boolean overflow) throws Exception {
+      File file = dir.resolve("dict.bin").toFile();
+      ChannelProvider provider = ChannelProvider.file(file);
+
+      XDimDictionary dict = new XDimDictionary();
+
+      if(overflow) {
+         dict.setOverflow(true);
+      }
+
+      dict.addValue("Boston");
+      dict.complete();
+
+      try(SeekableByteChannel channel = provider.newWriteChannel()) {
+         dict.write(channel);
+      }
+
+      XDimDictionary read = new XDimDictionary();
+
+      try(SeekableByteChannel channel = provider.newReadChannel()) {
+         read.read(provider, channel);
+      }
+
+      return read;
+   }
+}


### PR DESCRIPTION
## Problem

`MV.checkValidity(GroupRef[])` existed to refuse a grouping on a dimension whose dictionary overflowed `mv.dim.max.size`. **Nothing called it** — it was the only occurrence of that overload in community or enterprise, and `git log -S` shows it was never wired up.

The consequence is concrete. `XDimDictionary.setOverflow(true)` clears the distinct-value set, and `indexOf(Object, int row)` then returns *the row position* instead of a value index:

```java
if(overflow) {
   // if overflow, the index of a value is it's row position
   // ... But since we don't allow grouping and filtering, ...
   return row - baseRow;
}
```

So grouping on an overflowed column makes every row its own group. The comment says "we don't allow grouping and filtering" — but nothing enforced it. The only notice anyone got was a `LOG.warn` in `MVCreatorUtil`, written when the MV was built, possibly weeks before someone builds a dashboard that trips over it.

Separately, `MVBuilder` compared `mv.max.block` against `nextb` — an absolute index into the source table — not the length of the block being built. The allowance was therefore `mv.max.block - r`, shrinking as the build advanced; once the cursor passed `mv.max.block` the loop body never ran, so the distinct-count protection stopped and the "caused MV block to exceed maximum size" warning fired for every remaining block. The name, the message, and the comparison could not all three be right.

## Approach

**Warn, don't fail.** The dashboard still renders; the operator is told which column is affected and that `mv.dim.max.size` must be raised **and the MV regenerated** (the flag is baked into the `.mv` file). This reuses `Tool.addUserMessage`, the channel `MVAssetQuery` already uses a few lines above for the STRING-column aggregate warning.

Throwing was considered and rejected: `MVExecutionException.recreate` defaults to `true`, so with `mv.ondemand` enabled it would trigger `recreateMVOnDemand()` — a futile rebuild, since the dictionary overflows again.

Detail queries are excluded — overflow deliberately retains the raw values so detail display stays correct. Group resolution mirrors `MVQueryBuilder.transform` (alias rewrite for WS MVs, null-expression filtering, and its `isDistinct`/`aggregate.down` detail determination), done on copies since the refs are shared with the assembly.

## A note on `isOverflow()`

Answering the question at all requires reading each dictionary off storage: `XDimDictionary.read()` is a *delayed* read that leaves `overflow` unassigned until `read0()` runs, so `isOverflow()` reports a stale `false` on a cold dictionary.

I deliberately did **not** change `isOverflow()` itself. It is also read by `MVBuilder.hasNext()` on the incremental path, where making it truthful re-activates a branch that has never run and would alter the on-disk index layout of appended blocks. Instead this adds `checkOverflow()`, used only by the new path, and memoizes the per-column result on the `MV` so the cost is not repaid on every query.

**That leaves a known latent bug**: the incremental build still reads the stale `isOverflow()`. It needs its own change with incremental-MV coverage rather than a drive-by fix here.

## Also fixed

- The dead method dereferenced `palette[idx]` *before* testing `idx >= 0`, so it would have thrown `ArrayIndexOutOfBoundsException` on a group column absent from the MV.
- The `mv.max.block` warning no longer fires when the table simply runs out of rows (previously the last block of every distinct-count MV warned), and it names the break column instead of printing the data value in row 0. `"disinct"` → `"distinct"`.

## Risk

This **re-enables protection that is currently off** past row `mv.max.block`, so late blocks can now extend toward the cap (default `preferred * 10` = 10M rows) instead of stopping at `preferred`. That is the intended behavior and the first block could already reach that size, but it now applies to every block — worth watching peak heap when building a large distinct-count MV with a low-cardinality break column.

## Testing

178 MV tests pass; full reactor build green. Three new test files. Every behavioral change has a test that was **mutation-verified** — confirmed to fail when the fix is reverted:

| Change | Fails without the fix as |
|---|---|
| `checkOverflow()` forces the delayed read | `expected: <true> but was: <false>` |
| `isOverflow()` stays a plain field read | asserts it does *not* force the read |
| memo invalidated on palette change | `expected: <[City]> but was: <[]>` |
| bounds check before `palette[idx]` | `ArrayIndexOutOfBoundsException: Index -1` |
| per-column `break` | `<[City, City, City]>` |

There was previously no coverage of `MVBuilder` block sizing or dictionary overflow at all.

### Manual verification

1. Set `mv.dim.max.size` low (e.g. `100`) and **restart** — `XDimDictionary.MAX_SIZE` is statically cached.
2. Build an MV over a worksheet with a high-cardinality string column; confirm the build warning in the log.
3. Group a chart or crosstab on that column: the dashboard still renders **and** the warning names the column.
4. Show Details over the same MV: **no** warning, correct raw values.

## Not in scope

Filtering on an overflowed dimension is also broken (`fixFilter` → `indexOf(value, -1)` yields a garbage index) and still warns nothing. The original message claimed to cover "grouping and filtering"; this change covers grouping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
