### PR TITLE
Bug #76287, stop XJobPool from promising per-organization behavior it does not provide

### DIFF
--- a/core/src/main/java/inetsoft/mv/mr/XJobPool.java
+++ b/core/src/main/java/inetsoft/mv/mr/XJobPool.java
@@ -20,10 +20,11 @@ package inetsoft.mv.mr;
 import inetsoft.mv.MVExecutionException;
 import inetsoft.mv.fs.*;
 import inetsoft.mv.mr.internal.XJobStatus;
-import inetsoft.sree.SreeEnv;
 import inetsoft.util.GroupedThread;
 import inetsoft.util.TimedQueue;
 import inetsoft.mv.MVJob;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -38,26 +39,33 @@ import java.util.concurrent.locks.*;
  */
 public final class XJobPool extends GroupedThread {
    /**
-    * Add one map result to the associated job.
+    * Add one map result to the associated job. The organization id is unused -- job ids are
+    * unique per JVM and the pool is process-wide (see getPool()) -- and is retained only to
+    * keep the signature stable for callers.
+    *
     * @return true if the task is fulfilled.
     */
    public static boolean addResult(XMapResult result, String orgID) throws Exception {
-      return getPool(orgID).addResult0(result);
+      return getPool().addResult0(result);
    }
 
    /**
-    * Add one map failure to the associated job.
+    * Add one map failure to the associated job. The organization id is unused -- job ids are
+    * unique per JVM and the pool is process-wide (see getPool()) -- and is retained only to
+    * keep the signature stable for callers.
     */
    public static void addFailure(XMapFailure failure, String orgID) {
-      getPool(orgID).addFailure0(failure);
+      getPool().addFailure0(failure);
    }
 
    /**
-    * Execute one XJob.
+    * Execute one XJob. The organization id is unused: execute0() resolves the job's file
+    * system from the org carried by the job itself, and the pool is process-wide (see
+    * getPool()). It is retained only to keep the signature stable for callers.
     */
    public static Object execute(XJob job, String orgID) throws Exception {
       try {
-         return getPool(orgID).execute0(job);
+         return getPool().execute0(job);
       }
       catch(Exception ex) {
          throw new MVExecutionException(ex);
@@ -80,10 +88,10 @@ public final class XJobPool extends GroupedThread {
    }
 
    /**
-    * Cancel the job.
+    * Cancel the job. The organization id is unused; job ids are unique per JVM.
     */
    public static void cancel(String id, String orgID) {
-      XJobStatus status = getPool(orgID).smap.get(id);
+      XJobStatus status = getPool().smap.get(id);
 
       if(status != null) {
          status.cancel();
@@ -91,16 +99,21 @@ public final class XJobPool extends GroupedThread {
    }
 
    /**
-    * Get the job pool.
+    * Get the job pool. There is one pool, and one sanity check thread, per JVM: the pool
+    * performs no organization-specific work of its own, and its per-organization state (the
+    * file systems in fsystemOrgMap) is keyed by organization inside the single instance.
     */
-   private static final XJobPool getPool(String orgID) {
+   private static final XJobPool getPool() {
       if(pool == null) {
          plock.lock();
 
          try {
             if(pool == null) {
-               pool = new XJobPool(orgID);
-               pool.start(); // start sanity check thread
+               XJobPool jobPool = new XJobPool();
+               jobPool.start(); // start sanity check thread
+               // publish only after start(), so a thread taking the unsynchronized fast path
+               // above cannot observe a partially constructed pool
+               pool = jobPool;
             }
          }
          finally {
@@ -114,15 +127,8 @@ public final class XJobPool extends GroupedThread {
    /**
     * Create an instance of XJobPool.
     */
-   private XJobPool(String curOrg) {
+   private XJobPool() {
       super();
-
-      if(FSService.getServer(curOrg) == null) {
-         throw new RuntimeException("This host is not server node!");
-      }
-
-      String periodValue = SreeEnv.getProperty("fs.job.check.period");
-      period = periodValue != null ? Integer.parseInt(periodValue) : 500;
    }
 
    /**
@@ -297,7 +303,7 @@ public final class XJobPool extends GroupedThread {
 
          // sleep a while not to occupy too much resource
          try {
-            Thread.sleep(period);
+            Thread.sleep(getCheckPeriod());
          }
          catch(InterruptedException ex) {
             // ignore it
@@ -305,22 +311,47 @@ public final class XJobPool extends GroupedThread {
       }
    }
 
+   /**
+    * Get the sanity check interval. Read on every iteration so that a change to
+    * fs.job.check.period takes effect without a restart. The value is process-wide: this thread
+    * services the jobs of every organization.
+    */
+   private static int getCheckPeriod() {
+      try {
+         int period = FSService.getConfig().getJobCheckPeriod();
+         return period > 0 ? period : DEFAULT_CHECK_PERIOD;
+      }
+      catch(NumberFormatException ex) {
+         LOG.debug("Invalid fs.job.check.period, using {}", DEFAULT_CHECK_PERIOD, ex);
+         return DEFAULT_CHECK_PERIOD;
+      }
+   }
+
    private XFileSystem getOrgFSystem(String org) {
       plock.lock();
 
       try {
-         return fsystemOrgMap.computeIfAbsent(org, k -> FSService.getServer(k).getFSystem());
+         return fsystemOrgMap.computeIfAbsent(org, k -> {
+            XServerNode server = FSService.getServer(k);
+
+            if(server == null) {
+               throw new RuntimeException("This host is not server node!");
+            }
+
+            return server.getFSystem();
+         });
       }
       finally {
          plock.unlock();
       }
    }
 
+   private static final int DEFAULT_CHECK_PERIOD = 500;
    private static final Lock plock = new ReentrantLock();
-   private static XJobPool pool;
-   private final int period;
+   private static volatile XJobPool pool;
    private final Map<String, XFileSystem> fsystemOrgMap = new HashMap<>();
    private final Map<String, XJobStatus> smap = new HashMap<>();
    private final Lock lock = new ReentrantLock();
    private final Condition lockcnd = lock.newCondition();
+   private static final Logger LOG = LoggerFactory.getLogger(XJobPool.class);
 }

--- a/core/src/test/java/inetsoft/mv/fs/FSConfigJobCheckPeriodTest.java
+++ b/core/src/test/java/inetsoft/mv/fs/FSConfigJobCheckPeriodTest.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.mv.fs;
+
+import inetsoft.sree.SreeEnv;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mockStatic;
+
+/**
+ * Verifies that the sanity check interval is read live rather than frozen at first use.
+ * {@code XJobPool} used to parse fs.job.check.period once in its constructor, so the first
+ * organization to run a materialization job fixed the interval for the whole JVM; it now reads
+ * this method on every iteration of its sanity check loop.
+ */
+@Tag("core")
+class FSConfigJobCheckPeriodTest {
+   @Test
+   void defaultsWhenPropertyIsNotSet() {
+      try(MockedStatic<SreeEnv> sreeEnv = mockStatic(SreeEnv.class)) {
+         sreeEnv.when(() -> SreeEnv.getProperty("fs.job.check.period")).thenReturn(null);
+
+         assertEquals(500, FSService.getConfig().getJobCheckPeriod());
+      }
+   }
+
+   @Test
+   void reflectsAChangedPropertyWithoutRestart() {
+      FSConfig config = FSService.getConfig();
+
+      try(MockedStatic<SreeEnv> sreeEnv = mockStatic(SreeEnv.class)) {
+         sreeEnv.when(() -> SreeEnv.getProperty("fs.job.check.period")).thenReturn("250");
+         assertEquals(250, config.getJobCheckPeriod());
+
+         // the same config instance must pick up a later change, as the sanity check thread
+         // relies on re-reading the property rather than caching it
+         sreeEnv.when(() -> SreeEnv.getProperty("fs.job.check.period")).thenReturn("1000");
+         assertEquals(1000, config.getJobCheckPeriod());
+      }
+   }
+}


### PR DESCRIPTION
## Problem

`XJobPool.getPool(String orgID)` was parameterised by organization but stored its result in a single `private static XJobPool pool`. The first organization to run a materialization job after a restart created the pool for the whole JVM; every later organization silently reused it — including the polling interval that pool read from `fs.job.check.period` in its constructor and froze into a `final int`.

That matters because `SreeEnv.getProperty(name)` **is** organization-scoped by default (`PropertiesEngine.getProperty(name, false)` → `orgScope=true` → `useAvailableOrgProperty()`), `fs.job.check.period` is not in `EXCLUDED_ORG_PROPERTIES`, and the EM Organization properties table accepts arbitrary keys. So an operator could set a per-organization value and have it silently ignored for every tenant but whichever one happened to go first — with nothing reporting the discrepancy.

## Approach

Nothing about the sanity check thread is organization-specific, and the rest of the `fs.*` family (`fs.job.period`, `fs.map.expired`, `fs.desktop`) is already JVM-global infrastructure config in `FSConfigImpl`. So this declares the pool global rather than splitting it per organization — per-organization pools would mean one watchdog thread per tenant for no functional gain.

- `getPool(String orgID)` → `getPool()`, and the constructor loses its org parameter. The signature no longer advertises per-organization pools; the genuinely per-org state (`fsystemOrgMap`) stays keyed by organization inside the single instance.
- The interval is now read on every iteration through the existing — and previously **uncalled** — `FSConfig.getJobCheckPeriod()`, which already re-reads the property per call. A change now takes effect without a restart. Non-positive and unparseable values fall back to 500: with the read moved inside the loop, `Thread.sleep(0)` would busy-spin and `Thread.sleep(-n)` / `NumberFormatException` would kill the sanity thread outright.
- The `FSService.getServer(...) == null` check moved from the constructor into `getOrgFSystem()`, where the organization is actually known. It now validates every organization instead of only the first, and replaces a latent NPE on that path with the intended `RuntimeException`.
- `pool` is now `volatile` and published only after `start()`, so a reader on the double-checked-locking fast path cannot observe a partially constructed pool. (Pre-existing, but inside a hunk this change rewrites.)

## Deliberately unchanged

The public `execute` / `addResult` / `addFailure` / `cancel` entry points keep their `orgID` parameters, now documented as unused: job ids are unique per JVM (`AbstractJob.createID` is class name + global counter), so `smap` cannot collide across organizations, and `execute0` resolves the file system from the organization carried by the job itself. `XMapTaskPoolTest` asserts that `XMapTaskPool.Handler` passes each task's *own* org to these methods (coverage from #4336); removing the parameters would make those tests vacuous.

## Testing

- New `FSConfigJobCheckPeriodTest` covers the now-live contract one layer down: default 500 when the property is unset, and a changed value reflected on a later call through the same config instance.
- `./mvnw -pl core test -Dtest=FSConfigJobCheckPeriodTest,XMapTaskPoolTest` → 5 tests, all passing. `core` compiles clean.

## Follow-ups found while reviewing this code (not fixed here)

- `resetOrgCache(orgID)` clears only `fsystemOrgMap`. Both callers pair it with `FSService.clearServerNodeCache`, which **disposes** that organization's `XFileSystem` — so that org's in-flight `XJobStatus` objects keep running against a disposed file system, `smap` is never drained, and nothing ever cancels the pool thread.
- `FSService.getServer0` re-tests the stale local `xServerNode` inside the lock instead of re-reading `servers.get(orgId)`, so two racing threads can each build an `XServerNode` for the same organization.
- `XMapTaskPool` captures one `XBlockSystem` at first init from the *ambient* organization's data node and hands it to every task regardless of that task's organization — the same shape of bug as this one, in the neighbouring singleton.
- `FSService.refresh(orgId)` refreshes `getServer(orgId)`'s file system using `getDataNode()`, i.e. the current thread's organization rather than `orgId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
