### PR TITLE
Bug #76291, make graph.textlayout.maxstep and graph.circle.packing behave as named

### DIFF
--- a/core/src/main/java/inetsoft/graph/internal/text/FreeHelper.java
+++ b/core/src/main/java/inetsoft/graph/internal/text/FreeHelper.java
@@ -27,6 +27,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.awt.geom.*;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Free movement labels.
@@ -55,8 +57,8 @@ public class FreeHelper extends LabelHelper {
             // as "unlimited" in other properties, making it a plausible typo with exactly
             // the opposite of its intended effect.
             if(parsed < 0) {
-               LOG.warn("Negative graph.textlayout.maxstep value \"{}\" would stop labels " +
-                           "from moving at all. Using 1000.", maxstep);
+               warnOnce(maxstep, "Negative graph.textlayout.maxstep value \"{}\" would stop " +
+                           "labels from moving at all. Using 1000.");
             }
             else {
                maxval = parsed;
@@ -65,13 +67,24 @@ public class FreeHelper extends LabelHelper {
          }
          catch(NumberFormatException ex) {
             // this runs once per label, so throwing would fail the whole chart render
-            LOG.warn("Invalid graph.textlayout.maxstep value \"{}\", expected an integer. " +
-                        "Using 1000.", maxstep);
+            warnOnce(maxstep, "Invalid graph.textlayout.maxstep value \"{}\", expected an " +
+                        "integer. Using 1000.");
          }
       }
 
       maxStepsFromProperty = fromProperty;
       max_steps = new int[] {maxval, maxval, maxval, maxval};
+   }
+
+   /**
+    * Warn at most once for each bad graph.textlayout.maxstep value. The constructor runs
+    * once per label, so warning unconditionally would repeat for every label on a chart and
+    * again on every refresh of it.
+    */
+   private static void warnOnce(String value, String message) {
+      if(loggedBadMaxSteps.add(value)) {
+         LOG.warn(message, value);
+      }
    }
 
    /**
@@ -529,5 +542,6 @@ public class FreeHelper extends LabelHelper {
    private boolean outside = false;
    private int sameLocDir = 3; // direction (down) to move if two labels fall on exact same point
 
+   private static final Set<String> loggedBadMaxSteps = ConcurrentHashMap.newKeySet();
    private static final Logger LOG = LoggerFactory.getLogger(FreeHelper.class);
 }

--- a/core/src/main/java/inetsoft/graph/internal/text/FreeHelper.java
+++ b/core/src/main/java/inetsoft/graph/internal/text/FreeHelper.java
@@ -48,14 +48,25 @@ public class FreeHelper extends LabelHelper {
       if(maxstep != null) {
          try {
             // Properties.load() keeps trailing whitespace and parseInt does not trim it
-            maxval = Integer.parseInt(maxstep.trim());
-            fromProperty = true;
+            int parsed = Integer.parseInt(maxstep.trim());
+
+            // move() bails as soon as steps[n] > max_steps[n] and steps starts at 0, so a
+            // negative budget stops every free-moving label rather than freeing it. -1 reads
+            // as "unlimited" in other properties, making it a plausible typo with exactly
+            // the opposite of its intended effect.
+            if(parsed < 0) {
+               LOG.warn("Negative graph.textlayout.maxstep value \"{}\" would stop labels " +
+                           "from moving at all. Using 1000.", maxstep);
+            }
+            else {
+               maxval = parsed;
+               fromProperty = true;
+            }
          }
          catch(NumberFormatException ex) {
             // this runs once per label, so throwing would fail the whole chart render
             LOG.warn("Invalid graph.textlayout.maxstep value \"{}\", expected an integer. " +
                         "Using 1000.", maxstep);
-            maxval = 1000;
          }
       }
 

--- a/core/src/main/java/inetsoft/graph/internal/text/FreeHelper.java
+++ b/core/src/main/java/inetsoft/graph/internal/text/FreeHelper.java
@@ -23,6 +23,9 @@ import inetsoft.graph.guide.VLabel;
 import inetsoft.graph.internal.GTool;
 import inetsoft.graph.visual.VOText;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.awt.geom.*;
 
 /**
@@ -35,13 +38,29 @@ public class FreeHelper extends LabelHelper {
       // GTool/GImpl only exposes a read that takes a call-site default, and
       // DefaultProperties.getProperty(key, def) returns that default without consulting the
       // defaults layer, so the graph.textlayout.maxstep line in defaults.properties is not
-      // reachable from here. Keep the two values in sync -- PropertyDefaultsTest pins them.
-      String maxstep = GTool.getProperty("graph.textlayout.maxstep", "1000");
+      // reachable from here. A null default therefore distinguishes a value the operator set
+      // from an unset property, which is what isMaxStepsFromProperty() reports. Keep the
+      // fallback in sync with defaults.properties -- PropertyDefaultsTest pins them.
+      String maxstep = GTool.getProperty("graph.textlayout.maxstep", null);
+      boolean fromProperty = false;
+      int maxval = 1000;
 
       if(maxstep != null) {
-         int maxval = Integer.parseInt(maxstep);
-         max_steps = new int[] {maxval, maxval, maxval, maxval};
+         try {
+            // Properties.load() keeps trailing whitespace and parseInt does not trim it
+            maxval = Integer.parseInt(maxstep.trim());
+            fromProperty = true;
+         }
+         catch(NumberFormatException ex) {
+            // this runs once per label, so throwing would fail the whole chart render
+            LOG.warn("Invalid graph.textlayout.maxstep value \"{}\", expected an integer. " +
+                        "Using 1000.", maxstep);
+            maxval = 1000;
+         }
       }
+
+      maxStepsFromProperty = fromProperty;
+      max_steps = new int[] {maxval, maxval, maxval, maxval};
    }
 
    /**
@@ -49,6 +68,16 @@ public class FreeHelper extends LabelHelper {
     */
    public void setMaxSteps(int[] max) {
       this.max_steps = max;
+   }
+
+   /**
+    * Check if graph.textlayout.maxstep supplied the budget this helper was constructed with.
+    * A caller that narrows the budget per coordinate should bound its own value by that one
+    * rather than replace it, so that the property caps label movement as its name says.
+    * (76291)
+    */
+   public boolean isMaxStepsFromProperty() {
+      return maxStepsFromProperty;
    }
 
    /**
@@ -484,7 +513,10 @@ public class FreeHelper extends LabelHelper {
    private short[] steps = {(short) 0, (short) 0, (short) 0, (short) 0};
    private double[] edgedists = {0,  0,  0,  0};
    private int[] max_steps;
+   private final boolean maxStepsFromProperty;
    private boolean inPlot = true;
    private boolean outside = false;
    private int sameLocDir = 3; // direction (down) to move if two labels fall on exact same point
+
+   private static final Logger LOG = LoggerFactory.getLogger(FreeHelper.class);
 }

--- a/core/src/main/java/inetsoft/graph/internal/text/TextLayoutManager.java
+++ b/core/src/main/java/inetsoft/graph/internal/text/TextLayoutManager.java
@@ -184,6 +184,7 @@ public class TextLayoutManager {
 
          if(helper.isMaxStepsFromProperty()) {
             int[] max = helper.getMaxSteps();
+            // getMaxSteps() is overridable and the loop below mutates in place
             steps = steps.clone();
 
             for(int i = 0; i < steps.length; i++) {

--- a/core/src/main/java/inetsoft/graph/internal/text/TextLayoutManager.java
+++ b/core/src/main/java/inetsoft/graph/internal/text/TextLayoutManager.java
@@ -173,10 +173,25 @@ public class TextLayoutManager {
       helper.setCheckVO(vo instanceof TagFormVO);
       helper.setInPlot(inPlot && forceInPlot);
 
-      // restrict the movement so the label is not too far from the point
+      // restrict the movement so the label is not too far from the point. this covers every
+      // VOText (its constructor sets MOVE_FREE) and every tag form, so bound the coordinate's
+      // budget by an operator-set graph.textlayout.maxstep instead of replacing it outright,
+      // or the property has no effect on these labels at all. taking the smaller of the two
+      // keeps GeoCoord's tighter clamp for maps. (76291)
       if((vo instanceof VOText || vo instanceof TagFormVO) && collision == VLabel.MOVE_FREE) {
          String[] lines = text.getDisplayLabel();
-         helper.setMaxSteps(vgraph.getCoordinate().getMaxSteps(lines));
+         int[] steps = vgraph.getCoordinate().getMaxSteps(lines);
+
+         if(helper.isMaxStepsFromProperty()) {
+            int[] max = helper.getMaxSteps();
+            steps = steps.clone();
+
+            for(int i = 0; i < steps.length; i++) {
+               steps[i] = Math.min(steps[i], max[i]);
+            }
+         }
+
+         helper.setMaxSteps(steps);
       }
 
       return helper;

--- a/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/GraphGenerator.java
@@ -2680,6 +2680,9 @@ public abstract class GraphGenerator {
       spec.setGridBetween(fake);
       boolean width = inverted && inner && x || !(inverted && inner) && !x;
       spec.setAxisSize(width ? xdesc.getAxisWidth() : xdesc.getAxisHeight());
+      // reserves space for the outermost axis label so it fits without being moved; the only
+      // reader is RectCoord.getAxisMargin. this is not PlotDescriptor.isInPlot ("Keep Elements
+      // in Plot") despite the name. (76291)
       spec.setInPlot("true".equals(SreeEnv.getProperty("graph.axis.inplot")));
 
       if(scale instanceof TimeScale) {

--- a/core/src/main/java/inetsoft/report/composition/graph/SeparateGraphGenerator.java
+++ b/core/src/main/java/inetsoft/report/composition/graph/SeparateGraphGenerator.java
@@ -39,9 +39,12 @@ import inetsoft.uql.viewsheet.internal.ChartVSAssemblyInfo;
 import inetsoft.util.Catalog;
 import inetsoft.util.MessageException;
 import inetsoft.util.log.LogLevel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.awt.*;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.*;
 
 /**
@@ -423,7 +426,9 @@ public class SeparateGraphGenerator extends GraphGenerator {
             coord.setLayout(TreemapCoord.Layout.SQUARE);
          }
          else if(info.getRTChartType() == GraphTypes.CHART_CIRCLE_PACKING) {
-            switch(SreeEnv.getProperty("graph.circle.packing", "circle").toLowerCase()) {
+            String packing = SreeEnv.getProperty("graph.circle.packing", "circle");
+
+            switch(packing.toLowerCase(Locale.ROOT)) {
             case "circle":
                coord.setLayout(TreemapCoord.Layout.SQUARE);
                break;
@@ -432,6 +437,18 @@ public class SeparateGraphGenerator extends GraphGenerator {
                break;
             case "fill":
                coord.setLayout(TreemapCoord.Layout.FILL);
+               break;
+            default:
+               // TreemapCoord's field initializer is FILL, which is the right default for
+               // treemap/sunburst but the layout furthest from circle packing's default.
+               // Fall back to the unset behavior instead of silently selecting fill.
+               // this runs per chart per refresh, so warn once for each bad value
+               if(loggedPackingValues.add(packing)) {
+                  LOG.warn("Unrecognized graph.circle.packing value \"{}\", expected one of " +
+                              "circle, fill_x or fill. Using circle.", packing);
+               }
+
+               coord.setLayout(TreemapCoord.Layout.SQUARE);
                break;
             }
          }
@@ -656,4 +673,7 @@ public class SeparateGraphGenerator extends GraphGenerator {
    }
 
    private boolean scatter_matrix = false;
+
+   private static final Set<String> loggedPackingValues = ConcurrentHashMap.newKeySet();
+   private static final Logger LOG = LoggerFactory.getLogger(SeparateGraphGenerator.class);
 }

--- a/core/src/test/java/inetsoft/graph/internal/text/FreeHelperTest.java
+++ b/core/src/test/java/inetsoft/graph/internal/text/FreeHelperTest.java
@@ -1,0 +1,147 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.graph.internal.text;
+
+import inetsoft.graph.VGraph;
+import inetsoft.graph.coord.RectCoord;
+import inetsoft.graph.guide.VLabel;
+import inetsoft.sree.SreeEnv;
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests how FreeHelper reads graph.textlayout.maxstep. The value is the cap on how far a
+ * label may be moved to resolve overlapping, and TextLayoutManager.createHelper bounds the
+ * per-coordinate budget by it only when the operator actually set it -- so both the parsed
+ * value and isMaxStepsFromProperty() have to be right. (76291)
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class FreeHelperTest {
+   private static final String PROPERTY = "graph.textlayout.maxstep";
+
+   /**
+    * With the property unset, the budget falls back to 1000 in all four directions and is
+    * not reported as operator-set, so createHelper leaves the coordinate's budget alone.
+    */
+   @Test
+   void unsetPropertyFallsBackToDefaultAndIsNotFromProperty() {
+      SreeEnv.remove(PROPERTY);
+      FreeHelper helper = createHelper();
+
+      assertArrayEquals(new int[] {1000, 1000, 1000, 1000}, helper.getMaxSteps());
+      assertFalse(helper.isMaxStepsFromProperty(),
+                  "an unset property must not be reported as operator-set");
+   }
+
+   /**
+    * A value the operator set is applied in all four directions and reported so that
+    * createHelper bounds the coordinate's budget by it.
+    */
+   @Test
+   void setPropertyIsAppliedAndReportedAsFromProperty() {
+      withProperty("5", helper -> {
+         assertArrayEquals(new int[] {5, 5, 5, 5}, helper.getMaxSteps());
+         assertTrue(helper.isMaxStepsFromProperty());
+      });
+   }
+
+   /**
+    * Properties.load() keeps surrounding whitespace and Integer.parseInt does not trim it.
+    */
+   @Test
+   void surroundingWhitespaceIsTrimmed() {
+      withProperty(" 5 ", helper -> {
+         assertArrayEquals(new int[] {5, 5, 5, 5}, helper.getMaxSteps());
+         assertTrue(helper.isMaxStepsFromProperty());
+      });
+   }
+
+   /**
+    * A malformed value must not throw: the constructor runs once per label, so propagating
+    * a NumberFormatException would fail the whole chart render instead of degrading.
+    */
+   @ParameterizedTest
+   @ValueSource(strings = {"abc", "1,000", "1000.5", ""})
+   void malformedValueFallsBackWithoutThrowing(String value) {
+      withProperty(value, helper -> {
+         assertArrayEquals(new int[] {1000, 1000, 1000, 1000}, helper.getMaxSteps());
+         assertFalse(helper.isMaxStepsFromProperty(),
+                     "a value that could not be used must not be reported as operator-set");
+      });
+   }
+
+   /**
+    * A negative budget would stop every free-moving label, since move() returns as soon as
+    * steps[n] > max_steps[n] and steps starts at 0. "-1" reads as "unlimited" elsewhere, so
+    * it must not be taken at face value.
+    */
+   @ParameterizedTest
+   @ValueSource(strings = {"-1", "-1000"})
+   void negativeValueFallsBackToDefault(String value) {
+      withProperty(value, helper -> {
+         assertArrayEquals(new int[] {1000, 1000, 1000, 1000}, helper.getMaxSteps());
+         assertFalse(helper.isMaxStepsFromProperty());
+      });
+   }
+
+   /**
+    * Zero is left alone: it permits a single step, which is a coherent "barely move"
+    * setting rather than a value with the opposite of its apparent effect.
+    */
+   @Test
+   void zeroIsAccepted() {
+      withProperty("0", helper -> {
+         assertArrayEquals(new int[] {0, 0, 0, 0}, helper.getMaxSteps());
+         assertTrue(helper.isMaxStepsFromProperty());
+      });
+   }
+
+   /**
+    * The property is global, so it has to be removed again or it leaks into every other
+    * test sharing this JVM.
+    */
+   private void withProperty(String value, java.util.function.Consumer<FreeHelper> assertions) {
+      SreeEnv.setProperty(PROPERTY, value);
+
+      try {
+         assertions.accept(createHelper());
+      }
+      finally {
+         SreeEnv.remove(PROPERTY);
+      }
+   }
+
+   private FreeHelper createHelper() {
+      return new FreeHelper(new VLabel("abc"), new VGraph(new RectCoord()));
+   }
+}


