### PR TITLE
feat(admin-chat): server license key add/remove (Track C.5 area 5)

### DIFF
--- a/core/src/main/java/inetsoft/web/admin/ai/licensing/AdminLicensingController.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/licensing/AdminLicensingController.java
@@ -77,11 +77,19 @@ public class AdminLicensingController {
          .collect(Collectors.toList()));
    }
 
+   /**
+    * {@code key} is a query parameter, not a {@code {key}} path-variable segment -- 07-fix-r1-java.md:
+    * this repo's embedded Tomcat 10.1.x rejects a literal {@code %2F} in a request URI by default
+    * (`encodedSolidusHandling`), so a candidate key string containing a slash would 400 before ever
+    * reaching Spring MVC routing, not get this method's own clean {@code found: false} miss --
+    * the same defect class (and the same fix) Viewsheets' own {@code get_viewsheet_folder} found and
+    * applied first (`AdminViewsheetController#getFolder`).
+    */
    @Secured(@RequiredPermission(
       resourceType = ResourceType.EM_COMPONENT, resource = "settings/general",
       actions = ResourceAction.ACCESS))
-   @GetMapping("/api/wiz/v1/admin/licensing/keys/{key}")
-   public LicenseKeyLookupResult getLicenseKey(@PathVariable("key") String key, Principal user) {
+   @GetMapping("/api/wiz/v1/admin/licensing/key")
+   public LicenseKeyLookupResult getLicenseKey(@RequestParam("key") String key, Principal user) {
       requireSiteAdmin(user);
       requireEnterprise();
       Optional<License> found = licenseManager.getInstalledLicenses().stream()

--- a/core/src/main/java/inetsoft/web/admin/ai/licensing/AdminLicensingController.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/licensing/AdminLicensingController.java
@@ -1,0 +1,166 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.licensing;
+
+import inetsoft.report.internal.license.License;
+import inetsoft.report.internal.license.LicenseManager;
+import inetsoft.sree.security.*;
+import inetsoft.web.admin.ai.AdminAiCallerGuard;
+import inetsoft.web.admin.ai.AdminChangesetApplyService;
+import inetsoft.web.admin.ai.ResolvedPlan;
+import inetsoft.web.security.RequiredPermission;
+import inetsoft.web.security.Secured;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.security.Principal;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * REST controller for the licensing admin-plugin area (01-spec.md section 10). Placed in
+ * {@code community/core}, not {@code enterprise/} -- {@code LicenseKeySettingsService}/
+ * {@code LicenseManager} both already live in {@code community/core}, only the
+ * {@code LicenseStrategy} implementation ({@code EnterpriseLicenseStrategy}) lives in
+ * {@code enterprise/}, loaded reflectively (01-spec.md section 10).
+ *
+ * <p><b>03-reconcile.md addition 1, build-blocking:</b> unlike every other community-placed area
+ * (providers, cluster), community placement here does NOT mean this area works correctly on a
+ * community-only deployment. {@code LicenseManager} falls back to {@code NoopLicenseStrategy} when
+ * the enterprise module is absent, whose {@code parseLicense} ignores its argument and returns a
+ * default {@code License} with null {@code type()}/{@code expires()} -- calling
+ * {@code License.valid()} on that object throws an unhandled NPE
+ * ({@code LocalDateTime.now().isBefore(null)}), and its {@code getInstalledLicenses()} returns a
+ * permanent phantom single null-key entry, never empty. {@link #requireEnterprise()} refuses loud,
+ * on all four endpoints (reads included), before any of that code is ever reached.
+ */
+@RestController
+public class AdminLicensingController {
+   @Autowired
+   public AdminLicensingController(LicenseManager licenseManager,
+                                   LicenseChangePlanService planService,
+                                   LicenseChangesetApplyService applyService)
+   {
+      this.licenseManager = licenseManager;
+      this.planService = planService;
+      this.applyService = applyService;
+   }
+
+   @Secured(@RequiredPermission(
+      resourceType = ResourceType.EM_COMPONENT, resource = "settings/general",
+      actions = ResourceAction.ACCESS))
+   @GetMapping("/api/wiz/v1/admin/licensing/keys")
+   public LicenseKeyListResponse listLicenseKeys(Principal user) {
+      requireSiteAdmin(user);
+      requireEnterprise();
+      return new LicenseKeyListResponse(licenseManager.getInstalledLicenses().stream()
+         .map(LicenseKeyProjection::of)
+         .collect(Collectors.toList()));
+   }
+
+   @Secured(@RequiredPermission(
+      resourceType = ResourceType.EM_COMPONENT, resource = "settings/general",
+      actions = ResourceAction.ACCESS))
+   @GetMapping("/api/wiz/v1/admin/licensing/keys/{key}")
+   public LicenseKeyLookupResult getLicenseKey(@PathVariable("key") String key, Principal user) {
+      requireSiteAdmin(user);
+      requireEnterprise();
+      Optional<License> found = licenseManager.getInstalledLicenses().stream()
+         .filter(l -> Objects.equals(l.key(), key))
+         .findFirst();
+      return found.map(license -> new LicenseKeyLookupResult(true, LicenseKeyProjection.of(license)))
+         .orElseGet(() -> new LicenseKeyLookupResult(false, null));
+   }
+
+   /**
+    * Resolves a license key change plan (add/remove) without mutating anything. See
+    * {@code AdminAiController#preview} for the shape this mirrors.
+    */
+   @Secured(@RequiredPermission(
+      resourceType = ResourceType.EM_COMPONENT, resource = "settings/general",
+      actions = ResourceAction.ACCESS))
+   @PostMapping("/api/wiz/v1/admin/licensing/preview")
+   public ResolvedPlan preview(@RequestBody LicenseChangePlanRequest req, Principal user) {
+      requireSiteAdmin(user);
+      requireEnterprise();
+      return planService.resolve(req);
+   }
+
+   /**
+    * Applies a reviewed license change plan. Every verb in this area requires a Tier-2 backup
+    * (01-spec.md section 4/6/7/14 D4 -- unconditional), taken synchronously inside
+    * {@link LicenseChangesetApplyService#apply} before any mutation.
+    */
+   @Secured(@RequiredPermission(
+      resourceType = ResourceType.EM_COMPONENT, resource = "settings/general",
+      actions = ResourceAction.ACCESS))
+   @PostMapping("/api/wiz/v1/admin/licensing/apply")
+   public LicenseApplyResult apply(@RequestBody LicenseApplyRequest req, Principal user)
+      throws Exception
+   {
+      requireSiteAdmin(user);
+      requireEnterprise();
+      return applyService.apply(req, user);
+   }
+
+   /** Same rationale and shape as {@code AdminProviderController#requireSiteAdmin} -- see there. */
+   private void requireSiteAdmin(Principal user) {
+      AdminAiCallerGuard.requireBearerAuthenticatedRequest();
+
+      if(!OrganizationManager.getInstance().isSiteAdmin(user)) {
+         throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Site Administrator role required");
+      }
+   }
+
+   /** 03-reconcile.md addition 1 -- checked after authentication/authorization so an
+    * unauthenticated or non-site-admin caller learns nothing about the deployment's licensing tier
+    * before being refused for the more fundamental reason. 404, matching every other
+    * enterprise-only area's HTTP contract even though the mechanism differs (those areas' classes
+    * simply do not exist on community; this area's classes do, so the check is explicit). */
+   private static void requireEnterprise() {
+      if(!LicenseManager.isEnterprise()) {
+         throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+            "licensing management requires the enterprise module");
+      }
+   }
+
+   @ExceptionHandler(IllegalArgumentException.class)
+   @ResponseStatus(HttpStatus.BAD_REQUEST)
+   @ResponseBody
+   public Map<String, String> handleIllegalArgument(IllegalArgumentException ex) {
+      return Map.of("status", "failed", "error", String.valueOf(ex.getMessage()));
+   }
+
+   @ExceptionHandler(AdminChangesetApplyService.PlanHashMismatchException.class)
+   @ResponseStatus(HttpStatus.CONFLICT)
+   @ResponseBody
+   public Map<String, Object> handlePlanHashMismatch(
+      AdminChangesetApplyService.PlanHashMismatchException ex)
+   {
+      return Map.of("status", "conflict", "error", String.valueOf(ex.getMessage()),
+                    "plan", ex.current());
+   }
+
+   private final LicenseManager licenseManager;
+   private final LicenseChangePlanService planService;
+   private final LicenseChangesetApplyService applyService;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/licensing/LicenseApplyOutcome.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/licensing/LicenseApplyOutcome.java
@@ -1,0 +1,33 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.licensing;
+
+/**
+ * Outcome of one attempted license key change -- identical shape to the shared
+ * {@code inetsoft.web.admin.ai.ApplyOutcome} plus one field, {@code advisory}, matching
+ * {@code ProviderApplyOutcome}'s own "replicate, don't generalize" precedent (01-spec.md section 6).
+ *
+ * @param advisory non-error, non-null-only-when-relevant disclosure the caller must relay to the
+ *                 human verbatim (01-spec.md section 4/6): the claiming-node-drift notice on a
+ *                 successful {@code remove} rollback (re-add landed the key on a different cluster
+ *                 node than before).
+ */
+public record LicenseApplyOutcome(String property, String before, String after, String status,
+                                  String error, String advisory)
+{
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/licensing/LicenseApplyRequest.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/licensing/LicenseApplyRequest.java
@@ -1,0 +1,41 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.licensing;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Request body for {@code POST /api/wiz/v1/admin/licensing/apply}: a plan request plus the hash
+ * from {@code preview}. {@code acknowledgeDelicensing} must be exactly {@code true} when the
+ * freshly re-resolved plan would leave zero installed license keys (01-spec.md section 5/6) --
+ * an advisory gate, not a hard refusal (section 14 D3), mirroring
+ * {@code DataSourceApplyRequest.acknowledgeIrreversibleDelete}'s shape, not its meaning: that flag
+ * gates a non-compensable action, this one gates a reversible-but-severe one.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class LicenseApplyRequest extends LicenseChangePlanRequest {
+   public String getPlanHash() { return planHash; }
+   public void setPlanHash(String v) { this.planHash = v; }
+   public String getReviewOutcome() { return reviewOutcome; }
+   public void setReviewOutcome(String v) { this.reviewOutcome = v; }
+   public Boolean getAcknowledgeDelicensing() { return acknowledgeDelicensing; }
+   public void setAcknowledgeDelicensing(Boolean v) { this.acknowledgeDelicensing = v; }
+
+   private String planHash, reviewOutcome;
+   private Boolean acknowledgeDelicensing;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/licensing/LicenseApplyResult.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/licensing/LicenseApplyResult.java
@@ -1,0 +1,36 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.licensing;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import inetsoft.web.admin.ai.RollbackFailure;
+
+import java.util.List;
+
+/**
+ * Result of applying a whole license changeset -- identical shape to the shared
+ * {@code inetsoft.web.admin.ai.ApplyResult} except {@code results} carries
+ * {@link LicenseApplyOutcome}. {@code rollbackFailures} reuses the shared {@code RollbackFailure}
+ * unmodified.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record LicenseApplyResult(String transactionId, String status, String backupRef,
+                                 List<LicenseApplyOutcome> results,
+                                 List<RollbackFailure> rollbackFailures)
+{
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/licensing/LicenseChangePlanRequest.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/licensing/LicenseChangePlanRequest.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.licensing;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+/** Request body for {@code POST /api/wiz/v1/admin/licensing/preview}. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class LicenseChangePlanRequest {
+   public String getTask() { return task; }
+   public void setTask(String v) { this.task = v; }
+   public List<LicenseChangeRequest> getChanges() { return changes; }
+   public void setChanges(List<LicenseChangeRequest> v) { this.changes = v; }
+
+   private String task;
+   private List<LicenseChangeRequest> changes;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/licensing/LicenseChangePlanService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/licensing/LicenseChangePlanService.java
@@ -1,0 +1,302 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.licensing;
+
+import inetsoft.report.internal.license.License;
+import inetsoft.report.internal.license.LicenseManager;
+import inetsoft.report.internal.license.LicenseType;
+import inetsoft.util.audit.AdminChangeRecord;
+import inetsoft.web.admin.ai.PlanChange;
+import inetsoft.web.admin.ai.ResolvedPlan;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.*;
+
+/**
+ * Resolves a requested list of license key changes into a {@link ResolvedPlan} and hashes it --
+ * the licensing analog of {@code inetsoft.web.admin.ai.AdminChangePlanService} and (within this
+ * run) {@code ProviderChangePlanService}/{@code ClusterChangePlanService}, replicated rather than
+ * shared (01-spec.md section 6, carry-forward item 5).
+ *
+ * <p>Bypasses {@code LicenseKeySettingsService.setModel}/{@code updateKeys} entirely (01-spec.md
+ * section 0) -- that method does a nondeterministic replace-plus-remove that cannot recover a
+ * caller's "add"/"remove" intent from a partial list. Resolves each change against
+ * {@link LicenseManager#getInstalledLicenses()}/{@link LicenseManager#parseLicense(String)}
+ * directly, never against {@code LicenseKeyModel} (whose {@code valid()} always returns
+ * {@code true}, section 14 D2/D6, {@code stylebi#76344}).
+ *
+ * <p><b>03-reconcile.md addition 2, confirmed by reading {@code EnterpriseLicenseStrategy
+ * .addLicense} in full (04-build-java.md):</b> the method's only already-claimed check is
+ * {@code claimedLicense == null} (this node's own claim state) -- it never compares the requested
+ * key against {@code installedLicenses} before running the cluster-node claiming exchange
+ * ({@code AddLicenseMessage}). So a duplicate {@code add} of an already-installed, non-pooled key,
+ * in a multi-node cluster with an idle node, can cause a second node to also claim it. This
+ * service therefore refuses an {@code add} of an already-installed key outright ({@link
+ * #resolveAdd}), the same "refuse rather than accept a plan that could vacuously or riskily
+ * proceed" treatment already given a {@code remove} of a not-installed key.
+ *
+ * <p><b>This area is not gated here.</b> Per 03-reconcile.md addition 1, the
+ * {@code LicenseManager.isEnterprise()} gate lives at {@link AdminLicensingController}'s entry
+ * point, not in this service -- keeping this class callable (and testable) the same way regardless
+ * of which strategy backs {@link LicenseManager} in the calling context.
+ */
+@Component
+public class LicenseChangePlanService {
+   @Autowired
+   public LicenseChangePlanService(LicenseManager licenseManager) {
+      this.licenseManager = licenseManager;
+   }
+
+   /**
+    * Resolves and hashes a plan. Performs no mutation, but does perform a live read (the current
+    * installed-license set) plus one {@code parseLicense} per {@code add}.
+    *
+    * @throws IllegalArgumentException with a field-named message on a blank task, an empty change
+    *         list, an unrecognized verb, a blank/duplicate key, an {@code add} whose key resolves
+    *         to {@code LicenseType.INVALID}/fails {@code valid()}, an {@code add} of an
+    *         already-installed key (03-reconcile.md addition 2), or a {@code remove} of a key that
+    *         is not currently installed (01-spec.md section 2).
+    */
+   public ResolvedPlan resolve(LicenseChangePlanRequest req) {
+      if(req == null || req.getTask() == null || req.getTask().trim().isEmpty()) {
+         throw new IllegalArgumentException("task: a non-empty description is required");
+      }
+
+      if(req.getChanges() == null || req.getChanges().isEmpty()) {
+         throw new IllegalArgumentException("changes: at least one change is required");
+      }
+
+      Set<License> installed = licenseManager.getInstalledLicenses();
+      Map<String, License> byKey = new HashMap<>();
+
+      for(License license : installed) {
+         if(license.key() != null) {
+            byKey.put(license.key(), license);
+         }
+      }
+
+      List<ResolvedEntry> resolvedEntries = new ArrayList<>();
+      Set<String> seenKeys = new HashSet<>();
+      int index = 0;
+      int addCount = 0;
+      int removeCount = 0;
+
+      for(LicenseChangeRequest change : req.getChanges()) {
+         String label = "changes[" + index++ + "]";
+
+         if(change == null) {
+            throw new IllegalArgumentException(label + ": must not be null");
+         }
+
+         String verb = requireVerb(label, change.getVerb());
+         String key = requireKey(label, change.getKey());
+         requireUnseen(label, key, seenKeys);
+
+         if(VERB_ADD.equals(verb)) {
+            resolvedEntries.add(resolveAdd(label, key, byKey));
+            addCount++;
+         }
+         else {
+            resolvedEntries.add(resolveRemove(label, key, byKey));
+            removeCount++;
+         }
+      }
+
+      boolean deLicensingWarning =
+         computeDeLicensingWarning(installed.size(), addCount, removeCount);
+
+      List<PlanChange> changes = new ArrayList<>();
+
+      for(ResolvedEntry entry : resolvedEntries) {
+         changes.add(withWarningIfApplicable(entry, deLicensingWarning));
+      }
+
+      String task = req.getTask().trim();
+      return new ResolvedPlan(task, Collections.unmodifiableList(changes), true, true,
+                              hash(task, changes, installed.size()));
+   }
+
+   // ---------------------------------------------------------------- add
+
+   private ResolvedEntry resolveAdd(String label, String key, Map<String, License> byKey) {
+      if(byKey.containsKey(key)) {
+         throw new IllegalArgumentException(
+            label + ".key: \"" + key + "\" is already installed -- adding it again is refused " +
+            "rather than passed through, because EnterpriseLicenseStrategy.addLicense's cluster-" +
+            "node claiming exchange has no already-installed guard of its own and can cause a " +
+            "second cluster node to also claim a non-pooled key on a duplicate add " +
+            "(03-reconcile.md addition 2); remove it first if you intend to reinstall it");
+      }
+
+      License resolved = licenseManager.parseLicense(key);
+
+      if(resolved.type() == LicenseType.INVALID || !resolved.valid()) {
+         throw new IllegalArgumentException(
+            label + ".key: \"" + key + "\" does not resolve to a valid license (type=" +
+            resolved.type() + ", valid=" + resolved.valid() + ") -- refused rather than installed " +
+            "as a permanently-broken license entry (01-spec.md section 2/14 D2)");
+      }
+
+      LicenseKeyProjection projection = LicenseKeyProjection.of(resolved);
+      PlanChange change = new PlanChange(key, NOT_ORG_SCOPED, null, projection.canonical(),
+                                         AdminChangeRecord.RISK_HIGH, AdminChangeRecord.SCOPE_STORAGE,
+                                         true, "add license key " + key + " (" + resolved.type() + ")");
+      return new ResolvedEntry(VERB_ADD, change);
+   }
+
+   // ---------------------------------------------------------------- remove
+
+   private ResolvedEntry resolveRemove(String label, String key, Map<String, License> byKey) {
+      License current = byKey.get(key);
+
+      if(current == null) {
+         throw new IllegalArgumentException(
+            label + ".key: \"" + key + "\" is not currently installed -- removing it would be a " +
+            "silent no-op at the LicenseManager.removeLicense level (01-spec.md section 2), refused " +
+            "here instead");
+      }
+
+      LicenseKeyProjection projection = LicenseKeyProjection.of(current);
+      PlanChange change = new PlanChange(key, NOT_ORG_SCOPED, projection.canonical(), null,
+                                         AdminChangeRecord.RISK_HIGH, AdminChangeRecord.SCOPE_STORAGE,
+                                         true, "remove license key " + key + " (" + current.type() + ")");
+      return new ResolvedEntry(VERB_REMOVE, change);
+   }
+
+   // ---------------------------------------------------------------- de-licensing warning
+
+   /**
+    * {@code resultingInstalledCount = currentCount + addCount - removeCount} -- every accepted
+    * {@code add} is guaranteed to target a currently-not-installed key (a duplicate add is refused
+    * above) and every accepted {@code remove} is guaranteed to target a currently-installed key, so
+    * this net computation (01-spec.md section 5) needs no per-key set arithmetic beyond the two
+    * counts. Package-visible so {@link LicenseChangesetApplyService} can re-derive this fact from
+    * fresh state at apply time, exactly as it re-derives every other plan-time check (mirroring
+    * {@code DataSourceApplyRequest.acknowledgeIrreversibleDelete}'s own apply-time re-derivation
+    * pattern).
+    */
+   static boolean computeDeLicensingWarning(int currentInstalledCount, int addCount, int removeCount) {
+      return removeCount > 0 && currentInstalledCount + addCount - removeCount <= 0;
+   }
+
+   /** Prepends the de-licensing advisory to every {@code remove}-verb entry's description when the
+    * plan-wide count would reach zero (01-spec.md section 5) -- a first-class, structured-field
+    * disclosure (the {@link PlanChange#description()} column), not buried in free text elsewhere,
+    * matching how this program's own precedent (identities' partial-membership warning) surfaces a
+    * plan-level fact without a bespoke top-level field on the shared {@link ResolvedPlan}. */
+   private static PlanChange withWarningIfApplicable(ResolvedEntry entry, boolean deLicensingWarning) {
+      PlanChange change = entry.change();
+
+      if(!deLicensingWarning || !VERB_REMOVE.equals(entry.verb())) {
+         return change;
+      }
+
+      String description = "WARNING: after this plan applies, 0 license keys will remain " +
+         "installed -- acknowledgeDelicensing:true is required on apply (01-spec.md section 5/6). " +
+         change.description();
+      return new PlanChange(change.property(), change.orgId(), change.currentValue(),
+                            change.proposedValue(), change.risk(), change.snapshotScope(),
+                            change.recognized(), description);
+   }
+
+   // ---------------------------------------------------------------- validation helpers
+
+   static String requireVerb(String label, String verb) {
+      if(VERB_ADD.equals(verb) || VERB_REMOVE.equals(verb)) {
+         return verb;
+      }
+
+      throw new IllegalArgumentException(
+         label + ".verb: must be \"" + VERB_ADD + "\" or \"" + VERB_REMOVE + "\", got " + verb);
+   }
+
+   static String requireKey(String label, String key) {
+      if(key == null || key.trim().isEmpty()) {
+         throw new IllegalArgumentException(label + ".key: required");
+      }
+
+      return key.trim();
+   }
+
+   private static void requireUnseen(String label, String key, Set<String> seenKeys) {
+      if(!seenKeys.add(key)) {
+         throw new IllegalArgumentException(
+            label + ": duplicate entry for key \"" + key + "\"; list each key at most once");
+      }
+   }
+
+   // ---------------------------------------------------------------- hash
+
+   /**
+    * SHA-256 over the canonical plan. Same field-order/control-character contract as every prior
+    * area's own {@code hash} method, extended with the raw installed-license count (01-spec.md
+    * section 5) -- the de-licensing warning depends on the WHOLE deployment's installed count, not
+    * only the keys this plan touches, so a concurrent add/remove of a key this plan never mentions
+    * must still perturb the hash.
+    */
+   private static String hash(String task, List<PlanChange> changes, int installedCount) {
+      StringBuilder canonical = new StringBuilder(task).append('\n')
+         .append("installedCount:").append(installedCount).append(SEP);
+
+      for(PlanChange change : changes) {
+         canonical.append(change.property()).append(SEP)
+            .append(canonicalValue(change.currentValue())).append(SEP)
+            .append(canonicalValue(change.proposedValue())).append(SEP)
+            .append(change.risk()).append(SEP)
+            .append(change.snapshotScope()).append(SEP);
+      }
+
+      try {
+         byte[] digest = MessageDigest.getInstance("SHA-256")
+            .digest(canonical.toString().getBytes(StandardCharsets.UTF_8));
+         StringBuilder hex = new StringBuilder(digest.length * 2);
+
+         for(byte b : digest) {
+            hex.append(String.format("%02x", b));
+         }
+
+         return hex.toString();
+      }
+      catch(NoSuchAlgorithmException e) {
+         throw new IllegalStateException("SHA-256 is required to hash a license change plan", e);
+      }
+   }
+
+   private static String canonicalValue(String value) {
+      return value == null ? NULL_MARKER : value;
+   }
+
+   private static final char SEP = (char) 0x1f;
+   private static final String NULL_MARKER = String.valueOf((char) 0x01);
+   /** Licensing is deployment-wide, not org-scoped (01-spec.md section 1) -- every {@link
+    * PlanChange} this service builds passes this in place of a bare {@code null} literal so the
+    * omission reads as deliberate, matching {@code ProviderChangePlanService.NOT_ORG_SCOPED}. */
+   private static final String NOT_ORG_SCOPED = null;
+   static final String VERB_ADD = LicenseChangeRequest.VERB_ADD;
+   static final String VERB_REMOVE = LicenseChangeRequest.VERB_REMOVE;
+   private final LicenseManager licenseManager;
+
+   /** One resolved change plus the verb that produced it, so the de-licensing warning can be
+    * applied to only the {@code remove}-verb entries after the plan-wide count is known. */
+   private record ResolvedEntry(String verb, PlanChange change) {
+   }
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/licensing/LicenseChangeRequest.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/licensing/LicenseChangeRequest.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.licensing;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * One requested license key change: add or remove one key by its literal string (01-spec.md
+ * section 1/11). {@link LicenseChangePlanService#resolve} re-validates every field independently
+ * rather than trusting the caller, per this repo's CLAUDE.md tool-robustness rule -- verb aliasing
+ * (e.g. "install"/"uninstall") and the "no update verb exists" refusal are the plugin (TypeScript)
+ * tool layer's job, matching {@code ClusterChangePlanService.requireVerb}'s own precedent of
+ * exact-label-only validation in Java.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class LicenseChangeRequest {
+   public static final String VERB_ADD = "add";
+   public static final String VERB_REMOVE = "remove";
+
+   public String getVerb() { return verb; }
+   public void setVerb(String v) { this.verb = v; }
+
+   /** The literal license key string -- the only identifier this area has (01-spec.md section 2). */
+   public String getKey() { return key; }
+   public void setKey(String v) { this.key = v; }
+
+   private String verb;
+   private String key;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/licensing/LicenseChangesetApplyService.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/licensing/LicenseChangesetApplyService.java
@@ -1,0 +1,475 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.licensing;
+
+import inetsoft.report.internal.license.License;
+import inetsoft.report.internal.license.LicenseManager;
+import inetsoft.report.internal.license.LicenseType;
+import inetsoft.util.Tool;
+import inetsoft.util.audit.*;
+import inetsoft.web.admin.ai.*;
+import inetsoft.web.admin.general.LicenseKeySettingsService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.security.Principal;
+import java.security.SecureRandom;
+import java.sql.Timestamp;
+import java.util.*;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+
+/**
+ * Applies a whole license changeset, all-or-nothing, and audits every attempt -- the licensing
+ * analog of {@code inetsoft.web.admin.ai.AdminChangesetApplyService} and (within this run)
+ * {@code ProviderChangesetApplyService}/{@code ClusterChangesetApplyService}, replicated rather
+ * than shared (01-spec.md section 6, carry-forward item 5).
+ *
+ * <p>Every verb in this area is {@code snapshotScope: storage} unconditionally (01-spec.md section
+ * 4/7/14 D4), so the Tier-2 backup is taken synchronously here, before any change is attempted.
+ *
+ * <p>Calls {@link LicenseKeySettingsService#addServerKey}/{@code removeServerKey} -- never
+ * {@code LicenseManager.addLicense}/{@code removeLicense} directly -- so the cluster-broadcast and
+ * auth-cache-reset side effects {@code setModel} performs are always replicated (01-spec.md section
+ * 0).
+ */
+@Component
+public class LicenseChangesetApplyService {
+   @Autowired
+   public LicenseChangesetApplyService(LicenseChangePlanService planService,
+                                       LicenseManager licenseManager,
+                                       LicenseKeySettingsService licenseKeySettingsService,
+                                       AdminBackupService backupService)
+   {
+      this.planService = planService;
+      this.licenseManager = licenseManager;
+      this.licenseKeySettingsService = licenseKeySettingsService;
+      this.backupService = backupService;
+   }
+
+   /**
+    * Resolves fresh, gates on the plan hash and (when applicable) {@code acknowledgeDelicensing},
+    * backs up, then executes.
+    *
+    * @throws AdminChangesetApplyService.PlanHashMismatchException if the hash is missing or stale
+    *         (maps to HTTP 409) -- reused verbatim, per 01-spec.md section 6.
+    * @throws Exception if the Tier-2 backup itself fails, in which case nothing was applied.
+    */
+   public LicenseApplyResult apply(LicenseApplyRequest req, Principal user) throws Exception {
+      APPLY_LOCK.lock();
+
+      try {
+         ResolvedPlan plan = planService.resolve(req);
+
+         if(req.getPlanHash() == null || !plan.planHash().equals(req.getPlanHash())) {
+            throw new AdminChangesetApplyService.PlanHashMismatchException(plan);
+         }
+
+         if(plan.requiresAgentSignoff() &&
+            (req.getReviewOutcome() == null || req.getReviewOutcome().trim().isEmpty()))
+         {
+            throw new IllegalArgumentException(
+               "reviewOutcome: required because this changeset contains a high-risk change");
+         }
+
+         // Re-derived fresh, from live state, before any mutation -- mirrors
+         // DataSourceApplyRequest.acknowledgeIrreversibleDelete's own apply-time re-derivation
+         // rather than trusting a preview-time snapshot (03-reconcile.md, 01-spec.md section 6).
+         int installedCountNow = licenseManager.getInstalledLicenses().size();
+         int addCount = 0;
+         int removeCount = 0;
+
+         for(LicenseChangeRequest change : req.getChanges()) {
+            if(LicenseChangeRequest.VERB_ADD.equals(change.getVerb())) {
+               addCount++;
+            }
+            else if(LicenseChangeRequest.VERB_REMOVE.equals(change.getVerb())) {
+               removeCount++;
+            }
+         }
+
+         boolean deLicensingWarning = LicenseChangePlanService.computeDeLicensingWarning(
+            installedCountNow, addCount, removeCount);
+
+         if(deLicensingWarning && !Boolean.TRUE.equals(req.getAcknowledgeDelicensing())) {
+            throw new IllegalArgumentException(
+               "acknowledgeDelicensing: must be true because this changeset would leave 0 license " +
+               "keys installed (01-spec.md section 5/6)");
+         }
+
+         String txId = "license-" + newIdSuffix();
+         String backupRef = plan.requiresStorageBackup() ? backupService.backup(txId) : null;
+         String reviewOutcome = req.getReviewOutcome();
+         List<LicenseApplyOutcome> results = new ArrayList<>();
+         List<Undo> undoable = new ArrayList<>();
+         List<RollbackFailure> unknownStateFailures = new ArrayList<>();
+         boolean failed = false;
+
+         List<LicenseChangeRequest> originals = req.getChanges();
+
+         for(int i = 0; i < plan.changes().size(); i++) {
+            PlanChange change = plan.changes().get(i);
+            LicenseChangeRequest original = originals.get(i);
+            String key = change.property();
+
+            try {
+               applyOne(txId, plan.task(), key, original, backupRef, reviewOutcome, user, results,
+                       undoable);
+            }
+            catch(Exception e) {
+               // A throw carries no verifiable before/after evidence for THIS change -- must never
+               // be treated as rolled back. Same rule every prior area's apply service follows.
+               results.add(new LicenseApplyOutcome(key, null, null, AdminChangeRecord.STATUS_FAILED,
+                                                   messageOf(e), null));
+               unknownStateFailures.add(new RollbackFailure(key,
+                  "state unknown: apply did not return a verifiable outcome (" + messageOf(e) + ")"));
+               failed = true;
+               break;
+            }
+
+            if(AdminChangeRecord.STATUS_FAILED.equals(lastStatus(results))) {
+               failed = true;
+               break;
+            }
+         }
+
+         if(!failed) {
+            return new LicenseApplyResult(txId, AdminChangesetApplyService.STATUS_APPLIED, backupRef,
+                                          Collections.unmodifiableList(results), null);
+         }
+
+         Map<String, String> rollbackAdvisories = new LinkedHashMap<>();
+         List<RollbackFailure> failures = new ArrayList<>(unknownStateFailures);
+         failures.addAll(rollback(txId, plan.task(), undoable, backupRef, reviewOutcome, user,
+                                  rollbackAdvisories));
+         List<LicenseApplyOutcome> finalResults = results.stream()
+            .map(o -> mergeAdvisory(o, rollbackAdvisories.get(o.property())))
+            .collect(Collectors.toList());
+
+         if(failures.isEmpty()) {
+            return new LicenseApplyResult(txId, AdminChangesetApplyService.STATUS_ROLLED_BACK,
+                                          backupRef, Collections.unmodifiableList(finalResults), null);
+         }
+
+         LOG.error("License changeset {} rollback failed; keys still changed: {}", txId,
+                  failures.stream().map(RollbackFailure::property).collect(Collectors.joining(", ")));
+         return new LicenseApplyResult(txId, AdminChangesetApplyService.STATUS_ROLLBACK_FAILED,
+                                       backupRef, Collections.unmodifiableList(finalResults),
+                                       Collections.unmodifiableList(failures));
+      }
+      finally {
+         APPLY_LOCK.unlock();
+      }
+   }
+
+   private void applyOne(String txId, String task, String key, LicenseChangeRequest original,
+                         String backupRef, String reviewOutcome, Principal user,
+                         List<LicenseApplyOutcome> results, List<Undo> undoable)
+      throws Exception
+   {
+      String verb = LicenseChangePlanService.requireVerb("apply." + key, original.getVerb());
+
+      if(LicenseChangeRequest.VERB_ADD.equals(verb)) {
+         applyAdd(txId, task, key, backupRef, reviewOutcome, user, results, undoable);
+      }
+      else {
+         applyRemove(txId, task, key, backupRef, reviewOutcome, user, results, undoable);
+      }
+   }
+
+   // ---------------------------------------------------------------- add
+
+   /** Re-verifies not-already-installed AND re-resolves type/valid fresh (01-spec.md section 6/7)
+    * -- a key installed by a concurrent EM-console session between preview and apply, or one whose
+    * parse result changed, is refused here rather than acted on against stale evidence. */
+   private void applyAdd(String txId, String task, String key, String backupRef,
+                         String reviewOutcome, Principal user, List<LicenseApplyOutcome> results,
+                         List<Undo> undoable)
+      throws Exception
+   {
+      boolean alreadyInstalled = isInstalled(key);
+
+      if(alreadyInstalled) {
+         results.add(new LicenseApplyOutcome(key, null, null, AdminChangeRecord.STATUS_FAILED,
+            "already installed at apply time (concurrent change)", null));
+         writeAudit(txId, task, key, ActionRecord.ACTION_NAME_CREATE, AdminChangeRecord.ACTION_APPLY,
+                   null, null, AdminChangeRecord.STATUS_FAILED, backupRef, reviewOutcome, user);
+         return;
+      }
+
+      License resolved = licenseManager.parseLicense(key);
+
+      if(resolved.type() == LicenseType.INVALID || !resolved.valid()) {
+         results.add(new LicenseApplyOutcome(key, null, null, AdminChangeRecord.STATUS_FAILED,
+            "no longer resolves to a valid license at apply time (concurrent change)", null));
+         writeAudit(txId, task, key, ActionRecord.ACTION_NAME_CREATE, AdminChangeRecord.ACTION_APPLY,
+                   null, null, AdminChangeRecord.STATUS_FAILED, backupRef, reviewOutcome, user);
+         return;
+      }
+
+      licenseKeySettingsService.addServerKey(key);
+
+      boolean verified = isInstalled(key);
+      String status = verified ? AdminChangeRecord.STATUS_VERIFIED : AdminChangeRecord.STATUS_FAILED;
+      String after = verified ? LicenseKeyProjection.of(resolved).canonical() : null;
+      results.add(new LicenseApplyOutcome(key, null, after, status,
+                                          verified ? null : "key not found among installed licenses " +
+                                          "after add", null));
+      writeAudit(txId, task, key, ActionRecord.ACTION_NAME_CREATE, AdminChangeRecord.ACTION_APPLY,
+                null, after, status, backupRef, reviewOutcome, user);
+
+      if(verified) {
+         undoable.add(Undo.added(key));
+      }
+   }
+
+   // ---------------------------------------------------------------- remove
+
+   private void applyRemove(String txId, String task, String key, String backupRef,
+                            String reviewOutcome, Principal user, List<LicenseApplyOutcome> results,
+                            List<Undo> undoable)
+      throws Exception
+   {
+      Optional<License> current = findInstalled(key);
+
+      if(current.isEmpty()) {
+         results.add(new LicenseApplyOutcome(key, null, null, AdminChangeRecord.STATUS_FAILED,
+            "not installed at apply time (concurrent change)", null));
+         writeAudit(txId, task, key, ActionRecord.ACTION_NAME_DELETE, AdminChangeRecord.ACTION_APPLY,
+                   null, null, AdminChangeRecord.STATUS_FAILED, backupRef, reviewOutcome, user);
+         return;
+      }
+
+      String before = LicenseKeyProjection.of(current.get()).canonical();
+      licenseKeySettingsService.removeServerKey(key);
+
+      boolean verified = !isInstalled(key);
+      String status = verified ? AdminChangeRecord.STATUS_VERIFIED : AdminChangeRecord.STATUS_FAILED;
+      results.add(new LicenseApplyOutcome(key, before, null, status,
+                                          verified ? null : "key still present after remove", null));
+      writeAudit(txId, task, key, ActionRecord.ACTION_NAME_DELETE, AdminChangeRecord.ACTION_APPLY,
+                before, null, status, backupRef, reviewOutcome, user);
+
+      if(verified) {
+         undoable.add(Undo.removed(key));
+      }
+   }
+
+   // ---------------------------------------------------------------- rollback
+
+   private List<RollbackFailure> rollback(String txId, String task, List<Undo> undoable,
+                                          String backupRef, String reviewOutcome, Principal user,
+                                          Map<String, String> advisories)
+   {
+      List<RollbackFailure> failures = new ArrayList<>();
+
+      for(int i = undoable.size() - 1; i >= 0; i--) {
+         Undo undo = undoable.get(i);
+
+         try {
+            if(undo.kind == Undo.Kind.ADDED) {
+               rollbackAdded(txId, task, undo, backupRef, reviewOutcome, user, failures);
+            }
+            else {
+               rollbackRemoved(txId, task, undo, backupRef, reviewOutcome, user, failures, advisories);
+            }
+         }
+         catch(Exception e) {
+            failures.add(new RollbackFailure(undo.key, messageOf(e)));
+         }
+      }
+
+      return failures;
+   }
+
+   /** Undo of {@code add} is {@code remove} -- exact (01-spec.md section 4): {@code removeLicense}
+    * matches purely on key equality, so there is no partial-state risk. */
+   private void rollbackAdded(String txId, String task, Undo undo, String backupRef,
+                              String reviewOutcome, Principal user, List<RollbackFailure> failures)
+      throws Exception
+   {
+      if(!isInstalled(undo.key)) {
+         failures.add(new RollbackFailure(undo.key,
+            "rollback of add could not find the key to remove (already gone)"));
+         return;
+      }
+
+      licenseKeySettingsService.removeServerKey(undo.key);
+      boolean verified = !isInstalled(undo.key);
+      writeAudit(txId, task, undo.key, ActionRecord.ACTION_NAME_DELETE,
+                AdminChangeRecord.ACTION_ROLLBACK, null, null,
+                verified ? AdminChangeRecord.STATUS_VERIFIED : AdminChangeRecord.STATUS_FAILED,
+                backupRef, reviewOutcome, user);
+
+      if(!verified) {
+         failures.add(new RollbackFailure(undo.key,
+            "rollback of add reported the key as still present after remove"));
+      }
+   }
+
+   /**
+    * Undo of {@code remove} is {@code add} -- real but not exact (01-spec.md section 4): the
+    * claiming-node selection in {@code EnterpriseLicenseStrategy.addLicense} picks any node with an
+    * unclaimed slot, not necessarily the node that originally claimed the key, so a re-add can land
+    * on a different cluster node than before -- disclosed as a first-class {@code advisory}.
+    *
+    * <p>Re-checks not-already-installed before re-adding (03-reconcile.md addition 2/
+    * 02-verify-plan.md section 5): a concurrent operator action during the rollback window (EM
+    * console, a different admin-chat session) could have already re-added the same key through a
+    * different channel, and blindly retrying {@code addServerKey} would risk the same duplicate-add
+    * cluster-claim correctness gap a plan-time {@code add} of an already-installed key is refused
+    * for.
+    */
+   private void rollbackRemoved(String txId, String task, Undo undo, String backupRef,
+                                String reviewOutcome, Principal user, List<RollbackFailure> failures,
+                                Map<String, String> advisories)
+      throws Exception
+   {
+      if(isInstalled(undo.key)) {
+         failures.add(new RollbackFailure(undo.key,
+            "rollback of remove found the key already reinstalled by a concurrent change -- not " +
+            "re-added, to avoid the duplicate-add cluster-claim risk (03-reconcile.md addition 2)"));
+         return;
+      }
+
+      licenseKeySettingsService.addServerKey(undo.key);
+      boolean verified = isInstalled(undo.key);
+      String advisory = verified
+         ? "re-added key may have been claimed by a different cluster node than before -- " +
+           "addLicense's claiming-node selection picks any node with an unclaimed slot, not " +
+           "necessarily the original one (01-spec.md section 4)"
+         : null;
+      writeAudit(txId, task, undo.key, ActionRecord.ACTION_NAME_CREATE,
+                AdminChangeRecord.ACTION_ROLLBACK, null, null,
+                verified ? AdminChangeRecord.STATUS_VERIFIED : AdminChangeRecord.STATUS_FAILED,
+                backupRef, reviewOutcome, user);
+
+      if(!verified) {
+         failures.add(new RollbackFailure(undo.key,
+            "rollback of remove reported the key as still missing after re-add"));
+      }
+      else {
+         advisories.put(undo.key, advisory);
+      }
+   }
+
+   // ---------------------------------------------------------------- shared helpers
+
+   private boolean isInstalled(String key) {
+      return licenseManager.getInstalledLicenses().stream()
+         .anyMatch(l -> Objects.equals(l.key(), key));
+   }
+
+   private Optional<License> findInstalled(String key) {
+      return licenseManager.getInstalledLicenses().stream()
+         .filter(l -> Objects.equals(l.key(), key))
+         .findFirst();
+   }
+
+   private static LicenseApplyOutcome mergeAdvisory(LicenseApplyOutcome outcome,
+                                                     String rollbackAdvisory)
+   {
+      if(rollbackAdvisory == null) {
+         return outcome;
+      }
+
+      String combined = outcome.advisory() == null ? rollbackAdvisory :
+         outcome.advisory() + " | " + rollbackAdvisory;
+      return new LicenseApplyOutcome(outcome.property(), outcome.before(), outcome.after(),
+                                     outcome.status(), outcome.error(), combined);
+   }
+
+   private void writeAudit(String txId, String task, String key, String actionRecordName,
+                           String adminAction, String before, String after, String status,
+                           String backupRef, String reviewOutcome, Principal user)
+   {
+      try {
+         AdminChangeRecord record = new AdminChangeRecord();
+         record.setTransactionId(txId);
+         record.setTaskDescription(task);
+         record.setProperty(key);
+         record.setObjectType(ActionRecord.OBJECT_TYPE_EMPROPERTY);
+         record.setBeforeValue(before);
+         record.setAfterValue(after);
+         record.setAction(adminAction);
+         record.setStatus(status);
+         record.setRiskLevel(AdminChangeRecord.RISK_HIGH);
+         record.setSnapshotScope(AdminChangeRecord.SCOPE_STORAGE);
+         record.setBackupRef(backupRef);
+         record.setReviewOutcome(reviewOutcome);
+         // organizationId is deliberately left unset: licensing is deployment-wide, not org-scoped
+         // (01-spec.md section 1/8), so there is no organization to attribute this change to -- not
+         // an oversight, mirrors ProviderChangePlanService.NOT_ORG_SCOPED.
+         record.setUserName(user == null ? null : user.getName());
+         record.setActionTimestamp(new Timestamp(System.currentTimeMillis()));
+         record.setServerHostName(Tool.getHost());
+         Audit.getInstance().auditAdminChange(record, user);
+      }
+      catch(Exception auditFailure) {
+         // An audit write must never replace the real outcome -- same rule every prior area's apply
+         // service follows.
+         LOG.error("Failed to write license admin change audit record for transaction {}", txId,
+                   auditFailure);
+      }
+   }
+
+   private static String lastStatus(List<LicenseApplyOutcome> results) {
+      return results.isEmpty() ? null : results.get(results.size() - 1).status();
+   }
+
+   private static String messageOf(Exception e) {
+      return e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
+   }
+
+   private static String newIdSuffix() {
+      return String.format("%016x", RANDOM.nextLong());
+   }
+
+   /** One undo descriptor built during apply, replayed in reverse by {@link #rollback}. */
+   private static final class Undo {
+      enum Kind { ADDED, REMOVED }
+
+      static Undo added(String key) {
+         return new Undo(Kind.ADDED, key);
+      }
+
+      static Undo removed(String key) {
+         return new Undo(Kind.REMOVED, key);
+      }
+
+      private Undo(Kind kind, String key) {
+         this.kind = kind;
+         this.key = key;
+      }
+
+      final Kind kind;
+      final String key;
+   }
+
+   private static final Logger LOG = LoggerFactory.getLogger(LicenseChangesetApplyService.class);
+   private static final SecureRandom RANDOM = new SecureRandom();
+   /** Serializes the entire body of {@link #apply} -- same rationale and same JVM-local-only
+    * limitation as every prior area's own lock. */
+   private static final ReentrantLock APPLY_LOCK = new ReentrantLock();
+   private final LicenseChangePlanService planService;
+   private final LicenseManager licenseManager;
+   private final LicenseKeySettingsService licenseKeySettingsService;
+   private final AdminBackupService backupService;
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/licensing/LicenseKeyListResponse.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/licensing/LicenseKeyListResponse.java
@@ -1,0 +1,24 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.licensing;
+
+import java.util.List;
+
+/** Response body for {@code GET /api/wiz/v1/admin/licensing/keys} (01-spec.md section 3). */
+public record LicenseKeyListResponse(List<LicenseKeyProjection> keys) {
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/licensing/LicenseKeyLookupResult.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/licensing/LicenseKeyLookupResult.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.licensing;
+
+/**
+ * Response body for {@code GET /api/wiz/v1/admin/licensing/keys/{key}}.
+ * {@code found: false} is a normal answer, not an error, matching
+ * {@code get_permission_grant}'s own precedent (01-spec.md section 3) -- most literal key strings
+ * a caller might ask about were never installed.
+ */
+public record LicenseKeyLookupResult(boolean found, LicenseKeyProjection license) {
+}

--- a/core/src/main/java/inetsoft/web/admin/ai/licensing/LicenseKeyProjection.java
+++ b/core/src/main/java/inetsoft/web/admin/ai/licensing/LicenseKeyProjection.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.licensing;
+
+import inetsoft.report.internal.license.License;
+
+/**
+ * This area's own read/audit projection of a {@link License}, built directly off the real object
+ * -- never off {@code LicenseKeyModel}, whose {@code valid()} always returns {@code true}
+ * regardless of the underlying license's real validity ({@code stylebi#76344}, 01-spec.md section
+ * 14 D2/D6). {@code type} is the {@code LicenseType} enum name (or {@code null} on an
+ * unparseable/Noop-backed result), {@code description} is {@link License#description()}'s
+ * free-text string (the "Expired"/"Invalid" signal currently smuggled into that field).
+ */
+public record LicenseKeyProjection(String key, String type, boolean valid, String description) {
+   public static LicenseKeyProjection of(License license) {
+      return new LicenseKeyProjection(license.key(),
+                                      license.type() == null ? null : license.type().name(),
+                                      license.valid(), license.description());
+   }
+
+   /** Canonical string form used both for the plan hash's per-change projection (01-spec.md
+    * section 5) and for the audit {@code beforeValue}/{@code afterValue} columns (section 8). */
+   public String canonical() {
+      return "key=" + key + ";type=" + type + ";valid=" + valid + ";description=" + description;
+   }
+}

--- a/core/src/main/java/inetsoft/web/admin/general/LicenseKeySettingsService.java
+++ b/core/src/main/java/inetsoft/web/admin/general/LicenseKeySettingsService.java
@@ -87,6 +87,29 @@ public class LicenseKeySettingsService {
       }
    }
 
+   /**
+    * Adds a single server license key, replicating {@link #setModel}'s own cluster-broadcast and
+    * auth-cache-reset side effects ({@code addLicense}/{@code removeLicense} do not perform either
+    * on their own) without going through {@link #setModel}/{@link #updateKeys}'s nondeterministic
+    * replace-plus-remove logic. {@code public}, unlike {@link #getSingleServerLicenseKey}, so the
+    * {@code inetsoft.web.admin.ai.licensing} controller/services (a different package) can call it.
+    */
+   public void addServerKey(String key) throws Exception {
+      licenseManager.addLicense(key);
+      cluster.sendMessage(new ResetLicenseKeyMessage());
+      authenticationService.reset();
+   }
+
+   /**
+    * Removes a single server license key -- see {@link #addServerKey} for why the two extra side
+    * effects are replicated here.
+    */
+   public void removeServerKey(String key) throws Exception {
+      licenseManager.removeLicense(key);
+      cluster.sendMessage(new ResetLicenseKeyMessage());
+      authenticationService.reset();
+   }
+
    private List<LicenseKeyModel> getServerLicenseData() {
       return licenseManager.getInstalledLicenses().stream()
          .map(this::createLicenseKeyModel)

--- a/core/src/test/java/inetsoft/web/admin/ai/licensing/AdminLicensingControllerGetKeyTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/licensing/AdminLicensingControllerGetKeyTest.java
@@ -1,0 +1,140 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.licensing;
+
+import inetsoft.report.internal.license.License;
+import inetsoft.report.internal.license.LicenseManager;
+import inetsoft.report.internal.license.LicenseType;
+import inetsoft.sree.security.OrganizationManager;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.net.URI;
+import java.security.Principal;
+import java.time.LocalDateTime;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+
+/**
+ * Regression test for the fix in 07-fix-r1-java.md: {@code GET .../licensing/key} takes {@code key}
+ * as a query parameter, not a {@code {key}} path-variable segment -- this repo's embedded Tomcat
+ * 10.1.x rejects a literal {@code %2F} in a request URI by default, so the old path-variable shape
+ * would 400 on a slash-containing candidate key before ever reaching this controller's own clean
+ * {@code found: false} handling. Same defect class (and fix) as Viewsheets'
+ * {@code AdminViewsheetControllerGetFolderTest}.
+ *
+ * <p>Standalone {@link MockMvc} (no Spring context, matching {@code WizControllerErrorHandlerTest}'s
+ * own precedent) -- real Spring MVC request dispatch/binding runs, but there is no real embedded
+ * Tomcat connector underneath, so this does not, by itself, prove the original
+ * {@code encodedSolidusHandling} rejection would not recur; it does prove the new query-parameter
+ * shape correctly binds a slash-containing value end to end through Spring's own request processing,
+ * including the {@code %2F}-encoded form.
+ */
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class AdminLicensingControllerGetKeyTest {
+   @Mock private LicenseManager licenseManager;
+   @Mock private LicenseChangePlanService planService;
+   @Mock private LicenseChangesetApplyService applyService;
+   @Mock private OrganizationManager orgManager;
+   private MockedStatic<OrganizationManager> orgManagerStatic;
+   private MockedStatic<LicenseManager> licenseManagerStatic;
+   private MockMvc mvc;
+
+   private static final Principal TEST_PRINCIPAL = () -> "test-user";
+
+   @BeforeEach
+   void setUp() {
+      orgManagerStatic = mockStatic(OrganizationManager.class, withSettings().lenient());
+      orgManagerStatic.when(OrganizationManager::getInstance).thenReturn(orgManager);
+      lenient().when(orgManager.isSiteAdmin(TEST_PRINCIPAL)).thenReturn(true);
+
+      licenseManagerStatic = mockStatic(LicenseManager.class, withSettings().lenient());
+      licenseManagerStatic.when(LicenseManager::isEnterprise).thenReturn(true);
+
+      mvc = standaloneSetup(new AdminLicensingController(licenseManager, planService, applyService))
+         .setMessageConverters(new MappingJackson2HttpMessageConverter())
+         .build();
+   }
+
+   @AfterEach
+   void tearDown() {
+      orgManagerStatic.close();
+      licenseManagerStatic.close();
+   }
+
+   private static License license(String key) {
+      return License.builder().key(key).type(LicenseType.CPU)
+         .expires(LocalDateTime.now().plusYears(1)).build();
+   }
+
+   @Test void getLicenseKeyExtractsSlashContainingKeyFromQueryParameter() throws Exception {
+      when(licenseManager.getInstalledLicenses()).thenReturn(Set.of(license("AB/CD")));
+
+      mvc.perform(get("/api/wiz/v1/admin/licensing/key")
+            .param("key", "AB/CD")
+            .principal(TEST_PRINCIPAL)
+            .header("Authorization", "Bearer test-token"))
+         .andExpect(status().isOk())
+         .andExpect(content().string(containsString("\"found\":true")));
+   }
+
+   /** The exact byte sequence ({@code %2F}) the old path-variable request construction would have
+    * sent, now in the query string rather than the path -- confirms Spring correctly percent-decodes
+    * it back to a literal slash for a {@code @RequestParam}, unlike the path-segment shape this
+    * replaces. */
+   @Test void getLicenseKeyAcceptsPercentEncodedSlashInQueryString() throws Exception {
+      when(licenseManager.getInstalledLicenses()).thenReturn(Set.of(license("AB/CD")));
+
+      mvc.perform(get(URI.create("/api/wiz/v1/admin/licensing/key?key=AB%2FCD"))
+            .principal(TEST_PRINCIPAL)
+            .header("Authorization", "Bearer test-token"))
+         .andExpect(status().isOk())
+         .andExpect(content().string(containsString("\"found\":true")));
+   }
+
+   @Test void getLicenseKeyNoLongerMapsTheOldPathVariableShape() throws Exception {
+      mvc.perform(get("/api/wiz/v1/admin/licensing/keys/AB%2FCD")
+            .header("Authorization", "Bearer test-token"))
+         .andExpect(status().isNotFound());
+
+      verifyNoInteractions(licenseManager);
+   }
+
+   @Test void getLicenseKeyReturnsFoundFalseOnMiss() throws Exception {
+      when(licenseManager.getInstalledLicenses()).thenReturn(Set.of());
+
+      mvc.perform(get("/api/wiz/v1/admin/licensing/key")
+            .param("key", "GHOST")
+            .principal(TEST_PRINCIPAL)
+            .header("Authorization", "Bearer test-token"))
+         .andExpect(status().isOk())
+         .andExpect(content().string(containsString("\"found\":false")));
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/ai/licensing/LicenseChangePlanServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/licensing/LicenseChangePlanServiceTest.java
@@ -1,0 +1,277 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.licensing;
+
+import inetsoft.report.internal.license.License;
+import inetsoft.report.internal.license.LicenseManager;
+import inetsoft.report.internal.license.LicenseType;
+import inetsoft.web.admin.ai.PlanChange;
+import inetsoft.web.admin.ai.ResolvedPlan;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * 01-spec.md section 2 (add-time validity refusal, remove-of-absent refusal, already-installed-add
+ * refusal per 03-reconcile.md addition 2), section 5 (per-key hash projection, de-licensing net
+ * count), section 14 D2 (never trust {@code LicenseKeyModel.valid()} -- this service never
+ * constructs one at all, only real {@link License} objects).
+ */
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class LicenseChangePlanServiceTest {
+   @Mock private LicenseManager licenseManager;
+   private LicenseChangePlanService service;
+
+   @BeforeEach
+   void setUp() {
+      service = new LicenseChangePlanService(licenseManager);
+   }
+
+   private static License license(String key, LicenseType type, LocalDateTime expires) {
+      return License.builder().key(key).type(type).expires(expires).build();
+   }
+
+   private static LicenseChangeRequest add(String key) {
+      LicenseChangeRequest r = new LicenseChangeRequest();
+      r.setVerb(LicenseChangeRequest.VERB_ADD);
+      r.setKey(key);
+      return r;
+   }
+
+   private static LicenseChangeRequest remove(String key) {
+      LicenseChangeRequest r = new LicenseChangeRequest();
+      r.setVerb(LicenseChangeRequest.VERB_REMOVE);
+      r.setKey(key);
+      return r;
+   }
+
+   private static LicenseChangePlanRequest request(String task, List<LicenseChangeRequest> changes) {
+      LicenseChangePlanRequest req = new LicenseChangePlanRequest();
+      req.setTask(task);
+      req.setChanges(changes);
+      return req;
+   }
+
+   private void stubInstalled(License... installed) {
+      lenient().when(licenseManager.getInstalledLicenses())
+         .thenReturn(new LinkedHashSet<>(Arrays.asList(installed)));
+   }
+
+   // -------------------------------------------------------------------------
+   // basic request validation
+   // -------------------------------------------------------------------------
+
+   @Test void resolveThrowsOnBlankTask() {
+      LicenseChangePlanRequest req = request("  ", List.of(add("K1")));
+      assertTrue(assertThrows(IllegalArgumentException.class, () -> service.resolve(req))
+                    .getMessage().contains("task"));
+   }
+
+   @Test void resolveThrowsOnEmptyChanges() {
+      LicenseChangePlanRequest req = request("task", List.of());
+      assertThrows(IllegalArgumentException.class, () -> service.resolve(req));
+   }
+
+   @Test void resolveThrowsOnNullChanges() {
+      LicenseChangePlanRequest req = request("task", null);
+      assertThrows(IllegalArgumentException.class, () -> service.resolve(req));
+   }
+
+   @Test void resolveThrowsOnUnrecognizedVerb() {
+      LicenseChangeRequest change = add("K1");
+      change.setVerb("replace");
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(change))));
+      assertTrue(ex.getMessage().contains("verb"));
+   }
+
+   @Test void resolveThrowsOnBlankKey() {
+      LicenseChangeRequest change = add("   ");
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(change))));
+      assertTrue(ex.getMessage().contains("key"));
+   }
+
+   @Test void resolveThrowsOnDuplicateKeyEntries() {
+      stubInstalled();
+      lenient().when(licenseManager.parseLicense("K1"))
+         .thenReturn(license("K1", LicenseType.CPU, LocalDateTime.now().plusYears(1)));
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(add("K1"), remove("K1")))));
+      assertTrue(ex.getMessage().contains("duplicate"));
+   }
+
+   // -------------------------------------------------------------------------
+   // add
+   // -------------------------------------------------------------------------
+
+   @Test void resolveAcceptsValidAdd() {
+      stubInstalled();
+      License resolved = license("K1", LicenseType.CPU, LocalDateTime.now().plusYears(1));
+      when(licenseManager.parseLicense("K1")).thenReturn(resolved);
+
+      ResolvedPlan plan = service.resolve(request("task", List.of(add("K1"))));
+
+      assertEquals(1, plan.changes().size());
+      PlanChange change = plan.changes().get(0);
+      assertEquals("K1", change.property());
+      assertNull(change.currentValue());
+      assertNotNull(change.proposedValue());
+      assertEquals("high", change.risk());
+      assertEquals("storage", change.snapshotScope());
+      assertTrue(plan.requiresAgentSignoff());
+      assertTrue(plan.requiresStorageBackup());
+   }
+
+   @Test void resolveRefusesAddOfInvalidTypedKey() {
+      stubInstalled();
+      License invalid = license("BAD", LicenseType.INVALID, null);
+      when(licenseManager.parseLicense("BAD")).thenReturn(invalid);
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(add("BAD")))));
+      assertTrue(ex.getMessage().contains("BAD"));
+   }
+
+   @Test void resolveRefusesAddOfExpiredKey() {
+      stubInstalled();
+      // type != INVALID but valid() is false because it has already expired.
+      License expired = license("EXP", LicenseType.CPU, LocalDateTime.now().minusDays(1));
+      when(licenseManager.parseLicense("EXP")).thenReturn(expired);
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(add("EXP")))));
+      assertTrue(ex.getMessage().contains("EXP"));
+   }
+
+   /** 03-reconcile.md addition 2 -- build-blocking: an add of an already-installed key is refused
+    * outright, not merely folded into the plan hash, because {@code EnterpriseLicenseStrategy
+    * .addLicense}'s cluster-node claiming exchange has no already-installed guard of its own. */
+   @Test void resolveRefusesAddOfAlreadyInstalledKey() {
+      License already = license("K1", LicenseType.CPU, LocalDateTime.now().plusYears(1));
+      stubInstalled(already);
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(add("K1")))));
+      assertTrue(ex.getMessage().contains("already installed"));
+      verify(licenseManager, never()).parseLicense(any());
+   }
+
+   // -------------------------------------------------------------------------
+   // remove
+   // -------------------------------------------------------------------------
+
+   @Test void resolveAcceptsValidRemove() {
+      License installed = license("K1", LicenseType.CPU, LocalDateTime.now().plusYears(1));
+      stubInstalled(installed);
+
+      ResolvedPlan plan = service.resolve(request("task", List.of(remove("K1"))));
+
+      assertEquals(1, plan.changes().size());
+      PlanChange change = plan.changes().get(0);
+      assertEquals("K1", change.property());
+      assertNotNull(change.currentValue());
+      assertNull(change.proposedValue());
+   }
+
+   @Test void resolveRefusesRemoveOfNotInstalledKey() {
+      stubInstalled();
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.resolve(request("task", List.of(remove("GHOST")))));
+      assertTrue(ex.getMessage().contains("GHOST"));
+      assertTrue(ex.getMessage().contains("not currently installed"));
+   }
+
+   // -------------------------------------------------------------------------
+   // last-key-removal / de-licensing net count (section 5)
+   // -------------------------------------------------------------------------
+
+   @Test void resolveFlagsDeLicensingWarningWhenRemovingTheLastKey() {
+      License only = license("K1", LicenseType.CPU, LocalDateTime.now().plusYears(1));
+      stubInstalled(only);
+
+      ResolvedPlan plan = service.resolve(request("task", List.of(remove("K1"))));
+
+      assertTrue(plan.changes().get(0).description().contains("WARNING"));
+   }
+
+   @Test void resolveDoesNotFlagDeLicensingWarningWhenAnotherKeyRemains() {
+      License k1 = license("K1", LicenseType.CPU, LocalDateTime.now().plusYears(1));
+      License k2 = license("K2", LicenseType.CPU, LocalDateTime.now().plusYears(1));
+      stubInstalled(k1, k2);
+
+      ResolvedPlan plan = service.resolve(request("task", List.of(remove("K1"))));
+
+      assertFalse(plan.changes().get(0).description().contains("WARNING"));
+   }
+
+   @Test void resolveEvaluatesMixedAddAndRemoveNet() {
+      License only = license("K1", LicenseType.CPU, LocalDateTime.now().plusYears(1));
+      stubInstalled(only);
+      License newLicense = license("K2", LicenseType.CPU, LocalDateTime.now().plusYears(1));
+      when(licenseManager.parseLicense("K2")).thenReturn(newLicense);
+
+      // Removing K1 and adding K2 nets to 1 remaining key -- no de-licensing warning.
+      ResolvedPlan plan = service.resolve(request("task", List.of(remove("K1"), add("K2"))));
+
+      for(PlanChange change : plan.changes()) {
+         assertFalse(change.description().contains("WARNING"));
+      }
+   }
+
+   @Test void computeDeLicensingWarningNetsAddsAndRemoves() {
+      assertTrue(LicenseChangePlanService.computeDeLicensingWarning(1, 0, 1));
+      assertFalse(LicenseChangePlanService.computeDeLicensingWarning(2, 0, 1));
+      assertFalse(LicenseChangePlanService.computeDeLicensingWarning(1, 1, 1));
+      assertFalse(LicenseChangePlanService.computeDeLicensingWarning(0, 0, 0));
+   }
+
+   // -------------------------------------------------------------------------
+   // hash stability / drift sensitivity (section 5)
+   // -------------------------------------------------------------------------
+
+   @Test void hashIsStableAcrossIdenticalResolves() {
+      License installed = license("K1", LicenseType.CPU, LocalDateTime.now().plusYears(1));
+      stubInstalled(installed);
+
+      ResolvedPlan first = service.resolve(request("task", List.of(remove("K1"))));
+      ResolvedPlan second = service.resolve(request("task", List.of(remove("K1"))));
+
+      assertEquals(first.planHash(), second.planHash());
+   }
+
+   @Test void hashChangesWhenAnUnrelatedKeyIsInstalledConcurrently() {
+      License k1 = license("K1", LicenseType.CPU, LocalDateTime.now().plusYears(1));
+      stubInstalled(k1);
+      ResolvedPlan before = service.resolve(request("task", List.of(remove("K1"))));
+
+      License k2 = license("K2", LicenseType.CPU, LocalDateTime.now().plusYears(1));
+      stubInstalled(k1, k2);
+      ResolvedPlan after = service.resolve(request("task", List.of(remove("K1"))));
+
+      assertNotEquals(before.planHash(), after.planHash());
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/ai/licensing/LicenseChangesetApplyServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/ai/licensing/LicenseChangesetApplyServiceTest.java
@@ -1,0 +1,413 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.ai.licensing;
+
+import inetsoft.report.internal.license.License;
+import inetsoft.report.internal.license.LicenseManager;
+import inetsoft.report.internal.license.LicenseType;
+import inetsoft.uql.XPrincipal;
+import inetsoft.util.Tool;
+import inetsoft.util.audit.ActionRecord;
+import inetsoft.util.audit.AdminChangeRecord;
+import inetsoft.util.audit.Audit;
+import inetsoft.web.admin.ai.AdminBackupService;
+import inetsoft.web.admin.ai.AdminChangesetApplyService;
+import inetsoft.web.admin.general.LicenseKeySettingsService;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * 01-spec.md section 6 (apply/rollback per verb), section 7 (the Tier-2 backup, unconditional,
+ * taken synchronously before any mutation), section 5/6 ({@code acknowledgeDelicensing} advisory
+ * gate). {@code LicenseKeySettingsService} is mocked here (its own
+ * cluster-broadcast/auth-cache-reset side-effect ordering is covered directly by
+ * {@code LicenseKeySettingsServiceTest}); its mocked {@code addServerKey}/{@code removeServerKey}
+ * mutate a small in-memory installed-license set so verification/rollback assertions reflect real
+ * state transitions, matching {@code ProviderChangesetApplyServiceTest}'s own in-memory fake chain.
+ *
+ * <p>Mid-apply failures are injected by having a mocked {@code addServerKey}/{@code removeServerKey}
+ * call throw -- never by making a key resolve as invalid, because the top-of-{@code apply} fresh
+ * {@code resolve()} call would already refuse an invalid key before the loop is ever reached (the
+ * per-entry re-check inside {@code applyAdd} only ever matters for the narrower race between that
+ * fresh resolve and this specific entry's own turn in the loop, which a throwing mock reproduces
+ * without fighting the resolve-time validation).
+ */
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class LicenseChangesetApplyServiceTest {
+   @Mock private LicenseManager licenseManager;
+   @Mock private LicenseKeySettingsService licenseKeySettingsService;
+   @Mock private AdminBackupService backupService;
+   @Mock private XPrincipal user;
+
+   private final Set<License> installed = new LinkedHashSet<>();
+   private LicenseChangePlanService planService;
+   private LicenseChangesetApplyService service;
+
+   @BeforeEach
+   void setUp() throws Exception {
+      planService = new LicenseChangePlanService(licenseManager);
+      service = new LicenseChangesetApplyService(planService, licenseManager,
+                                                 licenseKeySettingsService, backupService);
+
+      lenient().when(licenseManager.getInstalledLicenses())
+         .thenAnswer(inv -> new LinkedHashSet<>(installed));
+      lenient().when(backupService.backup(anyString())).thenReturn("admin-snapshot/ref");
+
+      lenient().doAnswer(inv -> {
+         String key = inv.getArgument(0);
+         installed.add(licenseManager.parseLicense(key));
+         return null;
+      }).when(licenseKeySettingsService).addServerKey(anyString());
+
+      lenient().doAnswer(inv -> {
+         String key = inv.getArgument(0);
+         installed.removeIf(l -> Objects.equals(l.key(), key));
+         return null;
+      }).when(licenseKeySettingsService).removeServerKey(anyString());
+   }
+
+   private static License license(String key, LicenseType type, LocalDateTime expires) {
+      return License.builder().key(key).type(type).expires(expires).build();
+   }
+
+   private static License valid(String key) {
+      return license(key, LicenseType.CPU, LocalDateTime.now().plusYears(1));
+   }
+
+   private static LicenseChangeRequest add(String key) {
+      LicenseChangeRequest r = new LicenseChangeRequest();
+      r.setVerb(LicenseChangeRequest.VERB_ADD);
+      r.setKey(key);
+      return r;
+   }
+
+   private static LicenseChangeRequest remove(String key) {
+      LicenseChangeRequest r = new LicenseChangeRequest();
+      r.setVerb(LicenseChangeRequest.VERB_REMOVE);
+      r.setKey(key);
+      return r;
+   }
+
+   private static LicenseChangePlanRequest request(String task, List<LicenseChangeRequest> changes) {
+      LicenseChangePlanRequest req = new LicenseChangePlanRequest();
+      req.setTask(task);
+      req.setChanges(changes);
+      return req;
+   }
+
+   private static LicenseApplyRequest applyRequest(String task, String hash, String reviewOutcome,
+                                                    Boolean acknowledgeDelicensing,
+                                                    LicenseChangeRequest... changes)
+   {
+      LicenseApplyRequest req = new LicenseApplyRequest();
+      req.setTask(task);
+      req.setChanges(Arrays.asList(changes));
+      req.setPlanHash(hash);
+      req.setReviewOutcome(reviewOutcome);
+      req.setAcknowledgeDelicensing(acknowledgeDelicensing);
+      return req;
+   }
+
+   private MockedStatic<Audit> mockAudit() {
+      MockedStatic<Audit> audit = mockStatic(Audit.class);
+      Audit instance = mock(Audit.class);
+      audit.when(Audit::getInstance).thenReturn(instance);
+      return audit;
+   }
+
+   // -------------------------------------------------------------------------
+   // hash / reviewOutcome gates
+   // -------------------------------------------------------------------------
+
+   @Test void applyThrowsPlanHashMismatchOnStaleHash() {
+      when(licenseManager.parseLicense("K1")).thenReturn(valid("K1"));
+      LicenseApplyRequest req = applyRequest("task", "not-the-real-hash", "looks good", null, add("K1"));
+      assertThrows(AdminChangesetApplyService.PlanHashMismatchException.class,
+         () -> service.apply(req, user));
+   }
+
+   @Test void applyThrowsOnMissingReviewOutcome() {
+      when(licenseManager.parseLicense("K1")).thenReturn(valid("K1"));
+      String hash = planService.resolve(request("task", List.of(add("K1")))).planHash();
+      LicenseApplyRequest req = applyRequest("task", hash, "  ", null, add("K1"));
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.apply(req, user));
+      assertTrue(ex.getMessage().contains("reviewOutcome"));
+   }
+
+   /** A key that became installed between preview and apply is refused loud by the fresh top-of
+    * -apply resolve, before the hash is even compared (03-reconcile.md addition 2). */
+   @Test void applyRefusesLoudWhenAddKeyBecameInstalledConcurrently() {
+      when(licenseManager.parseLicense("K1")).thenReturn(valid("K1"));
+      String hash = planService.resolve(request("task", List.of(add("K1")))).planHash();
+      installed.add(valid("K1"));
+
+      LicenseApplyRequest req = applyRequest("task", hash, "looks good", null, add("K1"));
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.apply(req, user));
+      assertTrue(ex.getMessage().contains("already installed"));
+   }
+
+   // -------------------------------------------------------------------------
+   // acknowledgeDelicensing gate (section 5/6)
+   // -------------------------------------------------------------------------
+
+   @Test void applyThrowsWhenRemovingTheLastKeyWithoutAcknowledgeDelicensing() {
+      installed.add(valid("K1"));
+      String hash = planService.resolve(request("task", List.of(remove("K1")))).planHash();
+      LicenseApplyRequest req = applyRequest("task", hash, "looks good", null, remove("K1"));
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> service.apply(req, user));
+      assertTrue(ex.getMessage().contains("acknowledgeDelicensing"));
+   }
+
+   @Test void applySucceedsRemovingTheLastKeyWithAcknowledgeDelicensing() throws Exception {
+      installed.add(valid("K1"));
+      String hash = planService.resolve(request("task", List.of(remove("K1")))).planHash();
+      LicenseApplyRequest req = applyRequest("task", hash, "looks good", true, remove("K1"));
+      LicenseApplyResult result;
+
+      try(MockedStatic<Audit> audit = mockAudit()) {
+         result = service.apply(req, user);
+      }
+
+      assertEquals(AdminChangesetApplyService.STATUS_APPLIED, result.status());
+      assertTrue(installed.isEmpty());
+   }
+
+   // -------------------------------------------------------------------------
+   // success
+   // -------------------------------------------------------------------------
+
+   @Test void appliesAnAddAndReportsApplied() throws Exception {
+      when(licenseManager.parseLicense("K1")).thenReturn(valid("K1"));
+      String hash = planService.resolve(request("task", List.of(add("K1")))).planHash();
+      LicenseApplyRequest req = applyRequest("task", hash, "looks good", null, add("K1"));
+      LicenseApplyResult result;
+
+      try(MockedStatic<Audit> audit = mockAudit()) {
+         result = service.apply(req, user);
+      }
+
+      assertEquals(AdminChangesetApplyService.STATUS_APPLIED, result.status());
+      assertEquals("admin-snapshot/ref", result.backupRef());
+      assertNull(result.rollbackFailures());
+      assertEquals(1, result.results().size());
+      assertEquals(AdminChangeRecord.STATUS_VERIFIED, result.results().get(0).status());
+      assertTrue(installed.stream().anyMatch(l -> "K1".equals(l.key())));
+      verify(backupService).backup(anyString());
+   }
+
+   @Test void appliesARemoveAndReportsApplied() throws Exception {
+      installed.add(valid("K1"));
+      installed.add(valid("K2"));
+      String hash = planService.resolve(request("task", List.of(remove("K1")))).planHash();
+      LicenseApplyRequest req = applyRequest("task", hash, "looks good", null, remove("K1"));
+      LicenseApplyResult result;
+
+      try(MockedStatic<Audit> audit = mockAudit()) {
+         result = service.apply(req, user);
+      }
+
+      assertEquals(AdminChangesetApplyService.STATUS_APPLIED, result.status());
+      assertTrue(installed.stream().noneMatch(l -> "K1".equals(l.key())));
+      assertTrue(installed.stream().anyMatch(l -> "K2".equals(l.key())));
+   }
+
+   // -------------------------------------------------------------------------
+   // backup ordering (section 7)
+   // -------------------------------------------------------------------------
+
+   @Test void backupIsTakenBeforeAnyMutation() throws Exception {
+      when(licenseManager.parseLicense("K1")).thenReturn(valid("K1"));
+      String hash = planService.resolve(request("task", List.of(add("K1")))).planHash();
+      LicenseApplyRequest req = applyRequest("task", hash, "looks good", null, add("K1"));
+
+      InOrder order = inOrder(backupService, licenseKeySettingsService);
+
+      try(MockedStatic<Audit> audit = mockAudit()) {
+         service.apply(req, user);
+      }
+
+      order.verify(backupService).backup(anyString());
+      order.verify(licenseKeySettingsService).addServerKey("K1");
+   }
+
+   // -------------------------------------------------------------------------
+   // throw mid-apply -> rollback / rollback-failed (section 6, "fails by throwing")
+   // -------------------------------------------------------------------------
+
+   /** A throw carries no verifiable before/after evidence for the entry that threw, so its own
+    * state is unconditionally reported as "unknown" -- the overall status is {@code rollback-failed}
+    * even though the EARLIER change's own rollback succeeds cleanly, matching
+    * {@code ProviderChangesetApplyServiceTest.throwMidApplyRollsBackEarlierChangeButReportsRollbackFailedForTheUnknownState}'s
+    * own precedent exactly (guide section 2.5's "a throw is a failed change, not only a returned
+    * failed status" rule). */
+   @Test void midApplyFailureRollsBackThePreviouslyAppliedAddButReportsRollbackFailedForTheUnknownState()
+      throws Exception
+   {
+      when(licenseManager.parseLicense("K1")).thenReturn(valid("K1"));
+      when(licenseManager.parseLicense("K2")).thenReturn(valid("K2"));
+      String hash = planService.resolve(request("task", List.of(add("K1"), add("K2")))).planHash();
+      doThrow(new RuntimeException("simulated failure adding K2"))
+         .when(licenseKeySettingsService).addServerKey("K2");
+
+      LicenseApplyRequest req = applyRequest("task", hash, "looks good", null, add("K1"), add("K2"));
+      LicenseApplyResult result;
+
+      try(MockedStatic<Audit> audit = mockAudit()) {
+         result = service.apply(req, user);
+      }
+
+      assertEquals(AdminChangesetApplyService.STATUS_ROLLBACK_FAILED, result.status());
+      assertNotNull(result.rollbackFailures());
+      assertTrue(result.rollbackFailures().stream()
+         .anyMatch(f -> "K2".equals(f.property()) && f.error().contains("state unknown")));
+      // K1's own rollback succeeded cleanly even though the overall status is rollback-failed.
+      assertTrue(installed.isEmpty());
+      verify(licenseKeySettingsService).addServerKey("K1");
+      verify(licenseKeySettingsService).addServerKey("K2");
+      verify(licenseKeySettingsService).removeServerKey("K1");
+   }
+
+   @Test void rollbackFailureReportsRollbackFailedNamingTheKey() throws Exception {
+      when(licenseManager.parseLicense("K1")).thenReturn(valid("K1"));
+      when(licenseManager.parseLicense("K2")).thenReturn(valid("K2"));
+      String hash = planService.resolve(request("task", List.of(add("K1"), add("K2")))).planHash();
+      doThrow(new RuntimeException("simulated failure adding K2"))
+         .when(licenseKeySettingsService).addServerKey("K2");
+      // Rollback of K1's add (a removeServerKey call) silently fails to actually remove it.
+      doNothing().when(licenseKeySettingsService).removeServerKey("K1");
+
+      LicenseApplyRequest req = applyRequest("task", hash, "looks good", null, add("K1"), add("K2"));
+      LicenseApplyResult result;
+
+      try(MockedStatic<Audit> audit = mockAudit()) {
+         result = service.apply(req, user);
+      }
+
+      assertEquals(AdminChangesetApplyService.STATUS_ROLLBACK_FAILED, result.status());
+      assertNotNull(result.rollbackFailures());
+      assertTrue(result.rollbackFailures().stream().anyMatch(f -> "K1".equals(f.property())));
+   }
+
+   // -------------------------------------------------------------------------
+   // rollback of a remove -- claiming-node-drift advisory + re-check before re-adding
+   // (03-reconcile.md addition 2 / 01-spec.md section 4)
+   // -------------------------------------------------------------------------
+
+   @Test void rollbackOfRemoveCarriesClaimingNodeDriftAdvisory() throws Exception {
+      installed.add(valid("K1"));
+      installed.add(valid("K2"));
+      // K1's rollback re-adds it via addServerKey, which re-parses the key -- stubbed so the
+      // rollback path's re-installed License is well-formed, not a Mockito default null.
+      when(licenseManager.parseLicense("K1")).thenReturn(valid("K1"));
+      when(licenseManager.parseLicense("K3")).thenReturn(valid("K3"));
+      String hash = planService.resolve(
+         request("task", List.of(remove("K1"), add("K3")))).planHash();
+      doThrow(new RuntimeException("simulated failure adding K3"))
+         .when(licenseKeySettingsService).addServerKey("K3");
+
+      LicenseApplyRequest req = applyRequest("task", hash, "looks good", null, remove("K1"), add("K3"));
+      LicenseApplyResult result;
+
+      try(MockedStatic<Audit> audit = mockAudit()) {
+         result = service.apply(req, user);
+      }
+
+      // Overall status is rollback-failed (K3's own throw is an unconditional "unknown state"
+      // failure, matching the previous test's own rule) even though K1's remove was itself rolled
+      // back cleanly, with the claiming-node-drift advisory attached to its own outcome.
+      assertEquals(AdminChangesetApplyService.STATUS_ROLLBACK_FAILED, result.status());
+      assertTrue(installed.stream().anyMatch(l -> "K1".equals(l.key())));
+      LicenseApplyOutcome k1Outcome = result.results().stream()
+         .filter(o -> "K1".equals(o.property())).findFirst().orElseThrow();
+      assertNotNull(k1Outcome.advisory());
+      assertTrue(k1Outcome.advisory().contains("different cluster node"));
+   }
+
+   /** 03-reconcile.md addition 2 -- a rollback re-add must re-check installed-membership before
+    * calling {@code addServerKey}, not blindly retry, since a concurrent operator action could have
+    * already re-added the same key through a different channel during the rollback window. */
+   @Test void rollbackOfRemoveDoesNotReAddWhenAlreadyReinstalledConcurrently() throws Exception {
+      installed.add(valid("K1"));
+      when(licenseManager.parseLicense("K3")).thenReturn(valid("K3"));
+      String hash = planService.resolve(
+         request("task", List.of(remove("K1"), add("K3")))).planHash();
+
+      // The instant K3's add is attempted, a concurrent channel races K1 back in, then the add fails.
+      doAnswer(inv -> {
+         installed.add(valid("K1"));
+         throw new RuntimeException("simulated failure adding K3");
+      }).when(licenseKeySettingsService).addServerKey("K3");
+
+      LicenseApplyRequest req = applyRequest("task", hash, "looks good", null, remove("K1"), add("K3"));
+      LicenseApplyResult result;
+
+      try(MockedStatic<Audit> audit = mockAudit()) {
+         result = service.apply(req, user);
+      }
+
+      assertEquals(AdminChangesetApplyService.STATUS_ROLLBACK_FAILED, result.status());
+      verify(licenseKeySettingsService, never()).addServerKey("K1");
+      assertTrue(result.rollbackFailures().stream()
+         .anyMatch(f -> "K1".equals(f.property()) && f.error().contains("already reinstalled")));
+   }
+
+   // -------------------------------------------------------------------------
+   // audit (section 8) -- OBJECT_TYPE_EMPROPERTY, snapshotScope=storage, organizationId null
+   // -------------------------------------------------------------------------
+
+   @Test void writesAnAuditRecordWithLicensingFields() throws Exception {
+      when(licenseManager.parseLicense("K1")).thenReturn(valid("K1"));
+      String hash = planService.resolve(request("task", List.of(add("K1")))).planHash();
+      LicenseApplyRequest req = applyRequest("task", hash, "looks good", null, add("K1"));
+      Audit auditInstance = mock(Audit.class);
+
+      try(MockedStatic<Audit> audit = mockStatic(Audit.class);
+          MockedStatic<Tool> tool = mockStatic(Tool.class, CALLS_REAL_METHODS))
+      {
+         audit.when(Audit::getInstance).thenReturn(auditInstance);
+         tool.when(Tool::getHost).thenReturn("test-host");
+         service.apply(req, user);
+      }
+
+      ArgumentCaptor<AdminChangeRecord> captor = ArgumentCaptor.forClass(AdminChangeRecord.class);
+      verify(auditInstance).auditAdminChange(captor.capture(), eq(user));
+      AdminChangeRecord record = captor.getValue();
+      assertEquals(ActionRecord.OBJECT_TYPE_EMPROPERTY, record.getObjectType());
+      assertEquals(AdminChangeRecord.SCOPE_STORAGE, record.getSnapshotScope());
+      assertEquals(AdminChangeRecord.RISK_HIGH, record.getRiskLevel());
+      assertEquals("admin-snapshot/ref", record.getBackupRef());
+      assertEquals(AdminChangeRecord.ACTION_APPLY, record.getAction());
+      assertEquals(AdminChangeRecord.STATUS_VERIFIED, record.getStatus());
+      assertEquals("K1", record.getProperty());
+      assertNull(record.getOrganizationId());
+   }
+}

