### PR TITLE
Bug #76000, skip imported bookmarks whose owner does not exist

### DIFF
--- a/core/src/main/java/inetsoft/sree/internal/DeployManagerService.java
+++ b/core/src/main/java/inetsoft/sree/internal/DeployManagerService.java
@@ -1080,6 +1080,13 @@ public class DeployManagerService {
 
                IdentityID userID = IdentityID.getIdentityIDFromKey(userName);
                userID.setOrgID(OrganizationManager.getInstance().getCurrentOrgID());
+
+               // Bookmarks for an owner that does not exist in this organization are skipped
+               // by ViewsheetAsset.parseContent0(), so never prompt to resolve them.
+               if(!ViewsheetAsset.bookmarkOwnerExists(userID)) {
+                  continue;
+               }
+
                VSBookmark existing = engine.getVSBookmark(entry, new XPrincipal(userID));
 
                if(existing == null) {

--- a/core/src/main/java/inetsoft/util/dep/ViewsheetAsset.java
+++ b/core/src/main/java/inetsoft/util/dep/ViewsheetAsset.java
@@ -497,6 +497,18 @@ public class ViewsheetAsset extends AbstractSheetAsset implements FolderChangeab
 
          IdentityID identityID = IdentityID.getIdentityIDFromKey(name);
          identityID.setOrgID(OrganizationManager.getInstance().getCurrentOrgID());
+
+         // The owner is carried verbatim in the JAR and only has its org remapped above. If
+         // that user does not exist here (renamed, deleted, or never present in this org),
+         // importing the block would create bookmarks no one can reach. Skip just this owner
+         // -- other users' bookmarks in the same <AllBookmarks> block must still import.
+         if(!bookmarkOwnerExists(identityID)) {
+            LOG.warn("Skipping imported bookmarks for viewsheet '{}': user '{}' does not " +
+               "exist in organization '{}'", entry.getPath(), identityID.getName(),
+               identityID.getOrgID());
+            continue;
+         }
+
          XPrincipal principal = new XPrincipal(identityID);
          VSBookmark existing = engine.getVSBookmark(entry, principal);
 
@@ -827,6 +839,60 @@ public class ViewsheetAsset extends AbstractSheetAsset implements FolderChangeab
          {
             dependencies.add(newList.get(i));
          }
+      }
+   }
+
+   /**
+    * Check whether the owner of an imported {@code <AllBookmarks>} block actually exists in
+    * the target organization.
+    *
+    * <p>Bookmark owners are carried verbatim in the deployment JAR and only have their org ID
+    * remapped on import. If the named user does not exist on the target server -- because it
+    * was renamed, deleted, or never existed in this organization -- writing the bookmark would
+    * create an entry no one can ever reach. Callers skip those blocks instead.
+    *
+    * <p>This mirrors the owner validation that {@code DeployService.validateUsers()} applies
+    * to user-scoped asset owners, including its anonymous exemption. Unlike that method this
+    * is not fatal: a bookmark is auxiliary data and must never abort an otherwise valid
+    * import, so every failure path here fails open. It also omits that method's
+    * unregistered-user exemption -- an unregistered user is a {@code sreeUserData} file with
+    * no security identity, which is the orphan case itself.
+    *
+    * @param owner the org-corrected owner of the bookmark block.
+    *
+    * @return {@code true} if the bookmarks should be imported.
+    */
+   public static boolean bookmarkOwnerExists(IdentityID owner) {
+      if(owner == null || Tool.isEmptyString(owner.name)) {
+         return true;
+      }
+
+      if(XPrincipal.ANONYMOUS.equals(owner.name) || "_NULL_".equals(owner.name)) {
+         return true;
+      }
+
+      try {
+         SecurityProvider provider = SecurityEngine.getSecurity().getSecurityProvider();
+
+         // A virtual provider only recognizes admin/system/anonymous, so its getUser() cannot
+         // prove that any other name is absent. Test isVirtual() rather than
+         // isSecurityEnabled(): getSecurityProvider() also falls back to the virtual provider
+         // when security IS enabled but no real provider has been initialized, and
+         // AuthenticationChain.isVirtual() likewise reports true for a chain with no real
+         // providers. Trusting it there would drop every non-admin owner's bookmarks.
+         if(provider == null || provider.isVirtual()) {
+            return true;
+         }
+
+         return provider.getUser(owner) != null;
+      }
+      catch(Exception e) {
+         // Both SecurityEngine.getSecurity() (Spring bean lookup) and an external provider's
+         // getUser() (LDAP/SSO connection) can throw. parseContent0 declares throws Exception,
+         // so letting one escape would fail the whole viewsheet import over auxiliary data.
+         LOG.warn("Failed to check whether bookmark owner '{}' exists; importing its " +
+            "bookmarks anyway", owner.getName(), e);
+         return true;
       }
    }
 

