### PR TITLE
fix(binding): close six chart aesthetic frame defects found by live testing

### DIFF
--- a/core/src/main/java/inetsoft/report/composition/graph/GraphUtil.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/GraphUtil.java
@@ -1026,7 +1026,17 @@ public class GraphUtil {
                continue;
             }
 
-            temp = (StaticColorFrameWrapper) ((ChartAggregateRef) vref.get(i)).getColorFrameWrapper();
+            // Only a static per-measure colour has a default to fix. A measure carrying any other
+            // colour frame is drawn by that frame, so there is nothing here to give it and the
+            // cast this replaces was a ClassCastException that stopped the chart rendering
+            // entirely.
+            if(!(((ChartAggregateRef) vref.get(i)).getColorFrameWrapper()
+                    instanceof StaticColorFrameWrapper staticWrapper))
+            {
+               continue;
+            }
+
+            temp = staticWrapper;
             int idx = getColorIndex(usedColors, clrs, i);
             usedColors.add(clrs[idx]);
             temp.setDefaultColor(clrs[idx]);
@@ -1053,7 +1063,6 @@ public class GraphUtil {
             ChartAggregateRef aref = (ChartAggregateRef) arefs[i];
             boolean sameRef = Tool.equals(aref, movedRef);
             sameRef = sameRef && aref.equalsContent(movedRef);
-            frame = (StaticColorFrameWrapper) aref.getColorFrameWrapper();
 
             if(ref != null && aref.getFullName().equals(ref.getFullName())) {
                aggrIdx = i;
@@ -1068,6 +1077,16 @@ public class GraphUtil {
                continue;
             }
 
+            // Only a measure drawn by a static colour occupies one of the palette's colours. Any
+            // other frame draws its own, so it takes nothing out of the running -- and the cast
+            // this replaces was a ClassCastException that stopped the chart rendering entirely
+            // rather than merely picking a duplicate.
+            if(!(aref.getColorFrameWrapper() instanceof StaticColorFrameWrapper staticWrapper)) {
+               continue;
+            }
+
+            frame = staticWrapper;
+
             if(frame.getUserColor() != null) {
                usedColors.add(frame.getColor());
             }
@@ -1077,7 +1096,13 @@ public class GraphUtil {
          }
       }
 
-      frame = (StaticColorFrameWrapper) ref.getColorFrameWrapper();
+      // The measure being fixed is drawn by its own non-static frame, so it has no default colour
+      // to hand it and nothing to deduplicate.
+      if(!(ref.getColorFrameWrapper() instanceof StaticColorFrameWrapper target)) {
+         return;
+      }
+
+      frame = target;
 
       if(usedColors.isEmpty() && frame.getColor().equals(OLD_COLOR_PALETTE_DEFAULT_COLOR)) {
          return;

--- a/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
+++ b/core/src/main/java/inetsoft/uql/viewsheet/Viewsheet.java
@@ -3687,6 +3687,14 @@ public class Viewsheet extends AbstractSheet implements VSAssembly, VariableProv
     * @return a new map that contains the fixed mappings for the specified column
     */
    public Map<String, Color> getDimensionColors(String column) {
+      // A frame with no field has no column to key the fixed mappings by, so there is nothing to
+      // look up. Answered as "none" rather than left to NPE in getAttribute: every caller here
+      // reads the name off a VisualFrameModel, and one built outside the Composer's own factories
+      // may not carry it.
+      if(column == null) {
+         return new HashMap<>();
+      }
+
       // add delimiter at the end so that we don't match the wrong column
       final String columnNameKey = getAttribute(column, false) + COLUMN_DELIMITER;
 
@@ -3719,6 +3727,13 @@ public class Viewsheet extends AbstractSheet implements VSAssembly, VariableProv
     * @param dimensionColors the dimension value -> color map
     */
    public void setDimensionColors(String column, Map<String, Color> dimensionColors) {
+      // No column, nothing to key the mappings by -- see getDimensionColors. Storing them under a
+      // fabricated key would be worse than dropping them: nothing would ever read them back, and
+      // they would still shadow the real column's entries on the next removeIf.
+      if(column == null) {
+         return;
+      }
+
       final String columnNameKey = getAttribute(column, false) + COLUMN_DELIMITER;
 
       final Function<Map.Entry<String, Color>, String> mapKey =

--- a/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/BindingAgentController.java
@@ -246,8 +246,16 @@ public class BindingAgentController {
    /** @param table see {@link ShelfRequest#table()}. */
    public record AestheticFieldRequest(String assembly, String channel, FieldRef field,
                                        String table) {}
+   /**
+    * @param measure see
+    *        {@link ChartAestheticMutator#setFrame(inetsoft.web.binding.model.ChartBindingModel,
+    *        String, Map, boolean, java.util.Collection, String)}. Absent broadcasts the frame to
+    *        every measure, which is what a chart with one measure wants.
+    */
    public record AestheticFrameRequest(String assembly, String channel,
-                                       Map<String, Object> frame) {}
+                                       Map<String, Object> frame, String measure) {}
+   /** @param measure see {@link AestheticFrameRequest#measure()}. */
+   public record AestheticResetRequest(String assembly, String channel, String measure) {}
 
    @GetMapping("/api/wiz/v1/agent/binding/{sessionToken}/chart/aesthetics")
    public Map<String, Object> chartAesthetics(@PathVariable String sessionToken,
@@ -307,7 +315,19 @@ public class BindingAgentController {
    {
       requireEnabled();
       aestheticService.setFrame(sessionToken, user, request.assembly(), request.channel(),
-                                request.frame(), linkUri);
+                                request.frame(), request.measure(), linkUri);
+   }
+
+   @PostMapping("/api/wiz/v1/agent/binding/{sessionToken}/chart/frame/reset")
+   public void resetVisualFrame(@PathVariable String sessionToken,
+                                @RequestBody AestheticResetRequest request,
+                                @RequestParam(required = false, defaultValue = "") String linkUri,
+                                Principal user)
+      throws Exception
+   {
+      requireEnabled();
+      aestheticService.resetFrame(sessionToken, user, request.assembly(), request.channel(),
+                                  request.measure(), linkUri);
    }
 
    public record TableShelfRequest(String assembly, String shelf, List<FieldRef> fields) {}

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticAgentService.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticAgentService.java
@@ -35,10 +35,12 @@ import org.springframework.stereotype.Service;
 
 import java.security.Principal;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * Chart aesthetic mutations: channel field bindings and visual frames.
@@ -113,12 +115,30 @@ public class ChartAestheticAgentService {
    public void setFrame(String sessionToken, Principal user, String assemblyName, String channel,
                         Map<String, Object> frame, String linkUri) throws Exception
    {
+      setFrame(sessionToken, user, assemblyName, channel, frame, null, linkUri);
+   }
+
+   public void setFrame(String sessionToken, Principal user, String assemblyName, String channel,
+                        Map<String, Object> frame, String measure, String linkUri) throws Exception
+   {
       boolean relationChart = isRelationChart(sessionToken, user, assemblyName);
       String name = AestheticChannels.requireFrameChannel(channel, relationChart);
 
       apply(sessionToken, user, assemblyName, name, linkUri,
             (chart, model) -> ChartAestheticMutator.setFrame(
-               model, name, frame, relationChart, perMeasureFrameChannels(chart)));
+               model, name, frame, relationChart, perMeasureFrameChannels(chart), measure));
+   }
+
+   /** The aesthetic panes' "Reset to Default" button. */
+   public void resetFrame(String sessionToken, Principal user, String assemblyName, String channel,
+                          String measure, String linkUri) throws Exception
+   {
+      boolean relationChart = isRelationChart(sessionToken, user, assemblyName);
+      String name = AestheticChannels.requireFrameChannel(channel, relationChart);
+
+      apply(sessionToken, user, assemblyName, name, linkUri,
+            (chart, model) -> ChartAestheticMutator.resetFrame(
+               model, name, relationChart, perMeasureFrameChannels(chart), measure));
    }
 
    /** Reads the channels without opening a checkpoint. */
@@ -189,17 +209,45 @@ public class ChartAestheticAgentService {
     * {@code frameChannels} here: this endpoint has no assembly, so no chart to check the type
     * of, and listing them unconditionally would advertise a channel most charts cannot render.
     * {@code get_chart_aesthetics} reports them per-chart, once there is one to check.
+    *
+    * <p>{@code frameTypes} used to be a hard-coded {@code ["static", "categorical", "gradient",
+    * "palette"]}. That was wrong twice over: it named eleven fewer types than
+    * {@link VisualFrameAliases#create} builds, and it implied the answer does not depend on the
+    * channel when {@code gradient} exists only for colour and {@code linear} only for size and
+    * line. A caller following it would be refused for asking for something supported and
+    * accepted-then-refused for asking for something that is not — from the one endpoint whose
+    * job is to stop them guessing. It is derived from
+    * {@link VisualFrameAliases#typeNames(String)} now, so the two cannot drift again.
+    * {@code frameTypes} is kept as the union across channels for callers that read it.
     */
    public Map<String, Object> options() {
-      return Map.of(
-         "fieldChannels", AestheticChannels.FIELD_CHANNELS,
-         "frameChannels", AestheticChannels.SUPPORTED_FRAME_CHANNELS,
-         "frameTypes", List.of("static", "categorical", "gradient", "palette"),
-         "palettes", List.copyOf(VisualFrameAliases.PALETTES.keySet()),
-         "nodeChannels", AestheticChannels.NODE_CHANNELS,
-         "nodeChannelsNote", "node-color and node-size apply only to relation charts " +
-            "(network, tree, chord) — call get_chart_aesthetics on the chart to see whether " +
-            "they apply here.");
+      Map<String, Object> typesByChannel = new LinkedHashMap<>();
+      Set<String> union = new TreeSet<>();
+
+      for(String channel : AestheticChannels.SUPPORTED_FRAME_CHANNELS) {
+         List<String> types = VisualFrameAliases.typeNames(channel);
+         typesByChannel.put(channel, types);
+         union.addAll(types);
+      }
+
+      for(String channel : AestheticChannels.NODE_CHANNELS) {
+         typesByChannel.put(channel, VisualFrameAliases.typeNames(channel));
+      }
+
+      Map<String, Object> out = new LinkedHashMap<>();
+      out.put("fieldChannels", AestheticChannels.FIELD_CHANNELS);
+      out.put("frameChannels", AestheticChannels.SUPPORTED_FRAME_CHANNELS);
+      out.put("frameTypes", List.copyOf(union));
+      out.put("frameTypesByChannel", typesByChannel);
+      out.put("frameTypesNote",
+              "frameTypes is the union across channels; frameTypesByChannel is what each " +
+              "channel actually accepts, and is what set_visual_frame validates against.");
+      out.put("palettes", List.copyOf(VisualFrameAliases.PALETTES.keySet()));
+      out.put("nodeChannels", AestheticChannels.NODE_CHANNELS);
+      out.put("nodeChannelsNote",
+              "node-color and node-size apply only to relation charts (network, tree, chord) " +
+              "— call get_chart_aesthetics on the chart to see whether they apply here.");
+      return out;
    }
 
    private boolean isRelationChart(String sessionToken, Principal user, String assemblyName)

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticMutator.java
@@ -17,11 +17,14 @@
  */
 package inetsoft.web.wiz.binding;
 
+import inetsoft.graph.aesthetic.CategoricalColorFrame;
+import inetsoft.report.StyleConstants;
 import inetsoft.report.composition.RuntimeViewsheet;
 import inetsoft.uql.asset.SourceInfo;
 import inetsoft.uql.viewsheet.graph.GraphTypes;
 import inetsoft.web.binding.model.BindingRefModel;
 import inetsoft.web.binding.model.ChartBindingModel;
+import inetsoft.web.binding.model.ColorMapModel;
 import inetsoft.web.binding.model.graph.AestheticInfo;
 import inetsoft.web.binding.model.graph.ChartAggregateRefModel;
 import inetsoft.web.binding.model.graph.ChartRefModel;
@@ -29,12 +32,14 @@ import inetsoft.web.binding.model.graph.aesthetic.*;
 import inetsoft.web.binding.service.DataRefModelFactoryService;
 import inetsoft.web.wiz.binding.model.FieldRef;
 
+import java.awt.Color;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Read-modify-write over the thirteen aesthetic fields in {@link ChartBindingFields#AESTHETIC}.
@@ -175,9 +180,29 @@ public final class ChartAestheticMutator {
                                Map<String, Object> spec, boolean relationChart,
                                Collection<String> perMeasureFrameChannels)
    {
+      setFrame(model, channel, spec, relationChart, perMeasureFrameChannels, null);
+   }
+
+   /**
+    * @param measure one of the chart's own measures, to give it its own frame instead of giving
+    *        every measure the same one — the Composer's {@code CombinedColor}/{@code CombinedSize}
+    *        pane, which draws one editor per measure and labels it with the measure's name. It
+    *        applies only where the channel renders per measure and has no field bound, which is
+    *        exactly when that pane opens ({@code getEditPaneId} returns Combined when
+    *        {@code frames.length > 1}); anywhere else there is one frame for the channel and
+    *        naming a measure is refused rather than quietly widened to all of them. Null broadcasts
+    *        as before, which is right for the common single-measure chart and keeps "make the bars
+    *        blue" a one-call operation.
+    */
+   public static void setFrame(ChartBindingModel model, String channel,
+                               Map<String, Object> spec, boolean relationChart,
+                               Collection<String> perMeasureFrameChannels, String measure)
+   {
       String name = AestheticChannels.requireFrameChannel(channel, relationChart);
-      VisualFrameModel frame = VisualFrameAliases.create(name, spec, relationChart);
-      AestheticInfo field = acceptsField(name) ? read(model, name) : null;
+      AestheticInfo field = frameField(model, name);
+      VisualFrameModel frame = carryCategoricalColors(
+         VisualFrameAliases.create(name, spec, relationChart),
+         frameOf(model, name, perMeasureFrameChannels), name, fieldNameOf(field), spec);
 
       // A bound field carries its own frame (AestheticInfo.frame) -- that, not the top-level
       // ChartBindingModel.xxxFrame property, is what the interactive Composer's own dialog writes
@@ -186,6 +211,16 @@ public final class ChartAestheticMutator {
       // Writing only the top-level property round-trips cleanly through get_chart_aesthetics/
       // set_visual_frame -- both read and write the same wrong place -- but never reaches the chart.
       if(field != null) {
+         if(measure != null) {
+            throw new IllegalArgumentException(
+               "'" + fieldNameOf(field) + "' is bound to the " + name + " channel, so the channel " +
+               "has a single frame that varies over that field's values — there is no per-measure " +
+               "frame for 'measure' to name. The Composer opens its Combined pane only while the " +
+               "channel is empty. Clear the field with clear_aesthetic_field to give each measure " +
+               "its own " + name + ", or drop 'measure' to set the frame the field drives.");
+         }
+
+         requireFrameTheFieldCanDrive(name, frame, field);
          field.setFrame(frame);
          return;
       }
@@ -212,17 +247,38 @@ public final class ChartAestheticMutator {
          perMeasureFrameChannels.contains(name) ? aggregates(model) : List.of();
 
       if(!aggregates.isEmpty()) {
-         switch(name) {
-            case "color" -> aggregates.forEach(agg -> agg.setColorFrame((ColorFrameModel) frame));
-            case "shape" -> aggregates.forEach(agg -> agg.setShapeFrame((ShapeFrameModel) frame));
-            case "size" -> aggregates.forEach(agg -> agg.setSizeFrame((SizeFrameModel) frame));
-            case "line" -> aggregates.forEach(agg -> agg.setLineFrame((LineFrameModel) frame));
-            case "texture" ->
-               aggregates.forEach(agg -> agg.setTextureFrame((TextureFrameModel) frame));
-            default -> throw new IllegalArgumentException("Unhandled frame channel '" + name + "'.");
+         requireStaticColorOnMeasures(name, frame);
+
+         if(measure != null) {
+            assignAggregateFrame(requireTargetMeasure(aggregates, name, measure), name, frame);
+            return;
+         }
+
+         // A fresh instance per measure, not one object handed to all of them. They are separate
+         // frames in the Composer's own model -- that is what the Combined pane edits -- and
+         // sharing one meant a later per-measure write, or a reset, which edits the frame in
+         // place, reached every measure at once. Rebuilt from the spec rather than copied because
+         // create() is a pure function of it; carryCategoricalColors is not reapplied because it
+         // only touches a CategoricalColorModel, which requireStaticColorOnMeasures has already
+         // ruled out here.
+         for(ChartAggregateRefModel aggregate : aggregates) {
+            assignAggregateFrame(aggregate, name,
+                                 VisualFrameAliases.create(name, spec, relationChart));
          }
 
          return;
+      }
+
+      // 'measure' can only mean one of the per-measure slots, and this call is not writing one.
+      if(measure != null) {
+         throw new IllegalArgumentException(
+            "'measure' gives one of the chart's measures its own " + name + " — the Composer's " +
+            "Combined pane — and applies only where the channel renders per measure. " +
+            (perMeasureFrameChannels.contains(name)
+                ? "This chart has no measure for " + name + " to render from."
+                : "This chart type renders " + name + " from one chart-level frame rather than " +
+                  "from each measure, so every measure already shares it.") +
+            " Drop 'measure' to set the frame the channel does render from.");
       }
 
       // A node channel, which has no per-aggregate slot; a chart type whose renderer reads the
@@ -245,6 +301,603 @@ public final class ChartAestheticMutator {
          case "node-size" -> model.setNodeSizeFrame((SizeFrameModel) frame);
          default -> throw new IllegalArgumentException("Unhandled frame channel '" + name + "'.");
       }
+   }
+
+   /**
+    * Puts a channel's frame back to the values it would have had untouched — the "Reset to
+    * Default" button on the aesthetic panes.
+    *
+    * <p>Four panes carry that button and no two do the same thing:
+    *
+    * <ul>
+    *   <li>{@code categorical-color-pane} restores each colour to {@code cssColors[i]} or, failing
+    *       that, {@code defaultColors[i]} — the CSS theme's palette or the built-in one.</li>
+    *   <li>{@code combined-color-pane} restores each measure's colour to the default palette entry
+    *       for its position and clears {@code changed}. That position is what gives two measures
+    *       two colours again rather than both the first one.</li>
+    *   <li>{@code categorical-shape-pane} serves three families from one button, switching on the
+    *       chart's own: shapes back to {@code SHAPE_STYLES + IMAGE_SHAPES}, lines back to
+    *       {@code M_LINE_STYLES} twice over, textures back to {@code TEXTURE_STYLES} minus its
+    *       first entry (PATTERN_NONE, which is "no texture" and would reset a category to
+    *       invisible).</li>
+    *   <li>{@code linear-color-pane}'s {@code resetEditors()} re-syncs its radio buttons and
+    *       dropdowns against the current frame and changes no stored value at all.</li>
+    * </ul>
+    *
+    * <p>So the first three are implemented, each mirroring its pane exactly. Every other frame is
+    * refused by name rather than given an invented meaning: a reset that quietly did something
+    * other than the button would be worse than no reset. That leaves the graduated frames and the
+    * static shape/size/line/texture ones out, which is also where the Composer offers no reset.
+    *
+    * <p>The per-value pins are left alone, as the categorical pane's own reset leaves them — the
+    * button sits beside the palette editors, not beside "Assign Fixed Mapping".
+    */
+   public static void resetFrame(ChartBindingModel model, String channel, boolean relationChart,
+                                 Collection<String> perMeasureFrameChannels, String measure)
+   {
+      String name = AestheticChannels.requireFrameChannel(channel, relationChart);
+      AestheticInfo field = frameField(model, name);
+
+      if(field != null) {
+         if(measure != null) {
+            throw new IllegalArgumentException(
+               "'" + fieldNameOf(field) + "' is bound to the " + name + " channel, so it has one " +
+               "frame rather than one per measure. Drop 'measure'.");
+         }
+
+         field.setFrame(resetted(field.getFrame(), name, 0));
+         return;
+      }
+
+      List<ChartAggregateRefModel> aggregates =
+         perMeasureFrameChannels.contains(name) ? aggregates(model) : List.of();
+
+      if(!aggregates.isEmpty()) {
+         ChartAggregateRefModel only =
+            measure == null ? null : requireTargetMeasure(aggregates, name, measure);
+
+         // Walked by index rather than by List.indexOf: the position drives
+         // combined-color-pane's default, each measure taking the palette entry for its own place,
+         // and two measures alike enough to compare equal would both have looked up as position
+         // zero -- resetting to one colour, which is the outcome the position exists to prevent.
+         for(int i = 0; i < aggregates.size(); i++) {
+            ChartAggregateRefModel aggregate = aggregates.get(i);
+
+            if(only == null || aggregate == only) {
+               assignAggregateFrame(
+                  aggregate, name, resetted(aggregateFrameOf(aggregate, name), name, i));
+            }
+         }
+
+         return;
+      }
+
+      if(measure != null) {
+         throw new IllegalArgumentException(
+            "'measure' applies only where the " + name + " channel renders per measure, and this " +
+            "chart does not. Drop it to reset the frame the channel does render from.");
+      }
+
+      switch(name) {
+         case "color" -> model.setColorFrame((ColorFrameModel) resetted(model.getColorFrame(), name, 0));
+         case "shape" -> model.setShapeFrame((ShapeFrameModel) resetted(model.getShapeFrame(), name, 0));
+         case "size" -> model.setSizeFrame((SizeFrameModel) resetted(model.getSizeFrame(), name, 0));
+         case "line" -> model.setLineFrame((LineFrameModel) resetted(model.getLineFrame(), name, 0));
+         case "texture" ->
+            model.setTextureFrame((TextureFrameModel) resetted(model.getTextureFrame(), name, 0));
+         case "node-color" ->
+            model.setNodeColorFrame((ColorFrameModel) resetted(model.getNodeColorFrame(), name, 0));
+         case "node-size" ->
+            model.setNodeSizeFrame((SizeFrameModel) resetted(model.getNodeSizeFrame(), name, 0));
+         default -> throw new IllegalArgumentException("Unhandled frame channel '" + name + "'.");
+      }
+   }
+
+   /** The same frame with its values back at their defaults. See {@link #resetFrame}. */
+   private static VisualFrameModel resetted(VisualFrameModel frame, String channel, int position) {
+      if(frame instanceof CategoricalColorModel categorical) {
+         String[] colors = categorical.getColors();
+         String[] css = categorical.getCssColors();
+         String[] defaults = categorical.getDefaultColors();
+
+         if(colors == null) {
+            return frame;
+         }
+
+         for(int i = 0; i < colors.length; i++) {
+            String reset = css != null && i < css.length && css[i] != null && !css[i].isBlank()
+               ? css[i] : (defaults != null && i < defaults.length ? defaults[i] : colors[i]);
+
+            if(reset != null) {
+               colors[i] = reset;
+            }
+         }
+
+         categorical.setColors(colors);
+         return frame;
+      }
+
+      if(frame instanceof StaticColorModel staticColor) {
+         // combined-color-pane's own order: the palette entry for this measure's position, except
+         // for a waterfall's summary frame, which has a default of its own and is the one case
+         // that reads defaultColor. Taking defaultColor first instead reset every measure to the
+         // same colour, which is exactly what the position is there to prevent.
+         String summaryDefault = staticColor.getDefaultColor();
+         staticColor.setColor(
+            staticColor.isSummary() && summaryDefault != null && !summaryDefault.isBlank()
+               ? summaryDefault : defaultPaletteColor(position));
+         staticColor.setChanged(false);
+         return frame;
+      }
+
+      if(frame instanceof CategoricalShapeModel shapes) {
+         shapes.setShapes(DEFAULT_SHAPES.toArray(new String[0]));
+         return frame;
+      }
+
+      if(frame instanceof CategoricalLineModel lines) {
+         lines.setLines(DEFAULT_LINES);
+         return frame;
+      }
+
+      if(frame instanceof CategoricalTextureModel textures) {
+         textures.setTextures(DEFAULT_TEXTURES);
+         return frame;
+      }
+
+      throw new IllegalArgumentException(
+         "The " + channel + " channel is holding a '" + VisualFrameAliases.typeName(frame) +
+         "' frame, which has no default to go back to — only a categorical palette, a categorical " +
+         "shape/line/texture set and the per-measure static colours do, which are the panes the " +
+         "Composer puts a \"Reset to Default\" button on. Set the value you want with " +
+         "set_visual_frame instead.");
+   }
+
+   /**
+    * {@code ChartConfig.SHAPE_STYLES.concat(ChartConfig.IMAGE_SHAPES)} — the sixteen point shapes
+    * followed by the sixteen bundled images, in the order the pane's own reset uses. NIL is left
+    * out, as it is there: resetting a category to "no shape" would hide it.
+    */
+   private static final List<String> DEFAULT_SHAPES = List.of(
+      String.valueOf(StyleConstants.CIRCLE), String.valueOf(StyleConstants.TRIANGLE),
+      String.valueOf(StyleConstants.SQUARE), String.valueOf(StyleConstants.CROSS),
+      String.valueOf(StyleConstants.STAR), String.valueOf(StyleConstants.DIAMOND),
+      String.valueOf(StyleConstants.X), String.valueOf(StyleConstants.FILLED_CIRCLE),
+      String.valueOf(StyleConstants.FILLED_TRIANGLE), String.valueOf(StyleConstants.FILLED_SQUARE),
+      String.valueOf(StyleConstants.FILLED_DIAMOND), String.valueOf(StyleConstants.V_ANGLE),
+      String.valueOf(StyleConstants.RIGHT_ANGLE), String.valueOf(StyleConstants.LT_ANGLE),
+      String.valueOf(StyleConstants.V_LINE), String.valueOf(StyleConstants.H_LINE),
+      "100ArrowDown.svg", "101ArrowUp.svg", "102Check.svg", "103Cancel.svg",
+      "104Exclamation.svg", "105Flag.svg", "106Light.svg", "107Star.svg",
+      "108No.svg", "109Man.svg", "110Woman.svg", "111FaceHappy.svg",
+      "112FaceSad.svg", "113Face.svg", "114ArrowUperRight.svg", "115ArrowLowerRight.svg");
+
+   /**
+    * {@code ChartConfig.M_LINE_STYLES.concat(ChartConfig.M_LINE_STYLES)} — the five line styles
+    * the picker offers, listed twice, which is how the pane's reset covers ten categories with
+    * five styles.
+    */
+   private static final int[] DEFAULT_LINES = {
+      StyleConstants.THIN_LINE, StyleConstants.DOT_LINE, StyleConstants.DASH_LINE,
+      StyleConstants.MEDIUM_DASH, StyleConstants.LARGE_DASH,
+      StyleConstants.THIN_LINE, StyleConstants.DOT_LINE, StyleConstants.DASH_LINE,
+      StyleConstants.MEDIUM_DASH, StyleConstants.LARGE_DASH
+   };
+
+   /** {@code ChartConfig.TEXTURE_STYLES.slice(1)} — PATTERN_0 through PATTERN_19. */
+   private static final int[] DEFAULT_TEXTURES = {
+      0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19
+   };
+
+   /**
+    * The default palette entry for a measure's position, matching {@code combined-color-pane}'s
+    * {@code DefaultPalette.chart.flat()[i % length]}. {@code CategoricalColorFrame.COLOR_PALETTE}
+    * is the same list the Composer's palette is generated from, and is what
+    * {@code GraphUtil.fixDuplicateColor} hands a fresh measure.
+    */
+   private static String defaultPaletteColor(int position) {
+      Color[] palette = CategoricalColorFrame.COLOR_PALETTE;
+      Color color = palette[Math.max(position, 0) % palette.length];
+      return "#" + String.format("%06X", color.getRGB() & 0xFFFFFF);
+   }
+
+   /**
+    * The one measure a {@code measure}-scoped write targets, or a refusal naming the ones that
+    * exist.
+    *
+    * <p>Matched against every name the model carries for a measure, not just {@code getFullName()}.
+    * The aggregated name — {@code Sum(Sales)} — is what {@code get_binding} reports and what
+    * {@code set_chart_type}'s own per-measure parameter takes, so it has to work; but the same
+    * measure also answers to its bare column, and which of the two is populated depends on how the
+    * model was built ({@code FieldRefFactory} sets only the column name; the read path fills the
+    * rest in from the live {@code ChartRef}). Accepting either is the forgiving half of the rule
+    * that matters here — the caller has named one measure unambiguously, and refusing over which
+    * spelling they reached for would be a refusal with no purpose. The names actually available
+    * are listed back on a miss, so the next attempt does not have to guess.
+    */
+   private static ChartAggregateRefModel requireTargetMeasure(
+      List<ChartAggregateRefModel> aggregates, String channel, String measure)
+   {
+      List<String> known = new ArrayList<>();
+
+      for(ChartAggregateRefModel aggregate : aggregates) {
+         List<String> names = measureNames(aggregate);
+         known.addAll(names);
+
+         if(names.contains(measure)) {
+            return aggregate;
+         }
+      }
+
+      throw new IllegalArgumentException(
+         "No measure '" + measure + "' renders the " + channel + " channel on this chart. The " +
+         "ones that do answer to: " + String.join(", ", known) + ". get_binding reports them " +
+         "under the first of those spellings.");
+   }
+
+   /** Every name one measure answers to. See {@link #requireTargetMeasure}. */
+   private static List<String> measureNames(ChartAggregateRefModel aggregate) {
+      List<String> names = new ArrayList<>();
+
+      for(String name : Arrays.asList(aggregate.getFullName(), aggregate.getOriFullName(),
+                                      aggregate.getView(), aggregate.getName()))
+      {
+         if(name != null && !name.isBlank() && !names.contains(name)) {
+            names.add(name);
+         }
+      }
+
+      return names;
+   }
+
+   /** The name to report a measure under — the aggregated one where the model has it. */
+   private static String measureLabel(ChartAggregateRefModel aggregate) {
+      List<String> names = measureNames(aggregate);
+      return names.isEmpty() ? String.valueOf(aggregate.getFullName()) : names.get(0);
+   }
+
+   private static void assignAggregateFrame(ChartAggregateRefModel aggregate, String channel,
+                                            VisualFrameModel frame)
+   {
+      switch(channel) {
+         case "color" -> aggregate.setColorFrame((ColorFrameModel) frame);
+         case "shape" -> aggregate.setShapeFrame((ShapeFrameModel) frame);
+         case "size" -> aggregate.setSizeFrame((SizeFrameModel) frame);
+         case "line" -> aggregate.setLineFrame((LineFrameModel) frame);
+         case "texture" -> aggregate.setTextureFrame((TextureFrameModel) frame);
+         default -> throw new IllegalArgumentException("Unhandled frame channel '" + channel + "'.");
+      }
+   }
+
+   /**
+    * Fills in a mapping-only categorical colour frame's {@code colors} from whatever the channel
+    * already renders, so the request reaching the factory has the same shape the Composer's own
+    * dialog sends.
+    *
+    * <p>{@code CategoricalColorFrameModelFactory.updateVisualFrameWrapper0} returns early — before
+    * {@code assignMappedColors}, {@code setUseGlobal}, {@code setShareColors} and
+    * {@code setColorValueFrame} — when the model carries no colours. A frame built from
+    * {@code {type: "categorical", mapping: {...}}} alone therefore reached the factory, was
+    * accepted, and was discarded whole: the write reported success, {@code get_chart_aesthetics}
+    * read back {@code mapping: {}} with {@code useGlobal} flipped back to true, and the chart kept
+    * its old colours.
+    *
+    * <p>That precondition is not something to relax in the factory. The interactive path always
+    * satisfies it — {@code categorical-color-pane} renders one editor per entry of
+    * {@code frameModel.colors}, so Apply sends the whole palette alongside the colour maps — and
+    * the factory is shared with it. What was missing is that the agent path did not satisfy it.
+    * So it does now, and carrying the channel's current palette rather than inventing one means
+    * "pin these values" changes only those values, exactly as the dialog does: the factory pins
+    * every supplied colour with {@code setUserColor}, which is what Apply already does today.
+    *
+    * <p>With nothing to carry — a colour channel holding a static or linear frame, i.e. one with
+    * no categories to map — the request is refused rather than silently dropped. The Composer
+    * hides "Assign Fixed Mapping" in exactly that case ({@code isDimension()}), so this is the
+    * same answer, given out loud.
+    */
+   private static VisualFrameModel carryCategoricalColors(VisualFrameModel frame,
+                                                          VisualFrameModel existing,
+                                                          String channel, String fieldName,
+                                                          Map<String, Object> spec)
+   {
+      if(!(frame instanceof CategoricalColorModel built)) {
+         return frame;
+      }
+
+      carryShareColorState(built, existing, fieldName, spec);
+
+      if(built.getColors() != null && built.getColors().length > 0) {
+         return frame;
+      }
+
+      if(existing instanceof CategoricalColorModel current && current.getColors() != null &&
+         current.getColors().length > 0)
+      {
+         built.setColors(current.getColors());
+         return frame;
+      }
+
+      throw new IllegalArgumentException(
+         "The " + channel + " channel has no categorical palette to pin values against — it is " +
+         "not currently rendering by category, so there are no categories a 'mapping' could name. " +
+         "Bind a dimension to it with set_aesthetic_field first, or pass an explicit 'colors' " +
+         "list alongside the mapping.");
+   }
+
+   /**
+    * Gives an agent-built categorical colour frame the two properties the interactive path fills
+    * in for free, both of which {@code VSChartBindingFactory.applyColorsToViewsheet} reads the
+    * moment "Share Colors" is on.
+    *
+    * <p><b>{@code field}.</b> {@code VisualFrameModel}'s wrapper constructor seeds it from
+    * {@code wrapper.getVisualFrame().getField()}, so every frame model the Composer sends carries
+    * one. A frame built here is a bare {@code new CategoricalColorModel()} and carries none, and
+    * {@code applyColorsToViewsheet} passes it straight to {@code Viewsheet.setDimensionColors},
+    * whose {@code getAttribute} does {@code column.indexOf(":")} — a hard NPE, a 500, and no edit
+    * applied. That is a crash the agent path reached on every single {@code shareColors: true}
+    * call against a bound colour channel, so the carry-forward is what makes the option usable at
+    * all rather than a nicety.
+    *
+    * <p><b>{@code globalColorMaps}.</b> These are the viewsheet-level value-to-colour pins behind
+    * the categorical pane's "Assign Fixed Mapping" button, stored on the {@code Viewsheet} rather
+    * than on the frame and shared by every chart colouring by that column. {@code
+    * applyColorsToViewsheet} rewrites the whole column's entry from this array, and {@code
+    * Viewsheet.setDimensionColors} removes the column's existing keys before putting the new ones
+    * — so shipping an empty array does not leave the pins alone, it deletes them. Every frame
+    * write on a shared channel therefore has to restate them, whether or not it is about pins at
+    * all, which is what carrying them forward here is for. A {@code mapping} in the spec is merged
+    * on top rather than replacing them; see {@link #mergePins}.
+    *
+    * <p>The read side supplies them: {@code VSChartBindingFactory.applyColorsToFrame} populates
+    * {@code globalColorMaps} from {@code viewsheet.getDimensionColors(...)} when {@code createModel}
+    * builds the model, provided sharing is already on. When it is off that array is empty, and
+    * turning sharing on is precisely the transition {@code categorical-color-pane.shareColorsChange}
+    * handles by seeding {@code globalColorMaps} from {@code colorMaps} — the frame's own pins
+    * become the viewsheet's. Mirrored here for the same reason: the option is meant to change where
+    * the pins live, not whether they exist.
+    */
+   private static void carryShareColorState(CategoricalColorModel built, VisualFrameModel existing,
+                                            String fieldName, Map<String, Object> spec)
+   {
+      String field = existing == null ? null : existing.getField();
+      built.setField(field != null ? field : fieldName);
+
+      CategoricalColorModel current =
+         existing instanceof CategoricalColorModel model ? model : null;
+
+      // A spec that does not mention shareColors is not asking about the checkbox, so it leaves it
+      // where it is -- the way the Composer's Apply does, which posts back whatever
+      // CategoricalColorModel(wrapper) read off the frame. Forcing it off here instead meant every
+      // colour change silently switched sharing off for a chart that had it on, and the caller had
+      // no way to tell from the request that it would.
+      //
+      // Both flags are carried, not just the one the vocabulary names. They agree on every frame
+      // the Composer or this tool has written; a legacy frame where they do not is one neither can
+      // repair, so a write that was not asked about them must not normalise them either.
+      if(VisualFrameAliases.shareColors(spec) == null && current != null) {
+         built.setShareColors(current.isShareColors());
+         built.setUseGlobal(current.isUseGlobal());
+      }
+
+      if(!built.isUseGlobal()) {
+         return;
+      }
+
+      // Sharing is on, so the pins the factory reads are the viewsheet-level ones. Anything the
+      // caller supplied is in whichever array VisualFrameAliases could reach: it routes on the
+      // spec's own shareColors, which is absent in exactly the carried-forward case above.
+      ColorMapModel[] supplied = notEmpty(built.getGlobalColorMaps())
+         ? built.getGlobalColorMaps() : built.getColorMaps();
+      ColorMapModel[] carried = current == null ? null
+         : (notEmpty(current.getGlobalColorMaps())
+            ? current.getGlobalColorMaps() : current.getColorMaps());
+
+      built.setGlobalColorMaps(mergePins(carried, supplied));
+      // The array the factory is not reading must not keep a stale copy: describe() reports from
+      // whichever one the flag selects, and two disagreeing copies is how a read starts lying.
+      built.setColorMaps(new ColorMapModel[0]);
+   }
+
+   /**
+    * The channel's existing pins underneath, the caller's on top, keyed by the value they pin.
+    *
+    * <p>Merged rather than replaced because the two destinations otherwise behave differently for
+    * the same request. Unshared pins reach the chart through
+    * {@code ColorFrameModelFactory.assignMappedColors}, which calls {@code setColor(value, colour)}
+    * on the frame the channel already has — so naming one value leaves every other pin alone, which
+    * is what the tool documents. Shared pins instead reach it through
+    * {@code Viewsheet.setDimensionColors}, which drops the column's existing keys before putting
+    * the new ones — so the same request would unpin everything it did not name. This makes both
+    * mean "change the values I name".
+    *
+    * <p>The Composer has no equivalent problem to solve: its dialog opens pre-filled with the
+    * column's current pins, so the array it posts is already the merge.
+    */
+   private static ColorMapModel[] mergePins(ColorMapModel[] existing, ColorMapModel[] supplied) {
+      Map<String, ColorMapModel> merged = new LinkedHashMap<>();
+
+      for(ColorMapModel[] pins : Arrays.asList(existing, supplied)) {
+         for(ColorMapModel pin : pins == null ? new ColorMapModel[0] : pins) {
+            if(pin != null && pin.getOption() != null) {
+               merged.put(pin.getOption(), pin);
+            }
+         }
+      }
+
+      return merged.values().toArray(new ColorMapModel[0]);
+   }
+
+   private static boolean notEmpty(ColorMapModel[] maps) {
+      return maps != null && maps.length > 0;
+   }
+
+   /**
+    * Refuses a non-static colour frame about to be broadcast to the measures — i.e. a colour frame
+    * on a channel with no field bound, on a chart that renders colour per measure.
+    *
+    * <p>In exactly that configuration {@code VSFrameVisitor.createFrame} takes its
+    * {@code supportsFieldFrame()} branch and calls {@code GraphUtil.fixDuplicateColor}, which casts
+    * every aggregate's colour frame wrapper straight to {@code StaticColorFrameWrapper} with no
+    * {@code instanceof} in front of it. Anything else there is a {@code ClassCastException} at
+    * paint time — not a wrong colour, the whole chart stops rendering, and it stays that way
+    * because the bad frame is now stored on the measures. {@code set_visual_frame} still answered
+    * ok, and so did the {@code clear_aesthetic_field} and {@code set_aesthetic_field} calls that
+    * came after it; only the image was gone.
+    *
+    * <p>The cast is safe for the Composer because the Composer cannot produce the state:
+    * {@code color-field-mc.getEditPaneId()} opens {@code CategoricalColor}/{@code LinearColor}
+    * only when a field is bound, and falls back to {@code CombinedColor}/{@code StaticColor} —
+    * both static — when one is not. This is that same rule, enforced on the path that could
+    * otherwise reach the cast.
+    *
+    * <p>Checked here, at the aggregate broadcast, rather than for every field-less colour frame,
+    * because this is the write whose result the cast reads. The other two destinations cannot
+    * reach it: a {@code MergedChartInfo} chart (candle, stock, radar, relation, map) answers false
+    * for colour, so {@code createFrame} reads {@code getGeneralFrame()} and never enters that
+    * branch — a chart-level gradient there is legitimate — and a chart with no measure renders no
+    * colour frame at all. Node channels never reach the broadcast either; relation node colour
+    * renders through {@code GraphGenerator}'s own node path.
+    */
+   /**
+    * Refuses a frame whose kind the channel's bound field cannot drive.
+    *
+    * <p>{@code color-field-mc}/{@code shape-field-mc}{@code .getEditPaneId()} pick the editor from
+    * the bound field, not from the caller: a dimension (or a discrete aggregate, which groups like
+    * one) opens the <em>Categorical</em> pane and nothing else; a measure opens the
+    * <em>Linear</em> one — the graduated ramps, shape sets and texture sets. Static is offered
+    * only when nothing is bound. So a frame outside that set is a state the Composer cannot
+    * produce, and the backend, having never had to cope with it, does not.
+    *
+    * <p>Live repro: on a line chart with a dimension on shape,
+    * {@code set_visual_frame channel="line" {type: "static", line: "large dash"}} answered ok and
+    * the image did not change — and the categorical {@code lines} array came back with the static
+    * value sitting in one of its slots, so the request was neither honoured nor cleanly dropped.
+    * The control on another channel behaves the same: {@code {type: "static", color: "#FF0000"}}
+    * on a colour channel with a dimension bound rendered the ordinary categorical palette, with no
+    * red anywhere.
+    *
+    * <p>The measure branch is stated as "not static and not categorical" rather than as a list,
+    * because the graduated set is different for every family — gradient/palette/heat and the rest
+    * on colour, fill/oval/polygon on shape, {@code linear} on size and line, the prebuilt hatchings
+    * on texture — and {@link VisualFrameAliases#typeNames} already knows each of them. Naming the
+    * survivors in the message keeps the caller from having to guess which family they are in.
+    *
+    * <p>Node channels are left alone: their editors are the relation chart's own, this rule has
+    * not been checked against them, and refusing on a guess would break a path that may well work.
+    */
+   private static void requireFrameTheFieldCanDrive(String channel, VisualFrameModel frame,
+                                                    AestheticInfo field)
+   {
+      ChartRefModel dataInfo = field.getDataInfo();
+
+      if(AestheticChannels.NODE_CHANNELS.contains(channel) || dataInfo == null) {
+         return;
+      }
+
+      String type = VisualFrameAliases.typeName(frame);
+      String bound = fieldNameOf(field);
+
+      if(rendersByCategory(dataInfo)) {
+         if("categorical".equals(type)) {
+            return;
+         }
+
+         throw new IllegalArgumentException(
+            "'" + bound + "' is bound to the " + channel + " channel and groups into categories, " +
+            "so only {type: \"categorical\", ...} can drive it — a '" + type + "' frame is stored " +
+            "and never rendered, which reports success while the chart does not change. Give a " +
+            "categorical frame, or clear the field with clear_aesthetic_field if the intent was " +
+            "one fixed value for the whole chart. The Composer opens the categorical pane and no " +
+            "other while a dimension is bound here.");
+      }
+
+      if(!"static".equals(type) && !"categorical".equals(type)) {
+         return;
+      }
+
+      List<String> graduated = VisualFrameAliases.typeNames(channel).stream()
+         .filter(name -> !"static".equals(name) && !"categorical".equals(name))
+         .toList();
+
+      throw new IllegalArgumentException(
+         "'" + bound + "' is a measure bound to the " + channel + " channel, so the channel " +
+         "renders a graduated scale over its values and a '" + type + "' frame cannot drive it — " +
+         "it is stored and never rendered, which reports success while the chart does not change. " +
+         "Use one of " + graduated + ", or clear the field with clear_aesthetic_field if the " +
+         "intent was one fixed value for the whole chart.");
+   }
+
+   /**
+    * Whether a bound field makes its channel render one value per category rather than a graduated
+    * scale — {@code getEditPaneId}'s own test: anything that is not a measure, plus a discrete
+    * aggregate, which is an aggregate asked to group like a dimension.
+    */
+   private static boolean rendersByCategory(ChartRefModel dataInfo) {
+      if(!dataInfo.isMeasure()) {
+         return true;
+      }
+
+      return dataInfo instanceof ChartAggregateRefModel aggregate && aggregate.isDiscrete();
+   }
+
+   /**
+    * One entry per measure when the measures do not all render this channel the same way, or
+    * {@code null} when they do.
+    *
+    * <p>{@link #frameOf} reports the first measure's frame, which is the whole truth right up until
+    * the measures disagree — and they can now, because {@code setFrame}'s {@code measure} parameter
+    * gives one measure its own frame the way the Composer's Combined pane does. Reporting only the
+    * first would then describe a chart that is visibly drawing something else beside it, which is
+    * the failure this class spends its length avoiding. Emitted only on disagreement so the common
+    * chart's read stays as short as it was.
+    */
+   private static Map<String, Object> divergentMeasureFrames(
+      ChartBindingModel model, String channel, AestheticInfo field,
+      Collection<String> perMeasureFrameChannels)
+   {
+      if(field != null || !perMeasureFrameChannels.contains(channel)) {
+         return null;
+      }
+
+      List<ChartAggregateRefModel> aggregates = aggregates(model);
+
+      if(aggregates.size() < 2) {
+         return null;
+      }
+
+      Map<String, Object> byMeasure = new LinkedHashMap<>();
+      boolean diverges = false;
+      Object first = null;
+
+      for(int i = 0; i < aggregates.size(); i++) {
+         Object described =
+            VisualFrameAliases.describe(aggregateFrameOf(aggregates.get(i), channel));
+         byMeasure.put(measureLabel(aggregates.get(i)), described);
+
+         if(i == 0) {
+            first = described;
+         }
+         else if(!Objects.equals(first, described)) {
+            diverges = true;
+         }
+      }
+
+      return diverges ? byMeasure : null;
+   }
+
+   private static void requireStaticColorOnMeasures(String channel, VisualFrameModel frame) {
+      if(!"color".equals(channel) || frame instanceof StaticColorModel) {
+         return;
+      }
+
+      throw new IllegalArgumentException(
+         "The color channel has no field bound, so its frame is the one fixed colour the measures " +
+         "are drawn in — only {type: \"static\", color: \"#RRGGBB\"} can go there. A '" +
+         VisualFrameAliases.typeName(frame) + "' frame varies colour across categories or a value " +
+         "range, which needs something to vary over: bind a field with set_aesthetic_field first, " +
+         "then set this frame. (Storing it here does not merely go unrendered — it stops the chart " +
+         "rendering at all.) The Composer draws the same line: with nothing on the color shelf its " +
+         "swatch opens the static colour picker, never the categorical or gradient pane.");
    }
 
    /**
@@ -420,6 +1073,55 @@ public final class ChartAestheticMutator {
          AestheticChannels.NODE_CHANNELS.contains(channel);
    }
 
+   /**
+    * The {@code AestheticInfo} whose frame the renderer reads for this channel, or {@code null}
+    * when the channel currently renders from a field-less slot instead.
+    *
+    * <p>For most channels that is simply the channel's own field. For {@code line} and
+    * {@code texture} it is the <b>shape</b> field, and this method exists for that case alone.
+    *
+    * <p>The Composer has one control where this tool has three channels. The binding pane's Shape
+    * slot edits {@code lineFrame} on a chart whose type {@code GraphTypes.supportsLine} answers
+    * for, {@code textureFrame} where {@code supportsTexture} does, and {@code shapeFrame}
+    * otherwise — one slot, three frame families, picked by chart type
+    * ({@code shape-field-mc.getEditPaneId}). So binding a dimension to shape on a line chart puts
+    * a {@code CategoricalLineModel} on the <em>shape</em> field, and
+    * {@code VSLineFrameStrategy.getAestheticRef} returns that ref precisely because its frame is a
+    * {@code LineFrame}. {@code VSFrameVisitor.createFrame} then prefers it over every field-less
+    * slot. {@code VSTextureFrameStrategy} is the same method with {@code TextureFrame} in it.
+    *
+    * <p>Without this, {@code line} and {@code texture} were treated as channels that never have a
+    * field, so both the write and the read went to the per-measure slot — which the renderer
+    * ignores while the shape field holds one of their frames. Live repro: on a line chart with a
+    * dimension on shape, {@code set_visual_frame channel="line" {type: "static", line: "large
+    * dash"}} answered ok, round-tripped through {@code get_chart_aesthetics}, and left the image
+    * byte-for-byte unchanged; clearing the shape field made the same stored value render at once.
+    *
+    * <p>The frame-family test is the strategy's own, not "is anything bound to shape". A shape
+    * field holding a {@code ShapeFrame} — a point chart — leaves {@code line} and {@code texture}
+    * on their field-less slots, which is where that chart does read them from.
+    *
+    * <p>Multi-aesthetic charts are out of scope here as they are everywhere else in this class:
+    * the strategies read {@code aggr.getShapeField()} per measure and ignore the chart-level one,
+    * and {@code set_aesthetic_field} already refuses to run on them.
+    */
+   private static AestheticInfo frameField(ChartBindingModel model, String channel) {
+      if(acceptsField(channel)) {
+         return read(model, channel);
+      }
+
+      if(!"line".equals(channel) && !"texture".equals(channel)) {
+         return null;
+      }
+
+      AestheticInfo shape = read(model, "shape");
+      VisualFrameModel frame = shape == null ? null : shape.getFrame();
+      boolean carriesThisFamily = "line".equals(channel)
+         ? frame instanceof LineFrameModel : frame instanceof TextureFrameModel;
+
+      return carriesThisFamily ? shape : null;
+   }
+
    private static boolean acceptsFrame(String channel) {
       return AestheticChannels.FRAME_CHANNELS.contains(channel) ||
          AestheticChannels.NODE_CHANNELS.contains(channel);
@@ -429,13 +1131,21 @@ public final class ChartAestheticMutator {
                                                   Collection<String> perMeasureFrameChannels)
    {
       Map<String, Object> view = new LinkedHashMap<>();
-      AestheticInfo info = acceptsField(channel) ? read(model, channel) : null;
+      AestheticInfo info = frameField(model, channel);
 
       view.put("field", fieldNameOf(info));
       view.put("frame",
                VisualFrameAliases.describe(frameOf(model, channel, perMeasureFrameChannels)));
       view.put("acceptsField", acceptsField(channel));
       view.put("acceptsFrame", acceptsFrame(channel));
+
+      Map<String, Object> perMeasure =
+         divergentMeasureFrames(model, channel, info, perMeasureFrameChannels);
+
+      if(perMeasure != null) {
+         view.put("framesByMeasure", perMeasure);
+      }
+
       return view;
    }
 
@@ -489,7 +1199,7 @@ public final class ChartAestheticMutator {
    private static VisualFrameModel frameOf(ChartBindingModel model, String channel,
                                            Collection<String> perMeasureFrameChannels)
    {
-      AestheticInfo field = acceptsField(channel) ? read(model, channel) : null;
+      AestheticInfo field = frameField(model, channel);
 
       if(field != null) {
          return field.getFrame();

--- a/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticMutator.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/ChartAestheticMutator.java
@@ -732,33 +732,6 @@ public final class ChartAestheticMutator {
    }
 
    /**
-    * Refuses a non-static colour frame about to be broadcast to the measures — i.e. a colour frame
-    * on a channel with no field bound, on a chart that renders colour per measure.
-    *
-    * <p>In exactly that configuration {@code VSFrameVisitor.createFrame} takes its
-    * {@code supportsFieldFrame()} branch and calls {@code GraphUtil.fixDuplicateColor}, which casts
-    * every aggregate's colour frame wrapper straight to {@code StaticColorFrameWrapper} with no
-    * {@code instanceof} in front of it. Anything else there is a {@code ClassCastException} at
-    * paint time — not a wrong colour, the whole chart stops rendering, and it stays that way
-    * because the bad frame is now stored on the measures. {@code set_visual_frame} still answered
-    * ok, and so did the {@code clear_aesthetic_field} and {@code set_aesthetic_field} calls that
-    * came after it; only the image was gone.
-    *
-    * <p>The cast is safe for the Composer because the Composer cannot produce the state:
-    * {@code color-field-mc.getEditPaneId()} opens {@code CategoricalColor}/{@code LinearColor}
-    * only when a field is bound, and falls back to {@code CombinedColor}/{@code StaticColor} —
-    * both static — when one is not. This is that same rule, enforced on the path that could
-    * otherwise reach the cast.
-    *
-    * <p>Checked here, at the aggregate broadcast, rather than for every field-less colour frame,
-    * because this is the write whose result the cast reads. The other two destinations cannot
-    * reach it: a {@code MergedChartInfo} chart (candle, stock, radar, relation, map) answers false
-    * for colour, so {@code createFrame} reads {@code getGeneralFrame()} and never enters that
-    * branch — a chart-level gradient there is legitimate — and a chart with no measure renders no
-    * colour frame at all. Node channels never reach the broadcast either; relation node colour
-    * renders through {@code GraphGenerator}'s own node path.
-    */
-   /**
     * Refuses a frame whose kind the channel's bound field cannot drive.
     *
     * <p>{@code color-field-mc}/{@code shape-field-mc}{@code .getEditPaneId()} pick the editor from
@@ -885,6 +858,33 @@ public final class ChartAestheticMutator {
       return diverges ? byMeasure : null;
    }
 
+   /**
+    * Refuses a non-static colour frame about to be broadcast to the measures — i.e. a colour frame
+    * on a channel with no field bound, on a chart that renders colour per measure.
+    *
+    * <p>In exactly that configuration {@code VSFrameVisitor.createFrame} takes its
+    * {@code supportsFieldFrame()} branch and calls {@code GraphUtil.fixDuplicateColor}, which casts
+    * every aggregate's colour frame wrapper straight to {@code StaticColorFrameWrapper} with no
+    * {@code instanceof} in front of it. Anything else there is a {@code ClassCastException} at
+    * paint time — not a wrong colour, the whole chart stops rendering, and it stays that way
+    * because the bad frame is now stored on the measures. {@code set_visual_frame} still answered
+    * ok, and so did the {@code clear_aesthetic_field} and {@code set_aesthetic_field} calls that
+    * came after it; only the image was gone.
+    *
+    * <p>The cast is safe for the Composer because the Composer cannot produce the state:
+    * {@code color-field-mc.getEditPaneId()} opens {@code CategoricalColor}/{@code LinearColor}
+    * only when a field is bound, and falls back to {@code CombinedColor}/{@code StaticColor} —
+    * both static — when one is not. This is that same rule, enforced on the path that could
+    * otherwise reach the cast.
+    *
+    * <p>Checked here, at the aggregate broadcast, rather than for every field-less colour frame,
+    * because this is the write whose result the cast reads. The other two destinations cannot
+    * reach it: a {@code MergedChartInfo} chart (candle, stock, radar, relation, map) answers false
+    * for colour, so {@code createFrame} reads {@code getGeneralFrame()} and never enters that
+    * branch — a chart-level gradient there is legitimate — and a chart with no measure renders no
+    * colour frame at all. Node channels never reach the broadcast either; relation node colour
+    * renders through {@code GraphGenerator}'s own node path.
+    */
    private static void requireStaticColorOnMeasures(String channel, VisualFrameModel frame) {
       if(!"color".equals(channel) || frame instanceof StaticColorModel) {
          return;

--- a/core/src/main/java/inetsoft/web/wiz/binding/VisualFrameAliases.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/VisualFrameAliases.java
@@ -803,7 +803,10 @@ public final class VisualFrameAliases {
       Map<String, Object> mapping = mapping(spec);
       Boolean colorValueFrame = bool(spec, "colorValueFrame");
 
-      if(colors.isEmpty() && mapping.isEmpty() && colorValueFrame == null) {
+      // Tested for TRUE, not for presence: colorValueFrame satisfies this precondition by
+      // replacing what drives the chart, so only switching it on does. An explicit false says
+      // "read the palette", which leaves the frame with no palette to read all over again.
+      if(colors.isEmpty() && mapping.isEmpty() && !Boolean.TRUE.equals(colorValueFrame)) {
          throw new IllegalArgumentException(
             "A categorical colour frame needs a non-empty 'colors' list, a 'mapping' of value to " +
             "colour, or 'colorValueFrame', e.g. " +

--- a/core/src/main/java/inetsoft/web/wiz/binding/VisualFrameAliases.java
+++ b/core/src/main/java/inetsoft/web/wiz/binding/VisualFrameAliases.java
@@ -171,7 +171,8 @@ public final class VisualFrameAliases {
          case "color" -> {
             switch(type) {
                case "static", "brightness", "saturation" -> keys.add("color");
-               case "categorical" -> keys.addAll(List.of("colors", "mapping", "useGlobal"));
+               case "categorical" ->
+                  keys.addAll(List.of("colors", "mapping", "shareColors", "colorValueFrame"));
                case "gradient" -> keys.addAll(List.of("from", "to"));
                case "palette" -> keys.add("palette");
                default -> { /* fieldless */ }
@@ -185,18 +186,28 @@ public final class VisualFrameAliases {
             }
          }
          case "size" -> {
-            if("static".equals(type)) {
-               keys.add("size");
+            switch(type) {
+               case "static" -> keys.add("size");
+               // Both graduated size frames map their values onto the same smallest..largest
+               // range -- the two-handle slider in the Composer's binding-size pane. It lives on
+               // SizeFrameModel, so it is the same pair for linear and categorical alike; there
+               // is no per-category size list on the model to expose.
+               case "linear", "categorical" -> keys.addAll(List.of("smallest", "largest"));
+               default -> { /* fieldless */ }
             }
          }
          case "line" -> {
-            if("static".equals(type)) {
-               keys.add("line");
+            switch(type) {
+               case "static" -> keys.add("line");
+               case "categorical" -> keys.add("lines");
+               default -> { /* fieldless */ }
             }
          }
          default -> {
-            if("static".equals(type)) {
-               keys.add("texture");
+            switch(type) {
+               case "static" -> keys.add("texture");
+               case "categorical" -> keys.add("textures");
+               default -> { /* fieldless */ }
             }
          }
       }
@@ -229,6 +240,22 @@ public final class VisualFrameAliases {
       }
    }
 
+   /**
+    * A frame's {@code type} in the agent vocabulary, for naming it in an error message. Answers
+    * the class's simple name for a model {@link #describe} has no branch for, so a diagnostic
+    * never becomes a second, more confusing failure than the one it is reporting.
+    */
+   public static String typeName(VisualFrameModel frame) {
+      Map<String, Object> described = describe(frame);
+      Object type = described == null ? null : described.get("type");
+
+      if(type != null) {
+         return String.valueOf(type);
+      }
+
+      return frame == null ? "null" : frame.getClass().getSimpleName();
+   }
+
    /** Renders a frame back in the agent vocabulary. Never emits {@code clazz}. */
    public static Map<String, Object> describe(VisualFrameModel frame) {
       if(frame == null) {
@@ -248,18 +275,27 @@ public final class VisualFrameAliases {
          out.put("colors", model.getColors() == null
             ? List.of() : Arrays.asList(model.getColors()));
          Map<String, Object> mapping = new LinkedHashMap<>();
+         // The same selection ColorFrameModelFactory.CategoricalColorFactory makes on the way in:
+         // with sharing on the pins live on the viewsheet, off they live on this frame. Reading
+         // the other one would report mapping: {} for a chart that visibly has pinned colours.
+         ColorMapModel[] pins = model.isUseGlobal()
+            ? model.getGlobalColorMaps() : model.getColorMaps();
 
-         for(ColorMapModel map : model.getColorMaps() == null
-            ? new ColorMapModel[0] : model.getColorMaps())
-         {
+         for(ColorMapModel map : pins == null ? new ColorMapModel[0] : pins) {
             if(map != null && map.getOption() != null) {
-               mapping.put(map.getOption(), map.getColor());
+               mapping.put(map.getOption(), readableColor(map.getColor()));
             }
          }
 
          out.put("mapping", mapping);
-         // Reported because a true here means any mapping above is stored but not rendered.
-         out.put("useGlobal", model.isUseGlobal());
+         // One key, matching the one checkbox and the one key the write side takes. The frame's
+         // isUseGlobal() is reported through it rather than beside it: it is the flag the render
+         // path actually consults for the pins above, and a legacy frame where the two disagree
+         // is a state the Composer can neither produce nor repair -- so naming it here would offer
+         // the agent a distinction it has no way to act on. Writes leave such a frame's pair
+         // untouched instead (ChartAestheticMutator.carryShareColorState).
+         out.put("shareColors", model.isUseGlobal());
+         out.put("colorValueFrame", model.isColorValueFrame());
          return out;
       }
 
@@ -307,6 +343,30 @@ public final class VisualFrameAliases {
          return out;
       }
 
+      // These three fall through to BEHAVIOURAL below, which knows only their type name. That
+      // was correct while create() built them empty; now that they carry values, reporting the
+      // name alone would leave the read unable to see what the write set -- a frame that
+      // round-trips as {type: "categorical"} whatever it holds.
+      if(frame instanceof CategoricalLineModel model) {
+         out.put("type", "categorical");
+         out.put("lines", boxed(model.getLines()));
+         return out;
+      }
+
+      if(frame instanceof CategoricalTextureModel model) {
+         out.put("type", "categorical");
+         out.put("textures", boxed(model.getTextures()));
+         return out;
+      }
+
+      if(frame instanceof LinearSizeModel || frame instanceof CategoricalSizeModel) {
+         SizeFrameModel model = (SizeFrameModel) frame;
+         out.put("type", frame instanceof CategoricalSizeModel ? "categorical" : "linear");
+         out.put("smallest", model.getSmallest());
+         out.put("largest", model.getLargest());
+         return out;
+      }
+
       String behavioural = BEHAVIOURAL.get(frame.getClass());
 
       if(behavioural != null) {
@@ -327,6 +387,20 @@ public final class VisualFrameAliases {
       // it with set_visual_frame yet.
       out.put("type", "unsupported");
       out.put("detail", frame.getClass().getSimpleName());
+      return out;
+   }
+
+   private static List<Integer> boxed(int[] values) {
+      if(values == null) {
+         return List.of();
+      }
+
+      List<Integer> out = new ArrayList<>(values.length);
+
+      for(int value : values) {
+         out.add(value);
+      }
+
       return out;
    }
 
@@ -358,6 +432,30 @@ public final class VisualFrameAliases {
       }
 
       return "#" + value;
+   }
+
+   /**
+    * A colour on the way out, in the one spelling {@link #normalizeColor} takes on the way in.
+    *
+    * <p>The two arrays a categorical colour frame reports from are filled by different formatters.
+    * {@code CategoricalColorModel(wrapper)} uses {@code Tool.toString(Color)} for {@code colors}
+    * and {@code colorMaps}, which writes {@code #RRGGBB}; {@code
+    * VSChartBindingFactory.applyColorsToFrame} refills {@code globalColorMaps} from the viewsheet
+    * with {@code Tool.colorToHTMLString}, which returns six hex digits and no {@code #}. So a
+    * shared pin read back as {@code "000000"} — a value this tool's own {@code set_visual_frame}
+    * refuses, making the read impossible to feed back to the write.
+    *
+    * <p>Left alone rather than corrected if it is neither spelling: a diagnostic must not become a
+    * second failure, and reporting the raw value is more use than an exception when something
+    * upstream has put an unexpected string there.
+    */
+   private static String readableColor(String color) {
+      try {
+         return normalizeColor(color);
+      }
+      catch(IllegalArgumentException ex) {
+         return color;
+      }
    }
 
    // ── the coverage test's view ──────────────────────────────────────────────
@@ -454,16 +552,56 @@ public final class VisualFrameAliases {
 
       CategoricalShapeModel model = new CategoricalShapeModel();
       model.setShapes(shapes.toArray(new String[0]));
+      // CategoricalShapeFrameModelFactory ends its update with setChanged(model.isChanged()),
+      // which overwrites the flag setShape(i, ...) had just raised. A model left at the default
+      // false therefore stores the shapes and then reports the frame as untouched, so a chart
+      // type change discards them. An agent write is by definition a deliberate change.
+      model.setChanged(true);
       return model;
    }
 
    private static VisualFrameModel sizeFrame(Map<String, Object> spec, String type) {
       return switch(type) {
          case "static" -> staticSize(spec);
-         case "linear" -> new LinearSizeModel();
-         case "categorical" -> new CategoricalSizeModel();
+         case "linear" -> sizeRange(spec, new LinearSizeModel());
+         case "categorical" -> sizeRange(spec, new CategoricalSizeModel());
          default -> throw unknownType("size", type);
       };
+   }
+
+   /**
+    * The range a graduated size frame maps its values onto, from {@code SizeFrameModel}'s own
+    * {@code smallest}/{@code largest} — the two-handle slider the Composer shows once a field is
+    * bound to the size channel. Both are optional and default to 1 and 30, the same values the
+    * slider opens with.
+    *
+    * <p>{@code setChanged(true)} is not decoration here.
+    * {@code SizeFrameModelFactory.updateVisualFrameWrapper0} returns {@code null} — discarding
+    * the whole wrapper — when the model reports itself unchanged, so a linear or categorical
+    * size frame built without it was accepted, reported as success, and then dropped before it
+    * reached the chart. That is the same silent discard {@link #staticSize} already had to work
+    * around, one class up the hierarchy.
+    */
+   private static VisualFrameModel sizeRange(Map<String, Object> spec, SizeFrameModel model) {
+      Double smallest = number(spec, "smallest");
+      Double largest = number(spec, "largest");
+
+      if(smallest != null) {
+         model.setSmallest(smallest);
+      }
+
+      if(largest != null) {
+         model.setLargest(largest);
+      }
+
+      if(model.getSmallest() > model.getLargest()) {
+         throw new IllegalArgumentException(
+            "'smallest' (" + model.getSmallest() + ") cannot be greater than 'largest' (" +
+            model.getLargest() + ").");
+      }
+
+      model.setChanged(true);
+      return model;
    }
 
    private static VisualFrameModel staticSize(Map<String, Object> spec) {
@@ -487,9 +625,25 @@ public final class VisualFrameAliases {
       return switch(type) {
          case "static" -> staticLine(spec);
          case "linear" -> new LinearLineModel();
-         case "categorical" -> new CategoricalLineModel();
+         case "categorical" -> categoricalLine(spec);
          default -> throw unknownType("line", type);
       };
+   }
+
+   /**
+    * A line style per category — the {@code line-combo-box} row the Composer's categorical pane
+    * shows when the shape channel of a line chart carries a field.
+    *
+    * <p>{@code lines} is optional: an empty categorical frame is a meaningful request ("vary the
+    * line style by category, using the defaults"), and it is what binding a field produces
+    * before anything is picked. {@code CategoricalLineFrameModelFactory} returns the wrapper
+    * untouched for an empty array, so the defaults survive.
+    */
+   private static VisualFrameModel categoricalLine(Map<String, Object> spec) {
+      CategoricalLineModel model = new CategoricalLineModel();
+      model.setLines(intArray(spec, "lines", "line-style code"));
+      model.setChanged(true);
+      return model;
    }
 
    private static VisualFrameModel staticLine(Map<String, Object> spec) {
@@ -508,7 +662,7 @@ public final class VisualFrameAliases {
    private static VisualFrameModel textureFrame(Map<String, Object> spec, String type) {
       return switch(type) {
          case "static" -> staticTexture(spec);
-         case "categorical" -> new CategoricalTextureModel();
+         case "categorical" -> categoricalTexture(spec);
          case "grid" -> new GridTextureModel();
          case "left_tilt" -> new LeftTiltTextureModel();
          case "right_tilt" -> new RightTiltTextureModel();
@@ -528,6 +682,48 @@ public final class VisualFrameAliases {
       StaticTextureModel model = new StaticTextureModel();
       model.setTexture(texture.intValue());
       return model;
+   }
+
+   /** A texture per category. {@code textures} is optional, for the reason in {@link #categoricalLine}. */
+   private static VisualFrameModel categoricalTexture(Map<String, Object> spec) {
+      CategoricalTextureModel model = new CategoricalTextureModel();
+      model.setTextures(intArray(spec, "textures", "texture code"));
+      model.setChanged(true);
+      return model;
+   }
+
+   /**
+    * Reads a list of integer codes. A present-but-not-a-list value is refused rather than read
+    * as an empty list: {@code lines: 4097} means one line style, and silently building an empty
+    * categorical frame from it would report success and change nothing.
+    */
+   private static int[] intArray(Map<String, Object> spec, String key, String what) {
+      Object raw = spec == null ? null : spec.get(key);
+
+      if(raw == null) {
+         return new int[0];
+      }
+
+      if(!(raw instanceof Collection<?>)) {
+         throw new IllegalArgumentException(
+            "'" + key + "' must be a list of " + what + "s, e.g. \"" + key + "\": [4097, 4113], " +
+            "got '" + raw + "'.");
+      }
+
+      List<String> values = strList(spec, key);
+      int[] out = new int[values.size()];
+
+      for(int i = 0; i < out.length; i++) {
+         try {
+            out[i] = (int) Double.parseDouble(values.get(i));
+         }
+         catch(NumberFormatException e) {
+            throw new IllegalArgumentException(
+               "'" + key + "[" + i + "]' must be a " + what + ", got '" + values.get(i) + "'.");
+         }
+      }
+
+      return out;
    }
 
    private static Double number(Map<String, Object> spec, String key) {
@@ -560,42 +756,61 @@ public final class VisualFrameAliases {
    }
 
    /**
-    * A categorical colour frame, optionally with per-value colour mapping.
+    * A categorical colour frame, optionally with per-value colour pins.
     *
-    * <p><b>The {@code useGlobal}/{@code shareColors} footgun lives here.</b>
-    * {@code CategoricalColorModel} defaults both {@code useGlobal} and {@code shareColors} to
-    * {@code true}. While {@code useGlobal} is set the automatic palette wins at render time; and
-    * independently, while {@code shareColors} is set the whole frame is replaced by a cached
-    * shared frame for the same column before per-value colours are even applied. Either flag
-    * alone is enough to make an explicit per-value colour accepted, stored, and never rendered.
-    * That is a recorded defect, and it is invisible — the model round-trips perfectly and the
-    * chart shows something else.
+    * <p>{@code shareColors} is the categorical pane's <b>"Share Colors"</b> checkbox. That one
+    * checkbox drives two different flags on {@code CategoricalColorFrame}
+    * ({@code categorical-color-pane.shareColorsChange} sets both), and they are not the same
+    * mechanism:
     *
-    * <p>So supplying {@code colors} and/or a {@code mapping} clears both flags, because supplying
-    * either <i>is</i> the intent to override the automatic/shared palette. Asking for
-    * {@code useGlobal: true} alongside a mapping is refused rather than honoured, since that
-    * combination cannot render what was asked for.
+    * <ul>
+    *   <li>{@code shareColors} makes {@code VSFrameVisitor.createFrame} replace this frame
+    *       wholesale with a clone of whichever frame the viewsheet has already cached for the same
+    *       (column, date level). <b>That</b> is what makes one dimension render in the same colours
+    *       on every chart of the viewsheet, and it carries the ordinary {@code colors} palette, so
+    *       it needs nothing else set up first.</li>
+    *   <li>{@code useGlobal} makes {@code VSFrameVisitor.applyGlobalColors} stamp the viewsheet's
+    *       fixed value-to-colour pins over the result, and makes
+    *       {@code ColorFrameModelFactory.CategoricalColorFactory} read {@code globalColorMaps}
+    *       instead of {@code colorMaps}.</li>
+    * </ul>
+    *
+    * <p>Set together here, as the checkbox sets them. An omitted {@code shareColors} is left at a
+    * definite {@code false} and resolved against the channel's current frame by
+    * {@code ChartAestheticMutator.carryShareColorState}, which is the only place with the frame to
+    * leave alone — a spec that does not mention the checkbox is not asking to move it.
+    *
+    * <p>A {@code mapping} works either way; the flag decides where the pins land, exactly as
+    * {@code openColorMappingDialog}'s callback does ({@code if(useGlobal) globalColorMaps = maps;
+    * else colorMaps = maps;}). Off, they pin values on this chart. On, they pin them on the
+    * viewsheet, so every chart colouring by that column shows the same colour for that value —
+    * which is what "Assign Fixed Mapping" with "Share Colors" checked does in the Composer, and
+    * the more useful of the two. {@code ColorFrameModelFactory.CategoricalColorFactory} reads
+    * whichever array the flag selects, so writing to the other one is what would silently lose
+    * them.
+    *
+    * <p>{@code colorValueFrame} is the pane's other checkbox, "Use Column Values as Colors": the
+    * bound column's own values are read as colours rather than mapped to a palette, which
+    * {@code CategoricalColorFrameWrapper.getVisualFrame} implements by handing back a
+    * {@code ColorValueColorFrame} instead of the categorical one. The Composer only shows that
+    * checkbox where the deployment lists {@code ColorValueColorFrame} in the
+    * {@code custom.chart.frames} property, which is empty by default; the backend honours the flag
+    * either way, so it is accepted here and the visibility rule is documented rather than
+    * enforced — a deployment that has not enabled the checkbox has not disabled the feature.
     */
    private static VisualFrameModel categoricalColor(Map<String, Object> spec) {
       List<String> colors = strList(spec, "colors");
       Map<String, Object> mapping = mapping(spec);
+      Boolean colorValueFrame = bool(spec, "colorValueFrame");
 
-      if(colors.isEmpty() && mapping.isEmpty()) {
+      if(colors.isEmpty() && mapping.isEmpty() && colorValueFrame == null) {
          throw new IllegalArgumentException(
-            "A categorical colour frame needs a non-empty 'colors' list, or a 'mapping' of " +
-            "value to colour, e.g. {type: \"categorical\", mapping: {\"East\": \"#4E79A7\"}}.");
+            "A categorical colour frame needs a non-empty 'colors' list, a 'mapping' of value to " +
+            "colour, or 'colorValueFrame', e.g. " +
+            "{type: \"categorical\", mapping: {\"East\": \"#4E79A7\"}}.");
       }
 
-      Boolean useGlobal = bool(spec, "useGlobal");
-
-      if(Boolean.TRUE.equals(useGlobal) && !mapping.isEmpty()) {
-         throw new IllegalArgumentException(
-            "'useGlobal: true' cannot be combined with a 'mapping'. While useGlobal is set the " +
-            "automatic palette wins, so the mapped colours would be stored and never rendered — " +
-            "the model would round-trip perfectly and the chart would show something else. Drop " +
-            "useGlobal to apply the mapping, or drop the mapping to keep the automatic palette.");
-      }
-
+      Boolean share = shareColors(spec);
       CategoricalColorModel model = new CategoricalColorModel();
 
       if(!colors.isEmpty()) {
@@ -613,19 +828,48 @@ public final class VisualFrameAliases {
             maps.add(map);
          }
 
-         model.setColorMaps(maps.toArray(new ColorMapModel[0]));
+         // The flag picks the destination, the way the Color Mapping dialog's callback does.
+         // Writing to the array the factory is not reading is what loses the pins silently.
+         if(Boolean.TRUE.equals(share)) {
+            model.setGlobalColorMaps(maps.toArray(new ColorMapModel[0]));
+         }
+         else {
+            model.setColorMaps(maps.toArray(new ColorMapModel[0]));
+         }
       }
 
-      // Supplying colours and/or a mapping is the intent to override the automatic/shared
-      // palette. useGlobal and shareColors both default to true on a fresh CategoricalColorModel;
-      // leaving either set is what makes an explicit frame round-trip perfectly and never render.
-      // Default both false; honour an explicit useGlobal: true if the caller actually wants to
-      // keep sharing.
-      boolean share = Boolean.TRUE.equals(useGlobal);
-      model.setUseGlobal(share);
-      model.setShareColors(share);
+      // Both flags together, the way the "Share Colors" checkbox sets them. An omitted
+      // shareColors leaves them here at a definite false and is resolved against the channel's
+      // current frame by ChartAestheticMutator.carryShareColorState, which is the only place that
+      // has the frame to leave alone.
+      boolean shared = Boolean.TRUE.equals(share);
+      model.setUseGlobal(shared);
+      model.setShareColors(shared);
+
+      if(colorValueFrame != null) {
+         model.setColorValueFrame(colorValueFrame);
+      }
 
       return model;
+   }
+
+   /**
+    * The "Share Colors" checkbox as the spec asked for it, or {@code null} when the spec did not
+    * mention it — which means "leave the checkbox where it is", the way the Composer's Apply does.
+    * Resolving that against the channel's current frame needs the frame, so it happens in
+    * {@code ChartAestheticMutator}; this only reports what was asked.
+    *
+    * <p>Deliberately one key, not two. The underlying frame carries {@code useGlobal} and
+    * {@code shareColors} separately for historical reasons — {@code useGlobal} came first, for the
+    * Color Mapping dialog, and {@code shareColors} was added later for frame sharing, which is why
+    * {@code CategoricalColorFrameWrapper.parseContents} has a legacy default for one and not the
+    * other. The Composer has driven them from a single checkbox ever since; the dialog's own
+    * {@code toggleGlobal()} is left over from before that and is wired to nothing. Exposing both
+    * would offer a distinction the product does not have and no caller could use correctly, so
+    * the agent vocabulary has one name and the pair is derived from it.
+    */
+   static Boolean shareColors(Map<String, Object> spec) {
+      return bool(spec, "shareColors");
    }
 
    @SuppressWarnings("unchecked")

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticAgentServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticAgentServiceTest.java
@@ -358,4 +358,44 @@ class ChartAestheticAgentServiceTest {
    private static Principal principal() {
       return () -> "admin";
    }
+
+   /**
+    * frameTypes was a hard-coded four — static, categorical, gradient, palette — from the one
+    * endpoint whose job is to stop an agent guessing. It named eleven fewer types than
+    * VisualFrameAliases builds, and implied the answer does not depend on the channel when
+    * gradient exists only for colour and linear only for size and line.
+    */
+   @Test
+   void optionsReportsFrameTypesPerChannelFromTheBuilderItself() {
+      ChartAestheticAgentService service = serviceWith(
+         sessionsFor(mock(ChartVSAssembly.class)), new ChartBindingModel(),
+         mock(ChangeChartAestheticService.class));
+
+      Map<String, Object> options = service.options();
+      @SuppressWarnings("unchecked")
+      Map<String, Object> byChannel = (Map<String, Object>) options.get("frameTypesByChannel");
+
+      for(String channel : AestheticChannels.SUPPORTED_FRAME_CHANNELS) {
+         assertEquals(VisualFrameAliases.typeNames(channel), byChannel.get(channel),
+                      "the reported types for " + channel + " must be the builder's own");
+      }
+
+      assertEquals(VisualFrameAliases.typeNames("color"), byChannel.get("node-color"));
+      assertEquals(VisualFrameAliases.typeNames("size"), byChannel.get("node-size"));
+   }
+
+   @Test
+   void optionsFrameTypesIsTheUnionAcrossChannels() {
+      ChartAestheticAgentService service = serviceWith(
+         sessionsFor(mock(ChartVSAssembly.class)), new ChartBindingModel(),
+         mock(ChangeChartAestheticService.class));
+
+      @SuppressWarnings("unchecked")
+      List<String> types = (List<String>) service.options().get("frameTypes");
+
+      assertTrue(types.containsAll(List.of("heat", "linear", "grid", "triangle", "rainbow")),
+                 "types the builder accepts but the old hard-coded list refused: " + types);
+      assertTrue(types.containsAll(List.of("static", "categorical", "gradient", "palette")),
+                 "and the four it did report are still there: " + types);
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticMutatorTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/ChartAestheticMutatorTest.java
@@ -19,6 +19,7 @@ package inetsoft.web.wiz.binding;
 
 import inetsoft.uql.viewsheet.graph.GraphTypes;
 import inetsoft.web.binding.model.ChartBindingModel;
+import inetsoft.web.binding.model.ColorMapModel;
 import inetsoft.web.binding.model.graph.*;
 import inetsoft.web.binding.model.graph.aesthetic.*;
 import inetsoft.web.wiz.binding.model.FieldRef;
@@ -652,14 +653,14 @@ class ChartAestheticMutatorTest {
    @Test
    void describesTheBoundChannelsInTheAgentVocabulary() {
       ChartBindingModel model = new ChartBindingModel();
-      ChartAestheticMutator.setField(model, "color", dimension("Region"));
+      ChartAestheticMutator.setField(model, "color", measure("Sales", "Sum"));
       ChartAestheticMutator.setFrame(model, "color", spec("type", "palette", "palette", "Reds"));
 
       Map<String, Object> described = ChartAestheticMutator.describe(model);
       @SuppressWarnings("unchecked")
       Map<String, Object> color = (Map<String, Object>) described.get("color");
 
-      assertEquals("Region", color.get("field"));
+      assertEquals("Sales", color.get("field"));
       @SuppressWarnings("unchecked")
       Map<String, Object> frame = (Map<String, Object>) color.get("frame");
       assertEquals("palette", frame.get("type"));
@@ -824,5 +825,920 @@ class ChartAestheticMutatorTest {
       assertEquals("Region", nodeColor.get("field"));
       assertEquals(true, nodeColor.get("acceptsField"));
       assertEquals(true, nodeColor.get("acceptsFrame"));
+   }
+
+   // ── a mapping-only categorical colour frame keeps the channel's palette ───
+   //
+   // Live repro: with a dimension bound to colour, {type: "categorical", mapping: {...}} was
+   // accepted, reported success, and changed nothing — get_chart_aesthetics read back
+   // mapping: {} with useGlobal flipped back to true and the chart kept its old colours.
+   // CategoricalColorFrameModelFactory.updateVisualFrameWrapper0 returns early, before
+   // assignMappedColors/setUseGlobal/setShareColors, when the model carries no colours. The
+   // interactive pane always satisfies that precondition (it sends the whole palette alongside
+   // the colour maps); the agent path did not. Carrying the channel's current palette is what
+   // makes the request the same shape the dialog sends.
+
+   @Test
+   void aMappingOnlyColourFrameCarriesTheChannelsCurrentPalette() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setField(model, "color", dimension("Region"));
+      ChartAestheticMutator.setFrame(
+         model, "color", spec("type", "categorical", "colors", List.of("#111111", "#222222")));
+
+      ChartAestheticMutator.setFrame(
+         model, "color", spec("type", "categorical", "mapping", Map.of("East", "#d64541")));
+
+      CategoricalColorModel onField =
+         assertInstanceOf(CategoricalColorModel.class, model.getColorField().getFrame());
+      assertArrayEquals(new String[]{ "#111111", "#222222" }, onField.getColors(),
+                        "without colours the factory discards the whole frame, mapping included");
+      assertEquals(1, onField.getColorMaps().length);
+      assertEquals("East", onField.getColorMaps()[0].getOption());
+   }
+
+   /** The same carry-forward on an unbound channel, whose frame lives in a different slot. */
+   @Test
+   void aMappingOnlyColourFrameCarriesTheChartLevelPaletteToo() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setFrame(
+         model, "color", spec("type", "categorical", "colors", List.of("#333333")));
+
+      ChartAestheticMutator.setFrame(
+         model, "color", spec("type", "categorical", "mapping", Map.of("West", "#f28e2c")));
+
+      CategoricalColorModel frame =
+         assertInstanceOf(CategoricalColorModel.class, model.getColorFrame());
+      assertArrayEquals(new String[]{ "#333333" }, frame.getColors());
+   }
+
+   /** An explicit colours list is the caller's, not something to overwrite with the old palette. */
+   @Test
+   void anExplicitColourListIsNotOverwrittenByTheCarryForward() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setFrame(
+         model, "color", spec("type", "categorical", "colors", List.of("#111111", "#222222")));
+
+      ChartAestheticMutator.setFrame(
+         model, "color", spec("type", "categorical", "colors", List.of("#999999")));
+
+      assertArrayEquals(new String[]{ "#999999" },
+                        ((CategoricalColorModel) model.getColorFrame()).getColors());
+   }
+
+   /**
+    * With no categorical palette on the channel there are no categories a mapping could name.
+    * The Composer hides "Assign Fixed Mapping" in exactly that case; this says so out loud
+    * rather than storing something the factory will drop.
+    */
+   @Test
+   void refusesAMappingOnlyFrameWhenTheChannelHasNoPaletteToPinAgainst() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setFrame(model, "color", spec("type", "static", "color", "#4e79a7"));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartAestheticMutator.setFrame(
+            model, "color", spec("type", "categorical", "mapping", Map.of("East", "#d64541"))));
+
+      assertTrue(thrown.getMessage().contains("mapping"), thrown.getMessage());
+   }
+
+   /**
+    * The carry-forward is colour-only. Line and texture have no equivalent precondition —
+    * CategoricalLineFrameModelFactory leaves the wrapper's own defaults in place for an empty
+    * array instead of discarding the frame — so a bare categorical line frame still means "the
+    * defaults", not "whatever was there before".
+    */
+   @Test
+   void theCarryForwardLeavesOtherChannelsAlone() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setFrame(
+         model, "line", spec("type", "categorical", "lines", List.of(4097, 4113)));
+      ChartAestheticMutator.setFrame(model, "line", spec("type", "categorical"));
+
+      assertArrayEquals(new int[0],
+                        ((CategoricalLineModel) model.getLineFrame()).getLines(),
+                        "a bare categorical line frame means the defaults, not the old lines");
+   }
+
+   // ── line and texture render off the shape field, when it holds their frame ─
+   //
+   // The Composer has one Shape slot where this tool has three channels: it edits lineFrame on a
+   // chart GraphTypes.supportsLine answers for, textureFrame where supportsTexture does, and
+   // shapeFrame otherwise. So a dimension on shape puts a CategoricalLineModel on the SHAPE field,
+   // and VSLineFrameStrategy.getAestheticRef returns that ref exactly because its frame is a
+   // LineFrame -- createFrame then prefers it over every field-less slot.
+   //
+   // Live repro: line chart, dimension on shape, set_visual_frame channel="line"
+   // {type: "static", line: "large dash"} answered ok, round-tripped through
+   // get_chart_aesthetics, and left the image byte-for-byte unchanged. Clearing the shape field
+   // made the same stored value render at once.
+
+   @Test
+   void aLineFrameLandsOnTheShapeFieldWhenThatFieldCarriesALineFrame() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(model, "y", List.of(measure("Sales", "Sum")));
+      ChartAestheticMutator.setField(model, "shape", dimension("Year(ORDER_DATE)"));
+      model.getShapeField().setFrame(new CategoricalLineModel());
+
+      ChartAestheticMutator.setFrame(
+         model, "line", spec("type", "categorical", "lines", List.of(4241, 4097)));
+
+      CategoricalLineModel onShape = assertInstanceOf(
+         CategoricalLineModel.class, model.getShapeField().getFrame(),
+         "the shape field's frame is the one VSLineFrameStrategy hands the renderer");
+      assertArrayEquals(new int[]{ 4241, 4097 }, onShape.getLines());
+      ChartAggregateRefModel agg = (ChartAggregateRefModel) model.getYFields().get(0);
+      assertNull(agg.getLineFrame(),
+                 "writing the per-measure slot too would leave a second value nothing renders");
+   }
+
+   @Test
+   void aTextureFrameLandsOnTheShapeFieldWhenThatFieldCarriesATextureFrame() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(model, "y", List.of(measure("Sales", "Sum")));
+      ChartAestheticMutator.setField(model, "shape", dimension("Year(ORDER_DATE)"));
+      model.getShapeField().setFrame(new CategoricalTextureModel());
+
+      ChartAestheticMutator.setFrame(
+         model, "texture", spec("type", "categorical", "textures", List.of(19, 12)));
+
+      CategoricalTextureModel onShape = assertInstanceOf(
+         CategoricalTextureModel.class, model.getShapeField().getFrame());
+      assertArrayEquals(new int[]{ 19, 12 }, onShape.getTextures());
+   }
+
+   /** The read has to come from the same slot, or it reports a value the chart never shows. */
+   @Test
+   void theLineChannelReportsTheShapeFieldsFrameAndField() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(model, "y", List.of(measure("Sales", "Sum")));
+      ChartAestheticMutator.setField(model, "shape", dimension("Year(ORDER_DATE)"));
+      CategoricalLineModel onShape = new CategoricalLineModel();
+      onShape.setLines(new int[]{ 4097, 4113 });
+      model.getShapeField().setFrame(onShape);
+
+      @SuppressWarnings("unchecked")
+      Map<String, Object> line =
+         (Map<String, Object>) ChartAestheticMutator.describe(model).get("line");
+      @SuppressWarnings("unchecked")
+      Map<String, Object> frame = (Map<String, Object>) line.get("frame");
+
+      assertEquals("Year(ORDER_DATE)", line.get("field"));
+      assertEquals(List.of(4097, 4113), frame.get("lines"));
+      assertEquals(false, line.get("acceptsField"),
+                   "the field goes on shape, so line still refuses set_aesthetic_field");
+   }
+
+   /**
+    * The gate is the strategy's own frame-family test, not "is anything bound to shape". A point
+    * chart's shape field holds a ShapeFrame, and there line and texture really do render from
+    * their field-less slots.
+    */
+   @Test
+   void aShapeFieldHoldingAShapeFrameLeavesLineOnItsFieldLessSlot() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(model, "y", List.of(measure("Sales", "Sum")));
+      ChartAestheticMutator.setField(model, "shape", dimension("Year(ORDER_DATE)"));
+      model.getShapeField().setFrame(new CategoricalShapeModel());
+
+      ChartAestheticMutator.setFrame(model, "line", spec("type", "static", "line", 4241));
+
+      ChartAggregateRefModel agg = (ChartAggregateRefModel) model.getYFields().get(0);
+      assertInstanceOf(StaticLineModel.class, agg.getLineFrame());
+      assertInstanceOf(CategoricalShapeModel.class, model.getShapeField().getFrame(),
+                       "the shape field's own frame is not line's to overwrite");
+   }
+
+   /** With nothing on shape, both keep their existing field-less behaviour. */
+   @Test
+   void anUnboundShapeChannelLeavesLineAndTextureOnTheMeasures() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(model, "y", List.of(measure("Sales", "Sum")));
+
+      ChartAestheticMutator.setFrame(model, "line", spec("type", "static", "line", 4241));
+      ChartAestheticMutator.setFrame(model, "texture", spec("type", "static", "texture", 5));
+
+      ChartAggregateRefModel agg = (ChartAggregateRefModel) model.getYFields().get(0);
+      assertInstanceOf(StaticLineModel.class, agg.getLineFrame());
+      assertInstanceOf(StaticTextureModel.class, agg.getTextureFrame());
+   }
+
+   // ── a bound field decides which kind of frame can drive its channel ───────
+   //
+   // getEditPaneId() picks the editor from the bound field, not from the caller: a dimension (or a
+   // discrete aggregate) opens the Categorical pane and nothing else, a measure opens the Linear
+   // one, and Static is offered only when nothing is bound. Anything else is a state the Composer
+   // cannot produce and the backend does not cope with.
+   //
+   // Live repro: line chart, dimension on shape, set_visual_frame channel="line"
+   // {type: "static", line: "large dash"} answered ok, the image did not change, and the
+   // categorical lines array came back with the static value sitting in one of its slots.
+   // Control on another channel: {type: "static", color: "#FF0000"} on a colour channel with a
+   // dimension bound rendered the ordinary categorical palette, no red anywhere.
+
+   @Test
+   void refusesAStaticFrameOnAChannelBoundToADimension() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setField(model, "color", dimension("Region"));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartAestheticMutator.setFrame(
+            model, "color", spec("type", "static", "color", "#ff0000")));
+
+      assertTrue(thrown.getMessage().contains("categorical"), thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("clear_aesthetic_field"),
+                 "the refusal has to name the way to the fixed-value outcome, not just say no");
+   }
+
+   /** A ramp is as unrenderable there as a static value, and was equally silent. */
+   @Test
+   void refusesAGraduatedFrameOnAChannelBoundToADimension() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setField(model, "color", dimension("Region"));
+
+      assertThrows(IllegalArgumentException.class,
+                   () -> ChartAestheticMutator.setFrame(
+                      model, "color", spec("type", "palette", "palette", "Reds")));
+   }
+
+   @Test
+   void refusesAStaticFrameOnAChannelBoundToAMeasure() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setField(model, "color", measure("Sales", "Sum"));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartAestheticMutator.setFrame(
+            model, "color", spec("type", "static", "color", "#ff0000")));
+
+      assertTrue(thrown.getMessage().contains("gradient"),
+                 "the survivors differ per family, so the message names this channel's: " +
+                 thrown.getMessage());
+   }
+
+   @Test
+   void refusesACategoricalFrameOnAChannelBoundToAMeasure() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setField(model, "size", measure("Sales", "Sum"));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartAestheticMutator.setFrame(
+            model, "size", spec("type", "categorical", "smallest", 2, "largest", 20)));
+
+      assertTrue(thrown.getMessage().contains("linear"),
+                 "size's only graduated frame is linear: " + thrown.getMessage());
+   }
+
+   @Test
+   void acceptsACategoricalFrameOnAChannelBoundToADimension() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setField(model, "color", dimension("Region"));
+
+      ChartAestheticMutator.setFrame(
+         model, "color", spec("type", "categorical", "colors", List.of("#111111")));
+
+      assertInstanceOf(CategoricalColorModel.class, model.getColorField().getFrame());
+   }
+
+   @Test
+   void acceptsAGraduatedFrameOnAChannelBoundToAMeasure() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setField(model, "color", measure("Sales", "Sum"));
+
+      ChartAestheticMutator.setFrame(
+         model, "color", spec("type", "gradient", "from", "#eeeeff", "to", "#005599"));
+
+      assertInstanceOf(GradientColorModel.class, model.getColorField().getFrame());
+   }
+
+   /** The rule follows the bound field to wherever the channel reads it — shape, for line. */
+   @Test
+   void theRuleFollowsLineAndTextureToTheShapeField() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(model, "y", List.of(measure("Sales", "Sum")));
+      ChartAestheticMutator.setField(model, "shape", dimension("Year(ORDER_DATE)"));
+      model.getShapeField().setFrame(new CategoricalLineModel());
+
+      assertThrows(IllegalArgumentException.class,
+                   () -> ChartAestheticMutator.setFrame(
+                      model, "line", spec("type", "static", "line", 4241)));
+   }
+
+   /** With nothing bound the rule does not apply — static is exactly what that slot takes. */
+   @Test
+   void theRuleDoesNotApplyToAFieldLessChannel() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(model, "y", List.of(measure("Sales", "Sum")));
+
+      ChartAestheticMutator.setFrame(model, "color", spec("type", "static", "color", "#123456"));
+
+      ChartAggregateRefModel agg = (ChartAggregateRefModel) model.getYFields().get(0);
+      assertInstanceOf(StaticColorModel.class, agg.getColorFrame());
+   }
+
+   // ── a field-less colour frame on the measures must be static ──────────────
+   //
+   // Live repro: on a bar chart with the colour channel unbound, set_visual_frame color
+   // {type: "categorical", colors: [...]} answered ok and the chart stopped rendering entirely —
+   // every later get_viewsheet_image, clear_aesthetic_field and set_aesthetic_field on it returned
+   // a 500 too, because the bad frame was now sitting on the measures. The stack is
+   // GraphUtil.fixDuplicateColor:1056 casting ChartAggregateRef.getColorFrameWrapper() to
+   // StaticColorFrameWrapper. {type: "gradient"} did the same; {type: "static"} rendered fine and
+   // restored the chart. The Composer cannot reach the state at all: with nothing on the colour
+   // shelf, color-field-mc.getEditPaneId() only ever opens StaticColor or CombinedColor.
+
+   @Test
+   void refusesACategoricalColourFrameOnMeasuresWithNoColourField() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(model, "y", List.of(measure("Sales", "Sum")));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartAestheticMutator.setFrame(
+            model, "color", spec("type", "categorical", "colors", List.of("#111111"))));
+
+      assertTrue(thrown.getMessage().contains("static"), thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("set_aesthetic_field"),
+                 "the refusal has to name the way forward, not just the rule");
+   }
+
+   @Test
+   void refusesAGradientColourFrameOnMeasuresWithNoColourField() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(model, "y", List.of(measure("Sales", "Sum")));
+
+      assertThrows(IllegalArgumentException.class,
+                   () -> ChartAestheticMutator.setFrame(
+                      model, "color", spec("type", "gradient", "from", "#fff", "to", "#000")));
+   }
+
+   /** The one frame the measures can actually carry. */
+   @Test
+   void acceptsAStaticColourFrameOnMeasuresWithNoColourField() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(model, "y", List.of(measure("Sales", "Sum")));
+
+      ChartAestheticMutator.setFrame(model, "color", spec("type", "static", "color", "#4e79a7"));
+
+      ChartAggregateRefModel agg = (ChartAggregateRefModel) model.getYFields().get(0);
+      assertEquals("#4E79A7",
+                   assertInstanceOf(StaticColorModel.class, agg.getColorFrame()).getColor());
+   }
+
+   /** With a field bound the frame lands on the AestheticInfo, which the cast never sees. */
+   @Test
+   void aCategoricalColourFrameIsFineOnceAFieldIsBound() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(model, "y", List.of(measure("Sales", "Sum")));
+      ChartAestheticMutator.setField(model, "color", dimension("Region"));
+
+      ChartAestheticMutator.setFrame(
+         model, "color", spec("type", "categorical", "colors", List.of("#111111")));
+
+      assertInstanceOf(CategoricalColorModel.class, model.getColorField().getFrame());
+   }
+
+   /** The other channels have no such cast, and keep working field-less. */
+   @Test
+   void theStaticOnlyRuleIsColourOnly() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(model, "y", List.of(measure("Sales", "Sum")));
+
+      ChartAestheticMutator.setFrame(
+         model, "line", spec("type", "categorical", "lines", List.of(4097, 4113)));
+
+      ChartAggregateRefModel agg = (ChartAggregateRefModel) model.getYFields().get(0);
+      assertInstanceOf(CategoricalLineModel.class, agg.getLineFrame());
+   }
+
+   // ── Share Colors needs the field name and the viewsheet's existing pins ───
+   //
+   // Live repro: with a dimension on colour, set_visual_frame color
+   // {type: "categorical", colors: [...], useGlobal: true} returned a 500 every time, while the
+   // identical call with useGlobal false succeeded. VSChartBindingFactory.applyColorsToViewsheet
+   // only runs when the flag is set, and hands frame.getField() to Viewsheet.setDimensionColors,
+   // whose getAttribute does column.indexOf(":") -- NPE, because a frame built here is a bare
+   // new CategoricalColorModel() and nothing ever set its field.
+
+   @Test
+   void aSharedColourFrameCarriesTheFieldNameThatViewsheetLevelPinsAreKeyedBy() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setField(model, "color", dimension("Region"));
+
+      ChartAestheticMutator.setFrame(
+         model, "color",
+         spec("type", "categorical", "colors", List.of("#111111"), "shareColors", true));
+
+      CategoricalColorModel frame =
+         assertInstanceOf(CategoricalColorModel.class, model.getColorField().getFrame());
+      assertEquals("Region", frame.getField(),
+                   "a null here is an NPE in Viewsheet.setDimensionColors, not a missing label");
+   }
+
+   /** Carried even when sharing is off, so turning it on later is not the call that breaks. */
+   @Test
+   void anUnsharedColourFrameCarriesTheFieldNameToo() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setField(model, "color", dimension("Region"));
+
+      ChartAestheticMutator.setFrame(
+         model, "color", spec("type", "categorical", "colors", List.of("#111111")));
+
+      assertEquals("Region",
+                   ((CategoricalColorModel) model.getColorField().getFrame()).getField());
+   }
+
+   /**
+    * applyColorsToViewsheet rewrites the column's whole entry from globalColorMaps, and
+    * Viewsheet.setDimensionColors drops the column's existing keys first — so an empty array does
+    * not leave the viewsheet's fixed pins alone, it deletes them. The agent cannot author them, so
+    * carrying what the channel already has is the only way a frame write avoids destroying them.
+    */
+   @Test
+   void aSharedColourFrameCarriesTheViewsheetLevelPinsForward() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setField(model, "color", dimension("Region"));
+      ChartAestheticMutator.setFrame(
+         model, "color", spec("type", "categorical", "colors", List.of("#111111")));
+
+      CategoricalColorModel existing = (CategoricalColorModel) model.getColorField().getFrame();
+      existing.setGlobalColorMaps(new ColorMapModel[]{ new ColorMapModel("East", "#D64541") });
+
+      ChartAestheticMutator.setFrame(
+         model, "color",
+         spec("type", "categorical", "colors", List.of("#222222"), "shareColors", true));
+
+      CategoricalColorModel frame =
+         assertInstanceOf(CategoricalColorModel.class, model.getColorField().getFrame());
+      assertEquals(1, frame.getGlobalColorMaps().length,
+                   "an empty array here wipes the column's pins off the viewsheet");
+      assertEquals("East", frame.getGlobalColorMaps()[0].getOption());
+   }
+
+   /**
+    * Turning sharing on is the transition categorical-color-pane.shareColorsChange handles by
+    * seeding globalColorMaps from colorMaps — the frame's own pins become the viewsheet's. The
+    * option moves where the pins live; it does not discard them.
+    */
+   @Test
+   void turningSharingOnPromotesTheFramesOwnPinsToTheViewsheetLevelOnes() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setField(model, "color", dimension("Region"));
+      ChartAestheticMutator.setFrame(
+         model, "color", spec("type", "categorical", "colors", List.of("#111111")));
+
+      CategoricalColorModel existing = (CategoricalColorModel) model.getColorField().getFrame();
+      existing.setColorMaps(new ColorMapModel[]{ new ColorMapModel("West", "#F28E2C") });
+
+      ChartAestheticMutator.setFrame(
+         model, "color",
+         spec("type", "categorical", "colors", List.of("#222222"), "shareColors", true));
+
+      CategoricalColorModel frame =
+         assertInstanceOf(CategoricalColorModel.class, model.getColorField().getFrame());
+      assertEquals(1, frame.getGlobalColorMaps().length);
+      assertEquals("West", frame.getGlobalColorMaps()[0].getOption());
+   }
+
+   /**
+    * Pinning a value while sharing is on is the "Assign Fixed Mapping" + "Share Colors" pairing,
+    * and it must add to the column's pins rather than replace them: Viewsheet.setDimensionColors
+    * drops the column's existing keys before putting the new ones, so a request naming one value
+    * would otherwise unpin every other one. The unshared path already behaves that way, because
+    * assignMappedColors only calls setColor for the values it was given.
+    */
+   @Test
+   void aSharedMappingAddsToTheColumnsPinsInsteadOfReplacingThem() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setField(model, "color", dimension("Region"));
+      ChartAestheticMutator.setFrame(
+         model, "color", spec("type", "categorical", "colors", List.of("#111111")));
+
+      CategoricalColorModel existing = (CategoricalColorModel) model.getColorField().getFrame();
+      existing.setGlobalColorMaps(new ColorMapModel[]{ new ColorMapModel("East", "#D64541") });
+
+      ChartAestheticMutator.setFrame(
+         model, "color",
+         spec("type", "categorical", "shareColors", true, "mapping", Map.of("West", "#F28E2C")));
+
+      CategoricalColorModel frame =
+         assertInstanceOf(CategoricalColorModel.class, model.getColorField().getFrame());
+      Map<String, String> pins = new LinkedHashMap<>();
+
+      for(ColorMapModel pin : frame.getGlobalColorMaps()) {
+         pins.put(pin.getOption(), pin.getColor());
+      }
+
+      assertEquals(Map.of("East", "#D64541", "West", "#F28E2C"), pins,
+                   "naming one value must not unpin the others");
+   }
+
+   /** Naming a value that is already pinned re-colours it rather than duplicating it. */
+   @Test
+   void aSharedMappingOverwritesAPinItNames() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setField(model, "color", dimension("Region"));
+      ChartAestheticMutator.setFrame(
+         model, "color", spec("type", "categorical", "colors", List.of("#111111")));
+
+      CategoricalColorModel existing = (CategoricalColorModel) model.getColorField().getFrame();
+      existing.setGlobalColorMaps(new ColorMapModel[]{ new ColorMapModel("East", "#D64541") });
+
+      ChartAestheticMutator.setFrame(
+         model, "color",
+         spec("type", "categorical", "shareColors", true, "mapping", Map.of("East", "#000000")));
+
+      CategoricalColorModel frame =
+         assertInstanceOf(CategoricalColorModel.class, model.getColorField().getFrame());
+      assertEquals(1, frame.getGlobalColorMaps().length);
+      assertEquals("#000000", frame.getGlobalColorMaps()[0].getColor());
+   }
+
+   /**
+    * A spec that does not mention shareColors is not asking about the checkbox. Forcing it off
+    * meant every colour change silently switched sharing off for a chart that had it on, with
+    * nothing in the request to say so. The Composer's Apply posts back whatever
+    * CategoricalColorModel(wrapper) read off the frame, and this now does the same.
+    */
+   @Test
+   void anOmittedShareColorsLeavesTheChannelsCheckboxAlone() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setField(model, "color", dimension("Region"));
+      ChartAestheticMutator.setFrame(
+         model, "color",
+         spec("type", "categorical", "colors", List.of("#111111"), "shareColors", true));
+
+      ChartAestheticMutator.setFrame(
+         model, "color", spec("type", "categorical", "colors", List.of("#222222")));
+
+      CategoricalColorModel frame =
+         assertInstanceOf(CategoricalColorModel.class, model.getColorField().getFrame());
+      assertTrue(frame.isShareColors(), "changing a colour is not a request to stop sharing");
+      assertTrue(frame.isUseGlobal());
+      assertArrayEquals(new String[]{ "#222222" }, frame.getColors());
+   }
+
+   @Test
+   void anExplicitShareColorsFalseStillTurnsSharingOff() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setField(model, "color", dimension("Region"));
+      ChartAestheticMutator.setFrame(
+         model, "color",
+         spec("type", "categorical", "colors", List.of("#111111"), "shareColors", true));
+
+      ChartAestheticMutator.setFrame(
+         model, "color",
+         spec("type", "categorical", "colors", List.of("#222222"), "shareColors", false));
+
+      CategoricalColorModel frame =
+         assertInstanceOf(CategoricalColorModel.class, model.getColorField().getFrame());
+      assertFalse(frame.isShareColors());
+      assertFalse(frame.isUseGlobal());
+   }
+
+   /**
+    * The two flags agree on every frame the Composer or this tool writes; a legacy frame where
+    * they do not is one neither can repair, so a write that was not asked about them must not
+    * normalise them either.
+    */
+   @Test
+   void anOmittedShareColorsPreservesALegacyFramesDivergentPair() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setField(model, "color", dimension("Region"));
+      ChartAestheticMutator.setFrame(
+         model, "color", spec("type", "categorical", "colors", List.of("#111111")));
+
+      CategoricalColorModel existing = (CategoricalColorModel) model.getColorField().getFrame();
+      existing.setUseGlobal(true);
+      existing.setShareColors(false);
+
+      ChartAestheticMutator.setFrame(
+         model, "color", spec("type", "categorical", "colors", List.of("#222222")));
+
+      CategoricalColorModel frame =
+         assertInstanceOf(CategoricalColorModel.class, model.getColorField().getFrame());
+      assertTrue(frame.isUseGlobal());
+      assertFalse(frame.isShareColors());
+   }
+
+   /**
+    * With sharing carried forward rather than restated, the pins still have to land in the array
+    * the factory reads — VisualFrameAliases routed on the spec, which said nothing.
+    */
+   @Test
+   void anOmittedShareColorsStillRoutesPinsToTheSharedArray() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setField(model, "color", dimension("Region"));
+      ChartAestheticMutator.setFrame(
+         model, "color",
+         spec("type", "categorical", "colors", List.of("#111111"), "shareColors", true));
+
+      ChartAestheticMutator.setFrame(
+         model, "color", spec("type", "categorical", "mapping", Map.of("2022", "#000000")));
+
+      CategoricalColorModel frame =
+         assertInstanceOf(CategoricalColorModel.class, model.getColorField().getFrame());
+      assertEquals(1, frame.getGlobalColorMaps().length);
+      assertEquals("2022", frame.getGlobalColorMaps()[0].getOption());
+      assertEquals(0, frame.getColorMaps().length,
+                   "a stale copy in the array the factory ignores is how a read starts lying");
+   }
+
+   /** Sharing off never reaches applyColorsToViewsheet, so nothing is promoted. */
+   @Test
+   void anUnsharedColourFrameDoesNotPromoteAnything() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setField(model, "color", dimension("Region"));
+      ChartAestheticMutator.setFrame(
+         model, "color", spec("type", "categorical", "colors", List.of("#111111")));
+
+      CategoricalColorModel existing = (CategoricalColorModel) model.getColorField().getFrame();
+      existing.setColorMaps(new ColorMapModel[]{ new ColorMapModel("West", "#F28E2C") });
+
+      ChartAestheticMutator.setFrame(
+         model, "color", spec("type", "categorical", "colors", List.of("#222222")));
+
+      CategoricalColorModel frame =
+         assertInstanceOf(CategoricalColorModel.class, model.getColorField().getFrame());
+      assertEquals(0, frame.getGlobalColorMaps().length);
+   }
+
+   // ── one measure at a time: the Composer's Combined pane ───────────────────
+   //
+   // getEditPaneId() opens CombinedColor/CombinedSize when the channel is empty and frames.length
+   // > 1 -- one editor per measure, labelled with the measure's name. Without a way to name one,
+   // every field-less write went to all of them, so "make Profit orange" had to mean "make
+   // everything orange".
+
+   @Test
+   void aNamedMeasureGetsTheFrameAndTheOthersKeepTheirs() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(
+         model, "y", List.of(measure("Sales", "Sum"), measure("Profit", "Sum")));
+      ChartAestheticMutator.setFrame(model, "color", spec("type", "static", "color", "#111111"));
+
+      ChartAestheticMutator.setFrame(
+         model, "color", spec("type", "static", "color", "#F28E2C"), false,
+         AestheticChannels.FRAME_CHANNELS, "Profit");
+
+      assertEquals("#111111", colorOf(model, 0), "the measure that was not named keeps its own");
+      assertEquals("#F28E2C", colorOf(model, 1));
+   }
+
+   @Test
+   void anUnnamedMeasureStillBroadcasts() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(
+         model, "y", List.of(measure("Sales", "Sum"), measure("Profit", "Sum")));
+
+      ChartAestheticMutator.setFrame(model, "color", spec("type", "static", "color", "#111111"));
+
+      assertEquals("#111111", colorOf(model, 0));
+      assertEquals("#111111", colorOf(model, 1));
+   }
+
+   @Test
+   void refusesAMeasureTheChartDoesNotHave() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(model, "y", List.of(measure("Sales", "Sum")));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartAestheticMutator.setFrame(
+            model, "color", spec("type", "static", "color", "#111111"), false,
+            AestheticChannels.FRAME_CHANNELS, "Nope"));
+
+      assertTrue(thrown.getMessage().contains("Sales"),
+                 "naming the ones that exist is what turns a refusal into a next step: " +
+                 thrown.getMessage());
+   }
+
+   /** With a field bound there is one frame for the channel, not one per measure. */
+   @Test
+   void refusesAMeasureWhenTheChannelHasAFieldBound() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(model, "y", List.of(measure("Sales", "Sum")));
+      ChartAestheticMutator.setField(model, "color", dimension("Region"));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartAestheticMutator.setFrame(
+            model, "color", spec("type", "categorical", "colors", List.of("#111111")), false,
+            AestheticChannels.FRAME_CHANNELS, "Sales"));
+
+      assertTrue(thrown.getMessage().contains("clear_aesthetic_field"), thrown.getMessage());
+   }
+
+   /**
+    * frameOf() reports the first measure's frame, which stops being the whole truth the moment a
+    * measure-scoped write makes them differ. Reporting only the first would then describe a chart
+    * that is visibly drawing something else beside it.
+    */
+   @Test
+   void theReadReportsEveryMeasureOnceTheyDisagree() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(
+         model, "y", List.of(measure("Sales", "Sum"), measure("Profit", "Sum")));
+      ChartAestheticMutator.setFrame(model, "color", spec("type", "static", "color", "#111111"));
+      ChartAestheticMutator.setFrame(
+         model, "color", spec("type", "static", "color", "#F28E2C"), false,
+         AestheticChannels.FRAME_CHANNELS, "Profit");
+
+      @SuppressWarnings("unchecked")
+      Map<String, Object> color =
+         (Map<String, Object>) ChartAestheticMutator.describe(model).get("color");
+      @SuppressWarnings("unchecked")
+      Map<String, Object> byMeasure = (Map<String, Object>) color.get("framesByMeasure");
+
+      assertNotNull(byMeasure, "a read that hid this would report a colour half the chart is not");
+      assertEquals(Set.of("Sales", "Profit"), byMeasure.keySet());
+   }
+
+   /** Agreeing measures keep the common chart's read as short as it was. */
+   @Test
+   void theReadStaysShortWhileTheMeasuresAgree() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(
+         model, "y", List.of(measure("Sales", "Sum"), measure("Profit", "Sum")));
+      ChartAestheticMutator.setFrame(model, "color", spec("type", "static", "color", "#111111"));
+
+      @SuppressWarnings("unchecked")
+      Map<String, Object> color =
+         (Map<String, Object>) ChartAestheticMutator.describe(model).get("color");
+
+      assertFalse(color.containsKey("framesByMeasure"));
+   }
+
+   private static String colorOf(ChartBindingModel model, int index) {
+      ChartAggregateRefModel agg = (ChartAggregateRefModel) model.getYFields().get(index);
+      return assertInstanceOf(StaticColorModel.class, agg.getColorFrame()).getColor();
+   }
+
+   // ── "Reset to Default" ───────────────────────────────────────────────────
+   //
+   // Four panes carry the button and no two do the same thing; three of them are a model change
+   // and are mirrored here. categorical-color restores cssColors ?? defaultColors; combined-color
+   // restores each measure's palette entry for its own position; categorical-shape serves shapes,
+   // lines and textures from one button. linear-color's resetEditors() only re-syncs widgets.
+
+   @Test
+   void resetRestoresACategoricalPaletteToItsDefaults() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setField(model, "color", dimension("Region"));
+      ChartAestheticMutator.setFrame(
+         model, "color", spec("type", "categorical", "colors", List.of("#111111", "#222222")));
+
+      CategoricalColorModel frame = (CategoricalColorModel) model.getColorField().getFrame();
+      frame.setDefaultColors(new String[]{ "#4E79A7", "#F28E2C" });
+
+      ChartAestheticMutator.resetFrame(
+         model, "color", false, AestheticChannels.FRAME_CHANNELS, null);
+
+      assertArrayEquals(
+         new String[]{ "#4E79A7", "#F28E2C" },
+         ((CategoricalColorModel) model.getColorField().getFrame()).getColors());
+   }
+
+   /** The CSS theme's entry wins over the built-in one, as it does in the pane. */
+   @Test
+   void resetPrefersTheCssPaletteOverTheBuiltInOne() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setField(model, "color", dimension("Region"));
+      ChartAestheticMutator.setFrame(
+         model, "color", spec("type", "categorical", "colors", List.of("#111111")));
+
+      CategoricalColorModel frame = (CategoricalColorModel) model.getColorField().getFrame();
+      frame.setCssColors(new String[]{ "#00FF00" });
+      frame.setDefaultColors(new String[]{ "#4E79A7" });
+
+      ChartAestheticMutator.resetFrame(
+         model, "color", false, AestheticChannels.FRAME_CHANNELS, null);
+
+      assertArrayEquals(
+         new String[]{ "#00FF00" },
+         ((CategoricalColorModel) model.getColorField().getFrame()).getColors());
+   }
+
+   /** The button sits beside the palette editors, not beside "Assign Fixed Mapping". */
+   @Test
+   void resetLeavesThePinnedValuesPinned() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setField(model, "color", dimension("Region"));
+      ChartAestheticMutator.setFrame(
+         model, "color",
+         spec("type", "categorical", "colors", List.of("#111111"),
+              "mapping", Map.of("East", "#d64541")));
+
+      ((CategoricalColorModel) model.getColorField().getFrame())
+         .setDefaultColors(new String[]{ "#4E79A7" });
+
+      ChartAestheticMutator.resetFrame(
+         model, "color", false, AestheticChannels.FRAME_CHANNELS, null);
+
+      CategoricalColorModel frame = (CategoricalColorModel) model.getColorField().getFrame();
+      assertEquals(1, frame.getColorMaps().length);
+      assertEquals("East", frame.getColorMaps()[0].getOption());
+   }
+
+   @Test
+   void resetGivesEachMeasureThePaletteEntryForItsOwnPosition() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(
+         model, "y", List.of(measure("Sales", "Sum"), measure("Profit", "Sum")));
+      ChartAestheticMutator.setFrame(model, "color", spec("type", "static", "color", "#111111"));
+
+      ChartAestheticMutator.resetFrame(
+         model, "color", false, AestheticChannels.FRAME_CHANNELS, null);
+
+      assertNotEquals(colorOf(model, 0), colorOf(model, 1),
+                      "both measures resetting to one colour is what the position exists to stop");
+   }
+
+   @Test
+   void resetScopedToOneMeasureLeavesTheOthersAlone() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(
+         model, "y", List.of(measure("Sales", "Sum"), measure("Profit", "Sum")));
+      ChartAestheticMutator.setFrame(model, "color", spec("type", "static", "color", "#111111"));
+
+      ChartAestheticMutator.resetFrame(
+         model, "color", false, AestheticChannels.FRAME_CHANNELS, "Profit");
+
+      assertEquals("#111111", colorOf(model, 0));
+      assertNotEquals("#111111", colorOf(model, 1));
+   }
+
+   /** One button, three families -- categorical-shape-pane switches on the chart's own. */
+   @Test
+   void resetRestoresACategoricalLineSetToThePickersOwnList() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(model, "y", List.of(measure("Sales", "Sum")));
+      ChartAestheticMutator.setField(model, "shape", dimension("Year(ORDER_DATE)"));
+      CategoricalLineModel lines = new CategoricalLineModel();
+      lines.setLines(new int[]{ 4241, 4241 });
+      model.getShapeField().setFrame(lines);
+
+      ChartAestheticMutator.resetFrame(
+         model, "line", false, AestheticChannels.FRAME_CHANNELS, null);
+
+      int[] reset = ((CategoricalLineModel) model.getShapeField().getFrame()).getLines();
+      assertEquals(10, reset.length, "the five styles listed twice, as the pane's reset does");
+      assertEquals(4097, reset[0]);
+   }
+
+   @Test
+   void resetRestoresACategoricalTextureSetWithoutTheNoTextureEntry() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(model, "y", List.of(measure("Sales", "Sum")));
+      ChartAestheticMutator.setField(model, "shape", dimension("Year(ORDER_DATE)"));
+      CategoricalTextureModel textures = new CategoricalTextureModel();
+      textures.setTextures(new int[]{ 19, 19 });
+      model.getShapeField().setFrame(textures);
+
+      ChartAestheticMutator.resetFrame(
+         model, "texture", false, AestheticChannels.FRAME_CHANNELS, null);
+
+      int[] reset = ((CategoricalTextureModel) model.getShapeField().getFrame()).getTextures();
+      assertEquals(20, reset.length);
+      assertEquals(0, reset[0], "PATTERN_NONE is left out -- an invisible category is not a reset");
+   }
+
+   @Test
+   void resetRestoresACategoricalShapeSet() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartBindingMutator.setShelf(model, "y", List.of(measure("Sales", "Sum")));
+      ChartAestheticMutator.setField(model, "shape", dimension("Region"));
+      CategoricalShapeModel shapes = new CategoricalShapeModel();
+      shapes.setShapes(new String[]{ "907", "907" });
+      model.getShapeField().setFrame(shapes);
+
+      ChartAestheticMutator.resetFrame(
+         model, "shape", false, AestheticChannels.FRAME_CHANNELS, null);
+
+      String[] reset = ((CategoricalShapeModel) model.getShapeField().getFrame()).getShapes();
+      assertEquals(32, reset.length, "sixteen point shapes then the sixteen bundled images");
+      assertEquals("900", reset[0]);
+      assertEquals("100ArrowDown.svg", reset[16]);
+   }
+
+   /** A frame with no stored default is refused rather than given an invented one. */
+   @Test
+   void refusesToResetAFrameThatHasNoDefault() {
+      ChartBindingModel model = new ChartBindingModel();
+      ChartAestheticMutator.setField(model, "color", measure("Sales", "Sum"));
+      ChartAestheticMutator.setFrame(
+         model, "color", spec("type", "gradient", "from", "#eeeeff", "to", "#005599"));
+
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> ChartAestheticMutator.resetFrame(
+            model, "color", false, AestheticChannels.FRAME_CHANNELS, null));
+
+      assertTrue(thrown.getMessage().contains("set_visual_frame"),
+                 "the refusal has to name the way to get the value they want: " +
+                 thrown.getMessage());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/binding/VisualFrameAliasesTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/VisualFrameAliasesTest.java
@@ -830,4 +830,28 @@ class VisualFrameAliasesTest {
 
       assertEquals(true, VisualFrameAliases.describe(frame).get("colorValueFrame"));
    }
