### PR TITLE
75879, milestone points should be dimmed

### DIFF
--- a/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
+++ b/utils/inetsoft-xml-formats/src/main/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjector.java
@@ -65,7 +65,7 @@ public class SVGAnimationDOMInjector {
 
       String base = animHint.split(":")[0];
 
-      appendHoverCSS(svgRoot, doc, animHint);
+      appendHoverCSS(svgRoot, doc);
 
       // Hover-only mode (design-time surfaces): the hover-dim CSS injected above is enough for
       // highlighting to work, but the entrance animation must be suppressed. Return before
@@ -3573,7 +3573,7 @@ public class SVGAnimationDOMInjector {
     * <p>The {@code :has()} selector requires Chrome 105+, Firefox 121+, Safari 15.4+.
     * On older browsers the dim rules are silently ignored.
     */
-   private static void appendHoverCSS(Element svgRoot, Document doc, String animHint) {
+   private static void appendHoverCSS(Element svgRoot, Document doc) {
       String dim = String.format(java.util.Locale.US, "%.2f", AnimationConstants.HOVER_DIM_OPACITY);
       String tr  = AnimationConstants.HOVER_TRANSITION;
       appendStyle(svgRoot, doc,
@@ -3670,11 +3670,11 @@ public class SVGAnimationDOMInjector {
          // area series a smooth fade-in/fade-out on hover, exactly as for pure line series.
          ".inetsoft-line{pointer-events:all;transition:" + tr + "}");
 
-      appendMultiStyleHoverCSS(svgRoot, doc, animHint, dim);
+      appendMultiStyleHoverCSS(svgRoot, doc, dim);
    }
 
    /**
-    * Inject the cross-chart-type hover dim rules for a multi-style chart.
+    * Inject the cross-chart-type hover dim rules for a chart that draws both bars and points.
     *
     * <p>Every rule emitted by {@link #appendHoverCSS} has the same annotation class in its
     * {@code :has()} trigger as in its target, so an active bar can only ever dim other bars and an
@@ -3683,14 +3683,13 @@ public class SVGAnimationDOMInjector {
     * {@code inetsoft-point} groups, and hovering either left the other fully lit.  These rules dim
     * across the two types so the hovered VO is the only bright thing in the plot.
     *
-    * <p>Emitted only when the SVG really is a bar+point multi-style chart, because two
-    * <em>single</em>-style charts also draw both annotations and must keep their current behavior:
-    * <ul>
-    *   <li>Gantt — interval bars plus a {@code PointElement} milestone per bar.  A milestone marks
-    *       the end of its own bar, so a bar hover must not fade it.  Excluded by the gantt flag.</li>
-    *   <li>Box plot — boxes plus outlier points.  Excluded implicitly: {@code BoxVO} emits
-    *       {@code inetsoft-box}, so no {@code inetsoft-bar} group is present.</li>
-    * </ul>
+    * <p>Emitted whenever both annotations are present, which also covers gantt charts (interval
+    * bars plus milestone points).  A gantt milestone is not part of its row's bar: the milestone
+    * is an independent aggregate ({@code GanttChartInfo.getMilestoneField()}, forced to
+    * {@code CHART_POINT}) that only shares the category axis, so it dims like any other
+    * non-hovered measure — see bug #75879.  A box plot reaches these rules only through its
+    * outliers' own {@code inetsoft-point} groups paired with a real bar measure; boxes themselves
+    * emit {@code inetsoft-box} and are covered by their own cross rules.
     *
     * <p>Both directions are gated on {@code svg.ready} like every other point rule: point markers
     * animate their own opacity (A1), so dimming them before the entrance animation completes would
@@ -3698,14 +3697,8 @@ public class SVGAnimationDOMInjector {
     * carry no {@code inetsoft-active} class at all and are dimmed by the Angular directive's
     * inline-opacity mechanism instead.
     */
-   private static void appendMultiStyleHoverCSS(Element svgRoot, Document doc, String animHint,
-                                                String dim)
-   {
-      // The base hint is the first token and ":" is the separator, so a ":gantt" substring match is
-      // unambiguous (no base hint or other flag contains "gantt").
-      boolean gantt = animHint.contains(":" + SVGSupport.ANIMATION_FLAG_GANTT);
-
-      if(gantt || collectAnnotationGroups(svgRoot, SVGSupport.ANNOTATION_BAR).isEmpty() ||
+   private static void appendMultiStyleHoverCSS(Element svgRoot, Document doc, String dim) {
+      if(collectAnnotationGroups(svgRoot, SVGSupport.ANNOTATION_BAR).isEmpty() ||
          collectAnnotationGroups(svgRoot, SVGSupport.ANNOTATION_POINT).isEmpty())
       {
          return;

--- a/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
+++ b/utils/inetsoft-xml-formats/src/test/java/inetsoft/util/graphics/animation/SVGAnimationDOMInjectorTest.java
@@ -332,12 +332,13 @@ class SVGAnimationDOMInjectorTest {
    }
 
    /**
-    * Gantt charts draw interval bars plus one {@code PointElement} milestone per bar.  A milestone
-    * marks the end of its own bar, so hovering the bar must not fade it — the cross-type rules are
-    * suppressed for the gantt hint even though both annotation classes are present.
+    * Gantt charts draw interval bars plus milestone points.  A milestone is an independent
+    * aggregate that only shares the category axis with the bars — not part of any bar's mark — so
+    * the cross-type rules apply to gantt exactly as they do to a bar+point multi-style chart
+    * (bug #75879).
     */
    @Test
-   void hoverCssMultiStyleCrossTypeDimSkippedForGantt() throws Exception {
+   void hoverCssMultiStyleCrossTypeDimAppliesToGantt() throws Exception {
       Document doc = newDocument();
       addAnnotGroup(doc, SVGSupport.ANNOTATION_BAR, Map.of("row", "0", "col", "0"),
                     10, 10, 60, 20);
@@ -348,10 +349,14 @@ class SVGAnimationDOMInjectorTest {
          SVGSupport.ANIMATION_GROW + ":" + SVGSupport.ANIMATION_FLAG_GANTT);
       String css = allStyleContent(doc.getDocumentElement());
 
-      assertFalse(css.contains("svg.ready:has(.inetsoft-bar.inetsoft-active) .inetsoft-point"),
-                  "a gantt bar hover must not fade its own milestone");
-      assertFalse(css.contains("svg.ready:has(.inetsoft-point.inetsoft-active) .inetsoft-bar"),
-                  "a gantt milestone hover must not fade the bars");
+      assertTrue(
+         css.contains("svg.ready:has(.inetsoft-point.inetsoft-active) " +
+                      ".inetsoft-bar:not(.inetsoft-active)"),
+         "a gantt milestone hover must fade the bars");
+      assertTrue(
+         css.contains("svg.ready:has(.inetsoft-bar.inetsoft-active) " +
+                      ".inetsoft-point:not(.inetsoft-active)"),
+         "a gantt bar hover must fade the milestones");
    }
 
    @Test
@@ -1807,12 +1812,13 @@ class SVGAnimationDOMInjectorTest {
       assertEquals(milestoneDelay, parseDelay(labelStyle), 0.01,
                    "milestone label must fade in sync with the milestone marker");
 
-      // Bar hover must NOT dim milestone labels; point hover MUST dim other milestone labels.
-      // These rules are emitted globally by appendHoverCSS (not gated on the gantt flag); the
-      // assertions guard that the point-label class is wired into the correct hover rule.
+      // A milestone label dims with its marker: point hover dims the other milestones' labels
+      // (appendHoverCSS) and bar hover dims every milestone label (appendMultiStyleHoverCSS, which
+      // covers gantt since #75879).  The assertions guard that the point-label class is wired into
+      // both hover rules.
       String css = allStyleContent(doc.getDocumentElement());
-      assertFalse(css.contains(".inetsoft-bar.inetsoft-active) .inetsoft-point-label"),
-                  "bar hover must not dim milestone labels");
+      assertTrue(css.contains(".inetsoft-bar.inetsoft-active) .inetsoft-point-label:not(.inetsoft-active)"),
+                 "bar hover must dim milestone labels");
       assertTrue(css.contains(".inetsoft-point.inetsoft-active) .inetsoft-point-label:not(.inetsoft-active)"),
                  "point hover must dim other milestone labels");
    }


### PR DESCRIPTION
Root Cause:
Gantt charts draw interval bars (BarVO -> .inetsoft-bar) plus milestone markers (PointElement -> .inetsoft-point) in one SVG. The cross-chart-type hover-dim rules that make a point hover fade bars are emitted by
SVGAnimationDOMInjector.appendMultiStyleHoverCSS, but that method explicitly returned early whenever the ":gantt" animation-hint flag was present. The exclusion was added with #75871 on the premise that a gantt milestone marks the end of its own bar, so a bar hover must not fade it. That premise does not hold: GanttChartInfo.getMilestoneField() is an independent aggregate (forced to CHART_POINT) that only shares the category axis with the bars, so a milestone is not part of any bar's mark. With the rules suppressed, hovering a milestone dimmed only the other milestones and left every bar fully lit.

Fix:
Removed the gantt exclusion from appendMultiStyleHoverCSS, so the bar<->point cross-dim rules are emitted whenever an SVG contains both annotation classes - gantt included, exactly as for a bar+point multi-style chart and consistent with the box/point cross rules from #75875. Hovering a milestone now dims the bars and bar labels; hovering a bar dims the milestones and their labels. The guard that skips these rules for single-mark charts (plain bar, plain point, pure box plot) is unchanged, and the gantt entrance-animation timing (milestones fade in after the last bar) is untouched. Unit tests covering the old suppression were updated to assert the new behavior.