### PR TITLE
Stop answering a not-yet-rendered chart with the opposite advice

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/WizControllerErrorHandler.java
+++ b/core/src/main/java/inetsoft/web/wiz/WizControllerErrorHandler.java
@@ -112,7 +112,15 @@ public class WizControllerErrorHandler {
     * said <b>retry after 1s</b>. The advice was the exact inverse of the condition.
     *
     * <p>{@code Retry-After} carries the number as a header as well as in the message, since that is
-    * what the status code means and a client that honours it needs no message parsing.
+    * what the status code means and a client that honours it needs no message parsing. It is
+    * floored at 1: a 0 or negative header is not a shorter wait, it is a value the spec gives no
+    * meaning to, and a client that honours it would retry with no delay at all.
+    *
+    * <p>This is the only handler for the exception. {@code ViewsheetAgentController} carried a
+    * local one of its own, which — a local {@code @ExceptionHandler} always winning over a
+    * {@code @ControllerAdvice} — meant the two controllers that render answered the same condition
+    * with two different bodies. It was removed in favour of this one; {@code errorCode} is kept
+    * from it so nothing that read the local shape loses it.
     */
    @ExceptionHandler(RenderNotReadyException.class)
    public ResponseEntity<Map<String, String>> handleRenderNotReady(RenderNotReadyException e) {
@@ -123,8 +131,9 @@ public class WizControllerErrorHandler {
          "failure, and the same call should succeed once it is done. A chart with nothing bound " +
          "to it never becomes ready and is refused up front instead, so a wait here is a real " +
          "wait rather than a loop.");
+      payload.put("errorCode", "RENDER_NOT_READY");
       HttpHeaders headers = new HttpHeaders();
-      headers.set(HttpHeaders.RETRY_AFTER, String.valueOf(e.getRetryAfter()));
+      headers.set(HttpHeaders.RETRY_AFTER, String.valueOf(Math.max(1, e.getRetryAfter())));
       return new ResponseEntity<>(payload, headers, HttpStatus.SERVICE_UNAVAILABLE);
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/WizControllerErrorHandler.java
+++ b/core/src/main/java/inetsoft/web/wiz/WizControllerErrorHandler.java
@@ -20,12 +20,14 @@ package inetsoft.web.wiz;
 import inetsoft.util.Catalog;
 import inetsoft.util.InvalidUserException;
 import inetsoft.web.wiz.dispatch.CommandErrorException;
+import inetsoft.web.wiz.service.RenderNotReadyException;
 import inetsoft.web.wiz.service.UnsupportedDatasourceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -96,6 +98,34 @@ public class WizControllerErrorHandler {
       payload.put("error", e.getMessage());
       payload.put("datasourceType", e.getDatasourceType());
       return new ResponseEntity<>(payload, null, HttpStatus.UNPROCESSABLE_ENTITY);
+   }
+
+   /**
+    * Maps a render that has not finished yet to 503 with its own retry hint, instead of a 500 that
+    * tells the caller the opposite.
+    *
+    * <p>{@code RenderNotReadyException} is not an unexpected failure: {@code ScriptImageService}
+    * raises it deliberately, after its own four attempts, to say the graph is still being built and
+    * carries the seconds to wait. Unmapped, it fell through to the catch-all, which logged it as
+    * "Unexpected error in wiz agent request" and answered with the generic server-bug message — so
+    * the caller was told <b>retrying will fail the same way</b> while the exception it came from
+    * said <b>retry after 1s</b>. The advice was the exact inverse of the condition.
+    *
+    * <p>{@code Retry-After} carries the number as a header as well as in the message, since that is
+    * what the status code means and a client that honours it needs no message parsing.
+    */
+   @ExceptionHandler(RenderNotReadyException.class)
+   public ResponseEntity<Map<String, String>> handleRenderNotReady(RenderNotReadyException e) {
+      LOG.debug("Wiz render not ready: {}", e.getMessage());
+
+      Map<String, String> payload = new HashMap<>();
+      payload.put("error", e.getMessage() + ". The graph is still being built - this is not a " +
+         "failure, and the same call should succeed once it is done. A chart with nothing bound " +
+         "to it never becomes ready and is refused up front instead, so a wait here is a real " +
+         "wait rather than a loop.");
+      HttpHeaders headers = new HttpHeaders();
+      headers.set(HttpHeaders.RETRY_AFTER, String.valueOf(e.getRetryAfter()));
+      return new ResponseEntity<>(payload, headers, HttpStatus.SERVICE_UNAVAILABLE);
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptImageService.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptImageService.java
@@ -19,6 +19,7 @@ package inetsoft.web.wiz.script;
 
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.asset.Assembly;
+import inetsoft.uql.viewsheet.DataVSAssembly;
 import inetsoft.uql.viewsheet.FileFormatInfo;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.util.Tool;
@@ -115,6 +116,28 @@ public class ScriptImageService {
 
       if(assembly == null) {
          throw new PairingException("No such assembly \"" + assemblyName + "\"");
+      }
+
+      // An assembly with no source table has nothing bound to it at all - every field on a chart
+      // or table comes from one source, so no source means no shelf can hold anything - and so it
+      // never produces a graph. Without this, the loop below sleeps through all
+      // RENDER_MAX_ATTEMPTS attempts and then raises RenderNotReadyException, telling the caller
+      // to retry something that cannot become ready. Rendering right after each binding step is
+      // how a caller checks its work, so a freshly added assembly is the state it meets most
+      // often. The test is the bound source rather than the field lists on purpose: the shelves a
+      // chart reads depend on its type, and a relation chart's source/target or a candlestick's
+      // open/high/low/close are not reachable through getRTFields, so an empty field list is not
+      // evidence of an unbound chart while an absent source is.
+      if(assembly instanceof DataVSAssembly data) {
+         String source = data.getTableName();
+
+         if(source == null || source.isBlank()) {
+            throw new PairingException(
+               "\"" + assemblyName + "\" has no source bound to it, so there is no graph to " +
+               "render and no wait will produce one. Point it at a table first — " +
+               "set_chart_source or set_table_source, or the 'table' argument of the shelf " +
+               "and aesthetic writes — and render it after that.");
+         }
       }
 
       int w = clamp(width != null && width > 0 ? width : DEFAULT_WIDTH);

--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptImageService.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptImageService.java
@@ -19,7 +19,7 @@ package inetsoft.web.wiz.script;
 
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.asset.Assembly;
-import inetsoft.uql.viewsheet.DataVSAssembly;
+import inetsoft.uql.viewsheet.ChartVSAssembly;
 import inetsoft.uql.viewsheet.FileFormatInfo;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.util.Tool;
@@ -118,25 +118,35 @@ public class ScriptImageService {
          throw new PairingException("No such assembly \"" + assemblyName + "\"");
       }
 
-      // An assembly with no source table has nothing bound to it at all - every field on a chart
-      // or table comes from one source, so no source means no shelf can hold anything - and so it
-      // never produces a graph. Without this, the loop below sleeps through all
-      // RENDER_MAX_ATTEMPTS attempts and then raises RenderNotReadyException, telling the caller
-      // to retry something that cannot become ready. Rendering right after each binding step is
-      // how a caller checks its work, so a freshly added assembly is the state it meets most
-      // often. The test is the bound source rather than the field lists on purpose: the shelves a
-      // chart reads depend on its type, and a relation chart's source/target or a candlestick's
+      // A chart with no source table has nothing bound to it at all - every field on a chart
+      // comes from one source, so no source means no shelf can hold anything - and so it never
+      // produces a graph. Without this, the loop below sleeps through all RENDER_MAX_ATTEMPTS
+      // attempts and then raises RenderNotReadyException, telling the caller to retry something
+      // that cannot become ready. Rendering right after each binding step is how a caller checks
+      // its work, so a freshly added chart is the state it meets most often.
+      //
+      // Scoped to charts because only a chart can produce the condition this guards: the
+      // retryAfter that drives the loop is set in exactly one place, inside
+      // AssemblyImageService.processGetAssemblyImage's `assembly instanceof ChartVSAssembly`
+      // branch (an incomplete VGraphPair). Every other DataVSAssembly - table, crosstab, calc
+      // table - comes back with retryAfter <= 0 on the first attempt and, when the lightweight
+      // path does not support it, falls back to the whole-viewsheet render below, which succeeds
+      // whether or not a source is bound. Refusing those would take away a working image without
+      // preventing any retry loop.
+      //
+      // The test is the bound source rather than the field lists on purpose: the shelves a chart
+      // reads depend on its type, and a relation chart's source/target or a candlestick's
       // open/high/low/close are not reachable through getRTFields, so an empty field list is not
       // evidence of an unbound chart while an absent source is.
-      if(assembly instanceof DataVSAssembly data) {
-         String source = data.getTableName();
+      if(assembly instanceof ChartVSAssembly chart) {
+         String source = chart.getTableName();
 
          if(source == null || source.isBlank()) {
             throw new PairingException(
                "\"" + assemblyName + "\" has no source bound to it, so there is no graph to " +
                "render and no wait will produce one. Point it at a table first — " +
-               "set_chart_source or set_table_source, or the 'table' argument of the shelf " +
-               "and aesthetic writes — and render it after that.");
+               "set_chart_source, or the 'table' argument of the shelf and aesthetic writes — " +
+               "and render it after that.");
          }
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/script/ViewsheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ViewsheetAgentController.java
@@ -30,9 +30,7 @@ import inetsoft.web.wiz.script.model.ScriptContext;
 import inetsoft.web.wiz.script.model.ScriptExecResult;
 import inetsoft.web.wiz.script.model.ScriptInfo;
 import inetsoft.web.wiz.script.model.ScriptTargetsResponse;
-import inetsoft.web.wiz.service.RenderNotReadyException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -489,17 +487,6 @@ public class ViewsheetAgentController {
       body.put("error", e.getMessage());
       body.put("errorCode", e.getKind().name());
       return ResponseEntity.status(status).body(body);
-   }
-
-   /** The chart's graph hasn't finished computing yet — ask the caller to retry shortly. */
-   @ExceptionHandler(RenderNotReadyException.class)
-   public ResponseEntity<Map<String, String>> handleRenderNotReady(RenderNotReadyException e) {
-      Map<String, String> body = new LinkedHashMap<>();
-      body.put("error", e.getMessage());
-      body.put("errorCode", "RENDER_NOT_READY");
-      return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
-         .header(HttpHeaders.RETRY_AFTER, String.valueOf(Math.max(1, e.getRetryAfter())))
-         .body(body);
    }
 
    // ---------------------------------------------------------------------------

--- a/core/src/test/java/inetsoft/web/wiz/WizControllerErrorHandlerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/WizControllerErrorHandlerTest.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.wiz;
 
+import inetsoft.web.wiz.service.RenderNotReadyException;
 import inetsoft.web.wiz.service.UnsupportedDatasourceException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -27,9 +28,11 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
 
@@ -176,6 +179,29 @@ class WizControllerErrorHandlerTest {
    }
 
    /**
+    * A render that has not finished yet is not a failure — {@code ScriptImageService} raises
+    * {@code RenderNotReadyException} deliberately, after its own retries, and carries the seconds
+    * to wait. Unmapped it fell to the catch-all below and came back as the generic server-bug
+    * message, which tells the caller <em>retrying will fail the same way</em> — the exact inverse
+    * of what the exception says. 503 with {@code Retry-After} is the honest answer.
+    */
+   @Test
+   void renderNotReadyMapsToServiceUnavailableWithARetryAfterHeader() throws Exception {
+      String content = mvc.perform(get("/wiz-test/throw").param("type", "notready"))
+         .andExpect(status().isServiceUnavailable())
+         .andExpect(header().string("Retry-After", "2"))
+         .andReturn().getResponse().getContentAsString();
+
+      assertTrue(content.contains("retry after 2s"),
+                 "the exception's own wait must reach the caller, got: [" + content + "]");
+      assertTrue(content.contains("RENDER_NOT_READY"),
+                 "the errorCode kept from the removed local handler must survive, got: [" +
+                 content + "]");
+      assertFalse(content.contains("retrying will fail"),
+                  "and it must not carry the catch-all's do-not-retry advice, got: [" + content + "]");
+   }
+
+   /**
     * Any exception none of the handlers above recognize — an NPE deep in a binding/viewsheet
     * service, for example — must still come back as JSON 500, not fall through to Tomcat's own
     * default HTML error page (which ignores the client's {@code Accept: application/json} header
@@ -230,6 +256,10 @@ class WizControllerErrorHandlerTest {
             throw new inetsoft.util.InvalidUserException(
                "Invalid user found: Principal[Client[admin@172.18.0.1@a2f160d8]] instead of " +
                "Principal[Client[admin@172.18.0.1@ab0096b3]]", () -> "admin");
+         }
+
+         if("notready".equals(type)) {
+            throw new RenderNotReadyException(2);
          }
 
          if("unexpected".equals(type)) {

--- a/core/src/test/java/inetsoft/web/wiz/script/ScriptImageServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ScriptImageServiceTest.java
@@ -18,6 +18,7 @@
 package inetsoft.web.wiz.script;
 
 import inetsoft.report.composition.RuntimeViewsheet;
+import inetsoft.uql.asset.SourceInfo;
 import inetsoft.uql.viewsheet.ChartVSAssembly;
 import inetsoft.uql.viewsheet.Viewsheet;
 import inetsoft.util.cachefs.BinaryTransfer;
@@ -52,9 +53,17 @@ class ScriptImageServiceTest {
       return out.toByteArray();
    }
 
+   /**
+    * The chart is given a source because {@code getAssemblyImage} refuses an unbound one up front,
+    * before any render is attempted — see the pre-check there. A bare {@code new ChartVSAssembly}
+    * has no {@code SourceInfo}, so leaving it unbound would make every test below assert against
+    * that refusal rather than the render path it means to cover.
+    */
    private RuntimeViewsheet viewsheetWithChart(String chartName) {
       Viewsheet vs = new Viewsheet();
-      vs.addAssembly(new ChartVSAssembly(vs, chartName));
+      ChartVSAssembly chart = new ChartVSAssembly(vs, chartName);
+      chart.setSourceInfo(new SourceInfo(SourceInfo.ASSET, null, "Table1"));
+      vs.addAssembly(chart);
 
       RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
       when(rvs.getViewsheet()).thenReturn(vs);

--- a/core/src/test/java/inetsoft/web/wiz/script/ScriptImageServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ScriptImageServiceTest.java
@@ -94,6 +94,36 @@ class ScriptImageServiceTest {
          rvs, "NoSuchAssembly", null, null, TestPrincipals.user("alice", "host-org")));
    }
 
+   /**
+    * The refusal has to happen <em>before</em> the render loop, not after it. A chart with no
+    * source never produces a graph, so every attempt comes back not-ready and the loop ends in a
+    * RenderNotReadyException advising a retry that cannot succeed — the defect this PR exists to
+    * remove. {@code verifyNoInteractions} is the assertion that matters: it is what distinguishes
+    * "refused up front" from "refused after burning through four attempts and 2s of sleep".
+    *
+    * <p>Note the chart is built inline rather than through {@code viewsheetWithChart}, which binds
+    * a source precisely so the render-path tests do not land here.
+    */
+   @Test
+   void refusesAnUnboundChartWithoutAttemptingARender() {
+      Viewsheet vs = new Viewsheet();
+      vs.addAssembly(new ChartVSAssembly(vs, "Chart1"));
+
+      RuntimeViewsheet rvs = mock(RuntimeViewsheet.class);
+      when(rvs.getViewsheet()).thenReturn(vs);
+
+      AssemblyImageService imageService = mock(AssemblyImageService.class);
+      ScriptImageService svc = new ScriptImageService(
+         imageService, mock(BinaryTransferService.class), mock(VSExportService.class));
+
+      PairingException ex = assertThrows(PairingException.class, () -> svc.getAssemblyImage(
+         rvs, "Chart1", null, null, TestPrincipals.user("alice", "host-org")));
+
+      assertTrue(ex.getMessage().contains("set_chart_source"),
+                 "the refusal must name how to bind a source, got: [" + ex.getMessage() + "]");
+      verifyNoInteractions(imageService);
+   }
+
    @Test
    void returnsThePngOnASuccessfulRender() throws Exception {
       RuntimeViewsheet rvs = viewsheetWithChart("Chart1");


### PR DESCRIPTION
Rendering an assembly with nothing bound to it came back as

> An unexpected server error occurred while processing this request. This is a StyleBI-side bug -- it has been logged; **retrying will fail the same way**.

from an exception whose own message is

```
inetsoft.web.wiz.service.RenderNotReadyException: Chart image not ready; retry after 1s
        at inetsoft.web.wiz.script.ScriptImageService.getAssemblyImage(ScriptImageService.java:138)
```

The advice was the exact inverse of the condition. Found while covering L4 of the Composer plugin test plan.

## Two problems, one symptom

**The exception was never mapped.** `RenderNotReadyException` is purpose-built: `ScriptImageService` raises it deliberately, after its own four attempts, and carries the seconds to wait. Its javadoc already states the contract —

```java
 * @throws RenderNotReadyException if the graph hasn't finished computing after
 *         {@value #RENDER_MAX_ATTEMPTS} retries — caller should map this to a retryable HTTP
 *         status, not treat it as a hard failure.
```

— but `WizControllerErrorHandler` maps `SecurityException`, `UnsupportedDatasourceException`, `IllegalArgumentException`, `InvalidUserException` and `UnsupportedOperationException`, and not this one. So it fell to the catch-all, was logged as "Unexpected error in wiz agent request" — it is not unexpected — and answered with the generic server-bug text. Now 503, with the retry seconds in both `Retry-After` and the message.

**An unbound assembly can never become ready.** With no source bound there is nothing to render, so the loop slept through all four attempts (4 × 500ms) and then advised a retry that cannot succeed. It is refused up front instead, naming how to bind a source, which also returns the two seconds.

Each change fixes a different state, and either alone leaves one of them misadvised:

| state | before | only the mapping | only the pre-check | both |
|---|---|---|---|---|
| nothing bound — never renders | "this is a bug, don't retry" — right action, wrong reason | "retry in 1s" — **wrong action, retries forever** | refused, with the reason | ✅ |
| bound, still computing — will render | "this is a bug, don't retry" — **wrong action** | honest retry answer | still the same lie | ✅ |

Note the middle column: mapping alone makes the unbound case *worse*. The current message avoids a retry loop only by accident — it gives the right action for the wrong reason.

## Why the test is the source, not the field list

The obvious predicate — "no fields bound" — was rejected. `getRTFields` has no relation-specific override, so a network chart's `source`/`target` and a candlestick's `open`/`high`/`low`/`close` may not be reachable through it; an empty field list is therefore not evidence of an unbound chart, and wrongly refusing a bound one would be worse than the defect. An absent source *is* evidence: every field on a chart comes from one source table, so no source means no shelf can hold anything, whatever the chart type.

## Known limitation, reported rather than guessed

A chart that **is** bound and still yields no graph — source, `source`/`target` shelves and a `node-color` aesthetic all set — was observed in the same run, and still gets the 503 and its retry advice, which may not help for that cause. Its cause is not isolated: the recovery changed two things at once (repointing the source, and adding a measure), so attributing it would be a guess. Left as it is, and recorded in the test plan as a known limitation.

## Verification

Verified after a rebuild and restart: an assembly with no source is refused immediately, with the binding instructions.

Still owed: that a genuinely not-ready render answers 503 with `Retry-After`. It is hard to provoke on demand and may only be reachable by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

