### PR TITLE
feat(security): delegate all permission checks to authenticated wiz requests

### DIFF
--- a/core/src/main/java/inetsoft/sree/security/CompositeSecurityProvider.java
+++ b/core/src/main/java/inetsoft/sree/security/CompositeSecurityProvider.java
@@ -57,10 +57,11 @@ public class CompositeSecurityProvider extends AbstractSecurityProvider {
    private static CheckPermissionStrategy createCheckPermissionStrategy(SecurityProvider provider) {
       final String className =
          SreeEnv.getProperty(CheckPermissionStrategy.class.getName());
+      CheckPermissionStrategy strategy = null;
 
       if(className != null) {
          try {
-            return (CheckPermissionStrategy) Class.forName(className)
+            strategy = (CheckPermissionStrategy) Class.forName(className)
                .getConstructor(SecurityProvider.class)
                .newInstance(provider);
          }
@@ -69,7 +70,15 @@ public class CompositeSecurityProvider extends AbstractSecurityProvider {
          }
       }
 
-      return new DefaultCheckPermissionStrategy(provider);
+      if(strategy == null) {
+         strategy = new DefaultCheckPermissionStrategy(provider);
+      }
+
+      // StyleBI is a backend engine for wiz only (no direct/mixed usage is supported); wrapping
+      // here -- rather than only inside SecurityEngine.checkPermission -- is what makes the
+      // delegation reach every direct SecurityProvider.checkPermission(...) caller too, not just
+      // the ones that happen to go through SecurityEngine. See WizDelegatingCheckPermissionStrategy.
+      return new WizDelegatingCheckPermissionStrategy(strategy);
    }
 
    private static final Logger LOG =

--- a/core/src/main/java/inetsoft/sree/security/SRPrincipal.java
+++ b/core/src/main/java/inetsoft/sree/security/SRPrincipal.java
@@ -29,6 +29,7 @@ import org.w3c.dom.NodeList;
 
 import java.io.*;
 import java.lang.ref.WeakReference;
+import java.security.Principal;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -413,6 +414,20 @@ public class SRPrincipal extends XPrincipal implements Serializable, Externaliza
 
    public boolean isSelfOrganization() {
       return OrganizationManager.getInstance().getCurrentOrgID(this).equals(Organization.getSelfOrganizationID());
+   }
+
+   /**
+    * Checks whether {@code principal} was authenticated by WizServiceAuthenticationFilter (RSA
+    * JWT signature/expiry/audience verified) -- the single source of the "wiz" property, set only
+    * at {@code WizServiceAuthenticationFilter.validateTokenAndCreatePrincipal()}. StyleBI is a
+    * backend engine for wiz only (no direct/mixed usage is supported), so this is the shared test
+    * used everywhere a wiz-authenticated principal should be trusted unconditionally --
+    * SecurityEngine.isLogin(), WizDelegatingCheckPermissionStrategy, and any future call site --
+    * so the property name/comparison lives in exactly one place.
+    */
+   public static boolean isWizPrincipal(Principal principal) {
+      return principal instanceof SRPrincipal &&
+         "true".equalsIgnoreCase(((SRPrincipal) principal).getProperty("wiz"));
    }
 
    /**

--- a/core/src/main/java/inetsoft/sree/security/SecurityEngine.java
+++ b/core/src/main/java/inetsoft/sree/security/SecurityEngine.java
@@ -809,6 +809,16 @@ public class SecurityEngine implements MessageListener, AutoCloseable {
          return false;
       }
 
+      // StyleBI is a backend engine for wiz only (no direct/mixed usage is supported); wiz's own
+      // Entitlements system is the single permission authority, so any request authenticated by
+      // WizServiceAuthenticationFilter (RSA-verified JWT, property set only after that check
+      // passes) is trusted unconditionally here, for every resource type.
+      if(principal instanceof SRPrincipal &&
+         "true".equals(((SRPrincipal) principal).getProperty("wiz")))
+      {
+         return true;
+      }
+
       // in EE, admin needs to manage the resources in user scope.
       // To access the resource, admin will create principal to fetch
       // resource properly. The principal is not authenticated. To support
@@ -981,6 +991,13 @@ public class SecurityEngine implements MessageListener, AutoCloseable {
 
       if(principal == null) {
          return false;
+      }
+
+      // See the sibling String-resource overload above for why this is unconditional.
+      if(principal instanceof SRPrincipal &&
+         "true".equals(((SRPrincipal) principal).getProperty("wiz")))
+      {
+         return true;
       }
 
       // in EE, admin needs to manage the resources in user scope.

--- a/core/src/main/java/inetsoft/sree/security/SecurityEngine.java
+++ b/core/src/main/java/inetsoft/sree/security/SecurityEngine.java
@@ -809,16 +809,6 @@ public class SecurityEngine implements MessageListener, AutoCloseable {
          return false;
       }
 
-      // StyleBI is a backend engine for wiz only (no direct/mixed usage is supported); wiz's own
-      // Entitlements system is the single permission authority, so any request authenticated by
-      // WizServiceAuthenticationFilter (RSA-verified JWT, property set only after that check
-      // passes) is trusted unconditionally here, for every resource type.
-      if(principal instanceof SRPrincipal &&
-         "true".equals(((SRPrincipal) principal).getProperty("wiz")))
-      {
-         return true;
-      }
-
       // in EE, admin needs to manage the resources in user scope.
       // To access the resource, admin will create principal to fetch
       // resource properly. The principal is not authenticated. To support
@@ -991,13 +981,6 @@ public class SecurityEngine implements MessageListener, AutoCloseable {
 
       if(principal == null) {
          return false;
-      }
-
-      // See the sibling String-resource overload above for why this is unconditional.
-      if(principal instanceof SRPrincipal &&
-         "true".equals(((SRPrincipal) principal).getProperty("wiz")))
-      {
-         return true;
       }
 
       // in EE, admin needs to manage the resources in user scope.
@@ -1456,7 +1439,7 @@ public class SecurityEngine implements MessageListener, AutoCloseable {
       if(principal instanceof SRPrincipal) {
          SRPrincipal srPrincipal = (SRPrincipal) principal;
 
-         if(srPrincipal.isIgnoreLogin() || "true".equalsIgnoreCase(srPrincipal.getProperty("wiz"))) {
+         if(srPrincipal.isIgnoreLogin() || SRPrincipal.isWizPrincipal(srPrincipal)) {
             return true;
          }
 

--- a/core/src/main/java/inetsoft/sree/security/WizDelegatingCheckPermissionStrategy.java
+++ b/core/src/main/java/inetsoft/sree/security/WizDelegatingCheckPermissionStrategy.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.sree.security;
+
+import java.security.Principal;
+
+/**
+ * Wraps a {@link CheckPermissionStrategy} so that any wiz-authenticated principal (see
+ * {@link SRPrincipal#isWizPrincipal(Principal)}) is granted every permission unconditionally,
+ * regardless of {@link ResourceType}, without consulting the wrapped strategy.
+ * <p>
+ * This is wired into {@link CompositeSecurityProvider#create} so it is the single choke point for
+ * wiz delegation: {@code SecurityEngine.checkPermission(...)} and every direct
+ * {@code SecurityProvider.checkPermission(...)} caller elsewhere in the codebase (the EM access
+ * gate in {@code DefaultAuthorizationFilter}, {@code ClusterController}, and roughly two dozen more
+ * {@code web/admin/**} call sites) all end up going through a {@code CompositeSecurityProvider}
+ * instance, so they all see this behavior consistently.
+ */
+public class WizDelegatingCheckPermissionStrategy implements CheckPermissionStrategy {
+   public WizDelegatingCheckPermissionStrategy(CheckPermissionStrategy delegate) {
+      this.delegate = delegate;
+   }
+
+   @Override
+   public boolean checkPermission(Principal principal, ResourceType type, String resource,
+                                  ResourceAction action)
+   {
+      if(SRPrincipal.isWizPrincipal(principal)) {
+         return true;
+      }
+
+      return delegate.checkPermission(principal, type, resource, action);
+   }
+
+   private final CheckPermissionStrategy delegate;
+}

--- a/core/src/test/java/inetsoft/sree/security/CompositeSecurityProviderTest.java
+++ b/core/src/test/java/inetsoft/sree/security/CompositeSecurityProviderTest.java
@@ -1,0 +1,87 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.sree.security;
+
+/*
+ * CompositeSecurityProvider scenario table
+ *
+ * [Wiz delegation: wired]   principal is wiz-authenticated, checkPermission() called DIRECTLY on
+ *                           the provider (no SecurityEngine involved)                -> true
+ *
+ * This is the regression test for the finding that SecurityEngine.checkPermission is NOT the only
+ * permission gate: DefaultAuthorizationFilter (the actual front door for EM access),
+ * ClusterController, BasicAuthenticationFilter, and ~25 other admin/** call sites all call
+ * SecurityProvider.checkPermission(...) directly on the instance obtained from
+ * SecurityEngine.getSecurityProvider() -- which is always a CompositeSecurityProvider (see
+ * SecurityEngine.doInit()). Wiring the wiz bypass into createCheckPermissionStrategy() here, rather
+ * than only inside SecurityEngine.checkPermission(), is what makes it reach those call sites too.
+ */
+
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.util.XSessionService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+// CompositeSecurityProvider.create() reads SreeEnv (Spring-backed PropertiesEngine) to resolve an
+// optional custom CheckPermissionStrategy override, so this needs the same Spring test context
+// SecurityEnginePermissionTest/DefaultCheckPermissionStrategyTest use, not a bare unit test.
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class },
+   initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome()
+@Tag("core")
+class CompositeSecurityProviderTest {
+   private static final IdentityID USER_ID = new IdentityID("alice", "org1");
+
+   // [Wiz delegation: wired] a wiz principal is allowed even when checkPermission() is called
+   // directly on the provider -- the exact pattern DefaultAuthorizationFilter uses for the EM
+   // access gate, bypassing SecurityEngine.checkPermission entirely
+   @Test
+   void checkPermission_wizPrincipalCalledDirectlyOnProvider_returnsTrue() {
+      try(MockedStatic<XSessionService> sessionService = mockSessionService()) {
+         AuthenticationProvider authentication = mock(AuthenticationProvider.class);
+         AuthorizationProvider authorization = mock(AuthorizationProvider.class);
+         CompositeSecurityProvider provider =
+            CompositeSecurityProvider.create(authentication, authorization);
+         SRPrincipal principal = new SRPrincipal(USER_ID, new IdentityID[0], new String[0], "org1", 1L);
+         principal.setProperty("wiz", "true");
+
+         boolean allowed = provider.checkPermission(principal, ResourceType.EM, "*", ResourceAction.ACCESS);
+
+         assertTrue(allowed);
+         verifyNoInteractions(authentication, authorization);
+      }
+   }
+
+   private static MockedStatic<XSessionService> mockSessionService() {
+      MockedStatic<XSessionService> mocked = mockStatic(XSessionService.class);
+      mocked.when(XSessionService::getService).thenReturn(new XSessionService());
+      return mocked;
+   }
+}

