### PR TITLE
Bug #75968, enforce column-dependency check in the AI Wiz worksheet plugin

### DIFF
--- a/core/src/main/java/inetsoft/web/composer/ws/WorksheetControllerService.java
+++ b/core/src/main/java/inetsoft/web/composer/ws/WorksheetControllerService.java
@@ -65,7 +65,7 @@ public class WorksheetControllerService {
    /**
     * Check if allows deletion.
     */
-   protected boolean allowsDeletion(Worksheet ws, TableAssembly assembly, ColumnRef ref) {
+   public static boolean allowsDeletion(Worksheet ws, TableAssembly assembly, ColumnRef ref) {
       AssemblyRef[] arr = ws.getDependings(assembly.getAssemblyEntry());
 
       for(AssemblyRef assemblyRef : arr) {

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -54,6 +54,7 @@ import inetsoft.uql.util.filereader.ExcelFileSupport;
 import inetsoft.util.Catalog;
 import inetsoft.util.FileSystemService;
 import inetsoft.web.composer.ws.LayoutGraphService;
+import inetsoft.web.composer.ws.WorksheetControllerService;
 import inetsoft.web.composer.ws.assembly.WorksheetEventUtil;
 import inetsoft.web.composer.ws.event.WSLayoutGraphEvent;
 import inetsoft.web.portal.controller.database.QueryManagerService;
@@ -1991,15 +1992,23 @@ public class WorksheetAgentController {
                "Access denied: no READ permission on datasource " + dsName);
          }
 
-         UniformSQL sql = (UniformSQL) info.getQuery().getSQLDefinition();
+         // Work on a scratch clone of the live query (JDBCQuery.clone() deep-clones its
+         // SQLDefinition too) so a rejected edit -- parse failure, or the dependency check
+         // further down -- never mutates the assembly's persisted query or column selection.
+         // Mirrors SQLQueryDialogService, which builds an entirely new JDBCQuery for the same
+         // reason and only assigns it to the live info once the edit is accepted.
+         JDBCQuery scratchQuery = info.getQuery().clone();
+         UniformSQL sql = (UniformSQL) scratchQuery.getSQLDefinition();
 
          if(sql == null) {
             sql = new UniformSQL();
-            JDBCDataSource ds = (JDBCDataSource) info.getQuery().getDataSource();
+            JDBCDataSource ds = (JDBCDataSource) scratchQuery.getDataSource();
 
             if(ds != null) {
                sql.setDataSource(ds);
             }
+
+            scratchQuery.setSQLDefinition(sql);
          }
 
          // setSQLString() with parseSQL=true fires an async parse on a background thread
@@ -2024,9 +2033,6 @@ public class WorksheetAgentController {
             throw new PairingException("SQL parsing was interrupted.");
          }
 
-         info.getQuery().setSQLDefinition(sql);
-         sqlTable.setSQLEdited(true);
-
          // initColumnSelection does NOT work for SQL-edited assemblies (returns empty
          // selection). Use the same path as addSqlQuery / SQLQueryDialogService:
          // fixUniformSQLInfo expands SELECT *, then getColumnSelection reads result metadata.
@@ -2034,9 +2040,9 @@ public class WorksheetAgentController {
             new DefaultMetaDataProvider(xrepository).getSession();
          JDBCUtil.fixUniformSQLInfo(
             sql, xrepository, metaSession,
-            (JDBCDataSource) info.getQuery().getDataSource());
+            (JDBCDataSource) scratchQuery.getDataSource());
          ColumnSelection columns = queryManagerService.getColumnSelection(
-            info.getQuery(), new VariableTable(), sqlTable, metaSession, null);
+            scratchQuery, new VariableTable(), sqlTable, metaSession, null);
 
          if(columns == null || columns.getAttributeCount() == 0) {
             throw new PairingException(
@@ -2045,10 +2051,56 @@ public class WorksheetAgentController {
 
          WorksheetMutationSupport.sanitizeSqlColumnNames(columns);
          WorksheetMutationSupport.sanitizeSqlSelectionAliases(sql);
+
+         // Refuse an edit that drops or renames a column a dependent join/composite table
+         // still keys on -- mirrors SQLQueryDialogService's guard for the human-driven SQL
+         // Query dialog, which reverts rather than applying such an edit. Everything above
+         // this point ran against scratchQuery/sql (clones), so nothing has been committed
+         // to the live assembly yet, and this throws before anything is.
+         assertSqlEditAllowsColumnRemoval(ws, sqlTable, sqlTable.getColumnSelection(), columns);
+
+         info.getQuery().setSQLDefinition(sql);
+         sqlTable.setSQLEdited(true);
          sqlTable.setColumnSelection(columns);
          WorksheetEventUtil.refreshColumnSelection(rws, req.table(), true);
          return null;
       });
+   }
+
+   /**
+    * Refuses a SQL edit that would drop or rename a column a dependent join/composite table
+    * still keys on. Mirrors {@code SQLQueryDialogService}'s equivalent check for the
+    * human-driven SQL Query dialog, translated into a thrown {@link PairingException} instead
+    * of a reverted {@code MessageCommand} -- the wiz plugin has no dialog to revert back into.
+    *
+    * @param ws         the worksheet, for walking dependents
+    * @param assembly   the SQL-bound table whose column selection is about to change
+    * @param oldColumns the table's column selection before the edit
+    * @param newColumns the column selection the new SQL would produce
+    * @throws PairingException naming the first old column that is both absent from
+    *                          {@code newColumns} and still used by a dependent
+    */
+   private static void assertSqlEditAllowsColumnRemoval(Worksheet ws, TableAssembly assembly,
+                                                         ColumnSelection oldColumns,
+                                                         ColumnSelection newColumns)
+      throws PairingException
+   {
+      if(oldColumns == null) {
+         return;
+      }
+
+      ColumnSelection safeNewColumns = newColumns != null ? newColumns : new ColumnSelection();
+
+      for(int i = 0; i < oldColumns.getAttributeCount(); i++) {
+         ColumnRef attribute = (ColumnRef) oldColumns.getAttribute(i);
+
+         if(!safeNewColumns.containsAttribute(attribute) &&
+            !WorksheetControllerService.allowsDeletion(ws, assembly, attribute))
+         {
+            throw new PairingException(Catalog.getCatalog().getString(
+               "common.columnDependency", attribute.getAttribute()));
+         }
+      }
    }
 
    // ---------------------------------------------------------------------------

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -38,6 +38,7 @@ import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.util.XEmbeddedTable;
 import java.awt.Point;
 import java.util.Enumeration;
+import inetsoft.web.composer.ws.WorksheetControllerService;
 import inetsoft.web.composer.ws.assembly.WorksheetEventUtil;
 import inetsoft.web.wiz.pairing.*;
 import org.slf4j.Logger;
@@ -300,7 +301,8 @@ public class WorksheetEditService {
        *
        * @param table the assembly name
        * @param col   the column attribute name to remove
-       * @throws PairingException if no {@link TableAssembly} with {@code table} exists
+       * @throws PairingException if no {@link TableAssembly} with {@code table} exists, or if
+       *                          a dependent join/composite table still uses this column
        */
       public void removeColumn(String table, String col) throws PairingException {
          TableAssembly t = requireTable(table);
@@ -309,6 +311,13 @@ public class WorksheetEditService {
 
          if(toRemove != null) {
             WorksheetMutationSupport.assertSnapshotAllowsColumnRemove(t, table, col, toRemove);
+
+            if(toRemove instanceof ColumnRef cr &&
+               !WorksheetControllerService.allowsDeletion(ws, t, cr))
+            {
+               throw new PairingException(Catalog.getCatalog().getString(
+                  "common.columnDependency", col));
+            }
 
             // For embedded tables, also remove the data column from XEmbeddedTable.
             // Snapshots are excluded, and not just as an optimization: the guard above lets
@@ -425,7 +434,8 @@ public class WorksheetEditService {
        * @param table   the assembly name
        * @param col     the column attribute name to rename
        * @param newName the new alias
-       * @throws PairingException if no {@link TableAssembly} with {@code table} exists
+       * @throws PairingException if no {@link TableAssembly} with {@code table} exists, or if
+       *                          a dependent join/composite table still uses this column
        */
       public void renameColumn(String table, String col, String newName) throws PairingException {
          TableAssembly t = requireTable(table);
@@ -433,6 +443,11 @@ public class WorksheetEditService {
          DataRef existing = cs.getAttribute(col);
 
          if(existing instanceof ColumnRef cr) {
+            if(!WorksheetControllerService.allowsDeletion(ws, t, cr)) {
+               throw new PairingException(Catalog.getCatalog().getString(
+                  "common.columnDependency", col));
+            }
+
             cr.setAlias(newName);
          }
       }
@@ -1123,7 +1138,9 @@ public class WorksheetEditService {
        * @param table   the assembly name
        * @param col     the column attribute name
        * @param visible {@code true} to show, {@code false} to hide
-       * @throws PairingException if the table or column is not found
+       * @throws PairingException if the table or column is not found, or if hiding would
+       *                          break a dependent join/composite table that still uses
+       *                          this column
        */
       public void setColumnVisibility(String table, String col, boolean visible)
          throws PairingException
@@ -1134,6 +1151,11 @@ public class WorksheetEditService {
 
          if(!(ref instanceof ColumnRef cr)) {
             throw new PairingException("Column not found: " + col);
+         }
+
+         if(cr.isVisible() && !visible && !WorksheetControllerService.allowsDeletion(ws, t, cr)) {
+            throw new PairingException(Catalog.getCatalog().getString(
+               "common.columnDependency", col));
          }
 
          cr.setVisible(visible);

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -1162,6 +1162,97 @@ class WorksheetEditServiceMutatorsTest {
    }
 
    // =========================================================================
+   // Column-dependency guard tests (Redmine #75968)
+   //
+   // The Composer UI has always refused to hide/remove/rename a column a dependent
+   // join still keys on (SetColumnVisibleService / DeleteColumnsService / RenameColumnService,
+   // via WorksheetControllerService#allowsDeletion). The wiz plugin's Editor skipped that
+   // check entirely, letting an agent silently break a join. These tests lock in the fix.
+   // =========================================================================
+
+   @Test
+   void removeColumnRefusesAJoinKeyStillUsedByADependentJoin() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly left  = TestWorksheets.tableWithColumns(ws, "L", "id", "name");
+      EmbeddedTableAssembly right = TestWorksheets.tableWithColumns(ws, "R", "id", "value");
+      ws.addAssembly(left);
+      ws.addAssembly(right);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent,
+         ed -> ed.addJoin("J", "L", "id", "R", "id", "INNER", null, null));
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.removeColumn("L", "id")));
+
+      assertTrue(ex.getMessage().contains("id"), ex.getMessage());
+      assertNotNull(left.getColumnSelection(false).getAttribute("id"),
+         "the join key must survive the refusal");
+   }
+
+   @Test
+   void removeColumnStillWorksOnAColumnNotUsedByTheJoin() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly left  = TestWorksheets.tableWithColumns(ws, "L", "id", "name");
+      EmbeddedTableAssembly right = TestWorksheets.tableWithColumns(ws, "R", "id", "value");
+      ws.addAssembly(left);
+      ws.addAssembly(right);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed -> {
+         ed.addJoin("J", "L", "id", "R", "id", "INNER", null, null);
+         ed.removeColumn("L", "name");
+      });
+
+      assertNull(left.getColumnSelection(false).getAttribute("name"),
+         "a column the join doesn't key on must still be removable");
+   }
+
+   @Test
+   void setColumnVisibilityRefusesHidingAJoinKeyStillUsedByADependentJoin() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly left  = TestWorksheets.tableWithColumns(ws, "L", "id", "name");
+      EmbeddedTableAssembly right = TestWorksheets.tableWithColumns(ws, "R", "id", "value");
+      ws.addAssembly(left);
+      ws.addAssembly(right);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent,
+         ed -> ed.addJoin("J", "L", "id", "R", "id", "INNER", null, null));
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.setColumnVisibility("L", "id", false)));
+
+      assertTrue(ex.getMessage().contains("id"), ex.getMessage());
+      ColumnRef idRef = (ColumnRef) left.getColumnSelection(false).getAttribute("id");
+      assertTrue(idRef.isVisible(), "the join key must remain visible after the refusal");
+   }
+
+   @Test
+   void renameColumnRefusesRenamingAJoinKeyStillUsedByADependentJoin() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly left  = TestWorksheets.tableWithColumns(ws, "L", "id", "name");
+      EmbeddedTableAssembly right = TestWorksheets.tableWithColumns(ws, "R", "id", "value");
+      ws.addAssembly(left);
+      ws.addAssembly(right);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent,
+         ed -> ed.addJoin("J", "L", "id", "R", "id", "INNER", null, null));
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.renameColumn("L", "id", "renamedId")));
+
+      assertTrue(ex.getMessage().contains("id"), ex.getMessage());
+      ColumnRef idRef = (ColumnRef) left.getColumnSelection(false).getAttribute("id");
+      assertNull(idRef.getAlias(), "the join key must not be renamed by the refused edit");
+   }
+
+   // =========================================================================
    // Edit-in-place tests
    // =========================================================================
 


