### PR TITLE
fix(wiz): drop the date-comparison frame, which coloured nothing

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/DateComparisonService.java
@@ -19,7 +19,6 @@ package inetsoft.web.wiz.viewsheet;
 
 import inetsoft.web.composer.model.vs.*;
 import inetsoft.web.composer.vs.dialog.DateComparisonDialogService;
-import inetsoft.web.wiz.binding.VisualFrameAliases;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -40,8 +39,16 @@ import java.util.*;
  * once serialized a 67 KB timezone table into the response; the normalized shape here carries
  * only what a caller can act on.
  *
- * <p>{@code DateComparisonPaneModel} also carries a {@code VisualFrameModel}, so it reuses spec
- * 2c's frame vocabulary rather than a parallel one.
+ * <p>{@code DateComparisonPaneModel} also carries a {@code VisualFrameModel}, and this service
+ * deliberately does <b>not</b> expose it. The date-comparison palette is disabled product-wide:
+ * every point that would apply it is commented out behind an {@code @dcColorRemove} marker — the
+ * dialog row in {@code date-comparison-pane.component.html}, three blocks plus
+ * {@code refreshDcColorFrame()} in {@code ChartDcProcessor}, and the crosstab-to-chart handoff in
+ * {@code DateComparisonUtil}. What replaced it is {@code ChartDcProcessor}'s live path, where the
+ * trend point/line simply takes its bar's colour. The model still round-trips a frame, so a tool
+ * that accepted one would store it, report it back, and change nothing on the chart — a silent
+ * success is worse than no knob at all. If the marker is ever lifted, this is the place to
+ * re-expose it.
  */
 @Service
 public class DateComparisonService {
@@ -62,8 +69,7 @@ public class DateComparisonService {
     * @param endToday anchor the range on today instead of an explicit end
     */
    public record Comparison(Integer periods, String level, String endDate, boolean endToday,
-                            String interval, Boolean useFacet, Boolean onlyShowMostRecentDate,
-                            Map<String, Object> frame) {}
+                            String interval, Boolean useFacet, Boolean onlyShowMostRecentDate) {}
 
    /** The current settings, normalized. Never echoes the raw cell format. */
    public Map<String, Object> read(String sessionToken, Principal user, String assemblyName)
@@ -93,8 +99,6 @@ public class DateComparisonService {
       out.put("onlyShowMostRecentDate", model.isOnlyShowMostRecentDate());
       out.put("period", describePeriod(model.getPeriodPaneModel()));
       out.put("interval", describeInterval(model.getIntervalPaneModel()));
-      // The frame is described through 2c's vocabulary, so no FQCN reaches the caller.
-      out.put("frame", VisualFrameAliases.describe(model.getVisualFrameModel()));
       return out;
    }
 
@@ -194,10 +198,6 @@ public class DateComparisonService {
 
       if(comparison.onlyShowMostRecentDate() != null) {
          model.setOnlyShowMostRecentDate(comparison.onlyShowMostRecentDate());
-      }
-
-      if(comparison.frame() != null) {
-         model.setVisualFrameModel(VisualFrameAliases.create("color", comparison.frame()));
       }
 
       PeriodPaneModel periods = model.getPeriodPaneModel();

--- a/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/viewsheet/ViewsheetAssemblyAgentController.java
@@ -736,12 +736,11 @@ public class ViewsheetAssemblyAgentController {
 
    public record DateComparisonRequest(String assembly, Integer periods, String level,
                                        String endDate, Boolean endToday, String interval,
-                                       Boolean useFacet, Boolean onlyShowMostRecentDate,
-                                       Map<String, Object> frame) {
+                                       Boolean useFacet, Boolean onlyShowMostRecentDate) {
       DateComparisonService.Comparison comparison() {
          return new DateComparisonService.Comparison(
             periods, level, endDate, Boolean.TRUE.equals(endToday), interval, useFacet,
-            onlyShowMostRecentDate, frame);
+            onlyShowMostRecentDate);
       }
    }
 

--- a/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/viewsheet/DateComparisonServiceTest.java
@@ -57,8 +57,7 @@ class DateComparisonServiceTest {
    }
 
    private static DateComparisonService.Comparison comparison(String endDate, boolean endToday) {
-      return new DateComparisonService.Comparison(4, "year", endDate, endToday, null, null, null,
-                                                  null);
+      return new DateComparisonService.Comparison(4, "year", endDate, endToday, null, null, null);
    }
 
    /**
@@ -96,7 +95,7 @@ class DateComparisonServiceTest {
    }
 
    private static DateComparisonService.Comparison facetOnly() {
-      return new DateComparisonService.Comparison(null, null, null, false, null, true, null, null);
+      return new DateComparisonService.Comparison(null, null, null, false, null, true, null);
    }
 
    // ── the recorded defect ───────────────────────────────────────────────────
@@ -164,7 +163,7 @@ class DateComparisonServiceTest {
       assertThrows(IllegalArgumentException.class,
                    () -> DateComparisonService.requireEndAnchor(
                       new DateComparisonService.Comparison(0, "year", null, true, null, null,
-                                                           null, null)));
+                                                           null)));
    }
 
    @Test
@@ -255,6 +254,22 @@ class DateComparisonServiceTest {
                   "a cell format must not be echoed — that is the 67KB timezone-table regression");
       assertTrue(read.toString().length() < 2000,
                  "the normalized response should be small; got " + read.toString().length());
+   }
+
+   /**
+    * The date-comparison palette is disabled product-wide behind {@code @dcColorRemove} — the
+    * dialog row, ChartDcProcessor's three apply blocks, and the crosstab-to-chart handoff are all
+    * commented out. The pane model still round-trips a frame, so reporting one would describe a
+    * setting that colours nothing, and a caller reading it back would take that as confirmation
+    * the colour took effect.
+    */
+   @Test
+   void doesNotReportAFrameThatColoursNothing() throws Exception {
+      Map<String, Object> read = harness(model()).service.read("tok", principal(), "Chart1");
+
+      assertFalse(read.containsKey("frame"),
+                  "the DC palette is disabled behind @dcColorRemove; reporting it reads as a " +
+                  "colour that took effect");
    }
 
    @Test


### PR DESCRIPTION
## What

`set_date_comparison`'s `frame` never coloured anything. This drops it from the
backend: `Comparison` loses the field, `read()` stops describing it, `apply()`
stops writing it, and `DateComparisonRequest` drops it from the wire.

## Why

StyleBI's date-comparison palette is **disabled product-wide**. Every point that
would apply it is commented out behind an `@dcColorRemove` marker:

| Location | What is commented out |
|---|---|
| `date-comparison-pane.component.html:96-112` | the "Color Palette" row and its `color-cell` entry point |
| `ChartDcProcessor.java:487-496` | multi-styles charts stamping the palette onto `colorField` |
| `ChartDcProcessor.java:920-945` | giving each calc aggregate the palette's i-th colour |
| `ChartDcProcessor.java:973-1005` | `refreshDcColorFrame()`, the whole method |
| `DateComparisonUtil.java:176-177` | carrying the palette across a crosstab-to-chart share |

All of it dates to the 2024-07-12 initial open-source commit — this is not
recent breakage. What runs instead is `ChartDcProcessor.java:947-966`, where the
trend point/line takes the colour of the bar it belongs to and the legend is
hidden. The product replaced "date comparison gets its own palette" with "the
comparison series follows the original series", which leaves the palette with
no job.

`DateComparisonPaneModel` still round-trips a `VisualFrameModel`, and
`DateComparisonDialogService:86-98` even manufactures an empty
`CategoricalColorFrame` when none exists. So the value stored and read back
cleanly while changing nothing on screen.

Live-tested through the plugin's own MCP tools:

```
set_date_comparison  frame={type: "static", color: "#E01B24"}   -> ok
get_date_comparison                                             -> {type: "static", color: "#518db9"}
```

A knob that reports success and does nothing is worse than no knob. An agent
asked to colour a comparison would call it, be told it worked, and report a
colour change that never happened.

## Merge order: plugin first, then this

**Merge stylebi-wiz#1867 before this PR.**

An earlier revision of this description recommended the opposite, and that was
wrong. `WebConfig.objectMapper()` (`core/.../web/WebConfig.java:207-224`) never
disables `DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES`, so it keeps
Jackson's default of `true` — `ChartFormatRequestTest:37` calls this out as "the
server's strict binding that produced the 400".

So merging this first would make any in-flight plugin still sending
`"frame": {...}` get a 400 from `/date-comparison` until the plugin PR landed.
Dropping the sender first is the order with no window: the plugin stops sending
the field before the backend stops accepting it.

Caught in review — thanks.

## Notes

- The class javadoc records where the six `@dcColorRemove` markers are, so if the
  feature is ever restored this is the place to re-expose it.
- New regression test asserts `read()` reports no `frame` — a frame in the
  response reads as a colour that took effect.

## Tests

`DateComparisonServiceTest` + `ViewsheetAssemblyAgentControllerTest` — 49 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)