### PR DESCRIPTION
Three naming and fallback defects in the `graph.*` properties.

## 1. `graph.textlayout.maxstep` was discarded for the labels it appears to be for

`FreeHelper`'s constructor read the property, then `TextLayoutManager.createHelper` overwrote it on the next statement for any `VOText` or `TagFormVO` with `MOVE_FREE` — which is every `VOText` (`VOText`'s constructor sets `MOVE_FREE`) and every tag form. The replacement is a horizontal budget derived from the label width plus a hard-coded vertical `10`. Pie labels never reach `FreeHelper` at all; an `ArcVOText` gets an `ArcHelper` first.

Tracing every `setCollisionModifier` call site, the property survived only for bar labels pushed to `MOVE_UP`/`MOVE_RIGHT` (`BarVO`) and target-form labels (`TargetForm`). Point, line and pie labels — the ones an operator would touch this for — ignored it entirely.

The coordinate's per-direction budget is now bounded by the operator's value (element-wise `min`) rather than replacing it. This keeps the property acting as the cap its name describes, and matters because `GeoCoord.getMaxSteps` deliberately clamps to `{len, 4, len, 4}` with the comment *"don't move labels too far from points"* — an outright bypass would have discarded that and let map marker labels drift ~200px instead of 8px.

`min` also means the shipped default of `1000` is a genuine no-op, so an operator who copies `defaults.properties` into `sree.properties` doesn't silently trip a large behavior change.

