### PR TITLE
Bug #76278, enforce security.selfSignUp.enabled on the signup endpoints

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/controller/SignupController.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/SignupController.java
@@ -21,6 +21,7 @@ import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.portal.CustomThemesManager;
 import inetsoft.sree.portal.PortalThemesManager;
 import inetsoft.sree.security.*;
+import inetsoft.sree.security.SecurityException;
 import inetsoft.util.Catalog;
 import inetsoft.util.Tool;
 import inetsoft.web.portal.model.SignupResponseModel;
@@ -34,6 +35,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.view.RedirectView;
 
 import java.util.Date;
 import java.util.Objects;
@@ -42,11 +44,22 @@ import java.util.Objects;
 public class SignupController {
    public SignupController(UserSignupService userSignupService,
                            CustomThemesManager customThemesManager,
-                           PortalThemesManager portalThemesManager)
+                           PortalThemesManager portalThemesManager,
+                           SecurityEngine securityEngine)
    {
       this.userSignupService = userSignupService;
       this.customThemesManager = customThemesManager;
       this.portalThemesManager = portalThemesManager;
+      this.securityEngine = securityEngine;
+   }
+
+   /**
+    * Checks whether self signup is enabled. The login page only hides the sign up link when this
+    * is off, so every signup endpoint has to enforce it as well; otherwise the flow stays reachable
+    * for anyone who knows the URLs.
+    */
+   private boolean isSelfSignupEnabled() {
+      return securityEngine.isSelfSignupEnabled();
    }
 
    /**
@@ -56,6 +69,10 @@ public class SignupController {
     */
    @GetMapping("/signup.html")
    public ModelAndView showSignUpPage(HttpServletResponse response, @LinkUri String linkUri) {
+      if(!isSelfSignupEnabled()) {
+         return new ModelAndView(new RedirectView("login.html"));
+      }
+
       ModelAndView model = new ModelAndView("signup");
 
       boolean customLogo = portalThemesManager.hasCustomLogo(OrganizationManager.getInstance().getCurrentOrgID());
@@ -89,6 +106,10 @@ public class SignupController {
    public ModelAndView showSignUpDetailPage(
       HttpServletRequest request, HttpServletResponse response, @LinkUri String linkUri)
    {
+      if(!isSelfSignupEnabled()) {
+         return new ModelAndView(new RedirectView("login.html"));
+      }
+
       HttpSession session = request.getSession(false);
       Object emailObj = session.getAttribute(SIGNUP_USER_EMAIL);
       Object codeObj = session.getAttribute(SIGNUP_EMAIL_CODE);
@@ -126,7 +147,12 @@ public class SignupController {
    @ResponseBody
    public SignupResponseModel signupWithEmail(@RequestParam(name = "email") String signupEmail,
                                                HttpServletRequest request)
+      throws SecurityException
    {
+      if(!isSelfSignupEnabled()) {
+         throw new SecurityException("Self signup is not enabled");
+      }
+
       SignupResponseModel result = new SignupResponseModel();
       Catalog catalog = Catalog.getCatalog();
 
@@ -182,7 +208,11 @@ public class SignupController {
                                                  @RequestParam(name = "password") String password,
                                                  @RequestParam(name = "code") String code,
                                                  HttpServletRequest request)
+      throws SecurityException
    {
+      if(!isSelfSignupEnabled()) {
+         throw new SecurityException("Self signup is not enabled");
+      }
 
       SignupResponseModel result = new SignupResponseModel();
       HttpSession session = request.getSession(false);
@@ -290,7 +320,13 @@ public class SignupController {
     */
    @GetMapping("/signup/resendEmailCode")
    @ResponseBody
-   public SignupResponseModel resendEmailCode(HttpServletRequest request) {
+   public SignupResponseModel resendEmailCode(HttpServletRequest request)
+      throws SecurityException
+   {
+      if(!isSelfSignupEnabled()) {
+         throw new SecurityException("Self signup is not enabled");
+      }
+
       HttpSession session = request.getSession(false);
       SignupResponseModel responseModel = new SignupResponseModel();
 
@@ -343,6 +379,7 @@ public class SignupController {
    private final UserSignupService userSignupService;
    private final CustomThemesManager customThemesManager;
    private final PortalThemesManager portalThemesManager;
+   private final SecurityEngine securityEngine;
 
    private final static String SIGNUP_USER_EMAIL = "SIGNUP_USER_EMAIL";
    private final static String SIGNUP_EMAIL_CODE = "SIGNUP_EMAIL_CODE";

--- a/core/src/test/java/inetsoft/web/portal/controller/SignupControllerTest.java
+++ b/core/src/test/java/inetsoft/web/portal/controller/SignupControllerTest.java
@@ -35,13 +35,16 @@ package inetsoft.web.portal.controller;
  *
  * Cases deferred — need SreeEnv / OrganizationManager / HttpServletResponse:
  *
- * showSignUpPage() / showSignUpDetailPage() ModelAndView and cache headers
+ * showSignUpPage() / showSignUpDetailPage() ModelAndView and cache headers for the enabled path.
+ * The disabled path is covered by SelfSignupDisabled, which only asserts on the redirect view and
+ * so needs no theme/org stubbing.
  */
 
 import inetsoft.sree.internal.SUtil;
 import inetsoft.sree.portal.CustomThemesManager;
 import inetsoft.sree.portal.PortalThemesManager;
 import inetsoft.sree.security.*;
+import inetsoft.sree.security.SecurityException;
 import inetsoft.web.portal.model.SignupResponseModel;
 import inetsoft.web.portal.service.UserSignupService;
 import jakarta.mail.MessagingException;
@@ -54,6 +57,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.view.RedirectView;
 
 import javax.naming.NamingException;
 
@@ -71,19 +77,25 @@ class SignupControllerTest {
    private static final String SIGNUP_EMAIL = "user@example.com";
    private static final String VALID_CODE = "Ab12Cd";
    private static final String VALID_PASSWORD = "Password1!";
+   private static final String LINK_URI = "http://localhost:8080/";
 
    @Mock private UserSignupService userSignupService;
    @Mock private CustomThemesManager customThemesManager;
    @Mock private PortalThemesManager portalThemesManager;
+   @Mock private SecurityEngine securityEngine;
    @Mock private HttpServletRequest request;
    @Mock private HttpSession session;
+   @Mock private HttpServletResponse response;
 
    private SignupController signupController;
 
    @BeforeEach
    void setUp() {
       SUtil.setMultiTenant(true);
-      signupController = new SignupController(userSignupService, customThemesManager, portalThemesManager);
+      // every endpoint gates on this; the disabled case is overridden in SelfSignupDisabled
+      lenient().when(securityEngine.isSelfSignupEnabled()).thenReturn(true);
+      signupController = new SignupController(userSignupService, customThemesManager,
+                                             portalThemesManager, securityEngine);
    }
 
    // -------------------------------------------------------------------------
@@ -94,7 +106,7 @@ class SignupControllerTest {
    class SignupWithEmail {
 
       @Test
-      void invalidEmail_returnsFailure() {
+      void invalidEmail_returnsFailure() throws Exception {
          SignupResponseModel result = signupController.signupWithEmail("not-an-email", request);
 
          assertFalse(result.isSuccess());
@@ -182,7 +194,7 @@ class SignupControllerTest {
    class SubmitSignupDetail {
 
       @Test
-      void missingSessionEmail_redirectsToSignupPage() {
+      void missingSessionEmail_redirectsToSignupPage() throws Exception {
          when(request.getSession(false)).thenReturn(session);
          when(session.getAttribute("SIGNUP_EMAIL_CODE")).thenReturn(null);
          when(session.getAttribute("SIGNUP_USER_EMAIL")).thenReturn(null);
@@ -194,7 +206,7 @@ class SignupControllerTest {
       }
 
       @Test
-      void invalidUserName_returnsFailure() {
+      void invalidUserName_returnsFailure() throws Exception {
          stubSessionWithEmail();
          when(userSignupService.validUserName(SIGNUP_EMAIL)).thenReturn(false);
 
@@ -206,7 +218,7 @@ class SignupControllerTest {
       }
 
       @Test
-      void invalidPassword_returnsFailure() {
+      void invalidPassword_returnsFailure() throws Exception {
          stubSessionWithEmail();
          when(userSignupService.validUserName(SIGNUP_EMAIL)).thenReturn(true);
          when(userSignupService.validPassword(VALID_PASSWORD)).thenReturn(false);
@@ -219,7 +231,7 @@ class SignupControllerTest {
       }
 
       @Test
-      void expiredVerificationCode_returnsFailure() {
+      void expiredVerificationCode_returnsFailure() throws Exception {
          stubValidSession();
          when(userSignupService.validUserName(SIGNUP_EMAIL)).thenReturn(true);
          when(userSignupService.validPassword(VALID_PASSWORD)).thenReturn(true);
@@ -234,7 +246,7 @@ class SignupControllerTest {
       }
 
       @Test
-      void wrongVerificationCode_returnsFailure() {
+      void wrongVerificationCode_returnsFailure() throws Exception {
          stubValidSession();
          when(userSignupService.validUserName(SIGNUP_EMAIL)).thenReturn(true);
          when(userSignupService.validPassword(VALID_PASSWORD)).thenReturn(true);
@@ -248,7 +260,7 @@ class SignupControllerTest {
       }
 
       @Test
-      void userAlreadyExists_returnsFailure() {
+      void userAlreadyExists_returnsFailure() throws Exception {
          stubValidSession();
          stubValidSignupFields();
          when(userSignupService.existAuthenticationChain()).thenReturn(true);
@@ -262,7 +274,7 @@ class SignupControllerTest {
       }
 
       @Test
-      void createUserSuccess_clearsSessionAttributes() {
+      void createUserSuccess_clearsSessionAttributes() throws Exception {
          stubValidSession();
          stubValidSignupFields();
          when(userSignupService.existAuthenticationChain()).thenReturn(true);
@@ -307,7 +319,7 @@ class SignupControllerTest {
    class ResendEmailCode {
 
       @Test
-      void missingSession_returnsFailure() {
+      void missingSession_returnsFailure() throws Exception {
          when(request.getSession(false)).thenReturn(null);
 
          SignupResponseModel result = signupController.resendEmailCode(request);
@@ -362,6 +374,63 @@ class SignupControllerTest {
          when(session.getAttribute("SIGNUP_EMAIL_CODE")).thenReturn(VALID_CODE);
          when(session.getAttribute("SIGNUP_EMAIL_CODE_TIME"))
             .thenReturn(System.currentTimeMillis() - 120_000L);
+      }
+   }
+
+   // -------------------------------------------------------------------------
+   // self signup disabled — security.selfSignUp.enabled off must close the flow,
+   // not just hide the login-page link
+   // -------------------------------------------------------------------------
+
+   @Nested
+   class SelfSignupDisabled {
+      @BeforeEach
+      void disableSelfSignup() {
+         when(securityEngine.isSelfSignupEnabled()).thenReturn(false);
+      }
+
+      @Test
+      void showSignUpPage_redirectsToLogin() {
+         ModelAndView model = signupController.showSignUpPage(response, LINK_URI);
+
+         assertRedirectsToLogin(model);
+         verifyNoInteractions(userSignupService);
+      }
+
+      @Test
+      void showSignUpDetailPage_redirectsToLogin() {
+         ModelAndView model = signupController.showSignUpDetailPage(request, response, LINK_URI);
+
+         assertRedirectsToLogin(model);
+         verifyNoInteractions(userSignupService, request);
+      }
+
+      @Test
+      void signupWithEmail_isForbidden() {
+         assertThrows(SecurityException.class,
+                      () -> signupController.signupWithEmail(SIGNUP_EMAIL, request));
+         verifyNoInteractions(userSignupService);
+      }
+
+      @Test
+      void submitSignupDetail_isForbidden() {
+         assertThrows(SecurityException.class,
+                      () -> signupController.submitSignupDetail("First", "Last", VALID_PASSWORD,
+                                                                VALID_CODE, request));
+         verifyNoInteractions(userSignupService);
+      }
+
+      @Test
+      void resendEmailCode_isForbidden() {
+         assertThrows(SecurityException.class,
+                      () -> signupController.resendEmailCode(request));
+         verifyNoInteractions(userSignupService);
+      }
+
+      private void assertRedirectsToLogin(ModelAndView model) {
+         assertNotNull(model);
+         assertInstanceOf(RedirectView.class, model.getView());
+         assertEquals("login.html", ((RedirectView) model.getView()).getUrl());
       }
    }
 }


### PR DESCRIPTION
## Problem

Turning self-signup off removed the *Create an Account* link from the login page but did not close the signup flow.

`SecurityEngine.isSelfSignupEnabled()` reads `security.selfSignUp.enabled`, but its only production readers were display or SSO paths:

- `LoginController:135-137` — the `selfSignUpEnabled` model attribute that renders the link
- `SecurityConfigController:276` — reports the value back to Enterprise Manager
- `StyleBIGoogleSSOFilter:280` (enterprise) — gates Google SSO auto-registration

`SignupController` had five mapped endpoints and no reference to the property at all, and `AbstractSecurityFilter.publicResources` lists `/signup.html`, `/signupDetail.html`, and `/signup/**` unconditionally. So with the toggle off, anyone who knew the URLs could still reach the flow.

The emailed verification code means this was not an unauthenticated account-creation hole. The defect is narrower: the property presents as an on/off switch for self-registration, and an operator who turns it off should get the door closed, not the sign hidden. Worth noting the property has **no declared default** anywhere and the read is a strict `"true".equals(...)`, so the effective default is `false` — the flow was reachable on a default install where the flag reads as off.

## Fix

Inject `SecurityEngine` into `SignupController` and gate all five endpoints on `isSelfSignupEnabled()` as the **first statement**, before any session or mail work:

| Endpoint | Refusal |
|---|---|
| `GET /signup.html` | redirect to `login.html` |
| `GET /signupDetail.html` | redirect to `login.html` |
| `GET /signup/withEmail` | `SecurityException` → 403 |
| `GET /signup/userDetail` | `SecurityException` → 403 |
| `GET /signup/resendEmailCode` | `SecurityException` → 403 |

`ControllerErrorHandler` is `@ControllerAdvice(basePackages = { "inetsoft.web.portal" })` and already maps `SecurityException` to 403, so no new catalog keys are needed. This is the same pattern `ChangePasswordDialogController:59,73` uses. `signup.js` already has an `error:` callback on all three JSON calls, so a 403 degrades gracefully — though in practice legitimate users never reach them with the feature off, because the pages redirect away first.

`RedirectView` is used explicitly rather than a `"redirect:"` view name: views resolve through Thymeleaf here and there is no existing `redirect:` prefix usage in the codebase, so this avoids depending on view-resolver prefix handling.

## Scope decisions

- **Gate is `isSelfSignupEnabled()` alone**, which already ANDs `isSecurityEnabled()`. `LoginController` ANDs `LicenseManager.isEnterprise()` and a not-a-tenant-server check on top, but only to decide whether to render the link. Enforcing those server-side would close signup in community edition and on tenant servers — a behavior change beyond this defect.
- **`publicResources` is unchanged.** The paths must stay public while the feature is on, so the filter cannot gate them without threading the property into `AbstractSecurityFilter` — more surface than this warrants. Closing the flow is the controller's job.
- With security disabled, `isSelfSignupEnabled()` returns false and the endpoints now refuse. Not a user-visible regression: with no authentication chain the flow already failed at `existAuthenticationChain()` with `signup.not.support`, and the link was already hidden. This converts a soft failure into a 403.

## Not fixed here (pre-existing, flagged so they aren't mistaken for regressions)

- `showSignUpDetailPage` NPEs when there is no session (`getSession(false)` then dereferenced). The new guard runs first, so a disabled-signup request no longer reaches it, but the NPE remains on the enabled path.
- `StyleBIGoogleSSOFilter:280` reads `SreeEnv.getBooleanProperty` directly instead of going through `SecurityEngine`, so unlike every other reader it skips the `isSecurityEnabled()` AND. Real inconsistency, enterprise-side, separately tested — worth its own issue.
- `signup.js:311` sends a `name=` param that `submitSignupDetail` does not declare (harmlessly ignored; the username is derived server-side from the session email).

## Testing

New `SelfSignupDisabled` nested group in `SignupControllerTest`: the two redirects, the three 403s, and `verifyNoInteractions(userSignupService)` on each — which is what proves the guard runs before any email is sent.

`./mvnw test -pl core -Dtest=SignupControllerTest` → **22 tests, 0 failures** (17 pre-existing + 5 new). The nine existing test methods that call the now-`throws` endpoints gained a `throws Exception` clause.

Not yet run: the Docker end-to-end checks (feature off → 302/403 and no mail; feature on → full flow still completes). The enabled-path regression check is worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)