+
+   /**
+    * The precondition is satisfied by switching the checkbox ON, because that is what replaces the
+    * thing a palette would otherwise have to supply. An explicit {@code false} says "read the
+    * palette", which leaves the frame with no palette to read — the same half-specified shape the
+    * check exists to refuse, arriving through a key that looks like it answers it.
+    */
+   @Test
+   void refusesAnExplicitlyFalseColorValueFrameStandingInForAPalette() {
+      assertThrows(IllegalArgumentException.class,
+                   () -> VisualFrameAliases.create("color", spec("type", "categorical",
+                                                                 "colorValueFrame", false)));
+   }
+
+   @Test
+   void acceptsAnExplicitlyFalseColorValueFrameAlongsideAPalette() {
+      CategoricalColorModel frame = assertInstanceOf(
+         CategoricalColorModel.class,
+         VisualFrameAliases.create("color", spec("type", "categorical",
+                                                 "colors", java.util.List.of("#fff"),
+                                                 "colorValueFrame", false)));
+
+      assertFalse(frame.isColorValueFrame());
+   }
 }

--- a/core/src/test/java/inetsoft/web/wiz/binding/VisualFrameAliasesTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/binding/VisualFrameAliasesTest.java
@@ -17,11 +17,13 @@
  */
 package inetsoft.web.wiz.binding;
 