--- a/core/src/test/java/inetsoft/web/admin/general/LicenseKeySettingsServiceTest.java
+++ b/core/src/test/java/inetsoft/web/admin/general/LicenseKeySettingsServiceTest.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2024  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.admin.general;
+
+import inetsoft.report.internal.license.LicenseManager;
+import inetsoft.sree.internal.cluster.Cluster;
+import inetsoft.sree.security.AuthenticationService;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * 01-spec.md section 0: {@code addServerKey}/{@code removeServerKey} must call
+ * {@code LicenseManager.addLicense}/{@code removeLicense} and then replicate {@code setModel}'s own
+ * two side effects -- {@code cluster.sendMessage(new ResetLicenseKeyMessage())} and
+ * {@code authenticationService.reset()} -- in that exact order.
+ */
+@Tag("core")
+@ExtendWith(MockitoExtension.class)
+class LicenseKeySettingsServiceTest {
+   @Mock private LicenseManager licenseManager;
+   @Mock private Cluster cluster;
+   @Mock private AuthenticationService authenticationService;
+   private LicenseKeySettingsService service;
+
+   @BeforeEach
+   void setUp() {
+      service = new LicenseKeySettingsService(licenseManager, cluster, authenticationService);
+   }
+
+   @Test
+   void addServerKeyCallsAddLicenseThenBroadcastsThenResetsAuth() throws Exception {
+      InOrder order = inOrder(licenseManager, cluster, authenticationService);
+
+      service.addServerKey("KEY-1");
+
+      order.verify(licenseManager).addLicense("KEY-1");
+      order.verify(cluster).sendMessage(any(ResetLicenseKeyMessage.class));
+      order.verify(authenticationService).reset();
+      verifyNoMoreInteractions(licenseManager, cluster, authenticationService);
+   }
+
+   @Test
+   void removeServerKeyCallsRemoveLicenseThenBroadcastsThenResetsAuth() throws Exception {
+      InOrder order = inOrder(licenseManager, cluster, authenticationService);
+
+      service.removeServerKey("KEY-1");
+
+      order.verify(licenseManager).removeLicense("KEY-1");
+      order.verify(cluster).sendMessage(any(ResetLicenseKeyMessage.class));
+      order.verify(authenticationService).reset();
+      verifyNoMoreInteractions(licenseManager, cluster, authenticationService);
+   }
+}