### PR DESCRIPTION
## Summary

The Composer UI has always refused to hide, remove, or rename a column that a dependent join/composite table still keys on, showing "Some connectors depend on this column: X!" (`WorksheetControllerService#allowsDeletion`, used by `SetColumnVisibleService`, `DeleteColumnsService`, `RenameColumnService`, and `SQLQueryDialogService`). The AI Wiz worksheet chat plugin's backend skipped this check entirely across its `set_column_visibility`, `remove_column`, `rename_column`, and `edit_sql_query` tools, letting an agent silently invalidate a join.

Reported repro: asking the AI Wiz plugin to hide `CUSTOMER_ID` on a table joined to another table on that same column. The column got hidden with no warning, and the worksheet was left in an invalid state — subsequent column-info loads threw `MessageException: ... would result in a cross join ...`, seen by the user as infinite loading instead of a warning.

## Root Cause

`WorksheetEditService.Editor.setColumnVisibility`, `.removeColumn`, and `.renameColumn` (`core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java`), and `WorksheetAgentController.editSqlQuery` (`core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java`), mutated a table's column selection without ever calling `WorksheetControllerService#allowsDeletion` — the dependency-walk the equivalent Composer UI backends (`SetColumnVisibleService`, `DeleteColumnsService`, `RenameColumnService`, `SQLQueryDialogService`) all use.

