### PR TITLE
fix(wiz): apply and echo secondaryField/nOrP on autoBinding measure refs

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizAutoBindingService.java
@@ -938,8 +938,9 @@ public class WizAutoBindingService {
    /**
     * changeType()'s crosstab counterpart to {@link #applyFieldConfigs(VSChartInfo, Map)} — that one
     * only walks a {@link VSChartInfo}, so a crosstab recommendation's aggregate formulas were never
-    * overridden by the caller's resolved fieldConfigs. Only {@code aggregateFormula} applies here;
-    * a crosstab aggregate has no ranking/date-group/calculator of its own to carry over.
+    * overridden by the caller's resolved fieldConfigs. {@code aggregateFormula},
+    * {@code secondaryField}, and {@code nOrP} apply here; a crosstab aggregate has no
+    * ranking/date-group/calculator of its own to carry over.
     *
     * <p>Package-private and static so it can be unit-tested directly with mocked refs, mirroring
     * {@link #repartitionHeaders}.
@@ -962,7 +963,7 @@ public class WizAutoBindingService {
 
    /** Shared per-ref mutation for {@link #applyCrosstabAggregateFormulas} — applied to whichever
     *  {@code DataRef[]} (design or runtime) the caller passes in. */
-   private static void applyAggregateFormulasTo(DataRef[] aggregates, Map<String, SimpleFieldInfo> configMap) {
+   static void applyAggregateFormulasTo(DataRef[] aggregates, Map<String, SimpleFieldInfo> configMap) {
       if(aggregates == null) {
          return;
       }
@@ -974,8 +975,21 @@ public class WizAutoBindingService {
 
          SimpleFieldInfo fc = configMap.get(agg.getColumnValue());
 
-         if(fc instanceof MeasureFieldInfo meaFc && meaFc.getAggregateFormula() != null) {
-            agg.setFormulaValue(meaFc.getAggregateFormula());
+         if(fc instanceof MeasureFieldInfo meaFc) {
+            if(meaFc.getAggregateFormula() != null) {
+               agg.setFormulaValue(meaFc.getAggregateFormula());
+            }
+
+            // Same reasoning as the chart branch of applyFieldConfig: a two-column
+            // (WeightedAverage, ...) or N/P (PthPercentile, ...) formula needs its extra
+            // parameter carried over too, or it keeps the VSAggregateRef constructor default.
+            if(meaFc.getSecondaryField() != null) {
+               agg.setSecondaryColumnValue(meaFc.getSecondaryField());
+            }
+
+            if(meaFc.getNOrP() != null) {
+               agg.setN(meaFc.getNOrP());
+            }
          }
       }
    }
@@ -1247,7 +1261,7 @@ public class WizAutoBindingService {
       }
    }
 
-   private void applyFieldConfig(ChartRef ref, Map<String, SimpleFieldInfo> configMap,
+   static void applyFieldConfig(ChartRef ref, Map<String, SimpleFieldInfo> configMap,
                                   int chartType) {
       String fieldName = WizardRecommenderUtil.getChartRefFieldName(ref);
       SimpleFieldInfo fc = configMap.get(fieldName);
@@ -1312,6 +1326,18 @@ public class WizAutoBindingService {
                }
             }
 
+            // Two-column (WeightedAverage, Correlation, ...) and N/P (PthPercentile, NthLargest,
+            // ...) formulas need their extra parameter carried over too, or the ref keeps its
+            // VSAggregateRef constructor default (empty secondary column, N=1) no matter what the
+            // request sent.
+            if(meaFc.getSecondaryField() != null) {
+               agg.setSecondaryColumnValue(meaFc.getSecondaryField());
+            }
+
+            if(meaFc.getNOrP() != null) {
+               agg.setN(meaFc.getNOrP());
+            }
+
             // Apply discrete (plot un-aggregated) and secondaryY (secondary Y axis) INDEPENDENTLY,
             // matching the interactive editor (ChartAggregateInfoFactory.updateAggregateRef). The
             // invalid both-true combination is rejected upstream (fail-loud in the plugin's
@@ -1368,7 +1394,7 @@ public class WizAutoBindingService {
     * type: date types use a DateFormat pattern, numeric types a DecimalFormat pattern; other types
     * are left unformatted (a pattern there would be ambiguous).
     */
-   private void applyTitleAndFormat(ChartRef ref, SimpleFieldInfo fc) {
+   static void applyTitleAndFormat(ChartRef ref, SimpleFieldInfo fc) {
       String title = fc.getTitle();
 
       if(title != null && !title.isEmpty()) {

--- a/core/src/main/java/inetsoft/web/wiz/service/WizFieldInfoFactory.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizFieldInfoFactory.java
@@ -129,6 +129,8 @@ final class WizFieldInfoFactory {
       info.setAggregateFormula(agg.getFormula() != null ? agg.getFormula().getFormulaName() : null);
       info.setCalculateInfo(CalculateInfo.createCalcInfo(agg.getCalculator()));
       info.setPercentage(percentageName(agg.getPercentageOption()));
+      info.setSecondaryField(agg.getSecondaryColumnValue());
+      info.setNOrP(agg.getFormula() != null && agg.getFormula().hasN() ? agg.getN() : null);
       return info;
    }
 
@@ -147,6 +149,8 @@ final class WizFieldInfoFactory {
       info.setAggregateFormula(agg.getFormulaValue());
       info.setFullName(agg.getFullName());
       info.setCalculateInfo(CalculateInfo.createCalcInfo(agg.getCalculator()));
+      info.setSecondaryField(agg.getSecondaryColumnValue());
+      info.setNOrP(agg.getFormula() != null && agg.getFormula().hasN() ? agg.getN() : null);
 
       if(agg instanceof VSChartAggregateRef chartAgg) {
          info.setDiscrete(chartAgg.isDiscrete());

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceMeasureParamsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceMeasureParamsTest.java
@@ -1,0 +1,127 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
+import inetsoft.uql.erm.DataRef;
+import inetsoft.uql.viewsheet.VSAggregateRef;
+import inetsoft.uql.viewsheet.graph.VSChartAggregateRef;
+import inetsoft.web.wiz.model.MeasureFieldInfo;
+import inetsoft.web.wiz.model.SimpleFieldInfo;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Regression tests for {@link WizAutoBindingService#applyFieldConfig} and
+ * {@link WizAutoBindingService#applyAggregateFormulasTo}.
+ *
+ * <p>The bug (#76241 / #76239): both methods applied {@code aggregateFormula} from an incoming
+ * {@link MeasureFieldInfo} but never read {@code secondaryField} or {@code nOrP} — so a two-column
+ * formula (WeightedAverage, ...) or an N/P formula (PthPercentile, ...) always kept the
+ * {@code VSAggregateRef} constructor default (empty secondary column, N=1) regardless of what the
+ * autoBinding request sent. Fixed by applying both fields wherever {@code aggregateFormula} is
+ * applied.
+ */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
+@Tag("core")
+class WizAutoBindingServiceMeasureParamsTest {
+   private static MeasureFieldInfo measureFc(String aggregateFormula, String secondaryField, Integer nOrP) {
+      MeasureFieldInfo fc = new MeasureFieldInfo();
+      fc.setAggregateFormula(aggregateFormula);
+      fc.setSecondaryField(secondaryField);
+      fc.setNOrP(nOrP);
+      return fc;
+   }
+
+   // ── applyFieldConfig (chart path) ──────────────────────────────────────────
+
+   @Test
+   void secondaryFieldIsAppliedToChartAggregateRef() {
+      VSChartAggregateRef agg = mock(VSChartAggregateRef.class);
+      when(agg.getColumnValue()).thenReturn("PAID");
+      Map<String, SimpleFieldInfo> configMap =
+         Map.of("PAID", measureFc("WeightedAverage", "QUANTITY", null));
+
+      WizAutoBindingService.applyFieldConfig(agg, configMap, 0);
+
+      verify(agg).setSecondaryColumnValue("QUANTITY");
+   }
+
+   @Test
+   void nOrPIsAppliedToChartAggregateRef() {
+      VSChartAggregateRef agg = mock(VSChartAggregateRef.class);
+      when(agg.getColumnValue()).thenReturn("ORDER_VALUE");
+      Map<String, SimpleFieldInfo> configMap =
+         Map.of("ORDER_VALUE", measureFc("PthPercentile", null, 90));
+
+      WizAutoBindingService.applyFieldConfig(agg, configMap, 0);
+
+      verify(agg).setN(90);
+   }
+
+   @Test
+   void absentSecondaryFieldAndNOrPAreNotApplied() {
+      VSChartAggregateRef agg = mock(VSChartAggregateRef.class);
+      when(agg.getColumnValue()).thenReturn("PAID");
+      Map<String, SimpleFieldInfo> configMap = Map.of("PAID", measureFc("Sum", null, null));
+
+      WizAutoBindingService.applyFieldConfig(agg, configMap, 0);
+
+      verify(agg, never()).setSecondaryColumnValue(any());
+      verify(agg, never()).setN(anyInt());
+   }
+
+   // ── applyAggregateFormulasTo (crosstab path) ───────────────────────────────
+
+   @Test
+   void secondaryFieldIsAppliedToCrosstabAggregateRef() {
+      VSAggregateRef agg = mock(VSAggregateRef.class);
+      when(agg.getColumnValue()).thenReturn("PAID");
+      Map<String, SimpleFieldInfo> configMap =
+         Map.of("PAID", measureFc("WeightedAverage", "QUANTITY", null));
+
+      WizAutoBindingService.applyAggregateFormulasTo(new DataRef[] { agg }, configMap);
+
+      verify(agg).setSecondaryColumnValue("QUANTITY");
+   }
+
+   @Test
+   void nOrPIsAppliedToCrosstabAggregateRef() {
+      VSAggregateRef agg = mock(VSAggregateRef.class);
+      when(agg.getColumnValue()).thenReturn("ORDER_VALUE");
+      Map<String, SimpleFieldInfo> configMap =
+         Map.of("ORDER_VALUE", measureFc("PthPercentile", null, 90));
+
+      WizAutoBindingService.applyAggregateFormulasTo(new DataRef[] { agg }, configMap);
+
+      verify(agg).setN(90);
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceMeasureParamsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizAutoBindingServiceMeasureParamsTest.java
@@ -75,6 +75,25 @@ class WizAutoBindingServiceMeasureParamsTest {
       verify(agg).setSecondaryColumnValue("QUANTITY");
    }
 
+   /**
+    * Coverage proof that the fix is formula-agnostic, not incidentally correct for
+    * {@code WeightedAverage} alone: {@code AggregateFormula.isTwoColumns()} has 7 overrides
+    * ({@code Correlation}, {@code Covariance}, {@code WeightedAvg}, {@code SumWT}, {@code Sum2},
+    * {@code First}, {@code Last} — 6 of them user-facing, {@code Sum2} internal-only), and the
+    * write site never branches on which one is in play.
+    */
+   @Test
+   void secondaryFieldIsAppliedForAnyTwoColumnFormula() {
+      VSChartAggregateRef agg = mock(VSChartAggregateRef.class);
+      when(agg.getColumnValue()).thenReturn("PAID");
+      Map<String, SimpleFieldInfo> configMap =
+         Map.of("PAID", measureFc("SumWT", "QUANTITY", null));
+
+      WizAutoBindingService.applyFieldConfig(agg, configMap, 0);
+
+      verify(agg).setSecondaryColumnValue("QUANTITY");
+   }
+
    @Test
    void nOrPIsAppliedToChartAggregateRef() {
       VSChartAggregateRef agg = mock(VSChartAggregateRef.class);

--- a/core/src/test/java/inetsoft/web/wiz/service/WizFieldInfoFactoryMeasureParamsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizFieldInfoFactoryMeasureParamsTest.java
@@ -1,0 +1,98 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.uql.asset.AggregateFormula;
+import inetsoft.uql.viewsheet.VSAggregateRef;
+import inetsoft.uql.viewsheet.graph.VSChartAggregateRef;
+import inetsoft.web.wiz.model.MeasureFieldInfo;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression tests for the {@code secondaryField}/{@code nOrP} echo in
+ * {@link WizFieldInfoFactory#createChartMeasureFieldInfo} and
+ * {@link WizFieldInfoFactory#createCrosstabMeasureFieldInfo}.
+ *
+ * <p>The bug (#76241 / #76239): neither echo read {@code agg.getSecondaryColumnValue()} or
+ * {@code agg.getN()} back onto the response {@link MeasureFieldInfo}, so even after the write-side
+ * fix a caller reading the structured {@code secondaryField}/{@code nOrP} keys (rather than parsing
+ * {@code fullName}) still saw {@code null} for both. {@code nOrP} is gated on
+ * {@code AggregateFormula#hasN()} rather than echoed unconditionally, because
+ * {@code VSAggregateRef#getN()} has no "unset" sentinel of its own (it returns 1 whenever N was
+ * never set) and would otherwise fabricate {@code nOrP: 1} on every formula, including ones with no
+ * N/P concept at all (e.g. Sum).
+ */
+@Tag("core")
+class WizFieldInfoFactoryMeasureParamsTest {
+   @Test
+   void chartEchoReportsSecondaryFieldAndNOrP() {
+      VSChartAggregateRef agg = mock(VSChartAggregateRef.class);
+      when(agg.getColumnValue()).thenReturn("PAID");
+      when(agg.getSecondaryColumnValue()).thenReturn("QUANTITY");
+
+      AggregateFormula formula = mock(AggregateFormula.class);
+      when(formula.hasN()).thenReturn(true);
+      when(agg.getFormula()).thenReturn(formula);
+      when(agg.getN()).thenReturn(90);
+
+      MeasureFieldInfo info = WizFieldInfoFactory.createChartMeasureFieldInfo(agg);
+
+      assertEquals("QUANTITY", info.getSecondaryField());
+      assertEquals(90, info.getNOrP());
+   }
+
+   @Test
+   void chartEchoDoesNotFabricateNOrPForAFormulaWithoutN() {
+      VSChartAggregateRef agg = mock(VSChartAggregateRef.class);
+      when(agg.getColumnValue()).thenReturn("PAID");
+
+      AggregateFormula formula = mock(AggregateFormula.class);
+      when(formula.hasN()).thenReturn(false);
+      when(agg.getFormula()).thenReturn(formula);
+      // getN() has no unset state (defaults to 1) — must not be echoed when hasN() is false.
+      when(agg.getN()).thenReturn(1);
+
+      MeasureFieldInfo info = WizFieldInfoFactory.createChartMeasureFieldInfo(agg);
+
+      assertNull(info.getSecondaryField());
+      assertNull(info.getNOrP());
+   }
+
+   @Test
+   void crosstabEchoReportsSecondaryFieldAndNOrP() {
+      VSAggregateRef agg = mock(VSAggregateRef.class);
+      when(agg.getColumnValue()).thenReturn("ORDER_VALUE");
+      when(agg.getSecondaryColumnValue()).thenReturn("QUANTITY");
+
+      AggregateFormula formula = mock(AggregateFormula.class);
+      when(formula.hasN()).thenReturn(true);
+      when(agg.getFormula()).thenReturn(formula);
+      when(agg.getN()).thenReturn(90);
+
+      MeasureFieldInfo info = WizFieldInfoFactory.createCrosstabMeasureFieldInfo(agg);
+
+      assertEquals("QUANTITY", info.getSecondaryField());
+      assertEquals(90, info.getNOrP());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizFieldInfoFactoryMeasureParamsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizFieldInfoFactoryMeasureParamsTest.java
@@ -17,12 +17,19 @@
  */
 package inetsoft.web.wiz.service;
 
+import inetsoft.test.BaseTestConfiguration;
+import inetsoft.test.ConfigurationContextInitializer;
+import inetsoft.test.SreeHome;
 import inetsoft.uql.asset.AggregateFormula;
 import inetsoft.uql.viewsheet.VSAggregateRef;
 import inetsoft.uql.viewsheet.graph.VSChartAggregateRef;
 import inetsoft.web.wiz.model.MeasureFieldInfo;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -43,6 +50,10 @@ import static org.mockito.Mockito.when;
  * never set) and would otherwise fabricate {@code nOrP: 1} on every formula, including ones with no
  * N/P concept at all (e.g. Sum).
  */
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { BaseTestConfiguration.class }, initializers = ConfigurationContextInitializer.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SreeHome
 @Tag("core")
 class WizFieldInfoFactoryMeasureParamsTest {
    @Test


### PR DESCRIPTION
## Summary

Fixes #76241 (and the same-cause #76239).

`WizAutoBindingService.applyFieldConfig` (chart) and `applyAggregateFormulasTo` (crosstab) — the
methods that patch a recommender-built `VSAggregateRef`/`VSChartAggregateRef` with the caller's
resolved `fieldConfigs` on `/viewsheet/autoBinding` — applied `aggregateFormula` but never read
`MeasureFieldInfo.secondaryField` or `.nOrP`. So a two-column formula (`WeightedAverage`,
`Correlation`, ...) or an N/P formula (`PthPercentile`, `NthLargest`, ...) always kept the
`VSAggregateRef` constructor default (empty secondary column, N=1), no matter what the request
sent — e.g. `WeightedAverage(PAID, null)` instead of `WeightedAverage(PAID, QUANTITY)`, with every
row rendering null because the weighting column was never actually bound.

`WizFieldInfoFactory`'s response echo (`createChartMeasureFieldInfo` /
`createCrosstabMeasureFieldInfo`) had the same gap: even with the write-side fix, a caller reading
the structured `secondaryField`/`nOrP` response keys (rather than parsing `fullName`) would still
see `null`. The `nOrP` echo is gated on `AggregateFormula#hasN()` rather than echoed
unconditionally, because `VSAggregateRef#getN()` has no unset sentinel of its own — it returns `1`
whenever N was never set — so an ungated echo would fabricate `nOrP: 1` on every formula, including
ones with no N/P concept at all (e.g. `Sum`).

`applyFieldConfig`, `applyTitleAndFormat`, and `applyAggregateFormulasTo` were made
package-private `static` (were `private`) so they can be unit-tested directly with mocked refs —
mirroring the existing `applyDateGroup` convention in the same class. None use instance state, so
this is a visibility-only change.

## Root cause

`/viewsheet/autoBinding` lets the recommender build the chart ref (with defaults), then patches it
with the caller's `fieldConfigs`. The patch step read every other `MeasureFieldInfo` field it has
an aggregate-shaped use for, but never `secondaryField`/`nOrP` — an omission, not a name-casing or
deserialization bug (both fields deserialize correctly; confirmed by reading
`MeasureFieldInfo`/`AutoBindingRequest`).

## Test plan

- [x] `./mvnw.cmd -pl build-tools -am install -DskipTests -q` then `./mvnw.cmd -pl core compile
      -DskipTests -q` — clean compile, exit 0.
- [x] New regression tests: `WizAutoBindingServiceMeasureParamsTest` (5 tests — secondaryField/nOrP
      applied on both the chart and crosstab apply paths, plus a negative case) and
      `WizFieldInfoFactoryMeasureParamsTest` (3 tests — chart/crosstab echo round-trip, and the
      `hasN()` guard doesn't fabricate a default).
- [x] Full `inetsoft.web.wiz.**` package suite: 2546 tests, 0 failures, 0 errors, 1 pre-existing
      skip — no regressions from the visibility changes or the new logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)