### PR TITLE
Bug #76170, decrypt the self-sign-up POST credentials on read

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/service/PostSignUpUserData.java
+++ b/core/src/main/java/inetsoft/web/portal/service/PostSignUpUserData.java
@@ -20,6 +20,7 @@ package inetsoft.web.portal.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import inetsoft.sree.SreeEnv;
+import inetsoft.util.Tool;
 import jakarta.servlet.http.Cookie;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,9 +43,20 @@ public class PostSignUpUserData {
    public void sendUserData() {
       String postURL = SreeEnv.getProperty("selfSignUpPost.url");
       String postUsername = SreeEnv.getProperty("selfSignUpPost.username");
-      String postPassword = SreeEnv.getProperty("selfSignUpPost.password");
       String postHeader = SreeEnv.getProperty("selfSignUpPost.header");
-      String postSecret = SreeEnv.getProperty("selfSignUpPost.secretKey");
+
+      // Nothing in the product writes these two, so they are set by hand in the property store or
+      // through INETSOFTENV_*. Decrypt on read so an operator who does not want a credential
+      // sitting in the clear can store Tool.encryptPassword output instead: decryptPassword
+      // returns an unrecognised value unchanged (LocalPasswordEncryption's clear-text branch), so
+      // a plaintext value keeps working exactly as before.
+      //
+      // Deliberately not SreeEnv.getPassword. Under cloud secrets that treats the stored string as
+      // a secret-manager reference and would resolve a literal to null, and its hardcoded name
+      // switch reads a "password" field out of the JSON for anything outside the OpenID names -
+      // the wrong field for selfSignUpPost.secretKey.
+      String postPassword = Tool.decryptPassword(SreeEnv.getProperty("selfSignUpPost.password"));
+      String postSecret = Tool.decryptPassword(SreeEnv.getProperty("selfSignUpPost.secretKey"));
 
       HttpClient client = HttpClient.newHttpClient();
 


### PR DESCRIPTION
## Summary

`selfSignUpPost.password` and `selfSignUpPost.secretKey` are read with a plain `SreeEnv.getProperty`, and nothing in the tree ever writes them — so there is no way to hold either one encrypted, while every tool that classifies properties by name redacts both. This reads them through `Tool.decryptPassword`, as `OpenIDConfig.getClientSecret` and `LogSettingService.getFluentdSettings` already do for their own credentials, so the redaction and the storage form agree.

Filed as part of Redmine #76170, which reports that StyleBI has no single definition of a secret. Most of that issue concerns `AdminPropertyCatalog`, which is not on `main` — that half is a separate PR against the admin-chat branch. This is the one part that applies to shipped code.

## Backward compatibility

`Tool.decryptPassword` returns an unrecognised value unchanged — `LocalPasswordEncryption`'s final branch is literally `// clear text` — and returns `null` for `null`, which the existing null checks below still rely on. Both `JcePasswordEncryption` and `FipsPasswordEncryption` extend `LocalPasswordEncryption` and inherit that method `final`, so the behaviour is the same under FIPS. An existing plaintext deployment is unaffected.

## Why not `SreeEnv.getPassword`

That would have been the obvious choice, and it is wrong here for two reasons:

- Under cloud secrets it treats the stored string as a secret-manager reference (`SreeEnv.getPassword`, the `Tool.isCloudSecrets()` branch) and would resolve a hand-set literal to `null`. These two properties have no writer and no Enterprise Manager field, so a literal in `sree.properties` or an `INETSOFTENV_*` variable is the only way they are ever set.
- Its hardcoded name switch falls through to a `"password"` field for anything outside the OpenID names, which is the wrong field for `selfSignUpPost.secretKey`.

## Testing

`./mvnw compile -pl core` clean. `PostSignUpUserData` has no existing test and no seam — it constructs its `HttpClient` inline — so adding one would mean refactoring the class, which is out of scope for this fix. Verified by inspection of the decrypt contract above, plus the manual check that a plaintext value produces the same `Authorization: Basic` header as before and a `Tool.encryptPassword` ciphertext produces the same header from the encrypted form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
