### PR TITLE
Fix worksheetConditionValue rejected at pairing mint time

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/pairing/SheetPairingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/pairing/SheetPairingService.java
@@ -61,7 +61,7 @@ public class SheetPairingService {
     */
    private static final List<String> RECOGNIZED_KINDS = List.of(
       "viewsheetOnInit", "viewsheetOnLoad", "assemblyMain", "assemblyOnClick", "calcField",
-      "worksheetExpression", "worksheetCondition");
+      "worksheetExpression", "worksheetCondition", "worksheetConditionValue");
 
    /**
     * The two assembly-scoped script kinds (as opposed to viewsheetOnInit/viewsheetOnLoad, which
@@ -268,7 +268,7 @@ public class SheetPairingService {
     * and can be told; an agent hitting it later cannot get back to them.
     */
    private static final List<String> WORKSHEET_COLUMN_KINDS =
-      List.of("worksheetExpression", "worksheetCondition");
+      List.of("worksheetExpression", "worksheetCondition", "worksheetConditionValue");
 
    /**
     * Verifies a {@code worksheetExpression}/{@code worksheetCondition} context names a column

--- a/core/src/test/java/inetsoft/web/wiz/pairing/SheetPairingServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/pairing/SheetPairingServiceTest.java
@@ -413,6 +413,60 @@ class SheetPairingServiceTest {
    }
 
    /**
+    * worksheetConditionValue -- the narrower "edit a single condition value, not the whole
+    * condition" kind -- must be recognized and validated exactly like worksheetCondition: any
+    * column, not expression columns only.
+    */
+   @Test
+   void mintsAWorksheetConditionValueContextWhoseColumnExists() throws PairingException {
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      Worksheet ws = mock(Worksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+      when(ws.getAssembly("Query1")).thenReturn(tableWithColumn("Amount"));
+      SheetPairingService svc = serviceWithWorksheetRuntime(rws);
+      EditorContext ctx = new EditorContext("worksheetConditionValue", "Query1", "Amount", null);
+
+      String code = svc.mint("ws-1", "user", "sock-1", "user", SheetType.WORKSHEET, ctx);
+
+      assertEquals(ctx, svc.peek(code).editorContext());
+   }
+
+   /** Same (table, field) rule as worksheetCondition/worksheetExpression. */
+   @Test
+   void refusesAWorksheetConditionValueContextThatCarriesNoName() {
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      Worksheet ws = mock(Worksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+      when(ws.getAssembly("Query1")).thenReturn(tableWithColumn("Amount"));
+      SheetPairingService svc = serviceWithWorksheetRuntime(rws);
+      EditorContext ctx = new EditorContext("worksheetConditionValue", "Query1", null, null);
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.mint("ws-1", "user", "sock-1", "user", SheetType.WORKSHEET, ctx));
+
+      assertEquals(PairingException.Kind.INVALID_ARGUMENT, ex.getKind());
+      assertTrue(ex.getMessage().contains("'name'"), ex.getMessage());
+   }
+
+   /** The name must be VERIFIED, not merely present, same as worksheetCondition. */
+   @Test
+   void refusesAWorksheetConditionValueContextNamingAColumnTheTableDoesNotHave() {
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      Worksheet ws = mock(Worksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+      when(ws.getAssembly("Query1")).thenReturn(tableWithColumn("Amount"));
+      SheetPairingService svc = serviceWithWorksheetRuntime(rws);
+      EditorContext ctx = new EditorContext("worksheetConditionValue", "Query1", "NoSuchColumn", null);
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.mint("ws-1", "user", "sock-1", "user", SheetType.WORKSHEET, ctx));
+
+      assertEquals(PairingException.Kind.INVALID_ARGUMENT, ex.getKind());
+      assertTrue(ex.getMessage().contains("NoSuchColumn"),
+                 "message must name what was asked for: " + ex.getMessage());
+   }
+
+   /**
     * A REAL {@link TableAssembly} holding exactly one EXPRESSION column named {@code name}.
     *
     * <p>Real domain objects, not mocks, for two reasons: {@code TableAssembly.getColumnSelection}


### PR DESCRIPTION
## Root cause

`worksheetConditionValue` is a real, deliberately-designed, fully-wired `ScriptTarget.Kind` (`core/src/main/java/inetsoft/web/wiz/script/ScriptTarget.java:83-105`) — narrower than `worksheetCondition` on purpose: it edits a single condition's *value* only, leaving the operator and every other slot untouched, so the live UI (`FormulaEditorDialog`'s condition-value branch) doesn't grant an agent the ability to silently overwrite an operator the user never opened the dialog to change. `PaneScopeService`, `WorksheetScriptService`, and the plugin's own `scriptTarget`/`scriptTools` schema and tests already fully support it.

The one place it was missing: `SheetPairingService` (`core/src/main/java/inetsoft/web/wiz/pairing/SheetPairingService.java`) validates `editorContext.kind` at mint time against two independent, hand-maintained `String` lists that mirror `ScriptTarget.Kind`'s wire names — `RECOGNIZED_KINDS` (line 62-64) and `WORKSHEET_COLUMN_KINDS` (line 270-271). Neither was updated when `WORKSHEET_CONDITION_VALUE` was added to `ScriptTarget.Kind` elsewhere in the same feature, so clicking "Connect to Claude" inside a worksheet column's condition-value editor failed with `Unknown editorContext.kind: "worksheetConditionValue"` before a `ScriptTarget.Kind` object was ever constructed. `SheetSessionService.retarget` (Follow Focus) reuses the same validation method, so it was affected identically and is fixed by the same change.

Full investigation: `docs/superpowers/plans/2026-08-26-worksheet-condition-value-kind-mismatch-fix-plan.md` in the stylebi-wiz repo.

## Fix

Two one-line additions in `SheetPairingService.java`:
1. `"worksheetConditionValue"` added to `RECOGNIZED_KINDS`.
2. `"worksheetConditionValue"` added to `WORKSHEET_COLUMN_KINDS`, so it gets the same (table, field)-existence validation `worksheetCondition`/`worksheetExpression` already get, via the existing `hasColumn`/`hasExpressionColumn` ternary (no change needed there — `worksheetConditionValue` is not `"worksheetExpression"`, so it already routes to `hasColumn`, matching a condition value's "any column" semantics).

No behavior change for any other kind.

## Test plan

Added to `SheetPairingServiceTest.java`, mirroring the existing `worksheetCondition` coverage:
- `mintsAWorksheetConditionValueContextWhoseColumnExists`
- `refusesAWorksheetConditionValueContextThatCarriesNoName`
- `refusesAWorksheetConditionValueContextNamingAColumnTheTableDoesNotHave`

Ran `./mvnw -o test -pl core -Dtest=SheetPairingServiceTest`: 30/30 pass (27 existing + 3 new).
Ran `./mvnw -o test -pl core -Dtest="inetsoft.web.wiz.**"`: 2196 tests, 0 failures, 0 errors (1 skipped, pre-existing/unrelated) — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)