--- a/core/src/test/java/inetsoft/sree/security/SRPrincipalTest.java
+++ b/core/src/test/java/inetsoft/sree/security/SRPrincipalTest.java
@@ -31,6 +31,8 @@ package inetsoft.sree.security;
  * [Externalizable: round-trip]   principal has arrays, properties, params, locale                   -> readExternal() restores all persisted fields
  * [XML: round-trip]              principal written as XML                                            -> parseXML() restores all XML fields
  * [XML: missing-required-tags]   XML omits any one of clientInfo/secureID/age/accessed/properties   -> parseXML() throws IOException naming the missing element
+ * [IsWizPrincipal: true]         SRPrincipal with wiz="true" property                                -> isWizPrincipal() true
+ * [IsWizPrincipal: false]        SRPrincipal with no/other wiz property, or a non-SRPrincipal         -> isWizPrincipal() false
  *
  */
 
@@ -80,6 +82,32 @@ class SRPrincipalTest {
          principal.setProperty("__internal__", "true");
 
          assertNull(principal.createUser());
+      }
+   }
+
+   // [IsWizPrincipal: true] property set to exactly "true" (any case) marks the principal as wiz
+   @Test
+   void isWizPrincipal_propertyTrue_returnsTrue() {
+      try(MockedStatic<XSessionService> sessionService = mockSessionService()) {
+         SRPrincipal principal = newPrincipal();
+         principal.setProperty("wiz", "true");
+
+         assertTrue(SRPrincipal.isWizPrincipal(principal));
+      }
+   }
+
+   // [IsWizPrincipal: false] no property, a non-"true" value, or a non-SRPrincipal never qualifies
+   @Test
+   void isWizPrincipal_notMarked_returnsFalse() {
+      try(MockedStatic<XSessionService> sessionService = mockSessionService()) {
+         SRPrincipal noProperty = newPrincipal();
+         SRPrincipal wrongValue = newPrincipal();
+         wrongValue.setProperty("wiz", "yes");
+
+         assertFalse(SRPrincipal.isWizPrincipal(noProperty));
+         assertFalse(SRPrincipal.isWizPrincipal(wrongValue));
+         assertFalse(SRPrincipal.isWizPrincipal(null));
+         assertFalse(SRPrincipal.isWizPrincipal(() -> "not-an-sr-principal"));
       }
    }
 

