### PR TITLE
Bug #76289, stop mv.debug from disabling the asset data cache and give fs.desktop a single reader

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/execution/AssetDataCache.java
+++ b/core/src/main/java/inetsoft/report/composition/execution/AssetDataCache.java
@@ -849,7 +849,7 @@ public class AssetDataCache extends DataCache<DataKey, TableLens> {
          data = null;
       }
 
-      if(data != null && (!"true".equals(SreeEnv.getProperty("mv.debug")))) {
+      if(data != null) {
          final String tableName = table == null ? "null" : table.getAbsoluteName();
          LOG.debug("Using cached result set: {} rows: {}", tableName, data.getRowCount());
       }

--- a/core/src/main/java/inetsoft/sree/RepletEngine.java
+++ b/core/src/main/java/inetsoft/sree/RepletEngine.java
@@ -18,6 +18,7 @@
 package inetsoft.sree;
 
 import inetsoft.mv.*;
+import inetsoft.mv.fs.FSService;
 import inetsoft.report.LibManagerProvider;
 import inetsoft.report.filter.DefaultComparer;
 import inetsoft.report.internal.LicenseException;
@@ -1543,7 +1544,7 @@ public class RepletEngine extends AbstractAssetEngine
       writeLock.lock();
 
       try {
-         if("false".equals(SreeEnv.getProperty("fs.desktop"))) {
+         if(!FSService.getConfig().isDesktop()) {
             if(oentry.isRepositoryFolder()) {
                throw new MessageException(catalog.getString(
                        "common.invalidEntry", oentry));


### PR DESCRIPTION
Two property-polarity defects in the mv/fs slice, found by a property audit and verified against the current pin.

## Part 1 — `mv.debug` silently disabled the asset data cache server-wide

`AssetDataCache.getData` read `mv.debug` inside the condition that *selects the branch*, not around a log call:

```java
if(data != null && (!"true".equals(SreeEnv.getProperty("mv.debug")))) {
   LOG.debug("Using cached result set: {} rows: {}", tableName, data.getRowCount());
}
else {
   // re-executes the query and re-caches
}
```

With `mv.debug=true`, every cache hit fell into the `else` and the query was re-executed — at any log level, for every asset query, whether or not an MV was involved. The property reads as "log more", so an operator turning it on to investigate one slow dashboard made every dashboard on the server slower, with nothing saying so.

Two things confirm this was accidental rather than designed:

1. **All 16 other `mv.debug` readers are pure log guards** — `ViewsheetSandbox:7444,7469`, `PreAssetQuery:3127,3139,3154,3217,3225,3239`, `AssetQuery:160,179,3627`, `WSMVTransformer:67`, `XJobStatus:196`, `TransformationDescriptor:1936`, `MVTransformer:502`, `JDBCHandler:787`. Each wraps only a `LOG.debug(...)`. This was the sole outlier.
2. **A dedicated cache-bypass property already exists** four lines above — `AssetDataCache.isDebugData()` reads `debug.data` and is documented *"Disable all caching to force data query to execute on every refresh."* It is the established kill-switch, used at `XHandler:182`, `DefaultMetaDataProvider:473`, `ViewsheetSandbox:5229,5239,5537`, `AssetQuery:702`.

The `data != null` test was also doing double duty — guarding a log message *and* selecting a code path — which is what made the defect easy to miss on a read.

**Fix:** drop the `mv.debug` term. When `debug.data=true`, `data` is already `null` by the time control reaches this line, so that path is unchanged.

**Behavior note for reviewers:** the removed clause was also what made the *other* `mv.debug` log sites fire on repeat runs — with the cache hit now returned, `AssetQuery`/`PreAssetQuery`/`MVTransformer` don't execute and stay silent on a second load. Diagnosing MV usage across repeated loads now needs `debug.data=true` alongside `mv.debug=true`. That is the intended trade: the old coupling is exactly what made the property a server-wide performance trap.

## Part 2 — `fs.desktop` was tested with opposite polarity by its two readers

| Site | Test | Action |
|---|---|---|
| `FSService.java:260` (`FSConfigImpl.isDesktop()`) | `"true".equals(val)` | true ⇒ desktop file system |
| `RepletEngine.java:1546` (`changeFolder`) | `"false".equals(...)` | true ⇒ reject moving a repository folder |

One asks "is it true", the other "is it false", and they take unrelated actions on the answer.

`defaults.properties:72` declares `fs.desktop=false`, so a stock install is consistent — `isDesktop()` returns `false` (server mode) and the guard is active. But any value that is neither literal string, **including an empty one**, leaves the file system in server mode as `isDesktop()` intends while silently switching off the guard that rejects moving a repository folder. A property whose two readers disagree about what "not set" means is a defect however unlikely the value, because the failure is silent and the two behaviours are unrelated.

**Fix:** route `changeFolder` through the existing accessor — one accessor, one rule.

`FSService.getConfig()` returns a field-initialized `FSConfigImpl` via a lazily-constructed singleton whose constructor is `super()` only — no I/O, no cluster, no data server. It is side-effect free. (`getServer()` *does* start a data server and is deliberately not used here.) The `inetsoft.sree` → `inetsoft.mv.fs` dependency is already established via `SUtil`, `MVAction`, and `AbstractEditableAuthenticationProvider`, same `core` module; the existing `import inetsoft.mv.*;` does not cover the `fs` sub-package, hence the added import.

## Scope / risk

- Part 1: the only behaviour lost is the undocumented `mv.debug=true` ⇒ bypass-cache path, which `debug.data` covers by design.
- Part 2: identical behaviour for the declared default (`fs.desktop=false`) and for an explicit `true` — verified that `SreeEnv.getProperty` resolves through `DefaultProperties(sree.properties, defaults.properties)` (`PropertiesEngine:474`, `DefaultProperties:64-70`), so a stock install already returned `"false"` and the guard was already active. The change is confined to unset/blank/garbage values, where the guard now correctly activates instead of silently disengaging.
- No in-tree caller reaches the guarded overload with a `REPOSITORY_FOLDER` entry: controllers divert to `RepletRegistry` first, `RecycleUtils`/`DataSetService`/`RepletRegistryService` hard-code `Type.FOLDER`, and `RepletEngine:1730/1837` bypass via `super.changeFolder` by design.
- All other `isDesktop()` callers (`MVBuilder`, `MVCompositeDispatcher`, `MVDispatcher`, `MVIncremental`, `MVDef`, `MVSingleDispatcher`, `LocalFileSystem`) are untouched.

## Testing

`./mvnw clean compile -pl core` passes. `MVCompositeDispatcherTest`, `MVDispatcherTest`, `MVSingleDispatcherTest` pass (4 tests, 0 failures) — `MVSingleDispatcherTest:66` mocks `isDesktop()`, exercising the accessor the fix now depends on.

No new unit tests: there is no `AssetDataCacheTest` or `RepletEngineTest`, and `FSConfigImpl` is a private static class, so neither one-liner is reachable without disproportionate scaffolding. Manual verification suggested for a reviewer: with `fs.desktop` blanked, moving a repository folder must still be rejected with `common.invalidEntry` (today it succeeds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
