### PR TITLE
Bug #76318, stop script.java.allowed.classes from overriding the script sandbox deny lists

### DIFF
--- a/core/src/main/java/inetsoft/util/script/graal/ScriptHostAccess.java
+++ b/core/src/main/java/inetsoft/util/script/graal/ScriptHostAccess.java
@@ -34,7 +34,8 @@ public final class ScriptHostAccess {
    }
 
    // Deny-list ported verbatim from SecureClassShutter. Checked AFTER the exact
-   // allow-list (ALLOWED_CLASSES) but BEFORE the allowed prefixes — see classFilter().
+   // allow-list (ALLOWED_CLASSES) but BEFORE the operator-supplied
+   // extras (script.java.allowed.classes) and the allowed prefixes — see classFilter().
    // Dangerous packages — any class whose FQCN equals or starts with "<pkg>." is blocked.
    private static final Set<String> BLOCKED_PACKAGES = Set.of(
       "java.lang.reflect",
@@ -223,8 +224,12 @@ public final class ScriptHostAccess {
     *
     * <p>Delegates to {@link #isVisibleToScripts}, a faithful port of the proven
     * {@code SecureClassShutter.visibleToScripts} precedence from the main-branch
-    * Rhino baseline. Reads the {@code javascript.java.packages} and
-    * {@code javascript.java.com_org} properties once when the filter is built.
+    * Rhino baseline. Reads the {@code script.java.allowed.classes},
+    * {@code javascript.java.packages} and {@code javascript.java.com_org}
+    * properties once when the filter is built. The extra class names given by
+    * {@code script.java.allowed.classes} are additive only: they are consulted
+    * after the deny lists, so they cannot re-enable a class named by
+    * {@code BLOCKED_PACKAGES} or {@code BLOCKED_CLASSES}.
     * Dangerous classes (System/Runtime/Class/ClassLoader, threading,
     * inetsoft.report.internal.license.*, engine internals) are NOT on any allow
     * path, so they stay blocked.
@@ -260,7 +265,17 @@ public final class ScriptHostAccess {
       final String[] customPkgsF = customPkgs;
       final boolean comOrgF = comOrg;
 
-      return fqcn -> isVisibleToScripts(fqcn, extra, customPkgsF, comOrgF);
+      return classFilter(extra, customPkgsF, comOrgF);
+   }
+
+   /**
+    * Package-private overload taking the already-parsed property values, so tests
+    * can exercise the allow/deny precedence without a SreeEnv context.
+    */
+   static Predicate<String> classFilter(Set<String> extra, String[] customPkgs,
+                                        boolean comOrg)
+   {
+      return fqcn -> isVisibleToScripts(fqcn, extra, customPkgs, comOrg);
    }
 
    /**
@@ -284,14 +299,17 @@ public final class ScriptHostAccess {
          return true;
       }
 
-      // exact allow wins: curated classes, SreeEnv extras, primitive arrays, jdk proxies.
-      if(ALLOWED_CLASSES.contains(fqcn) || extra.contains(fqcn) ||
+      // exact allow wins: curated classes (audited, and deliberately allowed to
+      // override the package deny), primitive arrays, jdk proxies.
+      if(ALLOWED_CLASSES.contains(fqcn) ||
          isPrimitiveArrayType(fqcn) || fqcn.startsWith("jdk.proxy"))
       {
          return true;
       }
 
-      // deny: blocked packages, then blocked classes.
+      // deny: blocked packages, then blocked classes. Checked BEFORE the
+      // operator-supplied extras so script.java.allowed.classes cannot re-enable
+      // a class the sandbox blocks.
       for(String blockedPkg : BLOCKED_PACKAGES) {
          // Match exact package ("java.io") or sub-package/class ("java.io.File").
          // The "sun." entry already contains a trailing dot, so handle both styles.
@@ -304,6 +322,12 @@ public final class ScriptHostAccess {
 
       if(BLOCKED_CLASSES.contains(fqcn)) {
          return false;
+      }
+
+      // operator-supplied extras (script.java.allowed.classes): additive only, so
+      // this runs after the deny checks above and cannot cross them.
+      if(extra.contains(fqcn)) {
+         return true;
       }
 
       // arrays of an allowed object type.

--- a/core/src/test/java/inetsoft/util/script/graal/ScriptHostAccessTest.java
+++ b/core/src/test/java/inetsoft/util/script/graal/ScriptHostAccessTest.java
@@ -19,6 +19,8 @@ package inetsoft.util.script.graal;
 
 import org.graalvm.polyglot.*;
 import org.junit.jupiter.api.*;
+
+import java.util.Set;
 import static org.junit.jupiter.api.Assertions.*;
 
 @Tag("core")
@@ -27,6 +29,18 @@ class ScriptHostAccessTest {
       return Context.newBuilder("js")
          .allowHostAccess(ScriptHostAccess.hostAccess())
          .allowHostClassLookup(ScriptHostAccess.classFilter())
+         .build();
+   }
+
+   /**
+    * Builds a context as if script.java.allowed.classes named the given FQCNs,
+    * without needing a SreeEnv context. The remaining arguments mirror the
+    * production defaults (no javascript.java.packages, com_org on).
+    */
+   private Context newContext(Set<String> extra) {
+      return Context.newBuilder("js")
+         .allowHostAccess(ScriptHostAccess.hostAccess())
+         .allowHostClassLookup(ScriptHostAccess.classFilter(extra, new String[0], true))
          .build();
    }
 
@@ -136,6 +150,50 @@ class ScriptHostAccessTest {
             () -> ctx.eval("js", "Java.type('java.lang.Thread')"));
          assertThrows(PolyglotException.class,
             () -> ctx.eval("js", "Java.type('java.util.concurrent.ConcurrentHashMap')"));
+      }
+   }
+
+   /**
+    * script.java.allowed.classes is additive only: naming a BLOCKED_CLASSES entry
+    * must not re-enable it. Java.type resolution is the boundary being asserted
+    * here -- java.lang.Runtime is separately denied at the member level by
+    * hostAccess(), but java.io.File is not, so the class filter is what stops it.
+    */
+   @Test void extrasCannotUnblockBlockedClass() {
+      try(Context ctx = newContext(Set.of("java.lang.Runtime", "java.io.File"))) {
+         assertThrows(PolyglotException.class,
+            () -> ctx.eval("js", "Java.type('java.lang.Runtime')"));
+         assertThrows(PolyglotException.class,
+            () -> ctx.eval("js", "Java.type('java.io.File')"));
+      }
+   }
+
+   /** Same for a class reached through a BLOCKED_PACKAGES prefix. */
+   @Test void extrasCannotUnblockBlockedPackage() {
+      try(Context ctx = newContext(Set.of("java.lang.reflect.Method",
+                                          "inetsoft.report.internal.license.LicenseManager")))
+      {
+         assertThrows(PolyglotException.class,
+            () -> ctx.eval("js", "Java.type('java.lang.reflect.Method')"));
+         assertThrows(PolyglotException.class,
+            () -> ctx.eval("js",
+               "Java.type('inetsoft.report.internal.license.LicenseManager')"));
+      }
+   }
+
+   /**
+    * The property still does what it is for: a class on neither deny list, and on
+    * no default allow path, becomes visible when named. java.time is outside every
+    * allowed prefix/package, so it is denied until the property names it.
+    */
+   @Test void extrasStillAddNonBlockedClass() {
+      try(Context ctx = newContext()) {
+         assertThrows(PolyglotException.class,
+            () -> ctx.eval("js", "Java.type('java.time.LocalDate')"));
+      }
+
+      try(Context ctx = newContext(Set.of("java.time.LocalDate"))) {
+         assertDoesNotThrow(() -> ctx.eval("js", "Java.type('java.time.LocalDate')"));
       }
    }
 


### PR DESCRIPTION
## Problem

`ScriptHostAccess.isVisibleToScripts` tested the operator-supplied
`script.java.allowed.classes` extras in the same condition as the curated
`ALLOWED_CLASSES` set, *before* consulting `BLOCKED_PACKAGES` and
`BLOCKED_CLASSES`:

```java
// exact allow wins: curated classes, SreeEnv extras, primitive arrays, jdk proxies.
if(ALLOWED_CLASSES.contains(fqcn) || extra.contains(fqcn) ||
   isPrimitiveArrayType(fqcn) || fqcn.startsWith("jdk.proxy"))
```

Naming a denied class in that property therefore made it resolvable through
`Java.type(...)`, and through the legacy package-root shim as well, since
`GraalJavaScriptEngine` hands the same predicate to `LegacyJavaShim` →
`JavaPackageProxy` and `BindingRootProxy`.

Three things mark this as an oversight rather than a decision:

1. **The sibling operator control already behaved correctly.**
   `javascript.java.packages` is consulted *after* both deny checks. Two
   operator-supplied allow controls in one method disagreed on precedence, and
   only one of them documented why.
2. **The javadoc asserted the opposite** — "Dangerous classes … are NOT on any
   allow path, so they stay blocked." They were on one: this one.
3. **`ALLOWED_CLASSES` earned its pre-deny position by audit** (the comment
   above it says so). The extras were folded into that `if` and inherited the
   exception silently.

### Impact

Not remotely exploitable and not urgent: setting a server property requires
administrator access. What makes it worth fixing is the gap between the control
and its documentation — the property reads as an additive extension but was in
fact a deny-list override, and scripts are authored by anyone with write access
to a dashboard, not only by administrators.

Worth noting that `java.lang.Runtime` is the *weakest* example, not the
strongest: `hostAccess()` independently calls `.denyAccess(...)` on `System`,
`Runtime`, `Process`, `ProcessBuilder`, `Thread`, `Class`, `ClassLoader` and the
reflect types, so naming `Runtime` let `Java.type` resolve it but left
`getRuntime()` blocked. The classes that genuinely crossed the boundary are the
ones with no member-level deny — `java.io.File`, `java.net.URL`,
`java.util.concurrent.*`, `inetsoft.util.Plugins`, `inetsoft.storage.*`,
`inetsoft.report.internal.license.*`.

**No deployment can currently be affected.** `script.java.allowed.classes` is
referenced nowhere else in either repo — no bundled `.properties` default, no EM
UI, no other reader — so it cannot be set without hand-editing
`sree.properties`.

## Change

- Move the `extra.contains(fqcn)` test below both deny checks. `ALLOWED_CLASSES`
  keeps its pre-deny position, since that precedence is deliberate and
  documented.
- Add a package-private `classFilter(Set<String> extra, String[] customPkgs,
  boolean comOrg)` overload; the public no-arg version delegates to it. This
  lets the precedence be tested without a Spring/`SreeEnv` context — the
  existing `SreeEnv` reads are already wrapped in `catch(Exception ignore)` for
  the same reason. `GraalJavaScriptEngine` is unchanged.
- Correct the `classFilter` javadoc and the deny-list header comment, and state
  in the javadoc that the extras are additive only.

`isAllowedObjectArray` recurses back into `isVisibleToScripts` with the same
`extra` set, so array component types follow the corrected precedence for free.

## Tests

Three new tests in `ScriptHostAccessTest`, which had no coverage of this
property at all:

- `extrasCannotUnblockBlockedClass` — `java.lang.Runtime` and `java.io.File` in
  the extras, both still denied (`BLOCKED_CLASSES`)
- `extrasCannotUnblockBlockedPackage` — `java.lang.reflect.Method` and
  `LicenseManager`, both still denied (`BLOCKED_PACKAGES`)
- `extrasStillAddNonBlockedClass` — the positive half, so the fix doesn't
  quietly neuter the property: `java.time.LocalDate` is denied without the entry
  and resolves with it

`ScriptHostAccessTest` 16/16 pass, including the four that pin deliberate
behavior (`curatedExactClassOverBlockedPackage`, `dangerousClassesStillBlocked`,
`uncuratedBlockedPackageClassDenied`, `threadingStaysBlocked`). The paths that
share the same predicate instance are green too: `LegacyJavaShimTest` 18,
`HostBeanProxyTest` 7, `ScriptUtilDateUnwrapTest` 2, `JSObjectTest` 15.

## Notes

Two adjacent issues found while reading `isVisibleToScripts`, deliberately left
alone here since both are documented main-branch Rhino parity and changing them
is a behavior decision rather than a bug fix:

- `fqcn.startsWith("java.sql")` under a FORM license runs before *everything*,
  including the deny lists, and is a dotless prefix — it exposes all of
  `java.sql.*` (e.g. `DriverManager`) despite `"java.sql"` being in
  `BLOCKED_PACKAGES`. `uncuratedBlockedPackageClassDenied` passes only because
  `isFormLicensed()` returns `false` without a license context.
- `DEFAULT_JAVA_PKGS` is matched with a dotless `startsWith`, so `java.awtFoo`
  matches.

Community-only change; no enterprise PR and the enterprise gitlink is untouched.

Related: #75423, the GraalJS cutover that introduced `isVisibleToScripts` as a
port of `SecureClassShutter.visibleToScripts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