+import inetsoft.web.binding.model.ColorMapModel;
 import inetsoft.web.binding.model.graph.aesthetic.*;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -349,9 +351,10 @@ class VisualFrameAliasesTest {
    // ── per-value colour mapping, and the useGlobal footgun (2c Phase 3) ──────
 
    /**
-    * The recorded defect: while {@code useGlobal} is set the automatic palette wins, so a mapped
-    * colour is stored and never rendered — the model round-trips perfectly and the chart shows
-    * something else. Supplying a mapping must clear the flag.
+    * The recorded defect: while {@code useGlobal} is set, the model-to-wrapper conversion reads
+    * {@code globalColorMaps} in place of {@code colorMaps}, so a mapped colour is stored and never
+    * rendered — the model round-trips perfectly and the chart shows something else. Supplying a
+    * mapping must clear the flag.
     */
    @Test
    void aColourMappingClearsUseGlobalSoItActuallyRenders() {
@@ -388,25 +391,92 @@ class VisualFrameAliasesTest {
                   "same column even when useGlobal is cleared");
    }
 
+   /**
+    * "Assign Fixed Mapping" with "Share Colors" checked is a supported and useful combination —
+    * pinning a value's colour across the whole viewsheet. The flag picks which array the pins go
+    * in, the way {@code openColorMappingDialog}'s callback does; it does not make them illegal.
+    */
    @Test
-   void refusesUseGlobalTogetherWithAMapping() {
-      Exception thrown = assertThrows(
-         IllegalArgumentException.class,
-         () -> VisualFrameAliases.create("color", spec("type", "categorical", "useGlobal", true,
-                                                       "mapping", Map.of("East", "#fff"))));
+   void sharedPinsGoInTheViewsheetLevelArray() {
+      CategoricalColorModel frame = assertInstanceOf(
+         CategoricalColorModel.class,
+         VisualFrameAliases.create("color", spec("type", "categorical", "shareColors", true,
+                                                 "mapping", Map.of("2022", "#000000"))));
 
-      assertTrue(thrown.getMessage().contains("never rendered"),
-                 "the refusal has to say what would have happened, or it reads as arbitrary");
+      assertEquals(1, frame.getGlobalColorMaps().length,
+                   "the factory reads globalColorMaps while sharing is on");
+      assertEquals("2022", frame.getGlobalColorMaps()[0].getOption());
+      assertEquals("#000000", frame.getGlobalColorMaps()[0].getColor());
+      assertEquals(0, frame.getColorMaps().length,
+                   "the array the factory is not reading must stay empty, not hold a stale copy");
    }
 
    @Test
-   void acceptsUseGlobalOnItsOwn() {
+   void unsharedPinsGoInTheFramesOwnArray() {
       CategoricalColorModel frame = assertInstanceOf(
          CategoricalColorModel.class,
-         VisualFrameAliases.create("color", spec("type", "categorical", "useGlobal", true,
+         VisualFrameAliases.create("color", spec("type", "categorical", "shareColors", false,
+                                                 "mapping", Map.of("2022", "#000000"))));
+
+      assertEquals(1, frame.getColorMaps().length);
+      assertEquals(0, frame.getGlobalColorMaps().length);
+   }
+
+   /**
+    * The frame carries {@code useGlobal} and {@code shareColors} separately for historical
+    * reasons, but the Composer has driven them from one checkbox ever since {@code shareColors}
+    * was added, and the dialog's own {@code toggleGlobal()} is wired to nothing. Offering the
+    * agent both names would advertise a distinction the product does not have, so the second one
+    * is refused by name — and the refusal names the one that works.
+    */
+   @Test
+   void refusesUseGlobalAndNamesShareColorsInstead() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> VisualFrameAliases.create("color", spec("type", "categorical", "useGlobal", true,
+                                                       "colors", java.util.List.of("#fff"))));
+
+      assertTrue(thrown.getMessage().contains("useGlobal"), thrown.getMessage());
+      assertTrue(thrown.getMessage().contains("shareColors"),
+                 "a refusal that does not name the working key just stalls the caller");
+   }
+
+   /**
+    * One key drives both flags, the way the checkbox does. Either one left set alone renders
+    * differently from what was asked for.
+    */
+   @Test
+   void shareColorsDrivesBothOfTheFramesFlags() {
+      CategoricalColorModel frame = assertInstanceOf(
+         CategoricalColorModel.class,
+         VisualFrameAliases.create("color", spec("type", "categorical", "shareColors", true,
                                                  "colors", java.util.List.of("#fff"))));
 
-      assertTrue(frame.isUseGlobal());
+      assertTrue(frame.isShareColors());
+      assertTrue(frame.isUseGlobal(), "the checkbox drives both flags, so the alias must too");
+   }
+
+   @Test
+   void shareColorsFalseIsTheDefaultSoAnExplicitPaletteRendersAsGiven() {
+      CategoricalColorModel frame = assertInstanceOf(
+         CategoricalColorModel.class,
+         VisualFrameAliases.create("color", spec("type", "categorical", "shareColors", false,
+                                                 "colors", java.util.List.of("#fff"))));
+
+      assertFalse(frame.isShareColors());
+      assertFalse(frame.isUseGlobal());
+   }
+
+   /** Omitted means "leave the checkbox alone"; the resolution needs the frame, so it is not here. */
+   @Test
+   void anOmittedShareColorsIsReportedAsUnasked() {
+      assertNull(VisualFrameAliases.shareColors(spec("type", "categorical")));
+      assertEquals(Boolean.TRUE,
+                   VisualFrameAliases.shareColors(spec("type", "categorical",
+                                                       "shareColors", true)));
+      assertEquals(Boolean.FALSE,
+                   VisualFrameAliases.shareColors(spec("type", "categorical",
+                                                       "shareColors", false)));
    }
 
    @Test
@@ -435,16 +505,90 @@ class VisualFrameAliasesTest {
                    () -> VisualFrameAliases.create("color", spec("type", "categorical")));
    }
 
-   /** useGlobal is reported on read, because a true there means any mapping is inert. */
+   /** Share Colors is reported on read, because a true there changes what the chart draws. */
    @Test
-   void reportsUseGlobalAndTheMappingOnRead() {
+   void reportsShareColorsAndTheMappingOnRead() {
       VisualFrameModel frame = VisualFrameAliases.create(
          "color", spec("type", "categorical", "mapping", Map.of("East", "#4e79a7")));
 
       Map<String, Object> described = VisualFrameAliases.describe(frame);
 
-      assertEquals(false, described.get("useGlobal"));
+      assertEquals(false, described.get("shareColors"));
       assertEquals(Map.of("East", "#4E79A7"), described.get("mapping"));
+      assertFalse(described.containsKey("useGlobal"),
+                  "the two flags agree here, so one key reports both");
+   }
+
+   /**
+    * With sharing on the pins live in {@code globalColorMaps}. Reading {@code colorMaps} here
+    * would report {@code mapping: {}} for a chart that visibly has pinned colours — the same
+    * read-the-dead-slot failure the write side is careful to avoid.
+    */
+   @Test
+   void reportsSharedPinsFromTheArrayTheRendererActuallyReads() {
+      VisualFrameModel frame = VisualFrameAliases.create(
+         "color", spec("type", "categorical", "shareColors", true,
+                       "mapping", Map.of("2022", "#000000")));
+
+      Map<String, Object> described = VisualFrameAliases.describe(frame);
+
+      assertEquals(true, described.get("shareColors"));
+      assertEquals(Map.of("2022", "#000000"), described.get("mapping"));
+   }
+
+   /**
+    * Live repro: get_chart_aesthetics read a shared pin back as {@code "000000"} while the
+    * {@code colors} beside it were {@code "#000000"}, because
+    * {@code VSChartBindingFactory.applyColorsToFrame} refills globalColorMaps from the viewsheet
+    * with {@code Tool.colorToHTMLString} (six hex digits, no '#') while everything else uses
+    * {@code Tool.toString(Color)}. set_visual_frame refuses a bare six digits, so the read could
+    * not be fed back to the write.
+    */
+   @Test
+   void reportsAPinInTheSpellingTheWriteSideAccepts() {
+      CategoricalColorModel frame = new CategoricalColorModel();
+      frame.setColors(new String[]{ "#4E79A7" });
+      frame.setUseGlobal(true);
+      frame.setGlobalColorMaps(new ColorMapModel[]{ new ColorMapModel("2022", "000000") });
+
+      Map<String, Object> described = VisualFrameAliases.describe(frame);
+
+      assertEquals(Map.of("2022", "#000000"), described.get("mapping"));
+   }
+
+   /** A diagnostic must not become a second failure when something upstream stored junk. */
+   @Test
+   void reportsAnUnparseablePinVerbatimRatherThanThrowing() {
+      CategoricalColorModel frame = new CategoricalColorModel();
+      frame.setColors(new String[]{ "#4E79A7" });
+      frame.setUseGlobal(false);
+      frame.setColorMaps(new ColorMapModel[]{ new ColorMapModel("2022", "chartreuse") });
+
+      Map<String, Object> described = VisualFrameAliases.describe(frame);
+
+      assertEquals(Map.of("2022", "chartreuse"), described.get("mapping"));
+   }
+
+   /**
+    * A viewsheet saved before the Share Colors feature existed parses back with {@code useGlobal}
+    * true and {@code shareColors} false ({@code CategoricalColorFrameWrapper.parseContents}
+    * defaults the missing element to false while the field default is true). Reported through the
+    * flag the render path consults for the pins, since that is the one whose effect the caller can
+    * see on the chart. The pair is left untouched by writes rather than surfaced — the Composer
+    * can neither produce nor repair the divergence, so naming it would offer a distinction the
+    * agent has no way to act on.
+    */
+   @Test
+   void reportsTheRenderRelevantFlagForALegacyFrame() {
+      CategoricalColorModel frame = new CategoricalColorModel();
+      frame.setColors(new String[]{ "#4E79A7" });
+      frame.setUseGlobal(true);
+      frame.setShareColors(false);
+
+      Map<String, Object> described = VisualFrameAliases.describe(frame);
+
+      assertEquals(true, described.get("shareColors"));
+      assertFalse(described.containsKey("useGlobal"));
    }
 
    // ── node channels (spec 2c Phase 3) ───────────────────────────────────────
@@ -488,5 +632,202 @@ class VisualFrameAliasesTest {
          () -> VisualFrameAliases.create("node-size", spec("type", "static", "color", "#000"),
                                          true),
          "'color' is not a key node-size's static frame reads -- it reads 'size'");
+   }
+
+   // ── the graduated and per-category frames carry their configuration ───────
+   //
+   // create() used to build these with `new CategoricalLineModel()` and friends and nothing
+   // else, so the only reachable spec was the bare `{type: "categorical"}`. The per-category
+   // lists the Composer's own categorical pane edits -- lines, textures, shapes -- and the
+   // smallest/largest range its binding-size pane edits had no way in at all.
+
+   @Test
+   void buildsACategoricalLineFrameFromTheLineList() {
+      CategoricalLineModel frame = assertInstanceOf(
+         CategoricalLineModel.class,
+         VisualFrameAliases.create("line", spec("type", "categorical", "lines",
+                                                List.of(4097, 4113, 4145))));
+
+      assertArrayEquals(new int[]{ 4097, 4113, 4145 }, frame.getLines());
+      assertTrue(frame.isChanged(),
+                 "CategoricalLineFrameModelFactory ends with setChanged(model.isChanged()), so " +
+                 "a model left unchanged stores the lines and reports the frame as untouched");
+   }
+
+   @Test
+   void buildsACategoricalTextureFrameFromTheTextureList() {
+      CategoricalTextureModel frame = assertInstanceOf(
+         CategoricalTextureModel.class,
+         VisualFrameAliases.create("texture", spec("type", "categorical", "textures",
+                                                   List.of(-1, 3, 7))));
+
+      assertArrayEquals(new int[]{ -1, 3, 7 }, frame.getTextures());
+      assertTrue(frame.isChanged());
+   }
+
+   /**
+    * The bare form still means something -- "vary by category, using the defaults" -- and is
+    * what binding a field produces before anything is picked, so it must stay buildable.
+    */
+   @Test
+   void stillBuildsABareCategoricalLineOrTextureFrame() {
+      assertArrayEquals(new int[0], ((CategoricalLineModel) VisualFrameAliases.create(
+         "line", spec("type", "categorical"))).getLines());
+      assertArrayEquals(new int[0], ((CategoricalTextureModel) VisualFrameAliases.create(
+         "texture", spec("type", "categorical"))).getTextures());
+   }
+
+   @Test
+   void refusesASingleCodeWhereAListOfCodesIsRead() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> VisualFrameAliases.create("line", spec("type", "categorical", "lines", 4097)));
+
+      assertTrue(thrown.getMessage().contains("list"), thrown.getMessage());
+   }
+
+   @Test
+   void refusesANonNumericCodeInTheList() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> VisualFrameAliases.create("texture", spec("type", "categorical", "textures",
+                                                         List.of(1, "solid"))));
+
+      assertTrue(thrown.getMessage().contains("textures[1]"), thrown.getMessage());
+   }
+
+   @Test
+   void buildsAGraduatedSizeFrameFromSmallestAndLargest() {
+      LinearSizeModel linear = assertInstanceOf(
+         LinearSizeModel.class,
+         VisualFrameAliases.create("size", spec("type", "linear", "smallest", 4, "largest", 22)));
+
+      assertEquals(4d, linear.getSmallest());
+      assertEquals(22d, linear.getLargest());
+      assertTrue(linear.isChanged(),
+                 "SizeFrameModelFactory.updateVisualFrameWrapper0 returns null for an unchanged " +
+                 "model, discarding the whole wrapper before it reaches the chart");
+
+      CategoricalSizeModel categorical = assertInstanceOf(
+         CategoricalSizeModel.class,
+         VisualFrameAliases.create("size", spec("type", "categorical", "largest", 12)));
+
+      assertEquals(1d, categorical.getSmallest(), "SizeFrameModel's own default");
+      assertEquals(12d, categorical.getLargest());
+      assertTrue(categorical.isChanged());
+   }
+
+   @Test
+   void refusesASizeRangeThatIsInverted() {
+      Exception thrown = assertThrows(
+         IllegalArgumentException.class,
+         () -> VisualFrameAliases.create("size", spec("type", "linear",
+                                                      "smallest", 20, "largest", 5)));
+
+      assertTrue(thrown.getMessage().contains("largest"), thrown.getMessage());
+   }
+
+   @Test
+   void marksACategoricalShapeFrameAsChanged() {
+      CategoricalShapeModel frame = assertInstanceOf(
+         CategoricalShapeModel.class,
+         VisualFrameAliases.create("shape", spec("type", "categorical", "shapes",
+                                                 List.of("900", "901"))));
+
+      assertTrue(frame.isChanged());
+   }
+
+   @Test
+   void refusesTheNewKeysOnAChannelThatDoesNotReadThem() {
+      assertThrows(IllegalArgumentException.class,
+                   () -> VisualFrameAliases.create("texture", spec("type", "categorical",
+                                                                   "lines", List.of(4097))));
+      assertThrows(IllegalArgumentException.class,
+                   () -> VisualFrameAliases.create("color", spec("type", "categorical",
+                                                                 "colors", List.of("#000"),
+                                                                 "largest", 12)));
+      assertThrows(IllegalArgumentException.class,
+                   () -> VisualFrameAliases.create("size", spec("type", "static", "size", 8,
+                                                                "largest", 12)));
+   }
+
+   // ── describe() reports what create() now stores ───────────────────────────
+   //
+   // These three fell through to the BEHAVIOURAL table, which knows only a type name. That was
+   // right while they were built empty; now it would report {type: "categorical"} whatever the
+   // frame holds, so a write could not be read back.
+
+   @Test
+   void describesTheValuesAPerCategoryFrameHolds() {
+      Map<String, Object> line = VisualFrameAliases.describe(
+         VisualFrameAliases.create("line", spec("type", "categorical", "lines",
+                                                List.of(4097, 4241))));
+
+      assertEquals("categorical", line.get("type"));
+      assertEquals(List.of(4097, 4241), line.get("lines"));
+
+      Map<String, Object> texture = VisualFrameAliases.describe(
+         VisualFrameAliases.create("texture", spec("type", "categorical", "textures",
+                                                   List.of(0, 5))));
+
+      assertEquals("categorical", texture.get("type"));
+      assertEquals(List.of(0, 5), texture.get("textures"));
+   }
+
+   @Test
+   void describesAGraduatedSizeFramesRange() {
+      Map<String, Object> linear = VisualFrameAliases.describe(
+         VisualFrameAliases.create("size", spec("type", "linear", "smallest", 2, "largest", 18)));
+
+      assertEquals("linear", linear.get("type"));
+      assertEquals(2d, linear.get("smallest"));
+      assertEquals(18d, linear.get("largest"));
+
+      assertEquals("categorical", VisualFrameAliases.describe(
+         VisualFrameAliases.create("size", spec("type", "categorical"))).get("type"));
+   }
+
+   @Test
+   void aStaticSizeFrameIsStillDescribedAsStatic() {
+      Map<String, Object> described = VisualFrameAliases.describe(
+         VisualFrameAliases.create("size", spec("type", "static", "size", 8)));
+
+      assertEquals("static", described.get("type"),
+                   "the new SizeFrameModel branch must not shadow the StaticSizeModel one");
+      assertEquals(8d, described.get("size"));
+   }
+
+   /**
+    * "Use Column Values as Colors" -- the categorical pane's other checkbox. The flag stands on
+    * its own: it replaces what drives the chart rather than adding to the palette, so it satisfies
+    * the "needs colours or a mapping" precondition by itself.
+    */
+   @Test
+   void carriesTheColorValueFrameFlag() {
+      CategoricalColorModel frame = assertInstanceOf(
+         CategoricalColorModel.class,
+         VisualFrameAliases.create("color", spec("type", "categorical",
+                                                 "colorValueFrame", true)));
+
+      assertTrue(frame.isColorValueFrame());
+   }
+
+   @Test
+   void carriesTheColorValueFrameFlagAlongsideAPalette() {
+      CategoricalColorModel frame = assertInstanceOf(
+         CategoricalColorModel.class,
+         VisualFrameAliases.create("color", spec("type", "categorical",
+                                                 "colors", java.util.List.of("#fff"),
+                                                 "colorValueFrame", true)));
+
+      assertTrue(frame.isColorValueFrame());
+   }
+
+   @Test
+   void reportsTheColorValueFrameFlagOnRead() {
+      VisualFrameModel frame = VisualFrameAliases.create(
+         "color", spec("type", "categorical", "colorValueFrame", true));
+
+      assertEquals(true, VisualFrameAliases.describe(frame).get("colorValueFrame"));
    }
 }


