### PR TITLE
Bug #75914, add POST /api/wiz/visualization/rename

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/controller/WizVisualizationController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizVisualizationController.java
@@ -23,11 +23,13 @@ import inetsoft.web.composer.model.TreeNodeModel;
 import inetsoft.web.wiz.model.WizDashboardEvent;
 import inetsoft.web.wiz.model.WizDashboardResult;
 import inetsoft.web.wiz.model.WizFolderSaveResult;
+import inetsoft.web.wiz.model.WizVisualizationRenameResult;
 import inetsoft.web.wiz.model.WizVisualizationRenderEvent;
 import inetsoft.web.wiz.model.WizVisualizationRenderResult;
 import inetsoft.web.wiz.model.WizVisualizationSaveEvent;
 import inetsoft.web.wiz.model.WizVisualizationSaveResult;
 import inetsoft.web.wiz.request.WizFolderCreateRequest;
+import inetsoft.web.wiz.request.WizVisualizationRenameRequest;
 import inetsoft.web.wiz.service.RenderNotReadyException;
 import inetsoft.web.wiz.service.WizDashboardService;
 import inetsoft.web.wiz.service.WizVisualizationService;
@@ -106,6 +108,30 @@ public class WizVisualizationController {
       }
       catch(Exception e) {
          LOG.error("Failed to create visualization folder", e);
+         return ResponseEntity.internalServerError().body(Map.of("error", "An unexpected error occurred. Please try again."));
+      }
+   }
+
+   /**
+    * Renames a previously-saved wiz visualization in place — an alias-only update, so the
+    * visualization's identifier is unchanged.
+    */
+   @PostMapping(value = "/rename", produces = MediaType.APPLICATION_JSON_VALUE)
+   public ResponseEntity<?> renameVisualization(
+      @RequestBody WizVisualizationRenameRequest request, Principal principal)
+   {
+      try {
+         WizVisualizationRenameResult result = wizVisualizationService.renameVisualization(request, principal);
+         return ResponseEntity.ok(result);
+      }
+      catch(IllegalArgumentException e) {
+         return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+      }
+      catch(SecurityException e) {
+         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Map.of("error", e.getMessage()));
+      }
+      catch(Exception e) {
+         LOG.error("Failed to rename visualization", e);
          return ResponseEntity.internalServerError().body(Map.of("error", "An unexpected error occurred. Please try again."));
       }
    }

--- a/core/src/main/java/inetsoft/web/wiz/model/WizVisualizationRenameResult.java
+++ b/core/src/main/java/inetsoft/web/wiz/model/WizVisualizationRenameResult.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.model;
+
+/**
+ * The outcome of renaming a saved wiz visualization.
+ *
+ * @param identifier  the visualization's identifier — unchanged by an alias-only rename.
+ * @param displayName the new display name (alias), as actually persisted (trimmed).
+ */
+public record WizVisualizationRenameResult(String identifier, String displayName) {
+}

--- a/core/src/main/java/inetsoft/web/wiz/request/WizVisualizationRenameRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/request/WizVisualizationRenameRequest.java
@@ -1,0 +1,29 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package inetsoft.web.wiz.request;
+
+/**
+ * Renames a previously-saved wiz visualization in place — an alias-only update, so the
+ * visualization's identifier is unchanged by this call.
+ *
+ * @param identifier  the saved visualization's identifier, as returned by {@code /save}.
+ * @param displayName the new display name (alias).
+ */
+public record WizVisualizationRenameRequest(String identifier, String displayName) {
+}

--- a/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
+++ b/core/src/main/java/inetsoft/web/wiz/service/WizVisualizationService.java
@@ -39,11 +39,13 @@ import inetsoft.web.viewsheet.controller.AssemblyImageService;
 import inetsoft.web.viewsheet.service.ExportResponse;
 import inetsoft.web.viewsheet.service.VSExportService;
 import inetsoft.web.wiz.model.WizFolderSaveResult;
+import inetsoft.web.wiz.model.WizVisualizationRenameResult;
 import inetsoft.web.wiz.model.WizVisualizationRenderEvent;
 import inetsoft.web.wiz.model.WizVisualizationRenderResult;
 import inetsoft.web.wiz.model.WizVisualizationSaveEvent;
 import inetsoft.web.wiz.model.WizVisualizationSaveResult;
 import inetsoft.web.wiz.request.WizFolderCreateRequest;
