### PR TITLE
Bug #76170, withhold the share webhook URLs and re-verify the fluentd password

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/ai/AdminChangesetApplyService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminChangesetApplyService.java
@@ -122,9 +122,30 @@ public class AdminChangesetApplyService {
                           change.proposedValue(), backupRef, req.getReviewOutcome()),
                   user);
 
-               results.add(new ApplyOutcome(change.property(), applied.getBeforeValue(),
-                                            applied.getAfterValue(), applied.getStatus(),
-                                            applied.getError()));
+               // before/after are the STORED form, and for a credential that is normally
+               // ciphertext - which AdminChangeService argues carries nothing sensitive. It is
+               // only normally: Tool.decryptPassword passes plaintext straight through, so a
+               // credential can sit in the store in the clear and still work. That is not
+               // hypothetical - log.fluentd.security.password was written in the clear by the
+               // product's own writer until Redmine #76051, and INETSOFTENV_* promotion
+               // (StorageInitializer) and the raw EM properties page both still bypass every
+               // encrypting writer. So on an upgraded server the first apply would echo the old
+               // plaintext credential into this response, which the caller relays to a model
+               // provider off-host - the same egress this component masks reads for.
+               //
+               // Masked HERE and not in AdminChangeResult, which is the seam that matters:
+               // rollback replays applied.getBeforeValue() into undoableBefore below, and the
+               // `moved` comparison needs the real values too. Both read the result directly, so
+               // neither is affected. Only this response DTO is.
+               boolean maskValues = AdminPropertyCatalog.isEncryptedCredential(
+                  AdminPropertyName.parse(change.property()).baseName());
+
+               results.add(new ApplyOutcome(change.property(),
+                                            maskValues ? setMarker(applied.getBeforeValue())
+                                               : applied.getBeforeValue(),
+                                            maskValues ? setMarker(applied.getAfterValue())
+                                               : applied.getAfterValue(),
+                                            applied.getStatus(), applied.getError()));
 
                boolean verified = AdminChangeRecord.STATUS_VERIFIED.equals(applied.getStatus());
                // Path A (AdminChangeService): SreeEnv.save() can succeed and then a side-effect hook
