### PR TITLE
Bug #76346, expose worksheet table Mergeable and Visible-in-Viewsheet flags to the AI agent API

### DIFF
--- a/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/EditRequest.java
@@ -78,7 +78,8 @@ import java.util.Map;
  *   <li>{@code insert_row} — {@code table}, {@code index}</li>
  *   <li>{@code delete_row} — {@code table}, {@code index}</li>
  *   <li>{@code set_table_properties} — {@code table}; any of {@code newName} (or {@code alias},
- *       its accepted spelling), {@code description}, {@code maxRows}, {@code distinct}</li>
+ *       its accepted spelling), {@code description}, {@code maxRows}, {@code distinct},
+ *       {@code mergeable}, {@code visibleInViewsheet}</li>
  *   <li>{@code add_cross_join} — {@code name}, {@code leftTable}, {@code rightTable}</li>
  *   <li>{@code add_merge_join} — {@code name}, {@code tables}</li>
  *   <li>{@code reorder_columns} — {@code table}, {@code columnOrder}</li>
@@ -340,8 +341,128 @@ public record EditRequest(
     * single call). When present, this supersedes {@code leftTable}/{@code leftKey}/
     * {@code rightTable}/{@code rightKey}/{@code joinType}/{@code leftKeys}/{@code rightKeys}.
     */
