### PR TITLE
Add BrowsableQuery capability so OneDrive can be browsed

### DIFF
--- a/connectors/inetsoft-onedrive/src/main/java/inetsoft/uql/onedrive/OneDriveQuery.java
+++ b/connectors/inetsoft-onedrive/src/main/java/inetsoft/uql/onedrive/OneDriveQuery.java
@@ -52,9 +52,30 @@ import java.util.List;
       button = @Button(type = ButtonType.METHOD, method = "loadColumns")),
    @View1(type = ViewType.EDITOR, value = "columns", row = 9, col = 1, colspan = 3)
 })
-public class OneDriveQuery extends SelectableTabularQuery  {
+public class OneDriveQuery extends SelectableTabularQuery implements BrowsableQuery {
    public OneDriveQuery() {
       super(OneDriveDataSource.TYPE);
+   }
+
+   private static final List<String> ACCEPTED_EXTENSIONS =
+      List.of(".txt", ".csv", ".xls", ".xlsx");
+
+   @Override
+   public String getBrowsablePropertyName() {
+      return "path";
+   }
+
+   @Override
+   public List<String> getAcceptedExtensions() {
+      return ACCEPTED_EXTENSIONS;
+   }
+
+   @Override
+   public BrowsableQuery.BrowseListing browseChildren(String path, boolean recursive,
+                                                       List<String> acceptTypes, int maxEntries)
+      throws Exception
+   {
+      return OneDriveRuntime.listChildren(this, path, recursive, acceptTypes, maxEntries);
    }
 
    @Property(

--- a/connectors/inetsoft-onedrive/src/main/java/inetsoft/uql/onedrive/OneDriveRuntime.java
+++ b/connectors/inetsoft-onedrive/src/main/java/inetsoft/uql/onedrive/OneDriveRuntime.java
@@ -201,7 +201,7 @@ public class OneDriveRuntime extends TabularRuntime {
       }
 
       String lower = name.toLowerCase();
-      return acceptTypes.stream().anyMatch(lower::endsWith);
+      return acceptTypes.stream().map(String::toLowerCase).anyMatch(lower::endsWith);
    }
 
    private static String normalize(String path) {

--- a/connectors/inetsoft-onedrive/src/main/java/inetsoft/uql/onedrive/OneDriveRuntime.java
+++ b/connectors/inetsoft-onedrive/src/main/java/inetsoft/uql/onedrive/OneDriveRuntime.java
@@ -18,6 +18,7 @@
 package inetsoft.uql.onedrive;
 
 import com.microsoft.graph.authentication.IAuthenticationProvider;
+import com.microsoft.graph.models.DriveItem;
 import com.microsoft.graph.requests.*;
 import inetsoft.uql.*;
 import inetsoft.uql.schema.*;
@@ -108,6 +109,115 @@ public class OneDriveRuntime extends TabularRuntime {
       GraphServiceClient client = getClient(ds);
       return client.me().drive().root().itemWithPath(path).content().buildRequest().getRequestUrl().toString();
    }
+
+   public static BrowsableQuery.BrowseListing listChildren(OneDriveQuery query, String path,
+                                                            boolean recursive,
+                                                            List<String> acceptTypes,
+                                                            int maxEntries) throws Exception
+   {
+      OneDriveDataSource ds = (OneDriveDataSource) query.getDataSource();
+      GraphServiceClient client = getClient(ds);
+      List<BrowsableQuery.BrowseEntry> entries = new ArrayList<>();
+      int[] graphRequests = { 0 }; // shared across the whole recursive walk, not reset per folder
+
+      boolean truncated = withClassLoader(() ->
+         collectChildren(client, normalize(path), recursive, acceptTypes, maxEntries, entries,
+                          graphRequests));
+
+      return new BrowsableQuery.BrowseListing(entries, truncated);
+   }
+
+   /**
+    * Returns true when maxEntries or MAX_GRAPH_REQUESTS stopped the walk short.
+    *
+    * <p>Package-private rather than private so {@code OneDriveRuntimeTests} can drive it directly
+    * with a mocked {@code GraphServiceClient} -- {@code listChildren}'s own {@code getClient(ds)}
+    * builds a real client from a real {@code OneDriveAuthenticator}, the same reason this file's
+    * existing {@code getFile}/{@code getFileURL} tests stub at the query-method layer rather than
+    * exercising {@code getClient} for real.</p>
+    */
+   static boolean collectChildren(GraphServiceClient client, String path,
+                                           boolean recursive, List<String> acceptTypes,
+                                           int maxEntries,
+                                           List<BrowsableQuery.BrowseEntry> entries,
+                                           int[] graphRequests)
+   {
+      DriveItemCollectionPage page = (path.isEmpty()
+         ? client.me().drive().root().children()
+         : client.me().drive().root().itemWithPath(path).children())
+         .buildRequest().get();
+      graphRequests[0]++;
+
+      List<String> subfolders = new ArrayList<>();
+
+      while(page != null) {
+         for(DriveItem item : page.getCurrentPage()) {
+            if(entries.size() >= maxEntries) {
+               return true;
+            }
+
+            String childPath = path.isEmpty() ? item.name : path + "/" + item.name;
+
+            if(item.folder != null) {
+               entries.add(new BrowsableQuery.BrowseEntry(childPath, item.name, true));
+
+               if(recursive) {
+                  subfolders.add(childPath);
+               }
+            }
+            else if(accepts(acceptTypes, item.name)) {
+               entries.add(new BrowsableQuery.BrowseEntry(childPath, item.name, false));
+            }
+         }
+
+         DriveItemCollectionRequestBuilder next = page.getNextPage();
+
+         if(next == null) {
+            break;
+         }
+
+         if(graphRequests[0] >= MAX_GRAPH_REQUESTS) {
+            return true;
+         }
+
+         page = next.buildRequest().get();
+         graphRequests[0]++;
+      }
+
+      for(String sub : subfolders) {
+         if(graphRequests[0] >= MAX_GRAPH_REQUESTS ||
+            collectChildren(client, sub, true, acceptTypes, maxEntries, entries, graphRequests))
+         {
+            return true;
+         }
+      }
+
+      return false;
+   }
+
+   private static boolean accepts(List<String> acceptTypes, String name) {
+      if(acceptTypes.isEmpty()) {
+         return true;
+      }
+
+      String lower = name.toLowerCase();
+      return acceptTypes.stream().anyMatch(lower::endsWith);
+   }
+
+   private static String normalize(String path) {
+      return path == null ? "" : path;
+   }
+
+   /**
+    * Cap on live Graph HTTP calls (one per page fetched, root or nextLink continuation) within ONE
+    * browseChildren invocation -- independent of maxEntries. A folder tree with many small folders can
+    * exhaust this before ever collecting 2000 entries: each folder needs at least one network
+    * round-trip even if it turns out to hold only one item, unlike a local File.listFiles() call.
+    * 200 mirrors wiz's own MAX_BROWSE_REQUESTS naming/value (tabularFileProbe.ts) -- same order of
+    * magnitude judgment call (bound requests, not items, because Graph's own default page size,
+    * ~200/page, already bounds items-per-request).
+    */
+   static final int MAX_GRAPH_REQUESTS = 200;
 
    private static GraphServiceClient getClient(OneDriveDataSource dataSource) {
       return GraphServiceClient

--- a/connectors/inetsoft-onedrive/src/test/java/inetsoft/uql/onedrive/OneDriveAnnotationClassTest.java
+++ b/connectors/inetsoft-onedrive/src/test/java/inetsoft/uql/onedrive/OneDriveAnnotationClassTest.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.onedrive;
+
+import inetsoft.uql.tabular.SelectableTabularQuery;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A direct anchor on the one structural fact charter assertion #1
+ * (`docs/teams/2026-08-28-onedrive-tabular-target/`) rests on: core's own
+ * {@code WizDatasourceAnnotationClassTest.aBrowsableQueryIsAFileSource} already proves that ANY
+ * {@code SelectableTabularQuery} subclass is classified {@code "FILE"}, using a local fake --
+ * core cannot import this connector's classes to test the classifier against them directly. This
+ * test does not call the classifier (package-private, unreachable from here either way); it only
+ * pins the premise the classifier's proof depends on, so an accidental future change to
+ * {@code OneDriveQuery}'s superclass is caught here rather than discovered as a silent
+ * classification regression.
+ */
+@Tag("core")
+class OneDriveAnnotationClassTest {
+   @Test
+   void oneDriveQueryIsASelectableTabularQuery() {
+      assertTrue(SelectableTabularQuery.class.isAssignableFrom(OneDriveQuery.class));
+   }
+}

--- a/connectors/inetsoft-onedrive/src/test/java/inetsoft/uql/onedrive/OneDriveRuntimeTests.java
+++ b/connectors/inetsoft-onedrive/src/test/java/inetsoft/uql/onedrive/OneDriveRuntimeTests.java
@@ -343,6 +343,28 @@ public class OneDriveRuntimeTests {
       assertEquals(3, entries.size());
    }
 
+   /**
+    * P5 review round 1 finding: accepts() lowercased only the filename side of the comparison,
+    * never acceptTypes -- so an uppercase extension in acceptTypes (a future BrowsableQuery
+    * implementor's constant, or an edit to this one) would silently drop every matching file
+    * from the listing, the same "quietly wrong" failure shape the charter's counter-assertions
+    * exist to rule out for the Graph-error case, just via filtering instead of error handling.
+    */
+   @Test
+   void acceptTypesMatchesRegardlessOfCaseOnEitherSide() {
+      GraphServiceClient client = mock(GraphServiceClient.class);
+      DriveItemRequestBuilder root = mockClient(client);
+      stubChildren(root, page(fileItem("Report.CSV"), fileItem("b.txt")));
+
+      List<BrowsableQuery.BrowseEntry> entries = new ArrayList<>();
+      OneDriveRuntime.collectChildren(
+         client, "", false, List.of(".CSV"), 2000, entries, new int[] { 0 });
+
+      assertEquals(
+         List.of("Report.CSV"),
+         entries.stream().map(BrowsableQuery.BrowseEntry::name).toList());
+   }
+
    private Object[][] readExpected(String file) throws IOException {
       try(InputStream input = getClass().getResourceAsStream(file)) {
          ObjectMapper mapper = new ObjectMapper();

--- a/connectors/inetsoft-onedrive/src/test/java/inetsoft/uql/onedrive/OneDriveRuntimeTests.java
+++ b/connectors/inetsoft-onedrive/src/test/java/inetsoft/uql/onedrive/OneDriveRuntimeTests.java
@@ -19,9 +19,19 @@ package inetsoft.uql.onedrive;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.microsoft.graph.core.ClientException;
+import com.microsoft.graph.models.DriveItem;
+import com.microsoft.graph.models.File;
+import com.microsoft.graph.models.Folder;
+import com.microsoft.graph.requests.DriveItemCollectionPage;
+import com.microsoft.graph.requests.DriveItemCollectionRequest;
+import com.microsoft.graph.requests.DriveItemCollectionRequestBuilder;
+import com.microsoft.graph.requests.DriveItemRequestBuilder;
+import com.microsoft.graph.requests.GraphServiceClient;
 import inetsoft.report.lens.xnode.XNodeTableLens;
 import inetsoft.test.*;
 import inetsoft.uql.*;
+import inetsoft.uql.tabular.BrowsableQuery;
 import inetsoft.util.ConfigurationContext;
 import inetsoft.util.credential.*;
 import org.junit.jupiter.api.*;
@@ -34,9 +44,15 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(SpringExtension.class)
@@ -107,6 +123,224 @@ public class OneDriveRuntimeTests {
       finally {
          table.dispose();
       }
+   }
+
+   // ─── BrowsableQuery.browseChildren / OneDriveRuntime.collectChildren ──────
+   //
+   // Exercised directly against collectChildren (package-private for exactly this reason) with a
+   // fully mocked GraphServiceClient, rather than through listChildren -- listChildren's own
+   // getClient(ds) builds a REAL client from a real OneDriveAuthenticator, which this file's
+   // existing shouldReadCSV/shouldReadExcel tests never exercise either (they stub query.getFile()
+   // one layer up instead).
+
+   private DriveItem folderItem(String name) {
+      DriveItem item = new DriveItem();
+      item.name = name;
+      item.folder = new Folder();
+      return item;
+   }
+
+   private DriveItem fileItem(String name) {
+      DriveItem item = new DriveItem();
+      item.name = name;
+      item.file = new File();
+      return item;
+   }
+
+   /** A page whose getNextPage() is null -- the last (or only) page of a listing. */
+   private DriveItemCollectionPage page(DriveItem... items) {
+      DriveItemCollectionPage page = mock(DriveItemCollectionPage.class);
+      when(page.getCurrentPage()).thenReturn(List.of(items));
+      return page;
+   }
+
+   /**
+    * A client whose {@code me().drive().root()} resolves to {@code root} -- built by hand, one
+    * concretely-typed mock per hop, rather than {@code RETURNS_DEEP_STUBS}: several of this SDK's
+    * builder methods ({@code buildRequest()}, {@code get()}, {@code getNextPage()}) return a
+    * generic type parameter that erases to a common base class
+    * ({@code BaseCollectionRequestBuilder}/{@code BaseCollectionPage}) in the compiled bytecode,
+    * and Mockito's deep-stub auto-mocking picks that ERASED type -- producing an object the calling
+    * code's own implicit (compiler-inserted, covariant-generics) cast then rejects with a
+    * ClassCastException. Hand-built, concretely-typed mocks at every hop sidestep this entirely.
+    */
+   private DriveItemRequestBuilder mockClient(GraphServiceClient client) {
+      com.microsoft.graph.requests.UserRequestBuilder user =
+         mock(com.microsoft.graph.requests.UserRequestBuilder.class);
+      com.microsoft.graph.requests.DriveRequestBuilder drive =
+         mock(com.microsoft.graph.requests.DriveRequestBuilder.class);
+      DriveItemRequestBuilder root = mock(DriveItemRequestBuilder.class);
+      when(client.me()).thenReturn(user);
+      when(user.drive()).thenReturn(drive);
+      when(drive.root()).thenReturn(root);
+      return root;
+   }
+
+   /** Wires {@code builder.children().buildRequest().get()} to answer with {@code firstPage}. */
+   private void stubChildren(DriveItemRequestBuilder builder, DriveItemCollectionPage firstPage) {
+      DriveItemCollectionRequestBuilder childrenBuilder =
+         mock(DriveItemCollectionRequestBuilder.class);
+      DriveItemCollectionRequest request = mock(DriveItemCollectionRequest.class);
+      when(builder.children()).thenReturn(childrenBuilder);
+      when(childrenBuilder.buildRequest()).thenReturn(request);
+      when(request.get()).thenReturn(firstPage);
+   }
+
+   private void stubChildrenThrows(DriveItemRequestBuilder builder, RuntimeException failure) {
+      DriveItemCollectionRequestBuilder childrenBuilder =
+         mock(DriveItemCollectionRequestBuilder.class);
+      DriveItemCollectionRequest request = mock(DriveItemCollectionRequest.class);
+      when(builder.children()).thenReturn(childrenBuilder);
+      when(childrenBuilder.buildRequest()).thenReturn(request);
+      when(request.get()).thenThrow(failure);
+   }
+
+   /** Wires {@code page.getNextPage()} so following it re-fetches {@code nextPage}. */
+   private void stubNextPage(DriveItemCollectionPage page, DriveItemCollectionPage nextPage) {
+      DriveItemCollectionRequestBuilder nextBuilder = mock(DriveItemCollectionRequestBuilder.class);
+      DriveItemCollectionRequest nextRequest = mock(DriveItemCollectionRequest.class);
+      when(page.getNextPage()).thenReturn(nextBuilder);
+      when(nextBuilder.buildRequest()).thenReturn(nextRequest);
+      when(nextRequest.get()).thenReturn(nextPage);
+   }
+
+   @Test
+   void rootListingDistinguishesFoldersFromFiles() {
+      GraphServiceClient client = mock(GraphServiceClient.class);
+      DriveItemRequestBuilder root = mockClient(client);
+      stubChildren(root, page(folderItem("Test"), fileItem("a.csv")));
+
+      List<BrowsableQuery.BrowseEntry> entries = new ArrayList<>();
+      boolean truncated = OneDriveRuntime.collectChildren(
+         client, "", false, List.of(), 2000, entries, new int[] { 0 });
+
+      assertFalse(truncated);
+      assertEquals(2, entries.size());
+      assertTrue(entries.stream().anyMatch(e -> e.name().equals("Test") && e.folder()));
+      assertTrue(entries.stream().anyMatch(e -> e.name().equals("a.csv") && !e.folder()));
+   }
+
+   @Test
+   void paginationIsFollowedToCompletionRatherThanStoppingAtTheFirstPage() {
+      GraphServiceClient client = mock(GraphServiceClient.class);
+      DriveItemRequestBuilder root = mockClient(client);
+      DriveItemCollectionPage page1 = page(fileItem("page1.csv"));
+      DriveItemCollectionPage page2 = page(fileItem("page2.csv"));
+      stubNextPage(page1, page2);
+      stubChildren(root, page1);
+
+      List<BrowsableQuery.BrowseEntry> entries = new ArrayList<>();
+      boolean truncated = OneDriveRuntime.collectChildren(
+         client, "", false, List.of(), 2000, entries, new int[] { 0 });
+
+      assertFalse(truncated);
+      assertEquals(
+         List.of("page1.csv", "page2.csv"),
+         entries.stream().map(BrowsableQuery.BrowseEntry::name).toList());
+   }
+
+   @Test
+   void recursiveWalksIntoAReturnedSubFolderWithJoinedPaths() {
+      GraphServiceClient client = mock(GraphServiceClient.class);
+      DriveItemRequestBuilder root = mockClient(client);
+      stubChildren(root, page(folderItem("Test")));
+
+      DriveItemRequestBuilder sub = mock(DriveItemRequestBuilder.class);
+      when(root.itemWithPath("Test")).thenReturn(sub);
+      stubChildren(sub, page(fileItem("a.csv")));
+
+      List<BrowsableQuery.BrowseEntry> entries = new ArrayList<>();
+      boolean truncated = OneDriveRuntime.collectChildren(
+         client, "", true, List.of(), 2000, entries, new int[] { 0 });
+
+      assertFalse(truncated);
+      assertTrue(entries.stream().anyMatch(e -> e.path().equals("Test") && e.folder()));
+      assertTrue(entries.stream().anyMatch(e -> e.path().equals("Test/a.csv") && !e.folder()));
+   }
+
+   @Test
+   void maxEntriesReachedMidWalkStopsEarlyAndReportsTruncated() {
+      GraphServiceClient client = mock(GraphServiceClient.class);
+      DriveItemRequestBuilder root = mockClient(client);
+      stubChildren(root, page(fileItem("a.csv"), fileItem("b.csv"), fileItem("c.csv")));
+
+      List<BrowsableQuery.BrowseEntry> entries = new ArrayList<>();
+      boolean truncated = OneDriveRuntime.collectChildren(
+         client, "", false, List.of(), 2, entries, new int[] { 0 });
+
+      assertTrue(truncated);
+      assertEquals(2, entries.size());
+   }
+
+   /**
+    * A folder tree exceeding MAX_GRAPH_REQUESTS stops and reports truncated -- independent of
+    * maxEntries, which this case never comes close to (each folder holds only one item).
+    */
+   @Test
+   void graphRequestCapStopsTheWalkIndependentlyOfTheEntriesCap() {
+      // A chain of single-subfolder folders: "f", "f/f", "f/f/f", ... -- each fetch finds exactly
+      // one more folder to recurse into, so the walk never comes close to the entries cap and is
+      // stopped purely by MAX_GRAPH_REQUESTS.
+      GraphServiceClient client = mock(GraphServiceClient.class);
+      DriveItemRequestBuilder root = mockClient(client);
+      stubChildren(root, page(folderItem("f")));
+
+      // Every recursive call re-derives its builder from root().itemWithPath(fullPath) directly
+      // (see collectChildren's own ternary) -- never by chaining off the previous itemWithPath
+      // result -- so each stub below is keyed off root, not off the previous iteration's builder.
+      String path = "f";
+
+      for(int i = 0; i < OneDriveRuntime.MAX_GRAPH_REQUESTS + 5; i++) {
+         DriveItemRequestBuilder next = mock(DriveItemRequestBuilder.class);
+         when(root.itemWithPath(path)).thenReturn(next);
+         stubChildren(next, page(folderItem("f")));
+         path = path + "/f";
+      }
+
+      List<BrowsableQuery.BrowseEntry> entries = new ArrayList<>();
+      boolean truncated = OneDriveRuntime.collectChildren(
+         client, "", true, List.of(), 100_000, entries, new int[] { 0 });
+
+      assertTrue(truncated);
+      assertTrue(entries.size() < 100_000, "must have stopped well short of the entries cap");
+   }
+
+   @Test
+   void aGraphFailurePropagatesUncaughtRatherThanReturningAnEmptyListing() {
+      GraphServiceClient client = mock(GraphServiceClient.class);
+      DriveItemRequestBuilder root = mockClient(client);
+      stubChildrenThrows(root, new ClientException("throttled", null));
+
+      assertThrows(ClientException.class, () -> OneDriveRuntime.collectChildren(
+         client, "", false, List.of(), 2000, new ArrayList<>(), new int[] { 0 }));
+   }
+
+   @Test
+   void acceptTypesFiltersFilesButNeverFolders() {
+      GraphServiceClient client = mock(GraphServiceClient.class);
+      DriveItemRequestBuilder root = mockClient(client);
+      stubChildren(root, page(folderItem("Test"), fileItem("a.csv"), fileItem("b.txt")));
+
+      List<BrowsableQuery.BrowseEntry> entries = new ArrayList<>();
+      OneDriveRuntime.collectChildren(
+         client, "", false, List.of(".csv"), 2000, entries, new int[] { 0 });
+
+      assertEquals(
+         List.of("Test", "a.csv"),
+         entries.stream().map(BrowsableQuery.BrowseEntry::name).toList());
+   }
+
+   @Test
+   void emptyAcceptTypesAcceptsEveryFile() {
+      GraphServiceClient client = mock(GraphServiceClient.class);
+      DriveItemRequestBuilder root = mockClient(client);
+      stubChildren(root, page(fileItem("a.csv"), fileItem("b.txt"), fileItem("c.dat")));
+
+      List<BrowsableQuery.BrowseEntry> entries = new ArrayList<>();
+      OneDriveRuntime.collectChildren(
+         client, "", false, List.of(), 2000, entries, new int[] { 0 });
+
+      assertEquals(3, entries.size());
    }
 
    private Object[][] readExpected(String file) throws IOException {

--- a/connectors/inetsoft-onedrive/src/test/java/inetsoft/uql/onedrive/OneDriveTabularContractTest.java
+++ b/connectors/inetsoft-onedrive/src/test/java/inetsoft/uql/onedrive/OneDriveTabularContractTest.java
@@ -1,0 +1,107 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.onedrive;
+
+import inetsoft.uql.tabular.PropertyMeta;
+import inetsoft.uql.tabular.TabularQuerySchema;
+import inetsoft.uql.tabular.TabularSchemaExtractor;
+import inetsoft.uql.tabular.TabularUtil;
+import inetsoft.uql.util.Config;
+import inetsoft.util.ConfigurationContext;
+import inetsoft.web.wiz.service.TabularQueryContractSupport;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Confirms charter assertion #5 (this run's `docs/teams/2026-08-28-onedrive-tabular-target/`):
+ * {@code create_worksheet_table} builds a real OneDrive-backed table through the already-generic
+ * {@code TabularQueryContractSupport.applyQueryContract} -- OneDrive needs no StyleBI-side change
+ * for this, because {@code OneDriveQuery.path} is a plain {@code String} property, so
+ * {@code applyQueryContract} routes it through its ordinary bean-property-write branch rather than
+ * the {@code java.io.File}-typed one. Lives beside {@code OneDriveRuntimeTests} rather than in
+ * core's own {@code TabularQueryContractSupportTest} (which tests the mechanism itself against its
+ * own fake fixtures) because this test's whole point is that OneDrive's REAL property names round-
+ * trip through it -- something only a real (non-mock) {@code OneDriveQuery} can prove.
+ */
+@Tag("core")
+class OneDriveTabularContractTest {
+   /**
+    * Mirrors {@code TabularQueryContractSupportTest}'s identical setup: {@code LayoutCreator}
+    * resolves a view's label through {@code Config.getConfig()}, a Spring bean this plain unit
+    * test has no context for.
+    */
+   @BeforeAll
+   static void installContext() {
+      previous = ConfigurationContext.getContext();
+      Config config = mock(Config.class);
+      when(config.getResourceBundle(any())).thenReturn(null);
+
+      ApplicationContext context = mock(ApplicationContext.class);
+      when(context.getBean(Config.class)).thenReturn(config);
+      ConfigurationContext.getContext().setApplicationContext(context);
+   }
+
+   @AfterAll
+   static void clearContext() {
+      if(previous != null) {
+         previous.setApplicationContext(null);
+      }
+   }
+
+   private static ConfigurationContext previous;
+
+   private static String apply(OneDriveQuery query, Map<String, Object> queryParams)
+      throws Exception
+   {
+      Map<String, PropertyMeta> pmap = TabularUtil.getPropertyMap(query.getClass());
+      TabularQuerySchema schema = new TabularSchemaExtractor().extract(query, query.getType());
+      return TabularQueryContractSupport.applyQueryContract(
+         query, pmap, schema, queryParams, "myds");
+   }
+
+   @Test
+   void pathRoundTripsThroughTheOrdinaryStringBranch() throws Exception {
+      OneDriveQuery query = new OneDriveQuery();
+
+      apply(query, Map.of("path", "Test/Sales.csv"));
+
+      assertEquals("Test/Sales.csv", query.getPath());
+   }
+
+   @Test
+   void unknownPropertyNameIsRejectedWithOneDrivesOwnRealPropertyList() {
+      OneDriveQuery query = new OneDriveQuery();
+
+      IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+         () -> apply(query, Map.of("bogusParam", "x")));
+      assertTrue(ex.getMessage().contains("bogusParam"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("path"), ex.getMessage());
+   }
+}

--- a/core/src/main/java/inetsoft/uql/tabular/BrowsableQuery.java
+++ b/core/src/main/java/inetsoft/uql/tabular/BrowsableQuery.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.uql.tabular;
+
+import java.util.List;
+
+/**
+ * A TabularQuery whose file/item property cannot be walked as a local java.io.File -- addressed
+ * through a remote API instead (a cloud-drive item, a document-library item, ...) -- but which can
+ * still enumerate its own children. WizTabularController.browse() dispatches here BEFORE its
+ * local-filesystem findFileView()/collect() path, by a type test (instanceof BrowsableQuery),
+ * matching the same discipline SelectableTabularQuery already established: a capability test, not
+ * a name check on the connector.
+ */
+public interface BrowsableQuery {
+   /**
+    * Name of the property this query browses -- what WizTabularBrowseRequest.property() is matched
+    * against when the caller names one explicitly. A connector with exactly one browsable property
+    * (every implementor so far) returns its constant name.
+    */
+   String getBrowsablePropertyName();
+
+   /**
+    * The connector's own extension whitelist (e.g. [".txt", ".csv", ".xls", ".xlsx"]),
+    * read by the controller and skipped when the caller's request carries all=true --
+    * mirroring exactly how WizTabularController.browse()'s local-file path reads
+    * acceptTypes off a @PropertyEditor, just declared in code instead of an
+    * annotation because there is no java.io.File-typed property to hang the annotation off.
+    */
+   List<String> getAcceptedExtensions();
+
+   /**
+    * List one folder's entries, optionally recursing into sub-folders.
+    *
+    * @param path        folder to list, relative to this connector's own root; "" is the root.
+    * @param recursive   true walks sub-folders in the same call (bounded by maxEntries).
+    * @param acceptTypes extension whitelist to apply to files (folders are always listed); empty
+    *                    accepts every file. Already resolved by the caller against "all".
+    * @param maxEntries  stop and report truncated once this many entries have been collected.
+    * @throws Exception  a real failure (auth, network, throttling) -- never swallowed into an
+    *                     empty/short listing. The caller must let this propagate.
+    */
+   BrowseListing browseChildren(String path, boolean recursive, List<String> acceptTypes,
+                                int maxEntries) throws Exception;
+
+   record BrowseEntry(String path, String name, boolean folder) {}
+
+   /** truncated is true when maxEntries (or an internal request-count cap) stopped the walk. */
+   record BrowseListing(List<BrowseEntry> entries, boolean truncated) {}
+}

--- a/core/src/main/java/inetsoft/web/wiz/controller/WizTabularController.java
+++ b/core/src/main/java/inetsoft/web/wiz/controller/WizTabularController.java
@@ -24,6 +24,7 @@ import inetsoft.uql.DataSourceListing;
 import inetsoft.uql.DataSourceListingService;
 import inetsoft.uql.XDataSource;
 import inetsoft.uql.XRepository;
+import inetsoft.uql.tabular.BrowsableQuery;
 import inetsoft.uql.tabular.LayoutCreator;
 import inetsoft.uql.tabular.TabularDataSource;
 import inetsoft.uql.tabular.TabularEditor;
@@ -64,6 +65,7 @@ import java.io.File;
 import java.nio.file.Files;
 import java.security.Principal;
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * The wiz API for creating and editing tabular (non-JDBC) data sources.
@@ -681,7 +683,7 @@ public class WizTabularController {
     * this honest when a connector adds a format.</p>
     */
    private WizTabularBrowseResult browse(String datasource, String path,
-                                         WizTabularBrowseRequest request)
+                                         WizTabularBrowseRequest request) throws Exception
    {
       TabularQuery query = TabularUtil.createQuery(datasource);
 
@@ -693,6 +695,10 @@ public class WizTabularController {
 
       TabularView view = new LayoutCreator().createLayout(query);
       TabularUtil.callEditorMethods(view.getViews(), query);
+
+      if(query instanceof BrowsableQuery browsable) {
+         return browseViaCapability(datasource, path, request, browsable);
+      }
 
       TabularView fileView = findFileView(view, request.property());
 
@@ -746,6 +752,42 @@ public class WizTabularController {
                         String.CASE_INSENSITIVE_ORDER));
 
       return new WizTabularBrowseResult(datasource, path, entries, truncated);
+   }
+
+   /**
+    * The browse itself, for a connector that answers browseChildren() through a remote API
+    * instead of a local java.io.File tree -- see BrowsableQuery's own doc for why the two paths
+    * cannot share collect().
+    */
+   private WizTabularBrowseResult browseViaCapability(String datasource, String path,
+                                                       WizTabularBrowseRequest request,
+                                                       BrowsableQuery browsable) throws Exception
+   {
+      String propertyName = browsable.getBrowsablePropertyName();
+
+      if(request.property() != null && !request.property().isEmpty() &&
+         !request.property().equals(propertyName))
+      {
+         throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Data source \"" +
+            datasource + "\" has no browsable file property named \"" + request.property() +
+            "\" -- its browsable property is \"" + propertyName + "\".");
+      }
+
+      List<String> acceptTypes = request.all() ? List.of() : browsable.getAcceptedExtensions();
+      BrowsableQuery.BrowseListing listing =
+         browsable.browseChildren(path, request.recursive(), acceptTypes, MAX_BROWSE_ENTRIES);
+
+      List<WizTabularBrowseResult.WizTabularBrowseEntry> entries = listing.entries().stream()
+         .map(e -> new WizTabularBrowseResult.WizTabularBrowseEntry(e.path(), e.name(), e.folder()))
+         .collect(Collectors.toCollection(ArrayList::new));
+
+      // Same stable order as the local-file path: folders first, then alphabetical.
+      entries.sort(Comparator.comparing(
+            WizTabularBrowseResult.WizTabularBrowseEntry::folder, Comparator.reverseOrder())
+         .thenComparing(WizTabularBrowseResult.WizTabularBrowseEntry::path,
+                        String.CASE_INSENSITIVE_ORDER));
+
+      return new WizTabularBrowseResult(datasource, path, entries, listing.truncated());
    }
 
    /**

--- a/core/src/test/java/inetsoft/web/wiz/controller/FakeLocalFileQuery.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/FakeLocalFileQuery.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.controller;
+
+import inetsoft.uql.tabular.*;
+
+import java.io.File;
+
+/**
+ * Minimal, REAL (non-mock) local-filesystem browsable connector, mirroring
+ * {@code ServerFileQuery}'s own {@code getFileFolder()} shape ({@code relativeTo}/
+ * {@code acceptTypes} editor properties on a {@code java.io.File}-typed property) closely enough
+ * to exercise {@code WizTabularController}'s pre-existing {@code findFileView}/{@code collect()}
+ * path without depending on the {@code inetsoft-serverfile} connector module (core does not depend
+ * on it). A TOP-LEVEL public class, not a nested one: {@code TabularUtil.callEditorMethods}
+ * resolves {@code relativeTo} by reflectively invoking {@code getRootFolder()} from a different
+ * package, which silently fails (caught, logged, left null) against a non-public declaring class.
+ */
+@View(vertical = false, value = { @View1("fileFolder") })
+public class FakeLocalFileQuery extends SelectableTabularQuery {
+   public FakeLocalFileQuery() {
+      super("FakeLocalFile");
+   }
+
+   @Property(label = "File/Folder", required = true)
+   @PropertyEditor(editorProperties = {
+      @EditorProperty(name = "relativeTo", method = "getRootFolder"),
+      @EditorProperty(name = "acceptTypes", value = ".txt,.csv,.xls,.xlsx")
+   })
+   public File getFileFolder() {
+      return fileFolder;
+   }
+
+   public void setFileFolder(File fileFolder) {
+      this.fileFolder = fileFolder;
+   }
+
+   public String getRootFolder() {
+      return rootFolder;
+   }
+
+   public void setRootFolder(String rootFolder) {
+      this.rootFolder = rootFolder;
+   }
+
+   @Override
+   protected ColumnDefinition[] loadColumns() {
+      return new ColumnDefinition[0];
+   }
+
+   private File fileFolder;
+   private String rootFolder;
+}

--- a/core/src/test/java/inetsoft/web/wiz/controller/WizTabularControllerTest.java
+++ b/core/src/test/java/inetsoft/web/wiz/controller/WizTabularControllerTest.java
@@ -25,23 +25,34 @@ import inetsoft.uql.DataSourceListingService;
 import inetsoft.uql.XDataSource;
 import inetsoft.uql.XRepository;
 import inetsoft.uql.jdbc.JDBCDataSource;
-import inetsoft.uql.tabular.TabularDataSource;
+import inetsoft.uql.tabular.*;
+import inetsoft.uql.util.Config;
+import inetsoft.util.ConfigurationContext;
 import inetsoft.util.MessageException;
 import inetsoft.web.portal.data.DataSourceDefinition;
 import inetsoft.web.portal.data.DatasourcesService;
+import inetsoft.web.wiz.model.WizTabularBrowseResult;
 import inetsoft.web.wiz.model.WizTabularListing;
 import inetsoft.web.wiz.model.WizTabularListings;
 import inetsoft.web.wiz.model.WizTabularSaveResult;
+import inetsoft.web.wiz.request.WizTabularBrowseRequest;
 import inetsoft.web.wiz.request.WizTabularCreateRequest;
+import inetsoft.web.wiz.service.FakeBrowsableQuery;
 import inetsoft.web.wiz.service.UnsupportedDatasourceException;
 import inetsoft.web.wiz.service.WorksheetTableService;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.MockedStatic;
+import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.io.File;
+import java.nio.file.Path;
 import java.security.Principal;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -56,6 +67,33 @@ import static org.mockito.Mockito.*;
  */
 @Tag("core")
 class WizTabularControllerTest {
+   /**
+    * LayoutCreator resolves a view's display label through the connector's resource bundle via
+    * {@code Config.getConfig()} -- a Spring bean. There is no context in a plain unit test, so a
+    * stub answering no bundle is installed for the browse tests below, which are the first in
+    * this file to reach {@code browse()} and therefore the first to reach LayoutCreator at all.
+    * Mirrors TabularQueryContractSupportTest's identical setup.
+    */
+   @BeforeAll
+   static void installConfigContext() {
+      previousContext = ConfigurationContext.getContext();
+      Config config = mock(Config.class);
+      when(config.getResourceBundle(any())).thenReturn(null);
+
+      ApplicationContext springContext = mock(ApplicationContext.class);
+      when(springContext.getBean(Config.class)).thenReturn(config);
+      ConfigurationContext.getContext().setApplicationContext(springContext);
+   }
+
+   @AfterAll
+   static void clearConfigContext() {
+      if(previousContext != null) {
+         previousContext.setApplicationContext(null);
+      }
+   }
+
+   private static ConfigurationContext previousContext;
+
    private DatasourcesService datasourcesService;
    private SecurityEngine securityEngine;
    private XRepository xrepository;
@@ -455,5 +493,122 @@ class WizTabularControllerTest {
          assertEquals(HttpStatus.NOT_FOUND, e.getStatusCode());
          verify(datasourcesService, never()).getDataSourceFromListing(anyString());
       }
+   }
+
+   // ─── browseTabularFiles: BrowsableQuery connectors (e.g. OneDrive) ────────
+
+   private WizTabularBrowseResult browseWith(FakeBrowsableQuery query, WizTabularBrowseRequest request)
+      throws Exception
+   {
+      try(MockedStatic<TabularUtil> tabularUtil = mockStatic(TabularUtil.class, CALLS_REAL_METHODS)) {
+         tabularUtil.when(() -> TabularUtil.createQuery(request.datasource())).thenReturn(query);
+
+         return controller.browseTabularFiles(request, principal);
+      }
+   }
+
+   @Test
+   void browsableQueryConnectorIsNoLongerRefused() throws Exception {
+      FakeBrowsableQuery query = new FakeBrowsableQuery();
+      query.setCanned(new BrowsableQuery.BrowseListing(
+         List.of(new BrowsableQuery.BrowseEntry("Test", "Test", true)), false));
+
+      WizTabularBrowseResult result = browseWith(query,
+         new WizTabularBrowseRequest("onedrive", "", null, false, false));
+
+      assertEquals(1, result.entries().size());
+      assertEquals("Test", result.entries().get(0).name());
+   }
+
+   @Test
+   void browsableQueryEntriesAndTruncatedComeFromTheCannedListingUnchanged() throws Exception {
+      FakeBrowsableQuery query = new FakeBrowsableQuery();
+      query.setCanned(new BrowsableQuery.BrowseListing(
+         List.of(new BrowsableQuery.BrowseEntry("Test/a.csv", "a.csv", false),
+                 new BrowsableQuery.BrowseEntry("Test/sub", "sub", true)),
+         true));
+
+      WizTabularBrowseResult result = browseWith(query,
+         new WizTabularBrowseRequest("onedrive", "Test", null, false, false));
+
+      assertEquals("onedrive", result.datasource());
+      assertEquals("Test", result.path());
+      assertTrue(result.truncated());
+      // Re-sorted folders-first (same stable order the local-file path uses), not an unsorted
+      // echo of the canned listing.
+      assertEquals(
+         List.of("Test/sub", "Test/a.csv"),
+         result.entries().stream().map(WizTabularBrowseResult.WizTabularBrowseEntry::path).toList());
+   }
+
+   @Test
+   void browsableQueryAllTruePassesAnEmptyAcceptTypesList() throws Exception {
+      FakeBrowsableQuery query = new FakeBrowsableQuery();
+      query.setAcceptedExtensions(List.of(".csv"));
+
+      browseWith(query, new WizTabularBrowseRequest("onedrive", "", null, true, false));
+
+      assertEquals(List.of(), query.getLastAcceptTypes());
+   }
+
+   @Test
+   void browsableQueryAllFalseUsesTheConnectorsOwnAcceptedExtensions() throws Exception {
+      FakeBrowsableQuery query = new FakeBrowsableQuery();
+      query.setAcceptedExtensions(List.of(".csv", ".txt"));
+
+      browseWith(query, new WizTabularBrowseRequest("onedrive", "", null, false, false));
+
+      assertEquals(List.of(".csv", ".txt"), query.getLastAcceptTypes());
+   }
+
+   @Test
+   void browsableQueryRejectsAPropertyNameOtherThanItsOwn() throws Exception {
+      FakeBrowsableQuery query = new FakeBrowsableQuery();
+
+      ResponseStatusException e = assertThrows(ResponseStatusException.class, () -> browseWith(
+         query, new WizTabularBrowseRequest("onedrive", "", "bogusProperty", false, false)));
+
+      assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, e.getStatusCode());
+   }
+
+   @Test
+   void browsableQueryPropagatesAThrownFailureRatherThanReturningAnEmptyListing() throws Exception {
+      FakeBrowsableQuery query = new FakeBrowsableQuery();
+      query.setFailure(new IllegalStateException("token expired"));
+
+      assertThrows(IllegalStateException.class, () -> browseWith(
+         query, new WizTabularBrowseRequest("onedrive", "", null, false, false)));
+   }
+
+   /*
+    * The pre-existing local-file (ServerFile-shaped) path had zero test coverage before this run
+    * (confirmed independently by both the architect and the verifier during P1 -- see
+    * docs/teams/2026-08-28-onedrive-tabular-target/04-build.md). Backfilled here, alongside the
+    * new BrowsableQuery branch it now sits next to, rather than left as a separate follow-up: the
+    * fixture this needs (a File-typed browsable property) is cheap once FakeBrowsableQuery's own
+    * ConfigurationContext/MockedStatic scaffolding already exists in this file.
+    */
+   @Test
+   void localFileConnectorIsUnaffectedByTheNewBrowsableQueryBranch(@TempDir Path tempDir)
+      throws Exception
+   {
+      java.nio.file.Files.createDirectories(tempDir.resolve("sub"));
+      java.nio.file.Files.writeString(tempDir.resolve("sub/a.csv"), "a,b\n1,2\n");
+
+      FakeLocalFileQuery query = new FakeLocalFileQuery();
+      query.setRootFolder(tempDir.toString());
+
+      WizTabularBrowseResult result;
+
+      try(MockedStatic<TabularUtil> tabularUtil = mockStatic(TabularUtil.class, CALLS_REAL_METHODS)) {
+         tabularUtil.when(() -> TabularUtil.createQuery("serverfile")).thenReturn(query);
+
+         result = controller.browseTabularFiles(
+            new WizTabularBrowseRequest("serverfile", "", null, false, false), principal);
+      }
+
+      assertEquals(1, result.entries().size());
+      assertEquals("sub", result.entries().get(0).name());
+      assertTrue(result.entries().get(0).folder());
    }
 }

--- a/core/src/test/java/inetsoft/web/wiz/service/FakeBrowsableQuery.java
+++ b/core/src/test/java/inetsoft/web/wiz/service/FakeBrowsableQuery.java
@@ -1,0 +1,105 @@
+/*
+ * This file is part of StyleBI.
+ * Copyright (C) 2026  InetSoft Technology
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package inetsoft.web.wiz.service;
+
+import inetsoft.uql.tabular.BrowsableQuery;
+import inetsoft.uql.tabular.ColumnDefinition;
+import inetsoft.uql.tabular.SelectableTabularQuery;
+
+import java.util.List;
+
+/**
+ * Minimal, REAL (non-mock) stand-in for a {@link BrowsableQuery} such as {@code OneDriveQuery} --
+ * exists only so {@code WizTabularController.browse()}'s {@code instanceof BrowsableQuery} test
+ * has something to answer {@code true} for, without depending on the {@code inetsoft-onedrive}
+ * connector module (core does not depend on it). Mirrors {@link FakeSelectableFileQuery}'s
+ * existing pattern.
+ */
+public class FakeBrowsableQuery extends SelectableTabularQuery implements BrowsableQuery {
+   public FakeBrowsableQuery() {
+      super("FakeBrowsable");
+   }
+
+   @Override
+   protected ColumnDefinition[] loadColumns() {
+      return new ColumnDefinition[0];
+   }
+
+   @Override
+   public String getBrowsablePropertyName() {
+      return "path";
+   }
+
+   @Override
+   public List<String> getAcceptedExtensions() {
+      return acceptedExtensions;
+   }
+
+   public void setAcceptedExtensions(List<String> acceptedExtensions) {
+      this.acceptedExtensions = acceptedExtensions;
+   }
+
+   @Override
+   public BrowseListing browseChildren(String path, boolean recursive, List<String> acceptTypes,
+                                        int maxEntries)
+      throws Exception
+   {
+      lastPath = path;
+      lastRecursive = recursive;
+      lastAcceptTypes = acceptTypes;
+      lastMaxEntries = maxEntries;
+
+      if(failure != null) {
+         throw failure;
+      }
+
+      return canned;
+   }
+
+   public void setCanned(BrowseListing canned) {
+      this.canned = canned;
+   }
+
+   public void setFailure(Exception failure) {
+      this.failure = failure;
+   }
+
+   public String getLastPath() {
+      return lastPath;
+   }
+
+   public boolean isLastRecursive() {
+      return lastRecursive;
+   }
+
+   public List<String> getLastAcceptTypes() {
+      return lastAcceptTypes;
+   }
+
+   public int getLastMaxEntries() {
+      return lastMaxEntries;
+   }
+
+   private List<String> acceptedExtensions = List.of(".csv", ".txt");
+   private BrowseListing canned = new BrowseListing(List.of(), false);
+   private Exception failure;
+   private String lastPath;
+   private boolean lastRecursive;
+   private List<String> lastAcceptTypes;
+   private int lastMaxEntries;
+}


### PR DESCRIPTION
## Summary
- `WizTabularController.browse()` refused any OneDrive datasource with "not a file-based connector": `OneDriveQuery.path` is a plain `String` (a Graph item path, not a local file), so it never matched `findFileView`'s `File`-typed property test, and `collect()`'s own walk is irreducibly `java.io.File`-based.
- Adds a new `inetsoft.uql.tabular.BrowsableQuery` capability interface, implemented by `OneDriveQuery`/`OneDriveRuntime` via Microsoft Graph's `children` endpoint (paginated to completion, bounded by a new `MAX_GRAPH_REQUESTS=200` independent of the existing `MAX_BROWSE_ENTRIES=2000` entry cap). `WizTabularController.browse()` dispatches to it via `instanceof`, before the existing local-file `findFileView`/`collect()` path, so ServerFile's behavior is unchanged.
- Backfills the pre-existing local-file browse path's first-ever test coverage in `WizTabularControllerTest` (found to have none while extending that file for this change).
- Companion PR on the wiz-services repo: https://github.com/inetsoft-technology/stylebi-wiz/pull/1902

Design/verification trail: `docs/teams/2026-08-28-onedrive-tabular-target/` in the `stylebi-wiz` repo (`00-charter.md`, `01-design.md`, `02-verify-plan.md`, `03-reconcile.md`, `04-build.md`).

## Test plan
- [x] `./mvnw -pl core -am test -o` — 7833 tests, 0 failures
- [x] `./mvnw -pl connectors/inetsoft-onedrive -am test -o` — 13 tests, 0 failures
- [ ] Live OneDrive OAuth/browse/annotate/build — blocked, no Microsoft 365 test tenant available this run (charter Decision log #2)