--- a/core/src/test/java/inetsoft/sree/security/SecurityEnginePermissionTest.java
+++ b/core/src/test/java/inetsoft/sree/security/SecurityEnginePermissionTest.java
@@ -45,8 +45,6 @@ import static org.mockito.Mockito.*;
  * SecurityEngine permission scenario table:
  *  [Basic allow]      security provider is unavailable                            -> allowed
  *  [Basic deny]       principal is null while a provider exists                   -> denied
- *  [Wiz delegation]   principal carries wiz="true", any resource type             -> allowed, provider untouched
- *  [Wiz gate]         principal carries wiz="yes" (not exactly "true")            -> provider decision returned
  *  [Login guard]      non-exempt resource with unauthenticated principal          -> SecurityException
  *  [Exempt path]      MY_DASHBOARDS skips login guard                             -> provider result returned
  *  [Fallback admin]   requested action denied but ADMIN granted                   -> allowed
@@ -126,75 +124,14 @@ class SecurityEnginePermissionTest {
       verifyNoInteractions(provider);
    }
 
-   // [Scenario: wiz delegation] a principal authenticated by WizServiceAuthenticationFilter (property
-   // wiz="true", set only after RSA JWT signature verification) bypasses the provider entirely, for
-   // every resource type -- StyleBI is the backend engine for wiz only, wiz's own Entitlements system
-   // is the single authority, so there is no per-type carve-out here.
-   // Setup: provider is not stubbed at all; if the bypass didn't short-circuit, the mock would return
-   // false and the assertion would fail, and verifyNoInteractions would catch it being called at all
-   @ParameterizedTest
-   @MethodSource("wizPrincipalResourceTypes")
-   void checkPermission_wizPrincipal_bypassesProviderForAnyResourceType(ResourceType resourceType)
-      throws Exception
-   {
-      SRPrincipal principal = new SRPrincipal(USER_ID);
-      principal.setProperty("wiz", "true");
-      SecurityProvider provider = mock(SecurityProvider.class);
-      setProvider(provider);
-
-      boolean allowed = engine.checkPermission(principal, resourceType, "*", ResourceAction.ACCESS);
-
-      assertTrue(allowed);
-      verifyNoInteractions(provider);
-   }
-
-   private static Stream<Arguments> wizPrincipalResourceTypes() {
-      return Stream.of(
-         // hierarchical, object-ACL resource type (worksheet)
-         Arguments.of(ResourceType.ASSET),
-         // capability-switch resource type checked throughout inetsoft.web.wiz
-         Arguments.of(ResourceType.VIEWSHEET),
-         // admin console resource type -- delegation is unconditional, no type is special-cased
-         Arguments.of(ResourceType.EM)
-      );
-   }
-
-   // [Scenario: wiz delegation, identity-keyed overload] the same bypass applies to the
-   // checkPermission(Principal, ResourceType, IdentityID, ResourceAction) overload
-   @Test
-   void checkPermission_wizPrincipalIdentityOverload_bypassesProvider() throws Exception {
-      SRPrincipal principal = new SRPrincipal(USER_ID);
-      principal.setProperty("wiz", "true");
-      SecurityProvider provider = mock(SecurityProvider.class);
-      setProvider(provider);
-
-      boolean allowed = engine.checkPermission(principal, ResourceType.SECURITY_ROLE,
-         new IdentityID("aa", "org1"), ResourceAction.ADMIN);
-
-      assertTrue(allowed);
-      verifyNoInteractions(provider);
-   }
-
-   // [Scenario: wiz gate] a stray property value that isn't exactly "true" must not bypass -- guards
-   // against a loose comparison accidentally trusting an unrelated property
-   // Setup: principal is otherwise logged in normally; provider denies both READ and ADMIN
-   @Test
-   void checkPermission_wizPropertyNotExactlyTrue_doesNotBypass() throws Exception {
-      SecurityProvider provider = mock(SecurityProvider.class);
-      setProvider(provider);
-      SRPrincipal principal = loggedInPrincipal(USER_ID, 11L);
-      principal.setProperty("wiz", "yes");
-
-      when(provider.checkPermission(principal, ResourceType.VIEWSHEET, "*", ResourceAction.ACCESS))
-         .thenReturn(false);
-      when(provider.checkPermission(principal, ResourceType.VIEWSHEET, "*", ResourceAction.ADMIN))
-         .thenReturn(false);
-
-      boolean allowed = engine.checkPermission(principal, ResourceType.VIEWSHEET, "*",
-         ResourceAction.ACCESS);
-
-      assertFalse(allowed);
-   }
+   // Wiz delegation itself is NOT tested here anymore -- it moved out of SecurityEngine entirely.
+   // A raw mock SecurityProvider (as used throughout this file) has no notion of the wiz property,
+   // so it can no longer prove anything about delegation. The real behavior now lives in
+   // CompositeSecurityProvider (via WizDelegatingCheckPermissionStrategy, wired in
+   // createCheckPermissionStrategy()) precisely so it also covers the many call sites that call
+   // SecurityProvider.checkPermission(...) directly and never go through SecurityEngine at all
+   // (DefaultAuthorizationFilter's EM access gate, ClusterController, etc.) -- see
+   // WizDelegatingCheckPermissionStrategyTest and CompositeSecurityProviderTest.
 
    // [Scenario: login guard / exempt path] unauthenticated principal handling depends on resource type
    // Setup: provider exists, principal is not cached as a logged-in user, and only exempt resource types bypass login validation

