### PR TITLE
Enforce the plot-resize range on the agent path

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartElementService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartElementService.java
@@ -273,17 +273,7 @@ public class ChartElementService {
             return result;
          }
 
-         VGraphPair pair;
-
-         box.lockRead();
-
-         try {
-            pair = box.getVGraphPair(chart.getAbsoluteName());
-         }
-         finally {
-            box.unlockRead();
-         }
-
+         VGraphPair pair = vgraphPair(box, chart);
          VGraph real = pair == null ? null : pair.getRealSizeVGraph();
 
          if(real == null) {
@@ -389,6 +379,15 @@ public class ChartElementService {
       sessions.read(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
          ChartVSAssembly chart = requireChart(rvs, assemblyName);
          VSChartInfo info = chart.getVSChartInfo();
+
+         // No chart info means neither bound exists to check against - no baseline and no
+         // maximum - so the ratio falls through to the blunt 0 < ratio <= MAX_PLOT_RATIO guard
+         // rather than being refused for bounds that cannot be computed, the same stance this
+         // method takes for a chart with no laid-out graph.
+         if(info == null) {
+            return null;
+         }
+
          // VSChartPlotResizeService applies one ratio to BOTH directions for these, dividing it by
          // each direction's own initial ratio - so both bounds have to hold. Checking only the
          // direction the caller named would let half of such a write through inert.
@@ -433,17 +432,30 @@ public class ChartElementService {
          return null;
       }
 
-      VGraphPair pair;
+      VGraphPair pair = vgraphPair(box, chart);
+
+      return pair == null ? null : pair.getRealSizeVGraph();
+   }
+
+   /**
+    * The chart's graph pair, read under the sandbox's read lock.
+    *
+    * <p>One copy of the lock/unlock dance for the two callers that need it: {@link #readPlotSize},
+    * which turns each of the three ways this can come back empty into its own
+    * {@code geometryUnavailable} message, and {@link #laidOutGraph}, which only needs to know
+    * whether there is a graph to measure.
+    */
+   private static VGraphPair vgraphPair(ViewsheetSandbox box, ChartVSAssembly chart)
+      throws Exception
+   {
       box.lockRead();
 
       try {
-         pair = box.getVGraphPair(chart.getAbsoluteName());
+         return box.getVGraphPair(chart.getAbsoluteName());
       }
       finally {
          box.unlockRead();
       }
-
-      return pair == null ? null : pair.getRealSizeVGraph();
    }
 
    /** Below the baseline the write is accepted and inert, which is worse than a refusal. */

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartElementService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartElementService.java
@@ -29,6 +29,7 @@ import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.report.composition.execution.ViewsheetSandbox;
 import inetsoft.report.composition.graph.*;
 import inetsoft.report.composition.region.ChartArea;
+import inetsoft.uql.viewsheet.graph.GraphTypes;
 import inetsoft.uql.viewsheet.graph.VSChartInfo;
 import inetsoft.web.viewsheet.controller.chart.*;
 import inetsoft.web.viewsheet.event.chart.*;
@@ -152,16 +153,21 @@ public class ChartElementService {
     * Resizes the plot area, or resets it.
     *
     * <p>The ratio <em>scales the plot's minimum size</em> — {@code VGraphPair} applies it as
-    * {@code minPlotHeight *= heightRatio} — so above 1 enlarges the plot and makes the assembly
-    * scroll, 1 is the default, and below 1 lowers a minimum the plot already exceeds and so
-    * usually changes nothing visible.
+    * {@code minPlotHeight *= heightRatio} — so a large enough ratio enlarges the plot and makes
+    * the assembly scroll. <b>The threshold is the chart's own {@code initialRatio}, not 1</b>:
+    * {@code VGraphPair} re-derives the ratio only while {@code percent = ratio / initialRatio} is
+    * at least 1, so on a chart whose baseline is 2.75 a ratio of 2 is stored and inert.
+    *
+    * <p><b>The range is now enforced.</b> See {@link #requireRatioInRange} — it was enforced
+    * only by the Composer's resize slider, which this tool does not go through.
     *
     * <p>This was originally documented and validated as "the plot's share of the assembly, 0 to
     * 1", which is not what the underlying event does. Because the validation enforced that range,
     * the only values the tool accepted were the ones that do nothing — the tool returned success
     * and never changed a pixel.
     *
-    * @param ratio    scale for the plot's minimum size; above 1 enlarges it
+    * @param ratio    scale for the plot's minimum size; must be within the chart's own
+    *                 {@code initialRatio}..{@code max*Ratio} range
     * @param vertical true to resize the height, false the width
     */
    public void resizePlot(String sessionToken, Principal user, String assemblyName, Double ratio,
@@ -173,6 +179,13 @@ public class ChartElementService {
             " — it scales the plot's minimum size, so a value above 1 enlarges the plot and makes " +
             "it scroll, while 1 or less usually changes nothing visible. Got " + ratio +
             ". Pass reset:true to restore the default instead.");
+      }
+
+      // Resolved before the runtime is mutated, like legendEvent in setVisibility and for the
+      // same reason: the mutation checkpoints and broadcasts in a finally, so a refusal raised
+      // inside it would spend an undo step and a Composer refresh on a call that changed nothing.
+      if(!reset) {
+         requireRatioInRange(sessionToken, user, assemblyName, ratio, vertical);
       }
 
       sessions.mutate(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
@@ -337,6 +350,122 @@ public class ChartElementService {
       }
 
       return Map.of("maxWidthRatio", round(maxWidth), "maxHeightRatio", round(maxHeight));
+   }
+
+   /**
+    * Refuses a ratio outside the range the Composer's own resize slider can produce.
+    *
+    * <p><b>The range was enforced by a widget, not by the server.</b> The slider is drawn with
+    * {@code min=initialRatio} and {@code max=maxHorizontalResize/maxVerticalResize}
+    * (vs-chart.component.html), while {@link VSChartPlotResizeService} validates nothing at all -
+    * it writes whatever {@code sizeRatio} arrives. A person dragging that slider cannot leave the
+    * range, so this tool, which posts the event directly, was the first caller able to.
+    *
+    * <p>Both ends were reachable and neither was reported. <b>Below {@code initialRatio}</b> the
+    * write is stored and inert: {@code VGraphPair} re-derives the ratio only while
+    * {@code percent = ratio / initialRatio} is at least 1, so the call returned success and
+    * changed nothing - the silent-degradation shape {@link #readPlotSize} exists to make visible.
+    * <b>Above the maximum</b> it does take effect, but it lands the sheet in a state no Composer
+    * user can reach: past that point every axis unit already has a full unit of space, so a
+    * larger ratio only adds empty space.
+    *
+    * <p><b>Read through its own session read</b>, like {@link #legendEvent}, so a refusal costs no
+    * undo step - see the note at that method.
+    *
+    * <p>The maximum needs the laid-out graph, so a chart that has none - unbound, empty, still
+    * computing - is checked against the lower bound alone rather than being refused for a bound
+    * that cannot be computed. The lower bound never needs the graph: {@code initialRatio} is on
+    * the chart info.
+    *
+    * <p><b>This guards the agent path only.</b> {@code VSChartPlotResizeService} is still
+    * unvalidated. It is reachable today from here and from the slider, and both now bound it, so
+    * nothing out of range can be written - but any new caller added to that service must carry
+    * the same check or the gap reopens.
+    */
+   private void requireRatioInRange(String sessionToken, Principal user, String assemblyName,
+                                    double ratio, boolean vertical)
+      throws Exception
+   {
+      sessions.read(sessionToken, user, (rvs, runtimeId, dispatcher) -> {
+         ChartVSAssembly chart = requireChart(rvs, assemblyName);
+         VSChartInfo info = chart.getVSChartInfo();
+         // VSChartPlotResizeService applies one ratio to BOTH directions for these, dividing it by
+         // each direction's own initial ratio - so both bounds have to hold. Checking only the
+         // direction the caller named would let half of such a write through inert.
+         boolean square = GraphTypeUtil.isWordCloud(info) ||
+            info.getChartType() == GraphTypes.CHART_CIRCULAR;
+         boolean width = square || !vertical;
+         boolean height = square || vertical;
+
+         if(width) {
+            requireAtLeastInitial(ratio, info.getInitialWidthRatio(), "width");
+         }
+
+         if(height) {
+            requireAtLeastInitial(ratio, info.getInitialHeightRatio(), "height");
+         }
+
+         VGraph real = laidOutGraph(rvs, chart);
+
+         if(real != null) {
+            Map<String, Object> max = maxRatios(real, info);
+
+            if(width) {
+               requireAtMost(ratio, max.get("maxWidthRatio"), "width");
+            }
+
+            if(height) {
+               requireAtMost(ratio, max.get("maxHeightRatio"), "height");
+            }
+         }
+
+         return null;
+      });
+   }
+
+   /** The chart's laid-out graph, or null when there is none to measure. */
+   private static VGraph laidOutGraph(RuntimeViewsheet rvs, ChartVSAssembly chart)
+      throws Exception
+   {
+      ViewsheetSandbox box = rvs.getViewsheetSandbox().orElse(null);
+
+      if(box == null) {
+         return null;
+      }
+
+      VGraphPair pair;
+      box.lockRead();
+
+      try {
+         pair = box.getVGraphPair(chart.getAbsoluteName());
+      }
+      finally {
+         box.unlockRead();
+      }
+
+      return pair == null ? null : pair.getRealSizeVGraph();
+   }
+
+   /** Below the baseline the write is accepted and inert, which is worse than a refusal. */
+   private static void requireAtLeastInitial(double ratio, double initial, String direction) {
+      if(ratio < initial) {
+         throw new IllegalArgumentException(
+            "resize_plot's 'ratio' of " + round(ratio) + " is below this chart's " + direction +
+            " baseline of " + round(initial) + ", so it would be stored and change nothing - the " +
+            "layout re-applies a resize only while ratio / baseline is at least 1. Pass at least " +
+            round(initial) + " to enlarge the plot, or reset:true to restore the default size.");
+      }
+   }
+
+   /** Past the maximum a resize only adds empty space, and no Composer user can get there. */
+   private static void requireAtMost(double ratio, Object max, String direction) {
+      if(max instanceof Number bound && ratio > bound.doubleValue()) {
+         throw new IllegalArgumentException(
+            "resize_plot's 'ratio' of " + round(ratio) + " is above this chart's " + direction +
+            " maximum of " + bound + ", which is as far as the Composer's own resize slider goes " +
+            "- every axis unit already has a full unit of space there, so a larger ratio only " +
+            "adds empty space. Pass " + bound + " or less.");
+      }
    }
 
    private static Map<String, Object> size(Rectangle2D bounds) {

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartElementServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartElementServiceTest.java
@@ -325,15 +325,15 @@ class ChartElementServiceTest {
 
    @Test
    void resizesThePlotVertically() throws Exception {
-      Harness h = harness(mock(ChartVSAssembly.class));
+      Harness h = harness(resizableChart(1, 1));
 
-      h.service.resizePlot("tok", principal(), "Chart1", 0.6, true, false, "");
+      h.service.resizePlot("tok", principal(), "Chart1", 2d, true, false, "");
 
       ArgumentCaptor<VSChartPlotResizeEvent> captor =
          ArgumentCaptor.forClass(VSChartPlotResizeEvent.class);
       verify(h.plot).eventHandler(eq("rt1"), captor.capture(), anyString(),
                                   any(Principal.class), any());
-      assertEquals(0.6, captor.getValue().getSizeRatio());
+      assertEquals(2d, captor.getValue().getSizeRatio());
       assertTrue(captor.getValue().isHeightResized());
       assertFalse(captor.getValue().isReset());
    }
@@ -364,7 +364,7 @@ class ChartElementServiceTest {
     */
    @Test
    void acceptsARatioAboveOneBecauseThatIsTheRangeThatDoesAnything() throws Exception {
-      Harness h = harness(mock(ChartVSAssembly.class));
+      Harness h = harness(resizableChart(1, 1));
 
       h.service.resizePlot("tok", principal(), "Chart1", 1.5, true, false, "");
 
@@ -373,6 +373,69 @@ class ChartElementServiceTest {
       verify(h.plot).eventHandler(eq("rt1"), captor.capture(), anyString(),
                                   any(Principal.class), any());
       assertEquals(1.5, captor.getValue().getSizeRatio());
+   }
+
+   /**
+    * The lower bound. Below the chart's own baseline the write is stored and inert -
+    * {@code VGraphPair} re-derives the ratio only while {@code ratio / initialRatio} is at least
+    * 1 - so it is refused rather than answered with a success that changes nothing.
+    */
+   @Test
+   void refusesARatioBelowTheChartsOwnBaseline() throws Exception {
+      Harness h = harness(resizableChart(2.75, 2.75));
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> h.service.resizePlot("tok", principal(), "Chart1", 2d, true, false, ""));
+
+      assertTrue(thrown.getMessage().contains("2.75"), "the refusal has to name the bound");
+      assertTrue(thrown.getMessage().contains("reset"), "and the way to make the plot smaller");
+      verifyNoInteractions(h.plot);
+      verify(h.sessions, never()).mutate(anyString(), any(Principal.class), any());
+   }
+
+   @Test
+   void acceptsARatioExactlyAtTheBaseline() throws Exception {
+      Harness h = harness(resizableChart(2.75, 2.75));
+
+      h.service.resizePlot("tok", principal(), "Chart1", 2.75, true, false, "");
+
+      verify(h.plot).eventHandler(eq("rt1"), any(VSChartPlotResizeEvent.class), anyString(),
+                                  any(Principal.class), any());
+   }
+
+   /**
+    * {@code VSChartPlotResizeService} applies one ratio to <em>both</em> directions on a circular
+    * chart, dividing it by each direction's own baseline, so both bounds have to hold. Checking
+    * only the direction the caller named would let half of such a write through inert.
+    */
+   @Test
+   void checksBothBaselinesOnAChartThatResizesSquare() {
+      ChartVSAssembly circular = resizableChart(3, 1);
+      when(circular.getVSChartInfo().getChartType()).thenReturn(GraphTypes.CHART_CIRCULAR);
+      Harness h = harness(circular);
+
+      Exception thrown = assertThrows(
+         Exception.class,
+         () -> h.service.resizePlot("tok", principal(), "Chart1", 2d, true, false, ""));
+
+      assertTrue(thrown.getMessage().contains("width"),
+                 "a vertical resize on a square chart is still bounded by the width baseline");
+   }
+
+   /**
+    * A chart with no info has neither baseline nor maximum to check against, so the range check
+    * has nothing to say and must stand aside rather than throw on the way to reading a bound that
+    * does not exist.
+    */
+   @Test
+   void aChartWithNoInfoIsLeftToTheBluntGuard() throws Exception {
+      Harness h = harness(mock(ChartVSAssembly.class));
+
+      h.service.resizePlot("tok", principal(), "Chart1", 2d, true, false, "");
+
+      verify(h.plot).eventHandler(eq("rt1"), any(VSChartPlotResizeEvent.class), anyString(),
+                                  any(Principal.class), any());
    }
 
    @Test
@@ -619,6 +682,17 @@ class ChartElementServiceTest {
       VSChartInfo info = mock(VSChartInfo.class);
       when(info.getUnitHeightRatio()).thenReturn(heightRatio);
       when(info.isHeightResized()).thenReturn(heightResized);
+      ChartVSAssembly assembly = mock(ChartVSAssembly.class);
+      when(assembly.getVSChartInfo()).thenReturn(info);
+      return assembly;
+   }
+
+   /** A chart whose plot-resize baselines are the minimums the Composer's slider is drawn with. */
+   private static ChartVSAssembly resizableChart(double initialWidth, double initialHeight) {
+      VSChartInfo info = mock(VSChartInfo.class);
+      when(info.getInitialWidthRatio()).thenReturn(initialWidth);
+      when(info.getInitialHeightRatio()).thenReturn(initialHeight);
+      when(info.getChartType()).thenReturn(GraphTypes.CHART_BAR);
       ChartVSAssembly assembly = mock(ChartVSAssembly.class);
       when(assembly.getVSChartInfo()).thenReturn(info);
       return assembly;


### PR DESCRIPTION
`resize_chart_plot`'s ratio range was enforced by a UI widget, so the agent tool was the first caller in the product able to leave it. Found while working through the outstanding items on L4 of the Composer plugin test plan.

## Where the bound actually lived

`vs-chart.component.html` draws the plot resizer as

```html
<input type="range" [attr.min]="model.initialHeightRatio"
                    [attr.max]="model.maxVerticalResize" step="0.01" ...>
```

A person dragging that slider physically cannot produce a value outside the range — so `VSChartPlotResizeService` never had to validate, and doesn't: it writes whatever `sizeRatio` arrives. `ChartElementService` copied the max formula for its **read** (`maxRatios`, lifted from `VSChartAreasService`) and never consulted it on its **write**, whose only guard was `0 < ratio <= 10`. The same class computed the bound for the caller to look at and ignored it when writing.

## Both ends were reachable, and the low end was the silent one

- **Below `initialRatio`** the write was stored and inert: `VGraphPair` re-derives the ratio only while `percent = ratio / initialRatio` is at least 1. The call returned success and changed nothing. This also made the tool's own description wrong — "above 1 enlarges, 2 gives it twice the room" is false on any chart whose baseline exceeds 1, and the test asset's is 2.75.
- **Above `max*Ratio`** the write took real effect but left the sheet in a state no Composer user can reach. Confirmed before the fix: on a chart with `maxHeightRatio: 5.5`, `ratio: 8` stored verbatim, `percent: 2.91`, expanded plot 165 → 480 (exactly `minPlot` 60 × 8), no clamp anywhere.

## The fix

`requireRatioInRange` refuses both ends, naming the bound, and points at `reset: true` for the low end — "make it smaller" is what a below-baseline ratio means, and reset is the product's answer to it. Clamping was considered and rejected: on the low end it would invert the caller's intent, and silently adjusting a number is the same class of defect as silently dropping it.

It resolves **before** `sessions.mutate`, like `legendEvent`, so a refusal costs no undo step. Word cloud and circular charts take `VSChartPlotResizeService`'s `square` branch — one ratio applied to both directions against two different baselines — so both bounds are checked for them rather than only the direction the caller named. A chart with no laid-out graph has no maximum to compute, so it is bounded by the baseline and the blunt `<= 10` guard alone rather than being refused for a bound that does not exist; the lower bound never needs the graph.

## Deliberately not fixed

`VSChartPlotResizeService` is still unvalidated. Its only callers are the slider and `ChartElementService.resizePlot` — grep-confirmed: one `eventHandler` call site in the whole wiz tier, one caller of `resizePlot`, one plugin POST to `chart/plot-size` — and both now bound it, so nothing out of range is reachable today. But the guard is duplicated per caller rather than centralised at the service, so **a third caller added there would reopen the gap**. Centralising means adding VGraph plumbing to that method, which it does not have.

## Verified live

After a full rebuild and server restart, on a saved viewsheet with a bound chart (baseline 2.75, maximum 5.5) and an unbound one:

| call | result |
|---|---|
| bound chart, `ratio: 2` | refused, naming 2.75 and `reset: true` |
| bound chart, `ratio: 8` | refused, naming 5.5 |
| bound chart, `ratio: 4` | applied — `percent: 1.45`, expanded plot 165 → 240 = `minPlot` 60 × 4, `vScrollable` true |
| unbound chart, `ratio: 3` | allowed — a missing maximum falls through rather than refusing |
| unbound chart, `ratio: 0.5` | refused, naming its baseline of 1.0 |

The first and last are the ones that matter: both were previously accepted and silently did nothing.

**Still unverified live:** the relation / word cloud / dot plot branch (both bounds fixed at 5). No test asset has such a chart, so that branch rests on the source reading alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