### PR DESCRIPTION
## Summary
- Admin-chat plugin support for server license key add/remove: `LicenseKeySettingsService.setModel`/`updateKeys` does a nondeterministic replace-plus-remove and cannot be safely wrapped, so this adds two new, narrow, additive methods (`addServerKey`/`removeServerKey`) that call `LicenseManager.addLicense`/`removeLicense` directly and replicate `setModel`'s own `ResetLicenseKeyMessage` cluster broadcast + `authenticationService.reset()` side effects.
- New `AdminLicensingController` (community-tier, matching the C.4/presentation/cluster placement precedent) exposes `list_license_keys`, `get_license_key`, `preview_license_changes`, `apply_license_changes`, gated behind `AdminAiCallerGuard`/site-admin **and** `LicenseManager.isEnterprise()` on all four endpoints (reads included) — a community-only deployment would otherwise hit an NPE on add (via `NoopLicenseStrategy`'s null-backed `License`) and a phantom single-key entry on reads.
- Refuses, rather than silently passing through: adding an already-installed key (the underlying cluster-node claiming exchange has no already-installed guard and can double-claim a non-pooled key), removing a not-installed key (would otherwise silently no-op), and any malformed/`INVALID`-typed key on add. An advisory `acknowledgeDelicensing` gate (not a hard refusal) covers removing the last installed key, matching the underlying product's own lack of a hard block there.
- One real transport defect found by this track's own verify pass and fixed in this PR: `get_license_key`'s candidate key was originally a URL path segment, which this repo's embedded Tomcat rejects for any literal `/` before Spring MVC routing runs; moved to a query parameter (matching Viewsheets' identical fix for `get_viewsheet_folder`), with a new regression test (`AdminLicensingControllerGetKeyTest`) proving the old route is gone and the new shape round-trips a slash-containing value correctly.
- Confirmed clean by an independent P5 review round (no build-blocking defect) and by this PR-review pass's own re-derivation of the plan-time/apply-time/rollback-time already-installed-add refusal and the encoded-slash fix, straight from current source.

## Test plan
- [x] `LicenseKeySettingsServiceTest`, `LicenseChangePlanServiceTest`, `LicenseChangesetApplyServiceTest`, `AdminLicensingControllerGetKeyTest` — 37/37 passing, re-run independently by this PR-review pass
- [x] Full `core` module compile/test-compile unaffected
- [x] Diff scope re-confirmed against `origin/stylebi-wiz-main-rebase` (the correct base for this submodule): 16 files, 2157 insertions, 0 deletions — exactly the `ai/licensing` package + `LicenseKeySettingsService.java` + 4 test files