-   List<WorksheetMutationSupport.JoinPathSpec> joinPaths
+   List<WorksheetMutationSupport.JoinPathSpec> joinPaths,
+   /**
+    * Whether the table's query is merged into a single SQL statement for set_table_properties —
+    * the Composer's own table-properties dialog "Mergeable" checkbox
+    * ({@link inetsoft.uql.asset.TableAssembly#setSQLMergeable}). {@code null} leaves it
+    * unchanged, matching {@code distinct}.
+    */
+   Boolean mergeable,
+   /**
+    * Whether the table is exposed to viewsheets bound to this worksheet, for
+    * set_table_properties — the Composer's own table-properties dialog "Visible in Viewsheet"
+    * checkbox ({@link inetsoft.uql.asset.TableAssembly#setVisibleTable}). {@code null} leaves it
+    * unchanged, matching {@code distinct}/{@code mergeable}. Distinct from {@code visible}, which
+    * is a per-column flag for set_column_visibility.
+    */
+   Boolean visibleInViewsheet
 ) {
+   /**
+    * Compatibility constructor for callers built before {@code visibleInViewsheet} was added —
+    * defaults it to {@code null}.
+    */
+   public EditRequest(
+      String op, String table, String column, String name, String type, String newName,
+      String field, String operation, List<String> values, String direction,
+      List<WorksheetMutationSupport.GroupSpec> groups,
+      List<WorksheetMutationSupport.AggregateSpec> aggregates, String expression, boolean sql,
+      String leftTable, String leftKey, String rightTable, String rightKey, String joinType,
+      Boolean visible, List<String> tables, String source, String concatType,
+      List<WorksheetMutationSupport.ConditionNode> conditions,
+      WorksheetMutationSupport.RankingSpec ranking, Integer headerColumns, String dateOption,
+      double[] boundaries, String datasource, String schema, String catalog, String logicalModel,
+      List<String> leftKeys, List<String> rightKeys, Integer row, Integer col, String value,
+      Integer index, String alias, String description, Integer maxRows, Boolean distinct,
+      List<String> columnOrder, List<WorksheetMutationSupport.GroupMapping> groupMappings,
+      Boolean groupOthers, Map<String, String> variableValues, Integer x, Integer y, String label,
+      String defaultValue, String mode, Boolean insert, List<String> subtables,
+      String sourceTable, String attribute, String endpoint, Map<String, String> parameters,
+      List<String> lookup, Boolean lookupExpandArrays, Boolean lookupTopLevelOnly, String suffix,
+      List<WorksheetMutationSupport.CustomLookupSpec> customLookups, Boolean crosstab,
+      List<String> labels, WorksheetMutationSupport.VariableChoicesSpec choices,
+      List<WorksheetMutationSupport.JoinPathSpec> joinPaths, Boolean mergeable)
+   {
+      this(op, table, column, name, type, newName, field, operation, values, direction, groups,
+           aggregates, expression, sql, leftTable, leftKey, rightTable, rightKey, joinType,
+           visible, tables, source, concatType, conditions, ranking, headerColumns, dateOption,
+           boundaries, datasource, schema, catalog, logicalModel, leftKeys, rightKeys, row, col,
+           value, index, alias, description, maxRows, distinct, columnOrder, groupMappings,
+           groupOthers, variableValues, x, y, label, defaultValue, mode, insert, subtables,
+           sourceTable, attribute, endpoint, parameters, lookup, lookupExpandArrays,
+           lookupTopLevelOnly, suffix, customLookups, crosstab, labels, choices, joinPaths,
+           mergeable, null);
+   }
+
+   /**
+    * Compatibility constructor for callers built before {@code mergeable} was added —
+    * defaults it to {@code null}.
+    */
+   public EditRequest(
+      String op, String table, String column, String name, String type, String newName,
+      String field, String operation, List<String> values, String direction,
+      List<WorksheetMutationSupport.GroupSpec> groups,
+      List<WorksheetMutationSupport.AggregateSpec> aggregates, String expression, boolean sql,
+      String leftTable, String leftKey, String rightTable, String rightKey, String joinType,
+      Boolean visible, List<String> tables, String source, String concatType,
+      List<WorksheetMutationSupport.ConditionNode> conditions,
+      WorksheetMutationSupport.RankingSpec ranking, Integer headerColumns, String dateOption,
+      double[] boundaries, String datasource, String schema, String catalog, String logicalModel,
+      List<String> leftKeys, List<String> rightKeys, Integer row, Integer col, String value,
+      Integer index, String alias, String description, Integer maxRows, Boolean distinct,
+      List<String> columnOrder, List<WorksheetMutationSupport.GroupMapping> groupMappings,
+      Boolean groupOthers, Map<String, String> variableValues, Integer x, Integer y, String label,
+      String defaultValue, String mode, Boolean insert, List<String> subtables,
+      String sourceTable, String attribute, String endpoint, Map<String, String> parameters,
+      List<String> lookup, Boolean lookupExpandArrays, Boolean lookupTopLevelOnly, String suffix,
+      List<WorksheetMutationSupport.CustomLookupSpec> customLookups, Boolean crosstab,
+      List<String> labels, WorksheetMutationSupport.VariableChoicesSpec choices,
+      List<WorksheetMutationSupport.JoinPathSpec> joinPaths)
+   {
+      this(op, table, column, name, type, newName, field, operation, values, direction, groups,
+           aggregates, expression, sql, leftTable, leftKey, rightTable, rightKey, joinType,
+           visible, tables, source, concatType, conditions, ranking, headerColumns, dateOption,
+           boundaries, datasource, schema, catalog, logicalModel, leftKeys, rightKeys, row, col,
+           value, index, alias, description, maxRows, distinct, columnOrder, groupMappings,
+           groupOthers, variableValues, x, y, label, defaultValue, mode, insert, subtables,
+           sourceTable, attribute, endpoint, parameters, lookup, lookupExpandArrays,
+           lookupTopLevelOnly, suffix, customLookups, crosstab, labels, choices, joinPaths, null);
+   }
+
+   /**
+    * Compatibility constructor for callers built before {@code joinPaths} was added —
+    * defaults it to {@code null}.
+    */
+   public EditRequest(
+      String op, String table, String column, String name, String type, String newName,
+      String field, String operation, List<String> values, String direction,
+      List<WorksheetMutationSupport.GroupSpec> groups,
+      List<WorksheetMutationSupport.AggregateSpec> aggregates, String expression, boolean sql,
+      String leftTable, String leftKey, String rightTable, String rightKey, String joinType,
+      Boolean visible, List<String> tables, String source, String concatType,
+      List<WorksheetMutationSupport.ConditionNode> conditions,
+      WorksheetMutationSupport.RankingSpec ranking, Integer headerColumns, String dateOption,
+      double[] boundaries, String datasource, String schema, String catalog, String logicalModel,
+      List<String> leftKeys, List<String> rightKeys, Integer row, Integer col, String value,
+      Integer index, String alias, String description, Integer maxRows, Boolean distinct,
+      List<String> columnOrder, List<WorksheetMutationSupport.GroupMapping> groupMappings,
+      Boolean groupOthers, Map<String, String> variableValues, Integer x, Integer y, String label,
+      String defaultValue, String mode, Boolean insert, List<String> subtables,
+      String sourceTable, String attribute, String endpoint, Map<String, String> parameters,
+      List<String> lookup, Boolean lookupExpandArrays, Boolean lookupTopLevelOnly, String suffix,
+      List<WorksheetMutationSupport.CustomLookupSpec> customLookups, Boolean crosstab,
+      List<String> labels, WorksheetMutationSupport.VariableChoicesSpec choices)
+   {
+      this(op, table, column, name, type, newName, field, operation, values, direction, groups,
+           aggregates, expression, sql, leftTable, leftKey, rightTable, rightKey, joinType,
+           visible, tables, source, concatType, conditions, ranking, headerColumns, dateOption,
+           boundaries, datasource, schema, catalog, logicalModel, leftKeys, rightKeys, row, col,
+           value, index, alias, description, maxRows, distinct, columnOrder, groupMappings,
+           groupOthers, variableValues, x, y, label, defaultValue, mode, insert, subtables,
+           sourceTable, attribute, endpoint, parameters, lookup, lookupExpandArrays,
+           lookupTopLevelOnly, suffix, customLookups, crosstab, labels, choices, null);
+   }
+
    /**
     * Compatibility constructor for callers built before {@code crosstab} was added —
     * defaults {@code crosstab} and {@code labels} (added later, same reason) to {@code null}.
@@ -372,7 +493,7 @@ public record EditRequest(
            value, index, alias, description, maxRows, distinct, columnOrder, groupMappings,
            groupOthers, variableValues, x, y, label, defaultValue, mode, insert, subtables,
            sourceTable, attribute, endpoint, parameters, lookup, lookupExpandArrays,
-           lookupTopLevelOnly, suffix, customLookups, null, null, null, null);
+           lookupTopLevelOnly, suffix, customLookups, null, null);
    }
 
    /**
@@ -406,6 +527,6 @@ public record EditRequest(
            value, index, alias, description, maxRows, distinct, columnOrder, groupMappings,
            groupOthers, variableValues, x, y, label, defaultValue, mode, insert, subtables,
            sourceTable, attribute, endpoint, parameters, lookup, lookupExpandArrays,
-           lookupTopLevelOnly, suffix, customLookups, crosstab, labels, null, null);
+           lookupTopLevelOnly, suffix, customLookups, crosstab, labels, null);
    }
 }

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetAgentController.java
@@ -1823,7 +1823,8 @@ public class WorksheetAgentController {
             // which is the whole defect this op was fixed for.
             editor.setTableProperties(
                req.table(), req.newName() != null ? req.newName() : req.alias(),
-               req.description(), req.maxRows(), req.distinct());
+               req.description(), req.maxRows(), req.distinct(), req.mergeable(),
+               req.visibleInViewsheet());
          case "add_cross_join" ->
             editor.addCrossJoin(req.name(), req.leftTable(), req.rightTable());
          case "add_merge_join" ->

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetEditService.java
@@ -1847,6 +1847,8 @@ public class WorksheetEditService {
        * @param description table description, or {@code null} to leave unchanged
        * @param maxRows     max rows limit, or {@code null} to leave unchanged
        * @param distinct    distinct flag, or {@code null} to leave unchanged
+       * @param mergeable   SQL-mergeable flag, or {@code null} to leave unchanged
+       * @param visibleInViewsheet visible-in-viewsheet flag, or {@code null} to leave unchanged
        * @throws PairingException if the table is not found
        */
       /**
@@ -1866,7 +1868,8 @@ public class WorksheetEditService {
        * setters cannot fail, so ordering it this way makes the whole call all-or-nothing.
        */
       public void setTableProperties(String table, String newName, String description,
-                                      Integer maxRows, Boolean distinct)
+                                      Integer maxRows, Boolean distinct, Boolean mergeable,
+                                      Boolean visibleInViewsheet)
          throws PairingException
       {
          // Resolved before the rename so an unknown table is reported against the name the caller
@@ -1901,6 +1904,14 @@ public class WorksheetEditService {
 
          if(distinct != null) {
             t.setDistinct(distinct);
+         }
+
+         if(mergeable != null) {
+            t.setSQLMergeable(mergeable);
+         }
+
+         if(visibleInViewsheet != null) {
+            t.setVisibleTable(visibleInViewsheet);
          }
       }
 

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/WorksheetReadService.java
@@ -132,7 +132,7 @@ public class WorksheetReadService {
          // -1 and 0 both report null rather than reading back as a limit of -1 or of zero rows.
          // Note this is the effective limit, capped by query.runtime.maxrow; see TableModel.
          maxRows <= 0 ? null : maxRows,
-         t.isDistinct(), t.isVisibleTable(), tableMode(t),
+         t.isDistinct(), t.isSQLMergeable(), t.isVisibleTable(), tableMode(t),
          offset == null ? null : offset.x, offset == null ? null : offset.y);
    }
 

