### PR TITLE
Bug #75980, add N-ary join support to the MCP worksheet add_join op

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
@@ -48,7 +48,7 @@ import java.util.Map;
  *       error from this call.</li>
  *   <li>{@code add_expression_column} — {@code table}, {@code name}, {@code expression}, {@code type}, {@code sql}</li>
  *   <li>{@code set_sort} — {@code table}, {@code field}, {@code direction} ("ASC" | "DESC")</li>
- *   <li>{@code add_join} — {@code name}, {@code leftTable}, {@code leftKey}, {@code rightTable}, {@code rightKey}, {@code joinType}; for multi-key joins use {@code leftKeys}/{@code rightKeys} instead of single key fields</li>
+ *   <li>{@code add_join} — {@code name}, {@code leftTable}, {@code leftKey}, {@code rightTable}, {@code rightKey}, {@code joinType}; for multi-key joins use {@code leftKeys}/{@code rightKeys} instead of single key fields. For three or more tables joined in a single call, supply {@code joinPaths} instead (each a {leftTable, leftKey, rightTable, rightKey, joinType} edge) — {@code leftTable}/{@code leftKey}/{@code rightTable}/{@code rightKey}/{@code joinType}/{@code leftKeys}/{@code rightKeys} are ignored when {@code joinPaths} is present</li>
  *   <li>{@code remove_join} — {@code name}</li>
  *   <li>{@code add_table} — {@code table}, optional {@code datasource} (when provided, creates a bound table from the named datasource); optional {@code logicalModel} (when provided alongside datasource, {@code table} is an entity name within that logical model); optional {@code endpoint} (+ optional {@code parameters}/{@code lookup}/{@code lookupExpandArrays}/{@code lookupTopLevelOnly}) to bind a named REST/JSON connector's pre-built endpoint (and, optionally, one of its pre-built "Join With" lookup chains) instead of a physical table or logical model entity — {@code table} then names the NEW worksheet table rather than a physical path; optional {@code suffix} (+ optional {@code customLookups}) to bind a GENERIC/CUSTOM REST-JSON datasource's hand-authored URL suffix (and, optionally, up to 5 hand-authored custom lookup levels) instead — mutually exclusive with {@code endpoint}/{@code parameters}/{@code lookup}</li>
  *   <li>{@code edit_condition} — {@code table}, {@code field}, {@code operation}, {@code values}</li>
