### PR TITLE
fix(admin-chat): narrow AdminPropertyCatalog.isSecret false positives

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/ai/AdminPropertyCatalog.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminPropertyCatalog.java
@@ -208,10 +208,29 @@ public class AdminPropertyCatalog {
     * secret value read through this path leaves the host in a way the ordinary EM properties page
     * never does.
     *
-    * <p>Two independent tests, unioned. A name matches case-insensitively when it contains
-    * {@code password}, {@code secret} or {@code credential}, ends with {@code .key}, or starts
-    * with {@code license.}; and {@link #isEncryptedCredential} matches the properties whose
-    * <b>writer</b> encrypts them.
+    * <p>Two independent tests, unioned, then a name-shape exception list subtracted. A name
+    * matches case-insensitively when it contains {@code password}, {@code secret} or
+    * {@code credential}, ends with {@code .key}, or starts with {@code license.}; and
+    * {@link #isEncryptedCredential} matches the properties whose <b>writer</b> encrypts them.
+    * {@link #CONFIRMED_NOT_SECRET} then removes the specific names the shape test catches for the
+    * wrong reason - verified individually, the same way {@link #ENCRYPTED_CREDENTIALS} is, rather
+    * than by loosening the shared pattern:
+    *
+    * <ul>
+    *   <li>{@code enable.changepassword} - a boolean feature flag read with a plain
+    *       {@code SreeEnv.getProperty} ({@code SUtil}). It matches only because it contains the
+    *       substring {@code password}; it holds no credential value at all.</li>
+    *   <li>{@code sso.rsa.public.key} - the PUBLIC half of the SSO RSA keypair, written with a
+    *       plain {@code SreeEnv.setProperty} ({@code LocalPasswordEncryption}). Its sibling
+    *       {@code sso.rsa.private.key} is the actual secret and is deliberately left out of this
+    *       list, so it still matches on both {@code .key} and nothing else masking it.</li>
+    *   <li>{@code google.maps.key} - a Google Maps API key, read and written with plain
+    *       {@code SreeEnv.getProperty}/{@code setProperty} ({@code WebMapSettingsService},
+    *       {@code GoogleMapsService}). Google Maps keys are ordinarily restricted by HTTP referrer
+    *       rather than treated as a bearer credential, and nothing in this codebase encrypts it -
+    *       arguable, but the writer gives no reason to treat it as more sensitive than any other
+    *       configuration string.</li>
+    * </ul>
     *
     * <p><b>The writer half is why this is a union and not a pattern.</b> The name test alone
     * returned four genuine credentials in the clear (Redmine #76006):
@@ -248,6 +267,11 @@ public class AdminPropertyCatalog {
       }
 
       String lower = baseName.toLowerCase();
+
+      if(CONFIRMED_NOT_SECRET.contains(lower)) {
+         return false;
+      }
+
       return isEncryptedCredential(lower) ||
          lower.contains("password") || lower.contains("secret") ||
          lower.contains("credential") || lower.endsWith(".key") || lower.startsWith("license.");
@@ -360,6 +384,14 @@ public class AdminPropertyCatalog {
       "openid.client.secret", "stylebi.google.openid.client.secret",
       "mail.smtp.pass", "mail.smtp.clientsecret", "mail.smtp.accesstoken",
       "mail.smtp.refreshtoken", "log.fluentd.security.sharedkey");
+
+   /**
+    * Names the shape test in {@link #isSecret} catches for the wrong reason - each verified
+    * against its writer, per the javadoc on {@link #isSecret}. Not a general escape hatch: adding
+    * a name here means its plain-text writer was checked, not that the name merely "looks" safe.
+    */
+   private static final Set<String> CONFIRMED_NOT_SECRET = Set.of(
+      "enable.changepassword", "sso.rsa.public.key", "google.maps.key");
 
    private static final String RESOURCE = "admin-property-catalog.json";
    private final List<CatalogEntry> entries;

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminPropertyCatalogTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminPropertyCatalogTest.java
@@ -216,17 +216,43 @@ class AdminPropertyCatalogTest {
 
    @Test
    void keepsWithholdingSecretNamesThatNoWriterEncrypts() {
-      // The union must not have narrowed to the allow-list. Fifteen of the sixteen names isSecret
-      // withheld before #76006 are written by nothing that encrypts, so the writer test alone
-      // would have unmasked them all in order to close the four above.
+      // The union must not have narrowed to the allow-list. Fourteen of the sixteen names
+      // isSecret withheld before #76006 are written by nothing that encrypts, so the writer test
+      // alone would have unmasked them all in order to close the four above. (The sixteenth,
+      // enable.changepassword, moved to CONFIRMED_NOT_SECRET below - see the item-4 fix.)
       for(String name : new String[] { "license.key", "jwt.signing.key", "password.encryption.key",
-                                       "sso.rsa.private.key", "log.fluentd.security.password",
-                                       "enable.changepassword" })
+                                       "sso.rsa.private.key", "log.fluentd.security.password" })
       {
          assertFalse(AdminPropertyCatalog.isEncryptedCredential(name),
                      name + ": nothing encrypts this on write, so only the name test can cover it");
          assertTrue(AdminPropertyCatalog.isSecret(name), name + " must stay withheld");
       }
+   }
+
+   @Test
+   void unmasksConfirmedFalsePositivesTheShapeTestCaughtForTheWrongReason() {
+      // Known gap 4 (plugin/admin/README.md): the name-shape test over-matched these three.
+      // Each was individually verified against its writer/reader before being carved out, the
+      // same way ENCRYPTED_CREDENTIALS is verified - narrowing the shared pattern instead would
+      // risk unmasking an unrelated property that happens to share its shape.
+      for(String name : new String[] { "enable.changepassword", "sso.rsa.public.key",
+                                       "google.maps.key" })
+      {
+         assertFalse(AdminPropertyCatalog.isSecret(name),
+                     name + " is not a credential and must be readable through admin-chat");
+      }
+
+      // sso.rsa.public.key's PRIVATE counterpart must still be withheld - the exception list
+      // must name the exact false positive, not loosen the .key suffix test generally.
+      assertTrue(AdminPropertyCatalog.isSecret("sso.rsa.private.key"),
+                 "sso.rsa.private.key is the actual secret and must stay withheld");
+   }
+
+   @Test
+   void unmasksAConfirmedFalsePositiveWhateverCasingTheCallerUses() {
+      assertFalse(AdminPropertyCatalog.isSecret("Enable.ChangePassword"));
+      assertFalse(AdminPropertyCatalog.isSecret("SSO.RSA.Public.Key"));
+      assertFalse(AdminPropertyCatalog.isSecret("Google.Maps.Key"));
    }
 
    @Test


### PR DESCRIPTION
## Summary
- `AdminPropertyCatalog.isSecret`'s name-shape test masked three properties that hold no credential value: `enable.changepassword` (matches only on the substring "password"; it's a boolean flag), `sso.rsa.public.key` (the PUBLIC half of the SSO keypair — its private counterpart, `sso.rsa.private.key`, correctly still matches), and `google.maps.key` (a Google Maps API key, restricted by HTTP referrer rather than treated as a bearer credential, per its plain `SreeEnv` reader/writer).
- Each was individually verified against its actual reader/writer before being added to a new `CONFIRMED_NOT_SECRET` exception set — same verification standard `ENCRYPTED_CREDENTIALS` already uses — rather than loosening the shared name-shape pattern and risking a real secret slipping through.
- Follows the same convention Redmine #76006 (`2d30488d0`) used for the opposite direction (missed true positives): individually-verified names, documented reasoning in the `isSecret` javadoc, regression tests both ways.

Design source: `docs/superpowers/plans/2026-08-25-admin-plugin-master-plan.md` §4 Track A item 4, and the matching gap note in `plugin/admin/README.md` ("Known gaps and follow-ups" #4) in the `stylebi-wiz` repo.

## Test plan
- [x] `AdminPropertyCatalogTest` — 27/27 passing (`./mvnw -pl core -Dtest=AdminPropertyCatalogTest test`), including two new tests: false positives return `false` (with `sso.rsa.private.key` re-confirmed `true`), and case-insensitivity of the exception list.
- [x] Existing true-positive regression test for #76006 re-confirmed still passing (with `enable.changepassword` moved out of that list into the new false-positive test, since it's no longer expected to be withheld).

🤖 Generated with [Claude Code](https://claude.com/claude-code)