--- a/core/src/test/java/inetsoft/util/dep/ViewsheetAssetBookmarkOwnerTest.java
+++ b/core/src/test/java/inetsoft/util/dep/ViewsheetAssetBookmarkOwnerTest.java
@@ -1,0 +1,163 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2025  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.util.dep;
+
+/*
+ * Regression tests for the orphan-bookmark import bug.
+ *
+ * Bookmark owners ride inside the viewsheet's JAR entry as an <AllBookmarks> block and are
+ * carried verbatim; only the org ID is remapped on import. Importing a package into an org
+ * where the named user no longer exists (e.g. it was renamed) used to write a bookmark under
+ * that dead identity, producing a row in the bookmark list that no one can ever reach.
+ *
+ * ViewsheetAsset.bookmarkOwnerExists() is the guard both the import path
+ * (ViewsheetAsset.parseContent0) and the conflict scan
+ * (DeployManagerService.getBookmarkConflicts) consult, so it is tested directly here.
+ *
+ * Coverage scope:
+ *   [security on, user missing]     owner rejected -> caller skips the block
+ *   [security on, user present]     owner accepted -> unchanged behavior
+ *   [security on, anonymous/_NULL_] owner accepted (matches DeployService.importAsset)
+ *   [virtual provider]              always accepted; getUser() is never consulted
+ *   [null / blank owner]            accepted; malformed input is not this guard's job
+ *   [no provider]                   accepted; cannot prove absence without a provider
+ *   [engine / provider throws]      accepted; must never fail the viewsheet import
+ */
+
+import inetsoft.sree.security.*;
+import inetsoft.uql.XPrincipal;
+import org.junit.jupiter.api.*;
+import org.mockito.MockedStatic;
+import org.mockito.quality.Strictness;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Tag("core")
+class ViewsheetAssetBookmarkOwnerTest {
+   private static final String ORG = "org0";
+
+   private MockedStatic<SecurityEngine> securityEngineMock;
+   private SecurityEngine mockEngine;
+   private SecurityProvider mockProvider;
+
+   @BeforeEach
+   void setUp() {
+      securityEngineMock =
+         mockStatic(SecurityEngine.class, withSettings().strictness(Strictness.LENIENT));
+      mockEngine = mock(SecurityEngine.class, withSettings().lenient());
+      mockProvider = mock(SecurityProvider.class, withSettings().lenient());
+      when(mockEngine.getSecurityProvider()).thenReturn(mockProvider);
+      // stubbed explicitly rather than relying on Mockito's false for the isVirtual() default
+      // method: the whole guard hinges on this value
+      when(mockProvider.isVirtual()).thenReturn(false);
+      securityEngineMock.when(SecurityEngine::getSecurity).thenReturn(mockEngine);
+   }
+
+   @AfterEach
+   void tearDown() {
+      securityEngineMock.close();
+   }
+
+   private static IdentityID id(String name) {
+      return new IdentityID(name, ORG);
+   }
+
+   // ── the reported bug: admin was renamed to test, so admin no longer exists ──
+
+   // [security on, user missing] the whole point of the fix
+   @Test
+   void bookmarkOwnerExists_userRenamedAway_rejected() {
+      when(mockProvider.getUser(id("admin"))).thenReturn(null);
+
+      assertFalse(ViewsheetAsset.bookmarkOwnerExists(id("admin")));
+   }
+
+   // [security on, user present] the surviving owner in the same <AllBookmarks> block still
+   // imports — the guard must reject per-owner, not per-viewsheet
+   @Test
+   void bookmarkOwnerExists_existingUser_accepted() {
+      when(mockProvider.getUser(id("test"))).thenReturn(new FSUser(id("test")));
+
+      assertTrue(ViewsheetAsset.bookmarkOwnerExists(id("test")));
+   }
+
+   // ── exemptions mirroring DeployService.validateUsers / importAsset ──
+
+   // [security on, anonymous] no-security exports name anonymous as the owner
+   @Test
+   void bookmarkOwnerExists_anonymous_accepted() {
+      when(mockProvider.getUser(any(IdentityID.class))).thenReturn(null);
+
+      assertTrue(ViewsheetAsset.bookmarkOwnerExists(id(XPrincipal.ANONYMOUS)));
+      assertTrue(ViewsheetAsset.bookmarkOwnerExists(id("_NULL_")));
+   }
+
+   // ── a virtual provider only knows admin/system/anonymous, so its getUser() cannot prove
+   //    any other name is absent ──
+
+   // [virtual provider] accepted without ever consulting getUser(). SecurityEngine returns the
+   // virtual provider both when security is off AND when security is on but no real provider
+   // was initialized, so gating on isSecurityEnabled() instead would drop every non-admin
+   // owner's bookmarks in that second case.
+   @Test
+   void bookmarkOwnerExists_virtualProvider_acceptedWithoutUserLookup() {
+      when(mockProvider.isVirtual()).thenReturn(true);
+
+      assertTrue(ViewsheetAsset.bookmarkOwnerExists(id("anyone")));
+      verify(mockProvider, never()).getUser(any(IdentityID.class));
+   }
+
+   // ── defensive cases: never block an import on input this guard cannot judge ──
+
+   // [null / blank owner] malformed blocks are already skipped by parseContent0
+   @Test
+   void bookmarkOwnerExists_nullOrBlankOwner_accepted() {
+      assertTrue(ViewsheetAsset.bookmarkOwnerExists(null));
+      assertTrue(ViewsheetAsset.bookmarkOwnerExists(id("")));
+      assertTrue(ViewsheetAsset.bookmarkOwnerExists(id(null)));
+   }
+
+   // [no provider] absence cannot be proven, so do not drop data
+   @Test
+   void bookmarkOwnerExists_noSecurityProvider_accepted() {
+      when(mockEngine.getSecurityProvider()).thenReturn(null);
+
+      assertTrue(ViewsheetAsset.bookmarkOwnerExists(id("admin")));
+   }
+
+   // ── fail open: parseContent0 declares throws Exception, so an escape here would fail the
+   //    entire viewsheet import over auxiliary data ──
+
+   // [engine throws] Spring bean lookup fails (minimal context: shell, scheduler, initializer)
+   @Test
+   void bookmarkOwnerExists_securityEngineThrows_accepted() {
+      securityEngineMock.when(SecurityEngine::getSecurity)
+         .thenThrow(new RuntimeException("no application context"));
+
+      assertTrue(ViewsheetAsset.bookmarkOwnerExists(id("admin")));
+   }
+
+   // [provider throws] external provider (LDAP/SSO) connection failure
+   @Test
+   void bookmarkOwnerExists_providerLookupThrows_accepted() {
+      when(mockProvider.getUser(id("admin"))).thenThrow(new RuntimeException("LDAP down"));
+
+      assertTrue(ViewsheetAsset.bookmarkOwnerExists(id("admin")));
+   }
+}


