### PR TITLE
Test-only fault-injection hook for admin-chat compensating rollback

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/ai/AdminChangeService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminChangeService.java
@@ -28,6 +28,8 @@ import org.springframework.stereotype.Service;
 import java.security.Principal;
 import java.sql.Timestamp;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Service
 public class AdminChangeService {
@@ -41,8 +43,38 @@ public class AdminChangeService {
       requireNonBlank("property", req.getProperty());
       requireValidAction(req.getAction());
 
+      FaultInjectionProbe probe = FaultInjectionProbe.match(req);
+
+      // Placed BEFORE the try block below, deliberately: a throw here propagates all the way out
+      // of applyChange, the same as the (currently unreachable through any real call) unanticipated
+      // exception AdminChangesetApplyService.apply's own catch(Exception e) exists to handle. See
+      // docs/teams/2026-08-26-a1-fault-injection/01-design.md - this is a test-only hook, inert
+      // unless both FaultInjectionProbe gates hold, neither of which any real request can satisfy.
+      if(probe != null && probe.throwsFault()) {
+         throw new AdminChangeFaultInjectedException(req.getProperty(), req.getAction());
+      }
+
       AdminChangeResult result = new AdminChangeResult();
       result.setProperty(req.getProperty());
+
+      if(probe != null) {
+         // A "soft" fault: applyChange returns normally with status FAILED, exactly like a real
+         // failure that never touched SreeEnv would - never a thrown exception. Unlike the throw
+         // above, this never touches SreeEnv and is audited through the same writeAudit call the
+         // real failure path below uses, so it is provably inert against server state.
+         result.setStatus(AdminChangeRecord.STATUS_FAILED);
+         result.setError("fault injection: forced failure for " + req.getProperty());
+
+         try {
+            writeAudit(req, principal, null, null, result.getStatus(), result.getError());
+         }
+         catch(Exception auditFailure) {
+            LOG.error("Failed to write admin change audit record for transaction {}",
+                      req.getTransactionId(), auditFailure);
+         }
+
+         return result;
+      }
 
       // Unlike PropertiesController.editProperty (which treats a "" value as "keep the
       // current value"), admin-chat treats "" as an explicit set-to-empty; reset-to-default is
@@ -232,6 +264,86 @@ public class AdminChangeService {
       Audit.getInstance().auditAdminChange(record, principal);
    }
 
+   /**
+    * Test-only fault injection, matched against every {@code applyChange} call. Both gates below
+    * must hold, and neither is settable by any HTTP request, so this is inert in any real
+    * deployment:
+    *
+    * <ul>
+    *   <li>the JVM system property {@link #FAULT_INJECTION_ENABLED_PROPERTY}, read fresh on every
+    *       call and settable only by a {@code -D} flag at server start; and</li>
+    *   <li>a property name matching {@link #FAULT_INJECTION_PATTERN} -
+    *       {@code test.faultinjection.<apply|rollback>.<throw|fail>.<label>} - a namespace that
+    *       does not collide with any real StyleBI property.</li>
+    * </ul>
+    *
+    * <p>The pattern is matched against the property name AFTER {@link AdminPropertyName#parse}
+    * lowercases it (every real caller reaches this method with an already-resolved,
+    * already-lowercased {@code PlanChange.property()} - see {@code AdminPropertyCatalog.resolve}
+    * and {@code AdminChangePlanService.resolve}), so the reserved namespace is spelled all
+    * lower-case; {@link #FAULT_INJECTION_PATTERN} is compiled case-insensitively as well so a test
+    * calling {@link #applyChange} directly, before that normalization, still matches.</p>
+    *
+    * <p>Exists to exercise {@code AdminChangesetApplyService}'s compensating-transaction paths
+    * ({@code rolled-back}, {@code rollback-failed}) against this REAL class, not a mock - see
+    * {@code docs/teams/2026-08-26-a1-fault-injection/01-design.md} in the stylebi-wiz repo for the
+    * full design and the exact request sequences that exercise each outcome.
+    */
+   private static final class FaultInjectionProbe {
+      private FaultInjectionProbe(boolean throwsFault) {
+         this.throwsFault = throwsFault;
+      }
+
+      /** {@code true} for a {@code throw}-mode probe, {@code false} for a {@code fail}-mode one. */
+      boolean throwsFault() {
+         return throwsFault;
+      }
+
+      /** @return a matching probe for this request, or {@code null} if either gate does not hold. */
+      static FaultInjectionProbe match(AdminChangeRequest req) {
+         if(!Boolean.getBoolean(FAULT_INJECTION_ENABLED_PROPERTY)) {
+            return null;
+         }
+
+         String property = req.getProperty();
+         Matcher m = property == null ? null : FAULT_INJECTION_PATTERN.matcher(property);
+
+         if(m == null || !m.matches()) {
+            return null;
+         }
+
+         // Firing only on the matching action lets one probe apply completely normally and fail
+         // only on its rollback (or vice versa) - required to exercise a rollback-failed scenario
+         // where the item that fails to roll back is not the same item whose apply triggered the
+         // rollback in the first place. See 01-design.md §2.3, scenario 3.
+         String targetAction = "apply".equals(m.group(1))
+            ? AdminChangeRecord.ACTION_APPLY : AdminChangeRecord.ACTION_ROLLBACK;
+
+         if(!targetAction.equals(req.getAction())) {
+            return null;
+         }
+
+         return new FaultInjectionProbe("throw".equals(m.group(2)));
+      }
+
+      private final boolean throwsFault;
+   }
+
+   /**
+    * Thrown only by {@link FaultInjectionProbe} in {@code throw} mode. Never thrown in a real
+    * deployment - see that class's javadoc for the two gates that must both hold first.
+    */
+   public static final class AdminChangeFaultInjectedException extends RuntimeException {
+      public AdminChangeFaultInjectedException(String property, String action) {
+         super("fault injection: forced throw for " + property + " (" + action + ")");
+      }
+   }
+
+   private static final String FAULT_INJECTION_ENABLED_PROPERTY =
+      "inetsoft.admin.ai.faultInjection.enabled";
+   private static final Pattern FAULT_INJECTION_PATTERN = Pattern.compile(
+      "^test\\.faultinjection\\.(apply|rollback)\\.(throw|fail)\\.[a-zA-Z0-9-]+$",
+      Pattern.CASE_INSENSITIVE);
    private static final Logger LOG = LoggerFactory.getLogger(AdminChangeService.class);
    private final PropertyChangeSideEffects sideEffects;
 }

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminChangeFaultInjectionIntegrationTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminChangeFaultInjectionIntegrationTest.java
@@ -1,0 +1,197 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai;
+
+import inetsoft.sree.SreeEnv;
+import inetsoft.util.audit.*;
+import inetsoft.web.admin.properties.PropertyChangeSideEffects;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.quality.Strictness;
+
+import java.security.Principal;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Wires the REAL {@link AdminChangeService} - not a mock - into a real
+ * {@link AdminChangesetApplyService}, through the test-only fault-injection hook, to prove what
+ * {@code AdminChangesetApplyServiceTest} cannot: that the compensating-transaction paths
+ * ({@code rolled-back}, {@code rollback-failed}, and the "fails by throwing" branch specifically)
+ * are reachable through the ACTUAL apply implementation, not only through a mock configured to
+ * throw. See {@code docs/teams/2026-08-26-a1-fault-injection/01-design.md} (stylebi-wiz repo) for
+ * the full design and why this distinction matters: before this hook existed, nothing in the
+ * codebase could make the real {@code AdminChangeService.applyChange} throw, so
+ * {@code AdminChangesetApplyService.apply}'s {@code catch(Exception e)} branch around it had never
+ * executed outside a mocked unit test.
+ */
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class AdminChangeFaultInjectionIntegrationTest {
+   private static final String FAULT_INJECTION_ENABLED_PROPERTY =
+      "inetsoft.admin.ai.faultInjection.enabled";
+
+   @Mock private AdminBackupService backupService;
+   @Mock private Principal principal;
+   @Mock private PropertyChangeSideEffects sideEffects;
+   private MockedStatic<SreeEnv> sreeEnv;
+   private MockedStatic<Audit> auditStatic;
+   private AdminChangesetApplyService service;
+   private AdminChangePlanService planService;
+   /**
+    * A tiny in-memory fake behind the static {@code SreeEnv} mock, keyed by property. Needed
+    * because, unlike {@code AdminChangesetApplyServiceTest} (which mocks {@code AdminChangeService}
+    * itself and so never actually calls {@code SreeEnv}), this class wires in the REAL
+    * {@code AdminChangeService} - so {@code SreeEnv.getProperty} is read for real, more than once
+    * per property (once by {@code request()}'s own {@code planService.resolve} call to compute the
+    * hash, again by {@code AdminChangesetApplyService.apply}'s internal re-resolve, again by
+    * {@code AdminChangeService.applyChange}'s own before/after reads) - a fixed
+    * {@code .thenReturn(a).thenReturn(b)} sequence drifts out of step with that and produces a
+    * spurious {@code PlanHashMismatchException}. A stateful fake keeps every read consistent with
+    * the writes that actually happened, the same as the real property store would.
+    */
+   private final Map<String, String> store = new HashMap<>();
+
+   @BeforeEach void setUp() {
+      System.setProperty(FAULT_INJECTION_ENABLED_PROPERTY, "true");
+      sreeEnv = mockStatic(SreeEnv.class, withSettings().strictness(Strictness.LENIENT));
+      sreeEnv.when(() -> SreeEnv.getProperty(anyString(), eq(false), eq(false)))
+             .thenAnswer(inv -> store.get(inv.getArgument(0)));
+      sreeEnv.when(() -> SreeEnv.setProperty(anyString(), anyString()))
+             .thenAnswer(inv -> store.put(inv.getArgument(0), inv.getArgument(1)));
+      auditStatic = mockStatic(Audit.class, withSettings().strictness(Strictness.LENIENT));
+      auditStatic.when(Audit::getInstance).thenReturn(mock(Audit.class));
+      AdminPropertyCatalog catalog = new AdminPropertyCatalog();
+      planService = new AdminChangePlanService(catalog, new AdminRiskClassifier(catalog));
+      // The REAL AdminChangeService - the whole point of this test class.
+      AdminChangeService realChangeService = new AdminChangeService(sideEffects);
+      service = new AdminChangesetApplyService(planService, realChangeService, backupService);
+   }
+
+   @AfterEach void tearDown() {
+      sreeEnv.close();
+      auditStatic.close();
+      System.clearProperty(FAULT_INJECTION_ENABLED_PROPERTY);
+   }
+
+   /** Both probe properties are uncatalogued, so every plan below needs signoff + a backup. */
+   private ApplyRequest request(String task, String... propertyValuePairs) {
+      List<PlanRequest.Change> changes = new ArrayList<>();
+
+      for(int i = 0; i < propertyValuePairs.length; i += 2) {
+         PlanRequest.Change change = new PlanRequest.Change();
+         change.setProperty(propertyValuePairs[i]);
+         change.setValue(propertyValuePairs[i + 1]);
+         changes.add(change);
+      }
+
+      ApplyRequest req = new ApplyRequest();
+      req.setTask(task);
+      req.setChanges(changes);
+      req.setReviewOutcome("approved");
+      PlanRequest probe = new PlanRequest();
+      probe.setTask(task);
+      probe.setChanges(changes);
+      req.setPlanHash(planService.resolve(probe).planHash());
+      return req;
+   }
+
+   @Test void anUncataloguedPropertyRequiresBackupAndSignoff() {
+      // Closes plugin/admin/README.md gap #1's first two clauses: no code change needed, an
+      // uncatalogued property already produces requiresStorageBackup + requiresAgentSignoff.
+      PlanRequest req = new PlanRequest();
+      req.setTask("t");
+      PlanRequest.Change change = new PlanRequest.Change();
+      change.setProperty("admin.chat.livecheck.probe");
+      change.setValue("1");
+      req.setChanges(List.of(change));
+
+      ResolvedPlan plan = planService.resolve(req);
+
+      assertTrue(plan.requiresStorageBackup());
+      assertTrue(plan.requiresAgentSignoff());
+      assertFalse(plan.changes().get(0).recognized());
+   }
+
+   @Test void rolledBack_softFailureRollsBackTheEarlierRealChangeCleanly() throws Exception {
+      when(backupService.backup(anyString())).thenReturn("snap-1");
+      // demo.livecheck.r1a does NOT match the fault-injection pattern at all - it is an ordinary
+      // (uncatalogued, but otherwise real) property, included to prove its rollback, triggered by
+      // r1b's fault, is a genuine SreeEnv round trip through the real AdminChangeService.
+      store.put("demo.livecheck.r1a", "before");
+
+      ApplyResult applied = service.apply(request("t",
+         "demo.livecheck.r1a", "after",
+         "test.faultinjection.apply.fail.r1b", "x"), principal);
+
+      assertEquals(AdminChangesetApplyService.STATUS_ROLLED_BACK, applied.status());
+      assertNull(applied.rollbackFailures());
+      sreeEnv.verify(() -> SreeEnv.setProperty("demo.livecheck.r1a", "after"));
+      // The undo restores the real before-value the server itself recorded during the apply -
+      // and the fake store ends up back where it started, the same as a real property would.
+      sreeEnv.verify(() -> SreeEnv.setProperty("demo.livecheck.r1a", "before"));
+      assertEquals("before", store.get("demo.livecheck.r1a"));
+   }
+
+   @Test void rollbackFailed_throwOnApplyIsCaughtByTheRealCatchBlock() throws Exception {
+      // The simple case: a throw-mode probe as the ONLY change. Proves the previously-dead
+      // catch(Exception e) branch in AdminChangesetApplyService.apply now executes for real.
+      when(backupService.backup(anyString())).thenReturn("snap-2");
+
+      ApplyResult applied = service.apply(request("t",
+         "test.faultinjection.apply.throw.r2", "x"), principal);
+
+      assertEquals(AdminChangesetApplyService.STATUS_ROLLBACK_FAILED, applied.status());
+      assertEquals(1, applied.rollbackFailures().size());
+      assertEquals("test.faultinjection.apply.throw.r2",
+                   applied.rollbackFailures().get(0).property());
+      assertTrue(applied.rollbackFailures().get(0).error().contains("state unknown"));
+      // Plan resolution legitimately reads the current value to compute the hash - the fault
+      // fires only inside applyChange, after resolution - so only a read, never a write, happens.
+      sreeEnv.verify(() -> SreeEnv.setProperty(anyString(), anyString()), never());
+      assertNull(store.get("test.faultinjection.apply.throw.r2"));
+   }
+
+   @Test
+   void rollbackFailed_namesTheItemWhoseOwnRollbackFailedNotTheItemThatTriggeredIt() throws Exception {
+      // The operationally realistic case (design doc §2.3 scenario 3): the item that fails to
+      // roll back (r3) is NOT the item whose apply failure triggered the rollback (r4) - the
+      // harder shape AdminChangesetApplyService's own javadoc discusses.
+      when(backupService.backup(anyString())).thenReturn("snap-3");
+      store.put("test.faultinjection.rollback.throw.r3", "before");
+
+      ApplyResult applied = service.apply(request("t",
+         "test.faultinjection.rollback.throw.r3", "after",
+         "test.faultinjection.apply.fail.r4", "x"), principal);
+
+      assertEquals(AdminChangesetApplyService.STATUS_ROLLBACK_FAILED, applied.status());
+      assertEquals(1, applied.rollbackFailures().size());
+      assertEquals("test.faultinjection.rollback.throw.r3",
+                   applied.rollbackFailures().get(0).property());
+      // r3 really did apply for real through the actual AdminChangeService before its rollback
+      // failed - this is the write the operator would be left with, unresolved and unreverted.
+      sreeEnv.verify(
+         () -> SreeEnv.setProperty("test.faultinjection.rollback.throw.r3", "after"));
+      assertEquals("after", store.get("test.faultinjection.rollback.throw.r3"));
+      verify(backupService).backup(applied.transactionId());
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminChangeServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminChangeServiceTest.java
@@ -52,6 +52,9 @@ class AdminChangeServiceTest {
 
    @AfterEach void tearDown() {
       sreeEnv.close(); auditStatic.close(); toolStatic.close();
+      // Belt-and-braces: no test above this line sets it, but a fault-injection test failing
+      // mid-assertion must never leave the JVM system property flag on for every test after it.
+      System.clearProperty(FAULT_INJECTION_ENABLED_PROPERTY);
    }
 
    private AdminChangeRequest req(String prop, String val) {
@@ -418,5 +421,130 @@ class AdminChangeServiceTest {
       sreeEnv.verify(() -> SreeEnv.setProperty("mail.smtp.tokenuri",
                                                "https://oauth2.example/token"));
       sreeEnv.verify(() -> SreeEnv.setPassword(anyString(), anyString()), never());
+   }
+
+   // ── test-only fault injection (Track A#1, docs/teams/2026-08-26-a1-fault-injection) ──────
+
+   /**
+    * Mirrors the private constant in {@code AdminChangeService} - kept as a literal here
+    * deliberately, so a test failure that changes the constant's spelling is caught as a real
+    * regression rather than silently recompiling against whatever the source currently says.
+    */
+   private static final String FAULT_INJECTION_ENABLED_PROPERTY =
+      "inetsoft.admin.ai.faultInjection.enabled";
+
+   @Test void doesNothingWhenTheReservedNameIsUsedButTheFlagIsNotSet() throws Exception {
+      // The flag is never set in this test - proves the reserved-name pattern alone is inert,
+      // which is the whole point of requiring BOTH gates.
+      sreeEnv.when(() -> SreeEnv.getProperty("test.faultinjection.apply.throw.p1", false, false))
+             .thenReturn(null).thenReturn("500");
+
+      AdminChangeResult res =
+         service.applyChange(req("test.faultinjection.apply.throw.p1", "500"), principal);
+
+      assertEquals(AdminChangeRecord.STATUS_VERIFIED, res.getStatus());
+      sreeEnv.verify(() -> SreeEnv.setProperty("test.faultinjection.apply.throw.p1", "500"));
+   }
+
+   @Test void doesNothingForAnOrdinaryPropertyEvenWhenTheFlagIsSet() throws Exception {
+      // The flag alone is not enough either - an unrelated property name must behave exactly as
+      // it does in every other test in this file.
+      System.setProperty(FAULT_INJECTION_ENABLED_PROPERTY, "true");
+      sreeEnv.when(() -> SreeEnv.getProperty("max.rows", false, false))
+             .thenReturn("100").thenReturn("500");
+
+      AdminChangeResult res = service.applyChange(req("max.rows", "500"), principal);
+
+      assertEquals(AdminChangeRecord.STATUS_VERIFIED, res.getStatus());
+      sreeEnv.verify(() -> SreeEnv.setProperty("max.rows", "500"));
+   }
+
+   @Test void throwModeThrowsOnApplyWithoutTouchingSreeEnv() {
+      System.setProperty(FAULT_INJECTION_ENABLED_PROPERTY, "true");
+
+      AdminChangeService.AdminChangeFaultInjectedException thrown = assertThrows(
+         AdminChangeService.AdminChangeFaultInjectedException.class,
+         () -> service.applyChange(req("test.faultinjection.apply.throw.p2", "x"), principal));
+
+      assertTrue(thrown.getMessage().contains("test.faultinjection.apply.throw.p2"));
+      sreeEnv.verifyNoInteractions();
+      // A throw-mode probe propagates BEFORE writeAudit runs (see AdminChangeService's own
+      // placement, before its try block) - the caller (AdminChangesetApplyService) is the one
+      // that must decide how to record an unknown-state failure, not this method.
+      verifyNoInteractions(audit);
+   }
+
+   @Test void failModeReturnsFailedWithoutThrowingOrTouchingSreeEnv() {
+      System.setProperty(FAULT_INJECTION_ENABLED_PROPERTY, "true");
+
+      AdminChangeResult res =
+         service.applyChange(req("test.faultinjection.apply.fail.p3", "x"), principal);
+
+      assertEquals(AdminChangeRecord.STATUS_FAILED, res.getStatus());
+      assertTrue(res.getError().contains("test.faultinjection.apply.fail.p3"));
+      sreeEnv.verifyNoInteractions();
+      ArgumentCaptor<AdminChangeRecord> cap = ArgumentCaptor.forClass(AdminChangeRecord.class);
+      verify(audit).auditAdminChange(cap.capture(), eq(principal));
+      assertEquals(AdminChangeRecord.STATUS_FAILED, cap.getValue().getStatus());
+      assertNull(cap.getValue().getBeforeValue());
+      assertNull(cap.getValue().getAfterValue());
+   }
+
+   @Test void aProbeOnlyFiresOnItsConfiguredAction() throws Exception {
+      // An "apply"-mode probe must behave as an ORDINARY property (real SreeEnv write) when the
+      // action is ROLLBACK - this is what lets a single probe apply cleanly and only fail its own
+      // later rollback (the "rollback" mode probes below), or vice versa.
+      System.setProperty(FAULT_INJECTION_ENABLED_PROPERTY, "true");
+      AdminChangeRequest r = req("test.faultinjection.apply.throw.p4", "restored");
+      r.setAction(AdminChangeRecord.ACTION_ROLLBACK);
+      sreeEnv.when(() -> SreeEnv.getProperty("test.faultinjection.apply.throw.p4", false, false))
+             .thenReturn("other").thenReturn("restored");
+
+      AdminChangeResult res = service.applyChange(r, principal);
+
+      assertEquals(AdminChangeRecord.STATUS_VERIFIED, res.getStatus());
+      sreeEnv.verify(
+         () -> SreeEnv.setProperty("test.faultinjection.apply.throw.p4", "restored"));
+   }
+
+   @Test void rollbackModeAppliesNormallyThenThrowsOnlyOnItsOwnRollback() throws Exception {
+      System.setProperty(FAULT_INJECTION_ENABLED_PROPERTY, "true");
+      sreeEnv.when(() -> SreeEnv.getProperty("test.faultinjection.rollback.throw.p5", false, false))
+             .thenReturn("before").thenReturn("after");
+
+      // APPLY: fires no probe (this one only matches action=rollback), writes for real.
+      AdminChangeResult applied =
+         service.applyChange(req("test.faultinjection.rollback.throw.p5", "after"), principal);
+      assertEquals(AdminChangeRecord.STATUS_VERIFIED, applied.getStatus());
+      sreeEnv.verify(
+         () -> SreeEnv.setProperty("test.faultinjection.rollback.throw.p5", "after"));
+
+      // ROLLBACK of the same property: now the probe fires and throws, no further SreeEnv write.
+      AdminChangeRequest rollback =
+         req("test.faultinjection.rollback.throw.p5", "before");
+      rollback.setAction(AdminChangeRecord.ACTION_ROLLBACK);
+
+      assertThrows(AdminChangeService.AdminChangeFaultInjectedException.class,
+         () -> service.applyChange(rollback, principal));
+      // Still only the one setProperty call from the apply above - the rollback attempt wrote
+      // nothing.
+      sreeEnv.verify(
+         () -> SreeEnv.setProperty(eq("test.faultinjection.rollback.throw.p5"), anyString()),
+         times(1));
+   }
+
+   @Test void rejectsAMalformedFaultInjectionNameEvenWithTheFlagSet() throws Exception {
+      // Close enough to the reserved namespace to be a plausible typo, but not a real match
+      // (missing the trailing label segment) - must fall through to the ordinary path rather
+      // than silently matching a broader pattern than intended.
+      System.setProperty(FAULT_INJECTION_ENABLED_PROPERTY, "true");
+      sreeEnv.when(() -> SreeEnv.getProperty("test.faultinjection.apply.throw", false, false))
+             .thenReturn(null).thenReturn("x");
+
+      AdminChangeResult res =
+         service.applyChange(req("test.faultinjection.apply.throw", "x"), principal);
+
+      assertEquals(AdminChangeRecord.STATUS_VERIFIED, res.getStatus());
+      sreeEnv.verify(() -> SreeEnv.setProperty("test.faultinjection.apply.throw", "x"));
    }
 }


### PR DESCRIPTION
## Summary

Track A#1 of `docs/superpowers/plans/2026-08-25-admin-plugin-master-plan.md` (stylebi-wiz repo):
three admin-chat behaviours (backup/storage-snapshot path, `requiresAgentSignoff` path,
`rolled-back`/`rollback-failed`) had never been exercised against the real server code, because
nothing could induce a mid-apply failure through the public API.

Two closed with **no code change** (see design doc): an uncatalogued property name already
produces `requiresStorageBackup: true` and `requiresAgentSignoff: true`
(`AdminRiskClassifier`'s `entry == null` branch) - that's a strictly *safer* way to exercise the
backup path than the one real storage-scoped catalogued property, since it fires no real
repository-wide event.

The third (`rolled-back`/`rollback-failed`) needed real code: `AdminChangeService.applyChange`
wraps its entire body in `try/catch(Exception)` and converts every exception into a normal
`status: "failed"` return, so nothing in the codebase could make it throw outside a mocked unit
test - meaning `AdminChangesetApplyService.apply`'s own "a change can fail by throwing" branch
(the one `AREA-SPEC-GUIDE.md` §2.5 calls out by name) had never executed against the real class.

This PR adds a fault-injection check gated by BOTH a JVM system property
(`inetsoft.admin.ai.faultInjection.enabled`, settable only by a `-D` flag at server start, never
by any request) AND a reserved property-name pattern
(`test.faultinjection.<apply|rollback>.<throw|fail>.<label>`) that cannot collide with any real
property - letting a test force a specific change in a multi-change `apply_changes` batch to fail
either by throwing or by returning `status: "failed"`, through the real apply/rollback path.

Full design, verification record, and security review:
`docs/teams/2026-08-26-a1-fault-injection/` in the `stylebi-wiz` repo (`01-design.md`,
`03-verify.md`, `04-review.md`).

## Test plan

- [x] `AdminChangeServiceTest` - 7 new tests (24 existing untouched, all still pass): reserved
      name alone is inert without the flag; flag alone is inert on an ordinary property; throw
      mode throws without touching `SreeEnv`; fail mode returns failed without throwing; a probe
      only fires on its configured action; a near-miss name falls through to the ordinary path.
- [x] `AdminChangeFaultInjectionIntegrationTest` (new) - wires the REAL `AdminChangeService` into
      a real `AdminChangesetApplyService` and proves, for the first time outside a mock: a soft
      failure produces `rolled-back` with a genuine SreeEnv rollback round trip; a throw is caught
      by the previously-dead `catch(Exception e)` branch and produces `rollback-failed`; the
      harder case where the item whose own rollback fails differs from the item that triggered it
      is named correctly.
- [x] `./mvnw.cmd -pl core -o test -Dtest='inetsoft.web.admin.ai.**'` - 178/178 passing, no
      regressions anywhere else in the package.
- [x] Security review (manual, against the real diff - see `04-review.md`): confirmed by grep
      that no `System.setProperty` call site anywhere in `core/src/main/java` accepts
      caller-supplied input, so the primary gate has no bridge from any request. No findings.
- [ ] Genuine live-server verification (real JVM flag on a running deployment, driven through the
      actual `apply_changes` MCP tool) - not attempted; a running `wiz-stylebi` container exists
      in this environment but is shared infrastructure other concurrent tracks may depend on, and
      redeploying it with this branch was out of scope for this change. See `03-verify.md` for the
      honest accounting of what is and isn't established.

🤖 Generated with [Claude Code](https://claude.com/claude-code)