--- a/core/src/main/java/inetsoft/web/wiz/worksheet/model/WorksheetModel.java
+++ b/core/src/main/java/inetsoft/web/wiz/worksheet/model/WorksheetModel.java
@@ -100,6 +100,8 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
     *                           it is positive — and all of those report {@code null}, so {@code 0}
     *                           is not a limit of zero rows.
     * @param distinct           whether the table returns only distinct rows
+    * @param mergeable          whether the table's query is merged into a single SQL statement —
+    *                           the Composer's own table-properties dialog "Mergeable" checkbox
     * @param visibleInViewsheet whether the table is exposed to viewsheets bound to this sheet
     * @param mode               the table's display mode — {@code live}, {@code full},
     *                           {@code detail} or {@code edit} — derived from the same three flags
@@ -132,6 +134,7 @@ public record WorksheetModel(List<TableModel> tables, List<VariableModel> variab
       String description,
       Integer maxRows,
       boolean distinct,
+      boolean mergeable,
       boolean visibleInViewsheet,
       String mode,
       Integer x,

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetEditServiceMutatorsTest.java
@@ -3507,7 +3507,8 @@ class WorksheetEditServiceMutatorsTest {
       Principal agent = TestPrincipals.user("alice", "host-org");
       WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
 
-      svc.apply("TOK", agent, ed -> ed.setTableProperties("T", "Scores", null, null, null));
+      svc.apply("TOK", agent,
+                ed -> ed.setTableProperties("T", "Scores", null, null, null, null, null));
 
       assertNotNull(ws.getAssembly("Scores"));
       assertNull(ws.getAssembly("T"));
@@ -3522,12 +3523,77 @@ class WorksheetEditServiceMutatorsTest {
       WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
 
       svc.apply("TOK", agent,
-                ed -> ed.setTableProperties("T", "Scores", "the description", 25, true));
+                ed -> ed.setTableProperties(
+                   "T", "Scores", "the description", 25, true, false, false));
 
       TableAssembly renamed = (TableAssembly) ws.getAssembly("Scores");
       assertEquals("the description", renamed.getDescription());
       assertEquals(25, renamed.getMaxRows());
       assertTrue(renamed.isDistinct());
+      assertFalse(renamed.isSQLMergeable());
+      assertFalse(renamed.isVisibleTable());
+   }
+
+   @Test
+   void setTablePropertiesSetsTheMergeableFlag() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly t = TestWorksheets.nonEmbeddedTableWithColumns(ws, "T", "a");
+      t.setSQLMergeable(true);
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent,
+                ed -> ed.setTableProperties("T", null, null, null, null, false, null));
+
+      assertFalse(((TableAssembly) ws.getAssembly("T")).isSQLMergeable());
+   }
+
+   @Test
+   void omittingMergeableLeavesTheExistingFlagAlone() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly t = TestWorksheets.nonEmbeddedTableWithColumns(ws, "T", "a");
+      t.setSQLMergeable(false);
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent,
+                ed -> ed.setTableProperties("T", null, "note", null, null, null, null));
+
+      assertFalse(((TableAssembly) ws.getAssembly("T")).isSQLMergeable(),
+                  "mergeable was omitted, so the existing flag must be untouched");
+   }
+
+   @Test
+   void setTablePropertiesSetsTheVisibleInViewsheetFlag() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly t = TestWorksheets.nonEmbeddedTableWithColumns(ws, "T", "a");
+      t.setVisibleTable(true);
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent,
+                ed -> ed.setTableProperties("T", null, null, null, null, null, false));
+
+      assertFalse(((TableAssembly) ws.getAssembly("T")).isVisibleTable());
+   }
+
+   @Test
+   void omittingVisibleInViewsheetLeavesTheExistingFlagAlone() throws Exception {
+      Worksheet ws = new Worksheet();
+      TableAssembly t = TestWorksheets.nonEmbeddedTableWithColumns(ws, "T", "a");
+      t.setVisibleTable(false);
+      ws.addAssembly(t);
+      Principal agent = TestPrincipals.user("alice", "host-org");
+      WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
+
+      svc.apply("TOK", agent,
+                ed -> ed.setTableProperties("T", null, "note", null, null, null, null));
+
+      assertFalse(((TableAssembly) ws.getAssembly("T")).isVisibleTable(),
+                  "visibleInViewsheet was omitted, so the existing flag must be untouched");
    }
 
    /**
@@ -3545,7 +3611,8 @@ class WorksheetEditServiceMutatorsTest {
       WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
 
       assertThrows(Exception.class, () -> svc.apply(
-         "TOK", agent, ed -> ed.setTableProperties("T", "Taken", "should not land", 9, true)));
+         "TOK", agent,
+         ed -> ed.setTableProperties("T", "Taken", "should not land", 9, true, null, null)));
 
       TableAssembly untouched = (TableAssembly) ws.getAssembly("T");
       assertNotNull(untouched, "the table must keep its original name");
@@ -3560,7 +3627,8 @@ class WorksheetEditServiceMutatorsTest {
       Principal agent = TestPrincipals.user("alice", "host-org");
       WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
 
-      svc.apply("TOK", agent, ed -> ed.setTableProperties("T", null, "just a note", null, null));
+      svc.apply("TOK", agent,
+                ed -> ed.setTableProperties("T", null, "just a note", null, null, null, null));
 
       assertNotNull(ws.getAssembly("T"));
       assertEquals("just a note", ((TableAssembly) ws.getAssembly("T")).getDescription());
@@ -3579,7 +3647,8 @@ class WorksheetEditServiceMutatorsTest {
       WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
 
       assertThrows(Exception.class, () -> svc.apply(
-         "TOK", agent, ed -> ed.setTableProperties("T", "   ", "should not land", null, null)));
+         "TOK", agent,
+         ed -> ed.setTableProperties("T", "   ", "should not land", null, null, null, null)));
 
       assertNotNull(ws.getAssembly("T"), "the table keeps its name");
       assertNull(((TableAssembly) ws.getAssembly("T")).getDescription(),
@@ -3595,7 +3664,8 @@ class WorksheetEditServiceMutatorsTest {
       Principal agent = TestPrincipals.user("alice", "host-org");
       WorksheetEditService svc = service(rws(ws), "Worksheet/ws1", agent, "TOK");
 
-      svc.apply("TOK", agent, ed -> ed.setTableProperties("T", "T", "kept", null, null));
+      svc.apply("TOK", agent,
+                ed -> ed.setTableProperties("T", "T", "kept", null, null, null, null));
 
       assertEquals("kept", ((TableAssembly) ws.getAssembly("T")).getDescription());
    }

--- a/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/worksheet/WorksheetReadServiceTest.java
@@ -590,6 +590,7 @@ class WorksheetReadServiceTest {
       t.setDescription("what this table is for");
       t.setMaxRows(25);
       t.setDistinct(true);
+      t.setSQLMergeable(false);
       ws.addAssembly(t);
 
       WorksheetModel.TableModel m = tableNamed(read(ws), "T");
@@ -597,6 +598,7 @@ class WorksheetReadServiceTest {
       assertEquals("what this table is for", m.description());
       assertEquals(Integer.valueOf(25), m.maxRows());
       assertTrue(m.distinct());
+      assertFalse(m.mergeable());
    }
 
    /**


### PR DESCRIPTION
## Summary

The AI agent's worksheet-editing REST API (`set_table_properties`, backing the `stylebi-composer-chat` plugin's tool of the same name) previously supported only `newName`/`description`/`maxRows`/`distinct`, with no way to read or write a worksheet table's Advanced **"Mergeable"** checkbox or its **"Visible in Viewsheet"** checkbox — both already supported by the Composer's own table-properties dialog via `TableAssembly.setSQLMergeable`/`setVisibleTable`.

## Root Cause

`EditRequest`, `WorksheetAgentController.dispatch()`, and `WorksheetEditService.Editor#setTableProperties` simply never carried these two fields, and the read-side `WorksheetModel.TableModel` / `WorksheetReadService` never reported `mergeable` (it already reported `visibleInViewsheet` for read).

## Fix

- Added `mergeable` and `visibleInViewsheet` as optional fields on `EditRequest` (new backward-compatible constructor overloads preserve every existing caller).
- Threaded both through `WorksheetAgentController`'s dispatch and `WorksheetEditService.Editor#setTableProperties` — `null` continues to mean "leave unchanged", matching `distinct`.
- Added `mergeable` to `WorksheetModel.TableModel` / `WorksheetReadService` so the read side reports both flags.

## Test Plan

- [x] `mvnw -pl core -am test-compile` — clean compile
- [x] `mvnw -pl core test -Dtest=WorksheetEditServiceMutatorsTest,WorksheetReadServiceTest,WorksheetAgentControllerTest` — 264/264 pass, including new tests for both flags (set + omit-leaves-unchanged cases)
- [x] Code review pass (2 rounds) with no blocking issues

Fixes Redmine #76346.