### PR DESCRIPTION
Every defect here was reproduced through the agent tools against a running chart, with a control experiment, before being fixed. Each one had the same shape: the write reported success, the read agreed with it, and the chart drew something else.

## `line` and `texture` read and write the shape field's frame

The Composer has one **Shape** slot where the agent vocabulary has three channels. Its swatch edits `lineFrame` on a chart `GraphTypes.supportsLine` answers for, `textureFrame` where `supportsTexture` does, and `shapeFrame` otherwise — one slot, three frame families, picked by chart type (`shape-field-mc.getEditPaneId`).

So binding a dimension to shape on a line chart puts a `CategoricalLineModel` on the **shape** field, and `VSLineFrameStrategy.getAestheticRef` returns that ref precisely because its frame is a `LineFrame`. `VSFrameVisitor.createFrame` then prefers it over every field-less slot. Treating `line` and `texture` as channels that never have a field sent both the read and the write to the per-measure slot, which the renderer ignores in that state.

**Live repro** — line chart, dimension on shape:
```
set_visual_frame channel="line" {type: "static", line: "large dash"}   → ok
render                                                                → byte-for-byte unchanged
clear_aesthetic_field channel="shape"                                 → the same stored value renders at once
```
Confirmed again on `texture` with a bar chart.

## A bound field decides which frame kinds its channel takes

