### PR TITLE
feat(admin-chat): cluster area -- pause/resume by server name

### DIFF
--- a/core/src/main/java/inetsoft/util/audit/ActionRecord.java
+++ b/core/src/main/java/inetsoft/util/audit/ActionRecord.java
@@ -201,6 +201,10 @@ public class ActionRecord implements AuditRecord {
     */
    public static final String OBJECT_TYPE_VIRTUAL_PRIVATE_MODEL = "vpm";
    /**
+    * Object type cluster (a cluster server node, admin-chat pause/resume).
+    */
+   public static final String OBJECT_TYPE_CLUSTER = "cluster";
+   /**
     * Action status success.
     */
    public static final String ACTION_STATUS_SUCCESS = "success";

--- a/core/src/main/java/inetsoft/web/admin/ai/cluster/AdminClusterController.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/cluster/AdminClusterController.java
@@ -1,0 +1,171 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.cluster;
+
+import inetsoft.sree.security.*;
+import inetsoft.web.admin.ai.AdminAiCallerGuard;
+import inetsoft.web.admin.ai.AdminChangesetApplyService;
+import inetsoft.web.admin.ai.ResolvedPlan;
+import inetsoft.web.cluster.ServerClusterClient;
+import inetsoft.web.cluster.ServerClusterStatus;
+import inetsoft.web.security.RequiredPermission;
+import inetsoft.web.security.Secured;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.security.Principal;
+import java.util.*;
+
+/**
+ * REST controller for the cluster admin-plugin area (01-spec.md section 10). Placed in
+ * {@code community/core}, not {@code enterprise/}, matching the C.4/providers community-placement
+ * precedent -- {@code ClusterController}/{@code ClusterService} both already live entirely in
+ * {@code community/core}, and this area is not enterprise-gated at the tool level (the one universal
+ * exception, matching every prior area: {@code get_changeset} read-back stays enterprise-only).
+ *
+ * <p>{@code @Secured} names {@code monitoring/cluster}, the same resource string the real
+ * {@code ClusterController} uses for its own {@code pause-server}/{@code resume-server} endpoints.
+ * Per 01-spec.md section 4a/section 2.1a trace, this is not "inherited protection" -- the whole
+ * {@code @Secured} gate on those endpoints is inert today, by two independent mechanisms (the
+ * program-wide wiz-caller {@code checkPermission} bypass, and {@code monitoring/cluster}'s own
+ * unflagged {@code hiddenForMultiTenancy}/{@code requiresMultiTenancy} defaults) -- so the sole real
+ * gate here is {@code AdminAiCallerGuard} + {@code OrganizationManager.isSiteAdmin}, added for
+ * consistency with every prior area's belt-and-suspenders posture.
+ */
+@RestController
+public class AdminClusterController {
+   @Autowired
+   public AdminClusterController(ClusterChangePlanService planService,
+                                 ClusterChangesetApplyService applyService, ServerClusterClient client)
+   {
+      this.planService = planService;
+      this.applyService = applyService;
+      this.client = client;
+   }
+
+   /** Neither read tool requires {@code cluster.pause.enabled} (01-spec.md item 10) -- matching the
+    * real EM UI, which keeps the whole node/status table visible and only hides the Pause/Resume
+    * button row when the property is off. */
+   @Secured(@RequiredPermission(
+      resourceType = ResourceType.EM_COMPONENT, resource = "monitoring/cluster",
+      actions = ResourceAction.ACCESS))
+   @GetMapping("/api/wiz/v1/admin/cluster/nodes")
+   public List<ClusterNodeStatus> listClusterNodes(Principal user) {
+      requireSiteAdmin(user);
+      List<ClusterNodeStatus> nodes = new ArrayList<>();
+
+      for(String server : client.getConfiguredServers()) {
+         nodes.add(projection(server));
+      }
+
+      return nodes;
+   }
+
+   /** Existence is resolved against a fresh {@code getConfiguredServers()} read before
+    * {@code getStatus} is ever called on the name, so an unrecognized name is a structured 404,
+    * never a silently default-constructed {@code ServerClusterStatus}
+    * ({@code ServerClusterClient.getClusterNodeStatus}'s own DOWN/paused=false fallback for an
+    * unmapped address would otherwise look like a real, if unreachable, node) -- 01-spec.md section
+    * 3, mirroring {@code AdminProviderController.requireExists}. */
+   @Secured(@RequiredPermission(
+      resourceType = ResourceType.EM_COMPONENT, resource = "monitoring/cluster",
+      actions = ResourceAction.ACCESS))
+   @GetMapping("/api/wiz/v1/admin/cluster/nodes/{server}")
+   public ClusterNodeStatus getClusterNode(@PathVariable("server") String server, Principal user) {
+      requireSiteAdmin(user);
+      requireExists(server, client.getConfiguredServers());
+      return projection(server);
+   }
+
+   /**
+    * Resolves a cluster pause/resume change plan without mutating anything. See
+    * {@code AdminAiController#preview} for the shape this mirrors.
+    *
+    * <p>The required membership-churn disclosure (see {@link ClusterChangePlanService}'s own class
+    * javadoc) belongs in the plugin (TypeScript) tool description for {@code preview_cluster_changes}
+    * -- this endpoint does not add prose to the wire response beyond what {@link ResolvedPlan}/
+    * {@code PlanChange.description()} already carry.
+    */
+   @Secured(@RequiredPermission(
+      resourceType = ResourceType.EM_COMPONENT, resource = "monitoring/cluster",
+      actions = ResourceAction.ACCESS))
+   @PostMapping("/api/wiz/v1/admin/cluster/preview")
+   public ResolvedPlan preview(@RequestBody ClusterChangePlanRequest req, Principal user) {
+      requireSiteAdmin(user);
+      return planService.resolve(req);
+   }
+
+   /**
+    * Applies a reviewed cluster change plan. No verb in this area ever requires a Tier-2 backup
+    * (01-spec.md section 7) -- unlike every prior area's own apply endpoint, nothing is backed up
+    * here.
+    */
+   @Secured(@RequiredPermission(
+      resourceType = ResourceType.EM_COMPONENT, resource = "monitoring/cluster",
+      actions = ResourceAction.ACCESS))
+   @PostMapping("/api/wiz/v1/admin/cluster/apply")
+   public ClusterApplyResult apply(@RequestBody ClusterApplyRequest req, Principal user) {
+      requireSiteAdmin(user);
+      return applyService.apply(req, user);
+   }
+
+   private ClusterNodeStatus projection(String server) {
+      ServerClusterStatus status = client.getStatus(server);
+      return new ClusterNodeStatus(server, ClusterStatusLabel.displayStatus(status),
+                                   ClusterStatusLabel.reachable(status));
+   }
+
+   /** Same rationale and shape as {@code AdminProviderController#requireSiteAdmin} -- see there. */
+   private void requireSiteAdmin(Principal user) {
+      AdminAiCallerGuard.requireBearerAuthenticatedRequest();
+
+      if(!OrganizationManager.getInstance().isSiteAdmin(user)) {
+         throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Site Administrator role required");
+      }
+   }
+
+   private static void requireExists(String server, Set<String> configured) {
+      if(!configured.contains(server)) {
+         throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+            "not found: no server named \"" + server + "\" in this cluster");
+      }
+   }
+
+   @ExceptionHandler(IllegalArgumentException.class)
+   @ResponseStatus(HttpStatus.BAD_REQUEST)
+   @ResponseBody
+   public Map<String, String> handleIllegalArgument(IllegalArgumentException ex) {
+      return Map.of("status", "failed", "error", String.valueOf(ex.getMessage()));
+   }
+
+   @ExceptionHandler(AdminChangesetApplyService.PlanHashMismatchException.class)
+   @ResponseStatus(HttpStatus.CONFLICT)
+   @ResponseBody
+   public Map<String, Object> handlePlanHashMismatch(
+      AdminChangesetApplyService.PlanHashMismatchException ex)
+   {
+      return Map.of("status", "conflict", "error", String.valueOf(ex.getMessage()),
+                    "plan", ex.current());
+   }
+
+   private final ClusterChangePlanService planService;
+   private final ClusterChangesetApplyService applyService;
+   private final ServerClusterClient client;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterApplyOutcome.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterApplyOutcome.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.cluster;
+
+/**
+ * Outcome of one attempted pause/resume, one entry per (verb, server) in the plan. {@code status} is
+ * {@code AdminChangeRecord.STATUS_VERIFIED}/{@code STATUS_FAILED} only -- this area never produces a
+ * rolled-back outcome (01-spec.md section 6, 03-reconcile.md's required addition: each server's
+ * pause/resume is independent and self-inverse, so a per-server failure is reported, not compensated).
+ *
+ * @param property the server name (matches {@code PlanChange.property()}).
+ * @param before   the status label read at plan-resolve time.
+ * @param after    the status label read back fresh, immediately after the pause/resume call -- the
+ *                 direct fix for {@code stylebi#76343} (the raw endpoint discards this signal today).
+ *                 {@code null} when the attempt threw before a read-back could be taken.
+ * @param status   {@code "verified"} when {@code after} matches the plan's proposed state,
+ *                 {@code "failed"} otherwise (including the pre-existing silent-failure case: the
+ *                 node was unreachable, or the pause/resume message did not complete).
+ * @param error    non-null only when {@code status} is {@code "failed"}.
+ */
+public record ClusterApplyOutcome(String property, String before, String after, String status,
+                                  String error)
+{
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterApplyRequest.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterApplyRequest.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.cluster;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/** Request body for {@code POST /api/wiz/v1/admin/cluster/apply}: a plan request plus the hash from
+ * {@code preview} and a mandatory (this area's {@code risk: high} is unconditional, section 4/6)
+ * {@code reviewOutcome}. No Tier-2 backup is ever taken for this area (section 7), unlike the
+ * shape every prior area's own apply-request carries. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ClusterApplyRequest extends ClusterChangePlanRequest {
+   public String getPlanHash() { return planHash; }
+   public void setPlanHash(String v) { this.planHash = v; }
+   public String getReviewOutcome() { return reviewOutcome; }
+   public void setReviewOutcome(String v) { this.reviewOutcome = v; }
+
+   private String planHash, reviewOutcome;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterApplyResult.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterApplyResult.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.cluster;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+/**
+ * Result of applying a whole cluster changeset. Unlike every prior area's own apply result, there is
+ * no {@code rollbackFailures} field at all -- this area never rolls back (01-spec.md section 6): each
+ * server's pause/resume is independent and self-inverse, so a per-server failure is reported via
+ * {@code results}, never compensated.
+ *
+ * @param status     {@code "applied"} (every entry verified), {@code "partial"} (a mix -- the one new
+ *                   changeset-status value this area introduces), or {@code "failed"} (every entry
+ *                   failed). Never {@code "rolled-back"}/{@code "rollback-failed"} (03-reconcile.md).
+ * @param backupRef  always {@code null} -- no verb in this area requires a Tier-2 snapshot (section
+ *                   7), carried as an explicit field rather than omitted so the shape stays uniform
+ *                   with every other area's own apply result.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ClusterApplyResult(String transactionId, String status, String backupRef,
+                                 List<ClusterApplyOutcome> results)
+{
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterChangePlanRequest.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterChangePlanRequest.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.cluster;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+/** Request body for {@code POST /api/wiz/v1/admin/cluster/preview}. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ClusterChangePlanRequest {
+   public String getTask() { return task; }
+   public void setTask(String v) { this.task = v; }
+   public List<ClusterChangeRequest> getChanges() { return changes; }
+   public void setChanges(List<ClusterChangeRequest> v) { this.changes = v; }
+
+   private String task;
+   private List<ClusterChangeRequest> changes;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterChangePlanService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterChangePlanService.java
@@ -1,0 +1,275 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.cluster;
+
+import inetsoft.util.audit.AdminChangeRecord;
+import inetsoft.web.admin.ai.PlanChange;
+import inetsoft.web.admin.ai.ResolvedPlan;
+import inetsoft.web.admin.cluster.ClusterService;
+import inetsoft.web.cluster.ServerClusterClient;
+import inetsoft.web.cluster.ServerClusterStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.*;
+
+/**
+ * Resolves a requested list of cluster pause/resume changes into a {@link ResolvedPlan} and hashes
+ * it -- the cluster analog of {@code inetsoft.web.admin.ai.AdminChangePlanService} and (within this
+ * run) {@code ProviderChangePlanService}/{@code IdentityChangePlanService}/etc, but deliberately NOT
+ * a compensating-transaction design (01-spec.md section 4, 03-reconcile.md): each server's pause/
+ * resume is independent and self-inverse, so there is no whole-plan rollback to design at all.
+ *
+ * <p><b>Both verbs are {@code risk: high}/{@code snapshotScope: value} unconditionally, as two
+ * hardcoded label constants -- never a call to {@code AdminRiskClassifier.classify()}.</b> There is
+ * no {@code AdminPropertyName} for a cluster server to classify against; "reuse
+ * {@code AdminRiskClassifier}'s two axes" (03-reconcile.md's precision line) means reusing the two
+ * label values it would have produced, not invoking it.
+ *
+ * <p><b>Required disclosure, at the same prominence as every other risk fact this area carries
+ * (03-reconcile.md, not optional): a paused node's pause state does NOT survive that node leaving and
+ * rejoining the cluster.</b> {@code ServerClusterClient}'s {@code memberRemoved} listener
+ * unconditionally clears a node's paused flag the instant it drops cluster membership -- a crash, a
+ * planned restart (the very action "pause for maintenance" exists to precede), or a transient network
+ * partition all trigger it, with no error, no log line above {@code DEBUG}, and no signal to any
+ * caller, including this area's own tools, that the operator's last explicit action silently stopped
+ * being true. A successful {@code apply_cluster_changes} pause result is a point-in-time
+ * confirmation, not a standing guarantee -- re-issue pause after any such event if the intent was to
+ * keep the node out of rotation. No mechanism-level fix is in scope for this cut (closing it would
+ * need a persisted "operator intent" store that does not exist today, predating admin-chat entirely);
+ * this class and {@link ClusterChangesetApplyService} disclose it, they do not attempt to work around
+ * it. The plugin (TypeScript) tool descriptions for {@code preview_cluster_changes}/
+ * {@code apply_cluster_changes} must state this plainly too (03-reconcile.md item 2) -- carried here
+ * as the authoritative Java-side statement of the fact for that layer to restate, not duplicate.
+ *
+ * <p>Wraps {@link ClusterService}/{@link ServerClusterClient} directly -- there is no Public API
+ * (*ApiService) layer for cluster (01-spec.md section 0), and both live entirely in
+ * {@code community/core}.
+ */
+@Component
+public class ClusterChangePlanService {
+   @Autowired
+   public ClusterChangePlanService(ClusterService clusterService, ServerClusterClient client) {
+      this.clusterService = clusterService;
+      this.client = client;
+   }
+
+   /**
+    * Resolves and hashes a plan. Performs no mutation, but does perform live reads (a fresh
+    * {@code getConfiguredServers()}/{@code getStatus()} per server named in the request, plus the
+    * {@code cluster.pause.enabled} property).
+    *
+    * @throws IllegalArgumentException with a field-named message on a blank task, an empty change
+    *                                 list, an unrecognized verb, a blank/unrecognized server name, a
+    *                                 duplicate (verb, server) entry, a same-server entry targeted by
+    *                                 both verbs in the same plan, or {@code cluster.pause.enabled} not
+    *                                 being {@code "true"} (item 10 -- checked once per plan, not per
+    *                                 entry, since it is a single deployment-wide read).
+    */
+   public ResolvedPlan resolve(ClusterChangePlanRequest req) {
+      if(req == null || req.getTask() == null || req.getTask().trim().isEmpty()) {
+         throw new IllegalArgumentException("task: a non-empty description is required");
+      }
+
+      if(req.getChanges() == null || req.getChanges().isEmpty()) {
+         throw new IllegalArgumentException("changes: at least one change is required");
+      }
+
+      Set<String> configured = client.getConfiguredServers();
+      List<PlanChange> changes = new ArrayList<>();
+      Map<String, String> seenServerVerb = new LinkedHashMap<>();
+      int index = 0;
+
+      for(ClusterChangeRequest change : req.getChanges()) {
+         String label = "changes[" + index++ + "]";
+
+         if(change == null) {
+            throw new IllegalArgumentException(label + ": must not be null");
+         }
+
+         String verb = requireVerb(label, change.getVerb());
+         String server = requireNonBlank(label + ".server", change.getServer());
+         requireNoConflict(label, server, verb, seenServerVerb);
+         requireConfigured(label, server, configured);
+         changes.add(resolveOne(server, verb));
+      }
+
+      // 01-spec.md section 5 step 5: checked once per plan, after every entry resolves, not per
+      // entry -- a single deployment-wide SreeEnv read, enforced for EITHER verb (item 10's sharper
+      // finding: the EM UI hides both Pause and Resume when this property is off, not just Pause).
+      requirePauseEnabled();
+
+      String task = req.getTask().trim();
+      return new ResolvedPlan(task, Collections.unmodifiableList(changes), false, true,
+                              hash(task, changes));
+   }
+
+   private PlanChange resolveOne(String server, String verb) {
+      ServerClusterStatus status = client.getStatus(server);
+      String currentLabel = ClusterStatusLabel.displayStatus(status);
+      boolean paused = status.isPaused();
+      String proposed;
+      boolean noOp;
+
+      if(ClusterChangeRequest.VERB_PAUSE.equals(verb)) {
+         noOp = paused;
+         proposed = noOp ? currentLabel : ClusterStatusLabel.STATUS_PAUSED;
+      }
+      else {
+         noOp = !paused;
+         proposed = noOp ? currentLabel :
+            (ClusterStatusLabel.reachable(status) ? ClusterStatusLabel.STATUS_RUNNING :
+             ClusterStatusLabel.STATUS_STOPPED);
+      }
+
+      // Item 4's no-op detection: still produces a PlanChange, never silently dropped, with the
+      // description saying so -- the caller should be told rather than left to infer it from a bare
+      // 200 the way ClusterService.pauseServers/resumeServers' own skip already special-cases
+      // server-side with no signal at all.
+      String description = verb + " server " + server + (noOp ? " (already in target state; no-op)" : "");
+      return new PlanChange(server, NOT_ORG_SCOPED, currentLabel, proposed, AdminChangeRecord.RISK_HIGH,
+                            AdminChangeRecord.SCOPE_VALUE, true, description);
+   }
+
+   private void requirePauseEnabled() {
+      if(!clusterService.getClusterEnabled().pauseEnabled()) {
+         throw new IllegalArgumentException(
+            "cluster.pause.enabled is not \"true\" for this deployment -- pause/resume is refused for " +
+            "both verbs, mirroring the EM UI, which hides both the Pause and Resume buttons when this " +
+            "property is off (01-spec.md item 10). stylebi#76342 remains open at the product/raw-" +
+            "endpoint layer; this area closes the gap only for its own admin-chat path.");
+      }
+   }
+
+   // ---------------------------------------------------------------- validation helpers
+
+   /** Same server, same verb twice: a plain duplicate. Same server, opposite verbs: contradictory,
+    * not a duplicate -- refused with a different, clearer message (01-spec.md section 11, a
+    * validation case no prior area needed since none of their units were self-inverse pairs
+    * addressable in the same request). Because a valid plan can therefore contain each server at
+    * most once, {@code server} alone is a safe {@link PlanChange#property()} key. */
+   private static void requireNoConflict(String label, String server, String verb,
+                                         Map<String, String> seenServerVerb)
+   {
+      String priorVerb = seenServerVerb.putIfAbsent(server, verb);
+
+      if(priorVerb == null) {
+         return;
+      }
+
+      if(priorVerb.equals(verb)) {
+         throw new IllegalArgumentException(
+            label + ": duplicate entry for server \"" + server + "\" with verb \"" + verb +
+            "\"; list each (verb, server) pair at most once");
+      }
+
+      throw new IllegalArgumentException(
+         label + ": server \"" + server + "\" is targeted by both \"pause\" and \"resume\" in the " +
+         "same plan -- contradictory for the same server in the same plan; split into two plans " +
+         "applied in sequence, or drop one");
+   }
+
+   /** 01-spec.md section 2's own decision: a cluster server name that isn't in the live
+    * {@code getConfiguredServers()} set names nothing -- there is no node to pause. Refused, loud,
+    * naming the unrecognized server, before ever reaching {@code pauseServers}/{@code resumeServers}
+    * -- never let a typo silently resolve to the same "looks like a down node" state a real outage
+    * produces. */
+   private static void requireConfigured(String label, String server, Set<String> configured) {
+      if(!configured.contains(server)) {
+         throw new IllegalArgumentException(
+            label + ".server: \"" + server + "\" is not a configured server in this cluster");
+      }
+   }
+
+   static String requireVerb(String label, String verb) {
+      String trimmed = verb == null ? null : verb.trim();
+
+      if(ClusterChangeRequest.VERB_PAUSE.equals(trimmed) || ClusterChangeRequest.VERB_RESUME.equals(trimmed)) {
+         return trimmed;
+      }
+
+      throw new IllegalArgumentException(
+         label + ".verb: must be \"" + ClusterChangeRequest.VERB_PAUSE + "\" or \"" +
+         ClusterChangeRequest.VERB_RESUME + "\", got " + String.valueOf(verb));
+   }
+
+   private static String requireNonBlank(String field, String value) {
+      if(value == null || value.trim().isEmpty()) {
+         throw new IllegalArgumentException(field + ": required");
+      }
+
+      return value.trim();
+   }
+
+   // ---------------------------------------------------------------- hash
+
+   /**
+    * SHA-256 over the canonical plan: task text, plus per-entry (server, currentValue, proposedValue,
+    * risk, snapshotScope) -- same field set and control-character canonicalization convention every
+    * prior area's own {@code hash} method uses (03-reconcile.md's precision line; no whole-chain
+    * projection input, unlike providers -- cluster has no "chain" concept). Because
+    * {@code currentValue} is captured live at preview time, a node that changes status between
+    * preview and apply (crashes, or another admin/EM session pauses or resumes it) produces a
+    * different hash on apply's fresh re-resolve, refused via the existing
+    * {@code AdminChangesetApplyService.PlanHashMismatchException}/HTTP 409 path.
+    */
+   private static String hash(String task, List<PlanChange> changes) {
+      StringBuilder canonical = new StringBuilder(task).append('\n');
+
+      for(PlanChange change : changes) {
+         canonical.append(change.property()).append(SEP)
+            .append(canonical(change.currentValue())).append(SEP)
+            .append(canonical(change.proposedValue())).append(SEP)
+            .append(change.risk()).append(SEP)
+            .append(change.snapshotScope()).append(SEP);
+      }
+
+      try {
+         byte[] digest = MessageDigest.getInstance("SHA-256")
+            .digest(canonical.toString().getBytes(StandardCharsets.UTF_8));
+         StringBuilder hex = new StringBuilder(digest.length * 2);
+
+         for(byte b : digest) {
+            hex.append(String.format("%02x", b));
+         }
+
+         return hex.toString();
+      }
+      catch(NoSuchAlgorithmException e) {
+         throw new IllegalStateException("SHA-256 is required to hash a cluster change plan", e);
+      }
+   }
+
+   private static String canonical(String value) {
+      return value == null ? NULL_MARKER : value;
+   }
+
+   private static final char SEP = (char) 0x1f;
+   private static final String NULL_MARKER = String.valueOf((char) 0x01);
+   /** Cluster nodes are whole-deployment, not org-scoped (01-spec.md section 1/org-boundary section)
+    * -- every {@link PlanChange} this service builds passes this in place of a bare {@code null}
+    * literal so the omission reads as deliberate, matching {@code ProviderChangePlanService
+    * .NOT_ORG_SCOPED}'s own precedent (folded in from the start here, rather than as a P4 follow-up
+    * the way providers needed). */
+   private static final String NOT_ORG_SCOPED = null;
+   private final ClusterService clusterService;
+   private final ServerClusterClient client;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterChangeRequest.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterChangeRequest.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.cluster;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * One requested change: pause or resume one named cluster server node (01-spec.md section 1/11).
+ * {@link ClusterChangePlanService#resolve} re-validates every field independently rather than
+ * trusting the caller, per this repo's CLAUDE.md tool-robustness rule -- verb aliasing
+ * ({@code "stop"}/{@code "unpause"}/{@code "start"}) is the plugin (TypeScript) tool layer's job,
+ * matching {@code ProviderChangeRequest}/{@code IdentityChangePlanService}'s own precedent of
+ * exact-label-only validation in Java (04-build-java.md).
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ClusterChangeRequest {
+   public static final String VERB_PAUSE = "pause";
+   public static final String VERB_RESUME = "resume";
+
+   public String getVerb() { return verb; }
+   public void setVerb(String v) { this.verb = v; }
+
+   /** The server name, exactly as {@code ServerClusterClient.getConfiguredServers()} returns it. */
+   public String getServer() { return server; }
+   public void setServer(String v) { this.server = v; }
+
+   private String verb;
+   private String server;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterChangesetApplyService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterChangesetApplyService.java
@@ -46,10 +46,12 @@ import java.util.concurrent.locks.ReentrantLock;
  * each server's pause/resume is independent and self-inverse: if pausing server C fails after A and B
  * succeeded, there is nothing to fix by force-resuming A and B, only two other admins' successful,
  * intended pauses to needlessly undo. Every entry is attempted regardless of any other entry's
- * outcome, and a per-server status report -- read back fresh, immediately after the call, the direct
- * fix for {@code stylebi#76343} -- is the correct outcome. "Rollback", to the extent this area has
- * one, is exposing the paired verb: {@code apply_cluster_changes} with {@code {verb: "resume", server:
- * X}} is the live undo of a prior {@code {verb: "pause", server: X}}, and vice versa.
+ * outcome, and a per-server status report -- read back, with a short bounded retry/poll past
+ * {@code ServerClusterClient}'s own ~50ms debounced status-map write (see
+ * {@link #readBackWithRetry}), the direct fix for {@code stylebi#76343} -- is the correct outcome.
+ * "Rollback", to the extent this area has one, is exposing the paired verb:
+ * {@code apply_cluster_changes} with {@code {verb: "resume", server: X}} is the live undo of a prior
+ * {@code {verb: "pause", server: X}}, and vice versa.
  *
  * <p><b>Required disclosure, repeated here at the same prominence as {@link ClusterChangePlanService}
  * (03-reconcile.md, not optional): a "verified" pause outcome is a point-in-time confirmation, not a
@@ -157,19 +159,65 @@ public class ClusterChangesetApplyService {
          clusterService.resumeServers(new String[] { server });
       }
 
-      // Read back fresh, immediately after the call -- the direct fix for stylebi#76343, since
+      // Read back, with a short bounded retry/poll -- the direct fix for stylebi#76343, since
       // pauseServers/resumeServers themselves are void and discard the per-server signal entirely.
-      ServerClusterStatus after = client.getStatus(server);
+      // A SINGLE immediate read is not safe here (07-review-r1.md section 3): the target node sends
+      // its completion reply, which is what pauseServers/resumeServers' own message round-trip
+      // blocks on, BEFORE its own status-map write lands -- ServerClusterClient.setClusterNodeStatus
+      // schedules that write on a ~50ms-debounced TimedQueue.TimedRunnable, not synchronously. An
+      // immediate read-back can therefore see the pre-pause/pre-resume status and report a false
+      // STATUS_FAILED for an operation that in fact succeeded. readBackWithRetry polls past that
+      // window before concluding failure.
+      ServerClusterStatus after = readBackWithRetry(server, change.proposedValue());
       String afterLabel = ClusterStatusLabel.displayStatus(after);
       boolean verified = afterLabel.equals(change.proposedValue());
       String status = verified ? AdminChangeRecord.STATUS_VERIFIED : STATUS_FAILED;
       String error = verified ? null :
          "read-back status \"" + afterLabel + "\" does not match the proposed state \"" +
-         change.proposedValue() + "\" -- the server may be unreachable, or the pause/resume message " +
-         "did not complete (stylebi#76343: the raw endpoint discards this signal, this area's own " +
-         "read-back is the fix)";
+         change.proposedValue() + "\" after retrying past the status-map write debounce window -- " +
+         "the server may be unreachable, or the pause/resume message did not complete " +
+         "(stylebi#76343: the raw endpoint discards this signal, this area's own read-back is the " +
+         "fix)";
       results.add(new ClusterApplyOutcome(server, before, afterLabel, status, error));
       writeAudit(txId, task, server, before, afterLabel, status, reviewOutcome, user);
+   }
+
+   /**
+    * Reads back {@code server}'s status, retrying past {@code ServerClusterClient}'s own ~50ms
+    * debounced status-map write (07-review-r1.md section 3) before giving up. The target's
+    * completion reply -- what {@code pauseServers}/{@code resumeServers}' own message round-trip
+    * blocks on -- is sent BEFORE that debounced write lands, so a single immediate read is not a
+    * reliable signal: on a fast/local network the first read is quite likely to see the pre-pause/
+    * pre-resume status. Polls up to {@link #READBACK_MAX_ATTEMPTS} times, {@link
+    * #READBACK_POLL_INTERVAL_MS} apart (worst case
+    * {@code (READBACK_MAX_ATTEMPTS - 1) * READBACK_POLL_INTERVAL_MS} ~= 180ms, comfortably past the
+    * 50ms window with margin), stopping as soon as the read-back label matches {@code proposedLabel}.
+    * If it never matches, returns the LAST read (a real, if stale-relative-to-this-window, status) so
+    * the caller's own "does read-back match proposed" comparison still drives the final
+    * verified/failed determination -- this method itself never decides pass/fail, only how long to
+    * keep looking before settling.
+    */
+   private ServerClusterStatus readBackWithRetry(String server, String proposedLabel) {
+      ServerClusterStatus status = client.getStatus(server);
+
+      for(int attempt = 1;
+          attempt < READBACK_MAX_ATTEMPTS && !ClusterStatusLabel.displayStatus(status).equals(proposedLabel);
+          attempt++)
+      {
+         sleepPastDebounceWindow();
+         status = client.getStatus(server);
+      }
+
+      return status;
+   }
+
+   private void sleepPastDebounceWindow() {
+      try {
+         Thread.sleep(READBACK_POLL_INTERVAL_MS);
+      }
+      catch(InterruptedException e) {
+         Thread.currentThread().interrupt();
+      }
    }
 
    private static String overallStatus(List<ClusterApplyOutcome> results) {
@@ -238,6 +286,11 @@ public class ClusterChangesetApplyService {
    }
 
    private static final Logger LOG = LoggerFactory.getLogger(ClusterChangesetApplyService.class);
+   /** {@link #readBackWithRetry}'s bounded poll: up to 4 reads, 60ms apart -- worst case ~180ms,
+    * comfortably past {@code ServerClusterClient}'s own ~50ms status-map write debounce
+    * (07-review-r1.md section 3). */
+   private static final int READBACK_MAX_ATTEMPTS = 4;
+   private static final long READBACK_POLL_INTERVAL_MS = 60;
    private static final SecureRandom RANDOM = new SecureRandom();
    /** Serializes the entire body of {@link #apply} -- same rationale and same JVM-local-only
     * limitation as every prior area's own lock. */

--- a/core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterChangesetApplyService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterChangesetApplyService.java
@@ -1,0 +1,248 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.cluster;
+
+import inetsoft.util.Tool;
+import inetsoft.util.audit.*;
+import inetsoft.web.admin.ai.AdminChangesetApplyService;
+import inetsoft.web.admin.ai.PlanChange;
+import inetsoft.web.admin.ai.ResolvedPlan;
+import inetsoft.web.admin.cluster.ClusterService;
+import inetsoft.web.cluster.ServerClusterClient;
+import inetsoft.web.cluster.ServerClusterStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.security.Principal;
+import java.security.SecureRandom;
+import java.sql.Timestamp;
+import java.util.*;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Applies a whole cluster pause/resume changeset and audits every attempt -- the cluster analog of
+ * {@code inetsoft.web.admin.ai.AdminChangesetApplyService}/{@code ProviderChangesetApplyService},
+ * but deliberately NOT a compensating transaction (01-spec.md section 6, 03-reconcile.md).
+ *
+ * <p><b>The apply loop does not stop-and-rollback on a per-server failure, and there is no
+ * {@code undoable} list, no reverse-order undo pass, and no {@code rollback-failed} status</b> --
+ * each server's pause/resume is independent and self-inverse: if pausing server C fails after A and B
+ * succeeded, there is nothing to fix by force-resuming A and B, only two other admins' successful,
+ * intended pauses to needlessly undo. Every entry is attempted regardless of any other entry's
+ * outcome, and a per-server status report -- read back fresh, immediately after the call, the direct
+ * fix for {@code stylebi#76343} -- is the correct outcome. "Rollback", to the extent this area has
+ * one, is exposing the paired verb: {@code apply_cluster_changes} with {@code {verb: "resume", server:
+ * X}} is the live undo of a prior {@code {verb: "pause", server: X}}, and vice versa.
+ *
+ * <p><b>Required disclosure, repeated here at the same prominence as {@link ClusterChangePlanService}
+ * (03-reconcile.md, not optional): a "verified" pause outcome is a point-in-time confirmation, not a
+ * standing guarantee.</b> If the paused node later crashes, is restarted, or briefly leaves the
+ * cluster for any reason, its paused flag is silently cleared on rejoin with no error, no log line
+ * above {@code DEBUG}, and no signal back through this area's own tools -- a caller relying on this
+ * apply's own "verified" result to mean "still paused" later would be wrong, with nothing in this
+ * design telling them so. See {@link ClusterChangePlanService}'s own class javadoc for the full
+ * account.
+ */
+@Component
+public class ClusterChangesetApplyService {
+   /** The one genuinely new changeset-status vocabulary value this area introduces (01-spec.md
+    * section 6 step 6) -- none of {@code AdminChangesetApplyService.STATUS_ROLLED_BACK}/
+    * {@code STATUS_ROLLBACK_FAILED} apply here, by design, so reusing that three-value enum would
+    * silently imply a full-set-atomicity guarantee this area does not provide. */
+   public static final String STATUS_PARTIAL = "partial";
+   /** Reused for its literal string value only, per 03-reconcile.md -- never a call through the
+    * shared compensating-transaction class. */
+   public static final String STATUS_APPLIED = AdminChangesetApplyService.STATUS_APPLIED;
+   public static final String STATUS_FAILED = AdminChangeRecord.STATUS_FAILED;
+
+   @Autowired
+   public ClusterChangesetApplyService(ClusterChangePlanService planService,
+                                       ClusterService clusterService, ServerClusterClient client)
+   {
+      this.planService = planService;
+      this.clusterService = clusterService;
+      this.client = client;
+   }
+
+   /**
+    * Re-resolves via {@link ClusterChangePlanService#resolve}, gates on the plan hash and
+    * {@code reviewOutcome} (this area's {@code risk: high} is unconditional, so
+    * {@code requiresAgentSignoff} is always {@code true}), then executes every entry, continuing
+    * through per-server failures rather than stopping and unwinding.
+    *
+    * @throws AdminChangesetApplyService.PlanHashMismatchException if the hash is missing or stale
+    *         (maps to HTTP 409), reused verbatim.
+    */
+   public ClusterApplyResult apply(ClusterApplyRequest req, Principal user) {
+      APPLY_LOCK.lock();
+
+      try {
+         ResolvedPlan plan = planService.resolve(req);
+
+         if(req.getPlanHash() == null || !plan.planHash().equals(req.getPlanHash())) {
+            throw new AdminChangesetApplyService.PlanHashMismatchException(plan);
+         }
+
+         if(req.getReviewOutcome() == null || req.getReviewOutcome().trim().isEmpty()) {
+            throw new IllegalArgumentException(
+               "reviewOutcome: required -- risk: high is unconditional for this area (01-spec.md " +
+               "section 4/6)");
+         }
+
+         String txId = "cluster-" + newIdSuffix();
+         String reviewOutcome = req.getReviewOutcome();
+         List<ClusterChangeRequest> originals = req.getChanges();
+         List<ClusterApplyOutcome> results = new ArrayList<>();
+
+         for(int i = 0; i < plan.changes().size(); i++) {
+            PlanChange change = plan.changes().get(i);
+            ClusterChangeRequest original = originals.get(i);
+
+            try {
+               applyOne(txId, plan.task(), change, original, reviewOutcome, user, results);
+            }
+            catch(Exception e) {
+               // A throw carries no verifiable before/after evidence for THIS entry, but must never
+               // stop the remaining entries -- item 4's structural divergence from every other area.
+               String server = change.property();
+               String message = messageOf(e);
+               results.add(new ClusterApplyOutcome(server, change.currentValue(), null, STATUS_FAILED,
+                                                    message));
+               writeAudit(txId, plan.task(), server, change.currentValue(), null, STATUS_FAILED,
+                         reviewOutcome, user);
+            }
+         }
+
+         return new ClusterApplyResult(txId, overallStatus(results), null,
+                                       Collections.unmodifiableList(results));
+      }
+      finally {
+         APPLY_LOCK.unlock();
+      }
+   }
+
+   private void applyOne(String txId, String task, PlanChange change, ClusterChangeRequest original,
+                         String reviewOutcome, Principal user, List<ClusterApplyOutcome> results)
+   {
+      String server = change.property();
+      String verb = ClusterChangePlanService.requireVerb("apply", original.getVerb());
+      String before = change.currentValue();
+
+      // Delegates to ClusterService's own pauseServers/resumeServers rather than calling
+      // ServerClusterClient.pauseServer/resumeServer directly, so the already-tested "skip if already
+      // in the target paused state" logic (ClusterService.java:104-106/120-122) is reused, not
+      // reimplemented a second, independently-buggable way (this repo's CLAUDE.md tool-robustness
+      // principle, applied to internal reuse as much as external input).
+      if(ClusterChangeRequest.VERB_PAUSE.equals(verb)) {
+         clusterService.pauseServers(new String[] { server });
+      }
+      else {
+         clusterService.resumeServers(new String[] { server });
+      }
+
+      // Read back fresh, immediately after the call -- the direct fix for stylebi#76343, since
+      // pauseServers/resumeServers themselves are void and discard the per-server signal entirely.
+      ServerClusterStatus after = client.getStatus(server);
+      String afterLabel = ClusterStatusLabel.displayStatus(after);
+      boolean verified = afterLabel.equals(change.proposedValue());
+      String status = verified ? AdminChangeRecord.STATUS_VERIFIED : STATUS_FAILED;
+      String error = verified ? null :
+         "read-back status \"" + afterLabel + "\" does not match the proposed state \"" +
+         change.proposedValue() + "\" -- the server may be unreachable, or the pause/resume message " +
+         "did not complete (stylebi#76343: the raw endpoint discards this signal, this area's own " +
+         "read-back is the fix)";
+      results.add(new ClusterApplyOutcome(server, before, afterLabel, status, error));
+      writeAudit(txId, task, server, before, afterLabel, status, reviewOutcome, user);
+   }
+
+   private static String overallStatus(List<ClusterApplyOutcome> results) {
+      boolean anyVerified = false;
+      boolean anyFailed = false;
+
+      for(ClusterApplyOutcome outcome : results) {
+         if(AdminChangeRecord.STATUS_VERIFIED.equals(outcome.status())) {
+            anyVerified = true;
+         }
+         else {
+            anyFailed = true;
+         }
+      }
+
+      if(anyFailed && anyVerified) {
+         return STATUS_PARTIAL;
+      }
+
+      return anyFailed ? STATUS_FAILED : STATUS_APPLIED;
+   }
+
+   private void writeAudit(String txId, String task, String server, String before, String after,
+                           String status, String reviewOutcome, Principal user)
+   {
+      try {
+         AdminChangeRecord record = new AdminChangeRecord();
+         record.setTransactionId(txId);
+         record.setTaskDescription(task);
+         record.setProperty(server);
+         record.setObjectType(ActionRecord.OBJECT_TYPE_CLUSTER);
+         record.setBeforeValue(before);
+         record.setAfterValue(after);
+         // Always ACTION_APPLY, never ACTION_ROLLBACK -- this area never writes a rollback record
+         // (01-spec.md section 8, worth stating explicitly since every prior area's audit trail uses
+         // both).
+         record.setAction(AdminChangeRecord.ACTION_APPLY);
+         record.setStatus(status);
+         record.setRiskLevel(AdminChangeRecord.RISK_HIGH);
+         record.setSnapshotScope(AdminChangeRecord.SCOPE_VALUE);
+         // backupRef always null -- no verb in this area requires a Tier-2 snapshot (section 7).
+         record.setBackupRef(null);
+         record.setReviewOutcome(reviewOutcome);
+         // organizationId deliberately left unset -- cluster nodes are whole-deployment, not
+         // org-scoped (section 1/org-boundary section), mirrors ClusterChangePlanService
+         // .NOT_ORG_SCOPED.
+         record.setUserName(user == null ? null : user.getName());
+         record.setActionTimestamp(new Timestamp(System.currentTimeMillis()));
+         record.setServerHostName(Tool.getHost());
+         Audit.getInstance().auditAdminChange(record, user);
+      }
+      catch(Exception auditFailure) {
+         // An audit write must never replace the real outcome -- same rule every prior area's apply
+         // service follows.
+         LOG.error("Failed to write cluster admin change audit record for transaction {}", txId,
+                   auditFailure);
+      }
+   }
+
+   private static String messageOf(Exception e) {
+      return e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
+   }
+
+   private static String newIdSuffix() {
+      return String.format("%016x", RANDOM.nextLong());
+   }
+
+   private static final Logger LOG = LoggerFactory.getLogger(ClusterChangesetApplyService.class);
+   private static final SecureRandom RANDOM = new SecureRandom();
+   /** Serializes the entire body of {@link #apply} -- same rationale and same JVM-local-only
+    * limitation as every prior area's own lock. */
+   private static final ReentrantLock APPLY_LOCK = new ReentrantLock();
+   private final ClusterChangePlanService planService;
+   private final ClusterService clusterService;
+   private final ServerClusterClient client;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterNodeStatus.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterNodeStatus.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.cluster;
+
+/**
+ * Read-tool projection for one configured cluster server (01-spec.md section 3): the same
+ * {@code "Running"|"Paused"|"Stopped"} display label {@code ClusterService.getClusterStatus()}
+ * already computes, plus {@code reachable} -- this area's own addition, {@code status != DOWN},
+ * surfacing at read time the blind spot that a {@code DOWN} node's pause/resume silently no-ops
+ * server-side today (section 1 of the scoping doc, re-verified in 01-spec.md section 3).
+ */
+public record ClusterNodeStatus(String server, String status, boolean reachable) {
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterStatusLabel.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/cluster/ClusterStatusLabel.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.cluster;
+
+import inetsoft.web.cluster.ServerClusterStatus;
+
+/**
+ * The same three-way display label {@code ClusterService.getClusterStatus()} computes per node
+ * (paused takes priority over running/down), reproduced here so this area's read tools, plan
+ * resolution, and apply read-back can all compute it for a single, freshly-read
+ * {@link ServerClusterStatus} without a second round trip through {@code ClusterService}'s own
+ * all-servers method (01-spec.md section 3/5/6).
+ */
+final class ClusterStatusLabel {
+   private ClusterStatusLabel() {
+   }
+
+   static final String STATUS_RUNNING = "Running";
+   static final String STATUS_PAUSED = "Paused";
+   static final String STATUS_STOPPED = "Stopped";
+
+   static String displayStatus(ServerClusterStatus status) {
+      if(status.isPaused()) {
+         return STATUS_PAUSED;
+      }
+
+      return reachable(status) ? STATUS_RUNNING : STATUS_STOPPED;
+   }
+
+   /** {@code status != DOWN} -- 01-spec.md section 3's own definition. */
+   static boolean reachable(ServerClusterStatus status) {
+      return status.getStatus() != ServerClusterStatus.Status.DOWN;
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/ai/cluster/ClusterChangePlanServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/cluster/ClusterChangePlanServiceTest.java
@@ -1,0 +1,280 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.cluster;
+
+import inetsoft.util.audit.AdminChangeRecord;
+import inetsoft.web.admin.ai.PlanChange;
+import inetsoft.web.admin.ai.ResolvedPlan;
+import inetsoft.web.admin.cluster.ClusterEnabledModel;
+import inetsoft.web.admin.cluster.ClusterService;
+import inetsoft.web.cluster.ServerClusterClient;
+import inetsoft.web.cluster.ServerClusterStatus;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * 01-spec.md section 2 (unrecognized-server hard refusal), section 5 (no-op detection, the
+ * {@code cluster.pause.enabled} whole-plan gate, the hash), and section 11 (duplicate vs.
+ * contradictory same-server entries).
+ */
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class ClusterChangePlanServiceTest {
+   @Mock private ClusterService clusterService;
+   @Mock private ServerClusterClient client;
+   private ClusterChangePlanService service;
+
+   @BeforeEach void setUp() {
+      service = new ClusterChangePlanService(clusterService, client);
+      lenient().when(clusterService.getClusterEnabled())
+         .thenReturn(ClusterEnabledModel.builder().enabled(true).pauseEnabled(true).build());
+   }
+
+   // -------------------------------------------------------------------------
+   // basic request validation
+   // -------------------------------------------------------------------------
+
+   @Test void resolveThrowsOnBlankTask() {
+      ClusterChangePlanRequest req = request("  ", List.of(pause("s1")));
+      assertTrue(assertThrows(IllegalArgumentException.class, () -> service.resolve(req))
+                    .getMessage().contains("task"));
+   }
+
+   @Test void resolveThrowsOnEmptyChanges() {
+      assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of())));
+   }
+
+   @Test void resolveThrowsOnUnrecognizedVerb() {
+      ClusterChangeRequest change = pause("s1");
+      change.setVerb("rename");
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(change))));
+      assertTrue(ex.getMessage().contains("verb"));
+   }
+
+   @Test void resolveThrowsOnBlankServer() {
+      ClusterChangeRequest change = pause("  ");
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(change))));
+      assertTrue(ex.getMessage().contains("server"));
+   }
+
+   // -------------------------------------------------------------------------
+   // unrecognized server -- section 2's own decision: a hard refusal, not downgrade-and-proceed
+   // -------------------------------------------------------------------------
+
+   @Test void resolveThrowsOnUnrecognizedServer() {
+      stubConfigured("s1");
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(pause("typo-server")))));
+      assertTrue(ex.getMessage().contains("typo-server"));
+   }
+
+   // -------------------------------------------------------------------------
+   // duplicate vs. contradictory entries (section 11)
+   // -------------------------------------------------------------------------
+
+   @Test void resolveThrowsOnDuplicateSameServerSameVerb() {
+      stubConfigured("s1");
+      stubStatus("s1", ServerClusterStatus.Status.OK, false);
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(pause("s1"), pause("s1")))));
+      assertTrue(ex.getMessage().contains("duplicate"));
+   }
+
+   @Test void resolveThrowsOnContradictorySameServerOppositeVerbs() {
+      stubConfigured("s1");
+      stubStatus("s1", ServerClusterStatus.Status.OK, false);
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(pause("s1"), resume("s1")))));
+      assertTrue(ex.getMessage().contains("contradictory"));
+   }
+
+   @Test void resolveAllowsSameVerbOnDifferentServers() {
+      stubConfigured("s1", "s2");
+      stubStatus("s1", ServerClusterStatus.Status.OK, false);
+      stubStatus("s2", ServerClusterStatus.Status.OK, false);
+      ResolvedPlan plan = service.resolve(request("task", List.of(pause("s1"), pause("s2"))));
+      assertEquals(2, plan.changes().size());
+   }
+
+   // -------------------------------------------------------------------------
+   // cluster.pause.enabled -- checked once per plan, for either verb (item 10)
+   // -------------------------------------------------------------------------
+
+   @Test void resolveThrowsWhenPauseDisabledForPauseVerb() {
+      stubConfigured("s1");
+      stubStatus("s1", ServerClusterStatus.Status.OK, false);
+      when(clusterService.getClusterEnabled())
+         .thenReturn(ClusterEnabledModel.builder().enabled(true).pauseEnabled(false).build());
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(pause("s1")))));
+      assertTrue(ex.getMessage().contains("cluster.pause.enabled"));
+   }
+
+   @Test void resolveThrowsWhenPauseDisabledForResumeVerbToo() {
+      stubConfigured("s1");
+      stubStatus("s1", ServerClusterStatus.Status.PAUSED, true);
+      when(clusterService.getClusterEnabled())
+         .thenReturn(ClusterEnabledModel.builder().enabled(true).pauseEnabled(false).build());
+      // Item 10's sharper finding: the EM UI hides BOTH buttons when the property is off, so resume
+      // is refused too, not just pause.
+      assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(resume("s1")))));
+   }
+
+   // -------------------------------------------------------------------------
+   // no-op detection (item 4) -- still produces a PlanChange, never silently dropped
+   // -------------------------------------------------------------------------
+
+   @Test void resolvePauseAlreadyPausedIsNoOpButStillProducesAPlanChange() {
+      stubConfigured("s1");
+      stubStatus("s1", ServerClusterStatus.Status.OK, true);
+      ResolvedPlan plan = service.resolve(request("task", List.of(pause("s1"))));
+      PlanChange change = plan.changes().get(0);
+      assertEquals("Paused", change.currentValue());
+      assertEquals("Paused", change.proposedValue());
+      assertTrue(change.description().contains("no-op"));
+   }
+
+   @Test void resolveResumeAlreadyRunningIsNoOpButStillProducesAPlanChange() {
+      stubConfigured("s1");
+      stubStatus("s1", ServerClusterStatus.Status.OK, false);
+      ResolvedPlan plan = service.resolve(request("task", List.of(resume("s1"))));
+      PlanChange change = plan.changes().get(0);
+      assertEquals("Running", change.currentValue());
+      assertEquals("Running", change.proposedValue());
+      assertTrue(change.description().contains("no-op"));
+   }
+
+   @Test void resolvePauseOnRunningServerProposesPaused() {
+      stubConfigured("s1");
+      stubStatus("s1", ServerClusterStatus.Status.OK, false);
+      ResolvedPlan plan = service.resolve(request("task", List.of(pause("s1"))));
+      PlanChange change = plan.changes().get(0);
+      assertEquals("Running", change.currentValue());
+      assertEquals("Paused", change.proposedValue());
+      assertFalse(change.description().contains("no-op"));
+   }
+
+   @Test void resolveResumeOnPausedReachableServerProposesRunning() {
+      stubConfigured("s1");
+      stubStatus("s1", ServerClusterStatus.Status.OK, true);
+      ResolvedPlan plan = service.resolve(request("task", List.of(resume("s1"))));
+      assertEquals("Running", plan.changes().get(0).proposedValue());
+   }
+
+   @Test void resolveResumeOnPausedUnreachableServerProposesStopped() {
+      stubConfigured("s1");
+      stubStatus("s1", ServerClusterStatus.Status.DOWN, true);
+      ResolvedPlan plan = service.resolve(request("task", List.of(resume("s1"))));
+      assertEquals("Stopped", plan.changes().get(0).proposedValue());
+   }
+
+   // -------------------------------------------------------------------------
+   // risk/scope axes -- hardcoded, per 03-reconcile.md's precision line (never AdminRiskClassifier
+   // .classify())
+   // -------------------------------------------------------------------------
+
+   @Test void everyChangeIsRiskHighScopeValueAndOrgIdNull() {
+      stubConfigured("s1");
+      stubStatus("s1", ServerClusterStatus.Status.OK, false);
+      PlanChange change = service.resolve(request("task", List.of(pause("s1")))).changes().get(0);
+      assertEquals(AdminChangeRecord.RISK_HIGH, change.risk());
+      assertEquals(AdminChangeRecord.SCOPE_VALUE, change.snapshotScope());
+      assertNull(change.orgId());
+      assertTrue(change.recognized());
+   }
+
+   @Test void resolvedPlanNeverRequiresStorageBackupButAlwaysRequiresAgentSignoff() {
+      stubConfigured("s1");
+      stubStatus("s1", ServerClusterStatus.Status.OK, false);
+      ResolvedPlan plan = service.resolve(request("task", List.of(pause("s1"))));
+      assertFalse(plan.requiresStorageBackup());
+      assertTrue(plan.requiresAgentSignoff());
+   }
+
+   // -------------------------------------------------------------------------
+   // hash (section 5)
+   // -------------------------------------------------------------------------
+
+   @Test void hashChangesWhenCurrentStatusReadChangesBetweenTwoResolveCalls() {
+      stubConfigured("s1");
+      stubStatus("s1", ServerClusterStatus.Status.OK, false);
+      String hash1 = service.resolve(request("task", List.of(pause("s1")))).planHash();
+
+      stubStatus("s1", ServerClusterStatus.Status.OK, true);
+      String hash2 = service.resolve(request("task", List.of(pause("s1")))).planHash();
+
+      assertNotEquals(hash1, hash2);
+   }
+
+   @Test void hashIsStableAcrossIdenticalResolves() {
+      stubConfigured("s1");
+      stubStatus("s1", ServerClusterStatus.Status.OK, false);
+      String hash1 = service.resolve(request("task", List.of(pause("s1")))).planHash();
+      String hash2 = service.resolve(request("task", List.of(pause("s1")))).planHash();
+      assertEquals(hash1, hash2);
+   }
+
+   // -------------------------------------------------------------------------
+   // helpers
+   // -------------------------------------------------------------------------
+
+   private void stubConfigured(String... servers) {
+      lenient().when(client.getConfiguredServers()).thenReturn(Set.of(servers));
+   }
+
+   private void stubStatus(String server, ServerClusterStatus.Status status, boolean paused) {
+      ServerClusterStatus s = new ServerClusterStatus();
+      s.setStatus(status);
+      s.setPaused(paused);
+      lenient().when(client.getStatus(server)).thenReturn(s);
+   }
+
+   private static ClusterChangeRequest pause(String server) {
+      ClusterChangeRequest c = new ClusterChangeRequest();
+      c.setVerb(ClusterChangeRequest.VERB_PAUSE);
+      c.setServer(server);
+      return c;
+   }
+
+   private static ClusterChangeRequest resume(String server) {
+      ClusterChangeRequest c = new ClusterChangeRequest();
+      c.setVerb(ClusterChangeRequest.VERB_RESUME);
+      c.setServer(server);
+      return c;
+   }
+
+   private static ClusterChangePlanRequest request(String task, List<ClusterChangeRequest> changes) {
+      ClusterChangePlanRequest req = new ClusterChangePlanRequest();
+      req.setTask(task);
+      req.setChanges(changes);
+      return req;
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/ai/cluster/ClusterChangesetApplyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/cluster/ClusterChangesetApplyServiceTest.java
@@ -119,6 +119,63 @@ class ClusterChangesetApplyServiceTest {
    }
 
    // -------------------------------------------------------------------------
+   // 07-review-r1.md section 3: the read-back races ServerClusterClient's own ~50ms-debounced
+   // status-map write -- the target's completion reply (what pauseServers/resumeServers' own message
+   // round trip blocks on) is sent BEFORE that write lands. These tests model that with a REAL
+   // stale-then-fresh sequence across successive getStatus() calls (Mockito's consecutive-stubbing,
+   // not a single doAnswer that mutates synchronously the way the old, race-blind test above does) --
+   // the old immediate-single-read code would have failed the first of these two.
+   // -------------------------------------------------------------------------
+
+   @Test void readBackRetriesPastTheDebounceWindowBeforeReportingVerified() {
+      ServerClusterStatus stale = statusOf(ServerClusterStatus.Status.OK, false); // pre-pause
+      ServerClusterStatus fresh = statusOf(ServerClusterStatus.Status.OK, true);  // post-pause, once
+                                                                                   // the debounced
+                                                                                   // write has landed
+      // First read (immediately after the call) and one retry still see the pre-pause status --
+      // exactly the race 07-review-r1.md traced -- before the write lands on the third read.
+      when(client.getStatus("s1")).thenReturn(stale).thenReturn(stale).thenReturn(fresh);
+      String hash = planService.resolve(request("task", List.of(pause("s1")))).planHash();
+      // Re-stub after resolve() (which itself calls getStatus once to build the plan) so the
+      // apply-time sequence starts fresh at "stale, stale, fresh" for applyOne's own read-back.
+      when(client.getStatus("s1")).thenReturn(stale).thenReturn(stale).thenReturn(fresh);
+
+      try(MockedStatic<Audit> audit = mockAudit()) {
+         var result = service.apply(applyRequest("task", hash, "looks good", pause("s1")), user);
+
+         ClusterApplyOutcome outcome = result.results().get(0);
+         assertEquals(AdminChangeRecord.STATUS_VERIFIED, outcome.status());
+         assertEquals("Paused", outcome.after());
+         assertEquals(ClusterChangesetApplyService.STATUS_APPLIED, result.status());
+         // At least 3 calls: the plan's own fresh re-resolve (1) plus the read-back's own two stale
+         // reads and one fresh read (3) -- proves the retry loop actually polled rather than trusting
+         // a single immediate read.
+         verify(client, atLeast(4)).getStatus("s1");
+      }
+   }
+
+   @Test void readBackReportsFailedOnlyAfterExhaustingRetriesNotOnTheFirstStaleRead() {
+      ServerClusterStatus stale = statusOf(ServerClusterStatus.Status.OK, false);
+      // Never becomes paused -- a genuine failure (e.g. the message truly never completed), not a
+      // debounce-window race. Every getStatus() call for the life of this test returns the same
+      // stale status.
+      when(client.getStatus("s1")).thenReturn(stale);
+      String hash = planService.resolve(request("task", List.of(pause("s1")))).planHash();
+
+      try(MockedStatic<Audit> audit = mockAudit()) {
+         var result = service.apply(applyRequest("task", hash, "looks good", pause("s1")), user);
+
+         ClusterApplyOutcome outcome = result.results().get(0);
+         assertEquals(AdminChangeRecord.STATUS_FAILED, outcome.status());
+         assertTrue(outcome.error().contains("debounce"));
+         assertEquals(ClusterChangesetApplyService.STATUS_FAILED, result.status());
+         // The retry loop must still have polled multiple times before giving up, not failed fast on
+         // the very first read.
+         verify(client, atLeast(4)).getStatus("s1");
+      }
+   }
+
+   // -------------------------------------------------------------------------
    // failure does not stop subsequent entries -- item 4's structural divergence
    // -------------------------------------------------------------------------
 
@@ -255,10 +312,14 @@ class ClusterChangesetApplyServiceTest {
    }
 
    private void stubStatus(String server, ServerClusterStatus.Status status, boolean paused) {
+      lenient().when(client.getStatus(server)).thenReturn(statusOf(status, paused));
+   }
+
+   private static ServerClusterStatus statusOf(ServerClusterStatus.Status status, boolean paused) {
       ServerClusterStatus s = new ServerClusterStatus();
       s.setStatus(status);
       s.setPaused(paused);
-      lenient().when(client.getStatus(server)).thenReturn(s);
+      return s;
    }
 
    private static ClusterChangeRequest pause(String server) {

--- a/core/src/test/java/inetsoft/web/admin/ai/cluster/ClusterChangesetApplyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/cluster/ClusterChangesetApplyServiceTest.java
@@ -1,0 +1,288 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.cluster;
+
+import inetsoft.uql.XPrincipal;
+import inetsoft.util.Tool;
+import inetsoft.util.audit.AdminChangeRecord;
+import inetsoft.util.audit.ActionRecord;
+import inetsoft.util.audit.Audit;
+import inetsoft.web.admin.ai.AdminChangesetApplyService;
+import inetsoft.web.admin.cluster.ClusterEnabledModel;
+import inetsoft.web.admin.cluster.ClusterService;
+import inetsoft.web.cluster.ServerClusterClient;
+import inetsoft.web.cluster.ServerClusterStatus;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * 01-spec.md section 6 (apply, per-server read-back, the {@code "partial"} changeset-status
+ * vocabulary -- this area's own structural divergence from every prior area: no undo list, no
+ * reverse-order pass, apply continues through per-server failures rather than stopping and
+ * unwinding).
+ */
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class ClusterChangesetApplyServiceTest {
+   @Mock private ClusterService clusterService;
+   @Mock private ServerClusterClient client;
+   @Mock private XPrincipal user;
+
+   private ClusterChangePlanService planService;
+   private ClusterChangesetApplyService service;
+
+   @BeforeEach void setUp() {
+      planService = new ClusterChangePlanService(clusterService, client);
+      service = new ClusterChangesetApplyService(planService, clusterService, client);
+      lenient().when(clusterService.getClusterEnabled())
+         .thenReturn(ClusterEnabledModel.builder().enabled(true).pauseEnabled(true).build());
+      lenient().when(client.getConfiguredServers()).thenReturn(Set.of("s1", "s2"));
+   }
+
+   // -------------------------------------------------------------------------
+   // hash / reviewOutcome gates
+   // -------------------------------------------------------------------------
+
+   @Test void applyThrowsPlanHashMismatchOnStaleHash() {
+      stubStatus("s1", ServerClusterStatus.Status.OK, false);
+      ClusterApplyRequest req = applyRequest("task", "not-the-real-hash", "looks good",
+                                             pause("s1"));
+      assertThrows(AdminChangesetApplyService.PlanHashMismatchException.class,
+         () -> service.apply(req, user));
+   }
+
+   @Test void applyThrowsOnMissingReviewOutcome() {
+      stubStatus("s1", ServerClusterStatus.Status.OK, false);
+      String hash = planService.resolve(request("task", List.of(pause("s1")))).planHash();
+      ClusterApplyRequest req = applyRequest("task", hash, "  ", pause("s1"));
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.apply(req, user));
+      assertTrue(ex.getMessage().contains("reviewOutcome"));
+   }
+
+   // -------------------------------------------------------------------------
+   // success -- read-back drives "verified", uses a FRESH getStatus call, not the pre-apply snapshot
+   // -------------------------------------------------------------------------
+
+   @Test void appliesAPauseAndReportsVerifiedFromFreshReadBack() {
+      stubStatus("s1", ServerClusterStatus.Status.OK, false);
+      String hash = planService.resolve(request("task", List.of(pause("s1")))).planHash();
+
+      // After pauseServers() is called, the NEXT getStatus() read (the read-back) reflects the
+      // server as paused -- simulating the real state transition; the plan's own pre-apply snapshot
+      // (captured moments earlier inside apply()'s re-resolve) must not be reused for verification.
+      doAnswer(inv -> {
+         stubStatus("s1", ServerClusterStatus.Status.OK, true);
+         return null;
+      }).when(clusterService).pauseServers(new String[] { "s1" });
+
+      try(MockedStatic<Audit> audit = mockAudit()) {
+         var result = service.apply(applyRequest("task", hash, "looks good", pause("s1")), user);
+
+         assertEquals(ClusterChangesetApplyService.STATUS_APPLIED, result.status());
+         assertNull(result.backupRef());
+         assertEquals(1, result.results().size());
+         ClusterApplyOutcome outcome = result.results().get(0);
+         assertEquals("s1", outcome.property());
+         assertEquals("Running", outcome.before());
+         assertEquals("Paused", outcome.after());
+         assertEquals(AdminChangeRecord.STATUS_VERIFIED, outcome.status());
+         assertNull(outcome.error());
+         verify(clusterService).pauseServers(new String[] { "s1" });
+      }
+   }
+
+   // -------------------------------------------------------------------------
+   // failure does not stop subsequent entries -- item 4's structural divergence
+   // -------------------------------------------------------------------------
+
+   @Test void aSingleEntryFailureDoesNotStopProcessingOfSubsequentEntries() {
+      stubStatus("s1", ServerClusterStatus.Status.DOWN, false);
+      stubStatus("s2", ServerClusterStatus.Status.OK, false);
+      String hash = planService.resolve(
+         request("task", List.of(pause("s1"), pause("s2")))).planHash();
+
+      // s1 is DOWN and stays DOWN after the (silently-failing) pause call -- read-back label stays
+      // "Stopped", never matching the proposed "Paused". s2 succeeds normally.
+      doAnswer(inv -> {
+         stubStatus("s2", ServerClusterStatus.Status.OK, true);
+         return null;
+      }).when(clusterService).pauseServers(new String[] { "s2" });
+
+      try(MockedStatic<Audit> audit = mockAudit()) {
+         var result = service.apply(
+            applyRequest("task", hash, "looks good", pause("s1"), pause("s2")), user);
+
+         assertEquals(ClusterChangesetApplyService.STATUS_PARTIAL, result.status());
+         assertEquals(2, result.results().size());
+         assertEquals(AdminChangeRecord.STATUS_FAILED, result.results().get(0).status());
+         assertNotNull(result.results().get(0).error());
+         assertEquals(AdminChangeRecord.STATUS_VERIFIED, result.results().get(1).status());
+         // Both were attempted -- s2's pauseServers call happened despite s1 already failing.
+         verify(clusterService).pauseServers(new String[] { "s1" });
+         verify(clusterService).pauseServers(new String[] { "s2" });
+      }
+   }
+
+   // -------------------------------------------------------------------------
+   // overall status vocabulary -- applied / partial / failed (item 6)
+   // -------------------------------------------------------------------------
+
+   @Test void overallStatusIsFailedWhenEveryEntryFails() {
+      stubStatus("s1", ServerClusterStatus.Status.DOWN, false);
+      String hash = planService.resolve(request("task", List.of(pause("s1")))).planHash();
+
+      try(MockedStatic<Audit> audit = mockAudit()) {
+         var result = service.apply(applyRequest("task", hash, "looks good", pause("s1")), user);
+         assertEquals(ClusterChangesetApplyService.STATUS_FAILED, result.status());
+      }
+   }
+
+   @Test void overallStatusIsAppliedWhenEveryEntrySucceeds() {
+      stubStatus("s1", ServerClusterStatus.Status.OK, false);
+      stubStatus("s2", ServerClusterStatus.Status.OK, false);
+      String hash = planService.resolve(
+         request("task", List.of(pause("s1"), pause("s2")))).planHash();
+
+      doAnswer(inv -> { stubStatus("s1", ServerClusterStatus.Status.OK, true); return null; })
+         .when(clusterService).pauseServers(new String[] { "s1" });
+      doAnswer(inv -> { stubStatus("s2", ServerClusterStatus.Status.OK, true); return null; })
+         .when(clusterService).pauseServers(new String[] { "s2" });
+
+      try(MockedStatic<Audit> audit = mockAudit()) {
+         var result = service.apply(
+            applyRequest("task", hash, "looks good", pause("s1"), pause("s2")), user);
+         assertEquals(ClusterChangesetApplyService.STATUS_APPLIED, result.status());
+      }
+   }
+
+   // -------------------------------------------------------------------------
+   // a throw mid-apply is recorded as failed, never stops remaining entries, never rolled back
+   // -------------------------------------------------------------------------
+
+   @Test void aThrowDuringApplyIsRecordedAsFailedAndDoesNotAbortRemainingEntries() {
+      stubStatus("s1", ServerClusterStatus.Status.OK, false);
+      stubStatus("s2", ServerClusterStatus.Status.OK, false);
+      String hash = planService.resolve(
+         request("task", List.of(pause("s1"), pause("s2")))).planHash();
+
+      doThrow(new RuntimeException("cluster message bus unavailable"))
+         .when(clusterService).pauseServers(new String[] { "s1" });
+      doAnswer(inv -> { stubStatus("s2", ServerClusterStatus.Status.OK, true); return null; })
+         .when(clusterService).pauseServers(new String[] { "s2" });
+
+      try(MockedStatic<Audit> audit = mockAudit()) {
+         var result = service.apply(
+            applyRequest("task", hash, "looks good", pause("s1"), pause("s2")), user);
+
+         assertEquals(ClusterChangesetApplyService.STATUS_PARTIAL, result.status());
+         assertEquals(AdminChangeRecord.STATUS_FAILED, result.results().get(0).status());
+         assertTrue(result.results().get(0).error().contains("cluster message bus unavailable"));
+         assertEquals(AdminChangeRecord.STATUS_VERIFIED, result.results().get(1).status());
+         verify(clusterService).pauseServers(new String[] { "s2" });
+      }
+   }
+
+   // -------------------------------------------------------------------------
+   // audit (section 8) -- OBJECT_TYPE_CLUSTER, snapshotScope=value, backupRef=null, every outcome
+   // -------------------------------------------------------------------------
+
+   @Test void writesAnAuditRecordWithClusterObjectTypeAndNullBackupRefForEveryOutcome() {
+      stubStatus("s1", ServerClusterStatus.Status.DOWN, false);
+      String hash = planService.resolve(request("task", List.of(pause("s1")))).planHash();
+      Audit auditInstance = mock(Audit.class);
+
+      // Tool.getHost() reads SreeEnv, which throws ShutdownException with no Spring context
+      // available (the same "harmless log noise" every prior area's own apply-service test hits) --
+      // stubbed here too, specifically so the audit write actually reaches Audit.getInstance()
+      // .auditAdminChange(...) and this test can assert on the record's real field values, rather
+      // than only proving the write was attempted the way every prior area's test settles for.
+      try(MockedStatic<Audit> audit = mockStatic(Audit.class);
+          MockedStatic<Tool> tool = mockStatic(Tool.class, CALLS_REAL_METHODS))
+      {
+         audit.when(Audit::getInstance).thenReturn(auditInstance);
+         tool.when(Tool::getHost).thenReturn("test-host");
+         service.apply(applyRequest("task", hash, "looks good", pause("s1")), user);
+      }
+
+      ArgumentCaptor<AdminChangeRecord> captor = ArgumentCaptor.forClass(AdminChangeRecord.class);
+      verify(auditInstance).auditAdminChange(captor.capture(), eq(user));
+      AdminChangeRecord record = captor.getValue();
+      assertEquals(ActionRecord.OBJECT_TYPE_CLUSTER, record.getObjectType());
+      assertEquals(AdminChangeRecord.SCOPE_VALUE, record.getSnapshotScope());
+      assertEquals(AdminChangeRecord.RISK_HIGH, record.getRiskLevel());
+      assertNull(record.getBackupRef());
+      assertEquals(AdminChangeRecord.ACTION_APPLY, record.getAction());
+      assertEquals(AdminChangeRecord.STATUS_FAILED, record.getStatus());
+      assertNull(record.getOrganizationId());
+   }
+
+   // -------------------------------------------------------------------------
+   // helpers
+   // -------------------------------------------------------------------------
+
+   private MockedStatic<Audit> mockAudit() {
+      MockedStatic<Audit> audit = mockStatic(Audit.class);
+      Audit instance = mock(Audit.class);
+      audit.when(Audit::getInstance).thenReturn(instance);
+      return audit;
+   }
+
+   private void stubStatus(String server, ServerClusterStatus.Status status, boolean paused) {
+      ServerClusterStatus s = new ServerClusterStatus();
+      s.setStatus(status);
+      s.setPaused(paused);
+      lenient().when(client.getStatus(server)).thenReturn(s);
+   }
+
+   private static ClusterChangeRequest pause(String server) {
+      ClusterChangeRequest c = new ClusterChangeRequest();
+      c.setVerb(ClusterChangeRequest.VERB_PAUSE);
+      c.setServer(server);
+      return c;
+   }
+
+   private static ClusterChangePlanRequest request(String task, List<ClusterChangeRequest> changes) {
+      ClusterChangePlanRequest req = new ClusterChangePlanRequest();
+      req.setTask(task);
+      req.setChanges(changes);
+      return req;
+   }
+
+   private static ClusterApplyRequest applyRequest(String task, String planHash, String reviewOutcome,
+                                                    ClusterChangeRequest... changes)
+   {
+      ClusterApplyRequest req = new ClusterApplyRequest();
+      req.setTask(task);
+      req.setChanges(List.of(changes));
+      req.setPlanHash(planHash);
+      req.setReviewOutcome(reviewOutcome);
+      return req;
+   }
+}


### PR DESCRIPTION
## Summary

Ninth EM area for the admin-chat plugin: cluster node pause/resume, by server name(s). Narrowest
area yet -- two self-inverse verbs, no create, no stored-state mutation, and (unlike every prior
area) no compensating-transaction/rollback machinery: each server's pause/resume is independent, so
a per-server failure is reported (`"partial"` overall status), not undone.

New package `community/core/src/main/java/inetsoft/web/admin/ai/cluster/`:

- `list_cluster_nodes`/`get_cluster_node` read tools wrapping the existing `ClusterService.getClusterStatus()`.
- `preview_cluster_changes`/`apply_cluster_changes`, one plan entry per `(verb, server)` pair.
- Hard refusal on an unrecognized server name, validated against a fresh `getClusterStatus()` read
  before ever reaching the underlying `pauseServers`/`resumeServers` call.
- `cluster.pause.enabled` enforced Java-side, for both verbs -- works around `stylebi#76342`
  (today the property only gates the EM UI button, nothing server-side checks it).
- Per-server post-action status read-back, with a short bounded retry/poll (up to ~180ms) past the
  underlying `ServerClusterClient`'s own ~50ms debounced status-map write -- works around
  `stylebi#76343` (the raw endpoint silently discards per-server pause/resume results today) *and*
  closes a read-back race this PR's own review round found and fixed (see below).
- New `ActionRecord.OBJECT_TYPE_CLUSTER` constant; new `"partial"` changeset-status vocabulary value.
- A paused node's pause state does not survive that node leaving and rejoining the cluster (crash,
  restart, network partition) -- disclosed prominently in class javadoc; no product-level fix is in
  scope for this cut (would require a persisted "operator intent" store that doesn't exist today).

## Review history (this PR's own commits)

Two rounds of independent adversarial review during development:
- Round 1 found a real defect: the apply-time read-back raced the target node's own asynchronous
  debounced status-map write, and could plausibly report `"failed"` for a pause/resume that actually
  succeeded.
- Fixed in this same PR (`readBackWithRetry`, bounded 4-attempt/60ms poll, ~180ms worst case, comfortably
  past the ~50ms debounce), with two new regression tests exercising the real stale-then-fresh async
  timing shape (Mockito consecutive-return stubbing), not a synchronous mock.
- Round 2 independently re-derived the fix's correctness and re-confirmed both tests are
  non-tautological (the first is independently confirmed to have failed against the pre-fix code).

Full archive: `docs/teams/2026-08-27-track-c5-cluster/` in the `stylebi-wiz` repo (charter, spec,
reconcile, both build logs, both review rounds).

## Test plan

- [x] `ClusterChangePlanServiceTest` (19 tests) / `ClusterChangesetApplyServiceTest` (10 tests,
      including the 2 new race-regression tests) -- 29/29 passing, independently re-run 3 times
      across build/review/re-review, exact match every time.
- [x] Diff scope independently confirmed clean: 13 files, all under the new `ai/cluster/` package,
      its test package, or the one 4-line `ActionRecord.java` addition -- no drive-by changes.
- [x] Live multi-node partial-failure/`DOWN`-node behavior not yet exercised (needs a real
      multi-node cluster) -- disclosed as an open item, not blocking this cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)