### PR TITLE
Bug #76277, bound the self-signup notification POST and send it after the account is created

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/service/PostSignUpUserData.java
+++ b/core/src/main/java/inetsoft/web/portal/service/PostSignUpUserData.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.net.*;
 import java.net.http.*;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.*;
 
 public class PostSignUpUserData {
@@ -46,13 +47,17 @@ public class PostSignUpUserData {
       String postHeader = SreeEnv.getProperty("selfSignUpPost.header");
       String postSecret = SreeEnv.getProperty("selfSignUpPost.secretKey");
 
-      HttpClient client = HttpClient.newHttpClient();
-
       if(postURL != null) {
-         try {
+         try(HttpClient client = HttpClient.newBuilder()
+                .connectTimeout(CONNECT_TIMEOUT)
+                .build())
+         {
+            String userData = parseUserData();
+
             HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
                .uri(URI.create(postURL))
-               .method("POST", HttpRequest.BodyPublishers.ofString(parseUserData(), StandardCharsets.UTF_8))
+               .timeout(RESPONSE_TIMEOUT)
+               .method("POST", HttpRequest.BodyPublishers.ofString(userData, StandardCharsets.UTF_8))
                .header("Content-Type", "application/json; charset=UTF-8");
 
             if(postUsername != null && postPassword != null) {
@@ -70,7 +75,7 @@ public class PostSignUpUserData {
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
             int statusCode = response.statusCode();
 
-            LOG.debug("Writing PostSignUp User: (" + parseUserData() + ") to <" + postURL + "> returned code: " + statusCode);
+            LOG.debug("Writing PostSignUp User: (" + userData + ") to <" + postURL + "> returned code: " + statusCode);
 
             if(statusCode < 200 || statusCode >= 300) {
                if(statusCode >= 500) {
@@ -155,6 +160,9 @@ public class PostSignUpUserData {
    private String firstName = "";
    private String lastName = "";
    private String cookies = null;
+
+   private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(5);
+   private static final Duration RESPONSE_TIMEOUT = Duration.ofSeconds(20);
 
    private static final Logger LOG =
       LoggerFactory.getLogger(PostSignUpUserData.class);

--- a/core/src/main/java/inetsoft/web/portal/service/UserSignupService.java
+++ b/core/src/main/java/inetsoft/web/portal/service/UserSignupService.java
@@ -22,6 +22,7 @@ import inetsoft.sree.internal.Mailer;
 import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.security.*;
 import inetsoft.uql.XPrincipal;
+import inetsoft.util.ThreadPool;
 import inetsoft.util.Tool;
 import inetsoft.util.audit.Audit;
 import inetsoft.util.audit.IdentityInfoRecord;
@@ -259,7 +260,6 @@ public class UserSignupService {
       String cookies = principal != null ? principal.getProperty("SignupCookies") : null;
 
       PostSignUpUserData postUserData = new PostSignUpUserData(email, names[0], names[1], cookies);
-      postUserData.sendUserData();
 
       if(!names[0].contains("@")) {
          //alias cannot be email because no special characters
@@ -267,6 +267,10 @@ public class UserSignupService {
       }
 
       editProvider.addUser(identity);
+
+      // notify the external system only after the account exists, and off the request thread
+      // so an unresponsive endpoint cannot delay or block sign-up
+      ThreadPool.addOnDemand(postUserData::sendUserData);
 
       IdentityInfoRecord identityInfoRecord = SUtil.getIdentityInfoRecord(identity.getIdentityID(),
          identity.getType(), IdentityInfoRecord.ACTION_TYPE_CREATE, null,

--- a/core/src/main/java/inetsoft/web/portal/service/UserSignupService.java
+++ b/core/src/main/java/inetsoft/web/portal/service/UserSignupService.java
@@ -269,8 +269,16 @@ public class UserSignupService {
       editProvider.addUser(identity);
 
       // notify the external system only after the account exists, and off the request thread
-      // so an unresponsive endpoint cannot delay or block sign-up
-      ThreadPool.addOnDemand(postUserData::sendUserData);
+      // so an unresponsive endpoint cannot delay or block sign-up. A ContextRunnable is used so
+      // that ThreadPool copies the calling thread's principal and org id onto the worker thread;
+      // sendUserData() reads the selfSignUpPost.* properties through the org-scoped
+      // SreeEnv.getProperty(name), which would otherwise miss any per-org override.
+      ThreadPool.addOnDemand(new ThreadPool.AbstractContextRunnable() {
+         @Override
+         public void run() {
+            postUserData.sendUserData();
+         }
+      });
 
       IdentityInfoRecord identityInfoRecord = SUtil.getIdentityInfoRecord(identity.getIdentityID(),
          identity.getType(), IdentityInfoRecord.ACTION_TYPE_CREATE, null,

--- a/core/src/test/java/inetsoft/web/portal/service/UserSignupServiceTest.java
+++ b/core/src/test/java/inetsoft/web/portal/service/UserSignupServiceTest.java
@@ -37,6 +37,7 @@ package inetsoft.web.portal.service;
 import inetsoft.sree.SreeEnv;
 import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.security.*;
+import inetsoft.util.ThreadContext;
 import inetsoft.util.audit.Audit;
 import inetsoft.util.audit.IdentityInfoRecord;
 import inetsoft.web.admin.security.AuthenticationProviderService;
@@ -53,6 +54,7 @@ import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.security.Principal;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -525,6 +527,59 @@ class UserSignupServiceTest {
             assertFalse(postedBeforeAdd.get(), "sendUserData ran before the user was persisted");
             assertNotSame(Thread.currentThread(), postThread.get(),
                           "sendUserData ran on the calling (request) thread");
+         }
+      }
+
+      @Test
+      void createUser_propagatesOrgContextToNotificationThread() throws Exception {
+         EditableAuthenticationProvider editProvider = mock(EditableAuthenticationProvider.class);
+         CountDownLatch posted = new CountDownLatch(1);
+         AtomicReference<String> postOrgId = new AtomicReference<>();
+         AtomicReference<Principal> postPrincipal = new AtomicReference<>();
+         Principal caller = mock(Principal.class);
+         when(caller.getName()).thenReturn(DEFAULT_ORG_USER.convertToKey());
+
+         when(authenticationProviderService.getAuthenticationChain())
+            .thenReturn(Optional.of(authenticationChain));
+         when(authenticationChain.getProviders()).thenReturn(List.of(editProvider));
+         when(editProvider.getRoles()).thenReturn(new IdentityID[0]);
+
+         try(MockedStatic<SUtil> sutilMock = Mockito.mockStatic(SUtil.class, Mockito.CALLS_REAL_METHODS);
+             MockedStatic<Audit> auditMock = Mockito.mockStatic(Audit.class);
+             MockedConstruction<SRPrincipal> ignored = Mockito.mockConstruction(SRPrincipal.class);
+             MockedConstruction<PostSignUpUserData> ignored2 = Mockito.mockConstruction(
+                PostSignUpUserData.class,
+                (postUserData, context) -> doAnswer(invocation -> {
+                   postOrgId.set(OrganizationContextHolder.getCurrentOrgId());
+                   postPrincipal.set(ThreadContext.getContextPrincipal());
+                   posted.countDown();
+                   return null;
+                }).when(postUserData).sendUserData()))
+         {
+            sutilMock.when(() -> SUtil.getIdentityInfoRecord(
+                  any(IdentityID.class), anyInt(), anyString(), any(), anyString()))
+               .thenReturn(mock(IdentityInfoRecord.class));
+            auditMock.when(Audit::getInstance).thenReturn(mock(Audit.class));
+
+            // the notification reads the org-scoped selfSignUpPost.* properties, so the worker
+            // thread must see the caller's principal and org id
+            OrganizationContextHolder.setCurrentOrgId(DEFAULT_ORG_USER.getOrgID());
+            ThreadContext.setContextPrincipal(caller);
+
+            try {
+               userSignupService.createUser(
+                  DEFAULT_ORG_USER, null, SIGNUP_EMAIL, true, GOOGLE_USER_ID, null);
+            }
+            finally {
+               ThreadContext.setContextPrincipal(null);
+               OrganizationContextHolder.clear();
+            }
+
+            assertTrue(posted.await(10, TimeUnit.SECONDS), "sendUserData was never dispatched");
+            assertEquals(DEFAULT_ORG_USER.getOrgID(), postOrgId.get(),
+                         "org id was not propagated to the notification thread");
+            assertSame(caller, postPrincipal.get(),
+                       "principal was not propagated to the notification thread");
          }
       }
 

--- a/core/src/test/java/inetsoft/web/portal/service/UserSignupServiceTest.java
+++ b/core/src/test/java/inetsoft/web/portal/service/UserSignupServiceTest.java
@@ -56,6 +56,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -456,7 +460,9 @@ class UserSignupServiceTest {
 
          try(MockedStatic<SUtil> sutilMock = Mockito.mockStatic(SUtil.class, Mockito.CALLS_REAL_METHODS);
              MockedStatic<Audit> auditMock = Mockito.mockStatic(Audit.class);
-             MockedConstruction<SRPrincipal> ignored = Mockito.mockConstruction(SRPrincipal.class))
+             MockedConstruction<SRPrincipal> ignored = Mockito.mockConstruction(SRPrincipal.class);
+             MockedConstruction<PostSignUpUserData> postData =
+                Mockito.mockConstruction(PostSignUpUserData.class))
          {
             sutilMock.when(() -> SUtil.getIdentityInfoRecord(
                   any(IdentityID.class), anyInt(), anyString(), any(), anyString()))
@@ -473,6 +479,52 @@ class UserSignupServiceTest {
             assertEquals(GOOGLE_USER_ID, created.getGoogleSSOId());
             verify(editProvider).addUser(any(FSUser.class));
             verify(audit).auditIdentityInfo(any(), any());
+            // await the dispatched notification so no pool work escapes the mock scope
+            verify(postData.constructed().get(0), timeout(10000)).sendUserData();
+         }
+      }
+
+      @Test
+      void createUser_postsUserDataOffRequestThreadAfterPersist() throws Exception {
+         EditableAuthenticationProvider editProvider = mock(EditableAuthenticationProvider.class);
+         CountDownLatch posted = new CountDownLatch(1);
+         AtomicBoolean postedBeforeAdd = new AtomicBoolean(false);
+         AtomicReference<Thread> postThread = new AtomicReference<>();
+
+         when(authenticationProviderService.getAuthenticationChain())
+            .thenReturn(Optional.of(authenticationChain));
+         when(authenticationChain.getProviders()).thenReturn(List.of(editProvider));
+         when(editProvider.getRoles()).thenReturn(new IdentityID[0]);
+
+         try(MockedStatic<SUtil> sutilMock = Mockito.mockStatic(SUtil.class, Mockito.CALLS_REAL_METHODS);
+             MockedStatic<Audit> auditMock = Mockito.mockStatic(Audit.class);
+             MockedConstruction<SRPrincipal> ignored = Mockito.mockConstruction(SRPrincipal.class);
+             MockedConstruction<PostSignUpUserData> ignored2 = Mockito.mockConstruction(
+                PostSignUpUserData.class,
+                (postUserData, context) -> doAnswer(invocation -> {
+                   postThread.set(Thread.currentThread());
+                   posted.countDown();
+                   return null;
+                }).when(postUserData).sendUserData()))
+         {
+            sutilMock.when(() -> SUtil.getIdentityInfoRecord(
+                  any(IdentityID.class), anyInt(), anyString(), any(), anyString()))
+               .thenReturn(mock(IdentityInfoRecord.class));
+            auditMock.when(Audit::getInstance).thenReturn(mock(Audit.class));
+
+            // record whether the POST had already fired at the moment the user was persisted
+            doAnswer(invocation -> {
+               postedBeforeAdd.set(posted.getCount() == 0);
+               return null;
+            }).when(editProvider).addUser(any(FSUser.class));
+
+            userSignupService.createUser(
+               DEFAULT_ORG_USER, null, SIGNUP_EMAIL, true, GOOGLE_USER_ID, null);
+
+            assertTrue(posted.await(10, TimeUnit.SECONDS), "sendUserData was never dispatched");
+            assertFalse(postedBeforeAdd.get(), "sendUserData ran before the user was persisted");
+            assertNotSame(Thread.currentThread(), postThread.get(),
+                          "sendUserData ran on the calling (request) thread");
          }
       }
 
@@ -487,7 +539,9 @@ class UserSignupServiceTest {
 
          try(MockedStatic<SUtil> sutilMock = Mockito.mockStatic(SUtil.class, Mockito.CALLS_REAL_METHODS);
              MockedStatic<Audit> auditMock = Mockito.mockStatic(Audit.class);
-             MockedConstruction<SRPrincipal> ignored = Mockito.mockConstruction(SRPrincipal.class))
+             MockedConstruction<SRPrincipal> ignored = Mockito.mockConstruction(SRPrincipal.class);
+             MockedConstruction<PostSignUpUserData> postData =
+                Mockito.mockConstruction(PostSignUpUserData.class))
          {
             sutilMock.when(() -> SUtil.getIdentityInfoRecord(
                   any(IdentityID.class), anyInt(), anyString(), any(), anyString()))
@@ -502,6 +556,8 @@ class UserSignupServiceTest {
             assertNotNull(created);
             verify(editProvider).addUser(any(FSUser.class));
             verify(audit).auditIdentityInfo(any(), any());
+            // await the dispatched notification so no pool work escapes the mock scope
+            verify(postData.constructed().get(0), timeout(10000)).sendUserData();
          }
       }
    }


### PR DESCRIPTION
## Problem

`PostSignUpUserData.sendUserData()` made a synchronous outbound HTTP POST to the operator-configured `selfSignUpPost.url` with **no connect timeout and no request timeout**, and `UserSignupService.createUser()` invoked it **before** the account was persisted:

- `PostSignUpUserData.java` — `HttpClient.newHttpClient()` (no `.connectTimeout(...)`), `HttpRequest.newBuilder()` (no `.timeout(...)`), then the blocking `client.send(...)`.
- `UserSignupService.java:262` — `postUserData.sendUserData()`; `editProvider.addUser(identity)` only at line 269.

The destination is a third-party system outside StyleBI's control. On an install with self-signup enabled and that property set, an endpoint that black-holes packets rather than refusing the connection makes signup **hang rather than fail**, the user gets **no account**, and repeated attempts consume request threads.

The method's own error handling already treats a failed POST as non-fatal (log and return), so the account was never intended to depend on it.

Two production entry points reach this code, both on request threads: `SignupController` (`/signup/userDetail`) and, in the enterprise repo, `StyleBIGoogleSSOFilter` via `autoRegisterUser` — which picks up this fix with no enterprise change.

## Fix

`PostSignUpUserData.java`
- `.connectTimeout(CONNECT_TIMEOUT)` (5s) on the client and `.timeout(RESPONSE_TIMEOUT)` (20s) on the request, as `Duration` constants — matching the house style in `HttpAssistantDocSearchGateway`.
- Client is now built only when `selfSignUpPost.url` is set, and wrapped in try-with-resources so its selector thread is released (`HttpClient` is `AutoCloseable` on Java 21) — this also fixes a per-signup client leak.
- `parseUserData()` computed once instead of twice.

`UserSignupService.java`
- The POST moved to after `editProvider.addUser(identity)` and dispatched via `ThreadPool.addOnDemand(...)`, the documented idiom for this ("should be used instead of creating a new GroupedThread every time"). The account is now created regardless of the endpoint, and the request thread never waits on it.
- The dispatched task is a `ThreadPool.AbstractContextRunnable`, not a bare `Runnable`. `ThreadPool.add()` copies the calling thread's principal and org id onto the worker only for `ContextRunnable` commands (`ThreadPool.java:208-232`), and `sendUserData()` reads the `selfSignUpPost.*` properties through the single-arg `SreeEnv.getProperty(name)`, which resolves with `orgScope=true` (`PropertiesEngine.getProperty(name, earlyLoaded)` -> `getProperty(name, earlyLoaded, true)`). Without that context, `useAvailableOrgProperty()` would silently miss a per-org `inetsoft.org.<orgid>.selfSignUpPost.url` override and post to the global endpoint instead. Thanks to @claude for catching this.

## Testing

- `./mvnw test -pl core -Dtest=UserSignupServiceTest,SignupControllerTest` — 64/64 pass.
- New `createUser_postsUserDataOffRequestThreadAfterPersist` asserts the POST had not fired at the moment `addUser` ran and that it executes on a different thread, so the ordering regression cannot silently return.
- New `createUser_propagatesOrgContextToNotificationThread` sets an org id and principal on the calling thread and asserts both are visible inside `sendUserData()`; it fails on a bare-`Runnable` dispatch.
- The two pre-existing `createUser` tests now stub `PostSignUpUserData` construction and await the dispatched task, so no pool work escapes the mock scope.

## Note for reviewers

The notification is now best-effort: `ThreadPool` workers are daemon threads, so a queued or in-flight POST is lost without a log if the JVM shuts down immediately after a signup. That window is narrow and is the deliberate trade-off for not blocking signup; if a silent miss is unacceptable for this hook, the alternative is to keep it synchronous after `addUser` (now bounded at ~25s by the new timeouts) or add a durable retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