`getEditPaneId` picks the editor from the bound field: a dimension (or a discrete aggregate) opens the **Categorical** pane and nothing else, a measure opens the **Linear** one, and **Static** is offered only when nothing is bound. Anything else is a state the Composer cannot produce and the backend does not cope with.

**Live repro**: `{type: "static", color: "#FF0000"}` on a colour channel with a dimension bound rendered the ordinary categorical palette, no red anywhere. On the line channel the static value ended up sitting in one slot of the categorical `lines` array — neither honoured nor cleanly dropped.

## A field-less colour frame on the measures must be static

`GraphUtil.fixDuplicateColor` casts every aggregate's colour frame wrapper to `StaticColorFrameWrapper` with no `instanceof` in front of it. The cast is safe for the Composer because `getEditPaneId` falls back to `CombinedColor`/`StaticColor` when nothing is bound.

**Live repro** — bar chart, colour channel unbound:
```
set_visual_frame channel="color" {type: "categorical", colors: [...]}  → ok
get_viewsheet_image                                                    → 500
clear_aesthetic_field / set_aesthetic_field on it                      → 500
set_visual_frame channel="color" {type: "static", color: "..."}        → renders again
```
`{type: "gradient"}` did the same. The stack is `GraphUtil.fixDuplicateColor` → `ClassCastException`. Guarded on the agent path, and the three casts now skip what they cannot fix rather than stopping the chart.