### PR DESCRIPTION
## Problem

Importing a bookmark-containing asset package into an organization where the bookmark's owner has since been renamed creates a bookmark owned by a user that no longer exists — an orphan row in the bookmark list that no one can reach. No conflict prompt appears; the import just completes.

Reproduction from the report:

1. Site admin imports the package (a viewsheet `chart` + worksheet `chartUI`, exported from `host-org`).
2. Clone a new `org0` — `admin` and its bookmark `bk1` are copied over.
3. Rename `admin` → `test` in `org0`.
4. Import the same package into `org0`.

Result: two `bk1` rows — one owned by `test`, one owned by the now-nonexistent `admin`.

## Root cause

Bookmarks are not separate JAR entries; they ride inside the viewsheet's own JAR entry as an `<AllBookmarks>` block. Unpacking the attached package confirms it contains `<name>admin~;~host-org</name>` verbatim.

`ViewsheetAsset.parseContent0()` took that owner name as-is and only remapped the org ID:

```java
IdentityID identityID = IdentityID.getIdentityIDFromKey(name);   // "admin"
identityID.setOrgID(OrganizationManager.getInstance().getCurrentOrgID()); // -> org0
```

Nothing checked that `admin` exists in `org0`, and `setVSBookmark()` then wrote straight to `IndexedStorage` under that dead identity.

