### PR TITLE
Bug #76290, share the AI assistant visibility rule and fix the WebSocket TLS asymmetry

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/presentation/AISettingsService.java
+++ b/core/src/main/java/inetsoft/web/admin/presentation/AISettingsService.java
@@ -101,15 +101,13 @@ public class AISettingsService {
       SreeEnv.save();
    }
 
+   /**
+    * Returns {@code true} if the AI assistant should be shown in the UI. Delegates to
+    * {@link AIAssistantController#isAiAssistantVisible()}, which owns the rule and the
+    * properties it reads.
+    */
    public boolean isAiAssistantVisible() {
-      if(!"true".equalsIgnoreCase(SreeEnv.getProperty(AIAssistantController.AI_ASSISTANT_VISIBLE, "false"))) {
-         return false;
-      }
-
-      String internalUrl = SreeEnv.getProperty(AIAssistantController.CHAT_APP_INTERNAL_URL);
-      String serverUrl = SreeEnv.getProperty(AIAssistantController.CHAT_APP_SERVER_URL);
-      return (internalUrl != null && !internalUrl.trim().isEmpty())
-         || (serverUrl != null && !serverUrl.trim().isEmpty());
+      return AIAssistantController.isAiAssistantVisible();
    }
 
    @Audited(

--- a/core/src/main/java/inetsoft/web/assistant/AIAssistantController.java
+++ b/core/src/main/java/inetsoft/web/assistant/AIAssistantController.java
@@ -128,16 +128,8 @@ public class AIAssistantController {
    }
 
    @GetMapping("/api/assistant/ai-assistant-visible")
-   public boolean isAiAssistantVisible() {
-      if(!"true".equalsIgnoreCase(SreeEnv.getProperty(AI_ASSISTANT_VISIBLE, "false"))) {
-         return false;
-      }
-
-      // Visible only when at least one assistant URL is configured (proxy or direct mode).
-      String internalUrl = SreeEnv.getProperty(CHAT_APP_INTERNAL_URL);
-      String serverUrl = SreeEnv.getProperty(CHAT_APP_SERVER_URL);
-      return (internalUrl != null && !internalUrl.trim().isEmpty())
-         || (serverUrl != null && !serverUrl.trim().isEmpty());
+   public boolean getAiAssistantVisible() {
+      return isAiAssistantVisible();
    }
 
    /**
@@ -172,6 +164,33 @@ public class AIAssistantController {
     */
    public static boolean isSslVerifyEnabled() {
       return "true".equalsIgnoreCase(SreeEnv.getProperty("chat.app.server.ssl.verify", "false"));
+   }
+
+   /**
+    * Returns {@code true} if the AI assistant should be shown in the UI.
+    *
+    * <p>Requires {@code ai.assistant.visible} to be enabled <em>and</em> at least one assistant
+    * URL to be configured -- {@code chat.app.internal.url} (proxy mode) or
+    * {@code chat.app.server.url} (direct mode). Enabling the flag without a URL would surface an
+    * assistant panel that cannot reach a server.
+    *
+    * <p>Public and static so this is the single definition of the rule. {@code AISettingsService}
+    * delegates here rather than repeating it; the three callers that gate on assistant visibility
+    * (EmNavBarController, PortalController, SetPrincipalCommand) go through that service. Note
+    * this is the visibility rule only -- every one of those callers also checks
+    * {@code ResourceType.AI_ASSISTANT} permission separately.
+    *
+    * @return whether the assistant is both enabled and reachable-in-principle.
+    */
+   public static boolean isAiAssistantVisible() {
+      if(!"true".equalsIgnoreCase(SreeEnv.getProperty(AI_ASSISTANT_VISIBLE, "false"))) {
+         return false;
+      }
+
+      String internalUrl = SreeEnv.getProperty(CHAT_APP_INTERNAL_URL);
+      String serverUrl = SreeEnv.getProperty(CHAT_APP_SERVER_URL);
+      return (internalUrl != null && !internalUrl.trim().isEmpty())
+         || (serverUrl != null && !serverUrl.trim().isEmpty());
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/assistant/AssistantWebSocketProxyHandler.java
+++ b/core/src/main/java/inetsoft/web/assistant/AssistantWebSocketProxyHandler.java
@@ -20,7 +20,6 @@ package inetsoft.web.assistant;
 import inetsoft.sree.SreeEnv;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
-import org.apache.hc.core5.ssl.SSLContextBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -31,11 +30,15 @@ import org.springframework.web.socket.handler.AbstractWebSocketHandler;
 import org.springframework.http.HttpHeaders;
 
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509ExtendedTrustManager;
 import java.io.IOException;
+import java.net.Socket;
 import java.net.URI;
 import java.security.KeyManagementException;
-import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.*;
@@ -224,22 +227,22 @@ public class AssistantWebSocketProxyHandler extends AbstractWebSocketHandler {
       StandardWebSocketClient client = new StandardWebSocketClient();
 
       // SSL verification is configurable via chat.app.server.ssl.verify.
-      // Default: trust all, suitable for private-network deployments with self-signed certs
-      // (matching the nginx "proxy_ssl_verify off" used in Docker Compose).
+      // Default: skip both certificate chain and hostname verification, suitable for
+      // private-network deployments with self-signed certs (matching the nginx
+      // "proxy_ssl_verify off" used in Docker Compose).
       // Set to "true" to use the JVM default trust store in production.
       // Changing this property requires a server restart.
       if(!AIAssistantController.isSslVerifyEnabled()) {
-         LOG.warn("SSL certificate verification is disabled for AI assistant WebSocket proxy " +
-            "connections (chat.app.server.ssl.verify=false). Set to true in production when the " +
-            "assistant server uses a CA-signed certificate.");
+         LOG.warn("SSL certificate and hostname verification are disabled for AI assistant " +
+            "WebSocket proxy connections (chat.app.server.ssl.verify=false). Set to true in " +
+            "production when the assistant server uses a CA-signed certificate.");
 
          try {
-            SSLContext sslContext = SSLContextBuilder.create()
-               .loadTrustMaterial(null, (chain, authType) -> true)
-               .build();
+            SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(null, new TrustManager[] { TRUST_ALL }, null);
             client.setUserProperties(Map.of("org.apache.tomcat.websocket.SSL_CONTEXT", sslContext));
          }
-         catch(NoSuchAlgorithmException | KeyManagementException | KeyStoreException e) {
+         catch(NoSuchAlgorithmException | KeyManagementException e) {
             LOG.warn("Could not configure trust-all SSL context for assistant WebSocket proxy", e);
          }
       }
@@ -285,6 +288,56 @@ public class AssistantWebSocketProxyHandler extends AbstractWebSocketHandler {
    private volatile StandardWebSocketClient wsClient;
    private volatile ScheduledExecutorService cleanup;
    private final Map<String, WebSocketSession> upstreamSessions = new ConcurrentHashMap<>();
+
+   /**
+    * Trusts every certificate chain <em>and</em> every hostname, for
+    * chat.app.server.ssl.verify=false.
+    *
+    * <p>This must be an {@link X509ExtendedTrustManager}, not a plain {@code X509TrustManager},
+    * and that is not a style preference. JSSE performs hostname verification <em>inside</em> the
+    * trust manager, so a plain {@code X509TrustManager} gets wrapped in one that still runs the
+    * identity check -- and Tomcat's {@code WsWebSocketContainer.createSSLEngine} unconditionally
+    * sets the endpoint identification algorithm to "HTTPS" with no user property to override it.
+    * With a plain manager the chain is trusted but a certificate whose CN/SAN does not match the
+    * host is still refused, which is not what the operator asked for. Overriding the
+    * {@code SSLEngine} and {@code Socket} overloads here is what actually disables the check.
+    *
+    * <p>The HTTP-side counterpart is {@code AIAssistantController.createHealthClient}, which
+    * reaches the same result differently: {@code HttpClient} lets it clear the algorithm via
+    * {@code SSLParameters.setEndpointIdentificationAlgorithm("")}, an option the Tomcat
+    * WebSocket client does not expose.
+    */
+   private static final X509ExtendedTrustManager TRUST_ALL = new X509ExtendedTrustManager() {
+      @Override
+      public void checkClientTrusted(X509Certificate[] chain, String authType) {
+      }
+
+      @Override
+      public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket) {
+      }
+
+      @Override
+      public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine) {
+      }
+
+      @Override
+      public void checkServerTrusted(X509Certificate[] chain, String authType) {
+      }
+
+      @Override
+      public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket) {
+      }
+
+      @Override
+      public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine) {
+      }
+
+      @Override
+      public X509Certificate[] getAcceptedIssuers() {
+         return new X509Certificate[0];
+      }
+   };
+
    private static final List<String> FORWARD_WS_HEADERS =
       List.of("Authorization", "x-client-id", "x-request-id");
    private static final Logger LOG = LoggerFactory.getLogger(AssistantWebSocketProxyHandler.class);

--- a/core/src/test/java/inetsoft/web/assistant/AIAssistantControllerTest.java
+++ b/core/src/test/java/inetsoft/web/assistant/AIAssistantControllerTest.java
@@ -1,0 +1,135 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.assistant;
+
+/*
+ * Test strategy
+ *
+ * The assistant-visibility rule existed twice -- here and in AISettingsService -- as
+ * byte-identical bodies. Either copy could be changed without the other, and nothing failed.
+ * AIAssistantController.isAiAssistantVisible() is now the single definition and the service
+ * delegates to it.
+ *
+ * The rule is: ai.assistant.visible must be on (case-insensitively) AND at least one of
+ * chat.app.internal.url (proxy mode) / chat.app.server.url (direct mode) must be non-blank.
+ * Enabling the flag with no URL would show a panel that cannot reach a server.
+ *
+ * Behavioral guarantees covered:
+ *
+ * [G1] The flag gates first: absent, "false", or unrecognized means not visible whatever the
+ *      URLs say, and "TRUE" in any case counts as on.
+ * [G2] With the flag on, either URL alone suffices; neither, empty, or whitespace-only does not.
+ * [G3] AISettingsService agrees with the controller for every one of the above cases. This is
+ *      what makes the de-duplication a regression test and not just a refactor -- reintroducing
+ *      a second copy that drifts fails here.
+ */
+
+import inetsoft.sree.SreeEnv;
+import inetsoft.web.admin.presentation.AISettingsService;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class AIAssistantControllerTest {
+   private MockedStatic<SreeEnv> sreeEnvStatic;
+
+   @BeforeEach
+   void setUp() {
+      sreeEnvStatic = mockStatic(SreeEnv.class, withSettings().lenient());
+   }
+
+   @AfterEach
+   void tearDown() {
+      sreeEnvStatic.close();
+   }
+
+   private void configure(String visible, String internalUrl, String serverUrl) {
+      // The flag is read with a default; the two URLs are read without one.
+      sreeEnvStatic.when(
+            () -> SreeEnv.getProperty(AIAssistantController.AI_ASSISTANT_VISIBLE, "false"))
+         .thenReturn(visible == null ? "false" : visible);
+      sreeEnvStatic.when(() -> SreeEnv.getProperty(AIAssistantController.CHAT_APP_INTERNAL_URL))
+         .thenReturn(internalUrl);
+      sreeEnvStatic.when(() -> SreeEnv.getProperty(AIAssistantController.CHAT_APP_SERVER_URL))
+         .thenReturn(serverUrl);
+   }
+
+   // [G1] the flag gates everything, and its check is case-insensitive
+   @ParameterizedTest
+   @ValueSource(strings = { "false", "FALSE", "no", "1", "" })
+   void notVisibleWhenFlagIsNotTrue(String flag) {
+      configure(flag, "https://assistant.internal", "https://assistant.example.com");
+      assertFalse(AIAssistantController.isAiAssistantVisible(),
+                  "a configured URL must not make the assistant visible while the flag is off");
+   }
+
+   @ParameterizedTest
+   @ValueSource(strings = { "true", "TRUE", "True" })
+   void flagCheckIsCaseInsensitive(String flag) {
+      configure(flag, "https://assistant.internal", null);
+      assertTrue(AIAssistantController.isAiAssistantVisible());
+   }
+
+   @Test
+   void notVisibleWhenFlagIsAbsent() {
+      configure(null, "https://assistant.internal", null);
+      assertFalse(AIAssistantController.isAiAssistantVisible());
+   }
+
+   // [G2] with the flag on, visibility follows the URLs
+   @ParameterizedTest
+   @CsvSource(nullValues = "NULL", value = {
+      // internalUrl, serverUrl, expectedVisible
+      "https://assistant.internal, NULL,                        true",
+      "NULL,                       https://assistant.test,      true",
+      "https://assistant.internal, https://assistant.test,      true",
+      "NULL,                       NULL,                        false",
+      "'',                         '',                          false",
+      "'   ',                      '   ',                       false",
+      "'   ',                      https://assistant.test,      true",
+      "https://assistant.internal, '   ',                       true"
+   })
+   void visibilityFollowsTheConfiguredUrls(String internalUrl, String serverUrl, boolean expected) {
+      configure("true", internalUrl, serverUrl);
+      assertEquals(expected, AIAssistantController.isAiAssistantVisible());
+   }
+
+   // [G3] the service must not drift from the controller
+   @ParameterizedTest
+   @CsvSource(nullValues = "NULL", value = {
+      "NULL,  https://assistant.internal, NULL",
+      "false, https://assistant.internal, NULL",
+      "true,  NULL,                       NULL",
+      "true,  '   ',                      '   '",
+      "true,  https://assistant.internal, NULL",
+      "true,  NULL,                       https://assistant.test",
+      "TRUE,  https://assistant.internal, https://assistant.test"
+   })
+   void serviceAgreesWithController(String visible, String internalUrl, String serverUrl) {
+      configure(visible, internalUrl, serverUrl);
+      assertEquals(AIAssistantController.isAiAssistantVisible(),
+                   new AISettingsService().isAiAssistantVisible(),
+                   "AISettingsService must delegate, not keep its own copy of the rule");
+   }
+}

--- a/core/src/test/java/inetsoft/web/assistant/AssistantWebSocketProxyHandlerTest.java
+++ b/core/src/test/java/inetsoft/web/assistant/AssistantWebSocketProxyHandlerTest.java
@@ -1,0 +1,129 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.assistant;
+
+/*
+ * Test strategy
+ *
+ * chat.app.server.ssl.verify=false is documented as relaxing TLS for the assistant's three
+ * server-to-server transports. Two of them relaxed both halves -- AssistantProxyController via
+ * NoopHostnameVerifier, AIAssistantController's health client via
+ * SSLParameters.setEndpointIdentificationAlgorithm("") -- but this WebSocket handler built its
+ * trust-all context with Apache httpcore5's SSLContextBuilder, whose TrustManagerDelegate
+ * implements the PLAIN X509TrustManager. JSSE wraps a plain manager in one that still performs
+ * the identity check, and Tomcat's WsWebSocketContainer.createSSLEngine unconditionally sets the
+ * endpoint identification algorithm to "HTTPS" with no user property to override it. So a
+ * self-signed cert was accepted while a CN/SAN mismatch was still refused, even though the
+ * operator had disabled verification for exactly that case.
+ *
+ * The fix supplies an X509ExtendedTrustManager instead. Because JSSE performs hostname
+ * verification inside the trust manager, an extended manager whose SSLEngine/Socket overloads
+ * no-op is what disables the check; there is no separate flag to assert on.
+ *
+ * These tests deliberately do not call buildWsClient(). Constructing a StandardWebSocketClient
+ * needs a jakarta.websocket container implementation, which core has only as a "provided" API --
+ * the implementation arrives from the server module at runtime. Rather than add a Tomcat test
+ * dependency to core's pom, [G2] reproduces the one thing Tomcat does that matters here: it
+ * requests "HTTPS" endpoint identification on the engine. Asserting our manager passes anyway
+ * tests the mechanism more directly than asserting a user-property key would.
+ *
+ * Behavioral guarantees covered:
+ *
+ * [G1] TRUST_ALL is an X509ExtendedTrustManager, not merely an X509TrustManager. This is the
+ *      property the whole fix rests on -- reverting to httpcore5's SSLContextBuilder fails here.
+ * [G2] It still accepts an untrusted chain when the engine requests "HTTPS" endpoint
+ *      identification, which is what Tomcat's WebSocket client always does.
+ * [G3] Every check* overload accepts an untrusted chain rather than throwing, including the
+ *      SSLEngine and Socket overloads that the identity check rides on.
+ */
+
+import org.junit.jupiter.api.*;
+
+import javax.net.ssl.*;
+import java.lang.reflect.Field;
+import java.net.Socket;
+import java.security.cert.X509Certificate;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+@Tag("core")
+class AssistantWebSocketProxyHandlerTest {
+   private X509ExtendedTrustManager trustAll() throws Exception {
+      Field field = AssistantWebSocketProxyHandler.class.getDeclaredField("TRUST_ALL");
+      field.setAccessible(true);
+      return assertInstanceOf(
+         X509ExtendedTrustManager.class, field.get(null),
+         "must be X509ExtendedTrustManager: JSSE wraps a plain X509TrustManager in one that " +
+            "still performs hostname verification, and Tomcat forces the HTTPS endpoint " +
+            "identification algorithm with no way to switch it off");
+   }
+
+   private static X509Certificate[] untrustedChain() {
+      return new X509Certificate[] { mock(X509Certificate.class) };
+   }
+
+   // [G1]
+   @Test
+   void trustManagerIsTheExtendedVariant() throws Exception {
+      assertNotNull(trustAll());
+   }
+
+   @Test
+   void trustAllInitializesAnSslContext() throws Exception {
+      // Guards the wiring buildWsClient depends on: an SSLContext will accept this manager.
+      SSLContext context = SSLContext.getInstance("TLS");
+      assertDoesNotThrow(() -> context.init(null, new TrustManager[] { trustAll() }, null));
+   }
+
+   // [G2] -- the case the old plain-manager implementation got wrong
+   @Test
+   void acceptsUntrustedChainEvenWhenTheEngineRequestsHttpsIdentification() throws Exception {
+      SSLContext context = SSLContext.getInstance("TLS");
+      context.init(null, new TrustManager[] { trustAll() }, null);
+
+      // Exactly what Tomcat's WsWebSocketContainer.createSSLEngine does, unconditionally.
+      SSLEngine engine = context.createSSLEngine("wrong-host.example.com", 443);
+      SSLParameters params = engine.getSSLParameters();
+      params.setEndpointIdentificationAlgorithm("HTTPS");
+      engine.setSSLParameters(params);
+      engine.setUseClientMode(true);
+
+      assertEquals("HTTPS", engine.getSSLParameters().getEndpointIdentificationAlgorithm(),
+                   "the test is only meaningful if identification really is requested");
+      assertDoesNotThrow(() -> trustAll().checkServerTrusted(untrustedChain(), "RSA", engine));
+   }
+
+   // [G3]
+   @Test
+   void everyCheckOverloadAcceptsAnUntrustedChain() throws Exception {
+      X509ExtendedTrustManager manager = trustAll();
+      X509Certificate[] chain = untrustedChain();
+
+      assertDoesNotThrow(() -> {
+         manager.checkServerTrusted(chain, "RSA");
+         manager.checkServerTrusted(chain, "RSA", (Socket) null);
+         manager.checkServerTrusted(chain, "RSA", (SSLEngine) null);
+         manager.checkClientTrusted(chain, "RSA");
+         manager.checkClientTrusted(chain, "RSA", (Socket) null);
+         manager.checkClientTrusted(chain, "RSA", (SSLEngine) null);
+      }, "the SSLEngine/Socket overloads are the ones the identity check rides on");
+
+      assertEquals(0, manager.getAcceptedIssuers().length);
+   }
+}


### PR DESCRIPTION
Two defects in the AI assistant property paths, from a report covering the `ai.*`, `chat.*` and `wiz.*` prefixes.

The report was verified against `935c85a58`, which is on the unmerged `stylebi-wiz-main-rebase` branch rather than `main`. Two of its four findings concern code that does not exist on `main` (`ai.snapshot.count` and `wiz.agent.script.require-script-pane`); those are handled separately against that branch. This PR carries the two that are real here.

## 1. `isAiAssistantVisible` existed twice

`AISettingsService.isAiAssistantVisible` and `AIAssistantController.isAiAssistantVisible` had byte-identical bodies apart from constant qualification. Either copy could be changed without the other, and nothing failed if only one was.

The rule now lives once, as a `public static` on `AIAssistantController` next to `isSslVerifyEnabled()` and beside the `AI_ASSISTANT_VISIBLE` / `CHAT_APP_*` constants it reads; `AISettingsService` delegates to it.

The mapped method is renamed to `getAiAssistantVisible()` so the static can take the name — a static and an instance method cannot share a signature. **The endpoint URL `/api/assistant/ai-assistant-visible` is unchanged.** The three production callers (`EmNavBarController`, `PortalController`, `SetPrincipalCommand`) go through the service and needed no edits.

## 2. The WebSocket proxy relaxed TLS asymmetrically

`chat.app.server.ssl.verify=false` is documented as relaxing TLS for the assistant's three server-to-server transports. Two of them relaxed both halves; the WebSocket proxy relaxed only the certificate chain:

| Site | Hostname check |
|---|---|
| `AssistantProxyController.buildClient` — `NoopHostnameVerifier.INSTANCE` | disabled |
| `AIAssistantController.createHealthClient` — `setEndpointIdentificationAlgorithm("")` | disabled |
| `AssistantWebSocketProxyHandler.buildWsClient` — nothing | **enforced** |

So a self-signed certificate was accepted, but one whose CN/SAN did not match the host was still refused — after the operator had disabled verification for exactly that case, and after a warning telling them the check was off.

Two facts, both verified against the resolved jars rather than from memory:

- `tomcat-embed-websocket`: `WsWebSocketContainer.createSSLEngine` unconditionally sets `endpointIdentificationAlgorithm("HTTPS")`. `SSL_CONTEXT` is the only user property, and it was already in use — there is no knob to switch the check off.
- `httpcore5`: `SSLContextBuilder$TrustManagerDelegate` implements the *plain* `X509TrustManager`, so JSSE wraps it in a manager that still runs the identity check.

Because JSSE performs hostname verification *inside* the trust manager, supplying an `X509ExtendedTrustManager` whose `SSLEngine`/`Socket` overloads no-op bypasses it. That is the fix. The comment and warning text now say the relaxation covers both halves.

This reads as an oversight rather than a deliberate posture: `stylebi-wiz-main-rebase` has already extracted the HTTP path into a static `applyAssistantTls` whose javadoc describes this exact problem, while leaving `buildWsClient` untouched.

## Verification

Confirmed with a real TLS handshake against a certificate with `CN=definitely-not-localhost.invalid`, connecting to `127.0.0.1`, with `endpointIdentificationAlgorithm("HTTPS")` set as Tomcat sets it:

| Trust manager | Result |
|---|---|
| plain `X509TrustManager` (before) | REFUSED: `No subject alternative names present` |
| `X509ExtendedTrustManager` (after) | HANDSHAKE OK |

New tests (`core/src/test/java/inetsoft/web/assistant/`, 28 tests):

- `AIAssistantControllerTest` — the visibility rule across flag casing, absent/empty/whitespace URLs, and both modes; plus assertions that `AISettingsService` returns the same value for every case, so a reintroduced second copy that drifts fails here.
- `AssistantWebSocketProxyHandlerTest` — that the trust manager is the extended variant and still accepts an untrusted chain when the engine requests `"HTTPS"` identification. Reverting to `SSLContextBuilder` fails these.

`EmNavBarControllerTest` and the presentation-settings tests pass unchanged (80/80 in the affected slice). `enterprise` and `server` compile clean against the renamed method.

**Not covered:** the Docker end-to-end run with a mismatched assistant certificate. The handshake test above exercises the same mechanism directly, but the full-stack path is unrun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)