### PR TITLE
Fix two ways the tabular query contract fails on a connector nobody looked at

### DIFF
--- a/core/src/main/java/inetsoft/uql/tabular/TabularQueryContract.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularQueryContract.java
@@ -28,9 +28,10 @@ import com.fasterxml.jackson.databind.JsonNode;
  * the unreferenced-property list. All of that is INPUT to
  * {@link TabularQueryParamsSchemaBuilder}, and none of it is something a caller can act on that
  * {@code queryParamsSchema} does not already say: the conditional structure is expressed as
- * {@code allOf}/{@code if}/{@code then}, the notes are folded into the root description, and the
- * facts that survive nowhere else — which property names a file, which selects a sheet — are
- * stamped as {@code format}.</p>
+ * {@code allOf}/{@code if}/{@code then} and the notes are folded into the root description. A
+ * property is identified by its own name, its {@code description} (the connector's
+ * {@code @Property} label) and its {@code pattern} — the same way every parse option already
+ * is.</p>
  *
  * <p>Two types rather than one type with five {@code @JsonIgnore} getters, because the two are
  * different things and only one of them is a promise to a caller. With the annotation approach the

--- a/core/src/main/java/inetsoft/uql/tabular/TabularQueryParamsSchemaBuilder.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularQueryParamsSchemaBuilder.java
@@ -83,7 +83,7 @@ public final class TabularQueryParamsSchemaBuilder {
             continue;
          }
 
