### PR TITLE
fix(wiz): restore nOrP wire binding on MeasureFieldInfo

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/model/MeasureFieldInfo.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/MeasureFieldInfo.java
@@ -17,7 +17,9 @@
  */
 package inetsoft.web.wiz.model;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import inetsoft.web.binding.model.graph.CalculateInfo;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -46,10 +48,13 @@ public class MeasureFieldInfo extends SimpleFieldInfo {
       this.secondaryField = secondaryField;
    }
 
+   @JsonProperty("nOrP")
    public Integer getNOrP() {
       return nOrP;
    }
 
+   @JsonProperty("nOrP")
+   @JsonAlias("norP")
    public void setNOrP(Integer nOrP) {
       this.nOrP = nOrP;
    }

--- a/core/src/test/java/inetsoft/web/wiz/model/MeasureFieldInfoNOrPRoundTripTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/model/MeasureFieldInfoNOrPRoundTripTest.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Bug #76239: wiz-services sends fieldConfigs measures keyed "nOrP" (bindingSchema.ts:91), but
+ * MeasureFieldInfo.getNOrP()/setNOrP() had no @JsonProperty override, so Jackson's default bean
+ * mangling expected "norP" instead — the mismatch was silently swallowed by the class hierarchy's
+ * @JsonIgnoreProperties(ignoreUnknown = true), leaving getNOrP() null. Deserializes through
+ * AutoBindingRequest.fieldConfigs so the fieldType discriminator (SimpleFieldInfo -> MeasureFieldInfo)
+ * is exercised, matching the real /viewsheet/autoBinding request shape.
+ */
+@Tag("core")
+public class MeasureFieldInfoNOrPRoundTripTest {
+   @Test
+   public void nOrPBinds() throws Exception {
+      String json = "{\"fieldConfigs\":[{"
+         + "\"field\":\"ORDER_VALUE\",\"fieldType\":\"measure\","
+         + "\"aggregateFormula\":\"PthPercentile\",\"nOrP\":90}]}";
+
+      ObjectMapper m = new ObjectMapper();
+      AutoBindingRequest req = m.readValue(json, AutoBindingRequest.class);
+
+      MeasureFieldInfo field = (MeasureFieldInfo) req.getFieldConfigs().get(0);
+      assertEquals(Integer.valueOf(90), field.getNOrP());
+   }
+
+   @Test
+   public void norPAliasStillBinds() throws Exception {
+      // The Jackson-derived name from before this fix; kept working via @JsonAlias so any
+      // caller that relied on the old (broken) wire contract does not regress.
+      String json = "{\"fieldConfigs\":[{"
+         + "\"field\":\"ORDER_VALUE\",\"fieldType\":\"measure\","
+         + "\"aggregateFormula\":\"PthPercentile\",\"norP\":90}]}";
+
+      ObjectMapper m = new ObjectMapper();
+      AutoBindingRequest req = m.readValue(json, AutoBindingRequest.class);
+
+      MeasureFieldInfo field = (MeasureFieldInfo) req.getFieldConfigs().get(0);
+      assertEquals(Integer.valueOf(90), field.getNOrP());
+   }
+
+   @Test
+   public void secondaryFieldStillRoundTrips() throws Exception {
+      // secondaryField is spelled identically on both sides already; must not regress.
+      String json = "{\"fieldConfigs\":[{"
+         + "\"field\":\"PAID\",\"fieldType\":\"measure\","
+         + "\"aggregateFormula\":\"WeightedAverage\",\"secondaryField\":\"QUANTITY\"}]}";
+
+      ObjectMapper m = new ObjectMapper();
+      AutoBindingRequest req = m.readValue(json, AutoBindingRequest.class);
+
+      MeasureFieldInfo field = (MeasureFieldInfo) req.getFieldConfigs().get(0);
+      assertEquals("QUANTITY", field.getSecondaryField());
+   }
+}


### PR DESCRIPTION
## Summary

Fixes bug #76239's deserialization half: `PthPercentile`'s P parameter (and N for any other
`hasN()` formula) was silently dropped on `/viewsheet/autoBinding`.

`MeasureFieldInfo.getNOrP()`/`setNOrP(Integer)` had no `@JsonProperty` override, so Jackson's
default bean-property mangling expected the JSON key `norP`, while wiz-services correctly sends
`nOrP` (`bindingSchema.ts:91`). The mismatch was silently swallowed by
`@JsonIgnoreProperties(ignoreUnknown = true)` on `AutoBindingRequest`/`SimpleFieldInfo`/
`MeasureFieldInfo`, leaving `getNOrP()` null after deserialization even though the correct value
was on the wire — no error, no warning.

Fix: add `@JsonProperty("nOrP")` to both accessors, and `@JsonAlias("norP")` to the setter so any
caller still relying on the old Jackson-derived name keeps working.

This restores `nOrP` for every `hasN()` formula (`PthPercentile`, `NthLargest`, `NthSmallest`,
`NthMostFrequent`) and every consumer of `MeasureFieldInfo.getNOrP()` — not just the chart path
reported in #76239.

**This is only the deserialization half.** The write side — `WizAutoBindingService.applyFieldConfig`
not reading `getNOrP()` at all on the `VSChartAggregateRef` branch that actually executes on
`/viewsheet/autoBinding` — is fixed separately in PR #4820 (the sibling fix for #76241). Neither
PR alone fixes #76239's reported symptom; both are required.

## Test plan

- [x] New test `core/src/test/java/inetsoft/web/wiz/model/MeasureFieldInfoNOrPRoundTripTest.java`
  deserializes through `AutoBindingRequest.fieldConfigs` (exercising the `fieldType` discriminator)
  against jackson-databind **2.21.4** (the version pinned in `bom/pom.xml` and confirmed via
  `mvnw dependency:tree`, not a substitute jar):
  - `nOrP: 90` binds to `getNOrP() == 90`
  - `norP: 90` (the old Jackson-derived name) still binds via `@JsonAlias`
  - `secondaryField` still round-trips unaffected
- [x] Confirmed the new test fails without the fix (`nOrPBinds`: `expected: <90> but was: <null>`)
  and passes with it — verified both ways by temporarily reverting the annotations (not `git stash`)
- [x] `WizConditionModelRoundTripTest` (unrelated `ConditionSpec.nOrP`, deliberately `norP`-keyed)
  still passes — confirms no regression on that sibling class
- Ran: `./mvnw.cmd -pl core test -Dtest=MeasureFieldInfoNOrPRoundTripTest,WizConditionModelRoundTripTest -q`