## Share Colors is one setting under one name, and is left alone unless asked

The frame carries `useGlobal` and `shareColors` separately for historical reasons — `useGlobal` came first for the Color Mapping dialog, `shareColors` was added later for frame sharing, which is why `CategoricalColorFrameWrapper.parseContents` has a legacy default for one and not the other. The Composer has driven them from a single checkbox ever since; the dialog's own `toggleGlobal()` is left over from before that and is wired to nothing.

Exposing both offered a distinction the product does not have, so the vocabulary has one name. And a spec that does not mention it now leaves the checkbox where it is, as Apply does — forcing it off meant every colour change silently stopped a chart sharing its palette, with nothing in the request to say so.

**Verified live**: two charts colouring by the same column converge on one palette; a pin set on one reaches the other; `shareColors: false` restores independence.

## Share Colors no longer 500s, and no longer destroys the viewsheet's pins

`VSChartBindingFactory.applyColorsToViewsheet` runs only when the flag is set, and hands `frame.getField()` to `Viewsheet.setDimensionColors`, whose `getAttribute` does `column.indexOf(":")`. A frame built on the agent path is a bare `new CategoricalColorModel()` and carries no field, so every `shareColors: true` call against a bound colour channel was a hard NPE — a 500 with no edit applied.

It also rewrites the column's whole entry from `globalColorMaps`, and `setDimensionColors` drops the column's existing keys before putting the new ones, so shipping an empty array deleted the viewsheet's pins rather than leaving them alone. Both are carried forward now, and `Viewsheet` answers "none" for a null column instead of throwing.