-         JsonNode fragment = buildParamFragment(query, prop, param, resolveTags, schema);
+         JsonNode fragment = buildParamFragment(query, prop, param, resolveTags);
 
          if(fragment != null) {
             fragments.put(param.getName(), fragment);
@@ -275,8 +275,7 @@ public final class TabularQueryParamsSchemaBuilder {
    }
 
    private static JsonNode buildParamFragment(TabularQuery query, PropertyMeta prop,
-                                              TabularQuerySchema.Param param, boolean resolveTags,
-                                              TabularQuerySchema schema)
+                                              TabularQuerySchema.Param param, boolean resolveTags)
    {
       Class<?> type = prop.getDescriptor().getPropertyType();
       boolean composite = TabularSchemaExtractor.isCompositeType(type) && type != File.class;
@@ -285,76 +284,7 @@ public final class TabularQueryParamsSchemaBuilder {
          return buildCompositeFragment(query, prop, param);
       }
 
-      JsonNode node = buildScalarFragment(query, param, resolveTags);
-
-      if(node instanceof ObjectNode obj) {
-         applyRoleFormat(obj, param, schema);
-      }
-
-      return node;
-   }
-
-   /**
-    * Stamps {@code format} on the two properties a caller has to identify by ROLE rather than by
-    * name, and which nothing else in the schema distinguishes.
-    *
-    * <p>A file path is a {@code java.io.File} property, and {@code jsonType} flattens it to
-    * {@code "string"} like every other non-numeric -- so without this, "which property names the
-    * file" is unanswerable from the schema. The sheet selector is worse: its signature is
-    * "a String with a tagsMethod that dependsOn the file property", three facts that only exist
-    * in the extractor's own {@code Param} view.</p>
-    *
-    * <p>DECIDED HERE, not by the caller, because this is where the evidence is. A consumer reading
-    * the published schema sees a projection: the File type is gone, the tagsMethod name is
-    * deliberately not published, and dependsOn survives only as {@code if}/{@code then} structure.
-    * Re-deriving the role from that is guesswork over a lossy view, while this side still holds the
-    * raw values.</p>
-    *
-    * <p>Ambiguity REFUSES rather than picking one. A wrong sheet property builds a table over the
-    * wrong sheet and reports success -- there is no error anywhere for anyone to notice. Today no
-    * shipped connector reaches that branch (ServerFileQuery declares exactly one candidate), so
-    * the strict choice costs nothing now and only ever fires on a connector nobody has looked at.</p>
-    */
-   private static void applyRoleFormat(ObjectNode node, TabularQuerySchema.Param param,
-                                       TabularQuerySchema schema)
-   {
-      if(File.class.getName().equals(param.getJavaType())) {
-         node.put("format", "file-path");
-         return;
-      }
-
-      if(!"java.lang.String".equals(param.getJavaType())
-         || param.getTagsMethod() == null || param.getTagsMethod().isEmpty()
-         || param.getDependsOn() == null || param.getDependsOn().isEmpty())
-      {
-         return;
-      }
-
-      List<String> filePaths = schema.getParams().stream()
-         .filter(p -> File.class.getName().equals(p.getJavaType()))
-         .map(TabularQuerySchema.Param::getName)
-         .toList();
-
-      if(filePaths.stream().noneMatch(f -> param.getDependsOn().contains(f))) {
-         return;
-      }
-
-      List<String> siblings = schema.getParams().stream()
-         .filter(p -> "java.lang.String".equals(p.getJavaType()))
-         .filter(p -> p.getTagsMethod() != null && !p.getTagsMethod().isEmpty())
-         .filter(p -> p.getDependsOn() != null
-                       && p.getDependsOn().stream().anyMatch(filePaths::contains))
-         .map(TabularQuerySchema.Param::getName)
-         .toList();
-
-      if(siblings.size() > 1) {
-         throw new IllegalStateException(
-            "Data source type '" + schema.getDataSourceType() + "' declares " + siblings.size() +
-            " candidate sheet-selector properties (" + String.join(", ", siblings) +
-            ") -- ambiguous, refusing rather than guessing which one selects the sheet.");
-      }
-
-      node.put("format", "file-sheet");
+      return buildScalarFragment(query, param, resolveTags);
    }
 
    /**

--- a/core/src/main/java/inetsoft/uql/tabular/TabularSchemaExtractor.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularSchemaExtractor.java
@@ -199,6 +199,9 @@ public class TabularSchemaExtractor {
       // A property whose setter has already failed to return once is not offered to probe() again
       // -- see poison(). Removed from the list rather than skipped in the loop below, because the
       // second pass reads this same list to find its inner axes and must not reach it either.
+      //
+      // This covers what was poisoned BEFORE this call. An axis poisoned by the first pass below is
+      // still in the list, so the second pass checks again for itself.
       axes.removeIf(axis -> isPoisoned(pmap, axis.name));
 
       Probe baseline = probe(cls, dataSource, Collections.emptyMap());
@@ -231,7 +234,7 @@ public class TabularSchemaExtractor {
       }
 
       matrix.putAll(firstPass);
-      addCombinationGates(cls, dataSource, params, axes, firstPass, matrix);
+      addCombinationGates(cls, dataSource, params, axes, pmap, firstPass, matrix);
 
       return matrix;
    }
@@ -256,6 +259,7 @@ public class TabularSchemaExtractor {
     */
    private void addCombinationGates(Class<?> cls, XDataSource dataSource,
                                     List<TabularQuerySchema.Param> params, List<Axis> axes,
+                                    Map<String, PropertyMeta> pmap,
                                     Map<String, Map<String, List<String>>> firstPass,
                                     Map<String, Map<String, List<String>>> matrix)
    {
@@ -306,6 +310,18 @@ public class TabularSchemaExtractor {
                Map<String, List<String>> found = new LinkedHashMap<>();
 
                for(Object value : inner.values) {
+                  // Poison is checked HERE, per value, rather than being left to the list this
+                  // reads having been filtered. That filter ran before the first pass, and this is
+                  // where an axis hidden at baseline is first reached at all -- probe0 declines to
+                  // write it while its panel is shut, so the first pass never enters its setter and
+                  // never poisons it. What did not return is the PROPERTY, not one of its values,
+                  // so the remaining values are abandoned with it, and so is every later outer row
+                  // that reveals the same property. Without this, one broken setter strands a
+                  // thread per revealing axis instead of one for the life of the process.
+                  if(isPoisoned(pmap, inner.name)) {
+                     break;
+                  }
+
                   Map<String, Object> combo = new LinkedHashMap<>();
                   combo.put(outer.getKey(), outerValue);
                   combo.put(inner.name, value);
@@ -409,6 +425,12 @@ public class TabularSchemaExtractor {
          return null;
       }
       catch(InterruptedException ex) {
+         // Same signal as the timeout branch, for the same reason: if the setter really is stuck,
+         // the pooled thread is lost either way and an interrupt is the only thing left to offer a
+         // BLOCKING one. Not poisoned, though -- an interrupt says the waiter was told to stop, not
+         // that the setter would never have returned, and poisoning on that would drop an axis for
+         // the life of the process over a shutdown.
+         task.cancel(true);
          Thread.currentThread().interrupt();
          return null;
       }
@@ -422,10 +444,10 @@ public class TabularSchemaExtractor {
    /**
     * One probe, as it runs on the pool thread.
     *
-    * <p>Two rules govern the writes, and both are taken from the interactive path rather than
-    * invented here. A value is applied only where the layout does not place that parameter at all
-    * or currently shows it -- the rule {@link TabularUtil#setValuesToBean} follows when a dialog
-    * submits a form. And values are applied ONE AT A TIME with the conditions re-evaluated in
+    * <p>Two rules govern the writes, and both follow the interactive path's intent rather than
+    * being invented here. A value is applied only where the layout does not place that parameter at
+    * all or currently shows it -- the question {@link TabularUtil#setValuesToBean} asks when a
+    * dialog submits a form. And values are applied ONE AT A TIME with the conditions re-evaluated in
     * between -- what the dialog's refresh round trip does.
     *
     * <p>Both matter because a setter is not a pure function of its argument. {@link #isSelfGating}
@@ -438,9 +460,13 @@ public class TabularSchemaExtractor {
     * can work: its second parameter is by definition not shown until the first has been applied,
     * so a single combined write would silently drop it.
     *
-    * <p>The visibility consulted is the ancestor-aware one {@link #collectVisible} computes, not
-    * the per-node {@code TabularView#isVisible} flag. A field inside a hidden panel carries no
-    * flag of its own -- reading that flag alone would let exactly this case through.
+    * <p>The visibility question is answered STRICTLY here, and that is where this parts company
+    * with {@code setValuesToBean}: that method reads the per-node {@code TabularView#isVisible}
+    * flag, while this reads the ancestor-aware walk {@link #collectVisible} performs.
+    * {@code LayoutCreator} sets the flag true on every node it builds and {@code callVisibleMethod}
+    * does not propagate a false down, so a field inside a hidden panel reports itself visible --
+    * and the case that motivated this rule is exactly such a field. The per-node flag is the right
+    * question for a form the user was looking at; it is not enough for one nobody rendered.
     */
    private Probe probe0(Class<?> cls, XDataSource dataSource, Map<String, Object> values)
       throws Exception

--- a/core/src/main/java/inetsoft/uql/tabular/TabularSchemaExtractor.java
+++ b/core/src/main/java/inetsoft/uql/tabular/TabularSchemaExtractor.java
@@ -19,11 +19,15 @@ package inetsoft.uql.tabular;
 
 import inetsoft.uql.XDataSource;
 import inetsoft.uql.util.Config;
+import inetsoft.util.ThreadContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.lang.reflect.Method;
+import java.security.Principal;
 import java.util.*;
+import java.util.concurrent.*;
 
 /**
  * Derives a {@link TabularQuerySchema} — the parameters needed to build a query,
@@ -143,10 +147,7 @@ public class TabularSchemaExtractor {
 
       try {
          TabularView root = new LayoutCreator().createLayout(query);
-         TabularUtil.callViewMethods(root.getViews(), query);
-
-         Probe visible = new Probe();
-         collectVisible(root.getViews(), true, false, visible);
+         Probe visible = evaluate(root, query);
 
          for(String name : names) {
             // Only parameters the layout actually places can be judged. One the @View annotation
@@ -192,7 +193,14 @@ public class TabularSchemaExtractor {
       Class<?> cls, XDataSource dataSource, List<TabularQuerySchema.Param> params)
    {
       Map<String, Map<String, List<String>>> matrix = new LinkedHashMap<>();
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(cls);
       List<Axis> axes = findAxes(params);
+
+      // A property whose setter has already failed to return once is not offered to probe() again
+      // -- see poison(). Removed from the list rather than skipped in the loop below, because the
+      // second pass reads this same list to find its inner axes and must not reach it either.
+      axes.removeIf(axis -> isPoisoned(pmap, axis.name));
+
       Probe baseline = probe(cls, dataSource, Collections.emptyMap());
 
       if(axes.isEmpty() || baseline == null) {
@@ -362,45 +370,189 @@ public class TabularSchemaExtractor {
    /**
     * Sets the given values on a fresh query and evaluates the visibility conditions.
     *
+    * <p>Run on a pooled thread under a deadline. Every value a probe writes reaches a connector's
+    * own setter, and a setter is ordinary code in a plugin jar this class cannot audit -- there are
+    * eighty-nine of them -- so the call is a trust boundary rather than a local method call.
+    * Without a deadline, a setter that does not return takes the request thread with it, and on a
+    * path whose caller retries, one such setter costs a thread per attempt.
+    *
     * @return what is visible under those values, or {@code null} if the probe could
     *         not be run
     */
    private Probe probe(Class<?> cls, XDataSource dataSource, Map<String, Object> values) {
+      // Connector code runs on the pool thread, so the caller's context has to travel with it --
+      // the same reason callEditorMethods hands its principal to the threads it starts. The
+      // principal is all that travels: the one reader of TabularUtil's session id is
+      // callButtonMethods, and a probe never calls it.
+      Principal principal = ThreadContext.getContextPrincipal();
+      Future<Probe> task = PROBES.submit(() -> {
+         ThreadContext.setContextPrincipal(principal);
+
+         try {
+            return probe0(cls, dataSource, values);
+         }
+         finally {
+            // A pooled thread outlives the probe, and a principal left on it would answer for
+            // whoever borrows it next.
+            ThreadContext.setContextPrincipal(null);
+         }
+      });
+
       try {
-         Object probe = cls.getDeclaredConstructor().newInstance();
-
-         // The probe has to stand where the real query stands. A visibility condition may read the
-         // data source -- a connector varies what it offers by which account it is pointed at --
-         // and a probe built without one would answer for a query nobody is going to run.
-         if(dataSource != null && probe instanceof TabularQuery) {
-            ((TabularQuery) probe).setDataSource(dataSource);
-         }
-
-         Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(cls);
-
-         for(Map.Entry<String, Object> e : values.entrySet()) {
-            PropertyMeta prop = pmap.get(e.getKey());
-
-            if(prop == null) {
-               return null;
-            }
-
-            prop.setValue(probe, e.getValue());
-         }
-
-         TabularView root = new LayoutCreator().createLayout(probe);
-         TabularUtil.callViewMethods(root.getViews(), probe);
-
-         Probe result = new Probe();
-         collectVisible(root.getViews(), true, false, result);
-         values.keySet().forEach(result.conditionalVisible::remove);
-
-         return result;
+         return task.get(probeTimeoutMs, TimeUnit.MILLISECONDS);
       }
-      catch(Exception ex) {
-         LOG.debug("Failed to probe visibility for {} with {}", cls.getName(), values, ex);
+      catch(TimeoutException ex) {
+         // Best-effort: a setter looping with no blocking call in it offers the interrupt nowhere
+         // to land, and Thread.stop is gone. What bounds the damage is poison(), not this.
+         task.cancel(true);
+         poison(cls, values);
          return null;
       }
+      catch(InterruptedException ex) {
+         Thread.currentThread().interrupt();
+         return null;
+      }
+      catch(ExecutionException ex) {
+         LOG.debug("Failed to probe visibility for {} with {}", cls.getName(), values,
+                   ex.getCause());
+         return null;
+      }
+   }
+
+   /**
+    * One probe, as it runs on the pool thread.
+    *
+    * <p>Two rules govern the writes, and both are taken from the interactive path rather than
+    * invented here. A value is applied only where the layout does not place that parameter at all
+    * or currently shows it -- the rule {@link TabularUtil#setValuesToBean} follows when a dialog
+    * submits a form. And values are applied ONE AT A TIME with the conditions re-evaluated in
+    * between -- what the dialog's refresh round trip does.
+    *
+    * <p>Both matter because a setter is not a pure function of its argument. {@link #isSelfGating}
+    * already records the family: setters that grow the list a panel's visibility is computed from.
+    * Reached in a state no dialog can produce -- a value written into a field that is not on
+    * screen, on an instance where nothing else has been set -- such a setter can do considerably
+    * worse than mislead, up to not returning at all.
+    *
+    * <p>Applying one value at a time is also the only order in which {@link #addCombinationGates}
+    * can work: its second parameter is by definition not shown until the first has been applied,
+    * so a single combined write would silently drop it.
+    *
+    * <p>The visibility consulted is the ancestor-aware one {@link #collectVisible} computes, not
+    * the per-node {@code TabularView#isVisible} flag. A field inside a hidden panel carries no
+    * flag of its own -- reading that flag alone would let exactly this case through.
+    */
+   private Probe probe0(Class<?> cls, XDataSource dataSource, Map<String, Object> values)
+      throws Exception
+   {
+      Object probe = cls.getDeclaredConstructor().newInstance();
+
+      // The probe has to stand where the real query stands. A visibility condition may read the
+      // data source -- a connector varies what it offers by which account it is pointed at --
+      // and a probe built without one would answer for a query nobody is going to run.
+      if(dataSource != null && probe instanceof TabularQuery) {
+         ((TabularQuery) probe).setDataSource(dataSource);
+      }
+
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(cls);
+      TabularView root = new LayoutCreator().createLayout(probe);
+      Probe state = evaluate(root, probe);
+
+      for(Map.Entry<String, Object> e : values.entrySet()) {
+         PropertyMeta prop = pmap.get(e.getKey());
+
+         if(prop == null) {
+            return null;
+         }
+
+         // Placed by the layout but not currently shown: this value cannot be applied, so there is
+         // no state to report. Answering null is right rather than merely safe -- reporting the
+         // baseline instead would describe an axis that was never varied as one that gates nothing.
+         if(state.known.contains(e.getKey()) && !state.allVisible.contains(e.getKey())) {
+            return null;
+         }
+
+         prop.setValue(probe, e.getValue());
+         state = evaluate(root, probe);
+      }
+
+      values.keySet().forEach(state.conditionalVisible::remove);
+
+      return state;
+   }
+
+   /**
+    * Evaluates the connector's visibility conditions against the bean as it stands, and reports
+    * what they show.
+    *
+    * <p>Only {@code visibleMethod} and {@code enabledMethod} are invoked, which is what keeps this
+    * local: it does not resolve dropdown contents and does not reach the network.
+    */
+   private Probe evaluate(TabularView root, Object bean) {
+      TabularUtil.callViewMethods(root.getViews(), bean);
+
+      Probe out = new Probe();
+      collectVisible(root.getViews(), true, false, out);
+
+      return out;
+   }
+
+   /**
+    * Records that a setter did not return, so the property it belongs to is never probed again.
+    *
+    * <p>Keyed on the class that DECLARES the setter rather than on the query class being probed. A
+    * setter inherited by every REST connector is then one entry instead of one per connector, so
+    * the threads such a setter strands are bounded by how many broken setters exist rather than by
+    * how many data sources anyone happens to ask about.
+    *
+    * <p>Only the value applied LAST is blamed. {@link #addCombinationGates} applies its outer value
+    * first, and an outer axis has already completed a probe of its own in the first pass -- an axis
+    * whose setter hangs is poisoned and dropped before the pair pass can reach it. So when a
+    * two-value probe times out, what hung is the value applied second.
+    */
+   private void poison(Class<?> cls, Map<String, Object> values) {
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(cls);
+      String name = null;
+
+      for(String candidate : values.keySet()) {
+         name = candidate;
+      }
+
+      PropertyMeta prop = name == null ? null : pmap.get(name);
+      String key = prop == null ? null : poisonKey(prop, name);
+
+      if(key != null) {
+         POISONED.add(key);
+      }
+
+      LOG.warn("A tabular query setter did not return within {}ms while probing {} with {}. Its " +
+               "thread cannot be reclaimed, so {} is not probed again in this process; whatever " +
+               "it gates is left undescribed rather than guessed.",
+               probeTimeoutMs, cls.getName(), values, key != null ? key : name);
+   }
+
+   private static boolean isPoisoned(Map<String, PropertyMeta> pmap, String name) {
+      PropertyMeta prop = pmap.get(name);
+      return prop != null && POISONED.contains(poisonKey(prop, name));
+   }
+
+   private static String poisonKey(PropertyMeta prop, String name) {
+      Method setter = prop.getDescriptor().getWriteMethod();
+
+      return (setter == null ? "?" : setter.getDeclaringClass().getName()) + "#" + name;
+   }
+
+   /**
+    * FOR TESTS: shortens the deadline, so a case about a setter that does not return costs
+    * milliseconds instead of seconds.
+    */
+   static void setProbeTimeout(long ms) {
+      probeTimeoutMs = ms;
+   }
+
+   /** FOR TESTS: forgets which setters have hung, so one case cannot decide the next one. */
+   static void clearPoisoned() {
+      POISONED.clear();
    }
 
    /**
@@ -680,6 +832,38 @@ public class TabularSchemaExtractor {
    }
 
    private static final int MAX_NESTING = 2;
+
+   /**
+    * How long one probe may run before the axis it was probing is abandoned.
+    *
+    * <p>A probe is reflection over an in-memory bean, so a connector that behaves finishes in
+    * microseconds. The bound is this loose because the only thing it has to separate is "slow"
+    * from "never returns": a setter that genuinely took a second would still be a defect worth
+    * surfacing rather than a case worth accommodating.
+    */
+   private static final long DEFAULT_PROBE_TIMEOUT_MS = 2000;
+
+   private static volatile long probeTimeoutMs = DEFAULT_PROBE_TIMEOUT_MS;
+
+   /**
+    * Probes run here rather than on the caller's thread, so one that does not return can be
+    * abandoned.
+    *
+    * <p>Cached rather than fixed. An abandoned probe keeps its thread for the life of the process
+    * -- a tight loop in a setter offers the interrupt nowhere to land, and Thread.stop was removed
+    * in JDK 20 -- so a fixed pool would be consumed by exactly the failures this exists to
+    * survive. The leak is bounded by {@link #POISONED} instead: a property is probed at most once
+    * after it hangs.
+    */
+   private static final ExecutorService PROBES = Executors.newCachedThreadPool(runnable -> {
+      Thread thread = new Thread(runnable, "TabularSchemaProbe");
+      thread.setDaemon(true);
+
+      return thread;
+   });
+
+   /** Setters that did not return, keyed by declaring class -- see {@link #poison}. */
+   private static final Set<String> POISONED = ConcurrentHashMap.newKeySet();
 
    private static final Logger LOG = LoggerFactory.getLogger(TabularSchemaExtractor.class);
 }

--- a/core/src/test/java/inetsoft/uql/tabular/TabularQueryParamsSchemaBuilderTest.java
+++ b/core/src/test/java/inetsoft/uql/tabular/TabularQueryParamsSchemaBuilderTest.java
@@ -239,25 +239,44 @@ class TabularQueryParamsSchemaBuilderTest {
 
    // --- role formats, and the wire a consumer actually receives ----------
 
+   /**
+    * A file property and a sheet selector are matched by NAME, the same way every parse option
+    * already is, so no property carries a role marker.
+    *
+    * <p>The marker this replaces was inferred rather than declared: "String with a tagsMethod that
+    * dependsOn the file property" is a description of an editor that recomputes its choices when the
+    * file changes, which is equally true of a charset picker. Both file connectors shipped declare
+    * two such properties (excelSheet and encoding), and one of them names its file with a String
+    * rather than a java.io.File, so neither half of the inference held on either connector.</p>
+    */
    @Test
-   void fileAndSheetPropertiesAreIdentifiableByRoleNotByName() {
-      // jsonType flattens java.io.File to "string" like every other non-numeric, and the sheet
-      // selector's signature (String + tagsMethod + dependsOn the file property) lives only in the
-      // extractor's Param view -- so without these two formats neither role is answerable from the
-      // published schema at all, which is what kept a second flat view of the contract alive.
-      JsonNode props = excelSchema().get("properties");
+   void noPropertyCarriesARoleFormat() {
+      JsonNode fileProps = excelSchema().get("properties");
 
-      assertEquals("string", props.get("fileFolder").get("type").asText());
-      assertEquals("file-path", props.get("fileFolder").get("format").asText());
-      assertEquals("file-sheet", props.get("excelSheet").get("format").asText());
-   }
+      assertEquals("string", fileProps.get("fileFolder").get("type").asText());
+      assertFalse(fileProps.get("fileFolder").has("format"),
+                  "the file property is matched by name, not by a role marker");
+      assertFalse(fileProps.get("excelSheet").has("format"),
+                  "and so is the sheet selector");
 
-   @Test
-   void aRoleFormatIsNeverStampedOnAnOrdinaryProperty() {
       JsonNode props = properties();
 
       assertFalse(props.get("pageSize").has("format"));
       assertFalse(props.get("namePattern").has("format"));
+   }
+
+   /**
+    * What a caller matches on instead: the property's own name, the label the connector gave it, and
+    * the pattern it declares. Publishing these is what lets `binding.path` and `binding.sheet` be
+    * placed without a marker.
+    */
+   @Test
+   void aFilePropertyStaysIdentifiableByItsLabelAndPattern() {
+      JsonNode props = excelSchema().get("properties");
+
+      assertTrue(props.get("fileFolder").get("description").asText().contains("File Folder"));
+      assertEquals("^.*\\.(txt|csv|xls|xlsx)$", props.get("fileFolder").get("pattern").asText());
+      assertTrue(props.get("excelSheet").get("description").asText().contains("Sheet"));
    }
 
    @Test

--- a/core/src/test/java/inetsoft/uql/tabular/TabularSchemaExtractorTest.java
+++ b/core/src/test/java/inetsoft/uql/tabular/TabularSchemaExtractorTest.java
@@ -20,6 +20,7 @@ package inetsoft.uql.tabular;
 import inetsoft.uql.util.Config;
 import inetsoft.util.ConfigurationContext;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.springframework.context.ApplicationContext;
 
 import java.util.*;
@@ -40,6 +41,12 @@ import static org.mockito.Mockito.when;
  * exhibits all three would not.</p>
  */
 @Tag("core")
+// Two pieces of process-wide state are written here: the ConfigurationContext the @BeforeAll
+// installs, and the probe deadline and poison record restoreProbeDefaults() hands back. Neither can
+// be made per-test -- the poison record is process-wide BY DESIGN, since what it bounds is threads
+// this process cannot reclaim -- so the class is serialized against anything else claiming them
+// instead.
+@ResourceLock("TabularSchemaExtractor-process-state")
 class TabularSchemaExtractorTest {
    /**
     * {@code LayoutCreator} resolves labels through the connector's resource bundle, which it reaches
@@ -257,6 +264,32 @@ class TabularSchemaExtractorTest {
 
       assertEquals(1, StuckFixtureQuery.entered.get(),
                    "a second extract must not enter it again");
+   }
+
+   /**
+    * The bound {@link TabularSchemaExtractor#poison} claims -- one stranded thread per broken setter
+    * for the life of the process -- has to hold WITHIN one extract as well as across calls.
+    *
+    * <p>The axis that hangs here is not reachable in the first pass at all: its panel is hidden until
+    * an outer value opens it, so the write is skipped and the setter is never entered. It is reached
+    * in the pair pass instead, as the inner half of a pair -- and it is reachable that way TWICE,
+    * once under each outer axis. Filtering the axis list on entry cannot help: the poison is recorded
+    * after that filter has already run.
+    */
+   @Test
+   void anAxisPoisonedInTheFirstPassIsNotProbedAgainAsAnInnerAxis() {
+      TabularSchemaExtractor.setProbeTimeout(150);
+      PairStuckFixtureQuery.entered.set(0);
+
+      TabularQuerySchema schema = new TabularSchemaExtractor()
+         .extract(new PairStuckFixtureQuery(), PairStuckFixtureQuery.TYPE);
+
+      assertEquals(1, PairStuckFixtureQuery.entered.get(),
+                   "the hanging setter is entered once across the whole extract, not once per " +
+                   "outer axis that reveals it");
+      assertNotNull(schema.getDependencyMatrix().get("outerA"),
+                    "the axes that do return are still described");
+      assertNotNull(schema.getDependencyMatrix().get("outerB"));
    }
 
    private TabularQuerySchema extract() {
@@ -578,5 +611,88 @@ class TabularSchemaExtractorTest {
       private Level mode = Level.NONE;
       private String detail;
       private boolean stuck;
+   }
+
+   /**
+    * A connector whose hanging setter is not reachable on a blank query: {@code stuck} sits in a
+    * panel that opens once EITHER outer axis is set, so the pair pass reaches it twice. {@code deep}
+    * is gated on two values at once and so is never reached in the first pass, which is what makes
+    * the pair pass run at all.
+    */
+   @View(vertical = true, value = {
+      @View1(value = "outerA"),
+      @View1(value = "outerB"),
+      @View1(vertical = true, type = ViewType.PANEL, visibleMethod = "isEitherOuter", elements = {
+         @View2("stuck"),
+      }),
+      @View1(value = "deep", visibleMethod = "isOuterAAndStuck"),
+   })
+   public static class PairStuckFixtureQuery extends TabularQuery {
+      public PairStuckFixtureQuery() {
+         super(TYPE);
+      }
+
+      @Property(label = "Outer A")
+      public boolean isOuterA() {
+         return outerA;
+      }
+
+      public void setOuterA(boolean outerA) {
+         this.outerA = outerA;
+      }
+
+      @Property(label = "Outer B")
+      public boolean isOuterB() {
+         return outerB;
+      }
+
+      public void setOuterB(boolean outerB) {
+         this.outerB = outerB;
+      }
+
+      @Property(label = "Stuck")
+      public boolean isStuck() {
+         return stuck;
+      }
+
+      public void setStuck(boolean stuck) {
+         if(stuck) {
+            entered.incrementAndGet();
+
+            try {
+               Thread.sleep(60000);
+            }
+            catch(InterruptedException ex) {
+               Thread.currentThread().interrupt();
+            }
+         }
+
+         this.stuck = stuck;
+      }
+
+      @Property(label = "Deep")
+      public String getDeep() {
+         return deep;
+      }
+
+      public void setDeep(String deep) {
+         this.deep = deep;
+      }
+
+      public boolean isEitherOuter() {
+         return outerA || outerB;
+      }
+
+      public boolean isOuterAAndStuck() {
+         return outerA && stuck;
+      }
+
+      static final String TYPE = "Test.PairStuck";
+      static final AtomicInteger entered = new AtomicInteger();
+
+      private boolean outerA;
+      private boolean outerB;
+      private boolean stuck;
+      private String deep;
    }
 }

--- a/core/src/test/java/inetsoft/uql/tabular/TabularSchemaExtractorTest.java
+++ b/core/src/test/java/inetsoft/uql/tabular/TabularSchemaExtractorTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.*;
 import org.springframework.context.ApplicationContext;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
@@ -62,6 +63,16 @@ class TabularSchemaExtractorTest {
       if(previous != null) {
          previous.setApplicationContext(null);
       }
+   }
+
+   /**
+    * Both the deadline and the record of which setters have hung are per-process, so a case that
+    * changes either has to hand them back -- otherwise it decides the next one.
+    */
+   @AfterEach
+   void restoreProbeDefaults() {
+      TabularSchemaExtractor.setProbeTimeout(2000);
+      TabularSchemaExtractor.clearPoisoned();
    }
 
    @Test
@@ -200,6 +211,54 @@ class TabularSchemaExtractorTest {
          new FixtureQuery(), List.of("hidden")).isEmpty());
    }
 
+   /**
+    * The case that motivates writing only what is on screen: a boolean whose editor sits in a panel
+    * nothing has turned on yet. Its setter is never entered, because a value written there puts the
+    * bean in a state no dialog can produce -- and on a real REST connector, the state one such
+    * setter loops in forever.
+    */
+   @Test
+   void aValueTheLayoutDoesNotShowIsNeverWritten() {
+      OffScreenFixtureQuery.writes.set(0);
+
+      TabularQuerySchema schema = new TabularSchemaExtractor()
+         .extract(new OffScreenFixtureQuery(), OffScreenFixtureQuery.TYPE);
+
+      assertEquals(0, OffScreenFixtureQuery.writes.get(),
+                   "a parameter the layout does not show should not be written by a probe");
+      assertNotNull(schema.getParam("offScreen"), "it is still reported as a parameter");
+      assertNull(schema.getDependencyMatrix().get("offScreen"),
+                 "and it gates nothing, having never been varied");
+      assertNotNull(schema.getDependencyMatrix().get("mode"),
+                    "the axes that CAN be set are still probed");
+   }
+
+   /**
+    * A setter that does not return costs the axis it was probing and nothing else. The rest of the
+    * matrix is still built, and the property is not handed to a probe a second time -- the thread
+    * an abandoned probe strands cannot be reclaimed, so a caller that retries must not be able to
+    * strand another.
+    */
+   @Test
+   void aSetterThatDoesNotReturnIsAbandonedAndNotProbedAgain() {
+      TabularSchemaExtractor.setProbeTimeout(150);
+      StuckFixtureQuery.entered.set(0);
+
+      TabularQuerySchema schema = new TabularSchemaExtractor()
+         .extract(new StuckFixtureQuery(), StuckFixtureQuery.TYPE);
+
+      assertEquals(1, StuckFixtureQuery.entered.get(), "the hanging setter is entered once");
+      assertNull(schema.getDependencyMatrix().get("stuck"),
+                 "an axis whose setter did not return is dropped rather than described");
+      assertNotNull(schema.getDependencyMatrix().get("mode"),
+                    "and the axes that do return are still probed");
+
+      new TabularSchemaExtractor().extract(new StuckFixtureQuery(), StuckFixtureQuery.TYPE);
+
+      assertEquals(1, StuckFixtureQuery.entered.get(),
+                   "a second extract must not enter it again");
+   }
+
    private TabularQuerySchema extract() {
       return new TabularSchemaExtractor().extract(new FixtureQuery(), FixtureQuery.TYPE);
    }
@@ -211,6 +270,8 @@ class TabularSchemaExtractorTest {
    public enum LinkStyle { BODY, HEADER }
 
    public enum Scope { ALL, NAMED }
+
+   public enum Level { NONE, DETAIL }
 
    /**
     * A connector reduced to the structures under test.
@@ -387,5 +448,135 @@ class TabularSchemaExtractorTest {
       private String note;
       private String hidden;
       private final List<String> notes = new ArrayList<>();
+   }
+
+   /**
+    * One axis that can be set and one that cannot: {@code offScreen} sits in a panel whose
+    * visibility is computed from a list only a button grows, which is the shape a REST connector's
+    * lookup fields have.
+    */
+   @View(vertical = true, value = {
+      @View1(value = "mode"),
+      @View1(value = "detail", visibleMethod = "isDetailMode"),
+      @View1(vertical = true, type = ViewType.PANEL, visibleMethod = "isRowsAdded", elements = {
+         @View2("offScreen"),
+      }),
+   })
+   public static class OffScreenFixtureQuery extends TabularQuery {
+      public OffScreenFixtureQuery() {
+         super(TYPE);
+      }
+
+      @Property(label = "Mode")
+      @PropertyEditor(tags = { "NONE", "DETAIL" })
+      public Level getMode() {
+         return mode;
+      }
+
+      public void setMode(Level mode) {
+         this.mode = mode;
+      }
+
+      @Property(label = "Detail")
+      public String getDetail() {
+         return detail;
+      }
+
+      public void setDetail(String detail) {
+         this.detail = detail;
+      }
+
+      @Property(label = "Off Screen")
+      public boolean isOffScreen() {
+         return offScreen;
+      }
+
+      public void setOffScreen(boolean offScreen) {
+         writes.incrementAndGet();
+         this.offScreen = offScreen;
+      }
+
+      public boolean isDetailMode() {
+         return mode == Level.DETAIL;
+      }
+
+      /** Nothing a probe can set turns this on -- only the button that grows the list. */
+      public boolean isRowsAdded() {
+         return !rows.isEmpty();
+      }
+
+      static final String TYPE = "Test.OffScreen";
+      static final AtomicInteger writes = new AtomicInteger();
+
+      private Level mode = Level.NONE;
+      private String detail;
+      private boolean offScreen;
+      private final List<String> rows = new ArrayList<>();
+   }
+
+   /**
+    * A connector whose setter does not return. It sleeps rather than spins so the abandoned probe
+    * releases its thread when cancelled -- a real one has no such courtesy, which is the whole
+    * reason the deadline is paired with a record of what has already hung.
+    */
+   @View(vertical = true, value = {
+      @View1(value = "mode"),
+      @View1(value = "detail", visibleMethod = "isDetailMode"),
+      @View1(value = "stuck"),
+   })
+   public static class StuckFixtureQuery extends TabularQuery {
+      public StuckFixtureQuery() {
+         super(TYPE);
+      }
+
+      @Property(label = "Mode")
+      @PropertyEditor(tags = { "NONE", "DETAIL" })
+      public Level getMode() {
+         return mode;
+      }
+
+      public void setMode(Level mode) {
+         this.mode = mode;
+      }
+
+      @Property(label = "Detail")
+      public String getDetail() {
+         return detail;
+      }
+
+      public void setDetail(String detail) {
+         this.detail = detail;
+      }
+
+      @Property(label = "Stuck")
+      public boolean isStuck() {
+         return stuck;
+      }
+
+      public void setStuck(boolean stuck) {
+         if(stuck) {
+            entered.incrementAndGet();
+
+            try {
+               Thread.sleep(60000);
+            }
+            catch(InterruptedException ex) {
+               Thread.currentThread().interrupt();
+            }
+         }
+
+         this.stuck = stuck;
+      }
+
+      public boolean isDetailMode() {
+         return mode == Level.DETAIL;
+      }
+
+      static final String TYPE = "Test.Stuck";
+      static final AtomicInteger entered = new AtomicInteger();
+
+      private Level mode = Level.NONE;
+      private String detail;
+      private boolean stuck;
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/FakeExcelLikeQuery.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/FakeExcelLikeQuery.java
@@ -30,12 +30,14 @@ import java.io.File;
  * {@code ServerFileQuery} -- a {@code java.io.File} property ({@code fileFolder}) resolved
  * against {@code getRootFolder()} (reached by name, not {@code @Property}, exactly like the real
  * class), plus {@code isExcel()}/{@code getExcelSheetNames()} (also reached by name) and an
- * {@code excelSheet} String property whose {@code @PropertyEditor(dependsOn = {"fileFolder"},
- * tagsMethod = "getExcelSheetNames")} matches the capability 5b sheet-property heuristic exactly.
+ * {@code excelSheet} String property carrying the same
+ * {@code @PropertyEditor(dependsOn = {"fileFolder"}, tagsMethod = "getExcelSheetNames")} the real
+ * class declares.
  *
  * <p>{@code isExcel()}/the sheet list are test-controlled directly (not derived from real file
  * content) via {@link #setExcelForTest}/{@link #setSheetNamesForTest} -- this fixture exists to
- * test the AMBIGUITY REFUSAL logic, not a real spreadsheet parser.</p>
+ * test what the published schema says about a file-addressed query, not a real spreadsheet
+ * parser.</p>
  *
  * <p>{@code @View} is REQUIRED -- see {@link FakeNamedConnectorQuery}'s own doc for why.</p>
  */
@@ -45,7 +47,7 @@ public class FakeExcelLikeQuery extends TabularQuery {
       super("FakeExcelLike");
    }
 
-   @Property(label = "File Folder", required = true)
+   @Property(label = "File Folder", pattern = {"^.*\\.(txt|csv|xls|xlsx)$"}, required = true)
    public File getFileFolder() {
       return fileFolder;
    }

--- a/docs/tabular-unified-query-contract-backend-design.md
+++ b/docs/tabular-unified-query-contract-backend-design.md
@@ -825,9 +825,22 @@ Property-finding heuristic, matched EXACTLY to the wiz-side design's findSheetPr
 (stylebi-wiz docs/superpowers/specs/2026-08-25-tabular-unified-query-contract-wiz-design.md
 section 4.3) so both sides agree on which property is "the sheet one": among
 schema.getParams(), the sheet property is any param whose javaType is java.lang.String, whose
-tagsMethod is non-empty, and whose dependsOn includes the file property's name. Confirmed
-against ServerFileQuery.java:120-123: excelSheet is the unique property matching all three
-(dependsOn = {"fileFolder"}, tagsMethod = "getExcelSheetNames").
+tagsMethod is non-empty, and whose dependsOn includes the file property's name.
+
+CORRECTION (2026-08-27). This section previously recorded excelSheet as the unique property
+matching all three on ServerFileQuery. It is not: encoding matches all three as well
+(ServerFileQuery.java:138-143 -- dependsOn = {"fileFolder"}, tagsMethod = "getEncodingTypes"),
+because the three conditions describe an editor that recomputes its choices when the file
+changes rather than anything about selecting a sheet, and dependsOn is an editor-redraw
+dependency rather than a semantic gate. OneDriveQuery matches nothing at all, since it names its
+file with a String rather than a java.io.File. findSheetParam (TabularQueryContractSupport)
+returns the FIRST match in schema.getParams() order, which is @View presentation order, and
+ServerFileQuery's @View lists excelSheet above encoding -- so capability 5b names the right
+property today by layout order, not by the heuristic being decisive. Reordering that @View would
+have it tell a caller to supply queryParams.encoding to pick a sheet. The OTHER consumer of the
+same heuristic, TabularQueryParamsSchemaBuilder's format: "file-path"/"file-sheet" role markers,
+was removed for this reason: a property is identified by its own name, its description (the
+connector's @Property label) and its pattern instead.
 
     -- runs in step 4b, immediately after a successful File-typed write:
     isExcel = callQueryMethod(query, "isExcel", dsName)         -- reflection, unchanged


### PR DESCRIPTION
Two independent defects in the path that builds a tabular data source's parameter contract. Both were written with a stated premise about what shipped connectors declare, and both premises were wrong on the connectors that exist.

---

# 1. Probe a connector's setters only where a dialog could reach them, and under a deadline

`647ed1cb1` — `TabularSchemaExtractor`

## Problem

Every value `TabularSchemaExtractor` probes with reaches a connector's own setter, and `probe()` wrote it straight onto a freshly constructed bean: one property set, nothing else, regardless of what the layout currently shows. That is a state no dialog can produce, and nothing bounded how long the setter could take.

Reached that way, `RestJsonQuery.setLookupIgnoreBaseUrl(0, true)` never returns:

```java
// RestJsonQuery:857
if(index >= lookupIgnoreBaseUrl.size()) {
   if(index < LOOKUP_QUERY_LIMIT && ignoreBaseUrl) {
      while (lookupIgnoreBaseUrl.size() <= index) {
         addLookupQuery();            // base version appends to lookupIgnoreBaseUrl
      }
   }
   ...
```

`EndpointJsonQuery` overrides `addLookupQuery` without calling `super`, and its version only appends to `lookupEndpoints` — on a fresh probe it does not even get that far, because `endpoint` is null and it returns at the first guard. The loop condition can never be satisfied.

`lookupIgnoreBaseUrl0..4` are inherited by every `Rest.*` query class and `findAxes` probes a boolean with `TRUE` first, so this was reached on **every** REST endpoint table build. The loop allocates nothing and blocks on nothing, so `interrupt()` has nowhere to land and `Thread.stop` is gone: the request thread spins at 100% and is never reclaimed. A thread dump from a running instance showed three `http-nio-8080-exec` threads in this state, 18 minutes of CPU each — one per build attempt, and the caller retries.

`isSelfGating`'s own javadoc already names the family ("setters that grow the list a panel's visibility is computed from"), but it runs after `probe` returns.

## Fix

**Take the write rules from the interactive path** rather than writing directly:

- Apply a value only where the layout does not place that parameter, or currently shows it — the rule `TabularUtil.setValuesToBean` follows when a dialog submits a form. Read through `collectVisible`, not the per-node `TabularView.isVisible` flag: `LayoutCreator` sets that flag `true` on every node and `callVisibleMethod` does not propagate to children, so a field inside a hidden panel reports itself visible. Only the ancestor-aware view sees this case.
- Apply values one at a time with the conditions re-evaluated between them — what the dialog's refresh round trip does, and the only order in which `addCombinationGates` can set a parameter whose outer value has to reveal it first.

An axis whose value cannot be applied answers `null`, which `buildDependencyMatrix` already treats as "drop this axis" — no new failure path.

`setValuesToBean` itself is deliberately not called: it is a whole-form submit, and its `affectedViews` suppression would silently drop `paginationType` on the ten connectors that list it under `@View1(value = "endpoint", affectedViews = {...})`.

**Run each probe under a deadline**, because the rules above bound which setters are entered, not what one does once entered — this class calls into 89 plugin jars it cannot audit. On timeout the axis is dropped and the property is recorded so it is never probed again, keyed on the class **declaring** the setter so an inherited one is a single entry rather than one per connector. A caller that retries cannot strand another thread.

The abandoned thread still cannot be reclaimed; what changes is that there is at most one per broken setter for the life of the process, instead of one per request.

## Tests

Two cases on their own fixtures:

- `aValueTheLayoutDoesNotShowIsNeverWritten` — a boolean in a panel gated on a list only a button grows: the setter is never entered, the parameter is still reported, it gates nothing, and the axes that *can* be set are still probed.
- `aSetterThatDoesNotReturnIsAbandonedAndNotProbedAgain` — the setter is entered once, its axis is dropped, the other axes still produce a matrix, and a second `extract` does not enter it again.

Both pre-existing two-level gate cases (`mode & linkStyle`, `scoped & scope`) pass on the new one-value-at-a-time path.

---

# 2. Identify a file target's properties by name, not by an inferred role marker

`b6bb3c711` — `TabularQueryParamsSchemaBuilder`

## Problem

`applyRoleFormat` stamped `format: "file-path"` on the property naming a file and `format: "file-sheet"` on the sheet selector, so a caller holding a path and a sheet could find the properties to put them in. Neither inference held on either shipped file connector.

The sheet signature — a `String` with a `tagsMethod` that `dependsOn` a `File`-typed property — describes an editor whose choices are recomputed when the file changes. A charset picker fits it exactly:

```java
@Property(label = "Sheet")
@PropertyEditor(dependsOn = {"fileFolder"}, enabledMethod = "isExcel", tagsMethod = "getExcelSheetNames")
public String getExcelSheet()

@Property(label = "Encoding")
@PropertyEditor(enabledMethod = "isText", dependsOn = {"fileFolder"}, tagsMethod = "getEncodingTypes")
public String getEncoding()
```

`dependsOn` is documented as *"the list of properties on which **the editor** depends"* — a redraw dependency, not a semantic gate — so nothing in the signature separates the two. `isExcel`/`isText` do not either: both return true for a directory, which is what the data source that surfaced this is.

The ambiguity guard threw, and it threw from inside the per-property loop in `build`, taking the whole schema with it. `GET /tabular/query-schema` answered 500 for every `SERVER_FILE` data source — including the `file-path` marker, which was never ambiguous:

```
java.lang.IllegalStateException: Data source type 'SERVER_FILE' declares 2 candidate sheet-selector
properties (excelSheet, encoding) -- ambiguous, refusing rather than guessing which one selects the sheet.
        at TabularQueryParamsSchemaBuilder.applyRoleFormat(TabularQueryParamsSchemaBuilder.java:353)
        at TabularQueryParamsSchemaBuilder.buildParamFragment(TabularQueryParamsSchemaBuilder.java:291)
        at TabularQueryParamsSchemaBuilder.build(TabularQueryParamsSchemaBuilder.java:86)
        at WizTabularController.getQuerySchema(WizTabularController.java:315)
```

`OneDriveQuery` reached neither branch: it names its file with a `String` (`path`), not a `java.io.File`, so `filePaths` is empty, the type rule marks nothing and the sheet rule returns before the ambiguity check. Of the two file connectors that exist, one answered 500 and the other answered a schema with no markers at all.

The method's javadoc asserted the opposite — *"Today no shipped connector reaches that branch (ServerFileQuery declares exactly one candidate) … only ever fires on a connector nobody has looked at"* — and the existing test used a single-candidate fixture, so the branch had no coverage.

## Fix

Remove the inference rather than adding a discriminator. Nothing declared on a connector says "this selects the sheet", and the only thing that separates the two candidates today is which `enabledMethod` name they carry, which is the connector-specific guesswork this class was written to avoid.

What a caller matches on instead is already published for every property: its own name, the connector's `@Property` label as its `description`, and any `pattern` it declares — the file property declares `^.*\.(txt|csv|xls|xlsx)$` in **both** connectors, including the one whose file property is a `String`. That is the matching `binding.parseOptions` has always needed, since those keys are already the connector's own names; `path` and `sheet` being special-cased was the anomaly.

## Tests

- `noPropertyCarriesARoleFormat` — replaces the two role-format cases: no property in either fixture carries `format`.
- `aFilePropertyStaysIdentifiableByItsLabelAndPattern` — the replacement signals are present: the label reaches `description` and the file-extension `pattern` is published. `FakeExcelLikeQuery` gains the `pattern` both real connectors declare, so this is exercised rather than asserted against an empty fixture.

---

## Verification

```
Tests run: 98, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

`TabularSchemaExtractorTest` (15, was 13), `TabularQueryParamsSchemaBuilderTest` (18), `TabularQueryParamsSchemaBuilderResolveTagsTest` (6), `TabularQueryContractSupportTest` (34), `WorksheetTableServiceLookupWiringTest` (2), `WorksheetTableServicePermissionTest` (23).

Verified against fixtures rather than real connectors: connector query classes live in plugin jars and are not on core's classpath, which is why this suite uses fixtures at all. Each fixture reproduces the shape that failed — a property placed inside a panel whose `visibleMethod` reads a list nothing settable grows, and a file property carrying the real extension pattern.

## Caller side

The four prompts and three comments that told the model to look for `format: "file-path"` / `"file-sheet"` are updated in `stylebi-wiz` (`Match a file target's properties by name, not by a role marker`) and have to ship together with part 2 — left as they were, they send the model looking for a field the contract no longer carries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