@@ -334,7 +334,13 @@ public record EditRequest(
     * a query against an existing worksheet table's columns. {@code null} leaves it unchanged.
     * See {@link WorksheetMutationSupport.VariableChoicesSpec}.
     */
-   WorksheetMutationSupport.VariableChoicesSpec choices
+   WorksheetMutationSupport.VariableChoicesSpec choices,
+   /**
+    * Join edges for an N-ary add_join (three or more tables joined into one assembly in a
+    * single call). When present, this supersedes {@code leftTable}/{@code leftKey}/
+    * {@code rightTable}/{@code rightKey}/{@code joinType}/{@code leftKeys}/{@code rightKeys}.
+    */
+   List<WorksheetMutationSupport.JoinPathSpec> joinPaths
 ) {
    /**
     * Compatibility constructor for callers built before {@code crosstab} was added —
@@ -366,7 +372,7 @@ public record EditRequest(
            value, index, alias, description, maxRows, distinct, columnOrder, groupMappings,
            groupOthers, variableValues, x, y, label, defaultValue, mode, insert, subtables,
            sourceTable, attribute, endpoint, parameters, lookup, lookupExpandArrays,
-           lookupTopLevelOnly, suffix, customLookups, null, null);
+           lookupTopLevelOnly, suffix, customLookups, null, null, null, null);
    }
 
    /**
@@ -400,6 +406,6 @@ public record EditRequest(
            value, index, alias, description, maxRows, distinct, columnOrder, groupMappings,
            groupOthers, variableValues, x, y, label, defaultValue, mode, insert, subtables,
            sourceTable, attribute, endpoint, parameters, lookup, lookupExpandArrays,
-           lookupTopLevelOnly, suffix, customLookups, crosstab, labels, null);
+           lookupTopLevelOnly, suffix, customLookups, crosstab, labels, null, null);
    }
 }

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -1729,10 +1729,16 @@ public class WorksheetAgentController {
          }
          case "set_sort" ->
             editor.setSort(req.table(), req.field(), req.direction());
-         case "add_join" ->
-            editor.addJoin(req.name(), req.leftTable(), req.leftKey(),
-                           req.rightTable(), req.rightKey(), req.joinType(),
-                           req.leftKeys(), req.rightKeys());
+         case "add_join" -> {
+            if(req.joinPaths() != null && !req.joinPaths().isEmpty()) {
+               editor.addJoin(req.name(), req.joinPaths());
+            }
+            else {
+               editor.addJoin(req.name(), req.leftTable(), req.leftKey(),
+                              req.rightTable(), req.rightKey(), req.joinType(),
+                              req.leftKeys(), req.rightKeys());
+            }
+         }
          case "remove_join" ->
             editor.removeJoin(req.name());
          case "add_table" ->

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -40,6 +40,7 @@ import java.awt.Point;
 import java.util.Enumeration;
 import inetsoft.web.composer.ws.WorksheetControllerService;
 import inetsoft.web.composer.ws.assembly.WorksheetEventUtil;
+import inetsoft.web.composer.ws.joins.InnerJoinService;
 import inetsoft.web.wiz.pairing.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,7 +48,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.security.Principal;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Session-resolved edit service for worksheets.
@@ -63,12 +66,14 @@ public class WorksheetEditService {
    public WorksheetEditService(SheetSessionService sessions,
                                SheetRuntimeAccess runtimeAccess,
                                SheetAgentBroadcastService broadcast,
-                               SecurityEngine securityEngine)
+                               SecurityEngine securityEngine,
+                               InnerJoinService innerJoinService)
    {
       this.sessions = sessions;
       this.runtimeAccess = runtimeAccess;
       this.broadcast = broadcast;
       this.securityEngine = securityEngine;
+      this.innerJoinService = innerJoinService;
    }
 
    /**
@@ -94,7 +99,7 @@ public class WorksheetEditService {
          SheetType.WORKSHEET, session.runtimeId(), agent);
       applySocketSession(rws, session);
 
-      Editor editor = new Editor(rws.getWorksheet(), agent, securityEngine);
+      Editor editor = new Editor(rws.getWorksheet(), agent, securityEngine, innerJoinService);
 
       try {
          mutation.accept(editor);
@@ -275,6 +280,7 @@ public class WorksheetEditService {
    private final SheetRuntimeAccess runtimeAccess;
    private final SheetAgentBroadcastService broadcast;
    private final SecurityEngine securityEngine;
+   private final InnerJoinService innerJoinService;
    private static final Logger LOG = LoggerFactory.getLogger(WorksheetEditService.class);
 
    // =========================================================================
@@ -289,10 +295,12 @@ public class WorksheetEditService {
     */
    public static final class Editor {
 
-      Editor(Worksheet ws, Principal agent, SecurityEngine securityEngine) {
+      Editor(Worksheet ws, Principal agent, SecurityEngine securityEngine,
+             InnerJoinService innerJoinService) {
          this.ws = ws;
          this.agent = agent;
          this.securityEngine = securityEngine;
+         this.innerJoinService = innerJoinService;
       }
 
       /**
@@ -667,6 +675,110 @@ public class WorksheetEditService {
                                             new TableAssembly[]{ left, right },
                                             new TableAssemblyOperator[]{ top });
          placeAssembly(join);
+      }
+
+      /**
+       * Creates a new {@link RelationalJoinTableAssembly} spanning three or more tables in a
+       * single call, matching the Composer UI's multi-select-then-join capability (as opposed
+       * to {@link #addJoin(String, String, String, String, String, String, List, List)}, which
+       * joins exactly two).
+       *
+       * <p>The edges need not form a single left-to-right chain — either side of any edge may
+       * name a table introduced by another edge (e.g. a hub table joined to two others) — because
+       * this delegates to {@link InnerJoinService#editExistingJoinTable}, the same mechanism
+       * behind Composer's own N-ary join (normally reached only via a live STOMP session through
+       * {@code WSJoinTablesEvent}), which resolves edges by table name rather than by position.
+       * That method takes a plain {@link Worksheet} and no runtime/session context, so it is
+       * safe to call here — this mirrors {@code WorksheetTableService.buildJoinTable}, which
+       * already calls it the same way for the {@code add_table} "relational join table" type.
+       *
+       * @param name      the name for the new join assembly
+       * @param joinPaths the join edges (at least one); each names its own left/right table and
+       *                  key columns, so tables may be introduced across multiple edges
+       * @throws PairingException if {@code name}/{@code joinPaths} are empty, a referenced table
+       *                    is not found, an edge specifies {@code joinType == "MERGE"}, or a
+       *                    {@code "CROSS"} edge is combined with any other edge (a cross join is
+       *                    an exclusive operation — {@link TableAssemblyOperator#checkValidity}
+       *                    rejects it once the combined operator holds more than one edge — so
+       *                    a lone {@code joinPaths} entry may be {@code "CROSS"}, but a 2+-edge
+       *                    call may not mix one in)
+       */
+      public void addJoin(String name, List<WorksheetMutationSupport.JoinPathSpec> joinPaths)
+         throws PairingException, SecurityException
+      {
+         if(name == null || name.isBlank()) {
+            throw new PairingException("Join requires a name.");
+         }
+
+         if(joinPaths == null || joinPaths.isEmpty()) {
+            throw new PairingException("Multi-table join requires at least one join path.");
+         }
+
+         Set<TableAssembly> tableSet = new LinkedHashSet<>();
+         TableAssemblyOperator noperator = new TableAssemblyOperator();
+         boolean crossJoin = false;
+
+         for(WorksheetMutationSupport.JoinPathSpec path : joinPaths) {
+            if("MERGE".equalsIgnoreCase(path.joinType())) {
+               throw new PairingException(
+                  "Multi-table join does not support MERGE per edge (\"" + path.leftTable() +
+                  "\" / \"" + path.rightTable() + "\"); use add_merge_join instead.");
+            }
+
+            if("CROSS".equalsIgnoreCase(path.joinType()) && joinPaths.size() > 1) {
+               throw new PairingException(
+                  "Multi-table join does not support combining CROSS with other edges (\"" +
+                  path.leftTable() + "\" / \"" + path.rightTable() + "\" is CROSS, but " +
+                  joinPaths.size() + " edges were given); a cross join must be the only edge " +
+                  "in the call, or use add_cross_join for a standalone two-table cross join.");
+            }
+
+            TableAssembly left = requireTable(path.leftTable());
+            TableAssembly right = requireTable(path.rightTable());
+            tableSet.add(left);
+            tableSet.add(right);
+
+            int operation = parseJoinType(path.joinType());
+            crossJoin = crossJoin || operation == TableAssemblyOperator.CROSS_JOIN;
+
+            TableAssemblyOperator.Operator op = new TableAssemblyOperator.Operator();
+            op.setLeftTable(path.leftTable());
+            op.setRightTable(path.rightTable());
+
+            if(operation != TableAssemblyOperator.CROSS_JOIN) {
+               op.setLeftAttribute(new AttributeRef(null, path.leftKey()));
+               op.setRightAttribute(new AttributeRef(null, path.rightKey()));
+            }
+
+            op.setOperation(operation);
+            noperator.addOperator(op);
+         }
+
+         if(crossJoin) {
+            requirePermission(ResourceType.CROSS_JOIN);
+         }
+
+         RelationalJoinTableAssembly join = new RelationalJoinTableAssembly(
+            ws, name, tableSet.toArray(new TableAssembly[0]), new TableAssemblyOperator[0]);
+
+         // Position + register before wiring the edges (matching placeAssembly's order for
+         // every other join creator here), since editExistingJoinTable needs the assembly
+         // already registered in ws to resolve table names against.
+         join.setPixelOffset(new Point(25, 25));
+         AssetEventUtil.adjustAssemblyPosition(join, ws);
+         ws.addAssembly(join);
+
+         try {
+            innerJoinService.editExistingJoinTable(ws, join, noperator, true);
+         }
+         catch(PairingException | SecurityException e) {
+            ws.removeAssembly(name);
+            throw e;
+         }
+         catch(Exception e) {
+            ws.removeAssembly(name);
+            throw new PairingException("Failed to build multi-table join: " + e.getMessage());
+         }
       }
 
       /**
@@ -2608,5 +2720,6 @@ public class WorksheetEditService {
       private final Worksheet ws;
       private final Principal agent;
       private final SecurityEngine securityEngine;
+      private final InnerJoinService innerJoinService;
    }
 }

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -136,6 +136,31 @@ public final class WorksheetMutationSupport {
    }
 
    /**
+    * Describes one edge of an N-ary {@code add_join} (three or more tables joined into a single
+    * assembly in one call, as opposed to the pairwise {@code leftTable}/{@code rightTable} form).
+    *
+    * @param leftTable  a source table assembly name — either side of any edge may name a table
+    *                    introduced by another edge, so the edges need not form a single left-to-
+    *                    right chain (e.g. a hub table joined to two others)
+    * @param leftKey    the column name from {@code leftTable} to join on; ignored for
+    *                    {@code joinType == "CROSS"}
+    * @param rightTable the other source table assembly name
+    * @param rightKey   the column name from {@code rightTable} to join on; ignored for
+    *                    {@code joinType == "CROSS"}
+    * @param joinType   one of {@code "INNER"}, {@code "LEFT"}, {@code "RIGHT"}, {@code "FULL"},
+    *                   {@code "CROSS"} (case-insensitive; defaults to {@code "INNER"}).
+    *                   {@code "MERGE"} is not valid per-edge here — a merge join is a distinct
+    *                   assembly type ({@code MergeJoinTableAssembly}) that cannot be mixed into a
+    *                   multi-table {@code RelationalJoinTableAssembly}; use {@code add_merge_join}.
+    *                   {@code "CROSS"} is likewise an exclusive operation and may only appear
+    *                   when it is the SOLE edge in the call — combined with any other edge it is
+    *                   rejected, since {@link TableAssemblyOperator#checkValidity} refuses an
+    *                   exclusive operator once more than one edge is present.
+    */
+   public record JoinPathSpec(String leftTable, String leftKey, String rightTable, String rightKey,
+                              String joinType) {}
+
+   /**
     * Builds the {@link ConditionList} for one named-group mapping, honoring the mapping's
     * {@code operation} (any operator accepted by {@link #parseOperation}, defaulting to
     * {@code EQUAL_TO} when omitted, matching this method's historical behavior).

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetAgentControllerTest.java
@@ -43,6 +43,7 @@ import inetsoft.uql.tabular.RestParameter;
 import inetsoft.uql.tabular.TabularDataSource;
 import inetsoft.uql.tabular.TabularUtil;
 import inetsoft.web.composer.ws.LayoutGraphService;
+import inetsoft.web.composer.ws.joins.InnerJoinService;
 import inetsoft.web.portal.controller.database.DataSourceService;
 import inetsoft.web.portal.controller.database.QueryManagerService;
 import inetsoft.web.wiz.pairing.*;
@@ -395,7 +396,7 @@ class WorksheetAgentControllerTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
 
       EditRequest req = new EditRequest("remove_column", "T", "x",
          null, null, null, null, null, null, null, null, null, null, false,
@@ -445,7 +446,7 @@ class WorksheetAgentControllerTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
 
       List<WorksheetMutationSupport.GroupSpec> groups = List.of(
          new WorksheetMutationSupport.GroupSpec("cust", null),
@@ -517,7 +518,9 @@ class WorksheetAgentControllerTest {
          null,                  // suffix
          null,                  // customLookups
          true,                  // crosstab
-         null                   // labels
+         null,                  // labels
+         null,                  // choices
+         null                   // joinPaths
       );
 
       WorksheetAgentController ctrl = controller(featureOn(),
@@ -556,7 +559,7 @@ class WorksheetAgentControllerTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
 
       WorksheetAgentController ctrl = controller(featureOn(),
          mock(SheetJoinService.class), mock(SheetSessionService.class),
@@ -591,7 +594,7 @@ class WorksheetAgentControllerTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
 
       // "add_column" with no 'name' on an EMBEDDED table must auto-generate the
       // next available "col" + N, matching the Composer UI's own insert-column
@@ -637,7 +640,7 @@ class WorksheetAgentControllerTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
 
       editSvc.apply("TOK-ACM", agent, editor -> editor.addMirror("M", "T"));
 
@@ -684,7 +687,7 @@ class WorksheetAgentControllerTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
 
       // Regression for the "alias" vs "name" mixup: calling add_expression_column
       // without 'name' used to silently succeed and create an unreferenceable
@@ -732,7 +735,7 @@ class WorksheetAgentControllerTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
 
       EditRequest req = new EditRequest("edit_expression", "T", null,
          null, null, null, null, null, null, null, null, null, null, false,
@@ -786,7 +789,7 @@ class WorksheetAgentControllerTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
 
       WorksheetAgentController ctrl = controller(featureOn(),
          mock(SheetJoinService.class), mock(SheetSessionService.class),
@@ -823,7 +826,7 @@ class WorksheetAgentControllerTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
 
       WorksheetAgentController ctrl = controller(featureOn(),
          mock(SheetJoinService.class), mock(SheetSessionService.class),
@@ -858,7 +861,7 @@ class WorksheetAgentControllerTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
 
       WorksheetAgentController ctrl = controller(featureOn(),
          mock(SheetJoinService.class), mock(SheetSessionService.class),
@@ -899,7 +902,8 @@ class WorksheetAgentControllerTest {
                                                       // suffix, customLookups
          null,                        // crosstab
          null,                        // labels
-         choices                      // choices
+         choices,                     // choices
+         null                         // joinPaths
       );
 
       ctrl.edit("TOK-AVC", req, agent);
@@ -968,7 +972,7 @@ class WorksheetAgentControllerTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
 
       WorksheetAgentController ctrl = controller(featureOn(),
          mock(SheetJoinService.class), mock(SheetSessionService.class),
@@ -996,7 +1000,7 @@ class WorksheetAgentControllerTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
 
       WorksheetAgentController ctrl = controller(featureOn(),
          mock(SheetJoinService.class), mock(SheetSessionService.class),
@@ -1023,7 +1027,7 @@ class WorksheetAgentControllerTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
 
       WorksheetAgentController ctrl = controller(featureOn(),
          mock(SheetJoinService.class), mock(SheetSessionService.class),
@@ -1051,7 +1055,7 @@ class WorksheetAgentControllerTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
 
       WorksheetAgentController ctrl = controller(featureOn(),
          mock(SheetJoinService.class), mock(SheetSessionService.class),
@@ -1076,7 +1080,7 @@ class WorksheetAgentControllerTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
 
       return controller(featureOn(), mock(SheetJoinService.class), mock(SheetSessionService.class),
          mock(WorksheetReadService.class), editSvc, mock(WorksheetService.class));
@@ -2288,7 +2292,7 @@ class WorksheetAgentControllerTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService editSvc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
 
       SecurityEngine securityEngine = mock(SecurityEngine.class);
       // Free-Form SQL right is granted, so we get past the action gate and into the lambda.

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -37,6 +37,7 @@ import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.erm.ExpressionRef;
 import inetsoft.uql.schema.XSchema;
 import inetsoft.uql.util.XEmbeddedTable;
+import inetsoft.web.composer.ws.joins.InnerJoinService;
 import inetsoft.web.wiz.pairing.*;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -91,7 +92,7 @@ class WorksheetEditServiceMutatorsTest {
       when(runtimeAccess.getSheetForPairing(eq(SheetType.WORKSHEET), eq(runtimeId), eq(agent)))
          .thenReturn(rws);
 
-      return new WorksheetEditService(sessions, runtimeAccess, broadcast, securityEngine);
+      return new WorksheetEditService(sessions, runtimeAccess, broadcast, securityEngine, mock(InnerJoinService.class));
    }
 
    private RuntimeWorksheet rws(Worksheet ws) {

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceTest.java
@@ -18,6 +18,7 @@
 package inetsoft.web.wiz.worksheet;
 
 import inetsoft.report.composition.RuntimeWorksheet;
+import inetsoft.sree.security.ResourceType;
 import inetsoft.sree.security.SecurityEngine;
 import inetsoft.uql.ColumnSelection;
 import inetsoft.uql.Condition;
@@ -27,6 +28,7 @@ import inetsoft.uql.asset.*;
 import inetsoft.uql.erm.AttributeRef;
 import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.schema.XSchema;
+import inetsoft.web.composer.ws.joins.InnerJoinService;
 import inetsoft.web.wiz.pairing.*;
 import inetsoft.web.wiz.pairing.TestPrincipals;
 import inetsoft.web.wiz.pairing.TestWorksheets;
@@ -66,7 +68,7 @@ class WorksheetEditServiceTest {
          .thenReturn(rws);
 
       WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess, broadcast,
-         mock(SecurityEngine.class));
+         mock(SecurityEngine.class), mock(InnerJoinService.class));
       svc.apply("TOK", agent, ed -> ed.removeColumn("T", "a"));
 
       assertNull(t.getColumnSelection(false).getAttribute("a"));
@@ -79,7 +81,7 @@ class WorksheetEditServiceTest {
       when(sessions.resolve(any(), any())).thenReturn(null);
       WorksheetEditService svc = new WorksheetEditService(sessions,
          mock(SheetRuntimeAccess.class), mock(SheetAgentBroadcastService.class),
-         mock(SecurityEngine.class));
+         mock(SecurityEngine.class), mock(InnerJoinService.class));
       assertThrows(PairingException.class,
          () -> svc.apply("BAD", TestPrincipals.user("alice", "host-org"), ed -> {}));
    }
@@ -102,7 +104,7 @@ class WorksheetEditServiceTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
       svc.apply("TOK", agent, ed -> ed.addColumn("T", "c", "string"));
 
       assertNotNull(t.getColumnSelection(false).getAttribute("c"));
@@ -126,7 +128,7 @@ class WorksheetEditServiceTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
       svc.apply("TOK", agent, ed -> ed.renameColumn("T", "a", "alpha"));
 
       ColumnSelection cs = t.getColumnSelection(false);
@@ -155,7 +157,7 @@ class WorksheetEditServiceTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
 
       List<WorksheetMutationSupport.GroupMapping> mappings = List.of(
          new WorksheetMutationSupport.GroupMapping("Northeast", List.of("NY", "NJ", "CT")),
@@ -188,7 +190,7 @@ class WorksheetEditServiceTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
 
       svc.apply("TOK", agent,
                 ed -> ed.addNamedGroup("StateRegion", null, null, null, List.of(), false));
@@ -215,7 +217,7 @@ class WorksheetEditServiceTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
 
       assertThrows(PairingException.class,
          () -> svc.apply("TOK", agent,
@@ -238,7 +240,7 @@ class WorksheetEditServiceTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
 
       assertThrows(PairingException.class,
          () -> svc.apply("TOK", agent,
@@ -261,7 +263,7 @@ class WorksheetEditServiceTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
 
       List<WorksheetMutationSupport.GroupMapping> mappings = List.of(
          new WorksheetMutationSupport.GroupMapping("Northeast", List.of("NY", "NJ", "CT")),
@@ -302,7 +304,7 @@ class WorksheetEditServiceTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
 
       // Mirrors the real repro: leftKey/rightKey/joinType supplied but name omitted.
       assertThrows(PairingException.class,
@@ -335,7 +337,7 @@ class WorksheetEditServiceTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
 
       assertThrows(PairingException.class,
          () -> svc.apply("TOK", agent,
@@ -363,7 +365,7 @@ class WorksheetEditServiceTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
 
       svc.apply("TOK", agent,
                 ed -> ed.addNamedGroup("StateRegion", null, null, "string", List.of(), false));
@@ -423,7 +425,7 @@ class WorksheetEditServiceTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
 
       List<WorksheetMutationSupport.GroupMapping> mappings = List.of(
          new WorksheetMutationSupport.GroupMapping("N", List.of("NJ", "NY", "NV")));
@@ -461,7 +463,7 @@ class WorksheetEditServiceTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
 
       List<WorksheetMutationSupport.GroupMapping> mappings = List.of(
          new WorksheetMutationSupport.GroupMapping("NotNYNJ", List.of("NY", "NJ"), "!="));
@@ -503,7 +505,7 @@ class WorksheetEditServiceTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
 
       List<WorksheetMutationSupport.GroupMapping> mappings = List.of(
          new WorksheetMutationSupport.GroupMapping("N", List.of("N"), "STARTING_WITH"),
@@ -543,7 +545,7 @@ class WorksheetEditServiceTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
 
       List<WorksheetMutationSupport.GroupMapping> mappings = List.of(
          new WorksheetMutationSupport.GroupMapping("Mid", List.of("10"), "BETWEEN"));
@@ -577,7 +579,7 @@ class WorksheetEditServiceTest {
       when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
 
       WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
-         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class));
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
 
       List<WorksheetMutationSupport.GroupMapping> mappings = List.of(
          new WorksheetMutationSupport.GroupMapping("NotAnything", List.of(), "!="));
@@ -587,5 +589,300 @@ class WorksheetEditServiceTest {
                          ed -> ed.addNamedGroup("G2", null, null, "string", mappings, false)));
       assertTrue(ex.getMessage().contains("at least one value"));
       assertNull(ws.getAssembly("G2"), "a rejected group must not be partially created");
+   }
+
+   /**
+    * Bug #75980: add_join only joined two tables at a time, forcing a chain of assemblies for
+    * a 3+-table join instead of a single combined view like Composer's own multi-select join.
+    * This exercises the {@code joinPaths} overload end to end with a REAL
+    * {@link InnerJoinService} (not a mock) so the join wiring itself is verified, not just that
+    * some call was made — mirroring the direct-construction pattern already used by
+    * {@link inetsoft.web.composer.ws.joins.InnerJoinServiceOperatorOrientationTest}.
+    */
+   @Test
+   void addJoinWithPathsBuildsSingleAssemblyOverThreeTables() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly orders = TestWorksheets.tableWithColumns(
+         ws, "ORDER_DETAILS1", "order_id", "product_id");
+      EmbeddedTableAssembly products = TestWorksheets.tableWithColumns(
+         ws, "PRODUCTS1", "product_id", "category_id");
+      EmbeddedTableAssembly categories = TestWorksheets.tableWithColumns(
+         ws, "CATEGORIES1", "category_id", "name");
+      ws.addAssembly(orders);
+      ws.addAssembly(products);
+      ws.addAssembly(categories);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      JoinSession s = new JoinSession("TOK", "Worksheet/foo-7", "alice~;~host-org",
+                                     SheetType.WORKSHEET, 0L, Long.MAX_VALUE,
+                                     JoinSession.ConnectionMode.PAIRED, null, null, null);
+      when(sessions.resolve(eq("TOK"), any())).thenReturn(s);
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class),
+         new InnerJoinService(null, null));
+
+      List<WorksheetMutationSupport.JoinPathSpec> paths = List.of(
+         new WorksheetMutationSupport.JoinPathSpec(
+            "ORDER_DETAILS1", "product_id", "PRODUCTS1", "product_id", "INNER"),
+         new WorksheetMutationSupport.JoinPathSpec(
+            "PRODUCTS1", "category_id", "CATEGORIES1", "category_id", "LEFT"));
+
+      svc.apply("TOK", agent, ed -> ed.addJoin("JOINED", paths));
+
+      RelationalJoinTableAssembly joined = (RelationalJoinTableAssembly) ws.getAssembly("JOINED");
+      assertNotNull(joined);
+      assertEquals(3, joined.getTableAssemblies().length);
+
+      TableAssemblyOperator opOrdersProducts = joined.getOperator("ORDER_DETAILS1", "PRODUCTS1");
+      assertNotNull(opOrdersProducts);
+      assertEquals(1, opOrdersProducts.getOperatorCount());
+      assertEquals(TableAssemblyOperator.INNER_JOIN, opOrdersProducts.getOperator(0).getOperation());
+      assertEquals("product_id", opOrdersProducts.getOperator(0).getLeftAttribute().getAttribute());
+      assertEquals("product_id", opOrdersProducts.getOperator(0).getRightAttribute().getAttribute());
+
+      TableAssemblyOperator opProductsCategories =
+         joined.getOperator("PRODUCTS1", "CATEGORIES1");
+      assertNotNull(opProductsCategories);
+      assertEquals(1, opProductsCategories.getOperatorCount());
+      assertEquals(TableAssemblyOperator.LEFT_JOIN,
+                   opProductsCategories.getOperator(0).getOperation());
+   }
+
+   /**
+    * The star-join shape from the original repro (hub table joined to two others, not a linear
+    * left-to-right chain) must work — this is exactly why {@code editExistingJoinTable} is used
+    * instead of hand-rolling positional pairing.
+    */
+   @Test
+   void addJoinWithPathsSupportsStarShapedJoin() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly hub = TestWorksheets.tableWithColumns(
+         ws, "WORK_PACKAGES", "id", "project_id", "status_id");
+      EmbeddedTableAssembly projects = TestWorksheets.tableWithColumns(ws, "PROJECTS", "id");
+      EmbeddedTableAssembly statuses = TestWorksheets.tableWithColumns(ws, "STATUSES", "id");
+      ws.addAssembly(hub);
+      ws.addAssembly(projects);
+      ws.addAssembly(statuses);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      JoinSession s = new JoinSession("TOK", "Worksheet/foo-7", "alice~;~host-org",
+                                     SheetType.WORKSHEET, 0L, Long.MAX_VALUE,
+                                     JoinSession.ConnectionMode.PAIRED, null, null, null);
+      when(sessions.resolve(eq("TOK"), any())).thenReturn(s);
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class),
+         new InnerJoinService(null, null));
+
+      List<WorksheetMutationSupport.JoinPathSpec> paths = List.of(
+         new WorksheetMutationSupport.JoinPathSpec(
+            "WORK_PACKAGES", "project_id", "PROJECTS", "id", "INNER"),
+         new WorksheetMutationSupport.JoinPathSpec(
+            "WORK_PACKAGES", "status_id", "STATUSES", "id", "INNER"));
+
+      svc.apply("TOK", agent, ed -> ed.addJoin("JOINED", paths));
+
+      RelationalJoinTableAssembly joined = (RelationalJoinTableAssembly) ws.getAssembly("JOINED");
+      assertNotNull(joined);
+      assertEquals(3, joined.getTableAssemblies().length);
+      assertNotNull(joined.getOperator("WORK_PACKAGES", "PROJECTS"));
+      assertNotNull(joined.getOperator("WORK_PACKAGES", "STATUSES"));
+   }
+
+   @Test
+   void addJoinWithPathsRejectsMergeType() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly a = TestWorksheets.tableWithColumns(ws, "A", "k");
+      EmbeddedTableAssembly b = TestWorksheets.tableWithColumns(ws, "B", "k");
+      ws.addAssembly(a);
+      ws.addAssembly(b);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      JoinSession s = new JoinSession("TOK", "Worksheet/foo-7", "alice~;~host-org",
+                                     SheetType.WORKSHEET, 0L, Long.MAX_VALUE,
+                                     JoinSession.ConnectionMode.PAIRED, null, null, null);
+      when(sessions.resolve(eq("TOK"), any())).thenReturn(s);
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
+
+      List<WorksheetMutationSupport.JoinPathSpec> paths = List.of(
+         new WorksheetMutationSupport.JoinPathSpec("A", "k", "B", "k", "MERGE"));
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.addJoin("JOINED", paths)));
+      assertTrue(ex.getMessage().contains("add_merge_join"));
+      assertNull(ws.getAssembly("JOINED"), "a rejected multi-join must not be partially created");
+   }
+
+   @Test
+   void addJoinWithPathsRejectsEmptyPathList() throws Exception {
+      Worksheet ws = new Worksheet();
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      JoinSession s = new JoinSession("TOK", "Worksheet/foo-7", "alice~;~host-org",
+                                     SheetType.WORKSHEET, 0L, Long.MAX_VALUE,
+                                     JoinSession.ConnectionMode.PAIRED, null, null, null);
+      when(sessions.resolve(eq("TOK"), any())).thenReturn(s);
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
+
+      assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.addJoin("JOINED", List.of())));
+      assertNull(ws.getAssembly("JOINED"));
+   }
+
+   /**
+    * A CROSS edge is an exclusive operation ({@link TableAssemblyOperator#checkValidity} refuses
+    * one once the combined operator holds more than one edge), so it may only appear as the SOLE
+    * edge in a joinPaths call — combining it with any other edge must be refused up front, before
+    * touching the worksheet, rather than posted and failing deep inside InnerJoinService.
+    */
+   @Test
+   void addJoinWithPathsRejectsCrossCombinedWithOtherEdges() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly a = TestWorksheets.tableWithColumns(ws, "A", "id");
+      EmbeddedTableAssembly b = TestWorksheets.tableWithColumns(ws, "B", "id");
+      EmbeddedTableAssembly c = TestWorksheets.tableWithColumns(ws, "C", "id");
+      ws.addAssembly(a);
+      ws.addAssembly(b);
+      ws.addAssembly(c);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      JoinSession s = new JoinSession("TOK", "Worksheet/foo-7", "alice~;~host-org",
+                                     SheetType.WORKSHEET, 0L, Long.MAX_VALUE,
+                                     JoinSession.ConnectionMode.PAIRED, null, null, null);
+      when(sessions.resolve(eq("TOK"), any())).thenReturn(s);
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), mock(InnerJoinService.class));
+
+      List<WorksheetMutationSupport.JoinPathSpec> paths = List.of(
+         new WorksheetMutationSupport.JoinPathSpec("A", "id", "B", "id", "INNER"),
+         new WorksheetMutationSupport.JoinPathSpec("B", null, "C", null, "CROSS"));
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.addJoin("JOINED", paths)));
+      assertTrue(ex.getMessage().contains("CROSS"));
+      assertNull(ws.getAssembly("JOINED"), "a rejected multi-join must not be partially created");
+      assertEquals(3, ws.getAssemblies().length, "no assembly beyond the pre-existing 3 tables");
+   }
+
+   /**
+    * A lone CROSS edge (the only entry in joinPaths) is exactly what the two-table
+    * {@code add_cross_join} already supports, so it must still work here.
+    */
+   @Test
+   void addJoinWithPathsAllowsSoleCrossEdge() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly a = TestWorksheets.tableWithColumns(ws, "A", "id");
+      EmbeddedTableAssembly b = TestWorksheets.tableWithColumns(ws, "B", "id");
+      ws.addAssembly(a);
+      ws.addAssembly(b);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      JoinSession s = new JoinSession("TOK", "Worksheet/foo-7", "alice~;~host-org",
+                                     SheetType.WORKSHEET, 0L, Long.MAX_VALUE,
+                                     JoinSession.ConnectionMode.PAIRED, null, null, null);
+      when(sessions.resolve(eq("TOK"), any())).thenReturn(s);
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      SecurityEngine securityEngine = mock(SecurityEngine.class);
+      when(securityEngine.checkPermission(any(), eq(ResourceType.CROSS_JOIN), anyString(), any()))
+         .thenReturn(true);
+
+      WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), securityEngine, new InnerJoinService(null, null));
+
+      List<WorksheetMutationSupport.JoinPathSpec> paths = List.of(
+         new WorksheetMutationSupport.JoinPathSpec("A", null, "B", null, "CROSS"));
+
+      svc.apply("TOK", agent, ed -> ed.addJoin("JOINED", paths));
+
+      RelationalJoinTableAssembly joined = (RelationalJoinTableAssembly) ws.getAssembly("JOINED");
+      assertNotNull(joined);
+      TableAssemblyOperator op = joined.getOperator("A", "B");
+      assertNotNull(op);
+      assertEquals(TableAssemblyOperator.CROSS_JOIN, op.getOperator(0).getOperation());
+   }
+
+   /**
+    * If {@link InnerJoinService#editExistingJoinTable} fails after the new join assembly has
+    * already been registered in the live worksheet, the assembly must be removed again rather
+    * than left behind half-wired — a caller that never gets an "ok" response should never find a
+    * broken assembly on the next read either.
+    */
+   @Test
+   void addJoinWithPathsRemovesAssemblyWhenWiringFailsAfterRegistration() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly a = TestWorksheets.tableWithColumns(ws, "A", "id");
+      EmbeddedTableAssembly b = TestWorksheets.tableWithColumns(ws, "B", "id");
+      ws.addAssembly(a);
+      ws.addAssembly(b);
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      SheetSessionService sessions = mock(SheetSessionService.class);
+      SheetRuntimeAccess runtimeAccess = mock(SheetRuntimeAccess.class);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      JoinSession s = new JoinSession("TOK", "Worksheet/foo-7", "alice~;~host-org",
+                                     SheetType.WORKSHEET, 0L, Long.MAX_VALUE,
+                                     JoinSession.ConnectionMode.PAIRED, null, null, null);
+      when(sessions.resolve(eq("TOK"), any())).thenReturn(s);
+      when(runtimeAccess.getSheetForPairing(any(), any(), any())).thenReturn(rws);
+
+      InnerJoinService failingJoinService = mock(InnerJoinService.class);
+      doThrow(new RuntimeException("boom")).when(failingJoinService)
+         .editExistingJoinTable(any(), any(), any(), anyBoolean());
+
+      WorksheetEditService svc = new WorksheetEditService(sessions, runtimeAccess,
+         mock(SheetAgentBroadcastService.class), mock(SecurityEngine.class), failingJoinService);
+
+      List<WorksheetMutationSupport.JoinPathSpec> paths = List.of(
+         new WorksheetMutationSupport.JoinPathSpec("A", "id", "B", "id", "INNER"));
+
+      PairingException ex = assertThrows(PairingException.class,
+         () -> svc.apply("TOK", agent, ed -> ed.addJoin("JOINED", paths)));
+      assertTrue(ex.getMessage().contains("Failed to build multi-table join"));
+      assertNull(ws.getAssembly("JOINED"),
+                 "a join whose wiring failed after registration must not remain in the worksheet");
+      assertEquals(2, ws.getAssemblies().length, "no assembly beyond the pre-existing 2 tables");
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetScriptControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetScriptControllerTest.java
@@ -35,6 +35,7 @@ import inetsoft.uql.erm.DataRef;
 import inetsoft.uql.erm.ExpressionRef;
 import inetsoft.uql.XRepository;
 import inetsoft.web.composer.ws.LayoutGraphService;