## A mapping's pins go wherever the flag says the renderer reads them

`openColorMappingDialog` writes `globalColorMaps` when Share Colors is on and `colorMaps` when it is off; `ColorFrameModelFactory` reads whichever the flag selects. The agent path wrote `colorMaps` unconditionally and refused the combination outright — turning a supported and more useful pairing (pinning a value across the whole viewsheet) into an error.

Both directions are routed now, the read reports from the array the renderer actually uses, and a mapping merges with the column's existing pins rather than replacing them: `setDimensionColors` would otherwise unpin every value the request did not name.

---

## Also adds what the panes had and the tools did not

- **One measure at a time** — the Combined pane, which draws one editor per measure. Applies only where the channel renders per measure and has no field bound, which is exactly when that pane opens.
- **Reset to Default** — for the three frames that have a default: a categorical colour palette, a categorical shape/line/texture set, and the per-measure static colours. Everything else is refused by name, which is also where the Composer offers no reset.
- **Use Column Values as Colors** — accepted; the Composer only shows the checkbox where the deployment lists `ColorValueColorFrame` in `custom.chart.frames`.

The read reports per-measure frames when the measures disagree, so it stops describing a chart that is visibly drawing something else beside it. Colours in a mapping are reported in the one spelling the write side accepts — `VSChartBindingFactory.applyColorsToFrame` refills `globalColorMaps` with `Tool.colorToHTMLString`, which omits the `#`, while everything else uses `Tool.toString(Color)`.

## Testing

`inetsoft.web.wiz.binding.*` plus `GraphUtil*` and `PasteAestheticRefFirstBindFrameTest`: **472 tests, 0 failures**. Every defect above has a regression test carrying its live repro in the comment.

## Known issue, not addressed here

`colorValueFrame` is accepted and stored on the model but does not survive a round trip — the Composer's own checkbox has the same behaviour, so it is not specific to this path. Diagnosis is not settled and the fix is deliberately left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
