### PR TITLE
Bug #76284, add missing vs.mv.missing catalog entry

### DIFF
--- a/core/src/main/resources/inetsoft/util/srinter.properties
+++ b/core/src/main/resources/inetsoft/util/srinter.properties
@@ -5570,6 +5570,7 @@ vs.import.excel.unavailable=Excel file has improper format. Only Excel files exp
 vs.mv.complete=Data is ready. Refresh Dashboard?
 vs.mv.exist=If you modify this Dashboard, an administrator may need to generate a new materialized view.\nDo you want to continue?
 vs.mv.hint=
+vs.mv.missing=The materialized view required for this Dashboard is not available.
 vs.mv.portal.vpm=Materialization not allowed for source with VPM.
 vs.mv.tabular.query.variables=Materialization not allowed for sources that contain variables in query.
 vs.mv.prepare=Preparing data cache, please wait...


### PR DESCRIPTION
## Problem

Every "materialized view is missing" message is built from
`Catalog.getCatalog().getString("vs.mv.missing")`, but no resource bundle in this repo defines
that key. `Catalog.getString0` falls back to returning the key itself when a lookup misses
(`core/src/main/java/inetsoft/util/Catalog.java:597-599` — `if(obj == null && def) { obj = id; }`,
and every public `getString` overload passes `def == true`).

The result is that users see the raw string `vs.mv.missing` in a modal error dialog whenever a
required materialized view is absent.

## Call sites

All five are user-facing, and all render as error dialogs:

| Location | How it surfaces |
| --- | --- |
| `inetsoft/mv/MVManager.java:397` | `MessageException(ERROR)` — `mv.required` runtime branch |
| `inetsoft/mv/MVManager.java:402` | `mv.metadata` design-time branch |
| `report/composition/execution/AssetQuery.java:140` | `MessageException(ERROR)` from the generic `catch(Exception)` in `createAssetQuery` |
| `report/composition/execution/AssetQuery.java:197` | `MessageException(ERROR)` from the `MVExecutionException` retry path |
| `web/composer/vs/controller/ComposerViewsheetService.java:574` | `MessageCommand` with `Type.ERROR` after the user cancels a pending MV |

`MessageCommand.Type.ERROR` hits the `default:` branch of `processMessageCommand`
(`web/projects/portal/src/app/vsobjects/viewer-app.component.ts:2556`), which renders a modal
error dialog.

Both `mv.required` and `mv.metadata` are reachable through Enterprise Manager checkboxes.

## Fix

A single entry added to `core/src/main/resources/inetsoft/util/srinter.properties`, placed
alphabetically among its `vs.mv.*` siblings:

```properties
vs.mv.missing=The materialized view required for this Dashboard is not available.
```

Wording follows the conventions of the six existing `vs.mv.*` keys: a full capitalized sentence
with a terminal period and capitalized "Dashboard" (as in `vs.mv.complete` and `vs.mv.exist`).

No question form is used, because every live path is a hard error rather than a prompt. The
`ConfirmException(msg, ConfirmException.INFO)` "generate it now?" branch at `MVManager.java:405`
is currently unreachable: `processMissingMV` is private, its only live caller
(`MVManager.java:198`) passes `entry = null`, and the caller that would pass a non-null `entry`
(`MVManager.java:329`) is commented out. With `entry == null` that branch falls through to
`MessageException(ERROR)`. The wording still reads correctly as a confirmation body if that
branch is ever revived, since the dialog's OK/Cancel buttons supply the action.

## Scope

Resource-bundle change only — no Java changes.

Deliberately left alone:

- The four sample bundles in `community-examples/localize/` (`srinter_en_US`, `_fr_FR`, `_ja_JP`,
  `_zh_CN`) also lack the key, but they are unbuilt customer localization samples and adding
  entries to the translated ones would mean inventing wording.
- The dead `ConfirmException` branch and its commented-out caller in `MVManager` — reviving or
  removing that is a separate change.

## Testing

- Loaded the bundle through `java.util.Properties` using the same ISO-8859-1 semantics: 5532 keys
  parse without error and `vs.mv.missing` resolves to the intended sentence rather than the key
  literal. Sibling keys still resolve unchanged.
- The added line has no trailing whitespace, no CR, and is pure ASCII, so no `\`, `:`, or `=`
  escaping is required.
- `grep` confirms only the five production call sites reference the key; no test asserts on the
  old fallback text, and there are no catalog or bundle-validation tests under `core/src/test`.
- Not run: no Maven build, since a resource-only addition cannot affect compilation.
- Not verified: the end-to-end check (enable `mv.required`, open a dashboard whose source has no
  generated materialized view, confirm the dialog text) needs a running server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
