### PR TITLE
Fix add_join accepting a missing name, permanently corrupting the worksheet runtime

### DIFF
--- a/core/src/main/java/inetsoft/uql/asset/Worksheet.java
+++ b/core/src/main/java/inetsoft/uql/asset/Worksheet.java
@@ -352,6 +352,17 @@ public class Worksheet extends AbstractSheet implements VariableProvider {
     */
    public boolean addAssembly(WSAssembly assembly) {
       String name = assembly.getName();
+
+      // A null/blank name can never be looked back up: getAssembly() short-circuits null to
+      // null (harmless), but createCache()'s ConcurrentHashMap.put(null, ...) throws NPE
+      // partway through the rebuild loop, which permanently poisons the lazy name cache (amap
+      // never gets reassigned) for every assembly in this worksheet, not just this one -- so
+      // this must be refused before it ever reaches the assemblies list.
+      if(name == null || name.isBlank()) {
+         LOG.error("Could not add assembly " + assembly + ", name must not be empty");
+         return false;
+      }
+
       final boolean contained;
 
       synchronized(this) {

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -574,6 +574,10 @@ public class WorksheetEditService {
                           List<String> leftKeys, List<String> rightKeys)
          throws PairingException, SecurityException
       {
+         if(name == null || name.isBlank()) {
+            throw new PairingException("Join requires a name.");
+         }
+
          if("CROSS".equalsIgnoreCase(joinType)) {
             addCrossJoin(name, leftTable, rightTable);
             return;
@@ -650,8 +654,13 @@ public class WorksheetEditService {
        *
        * @param name    the assembly name
        * @param columns the column names to include in the private column selection
+       * @throws PairingException if {@code name} is missing or blank
        */
-      public void addTable(String name, String... columns) {
+      public void addTable(String name, String... columns) throws PairingException {
+         if(name == null || name.isBlank()) {
+            throw new PairingException("Table requires a name.");
+         }
+
          EmbeddedTableAssembly t = new EmbeddedTableAssembly(ws, name);
          ColumnSelection cs = new ColumnSelection();
 
@@ -1541,6 +1550,10 @@ public class WorksheetEditService {
       public void addCrossJoin(String name, String leftTable, String rightTable)
          throws PairingException, SecurityException
       {
+         if(name == null || name.isBlank()) {
+            throw new PairingException("Cross join requires a name.");
+         }
+
          requirePermission(ResourceType.CROSS_JOIN);
          TableAssembly left  = requireTable(leftTable);
          TableAssembly right = requireTable(rightTable);
@@ -1569,6 +1582,10 @@ public class WorksheetEditService {
        * @throws PairingException if fewer than two tables are given or a source is not found
        */
       public void addMergeJoin(String name, String[] tableNames) throws PairingException {
+         if(name == null || name.isBlank()) {
+            throw new PairingException("Merge join requires a name.");
+         }
+
          if(tableNames == null || tableNames.length < 2) {
             throw new PairingException("Merge join requires at least 2 tables.");
          }

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -1794,6 +1794,10 @@ public class WorksheetEditService {
                                 List<WorksheetMutationSupport.GroupMapping> mappings,
                                 boolean groupOthers) throws PairingException
       {
+         if(name == null || name.isBlank()) {
+            throw new PairingException("Named group requires a name.");
+         }
+
          if((table == null) != (column == null)) {
             throw new PairingException(
                "table and column must both be specified, or both omitted for a standalone grouping");

--- a/core/src/test/java/inetsoft/uql/asset/WorksheetTest.java
+++ b/core/src/test/java/inetsoft/uql/asset/WorksheetTest.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.asset;
+
+import inetsoft.web.wiz.pairing.TestWorksheets;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import inetsoft.web.wiz.pairing.WizAgentTestSupport;
+
+@WizAgentTestSupport
+class WorksheetTest {
+
+   /**
+    * Regression for a null/blank-named assembly permanently poisoning the lazy name cache:
+    * createCache() iterates every assembly and calls {@code ConcurrentHashMap.put(name, ...)},
+    * which throws NPE on a null key before {@code this.amap} is reassigned, so once a
+    * null-named assembly is present every future getAssembly() call (on ANY name) retries and
+    * fails the same way, forever. addAssembly() must refuse a null/blank name outright so it
+    * never reaches the assemblies list.
+    */
+   @Test
+   void addAssemblyRejectsNullNameAndDoesNotPoisonLookupForOtherAssemblies() {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "Orders", "id");
+      ws.addAssembly(t);
+
+      EmbeddedTableAssembly nullNamed = new EmbeddedTableAssembly(ws, null);
+      assertFalse(ws.addAssembly(nullNamed));
+
+      assertSame(t, ws.getAssembly("Orders"));
+      assertEquals(1, ws.getAssemblies().length);
+   }
+
+   @Test
+   void addAssemblyRejectsBlankName() {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly blankNamed = new EmbeddedTableAssembly(ws, "  ");
+      assertFalse(ws.addAssembly(blankNamed));
+      assertEquals(0, ws.getAssemblies().length);
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceTest.java
@@ -278,6 +278,42 @@ class WorksheetEditServiceTest {
    }
 
    @Test
+   void addJoinRejectsMissingNameAndDoesNotPoisonAssemblyLookup() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly left = TestWorksheets.tableWithColumns(ws, "CUSTOMERS1", "REGION_ID");
+      EmbeddedTableAssembly right = TestWorksheets.tableWithColumns(ws, "REGIONS1", "REGION_ID");
+      ws.addAssembly(left);
+      ws.addAssembly(right);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      JoinSession s = new JoinSession("TOK", "Worksheet/foo-7", "alice~;~host-org",
+                                     SheetType.WORKSHEET, 0L, Long.MAX_VALUE,
+                                     JoinSession.ConnectionMode.PAIRED, null, null, null);
+      when(sessions.resolve(eq("TOK"), any())).thenReturn(s);
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+
+      // Mirrors the real repro: leftKey/rightKey/joinType supplied but name omitted.
+      assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent,
+                         ed -> ed.addJoin(null, "CUSTOMERS1", "REGION_ID",
+                                          "REGIONS1", "REGION_ID", "INNER", null, null)));
+
+      // The rejected join must never have reached Worksheet.addAssembly(), so the name cache
+      // is never poisoned: lookups for the pre-existing tables still resolve.
+      assertSame(left, ws.getAssembly("CUSTOMERS1"));
+      assertSame(right, ws.getAssembly("REGIONS1"));
+      assertEquals(2, ws.getAssemblies().length);
+   }
+
+   @Test
    void editNamedGroupOnStandaloneGroupSurvivesClone() throws Exception {
       Worksheet ws = new Worksheet();
       RuntimeWorksheet rws = mock(RuntimeWorksheet.class);

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceTest.java
@@ -314,6 +314,36 @@ class WorksheetEditServiceTest {
    }
 
    @Test
+   void addNamedGroupRejectsMissingNameAndDoesNotPoisonAssemblyLookup() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "a");
+      ws.addAssembly(t);
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      JoinSession s = new JoinSession("TOK", "Worksheet/foo-7", "alice~;~host-org",
+                                     SheetType.WORKSHEET, 0L, Long.MAX_VALUE,
+                                     JoinSession.ConnectionMode.PAIRED, null, null, null);
+      when(sessions.resolve(eq("TOK"), any())).thenReturn(s);
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+
+      assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent,
+                         ed -> ed.addNamedGroup(null, null, null, "string", List.of(), false)));
+
+      // The rejected named group must never have reached Worksheet.addAssembly(), so the name
+      // cache is never poisoned: lookups for the pre-existing table still resolve.
+      assertSame(t, ws.getAssembly("T"));
+      assertEquals(1, ws.getAssemblies().length);
+   }
+
+   @Test
    void editNamedGroupOnStandaloneGroupSurvivesClone() throws Exception {
       Worksheet ws = new Worksheet();
       RuntimeWorksheet rws = mock(RuntimeWorksheet.class);


### PR DESCRIPTION
## Root cause

`add_join`'s own plugin schema requires `name`, but `WorksheetEditService.Editor.addJoin()` (`WorksheetEditService.java:571`) never validated it: a missing `"name"` in the request body deserializes to Java `null` with no error, and a `RelationalJoinTableAssembly` with a literal `null` name was constructed and added to the worksheet anyway.

`Worksheet.getAssembly()` resolves names through a lazily-rebuilt `ConcurrentHashMap` cache (`createCache()`). `ConcurrentHashMap.put(null, ...)` throws NPE by contract, and `addAssembly()` nulls out the cache (`amap = null`) on every successful add to force a rebuild on next access. Once the null-named assembly is present, **every** subsequent cache rebuild throws partway through the loop, so `this.amap` is never successfully reassigned — it stays permanently `null`. Every future `getAssembly()` call (used pervasively throughout the engine) retries the same doomed rebuild and throws again, forever, for the life of that runtime. This is why the corruption is permanent and survives reconnects to the same `runtimeId`.

Full investigation: `docs/superpowers/plans/2026-08-25-set-group-aggregate-session-corruption-fix-plan.md` in the stylebi-wiz repo (see "Update 2026-08-25 (later still)").

## Fix

1. Fail loud with a `PairingException` on a missing/blank `name` before constructing the assembly, in **every** join-creating op that shares the same caller-supplied-name gap (`addJoin`, `addCrossJoin`, `addMergeJoin`) plus `addTable` — mirroring the existing `leftKeys`/`rightKeys` length-check pattern already in `addJoin`. (`addRotate`/`addUnpivot`/`addConcatenation`/`addMirror` already default a missing name via `AssetUtil.getNextName`, so they were not affected.)
2. Defense in depth: `Worksheet.addAssembly()` itself now refuses (logs + returns `false`) a null/blank-named assembly before it ever reaches `assemblies`, so the name cache can never be poisoned even by a call site that isn't individually guarded.

The plugin-side half (schema validation to stop a malformed `add_join` call from ever reaching this endpoint) is tracked and being handled separately.

## Test plan

- `WorksheetEditServiceTest.addJoinRejectsMissingNameAndDoesNotPoisonAssemblyLookup` — reproduces the exact repro shape (join with `leftKey`/`rightKey`/`joinType` but no `name`), asserts it throws `PairingException`, and asserts pre-existing table lookups by name still resolve afterward (i.e. the cache is never poisoned).
- `WorksheetTest.addAssemblyRejectsNullNameAndDoesNotPoisonLookupForOtherAssemblies` / `addAssemblyRejectsBlankName` — the most valuable regression: proves `Worksheet.addAssembly()` refuses a null/blank name outright.
- Ran `./mvnw -o test -pl core -Dtest="inetsoft.web.wiz.**"`: 2194 tests, 0 failures, 0 errors (1 skipped) — no regressions in the wiz package from the `Worksheet.addAssembly()` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)