--- a/core/src/test/java/inetsoft/sree/security/SecurityEnginePermissionTest.java
+++ b/core/src/test/java/inetsoft/sree/security/SecurityEnginePermissionTest.java
@@ -45,6 +45,8 @@ import static org.mockito.Mockito.*;
  * SecurityEngine permission scenario table:
  *  [Basic allow]      security provider is unavailable                            -> allowed
  *  [Basic deny]       principal is null while a provider exists                   -> denied
+ *  [Wiz delegation]   principal carries wiz="true", any resource type             -> allowed, provider untouched
+ *  [Wiz gate]         principal carries wiz="yes" (not exactly "true")            -> provider decision returned
  *  [Login guard]      non-exempt resource with unauthenticated principal          -> SecurityException
  *  [Exempt path]      MY_DASHBOARDS skips login guard                             -> provider result returned
  *  [Fallback admin]   requested action denied but ADMIN granted                   -> allowed
@@ -122,6 +124,76 @@ class SecurityEnginePermissionTest {
 
       assertFalse(allowed);
       verifyNoInteractions(provider);
+   }
+
+   // [Scenario: wiz delegation] a principal authenticated by WizServiceAuthenticationFilter (property
+   // wiz="true", set only after RSA JWT signature verification) bypasses the provider entirely, for
+   // every resource type -- StyleBI is the backend engine for wiz only, wiz's own Entitlements system
+   // is the single authority, so there is no per-type carve-out here.
+   // Setup: provider is not stubbed at all; if the bypass didn't short-circuit, the mock would return
+   // false and the assertion would fail, and verifyNoInteractions would catch it being called at all
+   @ParameterizedTest
+   @MethodSource("wizPrincipalResourceTypes")
+   void checkPermission_wizPrincipal_bypassesProviderForAnyResourceType(ResourceType resourceType)
+      throws Exception
+   {
+      SRPrincipal principal = new SRPrincipal(USER_ID);
+      principal.setProperty("wiz", "true");
+      SecurityProvider provider = mock(SecurityProvider.class);
+      setProvider(provider);
+
+      boolean allowed = engine.checkPermission(principal, resourceType, "*", ResourceAction.ACCESS);
+
+      assertTrue(allowed);
+      verifyNoInteractions(provider);
+   }
+
+   private static Stream<Arguments> wizPrincipalResourceTypes() {
+      return Stream.of(
+         // hierarchical, object-ACL resource type (worksheet)
+         Arguments.of(ResourceType.ASSET),
+         // capability-switch resource type checked throughout inetsoft.web.wiz
+         Arguments.of(ResourceType.VIEWSHEET),
+         // admin console resource type -- delegation is unconditional, no type is special-cased
+         Arguments.of(ResourceType.EM)
+      );
+   }
+
+   // [Scenario: wiz delegation, identity-keyed overload] the same bypass applies to the
+   // checkPermission(Principal, ResourceType, IdentityID, ResourceAction) overload
+   @Test
+   void checkPermission_wizPrincipalIdentityOverload_bypassesProvider() throws Exception {
+      SRPrincipal principal = new SRPrincipal(USER_ID);
+      principal.setProperty("wiz", "true");
+      SecurityProvider provider = mock(SecurityProvider.class);
+      setProvider(provider);
+
+      boolean allowed = engine.checkPermission(principal, ResourceType.SECURITY_ROLE,
+         new IdentityID("aa", "org1"), ResourceAction.ADMIN);
+
+      assertTrue(allowed);
+      verifyNoInteractions(provider);
+   }
+
+   // [Scenario: wiz gate] a stray property value that isn't exactly "true" must not bypass -- guards
+   // against a loose comparison accidentally trusting an unrelated property
+   // Setup: principal is otherwise logged in normally; provider denies both READ and ADMIN
+   @Test
+   void checkPermission_wizPropertyNotExactlyTrue_doesNotBypass() throws Exception {
+      SecurityProvider provider = mock(SecurityProvider.class);
+      setProvider(provider);
+      SRPrincipal principal = loggedInPrincipal(USER_ID, 11L);
+      principal.setProperty("wiz", "yes");
+
+      when(provider.checkPermission(principal, ResourceType.VIEWSHEET, "*", ResourceAction.ACCESS))
+         .thenReturn(false);
+      when(provider.checkPermission(principal, ResourceType.VIEWSHEET, "*", ResourceAction.ADMIN))
+         .thenReturn(false);
+
+      boolean allowed = engine.checkPermission(principal, ResourceType.VIEWSHEET, "*",
+         ResourceAction.ACCESS);
+
+      assertFalse(allowed);
    }
 
    // [Scenario: login guard / exempt path] unauthenticated principal handling depends on resource type

