### PR TITLE
Bug #76317, make the documented empty security.robotsTag actually disable X-Robots-Tag

### DIFF
--- a/core/src/main/java/inetsoft/web/security/SecurityHeaderFilter.java
+++ b/core/src/main/java/inetsoft/web/security/SecurityHeaderFilter.java
@@ -39,9 +39,15 @@ import java.io.IOException;
  * {@code X-Content-Type-Options} header will be set to "nosniff". If it is not set to "true", the
  * header will not be added.
  * <p>
- * The {@code security.robotsTag} property controls the {@code X-Robots-Tag} header. By default,
- * it is set to "noindex, nofollow" to prevent search engines from indexing the application.
- * Set to an empty string to disable the header for publicly accessible dashboards.
+ * The {@code security.robotsTag} property controls the {@code X-Robots-Tag} header. If the
+ * property is not set, the header is set to "noindex, nofollow" to prevent search engines from
+ * indexing the application. Set it to an empty string to disable the header for publicly
+ * accessible dashboards.
+ * <p>
+ * The default is applied here rather than being passed to the {@link SreeEnv.Value} constructor
+ * on purpose. A {@code SreeEnv.Value} created with a default resolves through
+ * {@code SreeEnv.getProperty(name, def)}, and that path converts a stored empty string back into
+ * the default, which would make the empty-string opt-out above unreachable.
  */
 public class SecurityHeaderFilter extends AbstractSecurityFilter {
    public SecurityHeaderFilter(SessionLicenseServiceProvider sessionLicenseServiceProvider,
@@ -76,7 +82,11 @@ public class SecurityHeaderFilter extends AbstractSecurityFilter {
 
       String robotsTagValue = robotsTag.get();
 
-      if(robotsTagValue != null && !robotsTagValue.isEmpty()) {
+      if(robotsTagValue == null) {
+         robotsTagValue = DEFAULT_ROBOTS_TAG;
+      }
+
+      if(!robotsTagValue.isEmpty()) {
          httpResponse.setHeader("X-Robots-Tag", robotsTagValue);
       }
 
@@ -87,6 +97,7 @@ public class SecurityHeaderFilter extends AbstractSecurityFilter {
       new SreeEnv.Value("security.enableXSSProtection", 10000, "false");
    private final SreeEnv.Value enableContentTypeOptions =
       new SreeEnv.Value("security.enableContentTypeOptions", 10000, "false");
-   private final SreeEnv.Value robotsTag =
-      new SreeEnv.Value("security.robotsTag", 10000, "noindex, nofollow");
+   private final SreeEnv.Value robotsTag = new SreeEnv.Value("security.robotsTag", 10000);
+
+   static final String DEFAULT_ROBOTS_TAG = "noindex, nofollow";
 }

--- a/core/src/test/java/inetsoft/web/security/SecurityHeaderFilterTest.java
+++ b/core/src/test/java/inetsoft/web/security/SecurityHeaderFilterTest.java
@@ -209,8 +209,9 @@ class SecurityHeaderFilterTest {
    // ── X-Robots-Tag ───────────────────────────────────────────────────────────
 
    @Test
-   void doFilter_robotsTagDefault_setsNoindexNofollow() throws Exception {
-      stubProperty("security.robotsTag", "noindex, nofollow");
+   void doFilter_robotsTagUnset_setsNoindexNofollow() throws Exception {
+      // Nothing stored: the one-arg lookup returns null and doFilter applies its own default.
+      stubStoredProperty("security.robotsTag", null);
       MockHttpServletRequest request = request("/portal/dashboard");
       MockHttpServletResponse response = new MockHttpServletResponse();
 
@@ -220,15 +221,42 @@ class SecurityHeaderFilterTest {
    }
 
    @Test
+   void doFilter_robotsTagCustomValue_setsThatValue() throws Exception {
+      stubStoredProperty("security.robotsTag", "noarchive");
+      MockHttpServletRequest request = request("/portal/dashboard");
+      MockHttpServletResponse response = new MockHttpServletResponse();
+
+      filter.doFilter(request, response, chain);
+
+      assertEquals("noarchive", response.getHeader("X-Robots-Tag"));
+   }
+
+   @Test
    void doFilter_robotsTagExplicitlyEmpty_headerOmitted() throws Exception {
       // Documented escape hatch for publicly-indexable dashboards.
-      stubProperty("security.robotsTag", "");
+      stubStoredProperty("security.robotsTag", "");
       MockHttpServletRequest request = request("/portal/dashboard");
       MockHttpServletResponse response = new MockHttpServletResponse();
 
       filter.doFilter(request, response, chain);
 
       assertNull(response.getHeader("X-Robots-Tag"));
+   }
+
+   @Test
+   void doFilter_robotsTagNeverResolvesThroughDefaultingOverload() throws Exception {
+      // Guards the fix: SreeEnv.getProperty(name, def) routes through
+      // DefaultProperties.getProperty(key, defaultValue), which converts a stored "" back into
+      // the default. If security.robotsTag ever regains a constructor default it would take that
+      // path again and the empty-string opt-out above would silently stop working -- while
+      // still passing, if the test stubbed both overloads to the same value.
+      stubStoredProperty("security.robotsTag", "");
+      MockHttpServletRequest request = request("/portal/dashboard");
+
+      filter.doFilter(request, new MockHttpServletResponse(), chain);
+
+      sreeEnvMock.verify(
+         () -> SreeEnv.getProperty(eq("security.robotsTag"), anyString()), never());
    }
 
    // ── helpers ────────────────────────────────────────────────────────────────
@@ -261,5 +289,18 @@ class SecurityHeaderFilterTest {
    private void stubProperty(String key, String value) {
       sreeEnvMock.when(() -> SreeEnv.getProperty(eq(key))).thenReturn(value);
       sreeEnvMock.when(() -> SreeEnv.getProperty(eq(key), anyString())).thenReturn(value);
+   }
+
+   /**
+    * Stubs only the one-arg {@code SreeEnv.getProperty} overload, which is the single accessor a
+    * {@code SreeEnv.Value} built without a constructor default uses. Deliberately leaves the
+    * two-arg overload unstubbed: stubbing it to return the value directly would paper over
+    * {@code DefaultProperties.getProperty(key, defaultValue)}, which converts a stored empty
+    * string back into the supplied default. That conversion is exactly what made
+    * {@code security.robotsTag}'s documented empty-string opt-out unreachable in production while
+    * a both-overloads stub kept the test green.
+    */
+   private void stubStoredProperty(String key, String value) {
+      sreeEnvMock.when(() -> SreeEnv.getProperty(eq(key))).thenReturn(value);
    }
 }


### PR DESCRIPTION
## Problem

`SecurityHeaderFilter`'s class Javadoc tells operators to set `security.robotsTag` to an empty string to disable the `X-Robots-Tag` header "for publicly accessible dashboards". No stored empty value could reach the branch that omits it — the response still carried `noindex, nofollow`, exactly as if the property had never been set.

The filter's branch itself was correct. The problem was what `get()` could return:

```java
private final SreeEnv.Value robotsTag =
   new SreeEnv.Value("security.robotsTag", 10000, "noindex, nofollow");
```

Because a default was supplied, `SreeEnv.Value.updateValue` took the two-argument route (`SreeEnv.java:360`). That reaches `PropertiesEngine.getProperty(name, def, false)`, which delegates to `internalProperties` — a `DefaultProperties` — and `DefaultProperties.getProperty(key, defaultValue)` treats empty as absent:

```java
if(value == null || "".equals(value)) {
   value = defaultValue;
}
```

So a stored `""` became `noindex, nofollow` before `doFilter` ever saw it. All three operator routes ended in the same place:

| what the operator does | what is stored | what the filter gets |
| --- | --- | --- |
| blanks the row in Settings > All Properties | `""` | `noindex, nofollow` |
| deletes the property | (absent) | `noindex, nofollow` |
| never sets it | (absent) | `noindex, nofollow` |

Blanking the row does genuinely store an empty string — `PropertiesController.editProperty` re-reads the effective value with the one-arg `SreeEnv.getProperty`, finds nothing declared for this key (it is declared in no properties file; it existed only as the inline code default) and writes `""`. The operator saw a saved, empty value and a header that was still being sent.

## Fix

Drop the constructor default and apply it in `doFilter` when the value is `null`. The one-argument `get()` returns a stored `""` verbatim, so an empty value now means what the comment says it means. Behaviour is identical for every install that has not set the property.

The Javadoc now describes the null-vs-empty distinction, and carries a note explaining why the default lives in `doFilter` rather than the constructor — otherwise the next tidy-up moves it back and silently breaks the opt-out again.

## Tests

`doFilter_robotsTagExplicitlyEmpty_headerOmitted` was named for the documented escape hatch and passed, because its helper stubbed the layer that performs the conversion:

```java
sreeEnvMock.when(() -> SreeEnv.getProperty(eq(key), anyString())).thenReturn(value);
```

Stubbing the two-argument overload to return the value directly is precisely what removed the empty-to-default conversion. The test proved the filter's `if` worked; it could not prove an operator had a route to it.

- New `stubStoredProperty` helper stubs **only** the one-arg overload, with a comment on why stubbing both is what hid this. `stubProperty` stays for the XSS/content-type flags, which still legitimately use constructor defaults.
- `doFilter_robotsTagUnset_setsNoindexNofollow` — nothing stored, default applied.
- `doFilter_robotsTagCustomValue_setsThatValue` — new; nothing previously covered a non-default value.
- `doFilter_robotsTagExplicitlyEmpty_headerOmitted` — the escape hatch, no longer stubbing past the conversion.
- `doFilter_robotsTagNeverResolvesThroughDefaultingOverload` — new guard; `verify(..., never())` on the two-arg overload, so re-adding a constructor default fails the build even if someone also re-stubs both overloads.

Verified both directions: 11/11 pass with the fix; with the old field shape restored, 3 fail — including the two that previously passed regardless.

## Out of scope

- `DefaultProperties.getProperty(key, defaultValue)` never consults the `defaultProperties` layer, unlike its one-arg sibling at `DefaultProperties.java:64-72`. Any `SreeEnv.Value` built with a code default therefore shadows a value that would otherwise come from the defaults layer. No effect here (`security.robotsTag` is in no properties file), but it is a real latent issue worth its own ticket.
- The two "suspects" documented in the test file's header comment (EM paths not getting `X-Frame-Options: DENY`; `nosniff` defaulting off) are unrelated and remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
