### PR TITLE
Bug #76286, remove the dead map-task retry path in XJobStatus

### DIFF
--- a/core/src/main/java/inetsoft/mv/SubMVTask.java
+++ b/core/src/main/java/inetsoft/mv/SubMVTask.java
@@ -181,7 +181,5 @@ public final class SubMVTask extends AbstractMapTask {
       //
    }
 
-
-
    private static final Logger LOG = LoggerFactory.getLogger(SubMVTask.class);
 }

--- a/core/src/main/java/inetsoft/mv/SubMVTask.java
+++ b/core/src/main/java/inetsoft/mv/SubMVTask.java
@@ -103,7 +103,7 @@ public final class SubMVTask extends AbstractMapTask {
                throw new Exception("The sub mv of the block not found: " + bid);
             }
 
-            query = getQuery();
+            SubMVQuery query = getQuery();
             SubTableBlock data = null;
 
             try {
@@ -162,6 +162,10 @@ public final class SubMVTask extends AbstractMapTask {
    public void cancel() {
       super.cancel();
 
+      // read the query from the task's own state rather than a field assigned partway
+      // through run(), so a cancel arriving before the block is loaded is not lost
+      SubMVQuery query = getQuery();
+
       if(query != null) {
          query.cancel();
       }
@@ -178,7 +182,6 @@ public final class SubMVTask extends AbstractMapTask {
    }
 
 
-   private SubMVQuery query;
 
    private static final Logger LOG = LoggerFactory.getLogger(SubMVTask.class);
 }

--- a/core/src/main/java/inetsoft/mv/data/SubMVQuery.java
+++ b/core/src/main/java/inetsoft/mv/data/SubMVQuery.java
@@ -451,7 +451,7 @@ public final class SubMVQuery implements XTransferable, Cloneable {
    XFilterNode cond;
    boolean[] order;
    private boolean detail;
-   private boolean cancelled;
+   private volatile boolean cancelled;
    private int blockIndex = -1;
    private int maxrows = 0;
    private Integer timezoneOffset; // timezone offset of server

--- a/core/src/main/java/inetsoft/mv/fs/FSConfig.java
+++ b/core/src/main/java/inetsoft/mv/fs/FSConfig.java
@@ -42,7 +42,11 @@ public interface FSConfig {
    int getJobCheckPeriod();
 
    /**
-    * Get the expired period for a map task.
+    * Get the expired period for a map task. A map task that runs longer than this
+    * period fails the entire job; no retry is attempted and the block is not
+    * re-dispatched. At the default value this never fires, because getJobTimeout() is
+    * the same length and is checked first; lowering it below fs.job.period makes it the
+    * effective deadline and fails jobs sooner.
     */
    int getExpired();
 

--- a/core/src/main/java/inetsoft/mv/fs/FSService.java
+++ b/core/src/main/java/inetsoft/mv/fs/FSService.java
@@ -273,6 +273,10 @@ public final class FSService {
          return val != null ? Integer.parseInt(val) : 500;
       }
 
+      // fs.map.expired is a hard deadline, not a stuck-task detector: exceeding it
+      // fails the whole MV job (see XJobStatus.update), so it should not be lowered
+      // to distinguish a stuck task from a slow one. Defaults to the same 10 hours
+      // as fs.job.period, which is checked first.
       @Override
       public int getExpired() {
          String val = SreeEnv.getProperty("fs.map.expired");

--- a/core/src/main/java/inetsoft/mv/mr/AbstractJob.java
+++ b/core/src/main/java/inetsoft/mv/mr/AbstractJob.java
@@ -239,5 +239,5 @@ public abstract class AbstractJob implements XJob {
    private final Properties props = new Properties();
    private final String id;
    private String file;
-   private boolean cancelled;
+   private volatile boolean cancelled;
 }

--- a/core/src/main/java/inetsoft/mv/mr/AbstractMapTask.java
+++ b/core/src/main/java/inetsoft/mv/mr/AbstractMapTask.java
@@ -238,5 +238,5 @@ public abstract class AbstractMapTask implements XMapTask {
    private String id;
    private String bid;
    private String host;
-   private boolean cancelled;
+   private volatile boolean cancelled;
 }

--- a/core/src/main/java/inetsoft/mv/mr/internal/XJobStatus.java
+++ b/core/src/main/java/inetsoft/mv/mr/internal/XJobStatus.java
@@ -101,7 +101,6 @@ public final class XJobStatus {
 
       bset = new HashSet<>();
       dset = new HashSet<>();
-      fmap = new HashMap<>();
       completed = false;
 
       for(SBlock block : blocks) {
@@ -114,6 +113,13 @@ public final class XJobStatus {
 
       // dispatch map tasks
       for(int i = 0; i < blocks.size(); i++) {
+         // a task dispatched earlier may already have failed the job; the cancel sweep
+         // in complete() has run by now, so anything dispatched after it would not be
+         // cancelled and would scan its block for a result that is discarded
+         if(isCompleted()) {
+            return;
+         }
+
          SBlock block = blocks.get(i);
          String bid = block.getID();
          // MV data grid is no longer used so it's always local mode (spark is used for
@@ -186,6 +192,8 @@ public final class XJobStatus {
     * @param all true if all blocks are added, false if still streaming.
     */
    private void complete(boolean success, boolean all, String reason) {
+      boolean cancelTasks = false;
+
       if(!success) {
          // avoid excessive logging as this may be called many times.
          if(!warned) {
@@ -236,7 +244,20 @@ public final class XJobStatus {
          }
 
          if(!success) {
+            cancelTasks = true;
             this.state = FAILED;
+
+            // a streaming consumer already holds the live table from an earlier
+            // complete(true, false, ...) and would block on it forever, as the failure
+            // path never completes the reducer. terminate it so it sees a definite end.
+            if(reducer != null) {
+               try {
+                  reducer.cancel();
+               }
+               catch(Throwable ex) {
+                  LOG.error("Failed to cancel reduce task", ex);
+               }
+            }
          }
          else if(all) {
             this.state = SUCCESSFUL;
@@ -252,6 +273,15 @@ public final class XJobStatus {
       }
       finally {
          waitlock.unlock();
+      }
+
+      // the results of the map tasks still running for this job will be discarded,
+      // so ask them to stop. this is cooperative and best effort: a task already
+      // scanning its block stops at the next row-loop check, but one still queued in
+      // the map task pool will run in full, so this is an optimization rather than a
+      // guarantee. done outside waitlock, as it takes the pool-wide task monitor.
+      if(cancelTasks) {
+         XMapTaskPool.cancel(job.getID());
       }
    }
 
@@ -391,6 +421,14 @@ public final class XJobStatus {
          return;
       }
 
+      // the job is already done (it failed on another block, and its map tasks were
+      // cancelled). a cancelled task returns the rows it had scanned so far as a
+      // block that looks complete, so merging it here would feed truncated data to
+      // the reducer. state is volatile, so this sees the completing thread's write.
+      if(isCompleted()) {
+         return;
+      }
+
       String id = result.getXBlock();
       waitlock.lock();
 
@@ -427,27 +465,6 @@ public final class XJobStatus {
    }
 
    /**
-    * Set the host to be failed for the given block.
-    */
-   private void setFailed(String bid, String host) {
-      flock.lock();
-
-      try {
-         Set<String> fset = fmap.get(bid);
-
-         if(fset == null) {
-            fset = new HashSet<>();
-            fmap.put(bid, fset);
-         }
-
-         fset.add(host);
-      }
-      finally {
-         flock.unlock();
-      }
-   }
-
-   /**
     * Add one map failure to this status.
     */
    public void addFailure(XMapFailure failure) {
@@ -461,11 +478,10 @@ public final class XJobStatus {
       status.complete(false, failure.getReason());
       XMapTask task = status.getTask();
       String bid = task.getXBlock();
-      setFailed(bid, host);
 
       complete(false, false,
-               "Failed to dispatch job, could not create replacement " +
-                  "task for failed task: " + job.getXFile() + " at block: " + bid);
+               "The map task failed: " + job.getXFile() + " at block: " + bid +
+                  (failure.getReason() == null ? "" : ", reason: " + failure.getReason()));
    }
 
    /**
@@ -495,39 +511,26 @@ public final class XJobStatus {
             continue;
          }
 
-         // expired status? try re-running task
+         // expired map task? it is still executing in the local map task pool and
+         // cannot be re-dispatched (single node), so fail the job
          if(status.isExpired()) {
             XMapTask task = status.getTask();
             status.complete(false, "The map task is expired: " + task);
-            setFailed(task.getXBlock(), task.getHost());
-            XMapTask ntask = createMapper(task);
-
-            if(ntask == null) {
-               ftask = task;
-               break;
-            }
-
-            XMapStatus nstatus = new XMapStatus(ntask);
-            startTask(nstatus);
+            ftask = task;
+            break;
          }
       }
 
-      // failed map task could not be re-dispatched? complete this job
+      // expired map task? complete this job, there is no retry
       if(ftask != null) {
          complete(false, false,
-                  "Failed to dispatch job, failed task could not be " +
-                  "re-dispatched: " + job.getXFile() + " at block: " + ftask.getXBlock());
+                  "A map task exceeded fs.map.expired (" +
+                  FSService.getConfig().getExpired() + "ms), no retry is attempted: " +
+                  job.getXFile() + " at block: " + ftask.getXBlock());
          return true;
       }
 
       return false;
-   }
-
-   /**
-    * Create a new map task as replacement for the failed task.
-    */
-   private XMapTask createMapper(XMapTask task) {
-         return null;
    }
 
    /**
@@ -548,8 +551,6 @@ public final class XJobStatus {
    private int wperiod; // max job period
    private long started; // started moment
    private Map<XMapStatus, XMapStatus> mmap; // map status map
-   private Map<String, Set<String>> fmap;
-   private Lock flock = new ReentrantLock(); // fmap lock
    private Lock mlock = new ReentrantLock(); // mmap lock
    private Set<String> bset; // block id set
    private Set<String> dset; // dispatched id set

--- a/core/src/main/java/inetsoft/mv/mr/internal/XJobStatus.java
+++ b/core/src/main/java/inetsoft/mv/mr/internal/XJobStatus.java
@@ -341,7 +341,7 @@ public final class XJobStatus {
       if(!isSuccessful() && !isReady()) {
          // time out?
          if(!isCompleted()) {
-            complete(false, false, "The job has expired (" + wperiod + "): " + job.getXFile());
+            complete(false, false, "The job has expired (" + wperiod + "ms): " + job.getXFile());
          }
 
          throw new RuntimeException("Failed to execute job: " + job + ", reason: " + reason);
@@ -421,18 +421,20 @@ public final class XJobStatus {
          return;
       }
 
-      // the job is already done (it failed on another block, and its map tasks were
-      // cancelled). a cancelled task returns the rows it had scanned so far as a
-      // block that looks complete, so merging it here would feed truncated data to
-      // the reducer. state is volatile, so this sees the completing thread's write.
-      if(isCompleted()) {
-         return;
-      }
-
       String id = result.getXBlock();
       waitlock.lock();
 
       try {
+         // the job is already done (it failed on another block, and its map tasks were
+         // cancelled). a cancelled task returns the rows it had scanned so far as a block
+         // that looks complete, so merging it here would feed truncated data to the
+         // reducer. checked under waitlock, which complete() holds while it sets the
+         // state and cancels the reducer -- checking before acquiring it would leave a
+         // window where this passes and complete() then runs before the merge.
+         if(isCompleted()) {
+            return;
+         }
+
          // mark the block id as completed
          bset.remove(id);
          // mark the map task as completed
@@ -497,7 +499,7 @@ public final class XJobStatus {
 
       // check if the job is expired
       if(now - started > wperiod) {
-         complete(false, false, "The job has expired (" + wperiod + "): " + job.getXFile());
+         complete(false, false, "The job has expired (" + wperiod + "ms): " + job.getXFile());
          return true;
       }
 

--- a/core/src/main/java/inetsoft/mv/mr/internal/XMapTaskPool.java
+++ b/core/src/main/java/inetsoft/mv/mr/internal/XMapTaskPool.java
@@ -56,11 +56,13 @@ public final class XMapTaskPool {
          }
       }
 
-      pool.add0(task);
-
+      // register before submitting, otherwise a cancel() landing in between iterates a
+      // map that does not hold this task yet and it runs to completion
       synchronized(maptasks) {
          maptasks.put(task, "OK");
       }
+
+      pool.add0(task);
    }
 
    /**
@@ -140,6 +142,12 @@ public final class XMapTaskPool {
 
       @Override
       public void run() {
+         // cancelled while queued? the job it belongs to is already done, so its
+         // result would be discarded
+         if(task.isCancelled()) {
+            return;
+         }
+
          try {
             XMapResult result = task.run(sys);
             XJobPool.addResult(result, task.getOrgID());
@@ -181,6 +189,11 @@ public final class XMapTaskPool {
             while(!tasks.isEmpty()) {
                XMapTask task = tasks.remove();
                streamlock.unlock();
+
+               if(task.isCancelled()) {
+                  streamlock.lock();
+                  continue;
+               }
 
                try {
                   XMapResult result = task.run(sys);

--- a/core/src/test/java/inetsoft/mv/mr/internal/XJobStatusExpiredMapTaskTest.java
+++ b/core/src/test/java/inetsoft/mv/mr/internal/XJobStatusExpiredMapTaskTest.java
@@ -1,0 +1,233 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.mv.mr.internal;
+
+import inetsoft.mv.fs.FSConfig;
+import inetsoft.mv.fs.FSService;
+import inetsoft.mv.mr.XJob;
+import inetsoft.mv.mr.XMapResult;
+import inetsoft.mv.mr.XMapTask;
+import inetsoft.mv.mr.XReduceTask;
+import inetsoft.sree.SreeEnv;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies what {@link XJobStatus#update()} does with a map task that outlives
+ * {@code fs.map.expired}. There is no retry: the map task runs in the local
+ * {@link XMapTaskPool} on the only node there is, so the job fails and the abandoned task is
+ * cancelled. These tests pin that contract, and pin the failure message to name the property
+ * that caused it rather than claiming a re-dispatch was attempted.
+ */
+@Tag("core")
+class XJobStatusExpiredMapTaskTest {
+   @Test
+   void expiredMapTaskFailsTheJobNamingTheProperty() throws Exception {
+      XJobStatus status = newStartedStatus();
+
+      try(MockedStatic<FSService> fs = mockStatic(FSService.class);
+          MockedStatic<SreeEnv> sree = mockStatic(SreeEnv.class);
+          MockedStatic<XMapTaskPool> pool = mockStatic(XMapTaskPool.class))
+      {
+         FSConfig config = expiringConfig();
+         fs.when(FSService::getConfig).thenReturn(config);
+
+         assertTrue(status.update(), "an expired map task must complete the job");
+         assertTrue(status.isCompleted());
+
+         String reason = status.getReason();
+         assertNotNull(reason);
+         assertTrue(reason.contains("fs.map.expired"),
+                    "the failure must name the property that caused it: " + reason);
+         assertFalse(reason.contains("re-dispatched"),
+                     "no re-dispatch is attempted, so the message must not claim one: " + reason);
+      }
+   }
+
+   @Test
+   void givingUpCancelsTheStillRunningMapTask() throws Exception {
+      XJobStatus status = newStartedStatus();
+
+      try(MockedStatic<FSService> fs = mockStatic(FSService.class);
+          MockedStatic<SreeEnv> sree = mockStatic(SreeEnv.class);
+          MockedStatic<XMapTaskPool> pool = mockStatic(XMapTaskPool.class))
+      {
+         FSConfig config = expiringConfig();
+         fs.when(FSService::getConfig).thenReturn(config);
+
+         status.update();
+
+         // the expired task is still executing; its result is now discarded, so stop it
+         pool.verify(() -> XMapTaskPool.cancel(eq(JOB_ID)));
+      }
+   }
+
+   @Test
+   void aMapTaskWithinItsDeadlineLeavesTheJobRunning() throws Exception {
+      XJobStatus status = newStartedStatus();
+
+      try(MockedStatic<FSService> fs = mockStatic(FSService.class);
+          MockedStatic<SreeEnv> sree = mockStatic(SreeEnv.class);
+          MockedStatic<XMapTaskPool> pool = mockStatic(XMapTaskPool.class))
+      {
+         FSConfig config = mock(FSConfig.class);
+         when(config.getExpired()).thenReturn(Integer.MAX_VALUE);
+         fs.when(FSService::getConfig).thenReturn(config);
+
+         assertFalse(status.update(), "a task within its deadline must not complete the job");
+         assertFalse(status.isCompleted());
+         pool.verifyNoInteractions();
+      }
+   }
+
+   /**
+    * A task cancelled mid-scan returns the rows it had read so far as a block that looks
+    * complete (SubMVQuery.execute breaks its row loops, then still calls group.complete()),
+    * so a result arriving after the job has failed must not reach the reducer.
+    */
+   @Test
+   void aResultArrivingAfterTheJobFailedIsNotMergedIntoTheReducer() throws Exception {
+      XJobStatus status = newStartedStatus();
+      XReduceTask reducer = mock(XReduceTask.class);
+      set(status, "reducer", reducer);
+      set(status, "bset", new java.util.HashSet<>(java.util.List.of("block-0")));
+
+      try(MockedStatic<FSService> fs = mockStatic(FSService.class);
+          MockedStatic<SreeEnv> sree = mockStatic(SreeEnv.class);
+          MockedStatic<XMapTaskPool> pool = mockStatic(XMapTaskPool.class))
+      {
+         FSConfig config = expiringConfig();
+         fs.when(FSService::getConfig).thenReturn(config);
+
+         status.update();
+         assertTrue(status.isCompleted());
+
+         XMapResult late = mock(XMapResult.class);
+         when(late.getXBlock()).thenReturn("block-0");
+         when(late.getHost()).thenReturn("localhost");
+         status.addResult(late);
+
+         verify(reducer, never()).add(late);
+      }
+   }
+
+   @Test
+   void aResultForARunningJobStillReachesTheReducer() throws Exception {
+      XJobStatus status = newStartedStatus();
+      XReduceTask reducer = mock(XReduceTask.class);
+      set(status, "reducer", reducer);
+      set(status, "bset", new java.util.HashSet<>(java.util.List.of("block-0")));
+
+      XMapResult result = mock(XMapResult.class);
+      when(result.getXBlock()).thenReturn("block-0");
+      when(result.getHost()).thenReturn("localhost");
+
+      try(MockedStatic<SreeEnv> sree = mockStatic(SreeEnv.class)) {
+         status.addResult(result);
+      }
+
+      verify(reducer).add(result);
+   }
+
+   /**
+    * A streaming consumer already holds the live table handed out by an earlier
+    * complete(true, false, ...); the failure path never completes the reducer, so without
+    * this the consumer blocks on a table that is never terminated.
+    */
+   @Test
+   void failingTheJobTerminatesTheReducerForAStreamingConsumer() throws Exception {
+      XJobStatus status = newStartedStatus();
+      XReduceTask reducer = mock(XReduceTask.class);
+      set(status, "reducer", reducer);
+
+      try(MockedStatic<FSService> fs = mockStatic(FSService.class);
+          MockedStatic<SreeEnv> sree = mockStatic(SreeEnv.class);
+          MockedStatic<XMapTaskPool> pool = mockStatic(XMapTaskPool.class))
+      {
+         FSConfig config = expiringConfig();
+         fs.when(FSService::getConfig).thenReturn(config);
+
+         status.update();
+
+         verify(reducer).cancel();
+         verify(reducer, never()).complete(org.mockito.ArgumentMatchers.anyBoolean());
+      }
+   }
+
+   private static FSConfig expiringConfig() {
+      FSConfig config = mock(FSConfig.class);
+      when(config.getExpired()).thenReturn((int) MAP_TASK_DEADLINE);
+      return config;
+   }
+
+   /**
+    * Builds an XJobStatus holding one started, uncompleted map task, without going through
+    * startJob() -- which needs a real block file system.
+    */
+   @SuppressWarnings("unchecked")
+   private static XJobStatus newStartedStatus() throws Exception {
+      XJob job = mock(XJob.class);
+      when(job.getID()).thenReturn(JOB_ID);
+      when(job.getXFile()).thenReturn("mv-file");
+      when(job.isCancelled()).thenReturn(false);
+
+      XMapTask task = mock(XMapTask.class);
+      when(task.getHost()).thenReturn("localhost");
+      when(task.getXBlock()).thenReturn("block-0");
+
+      XJobStatus status = new XJobStatus(JOB_ID);
+      set(status, "job", job);
+      set(status, "started", System.currentTimeMillis());
+      set(status, "wperiod", Integer.MAX_VALUE);
+
+      XMapStatus mstatus = new XMapStatus(task);
+      mstatus.start();
+      // backdate the map task so it is deterministically past MAP_TASK_DEADLINE
+      Field mstarted = XMapStatus.class.getDeclaredField("started");
+      mstarted.setAccessible(true);
+      mstarted.setLong(mstatus, System.currentTimeMillis() - 10 * MAP_TASK_DEADLINE);
+      Field mmap = XJobStatus.class.getDeclaredField("mmap");
+      mmap.setAccessible(true);
+      ((Map<XMapStatus, XMapStatus>) mmap.get(status)).put(mstatus, mstatus);
+
+      return status;
+   }
+
+   private static void set(XJobStatus status, String name, Object value) throws Exception {
+      Field field = XJobStatus.class.getDeclaredField(name);
+      field.setAccessible(true);
+      field.set(status, value);
+   }
+
+   private static final String JOB_ID = "job-1";
+   private static final long MAP_TASK_DEADLINE = 1000;
+}

--- a/core/src/test/java/inetsoft/mv/mr/internal/XJobStatusExpiredMapTaskTest.java
+++ b/core/src/test/java/inetsoft/mv/mr/internal/XJobStatusExpiredMapTaskTest.java
@@ -29,8 +29,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -181,6 +183,62 @@ class XJobStatusExpiredMapTaskTest {
          verify(reducer).cancel();
          verify(reducer, never()).complete(org.mockito.ArgumentMatchers.anyBoolean());
       }
+   }
+
+   /**
+    * complete() writes the state and cancels the reducer while holding waitlock, so a
+    * completion check made before acquiring that lock can pass and then merge into an
+    * already-cancelled reducer. Reproduced deterministically by holding waitlock on this
+    * thread while addResult() blocks on it, then completing the job through the same
+    * (reentrant) lock before releasing it.
+    */
+   @Test
+   void aResultBlockedOnTheLockWhenTheJobFailsIsNotMergedIntoTheReducer() throws Exception {
+      XJobStatus status = newStartedStatus();
+      XReduceTask reducer = mock(XReduceTask.class);
+      set(status, "reducer", reducer);
+      set(status, "bset", new java.util.HashSet<>(java.util.List.of("block-0")));
+
+      XMapResult result = mock(XMapResult.class);
+      when(result.getXBlock()).thenReturn("block-0");
+      when(result.getHost()).thenReturn("localhost");
+
+      Field waitlockField = XJobStatus.class.getDeclaredField("waitlock");
+      waitlockField.setAccessible(true);
+      java.util.concurrent.locks.Lock waitlock =
+         (java.util.concurrent.locks.Lock) waitlockField.get(status);
+
+      Thread adder = new Thread(() -> status.addResult(result), "addResult");
+      waitlock.lock();
+
+      try(MockedStatic<SreeEnv> sree = mockStatic(SreeEnv.class);
+          MockedStatic<XMapTaskPool> pool = mockStatic(XMapTaskPool.class))
+      {
+         adder.start();
+
+         // let it clear the pre-lock checks and park on waitlock, which this thread holds
+         long deadline = System.currentTimeMillis() + 5000;
+
+         while(adder.getState() != Thread.State.WAITING && System.currentTimeMillis() < deadline) {
+            Thread.yield();
+         }
+
+         assertEquals(Thread.State.WAITING, adder.getState(),
+                      "the result thread should be parked on waitlock");
+
+         // waitlock is reentrant, so the job can be failed without releasing it first
+         Method complete = XJobStatus.class.getDeclaredMethod(
+            "complete", boolean.class, boolean.class, String.class);
+         complete.setAccessible(true);
+         complete.invoke(status, false, false, "another block failed");
+      }
+      finally {
+         waitlock.unlock();
+      }
+
+      adder.join(5000);
+      assertFalse(adder.isAlive(), "the result thread should have finished");
+      verify(reducer, never()).add(result);
    }
 
    private static FSConfig expiringConfig() {

--- a/core/src/test/java/inetsoft/mv/mr/internal/XMapTaskPoolTest.java
+++ b/core/src/test/java/inetsoft/mv/mr/internal/XMapTaskPoolTest.java
@@ -100,6 +100,24 @@ class XMapTaskPoolTest {
       }
    }
 
+   /**
+    * A task cancelled while still queued belongs to a job that is already cancelled or
+    * failed, so running it would scan a whole block for a result that is discarded.
+    */
+   @Test
+   void doesNotRunATaskThatWasCancelledWhileQueued() throws Exception {
+      XBlockSystem sys = mock(XBlockSystem.class);
+      XMapTask task = mock(XMapTask.class);
+      when(task.isCancelled()).thenReturn(true);
+
+      try(MockedStatic<XJobPool> jobPoolStatic = mockStatic(XJobPool.class)) {
+         newHandler(task, sys).run();
+
+         org.mockito.Mockito.verify(task, org.mockito.Mockito.never()).run(same(sys));
+         jobPoolStatic.verifyNoInteractions();
+      }
+   }
+
    private static Runnable newHandler(XMapTask task, XBlockSystem sys) throws Exception {
       Class<?> handlerClass = Class.forName(XMapTaskPool.class.getName() + "$Handler");
       Constructor<?> constructor =


### PR DESCRIPTION
## Problem

`XJobStatus.createMapper(XMapTask)` was a stub whose entire body was `return null`, so the expired-map-task branch in `update()` always fell straight through to failing the whole job. Everything written around it described a retry that could not happen: the "try re-running task" comment, the `setFailed(block, host)` host-avoidance bookkeeping, the `XMapStatus`/`startTask` branch, and the "could not be re-dispatched" wording.

One block slower than `fs.map.expired` therefore failed the entire materialized-view job, with no setting that made it recoverable.

## Why remove the retry instead of implementing it

Three things make it dead code rather than an unfinished feature:

1. **There is no other host.** `startJob()` hardcodes `host = "localhost"` — the MV data grid was replaced by Spark for distributed mode — and `XMapTaskPool` runs every task in a local thread pool regardless of `task.getHost()`. There is no node registry left; `XNodeRuler`, the old host-affinity calculator, has no callers.
2. **A same-host replacement is structurally impossible.** `XMapStatus` is keyed on `(host, blockId)` and `startTask()` early-returns on duplicates, so a replacement would be silently dropped and the job would then *hang* until `fs.job.period` instead of failing — strictly worse.
3. **The expired task is still running.** Expiry is a wall-clock check, not a death notice, so a retry would duplicate the work and race a second result into the reducer.

`fmap`/`setFailed` were write-only: populated from two call sites, read by nothing.

## `fs.map.expired`

At its default the branch is unreachable — `fs.job.period` is the same length and `update()` checks it first. It only opens when an operator lowers the property, and then every expiry is terminal, so lowering it to "detect a stuck task sooner" made jobs fail instead. The property is now documented for what it is: a hard deadline that becomes effective once lowered below `fs.job.period`.

## Stopping abandoned work

Failing the job left its map tasks running for a result that is discarded. Now:

- `complete()` cancels the job's map tasks, and terminates the reducer so a streaming consumer holding the live table sees a definite end. Previously the failure path never completed the reducer, and `MVQuery.complete()` only calls `table.complete()` when `all || isCancelled()`, so the consumer blocked on `moreRows()` forever.
- `addResult()` ignores results arriving after the job is done — a cancelled task returns the rows it had scanned as a block that *looks* complete (`SubMVQuery.execute()` breaks its row loops, then still calls `group.complete()`), which would feed truncated data to the reducer.
- `startJob()` stops dispatching once the job has completed, since the cancel sweep in `complete()` has already run by then.
- `XMapTaskPool` skips tasks cancelled while still queued, and registers a task before submitting it so a concurrent cancel cannot miss it.
- `SubMVTask.cancel()` reads the query from the task's own state rather than a field assigned partway through `run()`, so a cancel arriving before the block finishes loading is no longer dropped. Cancellation flags are made `volatile`, as they are set and polled by different threads.

Cancellation remains cooperative: a task scanning rows stops at the next check (every 256 rows), one blocked in the data source does not.

## Testing

New `XJobStatusExpiredMapTaskTest` covers the expiry path end to end — the job fails naming the property, the map tasks are cancelled, the reducer is terminated, post-completion results are not merged, and a result for a still-running job is. `XMapTaskPoolTest` gains a case for the queued-cancel skip.

`inetsoft.mv.**`: 187 pass. Full core suite: 4611 pass. (`FreeHelperTest` fails on `main` independently of this change — it calls `FreeHelper.isMaxStepsFromProperty()`, which does not exist in the source.)

Manual verification of the expiry path — lowering `fs.map.expired` and building an MV with a slow block — is being done separately, since the branch is unreachable at default settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
