### PR TITLE
Bug #75954, thread N through set_group_aggregate for parametrized formulas

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -1716,7 +1716,7 @@ public class WorksheetAgentController {
                                      req.aggregates() != null
                                         ? req.aggregates().stream()
                                             .map(a -> new WorksheetMutationSupport.AggregateSpec(
-                                                a.field(), a.formula(), a.alias()))
+                                                a.field(), a.formula(), a.alias(), a.n()))
                                             .toList()
                                         : List.of(),
                                      Boolean.TRUE.equals(req.crosstab()));

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetMutationSupport.java
@@ -72,8 +72,16 @@ public final class WorksheetMutationSupport {
     * @param formula a formula name recognised by {@link AggregateFormula#getFormula}
     *                (e.g. {@code "SUM"}, {@code "COUNT"}, {@code "AVG"})
     * @param alias   optional output alias; may be {@code null}
+    * @param n       the N/P operand for a parametrized formula (e.g. {@code "NthLargest"},
+    *                {@code "NthSmallest"}, {@code "NthMostFrequent"}, {@code "PthPercentile"});
+    *                {@code null} (or a formula that doesn't take one, per
+    *                {@link AggregateFormula#hasN}) is ignored
     */
-   public record AggregateSpec(String field, String formula, String alias) {}
+   public record AggregateSpec(String field, String formula, String alias, Integer n) {
+      public AggregateSpec(String field, String formula, String alias) {
+         this(field, formula, alias, null);
+      }
+   }
 
    /**
     * Describes a single group-by column for
@@ -648,6 +656,10 @@ public final class WorksheetMutationSupport {
 
          AggregateRef ar = new AggregateRef(colRef, formula);
 
+         if(spec.n() != null && formula.hasN()) {
+            ar.setN(spec.n());
+         }
+
          if(ainfo.containsAggregate(ar)) {
             // Second aggregate on the same column: clone the ref before aliasing.
             // The shared ref was (correctly) mutated by the first spec — that is how
@@ -662,7 +674,13 @@ public final class WorksheetMutationSupport {
                appliedAliases.add(spec.alias());
             }
 
-            ainfo.addSecondaryAggregate(new AggregateRef(cloned, formula));
+            AggregateRef secondary = new AggregateRef(cloned, formula);
+
+            if(spec.n() != null && formula.hasN()) {
+               secondary.setN(spec.n());
+            }
+
+            ainfo.addSecondaryAggregate(secondary);
          }
          else {
             // First aggregate on this column: set the alias on the shared ref from the
@@ -719,6 +737,11 @@ public final class WorksheetMutationSupport {
 
             // Create a new primary aggregate on the expression column.
             AggregateRef newAgg = new AggregateRef(exprCol, sref.getFormula());
+
+            if(sref.getFormula() != null && sref.getFormula().hasN()) {
+               newAgg.setN(sref.getN());
+            }
+
             ainfo.addAggregate(newAgg, false);
          }
 

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
@@ -737,7 +737,9 @@ public class WorksheetReadService {
          alias = cr.getAlias();
       }
 
-      return new WorksheetModel.AggregateModel.AggregateRefModel(column, formulaName, alias);
+      Integer n = formula != null && formula.hasN() ? ar.getN() : null;
+
+      return new WorksheetModel.AggregateModel.AggregateRefModel(column, formulaName, alias, n);
    }
 
    // -------------------------------------------------------------------------

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/model/WorksheetModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/model/WorksheetModel.java
@@ -233,9 +233,11 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
        * @param column  source column name
        * @param formula formula name (e.g. {@code "Sum"}, {@code "Count"})
        * @param alias   output alias; may be {@code null}
+       * @param n       the N/P operand for a parametrized formula (e.g. {@code "NthLargest"},
+       *                {@code "PthPercentile"}); {@code null} when the formula doesn't take one
        */
       @JsonInclude(JsonInclude.Include.NON_NULL)
-      public record AggregateRefModel(String column, String formula, String alias) {}
+      public record AggregateRefModel(String column, String formula, String alias, Integer n) {}
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -232,6 +232,74 @@ class WorksheetEditServiceMutatorsTest {
       assertEquals(1, ai.getAggregateCount());
    }
 
+   // Bug #75954: NthLargest/NthSmallest/etc. silently dropped their N operand and the
+   // aggregate quietly computed as N=1 (Max/Min) instead — no error anywhere.
+   @Test
+   void setGroupAggregateAppliesNForParametrizedFormula() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "cat", "val");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed ->
+         ed.setGroupAggregate("T",
+            groups("cat"),
+            List.of(new WorksheetMutationSupport.AggregateSpec(
+               "val", "NthLargest", "fifth_largest", 5)))
+      );
+
+      AggregateInfo ai = t.getAggregateInfo();
+      assertEquals(1, ai.getAggregateCount());
+      assertEquals(5, ai.getAggregate(0).getN());
+   }
+
+   // N must be ignored (not throw, not corrupt the ref) for a formula that doesn't use it.
+   @Test
+   void setGroupAggregateIgnoresNForNonParametrizedFormula() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "cat", "val");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed ->
+         ed.setGroupAggregate("T",
+            groups("cat"),
+            List.of(new WorksheetMutationSupport.AggregateSpec("val", "SUM", null, 5)))
+      );
+
+      AggregateInfo ai = t.getAggregateInfo();
+      assertEquals(1, ai.getAggregateCount());
+      assertEquals(0, ai.getAggregate(0).getN());
+   }
+
+   // Bug #75954 follow-up: a second (or later) aggregate on the same column goes through
+   // the secondary-aggregate -> new-expression-column -> new-primary-aggregate conversion
+   // (see the "Convert secondary aggregates" block below) rather than the plain path
+   // covered by setGroupAggregateAppliesNForParametrizedFormula above — N must survive
+   // that conversion too.
+   @Test
+   void setGroupAggregateAppliesNThroughSecondaryConversion() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "cat", "price");
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent, ed ->
+         ed.setGroupAggregate("T",
+            groups("cat"),
+            List.of(new WorksheetMutationSupport.AggregateSpec("price", "SUM", "total_price"),
+                    new WorksheetMutationSupport.AggregateSpec(
+                       "price", "NthLargest", "third_largest_price", 3))));
+
+      AggregateInfo ai = t.getAggregateInfo();
+      assertEquals(2, ai.getAggregateCount());
+      assertEquals(0, ai.getAggregate(0).getN());
+      assertEquals(3, ai.getAggregate(1).getN());
+   }
+
    @Test
    void sameColumnAggregatesKeepDistinctAliases() throws Exception {
       Worksheet ws = new Worksheet();

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
@@ -94,6 +94,51 @@ class WorksheetReadServiceTest {
       assertEquals("QUARTER", group.dateLevel());
    }
 
+   // Bug #75954: even after set_group_aggregate correctly applied N, read_worksheet_model
+   // reported the formula as bare "NthLargest" with N gone — this is the read-back half
+   // of that bug.
+   @Test
+   void readsNForParametrizedFormula() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "cat", "val");
+      ws.addAssembly(t);
+
+      WorksheetMutationSupport.applyAggregateInfo(t,
+         List.of(new WorksheetMutationSupport.GroupSpec("cat", null)),
+         List.of(new WorksheetMutationSupport.AggregateSpec("val", "NthLargest", null, 5)));
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      WorksheetModel m = new WorksheetReadService().read(rws);
+      WorksheetModel.AggregateModel.AggregateRefModel agg =
+         m.tables().get(0).aggregates().aggregates().get(0);
+      assertEquals("NthLargest", agg.formula());
+      assertEquals(5, agg.n());
+   }
+
+   // N must not be surfaced for a formula that doesn't use it, even if the underlying
+   // AggregateRef.num happens to be nonzero from a prior formula switch.
+   @Test
+   void omitsNForNonParametrizedFormula() throws Exception {
+      Worksheet ws = new Worksheet();
+      EmbeddedTableAssembly t = TestWorksheets.tableWithColumns(ws, "T", "cat", "val");
+      ws.addAssembly(t);
+
+      WorksheetMutationSupport.applyAggregateInfo(t,
+         List.of(new WorksheetMutationSupport.GroupSpec("cat", null)),
+         List.of(new WorksheetMutationSupport.AggregateSpec("val", "SUM", null)));
+
+      RuntimeWorksheet rws = mock(RuntimeWorksheet.class);
+      when(rws.getWorksheet()).thenReturn(ws);
+
+      WorksheetModel m = new WorksheetReadService().read(rws);
+      WorksheetModel.AggregateModel.AggregateRefModel agg =
+         m.tables().get(0).aggregates().aggregates().get(0);
+      assertEquals("SUM", agg.formula());
+      assertNull(agg.n());
+   }
+
    @Test
    void nullOrEmptyAggregateInfoReturnsNullAggregates() {
       Worksheet ws = new Worksheet();


### PR DESCRIPTION
## Summary

`set_group_aggregate` (the AI Wiz Composer plugin's worksheet grouping/aggregation tool) silently dropped the `N` operand for parametrized aggregate formulas (`NthLargest`, `NthSmallest`, `NthMostFrequent`, `PthPercentile`). Asking for "5th largest" (NthLargest, N=5) silently computed as N=1 (Max) instead — no error anywhere. `read_worksheet_model` also kept reporting the formula back as bare `"NthLargest"` with N gone, even once the value was applied correctly.

## Root Cause

Three places in the AI Wiz worksheet-edit pipeline dropped `N`:

1. `WorksheetMutationSupport.AggregateSpec` had no `n` field, so there was nowhere for it to travel to.
2. `WorksheetAgentController.dispatch()`'s `case "set_group_aggregate"` rebuilt the aggregate list field-by-field and omitted `n` in that rebuild.
3. `WorksheetMutationSupport.applyAggregateInfo` never called `AggregateRef.setN(...)` on either the primary aggregate or the secondary-aggregate → new-primary-aggregate conversion path used when a second aggregate targets the same column.
4. `WorksheetReadService`/`WorksheetModel.AggregateRefModel` had no way to surface `n` back out, so `read_worksheet_model` couldn't report it even after it was correctly applied.

## Fix

- `AggregateSpec` and `AggregateRefModel` now carry an optional `Integer n` (each keeps a back-compatible constructor overload for existing call sites).
- `applyAggregateInfo` threads `n` onto the `AggregateRef` in both aggregate-construction paths, gated on `AggregateFormula.hasN()`.
- `WorksheetAgentController` forwards `n` through instead of dropping it.
- `WorksheetReadService` surfaces `n` back out in `read_worksheet_model`, gated the same way.

This matches the existing, already-correct precedent in `GenerateWsService`/`WorksheetTableService` (used by `create_worksheet_table`), and the Angular Composer UI's own formula editor (`n`/`hasN` gating).

## Test Plan

- Added regression tests: N applied on write (`setGroupAggregateAppliesNForParametrizedFormula`), N ignored for non-parametrized formulas, N surviving the same-column secondary-aggregate conversion (`setGroupAggregateAppliesNThroughSecondaryConversion`), and N correctly round-tripping (or correctly omitted) through `read_worksheet_model` (`WorksheetReadServiceTest`).
- `mvn clean test -pl core -am` — `WorksheetEditServiceMutatorsTest` (157), `WorksheetReadServiceTest` (32), `WorksheetAgentControllerTest` (71), `GroupSpecDeserializationTest` (5) all pass.
- Manually verified live via the Composer plugin.

Fixes Redmine #75954.