### PR TITLE
Bug #76290, log an unparsable ai.snapshot.count and make the strict-pane flag settable by env var

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/general/DataSpaceSettingsService.java
+++ b/core/src/main/java/inetsoft/web/admin/general/DataSpaceSettingsService.java
@@ -214,21 +214,14 @@ public class DataSpaceSettingsService extends BackupSupport {
     * out of scope for this change - see the final-review deferred-findings note. This method
     * keeps exactly the configured count.
     *
-    * <p>Retention is controlled by {@code ai.snapshot.count}, defaulting to 10 when absent or
-    * unparsable; a value below 1 disables pruning entirely, matching {@code
-    * deleteRedundantBackupFiles}'s convention for {@code asset.backup.count}.
+    * <p>Retention is controlled by {@code ai.snapshot.count}, defaulting to
+    * {@link #DEFAULT_AI_SNAPSHOT_COUNT} when absent or unparsable; a value below 1 disables
+    * pruning entirely, matching {@code deleteRedundantBackupFiles}'s convention for {@code
+    * asset.backup.count}. An unparsable value is logged, because the effect -- how many
+    * snapshots survive cleanup -- is not something an operator would otherwise notice.
     */
    private void deleteRedundantAiSnapshotFiles() {
-      String countProp = SreeEnv.getProperty("ai.snapshot.count");
-      int count = 10;
-
-      if(countProp != null) {
-         try {
-            count = Integer.parseInt(countProp.trim());
-         }
-         catch(Exception ignore) {
-         }
-      }
+      int count = getAiSnapshotCount();
 
       if(count < 1) {
          return;
@@ -262,6 +255,36 @@ public class DataSpaceSettingsService extends BackupSupport {
          catch(IOException e) {
             LOG.error("Failed to delete AI snapshot file {}", zips.get(i), e);
          }
+      }
+   }
+
+   /**
+    * Gets the configured {@code ai.snapshot.count}. A non-numeric value logs a warning naming
+    * the property and the offending value, then falls back to {@link #DEFAULT_AI_SNAPSHOT_COUNT}
+    * -- the same shape as {@code ScheduleTask.getTaskTimeout}.
+    *
+    * <p>An absent property is the normal unconfigured case and stays silent; only a value that
+    * was set and cannot be read warns. Blank counts as absent: clearing the field in EM rather
+    * than deleting the row stores {@code ""} -- {@code PropertiesEngine.setProperty} removes a
+    * property only when the value is null -- and warning once per backup about a field the
+    * operator emptied on purpose is the recurring noise this warning exists to avoid.
+    *
+    * @return the configured count, or the default if unset, blank, or unparsable.
+    */
+   private static int getAiSnapshotCount() {
+      String countProp = SreeEnv.getProperty("ai.snapshot.count");
+
+      if(countProp == null || countProp.isBlank()) {
+         return DEFAULT_AI_SNAPSHOT_COUNT;
+      }
+
+      try {
+         return Integer.parseInt(countProp.trim());
+      }
+      catch(NumberFormatException e) {
+         LOG.warn("Invalid ai.snapshot.count value \"{}\", using the default of {}",
+                  countProp, DEFAULT_AI_SNAPSHOT_COUNT);
+         return DEFAULT_AI_SNAPSHOT_COUNT;
       }
    }
 
@@ -324,9 +347,16 @@ public class DataSpaceSettingsService extends BackupSupport {
     * which lists only {@link #BACKUP_FOLDER}, cannot delete a snapshot an audit record still
     * references - that method cannot reach this folder at all, which is the reason this sibling
     * folder exists rather than reusing {@link #BACKUP_FOLDER}. This folder is instead pruned by
-    * {@link #deleteRedundantAiSnapshotFiles}, to {@code ai.snapshot.count} (default 10).
+    * {@link #deleteRedundantAiSnapshotFiles}, to {@code ai.snapshot.count} (default
+    * {@link #DEFAULT_AI_SNAPSHOT_COUNT}).
     */
    private static final String AI_SNAPSHOT_FOLDER = "ai-snapshots";
+
+   /**
+    * Snapshots kept by {@link #deleteRedundantAiSnapshotFiles} when {@code ai.snapshot.count} is
+    * unset or unparsable. Named so this value and the javadoc quoting it cannot drift apart.
+    */
+   private static final int DEFAULT_AI_SNAPSHOT_COUNT = 10;
 
    private static final String BACKUP_PATH_SPLIT = "-";
 

--- a/core/src/main/java/inetsoft/web/wiz/script/PaneScopeService.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/PaneScopeService.java
@@ -44,7 +44,7 @@ import java.util.Set;
  *       it is checked whether the target is expression-level or viewsheet-level. Weakening this
  *       when strict posture is off would mean a session minted for one chart's script could edit
  *       another chart's, which defeats the reason pane scoping exists at all.</li>
- *   <li><b>The opt-in strict posture</b> ({@code wiz.agent.script.require-script-pane}). Off by
+ *   <li><b>The opt-in strict posture</b> ({@code wiz.agent.script.require.script.pane}). Off by
  *       default. When on, it additionally refuses the four viewsheet-level kinds
  *       ({@code viewsheetOnInit}/{@code viewsheetOnLoad}/{@code assemblyMain}/
  *       {@code assemblyOnClick}) too, requiring every action to come from a pane-scoped
@@ -52,7 +52,7 @@ import java.util.Set;
  * </ul>
  *
  * <p>{@code strict} is supplied by the caller rather than read here — the controller reads the
- * {@code wiz.agent.script.require-script-pane} property fresh from {@code SreeEnv} on every
+ * {@code wiz.agent.script.require.script.pane} property fresh from {@code SreeEnv} on every
  * request (mirroring {@link inetsoft.web.wiz.pairing.SheetAgentFeature}), so an administrator
  * flipping the posture takes effect immediately, and this class stays a plain, easily-tested
  * function of its inputs rather than a stateful singleton with its own environment dependency.</p>
@@ -289,8 +289,16 @@ public class PaneScopeService {
       };
    }
 
-   /** Off-by-default property name; see the class javadoc. Read by the controller, not here. */
-   public static final String STRICT_FLAG = "wiz.agent.script.require-script-pane";
+   /**
+    * Off-by-default property name; see the class javadoc. Read by the controller, not here.
+    *
+    * <p>Dots only, no hyphens. {@code StorageInitializer.setProperties} maps an
+    * {@code INETSOFTENV_*} variable to a property name by lowercasing and replacing every
+    * {@code _} with {@code .}, so a hyphenated name cannot be set by environment variable at
+    * all -- it would be reachable only from Settings &gt; All Properties, unlike every other
+    * property.
+    */
+   public static final String STRICT_FLAG = "wiz.agent.script.require.script.pane";
 
    /** The dialog-sibling family {@link #matchesGrant} treats as one grant; see its javadoc. */
    private static final Set<ScriptTarget.Kind> ASSEMBLY_SCRIPT_FAMILY =

--- a/core/src/main/java/inetsoft/web/wiz/script/ScriptTarget.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ScriptTarget.java
@@ -121,7 +121,7 @@ public final class ScriptTarget {
       /**
        * Whether an action addressed to this kind may run only from a session paired at that
        * expression's own script pane or formula editor -- never from a whole-sheet ("Connect to
-       * Claude" toolbar) session, regardless of the {@code wiz.agent.script.require-script-pane}
+       * Claude" toolbar) session, regardless of the {@code wiz.agent.script.require.script.pane}
        * strict posture (see {@link PaneScopeService}, which enforces this).
        *
        * <p>Deliberately NOT {@code location() == null}. Before G2 Task 8, {@code WORKSHEET_EXPRESSION}/

--- a/core/src/main/java/inetsoft/web/wiz/script/ViewsheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/script/ViewsheetAgentController.java
@@ -424,7 +424,7 @@ public class ViewsheetAgentController {
    /**
     * Enforces {@link PaneScopeService} for {@code target} against the joined session.
     *
-    * <p>Reads {@code wiz.agent.script.require-script-pane} fresh from {@code SreeEnv} on every
+    * <p>Reads {@code wiz.agent.script.require.script.pane} fresh from {@code SreeEnv} on every
     * call (never cached) so the strict posture can be toggled by an administrator without a
     * restart, mirroring {@link #requireEnabled}'s own {@link SheetAgentFeature#isEnabled} call.
     */

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetScriptService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetScriptService.java
@@ -458,7 +458,7 @@ public class WorksheetScriptService {
    /**
     * Reads the strict posture fresh from {@code SreeEnv} on every call (never cached), mirroring
     * {@code ViewsheetAgentController#requirePaneScope} — an administrator flipping
-    * {@code wiz.agent.script.require-script-pane} takes effect immediately.
+    * {@code wiz.agent.script.require.script.pane} takes effect immediately.
     */
    private void requirePaneScope(JoinSession session, ScriptTarget target) throws PairingException {
       boolean strict = SreeEnv.getBooleanProperty(PaneScopeService.STRICT_FLAG);

--- a/core/src/test/java/inetsoft/web/admin/general/DataSpaceSettingsServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/general/DataSpaceSettingsServiceTest.java
@@ -47,6 +47,9 @@ package inetsoft.web.admin.general;
  *      The guard is scoped to pruning only - a failure in the write itself still fails.
  */
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import inetsoft.sree.SreeEnv;
 import inetsoft.sree.security.OrganizationManager;
 import inetsoft.sree.security.SecurityEngine;
@@ -59,6 +62,9 @@ import inetsoft.util.config.KeyValueConfig;
 import inetsoft.web.admin.general.model.BackupDataModel;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -66,6 +72,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -329,5 +336,91 @@ class DataSpaceSettingsServiceTest {
 
       assertNull(result.path());
       assertTrue(result.status().contains("Failed"));
+   }
+
+   // [G9] an unparsable ai.snapshot.count falls back to the default of 10 rather than throwing
+   // or disabling pruning
+   @Test
+   void aiSnapshotPruning_unparsableCountFallsBackToTheDefault() throws Exception {
+      sreeEnvStatic.when(() -> SreeEnv.getProperty("ai.snapshot.count")).thenReturn("ten");
+      // 11 files against the default of 10 -> exactly one deletion proves the fallback value,
+      // which neither "throws" nor "disables pruning" would produce.
+      List<String> zips = new ArrayList<>();
+
+      for(int i = 1; i <= 11; i++) {
+         zips.add("admin-" + i + "-202601" + String.format("%02d", i) + ".zip");
+      }
+
+      when(externalStorageService.listFiles("ai-snapshots")).thenReturn(zips);
+
+      service.doBackup(BackupDataModel.builder().dataspace("admin-chg-11").aiSnapshot(true).build());
+
+      verify(externalStorageService, times(1)).delete(anyString());
+      verify(externalStorageService).delete("ai-snapshots" + File.separator + zips.get(0));
+   }
+
+   // [G9] the warning is half the fix: without it the fallback is silent, and how many snapshots
+   // survive cleanup is not something an operator would notice on their own
+   @Test
+   void aiSnapshotPruning_unparsableCountWarnsNamingThePropertyAndTheValue() throws Exception {
+      ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger)
+         org.slf4j.LoggerFactory.getLogger(DataSpaceSettingsService.class);
+      ListAppender<ILoggingEvent> appender = new ListAppender<>();
+      appender.start();
+      logger.addAppender(appender);
+
+      try {
+         sreeEnvStatic.when(() -> SreeEnv.getProperty("ai.snapshot.count")).thenReturn("ten");
+         when(externalStorageService.listFiles("ai-snapshots"))
+            .thenReturn(List.of("admin-1-20260101.zip"));
+
+         service.doBackup(
+            BackupDataModel.builder().dataspace("admin-chg-12").aiSnapshot(true).build());
+
+         List<ILoggingEvent> warnings = appender.list.stream()
+            .filter(e -> e.getLevel() == Level.WARN)
+            .filter(e -> e.getFormattedMessage().contains("ai.snapshot.count"))
+            .toList();
+
+         assertEquals(1, warnings.size(), "the fallback must report itself exactly once");
+         assertTrue(warnings.get(0).getFormattedMessage().contains("ten"),
+                    "the warning must quote the offending value: "
+                       + warnings.get(0).getFormattedMessage());
+      }
+      finally {
+         logger.detachAppender(appender);
+      }
+   }
+
+   // [G9] the normal unconfigured case must stay silent -- a warning on every backup would
+   // train operators to ignore it
+   @ParameterizedTest
+   @NullSource
+   @ValueSource(strings = { "", "   " })
+   void aiSnapshotPruning_absentOrBlankCountDoesNotWarn(String countProp) throws Exception {
+      // Blank has to count as absent, not as unparsable: PropertiesEngine.setProperty removes a
+      // property only when the value is null, so clearing the field in EM rather than deleting
+      // the row stores "" -- and parseInt("") throws, which would warn on every single backup.
+      ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger)
+         org.slf4j.LoggerFactory.getLogger(DataSpaceSettingsService.class);
+      ListAppender<ILoggingEvent> appender = new ListAppender<>();
+      appender.start();
+      logger.addAppender(appender);
+
+      try {
+         sreeEnvStatic.when(() -> SreeEnv.getProperty("ai.snapshot.count")).thenReturn(countProp);
+         when(externalStorageService.listFiles("ai-snapshots"))
+            .thenReturn(List.of("admin-1-20260101.zip"));
+
+         service.doBackup(
+            BackupDataModel.builder().dataspace("admin-chg-13").aiSnapshot(true).build());
+
+         assertTrue(appender.list.stream()
+                       .noneMatch(e -> e.getFormattedMessage().contains("ai.snapshot.count")),
+                    "an unconfigured or emptied ai.snapshot.count must not warn");
+      }
+      finally {
+         logger.detachAppender(appender);
+      }
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/script/PaneScopeServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/PaneScopeServiceTest.java
@@ -107,7 +107,7 @@ class PaneScopeServiceTest {
          () -> service.check(wholeSheetSession, calcFieldTarget));
 
       assertTrue(ex.getMessage().contains("open its formula editor"), ex.getMessage());
-      assertFalse(ex.getMessage().contains("require-script-pane"), ex.getMessage());
+      assertFalse(ex.getMessage().contains("require.script.pane"), ex.getMessage());
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/script/ViewsheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/script/ViewsheetAgentControllerTest.java
@@ -185,7 +185,7 @@ class ViewsheetAgentControllerTest {
    private static void assertRefusesCalcFieldReason(Executable action) {
       PairingException ex = assertThrows(PairingException.class, action);
       assertTrue(ex.getMessage().contains("open its formula editor"), ex.getMessage());
-      assertFalse(ex.getMessage().contains("require-script-pane"), ex.getMessage());
+      assertFalse(ex.getMessage().contains("require.script.pane"), ex.getMessage());
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetScriptControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetScriptControllerTest.java
@@ -267,7 +267,7 @@ class WorksheetScriptControllerTest {
             agent));
 
       assertTrue(ex.getMessage().contains("open its expression editor"), ex.getMessage());
-      assertFalse(ex.getMessage().contains("require-script-pane"), ex.getMessage());
+      assertFalse(ex.getMessage().contains("require.script.pane"), ex.getMessage());
    }
 
    @Test
@@ -285,7 +285,7 @@ class WorksheetScriptControllerTest {
          () -> stack.controller().writeScript(TOKEN, req, agent));
 
       assertTrue(ex.getMessage().contains("open its condition editor"), ex.getMessage());
-      assertFalse(ex.getMessage().contains("require-script-pane"), ex.getMessage());
+      assertFalse(ex.getMessage().contains("require.script.pane"), ex.getMessage());
 
       // The refusal must have happened before the real op ran -- the table stays untouched.
       assertNull(findCondition(t, "region"));


### PR DESCRIPTION
The two findings from the #76290 report that concern code living only on this branch. The other two are fixed against `main` in #4786.

> **Base is `stylebi-wiz-main-rebase`, not `main`.** The report was verified at `935c85a58`, which is on this branch. Neither `deleteRedundantAiSnapshotFiles` nor `wiz.agent.script.require-script-pane` exists on `main`, so neither could be fixed there.

## 1. `ai.snapshot.count` discarded an unparsable value without a word

`deleteRedundantAiSnapshotFiles` parsed the property inside a bare `catch(Exception ignore) {}` with no log. A typo silently reverted retention to 10, and how many AI snapshot files survive cleanup is not something an operator would notice.

The parse moves into `getAiSnapshotCount()`, following `ScheduleTask.getTaskTimeout` — the shape the report cites as the one that works:

- a named `DEFAULT_AI_SNAPSHOT_COUNT = 10` constant, so the javadoc's "default 10" cannot drift from the code
- `NumberFormatException` specifically, not bare `Exception`
- `LOG.warn` naming both the property and the offending value

**Absent and blank both stay silent.** `PropertiesEngine.setProperty` removes a property only when the value is `null`, so clearing the field in EM rather than deleting the row stores `""` — and `parseInt("")` throws, which would have made this warning fire on *every backup*. Warning about a field the operator emptied on purpose is exactly the recurring noise the warning exists to avoid, so only a value that was set and cannot be read warns. (Caught in review; the guard is `null || isBlank()`.)

## 2. A hyphenated property had no reachable environment-variable form

`wiz.agent.script.require-script-pane` was settable from Settings > All Properties but by no environment variable. `StorageInitializer.setProperties` builds the name via `substring(12).toLowerCase().replace('_', '.')` — no escape mechanism produces a hyphen, so no `INETSOFTENV_*` value could name it. The reverse mapping in `InitStorageJobResource` and the AWS/CDK templates is equally hyphen-blind.

Renamed to `wiz.agent.script.require.script.pane`, which `INETSOFTENV_WIZ_AGENT_SCRIPT_REQUIRE_SCRIPT_PANE` reaches. This is the cheaper of the two options the report offered — teaching the transform a hyphen convention would have to be matched across the Java bootstrap, the k8s operator, and the CDK templates, and would risk existing deployments' variables.

The name is centralized as `PaneScopeService.STRICT_FLAG`, so reads are unaffected; its javadoc now records *why* the name is dot-only, so a hyphen is not reintroduced. Since this branch is unmerged, no released deployment can have the old name configured, so no backward-compatible alias is needed.

**One trap worth flagging for review.** Four tests assert `!ex.getMessage().contains("require-script-pane")` — that a given refusal is about the formula editor, *not* the strict flag. After a rename those keep passing for the wrong reason: a substring that exists nowhere can never appear. They are updated to the new name; left alone they would have silently stopped testing anything.

## Verification

126/126 tests pass in the affected slice (`DataSpaceSettingsService`, `PaneScopeService`, `ScriptTarget`, `ViewsheetAgentController`, `WorksheetScriptService`, `WorksheetScriptController`), re-run against the current branch tip after rebasing onto `fbe33041d`.

Both new behaviors are pinned by tests that were confirmed to fail without the fix:

- removing the `LOG.warn` fails the warning test (`expected: <1> but was: <0>`)
- reverting the guard to `null`-only fails the `""` and `"   "` cases while `null` still passes

Also verified: zero remaining `require-script-pane` references in either repo (java/ts/html/yaml/json/md/properties); no `AdminPropertyCatalog` registration to update; the `INETSOFTENV_` transform does produce the new name.

**Not covered:** the Docker end-to-end check that the renamed property actually arrives via `INETSOFTENV_*` and shows up in Settings > All Properties. The transform is verified in isolation, but since the whole point of finding 2 is that the env-var route was unreachable, that round-trip is worth confirming before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)