--- a/core/src/test/java/inetsoft/sree/security/WizDelegatingCheckPermissionStrategyTest.java
+++ b/core/src/test/java/inetsoft/sree/security/WizDelegatingCheckPermissionStrategyTest.java
@@ -1,0 +1,103 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.sree.security;
+
+/*
+ * WizDelegatingCheckPermissionStrategy scenario table
+ *
+ * [Wiz: any type]        principal is wiz-authenticated (SRPrincipal, wiz="true")   -> true, delegate untouched
+ * [Non-wiz: delegates]   principal is not wiz-authenticated                          -> delegate's answer, called once
+ *
+ * This is the single choke point that both SecurityEngine.checkPermission and every direct
+ * SecurityProvider.checkPermission(...) caller (DefaultAuthorizationFilter, ClusterController,
+ * BasicAuthenticationFilter, etc.) go through once wired into CompositeSecurityProvider -- see
+ * CompositeSecurityProviderTest for proof of that end-to-end wiring.
+ */
+
+import inetsoft.uql.util.XSessionService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockedStatic;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class WizDelegatingCheckPermissionStrategyTest {
+   private static final IdentityID USER_ID = new IdentityID("alice", "org1");
+
+   // [Wiz: any type] a wiz-authenticated principal is allowed unconditionally, for any resource
+   // type, and the wrapped delegate is never consulted
+   @ParameterizedTest
+   @MethodSource("resourceTypes")
+   void checkPermission_wizPrincipal_bypassesDelegate(ResourceType type) {
+      try(MockedStatic<XSessionService> sessionService = mockSessionService()) {
+         CheckPermissionStrategy delegate = mock(CheckPermissionStrategy.class);
+         WizDelegatingCheckPermissionStrategy strategy =
+            new WizDelegatingCheckPermissionStrategy(delegate);
+         SRPrincipal principal = new SRPrincipal(USER_ID, new IdentityID[0], new String[0], "org1", 1L);
+         principal.setProperty("wiz", "true");
+
+         boolean allowed = strategy.checkPermission(principal, type, "*", ResourceAction.ACCESS);
+
+         assertTrue(allowed);
+         verifyNoInteractions(delegate);
+      }
+   }
+
+   private static Stream<Arguments> resourceTypes() {
+      return Stream.of(
+         // object-ACL resource type
+         Arguments.of(ResourceType.ASSET),
+         // capability-switch resource type
+         Arguments.of(ResourceType.VIEWSHEET),
+         // the actual gate DefaultAuthorizationFilter checks before EM is ever reached
+         Arguments.of(ResourceType.EM)
+      );
+   }
+
+   // [Non-wiz: delegates] a non-wiz principal's decision comes entirely from the wrapped delegate
+   @Test
+   void checkPermission_nonWizPrincipal_returnsDelegateDecision() {
+      try(MockedStatic<XSessionService> sessionService = mockSessionService()) {
+         CheckPermissionStrategy delegate = mock(CheckPermissionStrategy.class);
+         WizDelegatingCheckPermissionStrategy strategy =
+            new WizDelegatingCheckPermissionStrategy(delegate);
+         SRPrincipal principal = new SRPrincipal(USER_ID, new IdentityID[0], new String[0], "org1", 2L);
+
+         when(delegate.checkPermission(principal, ResourceType.EM, "*", ResourceAction.ACCESS))
+            .thenReturn(false);
+
+         boolean allowed = strategy.checkPermission(principal, ResourceType.EM, "*", ResourceAction.ACCESS);
+
+         assertFalse(allowed);
+         verify(delegate).checkPermission(principal, ResourceType.EM, "*", ResourceAction.ACCESS);
+      }
+   }
+
+   private static MockedStatic<XSessionService> mockSessionService() {
+      MockedStatic<XSessionService> mocked = mockStatic(XSessionService.class);
+      mocked.when(XSessionService::getService).thenReturn(new XSessionService());
+      return mocked;
+   }
+}


