### PR TITLE
Bug #76084, add edit_date_range_column/edit_numeric_range_column; Bug #75942, custom bucket labels

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
@@ -66,7 +66,14 @@ import java.util.Map;
  *   <li>{@code add_rotate} — {@code name}, {@code source}</li>
  *   <li>{@code add_unpivot} — {@code name}, {@code source}, {@code headerColumns}</li>
  *   <li>{@code add_date_range_column} — {@code table}, {@code column}, {@code dateOption}</li>
- *   <li>{@code add_numeric_range_column} — {@code table}, {@code column}, {@code boundaries}</li>
+ *   <li>{@code add_numeric_range_column} — {@code table}, {@code column}, {@code boundaries},
+ *       optional {@code labels} (one more entry than {@code boundaries})</li>
+ *   <li>{@code edit_date_range_column} — {@code table}, {@code column} (the existing range
+ *       column's own name), {@code dateOption}; the column is renamed to match, since its name
+ *       encodes its option (see {@code add_date_range_column})</li>
+ *   <li>{@code edit_numeric_range_column} — {@code table}, {@code column} (the existing range
+ *       column's own name), {@code boundaries}, optional {@code labels} (replaces any existing
+ *       labels; omitted/empty clears them back to the default auto-generated range text)</li>
  *   <li>{@code edit_cell} — {@code table}, {@code row}, {@code col}, {@code value}</li>
  *   <li>{@code insert_row} — {@code table}, {@code index}</li>
  *   <li>{@code delete_row} — {@code table}, {@code index}</li>
@@ -178,7 +185,7 @@ public record EditRequest(
    Integer headerColumns,
    /** Date grouping option for add_date_range_column. */
    String dateOption,
-   /** Numeric bucket boundaries for add_numeric_range_column. */
+   /** Numeric bucket boundaries for add_numeric_range_column / edit_numeric_range_column. */
    double[] boundaries,
    /** Datasource name for add_table (when provided, creates a PhysicalBoundTableAssembly). */
    String datasource,
@@ -312,11 +319,17 @@ public record EditRequest(
     * effect only once {@code groups} has at least 2 entries and {@code aggregates} at least 1;
     * with fewer, it is accepted but silently has no effect (same as the Composer dialog itself).
     */
-   Boolean crosstab
+   Boolean crosstab,
+   /**
+    * Optional custom bucket labels for add_numeric_range_column / edit_numeric_range_column —
+    * one more entry than {@code boundaries} (below the first, one between each pair, above the
+    * last). Omitted or empty keeps the engine's default auto-generated range text.
+    */
+   List<String> labels
 ) {
    /**
     * Compatibility constructor for callers built before {@code crosstab} was added —
-    * defaults it to {@code null} (treated as {@code false}).
+    * defaults {@code crosstab} and {@code labels} (added later, same reason) to {@code null}.
     */
    public EditRequest(
       String op, String table, String column, String name, String type, String newName,
@@ -344,6 +357,6 @@ public record EditRequest(
            value, index, alias, description, maxRows, distinct, columnOrder, groupMappings,
            groupOthers, variableValues, x, y, label, defaultValue, mode, insert, subtables,
            sourceTable, attribute, endpoint, parameters, lookup, lookupExpandArrays,
-           lookupTopLevelOnly, suffix, customLookups, null);
+           lookupTopLevelOnly, suffix, customLookups, null, null);
    }
 }

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -1778,7 +1778,13 @@ public class WorksheetAgentController {
          case "add_date_range_column" ->
             editor.addDateRangeColumn(req.table(), req.column(), req.dateOption());
          case "add_numeric_range_column" ->
-            editor.addNumericRangeColumn(req.table(), req.column(), req.boundaries());
+            editor.addNumericRangeColumn(req.table(), req.column(), req.boundaries(),
+               req.labels() != null ? req.labels().toArray(new String[0]) : null);
+         case "edit_date_range_column" ->
+            editor.editDateRangeColumn(req.table(), req.column(), req.dateOption());
+         case "edit_numeric_range_column" ->
+            editor.editNumericRangeColumn(req.table(), req.column(), req.boundaries(),
+               req.labels() != null ? req.labels().toArray(new String[0]) : null);
          case "edit_cell" -> {
             if(req.row() == null || req.col() == null) {
                throw new PairingException("edit_cell requires 'row' and 'col' fields");

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -941,7 +941,17 @@ public class WorksheetEditService {
 
          int option = parseDateOption(dateOption);
          DataRef baseRef = dateRef.getDataRef();
-         String baseAttr = baseRef != null ? baseRef.getAttribute() : dateRef.getAttribute();
+
+         if(baseRef == null) {
+            // Not reachable via add_date_range_column, which always constructs one with a
+            // non-null base ref — but falling back to dateRef.getAttribute() here (the range
+            // column's OWN name) would silently compute a wrong, nested name like
+            // "MonthOfYear(QuarterOfYear(orderDate))" instead of failing loud.
+            throw new PairingException(
+               "Column \"" + column + "\" has no source column reference and cannot be re-leveled.");
+         }
+
+         String baseAttr = baseRef.getAttribute();
          String currentName = dateRef.getName();
          String newName = DateRangeRef.getName(baseAttr, option);
 
@@ -962,6 +972,22 @@ public class WorksheetEditService {
 
          dateRef.setDateOption(option);
          dateRef.setName(newName);
+
+         // AbstractDataRef.hashCode() caches its result (chash) from getEntity()+getAttribute()
+         // at first use, and ColumnRef.getAttribute() delegates live to the wrapped ref's — so
+         // renaming dateRef changes what that hash SHOULD be without invalidating the wrapping
+         // ColumnRef's already-cached one. ColumnSelection's backing ListWithFastLookup uses
+         // that cached hashCode() for its O(1) addAttribute exclusivity check (rebuilt lazily by
+         // iterating current elements' hashCode(), so a per-element stale cache survives even a
+         // full rebuild). Left uninvalidated, a later add_date_range_column producing this same
+         // new name is not caught as a duplicate — confirmed empirically: without the reset
+         // below, two columns end up reporting the identical getName(). setDataRef() re-assigns
+         // the same ref purely to invalidate ColumnRef's own cname/chash, the same mechanism
+         // renameColumn's setAlias() already relies on for its own (narrower) case.
+         if(ref instanceof ColumnRef cr) {
+            cr.setDataRef(dateRef);
+         }
+
          t.setColumnSelection(cs, false);
       }
 
@@ -1008,8 +1034,22 @@ public class WorksheetEditService {
                "(e.g. \"Amount_range\"), not its source numeric column.");
          }
 
-         ValueRangeInfo info = new ValueRangeInfo();
+         // Mutate the existing ValueRangeInfo rather than replacing it wholesale: this tool
+         // only ever settles values/labels, but showBottomValue/showTopValue/inclusiveType are
+         // also user-settable (via the Composer's own Range Column dialog, or a future richer
+         // wiz op) and replacing the object outright would silently reset those three back to
+         // ValueRangeInfo's constructor defaults on every edit — an undocumented side effect
+         // for a tool whose whole contract is "boundaries and labels, nothing else."
+         ValueRangeInfo info = rangeRef.getValueRangeInfo();
+
+         if(info == null) {
+            info = new ValueRangeInfo();
+         }
+
          info.setValues(boundaries);
+         // Unconditional, even when labels is null/empty: the javadoc above promises omitting
+         // labels clears any existing ones, and that contract must hold now that boundaries'
+         // sibling settings survive the edit.
          info.setLabels(labels);
          rangeRef.setValueRangeInfo(info);
          t.setColumnSelection(cs, false);

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -844,14 +844,20 @@ public class WorksheetEditService {
        * @param table      the assembly name
        * @param column     the source numeric column name
        * @param boundaries the bucket boundary values (e.g. [0, 50, 100])
+       * @param labels     optional custom bucket labels, one more than {@code boundaries}
+       *                   (e.g. 2 boundaries -> 3 labels: below, between, above). {@code null}
+       *                   or empty keeps the engine's default auto-generated range text.
        */
-      public void addNumericRangeColumn(String table, String column, double[] boundaries)
+      public void addNumericRangeColumn(String table, String column, double[] boundaries,
+                                         String[] labels)
          throws PairingException
       {
          if(boundaries == null || boundaries.length == 0) {
             throw new PairingException(
                "boundaries must be a non-empty array of numbers (e.g. [0, 50, 100]).");
          }
+
+         validateLabelCount(boundaries, labels);
 
          TableAssembly t = requireTable(table);
          ColumnSelection cs = t.getColumnSelection(false);
@@ -866,11 +872,146 @@ public class WorksheetEditService {
          NumericRangeRef rangeRef = new NumericRangeRef(column + "_range", baseRef);
          ValueRangeInfo info = new ValueRangeInfo();
          info.setValues(boundaries);
+         info.setLabels(labels);
          rangeRef.setValueRangeInfo(info);
 
          ColumnRef colRef = new ColumnRef(rangeRef);
          colRef.setDataType(XSchema.STRING);
          cs.addAttribute(colRef);
+         t.setColumnSelection(cs, false);
+      }
+
+      /**
+       * Validates that a caller-supplied label array, if present, has exactly one more entry
+       * than there are boundaries — the count {@link NumericRangeRef#getExpression} and
+       * {@link NumericRangeRef#getScriptExpression} index into (bottom bucket + one per gap +
+       * top bucket) given the engine's fixed defaults of showing both the bottom and top
+       * buckets. A shorter array is not just cosmetically wrong: those methods index straight
+       * into it with no bounds check, so a mismatch throws {@code ArrayIndexOutOfBoundsException}
+       * deep inside expression generation instead of failing here with a clear message.
+       */
+      private static void validateLabelCount(double[] boundaries, String[] labels)
+         throws PairingException
+      {
+         if(labels == null || labels.length == 0) {
+            return;
+         }
+
+         int expected = boundaries.length + 1;
+
+         if(labels.length != expected) {
+            throw new PairingException(
+               "labels must have exactly " + expected + " entries for " + boundaries.length +
+               " boundaries (one below the first, one between each pair, one above the last) " +
+               "— got " + labels.length + ".");
+         }
+      }
+
+      /**
+       * Changes the grouping level of an existing date range column, in place. The column's
+       * name encodes its option (see {@link DateRangeRef#getName}), so it is renamed to match
+       * the new option — e.g. {@code "QuarterOfYear(Order Date)"} becomes
+       * {@code "MonthOfYear(Order Date)"} when {@code dateOption} changes from
+       * {@code QUARTER_OF_YEAR} to {@code MONTH_OF_YEAR}. Anything already bound to the old
+       * name is left pointing at nothing, the same as a manual {@code rename_column}.
+       *
+       * @param table      the assembly name
+       * @param column     the existing date range column's current name
+       * @param dateOption the new grouping option string (e.g. "YEAR", "QUARTER", "MONTH")
+       */
+      public void editDateRangeColumn(String table, String column, String dateOption)
+         throws PairingException
+      {
+         TableAssembly t = requireTable(table);
+         ColumnSelection cs = t.getColumnSelection(false);
+         DataRef ref = cs.getAttribute(column);
+
+         if(ref == null) {
+            throw new PairingException("Column not found: " + column);
+         }
+
+         DataRef unwrapped = ref instanceof ColumnRef cr ? cr.getDataRef() : ref;
+
+         if(!(unwrapped instanceof DateRangeRef dateRef)) {
+            throw new PairingException(
+               "Column \"" + column + "\" is not a date range column. Use " +
+               "add_date_range_column to create one, or pass the range column's own name " +
+               "(e.g. \"QuarterOfYear(Order Date)\"), not its source date column.");
+         }
+
+         int option = parseDateOption(dateOption);
+         DataRef baseRef = dateRef.getDataRef();
+         String baseAttr = baseRef != null ? baseRef.getAttribute() : dateRef.getAttribute();
+         String currentName = dateRef.getName();
+         String newName = DateRangeRef.getName(baseAttr, option);
+
+         // ColumnSelection enforces name-uniqueness only on addAttribute (a no-op add on
+         // collision); renaming an existing entry in place bypasses that check entirely, so a
+         // rename onto a name already held by another column (e.g. a second range column
+         // already added at the target option) would silently shadow it instead of failing.
+         if(!newName.equals(currentName)) {
+            DataRef existing = cs.getAttribute(newName);
+
+            if(existing != null && existing != ref) {
+               throw new PairingException(
+                  "Cannot change \"" + column + "\" to " + dateOption + " — table \"" + table +
+                  "\" already has a column named \"" + newName + "\". Remove or rename that " +
+                  "column first.");
+            }
+         }
+
+         dateRef.setDateOption(option);
+         dateRef.setName(newName);
+         t.setColumnSelection(cs, false);
+      }
+
+      /**
+       * Changes the bucket boundaries (and optionally the custom labels) of an existing
+       * numeric range column, in place. Unlike the date range column's name, a numeric range
+       * column's name ({@code column + "_range"}) does not encode its boundaries, so it is
+       * left unchanged.
+       *
+       * @param table      the assembly name
+       * @param column     the existing numeric range column's current name
+       * @param boundaries the new bucket boundary values (e.g. [0, 50, 100])
+       * @param labels     optional custom bucket labels, one more than {@code boundaries}. A
+       *                   {@code null}/empty array clears any custom labels back to the
+       *                   engine's default auto-generated range text — it does not preserve
+       *                   whatever labels the column already had, since there is no partial
+       *                   "leave labels alone" signal distinguishable from "clear them."
+       */
+      public void editNumericRangeColumn(String table, String column, double[] boundaries,
+                                          String[] labels)
+         throws PairingException
+      {
+         if(boundaries == null || boundaries.length == 0) {
+            throw new PairingException(
+               "boundaries must be a non-empty array of numbers (e.g. [0, 50, 100]).");
+         }
+
+         validateLabelCount(boundaries, labels);
+
+         TableAssembly t = requireTable(table);
+         ColumnSelection cs = t.getColumnSelection(false);
+         DataRef ref = cs.getAttribute(column);
+
+         if(ref == null) {
+            throw new PairingException("Column not found: " + column);
+         }
+
+         DataRef unwrapped = ref instanceof ColumnRef cr ? cr.getDataRef() : ref;
+
+         if(!(unwrapped instanceof NumericRangeRef rangeRef)) {
+            throw new PairingException(
+               "Column \"" + column + "\" is not a numeric range column. Use " +
+               "add_numeric_range_column to create one, or pass the range column's own name " +
+               "(e.g. \"Amount_range\"), not its source numeric column.");
+         }
+
+         ValueRangeInfo info = new ValueRangeInfo();
+         info.setValues(boundaries);
+         info.setLabels(labels);
+         rangeRef.setValueRangeInfo(info);
          t.setColumnSelection(cs, false);
       }
 

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -515,7 +515,8 @@ class WorksheetAgentControllerTest {
          null,                  // lookupTopLevelOnly
          null,                  // suffix
          null,                  // customLookups
-         true                   // crosstab
+         true,                  // crosstab
+         null                   // labels
       );
 
       WorksheetAgentController ctrl = controller(featureOn(),

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -868,6 +868,48 @@ class WorksheetEditServiceMutatorsTest {
    }
 
    @Test
+   void editDateRangeColumnRenameDoesNotLeaveStaleHashForLaterAdd() throws Exception {
+      // Regression test for a real bug caught in code review (not a hypothetical): the
+      // ColumnRef wrapping a DateRangeRef caches its hashCode() (AbstractDataRef.chash) on
+      // first use, from getEntity()+getAttribute() — and ColumnSelection's backing
+      // ListWithFastLookup uses that cached hashCode() for add_date_range_column's O(1)
+      // addAttribute exclusivity check (rebuilt lazily by iterating elements' hashCode(), so a
+      // per-element stale cache survives even a full map rebuild). Renaming dateRef in place
+      // without resetting that cache left a later add_date_range_column, whose generated name
+      // happened to collide with the just-renamed column, undetected — silently producing two
+      // columns both reporting getName() == "MonthOfYear(orderDate)". Empirically confirmed
+      // both that the bug existed (bare rename: 2 columns) and that WorksheetEditService's
+      // fix (ColumnRef#setDataRef to force cname/chash invalidation) resolves it (1 column).
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "orderDate", "total");
+      ws.addAssembly(t);
+      ColumnRef dateCol = (ColumnRef) t.getColumnSelection(false).getAttribute("orderDate");
+      dateCol.setDataType(XSchema.DATE);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.addDateRangeColumn("T", "orderDate", "QUARTER_OF_YEAR"));
+      // A second, distinct add exercises addAttribute's exclusivity check (and so builds
+      // ListWithFastLookup's indexOfs cache) the same way any real multi-column worksheet
+      // would before the edit below ever runs.
+      svc.apply("TOK", agent, ed -> ed.addNumericRangeColumn("T", "total", new double[] { 0, 1 }, null));
+      svc.apply("TOK", agent, ed ->
+         ed.editDateRangeColumn("T", "QuarterOfYear(orderDate)", "MONTH_OF_YEAR"));
+
+      // Reaches the exact name the rename above just produced.
+      svc.apply("TOK", agent, ed -> ed.addDateRangeColumn("T", "orderDate", "MONTH_OF_YEAR"));
+
+      ColumnSelection cs = t.getColumnSelection(false);
+      long monthColumns = cs.stream()
+         .filter(r -> "MonthOfYear(orderDate)".equals(r.getName()))
+         .count();
+      assertEquals(1, monthColumns,
+         "add_date_range_column must refuse (no-op) rather than duplicate a name the edit just produced");
+      assertEquals(4, cs.getAttributeCount(),
+         "the colliding add must be a no-op — no net column added");
+   }
+
+   @Test
    void editNumericRangeColumnChangesBoundariesWithoutRenaming() throws Exception {
       Worksheet ws = new Worksheet();
       EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "amount", "total");
@@ -886,6 +928,42 @@ class WorksheetEditServiceMutatorsTest {
       assertInstanceOf(NumericRangeRef.class, unwrapped);
       assertArrayEquals(new double[] { 0, 25, 75, 150 },
          ((NumericRangeRef) unwrapped).getValueRangeInfo().getValues());
+   }
+
+   @Test
+   void editNumericRangeColumnPreservesShowBottomTopAndInclusiveType() throws Exception {
+      // Regression test from code review: showBottomValue/showTopValue/inclusiveType are also
+      // user-settable (the Composer's own Range Column dialog exposes them) but this tool only
+      // ever takes boundaries/labels — replacing the ValueRangeInfo outright instead of mutating
+      // the existing one would silently reset those three back to constructor defaults on every
+      // edit, discarding a customization this tool was never asked to touch.
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "amount", "total");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.addNumericRangeColumn("T", "amount", new double[] { 0, 50, 100 }, null));
+
+      // Simulate a customization made through some other path (the Composer's Range Column
+      // dialog, in practice) that this tool never exposes a way to set itself.
+      ColumnRef added = (ColumnRef) t.getColumnSelection(false).getAttribute("amount_range");
+      NumericRangeRef addedRef = (NumericRangeRef) added.getDataRef();
+      addedRef.getValueRangeInfo().setShowBottomValue(false);
+      addedRef.getValueRangeInfo().setShowTopValue(false);
+      addedRef.getValueRangeInfo().setInclusiveType(InclusiveType.UPPER);
+
+      svc.apply("TOK", agent, ed ->
+         ed.editNumericRangeColumn("T", "amount_range", new double[] { 0, 25, 75, 150 }, null));
+
+      ColumnSelection cs = t.getColumnSelection(false);
+      DataRef edited = cs.getAttribute("amount_range");
+      DataRef unwrapped = edited instanceof ColumnRef cr ? cr.getDataRef() : edited;
+      ValueRangeInfo info = ((NumericRangeRef) unwrapped).getValueRangeInfo();
+      assertArrayEquals(new double[] { 0, 25, 75, 150 }, info.getValues());
+      assertFalse(info.isShowBottomValue(), "edit must not reset showBottomValue to its default");
+      assertFalse(info.isShowTopValue(), "edit must not reset showTopValue to its default");
+      assertEquals(InclusiveType.UPPER, info.getInclusiveType(), "edit must not reset inclusiveType to its default");
    }
 
    @Test
@@ -985,6 +1063,32 @@ class WorksheetEditServiceMutatorsTest {
       DataRef edited = cs.getAttribute("total_range");
       DataRef unwrapped = edited instanceof ColumnRef cr ? cr.getDataRef() : edited;
       assertEquals(0, ((NumericRangeRef) unwrapped).getValueRangeInfo().getLabels().length);
+   }
+
+   @Test
+   void editNumericRangeColumnOmittingLabelsClearsPreExistingOnes() throws Exception {
+      // Regression test from code review (stylebi-wiz PR #1857): the tool description claims
+      // omitting `labels` on an edit clears any PRE-EXISTING custom labels, distinct from
+      // addNumericRangeColumnAllowsOmittedLabels above, which only exercises a column that never
+      // had labels to begin with. Must hold even after editNumericRangeColumn started mutating
+      // the existing ValueRangeInfo (to preserve showBottomValue/showTopValue/inclusiveType)
+      // instead of always replacing it — labels must still not be one of the preserved fields.
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "total", "other");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.addNumericRangeColumn("T", "total",
+         new double[] { 10000, 50000 }, new String[] { "Below standard", "Meets standard", "Good" }));
+      svc.apply("TOK", agent, ed ->
+         ed.editNumericRangeColumn("T", "total_range", new double[] { 10000, 50000 }, null));
+
+      ColumnSelection cs = t.getColumnSelection(false);
+      DataRef edited = cs.getAttribute("total_range");
+      DataRef unwrapped = edited instanceof ColumnRef cr ? cr.getDataRef() : edited;
+      assertEquals(0, ((NumericRangeRef) unwrapped).getValueRangeInfo().getLabels().length,
+         "omitting labels on an edit must clear the column's previously-set custom labels");
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -753,6 +753,263 @@ class WorksheetEditServiceMutatorsTest {
       assertNotNull(cs.getAttribute("orderDate"));
    }
 
+   // =========================================================================
+   // editDateRangeColumn / editNumericRangeColumn (Bug #76084)
+   // =========================================================================
+
+   @Test
+   void editDateRangeColumnChangesOptionAndRenamesInPlace() throws Exception {
+      // The reported bug: an AI agent asked to change "QuarterOfYear(Order Date)" to a
+      // month-level grouping had no edit tool, so it deleted and re-added the column
+      // instead of updating it in place. This is the in-place path that must exist instead.
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "orderDate", "total");
+      ws.addAssembly(t);
+      ColumnRef dateCol = (ColumnRef) t.getColumnSelection(false).getAttribute("orderDate");
+      dateCol.setDataType(XSchema.DATE);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.addDateRangeColumn("T", "orderDate", "QUARTER_OF_YEAR"));
+      svc.apply("TOK", agent, ed ->
+         ed.editDateRangeColumn("T", "QuarterOfYear(orderDate)", "MONTH_OF_YEAR"));
+
+      ColumnSelection cs = t.getColumnSelection(false);
+      assertNull(cs.getAttribute("QuarterOfYear(orderDate)"),
+                 "old option's name must be gone — the column was renamed, not duplicated");
+      DataRef edited = cs.getAttribute("MonthOfYear(orderDate)");
+      assertNotNull(edited, "renamed column must exist under the new option's name");
+      DataRef unwrapped = edited instanceof ColumnRef cr ? cr.getDataRef() : edited;
+      assertInstanceOf(DateRangeRef.class, unwrapped);
+      assertEquals(DateRangeRef.MONTH_OF_YEAR_PART, ((DateRangeRef) unwrapped).getDateOption());
+      assertNotNull(cs.getAttribute("orderDate"), "source date column must be untouched");
+      assertEquals(1, cs.stream().filter(r -> r instanceof ColumnRef cr &&
+         cr.getDataRef() instanceof DateRangeRef).count(),
+         "must not leave a stray duplicate column behind");
+   }
+
+   @Test
+   void editDateRangeColumnFailsLoudOnNonRangeColumn() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "orderDate", "total");
+      ws.addAssembly(t);
+      ColumnRef dateCol = (ColumnRef) t.getColumnSelection(false).getAttribute("orderDate");
+      dateCol.setDataType(XSchema.DATE);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      // "orderDate" is the raw source column, not a range column derived from it.
+      PairingException ex = assertThrows(PairingException.class, () ->
+         svc.apply("TOK", agent, ed -> ed.editDateRangeColumn("T", "orderDate", "MONTH")));
+      assertTrue(ex.getMessage().contains("not a date range column"));
+   }
+
+   @Test
+   void editDateRangeColumnFailsLoudOnMissingColumn() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "orderDate", "total");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      PairingException ex = assertThrows(PairingException.class, () ->
+         svc.apply("TOK", agent, ed -> ed.editDateRangeColumn("T", "Nope(orderDate)", "MONTH")));
+      assertTrue(ex.getMessage().contains("Column not found"));
+   }
+
+   @Test
+   void editDateRangeColumnFailsLoudOnRenameCollision() throws Exception {
+      // Two range columns already exist at different options (QUARTER_OF_YEAR and
+      // MONTH_OF_YEAR). Editing the first to also become MONTH_OF_YEAR would rename it onto
+      // the second's name — must be refused, not silently shadow the other column.
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "orderDate", "total");
+      ws.addAssembly(t);
+      ColumnRef dateCol = (ColumnRef) t.getColumnSelection(false).getAttribute("orderDate");
+      dateCol.setDataType(XSchema.DATE);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.addDateRangeColumn("T", "orderDate", "QUARTER_OF_YEAR"));
+      svc.apply("TOK", agent, ed -> ed.addDateRangeColumn("T", "orderDate", "MONTH_OF_YEAR"));
+
+      PairingException ex = assertThrows(PairingException.class, () ->
+         svc.apply("TOK", agent, ed ->
+            ed.editDateRangeColumn("T", "QuarterOfYear(orderDate)", "MONTH_OF_YEAR")));
+      assertTrue(ex.getMessage().contains("MonthOfYear(orderDate)"));
+
+      ColumnSelection cs = t.getColumnSelection(false);
+      assertNotNull(cs.getAttribute("QuarterOfYear(orderDate)"), "refused edit must leave the original untouched");
+      DataRef stillMonth = cs.getAttribute("MonthOfYear(orderDate)");
+      assertNotNull(stillMonth, "the pre-existing MonthOfYear column must survive, not be shadowed");
+      assertEquals(2, cs.stream().filter(r -> r instanceof ColumnRef cr &&
+         cr.getDataRef() instanceof DateRangeRef).count(),
+         "still exactly two distinct range columns — no shadowing duplicate");
+   }
+
+   @Test
+   void editDateRangeColumnAllowsNoOpWhenOptionUnchanged() throws Exception {
+      // dateOption resolving to the SAME name as the column already has must not trip the
+      // new collision guard against itself.
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "orderDate", "total");
+      ws.addAssembly(t);
+      ColumnRef dateCol = (ColumnRef) t.getColumnSelection(false).getAttribute("orderDate");
+      dateCol.setDataType(XSchema.DATE);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.addDateRangeColumn("T", "orderDate", "QUARTER_OF_YEAR"));
+      svc.apply("TOK", agent, ed ->
+         ed.editDateRangeColumn("T", "QuarterOfYear(orderDate)", "QUARTER_OF_YEAR"));
+
+      ColumnSelection cs = t.getColumnSelection(false);
+      assertNotNull(cs.getAttribute("QuarterOfYear(orderDate)"));
+   }
+
+   @Test
+   void editNumericRangeColumnChangesBoundariesWithoutRenaming() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "amount", "total");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.addNumericRangeColumn("T", "amount", new double[] { 0, 50, 100 }, null));
+      svc.apply("TOK", agent, ed ->
+         ed.editNumericRangeColumn("T", "amount_range", new double[] { 0, 25, 75, 150 }, null));
+
+      ColumnSelection cs = t.getColumnSelection(false);
+      DataRef edited = cs.getAttribute("amount_range");
+      assertNotNull(edited, "column name must be unchanged — boundaries alone don't rename it");
+      DataRef unwrapped = edited instanceof ColumnRef cr ? cr.getDataRef() : edited;
+      assertInstanceOf(NumericRangeRef.class, unwrapped);
+      assertArrayEquals(new double[] { 0, 25, 75, 150 },
+         ((NumericRangeRef) unwrapped).getValueRangeInfo().getValues());
+   }
+
+   @Test
+   void editNumericRangeColumnFailsLoudOnEmptyBoundaries() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "amount", "total");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.addNumericRangeColumn("T", "amount", new double[] { 0, 50, 100 }, null));
+
+      PairingException ex = assertThrows(PairingException.class, () ->
+         svc.apply("TOK", agent, ed -> ed.editNumericRangeColumn("T", "amount_range", new double[0], null)));
+      assertTrue(ex.getMessage().contains("boundaries must be a non-empty array"));
+   }
+
+   @Test
+   void editNumericRangeColumnFailsLoudOnNonRangeColumn() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "amount", "total");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      PairingException ex = assertThrows(PairingException.class, () ->
+         svc.apply("TOK", agent, ed -> ed.editNumericRangeColumn("T", "amount", new double[] { 0, 50 }, null)));
+      assertTrue(ex.getMessage().contains("not a numeric range column"));
+   }
+
+   // =========================================================================
+   // Custom bucket labels on numeric range columns (Bug #75942)
+   // =========================================================================
+
+   @Test
+   void addNumericRangeColumnAppliesCustomLabels() throws Exception {
+      // The reported bug: asked for boundaries 10000/50000 labeled "Below standard" /
+      // "Meets standard" / "Good", the AI said this required a formula column even though
+      // the Composer's own Range Column dialog already supports it — ValueRangeInfo.labels.
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "total", "other");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.addNumericRangeColumn("T", "total",
+         new double[] { 10000, 50000 },
+         new String[] { "Below standard", "Meets standard", "Good" }));
+
+      ColumnSelection cs = t.getColumnSelection(false);
+      DataRef added = cs.getAttribute("total_range");
+      assertNotNull(added);
+      DataRef unwrapped = added instanceof ColumnRef cr ? cr.getDataRef() : added;
+      assertInstanceOf(NumericRangeRef.class, unwrapped);
+      assertArrayEquals(new String[] { "Below standard", "Meets standard", "Good" },
+         ((NumericRangeRef) unwrapped).getValueRangeInfo().getLabels());
+      // The label ordering claim itself, not just that setLabels was called: ask the
+      // generated script expression which label applies below the first boundary, and
+      // confirm it is the bottom label, not the top or middle one.
+      assertTrue(((NumericRangeRef) unwrapped).getScriptExpression().contains("\"Below standard\""));
+   }
+
+   @Test
+   void addNumericRangeColumnFailsLoudOnWrongLabelCount() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "total", "other");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      // 2 boundaries need 3 labels (below, between, above); only 2 given.
+      PairingException ex = assertThrows(PairingException.class, () ->
+         svc.apply("TOK", agent, ed -> ed.addNumericRangeColumn("T", "total",
+            new double[] { 10000, 50000 }, new String[] { "Low", "High" })));
+      assertTrue(ex.getMessage().contains("exactly 3 entries"));
+      assertTrue(ex.getMessage().contains("got 2"));
+
+      ColumnSelection cs = t.getColumnSelection(false);
+      assertNull(cs.getAttribute("total_range"), "refused add must not leave a half-built column");
+   }
+
+   @Test
+   void addNumericRangeColumnAllowsOmittedLabels() throws Exception {
+      // null/empty labels must not be misread as "wrong count" — it means "no custom labels".
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "total", "other");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed ->
+         ed.addNumericRangeColumn("T", "total", new double[] { 10000, 50000 }, null));
+      svc.apply("TOK", agent, ed -> ed.editNumericRangeColumn("T", "total_range",
+         new double[] { 10000, 50000 }, new String[0]));
+
+      ColumnSelection cs = t.getColumnSelection(false);
+      DataRef edited = cs.getAttribute("total_range");
+      DataRef unwrapped = edited instanceof ColumnRef cr ? cr.getDataRef() : edited;
+      assertEquals(0, ((NumericRangeRef) unwrapped).getValueRangeInfo().getLabels().length);
+   }
+
+   @Test
+   void editNumericRangeColumnFailsLoudOnWrongLabelCountAndLeavesColumnUnchanged() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "total", "other");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> ed.addNumericRangeColumn("T", "total",
+         new double[] { 10000, 50000 }, new String[] { "Below standard", "Meets standard", "Good" }));
+
+      PairingException ex = assertThrows(PairingException.class, () ->
+         svc.apply("TOK", agent, ed -> ed.editNumericRangeColumn("T", "total_range",
+            new double[] { 10000, 30000, 50000 }, new String[] { "Below standard", "Meets standard", "Good" })));
+      assertTrue(ex.getMessage().contains("exactly 4 entries"));
+
+      // Refused edit must leave the original boundaries/labels untouched.
+      ColumnSelection cs = t.getColumnSelection(false);
+      DataRef unwrapped = ((ColumnRef) cs.getAttribute("total_range")).getDataRef();
+      assertArrayEquals(new double[] { 10000, 50000 },
+         ((NumericRangeRef) unwrapped).getValueRangeInfo().getValues());
+   }
+
    @Test
    void setGroupAggregateFailsLoudOnUnrecognizedDateLevel() throws Exception {
       Worksheet ws = new Worksheet();


### PR DESCRIPTION
## Summary

- **Bug #76084**: `add_date_range_column`/`add_numeric_range_column` had no `edit_*` counterpart, so the wiz agent asked to change an existing range column's grouping option/boundaries fell back to deleting and re-adding it — orphaning anything already bound to the old column. Adds `editDateRangeColumn`/`editNumericRangeColumn` to `WorksheetEditService` and wires `edit_date_range_column`/`edit_numeric_range_column` into `WorksheetAgentController`'s op switch.
- **Bug #75942**: `ValueRangeInfo` already fully supports custom bucket labels (`getLabels()`/`setLabels`, consumed by `NumericRangeRef`'s expression generators) — the same feature the Composer's own Range Column dialog exposes — but neither `add_numeric_range_column` nor the new `edit_numeric_range_column` ever called `setLabels()`. Both now accept an optional `labels` array, validated against `boundaries.length + 1` up front (the count the engine's expression generators index into with no bounds check).

## Root Cause

- #76084: no backend method or op existed for editing a range column in place.
- #75942: `setLabels()` was simply never wired up on the add path, despite full engine support.

## Fix

- `editDateRangeColumn` renames the column to match its new option (the name encodes the grouping level, e.g. `QuarterOfYear(Order Date)` → `MonthOfYear(Order Date)`), guarded against colliding with another already-named range column.
- `editNumericRangeColumn` updates boundaries in place; the column's name (`column + "_range"`) is unaffected.
- New `labels` param on both `add_numeric_range_column`/`edit_numeric_range_column`, with a shared `validateLabelCount` helper failing loud on a wrong count instead of letting `NumericRangeRef.getExpression()`/`getScriptExpression()` throw `ArrayIndexOutOfBoundsException` deep in expression generation.
- `EditRequest`'s `labels` field is appended at the end of the record (after `crosstab`), not inserted near `boundaries`, to avoid breaking the existing hand-written compatibility constructor's positional delegation.

## Test Plan

- `mvnw clean test-compile -pl core` — clean compile (a non-clean incremental build initially masked a broken positional `EditRequest(...)` call in a test file elsewhere; caught via `clean` and fixed).
- `mvnw test -pl core -Dtest=WorksheetEditServiceMutatorsTest,WorksheetAgentControllerTest,WorksheetReadServiceTest,GroupSpecDeserializationTest` — 221/221 pass, including new coverage for both bugs (rename-collision guard, label-count validation, label ordering verified against actual generated expression text).
- Manually verified end-to-end against a rebuilt `stylebi-wiz` composer-chat plugin: editing an existing range column's option/boundaries now updates in place, and custom bucket labels apply correctly.

Companion PR (stylebi-wiz plugin, exposes these ops as MCP tools): to follow.

Fixes Redmine #76084, #75942.