The parse is now trimmed and guarded: it runs once per label, so a malformed value previously failed the entire chart render rather than degrading.

**Note:** the property can only *narrow* label travel, never widen it. That is faithful to `maxstep` and to the original constructor's use of it as a cap. If "let labels roam further to unclutter a crowded chart" is wanted, that needs a separately-named property — this one cannot carry both meanings.

## 2. `graph.circle.packing` failed to the option furthest from its default

`SeparateGraphGenerator` matched the value in a `switch` with cases for `circle`, `fill_x` and `fill` and no `default`. An unrecognised value left `TreemapCoord` at its field initialiser, `Layout.FILL`, while leaving the property *unset* gives `Layout.SQUARE` via the `"circle"` call-site default. So a typo silently selected the layout furthest from the default, with nothing logged.

Added a `default` branch that falls back to `SQUARE` and warns. The warning is keyed on the offending value through a static set, because this runs per chart per refresh and would otherwise flood the log on an auto-refreshing dashboard.

Matching is now on `Locale.ROOT`: under `tr-TR`, `"FILL".toLowerCase()` yields `"fıll"`, which would have missed `case "fill"` and — now that a `default` branch exists — actively selected the wrong layout where the old fall-through happened to be correct.

Scope is contained to `CHART_CIRCLE_PACKING`. The polar branch above still forces `SQUARE`, and treemap/sunburst never consult the property, so they keep `FILL` as intended.

