### PR TITLE
Bug #76018, re-save runtime partition after shrinkColumnHeight in physical model editor

### DIFF
--- a/core/src/main/java/inetsoft/web/portal/controller/database/PhysicalModelManagerService.java
+++ b/core/src/main/java/inetsoft/web/portal/controller/database/PhysicalModelManagerService.java
@@ -110,6 +110,13 @@ public class PhysicalModelManagerService {
       // for table location of portal <--- studio
       graphService.shrinkColumnHeight(runtimeXPartition);
 
+      // RuntimePartitionService.openModel() cached runtimeXPartition before the shrink
+      // above was applied, and the cache stores a serialized copy -- so without saving
+      // again here, every other reader of this runtime id (e.g. the graph-model fetch
+      // the client issues right after opening the view) would see the un-shrunk,
+      // Studio-scale positions instead of the compact Portal ones.
+      this.runtimePartitionService.saveRuntimePartition(runtimeXPartition);
+
       return physicalModelService.createModel(dataModel, runtimeXPartition);
    }
 
@@ -169,6 +176,11 @@ public class PhysicalModelManagerService {
 
       // for table location of portal <--- studio
       graphService.shrinkColumnHeight(rp);
+
+      // see the identical comment in openModel(): the cache entry for rp was written
+      // before this shrink, and stores a serialized copy, so it must be re-saved here
+      // or other readers of this runtime id will see the un-shrunk positions.
+      this.runtimePartitionService.saveRuntimePartition(rp);
 
       return physicalModelService.createModel(dataModel, rp);
    }


### PR DESCRIPTION
## Summary

In the Physical Model (physical view) editor, applying Auto Layout, saving, and reopening the view showed the layout reverted instead of preserved.

## Root Cause

`RuntimePartitionService` caches `RuntimeXPartition` objects in a serializing cache, so any `cache.get()` returns a deserialized copy disconnected from an in-memory object mutated after the cache write (the same class of bug previously fixed in #75893 for Bug #75893).

`PhysicalModelManagerService.openModel()` and `.createModel()` both:
1. Build a `RuntimeXPartition` from the persisted (Studio-scale) partition via `RuntimePartitionService`, which caches it immediately.
2. Call `graphService.shrinkColumnHeight(...)` on that same in-memory object, converting Studio-scale (full column-height) table positions to compact Portal-scale positions — but never save that mutation back to the cache.
3. Return a `PhysicalModelDefinition` built directly from the correctly-shrunk in-memory object, so the very first page paint looks right.
4. The frontend immediately issues a follow-up `POST /api/data/physicalmodel/graph` request, which reads the partition back out of the cache — getting the stale, un-shrunk copy. This renders the wrong (stretched-out) layout, and is also what a later Save reads and persists, discarding whatever layout (including one just set via Auto Layout) the user actually saw.

Confirmed via live reproduction with temporary diagnostic logging (since removed): the raw partition bounds correctly round-tripped through shrink, but the graph model actually returned to the client used stale (un-shrunk) values.

## Fix

Re-save the runtime partition to the cache immediately after `shrinkColumnHeight(...)` in both `openModel()` and `createModel()`, so the cache reflects the shrunk state before any other reader can observe it. A code-reviewer pass confirmed the other `shrinkColumnHeight`/`unfoldColumnHeight` call sites already have a proper save afterward, so these were the only two gaps.

## Test Plan

- [x] `core` module builds cleanly (`clean test-compile`)
- [x] Existing `PhysicalGraphServiceTests` (5 tests) still pass
- [x] Manually reproduced and confirmed fixed: open a physical view, Auto Layout → Vertical, Save, reopen — layout now persists correctly

Fixes Redmine #76018.