## Fix

- `WorksheetControllerService#allowsDeletion(Worksheet, TableAssembly, ColumnRef)` widened from `protected` instance method to `public static` (it has no instance-state dependency), so it can be reused from the wiz plugin package without duplicating the join-dependency-walk logic.
- `Editor.removeColumn` / `Editor.setColumnVisibility` / `Editor.renameColumn` now call `allowsDeletion` before mutating (unconditional for remove/rename, gated on the visible→hidden transition for visibility — mirroring each Composer UI equivalent exactly), throwing `PairingException` with the same `common.columnDependency` catalog message on refusal.
- `WorksheetAgentController.editSqlQuery` reworked to parse the new SQL against a **scratch clone** of the live query (`JDBCQuery#clone()` deep-clones its `SQLDefinition`) instead of mutating the live objects in place, so a rejected edit never leaves the persisted query and column selection out of sync. A new `assertSqlEditAllowsColumnRemoval` guard (mirroring `SQLQueryDialogService`'s equivalent check) refuses the edit if any column the new SQL drops is still used by a dependent, before anything is committed to the live assembly.

## Test Plan

- Added 4 regression tests to `WorksheetEditServiceMutatorsTest` covering: `removeColumn` refusing a join key, `removeColumn` still working on a non-key column, `setColumnVisibility` refusing to hide a join key, and `renameColumn` refusing to rename a join key.
- `./mvnw -o clean install -pl core -am -DskipTests` — build succeeds.
- `./mvnw -o test -pl core -Dtest=WorksheetEditServiceMutatorsTest,WorksheetAgentControllerTest,WorksheetEditServiceTest` — 193 tests, 0 failures.
- `editSqlQuery`'s new guard was verified by code review only (three independent review passes, no issues found) rather than an automated test — the existing test file documents that a real SQL-parsing path requires JDBC/credential infrastructure this test context doesn't provide, and this fix's scratch-clone/guard logic reuses primitives (`WorksheetControllerService#allowsDeletion`, `ColumnSelection#containsAttribute`) already covered elsewhere.

Fixes Redmine #75968.