## 3. `graph.axis.inplot` does not put axes in the plot

The name reads as the property behind the `PlotDescriptor` "Keep Elements in Plot" chart option, and is not. `AxisSpec.setInPlot`'s own javadoc describes reserving space for the max label; its only reader is `RectCoord.getAxisMargin`, which returns half the outermost label's width or height for `RectCoord.getAxisBounds` to fold into the coordinate bounds. Nothing repositions an axis.

This is **comment-only** — no rename. `AxisSpec.setInPlot`/`isInPlot` are `@TernMethod` with published `ProductDocs` URLs, so customer chart scripts call them by name, and the property key is shipped in `defaults.properties` and listed in EM's `booleanProperties`. A rename would also buy operators nothing: EM's property settings view renders only Name and Value, with no description field anywhere, so the name is never explained in the product either way. The external ProductDocs entries for `graph.axis.inplot` and `AxisSpec.setInPlot` are the only operator-facing description and still need correcting — that's a separate docs ticket.

## Notes

- `graph.circle.packing` is deliberately **not** added to `defaults.properties`. The call site uses `SreeEnv.getProperty(name, def)`, which routes through `DefaultProperties.getProperty(key, def)` and consults only `mainProperties` — a declaration there would be unreachable and would recreate exactly the trap documented in `FreeHelper`'s comment.
- Behavior is unchanged on the default path in both fixes: unset properties produce identical layout to before.

## Testing

`community/core` compiles clean; `PropertyDefaultsTest` passes 6/6 (it pins the `graph.textlayout.maxstep` default against `FreeHelper`'s fallback, which is still `1000`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
