### PR TITLE
Bug #75950, #76328: set_ranking $(variable) binding, variable enumerated values

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
@@ -102,10 +102,9 @@ import java.util.Map;
  *   <li>{@code duplicate_assembly} — {@code table} (source), {@code name} (new name)</li>
  *   <li>{@code set_primary_assembly} — {@code table}</li>
  *   <li>{@code edit_variable} — {@code name}, {@code type}, {@code label}, {@code defaultValue};
- *       optional {@code values} (enumerated picker values — empty clears it, matching the
- *       Composer's own Variable dialog "Values"; omitted leaves it unchanged), optional
- *       {@code labels} (display labels parallel to {@code values}; defaults to {@code values}
- *       themselves), optional {@code multipleSelection} (checkbox/multi-select vs single-select)</li>
+ *       optional {@code choices} (the enumerated "Values" picker — embedded list or query
+ *       source, plus display style — matching the Composer's own Variable dialog; {@code null}
+ *       leaves it unchanged, see {@link WorksheetMutationSupport.VariableChoicesSpec})</li>
  *   <li>{@code rename_variable} — {@code name}, {@code newName}</li>
  *   <li>{@code delete_variable} — {@code name}</li>
  *   <li>{@code edit_named_group} — {@code name}, {@code groupMappings} (see {@code add_named_group}
@@ -146,10 +145,7 @@ public record EditRequest(
    String field,
    /** Comparison operator for add_filter, e.g. {@code "="}, {@code "!="}. */
    String operation,
-   /**
-    * Literal values for add_filter / edit_condition. Also doubles as the enumerated picker
-    * values for edit_variable (see {@code labels} and {@code multipleSelection}).
-    */
+   /** Literal values for add_filter / edit_condition. */
    List<String> values,
    /** Sort direction — {@code "ASC"} or {@code "DESC"} — for set_sort. */
    String direction,
@@ -331,16 +327,14 @@ public record EditRequest(
     * Optional custom bucket labels for add_numeric_range_column / edit_numeric_range_column —
     * one more entry than {@code boundaries} (below the first, one between each pair, above the
     * last). Omitted or empty keeps the engine's default auto-generated range text.
-    *
-    * <p>Also doubles as the display labels parallel to {@code values} for edit_variable
-    * (one-to-one with {@code values}, not the numeric-range "one more entry" shape above).
     */
    List<String> labels,
    /**
-    * {@code true} for a checkbox/multi-select enumerated picker, {@code false} for a
-    * single-select combobox, for edit_variable. Omit to leave unchanged.
+    * The variable's enumerated "Values" picker for edit_variable — either an embedded list or
+    * a query against an existing worksheet table's columns. {@code null} leaves it unchanged.
+    * See {@link WorksheetMutationSupport.VariableChoicesSpec}.
     */
-   Boolean multipleSelection
+   WorksheetMutationSupport.VariableChoicesSpec choices
 ) {
    /**
     * Compatibility constructor for callers built before {@code crosstab} was added —
@@ -376,7 +370,7 @@ public record EditRequest(
    }
 
    /**
-    * Compatibility constructor for callers built before {@code multipleSelection} was added —
+    * Compatibility constructor for callers built before {@code choices} was added —
     * defaults it to {@code null}.
     */
    public EditRequest(

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
@@ -101,7 +101,11 @@ import java.util.Map;
  *   <li>{@code set_assembly_position} — {@code table}, {@code x}, {@code y}</li>
  *   <li>{@code duplicate_assembly} — {@code table} (source), {@code name} (new name)</li>
  *   <li>{@code set_primary_assembly} — {@code table}</li>
- *   <li>{@code edit_variable} — {@code name}, {@code type}, {@code label}, {@code defaultValue}</li>
+ *   <li>{@code edit_variable} — {@code name}, {@code type}, {@code label}, {@code defaultValue};
+ *       optional {@code values} (enumerated picker values — empty clears it, matching the
+ *       Composer's own Variable dialog "Values"; omitted leaves it unchanged), optional
+ *       {@code labels} (display labels parallel to {@code values}; defaults to {@code values}
+ *       themselves), optional {@code multipleSelection} (checkbox/multi-select vs single-select)</li>
  *   <li>{@code rename_variable} — {@code name}, {@code newName}</li>
  *   <li>{@code delete_variable} — {@code name}</li>
  *   <li>{@code edit_named_group} — {@code name}, {@code groupMappings} (see {@code add_named_group}
@@ -142,7 +146,10 @@ public record EditRequest(
    String field,
    /** Comparison operator for add_filter, e.g. {@code "="}, {@code "!="}. */
    String operation,
-   /** Literal values for add_filter. */
+   /**
+    * Literal values for add_filter / edit_condition. Also doubles as the enumerated picker
+    * values for edit_variable (see {@code labels} and {@code multipleSelection}).
+    */
    List<String> values,
    /** Sort direction — {@code "ASC"} or {@code "DESC"} — for set_sort. */
    String direction,
@@ -324,8 +331,16 @@ public record EditRequest(
     * Optional custom bucket labels for add_numeric_range_column / edit_numeric_range_column —
     * one more entry than {@code boundaries} (below the first, one between each pair, above the
     * last). Omitted or empty keeps the engine's default auto-generated range text.
+    *
+    * <p>Also doubles as the display labels parallel to {@code values} for edit_variable
+    * (one-to-one with {@code values}, not the numeric-range "one more entry" shape above).
     */
-   List<String> labels
+   List<String> labels,
+   /**
+    * {@code true} for a checkbox/multi-select enumerated picker, {@code false} for a
+    * single-select combobox, for edit_variable. Omit to leave unchanged.
+    */
+   Boolean multipleSelection
 ) {
    /**
     * Compatibility constructor for callers built before {@code crosstab} was added —
@@ -358,5 +373,39 @@ public record EditRequest(
            groupOthers, variableValues, x, y, label, defaultValue, mode, insert, subtables,
            sourceTable, attribute, endpoint, parameters, lookup, lookupExpandArrays,
            lookupTopLevelOnly, suffix, customLookups, null, null);
+   }
+
+   /**
+    * Compatibility constructor for callers built before {@code multipleSelection} was added —
+    * defaults it to {@code null}.
+    */
+   public EditRequest(
+      String op, String table, String column, String name, String type, String newName,
+      String field, String operation, List<String> values, String direction,
+      List<WorksheetMutationSupport.GroupSpec> groups,
+      List<WorksheetMutationSupport.AggregateSpec> aggregates, String expression, boolean sql,
+      String leftTable, String leftKey, String rightTable, String rightKey, String joinType,
+      Boolean visible, List<String> tables, String source, String concatType,
+      List<WorksheetMutationSupport.ConditionNode> conditions,
+      WorksheetMutationSupport.RankingSpec ranking, Integer headerColumns, String dateOption,
+      double[] boundaries, String datasource, String schema, String catalog, String logicalModel,
+      List<String> leftKeys, List<String> rightKeys, Integer row, Integer col, String value,
+      Integer index, String alias, String description, Integer maxRows, Boolean distinct,
+      List<String> columnOrder, List<WorksheetMutationSupport.GroupMapping> groupMappings,
+      Boolean groupOthers, Map<String, String> variableValues, Integer x, Integer y, String label,
+      String defaultValue, String mode, Boolean insert, List<String> subtables,
+      String sourceTable, String attribute, String endpoint, Map<String, String> parameters,
+      List<String> lookup, Boolean lookupExpandArrays, Boolean lookupTopLevelOnly, String suffix,
+      List<WorksheetMutationSupport.CustomLookupSpec> customLookups, Boolean crosstab,
+      List<String> labels)
+   {
+      this(op, table, column, name, type, newName, field, operation, values, direction, groups,
+           aggregates, expression, sql, leftTable, leftKey, rightTable, rightKey, joinType,
+           visible, tables, source, concatType, conditions, ranking, headerColumns, dateOption,
+           boundaries, datasource, schema, catalog, logicalModel, leftKeys, rightKeys, row, col,
+           value, index, alias, description, maxRows, distinct, columnOrder, groupMappings,
+           groupOthers, variableValues, x, y, label, defaultValue, mode, insert, subtables,
+           sourceTable, attribute, endpoint, parameters, lookup, lookupExpandArrays,
+           lookupTopLevelOnly, suffix, customLookups, crosstab, labels, null);
    }
 }

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -1846,7 +1846,8 @@ public class WorksheetAgentController {
          case "set_primary_assembly" ->
             editor.setPrimaryAssembly(req.table());
          case "edit_variable" ->
-            editor.editVariable(req.name(), req.type(), req.label(), req.defaultValue());
+            editor.editVariable(req.name(), req.type(), req.label(), req.defaultValue(),
+                                req.values(), req.labels(), req.multipleSelection());
          case "rename_variable" ->
             editor.renameVariable(req.name(), req.newName());
          case "delete_variable" ->
@@ -2421,17 +2422,26 @@ public class WorksheetAgentController {
 
       editService.applyOnRuntime(sessionToken, user, rws -> {
          Worksheet ws = rws.getWorksheet();
-         createVariable(ws, varName, req.type(), req.label(), req.defaultValue());
+         createVariable(ws, varName, req.type(), req.label(), req.defaultValue(),
+                        req.values(), req.labels(), req.multipleSelection());
          return null;
       });
    }
 
    /**
     * Shared helper that creates a {@link DefaultVariableAssembly} with the given
-    * name, type, label, and default value.
+    * name, type, label, default value, and (optional) enumerated value list.
+    *
+    * @param values enumerated picker values ("Values" in the Composer's own Variable
+    *               dialog), or {@code null}/empty to leave the variable free-form
+    * @param labels display labels parallel to {@code values}; defaults to {@code values}
+    *               themselves when {@code null}/empty
+    * @param multipleSelection {@code true} for a checkbox/multi-select picker, {@code false}
+    *               (or {@code null}) for a single-select combobox
     */
-   private void createVariable(Worksheet ws, String name, String type,
-                               String label, String defaultValue)
+   private void createVariable(Worksheet ws, String name, String type, String label,
+                               String defaultValue, List<String> values, List<String> labels,
+                               Boolean multipleSelection)
       throws PairingException
    {
       if(ws.getAssembly(name) != null) {
@@ -2480,6 +2490,8 @@ public class WorksheetAgentController {
             var.setValueNode(valueNode);
          }
       }
+
+      WorksheetMutationSupport.applyVariableChoices(var, values, labels, multipleSelection);
 
       DefaultVariableAssembly assembly = new DefaultVariableAssembly(ws, name);
       assembly.setVariable(var);
@@ -2585,8 +2597,17 @@ public class WorksheetAgentController {
    // Variables endpoint
    // ---------------------------------------------------------------------------
 
-   public record VariableRequest(String name, String type, String label,
-                                 String defaultValue) {}
+   /**
+    * @param values enumerated picker values ("Values" in the Composer's own Variable dialog),
+    *               or {@code null}/empty for a free-form value
+    * @param labels display labels parallel to {@code values}; defaults to {@code values}
+    *               themselves when {@code null}/empty
+    * @param multipleSelection {@code true} for a checkbox/multi-select picker, {@code false}
+    *               (or {@code null}) for a single-select combobox
+    */
+   public record VariableRequest(String name, String type, String label, String defaultValue,
+                                 List<String> values, List<String> labels,
+                                 Boolean multipleSelection) {}
 
    /**
     * Add a user variable to the worksheet.
@@ -2605,7 +2626,8 @@ public class WorksheetAgentController {
 
       editService.applyOnRuntime(sessionToken, user, rws -> {
          Worksheet ws = rws.getWorksheet();
-         createVariable(ws, body.name(), body.type(), body.label(), body.defaultValue());
+         createVariable(ws, body.name(), body.type(), body.label(), body.defaultValue(),
+                        body.values(), body.labels(), body.multipleSelection());
          return null;
       });
    }

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -1847,7 +1847,7 @@ public class WorksheetAgentController {
             editor.setPrimaryAssembly(req.table());
          case "edit_variable" ->
             editor.editVariable(req.name(), req.type(), req.label(), req.defaultValue(),
-                                req.values(), req.labels(), req.multipleSelection());
+                                req.choices());
          case "rename_variable" ->
             editor.renameVariable(req.name(), req.newName());
          case "delete_variable" ->
@@ -2422,26 +2422,21 @@ public class WorksheetAgentController {
 
       editService.applyOnRuntime(sessionToken, user, rws -> {
          Worksheet ws = rws.getWorksheet();
-         createVariable(ws, varName, req.type(), req.label(), req.defaultValue(),
-                        req.values(), req.labels(), req.multipleSelection());
+         createVariable(ws, varName, req.type(), req.label(), req.defaultValue(), req.choices());
          return null;
       });
    }
 
    /**
     * Shared helper that creates a {@link DefaultVariableAssembly} with the given
-    * name, type, label, default value, and (optional) enumerated value list.
+    * name, type, label, default value, and (optional) enumerated value picker.
     *
-    * @param values enumerated picker values ("Values" in the Composer's own Variable
-    *               dialog), or {@code null}/empty to leave the variable free-form
-    * @param labels display labels parallel to {@code values}; defaults to {@code values}
-    *               themselves when {@code null}/empty
-    * @param multipleSelection {@code true} for a checkbox/multi-select picker, {@code false}
-    *               (or {@code null}) for a single-select combobox
+    * @param choices the variable's enumerated "Values" picker (embedded list or query
+    *               source), or {@code null} to leave the variable free-form
     */
    private void createVariable(Worksheet ws, String name, String type, String label,
-                               String defaultValue, List<String> values, List<String> labels,
-                               Boolean multipleSelection)
+                               String defaultValue,
+                               WorksheetMutationSupport.VariableChoicesSpec choices)
       throws PairingException
    {
       if(ws.getAssembly(name) != null) {
@@ -2491,7 +2486,7 @@ public class WorksheetAgentController {
          }
       }
 
-      WorksheetMutationSupport.applyVariableChoices(var, values, labels, multipleSelection);
+      WorksheetMutationSupport.applyVariableChoices(ws, var, choices);
 
       DefaultVariableAssembly assembly = new DefaultVariableAssembly(ws, name);
       assembly.setVariable(var);
@@ -2598,16 +2593,11 @@ public class WorksheetAgentController {
    // ---------------------------------------------------------------------------
 
    /**
-    * @param values enumerated picker values ("Values" in the Composer's own Variable dialog),
-    *               or {@code null}/empty for a free-form value
-    * @param labels display labels parallel to {@code values}; defaults to {@code values}
-    *               themselves when {@code null}/empty
-    * @param multipleSelection {@code true} for a checkbox/multi-select picker, {@code false}
-    *               (or {@code null}) for a single-select combobox
+    * @param choices the variable's enumerated "Values" picker (embedded list or query
+    *               source), or {@code null} for a free-form value
     */
    public record VariableRequest(String name, String type, String label, String defaultValue,
-                                 List<String> values, List<String> labels,
-                                 Boolean multipleSelection) {}
+                                 WorksheetMutationSupport.VariableChoicesSpec choices) {}
 
    /**
     * Add a user variable to the worksheet.
@@ -2627,7 +2617,7 @@ public class WorksheetAgentController {
       editService.applyOnRuntime(sessionToken, user, rws -> {
          Worksheet ws = rws.getWorksheet();
          createVariable(ws, body.name(), body.type(), body.label(), body.defaultValue(),
-                        body.values(), body.labels(), body.multipleSelection());
+                        body.choices());
          return null;
       });
    }

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -2260,9 +2260,18 @@ public class WorksheetEditService {
        * @param type         new data type, or {@code null} to leave unchanged
        * @param label        new display label, or {@code null} to leave unchanged
        * @param defaultValue new default value, or {@code null} to leave unchanged
+       * @param values       enumerated picker values ("Values" in the Composer's own Variable
+       *                     dialog) — empty clears it back to free-form, {@code null} leaves it
+       *                     unchanged
+       * @param labels       display labels parallel to {@code values}; defaults to
+       *                     {@code values} themselves when {@code null}/empty
+       * @param multipleSelection {@code true} for a checkbox/multi-select picker, {@code false}
+       *                     for a single-select combobox, or {@code null} to leave unchanged
        * @throws PairingException if the assembly is not found or not a variable
        */
-      public void editVariable(String name, String type, String label, String defaultValue)
+      public void editVariable(String name, String type, String label, String defaultValue,
+                               List<String> values, List<String> labels,
+                               Boolean multipleSelection)
          throws PairingException
       {
          Assembly a = ws.getAssembly(name);
@@ -2305,6 +2314,8 @@ public class WorksheetEditService {
                var.setValueNode(valueNode);
             }
          }
+
+         WorksheetMutationSupport.applyVariableChoices(var, values, labels, multipleSelection);
       }
 
       /**

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -2260,18 +2260,12 @@ public class WorksheetEditService {
        * @param type         new data type, or {@code null} to leave unchanged
        * @param label        new display label, or {@code null} to leave unchanged
        * @param defaultValue new default value, or {@code null} to leave unchanged
-       * @param values       enumerated picker values ("Values" in the Composer's own Variable
-       *                     dialog) — empty clears it back to free-form, {@code null} leaves it
-       *                     unchanged
-       * @param labels       display labels parallel to {@code values}; defaults to
-       *                     {@code values} themselves when {@code null}/empty
-       * @param multipleSelection {@code true} for a checkbox/multi-select picker, {@code false}
-       *                     for a single-select combobox, or {@code null} to leave unchanged
+       * @param choices      the variable's enumerated "Values" picker (embedded list or query
+       *                     source), or {@code null} to leave it unchanged
        * @throws PairingException if the assembly is not found or not a variable
        */
       public void editVariable(String name, String type, String label, String defaultValue,
-                               List<String> values, List<String> labels,
-                               Boolean multipleSelection)
+                               WorksheetMutationSupport.VariableChoicesSpec choices)
          throws PairingException
       {
          Assembly a = ws.getAssembly(name);
@@ -2315,7 +2309,7 @@ public class WorksheetEditService {
             }
          }
 
-         WorksheetMutationSupport.applyVariableChoices(var, values, labels, multipleSelection);
+         WorksheetMutationSupport.applyVariableChoices(ws, var, choices);
       }
 
       /**

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -2274,11 +2274,19 @@ public class WorksheetEditService {
             throw new PairingException("Variable assembly not found: " + name);
          }
 
-         AssetVariable var = va.getVariable();
+         AssetVariable existing = va.getVariable();
 
-         if(var == null) {
+         if(existing == null) {
             throw new PairingException("Variable has no definition: " + name);
          }
+
+         // Every edit below is applied to a scratch copy, published only at the very end.
+         // applyOnRuntime mutates the live worksheet with no rollback on a thrown exception, so
+         // editing 'existing' in place would let an invalid 'choices' (mismatched labels/values,
+         // an unknown displayStyle, a circular query source, ...) discovered partway through
+         // leave the already-applied label/type/defaultValue changes committed even though the
+         // whole call is reported as a failure.
+         AssetVariable var = (AssetVariable) existing.clone();
 
          if(label != null) {
             var.setAlias(label);
@@ -2310,6 +2318,8 @@ public class WorksheetEditService {
          }
 
          WorksheetMutationSupport.applyVariableChoices(ws, var, choices);
+
+         va.setVariable(var);
       }
 
       /**

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -1548,6 +1548,25 @@ public final class WorksheetMutationSupport {
             "), got " + labels.size() + ".");
       }
 
+      String type = var.getTypeNode() != null ? var.getTypeNode().getType() : XSchema.STRING;
+      Object[] typedValues = new Object[values.size()];
+
+      for(int i = 0; i < values.size(); i++) {
+         String v = values.get(i);
+         Object typed = Tool.getData(type, v);
+
+         // Tool.getData silently returns null for an entry that doesn't parse as 'type' (e.g.
+         // "abc" for an integer variable) instead of throwing -- fail loud here instead,
+         // matching every other validation in this method, rather than writing a value whose
+         // label ('v') and underlying null value end up silently out of sync.
+         if(typed == null && v != null && !v.isEmpty()) {
+            throw new IllegalArgumentException(
+               "'values' entry \"" + v + "\" is not a valid " + type + " value.");
+         }
+
+         typedValues[i] = typed;
+      }
+
       // Switching to embedded mode must clear any leftover query-mode source -- otherwise
       // AssetVariable carries both a non-null tableName AND populated choices/values, and the
       // Composer's own read path (VariableAssemblyDialogService) treats a non-null tableName as
@@ -1563,7 +1582,6 @@ public final class WorksheetMutationSupport {
       }
 
       List<String> effectiveLabels = labels != null && !labels.isEmpty() ? labels : values;
-      String type = var.getTypeNode() != null ? var.getTypeNode().getType() : XSchema.STRING;
 
       // UserVariable defaults sortValue to true, which silently re-sorts choices/values
       // alphabetically by label the moment both arrays are set -- discarding the caller's
@@ -1571,7 +1589,7 @@ public final class WorksheetMutationSupport {
       // Variable dialog) always disables it for the same reason; match that here.
       var.setSortValue(false);
       var.setChoices(effectiveLabels.toArray());
-      var.setValues(values.stream().map(v -> Tool.getData(type, v)).toArray());
+      var.setValues(typedValues);
    }
 
    private static void applyQueryVariableChoices(Worksheet ws, AssetVariable var, String table,

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -34,6 +34,7 @@ import inetsoft.uql.jdbc.UniformSQL;
 import inetsoft.uql.path.XSelection;
 import inetsoft.uql.schema.UserVariable;
 import inetsoft.uql.schema.XSchema;
+import inetsoft.util.Tool;
 import inetsoft.web.wiz.pairing.PairingException;
 
 import java.util.*;
@@ -1366,7 +1367,10 @@ public final class WorksheetMutationSupport {
     * Describes a ranking condition.
     *
     * @param field     column to rank — a group/dimension column or an aggregate column
-    * @param n         number of rows (top/bottom N)
+    * @param n         number of rows (top/bottom N) — an {@link Integer}, a numeric
+    *                  {@link String}, or a {@code "$(variableName)"} reference to bind the
+    *                  count to a worksheet variable (same syntax filter condition values
+    *                  support). See {@link RankingCondition#setN}.
     * @param operation {@code "TOP_N"} or {@code "BOTTOM_N"}
     * @param groupOthers {@code true} to group remaining rows as "Others"
     * @param of        optional aggregate column to rank {@code field} by (e.g. {@code field}
@@ -1375,13 +1379,13 @@ public final class WorksheetMutationSupport {
     *                  ranking-condition editor. Only meaningful when {@code field} is a group
     *                  column; omit when {@code field} is itself the aggregate to rank by.
     */
-   public record RankingSpec(String field, int n, String operation,
+   public record RankingSpec(String field, Object n, String operation,
                              boolean groupOthers, String of) {
       /**
        * Compact form for callers that don't need {@code of} (e.g. ranking directly by an
        * aggregate or group column with no separate "of" value).
        */
-      public RankingSpec(String field, int n, String operation, boolean groupOthers) {
+      public RankingSpec(String field, Object n, String operation, boolean groupOthers) {
          this(field, n, operation, groupOthers, null);
       }
    }
@@ -1414,7 +1418,12 @@ public final class WorksheetMutationSupport {
 
       inetsoft.uql.asset.RankingCondition rc = new inetsoft.uql.asset.RankingCondition();
       rc.setOperation(op);
-      rc.setN(spec.n());
+
+      if(!rc.setN(spec.n())) {
+         throw new IllegalArgumentException(
+            "'n' must be an integer or a \"$(variableName)\" reference, got: " + spec.n());
+      }
+
       rc.setGroupOthers(spec.groupOthers());
 
       if(spec.of() != null && !spec.of().isBlank()) {
@@ -1428,6 +1437,72 @@ public final class WorksheetMutationSupport {
       ConditionList cl = new ConditionList();
       cl.append(new ConditionItem(ref, rc, 0));
       t.setRankingConditionList(cl);
+   }
+
+   /**
+    * Populates a variable's enumerated value list — the "Values" picker in the Composer's own
+    * Variable dialog — from parallel {@code values}/{@code labels} lists, matching
+    * {@link UserVariable#setValues}/{@link UserVariable#setChoices}. Mirrors
+    * {@code VariableAssemblyDialogService.convertModelToAssetVariable}, the Composer dialog's
+    * own implementation of the same conversion.
+    *
+    * <p>{@code values} empty clears any existing enumeration (reverts the variable to a
+    * free-form value); {@code null} leaves the existing enumeration untouched. When
+    * {@code labels} is null/empty, {@code values} double as their own display labels.
+    *
+    * <p>Also sets {@link AssetVariable#setDisplayStyle}: unlike the base
+    * {@link UserVariable#getDisplayStyle}, {@link AssetVariable} does not auto-derive its
+    * display style from whether choices/values are present, it only returns whatever was last
+    * explicitly stored — so a picker populated without this would carry values the Composer's
+    * own Variable UI never renders a control for. Style is recomputed whenever either
+    * {@code values} or {@code multipleSelection} is touched this call, so toggling one without
+    * resupplying the other still leaves the style consistent with the current state.
+    *
+    * @param var    the variable to populate; if its type node is already set, that determines
+    *               how each entry in {@code values} is typed, otherwise entries are typed as
+    *               {@link XSchema#STRING}
+    * @param values raw enumerated values, or {@code null} to leave unchanged
+    * @param labels display labels parallel to {@code values}; must be the same length if given
+    * @param multipleSelection {@code true} for a checkbox/multi-select picker, {@code false}
+    *               for a single-select combobox, or {@code null} to leave unchanged
+    */
+   public static void applyVariableChoices(AssetVariable var, List<String> values,
+                                           List<String> labels, Boolean multipleSelection)
+   {
+      if(multipleSelection != null) {
+         var.setMultipleSelection(multipleSelection);
+      }
+
+      if(values != null) {
+         if(values.isEmpty()) {
+            var.setChoices(null);
+            var.setValues(null);
+         }
+         else {
+            if(labels != null && !labels.isEmpty() && labels.size() != values.size()) {
+               throw new IllegalArgumentException(
+                  "'labels' must have the same number of entries as 'values' (" +
+                  values.size() + "), got " + labels.size() + ".");
+            }
+
+            List<String> effectiveLabels = labels != null && !labels.isEmpty() ? labels : values;
+            String type = var.getTypeNode() != null ? var.getTypeNode().getType() : XSchema.STRING;
+
+            // UserVariable defaults sortValue to true, which silently re-sorts choices/values
+            // alphabetically by label the moment both arrays are set -- discarding the caller's
+            // intended order with no error. VariableAssemblyDialogService (the Composer's own
+            // Variable dialog) always disables it for the same reason; match that here.
+            var.setSortValue(false);
+            var.setChoices(effectiveLabels.toArray());
+            var.setValues(values.stream().map(v -> Tool.getData(type, v)).toArray());
+         }
+      }
+
+      if(values != null || multipleSelection != null) {
+         var.setDisplayStyle(var.getChoices() != null && var.getValues() != null
+            ? (var.isMultipleSelection() ? UserVariable.LIST : UserVariable.COMBOBOX)
+            : UserVariable.NONE);
+      }
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -1440,69 +1440,190 @@ public final class WorksheetMutationSupport {
    }
 
    /**
-    * Populates a variable's enumerated value list — the "Values" picker in the Composer's own
-    * Variable dialog — from parallel {@code values}/{@code labels} lists, matching
-    * {@link UserVariable#setValues}/{@link UserVariable#setChoices}. Mirrors
+    * Describes a variable's enumerated "Values" picker. The Composer's own Variable dialog
+    * offers two mutually exclusive ways to populate it: a fixed embedded list ({@code values},
+    * optionally paired with {@code labels}), or a query against an existing worksheet table's
+    * columns ({@code table} + {@code labelColumn} + {@code valueColumn}). Specifying both
+    * {@code values} and {@code table} in the same spec is rejected rather than silently
+    * preferring one.
+    *
+    * @param values       embedded picker values; empty clears the picker back to free-form,
+    *                     {@code null} leaves any existing embedded list untouched. Mutually
+    *                     exclusive with {@code table}.
+    * @param labels       display labels parallel to {@code values}; must be the same length
+    *                     if given, otherwise {@code values} double as their own labels
+    * @param table        worksheet table supplying picker rows (query mode); {@code null}
+    *                     leaves any existing query source untouched. Mutually exclusive with
+    *                     {@code values}.
+    * @param labelColumn  column on {@code table} supplying each row's display label; required
+    *                     when {@code table} is given
+    * @param valueColumn  column on {@code table} supplying each row's underlying value;
+    *                     required when {@code table} is given
+    * @param displayStyle {@code "none"}, {@code "combobox"}, {@code "list"}, {@code "radio"},
+    *                     or {@code "checkboxes"} — matches the Composer's own picker style
+    *                     choices. {@code null} leaves the existing style untouched unless
+    *                     {@code values} or {@code table} was also given this call, in which
+    *                     case it defaults to {@code "combobox"}.
+    */
+   public record VariableChoicesSpec(List<String> values, List<String> labels, String table,
+                                     String labelColumn, String valueColumn,
+                                     String displayStyle) {}
+
+   /**
+    * Populates a variable's enumerated value list from a {@link VariableChoicesSpec}, matching
+    * {@link UserVariable#setValues}/{@link UserVariable#setChoices} (embedded mode) or
+    * {@link AssetVariable#setTableName}/{@link AssetVariable#setLabelAttribute}/
+    * {@link AssetVariable#setValueAttribute} (query mode). Mirrors
     * {@code VariableAssemblyDialogService.convertModelToAssetVariable}, the Composer dialog's
     * own implementation of the same conversion.
-    *
-    * <p>{@code values} empty clears any existing enumeration (reverts the variable to a
-    * free-form value); {@code null} leaves the existing enumeration untouched. When
-    * {@code labels} is null/empty, {@code values} double as their own display labels.
     *
     * <p>Also sets {@link AssetVariable#setDisplayStyle}: unlike the base
     * {@link UserVariable#getDisplayStyle}, {@link AssetVariable} does not auto-derive its
     * display style from whether choices/values are present, it only returns whatever was last
     * explicitly stored — so a picker populated without this would carry values the Composer's
-    * own Variable UI never renders a control for. Style is recomputed whenever either
-    * {@code values} or {@code multipleSelection} is touched this call, so toggling one without
-    * resupplying the other still leaves the style consistent with the current state.
+    * own Variable UI never renders a control for.
     *
-    * @param var    the variable to populate; if its type node is already set, that determines
-    *               how each entry in {@code values} is typed, otherwise entries are typed as
-    *               {@link XSchema#STRING}
-    * @param values raw enumerated values, or {@code null} to leave unchanged
-    * @param labels display labels parallel to {@code values}; must be the same length if given
-    * @param multipleSelection {@code true} for a checkbox/multi-select picker, {@code false}
-    *               for a single-select combobox, or {@code null} to leave unchanged
+    * @param ws   the worksheet {@code spec.table()} is resolved against (query mode only)
+    * @param var  the variable to populate; if its type node is already set, that determines
+    *             how each entry in embedded {@code values} is typed, otherwise entries are
+    *             typed as {@link XSchema#STRING}
+    * @param spec the picker to apply, or {@code null} to leave the variable's picker untouched
     */
-   public static void applyVariableChoices(AssetVariable var, List<String> values,
-                                           List<String> labels, Boolean multipleSelection)
+   public static void applyVariableChoices(Worksheet ws, AssetVariable var,
+                                           VariableChoicesSpec spec)
    {
-      if(multipleSelection != null) {
-         var.setMultipleSelection(multipleSelection);
+      if(spec == null) {
+         return;
       }
 
-      if(values != null) {
-         if(values.isEmpty()) {
-            var.setChoices(null);
-            var.setValues(null);
-         }
-         else {
-            if(labels != null && !labels.isEmpty() && labels.size() != values.size()) {
-               throw new IllegalArgumentException(
-                  "'labels' must have the same number of entries as 'values' (" +
-                  values.size() + "), got " + labels.size() + ".");
-            }
+      boolean hasValues = spec.values() != null;
+      boolean hasTable = spec.table() != null;
 
-            List<String> effectiveLabels = labels != null && !labels.isEmpty() ? labels : values;
-            String type = var.getTypeNode() != null ? var.getTypeNode().getType() : XSchema.STRING;
-
-            // UserVariable defaults sortValue to true, which silently re-sorts choices/values
-            // alphabetically by label the moment both arrays are set -- discarding the caller's
-            // intended order with no error. VariableAssemblyDialogService (the Composer's own
-            // Variable dialog) always disables it for the same reason; match that here.
-            var.setSortValue(false);
-            var.setChoices(effectiveLabels.toArray());
-            var.setValues(values.stream().map(v -> Tool.getData(type, v)).toArray());
-         }
+      if(hasValues && hasTable) {
+         throw new IllegalArgumentException(
+            "'values' and 'table' are mutually exclusive ways to populate a variable's " +
+            "picker -- specify one or the other, not both.");
       }
 
-      if(values != null || multipleSelection != null) {
-         var.setDisplayStyle(var.getChoices() != null && var.getValues() != null
-            ? (var.isMultipleSelection() ? UserVariable.LIST : UserVariable.COMBOBOX)
-            : UserVariable.NONE);
+      // Parsed up front, before any mutation below: applyOnRuntime mutates the live worksheet
+      // directly with no rollback on a thrown exception (see WorksheetEditService.apply), so an
+      // invalid displayStyle discovered only after values/table were already applied would
+      // leave the variable half-updated -- state committed, call still reported as failed.
+      Integer explicitStyle = spec.displayStyle() != null
+         ? parseVariableDisplayStyle(spec.displayStyle()) : null;
+
+      if(hasValues) {
+         applyEmbeddedVariableChoices(var, spec.values(), spec.labels());
       }
+      else if(hasTable) {
+         applyQueryVariableChoices(ws, var, spec.table(), spec.labelColumn(), spec.valueColumn());
+      }
+
+      if(explicitStyle != null) {
+         var.setDisplayStyle(explicitStyle);
+         var.setMultipleSelection(explicitStyle == UserVariable.LIST);
+      }
+      else if(hasValues || hasTable) {
+         // A picker source was (re)supplied but no explicit style was given -- default to a
+         // single-select combobox unless the source ended up empty (no picker at all), which
+         // must read back as NONE or the Composer UI shows a combobox with nothing in it.
+         boolean hasPicker = var.getTableName() != null ||
+            var.getChoices() != null && var.getValues() != null;
+         var.setDisplayStyle(hasPicker ? UserVariable.COMBOBOX : UserVariable.NONE);
+         var.setMultipleSelection(false);
+      }
+   }
+
+   private static void applyEmbeddedVariableChoices(AssetVariable var, List<String> values,
+                                                     List<String> labels)
+   {
+      // Validated before any mutation below -- see the comment on applyVariableChoices'
+      // displayStyle parse for why a validation failure must never land after a partial write.
+      if(!values.isEmpty() && labels != null && !labels.isEmpty() &&
+         labels.size() != values.size())
+      {
+         throw new IllegalArgumentException(
+            "'labels' must have the same number of entries as 'values' (" + values.size() +
+            "), got " + labels.size() + ".");
+      }
+
+      // Switching to embedded mode must clear any leftover query-mode source -- otherwise
+      // AssetVariable carries both a non-null tableName AND populated choices/values, and the
+      // Composer's own read path (VariableAssemblyDialogService) treats a non-null tableName as
+      // query mode unconditionally, silently ignoring the embedded list this call just set.
+      var.setTableName(null);
+      var.setLabelAttribute(null);
+      var.setValueAttribute(null);
+
+      if(values.isEmpty()) {
+         var.setChoices(null);
+         var.setValues(null);
+         return;
+      }
+
+      List<String> effectiveLabels = labels != null && !labels.isEmpty() ? labels : values;
+      String type = var.getTypeNode() != null ? var.getTypeNode().getType() : XSchema.STRING;
+
+      // UserVariable defaults sortValue to true, which silently re-sorts choices/values
+      // alphabetically by label the moment both arrays are set -- discarding the caller's
+      // intended order with no error. VariableAssemblyDialogService (the Composer's own
+      // Variable dialog) always disables it for the same reason; match that here.
+      var.setSortValue(false);
+      var.setChoices(effectiveLabels.toArray());
+      var.setValues(values.stream().map(v -> Tool.getData(type, v)).toArray());
+   }
+
+   private static void applyQueryVariableChoices(Worksheet ws, AssetVariable var, String table,
+                                                  String labelColumn, String valueColumn)
+   {
+      if(labelColumn == null || valueColumn == null) {
+         throw new IllegalArgumentException(
+            "'labelColumn' and 'valueColumn' are both required when 'table' is given.");
+      }
+
+      Assembly a = ws.getAssembly(table);
+
+      if(!(a instanceof TableAssembly t)) {
+         throw new IllegalArgumentException("Worksheet table not found: " + table);
+      }
+
+      DataRef labelRef = resolveField(t, labelColumn);
+      DataRef valueRef = resolveField(t, valueColumn);
+
+      if(labelRef == null) {
+         throw new IllegalArgumentException(
+            "'labelColumn' not found on table '" + table + "': " + labelColumn);
+      }
+
+      if(valueRef == null) {
+         throw new IllegalArgumentException(
+            "'valueColumn' not found on table '" + table + "': " + valueColumn);
+      }
+
+      // Switching to query mode must clear any leftover embedded list for the same reason
+      // applyEmbeddedVariableChoices clears the table name -- the two sources are mutually
+      // exclusive in how the Composer's own dialog reads a variable back.
+      var.setChoices(null);
+      var.setValues(null);
+      var.setTableName(table);
+      var.setLabelAttribute(labelRef);
+      var.setValueAttribute(valueRef);
+   }
+
+   /**
+    * Maps a display-style token to its {@link UserVariable} constant.
+    */
+   private static int parseVariableDisplayStyle(String style) {
+      return switch(style.toLowerCase()) {
+         case "none" -> UserVariable.NONE;
+         case "combobox" -> UserVariable.COMBOBOX;
+         case "list" -> UserVariable.LIST;
+         case "radio", "radio_buttons" -> UserVariable.RADIO_BUTTONS;
+         case "checkboxes" -> UserVariable.CHECKBOXES;
+         default -> throw new IllegalArgumentException(
+            "'" + style + "' is not a display style. Accepted: none, combobox, list, radio, " +
+            "checkboxes.");
+      };
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import inetsoft.uql.*;
 import inetsoft.uql.asset.*;
+import inetsoft.uql.asset.internal.AssetUtil;
 import inetsoft.uql.erm.AttributeRef;
 import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.erm.DataRefWrapper;
@@ -1600,6 +1601,8 @@ public final class WorksheetMutationSupport {
             "'valueColumn' not found on table '" + table + "': " + valueColumn);
       }
 
+      checkNoCircularVariableDependency(ws, var, t);
+
       // Switching to query mode must clear any leftover embedded list for the same reason
       // applyEmbeddedVariableChoices clears the table name -- the two sources are mutually
       // exclusive in how the Composer's own dialog reads a variable back.
@@ -1608,6 +1611,77 @@ public final class WorksheetMutationSupport {
       var.setTableName(table);
       var.setLabelAttribute(labelRef);
       var.setValueAttribute(valueRef);
+   }
+
+   /**
+    * Rejects a query-mode picker source that would create a circular dependency:
+    * {@code table} (or anything it depends on -- mirrors, joins, concatenations, recursively,
+    * via {@link AssetUtil#getDependedAssemblies}) carrying a filter or ranking condition that
+    * reads {@code $(var.getName())}. Computing the picker's own values would then require the
+    * variable's value first, which is exactly what the picker exists to supply.
+    *
+    * <p>Confirmed live (2026-08-26): mirroring a table whose own ranking condition read
+    * {@code $(TopN)}, then pointing {@code $(TopN)}'s picker at that mirror, silently built
+    * this cycle -- a query-mode variable picker is a worksheet-chat-only capability with no
+    * Composer dialog equivalent to catch it by construction, so it needs its own guard here.
+    */
+   private static void checkNoCircularVariableDependency(Worksheet ws, AssetVariable var,
+                                                          TableAssembly table)
+   {
+      String varName = var.getName();
+      Assembly[] deps = AssetUtil.getDependedAssemblies(ws, table, true);
+
+      for(Assembly a : deps) {
+         if(!(a instanceof TableAssembly t)) {
+            continue;
+         }
+
+         boolean referenced = referencesVariable(t.getPreConditionList(), varName) ||
+            referencesVariable(t.getPostConditionList(), varName) ||
+            referencesVariable(t.getRankingConditionList(), varName);
+
+         if(referenced) {
+            String via = t == table ? "" : " (depended on by '" + table.getName() + "')";
+            throw new IllegalArgumentException(
+               "'table' creates a circular dependency: '" + t.getName() + "'" + via +
+               " has a condition that reads $(" + varName + ") -- computing the picker's own " +
+               "values would require the variable's value first. Point the picker at a table " +
+               "that does not depend on this variable, e.g. an independent copy with its own " +
+               "conditions cleared, not a mirror of the filtered table.");
+         }
+      }
+   }
+
+   /**
+    * {@code true} if any condition in {@code wrapper} reads {@code $(varName)}.
+    */
+   private static boolean referencesVariable(ConditionListWrapper wrapper, String varName) {
+      if(wrapper == null || wrapper.isEmpty()) {
+         return false;
+      }
+
+      int size = wrapper.getConditionSize();
+
+      for(int i = 0; i < size; i++) {
+         if(!wrapper.isConditionItem(i)) {
+            continue;
+         }
+
+         ConditionItem item = wrapper.getConditionItem(i);
+         XCondition xc = item == null ? null : item.getXCondition();
+
+         if(xc == null) {
+            continue;
+         }
+
+         for(UserVariable uvar : xc.getAllVariables()) {
+            if(varName.equals(uvar.getName())) {
+               return true;
+            }
+         }
+      }
+
+      return false;
    }
 
    /**

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
@@ -647,6 +647,24 @@ public class WorksheetReadService {
    }
 
    private List<String> extractValues(XCondition xc) {
+      if(xc instanceof RankingCondition rc) {
+         // RankingCondition.getN() carries the ranking's row count, which -- since Bug #75950
+         // -- can itself be a "$(variableName)" reference (a raw String, or a UserVariable if
+         // this condition round-tripped through XML). Surfacing it here, the same way a filter
+         // condition's values are surfaced, is what lets rename_variable/delete_variable's
+         // findVariableReferences scan (stylebi-wiz's worksheetTools.ts) actually see it --
+         // without this, that scan finds every $(name) EXCEPT one used only as a ranking count,
+         // and rename/delete reports no dangling references while leaving a live one behind.
+         Object n = rc.getN();
+
+         if(n == null) {
+            return Collections.emptyList();
+         }
+
+         return Collections.singletonList(
+            n instanceof UserVariable uvar ? "$(" + uvar.getName() + ")" : n.toString());
+      }
+
       if(!(xc instanceof Condition c)) {
          return Collections.emptyList();
       }

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -37,6 +37,7 @@ import inetsoft.uql.erm.XEntity;
 import inetsoft.uql.erm.XLogicalModel;
 import inetsoft.uql.jdbc.JDBCDataSource;
 import inetsoft.uql.jdbc.JDBCQuery;
+import inetsoft.uql.schema.UserVariable;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.tabular.RestParameter;
 import inetsoft.uql.tabular.TabularDataSource;
@@ -840,11 +841,11 @@ class WorksheetAgentControllerTest {
    }
 
    @Test
-   void editAddVariableWiresValuesLabelsAndMultipleSelection() throws Exception {
+   void editAddVariableWiresChoicesThrough() throws Exception {
       // Regression for Bug #76328: add_variable/edit_variable had no way to populate
-      // UserVariable.setValues()/setChoices() (the Composer's own Variable dialog
-      // "Values" picker). Verifies the edit-dispatch add_variable path wires 'values',
-      // 'labels', and 'multipleSelection' all the way through to the created variable.
+      // UserVariable.setValues()/setChoices()/setDisplayStyle() (the Composer's own Variable
+      // dialog "Values" picker). Verifies the edit-dispatch add_variable path wires 'choices'
+      // all the way through to the created variable.
       Principal agent = TestPrincipals.user("alice", "host-org");
       Worksheet ws = new Worksheet();
 
@@ -863,6 +864,10 @@ class WorksheetAgentControllerTest {
          mock(SheetJoinService.class), mock(SheetSessionService.class),
          mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class));
 
+      WorksheetMutationSupport.VariableChoicesSpec choices =
+         new WorksheetMutationSupport.VariableChoicesSpec(
+            List.of("1", "5", "10"), List.of("One", "Five", "Ten"), null, null, null, "list");
+
       EditRequest req = new EditRequest(
          "add_variable",              // op
          null,                        // table
@@ -872,7 +877,7 @@ class WorksheetAgentControllerTest {
          null,                        // newName
          null,                        // field
          null,                        // operation
-         List.of("1", "5", "10"),     // values
+         null,                        // values
          null,                        // direction
          null,                        // groups
          null,                        // aggregates
@@ -893,8 +898,8 @@ class WorksheetAgentControllerTest {
                                                       // lookupExpandArrays, lookupTopLevelOnly,
                                                       // suffix, customLookups
          null,                        // crosstab
-         List.of("One", "Five", "Ten"), // labels
-         true                         // multipleSelection
+         null,                        // labels
+         choices                      // choices
       );
 
       ctrl.edit("TOK-AVC", req, agent);
@@ -906,6 +911,7 @@ class WorksheetAgentControllerTest {
       assertArrayEquals(new Object[] {1, 5, 10}, var.getValues(),
          "values must be typed to the variable's data type (Integer), not raw strings");
       assertTrue(var.isMultipleSelection());
+      assertEquals(UserVariable.LIST, var.getDisplayStyle());
    }
 
    // ---------------------------------------------------------------------------

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -839,6 +839,75 @@ class WorksheetAgentControllerTest {
                    "the original variable's type must be unchanged");
    }
 
+   @Test
+   void editAddVariableWiresValuesLabelsAndMultipleSelection() throws Exception {
+      // Regression for Bug #76328: add_variable/edit_variable had no way to populate
+      // UserVariable.setValues()/setChoices() (the Composer's own Variable dialog
+      // "Values" picker). Verifies the edit-dispatch add_variable path wires 'values',
+      // 'labels', and 'multipleSelection' all the way through to the created variable.
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      Worksheet ws = new Worksheet();
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      when(sessions.resolve(eq("TOK-AVC"), any())).thenReturn(session("TOK-AVC"));
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+
+      WorksheetAgentController ctrl = controller(featureOn(),
+         mock(SheetJoinService.class), mock(SheetSessionService.class),
+         mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class));
+
+      EditRequest req = new EditRequest(
+         "add_variable",              // op
+         null,                        // table
+         null,                        // column
+         "topN",                      // name
+         "integer",                   // type
+         null,                        // newName
+         null,                        // field
+         null,                        // operation
+         List.of("1", "5", "10"),     // values
+         null,                        // direction
+         null,                        // groups
+         null,                        // aggregates
+         null,                        // expression
+         false,                       // sql
+         null, null, null, null, null,  // leftTable, leftKey, rightTable, rightKey, joinType
+         null, null, null, null,         // visible, tables, source, concatType
+         null, null, null, null, null,   // conditions, ranking, headerColumns, dateOption, boundaries
+         null, null, null, null,         // datasource, schema, catalog, logicalModel
+         null, null,                     // leftKeys, rightKeys
+         null, null, null, null,         // row, col, value, index
+         null, null, null, null,         // alias, description, maxRows, distinct
+         null, null, null, null,         // columnOrder, groupMappings, groupOthers, variableValues
+         null, null, null, null,         // x, y, label, defaultValue
+         null, null, null,               // mode, insert, subtables
+         null, null,                     // sourceTable, attribute
+         null, null, null, null, null, null, null,  // endpoint, parameters, lookup,
+                                                      // lookupExpandArrays, lookupTopLevelOnly,
+                                                      // suffix, customLookups
+         null,                        // crosstab
+         List.of("One", "Five", "Ten"), // labels
+         true                         // multipleSelection
+      );
+
+      ctrl.edit("TOK-AVC", req, agent);
+
+      Assembly a = ws.getAssembly("topN");
+      assertTrue(a instanceof VariableAssembly);
+      AssetVariable var = ((VariableAssembly) a).getVariable();
+      assertArrayEquals(new Object[] {"One", "Five", "Ten"}, var.getChoices());
+      assertArrayEquals(new Object[] {1, 5, 10}, var.getValues(),
+         "values must be typed to the variable's data type (Integer), not raw strings");
+      assertTrue(var.isMultipleSelection());
+   }
+
    // ---------------------------------------------------------------------------
    // edit — rename_variable / delete_variable dispatch (Bug #75994)
    // ---------------------------------------------------------------------------

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -1720,6 +1720,116 @@ class WorksheetEditServiceMutatorsTest {
       assertTrue(ex.getMessage().contains("NoSuchTable"));
    }
 
+   @Test
+   void editVariableRejectsCircularQuerySourceViaRankingCondition() throws Exception {
+      // Confirmed live: mirroring a table whose own ranking condition reads $(TopN), then
+      // pointing $(TopN)'s own picker at that mirror, silently built a circular dependency --
+      // computing the picker's values would require the variable's value first.
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly allSales = TestWorksheets.tableWithColumns(ws, "AllSales", "Total");
+      ws.addAssembly(allSales);
+      WorksheetMutationSupport.setRanking(allSales,
+         new WorksheetMutationSupport.RankingSpec("Total", "$(TopN)", "TOP_N", false));
+      MirrorTableAssembly mirror = new MirrorTableAssembly(ws, "AllSalesMirror", allSales);
+      ws.addAssembly(mirror);
+      variableAssembly(ws, "TopN", XSchema.INTEGER);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+         svc.apply("TOK", agent, ed ->
+            ed.editVariable("TopN", null, null, null,
+               queryChoices("AllSalesMirror", "Total", "Total", null))));
+      assertTrue(ex.getMessage().contains("circular"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("AllSales"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("TopN"), ex.getMessage());
+
+      AssetVariable updated = ((DefaultVariableAssembly) ws.getAssembly("TopN")).getVariable();
+      assertNull(updated.getTableName(), "a rejected circular source must not be applied");
+   }
+
+   @Test
+   void editVariableRejectsCircularQuerySourceThroughTransitiveMirrorChain() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly allSales = TestWorksheets.tableWithColumns(ws, "AllSales", "Total");
+      ws.addAssembly(allSales);
+      WorksheetMutationSupport.setRanking(allSales,
+         new WorksheetMutationSupport.RankingSpec("Total", "$(TopN)", "TOP_N", false));
+      MirrorTableAssembly mirror1 = new MirrorTableAssembly(ws, "M1", allSales);
+      ws.addAssembly(mirror1);
+      MirrorTableAssembly mirror2 = new MirrorTableAssembly(ws, "M2", mirror1);
+      ws.addAssembly(mirror2);
+      variableAssembly(ws, "TopN", XSchema.INTEGER);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      // The cycle is two mirror-hops away from M2 -- proves the dependency walk is transitive,
+      // not just a check of the immediately-named table.
+      assertThrows(IllegalArgumentException.class, () ->
+         svc.apply("TOK", agent, ed ->
+            ed.editVariable("TopN", null, null, null,
+               queryChoices("M2", "Total", "Total", null))));
+   }
+
+   @Test
+   void editVariableRejectsCircularQuerySourceViaFilterCondition() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly allSales = TestWorksheets.tableWithColumns(ws, "AllSales", "Region");
+      ws.addAssembly(allSales);
+      WorksheetMutationSupport.addFilter(allSales, "Region", "=", "$(Region)");
+      variableAssembly(ws, "Region", XSchema.STRING);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+         svc.apply("TOK", agent, ed ->
+            ed.editVariable("Region", null, null, null,
+               queryChoices("AllSales", "Region", "Region", null))));
+      assertTrue(ex.getMessage().contains("circular"), ex.getMessage());
+   }
+
+   @Test
+   void editVariableAllowsQuerySourceFromIndependentCopy() throws Exception {
+      // Mirrors the live scenario's actual fix: an independent copy (not a mirror) with no
+      // conditions of its own has no dependency on the filtered/ranked table at all.
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly allSales = TestWorksheets.tableWithColumns(ws, "AllSales", "Total");
+      ws.addAssembly(allSales);
+      WorksheetMutationSupport.setRanking(allSales,
+         new WorksheetMutationSupport.RankingSpec("Total", "$(TopN)", "TOP_N", false));
+      EmbeddedTableAssembly copy = TestWorksheets.tableWithColumns(ws, "AllSalesValues", "Total");
+      ws.addAssembly(copy);
+      variableAssembly(ws, "TopN", XSchema.INTEGER);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed ->
+         ed.editVariable("TopN", null, null, null,
+            queryChoices("AllSalesValues", "Total", "Total", null)));
+
+      AssetVariable updated = ((DefaultVariableAssembly) ws.getAssembly("TopN")).getVariable();
+      assertEquals("AllSalesValues", updated.getTableName());
+   }
+
+   @Test
+   void editVariableAllowsQuerySourceReferencingADifferentVariable() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly allSales = TestWorksheets.tableWithColumns(ws, "AllSales", "Total");
+      ws.addAssembly(allSales);
+      WorksheetMutationSupport.setRanking(allSales,
+         new WorksheetMutationSupport.RankingSpec("Total", "$(OtherVar)", "TOP_N", false));
+      variableAssembly(ws, "TopN", XSchema.INTEGER);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed ->
+         ed.editVariable("TopN", null, null, null,
+            queryChoices("AllSales", "Total", "Total", null)));
+
+      AssetVariable updated = ((DefaultVariableAssembly) ws.getAssembly("TopN")).getVariable();
+      assertEquals("AllSales", updated.getTableName());
+   }
+
    // =========================================================================
    // Expression column test
    // =========================================================================

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -1320,6 +1320,173 @@ class WorksheetEditServiceMutatorsTest {
       assertEquals("orderNumber", ref.getAttribute());
    }
 
+   @Test
+   void setRankingAcceptsVariableBinding() throws Exception {
+      // Regression for Bug #75950: 'n' used to be hardcoded to a plain int, so a
+      // Top-N count could never be bound to a worksheet variable the way filter
+      // condition values support $(name). RankingCondition.setN(Object) already
+      // supported it -- the gap was purely in how RankingSpec carried the value.
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "employee", "total");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed ->
+         ed.setRanking("T",
+            new WorksheetMutationSupport.RankingSpec("total", "$(topN)", "TOP_N", false)));
+
+      ConditionList cl = t.getRankingConditionList().getConditionList();
+      RankingCondition rc = (RankingCondition) cl.getConditionItem(0).getXCondition();
+      assertTrue(Condition.isVariable(rc.getN()) || rc.getN() instanceof UserVariable,
+         "n should round-trip as a variable reference, got: " + rc.getN());
+      UserVariable[] vars = rc.getAllVariables();
+      assertEquals(1, vars.length);
+      assertEquals("topN", vars[0].getName());
+   }
+
+   @Test
+   void setRankingAcceptsNumericStringForN() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "employee", "total");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed ->
+         ed.setRanking("T",
+            new WorksheetMutationSupport.RankingSpec("total", "5", "TOP_N", false)));
+
+      ConditionList cl = t.getRankingConditionList().getConditionList();
+      RankingCondition rc = (RankingCondition) cl.getConditionItem(0).getXCondition();
+      assertEquals(5, rc.getN());
+   }
+
+   @Test
+   void setRankingRejectsInvalidN() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "employee", "total");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+         svc.apply("TOK", agent, ed ->
+            ed.setRanking("T",
+               new WorksheetMutationSupport.RankingSpec("total", "not-a-number", "TOP_N", false))));
+      assertTrue(ex.getMessage().contains("not-a-number"),
+         "error should name the rejected value, got: " + ex.getMessage());
+   }
+
+   // =========================================================================
+   // Variable choices tests (Bug #76328)
+   // =========================================================================
+
+   private static DefaultVariableAssembly variableAssembly(Worksheet ws, String name, String type) {
+      AssetVariable var = new AssetVariable(name);
+      var.setTypeNode(XSchema.createPrimitiveType(type));
+      DefaultVariableAssembly assembly = new DefaultVariableAssembly(ws, name);
+      assembly.setVariable(var);
+      ws.addAssembly(assembly);
+      return assembly;
+   }
+
+   @Test
+   void editVariableSetsTypedChoicesAndValues() throws Exception {
+      Worksheet ws = new Worksheet();
+      variableAssembly(ws, "topN", XSchema.INTEGER);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed ->
+         ed.editVariable("topN", null, null, null,
+            List.of("1", "5", "10"), List.of("One", "Five", "Ten"), false));
+
+      AssetVariable updated = ((DefaultVariableAssembly) ws.getAssembly("topN")).getVariable();
+      assertArrayEquals(new Object[] {"One", "Five", "Ten"}, updated.getChoices());
+      assertArrayEquals(new Object[] {1, 5, 10}, updated.getValues(),
+         "values must be typed to the variable's data type (Integer), not raw strings");
+      assertEquals(UserVariable.COMBOBOX, updated.getDisplayStyle());
+   }
+
+   @Test
+   void editVariableDefaultsLabelsToValuesWhenOmitted() throws Exception {
+      Worksheet ws = new Worksheet();
+      variableAssembly(ws, "region", XSchema.STRING);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed ->
+         ed.editVariable("region", null, null, null, List.of("East", "West"), null, null));
+
+      AssetVariable updated = ((DefaultVariableAssembly) ws.getAssembly("region")).getVariable();
+      assertArrayEquals(new Object[] {"East", "West"}, updated.getChoices());
+      assertArrayEquals(new Object[] {"East", "West"}, updated.getValues());
+   }
+
+   @Test
+   void editVariableEnablesMultipleSelection() throws Exception {
+      Worksheet ws = new Worksheet();
+      variableAssembly(ws, "region", XSchema.STRING);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed ->
+         ed.editVariable("region", null, null, null, List.of("East", "West"), null, true));
+
+      AssetVariable updated = ((DefaultVariableAssembly) ws.getAssembly("region")).getVariable();
+      assertTrue(updated.isMultipleSelection());
+      assertEquals(UserVariable.LIST, updated.getDisplayStyle());
+   }
+
+   @Test
+   void editVariableEmptyValuesClearsExistingChoices() throws Exception {
+      Worksheet ws = new Worksheet();
+      DefaultVariableAssembly assembly = variableAssembly(ws, "region", XSchema.STRING);
+      assembly.getVariable().setChoices(new Object[] {"East", "West"});
+      assembly.getVariable().setValues(new Object[] {"East", "West"});
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed ->
+         ed.editVariable("region", null, null, null, List.of(), null, null));
+
+      AssetVariable updated = ((DefaultVariableAssembly) ws.getAssembly("region")).getVariable();
+      assertNull(updated.getChoices());
+      assertNull(updated.getValues());
+   }
+
+   @Test
+   void editVariableOmittingValuesLeavesExistingChoicesUnchanged() throws Exception {
+      Worksheet ws = new Worksheet();
+      DefaultVariableAssembly assembly = variableAssembly(ws, "region", XSchema.STRING);
+      assembly.getVariable().setChoices(new Object[] {"East", "West"});
+      assembly.getVariable().setValues(new Object[] {"East", "West"});
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed ->
+         ed.editVariable("region", null, "New Label", null, null, null, null));
+
+      AssetVariable updated = ((DefaultVariableAssembly) ws.getAssembly("region")).getVariable();
+      assertArrayEquals(new Object[] {"East", "West"}, updated.getChoices());
+      assertArrayEquals(new Object[] {"East", "West"}, updated.getValues());
+   }
+
+   @Test
+   void editVariableRejectsMismatchedLabelsLength() throws Exception {
+      Worksheet ws = new Worksheet();
+      variableAssembly(ws, "region", XSchema.STRING);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+         svc.apply("TOK", agent, ed ->
+            ed.editVariable("region", null, null, null,
+               List.of("East", "West"), List.of("Only one"), null)));
+      assertTrue(ex.getMessage().contains("labels"));
+   }
+
    // =========================================================================
    // Expression column test
    // =========================================================================

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -1545,6 +1545,59 @@ class WorksheetEditServiceMutatorsTest {
    }
 
    @Test
+   void editVariableRejectsInvalidChoicesWithoutApplyingLabelTypeOrDefaultValue()
+      throws Exception
+   {
+      // Reviewer-caught regression: editVariable applied label/type/defaultValue directly to
+      // the LIVE AssetVariable before validating choices, so a rejected call (here: mismatched
+      // labels/values lengths) still left those earlier field changes committed on the live
+      // worksheet even though the whole call reported failure. editVariable now edits a scratch
+      // copy and only publishes it once every field -- including choices -- has validated.
+      Worksheet ws = new Worksheet();
+      DefaultVariableAssembly assembly = variableAssembly(ws, "region", XSchema.STRING);
+      assembly.getVariable().setAlias("Original Label");
+      // setTypeNode (inside variableAssembly's setup) auto-creates a placeholder value node
+      // whenever none exists yet, so the baseline here is that placeholder, not null -- capture
+      // it by reference to prove the rejected call didn't replace it with a new one.
+      Object originalValueNode = assembly.getVariable().getValueNode();
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      assertThrows(IllegalArgumentException.class, () ->
+         svc.apply("TOK", agent, ed ->
+            ed.editVariable("region", "integer", "New Label", "5",
+               embeddedChoices(List.of("East", "West"), List.of("Only one"), null))));
+
+      AssetVariable updated = ((DefaultVariableAssembly) ws.getAssembly("region")).getVariable();
+      assertEquals("Original Label", updated.getAlias(),
+         "a rejected call must not leave 'label' applied");
+      assertEquals(XSchema.STRING, updated.getTypeNode().getType(),
+         "a rejected call must not leave 'type' applied");
+      assertSame(originalValueNode, updated.getValueNode(),
+         "a rejected call must not leave 'defaultValue' applied");
+   }
+
+   @Test
+   void editVariableRejectsUnparsableEmbeddedValue() throws Exception {
+      Worksheet ws = new Worksheet();
+      variableAssembly(ws, "topN", XSchema.INTEGER);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      // Tool.getData("integer", "abc") silently returns null rather than throwing -- editVariable
+      // must reject this itself instead of writing a null value whose label ("abc") and
+      // underlying value end up silently out of sync.
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+         svc.apply("TOK", agent, ed ->
+            ed.editVariable("topN", null, null, null,
+               embeddedChoices(List.of("5", "abc"), null, null))));
+      assertTrue(ex.getMessage().contains("abc"), ex.getMessage());
+
+      AssetVariable updated = ((DefaultVariableAssembly) ws.getAssembly("topN")).getVariable();
+      assertNull(updated.getChoices(), "a rejected value must not leave a partial picker applied");
+   }
+
+   @Test
    void editVariableRejectsUnknownDisplayStyle() throws Exception {
       Worksheet ws = new Worksheet();
       variableAssembly(ws, "region", XSchema.STRING);

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -39,6 +39,8 @@ import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.util.XEmbeddedTable;
 import inetsoft.web.wiz.pairing.*;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
 
 import java.security.Principal;
@@ -1391,6 +1393,20 @@ class WorksheetEditServiceMutatorsTest {
       return assembly;
    }
 
+   private static WorksheetMutationSupport.VariableChoicesSpec embeddedChoices(
+      List<String> values, List<String> labels, String displayStyle)
+   {
+      return new WorksheetMutationSupport.VariableChoicesSpec(
+         values, labels, null, null, null, displayStyle);
+   }
+
+   private static WorksheetMutationSupport.VariableChoicesSpec queryChoices(
+      String table, String labelColumn, String valueColumn, String displayStyle)
+   {
+      return new WorksheetMutationSupport.VariableChoicesSpec(
+         null, null, table, labelColumn, valueColumn, displayStyle);
+   }
+
    @Test
    void editVariableSetsTypedChoicesAndValues() throws Exception {
       Worksheet ws = new Worksheet();
@@ -1400,13 +1416,15 @@ class WorksheetEditServiceMutatorsTest {
 
       svc.apply("TOK", agent, ed ->
          ed.editVariable("topN", null, null, null,
-            List.of("1", "5", "10"), List.of("One", "Five", "Ten"), false));
+            embeddedChoices(List.of("1", "5", "10"), List.of("One", "Five", "Ten"), null)));
 
       AssetVariable updated = ((DefaultVariableAssembly) ws.getAssembly("topN")).getVariable();
       assertArrayEquals(new Object[] {"One", "Five", "Ten"}, updated.getChoices());
       assertArrayEquals(new Object[] {1, 5, 10}, updated.getValues(),
          "values must be typed to the variable's data type (Integer), not raw strings");
-      assertEquals(UserVariable.COMBOBOX, updated.getDisplayStyle());
+      assertEquals(UserVariable.COMBOBOX, updated.getDisplayStyle(),
+         "no explicit displayStyle should default to a single-select combobox");
+      assertFalse(updated.isMultipleSelection());
    }
 
    @Test
@@ -1417,26 +1435,64 @@ class WorksheetEditServiceMutatorsTest {
       WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
 
       svc.apply("TOK", agent, ed ->
-         ed.editVariable("region", null, null, null, List.of("East", "West"), null, null));
+         ed.editVariable("region", null, null, null,
+            embeddedChoices(List.of("East", "West"), null, null)));
 
       AssetVariable updated = ((DefaultVariableAssembly) ws.getAssembly("region")).getVariable();
       assertArrayEquals(new Object[] {"East", "West"}, updated.getChoices());
       assertArrayEquals(new Object[] {"East", "West"}, updated.getValues());
    }
 
-   @Test
-   void editVariableEnablesMultipleSelection() throws Exception {
+   @ParameterizedTest
+   @CsvSource({
+      "list, true",
+      "checkboxes, false",
+      "radio, false",
+      "combobox, false",
+   })
+   void editVariableAppliesExplicitDisplayStyle(String style, boolean expectMultiple)
+      throws Exception
+   {
+      // Mirrors VariableAssemblyDialogService.convertModelToAssetVariable: multipleSelection
+      // is only ever derived from displayStyle == LIST, never from CHECKBOXES -- even though
+      // checkboxes are inherently multi-valued in the UI, isMultipleSelection() itself is not
+      // where that is expressed. Matching that exactly keeps this tool's output identical to
+      // what a human produces through the Composer's own Variable dialog.
       Worksheet ws = new Worksheet();
       variableAssembly(ws, "region", XSchema.STRING);
       Principal agent = TestPrincipals.user("alice", "host-org");
       WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
 
       svc.apply("TOK", agent, ed ->
-         ed.editVariable("region", null, null, null, List.of("East", "West"), null, true));
+         ed.editVariable("region", null, null, null,
+            embeddedChoices(List.of("East", "West"), null, style)));
 
       AssetVariable updated = ((DefaultVariableAssembly) ws.getAssembly("region")).getVariable();
-      assertTrue(updated.isMultipleSelection());
-      assertEquals(UserVariable.LIST, updated.getDisplayStyle());
+      assertEquals(expectMultiple, updated.isMultipleSelection());
+   }
+
+   @Test
+   void editVariableTogglingDisplayStyleAloneUpdatesExistingPicker() throws Exception {
+      // An explicit displayStyle must take effect even when neither 'values' nor 'table' is
+      // resupplied this call -- e.g. switching an existing combobox to a checkbox list without
+      // touching its value list.
+      Worksheet ws = new Worksheet();
+      DefaultVariableAssembly assembly = variableAssembly(ws, "region", XSchema.STRING);
+      assembly.getVariable().setChoices(new Object[] {"East", "West"});
+      assembly.getVariable().setValues(new Object[] {"East", "West"});
+      assembly.getVariable().setDisplayStyle(UserVariable.COMBOBOX);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed ->
+         ed.editVariable("region", null, null, null,
+            new WorksheetMutationSupport.VariableChoicesSpec(
+               null, null, null, null, null, "checkboxes")));
+
+      AssetVariable updated = ((DefaultVariableAssembly) ws.getAssembly("region")).getVariable();
+      assertEquals(UserVariable.CHECKBOXES, updated.getDisplayStyle());
+      assertArrayEquals(new Object[] {"East", "West"}, updated.getChoices(),
+         "toggling style alone must not disturb the existing value list");
    }
 
    @Test
@@ -1449,15 +1505,16 @@ class WorksheetEditServiceMutatorsTest {
       WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
 
       svc.apply("TOK", agent, ed ->
-         ed.editVariable("region", null, null, null, List.of(), null, null));
+         ed.editVariable("region", null, null, null, embeddedChoices(List.of(), null, null)));
 
       AssetVariable updated = ((DefaultVariableAssembly) ws.getAssembly("region")).getVariable();
       assertNull(updated.getChoices());
       assertNull(updated.getValues());
+      assertEquals(UserVariable.NONE, updated.getDisplayStyle());
    }
 
    @Test
-   void editVariableOmittingValuesLeavesExistingChoicesUnchanged() throws Exception {
+   void editVariableOmittingChoicesLeavesExistingPickerUnchanged() throws Exception {
       Worksheet ws = new Worksheet();
       DefaultVariableAssembly assembly = variableAssembly(ws, "region", XSchema.STRING);
       assembly.getVariable().setChoices(new Object[] {"East", "West"});
@@ -1466,7 +1523,7 @@ class WorksheetEditServiceMutatorsTest {
       WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
 
       svc.apply("TOK", agent, ed ->
-         ed.editVariable("region", null, "New Label", null, null, null, null));
+         ed.editVariable("region", null, "New Label", null, null));
 
       AssetVariable updated = ((DefaultVariableAssembly) ws.getAssembly("region")).getVariable();
       assertArrayEquals(new Object[] {"East", "West"}, updated.getChoices());
@@ -1483,8 +1540,184 @@ class WorksheetEditServiceMutatorsTest {
       IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
          svc.apply("TOK", agent, ed ->
             ed.editVariable("region", null, null, null,
-               List.of("East", "West"), List.of("Only one"), null)));
+               embeddedChoices(List.of("East", "West"), List.of("Only one"), null))));
       assertTrue(ex.getMessage().contains("labels"));
+   }
+
+   @Test
+   void editVariableRejectsUnknownDisplayStyle() throws Exception {
+      Worksheet ws = new Worksheet();
+      variableAssembly(ws, "region", XSchema.STRING);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+         svc.apply("TOK", agent, ed ->
+            ed.editVariable("region", null, null, null,
+               embeddedChoices(List.of("East", "West"), null, "dropdown"))));
+      assertTrue(ex.getMessage().contains("dropdown"));
+   }
+
+   @Test
+   void editVariableRejectsUnknownDisplayStyleWithoutMutatingExistingChoices() throws Exception {
+      // applyOnRuntime mutates the live worksheet with no rollback on a thrown exception, so a
+      // validation failure discovered only after values/table were already applied would leave
+      // the variable half-updated. displayStyle must be parsed before any mutation.
+      Worksheet ws = new Worksheet();
+      DefaultVariableAssembly assembly = variableAssembly(ws, "region", XSchema.STRING);
+      assembly.getVariable().setChoices(new Object[] {"East", "West"});
+      assembly.getVariable().setValues(new Object[] {"East", "West"});
+      assembly.getVariable().setDisplayStyle(UserVariable.COMBOBOX);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      assertThrows(IllegalArgumentException.class, () ->
+         svc.apply("TOK", agent, ed ->
+            ed.editVariable("region", null, null, null,
+               embeddedChoices(List.of("North", "South"), null, "dropdown"))));
+
+      AssetVariable updated = ((DefaultVariableAssembly) ws.getAssembly("region")).getVariable();
+      assertArrayEquals(new Object[] {"East", "West"}, updated.getChoices(),
+         "a rejected displayStyle must not leave the new (unvalidated) values committed");
+      assertArrayEquals(new Object[] {"East", "West"}, updated.getValues());
+      assertEquals(UserVariable.COMBOBOX, updated.getDisplayStyle());
+   }
+
+   @Test
+   void editVariableRejectsMismatchedLabelsLengthWithoutMutatingExistingQuerySource()
+      throws Exception
+   {
+      Worksheet ws = new Worksheet();
+      TableAssembly t = TestWorksheets.tableWithColumns(ws, "Regions", "RegionName", "RegionId");
+      ws.addAssembly(t);
+      DefaultVariableAssembly assembly = variableAssembly(ws, "region", XSchema.STRING);
+      assembly.getVariable().setTableName("Regions");
+      assembly.getVariable().setLabelAttribute(t.getColumnSelection().getAttribute("RegionName"));
+      assembly.getVariable().setValueAttribute(t.getColumnSelection().getAttribute("RegionId"));
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      assertThrows(IllegalArgumentException.class, () ->
+         svc.apply("TOK", agent, ed ->
+            ed.editVariable("region", null, null, null,
+               embeddedChoices(List.of("East", "West"), List.of("Only one"), null))));
+
+      AssetVariable updated = ((DefaultVariableAssembly) ws.getAssembly("region")).getVariable();
+      assertEquals("Regions", updated.getTableName(),
+         "a rejected labels/values mismatch must not clear the existing query source");
+      assertNotNull(updated.getLabelAttribute());
+      assertNotNull(updated.getValueAttribute());
+   }
+
+   @Test
+   void editVariableRejectsBothValuesAndTable() throws Exception {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(TestWorksheets.tableWithColumns(ws, "Regions", "RegionName", "RegionId"));
+      variableAssembly(ws, "region", XSchema.STRING);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+         svc.apply("TOK", agent, ed ->
+            ed.editVariable("region", null, null, null,
+               new WorksheetMutationSupport.VariableChoicesSpec(
+                  List.of("East", "West"), null, "Regions", "RegionName", "RegionId", null))));
+      assertTrue(ex.getMessage().contains("mutually exclusive"));
+   }
+
+   @Test
+   void editVariableSwitchesToQuerySource() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t =
+         TestWorksheets.tableWithColumns(ws, "Regions", "RegionName", "RegionId");
+      ws.addAssembly(t);
+      variableAssembly(ws, "region", XSchema.STRING);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed ->
+         ed.editVariable("region", null, null, null,
+            queryChoices("Regions", "RegionName", "RegionId", "combobox")));
+
+      AssetVariable updated = ((DefaultVariableAssembly) ws.getAssembly("region")).getVariable();
+      assertEquals("Regions", updated.getTableName());
+      assertNotNull(updated.getLabelAttribute());
+      assertEquals("RegionName", updated.getLabelAttribute().getAttribute());
+      assertNotNull(updated.getValueAttribute());
+      assertEquals("RegionId", updated.getValueAttribute().getAttribute());
+      assertEquals(UserVariable.COMBOBOX, updated.getDisplayStyle());
+   }
+
+   @Test
+   void editVariableSwitchingToQuerySourceClearsEmbeddedList() throws Exception {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(TestWorksheets.tableWithColumns(ws, "Regions", "RegionName", "RegionId"));
+      DefaultVariableAssembly assembly = variableAssembly(ws, "region", XSchema.STRING);
+      assembly.getVariable().setChoices(new Object[] {"East", "West"});
+      assembly.getVariable().setValues(new Object[] {"East", "West"});
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed ->
+         ed.editVariable("region", null, null, null,
+            queryChoices("Regions", "RegionName", "RegionId", null)));
+
+      AssetVariable updated = ((DefaultVariableAssembly) ws.getAssembly("region")).getVariable();
+      assertNull(updated.getChoices(),
+         "switching to query mode must clear the leftover embedded list");
+      assertNull(updated.getValues());
+   }
+
+   @Test
+   void editVariableSwitchingToEmbeddedClearsQuerySource() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly t = TestWorksheets.tableWithColumns(ws, "Regions", "RegionName", "RegionId");
+      ws.addAssembly(t);
+      DefaultVariableAssembly assembly = variableAssembly(ws, "region", XSchema.STRING);
+      assembly.getVariable().setTableName("Regions");
+      assembly.getVariable().setLabelAttribute(t.getColumnSelection().getAttribute("RegionName"));
+      assembly.getVariable().setValueAttribute(t.getColumnSelection().getAttribute("RegionId"));
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed ->
+         ed.editVariable("region", null, null, null,
+            embeddedChoices(List.of("East", "West"), null, null)));
+
+      AssetVariable updated = ((DefaultVariableAssembly) ws.getAssembly("region")).getVariable();
+      assertNull(updated.getTableName(),
+         "switching to embedded mode must clear the leftover query source");
+      assertNull(updated.getLabelAttribute());
+      assertNull(updated.getValueAttribute());
+   }
+
+   @Test
+   void editVariableRejectsQueryModeMissingValueColumn() throws Exception {
+      Worksheet ws = new Worksheet();
+      ws.addAssembly(TestWorksheets.tableWithColumns(ws, "Regions", "RegionName", "RegionId"));
+      variableAssembly(ws, "region", XSchema.STRING);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+         svc.apply("TOK", agent, ed ->
+            ed.editVariable("region", null, null, null,
+               queryChoices("Regions", "RegionName", null, null))));
+      assertTrue(ex.getMessage().contains("valueColumn"));
+   }
+
+   @Test
+   void editVariableRejectsQueryModeUnknownTable() throws Exception {
+      Worksheet ws = new Worksheet();
+      variableAssembly(ws, "region", XSchema.STRING);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+         svc.apply("TOK", agent, ed ->
+            ed.editVariable("region", null, null, null,
+               queryChoices("NoSuchTable", "RegionName", "RegionId", null))));
+      assertTrue(ex.getMessage().contains("NoSuchTable"));
    }
 
    // =========================================================================

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
@@ -118,6 +118,35 @@ class WorksheetReadServiceTest {
       assertEquals("EMBEDDED", m.tables().get(0).type());
    }
 
+   @Test
+   void rankingConditionSurfacesVariableReferenceInValues() {
+      // Regression: extractValues() previously returned an empty list for ANY
+      // RankingCondition, so a Top-N count bound to $(topN) (Bug #75950) was invisible to
+      // findVariableReferences (stylebi-wiz's worksheetTools.ts), which scans
+      // rankingConditions[].values for "$(name)" tokens to warn rename_variable/delete_variable
+      // about dangling references -- a ranking-only reference would silently report as none.
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "total");
+      ws.addAssembly(t);
+      WorksheetMutationSupport.setRanking(t,
+         new WorksheetMutationSupport.RankingSpec("total", "$(topN)", "TOP_N", false));
+
+      WorksheetModel.FilterModel ranking = tableNamed(read(ws), "T").rankingConditions().get(0);
+      assertEquals(List.of("$(topN)"), ranking.values());
+   }
+
+   @Test
+   void rankingConditionSurfacesNumericNInValues() {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "total");
+      ws.addAssembly(t);
+      WorksheetMutationSupport.setRanking(t,
+         new WorksheetMutationSupport.RankingSpec("total", 5, "TOP_N", false));
+
+      WorksheetModel.FilterModel ranking = tableNamed(read(ws), "T").rankingConditions().get(0);
+      assertEquals(List.of("5"), ranking.values());
+   }
+
    private static WorksheetModel.TableModel tableNamed(WorksheetModel m, String name) {
       return m.tables().stream().filter(t -> name.equals(t.name())).findFirst().orElseThrow();
    }


### PR DESCRIPTION
## Summary

Two related AI-agent worksheet-chat backend fixes, shipped together since they're both about parameterizing worksheet behavior via variables:

**Bug #75950** — `set_ranking`'s Top-N/Bottom-N row count (`n`) was hardcoded to a plain `int`, so it could never be bound to a worksheet variable via `$(variableName)`, even though `RankingCondition.setN(Object)` already fully supports it (an `Integer`, a numeric `String`, or a `"$(name)"` reference — the same mechanism filter condition values already use).

**Bug #76328** — `add_variable`/`edit_variable` had no way to populate a worksheet variable's enumerated "Values" picker (`UserVariable.setValues()`/`setChoices()`/`setDisplayStyle()`), matching what the Composer's own Variable dialog offers: an embedded list, a query against an existing worksheet table's columns, and the full combobox/list/radio/checkboxes display style range — not just a fixed list.

## Root Cause

- **#75950**: `WorksheetMutationSupport.RankingSpec.n` was declared `int`, so `setRanking()` could only ever hand `RankingCondition.setN` an autoboxed `Integer` — a `$(name)` string could never reach it.
- **#76328**: `WorksheetAgentController.createVariable()` / `WorksheetEditService.Editor.editVariable()` only ever read `name`/`type`/`label`/`defaultValue` off the request; nothing ever called `UserVariable.setChoices()`/`setValues()`/`setDisplayStyle()`/`AssetVariable.setTableName()`/`setLabelAttribute()`/`setValueAttribute()`.

## Fix

- `RankingSpec.n` widened from `int` to `Object`; `setRanking()` validates via `RankingCondition.setN(Object)`'s boolean return and throws `IllegalArgumentException` on an invalid value.
- New `WorksheetMutationSupport.VariableChoicesSpec` (embedded `values`/`labels`, or query-mode `table`/`labelColumn`/`valueColumn`, plus `displayStyle`) and `applyVariableChoices()`, modeled directly on the Composer's own `VariableAssemblyDialogService.convertModelToAssetVariable()`. Wired into both `add_variable` (direct REST endpoint + edit-dispatch path) and `edit_variable`.
- `EditRequest` gained a `choices` field (record's new last component), with a backward-compat constructor added for the previous shape — no existing positional-constructor call site needed to change.
- Fixed along the way: `UserVariable` defaults `sortValue=true`, which silently re-sorts a picker's values alphabetically the instant both arrays are set (now explicitly disabled, matching the Composer dialog's own behavior); `AssetVariable.getDisplayStyle()` doesn't auto-derive from choices/values like the base `UserVariable` does, so display style is now explicitly (re)computed whenever the picker changes; validation (labels/values length mismatch, unknown display style) now runs fully before any mutation of the live worksheet, since the edit pipeline has no rollback on a thrown exception.
- **Circular-dependency guard**: found via live testing — pointing a variable's query-mode picker at a table that itself depends on that same variable (e.g. a mirror of a table whose own ranking condition reads `$(thisVariable)`) is now rejected with a clear error, since computing the picker's own values would otherwise require the variable's value first.

## Test Plan

- `mvnw clean test -pl core -Dtest=WorksheetEditServiceMutatorsTest,WorksheetAgentControllerTest` — 219/219 passing, including new coverage for `$(variable)` ranking binding, embedded/query-mode variable choices, display style derivation, mutual-exclusivity/mode-switch clearing, and the circular-dependency guard (direct, transitive, and non-circular control cases).
- `mvnw clean test-compile -pl core` (whole module) — clean, confirming no other call site broke from the `EditRequest`/`RankingSpec` shape changes.
- Live-verified end-to-end against a local StyleBI deployment via the stylebi-composer-chat plugin (paired repo PR).
- Two independent code-reviewer passes, both clean after fixes (a partial-mutation-before-validation ordering bug caught and fixed in the second pass).

stylebi-wiz PR: https://github.com/inetsoft-technology/stylebi-wiz/pull/new/bug-75950-76328 (opening next)

Fixes Redmine #75950, #76328.