+import inetsoft.web.wiz.request.WizVisualizationRenameRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -498,6 +500,63 @@ public class WizVisualizationService {
 
       assetRepository.addFolder(newEntry, principal);
       return WizFolderSaveResult.ok(path);
+   }
+
+   /**
+    * Renames a previously-saved wiz visualization in place (POST
+    * /api/wiz/visualization/rename) — an alias-only update. {@link AssetEntry#equals} ignores
+    * alias, so the old/new entries handed to {@code changeSheet} below compare equal regardless
+    * of whether they are the same object or a copy: no content clone, no new identifier, and (per
+    * {@code AbstractAssetEngine#changeSheet0}'s {@code Tool.equals(oentry, nentry)} guards around
+    * {@code dependencyHandler.renameDependencies}/{@code changeSheetDependents}) no
+    * dependency-rename cascade fires. Reuses the exact primitive
+    * {@link inetsoft.web.composer.RenameAssetController}'s alias-only branch already does.
+    */
+   public WizVisualizationRenameResult renameVisualization(WizVisualizationRenameRequest request,
+                                                             Principal principal)
+      throws Exception
+   {
+      if(request == null || Tool.isEmptyString(request.identifier())) {
+         throw new IllegalArgumentException("identifier is required");
+      }
+
+      String displayName = Tool.isEmptyString(request.displayName())
+         ? null : request.displayName().trim();
+
+      if(Tool.isEmptyString(displayName)) {
+         throw new IllegalArgumentException("displayName is required");
+      }
+
+      AssetEntry entry = AssetEntry.createAssetEntry(request.identifier());
+
+      if(entry == null || !entry.isViewsheet()) {
+         throw new IllegalArgumentException("Invalid viewsheet identifier: " + request.identifier());
+      }
+
+      String path = entry.getPath();
+
+      if(path == null || !path.startsWith(VISUALIZATION_COMPONENTS_FOLDER_PATH + "/")) {
+         throw new IllegalArgumentException(
+            "Visualization is not in the managed visualizations folder: " + path);
+      }
+
+      // checkAssetPermission signals a WRITE denial via MessageException (see
+      // AbstractAssetEngine#checkAssetPermission0), not SecurityException — convert it so this
+      // reaches the controller's catch(SecurityException) branch instead of falling into
+      // catch(Exception) as a misleading "unexpected error" 500. Same conversion
+      // createVisualizationFolder already does above.
+      try {
+         assetRepository.checkAssetPermission(principal, entry, ResourceAction.WRITE);
+      }
+      catch(MessageException e) {
+         throw new SecurityException(e.getMessage());
+      }
+
+      entry.setAlias(displayName);
+      entry.setProperty("displayName", displayName);
+      assetRepository.changeSheet(entry, entry, principal, true);
+
+      return new WizVisualizationRenameResult(request.identifier(), displayName);
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizVisualizationControllerRenameTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizVisualizationControllerRenameTest.java
@@ -1,0 +1,89 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.controller;
+
+import inetsoft.sree.security.SecurityException;
+import inetsoft.web.wiz.model.WizVisualizationRenameResult;
+import inetsoft.web.wiz.request.WizVisualizationRenameRequest;
+import inetsoft.web.wiz.service.WizDashboardService;
+import inetsoft.web.wiz.service.WizVisualizationService;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.security.Principal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Verifies {@link WizVisualizationController#renameVisualization} maps
+ * {@link WizVisualizationService#renameVisualization} outcomes to the correct HTTP status,
+ * mirroring {@link WizVisualizationControllerRenderTest}'s shape — in particular that a
+ * {@link inetsoft.sree.security.SecurityException} maps to 403, not the generic 500
+ * {@code /save} would give it.
+ */
+@Tag("core")
+class WizVisualizationControllerRenameTest {
+   @Test
+   void returnsResultOnSuccess() throws Exception {
+      WizVisualizationService svc = mock(WizVisualizationService.class);
+      WizVisualizationRenameResult r = new WizVisualizationRenameResult("1^128^__NULL__^vs1", "New Name");
+      when(svc.renameVisualization(any(), any())).thenReturn(r);
+
+      ResponseEntity<?> resp = new WizVisualizationController(svc, mock(WizDashboardService.class))
+         .renameVisualization(new WizVisualizationRenameRequest("1^128^__NULL__^vs1", "New Name"), mock(Principal.class));
+
+      assertEquals(HttpStatus.OK, resp.getStatusCode());
+      assertSame(r, resp.getBody());
+   }
+
+   @Test
+   void mapsSecurityExceptionTo403() throws Exception {
+      WizVisualizationService svc = mock(WizVisualizationService.class);
+      when(svc.renameVisualization(any(), any())).thenThrow(new SecurityException("permission denied"));
+
+      ResponseEntity<?> resp = new WizVisualizationController(svc, mock(WizDashboardService.class))
+         .renameVisualization(new WizVisualizationRenameRequest("id", "New Name"), mock(Principal.class));
+
+      assertEquals(HttpStatus.FORBIDDEN, resp.getStatusCode());
+   }
+
+   @Test
+   void mapsIllegalArgumentTo400() throws Exception {
+      WizVisualizationService svc = mock(WizVisualizationService.class);
+      when(svc.renameVisualization(any(), any())).thenThrow(new IllegalArgumentException("bad id"));
+
+      ResponseEntity<?> resp = new WizVisualizationController(svc, mock(WizDashboardService.class))
+         .renameVisualization(new WizVisualizationRenameRequest("id", "New Name"), mock(Principal.class));
+
+      assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
+   }
+
+   @Test
+   void mapsGenericExceptionTo500() throws Exception {
+      WizVisualizationService svc = mock(WizVisualizationService.class);
+      when(svc.renameVisualization(any(), any())).thenThrow(new RuntimeException("boom"));
+
+      ResponseEntity<?> resp = new WizVisualizationController(svc, mock(WizDashboardService.class))
+         .renameVisualization(new WizVisualizationRenameRequest("id", "New Name"), mock(Principal.class));
+
+      assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, resp.getStatusCode());
+   }
+}

--- a/core/src/test/java/inetsoft/web/wiz/service/WizVisualizationServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/WizVisualizationServiceTest.java
@@ -35,10 +35,12 @@ import inetsoft.web.service.BinaryTransferService;
 import inetsoft.web.viewsheet.controller.AssemblyImageService;
 import inetsoft.web.viewsheet.service.VSExportService;
 import inetsoft.web.wiz.model.WizFolderSaveResult;
+import inetsoft.web.wiz.model.WizVisualizationRenameResult;
 import inetsoft.web.wiz.model.WizVisualizationRenderEvent;
 import inetsoft.web.wiz.model.WizVisualizationSaveEvent;
 import inetsoft.web.wiz.model.WizVisualizationSaveResult;
 import inetsoft.web.wiz.request.WizFolderCreateRequest;
+import inetsoft.web.wiz.request.WizVisualizationRenameRequest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -341,6 +343,104 @@ class WizVisualizationServiceTest {
 
       assertThrows(inetsoft.sree.security.SecurityException.class,
                    () -> service.renderVisualization(ev, mock(Principal.class)));
+   }
+
+   // ── renameVisualization ─────────────────────────────────────────────────────
+
+   @Test
+   void renameRejectsBlankIdentifier() throws Exception {
+      WizVisualizationService service = createService(mock(ViewsheetService.class), mock(AssetRepository.class));
+
+      assertThrows(IllegalArgumentException.class,
+                   () -> service.renameVisualization(
+                      new WizVisualizationRenameRequest("", "New Name"), mock(Principal.class)));
+   }
+
+   @Test
+   void renameRejectsBlankDisplayName() throws Exception {
+      WizVisualizationService service = createService(mock(ViewsheetService.class), mock(AssetRepository.class));
+
+      AssetEntry inside = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET,
+         WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/vs1", null);
+
+      assertThrows(IllegalArgumentException.class,
+                   () -> service.renameVisualization(
+                      new WizVisualizationRenameRequest(inside.toIdentifier(), "  "), mock(Principal.class)));
+   }
+
+   @Test
+   void renameRejectsIdentifierOutsideManagedFolder() throws Exception {
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      WizVisualizationService service = createService(mock(ViewsheetService.class), assetRepository);
+
+      AssetEntry outside = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET, "some/unmanaged/vs1", null);
+
+      assertThrows(IllegalArgumentException.class,
+                   () -> service.renameVisualization(
+                      new WizVisualizationRenameRequest(outside.toIdentifier(), "New Name"),
+                      mock(Principal.class)));
+
+      // The folder-scope check must happen before any asset is touched.
+      verifyNoInteractions(assetRepository);
+   }
+
+   @Test
+   void renameConvertsPermissionDenialToSecurityException() throws Exception {
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      WizVisualizationService service = createService(mock(ViewsheetService.class), assetRepository);
+
+      AssetEntry inside = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET,
+         WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/vs1", null);
+
+      // checkAssetPermission signals a WRITE denial via MessageException — the service must
+      // convert this to SecurityException so it reaches
+      // WizVisualizationController#renameVisualization's catch(SecurityException) branch (a real
+      // 403) instead of falling into catch(Exception) as a misleading "unexpected error" 500.
+      doThrow(new MessageException("Write access denied"))
+         .when(assetRepository).checkAssetPermission(
+            any(Principal.class), any(AssetEntry.class), eq(ResourceAction.WRITE));
+
+      assertThrows(inetsoft.sree.security.SecurityException.class,
+                   () -> service.renameVisualization(
+                      new WizVisualizationRenameRequest(inside.toIdentifier(), "New Name"),
+                      mock(Principal.class)));
+
+      verify(assetRepository, never()).changeSheet(
+         any(AssetEntry.class), any(AssetEntry.class), any(Principal.class), anyBoolean());
+   }
+
+   @Test
+   void renameSetsAliasAndPersistsAnAliasOnlyChangeSheet() throws Exception {
+      AssetRepository assetRepository = mock(AssetRepository.class);
+      WizVisualizationService service = createService(mock(ViewsheetService.class), assetRepository);
+
+      AssetEntry inside = new AssetEntry(
+         AssetRepository.GLOBAL_SCOPE, AssetEntry.Type.VIEWSHEET,
+         WizVisualizationService.VISUALIZATION_COMPONENTS_FOLDER_PATH + "/vs1", null);
+      String identifier = inside.toIdentifier();
+      Principal principal = mock(Principal.class);
+
+      WizVisualizationRenameResult result = service.renameVisualization(
+         new WizVisualizationRenameRequest(identifier, "  New Name  "), principal);
+
+      // The identifier is unchanged by an alias-only rename — toIdentifier() is derived from
+      // scope/type/user/path/orgID only, none of which this call touches.
+      assertEquals(identifier, result.identifier());
+      assertEquals("New Name", result.displayName());
+
+      verify(assetRepository).checkAssetPermission(
+         eq(principal), argThat(e -> identifier.equals(e.toIdentifier())), eq(ResourceAction.WRITE));
+
+      // oentry/nentry compare equal (AssetEntry#equals ignores alias) regardless of whether
+      // changeSheet is handed the same object or a copy — asserting on alias/path is what
+      // actually matters here.
+      verify(assetRepository).changeSheet(
+         argThat(e -> "New Name".equals(e.getAlias()) && identifier.equals(e.toIdentifier())),
+         argThat(e -> "New Name".equals(e.getAlias()) && identifier.equals(e.toIdentifier())),
+         eq(principal), eq(true));
    }
 
    private static WizVisualizationService createService(ViewsheetService viewsheetService,


### PR DESCRIPTION
## Summary

`wiz-services` has no way to rename a saved visualization: the `/api/wiz/visualization` controller it actually calls for every saved-visualization operation (`save`/`render`/`dashboard`/`delete`) has no rename endpoint. This adds one.

- New `POST /api/wiz/visualization/rename` on `WizVisualizationController`, taking `{identifier, displayName}`.
- New `WizVisualizationService.renameVisualization`: validates the identifier is inside `VISUALIZATION_COMPONENTS_FOLDER_PATH`, checks `WRITE` permission, then persists an **alias-only** rename via `assetRepository.changeSheet(entry, entry, principal, true)` — the same primitive `RenameAssetController`'s alias-only branch already uses. `AssetEntry#equals` ignores alias, so this is provably a no-op for `AbstractAssetEngine#changeSheet0`'s dependency-rename cascade (`Tool.equals(oentry, nentry)` guards) — no content clone, no new identifier.
- Permission denial is converted from `MessageException` (what `checkAssetPermission` actually throws) to `SecurityException`, mirroring `createVisualizationFolder`'s existing pattern, so a denied rename reaches the controller's `catch(SecurityException)` branch (403) instead of falling into `catch(Exception)` as a misleading 500 — the same gap `/save` has today.

## Companion PR

wiz-services + portal side (calls this endpoint, adds the rename UI): https://github.com/inetsoft-technology/stylebi-wiz/pull/1880. **This StyleBI endpoint must land before that side is functional end-to-end.**

## Test plan

- [x] `WizVisualizationServiceTest` (6 new cases: blank identifier/displayName, outside managed folder, permission-denial → `SecurityException`, happy path asserting the alias-only `changeSheet` call and unchanged identifier) — `./mvnw -o -pl core -Dtest=WizVisualizationServiceTest test`, 19/19 passed.
- [x] `WizVisualizationControllerRenameTest` (new file, mirrors `WizVisualizationControllerRenderTest`'s shape: 200/403/400/500 mapping) — 4/4 passed.