+import inetsoft.web.composer.ws.joins.InnerJoinService;
 import inetsoft.web.portal.controller.database.DataSourceService;
 import inetsoft.web.portal.controller.database.QueryManagerService;
 import inetsoft.web.wiz.pairing.*;
@@ -123,7 +124,7 @@ class WorksheetScriptControllerTest {
       SheetAgentBroadcastService broadcast = mock(SheetAgentBroadcastService.class);
 
       WorksheetEditService editService =
-         new WorksheetEditService(sessionService, runtimeAccess, broadcast, securityEngine);
+         new WorksheetEditService(sessionService, runtimeAccess, broadcast, securityEngine, mock(InnerJoinService.class));
 
       WorksheetAgentController worksheetController = new WorksheetAgentController(
          featureOn(), mock(SheetJoinService.class), sessionService,
@@ -351,7 +352,7 @@ class WorksheetScriptControllerTest {
 
       WorksheetEditService editService = new WorksheetEditService(
          sessionService, mock(SheetRuntimeAccess.class),
-         mock(SheetAgentBroadcastService.class), securityEngine);
+         mock(SheetAgentBroadcastService.class), securityEngine, mock(InnerJoinService.class));
       WorksheetScriptService scriptService = new WorksheetScriptService(
          editService, mock(WorksheetAgentController.class));
       WorksheetScriptController controller =


### PR DESCRIPTION
## Summary

The MCP worksheet agent's `add_join` operation could only join two tables at a time. Joining 3+ tables required chaining separate `add_join` calls into nested assemblies instead of a single combined view -- unlike Composer's own UI, which lets a user multi-select several tables and join them all at once.

## Root Cause

`WorksheetEditService.Editor.addJoin(...)` (server side of the agent-edit `add_join` op) always built a `RelationalJoinTableAssembly` over exactly `new TableAssembly[]{ left, right }`. Composer's own N-ary join capability (`WSJoinTablesEvent` -> `InnerJoinService.joinTables()` -> `InnerJoinService.editExistingJoinTable(...)`) was never wired to the agent-edit path -- the existing code comment claimed `InnerJoinService` "requires a live STOMP/runtime context and is not usable here," which is true for most of its methods but not for `editExistingJoinTable(Worksheet, RelationalJoinTableAssembly, TableAssemblyOperator, boolean)`, which takes a plain `Worksheet` and no session context. `WorksheetTableService.buildJoinTable` already calls it this exact way (for the `add_table` "relational join table" type), proving the mechanism is safe to reuse outside a live session.

## Fix

- New `WorksheetMutationSupport.JoinPathSpec` record describing one join edge (leftTable, leftKey, rightTable, rightKey, joinType).
- New `EditRequest.joinPaths` field (optional, appended via the existing compat-constructor pattern so no existing caller needs to change).
- New `Editor.addJoin(String name, List<JoinPathSpec> joinPaths)` overload: builds a `RelationalJoinTableAssembly` over every table named across the given edges, then delegates to `InnerJoinService.editExistingJoinTable(...)` to wire the real per-edge operators -- the same mechanism behind Composer's own N-ary join. Edges do not need to form a linear chain (a hub table can join to two others in one call).
- `WorksheetAgentController.dispatch()`'s `case "add_join"` now branches on `req.joinPaths()`: routes to the new N-ary method when present, otherwise keeps the existing pairwise behavior unchanged.
- A `CROSS` edge is only valid as the sole edge in `joinPaths`, since it is an exclusive operation server-side (`TableAssemblyOperator.checkValidity` rejects it once more than one edge is present) -- rejected with a clear message otherwise. `MERGE` is rejected per edge (structurally distinct assembly type; use `add_merge_join`). On any wiring failure after the assembly is registered, it is removed again rather than left behind broken.

Companion client-side change (MCP tool schema + precheck): https://github.com/inetsoft-technology/stylebi-wiz/pull/new/bug-75980

## Test Plan

- New unit tests in `WorksheetEditServiceTest.java`: 3-table success case, star-shaped/non-chain join (hub table joined to two others), MERGE rejection, CROSS-combined-with-other-edges rejection, sole-CROSS-edge success, empty-path-list rejection, and rollback verification when `InnerJoinService.editExistingJoinTable` fails after the assembly is already registered.
- `./mvnw test -pl core -Dtest=inetsoft.web.wiz.**`: 2598/2598 passing (1 pre-existing unrelated skip).
- `./mvnw clean install -pl core -am -DskipTests`: clean build.
- Reviewed via code-reviewer subagent (2 rounds); both findings from round 1 (CROSS-exclusivity validity check, missing rollback on wiring failure) fixed and covered by new tests before round 2.
- Live-verified against a running StyleBI instance with the companion stylebi-wiz plugin build.

Fixes Redmine #75980.