@@ -232,6 +253,15 @@ public class AdminChangesetApplyService {
       req.setBackupRef(backupRef);
       req.setReviewOutcome(reviewOutcome);
       return req;
+   }
+
+   /**
+    * The credential stand-in for {@link ApplyOutcome}: reports whether a value is present without
+    * reproducing it. Matches {@code AdminChangePlanService}'s wording for a masked currentValue, so
+    * a caller sees the same vocabulary at preview and at apply.
+    */
+   private static String setMarker(String value) {
+      return value == null ? null : "(set)";
    }
 
    private static String messageOf(Exception e) {

--- a/core/src/main/java/inetsoft/web/admin/ai/AdminChangesetApplyService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminChangesetApplyService.java
@@ -17,6 +17,7 @@
  */
 package inetsoft.web.admin.ai;
 
+import inetsoft.util.Tool;
 import inetsoft.util.audit.AdminChangeRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -259,9 +260,19 @@ public class AdminChangesetApplyService {
     * The credential stand-in for {@link ApplyOutcome}: reports whether a value is present without
     * reproducing it. Matches {@code AdminChangePlanService}'s wording for a masked currentValue, so
     * a caller sees the same vocabulary at preview and at apply.
+    *
+    * <p>Empty passes through as itself, not as {@code (set)}. A blank string is not a credential
+    * anyone holds, so reporting one as present would be a false answer with the same shape as the
+    * one this whole component exists to avoid. Unreachable through the plan path -
+    * {@code AdminChangePlanService} refuses an empty value for a credential and
+    * {@code SreeEnv.setPassword} guards on {@code Tool.isEmptyString} - but the comment at the
+    * masking site names {@code INETSOFTENV_*} promotion and the raw EM properties page as writers
+    * that reach the store past every one of those guards, and either can leave {@code ""} behind.
+    * {@code null} likewise stays {@code null}, so "no prior credential" remains distinguishable
+    * from one that was replaced.
     */
    private static String setMarker(String value) {
-      return value == null ? null : "(set)";
+      return Tool.isEmptyString(value) ? value : "(set)";
    }
 
    private static String messageOf(Exception e) {

--- a/core/src/main/java/inetsoft/web/admin/ai/AdminPropertiesController.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminPropertiesController.java
@@ -106,6 +106,7 @@ public class AdminPropertiesController {
       AdminRiskClassifier.RiskClassification risk = classifier.classify(name);
       String description = entry == null ? null : entry.description();
       boolean credential = AdminPropertyCatalog.isEncryptedCredential(name.baseName());
+      boolean confirmedSecret = AdminPropertyCatalog.isConfirmedSecret(name.baseName());
       boolean secret = AdminPropertyCatalog.isSecret(name.baseName());
       // A secret's value is not read AT ALL, not merely omitted from the response - see the test
       // that asserts SreeEnv is never called for one. Determining existence by reading it would
@@ -146,6 +147,18 @@ public class AdminPropertiesController {
             + "exactly as the Enterprise Manager field does. You will not be able to verify the "
             + "new value by reading it back.";
       }
+      else if(confirmedSecret) {
+         // The pattern wording below would be false twice over for these: the name does NOT match
+         // the pattern (a test asserts that), and membership in a hand-verified list IS evidence
+         // the property exists. Telling the caller "this says nothing about whether the property
+         // exists" would throw away a true answer, which is the same mistake the credential branch
+         // above was added to stop.
+         description = "This is a bearer credential - possession of the value is enough to use it, "
+            + "so it is not read here, not even to test whether one is set, because this endpoint's "
+            + "caller relays responses to a model provider off-host. The property exists. It cannot "
+            + "be changed here either: nothing in the product encrypts it, so admin-chat will not "
+            + "write it. Configure it through Enterprise Manager.";
+      }
       else if(secret) {
          description = "This name matches admin-chat's secret pattern, so its value is neither "
             + "read nor changed here - not even read to test whether one is present, so this says "
@@ -165,7 +178,15 @@ public class AdminPropertiesController {
       //
       // A name that is secret by PATTERN alone gets no such term and stays unknown. All that is
       // known there is that a string matched, which is exactly what the guidance says.
-      boolean confirmed = entry != null || credential || stored != null;
+      //
+      // CONFIRMED_SECRET needs the same term as the credential list, and for the same reason
+      // (Redmine #76170). Both webhook URLs are declared in defaults.properties, so the defaults
+      // chain made `stored` non-null and they reported confirmed until this path stopped reading
+      // them. Without this term they regress to unknown, whose guidance tells the caller the name
+      // may be a typo and that an unrecognised name is written verbatim and reports success -
+      // three claims that are all false here, since AdminChangePlanService refuses the change.
+      // They are verified against their writer exactly as the credential list is.
+      boolean confirmed = entry != null || credential || confirmedSecret || stored != null;
 
       return new PropertyView(name.key(),
          entry == null ? List.of() : (entry.aliases() == null ? List.of() : entry.aliases()),

--- a/core/src/main/java/inetsoft/web/admin/ai/AdminPropertyCatalog.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminPropertyCatalog.java
@@ -208,10 +208,13 @@ public class AdminPropertyCatalog {
     * secret value read through this path leaves the host in a way the ordinary EM properties page
     * never does.
     *
-    * <p>Two independent tests, unioned, then a name-shape exception list subtracted. A name
+    * <p>Four independent tests, unioned, then a name-shape exception list subtracted. A name
     * matches case-insensitively when it contains {@code password}, {@code secret} or
-    * {@code credential}, ends with {@code .key}, or starts with {@code license.}; and
-    * {@link #isEncryptedCredential} matches the properties whose <b>writer</b> encrypts them.
+    * {@code credential}, ends with {@code .key}, or starts with {@code license.};
+    * {@link #isEncryptedCredential} matches the properties whose <b>writer</b> encrypts them;
+    * {@link #CONFIRMED_SECRET} names the credentials neither of those two reaches; and
+    * {@link #COMPOSITE_SECRET_PROPERTIES} names the properties that carry a credential inside a
+    * larger composite string.
     * {@link #CONFIRMED_NOT_SECRET} then removes the specific names the shape test catches for the
     * wrong reason - verified individually, the same way {@link #ENCRYPTED_CREDENTIALS} is, rather
     * than by loosening the shared pattern:
@@ -253,9 +256,13 @@ public class AdminPropertyCatalog {
     * it is a credential by the product's own action, and the next one added is masked on read
     * without a second edit.
     *
-    * <p>The name test stays. It covers fifteen properties nothing writes through an encrypting
+    * <p>The name test stays. It covers the properties nothing writes through an encrypting
     * accessor — {@code license.*}, {@code jwt.signing.key}, {@code password.encryption.key},
     * {@code sso.rsa.private.key} among them — which the writer test would silently unmask.
+    * Deliberately no count: the previous wording said "fifteen", derived from the sixteen names
+    * the pre-#76006 pattern withheld, and was left behind by both the three carve-outs below and
+    * the reclassification in Redmine #76170. A number maintained by hand beside three sets that
+    * each move independently is one more fact to go stale, and this method has enough of those.
     *
     * <p>Masking a credential here does <b>not</b> make it unwritable: {@code AdminChangePlanService}
     * refuses a change only when a name is secret AND not an encrypted credential, and the egress
@@ -272,7 +279,8 @@ public class AdminPropertyCatalog {
          return false;
       }
 
-      return isEncryptedCredential(lower) || COMPOSITE_SECRET_PROPERTIES.contains(lower) ||
+      return CONFIRMED_SECRET.contains(lower) || isEncryptedCredential(lower) ||
+         COMPOSITE_SECRET_PROPERTIES.contains(lower) ||
          lower.contains("password") || lower.contains("secret") ||
          lower.contains("credential") || lower.endsWith(".key") || lower.startsWith("license.");
    }
@@ -281,12 +289,20 @@ public class AdminPropertyCatalog {
     * True when {@code baseName} names an application credential whose accessors encrypt on write
     * and decrypt on read, so admin-chat can set it through {@code SreeEnv.setPassword}.
     *
-    * <p><b>Classify by the WRITER, never by the reader.</b> An earlier version of this javadoc
-    * excluded {@code log.fluentd.security.password} on the grounds that it is "read with a plain
-    * {@code SreeEnv.getProperty}". That reasoning was wrong, even though the exclusion happened to
-    * be right. {@code LogSettingService} reads it with {@code getProperty} and then calls
-    * {@code Tool.decryptPassword} on the result two lines later - so by the reader it looks
-    * encrypted. It is not: the save path writes it with a bare {@code SreeEnv.setProperty}.
+    * <p><b>Classify by the WRITER, never by the reader.</b> {@code mail.smtp.tokenuri} is read
+    * with {@code SreeEnv.getPassword} ({@code EmailSettingsService}), which decrypts - so by the
+    * reader it looks like a stored credential. It is not: the same save block writes it with a
+    * bare {@code SreeEnv.setProperty}, and it is correctly absent from the list below.
+    *
+    * <p>This paragraph used to make the same point with {@code log.fluentd.security.password}, and
+    * that example is worth recording because of how it expired. It was excluded here on the
+    * grounds that its writer stored plaintext, which was true when written and became false in
+    * Redmine #76051 ({@code dc8877f8a}), where {@code LogSettingService} started routing it
+    * through the same {@code toPassword} helper as its sibling shared key. The exclusion, and the
+    * javadoc arguing for it, outlived that change and were corrected in Redmine #76170; the
+    * property is now listed below. The rule held - only the worked example rotted - but a
+    * hand-verified allow-list is only as current as the last time someone re-read the writer, and
+    * nothing here fails when a writer changes underneath it.
     *
     * <p>The reader cannot settle this because {@code Tool.decryptPassword} passes an unrecognised
     * (i.e. plaintext) value straight through - see {@code LocalPasswordEncryption.decryptPassword},
@@ -298,11 +314,13 @@ public class AdminPropertyCatalog {
     * name and the name does not correlate with the storage form in either direction:
     *
     * <ul>
-    *   <li><b>Matched but plaintext</b> - {@code log.fluentd.security.password} (bare
-    *       {@code setProperty}), {@code google.maps.key}, {@code sso.rsa.public.key} (a PUBLIC
-    *       key), {@code auth0.client.secret} (read plain, then copied into
+    *   <li><b>Matched but plaintext</b> - {@code google.maps.key}, {@code sso.rsa.public.key} (a
+    *       PUBLIC key), {@code auth0.client.secret} (read plain, then copied into
     *       {@code openid.client.secret} by the legacy migration, which encrypts on the way).
     *       Encrypting any of these would store ciphertext where a literal is expected.</li>
+    *   <li><b>Neither matched nor encrypted, yet still a credential</b> - the two webhook URLs in
+    *       {@link #CONFIRMED_SECRET}. The name does not correlate with the storage form, and
+    *       neither correlates with whether possessing the value grants access.</li>
     *   <li><b>Matched but not a secret at all</b> - {@code enable.changepassword} holds a boolean
     *       and matches on the substring "password".</li>
     *   <li><b>Matched and must never be written</b> - {@code password.encryption.key},
@@ -334,10 +352,13 @@ public class AdminPropertyCatalog {
     *       {@code mail.smtp.refreshtoken} - {@code EmailSettingsService} writes all four with
     *       {@code SreeEnv.setPassword}. Note {@code mail.smtp.tokenuri} sits beside them in the
     *       same save block and is written with a plain {@code setProperty}, so it is NOT here.</li>
-    *   <li>{@code log.fluentd.security.sharedkey} - {@code LogSettingService} writes it through
-    *       its {@code toPassword} helper, which calls {@code Tool.encryptPassword}. Its sibling
-    *       {@code log.fluentd.security.password} does not, which is why one is listed and the
-    *       other is not despite the adjacent names.</li>
+    *   <li>{@code log.fluentd.security.sharedkey}, {@code log.fluentd.security.password} -
+    *       {@code LogSettingService} writes both through its {@code toPassword} helper, which
+    *       calls {@code Tool.encryptPassword}. The password joined the shared key in Redmine
+    *       #76051; before that it was written with {@code sanitizeProperty}, i.e. in the clear.
+    *       Note {@code LogSettingService} has no {@code Tool.isCloudSecrets} branch at all, so
+    *       {@code AdminChangePlanService} will refuse both under cloud secrets. That is
+    *       over-cautious rather than wrong, and was already true of the shared key alone.</li>
     * </ul>
     *
     * <p>Reading is governed by {@link #isSecret}, which unions this list into its name test — so
@@ -383,12 +404,75 @@ public class AdminPropertyCatalog {
    private static final Set<String> ENCRYPTED_CREDENTIALS = Set.of(
       "openid.client.secret", "stylebi.google.openid.client.secret",
       "mail.smtp.pass", "mail.smtp.clientsecret", "mail.smtp.accesstoken",
-      "mail.smtp.refreshtoken", "log.fluentd.security.sharedkey");
+      "mail.smtp.refreshtoken", "log.fluentd.security.sharedkey",
+      "log.fluentd.security.password");
+
+   /**
+    * Credentials that neither the name shape nor {@link #ENCRYPTED_CREDENTIALS} reaches, withheld
+    * on read anyway because possession of the value is sufficient to use it.
+    *
+    * <p>The third test exists because the other two ask about the value's <i>name</i> and its
+    * <i>storage form</i>, and a bearer token can be confidential while being unremarkable in both
+    * (Redmine #76170). These two are incoming-webhook URLs: the token is in the path, there is no
+    * second factor and no request signature, so anything holding the URL can post to that channel
+    * or room.
+    *
+    * <p>Both verified, the same way every other entry here is:
+    *
+    * <ul>
+    *   <li>{@code share.slack.url}, {@code share.googlechat.url} - {@code ShareSettingsService}
+    *       reads both with a plain {@code SreeEnv.getProperty} and writes both with a plain
+    *       {@code SreeEnv.setProperty}; {@code ShareController} consumes them plain when it posts;
+    *       {@code defaults.properties} declares both empty. Nothing encrypts either one.</li>
+    * </ul>
+    *
+    * <p><b>Why not {@link #ENCRYPTED_CREDENTIALS}.</b> That list drives {@code SreeEnv.setPassword}
+    * on write ({@code AdminChangeService}), which would store ciphertext under a property every
+    * reader above expects to hold a literal URL - the mirror of the plaintext downgrade the
+    * allow-list exists to prevent. That list means "the writer encrypts this", which is a claim
+    * about the product's own behaviour; this one means "this value grants access", which is a claim
+    * about the value. Keeping them separate is what lets each stay checkable.
+    *
+    * <p><b>The cost, accepted.</b> {@code AdminChangePlanService} refuses a change when a name is
+    * secret and NOT an encrypted credential, so listing these makes them unsettable through
+    * admin-chat: an operator can no longer configure Slack or Google Chat sharing by chat, and
+    * must use Enterprise Manager. That is the wrong side of the trade for convenience and the
+    * right one for egress - a webhook URL read through this path leaves the host to a model
+    * provider, and unlike a password field there is no ciphertext step to blunt it. Encrypting
+    * them at rest instead would let the write survive, at the price of changing a shipped feature
+    * and migrating values already stored in the clear; that is a separate change.
+    *
+    * <p>Not a prefix. {@code share.googlechat.enabled} and the rest of {@code share.*} stay
+    * readable - an operator needs to know whether sharing is on, and only the URL is the
+    * credential. {@code mapbox.token} was considered and left out: like {@code google.maps.key} in
+    * {@link #CONFIRMED_NOT_SECRET}, it is a client-side map token ordinarily restricted by HTTP
+    * referrer rather than treated as a bearer credential.
+    */
+   private static final Set<String> CONFIRMED_SECRET = Set.of(
+      "share.slack.url", "share.googlechat.url");
+
+   /**
+    * True when {@code baseName} is one of the hand-verified bearer credentials in
+    * {@link #CONFIRMED_SECRET}.
+    *
+    * <p>Exposed for the same reason {@link #isEncryptedCredential} is: {@link #isSecret} collapses
+    * three different grounds for withholding into one boolean, and a caller that has to explain
+    * itself needs to know which ground applied. {@code AdminPropertiesController} uses it twice -
+    * to keep {@code exists} confirmed for a name verified against its writer, and to give the
+    * right reason for the mask. A name matched by the shape test alone gets neither, because a
+    * string match is genuinely all that is known about it.
+    */
+   public static boolean isConfirmedSecret(String baseName) {
+      return baseName != null && CONFIRMED_SECRET.contains(baseName.toLowerCase());
+   }
 
    /**
     * Names the shape test in {@link #isSecret} catches for the wrong reason - each verified
     * against its writer, per the javadoc on {@link #isSecret}. Not a general escape hatch: adding
     * a name here means its plain-text writer was checked, not that the name merely "looks" safe.
+    *
+    * <p>Must stay disjoint from {@link #CONFIRMED_SECRET}: {@link #isSecret} checks this set first
+    * and returns early, so a name in both would be readable with no diagnostic. A test asserts it.
     */
    private static final Set<String> CONFIRMED_NOT_SECRET = Set.of(
       "enable.changepassword", "sso.rsa.public.key", "google.maps.key");

--- a/core/src/main/java/inetsoft/web/admin/ai/AdminPropertyCatalog.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/AdminPropertyCatalog.java
@@ -442,6 +442,17 @@ public class AdminPropertyCatalog {
     * them at rest instead would let the write survive, at the price of changing a shipped feature
     * and migrating values already stored in the clear; that is a separate change.
     *
+    * <p><b>The other door to the same two values.</b> This list governs the property path only.
+    * The same two properties are also reachable as {@code share.slackUrl}/{@code googleChatUrl}
+    * through {@code AdminPresentationController}'s sub-model surface, in this same package and
+    * with the same caller behind it - and "show me the sharing settings" is the likelier route
+    * there. That surface withholds and refuses them through
+    * {@code PresentationSubModel.SHARE.secretFields()}, which is what makes the sentence above
+    * ("must use Enterprise Manager") a statement about admin-chat rather than about one endpoint.
+    * The claim is load-bearing: {@code AdminPropertiesController} hands it to an agent as
+    * instruction text, and telling an agent a value is unsettable when a sibling verb still sets
+    * it is the same class of false answer this class is otherwise built to avoid.
+    *
     * <p>Not a prefix. {@code share.googlechat.enabled} and the rest of {@code share.*} stay
     * readable - an operator needs to know whether sharing is on, and only the URL is the
     * credential. {@code mapbox.token} was considered and left out: like {@code google.maps.key} in

--- a/core/src/main/java/inetsoft/web/admin/ai/presentation/AdminPresentationController.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/presentation/AdminPresentationController.java
@@ -63,8 +63,11 @@ public class AdminPresentationController {
    /**
     * Reads one sub-model (when {@code subModel} is given) or all 16 (when omitted) -- mirroring
     * {@code getSettings}'s own full-builder response (01-spec.md section 3). {@code scope} is
-    * required, no default. {@code webMap.mapboxToken}/{@code googleKey} are masked
-    * (01-spec.md section 9) regardless of which is requested.
+    * required, no default. Every sub-model's secret-classified fields
+    * ({@link PresentationSubModel#secretFields()}: {@code webMap.mapboxToken}/{@code googleKey} and
+    * {@code share.slackUrl}/{@code googleChatUrl}) are masked (01-spec.md section 9) regardless of
+    * which is requested -- including the no-{@code subModel} form, which is the shortest path an
+    * agent has to all of them at once.
     */
    @Secured(@RequiredPermission(
       resourceType = ResourceType.EM_COMPONENT, resource = "settings/presentation/settings",
@@ -127,8 +130,7 @@ public class AdminPresentationController {
       throws Exception
    {
       JsonNode node = PresentationJson.toNode(access.read(subModel, user, global));
-      return subModel == PresentationSubModel.WEB_MAP
-         ? PresentationJson.maskWebMapSecrets(node) : node;
+      return PresentationJson.maskSecrets(subModel, node);
    }
 
    private static boolean requireScopeParam(String scope) {

--- a/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationChangePlanService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationChangePlanService.java
@@ -136,9 +136,7 @@ public class PresentationChangePlanService {
             spec = sanitizeLookAndFeelFileNames(label, spec);
          }
 
-         if(subModel == PresentationSubModel.WEB_MAP) {
-            requireNoSecretFields(label, spec);
-         }
+         requireNoSecretFields(label, subModel, spec);
 
          JsonNode mergedNode = PresentationJson.merge(currentNode, spec);
          Object proposedModel;
@@ -323,18 +321,30 @@ public class PresentationChangePlanService {
       return base;
    }
 
-   /** 01-spec.md section 9: {@code webMap.mapboxToken}/{@code googleKey} are treated as
+   /** 01-spec.md section 9: a sub-model's {@link PresentationSubModel#secretFields()} are treated as
     * secret-classified for this area even though the underlying service returns them in the clear --
     * refused outright in a write {@code spec} (matching {@code AdminPropertyCatalog.isSecret}'s own
     * "refuse to change a secret through admin-chat" treatment), masked on every read (see
-    * {@link #projectedValue}). */
-   private static void requireNoSecretFields(String label, JsonNode spec) {
-      for(String secret : PresentationJson.WEB_MAP_SECRET_FIELDS) {
+    * {@link #projectedValue}).
+    *
+    * <p>Called for every sub-model, not just the ones that have secrets -- the set is empty for the
+    * other fourteen, so the loop is a no-op. Guarding the call with a sub-model test is what let
+    * {@code share}'s two webhook URLs stay writable here after the properties path stopped writing
+    * them (Bug #76170), and it would let the next addition do the same.
+    *
+    * <p>Refusing the write is what makes {@code AdminPropertyCatalog}'s guidance for these names
+    * ("admin-chat will not write it ... configure it through Enterprise Manager") true of the whole
+    * admin-chat surface rather than of one endpoint. That string is instruction text read by an
+    * agent, so a sub-model that accepts a value the properties path refuses does not merely leave a
+    * second way in -- it makes the guidance a false statement. */
+   private static void requireNoSecretFields(String label, PresentationSubModel subModel,
+                                             JsonNode spec)
+   {
+      for(String secret : subModel.secretFields()) {
          if(spec.has(secret)) {
             throw new IllegalArgumentException(
-               label + ".spec." + secret + ": secret-classified third-party API keys cannot be " +
-               "set through admin-chat (01-spec.md section 9) -- change it through Enterprise " +
-               "Manager instead");
+               label + ".spec." + secret + ": secret-classified credentials cannot be set through " +
+               "admin-chat (01-spec.md section 9) -- change it through Enterprise Manager instead");
          }
       }
    }
@@ -342,9 +352,7 @@ public class PresentationChangePlanService {
    /** Package-visible so {@link PresentationChangesetApplyService} can compute the identical
     * before/after projection when verifying a write's read-back, instead of re-deriving its own. */
    static String projectedValue(PresentationSubModel subModel, JsonNode node) {
-      JsonNode projected = subModel == PresentationSubModel.WEB_MAP
-         ? PresentationJson.maskWebMapSecrets(node) : node;
-      return PresentationJson.writeString(projected);
+      return PresentationJson.writeString(PresentationJson.maskSecrets(subModel, node));
    }
 
    // ---------------------------------------------------------------- hash

--- a/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationJson.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationJson.java
@@ -49,8 +49,24 @@ final class PresentationJson {
 
    /** The caller-visible-when-non-blank field name test used for {@code webMap}'s two secret-classified
     * fields (01-spec.md section 9) -- masked on every read/projection, refused outright in a write
-    * {@code spec} (see {@code PresentationChangePlanService.requireNoSecretFields}). */
+    * {@code spec} (see {@code PresentationChangePlanService.requireNoSecretFields}).
+    *
+    * <p>Reached through {@link PresentationSubModel#secretFields()}, never by a
+    * {@code subModel == WEB_MAP} test at the call site: a per-sub-model condition spelled out
+    * separately in each of the three places that need it is what let {@code share}'s two webhook
+    * URLs stay unmasked while this pair was handled (Bug #76170). */
    static final Set<String> WEB_MAP_SECRET_FIELDS = Set.of("mapboxToken", "googleKey");
+
+   /** {@code share.slack.url} / {@code share.googlechat.url} as this area sees them. Both are
+    * incoming-webhook URLs -- the token is in the path, there is no second factor and no request
+    * signature, so anything holding the URL can post into that channel or room. They are secrets by
+    * possession, which is why neither the name shape nor the storage form (both are written with a
+    * bare {@code SreeEnv.setProperty} by {@code ShareSettingsService}) identifies them as one; see
+    * {@code AdminPropertyCatalog.CONFIRMED_SECRET}, which withholds the same two values on the
+    * properties path. Masked and refused here for the identical reason: this area's caller relays
+    * its responses to a model provider off-host. */
+   static final Set<String> SHARE_SECRET_FIELDS = Set.of("slackUrl", "googleChatUrl");
+
    static final String SECRET_MASK = "********";
 
    /** The exact JSON property names Jackson would (de)serialize for {@code modelClass}, i.e. the
@@ -104,14 +120,24 @@ final class PresentationJson {
       return merged;
    }
 
-   /** Masks {@code webMap.mapboxToken}/{@code googleKey} to a fixed placeholder wherever a value is
+   /** Masks {@code subModel}'s secret-classified fields to a fixed placeholder wherever a value is
     * about to be shown to a caller (a GET response, or a plan/audit {@code before}/{@code after}
     * projection) -- never used on the node that is about to be deserialized back into a model and
-    * written, only on display copies (01-spec.md section 9, "refuse to return ... the real value"). */
-   static JsonNode maskWebMapSecrets(JsonNode node) {
+    * written, only on display copies (01-spec.md section 9, "refuse to return ... the real value").
+    *
+    * <p>Takes the sub-model rather than a field set so that every caller that projects a value for
+    * display gets the masking that sub-model declares, without restating which sub-models have
+    * secrets. A sub-model with none returns the node unchanged. */
+   static JsonNode maskSecrets(PresentationSubModel subModel, JsonNode node) {
+      Set<String> fields = subModel.secretFields();
+
+      if(fields.isEmpty()) {
+         return node;
+      }
+
       ObjectNode copy = node.deepCopy();
 
-      for(String field : WEB_MAP_SECRET_FIELDS) {
+      for(String field : fields) {
          JsonNode value = copy.get(field);
 
          if(value != null && value.isTextual() && !value.asText().isEmpty()) {

--- a/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationSubModel.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/presentation/PresentationSubModel.java
@@ -120,6 +120,30 @@ public enum PresentationSubModel {
       return fieldNames;
    }
 
+   /** The subset of {@link #fieldNames()} whose values are secret-classified for this area: masked
+    * on every read and plan projection ({@link PresentationJson#maskSecrets}) and refused outright
+    * in a write {@code spec} ({@code PresentationChangePlanService.requireNoSecretFields}). Empty
+    * for the other fourteen sub-models.
+    *
+    * <p>Deliberately a property OF the sub-model rather than a condition at each call site. The
+    * three places that project or validate a value used to spell out {@code == WEB_MAP}
+    * independently, so {@code share}'s two webhook URLs -- withheld on the properties path by
+    * {@code AdminPropertyCatalog.CONFIRMED_SECRET} -- were still returned in full, and still
+    * settable, through this area (Bug #76170). Asking the sub-model makes the next addition one
+    * edit instead of three that can be made one at a time.
+    *
+    * <p>A switch rather than a constructor parameter so that the fourteen sub-models with no
+    * secrets do not each carry an empty set through the constructor; it is evaluated lazily, so it
+    * does not reintroduce the enum-constant/static-field initialization ordering hazard
+    * {@link PresentationJson}'s own javadoc describes. */
+   public Set<String> secretFields() {
+      return switch(this) {
+         case WEB_MAP -> PresentationJson.WEB_MAP_SECRET_FIELDS;
+         case SHARE -> PresentationJson.SHARE_SECRET_FIELDS;
+         default -> Set.of();
+      };
+   }
+
    /** Exact, case-sensitive match against the 16 names (01-spec.md section 11) -- no fuzzy/prefix
     * matching, since a wrong guess here would silently target the wrong sub-model.
     *

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminChangePlanServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminChangePlanServiceTest.java
@@ -294,10 +294,18 @@ class AdminChangePlanServiceTest {
    }
 
    @Test void stillRefusesASecretThatIsNotAnAllowListedCredential() {
-      // password.encryption.key is the master key; log.fluentd.security.password is read with a
-      // plain getProperty. Neither may be written here, and the allow-list is why.
+      // password.encryption.key is the master key and sso.rsa.private.key is generated material;
+      // none of these may be written here, and the allow-list is why. sso.rsa.private.key is the
+      // interesting one: LocalPasswordEncryption does write it with SreeEnv.setPassword, so the
+      // writer test would list it, and it is deliberately left off ENCRYPTED_CREDENTIALS anyway
+      // because generated key material must not be settable through admin-chat at all.
+      //
+      // log.fluentd.security.password used to be in this list on the grounds that it is "read with
+      // a plain getProperty" - a reader-based argument, which the class javadoc explains is never
+      // authoritative. Redmine #76051 then made its writer encrypt, and #76170 allow-listed it, so
+      // it is now settable and no longer belongs here.
       for(String prop : new String[] { "password.encryption.key", "jwt.signing.key",
-                                       "log.fluentd.security.password", "license.key" })
+                                       "sso.rsa.private.key", "license.key" })
       {
          IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
             () -> service.resolve(request("try it", prop, "x")));

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminChangeServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminChangeServiceTest.java
@@ -328,17 +328,44 @@ class AdminChangeServiceTest {
    }
 
    @Test void writesASecretNamedPropertyThatIsNotAnAllowListedCredentialVerbatim() {
-      // log.fluentd.security.password matches isSecret but is read with a plain getProperty.
-      // Encrypting it would hand the fluentd client ciphertext as its password. (The plan service
-      // refuses this property outright; this pins the write path regardless of how it is reached.)
-      sreeEnv.when(() -> SreeEnv.getProperty("log.fluentd.security.password", false, false))
+      // license.key matches isSecret on its prefix but every writer in the product stores it with
+      // a plain setProperty. Encrypting it would hand the license check ciphertext where it
+      // expects a key. (The plan service refuses this property outright; this pins the write path
+      // regardless of how it is reached.)
+      //
+      // This test used log.fluentd.security.password until Redmine #76170, on the reasoning that
+      // its reader called getProperty. Redmine #76051 had already made its writer encrypt, so the
+      // property it pinned had moved out from under it - see the test below, which now pins the
+      // opposite behaviour for that name.
+      sreeEnv.when(() -> SreeEnv.getProperty("license.key", false, false))
              .thenReturn(null)
              .thenReturn("literal");
 
-      service.applyChange(req("log.fluentd.security.password", "literal"), principal);
+      service.applyChange(req("license.key", "literal"), principal);
 
-      sreeEnv.verify(() -> SreeEnv.setProperty("log.fluentd.security.password", "literal"));
+      sreeEnv.verify(() -> SreeEnv.setProperty("license.key", "literal"));
       sreeEnv.verify(() -> SreeEnv.setPassword(anyString(), anyString()), never());
+   }
+
+   @Test void encryptsTheFluentdPasswordNowThatItsWriterDoesToo() {
+      // Redmine #76170. Redmine #76051 (dc8877f8a) moved LogSettingService's write of this
+      // property onto the same toPassword helper as log.fluentd.security.sharedkey, which calls
+      // Tool.encryptPassword - so the two adjacent halves of one Logging page are finally written
+      // the same way. Until it was allow-listed, admin-chat refused to set it at all; a write that
+      // got through would have put plaintext where the Logging page stores ciphertext.
+      sreeEnv.when(() -> SreeEnv.getProperty("log.fluentd.security.password", false, false))
+             .thenReturn(null)
+             .thenReturn("ENC(cipher)");
+      sreeEnv.when(() -> SreeEnv.getPassword("log.fluentd.security.password"))
+             .thenReturn("fluentd-pw");
+
+      AdminChangeResult res =
+         service.applyChange(req("log.fluentd.security.password", "fluentd-pw"), principal);
+
+      sreeEnv.verify(() -> SreeEnv.setPassword("log.fluentd.security.password", "fluentd-pw"));
+      sreeEnv.verify(
+         () -> SreeEnv.setProperty(eq("log.fluentd.security.password"), anyString()), never());
+      assertEquals(AdminChangeRecord.STATUS_VERIFIED, res.getStatus());
    }
 
    @Test void refusesToWriteACredentialAtApplyTimeWhenCloudSecretsAreOn() {

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminChangesetApplyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminChangesetApplyServiceTest.java
@@ -361,6 +361,83 @@ class AdminChangesetApplyServiceTest {
       verify(changeService, never()).applyChange(any(), any());
    }
 
+   @Test
+   void masksACredentialsStoredValuesInTheApplyResponse() throws Exception {
+      // Redmine #76170. before/after are the STORED form, justified on the grounds that a
+      // credential is stored as ciphertext and ciphertext is not the secret. Only normally:
+      // Tool.decryptPassword passes plaintext through, so a credential can sit in the store in
+      // the clear. log.fluentd.security.password did exactly that until Redmine #76051, and
+      // INETSOFTENV_* promotion and the raw EM properties page still bypass every encrypting
+      // writer. Echoing it here would hand the old credential to a model provider off-host.
+      stub("log.fluentd.security.password", "old-plaintext-pw");
+      when(changeService.applyChange(any(), eq(principal)))
+         .thenReturn(result("log.fluentd.security.password", "old-plaintext-pw", "ENC(new)",
+                            AdminChangeRecord.STATUS_VERIFIED, null));
+
+      ApplyResult applied = service.apply(
+         request("t", "log.fluentd.security.password", "new-pw"), principal);
+
+      ApplyOutcome outcome = applied.results().get(0);
+      assertEquals("(set)", outcome.before(), "the previous credential must not be echoed");
+      assertEquals("(set)", outcome.after(), "nor the new stored form");
+      assertFalse(String.valueOf(outcome.before()).contains("old-plaintext-pw"));
+   }
+
+   @Test
+   void stillReportsACredentialAsUnsetWhenItHadNoPriorValue() throws Exception {
+      // The mask must not erase the set/unset distinction - an operator reading the outcome needs
+      // to know whether the apply replaced a credential or established one.
+      stub("mail.smtp.pass", null);
+      when(changeService.applyChange(any(), eq(principal)))
+         .thenReturn(result("mail.smtp.pass", null, "ENC(new)",
+                            AdminChangeRecord.STATUS_VERIFIED, null));
+
+      ApplyResult applied = service.apply(request("t", "mail.smtp.pass", "hunter2"), principal);
+
+      ApplyOutcome outcome = applied.results().get(0);
+      assertNull(outcome.before(), "no prior credential must stay distinguishable from one set");
+      assertEquals("(set)", outcome.after());
+   }
+
+   @Test
+   void leavesAnOrdinaryPropertysValuesUnmaskedInTheApplyResponse() throws Exception {
+      // The mask is scoped to credentials. Masking ordinary values would cost the operator the
+      // before/after evidence the review gate exists to show them.
+      stub("query.runtime.maxrow", "100");
+      when(changeService.applyChange(any(), eq(principal)))
+         .thenReturn(result("query.runtime.maxrow", "100", "500",
+                            AdminChangeRecord.STATUS_VERIFIED, null));
+
+      ApplyResult applied = service.apply(request("t", "max.rows", "500"), principal);
+
+      ApplyOutcome outcome = applied.results().get(0);
+      assertEquals("100", outcome.before());
+      assertEquals("500", outcome.after());
+   }
+
+   @Test
+   void rollsBackACredentialWithItsRealStoredValueNotTheMaskedOne() throws Exception {
+      // The masking seam matters: it is in the response DTO, not in AdminChangeResult, because
+      // rollback replays applied.getBeforeValue(). If the mask leaked into that path, a rollback
+      // would write the literal string "(set)" into the credential property.
+      stub("mail.smtp.pass", "ENC(old)");
+      stub("query.runtime.maxrow", "100");
+      when(changeService.applyChange(any(), eq(principal)))
+         .thenReturn(result("mail.smtp.pass", "ENC(old)", "ENC(new)",
+                            AdminChangeRecord.STATUS_VERIFIED, null))
+         .thenReturn(result("query.runtime.maxrow", "100", "100",
+                            AdminChangeRecord.STATUS_FAILED, "did not take"))
+         .thenReturn(result("mail.smtp.pass", "ENC(new)", "ENC(old)",
+                            AdminChangeRecord.STATUS_VERIFIED, null));
+
+      service.apply(request("t", "mail.smtp.pass", "hunter2", "max.rows", "500"), principal);
+
+      verify(changeService).applyChange(argThat(
+         req -> AdminChangeRecord.ACTION_ROLLBACK.equals(req.getAction())
+            && "mail.smtp.pass".equals(req.getProperty())
+            && "ENC(old)".equals(req.getValue())), eq(principal));
+   }
+
    // ── rollback ─────────────────────────────────────────────────────────────
 
    @Test

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminPropertiesControllerTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminPropertiesControllerTest.java
@@ -163,6 +163,65 @@ class AdminPropertiesControllerTest {
    }
 
    @Test
+   void withholdsAWebhookUrlWhoseNameAndWriterBothLookHarmless() {
+      // Redmine #76170. A Slack or Google Chat incoming-webhook URL is a bearer credential - the
+      // token is in the path, and nothing else is required to post into that channel. #76006's
+      // remedy is an allow-list of properties whose WRITER encrypts, so it cannot reach these by
+      // construction: ShareSettingsService writes both with a plain setProperty. The name test
+      // misses them too, so before CONFIRMED_SECRET the full URL was read and returned.
+      //
+      // Stubbing a value matters here for the same reason as the credential test above: without
+      // it a removed mask would pass vacuously on a null.
+      for(String name : new String[] { "share.slack.url", "share.googlechat.url" })
+      {
+         sreeEnv.when(() -> SreeEnv.getProperty(name, false, false))
+            .thenReturn("https://hooks.example.test/services/T0/B0/" + name);
+
+         PropertyView view = controller.get(name, principal);
+
+         assertNull(view.currentValue(), name + ": the webhook URL must not be returned");
+         sreeEnv.verify(() -> SreeEnv.getProperty(name, false, false), never());
+      }
+   }
+
+   @Test
+   void tellsTheCallerAWithheldWebhookUrlExistsAndWhyItIsWithheld() {
+      // The regression masking these introduced, and the reason `confirmed` needed a third term.
+      // Both URLs are declared in defaults.properties, so the defaults chain resolved them through
+      // getProperty and `stored != null` reported them confirmed - until this path stopped reading
+      // them. Falling back to unknown hands the caller guidance saying the name may be a typo and
+      // that an unrecognised name is written verbatim while reporting success; all false here,
+      // because AdminChangePlanService refuses the change outright. Same failure the credential
+      // term was added to stop, on a list verified the same way.
+      PropertyView view = controller.get("share.slack.url", principal);
+
+      assertEquals(PropertyView.EXISTS_CONFIRMED, view.exists());
+      assertNull(view.guidance());
+      assertNull(view.currentValue());
+
+      // And the reason must be the true one. The pattern wording is false twice for these: the
+      // name does not match the pattern (see withholdsABearerCredentialThatNeitherItsNameNorIts-
+      // WriterGivesAway), and the list IS evidence the property exists.
+      assertFalse(view.description().contains("matches admin-chat's secret pattern"),
+                  "a CONFIRMED_SECRET name is not withheld by the name pattern");
+      assertFalse(view.description().contains("nothing about whether the property exists"),
+                  "membership in a hand-verified list is evidence the property exists");
+      assertTrue(view.description().contains("bearer credential"));
+   }
+
+   @Test
+   void leavesTheShareSettingsBesideAWebhookUrlReadable() {
+      // The mask must be the two URLs, not the share.* prefix - an operator needs to know whether
+      // sharing is enabled, and the flag discloses nothing.
+      sreeEnv.when(() -> SreeEnv.getProperty("share.slack.enabled", false, false))
+         .thenReturn("true");
+
+      PropertyView view = controller.get("share.slack.enabled", principal);
+
+      assertEquals("true", view.currentValue());
+   }
+
+   @Test
    void tellsTheCallerAWithheldCredentialExistsAndCanStillBeSet() {
       // Two regressions the mask would otherwise introduce, both of which cost an agent a task it
       // could complete. mail.smtp.pass is uncatalogued, so before #76006 its existence was known

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminPropertyCatalogTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminPropertyCatalogTest.java
@@ -18,7 +18,6 @@
 package inetsoft.web.admin.ai;
 
 import java.lang.reflect.Field;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -299,20 +298,25 @@ class AdminPropertyCatalogTest {
       // return still fires - so the test would have gone green on precisely the contradiction it
       // claims to catch. Reading the sets is the only way to assert a property OF the sets.
       //
-      // COMPOSITE_SECRET_PROPERTIES sits in the same union, so the early return shadows it
-      // identically - both hand-verified positive sets are checked here.
+      // COMPOSITE_SECRET_PROPERTIES and ENCRYPTED_CREDENTIALS sit in the same union, so the early
+      // return shadows them identically - every positive set is checked here, not just the two
+      // this bug happened to touch. ENCRYPTED_CREDENTIALS matters most of the three: a name in it
+      // AND in CONFIRMED_NOT_SECRET is read back in the clear with no diagnostic at all, which is
+      // exactly the failure this test was written to catch.
       Set<String> notSecret = nameSet("CONFIRMED_NOT_SECRET");
 
       assertFalse(notSecret.isEmpty(),
                   "CONFIRMED_NOT_SECRET is empty - the checks below would be vacuous");
 
-      for(String field : List.of("CONFIRMED_SECRET", "COMPOSITE_SECRET_PROPERTIES")) {
+      for(String field :
+          List.of("CONFIRMED_SECRET", "COMPOSITE_SECRET_PROPERTIES", "ENCRYPTED_CREDENTIALS"))
+      {
          Set<String> secret = nameSet(field);
          assertFalse(secret.isEmpty(), field + " is empty - the check below would be vacuous");
 
          Set<String> both = new HashSet<>(secret);
          both.retainAll(notSecret);
-         assertTrue(Collections.disjoint(secret, notSecret),
+         assertTrue(both.isEmpty(),
                     "a name cannot be both a verified secret and a verified non-secret; " +
                     "CONFIRMED_NOT_SECRET wins silently because isSecret returns early on it: " +
                     field + " " + both);

--- a/core/src/test/java/inetsoft/web/admin/ai/AdminPropertyCatalogTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/AdminPropertyCatalogTest.java
@@ -17,6 +17,8 @@
  */
 package inetsoft.web.admin.ai;
 
+import java.lang.reflect.Field;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -154,12 +156,19 @@ class AdminPropertyCatalogTest {
 
    @Test
    void classifiesEncryptedCredentialsByTheirWriterNotTheirName() {
-      // The four properties the name predicate does NOT match but which Enterprise Manager writes
-      // with setPassword. Before they were listed, admin-chat wrote them plain and silently
+      // The properties Enterprise Manager writes through an encrypting accessor. Before the four
+      // the name predicate does NOT match were listed, admin-chat wrote them plain and silently
       // downgraded a stored credential to plaintext at rest.
+      //
+      // log.fluentd.security.password is here as of Redmine #76170: Redmine #76051 (dc8877f8a)
+      // moved LogSettingService's write of it onto the same toPassword helper as the shared key,
+      // and the entry that should have followed did not. Unlike the four above, its name matches,
+      // so nothing leaked - the cost was that admin-chat refused to set a property it could have
+      // set correctly.
       for(String name : new String[] { "mail.smtp.pass", "mail.smtp.clientsecret",
                                        "mail.smtp.accesstoken", "mail.smtp.refreshtoken",
                                        "log.fluentd.security.sharedkey",
+                                       "log.fluentd.security.password",
                                        "openid.client.secret",
                                        "stylebi.google.openid.client.secret" })
       {
@@ -171,13 +180,19 @@ class AdminPropertyCatalogTest {
    @Test
    void excludesAdjacentPropertiesWhoseWriterDoesNotEncrypt() {
       // Each of these sits beside a listed property and reads like it belongs. None does.
-      //   mail.smtp.tokenuri              same save block as the four above, plain setProperty
-      //   log.fluentd.security.password   sibling of sharedkey, plain setProperty - its reader
-      //                                   calls decryptPassword, which proves nothing, because
-      //                                   decryptPassword passes plaintext straight through
+      //   mail.smtp.tokenuri              same save block as the four above, plain setProperty -
+      //                                   and it is READ with SreeEnv.getPassword, which decrypts,
+      //                                   so by its reader it looks encrypted. It is not. This is
+      //                                   the standing example of why only the writer settles it,
+      //                                   because decryptPassword passes plaintext straight
+      //                                   through (LocalPasswordEncryption's clear-text branch).
       //   auth0.client.secret             read plain; the legacy migration encrypts on the way out
       //   sso.rsa.public.key              a PUBLIC key
-      for(String name : new String[] { "mail.smtp.tokenuri", "log.fluentd.security.password",
+      //
+      // log.fluentd.security.password used to head this list and no longer belongs to it - see
+      // classifiesEncryptedCredentialsByTheirWriterNotTheirName above. It is the reason this test
+      // asserts against the WRITER and not against a remembered classification.
+      for(String name : new String[] { "mail.smtp.tokenuri",
                                        "auth0.client.secret", "sso.rsa.public.key",
                                        "google.maps.key", "enable.changepassword",
                                        "password.encryption.key", "jwt.signing.key" })
@@ -216,17 +231,99 @@ class AdminPropertyCatalogTest {
 
    @Test
    void keepsWithholdingSecretNamesThatNoWriterEncrypts() {
-      // The union must not have narrowed to the allow-list. Fourteen of the sixteen names
-      // isSecret withheld before #76006 are written by nothing that encrypts, so the writer test
-      // alone would have unmasked them all in order to close the four above. (The sixteenth,
-      // enable.changepassword, moved to CONFIRMED_NOT_SECRET below - see the item-4 fix.)
+      // The union must not have narrowed to the allow-list. Most of the names isSecret withheld
+      // before #76006 are written by nothing that encrypts, so the writer test alone would have
+      // unmasked them all in order to close the four that needed closing.
+      //
+      // Deliberately no count here or in the isSecret javadoc. The javadoc said "fifteen" and this
+      // comment said "fourteen" for the same group, and both were left behind by the three
+      // CONFIRMED_NOT_SECRET carve-outs and again by log.fluentd.security.password moving to the
+      // writer-classified list in #76170. What matters is that the group is non-empty, which the
+      // loop asserts.
       for(String name : new String[] { "license.key", "jwt.signing.key", "password.encryption.key",
-                                       "sso.rsa.private.key", "log.fluentd.security.password" })
+                                       "sso.rsa.private.key" })
       {
          assertFalse(AdminPropertyCatalog.isEncryptedCredential(name),
                      name + ": nothing encrypts this on write, so only the name test can cover it");
          assertTrue(AdminPropertyCatalog.isSecret(name), name + " must stay withheld");
       }
+   }
+
+   @Test
+   void withholdsABearerCredentialThatNeitherItsNameNorItsWriterGivesAway() {
+      // Redmine #76170. A Slack or Google Chat incoming-webhook URL carries its token in the path:
+      // possession is sufficient to post to that channel, with no second factor and no request
+      // signature. Both were returned in full to a caller that relays responses to a model
+      // provider off-host, because the two tests that existed ask about the NAME and about the
+      // STORAGE FORM, and a bearer token can be unremarkable in both.
+      for(String name : new String[] { "share.slack.url", "share.googlechat.url" })
+      {
+         assertFalse(matchesTheNamePattern(name),
+                     name + ": the point of this test is that the NAME does not match - if it now "
+                     + "does, CONFIRMED_SECRET is no longer what covers it");
+         assertFalse(AdminPropertyCatalog.isEncryptedCredential(name),
+                     name + ": nothing encrypts this on write, so the writer test cannot cover it "
+                     + "either - and listing it there would make admin-chat store ciphertext "
+                     + "under a property every reader expects to hold a literal URL");
+         assertTrue(AdminPropertyCatalog.isSecret(name),
+                    name + " grants access to whoever holds it and must not be read back");
+      }
+   }
+
+   @Test
+   void withholdsABearerCredentialWhateverCasingTheCallerUses() {
+      assertTrue(AdminPropertyCatalog.isSecret("Share.Slack.URL"));
+      assertTrue(AdminPropertyCatalog.isSecret("SHARE.GOOGLECHAT.URL"));
+   }
+
+   @Test
+   void withholdsOnlyTheWebhookUrlAndNotTheShareSettingsAroundIt() {
+      // The carve-out must be the two names, not the share.* prefix. An operator needs to see
+      // whether sharing is enabled, and only the URL is the credential.
+      for(String name : new String[] { "share.googlechat.enabled", "share.slack.enabled",
+                                       "share.email.enabled" })
+      {
+         assertFalse(AdminPropertyCatalog.isSecret(name), name + " is not a secret");
+      }
+   }
+
+   @Test
+   void keepsTheHandVerifiedNameListsDisjoint() throws Exception {
+      // isSecret checks CONFIRMED_NOT_SECRET first and returns early, so a name in both sets is
+      // read back in the clear with nothing to indicate the contradiction. The ordering inside
+      // isSecret is only safe while this holds.
+      //
+      // Reflected over the actual fields rather than asserted through isSecret over hardcoded
+      // names. That spelling looked equivalent and was not: adding one of the CONFIRMED_NOT_SECRET
+      // names to CONFIRMED_SECRET leaves assertFalse(isSecret(name)) passing, because the early
+      // return still fires - so the test would have gone green on precisely the contradiction it
+      // claims to catch. Reading the sets is the only way to assert a property OF the sets.
+      //
+      // COMPOSITE_SECRET_PROPERTIES sits in the same union, so the early return shadows it
+      // identically - both hand-verified positive sets are checked here.
+      Set<String> notSecret = nameSet("CONFIRMED_NOT_SECRET");
+
+      assertFalse(notSecret.isEmpty(),
+                  "CONFIRMED_NOT_SECRET is empty - the checks below would be vacuous");
+
+      for(String field : List.of("CONFIRMED_SECRET", "COMPOSITE_SECRET_PROPERTIES")) {
+         Set<String> secret = nameSet(field);
+         assertFalse(secret.isEmpty(), field + " is empty - the check below would be vacuous");
+
+         Set<String> both = new HashSet<>(secret);
+         both.retainAll(notSecret);
+         assertTrue(Collections.disjoint(secret, notSecret),
+                    "a name cannot be both a verified secret and a verified non-secret; " +
+                    "CONFIRMED_NOT_SECRET wins silently because isSecret returns early on it: " +
+                    field + " " + both);
+      }
+   }
+
+   @SuppressWarnings("unchecked")
+   private static Set<String> nameSet(String field) throws Exception {
+      Field f = AdminPropertyCatalog.class.getDeclaredField(field);
+      f.setAccessible(true);
+      return (Set<String>) f.get(null);
    }
 
    @Test

--- a/core/src/test/java/inetsoft/web/admin/ai/presentation/PresentationChangePlanServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/presentation/PresentationChangePlanServiceTest.java
@@ -31,6 +31,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.security.Principal;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -39,7 +40,7 @@ import static org.mockito.Mockito.lenient;
 /**
  * 01-spec.md section 0/2 (16-entry catalog, dead-field exclusion), section 4 (risk/scope split),
  * section 5 (partial-{@code spec} merge, {@code viewsheetToolbar}/{@code portalIntegration.tabs}
- * whole-list treatment), section 9 (webMap secret masking/refusal), section 11 (global-only refusal,
+ * whole-list treatment), section 9 (webMap/share secret masking/refusal), section 11 (global-only refusal,
  * verb/scope/subModel validation); 03-reconcile.md Addition 1 (lookAndFeel file name sanitization)
  * and Addition 2 (portalIntegration.tabs whole-list enforcement).
  */
@@ -130,8 +131,10 @@ class PresentationChangePlanServiceTest {
          return PresentationFontMappingSettingsModel.builder().fontMappings(List.of()).build();
       case SHARE:
          return PresentationShareSettingsModel.builder()
-            .emailEnabled(true).facebookEnabled(false).googleChatEnabled(false)
-            .linkedinEnabled(false).slackEnabled(false).twitterEnabled(false).linkEnabled(true)
+            .emailEnabled(true).facebookEnabled(false).googleChatEnabled(true)
+            .linkedinEnabled(false).slackEnabled(true).twitterEnabled(false).linkEnabled(true)
+            .slackUrl("https://hooks.slack.example/services/T0/B0/secret-slack-token")
+            .googleChatUrl("https://chat.googleapis.com/v1/spaces/S0?key=secret-chat-key")
             .openGraphTitle("").openGraphDescription("").openGraphSiteName("").openGraphImageUrl("")
             .build();
       case COMPOSER_MESSAGE:
@@ -432,5 +435,101 @@ class PresentationChangePlanServiceTest {
       assertFalse(current.contains("secret-token"), current);
       assertFalse(current.contains("secret-key"), current);
       assertTrue(current.contains("********"), current);
+   }
+
+   // ---------------------------------------------------------------- section 9: share webhook URLs
+
+   // The two share.* webhook URLs are secrets by possession: the token is in the path, so anything
+   // holding the URL can post into that channel. AdminPropertyCatalog.CONFIRMED_SECRET stopped the
+   // properties path returning them (Redmine #76170), but this area reached the same two values
+   // through PresentationSubModel.SHARE and masked only webMap - so "show me the sharing settings"
+   // still handed both to a caller that relays its responses to a model provider off-host, and an
+   // update spec carrying slackUrl was still applied. These four tests pin both halves.
+
+   @Test
+   void shareSlackUrlCannotBeSetThroughSpec() throws Exception {
+      stub(PresentationSubModel.SHARE, currentFor(PresentationSubModel.SHARE));
+      PresentationChangePlanRequest req = request("t",
+         change("share", "organization",
+                obj().put("slackUrl", "https://hooks.slack.example/services/T1/B1/attacker")));
+
+      IllegalArgumentException ex =
+         assertThrows(IllegalArgumentException.class, () -> service.resolve(req, PRINCIPAL));
+      assertTrue(ex.getMessage().contains("slackUrl"), ex.getMessage());
+   }
+
+   @Test
+   void shareGoogleChatUrlCannotBeSetThroughSpec() throws Exception {
+      stub(PresentationSubModel.SHARE, currentFor(PresentationSubModel.SHARE));
+      PresentationChangePlanRequest req = request("t",
+         change("share", "organization",
+                obj().put("googleChatUrl", "https://chat.googleapis.com/v1/spaces/S1?key=attacker")));
+
+      assertThrows(IllegalArgumentException.class, () -> service.resolve(req, PRINCIPAL));
+   }
+
+   @Test
+   void shareWebhookUrlsAreMaskedInThePlanProjection() throws Exception {
+      stub(PresentationSubModel.SHARE, currentFor(PresentationSubModel.SHARE));
+      PresentationChangePlanRequest req =
+         request("t", change("share", "organization", specFor(PresentationSubModel.SHARE)));
+
+      var plan = service.resolve(req, PRINCIPAL);
+      String current = plan.changes().get(0).currentValue();
+      String proposed = plan.changes().get(0).proposedValue();
+
+      for(String value : new String[] { current, proposed }) {
+         assertFalse(value.contains("secret-slack-token"), value);
+         assertFalse(value.contains("secret-chat-key"), value);
+         assertTrue(value.contains("********"), value);
+      }
+
+      // The non-secret share.* fields beside them stay readable - masking must not cost the agent
+      // the settings it legitimately needs to answer about.
+      assertTrue(current.contains("emailEnabled"), current);
+   }
+
+   @Test
+   void shareChangeStillWritesTheRealWebhookUrlsNotTheMask() throws Exception {
+      // The mask is a projection for display only. resolveEntries merges the spec into the
+      // UNMASKED current node, so the model that would be written keeps the real URLs - without
+      // this, an ordinary "turn off email sharing" update would round-trip "********" into the
+      // store and silently break both integrations.
+      stub(PresentationSubModel.SHARE, currentFor(PresentationSubModel.SHARE));
+      PresentationChangePlanRequest req =
+         request("t", change("share", "organization", obj().put("emailEnabled", false)));
+
+      var entries = service.resolveEntries(req, PRINCIPAL);
+      PresentationShareSettingsModel proposed =
+         (PresentationShareSettingsModel) entries.get(0).proposedModel();
+
+      assertEquals("https://hooks.slack.example/services/T0/B0/secret-slack-token",
+                   proposed.slackUrl());
+      assertEquals("https://chat.googleapis.com/v1/spaces/S0?key=secret-chat-key",
+                   proposed.googleChatUrl());
+      assertFalse(proposed.emailEnabled());
+   }
+
+   // ---------------------------------------------------------------- secretFields is per sub-model
+
+   @Test
+   void onlyTheTwoSubModelsWithCredentialsDeclareSecretFields() {
+      // Pinned as a property OF the enum rather than through a call site. Every projection and the
+      // write guard now ask the sub-model, so this list IS the area's secret classification; a name
+      // added to a model without being added here is masked nowhere, which is the shape of the bug
+      // that made share's URLs readable in the first place.
+      for(PresentationSubModel subModel : PresentationSubModel.values()) {
+         Set<String> secrets = subModel.secretFields();
+
+         switch(subModel) {
+         case WEB_MAP -> assertEquals(Set.of("mapboxToken", "googleKey"), secrets);
+         case SHARE -> assertEquals(Set.of("slackUrl", "googleChatUrl"), secrets);
+         default -> assertTrue(secrets.isEmpty(), subModel.key() + " " + secrets);
+         }
+
+         // A declared secret must be a field the sub-model actually has, or it masks nothing.
+         assertTrue(subModel.fieldNames().containsAll(secrets),
+                    subModel.key() + " declares a secret field it does not have: " + secrets);
+      }
    }
 }


### PR DESCRIPTION
## Summary

Two gaps in `AdminPropertyCatalog`'s definition of a secret, from Redmine #76170. Both were found by re-reading each property's **writer** rather than trusting the existing lists — the rule this class already documents.

Part 1 of that issue concerns `main` and shipped separately as #4817. `AdminPropertyCatalog` does not exist on `main` (the whole `web/admin/ai/` package is unmerged feature work), so this half can only target `stylebi-wiz-main-rebase`.

## 1. The two share webhook URLs were returned in full

`share.slack.url` and `share.googlechat.url` are incoming-webhook URLs: the token is in the path, no second factor, no request signature. Anything holding the URL can post into that channel or room.

Neither matches the name shape, and neither is written through an encrypting accessor — `ShareSettingsService` writes both with a plain `setProperty`. So **both existing tests miss them by construction**: #76006's remedy is an allow-list of properties whose writer encrypts. `AdminPropertiesController` read the full URL and returned it to a caller that relays responses to a model provider off-host.

`ENCRYPTED_CREDENTIALS` is the wrong home: it drives `SreeEnv.setPassword` on write, which would store ciphertext under a property `ShareSettingsService` and `ShareController` both read as a literal URL — the mirror of the plaintext downgrade that list exists to prevent. This adds a third hand-verified set, `CONFIRMED_SECRET`, unioned into `isSecret`. The two lists answer different questions — *does the product encrypt this value* vs *does possessing it grant access* — and keeping them separate is what lets each stay checkable.

**Accepted cost, recorded in the javadoc:** `AdminChangePlanService` refuses a change when a name is secret and not an encrypted credential, so these two are no longer settable through admin-chat and must be configured in Enterprise Manager. Encrypting them at rest instead would keep the write, at the price of changing a shipped feature and migrating values already stored in the clear.

`mapbox.token` was considered and left out — like `google.maps.key` it is a client-side map token, ordinarily restricted by referrer.

Masking must not delete a true answer, so `CONFIRMED_SECRET` gets the same term in the `confirmed` expression the credential list already has. Both URLs are declared in `defaults.properties`, so the defaults chain made `stored` non-null and they reported `EXISTS_CONFIRMED`; without the term they regress to `EXISTS_UNKNOWN`, whose guidance says the name may be a typo and that an unrecognised name is written verbatim while reporting success — all false here. That is the regression the credential term was added for in #76006.

## 2. `log.fluentd.security.password` was misclassified

Bug #76051 (`dc8877f8a`) routed `LogSettingService`'s write of it through the same `toPassword` → `Tool.encryptPassword` helper as its sibling shared key. The entry never followed, and the javadoc still used the property as its worked example of a value written in the clear — as did two tests.

Nothing leaked: the name contains `password`, so `isSecret` always matched. The cost was that admin-chat refused to set a property it could have set correctly. The "classify by the writer" rule is unchanged; the paragraph arguing for it keeps its example, now `mail.smtp.tokenuri`, which is read with `getPassword` and written with a bare `setProperty`.

## 3. …which exposed a plaintext echo, fixed here too

Making that property settable opened a real egress path. `AdminChangeService` keeps `beforeValue`/`afterValue` as the stored form, justified on the grounds that a credential is stored as ciphertext and ciphertext is not the secret. That holds only *normally*: `Tool.decryptPassword` passes plaintext straight through, so a credential can sit in the store in the clear and still work — exactly what this property did until #76051, and what `INETSOFTENV_*` promotion and the raw EM properties page still do for any of them. On an upgraded server the first apply would have echoed the old plaintext credential into the apply response, off-host.

`ApplyOutcome` now reports `(set)` for an encrypted credential. Masked at the **response DTO** and not in `AdminChangeResult` deliberately: rollback replays `applied.getBeforeValue()` and the `moved` comparison needs the real values, and both read the result object directly, so neither is affected. A `null` stays `null`, so "no prior credential" remains distinguishable from one that was replaced.

## Also

Drops the hand-maintained "fifteen properties" count from the `isSecret` javadoc rather than computing a third value. It disagreed with the "fourteen" in the corresponding test, and both had already been left behind by the three `CONFIRMED_NOT_SECRET` carve-outs before this change touched the group again.

The disjointness guard now reflects over both sets and asserts `Collections.disjoint`. Asserting it through `isSecret` over hardcoded names looked equivalent and was not: `isSecret` returns early on `CONFIRMED_NOT_SECRET`, so adding one of those names to `CONFIRMED_SECRET` left the assertion passing — green on precisely the contradiction it claims to catch.

## Testing

`202 tests, 0 failures, 0 errors` — the whole `inetsoft.web.admin.ai` package plus `LogSettingServiceTest` and `PropertiesControllerTest`:

```
./mvnw test -pl core -Dtest='inetsoft.web.admin.ai.*Test,LogSettingServiceTest,PropertiesControllerTest'
```

The fluentd reclassification broke two existing tests that used the property as their example of a secret-named non-credential. Both now use a property whose writer was re-checked (`sso.rsa.private.key`, `license.key`) and record why the old example expired — that breakage is the evidence the entry really had gone stale.

New coverage: both webhook URLs withheld and never read at all; their `exists`/description staying truthful; the `share.*` flags beside them staying readable; the fluentd password now written through `setPassword`; credential values masked in the apply response while an ordinary property's are not; and rollback still replaying the real stored value rather than the mask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