### PR DESCRIPTION
## Summary
- `SecurityEngine.checkPermission` (both the String-resource and IdentityID-keyed overloads) now short-circuits to `true`, unconditionally and for every `ResourceType`, for any principal carrying `wiz="true"`.
- That property is set exclusively by `WizServiceAuthenticationFilter` after RSA JWT signature, expiry, and audience verification succeed (`web/wiz/security/WizServiceAuthenticationFilter.java:323`) -- this trusts only requests that already passed that check, never a forged path/cookie signal alone.
- Replaces the earlier bidirectional capability-bridge design (mirroring wiz Entitlements into StyleBI's native ACLs via the EM API) with unconditional delegation: StyleBI is now wiz's sole client (no mixed wiz+StyleBI usage supported), so wiz's own Entitlements/`requirePermission` middleware becomes the single authority. StyleBI no longer maintains an independent permission judgment for wiz-originated requests.
- **Delegation is wired at the `SecurityProvider` level, not just inside `SecurityEngine.checkPermission`.** `CompositeSecurityProvider` is the only concrete `SecurityProvider` `SecurityEngine.doInit()` ever constructs, and its `checkPermission` delegates to a pluggable `CheckPermissionStrategy` (existing extension point). New `WizDelegatingCheckPermissionStrategy` wraps whichever strategy would otherwise run and short-circuits for a wiz principal, wired in `CompositeSecurityProvider.createCheckPermissionStrategy()`. This is what makes the delegation reach direct `SecurityProvider.checkPermission(...)` callers too -- `DefaultAuthorizationFilter`'s EM access gate, `ClusterController`, and ~25 more `web/admin/**` call sites -- not just callers that happen to go through `SecurityEngine`. The `"wiz"` property check is centralized in `SRPrincipal.isWizPrincipal(Principal)`, used by `isLogin()` and the new strategy alike.
- Companion wiz-repo change (same branch name `bug-76222-v2-permission-delegation`, https://github.com/inetsoft-technology/stylebi-wiz/pull/1830): removes an endpoint that leaked the now-highly-privileged wiz JWT to browser JS, and carries the full design writeup.

## Test plan
- [x] TDD: `WizDelegatingCheckPermissionStrategyTest` (bypass + non-wiz passthrough, both mocked), `CompositeSecurityProviderTest` (calls `checkPermission()` directly on the provider -- the exact `DefaultAuthorizationFilter` pattern -- with `verifyNoInteractions` on the underlying auth/authz chain), and `SRPrincipalTest` additions for `isWizPrincipal(...)`.
- [x] `SecurityEngineAuthenticationTest` / `SecurityEngineLifecycleTest` / `SecurityEnginePermissionTest` re-run clean alongside it, no regression.
- [x] Full `inetsoft.sree.security` package (38 test files) plus `DefaultAuthorizationFilterTest` and `ClusterControllerTest` (the two call sites the first review pass flagged as bypassed) all pass.
- [ ] Full `core` module test suite not run in this pass.
- [ ] Not yet verified end-to-end in a live wiz environment (StyleBI test instance currently has "Enable Security" globally disabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)