The missing prompt has the same source: `AbstractAssetEngine.getVSBookmark()` returns a **new empty** `VSBookmark` rather than `null` when nothing is stored, so `getBookmarkConflicts()` found no existing `bk1` for `admin` and emitted no conflict row.

The rename side is working correctly — `UserTreeService.renameUserAsset()` → `BlobIndexedStorage.migrateStorageData()` does move the bookmark key from `admin~;~org0` to `test~;~org0`. `admin` genuinely owned nothing at step 4; the import created the orphan from scratch.

`DeployService.validateUsers()` already applies exactly this existence check to user-scoped **asset owners** — bookmark owners were simply never fed into it.

## Fix

- New `ViewsheetAsset.bookmarkOwnerExists()`, consulted from both `parseContent0()` (import) and `DeployManagerService.getBookmarkConflicts()` (conflict scan) so the two cannot disagree.
- Skips just that owner's block with a warning — `continue`, not `return`, so other users' bookmarks in the same viewsheet still import.
- Anonymous / `_NULL_` owners are exempt, matching `DeployService.importAsset`.

Two details worth calling out for review:

**The guard tests `SecurityProvider.isVirtual()`, not `isSecurityEnabled()`.** `SecurityEngine.getSecurityProvider()` is `if(isSecurityEnabled() && provider != null) return provider; return vprovider;` — with security *enabled* but the provider not yet initialized it returns the virtual provider, which only recognizes `admin`/`system`/`anonymous`. Gating on `isSecurityEnabled()` would silently drop every other owner's bookmarks in that window. `AuthenticationChain.isVirtual()` reports true for an all-virtual or empty chain too, covering the same hole. Same pattern as `MVManager.java:463`.

**Every failure path fails open.** `parseContent0` declares `throws Exception`, so an escaping `SecurityEngine.getSecurity()` (Spring bean lookup) or `provider.getUser()` (LDAP/SSO) would fail the whole viewsheet import over auxiliary data. Both are inside the try, mirroring the existing `getAllUsers()` in the same class.

The unregistered-user exemption that `validateUsers` applies is deliberately **not** mirrored: an unregistered user is a `sreeUserData` file with no security identity, which is the orphan case itself. (Separately, `SUtil.getUnregisteredUsers()` builds a `Set<String>` and returns it via `toArray(new IdentityID[0])`, which throws `ArrayStoreException` whenever the set is non-empty — a pre-existing latent defect, not touched here.)

## Testing

New `ViewsheetAssetBookmarkOwnerTest` (8 tests) covers the renamed-away owner, a surviving owner in the same block, anonymous/`_NULL_`, a virtual provider, a null provider, null/blank owners, and both throw paths. Both new guards were mutation-tested — removing the `isVirtual()` check or the try/catch fails the corresponding tests. `ImportAssetControllerTest` still passes (13/13 total).


🤖 Generated with [Claude Code](https://claude.com/claude-code)
