### PR TITLE
Let node-color and node-size name a relation chart's node legend

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionResolver.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionResolver.java
@@ -333,7 +333,6 @@ final class ChartRegionResolver {
     * reports the field on the <b>shape</b> channel, while a line chart renders that legend as
     * <b>Line</b> — so a caller who read the aesthetics and said "shape" was naming this legend
     * correctly and being refused for it.
-    *
     */
    private static String channelFamily(String channel) {
       String name = channel == null ? "" : channel.trim().toLowerCase();

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionResolver.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ChartRegionResolver.java
@@ -114,9 +114,18 @@ final class ChartRegionResolver {
        * not to say the two always agree on <em>which</em> channel: a line chart renders the field
        * on its shape channel as a {@code line} legend. Empty for a legend with no describable
        * frame, which is also a legend with no field, so neither can be named.
+       *
+       * <p><b>A node aesthetic is reported as {@code node-color}/{@code node-size}</b>, the names
+       * that bind it. The underlying {@code aestheticType} is plain {@code Color}/{@code Size} for
+       * both a relation chart's node legend and its edge legend, so reporting that raw dropped a
+       * distinction this record already carries: {@code get_chart_aesthetics} put the field on
+       * {@code node-color} while this said {@code color} and reported {@code color} as empty, so
+       * the only name the reader was given for the legend was one that did not address it.
        */
       String channel() {
-         return aestheticType == null ? "" : aestheticType.toLowerCase();
+         String name = aestheticType == null ? "" : aestheticType.toLowerCase();
+
+         return nodeAesthetic && !name.isEmpty() ? "node-" + name : name;
       }
    }
 
@@ -255,6 +264,14 @@ final class ChartRegionResolver {
     * both put in front of the caller (see {@link #channelFamily}). Two legends in the same family
     * make it ambiguous, so that is refused with both fields named rather than resolved to the
     * first.
+    *
+    * <p><b>{@code node-color} and {@code node-size} narrow to the node legend</b> rather than
+    * folding onto {@code color}/{@code size}. Those are the only names that bind a relation
+    * chart's node aesthetic, and {@code get_chart_aesthetics} reports the field under them, so a
+    * caller naming what it bound was being refused; folding them instead would have resolved
+    * {@code node-color} to an <em>edge</em> legend on a chart that has no node aesthetic at all,
+    * which is the mis-resolution this method exists to prevent. Narrowing also makes the
+    * both-bound case unambiguous, since the node flag says which one was meant.
     */
    static LegendTarget requireLegendField(Legends legends, String target) {
       String wanted = target == null ? "" : target.trim();
@@ -279,9 +296,25 @@ final class ChartRegionResolver {
          }
       }
 
-      String family = channelFamily(wanted);
+      // node-color / node-size name a relation chart's node legend specifically. The underlying
+      // aestheticType is plain Color/Size for a node legend and its edge counterpart alike, so the
+      // node flag rather than the channel name is what tells them apart - and it is what makes
+      // "node-color" resolve to the node legend on a chart that has both, instead of being refused
+      // as ambiguous. Plain "color" stays permissive and matches either, so a chart carrying only
+      // a node legend still resolves it: there is one colour legend and no other thing meant.
+      String requested = wanted.toLowerCase();
+      boolean nodeWanted = requested.startsWith("node");
+      String named = requested;
+
+      if(nodeWanted) {
+         named = requested.substring("node".length());
+         named = named.startsWith("-") ? named.substring(1) : named;
+      }
+
+      String family = channelFamily(named);
       List<LegendTarget> byChannel = family.isEmpty() ? List.of() : legends.legends().stream()
          .filter(legend -> channelFamily(legend.aestheticType()).equals(family))
+         .filter(legend -> !nodeWanted || legend.nodeAesthetic())
          .toList();
 
       if(byChannel.size() == 1) {
@@ -300,6 +333,7 @@ final class ChartRegionResolver {
     * reports the field on the <b>shape</b> channel, while a line chart renders that legend as
     * <b>Line</b> — so a caller who read the aesthetics and said "shape" was naming this legend
     * correctly and being refused for it.
+    *
     */
    private static String channelFamily(String channel) {
       String name = channel == null ? "" : channel.trim().toLowerCase();

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionResolverTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/ChartRegionResolverTest.java
@@ -294,6 +294,81 @@ class ChartRegionResolverTest {
    }
 
    /**
+    * <b>The node aesthetic's own name.</b> A relation chart binds its node colour on
+    * {@code node-color}, and {@code get_chart_aesthetics} reports the field there - but the
+    * legend's {@code aestheticType} is a plain {@code Color}, the same value its edge legend
+    * carries. So a caller naming what it bound was being refused, and the channel this class
+    * reported back for the legend was one that did not address it.
+    */
+   @Test
+   void takesNodeColorToMeanTheNodeLegendAndNotTheEdgeOne() {
+      ChartRegionResolver.Legends legends = relationLegends();
+
+      assertEquals("Customer:Region",
+                   ChartRegionResolver.requireLegendField(legends, "node-color").field(),
+                   "the node flag says which of the two colour legends was meant");
+      assertEquals("node-color", legends.legends().get(0).channel(),
+                   "and the name it resolves by is the one reported for it");
+      assertEquals("color", legends.legends().get(1).channel(),
+                   "while the edge legend keeps the plain channel");
+      assertEquals("node-size",
+                   new ChartRegionResolver.LegendTarget("Sales", "Size", List.of(), true).channel(),
+                   "size is the other node channel there is");
+   }
+
+   /**
+    * The mis-resolution narrowing exists to prevent: folding {@code node-color} onto
+    * {@code color} would have hidden an <em>edge</em> legend on a chart with no node aesthetic at
+    * all, and reported success naming the node one.
+    */
+   @Test
+   void refusesNodeColorOnAChartWhoseOnlyColourLegendIsTheEdgeOne() {
+      ChartRegionResolver.Legends legends = new ChartRegionResolver.Legends(
+         List.of(new ChartRegionResolver.LegendTarget("Sales", "Color", List.of(), false)), true);
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartRegionResolver.requireLegendField(legends, "node-color"));
+
+      assertTrue(thrown.getMessage().contains("no 'node-color' legend"), "name what was asked for");
+      assertTrue(thrown.getMessage().contains("Sales"), "and the legend it does have");
+   }
+
+   /** Narrowing costs nothing when there is only the node legend to narrow to. */
+   @Test
+   void resolvesNodeColorWhenTheNodeLegendIsTheOnlyColourOne() {
+      ChartRegionResolver.Legends legends = new ChartRegionResolver.Legends(
+         List.of(new ChartRegionResolver.LegendTarget("Customer:Region", "Color", List.of(), true)),
+         true);
+
+      assertEquals("Customer:Region",
+                   ChartRegionResolver.requireLegendField(legends, "node-color").field());
+      assertEquals("Customer:Region",
+                   ChartRegionResolver.requireLegendField(legends, "NodeColor").field(),
+                   "forgiving about the dash and the case, like every other target here");
+      assertEquals("Customer:Region",
+                   ChartRegionResolver.requireLegendField(legends, "color").field(),
+                   "and plain colour still reaches it - there is one colour legend and no other " +
+                   "thing that could have been meant");
+   }
+
+   /**
+    * Plain {@code color} stays permissive rather than being narrowed the other way: with both
+    * legends bound it says nothing about which, so it is refused with both named - the same
+    * ruling two edge legends of one channel already get.
+    */
+   @Test
+   void plainColourIsStillAmbiguousWhenTheChartHasBothANodeAndAnEdgeLegend() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartRegionResolver.requireLegendField(relationLegends(), "color"));
+
+      assertTrue(thrown.getMessage().contains("more than one"), "say why it cannot be resolved");
+      assertTrue(thrown.getMessage().contains("node-color"),
+                 "and offer the name that does resolve it");
+   }
+
+   /**
     * The finding this whole path exists for: a target the chart has never heard of did not no-op,
     * it hid the chart's real legends and reported success naming the one asked for. So an
     * unknown field has to be refused, not passed through.
@@ -353,6 +428,14 @@ class ChartRegionResolverTest {
       assertThrows(IllegalArgumentException.class,
                    () -> ChartRegionResolver.requireLegendField(legends, ""),
                    "and the unnamed one is reachable by no target at all");
+   }
+
+   /** A relation chart's two colour legends: the node aesthetic and the edge one. */
+   private static ChartRegionResolver.Legends relationLegends() {
+      return new ChartRegionResolver.Legends(
+         List.of(new ChartRegionResolver.LegendTarget("Customer:Region", "Color", List.of(), true),
+                 new ChartRegionResolver.LegendTarget("Sales", "Color", List.of(), false)),
+         true);
    }
 
    private static ChartRegionResolver.Legends twoLegends() {


### PR DESCRIPTION
On a relation chart, the only names that *bind* a node aesthetic could not *address* its legend — and the name that could was reported as holding nothing. Found while covering the relation-chart branch of L4 in the Composer plugin test plan, the one branch of legend resolution that had no live coverage.

## The contradiction, as a caller meets it

On a network chart with `node-color` bound to `Customer:Region`:

```
get_chart_aesthetics   ->  "color":      { "field": null }
                          "node-color": { "field": "Customer:Region" }

list_chart_elements    ->  { "index": 0, "channel": "color", "field": "Customer:Region" }

hide target=node-color ->  refused: "This chart has no 'node-color' legend"
hide target=color      ->  accepted
```

So the documented route — read the aesthetics, name the channel the field is on — is refused, while the name that works is reported as empty. `set_aesthetic_field` accepts `node-color` and nothing else for this channel, so the caller has no way to learn the name that resolves.

## Root cause: the read dropped a distinction the model already carries

`LegendTarget` has a `nodeAesthetic` flag, and `legendFields` has always sent it on the hide event. But `channel()` returned `aestheticType` lower-cased, and `aestheticType` is plain `Color`/`Size` for a node legend and its edge counterpart alike — so the flag was discarded on the way out. `channel()` now prefixes `node-`, which fixes `list_chart_elements` and the refusal messages together, since both read it.

## Resolution narrows, it does not fold

`requireLegendField` strips the `node-` prefix to find the family, then keeps only legends whose `nodeAesthetic` is set.

Folding `node-color` onto `color` was the first attempt and is wrong: on a chart with an edge-colour legend and no node aesthetic at all, it resolves `node-color` to the **edge** legend — exactly the mis-resolution this method exists to prevent, and the shape of a bug this family has already shipped once. Narrowing also makes the both-bound case unambiguous, where folding would have refused it: the node flag says precisely which legend was meant.

Plain `color`/`size` stay permissive and match either, so a chart carrying only a node legend still resolves them. The resulting behaviour:

| chart has | `color` | `node-color` |
|---|---|---|
| only an edge colour legend | resolves to it | refused by name |
| only a node colour legend | resolves to it | resolves to it |
| both | ambiguous, refused with both fields named | resolves to the node one |

Resolution only selects *which* legend; the event is then built from the resolved target's field, `aestheticType` and `nodeAesthetic`, so the name the caller typed never reaches it. Hiding via `node-color`, via `color`, or via the field name produce an identical event.

## Live evidence behind it

On a network chart (`Customer:Region` → `Product:Category`, `Sum(Order:Paid)` on size, `Customer:Region` on node-color):

- hiding by field name `Customer:Region` hid **only** the node legend, the size legend surviving — so the node-aesthetic path itself resolves correctly and the destructive "hides them all" failure does not occur here
- with an edge colour bound as well, the two legends came back as `color` and `color`, told apart only by their fields
- naming `color` in that state was correctly refused as ambiguous, listing all three legends

## Verified live

After a rebuild and restart, on a rebuilt `Chart3`:

| check | result |
|---|---|
| `list_chart_elements` channel | `node-color`, agreeing with `get_chart_aesthetics` |
| hide `target: "node-color"` | node legend alone, size legend surviving (image-confirmed) |
| with an edge colour also bound, `node-color` | resolves **unambiguously** to the node legend |
| same state, plain `color` | refused as ambiguous |
| node aesthetic cleared, `node-color` | **refused by name**, the edge legend untouched |
| only one colour legend, plain `color` | still resolves — permissive path intact |

The refusal messages improved via the same `channel()` change: the ambiguity refusal now reads `Customer:Region (node-color), Customer:State (color), Sum(Order:Paid) (size)` where it used to print `(color), (color), (size)` and give the reader no way to tell which was which.

**The last two checks are what justify narrowing over folding.** Both are ordinary paths, and the folded version fails both — refusing the unambiguous case, and silently hiding an edge legend for a caller asking about a node one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

